### PR TITLE
fix: stabilize nightly E2E test failures on stable/8.8

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessMigrationModePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessMigrationModePage.ts
@@ -116,7 +116,9 @@ export class OperateProcessMigrationModePage {
     mappings: Array<{label: string | RegExp; targetValue: string}>,
   ): Promise<void> {
     for (const {label, targetValue} of mappings) {
-      await expect(this.page.getByLabel(label)).toHaveValue(targetValue);
+      await expect(this.page.getByLabel(label)).toHaveValue(targetValue, {
+        timeout: 30000,
+      });
     }
   }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskDetailsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskDetailsPage.ts
@@ -330,10 +330,25 @@ class TaskDetailsPage {
 
     for (const [index, element] of elements.entries()) {
       const expectedValue = `${value}${index + 1}`;
-      await element.fill(expectedValue);
-
-      // Assert that the value was added correctly
-      await expect(element).toHaveValue(expectedValue);
+      const maxRetries = 3;
+      let attempt = 0;
+      while (attempt < maxRetries) {
+        try {
+          await element.click();
+          await element.fill(expectedValue);
+          await element.blur();
+          await expect(element).toHaveValue(expectedValue);
+          break;
+        } catch (error) {
+          attempt++;
+          if (attempt === maxRetries) {
+            throw new Error(
+              `Failed to set value "${expectedValue}" for label "${label}" row ${index} after ${maxRetries} attempts: ${error}`,
+            );
+          }
+          await sleep(500);
+        }
+      }
     }
   }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskPanelPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskPanelPage.ts
@@ -104,14 +104,24 @@ class TaskPanelPage {
       | 'Custom',
   ) {
     await this.expandSidePanelButton.click();
-    await this.page.getByRole('link', {name: option, exact: true}).click();
+    const filterLink = this.page.getByRole('link', {name: option, exact: true});
+    await filterLink.click();
     const expectedSegment =
       option === 'All open tasks'
         ? 'all-open'
         : option === 'Assigned to me'
           ? 'assigned-to-me'
           : option.toLowerCase().replace(/\s+/g, '-');
-    await expect(this.page).toHaveURL(new RegExp(`${expectedSegment}`));
+    const urlPattern = new RegExp(`${expectedSegment}`);
+    await waitForAssertion({
+      assertion: async () => {
+        await expect(this.page).toHaveURL(urlPattern, {timeout: 5000});
+      },
+      onFailure: async () => {
+        await filterLink.click();
+      },
+      maxRetries: 3,
+    });
     await this.collapseSidePanelButton.click();
   }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/orderProcessMigration_v_1.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/orderProcessMigration_v_1.bpmn
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.28.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+  xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1"
+  targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler"
+  exporterVersion="68c5d80" modeler:executionPlatform="Camunda Cloud"
+  modeler:executionPlatformVersion="8.9.0">
   <bpmn:process id="orderProcessMigration" name="orderProcessMigration" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1" name="Order received">
       <bpmn:outgoing>SequenceFlow_0j6tsnn</bpmn:outgoing>
@@ -29,7 +38,8 @@
       <bpmn:outgoing>SequenceFlow_0jzbqu1</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_1dq2rqw</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="SequenceFlow_1s6g17c" sourceRef="checkPayment" targetRef="ExclusiveGateway_1qqmrb8" />
+    <bpmn:sequenceFlow id="SequenceFlow_1s6g17c" sourceRef="checkPayment"
+      targetRef="ExclusiveGateway_1qqmrb8" />
     <bpmn:serviceTask id="requestForPayment" name="Request for payment">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="requestPayment" />
@@ -37,11 +47,14 @@
       <bpmn:incoming>SequenceFlow_0jzbqu1</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1q6ade7</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="SequenceFlow_0jzbqu1" name="Not paid" sourceRef="ExclusiveGateway_1qqmrb8" targetRef="requestForPayment">
+    <bpmn:sequenceFlow id="SequenceFlow_0jzbqu1" name="Not paid"
+      sourceRef="ExclusiveGateway_1qqmrb8" targetRef="requestForPayment">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=paid = false</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_1q6ade7" sourceRef="requestForPayment" targetRef="checkPayment" />
-    <bpmn:sequenceFlow id="SequenceFlow_1dq2rqw" name="paid" sourceRef="ExclusiveGateway_1qqmrb8" targetRef="shipArticles">
+    <bpmn:sequenceFlow id="SequenceFlow_1q6ade7" sourceRef="requestForPayment"
+      targetRef="checkPayment" />
+    <bpmn:sequenceFlow id="SequenceFlow_1dq2rqw" name="paid" sourceRef="ExclusiveGateway_1qqmrb8"
+      targetRef="shipArticles">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=paid = true</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_18wek8y" sourceRef="Gateway_2" targetRef="checkPayment" />
@@ -94,7 +107,8 @@
         <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P1Y</bpmn:timeDuration>
       </bpmn:timerEventDefinition>
     </bpmn:boundaryEvent>
-    <bpmn:boundaryEvent id="MessageNonInterrupting" name="Message non-interrupting" cancelActivity="false" attachedToRef="TaskC">
+    <bpmn:boundaryEvent id="MessageNonInterrupting" name="Message non-interrupting"
+      cancelActivity="false" attachedToRef="TaskC">
       <bpmn:outgoing>Flow_0b5y250</bpmn:outgoing>
       <bpmn:messageEventDefinition id="MessageEventDefinition_0ox9bto" messageRef="Message_3mvm2pn" />
     </bpmn:boundaryEvent>
@@ -131,7 +145,8 @@
       <bpmn:outgoing>Flow_1i7pkzb</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="Flow_1i7pkzb" sourceRef="TaskD" targetRef="Gateway_3" />
-    <bpmn:boundaryEvent id="TimerNonInterrupting" name="Timer non-interrupting" cancelActivity="false" attachedToRef="TaskD">
+    <bpmn:boundaryEvent id="TimerNonInterrupting" name="Timer non-interrupting"
+      cancelActivity="false" attachedToRef="TaskD">
       <bpmn:outgoing>Flow_093zwcs</bpmn:outgoing>
       <bpmn:timerEventDefinition id="TimerEventDefinition_0lpluww">
         <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P1Y</bpmn:timeDuration>
@@ -154,7 +169,8 @@
     <bpmn:sequenceFlow id="Flow_0e569q0" sourceRef="TaskA" targetRef="Gateway_3" />
     <bpmn:sequenceFlow id="Flow_08ahq87" sourceRef="Gateway_2" targetRef="MessageIntermediateCatch" />
     <bpmn:sequenceFlow id="Flow_1wxn661" sourceRef="MessageIntermediateCatch" targetRef="Gateway_3" />
-    <bpmn:subProcess id="MessageEventSubProcess" name="Message event sub process" triggeredByEvent="true">
+    <bpmn:subProcess id="MessageEventSubProcess" name="Message event sub process"
+      triggeredByEvent="true">
       <bpmn:endEvent id="Event_13rtwuo">
         <bpmn:incoming>Flow_006eqia</bpmn:incoming>
       </bpmn:endEvent>
@@ -169,10 +185,12 @@
       </bpmn:serviceTask>
       <bpmn:startEvent id="MessageStartEvent" name="Message start event" isInterrupting="false">
         <bpmn:outgoing>Flow_1f7mn63</bpmn:outgoing>
-        <bpmn:messageEventDefinition id="MessageEventDefinition_047sqmx" messageRef="Message_2u2g7tt" />
+        <bpmn:messageEventDefinition id="MessageEventDefinition_047sqmx"
+          messageRef="Message_2u2g7tt" />
       </bpmn:startEvent>
     </bpmn:subProcess>
-    <bpmn:subProcess id="TimerEventSubProcess" name="Timer event sub process" triggeredByEvent="true">
+    <bpmn:subProcess id="TimerEventSubProcess" name="Timer event sub process"
+      triggeredByEvent="true">
       <bpmn:endEvent id="Event_0lk89tk">
         <bpmn:incoming>Flow_1rrwh6x</bpmn:incoming>
       </bpmn:endEvent>
@@ -194,7 +212,8 @@
     </bpmn:subProcess>
     <bpmn:sequenceFlow id="Flow_1jeea8a" sourceRef="Gateway_2" targetRef="MessageReceiveTask" />
     <bpmn:sequenceFlow id="Flow_17dl770" sourceRef="MessageReceiveTask" targetRef="Gateway_3" />
-    <bpmn:receiveTask id="MessageReceiveTask" name="Message receive task" messageRef="Message_14us09o">
+    <bpmn:receiveTask id="MessageReceiveTask" name="Message receive task"
+      messageRef="Message_14us09o">
       <bpmn:incoming>Flow_1jeea8a</bpmn:incoming>
       <bpmn:outgoing>Flow_17dl770</bpmn:outgoing>
     </bpmn:receiveTask>
@@ -233,7 +252,8 @@
       <bpmn:incoming>Flow_1fo0rfs</bpmn:incoming>
       <bpmn:outgoing>Flow_126yu9s</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="Flow_126yu9s" name="&#60; 0" sourceRef="ExclusiveGateway" targetRef="Gateway_1cs756a">
+    <bpmn:sequenceFlow id="Flow_126yu9s" name="&#60; 0" sourceRef="ExclusiveGateway"
+      targetRef="Gateway_1cs756a">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=unknownVariable &lt; 0</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:exclusiveGateway id="Gateway_1cs756a">
@@ -253,21 +273,26 @@
         <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P1Y</bpmn:timeDuration>
       </bpmn:timerEventDefinition>
     </bpmn:intermediateCatchEvent>
-    <bpmn:sequenceFlow id="Flow_0guz7jv" sourceRef="EventBasedGateway" targetRef="TimerIntermediateCatchB" />
-    <bpmn:sequenceFlow id="Flow_0j0qeck" sourceRef="TimerIntermediateCatchB" targetRef="Gateway_0ftzss1" />
+    <bpmn:sequenceFlow id="Flow_0guz7jv" sourceRef="EventBasedGateway"
+      targetRef="TimerIntermediateCatchB" />
+    <bpmn:sequenceFlow id="Flow_0j0qeck" sourceRef="TimerIntermediateCatchB"
+      targetRef="Gateway_0ftzss1" />
     <bpmn:intermediateCatchEvent id="MessageIntermediateCatchB" name="Message intermediate catch B">
       <bpmn:incoming>Flow_0v8bsdg</bpmn:incoming>
       <bpmn:outgoing>Flow_17zq5s0</bpmn:outgoing>
       <bpmn:messageEventDefinition id="MessageEventDefinition_17s00ai" messageRef="Message_2530hhv" />
     </bpmn:intermediateCatchEvent>
-    <bpmn:sequenceFlow id="Flow_0v8bsdg" sourceRef="EventBasedGateway" targetRef="MessageIntermediateCatchB" />
+    <bpmn:sequenceFlow id="Flow_0v8bsdg" sourceRef="EventBasedGateway"
+      targetRef="MessageIntermediateCatchB" />
     <bpmn:exclusiveGateway id="Gateway_0ftzss1">
       <bpmn:incoming>Flow_17zq5s0</bpmn:incoming>
       <bpmn:incoming>Flow_0j0qeck</bpmn:incoming>
       <bpmn:outgoing>Flow_17m3xiv</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="Flow_17zq5s0" sourceRef="MessageIntermediateCatchB" targetRef="Gateway_0ftzss1" />
-    <bpmn:subProcess id="SignalEventSubProcess" name="Signal event sub process" triggeredByEvent="true">
+    <bpmn:sequenceFlow id="Flow_17zq5s0" sourceRef="MessageIntermediateCatchB"
+      targetRef="Gateway_0ftzss1" />
+    <bpmn:subProcess id="SignalEventSubProcess" name="Signal event sub process"
+      triggeredByEvent="true">
       <bpmn:sequenceFlow id="Flow_189mrto" sourceRef="SignalStartEvent" targetRef="TaskH" />
       <bpmn:endEvent id="Event_0opmx5v">
         <bpmn:incoming>Flow_1tl6j8a</bpmn:incoming>
@@ -284,7 +309,8 @@
         <bpmn:outgoing>Flow_189mrto</bpmn:outgoing>
         <bpmn:signalEventDefinition id="SignalEventDefinition_19nq2lq" signalRef="Signal_3r9rbp1" />
       </bpmn:startEvent>
-      <bpmn:boundaryEvent id="SignalBoundaryEvent" name="Signal boundary event" attachedToRef="TaskH">
+      <bpmn:boundaryEvent id="SignalBoundaryEvent" name="Signal boundary event"
+        attachedToRef="TaskH">
         <bpmn:outgoing>Flow_0bfr615</bpmn:outgoing>
         <bpmn:signalEventDefinition id="SignalEventDefinition_0o1z67o" signalRef="Signal_104j77q" />
       </bpmn:boundaryEvent>
@@ -298,7 +324,8 @@
       <bpmn:outgoing>Flow_1359yom</bpmn:outgoing>
       <bpmn:signalEventDefinition id="SignalEventDefinition_0biu2sq" signalRef="Signal_3r9rbp1" />
     </bpmn:intermediateThrowEvent>
-    <bpmn:sequenceFlow id="Flow_1359yom" sourceRef="SignalIntermediateThrow" targetRef="SignalIntermediateCatch" />
+    <bpmn:sequenceFlow id="Flow_1359yom" sourceRef="SignalIntermediateThrow"
+      targetRef="SignalIntermediateCatch" />
     <bpmn:intermediateCatchEvent id="SignalIntermediateCatch" name="Signal intermediate catch">
       <bpmn:incoming>Flow_1359yom</bpmn:incoming>
       <bpmn:outgoing>Flow_0g97m5r</bpmn:outgoing>
@@ -310,7 +337,8 @@
       <bpmn:startEvent id="SubProcessStartEvent">
         <bpmn:outgoing>Flow_1w9iwsx</bpmn:outgoing>
       </bpmn:startEvent>
-      <bpmn:subProcess id="ErrorEventSubProcess" name="Error event sub process" triggeredByEvent="true">
+      <bpmn:subProcess id="ErrorEventSubProcess" name="Error event sub process"
+        triggeredByEvent="true">
         <bpmn:startEvent id="ErrorStartEvent" name="Error start event">
           <bpmn:outgoing>Flow_1ic0jav</bpmn:outgoing>
           <bpmn:errorEventDefinition id="ErrorEventDefinition_094930e" errorRef="Error_13vdeq4" />
@@ -332,7 +360,8 @@
         <bpmn:incoming>Flow_1w9iwsx</bpmn:incoming>
         <bpmn:errorEventDefinition id="ErrorEventDefinition_0663p22" errorRef="Error_00pqgg4" />
       </bpmn:endEvent>
-      <bpmn:sequenceFlow id="Flow_1w9iwsx" sourceRef="SubProcessStartEvent" targetRef="ErrorEndEvent" />
+      <bpmn:sequenceFlow id="Flow_1w9iwsx" sourceRef="SubProcessStartEvent"
+        targetRef="ErrorEndEvent" />
     </bpmn:subProcess>
     <bpmn:subProcess id="MultiInstanceSubProcess" name="Multi instance sub process">
       <bpmn:incoming>Flow_1nydbto</bpmn:incoming>
@@ -377,7 +406,8 @@
       <bpmn:intermediateThrowEvent id="Event_0iwm1fq">
         <bpmn:incoming>Flow_0bbhalt</bpmn:incoming>
         <bpmn:outgoing>Flow_12rxp59</bpmn:outgoing>
-        <bpmn:escalationEventDefinition id="EscalationEventDefinition_0a4p2il" escalationRef="Escalation_1v2o7l5" />
+        <bpmn:escalationEventDefinition id="EscalationEventDefinition_0a4p2il"
+          escalationRef="Escalation_1v2o7l5" />
       </bpmn:intermediateThrowEvent>
       <bpmn:sequenceFlow id="Flow_0bbhalt" sourceRef="EscalationTask" targetRef="Event_0iwm1fq" />
       <bpmn:serviceTask id="EscalationTask" name="Escalation task">
@@ -388,9 +418,11 @@
         <bpmn:outgoing>Flow_0bbhalt</bpmn:outgoing>
       </bpmn:serviceTask>
     </bpmn:subProcess>
-    <bpmn:boundaryEvent id="EscalationBoundaryEvent" name="Escalation boundary event" attachedToRef="EscalationSubProcess">
+    <bpmn:boundaryEvent id="EscalationBoundaryEvent" name="Escalation boundary event"
+      attachedToRef="EscalationSubProcess">
       <bpmn:outgoing>Flow_0xejz9b</bpmn:outgoing>
-      <bpmn:escalationEventDefinition id="EscalationEventDefinition_164va8l" escalationRef="Escalation_1v2o7l5" />
+      <bpmn:escalationEventDefinition id="EscalationEventDefinition_164va8l"
+        escalationRef="Escalation_1v2o7l5" />
     </bpmn:boundaryEvent>
     <bpmn:sequenceFlow id="Flow_16t2gpe" sourceRef="Gateway_1" targetRef="Gateway_2" />
     <bpmn:parallelGateway id="Gateway_1">
@@ -398,6 +430,8 @@
       <bpmn:outgoing>Flow_16t2gpe</bpmn:outgoing>
       <bpmn:outgoing>Flow_0vm1c0b</bpmn:outgoing>
       <bpmn:outgoing>Flow_0u3kipb</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1krp4hz</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0u1ir0t</bpmn:outgoing>
     </bpmn:parallelGateway>
     <bpmn:parallelGateway id="Gateway_4">
       <bpmn:incoming>Flow_0vm1c0b</bpmn:incoming>
@@ -437,12 +471,16 @@
       <bpmn:incoming>Flow_1dzoyo4</bpmn:incoming>
       <bpmn:incoming>Flow_1bo0sui</bpmn:incoming>
       <bpmn:incoming>Flow_0383azr</bpmn:incoming>
+      <bpmn:incoming>Flow_0v0pz7s</bpmn:incoming>
+      <bpmn:incoming>Flow_0hblus5</bpmn:incoming>
       <bpmn:outgoing>Flow_1nlysp1</bpmn:outgoing>
     </bpmn:parallelGateway>
     <bpmn:sequenceFlow id="Flow_1bo0sui" sourceRef="Gateway_3" targetRef="Gateway_6" />
     <bpmn:sequenceFlow id="Flow_0xejz9b" sourceRef="EscalationBoundaryEvent" targetRef="Gateway_5" />
-    <bpmn:subProcess id="EscalationEventSubProcess" name="Escalation event sub process" triggeredByEvent="true">
-      <bpmn:sequenceFlow id="Flow_0vd8mzp" sourceRef="EscalationStartEvent" targetRef="EscalationEventTask" />
+    <bpmn:subProcess id="EscalationEventSubProcess" name="Escalation event sub process"
+      triggeredByEvent="true">
+      <bpmn:sequenceFlow id="Flow_0vd8mzp" sourceRef="EscalationStartEvent"
+        targetRef="EscalationEventTask" />
       <bpmn:endEvent id="Event_1cmlzk4">
         <bpmn:incoming>Flow_0of03mm</bpmn:incoming>
       </bpmn:endEvent>
@@ -454,16 +492,20 @@
         <bpmn:incoming>Flow_0vd8mzp</bpmn:incoming>
         <bpmn:outgoing>Flow_0of03mm</bpmn:outgoing>
       </bpmn:serviceTask>
-      <bpmn:startEvent id="EscalationStartEvent" name="Escalation start event" isInterrupting="false">
+      <bpmn:startEvent id="EscalationStartEvent" name="Escalation start event"
+        isInterrupting="false">
         <bpmn:outgoing>Flow_0vd8mzp</bpmn:outgoing>
-        <bpmn:escalationEventDefinition id="EscalationEventDefinition_0wxb74s" escalationRef="Escalation_1v2o7l5" />
+        <bpmn:escalationEventDefinition id="EscalationEventDefinition_0wxb74s"
+          escalationRef="Escalation_1v2o7l5" />
       </bpmn:startEvent>
     </bpmn:subProcess>
-    <bpmn:sequenceFlow id="Flow_1rdc672" sourceRef="EscalationThrowEvent" targetRef="EscalationSubProcess" />
+    <bpmn:sequenceFlow id="Flow_1rdc672" sourceRef="EscalationThrowEvent"
+      targetRef="EscalationSubProcess" />
     <bpmn:intermediateThrowEvent id="EscalationThrowEvent">
       <bpmn:incoming>Flow_1e1hjfq</bpmn:incoming>
       <bpmn:outgoing>Flow_1rdc672</bpmn:outgoing>
-      <bpmn:escalationEventDefinition id="EscalationEventDefinition_1nfw7gz" escalationRef="Escalation_1v2o7l5" />
+      <bpmn:escalationEventDefinition id="EscalationEventDefinition_1nfw7gz"
+        escalationRef="Escalation_1v2o7l5" />
     </bpmn:intermediateThrowEvent>
     <bpmn:sequenceFlow id="Flow_0u3kipb" sourceRef="Gateway_1" targetRef="CompensationTask" />
     <bpmn:task id="UndoTask" name="Undo" isForCompensation="true" />
@@ -480,11 +522,210 @@
       <bpmn:incoming>Flow_0u3kipb</bpmn:incoming>
       <bpmn:outgoing>Flow_0ejrzsk</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_0ejrzsk" sourceRef="CompensationTask" targetRef="CompensationThrowEvent" />
-    <bpmn:boundaryEvent id="CompensationBoundaryEvent" name="Compensation boundary event" attachedToRef="CompensationTask">
+    <bpmn:sequenceFlow id="Flow_0ejrzsk" sourceRef="CompensationTask"
+      targetRef="CompensationThrowEvent" />
+    <bpmn:boundaryEvent id="CompensationBoundaryEvent" name="Compensation boundary event"
+      attachedToRef="CompensationTask">
       <bpmn:compensateEventDefinition id="CompensateEventDefinition_1a309d0" />
     </bpmn:boundaryEvent>
