### PR TITLE
fix: re-enable custom scenario for load tests

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -28,7 +28,7 @@ on:
         type: string
         required: false
       scenario:
-        description: 'Workload scenario to run'
+        description: 'Workload scenario to run.'
         required: false
         type: choice
         options:
@@ -131,12 +131,12 @@ on:
         default: ""
         required: false
       scenario:
-        description: 'Choose the variant of workload to use for the load test. Options: custom, latency, realistic, typical, max. If specified, this will override the load-test-load input when not set to "custom".'
+        description: 'Workload scenario to run. Options: latency, realistic, typical, max, archiver.'
         type: string
         required: false
-        default: custom
+        default: ""
       load-test-load:
-        description: 'Specifies which load test components to deploy. For example, `starter` can be assigned with the rate at which they start instances. Allows arbitrary helm arguments, like --set starter.rate=100. This is ignored when scenario is not "custom".'
+        description: 'Specifies which load test components to deploy. For example, `starter` can be assigned with the rate at which they start instances. Allows arbitrary helm arguments, like --set starter.rate=100. Can be combined with any scenario, or used alone when scenario is empty.'
         type: string
         required: false
       platform-helm-values:


### PR DESCRIPTION
This pull request updates the workflow configuration for the Camunda load test to clarify and improve the descriptions and default values for the `scenario` and `load-test-load` inputs. The changes primarily focus on making the workflow inputs more understandable and flexible.

**Workflow input improvements:**

* Updated the description for the `scenario` input to be clearer and more concise, and added the `archiver` option to the list of scenarios.
* Changed the default value of the `scenario` input from `custom` to an empty string, allowing for more flexible usage.
* Improved the description for the `load-test-load` input to clarify that it can be combined with any scenario or used alone, regardless of the `scenario` value.
* Added a period to the end of the `scenario` description in the first input section for consistency.