### PR TITLE
Emit `ProcessInstanceCreation.CREATED` event after start message correlation

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogProcessOperationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogProcessOperationsIT.java
@@ -9,10 +9,13 @@ package io.camunda.it.auditlog;
 
 import static io.camunda.it.auditlog.AuditLogUtils.DEFAULT_USERNAME;
 import static io.camunda.it.auditlog.AuditLogUtils.TENANT_A;
+import static io.camunda.it.util.TestHelper.deployProcessForTenantAndWaitForIt;
+import static io.camunda.it.util.TestHelper.startProcessInstanceWithMessageForTenant;
 import static io.camunda.it.util.TestHelper.waitForBatchOperationCompleted;
 import static io.camunda.it.util.TestHelper.waitForBatchOperationWithCorrectTotalCount;
 import static io.camunda.it.util.TestHelper.waitForDecisionsToBeDeployed;
 import static io.camunda.it.util.TestHelper.waitForJobs;
+import static io.camunda.it.util.TestHelper.waitForProcessInstances;
 import static io.camunda.it.util.TestHelper.waitForProcessInstancesToBeCompleted;
 import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
 import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
@@ -38,6 +41,7 @@ import io.camunda.client.api.search.response.Job;
 import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import java.time.Duration;
 import java.util.List;