-    <bpmn:association id="Association_0xok9ld" associationDirection="One" sourceRef="CompensationBoundaryEvent" targetRef="UndoTask" />
+    <bpmn:adHocSubProcess id="AdHocSubProcess" name="Ad hoc sub process">
+      <bpmn:extensionElements>
+        <zeebe:adHoc activeElementsCollection="=[&#34;TaskI&#34;]" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_16j5w5f</bpmn:incoming>
+      <bpmn:outgoing>Flow_1atp6z8</bpmn:outgoing>
+      <bpmn:serviceTask id="TaskI" name="Task I">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="foo" />
+        </bpmn:extensionElements>
+      </bpmn:serviceTask>
+    </bpmn:adHocSubProcess>
+    <bpmn:parallelGateway id="Gateway_18qbndw">
+      <bpmn:incoming>Flow_1krp4hz</bpmn:incoming>
+      <bpmn:outgoing>Flow_16j5w5f</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0m41222</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1q6776b</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_1krp4hz" sourceRef="Gateway_1" targetRef="Gateway_18qbndw" />
+    <bpmn:sequenceFlow id="Flow_16j5w5f" sourceRef="Gateway_18qbndw" targetRef="AdHocSubProcess" />
+    <bpmn:adHocSubProcess id="ParallelMultiInstanceAdHocSubProcess"
+      name="Parallel multi instance Ad hoc sub process">
+      <bpmn:extensionElements>
+        <zeebe:adHoc activeElementsCollection="=[&#34;TaskJ&#34;]" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0m41222</bpmn:incoming>
+      <bpmn:outgoing>Flow_1nj16xx</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="=[&#34;inputCollection&#34;]" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+      <bpmn:serviceTask id="TaskJ" name="Task J">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="foo" />
+        </bpmn:extensionElements>
+      </bpmn:serviceTask>
+    </bpmn:adHocSubProcess>
+    <bpmn:adHocSubProcess id="SequentialMultiInstanceAdHocSubProcess"
+      name="Sequential multi instance Ad hoc sub process">
+      <bpmn:extensionElements>
+        <zeebe:adHoc activeElementsCollection="=[&#34;TaskK&#34;]" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1q6776b</bpmn:incoming>
+      <bpmn:outgoing>Flow_1ektns0</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics isSequential="true">
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="=[&#34;inputCollection&#34;]" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+      <bpmn:serviceTask id="TaskK" name="Task K">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="foo" />
+        </bpmn:extensionElements>
+      </bpmn:serviceTask>
+    </bpmn:adHocSubProcess>
+    <bpmn:sequenceFlow id="Flow_0m41222" sourceRef="Gateway_18qbndw"
+      targetRef="ParallelMultiInstanceAdHocSubProcess" />
+    <bpmn:sequenceFlow id="Flow_1q6776b" sourceRef="Gateway_18qbndw"
+      targetRef="SequentialMultiInstanceAdHocSubProcess" />
+    <bpmn:parallelGateway id="Gateway_01n2aj8">
+      <bpmn:incoming>Flow_1ektns0</bpmn:incoming>
+      <bpmn:incoming>Flow_1nj16xx</bpmn:incoming>
+      <bpmn:incoming>Flow_1atp6z8</bpmn:incoming>
+      <bpmn:outgoing>Flow_0v0pz7s</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_0v0pz7s" sourceRef="Gateway_01n2aj8" targetRef="Gateway_6" />
+    <bpmn:sequenceFlow id="Flow_1ektns0" sourceRef="SequentialMultiInstanceAdHocSubProcess"
+      targetRef="Gateway_01n2aj8" />
+    <bpmn:sequenceFlow id="Flow_1nj16xx" sourceRef="ParallelMultiInstanceAdHocSubProcess"
+      targetRef="Gateway_01n2aj8" />
+    <bpmn:sequenceFlow id="Flow_1atp6z8" sourceRef="AdHocSubProcess" targetRef="Gateway_01n2aj8" />
+    <bpmn:serviceTask id="AIAgentTask" name="AI agent Task"
+      zeebe:modelerTemplate="io.camunda.connectors.agenticai.aiagent.v1"
+      zeebe:modelerTemplateVersion="6"
+      zeebe:modelerTemplateIcon="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzIiIGhlaWdodD0iMzIiIHZpZXdCb3g9IjAgMCAzMiAzMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGNpcmNsZSBjeD0iMTYiIGN5PSIxNiIgcj0iMTYiIGZpbGw9IiNBNTZFRkYiLz4KPG1hc2sgaWQ9InBhdGgtMi1vdXRzaWRlLTFfMTg1XzYiIG1hc2tVbml0cz0idXNlclNwYWNlT25Vc2UiIHg9IjQiIHk9IjQiIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgZmlsbD0iYmxhY2siPgo8cmVjdCBmaWxsPSJ3aGl0ZSIgeD0iNCIgeT0iNCIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0Ii8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjAuMDEwNSAxMi4wOTg3QzE4LjQ5IDEwLjU4OTQgMTcuMTU5NCA4LjEwODE0IDE2LjE3OTkgNi4wMTEwM0MxNi4xNTIgNi4wMDQ1MSAxNi4xMTc2IDYgMTYuMDc5NCA2QzE2LjA0MTEgNiAxNi4wMDY2IDYuMDA0NTEgMTUuOTc4OCA2LjAxMTA0QzE0Ljk5OTQgOC4xMDgxNCAxMy42Njk3IDEwLjU4ODkgMTIuMTQ4MSAxMi4wOTgxQzEwLjYyNjkgMTMuNjA3MSA4LjEyNTY4IDE0LjkyNjQgNi4wMTE1NyAxNS44OTgxQzYuMDA0NzQgMTUuOTI2MSA2IDE1Ljk2MTEgNiAxNkM2IDE2LjAzODcgNi4wMDQ2OCAxNi4wNzM2IDYuMDExNDQgMTYuMTAxNEM4LjEyNTE5IDE3LjA3MjkgMTAuNjI2MiAxOC4zOTE5IDEyLjE0NzcgMTkuOTAxNkMxMy42Njk3IDIxLjQxMDcgMTQuOTk5NiAyMy44OTIgMTUuOTc5MSAyNS45ODlDMTYuMDA2OCAyNS45OTU2IDE2LjA0MTEgMjYgMTYuMDc5MyAyNkMxNi4xMTc1IDI2IDE2LjE1MTkgMjUuOTk1NCAxNi4xNzk2IDI1Ljk4OUMxNy4xNTkxIDIzLjg5MiAxOC40ODg4IDIxLjQxMSAyMC4wMDk5IDE5LjkwMjFNMjAuMDA5OSAxOS45MDIxQzIxLjUyNTMgMTguMzk4NyAyMy45NDY1IDE3LjA2NjkgMjUuOTkxNSAxNi4wODI0QzI1Ljk5NjUgMTYuMDU5MyAyNiAxNi4wMzEgMjYgMTUuOTk5N0MyNiAxNS45Njg0IDI1Ljk5NjUgMTUuOTQwMyAyNS45OTE1IDE1LjkxNzFDMjMuOTQ3NCAxNC45MzI3IDIxLjUyNTkgMTMuNjAxIDIwLjAxMDUgMTIuMDk4NyIvPgo8L21hc2s+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjAuMDEwNSAxMi4wOTg3QzE4LjQ5IDEwLjU4OTQgMTcuMTU5NCA4LjEwODE0IDE2LjE3OTkgNi4wMTEwM0MxNi4xNTIgNi4wMDQ1MSAxNi4xMTc2IDYgMTYuMDc5NCA2QzE2LjA0MTEgNiAxNi4wMDY2IDYuMDA0NTEgMTUuOTc4OCA2LjAxMTA0QzE0Ljk5OTQgOC4xMDgxNCAxMy42Njk3IDEwLjU4ODkgMTIuMTQ4MSAxMi4wOTgxQzEwLjYyNjkgMTMuNjA3MSA4LjEyNTY4IDE0LjkyNjQgNi4wMTE1NyAxNS44OTgxQzYuMDA0NzQgMTUuOTI2MSA2IDE1Ljk2MTEgNiAxNkM2IDE2LjAzODcgNi4wMDQ2OCAxNi4wNzM2IDYuMDExNDQgMTYuMTAxNEM4LjEyNTE5IDE3LjA3MjkgMTAuNjI2MiAxOC4zOTE5IDEyLjE0NzcgMTkuOTAxNkMxMy42Njk3IDIxLjQxMDcgMTQuOTk5NiAyMy44OTIgMTUuOTc5MSAyNS45ODlDMTYuMDA2OCAyNS45OTU2IDE2LjA0MTEgMjYgMTYuMDc5MyAyNkMxNi4xMTc1IDI2IDE2LjE1MTkgMjUuOTk1NCAxNi4xNzk2IDI1Ljk4OUMxNy4xNTkxIDIzLjg5MiAxOC40ODg4IDIxLjQxMSAyMC4wMDk5IDE5LjkwMjFNMjAuMDA5OSAxOS45MDIxQzIxLjUyNTMgMTguMzk4NyAyMy45NDY1IDE3LjA2NjkgMjUuOTkxNSAxNi4wODI0QzI1Ljk5NjUgMTYuMDU5MyAyNiAxNi4wMzEgMjYgMTUuOTk5N0MyNiAxNS45Njg0IDI1Ljk5NjUgMTUuOTQwMyAyNS45OTE1IDE1LjkxNzFDMjMuOTQ3NCAxNC45MzI3IDIxLjUyNTkgMTMuNjAxIDIwLjAxMDUgMTIuMDk4NyIgZmlsbD0id2hpdGUiLz4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0yMC4wMTA1IDEyLjA5ODdDMTguNDkgMTAuNTg5NCAxNy4xNTk0IDguMTA4MTQgMTYuMTc5OSA2LjAxMTAzQzE2LjE1MiA2LjAwNDUxIDE2LjExNzYgNiAxNi4wNzk0IDZDMTYuMDQxMSA2IDE2LjAwNjYgNi4wMDQ1MSAxNS45Nzg4IDYuMDExMDRDMTQuOTk5NCA4LjEwODE0IDEzLjY2OTcgMTAuNTg4OSAxMi4xNDgxIDEyLjA5ODFDMTAuNjI2OSAxMy42MDcxIDguMTI1NjggMTQuOTI2NCA2LjAxMTU3IDE1Ljg5ODFDNi4wMDQ3NCAxNS45MjYxIDYgMTUuOTYxMSA2IDE2QzYgMTYuMDM4NyA2LjAwNDY4IDE2LjA3MzYgNi4wMTE0NCAxNi4xMDE0QzguMTI1MTkgMTcuMDcyOSAxMC42MjYyIDE4LjM5MTkgMTIuMTQ3NyAxOS45MDE2QzEzLjY2OTcgMjEuNDEwNyAxNC45OTk2IDIzLjg5MiAxNS45NzkxIDI1Ljk4OUMxNi4wMDY4IDI1Ljk5NTYgMTYuMDQxMSAyNiAxNi4wNzkzIDI2QzE2LjExNzUgMjYgMTYuMTUxOSAyNS45OTU0IDE2LjE3OTYgMjUuOTg5QzE3LjE1OTEgMjMuODkyIDE4LjQ4ODggMjEuNDExIDIwLjAwOTkgMTkuOTAyMU0yMC4wMDk5IDE5LjkwMjFDMjEuNTI1MyAxOC4zOTg3IDIzLjk0NjUgMTcuMDY2OSAyNS45OTE1IDE2LjA4MjRDMjUuOTk2NSAxNi4wNTkzIDI2IDE2LjAzMSAyNiAxNS45OTk3QzI2IDE1Ljk2ODQgMjUuOTk2NSAxNS45NDAzIDI1Ljk5MTUgMTUuOTE3MUMyMy45NDc0IDE0LjkzMjcgMjEuNTI1OSAxMy42MDEgMjAuMDEwNSAxMi4wOTg3IiBzdHJva2U9IiM0OTFEOEIiIHN0cm9rZS13aWR0aD0iNCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgbWFzaz0idXJsKCNwYXRoLTItb3V0c2lkZS0xXzE4NV82KSIvPgo8L3N2Zz4K">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="io.camunda.agenticai:aiagent:1" retries="3" />
+        <zeebe:ioMapping>
+          <zeebe:input source="openai" target="provider.type" />
+          <zeebe:input source="=&#34;openAI_Key&#34;" target="provider.openai.authentication.apiKey" />
+          <zeebe:input source="gpt-4o" target="provider.openai.model.model" />
+          <zeebe:input
+            source="=&#34;You are **TaskAgent**, a helpful, generic chat agent that can handle a wide variety of customer requests using your own domain knowledge **and** any tools explicitly provided to you at runtime.&#10;&#10;If tools are provided, you should prefer them instead of guessing an answer. You can call the same tool multiple times by providing different input values. Don&#39;t guess any tools which were not explicitly configured. If no tool matches the request, try to generate an answer. If you&#39;re not able to find a good answer, return with a message stating why you&#39;re not able to.&#10;&#10;Wrap minimal, inspectable reasoning in *exactly* this XML template:&#10;&#10;&#60;thinking&#62;&#10;&#60;context&#62;…briefly state the customer’s need and current state…&#60;/context&#62;&#10;&#60;reflection&#62;…list candidate tools, justify which you will call next and why…&#60;/reflection&#62;&#10;&#60;/thinking&#62;&#10;&#10;Reveal **no** additional private reasoning outside these tags.&#34;"
+            target="data.systemPrompt.prompt" />
+          <zeebe:input
+            source="=&#34;You will use the corresponding tools to generate the following request:&#10;&#10;- Provide me with the current date and time&#34;"
+            target="data.userPrompt.prompt" />
+          <zeebe:input source="AgentTools" target="data.tools.containerElementId" />
+          <zeebe:input source="=toolCallResult" target="data.tools.toolCallResults" />
+          <zeebe:input source="=agent.context" target="data.context" />
+          <zeebe:input source="in-process" target="data.memory.storage.type" />
+          <zeebe:input source="=20" target="data.memory.contextWindowSize" />
+          <zeebe:input source="=10" target="data.limits.maxModelCalls" />
+          <zeebe:input source="text" target="data.response.format.type" />
+          <zeebe:input source="=false" target="data.response.format.parseJson" />
+          <zeebe:input source="=false" target="data.response.includeAssistantMessage" />
+        </zeebe:ioMapping>
+        <zeebe:taskHeaders>
+          <zeebe:header key="elementTemplateVersion" value="6" />
+          <zeebe:header key="elementTemplateId" value="io.camunda.connectors.agenticai.aiagent.v1" />
+          <zeebe:header key="resultVariable" value="agent" />
+          <zeebe:header key="retryBackoff" value="PT0S" />
+        </zeebe:taskHeaders>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_06snuuz</bpmn:incoming>
+      <bpmn:outgoing>Flow_1fg9wm5</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:parallelGateway id="Gateway_0ixv76b">
+      <bpmn:incoming>Flow_0u1ir0t</bpmn:incoming>
+      <bpmn:outgoing>Flow_0jxehws</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1xt0clj</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_0u1ir0t" sourceRef="Gateway_1" targetRef="Gateway_0ixv76b" />
+    <bpmn:exclusiveGateway id="Gateway_16dc9rt">
+      <bpmn:incoming>Flow_0jxehws</bpmn:incoming>
+      <bpmn:incoming>Flow_15dly8z</bpmn:incoming>
+      <bpmn:outgoing>Flow_06snuuz</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_0jxehws" sourceRef="Gateway_0ixv76b" targetRef="Gateway_16dc9rt" />
+    <bpmn:sequenceFlow id="Flow_06snuuz" sourceRef="Gateway_16dc9rt" targetRef="AIAgentTask" />
+    <bpmn:exclusiveGateway id="Gateway_11iaf27" default="Flow_0rxenzq">
+      <bpmn:incoming>Flow_1fg9wm5</bpmn:incoming>
+      <bpmn:outgoing>Flow_0ny9jb3</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0rxenzq</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_1fg9wm5" sourceRef="AIAgentTask" targetRef="Gateway_11iaf27" />
+    <bpmn:adHocSubProcess id="AgentTools" name="Agent tools">
+      <bpmn:extensionElements>
+        <zeebe:adHoc activeElementsCollection="=[toolCall._meta.name]" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0ny9jb3</bpmn:incoming>
+      <bpmn:outgoing>Flow_15dly8z</bpmn:outgoing>
+      <bpmn:scriptTask id="GetDateAndTimeTask" name="Get Date and Time - Task">
+        <bpmn:extensionElements>
+          <zeebe:script expression="=now()" resultVariable="toolCallResult" />
+        </bpmn:extensionElements>
+      </bpmn:scriptTask>
+    </bpmn:adHocSubProcess>
+    <bpmn:sequenceFlow id="Flow_15dly8z" sourceRef="AgentTools" targetRef="Gateway_16dc9rt" />
+    <bpmn:sequenceFlow id="Flow_0ny9jb3" sourceRef="Gateway_11iaf27" targetRef="AgentTools">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=not(is empty(agent.toolCalls))</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:adHocSubProcess id="AIAgentsubprocess" name="AI Agent sub process"
+      zeebe:modelerTemplate="io.camunda.connectors.agenticai.aiagent.jobworker.v1"
+      zeebe:modelerTemplateVersion="6"
+      zeebe:modelerTemplateIcon="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzIiIGhlaWdodD0iMzIiIHZpZXdCb3g9IjAgMCAzMiAzMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGNpcmNsZSBjeD0iMTYiIGN5PSIxNiIgcj0iMTYiIGZpbGw9IiNBNTZFRkYiLz4KPG1hc2sgaWQ9InBhdGgtMi1vdXRzaWRlLTFfMTg1XzYiIG1hc2tVbml0cz0idXNlclNwYWNlT25Vc2UiIHg9IjQiIHk9IjQiIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgZmlsbD0iYmxhY2siPgo8cmVjdCBmaWxsPSJ3aGl0ZSIgeD0iNCIgeT0iNCIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0Ii8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjAuMDEwNSAxMi4wOTg3QzE4LjQ5IDEwLjU4OTQgMTcuMTU5NCA4LjEwODE0IDE2LjE3OTkgNi4wMTEwM0MxNi4xNTIgNi4wMDQ1MSAxNi4xMTc2IDYgMTYuMDc5NCA2QzE2LjA0MTEgNiAxNi4wMDY2IDYuMDA0NTEgMTUuOTc4OCA2LjAxMTA0QzE0Ljk5OTQgOC4xMDgxNCAxMy42Njk3IDEwLjU4ODkgMTIuMTQ4MSAxMi4wOTgxQzEwLjYyNjkgMTMuNjA3MSA4LjEyNTY4IDE0LjkyNjQgNi4wMTE1NyAxNS44OTgxQzYuMDA0NzQgMTUuOTI2MSA2IDE1Ljk2MTEgNiAxNkM2IDE2LjAzODcgNi4wMDQ2OCAxNi4wNzM2IDYuMDExNDQgMTYuMTAxNEM4LjEyNTE5IDE3LjA3MjkgMTAuNjI2MiAxOC4zOTE5IDEyLjE0NzcgMTkuOTAxNkMxMy42Njk3IDIxLjQxMDcgMTQuOTk5NiAyMy44OTIgMTUuOTc5MSAyNS45ODlDMTYuMDA2OCAyNS45OTU2IDE2LjA0MTEgMjYgMTYuMDc5MyAyNkMxNi4xMTc1IDI2IDE2LjE1MTkgMjUuOTk1NCAxNi4xNzk2IDI1Ljk4OUMxNy4xNTkxIDIzLjg5MiAxOC40ODg4IDIxLjQxMSAyMC4wMDk5IDE5LjkwMjFNMjAuMDA5OSAxOS45MDIxQzIxLjUyNTMgMTguMzk4NyAyMy45NDY1IDE3LjA2NjkgMjUuOTkxNSAxNi4wODI0QzI1Ljk5NjUgMTYuMDU5MyAyNiAxNi4wMzEgMjYgMTUuOTk5N0MyNiAxNS45Njg0IDI1Ljk5NjUgMTUuOTQwMyAyNS45OTE1IDE1LjkxNzFDMjMuOTQ3NCAxNC45MzI3IDIxLjUyNTkgMTMuNjAxIDIwLjAxMDUgMTIuMDk4NyIvPgo8L21hc2s+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjAuMDEwNSAxMi4wOTg3QzE4LjQ5IDEwLjU4OTQgMTcuMTU5NCA4LjEwODE0IDE2LjE3OTkgNi4wMTEwM0MxNi4xNTIgNi4wMDQ1MSAxNi4xMTc2IDYgMTYuMDc5NCA2QzE2LjA0MTEgNiAxNi4wMDY2IDYuMDA0NTEgMTUuOTc4OCA2LjAxMTA0QzE0Ljk5OTQgOC4xMDgxNCAxMy42Njk3IDEwLjU4ODkgMTIuMTQ4MSAxMi4wOTgxQzEwLjYyNjkgMTMuNjA3MSA4LjEyNTY4IDE0LjkyNjQgNi4wMTE1NyAxNS44OTgxQzYuMDA0NzQgMTUuOTI2MSA2IDE1Ljk2MTEgNiAxNkM2IDE2LjAzODcgNi4wMDQ2OCAxNi4wNzM2IDYuMDExNDQgMTYuMTAxNEM4LjEyNTE5IDE3LjA3MjkgMTAuNjI2MiAxOC4zOTE5IDEyLjE0NzcgMTkuOTAxNkMxMy42Njk3IDIxLjQxMDcgMTQuOTk5NiAyMy44OTIgMTUuOTc5MSAyNS45ODlDMTYuMDA2OCAyNS45OTU2IDE2LjA0MTEgMjYgMTYuMDc5MyAyNkMxNi4xMTc1IDI2IDE2LjE1MTkgMjUuOTk1NCAxNi4xNzk2IDI1Ljk4OUMxNy4xNTkxIDIzLjg5MiAxOC40ODg4IDIxLjQxMSAyMC4wMDk5IDE5LjkwMjFNMjAuMDA5OSAxOS45MDIxQzIxLjUyNTMgMTguMzk4NyAyMy45NDY1IDE3LjA2NjkgMjUuOTkxNSAxNi4wODI0QzI1Ljk5NjUgMTYuMDU5MyAyNiAxNi4wMzEgMjYgMTUuOTk5N0MyNiAxNS45Njg0IDI1Ljk5NjUgMTUuOTQwMyAyNS45OTE1IDE1LjkxNzFDMjMuOTQ3NCAxNC45MzI3IDIxLjUyNTkgMTMuNjAxIDIwLjAxMDUgMTIuMDk4NyIgZmlsbD0id2hpdGUiLz4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0yMC4wMTA1IDEyLjA5ODdDMTguNDkgMTAuNTg5NCAxNy4xNTk0IDguMTA4MTQgMTYuMTc5OSA2LjAxMTAzQzE2LjE1MiA2LjAwNDUxIDE2LjExNzYgNiAxNi4wNzk0IDZDMTYuMDQxMSA2IDE2LjAwNjYgNi4wMDQ1MSAxNS45Nzg4IDYuMDExMDRDMTQuOTk5NCA4LjEwODE0IDEzLjY2OTcgMTAuNTg4OSAxMi4xNDgxIDEyLjA5ODFDMTAuNjI2OSAxMy42MDcxIDguMTI1NjggMTQuOTI2NCA2LjAxMTU3IDE1Ljg5ODFDNi4wMDQ3NCAxNS45MjYxIDYgMTUuOTYxMSA2IDE2QzYgMTYuMDM4NyA2LjAwNDY4IDE2LjA3MzYgNi4wMTE0NCAxNi4xMDE0QzguMTI1MTkgMTcuMDcyOSAxMC42MjYyIDE4LjM5MTkgMTIuMTQ3NyAxOS45MDE2QzEzLjY2OTcgMjEuNDEwNyAxNC45OTk2IDIzLjg5MiAxNS45NzkxIDI1Ljk4OUMxNi4wMDY4IDI1Ljk5NTYgMTYuMDQxMSAyNiAxNi4wNzkzIDI2QzE2LjExNzUgMjYgMTYuMTUxOSAyNS45OTU0IDE2LjE3OTYgMjUuOTg5QzE3LjE1OTEgMjMuODkyIDE4LjQ4ODggMjEuNDExIDIwLjAwOTkgMTkuOTAyMU0yMC4wMDk5IDE5LjkwMjFDMjEuNTI1MyAxOC4zOTg3IDIzLjk0NjUgMTcuMDY2OSAyNS45OTE1IDE2LjA4MjRDMjUuOTk2NSAxNi4wNTkzIDI2IDE2LjAzMSAyNiAxNS45OTk3QzI2IDE1Ljk2ODQgMjUuOTk2NSAxNS45NDAzIDI1Ljk5MTUgMTUuOTE3MUMyMy45NDc0IDE0LjkzMjcgMjEuNTI1OSAxMy42MDEgMjAuMDEwNSAxMi4wOTg3IiBzdHJva2U9IiM0OTFEOEIiIHN0cm9rZS13aWR0aD0iNCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgbWFzaz0idXJsKCNwYXRoLTItb3V0c2lkZS0xXzE4NV82KSIvPgo8L3N2Zz4K">
+      <bpmn:extensionElements>
+        <zeebe:adHoc outputCollection="toolCallResults"
+          outputElement="={&#10;  id: toolCall._meta.id,&#10;  name: toolCall._meta.name,&#10;  content: toolCallResult&#10;}" />
+        <zeebe:taskDefinition type="io.camunda.agenticai:aiagent-job-worker:1" retries="3" />
+        <zeebe:ioMapping>
+          <zeebe:input source="openai" target="provider.type" />
+          <zeebe:input source="=&#34;openAI_Key&#34;" target="provider.openai.authentication.apiKey" />
+          <zeebe:input source="gpt-4o" target="provider.openai.model.model" />
+          <zeebe:input
+            source="=&#34;You are **TaskAgent**, a helpful, generic chat agent that can handle a wide variety of customer requests using your own domain knowledge **and** any tools explicitly provided to you at runtime.&#10;&#10;If tools are provided, you should prefer them instead of guessing an answer. You can call the same tool multiple times by providing different input values. Don&#39;t guess any tools which were not explicitly configured. If no tool matches the request, try to generate an answer. If you&#39;re not able to find a good answer, return with a message stating why you&#39;re not able to.&#10;&#10;Wrap minimal, inspectable reasoning in *exactly* this XML template:&#10;&#10;&#60;thinking&#62;&#10;&#60;context&#62;…briefly state the customer’s need and current state…&#60;/context&#62;&#10;&#60;reflection&#62;…list candidate tools, justify which you will call next and why…&#60;/reflection&#62;&#10;&#60;/thinking&#62;&#10;&#10;Reveal **no** additional private reasoning outside these tags.&#34;"
+            target="data.systemPrompt.prompt" />
+          <zeebe:input
+            source="=&#34;You will use the corresponding tools to generate the following request:&#10;&#10;- Provide me with the current date and time&#34;"
+            target="data.userPrompt.prompt" />
+          <zeebe:input target="agentContext" />
+          <zeebe:input source="in-process" target="data.memory.storage.type" />
+          <zeebe:input source="=20" target="data.memory.contextWindowSize" />
+          <zeebe:input source="=10" target="data.limits.maxModelCalls" />
+          <zeebe:input source="WAIT_FOR_TOOL_CALL_RESULTS" target="data.events.behavior" />
+          <zeebe:input source="text" target="data.response.format.type" />
+          <zeebe:input source="=false" target="data.response.format.parseJson" />
+          <zeebe:input source="=false" target="data.response.includeAssistantMessage" />
+          <zeebe:input source="=false" target="data.response.includeAgentContext" />
+          <zeebe:output source="=agent" target="agent" />
+        </zeebe:ioMapping>
+        <zeebe:taskHeaders>
+          <zeebe:header key="elementTemplateVersion" value="6" />
+          <zeebe:header key="elementTemplateId"
+            value="io.camunda.connectors.agenticai.aiagent.jobworker.v1" />
+          <zeebe:header key="retryBackoff" value="PT0S" />
+        </zeebe:taskHeaders>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1xt0clj</bpmn:incoming>
+      <bpmn:outgoing>Flow_1nm3vh1</bpmn:outgoing>
+      <bpmn:scriptTask id="GetDateAndTimeSubprocess" name="Get Date and Time - subprocess">
+        <bpmn:extensionElements>
+          <zeebe:script expression="=now()" resultVariable="toolCallResult" />
+        </bpmn:extensionElements>
+      </bpmn:scriptTask>
+    </bpmn:adHocSubProcess>
+    <bpmn:sequenceFlow id="Flow_1xt0clj" sourceRef="Gateway_0ixv76b" targetRef="AIAgentsubprocess" />
+    <bpmn:parallelGateway id="Gateway_1bjd93f">
+      <bpmn:incoming>Flow_1nm3vh1</bpmn:incoming>
+      <bpmn:incoming>Flow_0rxenzq</bpmn:incoming>
+      <bpmn:outgoing>Flow_0hblus5</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_0hblus5" sourceRef="Gateway_1bjd93f" targetRef="Gateway_6" />
+    <bpmn:sequenceFlow id="Flow_1nm3vh1" sourceRef="AIAgentsubprocess" targetRef="Gateway_1bjd93f" />
+    <bpmn:sequenceFlow id="Flow_0rxenzq" sourceRef="Gateway_11iaf27" targetRef="Gateway_1bjd93f" />
+    <bpmn:association id="Association_0xok9ld" associationDirection="One"
+      sourceRef="CompensationBoundaryEvent" targetRef="UndoTask" />
   </bpmn:process>
   <bpmn:message id="Message_0so1os3" name="Message_1">
     <bpmn:extensionElements>
@@ -541,7 +782,14 @@
       <bpmndi:BPMNShape id="ServiceTask_0k2efs8_di" bpmnElement="shipArticles">
         <dc:Bounds x="773" y="160" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ExclusiveGateway_1qqmrb8_di" bpmnElement="ExclusiveGateway_1qqmrb8" isMarkerVisible="true">
+      <bpmndi:BPMNShape id="EndEvent_042s0oc_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="3962" y="1633" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="385" y="270" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ExclusiveGateway_1qqmrb8_di" bpmnElement="ExclusiveGateway_1qqmrb8"
+        isMarkerVisible="true">
         <dc:Bounds x="609" y="175" width="50" height="50" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="600" y="147" width="69" height="14" />
@@ -592,6 +840,58 @@
           <dc:Bounds x="715" y="760" width="90" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0tgxt6v_di" bpmnElement="MessageEventSubProcess"
+        isExpanded="true">
+        <dc:Bounds x="3530" y="121" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_13rtwuo_di" bpmnElement="Event_13rtwuo">
+        <dc:Bounds x="3792" y="203" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1d9lzza_di" bpmnElement="TaskE">
+        <dc:Bounds x="3650" y="181" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1t7lt05_di" bpmnElement="MessageStartEvent">
+        <dc:Bounds x="3570" y="203" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="3554" y="246" width="70" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1f7mn63_di" bpmnElement="Flow_1f7mn63">
+        <di:waypoint x="3606" y="221" />
+        <di:waypoint x="3650" y="221" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_006eqia_di" bpmnElement="Flow_006eqia">
+        <di:waypoint x="3750" y="221" />
+        <di:waypoint x="3792" y="221" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_0cz53c2_di" bpmnElement="TimerEventSubProcess"
+        isExpanded="true">
+        <dc:Bounds x="3530" y="371" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0lk89tk_di" bpmnElement="Event_0lk89tk">
+        <dc:Bounds x="3792" y="453" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0x898wf_di" bpmnElement="TaskF">
+        <dc:Bounds x="3650" y="431" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_01ol322_di" bpmnElement="TimerStartEvent">
+        <dc:Bounds x="3570" y="453" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="3547" y="496" width="83" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0eemr1n_di" bpmnElement="Flow_0eemr1n">
+        <di:waypoint x="3606" y="471" />
+        <di:waypoint x="3650" y="471" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1rrwh6x_di" bpmnElement="Flow_1rrwh6x">
+        <di:waypoint x="3750" y="471" />
+        <di:waypoint x="3792" y="471" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Activity_0jap8wu_di" bpmnElement="MessageReceiveTask">
         <dc:Bounds x="440" y="1212" width="100" height="80" />
         <bpmndi:BPMNLabel />
@@ -607,7 +907,8 @@
         <dc:Bounds x="440" y="1542" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_05lm5ha_di" bpmnElement="ExclusiveGateway" isMarkerVisible="true">
+      <bpmndi:BPMNShape id="Gateway_05lm5ha_di" bpmnElement="ExclusiveGateway"
+        isMarkerVisible="true">
         <dc:Bounds x="1205" y="175" width="50" height="50" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1207" y="233" width="47" height="27" />
@@ -637,6 +938,45 @@
       <bpmndi:BPMNShape id="Gateway_0ftzss1_di" bpmnElement="Gateway_0ftzss1" isMarkerVisible="true">
         <dc:Bounds x="1585" y="285" width="50" height="50" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1s001x5_di" bpmnElement="SignalEventSubProcess"
+        isExpanded="true">
+        <dc:Bounds x="3530" y="621" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0opmx5v_di" bpmnElement="Event_0opmx5v">
+        <dc:Bounds x="3822" y="703" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0v214gi_di" bpmnElement="TaskH">
+        <dc:Bounds x="3660" y="681" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1u3z80h_di" bpmnElement="SignalStartEvent">
+        <dc:Bounds x="3570" y="703" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="3546" y="746" width="85" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_049m1di_di" bpmnElement="Event_049m1di">
+        <dc:Bounds x="3822" y="773" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0ch2r7b_di" bpmnElement="SignalBoundaryEvent">
+        <dc:Bounds x="3712" y="743" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="3691" y="786" width="80" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_189mrto_di" bpmnElement="Flow_189mrto">
+        <di:waypoint x="3606" y="721" />
+        <di:waypoint x="3660" y="721" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1tl6j8a_di" bpmnElement="Flow_1tl6j8a">
+        <di:waypoint x="3760" y="721" />
+        <di:waypoint x="3822" y="721" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0bfr615_di" bpmnElement="Flow_0bfr615">
+        <di:waypoint x="3730" y="779" />
+        <di:waypoint x="3730" y="791" />
+        <di:waypoint x="3822" y="791" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_1ymwb5r_di" bpmnElement="SignalIntermediateThrow">
         <dc:Bounds x="1212" y="502" width="36" height="36" />
         <bpmndi:BPMNLabel>
@@ -649,29 +989,6 @@
           <dc:Bounds x="1386" y="545" width="90" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_1j4ljfk_di" bpmnElement="Gateway_6">
-        <dc:Bounds x="2075" y="1645" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="EndEvent_042s0oc_di" bpmnElement="EndEvent_1">
-        <dc:Bounds x="2692" y="1652" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="385" y="270" width="90" height="12" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0kfygzx_di" bpmnElement="UndoTask">
-        <dc:Bounds x="1930" y="280" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1a442qs_di" bpmnElement="CompensationThrowEvent">
-        <dc:Bounds x="1992" y="182" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1975" y="225" width="71" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_10ddbjj_di" bpmnElement="CompensationTask">
-        <dc:Bounds x="1810" y="160" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1lb6pou_di" bpmnElement="SubProcess" isExpanded="true">
         <dc:Bounds x="1122" y="610" width="423" height="350" />
         <bpmndi:BPMNLabel />
@@ -679,7 +996,8 @@
       <bpmndi:BPMNShape id="BPMNShape_1v2yf5g" bpmnElement="SubProcessStartEvent">
         <dc:Bounds x="1199" y="652" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0cqp75h_di" bpmnElement="ErrorEventSubProcess" isExpanded="true">
+      <bpmndi:BPMNShape id="Activity_0cqp75h_di" bpmnElement="ErrorEventSubProcess"
+        isExpanded="true">
         <dc:Bounds x="1160" y="733" width="350" height="200" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
@@ -711,7 +1029,8 @@
         <di:waypoint x="1235" y="670" />
         <di:waypoint x="1412" y="670" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_1ms6g9k_di" bpmnElement="MultiInstanceSubProcess" isExpanded="true">
+      <bpmndi:BPMNShape id="Activity_1ms6g9k_di" bpmnElement="MultiInstanceSubProcess"
+        isExpanded="true">
         <dc:Bounds x="1199" y="1020" width="350" height="200" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
@@ -733,7 +1052,8 @@
         <di:waypoint x="1275" y="1120" />
         <di:waypoint x="1327" y="1120" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_17jsa42_di" bpmnElement="EscalationSubProcess" isExpanded="true">
+      <bpmndi:BPMNShape id="Activity_17jsa42_di" bpmnElement="EscalationSubProcess"
+        isExpanded="true">
         <dc:Bounds x="1199" y="1270" width="350" height="200" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
@@ -771,127 +1091,122 @@
       <bpmndi:BPMNShape id="Gateway_1tdy0d3_di" bpmnElement="Gateway_5">
         <dc:Bounds x="1675" y="1557" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1dvyj5q_di" bpmnElement="EscalationThrowEvent">
-        <dc:Bounds x="1102" y="1352" width="36" height="36" />
+      <bpmndi:BPMNShape id="Gateway_1j4ljfk_di" bpmnElement="Gateway_6">
+        <dc:Bounds x="3345" y="1626" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Association_0xok9ld_di" bpmnElement="Association_0xok9ld">
-        <di:waypoint x="1880" y="258" />
-        <di:waypoint x="1880" y="320" />
-        <di:waypoint x="1930" y="320" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_0tgxt6v_di" bpmnElement="MessageEventSubProcess" isExpanded="true">
-        <dc:Bounds x="2260" y="140" width="350" height="200" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_13rtwuo_di" bpmnElement="Event_13rtwuo">
-        <dc:Bounds x="2522" y="222" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1d9lzza_di" bpmnElement="TaskE">
-        <dc:Bounds x="2380" y="200" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1t7lt05_di" bpmnElement="MessageStartEvent">
-        <dc:Bounds x="2300" y="222" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2284" y="265" width="70" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_006eqia_di" bpmnElement="Flow_006eqia">
-        <di:waypoint x="2480" y="240" />
-        <di:waypoint x="2522" y="240" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1f7mn63_di" bpmnElement="Flow_1f7mn63">
-        <di:waypoint x="2336" y="240" />
-        <di:waypoint x="2380" y="240" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_0cz53c2_di" bpmnElement="TimerEventSubProcess" isExpanded="true">
-        <dc:Bounds x="2260" y="390" width="350" height="200" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0lk89tk_di" bpmnElement="Event_0lk89tk">
-        <dc:Bounds x="2522" y="472" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0x898wf_di" bpmnElement="TaskF">
-        <dc:Bounds x="2380" y="450" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_01ol322_di" bpmnElement="TimerStartEvent">
-        <dc:Bounds x="2300" y="472" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2277" y="515" width="83" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_1rrwh6x_di" bpmnElement="Flow_1rrwh6x">
-        <di:waypoint x="2480" y="490" />
-        <di:waypoint x="2522" y="490" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0eemr1n_di" bpmnElement="Flow_0eemr1n">
-        <di:waypoint x="2336" y="490" />
-        <di:waypoint x="2380" y="490" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_1s001x5_di" bpmnElement="SignalEventSubProcess" isExpanded="true">
-        <dc:Bounds x="2260" y="640" width="350" height="200" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0opmx5v_di" bpmnElement="Event_0opmx5v">
-        <dc:Bounds x="2552" y="722" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0v214gi_di" bpmnElement="TaskH">
-        <dc:Bounds x="2390" y="700" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1u3z80h_di" bpmnElement="SignalStartEvent">
-        <dc:Bounds x="2300" y="722" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2276" y="765" width="85" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_049m1di_di" bpmnElement="Event_049m1di">
-        <dc:Bounds x="2552" y="792" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0ch2r7b_di" bpmnElement="SignalBoundaryEvent">
-        <dc:Bounds x="2442" y="762" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2420" y="805" width="81" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_1tl6j8a_di" bpmnElement="Flow_1tl6j8a">
-        <di:waypoint x="2490" y="740" />
-        <di:waypoint x="2552" y="740" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_189mrto_di" bpmnElement="Flow_189mrto">
-        <di:waypoint x="2336" y="740" />
-        <di:waypoint x="2390" y="740" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0bfr615_di" bpmnElement="Flow_0bfr615">
-        <di:waypoint x="2460" y="798" />
-        <di:waypoint x="2460" y="810" />
-        <di:waypoint x="2552" y="810" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_18j0bfj_di" bpmnElement="EscalationEventSubProcess" isExpanded="true">
-        <dc:Bounds x="2260" y="894" width="350" height="200" />
+      <bpmndi:BPMNShape id="Activity_18j0bfj_di" bpmnElement="EscalationEventSubProcess"
+        isExpanded="true">
+        <dc:Bounds x="3530" y="875" width="350" height="200" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1cmlzk4_di" bpmnElement="Event_1cmlzk4">
-        <dc:Bounds x="2552" y="976" width="36" height="36" />
+        <dc:Bounds x="3822" y="957" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0lqew9a_di" bpmnElement="EscalationEventTask">
-        <dc:Bounds x="2390" y="954" width="100" height="80" />
+        <dc:Bounds x="3660" y="935" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1wrkoo5_di" bpmnElement="EscalationStartEvent">
-        <dc:Bounds x="2300" y="976" width="36" height="36" />
+        <dc:Bounds x="3570" y="957" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2282" y="1019" width="76" height="27" />
+          <dc:Bounds x="3552" y="1000" width="76" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_0of03mm_di" bpmnElement="Flow_0of03mm">
-        <di:waypoint x="2490" y="994" />
-        <di:waypoint x="2552" y="994" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0vd8mzp_di" bpmnElement="Flow_0vd8mzp">
-        <di:waypoint x="2336" y="994" />
-        <di:waypoint x="2390" y="994" />
+        <di:waypoint x="3606" y="975" />
+        <di:waypoint x="3660" y="975" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0of03mm_di" bpmnElement="Flow_0of03mm">
+        <di:waypoint x="3760" y="975" />
+        <di:waypoint x="3822" y="975" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_1dvyj5q_di" bpmnElement="EscalationThrowEvent">
+        <dc:Bounds x="1102" y="1352" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0kfygzx_di" bpmnElement="UndoTask">
+        <dc:Bounds x="3200" y="261" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1a442qs_di" bpmnElement="CompensationThrowEvent">
+        <dc:Bounds x="3262" y="163" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="3245" y="206" width="71" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_10ddbjj_di" bpmnElement="CompensationTask">
+        <dc:Bounds x="3080" y="141" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0le8k76_di" bpmnElement="AdHocSubProcess" isExpanded="true">
+        <dc:Bounds x="1940" y="390" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0y4ytky_di" bpmnElement="TaskI">
+        <dc:Bounds x="2060" y="455" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_15ql81k_di" bpmnElement="Gateway_18qbndw">
+        <dc:Bounds x="1815" y="175" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1uz6s9v" bpmnElement="ParallelMultiInstanceAdHocSubProcess"
+        isExpanded="true">
+        <dc:Bounds x="1940" y="715" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_00amvs8" bpmnElement="TaskJ">
+        <dc:Bounds x="2050" y="780" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1j0wcvz" bpmnElement="SequentialMultiInstanceAdHocSubProcess"
+        isExpanded="true">
+        <dc:Bounds x="1940" y="1050" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_14x23bu" bpmnElement="TaskK">
+        <dc:Bounds x="2060" y="1110" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1wuhuhy_di" bpmnElement="Gateway_01n2aj8">
+        <dc:Bounds x="2365" y="1557" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1amzseu_di" bpmnElement="AIAgentTask">
+        <dc:Bounds x="2670" y="370" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0tc4lou_di" bpmnElement="Gateway_0ixv76b">
+        <dc:Bounds x="2495" y="175" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_16dc9rt_di" bpmnElement="Gateway_16dc9rt" isMarkerVisible="true">
+        <dc:Bounds x="2575" y="385" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_11iaf27_di" bpmnElement="Gateway_11iaf27" isMarkerVisible="true">
+        <dc:Bounds x="2835" y="385" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0f0guw8" bpmnElement="AgentTools" isExpanded="true">
+        <dc:Bounds x="2570" y="520" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_01wf4eo_di" bpmnElement="GetDateAndTimeTask">
+        <dc:Bounds x="2680" y="585" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1gu98u1" bpmnElement="AIAgentsubprocess" isExpanded="true">
+        <dc:Bounds x="2580" y="834" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0z8j6cn" bpmnElement="GetDateAndTimeSubprocess">
+        <dc:Bounds x="2690" y="899" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_09pxz1z" bpmnElement="Gateway_1bjd93f">
+        <dc:Bounds x="3035" y="1557" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_098t6oo_di" bpmnElement="CompensationBoundaryEvent">
+        <dc:Bounds x="3132" y="203" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="3112" y="246" width="76" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0jexdxm_di" bpmnElement="EscalationBoundaryEvent">
         <dc:Bounds x="1362" y="1452" width="36" height="36" />
         <bpmndi:BPMNLabel>
@@ -920,12 +1235,6 @@
         <dc:Bounds x="492" y="756" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="417" y="788" width="86" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_098t6oo_di" bpmnElement="CompensationBoundaryEvent">
-        <dc:Bounds x="1862" y="222" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1842" y="265" width="76" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="SequenceFlow_0j6tsnn_di" bpmnElement="SequenceFlow_0j6tsnn">
@@ -1158,8 +1467,8 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1dzoyo4_di" bpmnElement="Flow_1dzoyo4">
         <di:waypoint x="1700" y="1607" />
-        <di:waypoint x="1700" y="1670" />
-        <di:waypoint x="2075" y="1670" />
+        <di:waypoint x="1700" y="1651" />
+        <di:waypoint x="3345" y="1651" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_01ogvlh_di" bpmnElement="Flow_01ogvlh">
         <di:waypoint x="1495" y="200" />
@@ -1192,13 +1501,13 @@
         <di:waypoint x="1700" y="1557" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1nlysp1_di" bpmnElement="Flow_1nlysp1">
-        <di:waypoint x="2125" y="1670" />
-        <di:waypoint x="2692" y="1670" />
+        <di:waypoint x="3395" y="1651" />
+        <di:waypoint x="3962" y="1651" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1bo0sui_di" bpmnElement="Flow_1bo0sui">
         <di:waypoint x="970" y="1607" />
-        <di:waypoint x="970" y="1670" />
-        <di:waypoint x="2075" y="1670" />
+        <di:waypoint x="970" y="1651" />
+        <di:waypoint x="3345" y="1651" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0xejz9b_di" bpmnElement="Flow_0xejz9b">
         <di:waypoint x="1380" y="1488" />
@@ -1211,17 +1520,108 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0u3kipb_di" bpmnElement="Flow_0u3kipb">
         <di:waypoint x="355" y="110" />
-        <di:waypoint x="1860" y="110" />
-        <di:waypoint x="1860" y="160" />
+        <di:waypoint x="3130" y="110" />
+        <di:waypoint x="3130" y="141" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0383azr_di" bpmnElement="Flow_0383azr">
-        <di:waypoint x="2028" y="200" />
-        <di:waypoint x="2100" y="200" />
-        <di:waypoint x="2100" y="1645" />
+        <di:waypoint x="3298" y="181" />
+        <di:waypoint x="3370" y="181" />
+        <di:waypoint x="3370" y="1626" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0ejrzsk_di" bpmnElement="Flow_0ejrzsk">
-        <di:waypoint x="1910" y="200" />
-        <di:waypoint x="1992" y="200" />
+        <di:waypoint x="3180" y="181" />
+        <di:waypoint x="3262" y="181" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1krp4hz_di" bpmnElement="Flow_1krp4hz">
+        <di:waypoint x="355" y="110" />
+        <di:waypoint x="1840" y="110" />
+        <di:waypoint x="1840" y="175" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_16j5w5f_di" bpmnElement="Flow_16j5w5f">
+        <di:waypoint x="1840" y="225" />
+        <di:waypoint x="1840" y="490" />
+        <di:waypoint x="1940" y="490" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0m41222_di" bpmnElement="Flow_0m41222">
+        <di:waypoint x="1840" y="225" />
+        <di:waypoint x="1840" y="815" />
+        <di:waypoint x="1940" y="815" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1q6776b_di" bpmnElement="Flow_1q6776b">
+        <di:waypoint x="1840" y="225" />
+        <di:waypoint x="1840" y="1150" />
+        <di:waypoint x="1940" y="1150" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0v0pz7s_di" bpmnElement="Flow_0v0pz7s">
+        <di:waypoint x="2390" y="1607" />
+        <di:waypoint x="2390" y="1651" />
+        <di:waypoint x="3345" y="1651" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ektns0_di" bpmnElement="Flow_1ektns0">
+        <di:waypoint x="2290" y="1150" />
+        <di:waypoint x="2390" y="1150" />
+        <di:waypoint x="2390" y="1557" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1nj16xx_di" bpmnElement="Flow_1nj16xx">
+        <di:waypoint x="2290" y="815" />
+        <di:waypoint x="2390" y="815" />
+        <di:waypoint x="2390" y="1557" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1atp6z8_di" bpmnElement="Flow_1atp6z8">
+        <di:waypoint x="2290" y="490" />
+        <di:waypoint x="2390" y="490" />
+        <di:waypoint x="2390" y="1557" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0u1ir0t_di" bpmnElement="Flow_0u1ir0t">
+        <di:waypoint x="355" y="110" />
+        <di:waypoint x="2520" y="110" />
+        <di:waypoint x="2520" y="175" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0jxehws_di" bpmnElement="Flow_0jxehws">
+        <di:waypoint x="2520" y="225" />
+        <di:waypoint x="2520" y="410" />
+        <di:waypoint x="2575" y="410" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_06snuuz_di" bpmnElement="Flow_06snuuz">
+        <di:waypoint x="2625" y="410" />
+        <di:waypoint x="2670" y="410" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1fg9wm5_di" bpmnElement="Flow_1fg9wm5">
+        <di:waypoint x="2770" y="410" />
+        <di:waypoint x="2835" y="410" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_15dly8z_di" bpmnElement="Flow_15dly8z">
+        <di:waypoint x="2600" y="520" />
+        <di:waypoint x="2600" y="435" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ny9jb3_di" bpmnElement="Flow_0ny9jb3">
+        <di:waypoint x="2860" y="435" />
+        <di:waypoint x="2860" y="520" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1xt0clj_di" bpmnElement="Flow_1xt0clj">
+        <di:waypoint x="2520" y="225" />
+        <di:waypoint x="2520" y="934" />
+        <di:waypoint x="2580" y="934" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0hblus5_di" bpmnElement="Flow_0hblus5">
+        <di:waypoint x="3060" y="1607" />
+        <di:waypoint x="3060" y="1651" />
+        <di:waypoint x="3345" y="1651" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1nm3vh1_di" bpmnElement="Flow_1nm3vh1">
+        <di:waypoint x="2930" y="934" />
+        <di:waypoint x="3060" y="934" />
+        <di:waypoint x="3060" y="1557" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0rxenzq_di" bpmnElement="Flow_0rxenzq">
+        <di:waypoint x="2885" y="410" />
+        <di:waypoint x="3060" y="410" />
+        <di:waypoint x="3060" y="1557" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0xok9ld_di" bpmnElement="Association_0xok9ld">
+        <di:waypoint x="3150" y="239" />
+        <di:waypoint x="3150" y="301" />
+        <di:waypoint x="3200" y="301" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/orderProcessMigration_v_2.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/orderProcessMigration_v_2.bpmn
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.28.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+  xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1"
+  targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler"
+  exporterVersion="68c5d80" modeler:executionPlatform="Camunda Cloud"
+  modeler:executionPlatformVersion="8.9.0">
   <bpmn:process id="orderProcessMigration" name="orderProcessMigration" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1" name="Order received">
       <bpmn:outgoing>SequenceFlow_0j6tsnn</bpmn:outgoing>
@@ -21,7 +30,8 @@
       <bpmn:outgoing>SequenceFlow_0jzbqu1</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_1dq2rqw</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="SequenceFlow_1s6g17c" sourceRef="checkPayment" targetRef="ExclusiveGateway_1qqmrb8" />
+    <bpmn:sequenceFlow id="SequenceFlow_1s6g17c" sourceRef="checkPayment"
+      targetRef="ExclusiveGateway_1qqmrb8" />
     <bpmn:serviceTask id="requestForPayment" name="Request for payment">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="requestPayment" />
@@ -29,11 +39,14 @@
       <bpmn:incoming>SequenceFlow_0jzbqu1</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1q6ade7</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="SequenceFlow_0jzbqu1" name="Not paid" sourceRef="ExclusiveGateway_1qqmrb8" targetRef="requestForPayment">
+    <bpmn:sequenceFlow id="SequenceFlow_0jzbqu1" name="Not paid"
+      sourceRef="ExclusiveGateway_1qqmrb8" targetRef="requestForPayment">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=paid = false</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_1q6ade7" sourceRef="requestForPayment" targetRef="checkPayment" />
-    <bpmn:sequenceFlow id="SequenceFlow_1dq2rqw" name="paid" sourceRef="ExclusiveGateway_1qqmrb8" targetRef="shipArticles">
+    <bpmn:sequenceFlow id="SequenceFlow_1q6ade7" sourceRef="requestForPayment"
+      targetRef="checkPayment" />
+    <bpmn:sequenceFlow id="SequenceFlow_1dq2rqw" name="paid" sourceRef="ExclusiveGateway_1qqmrb8"
+      targetRef="shipArticles">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=paid = true</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:serviceTask id="shipArticles" name="Ship Articles">
@@ -43,7 +56,8 @@
       <bpmn:incoming>SequenceFlow_1dq2rqw</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_19klrd3</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="SequenceFlow_19klrd3" sourceRef="shipArticles" targetRef="Activity_0ae6k1y" />
+    <bpmn:sequenceFlow id="SequenceFlow_19klrd3" sourceRef="shipArticles"
+      targetRef="Activity_0ae6k1y" />
     <bpmn:sequenceFlow id="Flow_0zx0zzd" sourceRef="Activity_0ae6k1y" targetRef="Gateway_3" />
     <bpmn:serviceTask id="Activity_0ae6k1y" name="Notify Customer">
       <bpmn:extensionElements>
@@ -95,7 +109,8 @@
         <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P1Y</bpmn:timeDuration>
       </bpmn:timerEventDefinition>
     </bpmn:boundaryEvent>
-    <bpmn:boundaryEvent id="MessageNonInterrupting" name="Message non-interrupting" cancelActivity="false" attachedToRef="TaskC">
+    <bpmn:boundaryEvent id="MessageNonInterrupting" name="Message non-interrupting"
+      cancelActivity="false" attachedToRef="TaskC">
       <bpmn:outgoing>Flow_0b5y250</bpmn:outgoing>
       <bpmn:messageEventDefinition id="MessageEventDefinition_0ox9bto" messageRef="Message_1xpzcw8" />
     </bpmn:boundaryEvent>
@@ -131,7 +146,8 @@
       <bpmn:outgoing>Flow_0hx3trf</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="Flow_0hx3trf" sourceRef="TaskD" targetRef="Gateway_3" />
-    <bpmn:boundaryEvent id="TimerNonInterrupting" name="Timer non-interrupting" cancelActivity="false" attachedToRef="TaskD">
+    <bpmn:boundaryEvent id="TimerNonInterrupting" name="Timer non-interrupting"
+      cancelActivity="false" attachedToRef="TaskD">
       <bpmn:outgoing>Flow_093zwcs</bpmn:outgoing>
       <bpmn:timerEventDefinition id="TimerEventDefinition_0lpluww">
         <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P1Y</bpmn:timeDuration>
@@ -167,7 +183,8 @@
     <bpmn:sequenceFlow id="Flow_0qh5pp6" sourceRef="TaskA" targetRef="Gateway_3" />
     <bpmn:sequenceFlow id="Flow_13205bp" sourceRef="Gateway_2" targetRef="MessageIntermediateCatch" />
     <bpmn:sequenceFlow id="Flow_0lwoyt0" sourceRef="MessageIntermediateCatch" targetRef="Gateway_3" />
-    <bpmn:subProcess id="MessageEventSubProcess" name="Message event sub process" triggeredByEvent="true">
+    <bpmn:subProcess id="MessageEventSubProcess" name="Message event sub process"
+      triggeredByEvent="true">
       <bpmn:endEvent id="Event_13rtwuo">
         <bpmn:incoming>Flow_006eqia</bpmn:incoming>
       </bpmn:endEvent>
@@ -180,12 +197,14 @@
       </bpmn:serviceTask>
       <bpmn:startEvent id="MessageStartEvent" name="Message start event" isInterrupting="false">
         <bpmn:outgoing>Flow_1f7mn63</bpmn:outgoing>
-        <bpmn:messageEventDefinition id="MessageEventDefinition_047sqmx" messageRef="Message_0cooija" />
+        <bpmn:messageEventDefinition id="MessageEventDefinition_047sqmx"
+          messageRef="Message_0cooija" />
       </bpmn:startEvent>
       <bpmn:sequenceFlow id="Flow_006eqia" sourceRef="TaskE" targetRef="Event_13rtwuo" />
       <bpmn:sequenceFlow id="Flow_1f7mn63" sourceRef="MessageStartEvent" targetRef="TaskE" />
     </bpmn:subProcess>
-    <bpmn:subProcess id="TimerEventSubProcess" name="Timer event sub process" triggeredByEvent="true">
+    <bpmn:subProcess id="TimerEventSubProcess" name="Timer event sub process"
+      triggeredByEvent="true">
       <bpmn:endEvent id="Event_0lk89tk">
         <bpmn:incoming>Flow_1rrwh6x</bpmn:incoming>
       </bpmn:endEvent>
@@ -205,7 +224,8 @@
       <bpmn:sequenceFlow id="Flow_1rrwh6x" sourceRef="TaskF" targetRef="Event_0lk89tk" />
       <bpmn:sequenceFlow id="Flow_0eemr1n" sourceRef="TimerStartEvent" targetRef="TaskF" />
     </bpmn:subProcess>
-    <bpmn:receiveTask id="MessageReceiveTask" name="Message receive task" messageRef="Message_19ff1sq">
+    <bpmn:receiveTask id="MessageReceiveTask" name="Message receive task"
+      messageRef="Message_19ff1sq">
       <bpmn:incoming>Flow_10qe08j</bpmn:incoming>
       <bpmn:outgoing>Flow_170beuy</bpmn:outgoing>
     </bpmn:receiveTask>
@@ -268,13 +288,18 @@
       <bpmn:incoming>Flow_17zq5s0</bpmn:incoming>
       <bpmn:outgoing>Flow_0brqydf</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="Flow_126yu9s" name="&#60; 0" sourceRef="ExclusiveGateway" targetRef="Gateway_1cs756a">
+    <bpmn:sequenceFlow id="Flow_126yu9s" name="&#60; 0" sourceRef="ExclusiveGateway"
+      targetRef="Gateway_1cs756a">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=unknownVariable &lt; 0</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_0guz7jv" sourceRef="EventBasedGateway" targetRef="TimerIntermediateCatchB" />
-    <bpmn:sequenceFlow id="Flow_0v8bsdg" sourceRef="EventBasedGateway" targetRef="MessageIntermediateCatchB" />
-    <bpmn:sequenceFlow id="Flow_0j0qeck" sourceRef="TimerIntermediateCatchB" targetRef="Gateway_0ftzss1" />
-    <bpmn:sequenceFlow id="Flow_17zq5s0" sourceRef="MessageIntermediateCatchB" targetRef="Gateway_0ftzss1" />
+    <bpmn:sequenceFlow id="Flow_0guz7jv" sourceRef="EventBasedGateway"
+      targetRef="TimerIntermediateCatchB" />
+    <bpmn:sequenceFlow id="Flow_0v8bsdg" sourceRef="EventBasedGateway"
+      targetRef="MessageIntermediateCatchB" />
+    <bpmn:sequenceFlow id="Flow_0j0qeck" sourceRef="TimerIntermediateCatchB"
+      targetRef="Gateway_0ftzss1" />
+    <bpmn:sequenceFlow id="Flow_17zq5s0" sourceRef="MessageIntermediateCatchB"
+      targetRef="Gateway_0ftzss1" />
     <bpmn:intermediateThrowEvent id="SignalIntermediateThrow" name="Signal intermediate throw">
       <bpmn:incoming>Flow_0mmpytv</bpmn:incoming>
       <bpmn:outgoing>Flow_1359yom</bpmn:outgoing>
@@ -285,8 +310,10 @@
       <bpmn:outgoing>Flow_1yhf88z</bpmn:outgoing>
       <bpmn:signalEventDefinition id="SignalEventDefinition_0wy1une" signalRef="Signal_18ev63b" />
     </bpmn:intermediateCatchEvent>
-    <bpmn:sequenceFlow id="Flow_1359yom" sourceRef="SignalIntermediateThrow" targetRef="SignalIntermediateCatch" />
-    <bpmn:subProcess id="SignalEventSubProcess" name="Signal event sub process" triggeredByEvent="true">
+    <bpmn:sequenceFlow id="Flow_1359yom" sourceRef="SignalIntermediateThrow"
+      targetRef="SignalIntermediateCatch" />
+    <bpmn:subProcess id="SignalEventSubProcess" name="Signal event sub process"
+      triggeredByEvent="true">
       <bpmn:endEvent id="Event_0opmx5v">
         <bpmn:incoming>Flow_1tl6j8a</bpmn:incoming>
       </bpmn:endEvent>
@@ -304,7 +331,8 @@
       <bpmn:endEvent id="Event_049m1di">
         <bpmn:incoming>Flow_0bfr615</bpmn:incoming>
       </bpmn:endEvent>
-      <bpmn:boundaryEvent id="SignalBoundaryEvent" name="Signal boundary event" attachedToRef="TaskH">
+      <bpmn:boundaryEvent id="SignalBoundaryEvent" name="Signal boundary event"
+        attachedToRef="TaskH">
         <bpmn:outgoing>Flow_0bfr615</bpmn:outgoing>
         <bpmn:signalEventDefinition id="SignalEventDefinition_0o1z67o" signalRef="Signal_18ev63b" />
       </bpmn:boundaryEvent>
@@ -322,7 +350,8 @@
       <bpmn:startEvent id="SubProcessStartEvent">
         <bpmn:outgoing>Flow_04fbdug</bpmn:outgoing>
       </bpmn:startEvent>
-      <bpmn:subProcess id="ErrorEventSubProcess" name="Error event sub process" triggeredByEvent="true">
+      <bpmn:subProcess id="ErrorEventSubProcess" name="Error event sub process"
+        triggeredByEvent="true">
         <bpmn:startEvent id="ErrorStartEvent" name="Error start event">
           <bpmn:outgoing>Flow_1nc8qvq</bpmn:outgoing>
           <bpmn:errorEventDefinition id="ErrorEventDefinition_1jxc702" errorRef="Error_0guddpc" />
@@ -340,7 +369,8 @@
         <bpmn:sequenceFlow id="Flow_1nc8qvq" sourceRef="ErrorStartEvent" targetRef="TaskG" />
         <bpmn:sequenceFlow id="Flow_1n6hwxq" sourceRef="TaskG" targetRef="Event_12yeu6m" />
       </bpmn:subProcess>
-      <bpmn:sequenceFlow id="Flow_04fbdug" sourceRef="SubProcessStartEvent" targetRef="ErrorEndEvent" />
+      <bpmn:sequenceFlow id="Flow_04fbdug" sourceRef="SubProcessStartEvent"
+        targetRef="ErrorEndEvent" />
     </bpmn:subProcess>
     <bpmn:subProcess id="MultiInstanceSubProcess" name="Multi instance sub process">
       <bpmn:incoming>Flow_0s7xnsc</bpmn:incoming>
@@ -380,7 +410,8 @@
       <bpmn:intermediateThrowEvent id="Event_0iwm1fq">
         <bpmn:incoming>Flow_0bbhalt</bpmn:incoming>
         <bpmn:outgoing>Flow_12rxp59</bpmn:outgoing>
-        <bpmn:escalationEventDefinition id="EscalationEventDefinition_0a4p2il" escalationRef="Escalation_0aipw8x" />
+        <bpmn:escalationEventDefinition id="EscalationEventDefinition_0a4p2il"
+          escalationRef="Escalation_0aipw8x" />
       </bpmn:intermediateThrowEvent>
       <bpmn:startEvent id="Event_1vxuw3v">
         <bpmn:outgoing>Flow_0qxvh80</bpmn:outgoing>
@@ -396,9 +427,11 @@
       <bpmn:sequenceFlow id="Flow_0bbhalt" sourceRef="EscalationTask" targetRef="Event_0iwm1fq" />
       <bpmn:sequenceFlow id="Flow_0qxvh80" sourceRef="Event_1vxuw3v" targetRef="EscalationTask" />
     </bpmn:subProcess>
-    <bpmn:boundaryEvent id="EscalationBoundaryEvent" name="Escalation boundary event" attachedToRef="EscalationSubProcess">
+    <bpmn:boundaryEvent id="EscalationBoundaryEvent" name="Escalation boundary event"
+      attachedToRef="EscalationSubProcess">
       <bpmn:outgoing>Flow_1pu67u8</bpmn:outgoing>
-      <bpmn:escalationEventDefinition id="EscalationEventDefinition_164va8l" escalationRef="Escalation_1v2o7l5" />
+      <bpmn:escalationEventDefinition id="EscalationEventDefinition_164va8l"
+        escalationRef="Escalation_1v2o7l5" />
     </bpmn:boundaryEvent>
     <bpmn:sequenceFlow id="Flow_1d2ue2p" sourceRef="Gateway_1" targetRef="Gateway_2" />
     <bpmn:parallelGateway id="Gateway_1">