@@ -72,8 +76,10 @@ public class AuditLogProcessOperationsIT {
   private static final String SERVICE_TASKS_PROCESS_ID = "service_tasks_v1";
   private static final String DECISION_ID = "decision_1";
   private static final String PROCESS_WITH_BUSINESS_RULE_TASK_ID = "business_rule_task_process";
+  private static final String PROCESS_WITH_MESSAGE_START = "process_with_message_start";
+  private static final String PROCESS_WITH_MESSAGE_START_2 = "process_with_message_start_2";
+  private static final String PROCESS_WITH_SIGNAL_START = "process_with_signal_start";
   private static CamundaClient adminClient;
-  private static AuditLogUtils utils;
 
   // Pre-created process instance for tests that only read/add variables
   private static long sharedProcessInstanceKey;
@@ -81,7 +87,7 @@ public class AuditLogProcessOperationsIT {
 
   @BeforeAll
   static void setup() {
-    utils = new AuditLogUtils(adminClient).init();
+    new AuditLogUtils(adminClient).init();
 
     final var deploymentFutures =
         java.util.stream.Stream.of(
@@ -90,7 +96,10 @@ public class AuditLogProcessOperationsIT {
                 "process/service_tasks_v1.bpmn",
                 "process/incident_process_v1.bpmn",
                 "decisions/decision_model.dmn",
-                "process/business_rule_task_process.bpmn")
+                "process/business_rule_task_process.bpmn",
+                "process/process_with_message_start.bpmn",
+                "process/process_with_message_start_2.bpmn",
+                "process/process_with_signal_start.bpmn")
             .map(
                 resource ->
                     adminClient
@@ -150,6 +159,152 @@ public class AuditLogProcessOperationsIT {
         processInstanceKey,
         processInstance.getProcessDefinitionKey(),
         SERVICE_TASKS_PROCESS_ID);
+  }
+
+  @Test
+  void shouldTrackProcessInstanceCreationViaMessageCorrelation(
+      @Authenticated(DEFAULT_USERNAME) final CamundaClient client) {
+    // when - correlate a message that starts the process instance
+    startProcessInstanceWithMessageForTenant(client, PROCESS_WITH_MESSAGE_START, TENANT_A);
+    final var processInstance =
+        waitForProcessInstances(client, f -> f.processDefinitionId(PROCESS_WITH_MESSAGE_START), 1)
+            .getFirst();
+    final var processInstanceKey = processInstance.getProcessInstanceKey();
+
+    // then - wait for audit log entry and verify
+    final var auditLogItems =
+        awaitAuditLogEntry(
+            client,
+            AuditLogEntityTypeEnum.PROCESS_INSTANCE,
+            AuditLogOperationTypeEnum.CREATE,
+            String.valueOf(processInstanceKey));
+
+    assertThat(auditLogItems).isNotEmpty();
+    final var auditLog = auditLogItems.stream().findFirst().orElseThrow();
+    assertProcessInstanceAuditLog(
+        auditLog,
+        AuditLogEntityTypeEnum.PROCESS_INSTANCE,
+        AuditLogOperationTypeEnum.CREATE,
+        processInstanceKey,
+        processInstance.getProcessDefinitionKey(),
+        PROCESS_WITH_MESSAGE_START);
+  }
+
+  @Test
+  void shouldTrackProcessInstanceCreationViaMessagePublication(
+      @Authenticated(DEFAULT_USERNAME) final CamundaClient client) {
+    // when - publish a message that starts the process instance
+    client
+        .newPublishMessageCommand()
+        .messageName(PROCESS_WITH_MESSAGE_START_2)
+        .withoutCorrelationKey()
+        .tenantId(TENANT_A)
+        .execute();
+    final var processInstance =
+        waitForProcessInstances(client, f -> f.processDefinitionId(PROCESS_WITH_MESSAGE_START_2), 1)
+            .getFirst();
+    final var processInstanceKey = processInstance.getProcessInstanceKey();
+
+    // then - wait for audit log entry and verify
+    final var auditLogItems =
+        awaitAuditLogEntry(
+            client,
+            AuditLogEntityTypeEnum.PROCESS_INSTANCE,
+            AuditLogOperationTypeEnum.CREATE,
+            String.valueOf(processInstanceKey));
+
+    assertThat(auditLogItems).isNotEmpty();
+    final var auditLog = auditLogItems.stream().findFirst().orElseThrow();
+    assertProcessInstanceAuditLog(
+        auditLog,
+        AuditLogEntityTypeEnum.PROCESS_INSTANCE,
+        AuditLogOperationTypeEnum.CREATE,
+        processInstanceKey,
+        processInstance.getProcessDefinitionKey(),
+        PROCESS_WITH_MESSAGE_START_2);
+  }
+
+  @Test
+  void shouldTrackProcessInstanceCreationViaSignalBroadcast(
+      @Authenticated(DEFAULT_USERNAME) final CamundaClient client) {
+    // when - broadcast a signal that starts the process instance
+    client
+        .newBroadcastSignalCommand()
+        .signalName(PROCESS_WITH_SIGNAL_START)
+        .tenantId(TENANT_A)
+        .send()
+        .join();
+    final var processInstance =
+        waitForProcessInstances(client, f -> f.processDefinitionId(PROCESS_WITH_SIGNAL_START), 1)
+            .getFirst();
+    final var processInstanceKey = processInstance.getProcessInstanceKey();
+
+    // then - wait for audit log entry and verify
+    final var auditLogItems =
+        awaitAuditLogEntry(
+            client,
+            AuditLogEntityTypeEnum.PROCESS_INSTANCE,
+            AuditLogOperationTypeEnum.CREATE,
+            String.valueOf(processInstanceKey));
+
+    assertThat(auditLogItems).isNotEmpty();
+    final var auditLog = auditLogItems.stream().findFirst().orElseThrow();
+    assertProcessInstanceAuditLog(
+        auditLog,
+        AuditLogEntityTypeEnum.PROCESS_INSTANCE,
+        AuditLogOperationTypeEnum.CREATE,
+        processInstanceKey,
+        processInstance.getProcessDefinitionKey(),
+        PROCESS_WITH_SIGNAL_START);
+  }
+
+  @Test
+  void shouldTrackProcessInstanceCreationViaConditionalEvaluation(
+      @Authenticated(DEFAULT_USERNAME) final CamundaClient client) {
+    // given - deploy a process with a conditional start event
+    final var processId = "conditional-eval-start-process";
+    final var process =
+        deployProcessForTenantAndWaitForIt(
+            client,
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .condition(c -> c.condition("=x > y"))
+                .endEvent()
+                .done(),
+            processId + ".bpmn",
+            TENANT_A);
+
+    // when - evaluate the conditional start event with matching variables
+    final var evaluationResponse =
+        client
+            .newEvaluateConditionalCommand()
+            .variables(Map.of("x", 1000, "y", 100))
+            .processDefinitionKey(process.getProcessDefinitionKey())
+            .tenantId(TENANT_A)
+            .send()
+            .join();
+
+    assertThat(evaluationResponse.getProcessInstances()).hasSize(1);
+    final var processInstanceKey =
+        evaluationResponse.getProcessInstances().getFirst().getProcessInstanceKey();
+
+    // then - wait for audit log entry and verify
+    final var auditLogItems =
+        awaitAuditLogEntry(
+            client,
+            AuditLogEntityTypeEnum.PROCESS_INSTANCE,
+            AuditLogOperationTypeEnum.CREATE,
+            String.valueOf(processInstanceKey));
+
+    assertThat(auditLogItems).isNotEmpty();
+    final var auditLog = auditLogItems.stream().findFirst().orElseThrow();
+    assertProcessInstanceAuditLog(
+        auditLog,
+        AuditLogEntityTypeEnum.PROCESS_INSTANCE,
+        AuditLogOperationTypeEnum.CREATE,
+        processInstanceKey,
+        process.getProcessDefinitionKey(),
+        processId);
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
@@ -129,10 +129,30 @@ public final class TestHelper {
       final BpmnModelInstance processDefinition,
       final String resourceName) {
     final var event =
-        client
-            .newDeployResourceCommand()
-            .addProcessModel(processDefinition, resourceName)
-            .execute()
+        deployResource(client, processDefinition, resourceName).getProcesses().getFirst();
+
+    // sync with secondary database
+    waitForProcessesToBeDeployed(
+        client, f -> f.processDefinitionKey(event.getProcessDefinitionKey()), 1);
+
+    return event;
+  }
+
+  /**
+   * Deploys a process for a tenant and waits for it to be available in the secondary database.
+   *
+   * @param client ... CamundaClient
+   * @param processDefinition ... BpmnModelInstance of the process definition
+   * @param tenantId the tenant to deploy the process for
+   * @return the deployed process
+   */
+  public static Process deployProcessForTenantAndWaitForIt(
+      final CamundaClient client,
+      final BpmnModelInstance processDefinition,
+      final String resourceName,
+      final String tenantId) {
+    final var event =
+        deployResourceForTenant(client, processDefinition, resourceName, tenantId)
             .getProcesses()
             .getFirst();
 
@@ -271,6 +291,16 @@ public final class TestHelper {
         .newCorrelateMessageCommand()
         .messageName(messageName)
         .withoutCorrelationKey()
+        .execute();
+  }
+
+  public static CorrelateMessageResponse startProcessInstanceWithMessageForTenant(
+      final CamundaClient camundaClient, final String messageName, final String tenantId) {
+    return camundaClient
+        .newCorrelateMessageCommand()
+        .messageName(messageName)
+        .withoutCorrelationKey()
+        .tenantId(tenantId)
         .execute();
   }
 
@@ -1198,11 +1228,11 @@ public final class TestHelper {
             });
   }
 
-  public static void waitForProcessInstances(
+  public static List<ProcessInstance> waitForProcessInstances(
       final CamundaClient camundaClient,
       final Consumer<ProcessInstanceFilter> fn,
       final int expectedProcessInstances) {
-    waitForItemsPaginated(
+    return waitForItemsPaginated(
         "should wait until process instances are available",
         expectedProcessInstances,
         page -> camundaClient.newProcessInstanceSearchRequest().filter(fn).page(page).execute());

--- a/qa/acceptance-tests/src/test/resources/process/process_with_message_start.bpmn
+++ b/qa/acceptance-tests/src/test/resources/process/process_with_message_start.bpmn
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_phase2" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.46.1">
+  <bpmn:process id="process_with_message_start" name="Phase 2 Test Process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_msg">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MED_Start" messageRef="Msg_Start" />
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_msg" targetRef="EndEvent_1" />
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmn:message id="Msg_Start" name="process_with_message_start" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="process_with_message_start">
+      <bpmndi:BPMNShape id="StartEvent_msg_di" bpmnElement="StartEvent_msg">
+        <dc:Bounds x="150" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="242" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1_di" bpmnElement="Flow_1">
+        <di:waypoint x="186" y="118" />
+        <di:waypoint x="242" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/acceptance-tests/src/test/resources/process/process_with_message_start_2.bpmn
+++ b/qa/acceptance-tests/src/test/resources/process/process_with_message_start_2.bpmn
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_phase2" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.46.1">
+  <bpmn:process id="process_with_message_start_2" name="Phase 2 Test Process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_msg">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MED_Start" messageRef="Msg_Start" />
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_msg" targetRef="EndEvent_1" />
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmn:message id="Msg_Start" name="process_with_message_start_2" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="process_with_message_start">
+      <bpmndi:BPMNShape id="StartEvent_msg_di" bpmnElement="StartEvent_msg">
+        <dc:Bounds x="150" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="242" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1_di" bpmnElement="Flow_1">
+        <di:waypoint x="186" y="118" />
+        <di:waypoint x="242" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/acceptance-tests/src/test/resources/process/process_with_signal_start.bpmn
+++ b/qa/acceptance-tests/src/test/resources/process/process_with_signal_start.bpmn
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_phase2" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.46.1">
+  <bpmn:process id="process_with_signal_start" name="Phase 2 Test Process" isExecutable="true">
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_signal" targetRef="EndEvent_1" />
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:startEvent id="StartEvent_signal">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+      <bpmn:signalEventDefinition id="SignalEventDefinition_1nspe2q" signalRef="Signal_2bjhm9g" />
+    </bpmn:startEvent>
+  </bpmn:process>
+  <bpmn:signal id="Signal_2bjhm9g" name="process_with_signal_start" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="process_with_signal_start">
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="242" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0ez1112_di" bpmnElement="StartEvent_signal">
+        <dc:Bounds x="150" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1_di" bpmnElement="Flow_1">
+        <di:waypoint x="186" y="118" />
+        <di:waypoint x="242" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventHandle.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventHandle.java
@@ -36,6 +36,8 @@ public final class EventHandle {
   private static final DirectBuffer NO_VARIABLES = new UnsafeBuffer();
 
   private final ProcessInstanceRecord recordForPICreation = new ProcessInstanceRecord();
+  private final ProcessInstanceCreationRecord recordForPICreationEvent =
+      new ProcessInstanceCreationRecord();
   private final MessageStartEventSubscriptionRecord startEventSubscriptionRecord =
       new MessageStartEventSubscriptionRecord();
 
@@ -250,17 +252,15 @@ public final class EventHandle {
     commandWriter.appendFollowUpCommand(
         processInstanceKey, ProcessInstanceIntent.ACTIVATE_ELEMENT, recordForPICreation);
 
-    final var creationRecord = new ProcessInstanceCreationRecord();
-    creationRecord
+    recordForPICreationEvent
         .setBpmnProcessId(process.getBpmnProcessId())
         .setProcessDefinitionKey(process.getKey())
         .setVersion(process.getVersion())
         .setProcessInstanceKey(processInstanceKey)
         .setRootProcessInstanceKey(processInstanceKey)
-        .setVariables(variablesBuffer)
         .setTenantId(tenantId);
 
     stateWriter.appendFollowUpEvent(
-        processInstanceKey, ProcessInstanceCreationIntent.CREATED, creationRecord);
+        processInstanceKey, ProcessInstanceCreationIntent.CREATED, recordForPICreationEvent);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventHandle.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventHandle.java
@@ -252,6 +252,8 @@ public final class EventHandle {
     commandWriter.appendFollowUpCommand(
         processInstanceKey, ProcessInstanceIntent.ACTIVATE_ELEMENT, recordForPICreation);
 
+    // emit CREATED event to indicate instance creation by an event trigger
+    // picked up by appliers and exporters accordingly, e.g., for metrics and audit logs
     recordForPICreationEvent
         .setBpmnProcessId(process.getBpmnProcessId())
         .setProcessDefinitionKey(process.getKey())

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventHandle.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventHandle.java
@@ -19,10 +19,12 @@ import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartEventSubscriptionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessEventIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
@@ -247,5 +249,18 @@ public final class EventHandle {
 
     commandWriter.appendFollowUpCommand(
         processInstanceKey, ProcessInstanceIntent.ACTIVATE_ELEMENT, recordForPICreation);
+
+    final var creationRecord = new ProcessInstanceCreationRecord();
+    creationRecord
+        .setBpmnProcessId(process.getBpmnProcessId())
+        .setProcessDefinitionKey(process.getKey())
+        .setVersion(process.getVersion())
+        .setProcessInstanceKey(processInstanceKey)
+        .setRootProcessInstanceKey(processInstanceKey)
+        .setVariables(variablesBuffer)
+        .setTenantId(tenantId);
+
+    stateWriter.appendFollowUpEvent(
+        processInstanceKey, ProcessInstanceCreationIntent.CREATED, creationRecord);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -557,6 +557,13 @@ public final class EventAppliers implements EventApplier {
             state.getProcessState(),
             state.getUsageMetricState()));
     register(
+        ProcessEventIntent.TRIGGERING,
+        3,
+        new ProcessEventTriggeringV3Applier(
+            state.getEventScopeInstanceState(),
+            state.getElementInstanceState(),
+            state.getProcessState()));
+    register(
         ProcessEventIntent.TRIGGERED,
         new ProcessEventTriggeredApplier(state.getEventScopeInstanceState()));
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessEventTriggeringV3Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessEventTriggeringV3Applier.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableEventScopeInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessState;
+import io.camunda.zeebe.msgpack.value.DocumentValue;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessEventRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessEventIntent;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+
+final class ProcessEventTriggeringV3Applier
+    implements TypedEventApplier<ProcessEventIntent, ProcessEventRecord> {
+  private static final DirectBuffer NO_VARIABLES = new UnsafeBuffer();
+  private final MutableEventScopeInstanceState eventScopeState;
+  private final EventSubProcessInterruptionMarker eventSubProcessInterruptionMarker;
+
+  public ProcessEventTriggeringV3Applier(
+      final MutableEventScopeInstanceState eventScopeState,
+      final MutableElementInstanceState elementInstanceState,
+      final MutableProcessState processState) {
+    this.eventScopeState = eventScopeState;
+    eventSubProcessInterruptionMarker =
+        new EventSubProcessInterruptionMarker(processState, elementInstanceState);
+  }
+
+  @Override
+  public void applyState(final long key, final ProcessEventRecord value) {
+    var variables = value.getVariablesBuffer();
+    if (variables.equals(DocumentValue.EMPTY_DOCUMENT)) {
+      // avoid storing an empty document
+      variables = NO_VARIABLES;
+    }
+
+    final var targetElementIdBuffer = value.getTargetElementIdBuffer();
+    final var scopeKey = value.getScopeKey();
+    final var processInstanceKey = value.getProcessInstanceKey();
+
+    if (value.getProcessDefinitionKey() == scopeKey) {
+      // scopeKey equals processDefinitionKey only when activating a process-level start event
+      eventScopeState.triggerStartEvent(
+          scopeKey, key, targetElementIdBuffer, variables, processInstanceKey);
+    } else {
+      eventScopeState.triggerEvent(
+          scopeKey, key, targetElementIdBuffer, variables, processInstanceKey);
+    }
+    eventSubProcessInterruptionMarker.markInstanceIfInterrupted(
+        scopeKey, value.getProcessDefinitionKey(), value.getTenantId(), targetElementIdBuffer);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/auditlog/ProcessEventsClaimsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/auditlog/ProcessEventsClaimsTest.java
@@ -26,6 +26,7 @@ import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -77,6 +78,173 @@ public class ProcessEventsClaimsTest {
             .findFirst();
     assertAuthorizationClaims(record);
     assertThat(record.get().getValue().getRootProcessInstanceKey()).isEqualTo(processInstanceKey);
+  }
+
+  @Test
+  public void shouldIncludeClaimsInProcessInstanceCreationCreatedEventsForMessageCorrelation() {
+    // given
+    deployMessageStartProcess();
+
+    // when
+    final var processInstanceKey =
+        engine
+            .messageCorrelation()
+            .withName("startMessage")
+            .withCorrelationKey("key-1")
+            .correlate(DEFAULT_USER.getUsername())
+            .getValue()
+            .getProcessInstanceKey();
+
+    // then
+    final var record =
+        RecordingExporter.processInstanceCreationRecords()
+            .withIntent(ProcessInstanceCreationIntent.CREATED)
+            .withInstanceKey(processInstanceKey)
+            .findFirst();
+    assertAuthorizationClaims(record);
+    assertThat(record.get().getValue().getRootProcessInstanceKey()).isEqualTo(processInstanceKey);
+  }
+
+  @Test
+  public void shouldIncludeClaimsInProcessInstanceCreationCreatedEventsForMessagePublication() {
+    // given
+    deployMessageStartProcess();
+
+    // when
+    engine
+        .message()
+        .withName("startMessage")
+        .withCorrelationKey("key-1")
+        .publish(DEFAULT_USER.getUsername());
+
+    // then
+    final var processInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .filterRootScope()
+            .getFirst()
+            .getKey();
+    final var record =
+        RecordingExporter.processInstanceCreationRecords()
+            .withIntent(ProcessInstanceCreationIntent.CREATED)
+            .withInstanceKey(processInstanceKey)
+            .findFirst();
+    assertAuthorizationClaims(record);
+    assertThat(record.get().getValue().getRootProcessInstanceKey()).isEqualTo(processInstanceKey);
+  }
+
+  @Test
+  public void shouldIncludeClaimsInProcessInstanceCreationCreatedEventsForSignalBroadcast() {
+    // given
+    deploySignalStartProcess();
+
+    // when
+    engine.signal().withSignalName("startSignal").broadcast(DEFAULT_USER.getUsername());
+
+    // then
+    final var processInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .filterRootScope()
+            .getFirst()
+            .getKey();
+    final var record =
+        RecordingExporter.processInstanceCreationRecords()
+            .withIntent(ProcessInstanceCreationIntent.CREATED)
+            .withInstanceKey(processInstanceKey)
+            .findFirst();
+    assertAuthorizationClaims(record);
+    assertThat(record.get().getValue().getRootProcessInstanceKey()).isEqualTo(processInstanceKey);
+  }
+
+  @Test
+  public void shouldIncludeClaimsInProcessInstanceCreationCreatedEventsForConditionalEvaluation() {
+    // given
+    deployConditionalStartProcess();
+
+    // when
+    engine
+        .conditionalEvaluation()
+        .withVariables(Map.of("x", 1000, "y", 100))
+        .evaluate(DEFAULT_USER.getUsername());
+
+    // then
+    final var processInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .filterRootScope()
+            .getFirst()
+            .getKey();
+    final var record =
+        RecordingExporter.processInstanceCreationRecords()
+            .withIntent(ProcessInstanceCreationIntent.CREATED)
+            .withInstanceKey(processInstanceKey)
+            .findFirst();
+    assertAuthorizationClaims(record);
+    assertThat(record.get().getValue().getRootProcessInstanceKey()).isEqualTo(processInstanceKey);
+  }
+
+  @Test
+  public void shouldNotIncludeUserClaimsInProcessInstanceCreationCreatedEventsForTimerTrigger() {
+    // given
+    deployTimerStartProcess();
+
+    // when - the engine fires the timer internally with no user context
+    engine.increaseTime(Duration.ofSeconds(2));
+
+    // then - the CREATED event must be present but must carry no user/client claims, which means
+    // AuditLogConfiguration will classify it as UNKNOWN actor and skip writing an audit log entry
+    final var processInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .filterRootScope()
+            .getFirst()
+            .getKey();
+    final var record =
+        RecordingExporter.processInstanceCreationRecords()
+            .withIntent(ProcessInstanceCreationIntent.CREATED)
+            .withInstanceKey(processInstanceKey)
+            .findFirst();
+    assertThat(record).isPresent();
+    assertThat(record.get().getAuthorizations())
+        .doesNotContainKey(Authorization.AUTHORIZED_USERNAME)
+        .doesNotContainKey(Authorization.AUTHORIZED_CLIENT_ID);
+  }
+
+  @Test
+  public void
+      shouldNotIncludeUserClaimsInProcessInstanceCreationCreatedEventsForBufferedMessageCorrelation() {
+    // given - a process with a message start event and a service task to keep the first instance
+    // alive
+    deployMessageStartProcessWithServiceTask();
+
+    // start the first instance with a user-issued publish command (first CREATED has user claims)
+    engine
+        .message()
+        .withName("startMessage")
+        .withCorrelationKey("key-1")
+        .publish(DEFAULT_USER.getUsername());
+    final var firstJob =
+        RecordingExporter.jobRecords(JobIntent.CREATED).withType("task").getFirst();
+
+    // publish a second message with the same correlation key — it will be buffered
+    engine
+        .message()
+        .withName("startMessage")
+        .withCorrelationKey("key-1")
+        .publish(DEFAULT_USER.getUsername());
+
+    // when - completing the first job triggers buffered message correlation internally (no user)
+    engine.job().withKey(firstJob.getKey()).complete();
+
+    // then - the second CREATED event is produced by an engine-internal follow-up event and must
+    // carry no user/client claims, so AuditLogConfiguration will not write an audit log entry
+    final var createdRecords =
+        RecordingExporter.processInstanceCreationRecords()
+            .withIntent(ProcessInstanceCreationIntent.CREATED)
+            .limit(2)
+            .asList();
+    assertThat(createdRecords).hasSize(2);
+    final var bufferedCreatedRecord = createdRecords.get(1);
+    assertThat(bufferedCreatedRecord.getAuthorizations())
+        .doesNotContainKey(Authorization.AUTHORIZED_USERNAME)
+        .doesNotContainKey(Authorization.AUTHORIZED_CLIENT_ID);
   }
 
   @Test
@@ -469,6 +637,72 @@ public class ProcessEventsClaimsTest {
             Bpmn.createExecutableProcess("childProcess")
                 .startEvent()
                 .serviceTask("childTask", t -> t.zeebeJobType("childTask"))
+                .endEvent()
+                .done())
+        .deploy(DEFAULT_USER.getUsername());
+  }
+
+  private void deployMessageStartProcess() {
+    engine
+        .deployment()
+        .withXmlResource(
+            "messageStartProcess.bpmn",
+            Bpmn.createExecutableProcess("messageStartProcess")
+                .startEvent()
+                .message("startMessage")
+                .endEvent()
+                .done())
+        .deploy(DEFAULT_USER.getUsername());
+  }
+
+  private void deployMessageStartProcessWithServiceTask() {
+    engine
+        .deployment()
+        .withXmlResource(
+            "messageStartProcess.bpmn",
+            Bpmn.createExecutableProcess("messageStartProcess")
+                .startEvent()
+                .message("startMessage")
+                .serviceTask("task", t -> t.zeebeJobType("task"))
+                .endEvent()
+                .done())
+        .deploy(DEFAULT_USER.getUsername());
+  }
+
+  private void deploySignalStartProcess() {
+    engine
+        .deployment()
+        .withXmlResource(
+            "signalStartProcess.bpmn",
+            Bpmn.createExecutableProcess("signalStartProcess")
+                .startEvent()
+                .signal("startSignal")
+                .endEvent()
+                .done())
+        .deploy(DEFAULT_USER.getUsername());
+  }
+
+  private void deployConditionalStartProcess() {
+    engine
+        .deployment()
+        .withXmlResource(
+            "conditionalStartProcess.bpmn",
+            Bpmn.createExecutableProcess("conditionalStartProcess")
+                .startEvent("start")
+                .condition(c -> c.condition("=x > y"))
+                .endEvent()
+                .done())
+        .deploy(DEFAULT_USER.getUsername());
+  }
+
+  private void deployTimerStartProcess() {
+    engine
+        .deployment()
+        .withXmlResource(
+            "timerStartProcess.bpmn",
+            Bpmn.createExecutableProcess("timerStartProcess")
+                .startEvent()
+                .timerWithCycle("R1/PT1S")
                 .endEvent()
                 .done())
         .deploy(DEFAULT_USER.getUsername());

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/metrics/usage/UsageMetricRpiTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/metrics/usage/UsageMetricRpiTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
@@ -36,9 +37,9 @@ public class UsageMetricRpiTest {
     // when
     engine.processInstance().ofBpmnProcessId("process").create();
 
-    // then
+    // then - the process completes, but the RPI count must still be 1
     engine.awaitProcessingOf(
-        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
             .filterRootScope()
             .getFirst());
 
@@ -48,7 +49,7 @@ public class UsageMetricRpiTest {
   }
 
   @Test
-  public void shouldTrackRpiMetricWhenProcessStartedViaMessageStartEvent() {
+  public void shouldTrackRpiMetricWhenProcessStartedViaPublishMessageStartEvent() {
     // given
     final var process =
         Bpmn.createExecutableProcess("process")
@@ -61,9 +62,34 @@ public class UsageMetricRpiTest {
     // when
     engine.message().withName("startMessage").withCorrelationKey("key-1").publish();
 
-    // then
+    // then - the process completes, but the RPI count must still be 1
     engine.awaitProcessingOf(
-        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+            .filterRootScope()
+            .getFirst());
+
+    final var bucket = engine.getProcessingState().getUsageMetricState().getActiveBucket();
+    assertThat(bucket).isNotNull();
+    assertThat(bucket.getTenantRPIMap()).containsEntry(TenantOwned.DEFAULT_TENANT_IDENTIFIER, 1L);
+  }
+
+  @Test
+  public void shouldTrackRpiMetricWhenProcessStartedViaCorrelateMessageStartEvent() {
+    // given
+    final var process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .message("startMessage")
+            .endEvent()
+            .done();
+    engine.deployment().withXmlResource(process).deploy();
+
+    // when
+    engine.messageCorrelation().withName("startMessage").withCorrelationKey("key-1").correlate();
+
+    // then - the process completes, but the RPI count must still be 1
+    engine.awaitProcessingOf(
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
             .filterRootScope()
             .getFirst());
 
@@ -86,9 +112,9 @@ public class UsageMetricRpiTest {
     // when
     engine.increaseTime(Duration.ofSeconds(2));
 
-    // then
+    // then - the process completes, but the RPI count must still be 1
     engine.awaitProcessingOf(
-        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
             .filterRootScope()
             .getFirst());
 
@@ -111,9 +137,9 @@ public class UsageMetricRpiTest {
     // when
     engine.signal().withSignalName("startSignal").broadcast();
 
-    // then
+    // then - the process completes, but the RPI count must still be 1
     engine.awaitProcessingOf(
-        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
             .filterRootScope()
             .getFirst());
 
@@ -137,8 +163,9 @@ public class UsageMetricRpiTest {
     engine.conditionalEvaluation().withVariables(Map.of("x", 1000, "y", 100)).evaluate();
 
     // then
+    // then - the process completes, but the RPI count must still be 1
     engine.awaitProcessingOf(
-        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
             .filterRootScope()
             .getFirst());
 
@@ -182,6 +209,42 @@ public class UsageMetricRpiTest {
   }
 
   @Test
+  public void shouldTrackRpiMetricWhenProcessStartedViaBufferedMessageCorrelation() {
+    // given - a process with a message start event and a service task to keep the instance alive
+    final var process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .message("startMessage")
+            .serviceTask("task", t -> t.zeebeJobType("task"))
+            .endEvent()
+            .done();
+    engine.deployment().withXmlResource(process).deploy();
+
+    // start the first process instance via message publication
+    engine.message().withName("startMessage").withCorrelationKey("key-1").publish();
+    final var firstJob =
+        RecordingExporter.jobRecords(JobIntent.CREATED).withType("task").getFirst();
+
+    // publish a second message with the same correlation key — it will be buffered because the
+    // first instance holds the correlation key lock
+    engine.message().withName("startMessage").withCorrelationKey("key-1").publish();
+
+    // when - completing the first instance triggers buffered message correlation
+    engine.job().withKey(firstJob.getKey()).complete();
+
+    // then - wait for the second job to be activated and verify two RPIs are counted
+    engine.awaitProcessingOf(
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withType("task")
+            .skipUntil(r -> r.getKey() != firstJob.getKey())
+            .getFirst());
+
+    final var bucket = engine.getProcessingState().getUsageMetricState().getActiveBucket();
+    assertThat(bucket).isNotNull();
+    assertThat(bucket.getTenantRPIMap()).containsEntry(TenantOwned.DEFAULT_TENANT_IDENTIFIER, 2L);
+  }
+
+  @Test
   public void shouldTrackRpiMetricForEachProcessInstanceStartedViaSignal() {
     // given - two processes with the same signal start event
     final var process1 =
@@ -201,9 +264,9 @@ public class UsageMetricRpiTest {
     // when
     engine.signal().withSignalName("sharedSignal").broadcast();
 
-    // then - both process instances should be counted
+    // then - both process instances should be counted after they have been completed
     final var activatedRecords =
-        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
             .filterRootScope()
             .limit(2)
             .asList();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/metrics/usage/UsageMetricRpiTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/metrics/usage/UsageMetricRpiTest.java
@@ -162,7 +162,6 @@ public class UsageMetricRpiTest {
     // when
     engine.conditionalEvaluation().withVariables(Map.of("x", 1000, "y", 100)).evaluate();
 
-    // then
     // then - the process completes, but the RPI count must still be 1
     engine.awaitProcessingOf(
         RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)

--- a/zeebe/engine/src/test/resources/state/appliers/golden/ProcessEvent_TRIGGERING_v3.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/ProcessEvent_TRIGGERING_v3.golden
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableEventScopeInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessState;
+import io.camunda.zeebe.msgpack.value.DocumentValue;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessEventRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessEventIntent;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+
+final class ProcessEventTriggeringV3Applier
+    implements TypedEventApplier<ProcessEventIntent, ProcessEventRecord> {
+  private static final DirectBuffer NO_VARIABLES = new UnsafeBuffer();
+  private final MutableEventScopeInstanceState eventScopeState;
+  private final EventSubProcessInterruptionMarker eventSubProcessInterruptionMarker;
+
+  public ProcessEventTriggeringV3Applier(
+      final MutableEventScopeInstanceState eventScopeState,
+      final MutableElementInstanceState elementInstanceState,
+      final MutableProcessState processState) {
+    this.eventScopeState = eventScopeState;
+    eventSubProcessInterruptionMarker =
+        new EventSubProcessInterruptionMarker(processState, elementInstanceState);
+  }
+
+  @Override
+  public void applyState(final long key, final ProcessEventRecord value) {
+    var variables = value.getVariablesBuffer();
+    if (variables.equals(DocumentValue.EMPTY_DOCUMENT)) {
+      // avoid storing an empty document
+      variables = NO_VARIABLES;
+    }
+
+    final var targetElementIdBuffer = value.getTargetElementIdBuffer();
+    final var scopeKey = value.getScopeKey();
+    final var processInstanceKey = value.getProcessInstanceKey();
+
+    if (value.getProcessDefinitionKey() == scopeKey) {
+      // scopeKey equals processDefinitionKey only when activating a process-level start event
+      eventScopeState.triggerStartEvent(
+          scopeKey, key, targetElementIdBuffer, variables, processInstanceKey);
+    } else {
+      eventScopeState.triggerEvent(
+          scopeKey, key, targetElementIdBuffer, variables, processInstanceKey);
+    }
+    eventSubProcessInterruptionMarker.markInstanceIfInterrupted(
+        scopeKey, value.getProcessDefinitionKey(), value.getTenantId(), targetElementIdBuffer);
+  }
+}


### PR DESCRIPTION
## Description

This pull request introduces key improvements to process instance creation event handling and enhances test coverage for both audit logging and usage metrics. The main changes include emitting a new event when a process instance is created via a start event, registering a new event applier for this event, and adding comprehensive tests to ensure correct authorization claims and RPI metric tracking across different process start mechanisms.

**Process Instance Creation Event Handling:**

* Added emission of a `ProcessInstanceCreationIntent.CREATED` event with a `ProcessInstanceCreationRecord` whenever a process instance is activated via a start event, ensuring that process instance creation is explicitly recorded.
* Registered a new event applier, `ProcessEventTriggeringV3Applier`, to handle the new process event intent and properly update state during process-level start events.

**Audit Logging and Authorization Claims Testing:**

* Added extensive tests in `ProcessEventsClaimsTest` to verify that authorization claims are correctly included (or omitted) in process instance creation events for various start mechanisms (message correlation, message publication, signal broadcast, conditional evaluation, timer triggers, and buffered message correlation).
* Introduced helper methods for deploying processes with different start events to support the new tests.

**Usage Metrics (RPI) Test Improvements:**

* Enhanced `UsageMetricRpiTest` to ensure that the RPI (Running Process Instances) metric is correctly tracked for process instances started via all supported mechanisms, including publish/correlate message start events, signal, timer, conditional, and buffered message correlation. Also, updated assertions to verify that the RPI count is correct after process completion, to ensure we don't miss an unexpected RPI count update after the event trigger was applied.

## Related issues

closes #52842 