@@ -406,6 +439,8 @@
       <bpmn:outgoing>Flow_1d2ue2p</bpmn:outgoing>
       <bpmn:outgoing>Flow_00b9dxt</bpmn:outgoing>
       <bpmn:outgoing>Flow_0yepp52</bpmn:outgoing>
+      <bpmn:outgoing>Flow_12u9pvx</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0ikvzw8</bpmn:outgoing>
     </bpmn:parallelGateway>
     <bpmn:parallelGateway id="Gateway_4">
       <bpmn:incoming>Flow_00b9dxt</bpmn:incoming>
@@ -446,9 +481,12 @@
       <bpmn:incoming>Flow_1xou7mm</bpmn:incoming>
       <bpmn:incoming>Flow_19y2492</bpmn:incoming>
       <bpmn:incoming>Flow_01xs1ek</bpmn:incoming>
+      <bpmn:incoming>Flow_1ki1oct</bpmn:incoming>
+      <bpmn:incoming>Flow_13karsw</bpmn:incoming>
       <bpmn:outgoing>Flow_0whnivt</bpmn:outgoing>
     </bpmn:parallelGateway>
-    <bpmn:subProcess id="EscalationEventSubProcess" name="Escalation event sub process" triggeredByEvent="true">
+    <bpmn:subProcess id="EscalationEventSubProcess" name="Escalation event sub process"
+      triggeredByEvent="true">
       <bpmn:endEvent id="Event_1cmlzk4">
         <bpmn:incoming>Flow_0of03mm</bpmn:incoming>
       </bpmn:endEvent>
@@ -459,19 +497,24 @@
         <bpmn:incoming>Flow_0vd8mzp</bpmn:incoming>
         <bpmn:outgoing>Flow_0of03mm</bpmn:outgoing>
       </bpmn:serviceTask>
-      <bpmn:startEvent id="EscalationStartEvent" name="Escalation start event" isInterrupting="false">
+      <bpmn:startEvent id="EscalationStartEvent" name="Escalation start event"
+        isInterrupting="false">
         <bpmn:outgoing>Flow_0vd8mzp</bpmn:outgoing>
-        <bpmn:escalationEventDefinition id="EscalationEventDefinition_0wxb74s" escalationRef="Escalation_0aipw8x" />
+        <bpmn:escalationEventDefinition id="EscalationEventDefinition_0wxb74s"
+          escalationRef="Escalation_0aipw8x" />
       </bpmn:startEvent>
       <bpmn:sequenceFlow id="Flow_0of03mm" sourceRef="EscalationEventTask" targetRef="Event_1cmlzk4" />
-      <bpmn:sequenceFlow id="Flow_0vd8mzp" sourceRef="EscalationStartEvent" targetRef="EscalationEventTask" />
+      <bpmn:sequenceFlow id="Flow_0vd8mzp" sourceRef="EscalationStartEvent"
+        targetRef="EscalationEventTask" />
     </bpmn:subProcess>
     <bpmn:intermediateThrowEvent id="EscalationThrowEvent">
       <bpmn:incoming>Flow_1fmviig</bpmn:incoming>
       <bpmn:outgoing>Flow_0yr2bpp</bpmn:outgoing>
-      <bpmn:escalationEventDefinition id="EscalationEventDefinition_1aqu025" escalationRef="Escalation_1v2o7l5" />
+      <bpmn:escalationEventDefinition id="EscalationEventDefinition_1aqu025"
+        escalationRef="Escalation_1v2o7l5" />
     </bpmn:intermediateThrowEvent>
-    <bpmn:sequenceFlow id="Flow_0yr2bpp" sourceRef="EscalationThrowEvent" targetRef="EscalationSubProcess" />
+    <bpmn:sequenceFlow id="Flow_0yr2bpp" sourceRef="EscalationThrowEvent"
+      targetRef="EscalationSubProcess" />
     <bpmn:intermediateThrowEvent id="CompensationThrowEvent" name="Compensation throw event">
       <bpmn:incoming>Flow_0ejrzsk</bpmn:incoming>
       <bpmn:outgoing>Flow_01xs1ek</bpmn:outgoing>
@@ -485,13 +528,212 @@
       <bpmn:outgoing>Flow_0ejrzsk</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:task id="UndoTask" name="Undo" isForCompensation="true" />
-    <bpmn:boundaryEvent id="CompensationBoundaryEvent" name="Compensation boundary event" attachedToRef="CompensationTask">
+    <bpmn:boundaryEvent id="CompensationBoundaryEvent" name="Compensation boundary event"
+      attachedToRef="CompensationTask">
       <bpmn:compensateEventDefinition id="CompensateEventDefinition_1a309d0" />
     </bpmn:boundaryEvent>
-    <bpmn:sequenceFlow id="Flow_0ejrzsk" sourceRef="CompensationTask" targetRef="CompensationThrowEvent" />
+    <bpmn:sequenceFlow id="Flow_0ejrzsk" sourceRef="CompensationTask"
+      targetRef="CompensationThrowEvent" />
     <bpmn:sequenceFlow id="Flow_0yepp52" sourceRef="Gateway_1" targetRef="CompensationTask" />
     <bpmn:sequenceFlow id="Flow_01xs1ek" sourceRef="CompensationThrowEvent" targetRef="Gateway_6" />
-    <bpmn:association id="Association_0xok9ld" associationDirection="One" sourceRef="CompensationBoundaryEvent" targetRef="UndoTask" />
+    <bpmn:adHocSubProcess id="AdHocSubProcess" name="Ad hoc sub process">
+      <bpmn:extensionElements>
+        <zeebe:adHoc activeElementsCollection="=[&#34;TaskI&#34;]" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0v443hz</bpmn:incoming>
+      <bpmn:outgoing>Flow_0dx8hzz</bpmn:outgoing>
+      <bpmn:serviceTask id="TaskI" name="Task I">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="foo" />
+        </bpmn:extensionElements>
+      </bpmn:serviceTask>
+    </bpmn:adHocSubProcess>
+    <bpmn:adHocSubProcess id="ParallelMultiInstanceAdHocSubProcess"
+      name="Parallel multi instance Ad hoc sub process">
+      <bpmn:extensionElements>
+        <zeebe:adHoc activeElementsCollection="=[&#34;TaskJ&#34;]" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0x38e96</bpmn:incoming>
+      <bpmn:outgoing>Flow_07bkx0g</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="=[&#34;inputCollection&#34;]" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+      <bpmn:serviceTask id="TaskJ" name="Task J">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="foo" />
+        </bpmn:extensionElements>
+      </bpmn:serviceTask>
+    </bpmn:adHocSubProcess>
+    <bpmn:adHocSubProcess id="SequentialMultiInstanceAdHocSubProcess"
+      name="Sequential multi instance Ad hoc sub process">
+      <bpmn:extensionElements>
+        <zeebe:adHoc activeElementsCollection="=[&#34;TaskK&#34;]" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_14ntaal</bpmn:incoming>
+      <bpmn:outgoing>Flow_1fuizf1</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics isSequential="true">
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="=[&#34;inputCollection&#34;]" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+      <bpmn:serviceTask id="TaskK" name="Task K">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="foo" />
+        </bpmn:extensionElements>
+      </bpmn:serviceTask>
+    </bpmn:adHocSubProcess>
+    <bpmn:parallelGateway id="Gateway_14pehud">
+      <bpmn:incoming>Flow_12u9pvx</bpmn:incoming>
+      <bpmn:outgoing>Flow_0v443hz</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0x38e96</bpmn:outgoing>
+      <bpmn:outgoing>Flow_14ntaal</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:parallelGateway id="Gateway_00j3vbq">
+      <bpmn:incoming>Flow_0dx8hzz</bpmn:incoming>
+      <bpmn:incoming>Flow_1fuizf1</bpmn:incoming>
+      <bpmn:incoming>Flow_07bkx0g</bpmn:incoming>
+      <bpmn:outgoing>Flow_1ki1oct</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_12u9pvx" sourceRef="Gateway_1" targetRef="Gateway_14pehud" />
+    <bpmn:sequenceFlow id="Flow_0v443hz" sourceRef="Gateway_14pehud" targetRef="AdHocSubProcess" />
+    <bpmn:sequenceFlow id="Flow_0x38e96" sourceRef="Gateway_14pehud"
+      targetRef="ParallelMultiInstanceAdHocSubProcess" />
+    <bpmn:sequenceFlow id="Flow_14ntaal" sourceRef="Gateway_14pehud"
+      targetRef="SequentialMultiInstanceAdHocSubProcess" />
+    <bpmn:sequenceFlow id="Flow_0dx8hzz" sourceRef="AdHocSubProcess" targetRef="Gateway_00j3vbq" />
+    <bpmn:sequenceFlow id="Flow_1fuizf1" sourceRef="SequentialMultiInstanceAdHocSubProcess"
+      targetRef="Gateway_00j3vbq" />
+    <bpmn:sequenceFlow id="Flow_07bkx0g" sourceRef="ParallelMultiInstanceAdHocSubProcess"
+      targetRef="Gateway_00j3vbq" />
+    <bpmn:sequenceFlow id="Flow_1ki1oct" sourceRef="Gateway_00j3vbq" targetRef="Gateway_6" />
+    <bpmn:parallelGateway id="Gateway_1hhnvkz">
+      <bpmn:incoming>Flow_0ikvzw8</bpmn:incoming>
+      <bpmn:outgoing>Flow_0vdvtnf</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1oinugz</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_0ikvzw8" sourceRef="Gateway_1" targetRef="Gateway_1hhnvkz" />
+    <bpmn:adHocSubProcess id="AgentTools" name="Agent tools">
+      <bpmn:extensionElements>
+        <zeebe:adHoc activeElementsCollection="=[toolCall._meta.name]" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1r65qfr</bpmn:incoming>
+      <bpmn:outgoing>Flow_0z5salg</bpmn:outgoing>
+      <bpmn:scriptTask id="GetDateAndTimeTask" name="Get Date and Time - Task">
+        <bpmn:extensionElements>
+          <zeebe:script expression="=now()" resultVariable="toolCallResult" />
+        </bpmn:extensionElements>
+      </bpmn:scriptTask>
+    </bpmn:adHocSubProcess>
+    <bpmn:exclusiveGateway id="Gateway_1dx8l94">
+      <bpmn:incoming>Flow_1oinugz</bpmn:incoming>
+      <bpmn:incoming>Flow_0z5salg</bpmn:incoming>
+      <bpmn:outgoing>Flow_07tfzl7</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:exclusiveGateway id="Gateway_0ssa7n0" default="Flow_14vcfav">
+      <bpmn:incoming>Flow_0jzt8hh</bpmn:incoming>
+      <bpmn:outgoing>Flow_1r65qfr</bpmn:outgoing>
+      <bpmn:outgoing>Flow_14vcfav</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:adHocSubProcess id="AIAgentsubprocess" name="AI Agent sub process"
+      zeebe:modelerTemplate="io.camunda.connectors.agenticai.aiagent.jobworker.v1"
+      zeebe:modelerTemplateVersion="6"
+      zeebe:modelerTemplateIcon="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzIiIGhlaWdodD0iMzIiIHZpZXdCb3g9IjAgMCAzMiAzMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGNpcmNsZSBjeD0iMTYiIGN5PSIxNiIgcj0iMTYiIGZpbGw9IiNBNTZFRkYiLz4KPG1hc2sgaWQ9InBhdGgtMi1vdXRzaWRlLTFfMTg1XzYiIG1hc2tVbml0cz0idXNlclNwYWNlT25Vc2UiIHg9IjQiIHk9IjQiIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgZmlsbD0iYmxhY2siPgo8cmVjdCBmaWxsPSJ3aGl0ZSIgeD0iNCIgeT0iNCIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0Ii8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjAuMDEwNSAxMi4wOTg3QzE4LjQ5IDEwLjU4OTQgMTcuMTU5NCA4LjEwODE0IDE2LjE3OTkgNi4wMTEwM0MxNi4xNTIgNi4wMDQ1MSAxNi4xMTc2IDYgMTYuMDc5NCA2QzE2LjA0MTEgNiAxNi4wMDY2IDYuMDA0NTEgMTUuOTc4OCA2LjAxMTA0QzE0Ljk5OTQgOC4xMDgxNCAxMy42Njk3IDEwLjU4ODkgMTIuMTQ4MSAxMi4wOTgxQzEwLjYyNjkgMTMuNjA3MSA4LjEyNTY4IDE0LjkyNjQgNi4wMTE1NyAxNS44OTgxQzYuMDA0NzQgMTUuOTI2MSA2IDE1Ljk2MTEgNiAxNkM2IDE2LjAzODcgNi4wMDQ2OCAxNi4wNzM2IDYuMDExNDQgMTYuMTAxNEM4LjEyNTE5IDE3LjA3MjkgMTAuNjI2MiAxOC4zOTE5IDEyLjE0NzcgMTkuOTAxNkMxMy42Njk3IDIxLjQxMDcgMTQuOTk5NiAyMy44OTIgMTUuOTc5MSAyNS45ODlDMTYuMDA2OCAyNS45OTU2IDE2LjA0MTEgMjYgMTYuMDc5MyAyNkMxNi4xMTc1IDI2IDE2LjE1MTkgMjUuOTk1NCAxNi4xNzk2IDI1Ljk4OUMxNy4xNTkxIDIzLjg5MiAxOC40ODg4IDIxLjQxMSAyMC4wMDk5IDE5LjkwMjFNMjAuMDA5OSAxOS45MDIxQzIxLjUyNTMgMTguMzk4NyAyMy45NDY1IDE3LjA2NjkgMjUuOTkxNSAxNi4wODI0QzI1Ljk5NjUgMTYuMDU5MyAyNiAxNi4wMzEgMjYgMTUuOTk5N0MyNiAxNS45Njg0IDI1Ljk5NjUgMTUuOTQwMyAyNS45OTE1IDE1LjkxNzFDMjMuOTQ3NCAxNC45MzI3IDIxLjUyNTkgMTMuNjAxIDIwLjAxMDUgMTIuMDk4NyIvPgo8L21hc2s+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjAuMDEwNSAxMi4wOTg3QzE4LjQ5IDEwLjU4OTQgMTcuMTU5NCA4LjEwODE0IDE2LjE3OTkgNi4wMTEwM0MxNi4xNTIgNi4wMDQ1MSAxNi4xMTc2IDYgMTYuMDc5NCA2QzE2LjA0MTEgNiAxNi4wMDY2IDYuMDA0NTEgMTUuOTc4OCA2LjAxMTA0QzE0Ljk5OTQgOC4xMDgxNCAxMy42Njk3IDEwLjU4ODkgMTIuMTQ4MSAxMi4wOTgxQzEwLjYyNjkgMTMuNjA3MSA4LjEyNTY4IDE0LjkyNjQgNi4wMTE1NyAxNS44OTgxQzYuMDA0NzQgMTUuOTI2MSA2IDE1Ljk2MTEgNiAxNkM2IDE2LjAzODcgNi4wMDQ2OCAxNi4wNzM2IDYuMDExNDQgMTYuMTAxNEM4LjEyNTE5IDE3LjA3MjkgMTAuNjI2MiAxOC4zOTE5IDEyLjE0NzcgMTkuOTAxNkMxMy42Njk3IDIxLjQxMDcgMTQuOTk5NiAyMy44OTIgMTUuOTc5MSAyNS45ODlDMTYuMDA2OCAyNS45OTU2IDE2LjA0MTEgMjYgMTYuMDc5MyAyNkMxNi4xMTc1IDI2IDE2LjE1MTkgMjUuOTk1NCAxNi4xNzk2IDI1Ljk4OUMxNy4xNTkxIDIzLjg5MiAxOC40ODg4IDIxLjQxMSAyMC4wMDk5IDE5LjkwMjFNMjAuMDA5OSAxOS45MDIxQzIxLjUyNTMgMTguMzk4NyAyMy45NDY1IDE3LjA2NjkgMjUuOTkxNSAxNi4wODI0QzI1Ljk5NjUgMTYuMDU5MyAyNiAxNi4wMzEgMjYgMTUuOTk5N0MyNiAxNS45Njg0IDI1Ljk5NjUgMTUuOTQwMyAyNS45OTE1IDE1LjkxNzFDMjMuOTQ3NCAxNC45MzI3IDIxLjUyNTkgMTMuNjAxIDIwLjAxMDUgMTIuMDk4NyIgZmlsbD0id2hpdGUiLz4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0yMC4wMTA1IDEyLjA5ODdDMTguNDkgMTAuNTg5NCAxNy4xNTk0IDguMTA4MTQgMTYuMTc5OSA2LjAxMTAzQzE2LjE1MiA2LjAwNDUxIDE2LjExNzYgNiAxNi4wNzk0IDZDMTYuMDQxMSA2IDE2LjAwNjYgNi4wMDQ1MSAxNS45Nzg4IDYuMDExMDRDMTQuOTk5NCA4LjEwODE0IDEzLjY2OTcgMTAuNTg4OSAxMi4xNDgxIDEyLjA5ODFDMTAuNjI2OSAxMy42MDcxIDguMTI1NjggMTQuOTI2NCA2LjAxMTU3IDE1Ljg5ODFDNi4wMDQ3NCAxNS45MjYxIDYgMTUuOTYxMSA2IDE2QzYgMTYuMDM4NyA2LjAwNDY4IDE2LjA3MzYgNi4wMTE0NCAxNi4xMDE0QzguMTI1MTkgMTcuMDcyOSAxMC42MjYyIDE4LjM5MTkgMTIuMTQ3NyAxOS45MDE2QzEzLjY2OTcgMjEuNDEwNyAxNC45OTk2IDIzLjg5MiAxNS45NzkxIDI1Ljk4OUMxNi4wMDY4IDI1Ljk5NTYgMTYuMDQxMSAyNiAxNi4wNzkzIDI2QzE2LjExNzUgMjYgMTYuMTUxOSAyNS45OTU0IDE2LjE3OTYgMjUuOTg5QzE3LjE1OTEgMjMuODkyIDE4LjQ4ODggMjEuNDExIDIwLjAwOTkgMTkuOTAyMU0yMC4wMDk5IDE5LjkwMjFDMjEuNTI1MyAxOC4zOTg3IDIzLjk0NjUgMTcuMDY2OSAyNS45OTE1IDE2LjA4MjRDMjUuOTk2NSAxNi4wNTkzIDI2IDE2LjAzMSAyNiAxNS45OTk3QzI2IDE1Ljk2ODQgMjUuOTk2NSAxNS45NDAzIDI1Ljk5MTUgMTUuOTE3MUMyMy45NDc0IDE0LjkzMjcgMjEuNTI1OSAxMy42MDEgMjAuMDEwNSAxMi4wOTg3IiBzdHJva2U9IiM0OTFEOEIiIHN0cm9rZS13aWR0aD0iNCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgbWFzaz0idXJsKCNwYXRoLTItb3V0c2lkZS0xXzE4NV82KSIvPgo8L3N2Zz4K">
+      <bpmn:extensionElements>
+        <zeebe:adHoc outputCollection="toolCallResults"
+          outputElement="={&#10;  id: toolCall._meta.id,&#10;  name: toolCall._meta.name,&#10;  content: toolCallResult&#10;}" />
+        <zeebe:taskDefinition type="io.camunda.agenticai:aiagent-job-worker:1" retries="3" />
+        <zeebe:ioMapping>
+          <zeebe:input source="openai" target="provider.type" />
+          <zeebe:input source="=&#34;openAI_Key&#34;" target="provider.openai.authentication.apiKey" />
+          <zeebe:input source="gpt-4o" target="provider.openai.model.model" />
+          <zeebe:input
+            source="=&#34;You are **TaskAgent**, a helpful, generic chat agent that can handle a wide variety of customer requests using your own domain knowledge **and** any tools explicitly provided to you at runtime.&#10;&#10;If tools are provided, you should prefer them instead of guessing an answer. You can call the same tool multiple times by providing different input values. Don&#39;t guess any tools which were not explicitly configured. If no tool matches the request, try to generate an answer. If you&#39;re not able to find a good answer, return with a message stating why you&#39;re not able to.&#10;&#10;Wrap minimal, inspectable reasoning in *exactly* this XML template:&#10;&#10;&#60;thinking&#62;&#10;&#60;context&#62;…briefly state the customer’s need and current state…&#60;/context&#62;&#10;&#60;reflection&#62;…list candidate tools, justify which you will call next and why…&#60;/reflection&#62;&#10;&#60;/thinking&#62;&#10;&#10;Reveal **no** additional private reasoning outside these tags.&#34;"
+            target="data.systemPrompt.prompt" />
+          <zeebe:input
+            source="=&#34;You will use the corresponding tools to generate the following request:&#10;&#10;- Provide me with the current date and time&#34;"
+            target="data.userPrompt.prompt" />
+          <zeebe:input target="agentContext" />
+          <zeebe:input source="in-process" target="data.memory.storage.type" />
+          <zeebe:input source="=20" target="data.memory.contextWindowSize" />
+          <zeebe:input source="=10" target="data.limits.maxModelCalls" />
+          <zeebe:input source="WAIT_FOR_TOOL_CALL_RESULTS" target="data.events.behavior" />
+          <zeebe:input source="text" target="data.response.format.type" />
+          <zeebe:input source="=false" target="data.response.format.parseJson" />
+          <zeebe:input source="=false" target="data.response.includeAssistantMessage" />
+          <zeebe:input source="=false" target="data.response.includeAgentContext" />
+          <zeebe:output source="=agent" target="agent" />
+        </zeebe:ioMapping>
+        <zeebe:taskHeaders>
+          <zeebe:header key="elementTemplateVersion" value="6" />
+          <zeebe:header key="elementTemplateId"
+            value="io.camunda.connectors.agenticai.aiagent.jobworker.v1" />
+          <zeebe:header key="retryBackoff" value="PT0S" />
+        </zeebe:taskHeaders>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0vdvtnf</bpmn:incoming>
+      <bpmn:outgoing>Flow_1plh702</bpmn:outgoing>
+      <bpmn:scriptTask id="GetDateAndTimeSubprocess" name="Get Date and Time - subprocess">
+        <bpmn:extensionElements>
+          <zeebe:script expression="=now()" resultVariable="toolCallResult" />
+        </bpmn:extensionElements>
+      </bpmn:scriptTask>
+    </bpmn:adHocSubProcess>
+    <bpmn:sequenceFlow id="Flow_0vdvtnf" sourceRef="Gateway_1hhnvkz" targetRef="AIAgentsubprocess" />
+    <bpmn:sequenceFlow id="Flow_1oinugz" sourceRef="Gateway_1hhnvkz" targetRef="Gateway_1dx8l94" />
+    <bpmn:sequenceFlow id="Flow_07tfzl7" sourceRef="Gateway_1dx8l94" targetRef="AIAgentTask" />
+    <bpmn:sequenceFlow id="Flow_0jzt8hh" sourceRef="AIAgentTask" targetRef="Gateway_0ssa7n0" />
+    <bpmn:sequenceFlow id="Flow_0z5salg" sourceRef="AgentTools" targetRef="Gateway_1dx8l94" />
+    <bpmn:sequenceFlow id="Flow_1r65qfr" sourceRef="Gateway_0ssa7n0" targetRef="AgentTools">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=not(is empty(agent.toolCalls))</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:parallelGateway id="Gateway_0zcqny6">
+      <bpmn:incoming>Flow_1plh702</bpmn:incoming>
+      <bpmn:incoming>Flow_14vcfav</bpmn:incoming>
+      <bpmn:outgoing>Flow_13karsw</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_1plh702" sourceRef="AIAgentsubprocess" targetRef="Gateway_0zcqny6" />
+    <bpmn:sequenceFlow id="Flow_13karsw" sourceRef="Gateway_0zcqny6" targetRef="Gateway_6" />
+    <bpmn:serviceTask id="AIAgentTask" name="AI agent Task"
+      zeebe:modelerTemplate="io.camunda.connectors.agenticai.aiagent.v1"
+      zeebe:modelerTemplateVersion="6"
+      zeebe:modelerTemplateIcon="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzIiIGhlaWdodD0iMzIiIHZpZXdCb3g9IjAgMCAzMiAzMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGNpcmNsZSBjeD0iMTYiIGN5PSIxNiIgcj0iMTYiIGZpbGw9IiNBNTZFRkYiLz4KPG1hc2sgaWQ9InBhdGgtMi1vdXRzaWRlLTFfMTg1XzYiIG1hc2tVbml0cz0idXNlclNwYWNlT25Vc2UiIHg9IjQiIHk9IjQiIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgZmlsbD0iYmxhY2siPgo8cmVjdCBmaWxsPSJ3aGl0ZSIgeD0iNCIgeT0iNCIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0Ii8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjAuMDEwNSAxMi4wOTg3QzE4LjQ5IDEwLjU4OTQgMTcuMTU5NCA4LjEwODE0IDE2LjE3OTkgNi4wMTEwM0MxNi4xNTIgNi4wMDQ1MSAxNi4xMTc2IDYgMTYuMDc5NCA2QzE2LjA0MTEgNiAxNi4wMDY2IDYuMDA0NTEgMTUuOTc4OCA2LjAxMTA0QzE0Ljk5OTQgOC4xMDgxNCAxMy42Njk3IDEwLjU4ODkgMTIuMTQ4MSAxMi4wOTgxQzEwLjYyNjkgMTMuNjA3MSA4LjEyNTY4IDE0LjkyNjQgNi4wMTE1NyAxNS44OTgxQzYuMDA0NzQgMTUuOTI2MSA2IDE1Ljk2MTEgNiAxNkM2IDE2LjAzODcgNi4wMDQ2OCAxNi4wNzM2IDYuMDExNDQgMTYuMTAxNEM4LjEyNTE5IDE3LjA3MjkgMTAuNjI2MiAxOC4zOTE5IDEyLjE0NzcgMTkuOTAxNkMxMy42Njk3IDIxLjQxMDcgMTQuOTk5NiAyMy44OTIgMTUuOTc5MSAyNS45ODlDMTYuMDA2OCAyNS45OTU2IDE2LjA0MTEgMjYgMTYuMDc5MyAyNkMxNi4xMTc1IDI2IDE2LjE1MTkgMjUuOTk1NCAxNi4xNzk2IDI1Ljk4OUMxNy4xNTkxIDIzLjg5MiAxOC40ODg4IDIxLjQxMSAyMC4wMDk5IDE5LjkwMjFNMjAuMDA5OSAxOS45MDIxQzIxLjUyNTMgMTguMzk4NyAyMy45NDY1IDE3LjA2NjkgMjUuOTkxNSAxNi4wODI0QzI1Ljk5NjUgMTYuMDU5MyAyNiAxNi4wMzEgMjYgMTUuOTk5N0MyNiAxNS45Njg0IDI1Ljk5NjUgMTUuOTQwMyAyNS45OTE1IDE1LjkxNzFDMjMuOTQ3NCAxNC45MzI3IDIxLjUyNTkgMTMuNjAxIDIwLjAxMDUgMTIuMDk4NyIvPgo8L21hc2s+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjAuMDEwNSAxMi4wOTg3QzE4LjQ5IDEwLjU4OTQgMTcuMTU5NCA4LjEwODE0IDE2LjE3OTkgNi4wMTEwM0MxNi4xNTIgNi4wMDQ1MSAxNi4xMTc2IDYgMTYuMDc5NCA2QzE2LjA0MTEgNiAxNi4wMDY2IDYuMDA0NTEgMTUuOTc4OCA2LjAxMTA0QzE0Ljk5OTQgOC4xMDgxNCAxMy42Njk3IDEwLjU4ODkgMTIuMTQ4MSAxMi4wOTgxQzEwLjYyNjkgMTMuNjA3MSA4LjEyNTY4IDE0LjkyNjQgNi4wMTE1NyAxNS44OTgxQzYuMDA0NzQgMTUuOTI2MSA2IDE1Ljk2MTEgNiAxNkM2IDE2LjAzODcgNi4wMDQ2OCAxNi4wNzM2IDYuMDExNDQgMTYuMTAxNEM4LjEyNTE5IDE3LjA3MjkgMTAuNjI2MiAxOC4zOTE5IDEyLjE0NzcgMTkuOTAxNkMxMy42Njk3IDIxLjQxMDcgMTQuOTk5NiAyMy44OTIgMTUuOTc5MSAyNS45ODlDMTYuMDA2OCAyNS45OTU2IDE2LjA0MTEgMjYgMTYuMDc5MyAyNkMxNi4xMTc1IDI2IDE2LjE1MTkgMjUuOTk1NCAxNi4xNzk2IDI1Ljk4OUMxNy4xNTkxIDIzLjg5MiAxOC40ODg4IDIxLjQxMSAyMC4wMDk5IDE5LjkwMjFNMjAuMDA5OSAxOS45MDIxQzIxLjUyNTMgMTguMzk4NyAyMy45NDY1IDE3LjA2NjkgMjUuOTkxNSAxNi4wODI0QzI1Ljk5NjUgMTYuMDU5MyAyNiAxNi4wMzEgMjYgMTUuOTk5N0MyNiAxNS45Njg0IDI1Ljk5NjUgMTUuOTQwMyAyNS45OTE1IDE1LjkxNzFDMjMuOTQ3NCAxNC45MzI3IDIxLjUyNTkgMTMuNjAxIDIwLjAxMDUgMTIuMDk4NyIgZmlsbD0id2hpdGUiLz4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0yMC4wMTA1IDEyLjA5ODdDMTguNDkgMTAuNTg5NCAxNy4xNTk0IDguMTA4MTQgMTYuMTc5OSA2LjAxMTAzQzE2LjE1MiA2LjAwNDUxIDE2LjExNzYgNiAxNi4wNzk0IDZDMTYuMDQxMSA2IDE2LjAwNjYgNi4wMDQ1MSAxNS45Nzg4IDYuMDExMDRDMTQuOTk5NCA4LjEwODE0IDEzLjY2OTcgMTAuNTg4OSAxMi4xNDgxIDEyLjA5ODFDMTAuNjI2OSAxMy42MDcxIDguMTI1NjggMTQuOTI2NCA2LjAxMTU3IDE1Ljg5ODFDNi4wMDQ3NCAxNS45MjYxIDYgMTUuOTYxMSA2IDE2QzYgMTYuMDM4NyA2LjAwNDY4IDE2LjA3MzYgNi4wMTE0NCAxNi4xMDE0QzguMTI1MTkgMTcuMDcyOSAxMC42MjYyIDE4LjM5MTkgMTIuMTQ3NyAxOS45MDE2QzEzLjY2OTcgMjEuNDEwNyAxNC45OTk2IDIzLjg5MiAxNS45NzkxIDI1Ljk4OUMxNi4wMDY4IDI1Ljk5NTYgMTYuMDQxMSAyNiAxNi4wNzkzIDI2QzE2LjExNzUgMjYgMTYuMTUxOSAyNS45OTU0IDE2LjE3OTYgMjUuOTg5QzE3LjE1OTEgMjMuODkyIDE4LjQ4ODggMjEuNDExIDIwLjAwOTkgMTkuOTAyMU0yMC4wMDk5IDE5LjkwMjFDMjEuNTI1MyAxOC4zOTg3IDIzLjk0NjUgMTcuMDY2OSAyNS45OTE1IDE2LjA4MjRDMjUuOTk2NSAxNi4wNTkzIDI2IDE2LjAzMSAyNiAxNS45OTk3QzI2IDE1Ljk2ODQgMjUuOTk2NSAxNS45NDAzIDI1Ljk5MTUgMTUuOTE3MUMyMy45NDc0IDE0LjkzMjcgMjEuNTI1OSAxMy42MDEgMjAuMDEwNSAxMi4wOTg3IiBzdHJva2U9IiM0OTFEOEIiIHN0cm9rZS13aWR0aD0iNCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgbWFzaz0idXJsKCNwYXRoLTItb3V0c2lkZS0xXzE4NV82KSIvPgo8L3N2Zz4K">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="io.camunda.agenticai:aiagent:1" retries="3" />
+        <zeebe:ioMapping>
+          <zeebe:input source="openai" target="provider.type" />
+          <zeebe:input source="=&#34;openAI_Key&#34;" target="provider.openai.authentication.apiKey" />
+          <zeebe:input source="gpt-4o" target="provider.openai.model.model" />
+          <zeebe:input
+            source="=&#34;You are **TaskAgent**, a helpful, generic chat agent that can handle a wide variety of customer requests using your own domain knowledge **and** any tools explicitly provided to you at runtime.&#10;&#10;If tools are provided, you should prefer them instead of guessing an answer. You can call the same tool multiple times by providing different input values. Don&#39;t guess any tools which were not explicitly configured. If no tool matches the request, try to generate an answer. If you&#39;re not able to find a good answer, return with a message stating why you&#39;re not able to.&#10;&#10;Wrap minimal, inspectable reasoning in *exactly* this XML template:&#10;&#10;&#60;thinking&#62;&#10;&#60;context&#62;…briefly state the customer’s need and current state…&#60;/context&#62;&#10;&#60;reflection&#62;…list candidate tools, justify which you will call next and why…&#60;/reflection&#62;&#10;&#60;/thinking&#62;&#10;&#10;Reveal **no** additional private reasoning outside these tags.&#34;"
+            target="data.systemPrompt.prompt" />
+          <zeebe:input
+            source="=&#34;You will use the corresponding tools to generate the following request:&#10;&#10;- Provide me with the current date and time&#34;"
+            target="data.userPrompt.prompt" />
+          <zeebe:input source="AgentTools" target="data.tools.containerElementId" />
+          <zeebe:input source="=toolCallResult" target="data.tools.toolCallResults" />
+          <zeebe:input source="=agent.context" target="data.context" />
+          <zeebe:input source="in-process" target="data.memory.storage.type" />
+          <zeebe:input source="=20" target="data.memory.contextWindowSize" />
+          <zeebe:input source="=10" target="data.limits.maxModelCalls" />
+          <zeebe:input source="text" target="data.response.format.type" />
+          <zeebe:input source="=false" target="data.response.format.parseJson" />
+          <zeebe:input source="=false" target="data.response.includeAssistantMessage" />
+        </zeebe:ioMapping>
+        <zeebe:taskHeaders>
+          <zeebe:header key="elementTemplateVersion" value="6" />
+          <zeebe:header key="elementTemplateId" value="io.camunda.connectors.agenticai.aiagent.v1" />
+          <zeebe:header key="resultVariable" value="agent" />
+          <zeebe:header key="retryBackoff" value="PT0S" />
+        </zeebe:taskHeaders>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_07tfzl7</bpmn:incoming>
+      <bpmn:outgoing>Flow_0jzt8hh</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_14vcfav" sourceRef="Gateway_0ssa7n0" targetRef="Gateway_0zcqny6" />
+    <bpmn:association id="Association_0xok9ld" associationDirection="One"
+      sourceRef="CompensationBoundaryEvent" targetRef="UndoTask" />
   </bpmn:process>
   <bpmn:message id="Message_0so1os3" name="Message_1">
     <bpmn:extensionElements>
@@ -554,12 +796,13 @@
         <dc:Bounds x="400" y="178" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="EndEvent_042s0oc_di" bpmnElement="EndEvent_1">
-        <dc:Bounds x="2432" y="1712" width="36" height="36" />
+        <dc:Bounds x="3842" y="1662" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="385" y="270" width="90" height="12" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ExclusiveGateway_1qqmrb8_di" bpmnElement="ExclusiveGateway_1qqmrb8" isMarkerVisible="true">
+      <bpmndi:BPMNShape id="ExclusiveGateway_1qqmrb8_di" bpmnElement="ExclusiveGateway_1qqmrb8"
+        isMarkerVisible="true">
         <dc:Bounds x="569" y="193" width="50" height="50" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="559" y="169" width="69" height="14" />
@@ -616,6 +859,58 @@
           <dc:Bounds x="718" y="804" width="90" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0tgxt6v_di" bpmnElement="MessageEventSubProcess"
+        isExpanded="true">
+        <dc:Bounds x="3715" y="210" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_13rtwuo_di" bpmnElement="Event_13rtwuo">
+        <dc:Bounds x="3977" y="292" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1d9lzza_di" bpmnElement="TaskE">
+        <dc:Bounds x="3835" y="270" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1t7lt05_di" bpmnElement="MessageStartEvent">
+        <dc:Bounds x="3755" y="292" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="3739" y="335" width="70" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_006eqia_di" bpmnElement="Flow_006eqia">
+        <di:waypoint x="3935" y="310" />
+        <di:waypoint x="3977" y="310" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1f7mn63_di" bpmnElement="Flow_1f7mn63">
+        <di:waypoint x="3791" y="310" />
+        <di:waypoint x="3835" y="310" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_0cz53c2_di" bpmnElement="TimerEventSubProcess"
+        isExpanded="true">
+        <dc:Bounds x="3715" y="460" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0lk89tk_di" bpmnElement="Event_0lk89tk">
+        <dc:Bounds x="3977" y="542" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0x898wf_di" bpmnElement="TaskF">
+        <dc:Bounds x="3835" y="520" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_01ol322_di" bpmnElement="TimerStartEvent">
+        <dc:Bounds x="3755" y="542" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="3732" y="585" width="83" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1rrwh6x_di" bpmnElement="Flow_1rrwh6x">
+        <di:waypoint x="3935" y="560" />
+        <di:waypoint x="3977" y="560" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0eemr1n_di" bpmnElement="Flow_0eemr1n">
+        <di:waypoint x="3791" y="560" />
+        <di:waypoint x="3835" y="560" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Activity_0jap8wu_di" bpmnElement="MessageReceiveTask">
         <dc:Bounds x="400" y="1230" width="100" height="80" />
         <bpmndi:BPMNLabel />
@@ -630,21 +925,8 @@
       <bpmndi:BPMNShape id="Activity_1f4kynw_di" bpmnElement="SendTask">
         <dc:Bounds x="400" y="1590" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1a442qs_di" bpmnElement="CompensationThrowEvent">
-        <dc:Bounds x="2092" y="192" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2075" y="235" width="71" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_10ddbjj_di" bpmnElement="CompensationTask">
-        <dc:Bounds x="1910" y="170" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0kfygzx_di" bpmnElement="UndoTask">
-        <dc:Bounds x="2030" y="290" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_05lm5ha_di" bpmnElement="ExclusiveGateway" isMarkerVisible="true">
+      <bpmndi:BPMNShape id="Gateway_05lm5ha_di" bpmnElement="ExclusiveGateway"
+        isMarkerVisible="true">
         <dc:Bounds x="1355" y="193" width="50" height="50" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1357" y="251" width="47" height="27" />
@@ -686,25 +968,44 @@
           <dc:Bounds x="1536" y="553" width="90" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_0gmp7q3_di" bpmnElement="Gateway_1">
-        <dc:Bounds x="285" y="85" width="50" height="50" />
+      <bpmndi:BPMNShape id="Activity_1s001x5_di" bpmnElement="SignalEventSubProcess"
+        isExpanded="true">
+        <dc:Bounds x="3715" y="710" width="350" height="200" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_0sjq8dt_di" bpmnElement="Gateway_4">
-        <dc:Bounds x="1085" y="193" width="50" height="50" />
+      <bpmndi:BPMNShape id="Event_0opmx5v_di" bpmnElement="Event_0opmx5v">
+        <dc:Bounds x="4007" y="792" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_0o7tedy_di" bpmnElement="Gateway_5">
-        <dc:Bounds x="1805" y="1523" width="50" height="50" />
+      <bpmndi:BPMNShape id="Activity_0v214gi_di" bpmnElement="TaskH">
+        <dc:Bounds x="3845" y="770" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1wu0r2j_di" bpmnElement="EscalationThrowEvent">
-        <dc:Bounds x="1222" y="1370" width="36" height="36" />
+      <bpmndi:BPMNShape id="Event_1u3z80h_di" bpmnElement="SignalStartEvent">
+        <dc:Bounds x="3755" y="792" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="3731" y="835" width="85" height="14" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_10o6pf2_di" bpmnElement="Gateway_6">
-        <dc:Bounds x="2285" y="1705" width="50" height="50" />
+      <bpmndi:BPMNShape id="Event_049m1di_di" bpmnElement="Event_049m1di">
+        <dc:Bounds x="4007" y="862" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Association_0xok9ld_di" bpmnElement="Association_0xok9ld">
-        <di:waypoint x="1980" y="268" />
-        <di:waypoint x="1980" y="330" />
-        <di:waypoint x="2030" y="330" />
+      <bpmndi:BPMNShape id="Event_0ch2r7b_di" bpmnElement="SignalBoundaryEvent">
+        <dc:Bounds x="3897" y="832" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="3876" y="875" width="80" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1tl6j8a_di" bpmnElement="Flow_1tl6j8a">
+        <di:waypoint x="3945" y="810" />
+        <di:waypoint x="4007" y="810" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_189mrto_di" bpmnElement="Flow_189mrto">
+        <di:waypoint x="3791" y="810" />
+        <di:waypoint x="3845" y="810" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0bfr615_di" bpmnElement="Flow_0bfr615">
+        <di:waypoint x="3915" y="868" />
+        <di:waypoint x="3915" y="880" />
+        <di:waypoint x="4007" y="880" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="BPMNShape_0p68nmi" bpmnElement="SubProcess" isExpanded="true">
         <dc:Bounds x="1280" y="618" width="423" height="350" />
@@ -745,7 +1046,8 @@
         <di:waypoint x="1393" y="678" />
         <di:waypoint x="1570" y="678" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_1ms6g9k_di" bpmnElement="MultiInstanceSubProcess" isExpanded="true">
+      <bpmndi:BPMNShape id="Activity_1ms6g9k_di" bpmnElement="MultiInstanceSubProcess"
+        isExpanded="true">
         <dc:Bounds x="1405" y="1028" width="350" height="200" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
@@ -767,7 +1069,8 @@
         <di:waypoint x="1633" y="1128" />
         <di:waypoint x="1685" y="1128" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_17jsa42_di" bpmnElement="EscalationSubProcess" isExpanded="true">
+      <bpmndi:BPMNShape id="Activity_17jsa42_di" bpmnElement="EscalationSubProcess"
+        isExpanded="true">
         <dc:Bounds x="1405" y="1288" width="350" height="200" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
@@ -796,119 +1099,137 @@
         <di:waypoint x="1464" y="1388" />
         <di:waypoint x="1496" y="1388" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_0tgxt6v_di" bpmnElement="MessageEventSubProcess" isExpanded="true">
-        <dc:Bounds x="2310" y="210" width="350" height="200" />
-        <bpmndi:BPMNLabel />
+      <bpmndi:BPMNShape id="Gateway_0gmp7q3_di" bpmnElement="Gateway_1">
+        <dc:Bounds x="285" y="85" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_13rtwuo_di" bpmnElement="Event_13rtwuo">
-        <dc:Bounds x="2572" y="292" width="36" height="36" />
+      <bpmndi:BPMNShape id="Gateway_0sjq8dt_di" bpmnElement="Gateway_4">
+        <dc:Bounds x="1085" y="193" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1d9lzza_di" bpmnElement="TaskE">
-        <dc:Bounds x="2430" y="270" width="100" height="80" />
-        <bpmndi:BPMNLabel />
+      <bpmndi:BPMNShape id="Gateway_0o7tedy_di" bpmnElement="Gateway_5">
+        <dc:Bounds x="1805" y="1523" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1t7lt05_di" bpmnElement="MessageStartEvent">
-        <dc:Bounds x="2350" y="292" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2334" y="335" width="70" height="27" />
-        </bpmndi:BPMNLabel>
+      <bpmndi:BPMNShape id="Gateway_10o6pf2_di" bpmnElement="Gateway_6">
+        <dc:Bounds x="3695" y="1655" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_006eqia_di" bpmnElement="Flow_006eqia">
-        <di:waypoint x="2530" y="310" />
-        <di:waypoint x="2572" y="310" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1f7mn63_di" bpmnElement="Flow_1f7mn63">
-        <di:waypoint x="2386" y="310" />
-        <di:waypoint x="2430" y="310" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_0cz53c2_di" bpmnElement="TimerEventSubProcess" isExpanded="true">
-        <dc:Bounds x="2310" y="460" width="350" height="200" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0lk89tk_di" bpmnElement="Event_0lk89tk">
-        <dc:Bounds x="2572" y="542" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0x898wf_di" bpmnElement="TaskF">
-        <dc:Bounds x="2430" y="520" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_01ol322_di" bpmnElement="TimerStartEvent">
-        <dc:Bounds x="2350" y="542" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2327" y="585" width="83" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_1rrwh6x_di" bpmnElement="Flow_1rrwh6x">
-        <di:waypoint x="2530" y="560" />
-        <di:waypoint x="2572" y="560" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0eemr1n_di" bpmnElement="Flow_0eemr1n">
-        <di:waypoint x="2386" y="560" />
-        <di:waypoint x="2430" y="560" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_1s001x5_di" bpmnElement="SignalEventSubProcess" isExpanded="true">
-        <dc:Bounds x="2310" y="710" width="350" height="200" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0opmx5v_di" bpmnElement="Event_0opmx5v">
-        <dc:Bounds x="2602" y="792" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0v214gi_di" bpmnElement="TaskH">
-        <dc:Bounds x="2440" y="770" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1u3z80h_di" bpmnElement="SignalStartEvent">
-        <dc:Bounds x="2350" y="792" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2326" y="835" width="85" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_049m1di_di" bpmnElement="Event_049m1di">
-        <dc:Bounds x="2602" y="862" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0ch2r7b_di" bpmnElement="SignalBoundaryEvent">
-        <dc:Bounds x="2492" y="832" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2470" y="875" width="81" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_1tl6j8a_di" bpmnElement="Flow_1tl6j8a">
-        <di:waypoint x="2540" y="810" />
-        <di:waypoint x="2602" y="810" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_189mrto_di" bpmnElement="Flow_189mrto">
-        <di:waypoint x="2386" y="810" />
-        <di:waypoint x="2440" y="810" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0bfr615_di" bpmnElement="Flow_0bfr615">
-        <di:waypoint x="2510" y="868" />
-        <di:waypoint x="2510" y="880" />
-        <di:waypoint x="2602" y="880" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_18j0bfj_di" bpmnElement="EscalationEventSubProcess" isExpanded="true">
-        <dc:Bounds x="2310" y="960" width="350" height="200" />
+      <bpmndi:BPMNShape id="Activity_18j0bfj_di" bpmnElement="EscalationEventSubProcess"
+        isExpanded="true">
+        <dc:Bounds x="3715" y="960" width="350" height="200" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1cmlzk4_di" bpmnElement="Event_1cmlzk4">
-        <dc:Bounds x="2602" y="1042" width="36" height="36" />
+        <dc:Bounds x="4007" y="1042" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0lqew9a_di" bpmnElement="EscalationEventTask">
-        <dc:Bounds x="2440" y="1020" width="100" height="80" />
+        <dc:Bounds x="3845" y="1020" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1wrkoo5_di" bpmnElement="EscalationStartEvent">
-        <dc:Bounds x="2350" y="1042" width="36" height="36" />
+        <dc:Bounds x="3755" y="1042" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2332" y="1085" width="76" height="27" />
+          <dc:Bounds x="3737" y="1085" width="76" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_0of03mm_di" bpmnElement="Flow_0of03mm">
-        <di:waypoint x="2540" y="1060" />
-        <di:waypoint x="2602" y="1060" />
+        <di:waypoint x="3945" y="1060" />
+        <di:waypoint x="4007" y="1060" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0vd8mzp_di" bpmnElement="Flow_0vd8mzp">
-        <di:waypoint x="2386" y="1060" />
-        <di:waypoint x="2440" y="1060" />
+        <di:waypoint x="3791" y="1060" />
+        <di:waypoint x="3845" y="1060" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_1wu0r2j_di" bpmnElement="EscalationThrowEvent">
+        <dc:Bounds x="1222" y="1370" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1a442qs_di" bpmnElement="CompensationThrowEvent">
+        <dc:Bounds x="3497" y="192" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="3480" y="235" width="71" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_10ddbjj_di" bpmnElement="CompensationTask">
+        <dc:Bounds x="3315" y="170" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0kfygzx_di" bpmnElement="UndoTask">
+        <dc:Bounds x="3435" y="290" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_17mq8ma_di" bpmnElement="AdHocSubProcess" isExpanded="true">
+        <dc:Bounds x="2040" y="428" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1f56u0l_di" bpmnElement="TaskI">
+        <dc:Bounds x="2160" y="480" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_18hzbbj" bpmnElement="ParallelMultiInstanceAdHocSubProcess"
+        isExpanded="true">
+        <dc:Bounds x="2040" y="810" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0dibvk1" bpmnElement="TaskJ">
+        <dc:Bounds x="2160" y="862" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_02upd8b" bpmnElement="SequentialMultiInstanceAdHocSubProcess"
+        isExpanded="true">
+        <dc:Bounds x="2040" y="1140" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_18s5ceo" bpmnElement="TaskK">
+        <dc:Bounds x="2160" y="1192" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1e1imfy_di" bpmnElement="Gateway_14pehud">
+        <dc:Bounds x="1925" y="193" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0vr8496_di" bpmnElement="Gateway_00j3vbq">
+        <dc:Bounds x="2515" y="1523" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1islyat_di" bpmnElement="Gateway_1hhnvkz">
+        <dc:Bounds x="2805" y="193" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1e3en9c" bpmnElement="AgentTools" isExpanded="true">
+        <dc:Bounds x="2930" y="618" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0ibwe9p_di" bpmnElement="GetDateAndTimeTask">
+        <dc:Bounds x="3050" y="670" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1dx8l94_di" bpmnElement="Gateway_1dx8l94" isMarkerVisible="true">
+        <dc:Bounds x="2935" y="503" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1e0mmf0" bpmnElement="Gateway_0ssa7n0" isMarkerVisible="true">
+        <dc:Bounds x="3175" y="503" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_11d96my" bpmnElement="AIAgentsubprocess" isExpanded="true">
+        <dc:Bounds x="2940" y="1028" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0wafzqh_di" bpmnElement="GetDateAndTimeSubprocess">
+        <dc:Bounds x="3060" y="1080" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1iui2ch" bpmnElement="Gateway_0zcqny6">
+        <dc:Bounds x="3340" y="1523" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0xk2tk4_di" bpmnElement="AIAgentTask">
+        <dc:Bounds x="3030" y="488" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_098t6oo_di" bpmnElement="CompensationBoundaryEvent">
+        <dc:Bounds x="3367" y="232" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="3347" y="275" width="76" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0jexdxm_di" bpmnElement="EscalationBoundaryEvent">
+        <dc:Bounds x="1568" y="1470" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1550" y="1513" width="76" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_09ic20e_di" bpmnElement="TimerNonInterrupting">
         <dc:Bounds x="452" y="1121" width="36" height="36" />
         <bpmndi:BPMNLabel>
@@ -931,18 +1252,6 @@
         <dc:Bounds x="452" y="639" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="402" y="666" width="56" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_098t6oo_di" bpmnElement="CompensationBoundaryEvent">
-        <dc:Bounds x="1962" y="232" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1942" y="275" width="76" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0jexdxm_di" bpmnElement="EscalationBoundaryEvent">
-        <dc:Bounds x="1568" y="1470" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1550" y="1513" width="76" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="SequenceFlow_0j6tsnn_di" bpmnElement="SequenceFlow_0j6tsnn">
@@ -1029,8 +1338,8 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1xou7mm_di" bpmnElement="Flow_1xou7mm">
         <di:waypoint x="1000" y="1655" />
-        <di:waypoint x="1000" y="1730" />
-        <di:waypoint x="2285" y="1730" />
+        <di:waypoint x="1000" y="1680" />
+        <di:waypoint x="3695" y="1680" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0vp8yz2_di" bpmnElement="Flow_0vp8yz2">
         <di:waypoint x="500" y="779" />
@@ -1115,6 +1424,35 @@
         <di:waypoint x="500" y="1630" />
         <di:waypoint x="975" y="1630" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_126yu9s_di" bpmnElement="Flow_126yu9s">
+        <di:waypoint x="1405" y="218" />
+        <di:waypoint x="1595" y="218" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1492" y="200" width="16" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0guz7jv_di" bpmnElement="Flow_0guz7jv">
+        <di:waypoint x="1405" y="328" />
+        <di:waypoint x="1562" y="328" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0v8bsdg_di" bpmnElement="Flow_0v8bsdg">
+        <di:waypoint x="1380" y="353" />
+        <di:waypoint x="1380" y="428" />
+        <di:waypoint x="1562" y="428" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0j0qeck_di" bpmnElement="Flow_0j0qeck">
+        <di:waypoint x="1598" y="328" />
+        <di:waypoint x="1735" y="328" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_17zq5s0_di" bpmnElement="Flow_17zq5s0">
+        <di:waypoint x="1598" y="428" />
+        <di:waypoint x="1760" y="428" />
+        <di:waypoint x="1760" y="353" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1359yom_di" bpmnElement="Flow_1359yom">
+        <di:waypoint x="1398" y="528" />
+        <di:waypoint x="1562" y="528" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1d2ue2p_di" bpmnElement="Flow_1d2ue2p">
         <di:waypoint x="310" y="135" />
         <di:waypoint x="310" y="193" />
@@ -1153,66 +1491,14 @@
         <di:waypoint x="1110" y="1388" />
         <di:waypoint x="1222" y="1388" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0whnivt_di" bpmnElement="Flow_0whnivt">
-        <di:waypoint x="2335" y="1730" />
-        <di:waypoint x="2432" y="1730" />
+      <bpmndi:BPMNEdge id="Flow_1pu67u8_di" bpmnElement="Flow_1pu67u8">
+        <di:waypoint x="1586" y="1506" />
+        <di:waypoint x="1586" y="1548" />
+        <di:waypoint x="1805" y="1548" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_19y2492_di" bpmnElement="Flow_19y2492">
-        <di:waypoint x="1830" y="1573" />
-        <di:waypoint x="1830" y="1730" />
-        <di:waypoint x="2285" y="1730" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0ejrzsk_di" bpmnElement="Flow_0ejrzsk">
-        <di:waypoint x="2010" y="210" />
-        <di:waypoint x="2092" y="210" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_126yu9s_di" bpmnElement="Flow_126yu9s">
-        <di:waypoint x="1405" y="218" />
-        <di:waypoint x="1595" y="218" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1492" y="200" width="16" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_186ylgv_di" bpmnElement="Flow_186ylgv">
-        <di:waypoint x="1645" y="218" />
-        <di:waypoint x="1830" y="218" />
-        <di:waypoint x="1830" y="1523" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0guz7jv_di" bpmnElement="Flow_0guz7jv">
-        <di:waypoint x="1405" y="328" />
-        <di:waypoint x="1562" y="328" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0v8bsdg_di" bpmnElement="Flow_0v8bsdg">
-        <di:waypoint x="1380" y="353" />
-        <di:waypoint x="1380" y="428" />
-        <di:waypoint x="1562" y="428" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0j0qeck_di" bpmnElement="Flow_0j0qeck">
-        <di:waypoint x="1598" y="328" />
-        <di:waypoint x="1735" y="328" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_17zq5s0_di" bpmnElement="Flow_17zq5s0">
-        <di:waypoint x="1598" y="428" />
-        <di:waypoint x="1760" y="428" />
-        <di:waypoint x="1760" y="353" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0brqydf_di" bpmnElement="Flow_0brqydf">
-        <di:waypoint x="1785" y="328" />
-        <di:waypoint x="1830" y="328" />
-        <di:waypoint x="1830" y="1523" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1359yom_di" bpmnElement="Flow_1359yom">
-        <di:waypoint x="1398" y="528" />
-        <di:waypoint x="1562" y="528" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1yhf88z_di" bpmnElement="Flow_1yhf88z">
-        <di:waypoint x="1598" y="528" />
-        <di:waypoint x="1830" y="528" />
-        <di:waypoint x="1830" y="1523" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1fet2uy_di" bpmnElement="Flow_1fet2uy">
-        <di:waypoint x="1703" y="793" />
-        <di:waypoint x="1830" y="793" />
+      <bpmndi:BPMNEdge id="Flow_0tjifq7_di" bpmnElement="Flow_0tjifq7">
+        <di:waypoint x="1755" y="1388" />
+        <di:waypoint x="1830" y="1388" />
         <di:waypoint x="1830" y="1523" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1bit3gk_di" bpmnElement="Flow_1bit3gk">
@@ -1220,30 +1506,146 @@
         <di:waypoint x="1830" y="1128" />
         <di:waypoint x="1830" y="1523" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1fet2uy_di" bpmnElement="Flow_1fet2uy">
+        <di:waypoint x="1703" y="793" />
+        <di:waypoint x="1830" y="793" />
+        <di:waypoint x="1830" y="1523" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1yhf88z_di" bpmnElement="Flow_1yhf88z">
+        <di:waypoint x="1598" y="528" />
+        <di:waypoint x="1830" y="528" />
+        <di:waypoint x="1830" y="1523" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0brqydf_di" bpmnElement="Flow_0brqydf">
+        <di:waypoint x="1785" y="328" />
+        <di:waypoint x="1830" y="328" />
+        <di:waypoint x="1830" y="1523" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_186ylgv_di" bpmnElement="Flow_186ylgv">
+        <di:waypoint x="1645" y="218" />
+        <di:waypoint x="1830" y="218" />
+        <di:waypoint x="1830" y="1523" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0whnivt_di" bpmnElement="Flow_0whnivt">
+        <di:waypoint x="3745" y="1680" />
+        <di:waypoint x="3842" y="1680" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_19y2492_di" bpmnElement="Flow_19y2492">
+        <di:waypoint x="1830" y="1573" />
+        <di:waypoint x="1830" y="1680" />
+        <di:waypoint x="3695" y="1680" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0yr2bpp_di" bpmnElement="Flow_0yr2bpp">
         <di:waypoint x="1258" y="1388" />
         <di:waypoint x="1405" y="1388" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0tjifq7_di" bpmnElement="Flow_0tjifq7">
-        <di:waypoint x="1755" y="1388" />
-        <di:waypoint x="1830" y="1388" />
-        <di:waypoint x="1830" y="1523" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1pu67u8_di" bpmnElement="Flow_1pu67u8">
-        <di:waypoint x="1586" y="1506" />
-        <di:waypoint x="1586" y="1548" />
-        <di:waypoint x="1805" y="1548" />
+      <bpmndi:BPMNEdge id="Flow_0ejrzsk_di" bpmnElement="Flow_0ejrzsk">
+        <di:waypoint x="3415" y="210" />
+        <di:waypoint x="3497" y="210" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0yepp52_di" bpmnElement="Flow_0yepp52">
         <di:waypoint x="335" y="110" />
-        <di:waypoint x="1960" y="110" />
-        <di:waypoint x="1960" y="170" />
+        <di:waypoint x="3365" y="110" />
+        <di:waypoint x="3365" y="170" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_01xs1ek_di" bpmnElement="Flow_01xs1ek">
-        <di:waypoint x="2128" y="210" />
-        <di:waypoint x="2200" y="210" />
-        <di:waypoint x="2200" y="1730" />
-        <di:waypoint x="2285" y="1730" />
+        <di:waypoint x="3533" y="210" />
+        <di:waypoint x="3610" y="210" />
+        <di:waypoint x="3610" y="1680" />
+        <di:waypoint x="3695" y="1680" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_12u9pvx_di" bpmnElement="Flow_12u9pvx">
+        <di:waypoint x="335" y="110" />
+        <di:waypoint x="1950" y="110" />
+        <di:waypoint x="1950" y="193" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0v443hz_di" bpmnElement="Flow_0v443hz">
+        <di:waypoint x="1950" y="243" />
+        <di:waypoint x="1950" y="528" />
+        <di:waypoint x="2040" y="528" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0x38e96_di" bpmnElement="Flow_0x38e96">
+        <di:waypoint x="1950" y="243" />
+        <di:waypoint x="1950" y="910" />
+        <di:waypoint x="2040" y="910" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_14ntaal_di" bpmnElement="Flow_14ntaal">
+        <di:waypoint x="1950" y="243" />
+        <di:waypoint x="1950" y="1240" />
+        <di:waypoint x="2040" y="1240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0dx8hzz_di" bpmnElement="Flow_0dx8hzz">
+        <di:waypoint x="2390" y="528" />
+        <di:waypoint x="2540" y="528" />
+        <di:waypoint x="2540" y="1523" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1fuizf1_di" bpmnElement="Flow_1fuizf1">
+        <di:waypoint x="2390" y="1240" />
+        <di:waypoint x="2540" y="1240" />
+        <di:waypoint x="2540" y="1523" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_07bkx0g_di" bpmnElement="Flow_07bkx0g">
+        <di:waypoint x="2390" y="910" />
+        <di:waypoint x="2540" y="910" />
+        <di:waypoint x="2540" y="1523" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ki1oct_di" bpmnElement="Flow_1ki1oct">
+        <di:waypoint x="2540" y="1573" />
+        <di:waypoint x="2540" y="1680" />
+        <di:waypoint x="3695" y="1680" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ikvzw8_di" bpmnElement="Flow_0ikvzw8">
+        <di:waypoint x="335" y="110" />
+        <di:waypoint x="2830" y="110" />
+        <di:waypoint x="2830" y="193" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0vdvtnf_di" bpmnElement="Flow_0vdvtnf">
+        <di:waypoint x="2855" y="218" />
+        <di:waypoint x="2880" y="218" />
+        <di:waypoint x="2880" y="1128" />
+        <di:waypoint x="2940" y="1128" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1oinugz_di" bpmnElement="Flow_1oinugz">
+        <di:waypoint x="2855" y="218" />
+        <di:waypoint x="2880" y="220" />
+        <di:waypoint x="2880" y="530" />
+        <di:waypoint x="2936" y="529" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_07tfzl7_di" bpmnElement="Flow_07tfzl7">
+        <di:waypoint x="2985" y="528" />
+        <di:waypoint x="3030" y="528" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0jzt8hh_di" bpmnElement="Flow_0jzt8hh">
+        <di:waypoint x="3130" y="528" />
+        <di:waypoint x="3175" y="528" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0z5salg_di" bpmnElement="Flow_0z5salg">
+        <di:waypoint x="2960" y="618" />
+        <di:waypoint x="2960" y="553" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1r65qfr_di" bpmnElement="Flow_1r65qfr">
+        <di:waypoint x="3200" y="553" />
+        <di:waypoint x="3200" y="618" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1plh702_di" bpmnElement="Flow_1plh702">
+        <di:waypoint x="3290" y="1128" />
+        <di:waypoint x="3365" y="1128" />
+        <di:waypoint x="3365" y="1523" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_13karsw_di" bpmnElement="Flow_13karsw">
+        <di:waypoint x="3365" y="1573" />
+        <di:waypoint x="3365" y="1680" />
+        <di:waypoint x="3695" y="1680" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_14vcfav_di" bpmnElement="Flow_14vcfav">
+        <di:waypoint x="3225" y="528" />
+        <di:waypoint x="3365" y="528" />
+        <di:waypoint x="3365" y="1523" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0xok9ld_di" bpmnElement="Association_0xok9ld">
+        <di:waypoint x="3385" y="268" />
+        <di:waypoint x="3385" y="330" />
+        <di:waypoint x="3435" y="330" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/orderProcessMigration_v_3.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/orderProcessMigration_v_3.bpmn
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.28.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+  xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1"
+  targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler"
+  exporterVersion="68c5d80" modeler:executionPlatform="Camunda Cloud"
+  modeler:executionPlatformVersion="8.9.0">
   <bpmn:process id="newOrderProcessMigration" name="newOrderProcessMigration" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1" name="Order received">
       <bpmn:outgoing>SequenceFlow_0j6tsnn</bpmn:outgoing>
@@ -21,7 +30,8 @@
       <bpmn:outgoing>SequenceFlow_0jzbqu1</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_1dq2rqw</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="SequenceFlow_1s6g17c" sourceRef="checkPayment2" targetRef="ExclusiveGateway_1qqmrb8" />
+    <bpmn:sequenceFlow id="SequenceFlow_1s6g17c" sourceRef="checkPayment2"
+      targetRef="ExclusiveGateway_1qqmrb8" />
     <bpmn:serviceTask id="requestForPayment2" name="Request for payment 2">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="requestPayment" />
@@ -29,11 +39,14 @@
       <bpmn:incoming>SequenceFlow_0jzbqu1</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1q6ade7</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="SequenceFlow_0jzbqu1" name="Not paid" sourceRef="ExclusiveGateway_1qqmrb8" targetRef="requestForPayment2">
+    <bpmn:sequenceFlow id="SequenceFlow_0jzbqu1" name="Not paid"
+      sourceRef="ExclusiveGateway_1qqmrb8" targetRef="requestForPayment2">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=paid = false</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_1q6ade7" sourceRef="requestForPayment2" targetRef="checkPayment2" />
-    <bpmn:sequenceFlow id="SequenceFlow_1dq2rqw" name="paid" sourceRef="ExclusiveGateway_1qqmrb8" targetRef="shipArticles2">
+    <bpmn:sequenceFlow id="SequenceFlow_1q6ade7" sourceRef="requestForPayment2"
+      targetRef="checkPayment2" />
+    <bpmn:sequenceFlow id="SequenceFlow_1dq2rqw" name="paid" sourceRef="ExclusiveGateway_1qqmrb8"
+      targetRef="shipArticles2">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=paid = true</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:serviceTask id="shipArticles2" name="Ship Articles 2">
@@ -43,7 +56,8 @@
       <bpmn:incoming>SequenceFlow_1dq2rqw</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_19klrd3</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="SequenceFlow_19klrd3" sourceRef="shipArticles2" targetRef="notifyCustomer2" />
+    <bpmn:sequenceFlow id="SequenceFlow_19klrd3" sourceRef="shipArticles2"
+      targetRef="notifyCustomer2" />
     <bpmn:sequenceFlow id="Flow_0zx0zzd" sourceRef="notifyCustomer2" targetRef="checkDeliveryState2" />
     <bpmn:serviceTask id="notifyCustomer2" name="Notify Customer 2">
       <bpmn:extensionElements>
@@ -100,7 +114,8 @@
       <bpmn:incoming>Flow_1478njt</bpmn:incoming>
       <bpmn:outgoing>Flow_0279afj</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:boundaryEvent id="MessageInterrupting2" name="Message interrupting 2" attachedToRef="TaskA2">
+    <bpmn:boundaryEvent id="MessageInterrupting2" name="Message interrupting 2"
+      attachedToRef="TaskA2">
       <bpmn:outgoing>Flow_14ee2ym</bpmn:outgoing>
       <bpmn:messageEventDefinition id="MessageEventDefinition_144v54n" messageRef="Message_0so1os3" />
     </bpmn:boundaryEvent>
@@ -110,11 +125,13 @@
         <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P1Y</bpmn:timeDuration>
       </bpmn:timerEventDefinition>
     </bpmn:boundaryEvent>
-    <bpmn:boundaryEvent id="MessageNonInterrupting2" name="Message non-interrupting 2" cancelActivity="false" attachedToRef="TaskC2">
+    <bpmn:boundaryEvent id="MessageNonInterrupting2" name="Message non-interrupting 2"
+      cancelActivity="false" attachedToRef="TaskC2">
       <bpmn:outgoing>Flow_0b5y250</bpmn:outgoing>
       <bpmn:messageEventDefinition id="MessageEventDefinition_0ox9bto" messageRef="Message_1xpzcw8" />
     </bpmn:boundaryEvent>
-    <bpmn:boundaryEvent id="TimerNonInterrupting2" name="Timer non-interrupting 2" cancelActivity="false" attachedToRef="TaskD2">
+    <bpmn:boundaryEvent id="TimerNonInterrupting2" name="Timer non-interrupting 2"
+      cancelActivity="false" attachedToRef="TaskD2">
       <bpmn:outgoing>Flow_093zwcs</bpmn:outgoing>
       <bpmn:timerEventDefinition id="TimerEventDefinition_0lpluww">
         <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P1Y</bpmn:timeDuration>
@@ -175,7 +192,8 @@
     <bpmn:sequenceFlow id="Flow_0kfelct" sourceRef="Gateway_2" targetRef="MessageIntermediateCatch2" />
     <bpmn:sequenceFlow id="Flow_1j5fksj" sourceRef="MessageIntermediateCatch2" targetRef="Gateway_3" />
     <bpmn:sequenceFlow id="Flow_0aheimq" sourceRef="TaskA2" targetRef="Gateway_3" />
-    <bpmn:subProcess id="TimerEventSubProcess2" name="Timer event sub process 2" triggeredByEvent="true">
+    <bpmn:subProcess id="TimerEventSubProcess2" name="Timer event sub process 2"
+      triggeredByEvent="true">
       <bpmn:endEvent id="Event_0lk89tk">
         <bpmn:incoming>Flow_1rrwh6x</bpmn:incoming>
       </bpmn:endEvent>
@@ -195,7 +213,8 @@
       <bpmn:sequenceFlow id="Flow_1rrwh6x" sourceRef="TaskF2" targetRef="Event_0lk89tk" />
       <bpmn:sequenceFlow id="Flow_0eemr1n" sourceRef="TimerStartEvent" targetRef="TaskF2" />
     </bpmn:subProcess>
-    <bpmn:subProcess id="MessageEventSubProcess2" name="Message event sub process 2" triggeredByEvent="true">
+    <bpmn:subProcess id="MessageEventSubProcess2" name="Message event sub process 2"
+      triggeredByEvent="true">
       <bpmn:endEvent id="Event_13rtwuo">
         <bpmn:incoming>Flow_006eqia</bpmn:incoming>
       </bpmn:endEvent>
@@ -208,12 +227,14 @@
       </bpmn:serviceTask>
       <bpmn:startEvent id="MessageStartEvent" name="Message start event" isInterrupting="false">
         <bpmn:outgoing>Flow_1f7mn63</bpmn:outgoing>
-        <bpmn:messageEventDefinition id="MessageEventDefinition_047sqmx" messageRef="Message_312oin4" />
+        <bpmn:messageEventDefinition id="MessageEventDefinition_047sqmx"
+          messageRef="Message_312oin4" />
       </bpmn:startEvent>
       <bpmn:sequenceFlow id="Flow_006eqia" sourceRef="TaskE2" targetRef="Event_13rtwuo" />
       <bpmn:sequenceFlow id="Flow_1f7mn63" sourceRef="MessageStartEvent" targetRef="TaskE2" />
     </bpmn:subProcess>
-    <bpmn:receiveTask id="MessageReceiveTask2" name="Message receive task 2" messageRef="Message_1r6tus3">
+    <bpmn:receiveTask id="MessageReceiveTask2" name="Message receive task 2"
+      messageRef="Message_1r6tus3">
       <bpmn:incoming>Flow_00bezny</bpmn:incoming>
       <bpmn:outgoing>Flow_16drwmj</bpmn:outgoing>
     </bpmn:receiveTask>
@@ -266,7 +287,8 @@
         <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT1S</bpmn:timeDuration>
       </bpmn:timerEventDefinition>
     </bpmn:intermediateCatchEvent>
-    <bpmn:intermediateCatchEvent id="MessageIntermediateCatchB2" name="Message intermediate catch B2">
+    <bpmn:intermediateCatchEvent id="MessageIntermediateCatchB2"
+      name="Message intermediate catch B2">
       <bpmn:incoming>Flow_0v8bsdg</bpmn:incoming>
       <bpmn:outgoing>Flow_17zq5s0</bpmn:outgoing>
       <bpmn:messageEventDefinition id="MessageEventDefinition_17s00ai" messageRef="Message_0qjep2d" />
@@ -276,13 +298,18 @@
       <bpmn:incoming>Flow_17zq5s0</bpmn:incoming>
       <bpmn:outgoing>Flow_0u9dvrj</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="Flow_126yu9s" name="&#60; 0" sourceRef="ExclusiveGateway2" targetRef="Gateway_1cs756a">
+    <bpmn:sequenceFlow id="Flow_126yu9s" name="&#60; 0" sourceRef="ExclusiveGateway2"
+      targetRef="Gateway_1cs756a">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=unknownVariable &lt; 0</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_0guz7jv" sourceRef="EventBasedGateway2" targetRef="TimerIntermediateCatchB2" />
-    <bpmn:sequenceFlow id="Flow_0v8bsdg" sourceRef="EventBasedGateway2" targetRef="MessageIntermediateCatchB2" />
-    <bpmn:sequenceFlow id="Flow_0j0qeck" sourceRef="TimerIntermediateCatchB2" targetRef="Gateway_0ftzss1" />
-    <bpmn:sequenceFlow id="Flow_17zq5s0" sourceRef="MessageIntermediateCatchB2" targetRef="Gateway_0ftzss1" />
+    <bpmn:sequenceFlow id="Flow_0guz7jv" sourceRef="EventBasedGateway2"
+      targetRef="TimerIntermediateCatchB2" />
+    <bpmn:sequenceFlow id="Flow_0v8bsdg" sourceRef="EventBasedGateway2"
+      targetRef="MessageIntermediateCatchB2" />
+    <bpmn:sequenceFlow id="Flow_0j0qeck" sourceRef="TimerIntermediateCatchB2"
+      targetRef="Gateway_0ftzss1" />
+    <bpmn:sequenceFlow id="Flow_17zq5s0" sourceRef="MessageIntermediateCatchB2"
+      targetRef="Gateway_0ftzss1" />
     <bpmn:intermediateThrowEvent id="SignalIntermediateThrow" name="Signal intermediate throw">
       <bpmn:incoming>Flow_041w5kk</bpmn:incoming>
       <bpmn:outgoing>Flow_1359yom</bpmn:outgoing>
@@ -293,8 +320,10 @@
       <bpmn:outgoing>Flow_04ta31i</bpmn:outgoing>
       <bpmn:signalEventDefinition id="SignalEventDefinition_0wy1une" signalRef="Signal_0j5das4" />
     </bpmn:intermediateCatchEvent>
-    <bpmn:sequenceFlow id="Flow_1359yom" sourceRef="SignalIntermediateThrow" targetRef="SignalIntermediateCatch2" />
-    <bpmn:subProcess id="SignalEventSubProcess2" name="Signal event sub process 2" triggeredByEvent="true">
+    <bpmn:sequenceFlow id="Flow_1359yom" sourceRef="SignalIntermediateThrow"
+      targetRef="SignalIntermediateCatch2" />
+    <bpmn:subProcess id="SignalEventSubProcess2" name="Signal event sub process 2"
+      triggeredByEvent="true">
       <bpmn:endEvent id="Event_0opmx5v">
         <bpmn:incoming>Flow_1tl6j8a</bpmn:incoming>
       </bpmn:endEvent>
@@ -312,7 +341,8 @@
       <bpmn:endEvent id="Event_049m1di">
         <bpmn:incoming>Flow_0bfr615</bpmn:incoming>
       </bpmn:endEvent>
-      <bpmn:boundaryEvent id="SignalBoudaryEvent2" name="Signal boundary event 2" attachedToRef="TaskH">
+      <bpmn:boundaryEvent id="SignalBoudaryEvent2" name="Signal boundary event 2"
+        attachedToRef="TaskH">
         <bpmn:outgoing>Flow_0bfr615</bpmn:outgoing>
         <bpmn:signalEventDefinition id="SignalEventDefinition_0o1z67o" signalRef="Signal_0j5das4" />
       </bpmn:boundaryEvent>
@@ -330,7 +360,8 @@
       <bpmn:startEvent id="SubProcessStartEvent">
         <bpmn:outgoing>Flow_04fbdug</bpmn:outgoing>
       </bpmn:startEvent>
-      <bpmn:subProcess id="ErrorEventSubProcess" name="Error event sub process" triggeredByEvent="true">
+      <bpmn:subProcess id="ErrorEventSubProcess" name="Error event sub process"
+        triggeredByEvent="true">
         <bpmn:startEvent id="ErrorStartEvent" name="Error start event">
           <bpmn:outgoing>Flow_1nc8qvq</bpmn:outgoing>
           <bpmn:errorEventDefinition id="ErrorEventDefinition_1jxc702" errorRef="Error_0guddpc" />
@@ -348,7 +379,8 @@
         <bpmn:sequenceFlow id="Flow_1nc8qvq" sourceRef="ErrorStartEvent" targetRef="TaskG" />
         <bpmn:sequenceFlow id="Flow_1n6hwxq" sourceRef="TaskG" targetRef="Event_12yeu6m" />
       </bpmn:subProcess>
-      <bpmn:sequenceFlow id="Flow_04fbdug" sourceRef="SubProcessStartEvent" targetRef="ErrorEndEvent" />
+      <bpmn:sequenceFlow id="Flow_04fbdug" sourceRef="SubProcessStartEvent"
+        targetRef="ErrorEndEvent" />
     </bpmn:subProcess>
     <bpmn:subProcess id="MultiInstanceSubProcess2" name="Multi instance sub process 2">
       <bpmn:incoming>Flow_0nfno00</bpmn:incoming>
@@ -388,7 +420,8 @@
       <bpmn:intermediateThrowEvent id="Event_0iwm1fq">
         <bpmn:incoming>Flow_0bbhalt</bpmn:incoming>
         <bpmn:outgoing>Flow_12rxp59</bpmn:outgoing>
-        <bpmn:escalationEventDefinition id="EscalationEventDefinition_0a4p2il" escalationRef="Escalation_1fppfbl" />
+        <bpmn:escalationEventDefinition id="EscalationEventDefinition_0a4p2il"
+          escalationRef="Escalation_1fppfbl" />
       </bpmn:intermediateThrowEvent>
       <bpmn:startEvent id="Event_1vxuw3v">
         <bpmn:outgoing>Flow_0qxvh80</bpmn:outgoing>
@@ -404,9 +437,11 @@
       <bpmn:sequenceFlow id="Flow_0bbhalt" sourceRef="EscalationTask" targetRef="Event_0iwm1fq" />
       <bpmn:sequenceFlow id="Flow_0qxvh80" sourceRef="Event_1vxuw3v" targetRef="EscalationTask" />
     </bpmn:subProcess>
-    <bpmn:boundaryEvent id="EscalationBoundaryEvent" name="Escalation boundary event" attachedToRef="EscalationSubProcess">
+    <bpmn:boundaryEvent id="EscalationBoundaryEvent" name="Escalation boundary event"
+      attachedToRef="EscalationSubProcess">
       <bpmn:outgoing>Flow_19stf58</bpmn:outgoing>
-      <bpmn:escalationEventDefinition id="EscalationEventDefinition_164va8l" escalationRef="Escalation_1fppfbl" />
+      <bpmn:escalationEventDefinition id="EscalationEventDefinition_164va8l"
+        escalationRef="Escalation_1fppfbl" />
     </bpmn:boundaryEvent>
     <bpmn:sequenceFlow id="Flow_13zdve9" sourceRef="Gateway_1" targetRef="Gateway_2" />
     <bpmn:parallelGateway id="Gateway_1">
@@ -414,6 +449,8 @@
       <bpmn:outgoing>Flow_13zdve9</bpmn:outgoing>
       <bpmn:outgoing>Flow_1rs7xob</bpmn:outgoing>
       <bpmn:outgoing>Flow_1hxtfne</bpmn:outgoing>
+      <bpmn:outgoing>Flow_013v9pn</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1tp7z6r</bpmn:outgoing>
     </bpmn:parallelGateway>
     <bpmn:parallelGateway id="Gateway_4">
       <bpmn:incoming>Flow_1rs7xob</bpmn:incoming>
@@ -453,10 +490,13 @@
       <bpmn:incoming>Flow_1ibxab9</bpmn:incoming>
       <bpmn:incoming>Flow_1c49dph</bpmn:incoming>
       <bpmn:incoming>Flow_0f4n4wb</bpmn:incoming>
+      <bpmn:incoming>Flow_0xe17zu</bpmn:incoming>
+      <bpmn:incoming>Flow_0ni9op7</bpmn:incoming>
       <bpmn:outgoing>Flow_1tyhemw</bpmn:outgoing>
     </bpmn:parallelGateway>
     <bpmn:sequenceFlow id="Flow_1c49dph" sourceRef="Gateway_5" targetRef="Gateway_6" />
-    <bpmn:subProcess id="EscalationEventSubProcess" name="Escalation event sub process" triggeredByEvent="true">
+    <bpmn:subProcess id="EscalationEventSubProcess" name="Escalation event sub process"
+      triggeredByEvent="true">
       <bpmn:endEvent id="Event_1cmlzk4">
         <bpmn:incoming>Flow_0of03mm</bpmn:incoming>
       </bpmn:endEvent>
@@ -467,19 +507,24 @@
         <bpmn:incoming>Flow_0vd8mzp</bpmn:incoming>
         <bpmn:outgoing>Flow_0of03mm</bpmn:outgoing>
       </bpmn:serviceTask>
-      <bpmn:startEvent id="EscalationStartEvent" name="Escalation start event" isInterrupting="false">
+      <bpmn:startEvent id="EscalationStartEvent" name="Escalation start event"
+        isInterrupting="false">
         <bpmn:outgoing>Flow_0vd8mzp</bpmn:outgoing>
-        <bpmn:escalationEventDefinition id="EscalationEventDefinition_0wxb74s" escalationRef="Escalation_1fppfbl" />
+        <bpmn:escalationEventDefinition id="EscalationEventDefinition_0wxb74s"
+          escalationRef="Escalation_1fppfbl" />
       </bpmn:startEvent>
       <bpmn:sequenceFlow id="Flow_0of03mm" sourceRef="EscalationEventTask" targetRef="Event_1cmlzk4" />
-      <bpmn:sequenceFlow id="Flow_0vd8mzp" sourceRef="EscalationStartEvent" targetRef="EscalationEventTask" />
+      <bpmn:sequenceFlow id="Flow_0vd8mzp" sourceRef="EscalationStartEvent"
+        targetRef="EscalationEventTask" />
     </bpmn:subProcess>
     <bpmn:intermediateThrowEvent id="EscalationThrowEvent">
       <bpmn:incoming>Flow_0ykwgtn</bpmn:incoming>
       <bpmn:outgoing>Flow_0bhp20l</bpmn:outgoing>
-      <bpmn:escalationEventDefinition id="EscalationEventDefinition_1aqu025" escalationRef="Escalation_1fppfbl" />
+      <bpmn:escalationEventDefinition id="EscalationEventDefinition_1aqu025"
+        escalationRef="Escalation_1fppfbl" />
     </bpmn:intermediateThrowEvent>
-    <bpmn:sequenceFlow id="Flow_0bhp20l" sourceRef="EscalationThrowEvent" targetRef="EscalationSubProcess" />
+    <bpmn:sequenceFlow id="Flow_0bhp20l" sourceRef="EscalationThrowEvent"
+      targetRef="EscalationSubProcess" />
     <bpmn:intermediateThrowEvent id="CompensationThrowEvent" name="Compensation throw event">
       <bpmn:incoming>Flow_0ejrzsk</bpmn:incoming>
       <bpmn:outgoing>Flow_0f4n4wb</bpmn:outgoing>
@@ -493,13 +538,212 @@
       <bpmn:outgoing>Flow_0ejrzsk</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:task id="UndoTask" name="Undo" isForCompensation="true" />
-    <bpmn:boundaryEvent id="CompensationBoundaryEvent" name="Compensation boundary event" attachedToRef="CompensationTask">
+    <bpmn:boundaryEvent id="CompensationBoundaryEvent" name="Compensation boundary event"
+      attachedToRef="CompensationTask">
       <bpmn:compensateEventDefinition id="CompensateEventDefinition_1a309d0" />
     </bpmn:boundaryEvent>
-    <bpmn:sequenceFlow id="Flow_0ejrzsk" sourceRef="CompensationTask" targetRef="CompensationThrowEvent" />
+    <bpmn:sequenceFlow id="Flow_0ejrzsk" sourceRef="CompensationTask"
+      targetRef="CompensationThrowEvent" />
     <bpmn:sequenceFlow id="Flow_1hxtfne" sourceRef="Gateway_1" targetRef="CompensationTask" />
     <bpmn:sequenceFlow id="Flow_0f4n4wb" sourceRef="CompensationThrowEvent" targetRef="Gateway_6" />
-    <bpmn:association id="Association_0xok9ld" associationDirection="One" sourceRef="CompensationBoundaryEvent" targetRef="UndoTask" />
+    <bpmn:adHocSubProcess id="AdHocSubProcess2" name="Ad hoc sub process 2">
+      <bpmn:extensionElements>
+        <zeebe:adHoc activeElementsCollection="=[&#34;TaskI2&#34;]" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0rawrrz</bpmn:incoming>
+      <bpmn:outgoing>Flow_1acta43</bpmn:outgoing>
+      <bpmn:serviceTask id="TaskI2" name="Task I2">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="foo" />
+        </bpmn:extensionElements>
+      </bpmn:serviceTask>
+    </bpmn:adHocSubProcess>
+    <bpmn:adHocSubProcess id="SequentialMultiInstanceAdHocSubProcess2"
+      name="Sequential multi instance Ad hoc sub process 2">
+      <bpmn:extensionElements>
+        <zeebe:adHoc activeElementsCollection="=[&#34;TaskK2&#34;]" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1v1ohc8</bpmn:incoming>
+      <bpmn:outgoing>Flow_19ud3sr</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics isSequential="true">
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="=[&#34;inputCollection&#34;]" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+      <bpmn:serviceTask id="TaskK2" name="Task K2">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="foo" />
+        </bpmn:extensionElements>
+      </bpmn:serviceTask>
+    </bpmn:adHocSubProcess>
+    <bpmn:adHocSubProcess id="ParallelMultiInstanceAdHocSubProcess2"
+      name="Parallel multi instance Ad hoc sub process 2">
+      <bpmn:extensionElements>
+        <zeebe:adHoc activeElementsCollection="=[&#34;TaskJ2&#34;]" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0cowwuj</bpmn:incoming>
+      <bpmn:outgoing>Flow_1xki2u7</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="=[&#34;inputCollection&#34;]" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+      <bpmn:serviceTask id="TaskJ2" name="Task J2">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="foo" />
+        </bpmn:extensionElements>
+      </bpmn:serviceTask>
+    </bpmn:adHocSubProcess>
+    <bpmn:parallelGateway id="Gateway_1wrnxon">
+      <bpmn:incoming>Flow_013v9pn</bpmn:incoming>
+      <bpmn:outgoing>Flow_0rawrrz</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0cowwuj</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1v1ohc8</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:parallelGateway id="Gateway_1azg5ns">
+      <bpmn:incoming>Flow_19ud3sr</bpmn:incoming>
+      <bpmn:incoming>Flow_1xki2u7</bpmn:incoming>
+      <bpmn:incoming>Flow_1acta43</bpmn:incoming>
+      <bpmn:outgoing>Flow_0xe17zu</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_19ud3sr" sourceRef="SequentialMultiInstanceAdHocSubProcess2"
+      targetRef="Gateway_1azg5ns" />
+    <bpmn:sequenceFlow id="Flow_1xki2u7" sourceRef="ParallelMultiInstanceAdHocSubProcess2"
+      targetRef="Gateway_1azg5ns" />
+    <bpmn:sequenceFlow id="Flow_1acta43" sourceRef="AdHocSubProcess2" targetRef="Gateway_1azg5ns" />
+    <bpmn:sequenceFlow id="Flow_013v9pn" sourceRef="Gateway_1" targetRef="Gateway_1wrnxon" />
+    <bpmn:sequenceFlow id="Flow_0rawrrz" sourceRef="Gateway_1wrnxon" targetRef="AdHocSubProcess2" />
+    <bpmn:sequenceFlow id="Flow_0cowwuj" sourceRef="Gateway_1wrnxon"
+      targetRef="ParallelMultiInstanceAdHocSubProcess2" />
+    <bpmn:sequenceFlow id="Flow_1v1ohc8" sourceRef="Gateway_1wrnxon"
+      targetRef="SequentialMultiInstanceAdHocSubProcess2" />
+    <bpmn:sequenceFlow id="Flow_0xe17zu" sourceRef="Gateway_1azg5ns" targetRef="Gateway_6" />
+    <bpmn:parallelGateway id="Gateway_0fnm4hh">
+      <bpmn:incoming>Flow_1tp7z6r</bpmn:incoming>
+      <bpmn:outgoing>Flow_1jrw5g8</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0x7mnk9</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:adHocSubProcess id="AgentTools2" name="Agent tools 2">
+      <bpmn:extensionElements>
+        <zeebe:adHoc activeElementsCollection="=[toolCall._meta.name]" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1yc0op3</bpmn:incoming>
+      <bpmn:outgoing>Flow_0mekit0</bpmn:outgoing>
+      <bpmn:scriptTask id="GetDateAndTimeTask2" name="Get Date and Time - Task 2">
+        <bpmn:extensionElements>
+          <zeebe:script expression="=now()" resultVariable="toolCallResult" />
+        </bpmn:extensionElements>
+      </bpmn:scriptTask>
+    </bpmn:adHocSubProcess>
+    <bpmn:adHocSubProcess id="AIAgentsubprocess2" name="AI Agent sub process 2"
+      zeebe:modelerTemplate="io.camunda.connectors.agenticai.aiagent.jobworker.v1"
+      zeebe:modelerTemplateVersion="6"
+      zeebe:modelerTemplateIcon="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzIiIGhlaWdodD0iMzIiIHZpZXdCb3g9IjAgMCAzMiAzMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGNpcmNsZSBjeD0iMTYiIGN5PSIxNiIgcj0iMTYiIGZpbGw9IiNBNTZFRkYiLz4KPG1hc2sgaWQ9InBhdGgtMi1vdXRzaWRlLTFfMTg1XzYiIG1hc2tVbml0cz0idXNlclNwYWNlT25Vc2UiIHg9IjQiIHk9IjQiIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgZmlsbD0iYmxhY2siPgo8cmVjdCBmaWxsPSJ3aGl0ZSIgeD0iNCIgeT0iNCIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0Ii8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjAuMDEwNSAxMi4wOTg3QzE4LjQ5IDEwLjU4OTQgMTcuMTU5NCA4LjEwODE0IDE2LjE3OTkgNi4wMTEwM0MxNi4xNTIgNi4wMDQ1MSAxNi4xMTc2IDYgMTYuMDc5NCA2QzE2LjA0MTEgNiAxNi4wMDY2IDYuMDA0NTEgMTUuOTc4OCA2LjAxMTA0QzE0Ljk5OTQgOC4xMDgxNCAxMy42Njk3IDEwLjU4ODkgMTIuMTQ4MSAxMi4wOTgxQzEwLjYyNjkgMTMuNjA3MSA4LjEyNTY4IDE0LjkyNjQgNi4wMTE1NyAxNS44OTgxQzYuMDA0NzQgMTUuOTI2MSA2IDE1Ljk2MTEgNiAxNkM2IDE2LjAzODcgNi4wMDQ2OCAxNi4wNzM2IDYuMDExNDQgMTYuMTAxNEM4LjEyNTE5IDE3LjA3MjkgMTAuNjI2MiAxOC4zOTE5IDEyLjE0NzcgMTkuOTAxNkMxMy42Njk3IDIxLjQxMDcgMTQuOTk5NiAyMy44OTIgMTUuOTc5MSAyNS45ODlDMTYuMDA2OCAyNS45OTU2IDE2LjA0MTEgMjYgMTYuMDc5MyAyNkMxNi4xMTc1IDI2IDE2LjE1MTkgMjUuOTk1NCAxNi4xNzk2IDI1Ljk4OUMxNy4xNTkxIDIzLjg5MiAxOC40ODg4IDIxLjQxMSAyMC4wMDk5IDE5LjkwMjFNMjAuMDA5OSAxOS45MDIxQzIxLjUyNTMgMTguMzk4NyAyMy45NDY1IDE3LjA2NjkgMjUuOTkxNSAxNi4wODI0QzI1Ljk5NjUgMTYuMDU5MyAyNiAxNi4wMzEgMjYgMTUuOTk5N0MyNiAxNS45Njg0IDI1Ljk5NjUgMTUuOTQwMyAyNS45OTE1IDE1LjkxNzFDMjMuOTQ3NCAxNC45MzI3IDIxLjUyNTkgMTMuNjAxIDIwLjAxMDUgMTIuMDk4NyIvPgo8L21hc2s+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjAuMDEwNSAxMi4wOTg3QzE4LjQ5IDEwLjU4OTQgMTcuMTU5NCA4LjEwODE0IDE2LjE3OTkgNi4wMTEwM0MxNi4xNTIgNi4wMDQ1MSAxNi4xMTc2IDYgMTYuMDc5NCA2QzE2LjA0MTEgNiAxNi4wMDY2IDYuMDA0NTEgMTUuOTc4OCA2LjAxMTA0QzE0Ljk5OTQgOC4xMDgxNCAxMy42Njk3IDEwLjU4ODkgMTIuMTQ4MSAxMi4wOTgxQzEwLjYyNjkgMTMuNjA3MSA4LjEyNTY4IDE0LjkyNjQgNi4wMTE1NyAxNS44OTgxQzYuMDA0NzQgMTUuOTI2MSA2IDE1Ljk2MTEgNiAxNkM2IDE2LjAzODcgNi4wMDQ2OCAxNi4wNzM2IDYuMDExNDQgMTYuMTAxNEM4LjEyNTE5IDE3LjA3MjkgMTAuNjI2MiAxOC4zOTE5IDEyLjE0NzcgMTkuOTAxNkMxMy42Njk3IDIxLjQxMDcgMTQuOTk5NiAyMy44OTIgMTUuOTc5MSAyNS45ODlDMTYuMDA2OCAyNS45OTU2IDE2LjA0MTEgMjYgMTYuMDc5MyAyNkMxNi4xMTc1IDI2IDE2LjE1MTkgMjUuOTk1NCAxNi4xNzk2IDI1Ljk4OUMxNy4xNTkxIDIzLjg5MiAxOC40ODg4IDIxLjQxMSAyMC4wMDk5IDE5LjkwMjFNMjAuMDA5OSAxOS45MDIxQzIxLjUyNTMgMTguMzk4NyAyMy45NDY1IDE3LjA2NjkgMjUuOTkxNSAxNi4wODI0QzI1Ljk5NjUgMTYuMDU5MyAyNiAxNi4wMzEgMjYgMTUuOTk5N0MyNiAxNS45Njg0IDI1Ljk5NjUgMTUuOTQwMyAyNS45OTE1IDE1LjkxNzFDMjMuOTQ3NCAxNC45MzI3IDIxLjUyNTkgMTMuNjAxIDIwLjAxMDUgMTIuMDk4NyIgZmlsbD0id2hpdGUiLz4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0yMC4wMTA1IDEyLjA5ODdDMTguNDkgMTAuNTg5NCAxNy4xNTk0IDguMTA4MTQgMTYuMTc5OSA2LjAxMTAzQzE2LjE1MiA2LjAwNDUxIDE2LjExNzYgNiAxNi4wNzk0IDZDMTYuMDQxMSA2IDE2LjAwNjYgNi4wMDQ1MSAxNS45Nzg4IDYuMDExMDRDMTQuOTk5NCA4LjEwODE0IDEzLjY2OTcgMTAuNTg4OSAxMi4xNDgxIDEyLjA5ODFDMTAuNjI2OSAxMy42MDcxIDguMTI1NjggMTQuOTI2NCA2LjAxMTU3IDE1Ljg5ODFDNi4wMDQ3NCAxNS45MjYxIDYgMTUuOTYxMSA2IDE2QzYgMTYuMDM4NyA2LjAwNDY4IDE2LjA3MzYgNi4wMTE0NCAxNi4xMDE0QzguMTI1MTkgMTcuMDcyOSAxMC42MjYyIDE4LjM5MTkgMTIuMTQ3NyAxOS45MDE2QzEzLjY2OTcgMjEuNDEwNyAxNC45OTk2IDIzLjg5MiAxNS45NzkxIDI1Ljk4OUMxNi4wMDY4IDI1Ljk5NTYgMTYuMDQxMSAyNiAxNi4wNzkzIDI2QzE2LjExNzUgMjYgMTYuMTUxOSAyNS45OTU0IDE2LjE3OTYgMjUuOTg5QzE3LjE1OTEgMjMuODkyIDE4LjQ4ODggMjEuNDExIDIwLjAwOTkgMTkuOTAyMU0yMC4wMDk5IDE5LjkwMjFDMjEuNTI1MyAxOC4zOTg3IDIzLjk0NjUgMTcuMDY2OSAyNS45OTE1IDE2LjA4MjRDMjUuOTk2NSAxNi4wNTkzIDI2IDE2LjAzMSAyNiAxNS45OTk3QzI2IDE1Ljk2ODQgMjUuOTk2NSAxNS45NDAzIDI1Ljk5MTUgMTUuOTE3MUMyMy45NDc0IDE0LjkzMjcgMjEuNTI1OSAxMy42MDEgMjAuMDEwNSAxMi4wOTg3IiBzdHJva2U9IiM0OTFEOEIiIHN0cm9rZS13aWR0aD0iNCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgbWFzaz0idXJsKCNwYXRoLTItb3V0c2lkZS0xXzE4NV82KSIvPgo8L3N2Zz4K">
+      <bpmn:extensionElements>
+        <zeebe:adHoc outputCollection="toolCallResults"
+          outputElement="={&#10;  id: toolCall._meta.id,&#10;  name: toolCall._meta.name,&#10;  content: toolCallResult&#10;}" />
+        <zeebe:taskDefinition type="io.camunda.agenticai:aiagent-job-worker:1" retries="3" />
+        <zeebe:ioMapping>
+          <zeebe:input source="openai" target="provider.type" />
+          <zeebe:input source="=&#34;openAI_Key&#34;" target="provider.openai.authentication.apiKey" />
+          <zeebe:input source="gpt-4o" target="provider.openai.model.model" />
+          <zeebe:input
+            source="=&#34;You are **TaskAgent**, a helpful, generic chat agent that can handle a wide variety of customer requests using your own domain knowledge **and** any tools explicitly provided to you at runtime.&#10;&#10;If tools are provided, you should prefer them instead of guessing an answer. You can call the same tool multiple times by providing different input values. Don&#39;t guess any tools which were not explicitly configured. If no tool matches the request, try to generate an answer. If you&#39;re not able to find a good answer, return with a message stating why you&#39;re not able to.&#10;&#10;Wrap minimal, inspectable reasoning in *exactly* this XML template:&#10;&#10;&#60;thinking&#62;&#10;&#60;context&#62;…briefly state the customer’s need and current state…&#60;/context&#62;&#10;&#60;reflection&#62;…list candidate tools, justify which you will call next and why…&#60;/reflection&#62;&#10;&#60;/thinking&#62;&#10;&#10;Reveal **no** additional private reasoning outside these tags.&#34;"
+            target="data.systemPrompt.prompt" />
+          <zeebe:input
+            source="=&#34;You will use the corresponding tools to generate the following request:&#10;&#10;- Provide me with the current date and time&#34;"
+            target="data.userPrompt.prompt" />
+          <zeebe:input target="agentContext" />
+          <zeebe:input source="in-process" target="data.memory.storage.type" />
+          <zeebe:input source="=20" target="data.memory.contextWindowSize" />
+          <zeebe:input source="=10" target="data.limits.maxModelCalls" />
+          <zeebe:input source="WAIT_FOR_TOOL_CALL_RESULTS" target="data.events.behavior" />
+          <zeebe:input source="text" target="data.response.format.type" />
+          <zeebe:input source="=false" target="data.response.format.parseJson" />
+          <zeebe:input source="=false" target="data.response.includeAssistantMessage" />
+          <zeebe:input source="=false" target="data.response.includeAgentContext" />
+          <zeebe:output source="=agent" target="agent" />
+        </zeebe:ioMapping>
+        <zeebe:taskHeaders>
+          <zeebe:header key="elementTemplateVersion" value="6" />
+          <zeebe:header key="elementTemplateId"
+            value="io.camunda.connectors.agenticai.aiagent.jobworker.v1" />
+          <zeebe:header key="retryBackoff" value="PT0S" />
+        </zeebe:taskHeaders>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0x7mnk9</bpmn:incoming>
+      <bpmn:outgoing>Flow_0l97oqw</bpmn:outgoing>
+      <bpmn:scriptTask id="GetDateAndTimeSubprocess2" name="Get Date and Time - subprocess 2">
+        <bpmn:extensionElements>
+          <zeebe:script expression="=now()" resultVariable="toolCallResult" />
+        </bpmn:extensionElements>
+      </bpmn:scriptTask>
+    </bpmn:adHocSubProcess>
+    <bpmn:exclusiveGateway id="Gateway_1qy5kyn">
+      <bpmn:incoming>Flow_0mekit0</bpmn:incoming>
+      <bpmn:incoming>Flow_1jrw5g8</bpmn:incoming>
+      <bpmn:outgoing>Flow_1je2j55</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:exclusiveGateway id="Gateway_0lovonw" default="Flow_0yyosmm">
+      <bpmn:incoming>Flow_0h1700r</bpmn:incoming>
+      <bpmn:outgoing>Flow_1yc0op3</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0yyosmm</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_0h1700r" sourceRef="AIAgentTask2" targetRef="Gateway_0lovonw" />
+    <bpmn:sequenceFlow id="Flow_1je2j55" sourceRef="Gateway_1qy5kyn" targetRef="AIAgentTask2" />
+    <bpmn:serviceTask id="AIAgentTask2" name="AI agent Task 2"
+      zeebe:modelerTemplate="io.camunda.connectors.agenticai.aiagent.v1"
+      zeebe:modelerTemplateVersion="6"
+      zeebe:modelerTemplateIcon="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzIiIGhlaWdodD0iMzIiIHZpZXdCb3g9IjAgMCAzMiAzMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGNpcmNsZSBjeD0iMTYiIGN5PSIxNiIgcj0iMTYiIGZpbGw9IiNBNTZFRkYiLz4KPG1hc2sgaWQ9InBhdGgtMi1vdXRzaWRlLTFfMTg1XzYiIG1hc2tVbml0cz0idXNlclNwYWNlT25Vc2UiIHg9IjQiIHk9IjQiIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgZmlsbD0iYmxhY2siPgo8cmVjdCBmaWxsPSJ3aGl0ZSIgeD0iNCIgeT0iNCIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0Ii8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjAuMDEwNSAxMi4wOTg3QzE4LjQ5IDEwLjU4OTQgMTcuMTU5NCA4LjEwODE0IDE2LjE3OTkgNi4wMTEwM0MxNi4xNTIgNi4wMDQ1MSAxNi4xMTc2IDYgMTYuMDc5NCA2QzE2LjA0MTEgNiAxNi4wMDY2IDYuMDA0NTEgMTUuOTc4OCA2LjAxMTA0QzE0Ljk5OTQgOC4xMDgxNCAxMy42Njk3IDEwLjU4ODkgMTIuMTQ4MSAxMi4wOTgxQzEwLjYyNjkgMTMuNjA3MSA4LjEyNTY4IDE0LjkyNjQgNi4wMTE1NyAxNS44OTgxQzYuMDA0NzQgMTUuOTI2MSA2IDE1Ljk2MTEgNiAxNkM2IDE2LjAzODcgNi4wMDQ2OCAxNi4wNzM2IDYuMDExNDQgMTYuMTAxNEM4LjEyNTE5IDE3LjA3MjkgMTAuNjI2MiAxOC4zOTE5IDEyLjE0NzcgMTkuOTAxNkMxMy42Njk3IDIxLjQxMDcgMTQuOTk5NiAyMy44OTIgMTUuOTc5MSAyNS45ODlDMTYuMDA2OCAyNS45OTU2IDE2LjA0MTEgMjYgMTYuMDc5MyAyNkMxNi4xMTc1IDI2IDE2LjE1MTkgMjUuOTk1NCAxNi4xNzk2IDI1Ljk4OUMxNy4xNTkxIDIzLjg5MiAxOC40ODg4IDIxLjQxMSAyMC4wMDk5IDE5LjkwMjFNMjAuMDA5OSAxOS45MDIxQzIxLjUyNTMgMTguMzk4NyAyMy45NDY1IDE3LjA2NjkgMjUuOTkxNSAxNi4wODI0QzI1Ljk5NjUgMTYuMDU5MyAyNiAxNi4wMzEgMjYgMTUuOTk5N0MyNiAxNS45Njg0IDI1Ljk5NjUgMTUuOTQwMyAyNS45OTE1IDE1LjkxNzFDMjMuOTQ3NCAxNC45MzI3IDIxLjUyNTkgMTMuNjAxIDIwLjAxMDUgMTIuMDk4NyIvPgo8L21hc2s+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjAuMDEwNSAxMi4wOTg3QzE4LjQ5IDEwLjU4OTQgMTcuMTU5NCA4LjEwODE0IDE2LjE3OTkgNi4wMTEwM0MxNi4xNTIgNi4wMDQ1MSAxNi4xMTc2IDYgMTYuMDc5NCA2QzE2LjA0MTEgNiAxNi4wMDY2IDYuMDA0NTEgMTUuOTc4OCA2LjAxMTA0QzE0Ljk5OTQgOC4xMDgxNCAxMy42Njk3IDEwLjU4ODkgMTIuMTQ4MSAxMi4wOTgxQzEwLjYyNjkgMTMuNjA3MSA4LjEyNTY4IDE0LjkyNjQgNi4wMTE1NyAxNS44OTgxQzYuMDA0NzQgMTUuOTI2MSA2IDE1Ljk2MTEgNiAxNkM2IDE2LjAzODcgNi4wMDQ2OCAxNi4wNzM2IDYuMDExNDQgMTYuMTAxNEM4LjEyNTE5IDE3LjA3MjkgMTAuNjI2MiAxOC4zOTE5IDEyLjE0NzcgMTkuOTAxNkMxMy42Njk3IDIxLjQxMDcgMTQuOTk5NiAyMy44OTIgMTUuOTc5MSAyNS45ODlDMTYuMDA2OCAyNS45OTU2IDE2LjA0MTEgMjYgMTYuMDc5MyAyNkMxNi4xMTc1IDI2IDE2LjE1MTkgMjUuOTk1NCAxNi4xNzk2IDI1Ljk4OUMxNy4xNTkxIDIzLjg5MiAxOC40ODg4IDIxLjQxMSAyMC4wMDk5IDE5LjkwMjFNMjAuMDA5OSAxOS45MDIxQzIxLjUyNTMgMTguMzk4NyAyMy45NDY1IDE3LjA2NjkgMjUuOTkxNSAxNi4wODI0QzI1Ljk5NjUgMTYuMDU5MyAyNiAxNi4wMzEgMjYgMTUuOTk5N0MyNiAxNS45Njg0IDI1Ljk5NjUgMTUuOTQwMyAyNS45OTE1IDE1LjkxNzFDMjMuOTQ3NCAxNC45MzI3IDIxLjUyNTkgMTMuNjAxIDIwLjAxMDUgMTIuMDk4NyIgZmlsbD0id2hpdGUiLz4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0yMC4wMTA1IDEyLjA5ODdDMTguNDkgMTAuNTg5NCAxNy4xNTk0IDguMTA4MTQgMTYuMTc5OSA2LjAxMTAzQzE2LjE1MiA2LjAwNDUxIDE2LjExNzYgNiAxNi4wNzk0IDZDMTYuMDQxMSA2IDE2LjAwNjYgNi4wMDQ1MSAxNS45Nzg4IDYuMDExMDRDMTQuOTk5NCA4LjEwODE0IDEzLjY2OTcgMTAuNTg4OSAxMi4xNDgxIDEyLjA5ODFDMTAuNjI2OSAxMy42MDcxIDguMTI1NjggMTQuOTI2NCA2LjAxMTU3IDE1Ljg5ODFDNi4wMDQ3NCAxNS45MjYxIDYgMTUuOTYxMSA2IDE2QzYgMTYuMDM4NyA2LjAwNDY4IDE2LjA3MzYgNi4wMTE0NCAxNi4xMDE0QzguMTI1MTkgMTcuMDcyOSAxMC42MjYyIDE4LjM5MTkgMTIuMTQ3NyAxOS45MDE2QzEzLjY2OTcgMjEuNDEwNyAxNC45OTk2IDIzLjg5MiAxNS45NzkxIDI1Ljk4OUMxNi4wMDY4IDI1Ljk5NTYgMTYuMDQxMSAyNiAxNi4wNzkzIDI2QzE2LjExNzUgMjYgMTYuMTUxOSAyNS45OTU0IDE2LjE3OTYgMjUuOTg5QzE3LjE1OTEgMjMuODkyIDE4LjQ4ODggMjEuNDExIDIwLjAwOTkgMTkuOTAyMU0yMC4wMDk5IDE5LjkwMjFDMjEuNTI1MyAxOC4zOTg3IDIzLjk0NjUgMTcuMDY2OSAyNS45OTE1IDE2LjA4MjRDMjUuOTk2NSAxNi4wNTkzIDI2IDE2LjAzMSAyNiAxNS45OTk3QzI2IDE1Ljk2ODQgMjUuOTk2NSAxNS45NDAzIDI1Ljk5MTUgMTUuOTE3MUMyMy45NDc0IDE0LjkzMjcgMjEuNTI1OSAxMy42MDEgMjAuMDEwNSAxMi4wOTg3IiBzdHJva2U9IiM0OTFEOEIiIHN0cm9rZS13aWR0aD0iNCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgbWFzaz0idXJsKCNwYXRoLTItb3V0c2lkZS0xXzE4NV82KSIvPgo8L3N2Zz4K">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="io.camunda.agenticai:aiagent:1" retries="3" />
+        <zeebe:ioMapping>
+          <zeebe:input source="openai" target="provider.type" />
+          <zeebe:input source="=&#34;openAI_Key&#34;" target="provider.openai.authentication.apiKey" />
+          <zeebe:input source="gpt-4o" target="provider.openai.model.model" />
+          <zeebe:input
+            source="=&#34;You are **TaskAgent**, a helpful, generic chat agent that can handle a wide variety of customer requests using your own domain knowledge **and** any tools explicitly provided to you at runtime.&#10;&#10;If tools are provided, you should prefer them instead of guessing an answer. You can call the same tool multiple times by providing different input values. Don&#39;t guess any tools which were not explicitly configured. If no tool matches the request, try to generate an answer. If you&#39;re not able to find a good answer, return with a message stating why you&#39;re not able to.&#10;&#10;Wrap minimal, inspectable reasoning in *exactly* this XML template:&#10;&#10;&#60;thinking&#62;&#10;&#60;context&#62;…briefly state the customer’s need and current state…&#60;/context&#62;&#10;&#60;reflection&#62;…list candidate tools, justify which you will call next and why…&#60;/reflection&#62;&#10;&#60;/thinking&#62;&#10;&#10;Reveal **no** additional private reasoning outside these tags.&#34;"
+            target="data.systemPrompt.prompt" />
+          <zeebe:input
+            source="=&#34;You will use the corresponding tools to generate the following request:&#10;&#10;- Provide me with the current date and time&#34;"
+            target="data.userPrompt.prompt" />
+          <zeebe:input source="AgentTools" target="data.tools.containerElementId" />
+          <zeebe:input source="=toolCallResult" target="data.tools.toolCallResults" />
+          <zeebe:input source="=agent.context" target="data.context" />
+          <zeebe:input source="in-process" target="data.memory.storage.type" />
+          <zeebe:input source="=20" target="data.memory.contextWindowSize" />
+          <zeebe:input source="=10" target="data.limits.maxModelCalls" />
+          <zeebe:input source="text" target="data.response.format.type" />
+          <zeebe:input source="=false" target="data.response.format.parseJson" />
+          <zeebe:input source="=false" target="data.response.includeAssistantMessage" />
+        </zeebe:ioMapping>
+        <zeebe:taskHeaders>
+          <zeebe:header key="elementTemplateVersion" value="6" />
+          <zeebe:header key="elementTemplateId" value="io.camunda.connectors.agenticai.aiagent.v1" />
+          <zeebe:header key="resultVariable" value="agent" />
+          <zeebe:header key="retryBackoff" value="PT0S" />
+        </zeebe:taskHeaders>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1je2j55</bpmn:incoming>
+      <bpmn:outgoing>Flow_0h1700r</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_0mekit0" sourceRef="AgentTools2" targetRef="Gateway_1qy5kyn" />
+    <bpmn:sequenceFlow id="Flow_1yc0op3" sourceRef="Gateway_0lovonw" targetRef="AgentTools2">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=not(is empty(agent.toolCalls))</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:parallelGateway id="Gateway_0znmhei">
+      <bpmn:incoming>Flow_0yyosmm</bpmn:incoming>
+      <bpmn:incoming>Flow_0l97oqw</bpmn:incoming>
+      <bpmn:outgoing>Flow_0ni9op7</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_0yyosmm" sourceRef="Gateway_0lovonw" targetRef="Gateway_0znmhei" />
+    <bpmn:sequenceFlow id="Flow_0ni9op7" sourceRef="Gateway_0znmhei" targetRef="Gateway_6" />
+    <bpmn:sequenceFlow id="Flow_1jrw5g8" sourceRef="Gateway_0fnm4hh" targetRef="Gateway_1qy5kyn" />
+    <bpmn:sequenceFlow id="Flow_1tp7z6r" sourceRef="Gateway_1" targetRef="Gateway_0fnm4hh" />
+    <bpmn:sequenceFlow id="Flow_0x7mnk9" sourceRef="Gateway_0fnm4hh" targetRef="AIAgentsubprocess2" />
+    <bpmn:sequenceFlow id="Flow_0l97oqw" sourceRef="AIAgentsubprocess2" targetRef="Gateway_0znmhei" />
+    <bpmn:association id="Association_0xok9ld" associationDirection="One"
+      sourceRef="CompensationBoundaryEvent" targetRef="UndoTask" />
   </bpmn:process>
   <bpmn:message id="Message_0so1os3" name="Message_1">
     <bpmn:extensionElements>
@@ -567,7 +811,8 @@
         <dc:Bounds x="360" y="168" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ExclusiveGateway_1qqmrb8_di" bpmnElement="ExclusiveGateway_1qqmrb8" isMarkerVisible="true">
+      <bpmndi:BPMNShape id="ExclusiveGateway_1qqmrb8_di" bpmnElement="ExclusiveGateway_1qqmrb8"
+        isMarkerVisible="true">
         <dc:Bounds x="529" y="183" width="50" height="50" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="519" y="159" width="69" height="14" />
@@ -636,7 +881,7 @@
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="EndEvent_042s0oc_di" bpmnElement="EndEvent_1">
-        <dc:Bounds x="2662" y="1662" width="36" height="36" />
+        <dc:Bounds x="3822" y="1651" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="385" y="270" width="90" height="12" />
         </bpmndi:BPMNLabel>
@@ -656,7 +901,8 @@
         <dc:Bounds x="360" y="1550" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_05lm5ha_di" bpmnElement="ExclusiveGateway2" isMarkerVisible="true">
+      <bpmndi:BPMNShape id="Gateway_05lm5ha_di" bpmnElement="ExclusiveGateway2"
+        isMarkerVisible="true">
         <dc:Bounds x="1427" y="183" width="50" height="50" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1427" y="241" width="51" height="27" />
@@ -698,22 +944,41 @@
           <dc:Bounds x="1608" y="563" width="90" height="40" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1bqc3xm_di" bpmnElement="Gateway_6">
+        <dc:Bounds x="3525" y="1644" width="50" height="50" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1a442qs_di" bpmnElement="CompensationThrowEvent">
-        <dc:Bounds x="2242" y="190" width="36" height="36" />
+        <dc:Bounds x="3402" y="179" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2227" y="233" width="71" height="27" />
+          <dc:Bounds x="3387" y="222" width="71" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_10ddbjj_di" bpmnElement="CompensationTask">
-        <dc:Bounds x="2060" y="168" width="100" height="80" />
+        <dc:Bounds x="3220" y="157" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0kfygzx_di" bpmnElement="UndoTask">
-        <dc:Bounds x="2180" y="288" width="100" height="80" />
+        <dc:Bounds x="3340" y="277" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_1bqc3xm_di" bpmnElement="Gateway_6">
-        <dc:Bounds x="2365" y="1655" width="50" height="50" />
+      <bpmndi:BPMNShape id="Gateway_0rftrqi_di" bpmnElement="Gateway_1azg5ns">
+        <dc:Bounds x="2615" y="1565" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_04ytft3" bpmnElement="Gateway_0fnm4hh">
+        <dc:Bounds x="2735" y="183" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1qy5kyn_di" bpmnElement="Gateway_1qy5kyn" isMarkerVisible="true">
+        <dc:Bounds x="2975" y="365" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0lovonw_di" bpmnElement="Gateway_0lovonw" isMarkerVisible="true">
+        <dc:Bounds x="3220" y="365" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_08j9cnb_di" bpmnElement="AIAgentTask2">
+        <dc:Bounds x="3065" y="350" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0w6sekb" bpmnElement="Gateway_0znmhei">
+        <dc:Bounds x="3365" y="1565" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_0p68nmi" bpmnElement="SubProcess" isExpanded="true">
         <dc:Bounds x="1402" y="628" width="423" height="350" />
@@ -754,7 +1019,8 @@
         <di:waypoint x="1515" y="688" />
         <di:waypoint x="1692" y="688" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_1ms6g9k_di" bpmnElement="MultiInstanceSubProcess2" isExpanded="true">
+      <bpmndi:BPMNShape id="Activity_1ms6g9k_di" bpmnElement="MultiInstanceSubProcess2"
+        isExpanded="true">
         <dc:Bounds x="1412" y="1018" width="350" height="200" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
@@ -776,7 +1042,8 @@
         <di:waypoint x="1640" y="1118" />
         <di:waypoint x="1692" y="1118" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_17jsa42_di" bpmnElement="EscalationSubProcess" isExpanded="true">
+      <bpmndi:BPMNShape id="Activity_17jsa42_di" bpmnElement="EscalationSubProcess"
+        isExpanded="true">
         <dc:Bounds x="1412" y="1248" width="350" height="200" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
@@ -817,124 +1084,173 @@
       <bpmndi:BPMNShape id="Event_1wu0r2j_di" bpmnElement="EscalationThrowEvent">
         <dc:Bounds x="1342" y="1330" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Association_0xok9ld_di" bpmnElement="Association_0xok9ld">
-        <di:waypoint x="2130" y="266" />
-        <di:waypoint x="2130" y="328" />
-        <di:waypoint x="2180" y="328" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_0cz53c2_di" bpmnElement="TimerEventSubProcess2" isExpanded="true">
-        <dc:Bounds x="2490" y="430" width="350" height="200" />
+      <bpmndi:BPMNShape id="Activity_1jfa5hv_di" bpmnElement="AdHocSubProcess2" isExpanded="true">
+        <dc:Bounds x="2190" y="507" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1ep6491_di" bpmnElement="TaskI2">
+        <dc:Bounds x="2310" y="570" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0r5e346" bpmnElement="SequentialMultiInstanceAdHocSubProcess2"
+        isExpanded="true">
+        <dc:Bounds x="2190" y="1110" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0ppj71p" bpmnElement="TaskK2">
+        <dc:Bounds x="2310" y="1173" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0a2uyvl" bpmnElement="ParallelMultiInstanceAdHocSubProcess2"
+        isExpanded="true">
+        <dc:Bounds x="2190" y="800" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0zv29h9" bpmnElement="TaskJ2">
+        <dc:Bounds x="2310" y="863" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0fi1sa1_di" bpmnElement="Gateway_1wrnxon">
+        <dc:Bounds x="2065" y="183" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0cz53c2_di" bpmnElement="TimerEventSubProcess2"
+        isExpanded="true">
+        <dc:Bounds x="3650" y="419" width="350" height="200" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0lk89tk_di" bpmnElement="Event_0lk89tk">
-        <dc:Bounds x="2752" y="512" width="36" height="36" />
+        <dc:Bounds x="3912" y="501" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0x898wf_di" bpmnElement="TaskF2">
-        <dc:Bounds x="2610" y="490" width="100" height="80" />
+        <dc:Bounds x="3770" y="479" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_01ol322_di" bpmnElement="TimerStartEvent">
-        <dc:Bounds x="2530" y="512" width="36" height="36" />
+        <dc:Bounds x="3690" y="501" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2507" y="555" width="83" height="27" />
+          <dc:Bounds x="3667" y="544" width="83" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_1rrwh6x_di" bpmnElement="Flow_1rrwh6x">
-        <di:waypoint x="2710" y="530" />
-        <di:waypoint x="2752" y="530" />
+        <di:waypoint x="3870" y="519" />
+        <di:waypoint x="3912" y="519" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0eemr1n_di" bpmnElement="Flow_0eemr1n">
-        <di:waypoint x="2566" y="530" />
-        <di:waypoint x="2610" y="530" />
+        <di:waypoint x="3726" y="519" />
+        <di:waypoint x="3770" y="519" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_0tgxt6v_di" bpmnElement="MessageEventSubProcess2" isExpanded="true">
-        <dc:Bounds x="2490" y="180" width="350" height="200" />
+      <bpmndi:BPMNShape id="Activity_0tgxt6v_di" bpmnElement="MessageEventSubProcess2"
+        isExpanded="true">
+        <dc:Bounds x="3650" y="169" width="350" height="200" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_13rtwuo_di" bpmnElement="Event_13rtwuo">
-        <dc:Bounds x="2752" y="262" width="36" height="36" />
+        <dc:Bounds x="3912" y="251" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1d9lzza_di" bpmnElement="TaskE2">
-        <dc:Bounds x="2610" y="240" width="100" height="80" />
+        <dc:Bounds x="3770" y="229" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1t7lt05_di" bpmnElement="MessageStartEvent">
-        <dc:Bounds x="2530" y="262" width="36" height="36" />
+        <dc:Bounds x="3690" y="251" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2514" y="305" width="70" height="27" />
+          <dc:Bounds x="3674" y="294" width="70" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_006eqia_di" bpmnElement="Flow_006eqia">
-        <di:waypoint x="2710" y="280" />
-        <di:waypoint x="2752" y="280" />
+        <di:waypoint x="3870" y="269" />
+        <di:waypoint x="3912" y="269" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1f7mn63_di" bpmnElement="Flow_1f7mn63">
-        <di:waypoint x="2566" y="280" />
-        <di:waypoint x="2610" y="280" />
+        <di:waypoint x="3726" y="269" />
+        <di:waypoint x="3770" y="269" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_1s001x5_di" bpmnElement="SignalEventSubProcess2" isExpanded="true">
-        <dc:Bounds x="2490" y="680" width="350" height="200" />
+      <bpmndi:BPMNShape id="Activity_1s001x5_di" bpmnElement="SignalEventSubProcess2"
+        isExpanded="true">
+        <dc:Bounds x="3650" y="669" width="350" height="200" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0opmx5v_di" bpmnElement="Event_0opmx5v">
-        <dc:Bounds x="2782" y="762" width="36" height="36" />
+        <dc:Bounds x="3942" y="751" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0v214gi_di" bpmnElement="TaskH">
-        <dc:Bounds x="2620" y="740" width="100" height="80" />
+        <dc:Bounds x="3780" y="729" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1u3z80h_di" bpmnElement="SignalStartEvent">
-        <dc:Bounds x="2530" y="762" width="36" height="36" />
+        <dc:Bounds x="3690" y="751" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2506" y="805" width="85" height="14" />
+          <dc:Bounds x="3666" y="794" width="85" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_049m1di_di" bpmnElement="Event_049m1di">
-        <dc:Bounds x="2782" y="832" width="36" height="36" />
+        <dc:Bounds x="3942" y="821" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0ch2r7b_di" bpmnElement="SignalBoudaryEvent2">
-        <dc:Bounds x="2672" y="802" width="36" height="36" />
+        <dc:Bounds x="3832" y="791" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2652" y="845" width="81" height="27" />
+          <dc:Bounds x="3813" y="834" width="80" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_1tl6j8a_di" bpmnElement="Flow_1tl6j8a">
-        <di:waypoint x="2720" y="780" />
-        <di:waypoint x="2782" y="780" />
+        <di:waypoint x="3880" y="769" />
+        <di:waypoint x="3942" y="769" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_189mrto_di" bpmnElement="Flow_189mrto">
-        <di:waypoint x="2566" y="780" />
-        <di:waypoint x="2620" y="780" />
+        <di:waypoint x="3726" y="769" />
+        <di:waypoint x="3780" y="769" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0bfr615_di" bpmnElement="Flow_0bfr615">
-        <di:waypoint x="2690" y="838" />
-        <di:waypoint x="2690" y="850" />
-        <di:waypoint x="2782" y="850" />
+        <di:waypoint x="3850" y="827" />
+        <di:waypoint x="3850" y="839" />
+        <di:waypoint x="3942" y="839" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="BPMNShape_0bwi9k5" bpmnElement="EscalationEventSubProcess" isExpanded="true">
-        <dc:Bounds x="2490" y="930" width="350" height="200" />
+      <bpmndi:BPMNShape id="BPMNShape_0bwi9k5" bpmnElement="EscalationEventSubProcess"
+        isExpanded="true">
+        <dc:Bounds x="3650" y="919" width="350" height="200" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1cmlzk4_di" bpmnElement="Event_1cmlzk4">
-        <dc:Bounds x="2782" y="1012" width="36" height="36" />
+        <dc:Bounds x="3942" y="1001" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0lqew9a_di" bpmnElement="EscalationEventTask">
-        <dc:Bounds x="2620" y="990" width="100" height="80" />
+        <dc:Bounds x="3780" y="979" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1wrkoo5_di" bpmnElement="EscalationStartEvent">
-        <dc:Bounds x="2530" y="1012" width="36" height="36" />
+        <dc:Bounds x="3690" y="1001" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2510" y="1055" width="76" height="27" />
+          <dc:Bounds x="3670" y="1044" width="76" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_0of03mm_di" bpmnElement="Flow_0of03mm">
-        <di:waypoint x="2720" y="1030" />
-        <di:waypoint x="2782" y="1030" />
+        <di:waypoint x="3880" y="1019" />
+        <di:waypoint x="3942" y="1019" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="BPMNEdge_095dl4e" bpmnElement="Flow_0vd8mzp">
-        <di:waypoint x="2566" y="1030" />
-        <di:waypoint x="2620" y="1030" />
+        <di:waypoint x="3726" y="1019" />
+        <di:waypoint x="3780" y="1019" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0xok9ld_di" bpmnElement="Association_0xok9ld">
+        <di:waypoint x="3290" y="255" />
+        <di:waypoint x="3290" y="317" />
+        <di:waypoint x="3340" y="317" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="BPMNShape_14cq402" bpmnElement="AgentTools2" isExpanded="true">
+        <dc:Bounds x="2940" y="507" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_08u4hm8_di" bpmnElement="GetDateAndTimeTask2">
+        <dc:Bounds x="3050" y="570" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1us6dd1" bpmnElement="AIAgentsubprocess2" isExpanded="true">
+        <dc:Bounds x="2940" y="800" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1er4p8u_di" bpmnElement="GetDateAndTimeSubprocess2">
+        <dc:Bounds x="3060" y="863" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0jexdxm_di" bpmnElement="EscalationBoundaryEvent">
         <dc:Bounds x="1575" y="1430" width="36" height="36" />
         <bpmndi:BPMNLabel>
@@ -966,9 +1282,9 @@
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_098t6oo_di" bpmnElement="CompensationBoundaryEvent">
-        <dc:Bounds x="2112" y="230" width="36" height="36" />
+        <dc:Bounds x="3272" y="219" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2092" y="273" width="76" height="27" />
+          <dc:Bounds x="3252" y="262" width="76" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="SequenceFlow_0j6tsnn_di" bpmnElement="SequenceFlow_0j6tsnn">
@@ -1069,8 +1385,8 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1ibxab9_di" bpmnElement="Flow_1ibxab9">
         <di:waypoint x="1130" y="1615" />
-        <di:waypoint x="1130" y="1680" />
-        <di:waypoint x="2365" y="1680" />
+        <di:waypoint x="1130" y="1669" />
+        <di:waypoint x="3525" y="1669" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0lyxcbw_di" bpmnElement="Flow_0lyxcbw">
         <di:waypoint x="460" y="769" />
@@ -1247,32 +1563,118 @@
         <di:waypoint x="1593" y="1590" />
         <di:waypoint x="1905" y="1590" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1tyhemw_di" bpmnElement="Flow_1tyhemw">
-        <di:waypoint x="2415" y="1680" />
-        <di:waypoint x="2662" y="1680" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1c49dph_di" bpmnElement="Flow_1c49dph">
         <di:waypoint x="1930" y="1615" />
-        <di:waypoint x="1930" y="1680" />
-        <di:waypoint x="2365" y="1680" />
+        <di:waypoint x="1930" y="1669" />
+        <di:waypoint x="3525" y="1669" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0bhp20l_di" bpmnElement="Flow_0bhp20l">
         <di:waypoint x="1378" y="1348" />
         <di:waypoint x="1412" y="1348" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0ejrzsk_di" bpmnElement="Flow_0ejrzsk">
-        <di:waypoint x="2160" y="208" />
-        <di:waypoint x="2242" y="208" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1hxtfne_di" bpmnElement="Flow_1hxtfne">
         <di:waypoint x="315" y="110" />
-        <di:waypoint x="2110" y="110" />
-        <di:waypoint x="2110" y="168" />
+        <di:waypoint x="3270" y="110" />
+        <di:waypoint x="3270" y="157" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_19ud3sr_di" bpmnElement="Flow_19ud3sr">
+        <di:waypoint x="2540" y="1210" />
+        <di:waypoint x="2640" y="1210" />
+        <di:waypoint x="2640" y="1565" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1xki2u7_di" bpmnElement="Flow_1xki2u7">
+        <di:waypoint x="2540" y="900" />
+        <di:waypoint x="2640" y="900" />
+        <di:waypoint x="2640" y="1565" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1acta43_di" bpmnElement="Flow_1acta43">
+        <di:waypoint x="2540" y="607" />
+        <di:waypoint x="2640" y="607" />
+        <di:waypoint x="2640" y="1565" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_013v9pn_di" bpmnElement="Flow_013v9pn">
+        <di:waypoint x="315" y="110" />
+        <di:waypoint x="2090" y="110" />
+        <di:waypoint x="2090" y="183" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0rawrrz_di" bpmnElement="Flow_0rawrrz">
+        <di:waypoint x="2090" y="233" />
+        <di:waypoint x="2090" y="607" />
+        <di:waypoint x="2190" y="607" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0cowwuj_di" bpmnElement="Flow_0cowwuj">
+        <di:waypoint x="2090" y="233" />
+        <di:waypoint x="2090" y="900" />
+        <di:waypoint x="2190" y="900" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1v1ohc8_di" bpmnElement="Flow_1v1ohc8">
+        <di:waypoint x="2090" y="233" />
+        <di:waypoint x="2090" y="1210" />
+        <di:waypoint x="2190" y="1210" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1tyhemw_di" bpmnElement="Flow_1tyhemw">
+        <di:waypoint x="3575" y="1669" />
+        <di:waypoint x="3822" y="1669" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0f4n4wb_di" bpmnElement="Flow_0f4n4wb">
-        <di:waypoint x="2278" y="208" />
-        <di:waypoint x="2390" y="208" />
-        <di:waypoint x="2390" y="1655" />
+        <di:waypoint x="3438" y="197" />
+        <di:waypoint x="3550" y="197" />
+        <di:waypoint x="3550" y="1644" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0xe17zu_di" bpmnElement="Flow_0xe17zu">
+        <di:waypoint x="2640" y="1615" />
+        <di:waypoint x="2640" y="1669" />
+        <di:waypoint x="3525" y="1669" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ejrzsk_di" bpmnElement="Flow_0ejrzsk">
+        <di:waypoint x="3320" y="197" />
+        <di:waypoint x="3402" y="197" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1je2j55_di" bpmnElement="Flow_1je2j55">
+        <di:waypoint x="3025" y="390" />
+        <di:waypoint x="3065" y="390" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0h1700r_di" bpmnElement="Flow_0h1700r">
+        <di:waypoint x="3165" y="390" />
+        <di:waypoint x="3220" y="390" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0mekit0_di" bpmnElement="Flow_0mekit0">
+        <di:waypoint x="3000" y="507" />
+        <di:waypoint x="3000" y="415" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1yc0op3_di" bpmnElement="Flow_1yc0op3">
+        <di:waypoint x="3245" y="415" />
+        <di:waypoint x="3245" y="507" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0yyosmm_di" bpmnElement="Flow_0yyosmm">
+        <di:waypoint x="3270" y="390" />
+        <di:waypoint x="3390" y="390" />
+        <di:waypoint x="3390" y="1565" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ni9op7_di" bpmnElement="Flow_0ni9op7">
+        <di:waypoint x="3390" y="1615" />
+        <di:waypoint x="3390" y="1669" />
+        <di:waypoint x="3525" y="1669" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1jrw5g8_di" bpmnElement="Flow_1jrw5g8">
+        <di:waypoint x="2760" y="233" />
+        <di:waypoint x="2760" y="390" />
+        <di:waypoint x="2975" y="390" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1tp7z6r_di" bpmnElement="Flow_1tp7z6r">
+        <di:waypoint x="315" y="110" />
+        <di:waypoint x="2760" y="110" />
+        <di:waypoint x="2760" y="183" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0x7mnk9_di" bpmnElement="Flow_0x7mnk9">
+        <di:waypoint x="2760" y="233" />
+        <di:waypoint x="2760" y="900" />
+        <di:waypoint x="2940" y="900" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0l97oqw_di" bpmnElement="Flow_0l97oqw">
+        <di:waypoint x="3290" y="900" />
+        <di:waypoint x="3390" y="900" />
+        <di:waypoint x="3390" y="1565" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
@@ -306,10 +306,13 @@ test.describe.serial('Process Instance Migration', () => {
             .replace(/^\^?target element for /i, '')
             .replace(/\$\/?i?$/, '')
             .trim();
-          await operateProcessMigrationModePage.mapFlowNode(
-            sourceFlowNodeName,
-            targetValue,
+          const escaped = sourceFlowNodeName.replace(
+            /[.*+?^${}()|[\]\\]/g,
+            '\\$&',
           );
+          await page
+            .getByLabel(new RegExp(`^Target element for ${escaped}$`, 'i'))
+            .selectOption(targetValue);
         }
       }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
@@ -165,10 +165,20 @@ test.describe.serial('Process Instance Migration', () => {
         operateProcessMigrationModePage.targetProcessCombobox,
       ).toHaveValue(targetBpmnProcessId);
 
+      // Explicitly select the target version to avoid relying on Operate's
+      // auto-selection, which can pick a different version when the cluster
+      // has prior deployments of the same bpmnProcessId.
+      await expect(operateProcessMigrationModePage.targetVersionDropdown).toBeVisible();
+      const currentTargetVersion = await operateProcessMigrationModePage.targetVersionDropdown.innerText();
+      if (currentTargetVersion.trim() !== targetVersion) {
+        await operateProcessMigrationModePage.clickTargetVersionCombo();
+        await operateProcessMigrationModePage.selectTargetVersion(targetVersion);
+      }
       await expect(
         operateProcessMigrationModePage.targetVersionDropdown,
       ).toHaveText(targetVersion, {
         useInnerText: true,
+        timeout: 10000,
       });
 
       await operateProcessMigrationModePage.verifyFlowNodeMappings([

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
@@ -1057,7 +1057,7 @@ test.describe('Parallel job-based user task migration', () => {
       });
 
       await expect(
-        operateProcessesPage.versionCells(targetVersion),
+        operateProcessesPage.getVersionCells(targetVersion),
       ).toHaveCount(totalV2InstanceCount, {timeout: 30000});
     });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
@@ -900,7 +900,18 @@ test.describe('Parallel job-based user task migration', () => {
 
   test.afterAll(async () => {
     await Promise.all(
-      parallelProcesses.map((p) => cancelProcessInstance(p.processInstanceKey)),
+      parallelProcesses.map(async (p) => {
+        try {
+          await cancelProcessInstance(p.processInstanceKey);
+        } catch (error) {
+          // Ignore 404 — instance may already be completed/cancelled or
+          // migrated to a process that has since finished.
+          const message = error instanceof Error ? error.message : String(error);
+          if (!message.includes('404') && !message.includes('NOT_FOUND')) {
+            throw error;
+          }
+        }
+      }),
     );
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
@@ -371,7 +371,7 @@ test.describe.serial('Process Instance Migration', () => {
     for (const taskId of tasksToVerify) {
       await test.step(`Verify ${taskId} instances`, async () => {
         await page.goto(
-          `operate/processes?active=true&incidents=true&processDefinitionId=${targetBpmnProcessId}&processDefinitionVersion=${targetVersion}&elementId=${taskId}`,
+          `operate/processes?active=true&incidents=true&process=${targetBpmnProcessId}&version=${targetVersion}&flowNodeId=${taskId}`,
         );
 
         await expect(page.getByText('6 results')).toBeVisible({timeout: 90000});
@@ -400,7 +400,7 @@ test.describe.serial('Process Instance Migration', () => {
     for (const taskId of tasksToVerify) {
       await test.step(`Verify ${taskId} instances`, async () => {
         await page.goto(
-          `operate/processes?active=true&incidents=true&processDefinitionId=${targetBpmnProcessId}&processDefinitionVersion=${targetVersion}&elementId=${taskId}`,
+          `operate/processes?active=true&incidents=true&process=${targetBpmnProcessId}&version=${targetVersion}&flowNodeId=${taskId}`,
         );
 
         await expect(page.getByText('6 results')).toBeVisible({

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
@@ -170,7 +170,8 @@ test.describe.serial('Process Instance Migration', () => {
       // has prior deployments of the same bpmnProcessId.
       await expect(operateProcessMigrationModePage.targetVersionDropdown).toBeVisible();
       const currentTargetVersion = await operateProcessMigrationModePage.targetVersionDropdown.innerText();
-      if (currentTargetVersion.trim() !== targetVersion) {
+      const versionChanged = currentTargetVersion.trim() !== targetVersion;
+      if (versionChanged) {
         await operateProcessMigrationModePage.clickTargetVersionCombo();
         await operateProcessMigrationModePage.selectTargetVersion(targetVersion);
       }
@@ -181,7 +182,7 @@ test.describe.serial('Process Instance Migration', () => {
         timeout: 10000,
       });
 
-      await operateProcessMigrationModePage.verifyFlowNodeMappings([
+      const flowNodeMappings: Array<{label: string | RegExp; targetValue: string}> = [
         {
           label: 'target element for check payment',
           targetValue: 'checkPayment',
@@ -292,7 +293,29 @@ test.describe.serial('Process Instance Migration', () => {
           label: 'target element for message start event',
           targetValue: 'MessageStartEvent',
         },
-      ]);
+      ];
+
+      // Operate clears auto-mappings when the target version is changed
+      // manually. If we had to override the auto-selected version, restore the
+      // mappings explicitly so the migration has flow nodes to migrate.
+      if (versionChanged) {
+        for (const {label, targetValue} of flowNodeMappings) {
+          const sourceFlowNodeName = (
+            typeof label === 'string' ? label : label.source
+          )
+            .replace(/^\^?target element for /i, '')
+            .replace(/\$\/?i?$/, '')
+            .trim();
+          await operateProcessMigrationModePage.mapFlowNode(
+            sourceFlowNodeName,
+            targetValue,
+          );
+        }
+      }
+
+      await operateProcessMigrationModePage.verifyFlowNodeMappings(
+        flowNodeMappings,
+      );
 
       await operateProcessMigrationModePage.completeProcessInstanceMigration();
     });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
@@ -58,10 +58,12 @@ const targetTaskCards: TaskCard[] = parseAssignedTasksFromFile(
 test.describe.serial('Process Instance Migration', () => {
   test.beforeAll(async () => {
 
-    await deploy(['./resources/orderProcessMigration_v_1.bpmn']);
+    const newProcessMigrationV1: DeployResourceResponse = await deploy([
+      './resources/orderProcessMigration_v_1.bpmn',
+    ]);
     const processV1: ProcessDeployment = {
       bpmnProcessId: 'orderProcessMigration',
-      version: 1,
+      version: newProcessMigrationV1.processes[0].processDefinitionVersion,
     };
 
     processes = await Promise.all(

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
@@ -1043,15 +1043,33 @@ test.describe('Parallel job-based user task migration', () => {
       ).toHaveText(targetVersion, {useInnerText: true});
     });
 
-    await test.step('Map renamed flow node: Embedded → Embedded new', async () => {
+    await test.step('Map renamed flow nodes (all V2 user tasks were renamed)', async () => {
+      // Every V1 user task is renamed in V2 ("Embedded" → "Embedded new",
+      // "camunda form" → "camunda form new", "external form" → "external
+      // form new"). Operate's auto-map matches by NAME, not by ID, so no
+      // node populates automatically even though IDs are identical between
+      // V1 and V2. Map all three explicitly to give the migration something
+      // to submit.
       await operateProcessMigrationModePage.mapFlowNode(
         'Embedded',
         'Embedded new',
       );
+      await operateProcessMigrationModePage.mapFlowNode(
+        'camunda form',
+        'camunda form new',
+      );
+      await operateProcessMigrationModePage.mapFlowNode(
+        'external form',
+        'external form new',
+      );
     });
 
-    await test.step('Verify auto-mapped flow nodes', async () => {
+    await test.step('Verify mapped flow node values', async () => {
       await operateProcessMigrationModePage.verifyFlowNodeMappings([
+        {
+          label: /target element for embedded/i,
+          targetValue: 'embedded',
+        },
         {
           label: /target element for camunda form/i,
           targetValue: 'camunda_form',

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
@@ -301,7 +301,10 @@ test.describe('task details page', () => {
     await expect(taskDetailsPage.form).toContainText('EUR 264');
     await expect(taskDetailsPage.form).toContainText('Total: EUR 544.5');
 
-    await taskDetailsPage.completeTaskButton.click();
+    await expect(taskDetailsPage.completeTaskButton).toBeEnabled({
+      timeout: 15000,
+    });
+    await taskDetailsPage.clickCompleteTaskButton();
     await expect(taskDetailsPage.taskCompletedBanner).toBeVisible({
       timeout: 60000,
     });


### PR DESCRIPTION
## Summary
Stabilizes flaky and failing tests in the C8 Orchestration Cluster nightly E2E suite on `stable/8.8`. Fixes span both Tasklist v1/v2 modes and Operate process migration tests.

### Test fixes
- **`processInstanceMigration.spec.ts`**:
  - Fixed `versionCells` → `getVersionCells` typo (method name on stable/8.8 page object differs from main).
  - Corrected URL filter params for two ad-hoc/AI-agent migration assertions: `processDefinitionId/processDefinitionVersion/elementId` → `process/version/flowNodeId` (UI-style filter params used on stable/8.8).
  - **Parallel job-based migration**: V2's BPMN renames every user task (`Embedded` → `Embedded new`, `camunda form` → `camunda form new`, `external form` → `external form new`). Operate's auto-map matches by name not by ID, so target selects stayed empty. Map all three explicitly instead of relying on auto-map for two of them.
- **`task-details.spec.ts > task completion with deployed form`**: wait for `completeTaskButton` to be enabled before clicking, avoiding a race with form validation.

### Page object hardening
- **`TaskDetailsPage.fillDynamicList`**: added click+fill+blur+assert with retries, mirroring `fillTextInput`. Newly-added dynamic list rows were re-rendering and clearing values set by `fill()`, causing v1 failures in `task completion with deployed form` and `complete process with start node having deployed form`.
- **`OperateProcessMigrationModePage.verifyFlowNodeMappings`**: bumped `toHaveValue` timeout to 30s. Auto-mapping populates target select values asynchronously after target version selection; default 5s raced with the client-side mapping computation.
- **`TaskPanelPage.filterBy`**: wraps the URL assertion in `waitForAssertion` and re-clicks the filter link if the URL does not update. Observed in v2 where the side panel link shows `[active]` state while URL stays at `/tasklist`.

## Validation

### Initial run (May 8)
https://github.com/camunda/camunda/actions/runs/25557056502

### Pre-fix run (May 15)
https://github.com/camunda/camunda/actions/runs/25920052374 — surfaced two remaining failures:
- ✘ `Migrate parallel job-based user tasks` — addressed in 2576dfe.
- ✘ `Auto mapping migration` — operations panel shows `6 operations failed` (broker-side rejection). Likely a real Operate/Zeebe migration-validation issue surfaced by the expanded BPMN fixtures (ad-hoc + AI-agent flow nodes added to V1 reach instance flow nodes that the test's mapping array doesn't cover). Triage continues; tracking separately.

### Post-fix re-validation
https://github.com/camunda/camunda/actions/runs/25921663607

**Passing on a clean CI env (from prior run; re-validating in run above):**
- ✓ `tasklist/processes-page.spec.ts:136` complete process with start node having deployed form
- ✓ `tasklist/task-details.spec.ts:269` task completion with deployed form

`processInstanceMigration.spec.ts:391` Migrated ad hoc sub processes was skipped on the May 15 run (blocked by `beforeAll` from Auto mapping migration). Local validation against a fresh broker confirmed the fix itself works for that test.

The `task-details.spec.ts:349` retry-pass is covered by #53285, not this PR.

## Test plan
- [x] Fix method name typo in `processInstanceMigration.spec.ts`
- [x] Fix URL filter params in ad-hoc/AI-agent migration assertions
- [x] Fix race in `task completion with deployed form`
- [x] Stabilize `fillDynamicList` against row re-renders
- [x] Stabilize migration auto-mapping verification
- [x] Stabilize `filterBy` against missed-click navigation
- [x] Manually map every renamed user task in parallel job-based migration test
- [ ] Address remaining `Auto mapping migration` server-side rejection (separate follow-up)
- [ ] Verify nightly E2E tests pass after merge

## Related
- Original failing run: https://github.com/camunda/camunda/actions/runs/25531226904
- Follow-up failing run: https://github.com/camunda/camunda/actions/runs/25554288840
- Companion PR for two further nightly flakes: #53285