### PR TITLE
feat: Operate Notebook - prompt-driven dashboard widgets

### DIFF
--- a/.claude/agent-memory/MEMORY.md
+++ b/.claude/agent-memory/MEMORY.md
@@ -1,0 +1,12 @@
+- [Notebook LLM transport](orchestrator/project_notebook_llm_transport.md) — browser-direct to Anthropic, key in gitignored .env.local, no backend proxy
+- [Notebook LLM model defaults](orchestrator/project_notebook_llm_model.md) — Sonnet 4.5 + single-shot + tool-use + curated endpoint cheat-sheet, all in one swappable config
+- [Notebook endpoint policy](orchestrator/project_notebook_endpoint_policy.md) — no allowlist, no confirm modals, hackday risk accepted; queries run on render, actions on click
+- [Notebook config validation](orchestrator/project_notebook_validation.md) — Zod-validate columns/endpoint, one-shot LLM retry with error feedback, then surface user error
+- [Notebook widget architecture](orchestrator/project_notebook_widget_arch.md) — registry/dispatch in WidgetRenderer; types: table/bpmn/metric/action-panel; existing Diagram is reusable
+- [Notebook charts](orchestrator/project_notebook_charts.md) — Carbon Charts (bar/line/donut), isolated to ChartWidget.tsx for future shadcn migration; needs dep approval
+- [Notebook detail widget](orchestrator/project_notebook_detail_widget.md) — single-entity card via StructuredList; introduces query.pathParams for GET-by-id
+- [Notebook polling](orchestrator/project_notebook_polling.md) — LLM-controlled refreshMs via TanStack Query refetchInterval, plus manual refresh button; clamp [2s,5min]
+- [Notebook persistence](orchestrator/project_notebook_persistence.md) — localStorage single-notebook at /notebooks (no :id), versioned key, debounced writes
+- [Notebook polish bar](orchestrator/project_notebook_polish_bar.md) — "mindblowing super pretty" is a first-class demo requirement; never cut appear animation, prompt input polish, or empty state
+- [Notebook demo script & multi-widget](orchestrator/project_notebook_demo_script.md) — Script A' Monday-morning-view, LLM returns array of 1+ configs, staggered cascade animation
+- [Notebook MVP scope](orchestrator/project_notebook_mvp_scope.md) — overrides earlier phase plan; ship route+prompt+LLM+metric+table+localStorage in ~3.5h, iterate from there

--- a/.claude/agent-memory/orchestrator/project_notebook_charts.md
+++ b/.claude/agent-memory/orchestrator/project_notebook_charts.md
@@ -1,0 +1,18 @@
+---
+name: Operate Notebook charts decision
+description: Charts are central to the demo; using Carbon Charts with isolation for future shadcn migration
+type: project
+---
+
+Notebook charts use **Carbon Charts (`@carbon/charts-react`)**. Stephan judged charts the most important demo feature ("will mindblow people"). New dep — requires "ask first" per AGENTS.md before merge.
+
+Camunda may migrate from Carbon to shadcn in the near future. Code must be structured so a future chart-lib swap is contained.
+
+**Why:** Carbon Charts gives bar/line/donut/etc. for free, matches Operate's design language, takes simple config objects (LLM-friendly). Stephan considered D3 but accepted Carbon Charts as the right hackday-scope choice.
+
+**How to apply:**
+- Initial chart subtypes: `bar`, `line`, `donut`. No others without explicit ask.
+- Carbon Charts imports live **only** inside `operate/client/src/App/Notebooks/widgets/ChartWidget.tsx`. No other file imports `@carbon/charts-react`.
+- Widget config uses **library-agnostic terms** (`chartType: 'bar' | 'line' | 'donut'`, generic data shape — not Carbon Charts-specific options). Config must survive a chart-lib swap. The translation from generic config → Carbon Charts options happens inside ChartWidget only.
+- This isolation pattern is the migration insurance: shadcn (or whatever replaces Carbon Charts) = rewrite one file, change one dep, no impact on LLM prompts/configs/persisted notebooks.
+- Pre-merge: someone (Stephan or orchestrator-on-his-behalf) needs to confirm the dep addition is OK with frontend dep owners.

--- a/.claude/agent-memory/orchestrator/project_notebook_demo_script.md
+++ b/.claude/agent-memory/orchestrator/project_notebook_demo_script.md
@@ -1,0 +1,36 @@
+---
+name: Operate Notebook demo script & multi-widget generation
+description: Locked-in demo script (variant A'); LLM must support generating N widgets in one shot
+type: project
+---
+
+**Locked-in demo script (Script A'):**
+
+1. "Set me up with a Monday morning view for our process health" → 4 widgets cascade in with staggered animation (metric, bar chart, BPMN+heatmap, table)
+2. "Add a trend chart for incidents over the last 24h" → 5th widget (line chart)
+3. "That stuck task — which instances are affected?" → 6th widget (table, contextual to BPMN heatmap)
+4. Reload browser → everything persists
+
+Stretch (if time): variant C ("Something looks off this morning") to demo vague-intent interpretation.
+
+**Critical capability — multi-widget generation:**
+
+The LLM contract is `prompt → array of WidgetConfig (length 1+)`. A single-widget response is just length 1. This is simpler than two code paths.
+
+**Why:** Stephan's call. A dashboard materializing from one prompt is more cinematic than four prompts each adding one widget. It's THE wow moment.
+
+**How to apply:**
+- Tool schema: `generate_widgets({ widgets: [...] })`. Always an array.
+- System prompt teaches when to generate many vs. one: vague/dashboard/view intent → 3-5 cohesive widgets; specific intent → exactly 1. Cap at 6.
+- System prompt demands **diversity** — each widget must show a different aspect, not duplicate.
+- Order matters: most impactful first (heatmap > metric > table).
+- Validation: any config in batch fails → retry whole batch once. Whole-batch retry, not per-config.
+- Latency: 4-config response is ~6-9s. Acceptable because cascade animation masks it.
+
+**Cascade animation (do not cut):**
+- Stagger widget mounts 150ms apart
+- Each: opacity 0→1 + translateY(8px → 0) over 200ms, eased
+- Total cascade for 4 widgets: ~800ms
+- Without this, multi-widget reveal feels flat
+
+**Pre-demo dress-rehearsal protocol:** before going on stage, run the locked-in prompts 5x in a row and confirm reliability. If variance is high, tighten system prompt or rephrase the prompt itself. Few-shot examples in the system prompt help here.

--- a/.claude/agent-memory/orchestrator/project_notebook_detail_widget.md
+++ b/.claude/agent-memory/orchestrator/project_notebook_detail_widget.md
@@ -1,0 +1,14 @@
+---
+name: Operate Notebook detail widget
+description: A single-entity card widget added to the registry alongside table/bpmn/metric/chart/action
+---
+
+Notebook widget registry includes a `detail` type: single-entity card showing chosen fields for one process instance / incident / etc.
+
+**Why:** Stephan asked for it during design. Useful demo case ("show me details of incident X"), cheap to implement, complements `table` (list view).
+
+**How to apply:**
+- Renders as Carbon `<StructuredListWrapper>` — labeled rows, one per field.
+- Config shape: `{ type: "detail", title, query: { endpoint, method: "GET", pathParams }, fields: [...] }`.
+- Schema extension: existing widget config draft only had `query.body` for POST searches. `detail` introduces `query.pathParams` for GET-by-id endpoints. Both should be supported alongside one another.
+- `fields` are validated against the endpoint's Zod response schema, same retry policy as `columns` for tables (one LLM retry on validation failure).

--- a/.claude/agent-memory/orchestrator/project_notebook_endpoint_policy.md
+++ b/.claude/agent-memory/orchestrator/project_notebook_endpoint_policy.md
@@ -1,0 +1,15 @@
+---
+name: Operate Notebook endpoint & mutation policy
+description: Hackday decision on what V2 endpoints widgets can call and how mutations are gated
+type: project
+---
+
+Notebook widgets can call **any V2 endpoint** the user is authorized for. No allowlist, no confirmation modals on mutations.
+
+**Why:** Hackday demo runs against toy clusters. Stephan explicitly accepted the risk. He noted that a productionized version would later restrict to read-only + a specific allowlist of writes — but not now.
+
+**How to apply:**
+- WidgetRenderer passes whatever endpoint/method/body the config specifies straight through Operate's existing `request/` utility (inherits CSRF + auth).
+- One free structural guardrail: `query` runs on widget render (reads); `actions[]` runs only on user click. The schema and system prompt should encode "mutations belong in `actions`," but the renderer does not enforce this — if a mutation ends up in `query`, it fires on render. Stephan accepted this.
+- If security-auditor flags this in Phase 2.8: answer is "accepted hackday risk, toy clusters only, productionization will add allowlist." Not a redesign.
+- Add a TODO at the top of WidgetRenderer: "productionize: restrict to read endpoints + allowlist of writes."

--- a/.claude/agent-memory/orchestrator/project_notebook_llm_model.md
+++ b/.claude/agent-memory/orchestrator/project_notebook_llm_model.md
@@ -1,0 +1,18 @@
+---
+name: Operate Notebook LLM model & prompt defaults
+description: Starting-point model/prompt choices for the notebook copilot, all easily swappable
+type: project
+---
+
+Notebook copilot starting defaults (all revisitable once interface is testable):
+- Model: Claude Sonnet 4.5
+- Single-shot (no streaming)
+- Tool-use for enforced JSON output (not freeform "respond with JSON")
+- System prompt: hand-curated cheat-sheet of the ~10 widget-relevant V2 endpoints, ~1-2 KB
+
+**Why:** Stephan wants to defer the real model/prompt tuning until we can actually type prompts and see results. So pick sensible defaults that won't embarrass us, but make swapping trivial.
+
+**How to apply:**
+- All of {model name, system prompt text, endpoint cheat-sheet, tool schema} live in **one config file** (e.g. `copilot/config.ts`). One-line swap to change model.
+- Revisit after Phase 3 is wired: if latency >5s → try Haiku; if JSON quality poor → tighten tool schema; if curated endpoints insufficient → expand list.
+- Do not scatter model strings or prompt fragments across the codebase.

--- a/.claude/agent-memory/orchestrator/project_notebook_llm_transport.md
+++ b/.claude/agent-memory/orchestrator/project_notebook_llm_transport.md
@@ -1,0 +1,16 @@
+---
+name: Operate Notebook LLM transport decision
+description: Hackday decision on how the notebook copilot calls the LLM and handles the API key
+type: project
+---
+
+Operate Notebook copilot calls Anthropic API **directly from the browser**. Key is read from `import.meta.env.VITE_ANTHROPIC_API_KEY`, loaded from `operate/client/.env.local` (gitignored by Vite). No backend proxy, no Java changes.
+
+**Why:** Hackday — simplest path. Stephan's only hard constraint: no keys in git history.
+
+**How to apply:**
+- Never commit `.env.local` or any file containing `sk-ant-*`. Grep staged diffs for `sk-ant-` before every commit touching copilot code.
+- Copilot UI must degrade gracefully when key is missing (clear message, no crash).
+- Add a TODO at the top of the copilot module: "revoke key after hackday — it is exposed in browser bundle/network tab."
+- Acknowledge in any demo: the key is visible in devtools at runtime; do not share the branch or a live URL publicly.
+- If security-auditor flags this in Phase 3.5, the answer is "accepted hackday risk" — not a redesign.

--- a/.claude/agent-memory/orchestrator/project_notebook_mvp_scope.md
+++ b/.claude/agent-memory/orchestrator/project_notebook_mvp_scope.md
@@ -1,0 +1,33 @@
+---
+name: Operate Notebook MVP scope (overrides earlier phase plan)
+description: Stripped-down MVP — route, prompt, LLM, two widgets, localStorage. Iterate from there.
+type: project
+---
+
+**MVP scope — overrides the earlier multi-phase plan.** Stephan's direction: stop planning everything up front, build the thinnest end-to-end loop, then iterate based on real friction.
+
+**What's in MVP (target ~3.5h agent work):**
+1. Route `/notebooks/:id` — loads from localStorage if exists, auto-creates empty notebook if not
+2. Page: prompt input + widget area, debounced save on every change
+3. LLM call: Anthropic browser-direct (key from `.env.local`), tool-use returns array of widget configs
+4. `MetricWidget` (Carbon `<Tile>` + TanStack Query)
+5. `TableWidget` (existing `DataTable` + TanStack Query)
+6. `WidgetRenderer` dispatch — metric/table only
+7. Phase 0 seed: deploy 1 BPMN + ~10 instances (10 min, not the elaborate version)
+
+**What's NOT in MVP — restore as iteration candidates in priority order:**
+1. `chart` widget (Carbon Charts — defer dep approval until needed)
+2. `bpmn` widget with heatmap overlay
+3. Multi-widget cascade animation
+4. Zod validation + retry loop (MVP: render what LLM returns; failures are visible and fixed reactively)
+5. Notebook switcher / delete / rename
+6. Polish pass (empty state, prompt input styling, animations)
+7. Error boundaries
+8. `refreshMs` auto-refresh and refresh buttons
+
+**Why:** Earlier I (orchestrator) was building a 13-17h plan up front. Stephan wants a 3-4h MVP that proves the architecture, then iterate. All the design decisions still apply when their feature is added — they just don't all ship in MVP.
+
+**How to apply:**
+- Don't dispatch agents for items not in MVP scope.
+- After MVP smoke-tests end-to-end, have an explicit "what hurt the most?" check with Stephan before deciding the next iteration.
+- Resist the urge to add "while I'm in there" features during MVP build — agents should be told MVP scope explicitly.

--- a/.claude/agent-memory/orchestrator/project_notebook_persistence.md
+++ b/.claude/agent-memory/orchestrator/project_notebook_persistence.md
@@ -1,0 +1,24 @@
+---
+name: Operate Notebook persistence & routing
+description: Multi-notebook localStorage with /notebooks list page and /notebooks/:id notebook view
+type: project
+---
+
+Notebook persistence is **localStorage, multi-notebook, no list page**. Routes:
+- `/notebooks` — **smart redirect** (NOT a page). If notebooks exist → redirect to most-recently-updated. If none exist → create a fresh notebook and redirect to its ID.
+- `/notebooks/:id` — individual notebook (this is the only real page)
+- Switching between notebooks: Carbon `<OverflowMenu>` or `<ComboBox>` switcher in the notebook header, with "New notebook" item at the bottom
+
+**Why:** Stephan said "we don't need a landing page" — explicitly killed the list page UX. Smart redirect keeps the URL clean and gets users to value instantly. Multi-notebook capability stays accessible via header switcher without a dedicated page.
+
+**How to apply:**
+- Two-key storage design:
+  - `operate.notebooks.v1.index` — `[{ id, title, updatedAt, widgetCount }, ...]`. Powers the list page in one read.
+  - `operate.notebooks.v1.<id>` — actual notebook content. One key per notebook.
+- Versioned keys for future schema breaks.
+- On any change inside a notebook: update both the notebook key and the index entry. Debounced ~500ms.
+- On load: validate with Zod; on failure show visible error toast and start blank. Do not silently swallow.
+- **Naming:** new notebooks start as "Untitled notebook." After first prompt, auto-rename to a truncated version of the prompt (~50 chars). User can click-to-edit the title inline.
+- **Notebook switcher** in the notebook header: shows other saved notebooks + "New notebook" + "Delete this notebook" actions. No dedicated list page.
+- **Delete:** in the switcher overflow menu → confirm modal → remove from index + delete the notebook key. Confirm modal IS used for delete (destructive, localStorage-only, standard UX hygiene). This does NOT contradict the "no confirm modals on mutations" rule which was about V2 API mutations. After delete, redirect to most-recent remaining notebook (or create a fresh one if none left).
+- **Future-proofing TODO:** "Notebook configs contain arbitrary endpoint/method/body. Before any share/export feature, treat configs as untrusted input and re-validate on load. Currently safe because configs only come from the user's own LLM session."

--- a/.claude/agent-memory/orchestrator/project_notebook_polish_bar.md
+++ b/.claude/agent-memory/orchestrator/project_notebook_polish_bar.md
@@ -1,0 +1,25 @@
+---
+name: Operate Notebook visual polish requirement
+description: Demo requires "mindblowing super pretty" widgets — polish is a first-class requirement, not nice-to-have
+type: project
+---
+
+Visual polish is a **first-class demo requirement** for the Operate Notebook hackday. Stephan's exact words: "a few widgets that are mindblowing super pretty." This raises the quality bar above "functional" and shapes what gets built and what gets cut.
+
+**Why:** The demo's wow factor is "type prompt → beautiful widget appears." If widgets look utilitarian or janky, the magic evaporates. This is the difference between a memorable demo and a forgettable one.
+
+**How to apply (priority order — cut from the bottom up if time-pressured):**
+
+1. **Widget appear animation** — when LLM finishes and widget mounts, fade-in/slide-up ~200ms eased. ~20 min. **Do not cut.** This IS the magic moment.
+2. **Prompt input polish** — large, centered, friendly placeholder, Carbon `<InlineLoading>` or shimmer while LLM works. ~30 min. **Do not cut.**
+3. **Empty state** — welcoming, intentional, not "TODO." First thing demo viewers see. ~30 min. **Do not cut.**
+4. **Chart styling** — Carbon Charts defaults are dry. Custom Operate-aligned colors, proper labels, sensible tooltips, no truncated legends. ~30 min × 3 subtypes.
+5. **BPMN overlay polish** — heatmap colored by stuck count, saturation by intensity. The "uniquely Operate" widget — must look stunning. ~1h.
+6. **Layout/spacing consistency** — 12-col grid, consistent gutters, uniform widget headers. ~30 min upfront.
+7. **Loading skeletons** — use Carbon's `<DataTableSkeleton>` etc. properly per widget type.
+
+**Cut order under time pressure:** chart `donut` subtype → BPMN overlay heatmap (ship plain BPMN) → Phase 4 error boundaries (let React Query error states show) → never cut #1-3 above.
+
+**Polish budget:** ~4-5h total spread across phases. Treat as engineering work, not "leftover time at the end."
+
+**Agent implication:** `ui-qa` is now load-bearing for SHIP verdict — not just a11y/Carbon compliance, but actual visual polish review. `product-reviewer` similarly weighted toward "does this look impressive?" not just "does the UX make sense?"

--- a/.claude/agent-memory/orchestrator/project_notebook_polling.md
+++ b/.claude/agent-memory/orchestrator/project_notebook_polling.md
@@ -1,0 +1,18 @@
+---
+name: Operate Notebook data freshness & polling
+description: How widgets auto-refresh and how manual refresh is exposed
+type: project
+---
+
+Widget auto-refresh is **LLM-controlled via the config** (`refreshMs` field), implemented through **TanStack Query**'s `refetchInterval` (the library formerly known as React Query — package: `@tanstack/react-query`). Every widget also gets a manual refresh button.
+
+**Why:** Operate already uses TanStack Query, which provides both auto-polling and manual refetch for free. Letting the LLM choose the interval per widget matches the prompt's intent (live-monitoring views vs. historical snapshots) without adding any infrastructure.
+
+**How to apply:**
+- Widget config: optional `refreshMs?: number`. Omitted = no auto-refresh.
+- `WidgetRenderer` wires this into `useQuery({ refetchInterval: refreshMs ?? false })`.
+- Every widget header has a Carbon refresh icon button → `refetch()`.
+- **Defensive bounds:** clamp `refreshMs` to `[2000, 300000]` ms in the renderer. Prevents LLM typos (`100`, `5000000`) from wrecking demos.
+- **System prompt guidance:** LLM should pick ~10000ms for live-monitoring intent, ~30000ms for less-volatile, omit for static/historical.
+- React Query's default `refetchIntervalInBackground: false` is fine — auto-pause when tab hidden.
+- Action-panel mutations: on `useMutation` success, call `queryClient.invalidateQueries()` coarsely (invalidate everything in the notebook). Cheap, correct enough for hackday.

--- a/.claude/agent-memory/orchestrator/project_notebook_validation.md
+++ b/.claude/agent-memory/orchestrator/project_notebook_validation.md
@@ -1,0 +1,18 @@
+---
+name: Operate Notebook config validation strategy
+description: How widget configs are validated against V2 schemas and how the LLM is asked to self-correct
+type: project
+---
+
+Widget configs from the LLM are validated before rendering, with a one-shot auto-retry on failure.
+
+**Why:** Hallucinated columns/endpoints are the most likely demo failure mode. Validating with Zod and feeding the error back to the LLM gives the best correctness-per-effort. Stephan picked this over "render anyway with fallback."
+
+**How to apply:**
+- Maintain a registry `ENDPOINT_SCHEMAS: Record<endpoint, ZodSchema>` mapping each curated V2 endpoint to its response schema from `@camunda/camunda-api-zod-schemas`.
+- On LLM response: parse JSON, then validate `columns[]` against the response schema and `endpoint` against the curated list.
+- On validation failure: send one follow-up message to the LLM with the specific error and valid options ("column `X` not on `Y`; valid fields: [...]"). Render the corrected config.
+- **Cap retries at 1.** Second failure → user-facing error: "Couldn't generate a valid widget — try rephrasing your prompt." No infinite loops.
+- If a curated endpoint has no Zod schema available, **drop it from the curated list** rather than write new schemas. Hackday scope.
+- System prompt should also include trimmed example *responses* per endpoint (not just requests) — validation is the safety net, prompt quality is the first line of defense.
+- **Revisit trigger:** if retries push perceived latency past ~6s consistently in demos, fall back to "render with `—` for missing fields + soft warning above table" and skip the retry.

--- a/.claude/agent-memory/orchestrator/project_notebook_widget_arch.md
+++ b/.claude/agent-memory/orchestrator/project_notebook_widget_arch.md
@@ -1,0 +1,21 @@
+---
+name: Operate Notebook widget architecture
+description: How widgets are structured and dispatched, and how BPMN reuse works
+type: project
+---
+
+Notebook widgets follow a **registry/dispatch pattern** in `WidgetRenderer`, with one component per widget type.
+
+**Why:** Stephan wants a flexible foundation that can grow beyond BPMN to other visualization types — but without one mega-component. Registry pattern keeps each widget simple and independent. Adding a type = adding a registry entry.
+
+**Findings on existing Diagram component (verified 2026-05-07):**
+- `modules/components/Diagram/index.tsx` (257 lines) takes all data via props (`xml`, `overlaysData`, etc.). The `observer()` wrap is for MobX-derived props from consumers, but Diagram itself imports zero stores.
+- `modules/components/DiagramShell` (78 lines) is a thin status wrapper.
+- **Reuse is clean** — pass XML + overlays as plain props. No shared-code refactor needed. Not in "ask first" territory.
+
+**How to apply:**
+- Initial widget types: `table`, `bpmn`, `metric`, `action-panel`. Charts deferred (see Q6).
+- `WidgetRenderer` dispatches on `config.type` via a registry map. No giant switch statement creep — adding a type = adding a registry entry.
+- Each widget in its own file under `operate/client/src/App/Notebooks/widgets/`.
+- BPMN widget: use existing `Diagram` + `DiagramShell` read-only. Fetch XML via React Query. No selection callbacks for hackday.
+- `metric` widget: a `<Tile>` showing `page.totalItems` (or a single field) from any `/search` endpoint. Cheap, demo-gold.

--- a/AGENT_CONTEXT.md
+++ b/AGENT_CONTEXT.md
@@ -1,0 +1,301 @@
+# Operate Notebook — Hackday Agent Context
+
+> This file provides full context for a Claude Code session inside the devcontainer.
+> Read this first before doing anything.
+
+## Project
+
+**Operate Notebook** — A Jupyter-style canvas inside Camunda Operate where users describe what
+they want to see in natural language, and an LLM generates React components (widgets) that query
+the V2 REST API and render live operational data.
+
+**Track:** VEX (Hackday)
+
+## What We're Building
+
+A new section in Operate's frontend that lets users:
+
+1. Create a **notebook/dashboard** (new route, e.g. `/notebooks/:id`)
+2. Add **cells/widgets** by typing a natural language prompt
+3. An LLM (copilot) converts the prompt into a **widget config** (JSON)
+4. A **runtime renderer** maps the config to React components using Operate's existing primitives
+5. Widgets query the **V2 REST API** for live data
+
+### Widget Types
+
+- **Tables/Lists** — process instances, incidents, variables, jobs (using existing `DataTable`/`SortableTable`)
+- **BPMN Diagrams** — with overlays (heatmaps, stuck indicators) using existing `bpmn-js` integration
+- **Charts** — time-series, distributions (may need a lightweight chart lib)
+- **Action Panels** — buttons that call V2 mutations (retry incident, cancel instance, etc.)
+
+### Widget Config Schema (Draft)
+
+```json
+{
+  "type": "table | diagram | chart | action-panel",
+  "title": "Stuck order-fulfillment instances",
+  "query": {
+    "endpoint": "/v2/process-instances/search",
+    "method": "POST",
+    "body": {
+      "filter": { "processDefinitionId": "order-fulfillment", "state": "ACTIVE" },
+      "sort": [{ "field": "startDate", "order": "ASC" }],
+      "size": 50
+    }
+  },
+  "columns": ["key", "processDefinitionId", "state", "startDate"],
+  "actions": [
+    { "label": "Cancel", "mutation": "/v2/process-instances/{key}/cancellation", "method": "POST" }
+  ]
+}
+```
+
+## Tech Stack (Existing in Operate)
+
+- **React 18** + React Router DOM 7 (lazy-loaded routes)
+- **Carbon Design System** (@carbon/react) — all UI primitives
+- **MobX** for UI state, **TanStack React Query** for server state
+- **styled-components** for CSS-in-JS
+- **bpmn-js** / **dmn-js** for diagram rendering
+- **Monaco Editor** for code/JSON editing
+- **Vite** for builds, **Vitest** + Playwright for testing
+- **Zod** for API schema validation (`@camunda/camunda-api-zod-schemas`)
+
+### Key Directories
+
+```
+operate/client/src/
+├── App/                          # Pages & routing
+│   ├── Dashboard/               # Existing dashboard (home page)
+│   ├── Processes/               # Process list
+│   └── ProcessInstance/         # Instance detail (has BPMN canvas)
+├── modules/
+│   ├── api/v2/                  # V2 API client wrappers
+│   ├── components/              # Reusable UI components (DataTable, Diagram, etc.)
+│   ├── queries/                 # TanStack Query hooks
+│   ├── mutations/               # TanStack Query mutations
+│   ├── stores/                  # MobX stores
+│   ├── hooks/                   # Custom React hooks
+│   └── request/                 # HTTP request utilities (fetch + CSRF + auth)
+```
+
+### V2 API Surface (Key Endpoints for Widgets)
+
+| Endpoint | Method | Use Case |
+|----------|--------|----------|
+| `/v2/process-instances/search` | POST | List/filter process instances |
+| `/v2/process-instances/{key}` | GET | Instance detail |
+| `/v2/process-instances/{key}/statistics/element-instances` | GET | Flow node stats |
+| `/v2/process-definitions/search` | POST | List process definitions |
+| `/v2/process-definitions/{key}/xml` | GET | BPMN XML for diagrams |
+| `/v2/process-definitions/statistics/element-instances` | POST | Element stats per definition |
+| `/v2/incidents/search` | POST | List incidents |
+| `/v2/incidents/statistics/process-instances-by-error` | POST | Incident distribution |
+| `/v2/incidents/{key}/resolution` | POST | Resolve incident (action) |
+| `/v2/variables/search` | POST | Variable lookup |
+| `/v2/jobs/search` | POST | Job queue inspection |
+| `/v2/jobs/statistics/time-series` | POST | Job metrics over time |
+| `/v2/user-tasks/search` | POST | User task list |
+| `/v2/element-instances/search` | POST | Flow node instances |
+| `/v2/process-instances/{key}/cancellation` | POST | Cancel instance (action) |
+| `/v2/batch-operations/search` | POST | Batch operation status |
+
+### Existing Component Primitives to Reuse
+
+- `DataTable`, `PaginatedSortableTable`, `SortableTable` — tables
+- `Diagram`, `DiagramShell` — BPMN canvas with overlays
+- `JSONEditor`, `DiffEditor` — Monaco-based editors
+- `FilterMultiSelect`, `FiltersPanel` — filtering UI
+- `Modal`, `ModalStateManager` — dialogs
+- `ResizablePanel` — split panes
+- `InfiniteScroller` — virtualized lists
+- `StateIcon`, `ElementInstanceIcon` — status indicators
+
+## Development Workflow
+
+### Running in This Container
+
+This container has `--dangerously-skip-permissions` — no permission prompts.
+
+```bash
+# Build Operate module (first time or after backend changes)
+./mvnw install -pl operate -am -Dquickly -T1C
+
+# Frontend dev server
+cd operate/client && npm install && npm run dev
+
+# Run tests
+cd operate/client && npm run test
+
+# Format before commit (MANDATORY)
+./mvnw license:format spotless:apply -T1C
+```
+
+### Agent Team
+
+The orchestrator coordinates all work. These agents are available:
+
+**Implementation agents (read/write):**
+| Agent | Source | Use for |
+|-------|--------|---------|
+| `frontend-dev` | custom (~/.claude/agents/) | React/Carbon component implementation |
+| `tdd-engineer` | custom | Write tests first, validate implementation |
+
+**Review agents (read-only):**
+| Agent | Source | Use for |
+|-------|--------|---------|
+| `code-reviewer` | plugin (pr-review-toolkit) | Quality, conventions, confidence ≥80 |
+| `security-auditor` | plugin (code-modernization) | OWASP/CWE adversarial review |
+| `architecture-critic` | plugin (code-modernization) | Skeptical design review, over-engineering |
+| `code-simplifier` | plugin (pr-review-toolkit) | Catches unnecessary complexity |
+| `silent-failure-hunter` | plugin (pr-review-toolkit) | Catches swallowed errors |
+| `product-reviewer` | custom (has memory) | UX, product coherence, user perspective |
+| `ui-qa` | custom | A11y (WCAG 2.1 AA) + Carbon compliance |
+
+**Verification agents:**
+| Agent | Source | Use for |
+|-------|--------|---------|
+| `e2e-verifier` | custom (has Playwright MCP) | Browser-based visual verification |
+
+### Orchestration Matrix
+
+**Follow this matrix exactly.** Each phase has a defined sequence of agents and a gate.
+
+#### Phase 1: Skeleton (route + blank canvas + widget placeholder)
+
+| Step | Agent | Task | Gate |
+|------|-------|------|------|
+| 1.1 | `tdd-engineer` | Write tests: route exists, NotebookPage renders, WidgetRenderer accepts config | Tests fail (red) |
+| 1.2 | `frontend-dev` | Implement: route, NotebookPage, "Add Widget" button, WidgetRenderer placeholder | Tests pass (green) |
+| 1.3 | Lint | `npm run lint` + `npm run fix:prettier` + spotless | Clean |
+| 1.4 | `code-reviewer` | Review implementation | No Critical findings |
+| 1.5 | `architecture-critic` | Review: is the component structure right? Over-engineered? | No Blockers |
+| 1.6 | `product-reviewer` | Does the skeleton make sense as a UX foundation? | Not RETHINK |
+| 1.7 | Build | `npm run test && npm run build` | Pass |
+| 1.8 | Commit | Conventional commit to feature branch | |
+| **1.9** | **HUMAN CHECKPOINT** | **Stephan pulls branch, opens in browser, gives go/no-go** | **Approval** |
+
+#### Phase 2: Widget Runtime (table + diagram + actions)
+
+| Step | Agent | Task | Gate |
+|------|-------|------|------|
+| 2.1 | `tdd-engineer` | Write tests: TableWidget renders data, DiagramWidget loads BPMN, ActionWidget calls mutations | Tests fail |
+| 2.2 | `frontend-dev` | Implement TableWidget using DataTable + React Query | Tests pass |
+| 2.3 | `frontend-dev` | Implement DiagramWidget using Diagram + BPMN XML fetch | Tests pass |
+| 2.4 | `frontend-dev` | Implement ActionWidget with mutation buttons | Tests pass |
+| 2.5 | `frontend-dev` | Wire prompt → hardcoded JSON config → renderer | Works |
+| 2.6 | Lint | `npm run lint` + `npm run fix:prettier` + spotless | Clean |
+| 2.7 | `code-reviewer` | Review all implementations | No Critical |
+| 2.8 | `security-auditor` | Audit: XSS in dynamic rendering? Injection via widget config? Unsafe mutations? | No Critical/High |
+| 2.9 | `product-reviewer` | Do widgets feel right? Is the interaction model intuitive? Useful empty/error states? | Not RETHINK |
+| 2.10 | `ui-qa` | A11y + Carbon compliance on all widgets | Not BLOCKED |
+| 2.11 | `silent-failure-hunter` | Check for swallowed fetch errors, missing error boundaries | Clean |
+| 2.12 | `e2e-verifier` | Open browser, verify widgets render with real/mock data | Verified |
+| 2.13 | Build + commit | `npm run test && npm run build` + commit | Pass |
+| **2.14** | **HUMAN CHECKPOINT** | **Stephan tests widgets against real cluster** | **Approval** |
+
+#### Phase 3: LLM Integration (copilot generates widget configs)
+
+| Step | Agent | Task | Gate |
+|------|-------|------|------|
+| 3.1 | `architecture-critic` | Review approach: where does LLM call live? Proxy? Direct? Token handling? | No Blockers |
+| 3.2 | `tdd-engineer` | Write tests: prompt input → LLM call → valid JSON config → rendered widget | Tests fail |
+| 3.3 | `frontend-dev` | Implement copilot: prompt input, API call, config parsing, error handling | Tests pass |
+| 3.4 | Lint | `npm run lint` + `npm run fix:prettier` + spotless | Clean |
+| 3.5 | `security-auditor` | Audit: prompt injection? API key exposure? Unsafe eval of LLM output? | No Critical/High |
+| 3.6 | `code-reviewer` | Review | No Critical |
+| 3.7 | `code-simplifier` | Is the LLM integration over-engineered for a hackday? | No Blockers |
+| 3.8 | `product-reviewer` | Does the prompt→widget flow feel magical? Are failure modes graceful? | Not RETHINK |
+| 3.9 | `e2e-verifier` | Type a prompt in browser, verify widget appears | Verified |
+| 3.10 | Build + commit | `npm run test && npm run build` + commit | Pass |
+| **3.11** | **HUMAN CHECKPOINT** | **Stephan tries natural language prompts against real data** | **Approval** |
+
+#### Phase 4: Polish (persistence, drag/drop, error boundaries)
+
+| Step | Agent | Task | Gate |
+|------|-------|------|------|
+| 4.1 | `frontend-dev` | Persist notebook state to localStorage | Works |
+| 4.2 | `frontend-dev` | Add error boundaries per widget (graceful failure) | Works |
+| 4.3 | `frontend-dev` | Widget reorder (drag/drop or move up/down buttons) | Works |
+| 4.4 | Lint | `npm run lint` + `npm run fix:prettier` + spotless | Clean |
+| 4.5 | `ui-qa` | Full a11y pass on complete notebook experience | SHIP |
+| 4.6 | `product-reviewer` | Full product review: is this demo-ready? Compelling story? | SHIP |
+| 4.7 | `code-reviewer` + `security-auditor` | Final review | Clean |
+| 4.8 | `e2e-verifier` | Full E2E: create notebook, add widgets, reorder, persist, reload | Verified |
+| 4.9 | Build + commit | `npm run test && npm run build` + commit | Pass |
+| **4.10** | **HUMAN CHECKPOINT** | **Stephan does final demo walkthrough** | **Done** |
+
+### Human Checkpoint Protocol
+
+At each checkpoint:
+1. **Commit** all changes to the feature branch with conventional commit
+2. **Summary** to human: what was built, all agent verdicts (pass/fail), any concerns
+3. **STOP** — do not proceed to next phase without explicit human approval
+4. **Prepare environment** for human testing (see below)
+5. Human provides feedback → address before moving on
+
+### Environment Preparation for Human Testing
+
+Before each human checkpoint, ensure:
+
+```bash
+# 1. Frontend builds cleanly
+cd operate/client && npm run build
+
+# 2. If human has a local cluster, just provide the Operate URL
+echo "Open: http://localhost:8080/notebooks"
+
+# 3. If no cluster is running, start one:
+# Option A: c8run (simplest)
+c8run
+
+# Option B: Docker compose (if available)
+docker compose -f docker-compose-operate.yml up -d
+
+# 4. Seed test data via V2 API (once cluster is up)
+# Deploy a sample process
+curl -X POST http://localhost:8080/v2/deployments \
+  -F "resources=@sample-process.bpmn"
+
+# Create process instances with various states
+for i in $(seq 1 10); do
+  curl -X POST http://localhost:8080/v2/process-instances \
+    -H "Content-Type: application/json" \
+    -d '{"processDefinitionId": "sample-process", "variables": {"orderId": "'$i'", "amount": '$((RANDOM % 10000))'}}'
+done
+```
+
+The goal: human opens one URL and sees working widgets with real data. No manual setup.
+
+## Implementation Plan
+
+### Phase 1: Skeleton
+1. Add `/notebooks` route to Operate's router
+2. Create `NotebookPage` component with a blank canvas
+3. Add "Add Widget" button that opens a prompt input (Monaco or textarea)
+4. Create `WidgetRenderer` that takes a JSON config and renders a placeholder
+
+### Phase 2: Widget Runtime
+5. Implement `TableWidget` — maps config to `DataTable` + React Query fetch
+6. Implement `DiagramWidget` — maps config to `Diagram` + BPMN XML fetch
+7. Implement `ActionWidget` — buttons that call V2 mutations
+8. Wire up the prompt → JSON config → renderer pipeline (hardcoded first)
+
+### Phase 3: LLM Integration
+9. Add copilot endpoint (could be a simple proxy to Claude API)
+10. System prompt that knows the V2 API schema and widget config format
+11. User prompt → LLM → JSON config → live widget
+
+### Phase 4: Polish
+12. Persist notebook state (localStorage or backend)
+13. Drag/drop widget reordering
+14. Widget resize
+15. Error boundaries per widget
+
+## Conventions (from AGENTS.md)
+
+- Follow Google Java Format (Spotless) for any backend changes
+- Frontend: Carbon Design System components, styled-components
+- Tests: `should` prefix, `// given / when / then`, AssertJ (backend), Vitest (frontend)
+- Commits: conventional commits, max 120 chars, no scopes
+- **Always** run `./mvnw license:format spotless:apply -T1C` before committing

--- a/operate/client/package-lock.json
+++ b/operate/client/package-lock.json
@@ -12,6 +12,8 @@
         "@bpmn-io/element-template-icon-renderer": "1.0.0",
         "@camunda/camunda-api-zod-schemas": "0.0.60",
         "@camunda/camunda-composite-components": "0.22.6",
+        "@carbon/charts": "^1.27.10",
+        "@carbon/charts-react": "^1.27.10",
         "@carbon/elements": "11.87.0",
         "@carbon/react": "1.105.0",
         "@devbookhq/splitter": "1.4.2",
@@ -539,6 +541,54 @@
         }
       }
     },
+    "node_modules/@carbon/charts": {
+      "version": "1.27.10",
+      "resolved": "https://registry.npmjs.org/@carbon/charts/-/charts-1.27.10.tgz",
+      "integrity": "sha512-tH6J1ljSVydguK+wtgdbsE0wTxebES2oHKmSKDsBM6NS/TYMi/cvsdbGnj7DOKzudeF5C8PFBogSAxY2gOChHw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@carbon/colors": "^11.37.0",
+        "@carbon/utils-position": "^1.3.0",
+        "@ibm/telemetry-js": "^1.9.1",
+        "@types/d3": "^7.4.3",
+        "@types/topojson": "^3.2.6",
+        "d3": "^7.9.0",
+        "d3-cloud": "^1.2.7",
+        "d3-sankey": "^0.12.3",
+        "date-fns": "^4.1.0",
+        "dompurify": "^3.3.2",
+        "html-to-image": "1.11.11",
+        "lodash-es": "^4.18.0",
+        "topojson-client": "^3.1.0",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@carbon/charts-react": {
+      "version": "1.27.10",
+      "resolved": "https://registry.npmjs.org/@carbon/charts-react/-/charts-react-1.27.10.tgz",
+      "integrity": "sha512-58Uz50rgzFygOR9vQSQxJbs+hud5yC6xRqtLJD4w8IW+Og+qdEFWT7VAeIjwX7DikiiNpuAnmE9eIIM4N3E4hQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@carbon/charts": "1.27.10",
+        "@carbon/icons-react": "^11.64.0",
+        "@ibm/telemetry-js": "^1.9.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.6 || ^17.0.1 || ^18.2.0 || ^19.0.0",
+        "react-dom": "^16.8.6 || ^17.0.1 || ^18.2.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@carbon/charts/node_modules/dompurify": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
+      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
     "node_modules/@carbon/colors": {
       "version": "11.50.0",
       "resolved": "https://registry.npmjs.org/@carbon/colors/-/colors-11.50.0.tgz",
@@ -743,6 +793,16 @@
       "dependencies": {
         "@ibm/telemetry-js": "^1.6.1",
         "@internationalized/number": "^3.6.1"
+      }
+    },
+    "node_modules/@carbon/utils-position": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@carbon/utils-position/-/utils-position-1.3.0.tgz",
+      "integrity": "sha512-bfar2dV+fQ15syIrH3n9ujY4PXd1Q+AF2VcTLJIC04IDe2f80zOnJlLNPc/RktHcWTZ7WSQm80cQo3abGcsfTA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ibm/telemetry-js": "^1.5.1"
       }
     },
     "node_modules/@codemirror/autocomplete": {
@@ -3470,6 +3530,259 @@
       "integrity": "sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==",
       "license": "MIT"
     },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
+      "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "license": "MIT",
@@ -3494,6 +3807,12 @@
       "dependencies": {
         "@types/estree": "*"
       }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
     },
     "node_modules/@types/hast": {
       "version": "3.0.4",
@@ -3574,6 +3893,58 @@
     "node_modules/@types/stylis": {
       "version": "4.2.7",
       "license": "MIT"
+    },
+    "node_modules/@types/topojson": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@types/topojson/-/topojson-3.2.6.tgz",
+      "integrity": "sha512-ppfdlxjxofWJ66XdLgIlER/85RvpGyfOf8jrWf+3kVIjEatFxEZYD/Ea83jO672Xu1HRzd/ghwlbcZIUNHTskw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*",
+        "@types/topojson-client": "*",
+        "@types/topojson-server": "*",
+        "@types/topojson-simplify": "*",
+        "@types/topojson-specification": "*"
+      }
+    },
+    "node_modules/@types/topojson-client": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@types/topojson-client/-/topojson-client-3.1.5.tgz",
+      "integrity": "sha512-C79rySTyPxnQNNguTZNI1Ct4D7IXgvyAs3p9HPecnl6mNrJ5+UhvGNYcZfpROYV2lMHI48kJPxwR+F9C6c7nmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*",
+        "@types/topojson-specification": "*"
+      }
+    },
+    "node_modules/@types/topojson-server": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/topojson-server/-/topojson-server-3.0.4.tgz",
+      "integrity": "sha512-5+ieK8ePfP+K2VH6Vgs1VCt+fO1U8XZHj0UsF+NktaF0DavAo1q3IvCBXgokk/xmtvoPltSUs6vxuR/zMdOE1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*",
+        "@types/topojson-specification": "*"
+      }
+    },
+    "node_modules/@types/topojson-simplify": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/topojson-simplify/-/topojson-simplify-3.0.3.tgz",
+      "integrity": "sha512-sBO5UZ0O2dB0bNwo0vut2yLHhj3neUGi9uL7/ROdm8Gs6dtt4jcB9OGDKr+M2isZwQM2RuzVmifnMZpxj4IGNw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*",
+        "@types/topojson-specification": "*"
+      }
+    },
+    "node_modules/@types/topojson-specification": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/topojson-specification/-/topojson-specification-1.0.5.tgz",
+      "integrity": "sha512-C7KvcQh+C2nr6Y2Ub4YfgvWvWCgP2nOQMtfhlnwsRL4pYmmwzBS7HclGiS87eQfDOU/DLQpX6GEscviaz4yLIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
@@ -4788,6 +5159,15 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/component-props": {
       "version": "1.1.1"
     },
@@ -4916,6 +5296,462 @@
     "node_modules/csstype": {
       "version": "3.2.3",
       "license": "MIT"
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-cloud": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/d3-cloud/-/d3-cloud-1.2.9.tgz",
+      "integrity": "sha512-leL1GLneC9ZQtnV+6TGWrNlGfI1WX7S2arcTv2vae12DaXo5wjm6GBCkskXbrDlyOymd/A75Pyj1H37MW4BZ/Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-dispatch": "^1.0.3"
+      }
+    },
+    "node_modules/d3-cloud/node_modules/d3-dispatch": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.6.tgz",
+      "integrity": "sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/data-urls": {
       "version": "5.0.0",
@@ -5073,6 +5909,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
       }
     },
     "node_modules/dequal": {
@@ -6485,6 +7330,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/html-to-image": {
+      "version": "1.11.11",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.11.tgz",
+      "integrity": "sha512-9gux8QhvjRO/erSnDPv28noDZcPZmYE7e1vFsBLKLlRlKDSqNJYebj6Qz1TGd5lsRV+X+xYyjCKjuZdABinWjA==",
+      "license": "MIT"
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "license": "MIT",
@@ -6519,7 +7370,6 @@
     },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -6621,6 +7471,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/invariant": {
@@ -7570,6 +8429,12 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -9440,6 +10305,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
+    },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.13",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.13.tgz",
@@ -9536,6 +10407,12 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
       "dev": true,
@@ -9587,7 +10464,6 @@
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/sass": {
@@ -10240,6 +11116,26 @@
     },
     "node_modules/toggle-selection": {
       "version": "1.0.6",
+      "license": "MIT"
+    },
+    "node_modules/topojson-client": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
+      "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "2"
+      },
+      "bin": {
+        "topo2geo": "bin/topo2geo",
+        "topomerge": "bin/topomerge",
+        "topoquantize": "bin/topoquantize"
+      }
+    },
+    "node_modules/topojson-client/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
     },
     "node_modules/totalist": {

--- a/operate/client/package.json
+++ b/operate/client/package.json
@@ -8,6 +8,8 @@
     "@bpmn-io/element-template-icon-renderer": "1.0.0",
     "@camunda/camunda-api-zod-schemas": "0.0.60",
     "@camunda/camunda-composite-components": "0.22.6",
+    "@carbon/charts": "^1.27.10",
+    "@carbon/charts-react": "^1.27.10",
     "@carbon/elements": "11.87.0",
     "@carbon/react": "1.105.0",
     "@devbookhq/splitter": "1.4.2",
@@ -62,8 +64,8 @@
     "knip": "knip --tsConfig tsconfig.app.json"
   },
   "devDependencies": {
-    "@camunda/lint-config": "file:../../webapp/client/packages/lint-config",
     "@camunda/c8-mocks": "file:../../webapp/client/packages/c8-mocks",
+    "@camunda/lint-config": "file:../../webapp/client/packages/lint-config",
     "@eslint/js": "9.39.4",
     "@playwright/test": "1.58.2",
     "@testing-library/dom": "10.4.1",

--- a/operate/client/scripts/sample-bpmn/order-process.bpmn
+++ b/operate/client/scripts/sample-bpmn/order-process.bpmn
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright Camunda Services GmbH
+
+    Licensed under the Camunda License 1.0. You may not use this file
+    except in compliance with the Camunda License 1.0.
+-->
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+                  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+                  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  id="Definitions_order" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="order-process" name="Order Process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Order received">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="Task_Validate" name="Validate order">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="validate-order" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="Task_Charge" name="Charge payment">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="charge-payment" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+      <bpmn:outgoing>Flow_3</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="Task_Reserve" name="Reserve inventory">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="reserve-inventory" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_3</bpmn:incoming>
+      <bpmn:outgoing>Flow_4</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="Task_Ship" name="Ship order">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="ship-order" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_4</bpmn:incoming>
+      <bpmn:outgoing>Flow_5</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="EndEvent_1" name="Order shipped">
+      <bpmn:incoming>Flow_5</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="Task_Validate" />
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="Task_Validate" targetRef="Task_Charge" />
+    <bpmn:sequenceFlow id="Flow_3" sourceRef="Task_Charge" targetRef="Task_Reserve" />
+    <bpmn:sequenceFlow id="Flow_4" sourceRef="Task_Reserve" targetRef="Task_Ship" />
+    <bpmn:sequenceFlow id="Flow_5" sourceRef="Task_Ship" targetRef="EndEvent_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="order-process">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="160" y="100" width="36" height="36" />
+        <bpmndi:BPMNLabel><dc:Bounds x="145" y="143" width="68" height="14" /></bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_Validate_di" bpmnElement="Task_Validate">
+        <dc:Bounds x="240" y="78" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_Charge_di" bpmnElement="Task_Charge">
+        <dc:Bounds x="380" y="78" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_Reserve_di" bpmnElement="Task_Reserve">
+        <dc:Bounds x="520" y="78" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_Ship_di" bpmnElement="Task_Ship">
+        <dc:Bounds x="660" y="78" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="800" y="100" width="36" height="36" />
+        <bpmndi:BPMNLabel><dc:Bounds x="785" y="143" width="68" height="14" /></bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1_di" bpmnElement="Flow_1">
+        <di:waypoint x="196" y="118" /><di:waypoint x="240" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_2_di" bpmnElement="Flow_2">
+        <di:waypoint x="340" y="118" /><di:waypoint x="380" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_3_di" bpmnElement="Flow_3">
+        <di:waypoint x="480" y="118" /><di:waypoint x="520" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_4_di" bpmnElement="Flow_4">
+        <di:waypoint x="620" y="118" /><di:waypoint x="660" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_5_di" bpmnElement="Flow_5">
+        <di:waypoint x="760" y="118" /><di:waypoint x="800" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/operate/client/scripts/sample-bpmn/payment-process.bpmn
+++ b/operate/client/scripts/sample-bpmn/payment-process.bpmn
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright Camunda Services GmbH
+
+    Licensed under the Camunda License 1.0. You may not use this file
+    except in compliance with the Camunda License 1.0.
+-->
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+                  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+                  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_payment" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="payment-process" name="Payment Process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Payment requested">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="Task_Authorize" name="Authorize">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="authorize-payment" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="Task_Capture" name="Capture">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="capture-payment" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+      <bpmn:outgoing>Flow_3</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="EndEvent_1" name="Payment captured">
+      <bpmn:incoming>Flow_3</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="Task_Authorize" />
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="Task_Authorize" targetRef="Task_Capture" />
+    <bpmn:sequenceFlow id="Flow_3" sourceRef="Task_Capture" targetRef="EndEvent_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="payment-process">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="160" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_Authorize_di" bpmnElement="Task_Authorize">
+        <dc:Bounds x="240" y="78" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_Capture_di" bpmnElement="Task_Capture">
+        <dc:Bounds x="380" y="78" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="520" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1_di" bpmnElement="Flow_1">
+        <di:waypoint x="196" y="118" /><di:waypoint x="240" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_2_di" bpmnElement="Flow_2">
+        <di:waypoint x="340" y="118" /><di:waypoint x="380" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_3_di" bpmnElement="Flow_3">
+        <di:waypoint x="480" y="118" /><di:waypoint x="520" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/operate/client/scripts/sample-bpmn/shipping-process.bpmn
+++ b/operate/client/scripts/sample-bpmn/shipping-process.bpmn
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright Camunda Services GmbH
+
+    Licensed under the Camunda License 1.0. You may not use this file
+    except in compliance with the Camunda License 1.0.
+-->
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+                  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+                  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_shipping" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="shipping-process" name="Shipping Process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Package ready">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="Task_Pack" name="Pack">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="pack-package" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:userTask id="Task_Review" name="Manual review">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+        <zeebe:assignmentDefinition assignee="demo" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+      <bpmn:outgoing>Flow_3</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:serviceTask id="Task_Dispatch" name="Dispatch">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="dispatch-package" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_3</bpmn:incoming>
+      <bpmn:outgoing>Flow_4</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="EndEvent_1" name="Dispatched">
+      <bpmn:incoming>Flow_4</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="Task_Pack" />
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="Task_Pack" targetRef="Task_Review" />
+    <bpmn:sequenceFlow id="Flow_3" sourceRef="Task_Review" targetRef="Task_Dispatch" />
+    <bpmn:sequenceFlow id="Flow_4" sourceRef="Task_Dispatch" targetRef="EndEvent_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="shipping-process">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="160" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_Pack_di" bpmnElement="Task_Pack">
+        <dc:Bounds x="240" y="78" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_Review_di" bpmnElement="Task_Review">
+        <dc:Bounds x="380" y="78" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_Dispatch_di" bpmnElement="Task_Dispatch">
+        <dc:Bounds x="520" y="78" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="660" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1_di" bpmnElement="Flow_1">
+        <di:waypoint x="196" y="118" /><di:waypoint x="240" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_2_di" bpmnElement="Flow_2">
+        <di:waypoint x="340" y="118" /><di:waypoint x="380" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_3_di" bpmnElement="Flow_3">
+        <di:waypoint x="480" y="118" /><di:waypoint x="520" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_4_di" bpmnElement="Flow_4">
+        <di:waypoint x="620" y="118" /><di:waypoint x="660" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/operate/client/scripts/seed-demo-data.sh
+++ b/operate/client/scripts/seed-demo-data.sh
@@ -1,0 +1,355 @@
+#!/usr/bin/env bash
+#
+# Copyright Camunda Services GmbH
+#
+# Licensed under the Camunda License 1.0. You may not use this file
+# except in compliance with the Camunda License 1.0.
+#
+# Seeds a Camunda 8 cluster with demo BPMN deployments and varied process
+# instances/incidents for the Operate Notebook hackday demo.
+#
+# Usage: bash seed-demo-data.sh [BASE_URL]
+# Default BASE_URL: http://host.docker.internal:8080
+
+set -euo pipefail
+
+BASE_URL="${1:-http://host.docker.internal:8080}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BPMN_DIR="${SCRIPT_DIR}/sample-bpmn"
+
+log()  { echo "[seed] $*" >&2; }
+warn() { echo "[seed][WARN] $*" >&2; }
+err()  { echo "[seed][ERR ] $*" >&2; }
+
+require_jq() {
+  if ! command -v jq >/dev/null 2>&1; then
+    err "jq is required but not installed."
+    exit 1
+  fi
+}
+
+api() {
+  # api METHOD PATH [JSON_BODY]
+  local method="$1" path="$2" body="${3:-}"
+  if [[ -n "$body" ]]; then
+    curl -sS -X "$method" "${BASE_URL}${path}" \
+      -H 'content-type: application/json' -d "$body"
+  else
+    curl -sS -X "$method" "${BASE_URL}${path}" \
+      -H 'content-type: application/json'
+  fi
+}
+
+check_topology() {
+  local code
+  code="$(curl -sS -o /dev/null -w '%{http_code}' "${BASE_URL}/v2/topology")"
+  if [[ "$code" != "200" ]]; then
+    err "Cluster ${BASE_URL} not reachable (HTTP ${code})."
+    exit 1
+  fi
+  log "Cluster reachable at ${BASE_URL}"
+}
+
+# Returns existing processDefinitionKey for a processDefinitionId, or empty.
+find_definition_key() {
+  local pdid="$1"
+  api POST /v2/process-definitions/search \
+    "{\"filter\":{\"processDefinitionId\":\"${pdid}\"},\"sort\":[{\"field\":\"version\",\"order\":\"DESC\"}],\"page\":{\"limit\":1}}" \
+    | jq -r '.items[0].processDefinitionKey // empty'
+}
+
+deploy_if_missing() {
+  # deploy_if_missing PROCESS_DEFINITION_ID FILE
+  local pdid="$1" file="$2"
+  local existing
+  existing="$(find_definition_key "$pdid")"
+  if [[ -n "$existing" ]]; then
+    log "Already deployed: ${pdid} (key=${existing}) — skipping deploy"
+    echo "$existing"
+    return
+  fi
+  log "Deploying ${pdid} from ${file}..."
+  local resp
+  resp="$(curl -sS -X POST "${BASE_URL}/v2/deployments" -F "resources=@${file}")"
+  local key
+  key="$(echo "$resp" | jq -r '.deployments[0].processDefinition.processDefinitionKey // empty')"
+  if [[ -z "$key" ]]; then
+    err "Deployment of ${pdid} failed: ${resp}"
+    exit 1
+  fi
+  local ver
+  ver="$(echo "$resp" | jq -r '.deployments[0].processDefinition.processDefinitionVersion')"
+  log "Deployed ${pdid} v${ver} (key=${key})"
+  echo "$key"
+}
+
+create_instance() {
+  # create_instance PROCESS_DEFINITION_ID JSON_VARIABLES
+  local pdid="$1" vars="$2"
+  local resp
+  resp="$(api POST /v2/process-instances \
+    "{\"processDefinitionId\":\"${pdid}\",\"variables\":${vars}}")"
+  local key
+  key="$(echo "$resp" | jq -r '.processInstanceKey // empty')"
+  if [[ -z "$key" ]]; then
+    err "Failed to create instance for ${pdid}: ${resp}"
+    return 1
+  fi
+  echo "$key"
+}
+
+# Activates up to N jobs of given type and fails them all with retries=0.
+# Echoes the count of jobs failed.
+fail_jobs() {
+  # fail_jobs JOB_TYPE MAX_JOBS ERROR_MESSAGE
+  local job_type="$1" max="$2" msg="$3"
+  local resp
+  resp="$(api POST /v2/jobs/activation \
+    "{\"type\":\"${job_type}\",\"timeout\":120000,\"maxJobsToActivate\":${max},\"worker\":\"seed-worker\"}")"
+  local keys
+  keys="$(echo "$resp" | jq -r '.jobs[].jobKey')"
+  local count=0
+  for k in $keys; do
+    local code
+    code="$(curl -sS -o /dev/null -w '%{http_code}' \
+      -X POST "${BASE_URL}/v2/jobs/${k}/failure" \
+      -H 'content-type: application/json' \
+      -d "{\"errorMessage\":$(jq -Rsa . <<<"$msg"),\"retries\":0}")"
+    if [[ "$code" == "204" ]]; then
+      count=$((count + 1))
+    else
+      warn "Failing job ${k} returned HTTP ${code}"
+    fi
+  done
+  echo "$count"
+}
+
+# Activates up to MAX jobs of TYPE, then completes COMPLETE_PCT% and fails the
+# rest with retries=0 (creating incidents). Output: "<completed> <failed>".
+funnel_jobs() {
+  # funnel_jobs JOB_TYPE MAX_JOBS COMPLETE_PCT ERROR_MESSAGE
+  local job_type="$1" max="$2" complete_pct="$3" msg="$4"
+  local resp
+  resp="$(api POST /v2/jobs/activation \
+    "{\"type\":\"${job_type}\",\"timeout\":120000,\"maxJobsToActivate\":${max},\"worker\":\"seed-worker\"}")"
+  local keys
+  keys="$(echo "$resp" | jq -r '.jobs[].jobKey')"
+  local total=0 completed=0 failed=0
+  for k in $keys; do total=$((total + 1)); done
+  if (( total == 0 )); then
+    echo "0 0"
+    return
+  fi
+  local complete_target=$(( total * complete_pct / 100 ))
+  local i=0
+  for k in $keys; do
+    i=$((i + 1))
+    if (( i <= complete_target )); then
+      local code
+      code="$(curl -sS -o /dev/null -w '%{http_code}' \
+        -X POST "${BASE_URL}/v2/jobs/${k}/completion" \
+        -H 'content-type: application/json' \
+        -d '{"variables":{}}')"
+      if [[ "$code" == "204" ]]; then
+        completed=$((completed + 1))
+      else
+        warn "Completing job ${k} returned HTTP ${code}"
+      fi
+    else
+      local code
+      code="$(curl -sS -o /dev/null -w '%{http_code}' \
+        -X POST "${BASE_URL}/v2/jobs/${k}/failure" \
+        -H 'content-type: application/json' \
+        -d "{\"errorMessage\":$(jq -Rsa . <<<"$msg"),\"retries\":0}")"
+      if [[ "$code" == "204" ]]; then
+        failed=$((failed + 1))
+      else
+        warn "Failing job ${k} returned HTTP ${code}"
+      fi
+    fi
+  done
+  echo "${completed} ${failed}"
+}
+
+rand() {
+  # rand MIN MAX (inclusive)
+  local min="$1" max="$2"
+  echo $(( RANDOM % (max - min + 1) + min ))
+}
+
+pick() {
+  # pick from $@ randomly
+  local -a arr=("$@")
+  echo "${arr[$(( RANDOM % ${#arr[@]} ))]}"
+}
+
+main() {
+  require_jq
+  check_topology
+
+  log "=== Step 1: Deploy BPMNs ==="
+  local order_key payment_key shipping_key
+  order_key="$(deploy_if_missing order-process    "${BPMN_DIR}/order-process.bpmn")"
+  payment_key="$(deploy_if_missing payment-process  "${BPMN_DIR}/payment-process.bpmn")"
+  shipping_key="$(deploy_if_missing shipping-process "${BPMN_DIR}/shipping-process.bpmn")"
+
+  log "=== Step 2: Create process instances ==="
+
+  local customers=("alice" "bob" "carol" "dave" "eve" "frank" "grace" "heidi")
+  local regions=("EU" "US" "APAC" "LATAM")
+
+  # Order process: 60 instances (the headliner) — most variety, drives funnel
+  local order_count=60
+  log "Creating ${order_count} order-process instances..."
+  for i in $(seq 1 $order_count); do
+    local cust amt region
+    cust="$(pick "${customers[@]}")"
+    amt="$(rand 10 9999)"
+    region="$(pick "${regions[@]}")"
+    local vars
+    vars="$(jq -nc --arg id "ORD-$(date +%s)-$i" --arg c "$cust" --argjson a "$amt" --arg r "$region" \
+      '{orderId:$id, customerId:$c, amount:$a, region:$r}')"
+    local pikey
+    if pikey="$(create_instance order-process "$vars")"; then
+      log "  order-process instance ${i}/${order_count} created (key=${pikey})"
+    fi
+  done
+
+  # Payment process: 10 instances
+  local payment_count=10
+  log "Creating ${payment_count} payment-process instances..."
+  for i in $(seq 1 $payment_count); do
+    local amt
+    amt="$(rand 5 500)"
+    local vars
+    vars="$(jq -nc --arg id "PAY-$(date +%s)-$i" --argjson a "$amt" \
+      '{paymentId:$id, amount:$a, currency:"EUR"}')"
+    local pikey
+    if pikey="$(create_instance payment-process "$vars")"; then
+      log "  payment-process instance ${i}/${payment_count} created (key=${pikey})"
+    fi
+  done
+
+  # Shipping process: 8 instances
+  local shipping_count=8
+  log "Creating ${shipping_count} shipping-process instances..."
+  for i in $(seq 1 $shipping_count); do
+    local vars
+    vars="$(jq -nc --arg id "SHP-$(date +%s)-$i" --arg w "$(rand 1 50)kg" \
+      '{shipmentId:$id, weight:$w}')"
+    local pikey
+    if pikey="$(create_instance shipping-process "$vars")"; then
+      log "  shipping-process instance ${i}/${shipping_count} created (key=${pikey})"
+    fi
+  done
+
+  log "Waiting 3s for jobs to materialize..."
+  sleep 3
+
+  log "=== Step 3: Drive the order-process funnel ==="
+  # Walk each order-process stage in sequence: complete most jobs (so instances
+  # progress to the next stage) and fail a slice (creating incidents). This
+  # produces a decreasing pyramid Validate -> Charge -> Reserve -> Ship while
+  # keeping a dramatic incident heatmap on Task_Validate.
+
+  # Stage 1: Validate. Heaviest fail rate (heatmap). ~30 instances move on.
+  log "Funnel stage 1: validate-order (complete ~60%, fail ~40% — heatmap)..."
+  read -r vc vf < <(funnel_jobs validate-order 80 60 \
+    'Validation service unreachable: connection timeout to validator-svc.internal:8443')
+  log "  -> validate-order: completed=${vc}, failed=${vf}"
+
+  log "Waiting 2s for next stage's jobs to materialize..."
+  sleep 2
+
+  # Stage 2: Charge. ~20 instances move on, ~10 incidents.
+  log "Funnel stage 2: charge-payment (complete ~70%, fail ~30%)..."
+  read -r cc cf < <(funnel_jobs charge-payment 50 70 \
+    'Insufficient funds: card declined by issuer')
+  log "  -> charge-payment: completed=${cc}, failed=${cf}"
+
+  sleep 2
+
+  # Stage 3: Reserve. ~15 move on, ~5 incidents.
+  log "Funnel stage 3: reserve-inventory (complete ~80%, fail ~20%)..."
+  read -r rc rf < <(funnel_jobs reserve-inventory 40 80 \
+    'Inventory service: SKU not available in warehouse-eu-1')
+  log "  -> reserve-inventory: completed=${rc}, failed=${rf}"
+
+  sleep 2
+
+  # Stage 4: Ship. ~10 complete to EndEvent, ~3 incidents.
+  log "Funnel stage 4: ship-order (complete ~85%, fail ~15%)..."
+  read -r sc sf < <(funnel_jobs ship-order 30 85 \
+    'Carrier API timeout: dhl-gateway.internal returned 504')
+  log "  -> ship-order: completed=${sc}, failed=${sf}"
+
+  # Extra incident drama on Task_Validate to keep the heatmap dramatic across
+  # re-runs (these are leftover validate jobs from the new instances).
+  log "Bonus heatmap: failing more validate-order jobs..."
+  local extra_v
+  extra_v="$(fail_jobs validate-order 10 \
+    'Validation service unreachable: connection timeout to validator-svc.internal:8443')"
+  log "  -> failed ${extra_v} extra validate-order jobs"
+
+  # Side processes: payment-process and shipping-process incidents
+  log "Failing authorize-payment jobs (payment-process)..."
+  local n
+  n="$(fail_jobs authorize-payment 2 'Payment gateway returned HTTP 502')"
+  log "  -> failed ${n} authorize-payment jobs"
+
+  log "Failing pack-package jobs (shipping-process)..."
+  n="$(fail_jobs pack-package 1 'Warehouse out of packing materials')"
+  log "  -> failed ${n} pack-package jobs"
+
+  log "Waiting 3s for incidents to be indexed..."
+  sleep 3
+
+  log "=== Step 4: Verification ==="
+  local def_count inst_total inst_active inc_count
+  def_count="$(api POST /v2/process-definitions/search '{"page":{"limit":1}}' | jq '.page.totalItems')"
+  inst_total="$(api POST /v2/process-instances/search '{"page":{"limit":1}}' | jq '.page.totalItems')"
+  inst_active="$(api POST /v2/process-instances/search '{"filter":{"state":"ACTIVE"},"page":{"limit":1}}' | jq '.page.totalItems')"
+  inc_count="$(api POST /v2/incidents/search '{"page":{"limit":1}}' | jq '.page.totalItems')"
+
+  echo
+  log "Cluster summary:"
+  log "  Process definitions:        ${def_count}"
+  log "  Process instances total:    ${inst_total}"
+  log "  Process instances ACTIVE:   ${inst_active}"
+  log "  Incidents:                  ${inc_count}"
+  log "  Headliner processDefinitionKey (order-process v1): ${order_key}"
+  log "  payment-process key:        ${payment_key}"
+  log "  shipping-process key:       ${shipping_key}"
+
+  # Per-stage funnel counts for order-process
+  echo
+  log "order-process funnel (element-instance statistics):"
+  local stats
+  stats="$(api POST "/v2/process-definitions/${order_key}/statistics/element-instances" '{}')"
+  if [[ -n "$stats" ]] && echo "$stats" | jq -e '.items' >/dev/null 2>&1; then
+    # Print one line per element of interest with active/incidents/completed.
+    local elements=("StartEvent_1" "Task_Validate" "Task_Charge" "Task_Reserve" "Task_Ship" "EndEvent_1")
+    printf '[seed]   %-16s %8s %10s %10s\n' "element" "active" "incidents" "completed" >&2
+    for el in "${elements[@]}"; do
+      local active inc completed
+      active="$(echo "$stats"     | jq -r --arg e "$el" '(.items[] | select(.elementId==$e) | .active)     // 0')"
+      inc="$(echo "$stats"        | jq -r --arg e "$el" '(.items[] | select(.elementId==$e) | .incidents)  // 0')"
+      completed="$(echo "$stats"  | jq -r --arg e "$el" '(.items[] | select(.elementId==$e) | .completed)  // 0')"
+      printf '[seed]   %-16s %8s %10s %10s\n' "$el" "$active" "$inc" "$completed" >&2
+    done
+  else
+    warn "Could not fetch element-instance statistics for order-process: ${stats}"
+  fi
+  echo
+
+  if (( inc_count < 5 )); then
+    warn "Fewer than 5 incidents present. Heatmap will look sparse."
+  fi
+  if (( inst_active < 20 )); then
+    warn "Fewer than 20 active instances. Demo widgets may look thin."
+  fi
+
+  log "Done."
+}
+
+main "$@"

--- a/operate/client/scripts/test-bedrock.mjs
+++ b/operate/client/scripts/test-bedrock.mjs
@@ -1,0 +1,357 @@
+#!/usr/bin/env node
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+/**
+ * Test harness for the real Bedrock-backed LLM. Calls the same Anthropic
+ * tool-use endpoint via SigV4 that the browser uses for free-text prompts,
+ * captures the responses, and writes them to disk for analysis.
+ *
+ * USAGE:
+ *   node scripts/test-bedrock.mjs                  # run all prompts in DEFAULT_PROMPTS
+ *   node scripts/test-bedrock.mjs --limit 5        # cap at N prompts (still respects --budget)
+ *   node scripts/test-bedrock.mjs --budget 50      # hard cap on total Bedrock calls (default 50)
+ *   node scripts/test-bedrock.mjs --prompt "..."   # one-off ad-hoc prompt
+ *
+ * Reads credentials from operate/client/.env.local. Saves responses to
+ * /tmp/bedrock-test-responses.json (cumulative — appends; resets on --fresh).
+ */
+
+import {readFileSync, writeFileSync, existsSync} from 'node:fs';
+import {createHash, createHmac} from 'node:crypto';
+import {fileURLToPath} from 'node:url';
+import {dirname, resolve} from 'node:path';
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const envPath = resolve(__dirname, '..', '.env.local');
+const RESPONSE_FILE = '/tmp/bedrock-test-responses.json';
+
+function loadEnv() {
+  if (!existsSync(envPath)) {
+    console.error(`No .env.local at ${envPath}`);
+    process.exit(1);
+  }
+  const env = {};
+  for (const line of readFileSync(envPath, 'utf8').split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eq = trimmed.indexOf('=');
+    if (eq < 0) continue;
+    env[trimmed.slice(0, eq).trim()] = trimmed.slice(eq + 1).trim();
+  }
+  return env;
+}
+
+const env = loadEnv();
+const ARN = env.VITE_AWS_BEDROCK_ARN;
+const ACCESS_KEY = env.VITE_AWS_ACCESS_KEY_ID;
+const SECRET_KEY = env.VITE_AWS_SECRET_ACCESS_KEY;
+
+if (!ARN || !ACCESS_KEY || !SECRET_KEY) {
+  console.error('Missing one of VITE_AWS_BEDROCK_ARN, VITE_AWS_ACCESS_KEY_ID, VITE_AWS_SECRET_ACCESS_KEY in .env.local');
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Argument parsing
+// ---------------------------------------------------------------------------
+
+const args = process.argv.slice(2);
+function arg(name, def) {
+  const i = args.indexOf(name);
+  return i >= 0 ? args[i + 1] : def;
+}
+const flag = (name) => args.includes(name);
+
+const BUDGET = parseInt(arg('--budget', '50'), 10);
+const LIMIT = parseInt(arg('--limit', '999'), 10);
+const ONE_PROMPT = arg('--prompt', null);
+const FRESH = flag('--fresh');
+
+// ---------------------------------------------------------------------------
+// SigV4 (mirrors browser awsSigV4.ts)
+// ---------------------------------------------------------------------------
+
+function sha256Hex(s) {
+  return createHash('sha256').update(s).digest('hex');
+}
+
+function hmac(key, data) {
+  return createHmac('sha256', key).update(data).digest();
+}
+
+function deriveSigningKey(secretKey, dateStamp, region, service) {
+  const kDate = hmac('AWS4' + secretKey, dateStamp);
+  const kRegion = hmac(kDate, region);
+  const kService = hmac(kRegion, service);
+  return hmac(kService, 'aws4_request');
+}
+
+function extractRegion(arn) {
+  const parts = arn.split(':');
+  if (parts.length < 6 || parts[0] !== 'arn' || parts[2] !== 'bedrock' || !parts[3]) {
+    throw new Error('Invalid ARN: ' + arn);
+  }
+  return parts[3];
+}
+
+function signRequest(host, path, body) {
+  const region = extractRegion(ARN);
+  const now = new Date();
+  const amzDate = now.toISOString().replace(/[:-]/g, '').slice(0, 15) + 'Z';
+  const dateStamp = amzDate.slice(0, 8);
+  const payloadHash = sha256Hex(body);
+
+  const canonicalHeaders =
+    `content-type:application/json\n` +
+    `host:${host}\n` +
+    `x-amz-content-sha256:${payloadHash}\n` +
+    `x-amz-date:${amzDate}\n`;
+  const signedHeaders = 'content-type;host;x-amz-content-sha256;x-amz-date';
+
+  // Double-encode each path segment for the canonical request (non-S3 SigV4 quirk)
+  const canonicalPath = path.split('/').map(encodeURIComponent).join('/');
+
+  const canonicalRequest = ['POST', canonicalPath, '', canonicalHeaders, signedHeaders, payloadHash].join('\n');
+  const credentialScope = `${dateStamp}/${region}/bedrock/aws4_request`;
+  const stringToSign = ['AWS4-HMAC-SHA256', amzDate, credentialScope, sha256Hex(canonicalRequest)].join('\n');
+  const signingKey = deriveSigningKey(SECRET_KEY, dateStamp, region, 'bedrock');
+  const signature = createHmac('sha256', signingKey).update(stringToSign).digest('hex');
+
+  return {
+    'content-type': 'application/json',
+    host,
+    'x-amz-content-sha256': payloadHash,
+    'x-amz-date': amzDate,
+    Authorization:
+      `AWS4-HMAC-SHA256 Credential=${ACCESS_KEY}/${credentialScope},` +
+      `SignedHeaders=${signedHeaders},Signature=${signature}`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// System prompt + tool schema (must mirror what the browser sends)
+// Source: operate/client/src/App/Notebooks/llm.ts at the time of writing this script.
+// If the browser side drifts, this file should be re-synced.
+// ---------------------------------------------------------------------------
+
+// Re-read the live prompt from the source so this script stays in sync with
+// the browser. We extract the SYSTEM_PROMPT template literal from llm.ts.
+function loadSystemPromptFromSource() {
+  const src = readFileSync(
+    resolve(__dirname, '..', 'src', 'App', 'Notebooks', 'llm.ts'),
+    'utf8',
+  );
+  const match = src.match(/const SYSTEM_PROMPT\s*=\s*\n?\s*`([\s\S]*?)`\.trim\(\);/);
+  if (!match) {
+    throw new Error('Could not find SYSTEM_PROMPT in llm.ts');
+  }
+  return match[1].trim();
+}
+const SYSTEM_PROMPT = loadSystemPromptFromSource();
+
+const CREATE_WIDGETS_TOOL = {
+  name: 'create_widgets',
+  description: 'Create an array of dashboard widgets based on the user prompt.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      widgets: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            id: {type: 'string'},
+            type: {
+              type: 'string',
+              enum: [
+                'metric', 'table', 'kpi', 'chart', 'bpmn',
+                'text', 'status-grid', 'activity-feed', 'funnel', 'trend', 'chart-list',
+              ],
+            },
+            title: {type: 'string'},
+            description: {type: 'string'},
+            query: {
+              type: 'object',
+              properties: {
+                endpoint: {type: 'string'},
+                method: {type: 'string', enum: ['GET', 'POST']},
+                body: {type: 'object'},
+              },
+              required: ['endpoint', 'method'],
+            },
+            field: {type: 'string'},
+            columns: {type: 'array', items: {type: 'string'}},
+            accent: {type: 'string', enum: ['info', 'success', 'warning', 'error', 'neutral']},
+            chartType: {
+              type: 'string',
+              enum: ['bar', 'line', 'donut', 'pie', 'stacked-bar', 'stacked-area', 'meter', 'treemap', 'radar'],
+            },
+            chartGroupBy: {type: 'string'},
+            chartValueField: {type: 'string'},
+            chartStackBy: {type: 'string'},
+            processDefinitionKey: {type: 'string'},
+            overlay: {
+              type: 'string',
+              enum: ['active', 'incidents', 'combined', 'stuck', 'none', 'heatmap'],
+            },
+            text: {type: 'string'},
+            kpis: {type: 'array', items: {type: 'object'}},
+          },
+          required: ['id', 'type', 'title', 'description', 'query'],
+        },
+      },
+    },
+    required: ['widgets'],
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Bedrock call
+// ---------------------------------------------------------------------------
+
+async function callBedrock(prompt) {
+  const region = extractRegion(ARN);
+  const host = `bedrock-runtime.${region}.amazonaws.com`;
+  const path = `/model/${encodeURIComponent(ARN)}/invoke`;
+  const url = `https://${host}${path}`;
+
+  const body = JSON.stringify({
+    anthropic_version: 'bedrock-2023-05-31',
+    max_tokens: 4096,
+    system: SYSTEM_PROMPT,
+    tools: [CREATE_WIDGETS_TOOL],
+    tool_choice: {type: 'tool', name: 'create_widgets'},
+    messages: [{role: 'user', content: prompt}],
+  });
+
+  const headers = signRequest(host, path, body);
+  // Hard 60s timeout — Bedrock occasionally hangs without responding when its
+  // edge IPs rotate out of the firewall allowlist. Better to fail fast than
+  // tie up the harness.
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), 60_000);
+  let res;
+  try {
+    res = await fetch(url, {method: 'POST', headers, body, signal: ctrl.signal});
+  } finally {
+    clearTimeout(timer);
+  }
+  const text = await res.text();
+  let parsed = null;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    /* leave as text */
+  }
+  return {ok: res.ok, status: res.status, body: parsed ?? text};
+}
+
+// ---------------------------------------------------------------------------
+// Curated test prompts — broad but each tests something specific
+// ---------------------------------------------------------------------------
+
+const DEFAULT_PROMPTS = [
+  // Cinematic multi-widget dashboards
+  'Set me up with a Monday morning view',
+  'Show me everything',
+  // Simple single-widget asks
+  'How many active process instances do I have right now?',
+  'List all open incidents',
+  'Show me a breakdown of incidents by error type',
+  // Process-specific
+  'Show me the order-process diagram with live state',
+  'Where are instances getting stuck?',
+  // Trends
+  'Show me incident trends over the last 7 days',
+  'How is workload looking over the last 24 hours?',
+  // Edge cases
+  'Show me jobs that are about to time out',
+  'Compare order-process vs payment-process',
+  'I am new to this system, give me an overview',
+];
+
+// ---------------------------------------------------------------------------
+// Persistence + budget
+// ---------------------------------------------------------------------------
+
+let store = {totalCalls: 0, runs: []};
+if (existsSync(RESPONSE_FILE) && !FRESH) {
+  try {
+    store = JSON.parse(readFileSync(RESPONSE_FILE, 'utf8'));
+  } catch {
+    /* start fresh on parse error */
+  }
+}
+
+function persist() {
+  writeFileSync(RESPONSE_FILE, JSON.stringify(store, null, 2));
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const promptsToRun = ONE_PROMPT ? [ONE_PROMPT] : DEFAULT_PROMPTS.slice(0, LIMIT);
+  console.log(`[bedrock-test] starting`);
+  console.log(`[bedrock-test] cumulative calls so far: ${store.totalCalls} / budget ${BUDGET}`);
+  console.log(`[bedrock-test] running ${promptsToRun.length} prompt(s)`);
+  console.log('');
+
+  for (const prompt of promptsToRun) {
+    if (store.totalCalls >= BUDGET) {
+      console.error(`[bedrock-test] budget exhausted (${store.totalCalls}/${BUDGET}). stopping.`);
+      break;
+    }
+    console.log(`[${store.totalCalls + 1}/${BUDGET}] PROMPT: "${prompt}"`);
+    const start = Date.now();
+    let result;
+    try {
+      result = await callBedrock(prompt);
+    } catch (err) {
+      result = {ok: false, status: 0, body: String(err)};
+    }
+    const ms = Date.now() - start;
+    store.totalCalls += 1;
+    store.runs.push({timestamp: new Date().toISOString(), prompt, ms, ...result});
+    persist();
+
+    if (result.ok && result.body?.content) {
+      const toolBlock = result.body.content.find((b) => b.type === 'tool_use');
+      if (toolBlock?.input?.widgets) {
+        const widgets = toolBlock.input.widgets;
+        console.log(`  ✓ ${ms}ms · ${widgets.length} widget(s):`);
+        for (const w of widgets) {
+          const detail = [w.type, w.title].filter(Boolean).join(' · ');
+          console.log(`    - ${detail}${w.query?.endpoint ? ' [' + w.query.endpoint + ']' : ''}`);
+        }
+      } else {
+        console.log(`  ✗ ${ms}ms · no tool_use block`);
+      }
+    } else {
+      console.log(`  ✗ ${ms}ms · status=${result.status}`);
+      const snippet = typeof result.body === 'string' ? result.body : JSON.stringify(result.body);
+      console.log(`    ${snippet.slice(0, 200)}`);
+    }
+    console.log('');
+  }
+
+  console.log(`[bedrock-test] done. cumulative calls: ${store.totalCalls}/${BUDGET}`);
+  console.log(`[bedrock-test] full responses saved to ${RESPONSE_FILE}`);
+}
+
+main().catch((err) => {
+  console.error('[bedrock-test] fatal:', err);
+  process.exit(1);
+});

--- a/operate/client/src/App/Layout/AppHeader/index.tsx
+++ b/operate/client/src/App/Layout/AppHeader/index.tsx
@@ -216,6 +216,21 @@ const AppHeader: React.FC = observer(() => {
                   },
                 },
               },
+              {
+                key: 'notebooks',
+                label: 'Notebooks',
+                isCurrentPage: currentPage === 'notebooks',
+                routeProps: {
+                  to: Paths.notebook('default'),
+                  onClick: () => {
+                    tracking.track({
+                      eventName: 'navigation',
+                      link: 'header-notebooks',
+                      currentPage,
+                    });
+                  },
+                },
+              },
               ...(isLargeScreen
                 ? [
                     {

--- a/operate/client/src/App/Notebooks/DEMO_SCRIPT.md
+++ b/operate/client/src/App/Notebooks/DEMO_SCRIPT.md
@@ -1,0 +1,139 @@
+<!--
+Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+one or more contributor license agreements. See the NOTICE file distributed
+with this work for additional information regarding copyright ownership.
+Licensed under the Camunda License 1.0. You may not use this file
+except in compliance with the Camunda License 1.0.
+-->
+
+# Operate Notebooks — Hackday demo (3 minutes)
+
+> A Jupyter-style canvas inside Operate where natural-language prompts generate live, V2-API-backed dashboards.
+
+---
+
+## Slide 1 — *Problem* (20 seconds)
+
+> **Operate's dashboard is static. We decided years ago what every customer sees — the same tables, the same tabs, the same charts, for everyone.**
+
+But customers don't come to Operate for one use case. The SRE on Monday morning wants a health overview. The same person at 3pm — debugging a production incident — wants a heatmap of where tokens are stuck. The platform owner wants worker capacity. The compliance lead wants throughput trends. **Same product, same data, wildly different questions.**
+
+Their only escape hatch today: click through three pages and read tables — or file a feature request and wait a quarter.
+
+---
+
+## Slide 2 — *Solution* (15 seconds)
+
+> **I got inspired by Jupyter notebooks** — a blank canvas where you type what you want and live cells appear. So I built that for Operate.
+
+Operate Notebooks is a Jupyter-style canvas inside Operate. Type what you want, an LLM generates a dashboard backed by live V2-API queries, and it renders in seconds. The app becomes adaptive — it shapes itself to whatever situation the user is in.
+
+> **Create as many dashboards as you want, as many as you need** — one per process, one per situation, one per Monday morning. Each notebook lives at its own URL, persists across reloads, and is yours to shape.
+
+Two paths to a dashboard:
+1. Curated suggestion pills → instant deterministic templates
+2. Free-text → real LLM (AWS Bedrock, Sonnet 4.5) generates widgets on the fly
+
+---
+
+## Slide 3 — *Demo* (~2 minutes, live in browser)
+
+### Setup before stage
+
+- Browser open to `http://localhost:3000/notebooks/test1`
+- Camunda cluster running at `host:8080` with seeded data (89+ instances, 30+ incidents)
+- Vite dev server running with the AWS Bedrock credentials in `.env.local`
+- Hard-refresh once just before going on
+
+### Beat 1 — One pill, full dashboard (35 sec)
+
+**Click "Showcase all widgets"** in the right sidebar.
+
+> "I'll start with our showcase — one click, every widget type the notebook can render, all backed by live V2 queries."
+
+Widgets cascade in (90ms staggered) — about 14 of them. While they animate, narrate:
+
+> "Live metrics — active instances, incidents. Trend sparklines from real time-bucketed queries. Carbon Charts — donut, pie, stacked bar, stacked area. A per-process status grid. The BPMN heatmap — the saturation comes from incident count per task. An interleaved activity stream. A conversion funnel through `order-process`. And a live incidents table at the bottom."
+
+Wait for them to settle. Pause for effect.
+
+### Beat 2 — The provenance moment (15 sec)
+
+Hover any widget. Click the `</>` icon.
+
+> "Every widget shows its description and the actual V2 endpoint. Nothing here is fabricated — this is `/v2/incidents/statistics/process-instances-by-error`, with the body and field mapping the LLM produced."
+
+Close the modal.
+
+### Beat 3 — The real LLM (60 sec)
+
+> "Pills are curated for safety. Now the magic moment — type something completely arbitrary."
+
+Click "Clear all widgets" (top-right). Then in the prompt textarea:
+
+```
+How is order-process doing today, and where are tokens stuck?
+```
+
+Click **Generate**. Spinner appears. About 10–15 seconds wait.
+
+> "That's hitting AWS Bedrock — Sonnet 4.5 — directly from the browser via SigV4-signed calls. While it thinks, what it's seeing: the system prompt I wrote it knows the V2 API surface, the widget config schema, layout rules, the height tiers. It returns a JSON tool call with widget configs."
+
+Widgets appear. Narrate what happened:
+
+> "It chose: a metric of active instances, the BPMN heatmap of order-process — see the dark red node, that's `Task_Validate` with 25 stuck — a chart of incidents by error type, and a table of the stuck instances. It built this dashboard in 12 seconds, never seen this prompt before."
+
+### Beat 4 — Process awareness (20 sec)
+
+In the prompt, type:
+
+```
+Compare order-process to payment-process side by side
+```
+
+Click Generate. 15 seconds.
+
+> "And it understands process names from the prompt — left side order-process, right side payment-process, BPMN diagrams of both. The widget configs come back referring to specific `processDefinitionKey`s. Even works when the user types a name we never explicitly enumerated."
+
+---
+
+## Total time: ~3 minutes
+
+| Section | Seconds |
+|---|---|
+| Slide 1: Problem | 20 |
+| Slide 2: Solution | 15 |
+| Slide 3 / Beat 1: showcase pill | 35 |
+| Slide 3 / Beat 2: provenance modal | 15 |
+| Slide 3 / Beat 3: live LLM prompt | 60 |
+| Slide 3 / Beat 4: comparison prompt | 20 |
+| **Total** | **~165s** |
+
+Pad with audience reaction time. If you're getting close to the wire, drop Beat 4.
+
+End the demo by leaving the live LLM-generated dashboard on screen — that's the closing image. No wrap slide needed; the working app is the punchline.
+
+---
+
+## Pre-flight checklist
+
+Before the demo (run 30 minutes before):
+
+- [ ] `bash operate/client/scripts/seed-demo-data.sh` (refreshes incidents on Task_Validate)
+- [ ] `cd operate/client && npm start -- --host 0.0.0.0` is running
+- [ ] Open `http://localhost:3000/notebooks/showcase` (or any id) and refresh once to pre-warm caches
+- [ ] Verify `.env.local` has `VITE_AWS_BEDROCK_ARN`, `VITE_AWS_ACCESS_KEY_ID`, `VITE_AWS_SECRET_ACCESS_KEY`
+- [ ] Test the live LLM with a single safe prompt to make sure the Bedrock IPs are still in the firewall allowlist
+- [ ] Have a fallback prompt ready in case a response is dud — `Show me a Monday morning view` (pill, instant, never fails)
+
+## Bail-out paths
+
+If Bedrock fails mid-demo, click any pill instead. The pill prompts route to static presets that are deterministic and instant — same widget types, same data. The audience won't know the difference unless you tell them.
+
+If the BPMN doesn't render, the diagram has likely been deployed but `processDefinitionId` lookup failed. Open `/v2/process-definitions/search` directly in a separate tab to confirm `order-process` is deployed.
+
+## What NOT to demo
+
+- Don't open the React DevTools — fragile.
+- Don't toggle to a non-existent process; the BPMN error state appears and breaks the flow.
+- Don't paste 1000 chars into the prompt. Keep prompts under 80 chars; they read better on stage.

--- a/operate/client/src/App/Notebooks/PromptInput.tsx
+++ b/operate/client/src/App/Notebooks/PromptInput.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import React from 'react';
+import {TextArea, Button, InlineLoading} from '@carbon/react';
+import {PromptSection, PromptRow} from './styled';
+
+type Props = {
+  value: string;
+  onChange: (value: string) => void;
+  onSubmit: () => void;
+  isLoading: boolean;
+};
+
+const PromptInput: React.FC<Props> = ({
+  value,
+  onChange,
+  onSubmit,
+  isLoading,
+}) => {
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
+      onSubmit();
+    }
+  };
+
+  return (
+    <PromptSection>
+      <TextArea
+        id="notebook-prompt"
+        labelText="Ask a question about your processes"
+        placeholder="Ask about your processes… (e.g. show active process instances)"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={handleKeyDown}
+        rows={3}
+        disabled={isLoading}
+      />
+      <PromptRow>
+        {isLoading && <InlineLoading description="Generating widgets…" />}
+        <Button
+          kind="primary"
+          onClick={onSubmit}
+          disabled={isLoading || value.trim() === ''}
+        >
+          Generate
+        </Button>
+      </PromptRow>
+    </PromptSection>
+  );
+};
+
+export {PromptInput};

--- a/operate/client/src/App/Notebooks/PromptInput.tsx
+++ b/operate/client/src/App/Notebooks/PromptInput.tsx
@@ -7,15 +7,68 @@
  */
 
 import React from 'react';
-import {TextArea, Button, InlineLoading} from '@carbon/react';
-import {PromptSection, PromptRow} from './styled';
+import {TextArea, Button, InlineLoading, Tag} from '@carbon/react';
+import {PromptSection, PromptRow, PromptSuggestions} from './styled';
 
 type Props = {
   value: string;
   onChange: (value: string) => void;
-  onSubmit: () => void;
+  /**
+   * Called when the user submits a prompt. `fromPill: true` indicates the
+   * prompt came from a clicked suggestion pill — those route to the static
+   * preset templates (instant, deterministic). Free-text submits go to the
+   * real LLM.
+   */
+  onSubmit: (promptOverride?: string, options?: {fromPill?: boolean}) => void;
   isLoading: boolean;
 };
+
+/**
+ * Curated example prompts shown as clickable pills below the textarea.
+ * Each one demonstrates a different widget type or bundle. Clicking populates
+ * the textarea and submits — they map to the keyword presets in presets.ts.
+ *
+ * Re-order to feature the most cinematic demos first.
+ */
+const SUGGESTIONS: Array<{label: string; prompt: string}> = [
+  {label: 'Showcase all widgets', prompt: 'Show me everything'},
+  {
+    label: 'Monday morning view',
+    prompt: 'Set me up with a Monday morning view',
+  },
+  {label: 'Process health overview', prompt: 'Process health overview'},
+  {label: 'Triage', prompt: "Something looks off, what's broken?"},
+  {label: 'List all incidents', prompt: 'List all incidents'},
+  {label: 'Where are instances stuck?', prompt: 'Where are instances stuck?'},
+  {
+    label: 'Compare all processes',
+    prompt: 'Compare all processes side by side',
+  },
+  {label: 'Workload', prompt: 'How is the workload looking?'},
+  {
+    label: 'Worker capacity',
+    prompt: 'Show me the worker capacity for each job type',
+  },
+  {
+    label: 'Top errors',
+    prompt: 'What error types are happening most?',
+  },
+  {
+    label: 'Slowest instances',
+    prompt: 'What are the slowest-running process instances?',
+  },
+  {
+    label: 'Task workload by assignee',
+    prompt: 'Who has the most user tasks pending right now?',
+  },
+  {label: 'Live activity stream', prompt: 'Show me a live activity stream'},
+  {label: 'Recent activity', prompt: 'Show me a recent activity stream'},
+  {label: 'Trends over time', prompt: 'Show me trends over time'},
+  {
+    label: 'Error types + recent examples',
+    prompt: 'Show me incidents by error type with recent examples',
+  },
+];
 
 const PromptInput: React.FC<Props> = ({
   value,
@@ -29,8 +82,31 @@ const PromptInput: React.FC<Props> = ({
     }
   };
 
+  // Click → populate the textarea and submit immediately. The `fromPill`
+  // flag tells the dispatcher to use the static preset templates instead of
+  // calling the real LLM (instant + deterministic). We also pass the prompt
+  // explicitly to bypass the parent's stale-state closure problem.
+  const handleSuggestion = (prompt: string) => {
+    onChange(prompt);
+    onSubmit(prompt, {fromPill: true});
+  };
+
   return (
     <PromptSection>
+      <PromptSuggestions>
+        {SUGGESTIONS.map((s) => (
+          <Tag
+            key={s.label}
+            type="cool-gray"
+            size="md"
+            onClick={() => handleSuggestion(s.prompt)}
+            disabled={isLoading}
+            style={{cursor: isLoading ? 'not-allowed' : 'pointer'}}
+          >
+            {s.label}
+          </Tag>
+        ))}
+      </PromptSuggestions>
       <TextArea
         id="notebook-prompt"
         labelText="Ask a question about your processes"
@@ -45,7 +121,7 @@ const PromptInput: React.FC<Props> = ({
         {isLoading && <InlineLoading description="Generating widgets…" />}
         <Button
           kind="primary"
-          onClick={onSubmit}
+          onClick={() => onSubmit()}
           disabled={isLoading || value.trim() === ''}
         >
           Generate

--- a/operate/client/src/App/Notebooks/PromptInput.tsx
+++ b/operate/client/src/App/Notebooks/PromptInput.tsx
@@ -57,17 +57,8 @@ const SUGGESTIONS: Array<{label: string; prompt: string}> = [
     label: 'Slowest instances',
     prompt: 'What are the slowest-running process instances?',
   },
-  {
-    label: 'Task workload by assignee',
-    prompt: 'Who has the most user tasks pending right now?',
-  },
   {label: 'Live activity stream', prompt: 'Show me a live activity stream'},
-  {label: 'Recent activity', prompt: 'Show me a recent activity stream'},
   {label: 'Trends over time', prompt: 'Show me trends over time'},
-  {
-    label: 'Error types + recent examples',
-    prompt: 'Show me incidents by error type with recent examples',
-  },
 ];
 
 const PromptInput: React.FC<Props> = ({
@@ -109,8 +100,8 @@ const PromptInput: React.FC<Props> = ({
       </PromptSuggestions>
       <TextArea
         id="notebook-prompt"
-        labelText="Ask a question about your processes"
-        placeholder="Ask about your processes… (e.g. show active process instances)"
+        labelText="Ask anything about your processes"
+        placeholder="e.g. how many incidents in payment-process?"
         value={value}
         onChange={(e) => onChange(e.target.value)}
         onKeyDown={handleKeyDown}

--- a/operate/client/src/App/Notebooks/WidgetFrame.tsx
+++ b/operate/client/src/App/Notebooks/WidgetFrame.tsx
@@ -1,0 +1,136 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import React, {useState} from 'react';
+import {IconButton, Modal} from '@carbon/react';
+import {Code, TrashCan} from '@carbon/react/icons';
+import type {WidgetConfig} from './types';
+import {
+  WidgetFrameContainer,
+  WidgetActions,
+  ConfigDescription,
+  ConfigSectionLabel,
+  ConfigPanelBlock,
+} from './styled';
+
+type Props = {
+  config: WidgetConfig;
+  children: React.ReactNode;
+  onRemove?: () => void;
+  // When true, the "show details" (</>) action and modal are skipped. Used
+  // for narrative widgets (text) where the markdown is the content and the
+  // config JSON has no useful information.
+  hideDetails?: boolean;
+};
+
+const PLACEHOLDER_DESCRIPTION = 'No description was provided for this widget.';
+
+/**
+ * Strip internal-only placeholder fields from a config before showing it in
+ * the details modal. The schema requires a `query` even for widgets that
+ * don't fetch (text, kpi) — but exposing "/__notebook_kpi__" to users makes
+ * the widget look broken. We rewrite/remove these fields so the modal shows
+ * only meaningful information.
+ */
+function presentableConfig(config: WidgetConfig): unknown {
+  const cloned: Record<string, unknown> = {...config};
+  if (
+    typeof cloned.query === 'object' &&
+    cloned.query !== null &&
+    'endpoint' in cloned.query &&
+    typeof (cloned.query as {endpoint?: unknown}).endpoint === 'string' &&
+    ((cloned.query as {endpoint: string}).endpoint as string).startsWith(
+      '/__notebook_',
+    )
+  ) {
+    delete cloned.query;
+  }
+  return cloned;
+}
+
+/**
+ * Text widgets are pure markdown — the JSON has no useful information
+ * beyond what the prose already says, so we hide the config block. Every
+ * other widget type (including kpi, which has multiple inner queries) shows
+ * its config so the audience can see exactly which V2 endpoints are called.
+ */
+function shouldShowConfigJson(config: WidgetConfig): boolean {
+  return config.type !== 'text';
+}
+
+/**
+ * Wraps a widget with a hover-revealed action bar (currently: a "Show details"
+ * toggle). When toggled, a Carbon Modal opens showing the LLM-authored
+ * description first, then the resolved HTTP request, then the raw
+ * WidgetConfig JSON for the curious.
+ */
+const WidgetFrame: React.FC<Props> = ({
+  config,
+  children,
+  onRemove,
+  hideDetails = false,
+}) => {
+  const [showDetails, setShowDetails] = useState(false);
+
+  return (
+    <WidgetFrameContainer>
+      <WidgetActions className="widget-actions" $visible={showDetails}>
+        {!hideDetails && (
+          <IconButton
+            kind="ghost"
+            size="sm"
+            align="left"
+            label="Show widget details"
+            onClick={() => setShowDetails(true)}
+          >
+            <Code />
+          </IconButton>
+        )}
+        {onRemove && (
+          <IconButton
+            kind="ghost"
+            size="sm"
+            align="left"
+            label="Remove widget"
+            onClick={onRemove}
+          >
+            <TrashCan />
+          </IconButton>
+        )}
+      </WidgetActions>
+
+      {children}
+
+      {showDetails && (
+        <Modal
+          open
+          modalHeading={config.title}
+          modalLabel="Widget details"
+          passiveModal
+          onRequestClose={() => setShowDetails(false)}
+          size="md"
+        >
+          <ConfigDescription>
+            {config.description ?? PLACEHOLDER_DESCRIPTION}
+          </ConfigDescription>
+
+          {shouldShowConfigJson(config) && (
+            <>
+              <ConfigSectionLabel>Generated config</ConfigSectionLabel>
+              <ConfigPanelBlock>
+                {JSON.stringify(presentableConfig(config), null, 2)}
+              </ConfigPanelBlock>
+            </>
+          )}
+        </Modal>
+      )}
+    </WidgetFrameContainer>
+  );
+};
+
+export {WidgetFrame};

--- a/operate/client/src/App/Notebooks/WidgetFrame.tsx
+++ b/operate/client/src/App/Notebooks/WidgetFrame.tsx
@@ -8,7 +8,7 @@
 
 import React, {useState} from 'react';
 import {Button, IconButton, Modal} from '@carbon/react';
-import {Code, Edit, TrashCan} from '@carbon/react/icons';
+import {Code, TrashCan} from '@carbon/react/icons';
 import {WidgetConfigSchema, type WidgetConfig} from './types';
 import {
   WidgetFrameContainer,
@@ -122,10 +122,23 @@ const WidgetFrame: React.FC<Props> = ({
 
     // Preserve the original id — editing should never silently re-key a
     // widget (would break React reconciliation and any saved layout).
-    const merged =
+    //
+    // Also restore the original `query` when it was stripped by
+    // `presentableConfig` (placeholder queries on kpi/text widgets are hidden
+    // from the user). The schema requires `query` for every widget; without
+    // this restore the user would be forced to invent a fake endpoint URL.
+    const parsedObj =
       parsed != null && typeof parsed === 'object'
-        ? {...(parsed as Record<string, unknown>), id: config.id}
-        : parsed;
+        ? (parsed as Record<string, unknown>)
+        : null;
+    let merged: unknown = parsed;
+    if (parsedObj != null) {
+      const next: Record<string, unknown> = {...parsedObj, id: config.id};
+      if (next.query == null) {
+        next.query = config.query;
+      }
+      merged = next;
+    }
 
     const result = WidgetConfigSchema.safeParse(merged);
     if (!result.success) {
@@ -158,17 +171,6 @@ const WidgetFrame: React.FC<Props> = ({
             onClick={openView}
           >
             <Code />
-          </IconButton>
-        )}
-        {!hideDetails && isEditable && (
-          <IconButton
-            kind="ghost"
-            size="sm"
-            align="left"
-            label="Edit widget config"
-            onClick={openEdit}
-          >
-            <Edit />
           </IconButton>
         )}
         {onRemove && (

--- a/operate/client/src/App/Notebooks/WidgetFrame.tsx
+++ b/operate/client/src/App/Notebooks/WidgetFrame.tsx
@@ -7,21 +7,30 @@
  */
 
 import React, {useState} from 'react';
-import {IconButton, Modal} from '@carbon/react';
-import {Code, TrashCan} from '@carbon/react/icons';
-import type {WidgetConfig} from './types';
+import {Button, IconButton, Modal} from '@carbon/react';
+import {Code, Edit, TrashCan} from '@carbon/react/icons';
+import {WidgetConfigSchema, type WidgetConfig} from './types';
 import {
   WidgetFrameContainer,
   WidgetActions,
   ConfigDescription,
   ConfigSectionLabel,
   ConfigPanelBlock,
+  ConfigEditorTextarea,
+  ConfigEditorActions,
+  ConfigEditorError,
 } from './styled';
 
 type Props = {
   config: WidgetConfig;
   children: React.ReactNode;
   onRemove?: () => void;
+  /**
+   * Called when the user saves an edited config from the details modal. The
+   * incoming `next` is already validated against `WidgetConfigSchema`, with
+   * `id` preserved from the original.
+   */
+  onUpdate?: (next: WidgetConfig) => void;
   // When true, the "show details" (</>) action and modal are skipped. Used
   // for narrative widgets (text) where the markdown is the content and the
   // config JSON has no useful information.
@@ -65,30 +74,101 @@ function shouldShowConfigJson(config: WidgetConfig): boolean {
 
 /**
  * Wraps a widget with a hover-revealed action bar (currently: a "Show details"
- * toggle). When toggled, a Carbon Modal opens showing the LLM-authored
- * description first, then the resolved HTTP request, then the raw
- * WidgetConfig JSON for the curious.
+ * toggle, an "Edit config" toggle, and a remove button). Selecting either of
+ * the first two opens a Carbon Modal showing the LLM-authored description
+ * first, then the config JSON — read-only by default, editable when the user
+ * clicks the pencil icon (or chose "Edit config" directly).
  */
 const WidgetFrame: React.FC<Props> = ({
   config,
   children,
   onRemove,
+  onUpdate,
   hideDetails = false,
 }) => {
-  const [showDetails, setShowDetails] = useState(false);
+  const [modalState, setModalState] = useState<'closed' | 'view' | 'edit'>(
+    'closed',
+  );
+  const [draft, setDraft] = useState<string>('');
+  const [error, setError] = useState<string | null>(null);
+
+  const openView = () => {
+    setModalState('view');
+    setError(null);
+  };
+  const openEdit = () => {
+    setDraft(JSON.stringify(presentableConfig(config), null, 2));
+    setModalState('edit');
+    setError(null);
+  };
+  const close = () => {
+    setModalState('closed');
+    setError(null);
+  };
+
+  const handleSave = () => {
+    if (onUpdate == null) {
+      return;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(draft);
+    } catch (err) {
+      setError(
+        err instanceof Error ? `Invalid JSON: ${err.message}` : 'Invalid JSON.',
+      );
+      return;
+    }
+
+    // Preserve the original id — editing should never silently re-key a
+    // widget (would break React reconciliation and any saved layout).
+    const merged =
+      parsed != null && typeof parsed === 'object'
+        ? {...(parsed as Record<string, unknown>), id: config.id}
+        : parsed;
+
+    const result = WidgetConfigSchema.safeParse(merged);
+    if (!result.success) {
+      const issues = result.error.issues
+        .slice(0, 5)
+        .map((i) => `• ${i.path.join('.') || '(root)'}: ${i.message}`)
+        .join('\n');
+      setError(`Invalid widget config:\n${issues}`);
+      return;
+    }
+
+    onUpdate(result.data);
+    close();
+  };
+
+  const isEditable = onUpdate != null && shouldShowConfigJson(config);
 
   return (
     <WidgetFrameContainer>
-      <WidgetActions className="widget-actions" $visible={showDetails}>
+      <WidgetActions
+        className="widget-actions"
+        $visible={modalState !== 'closed'}
+      >
         {!hideDetails && (
           <IconButton
             kind="ghost"
             size="sm"
             align="left"
             label="Show widget details"
-            onClick={() => setShowDetails(true)}
+            onClick={openView}
           >
             <Code />
+          </IconButton>
+        )}
+        {!hideDetails && isEditable && (
+          <IconButton
+            kind="ghost"
+            size="sm"
+            align="left"
+            label="Edit widget config"
+            onClick={openEdit}
+          >
+            <Edit />
           </IconButton>
         )}
         {onRemove && (
@@ -106,13 +186,13 @@ const WidgetFrame: React.FC<Props> = ({
 
       {children}
 
-      {showDetails && (
+      {modalState !== 'closed' && (
         <Modal
           open
           modalHeading={config.title}
-          modalLabel="Widget details"
+          modalLabel={modalState === 'edit' ? 'Edit widget' : 'Widget details'}
           passiveModal
-          onRequestClose={() => setShowDetails(false)}
+          onRequestClose={close}
           size="md"
         >
           <ConfigDescription>
@@ -121,10 +201,46 @@ const WidgetFrame: React.FC<Props> = ({
 
           {shouldShowConfigJson(config) && (
             <>
-              <ConfigSectionLabel>Generated config</ConfigSectionLabel>
-              <ConfigPanelBlock>
-                {JSON.stringify(presentableConfig(config), null, 2)}
-              </ConfigPanelBlock>
+              <ConfigSectionLabel>
+                {modalState === 'edit'
+                  ? 'Edit config (JSON)'
+                  : 'Generated config'}
+              </ConfigSectionLabel>
+
+              {modalState === 'view' && (
+                <>
+                  <ConfigPanelBlock>
+                    {JSON.stringify(presentableConfig(config), null, 2)}
+                  </ConfigPanelBlock>
+                  {isEditable && (
+                    <ConfigEditorActions>
+                      <Button kind="tertiary" size="sm" onClick={openEdit}>
+                        Edit
+                      </Button>
+                    </ConfigEditorActions>
+                  )}
+                </>
+              )}
+
+              {modalState === 'edit' && (
+                <>
+                  <ConfigEditorTextarea
+                    value={draft}
+                    onChange={(e) => setDraft(e.target.value)}
+                    spellCheck={false}
+                    aria-label="Widget config JSON"
+                  />
+                  {error && <ConfigEditorError>{error}</ConfigEditorError>}
+                  <ConfigEditorActions>
+                    <Button kind="ghost" size="sm" onClick={openView}>
+                      Cancel
+                    </Button>
+                    <Button kind="primary" size="sm" onClick={handleSave}>
+                      Save
+                    </Button>
+                  </ConfigEditorActions>
+                </>
+              )}
             </>
           )}
         </Modal>

--- a/operate/client/src/App/Notebooks/WidgetRenderer.test.tsx
+++ b/operate/client/src/App/Notebooks/WidgetRenderer.test.tsx
@@ -1,0 +1,80 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {render, screen} from 'modules/testing-library';
+import {WidgetRenderer} from './WidgetRenderer';
+import type {WidgetConfig} from './types';
+
+// Stub inner widgets so WidgetRenderer tests are isolated from their internals.
+vi.mock('./widgets/MetricWidget', () => ({
+  MetricWidget: ({config}: {config: WidgetConfig}) => (
+    <div data-testid="metric-widget">{config.title}</div>
+  ),
+}));
+
+vi.mock('./widgets/TableWidget', () => ({
+  TableWidget: ({config}: {config: WidgetConfig}) => (
+    <div data-testid="table-widget">{config.title}</div>
+  ),
+}));
+
+const metricConfig: WidgetConfig = {
+  id: 'w-metric-1',
+  type: 'metric',
+  title: 'Active Instances',
+  query: {endpoint: '/v2/process-instances/search', method: 'POST'},
+  field: 'page.totalItems',
+};
+
+const tableConfig: WidgetConfig = {
+  id: 'w-table-1',
+  type: 'table',
+  title: 'Instance Table',
+  query: {endpoint: '/v2/process-instances/search', method: 'POST'},
+  columns: ['id', 'state'],
+};
+
+describe('<WidgetRenderer />', () => {
+  it('should render MetricWidget when config.type is "metric"', () => {
+    // given
+    // when
+    render(<WidgetRenderer config={metricConfig} />);
+
+    // then
+    expect(screen.getByTestId('metric-widget')).toBeInTheDocument();
+    expect(screen.getByText('Active Instances')).toBeInTheDocument();
+    expect(screen.queryByTestId('table-widget')).not.toBeInTheDocument();
+  });
+
+  it('should render TableWidget when config.type is "table"', () => {
+    // given
+    // when
+    render(<WidgetRenderer config={tableConfig} />);
+
+    // then
+    expect(screen.getByTestId('table-widget')).toBeInTheDocument();
+    expect(screen.getByText('Instance Table')).toBeInTheDocument();
+    expect(screen.queryByTestId('metric-widget')).not.toBeInTheDocument();
+  });
+
+  it('should render a fallback for unknown widget types', () => {
+    // given – cast to bypass TS so we can exercise the runtime branch
+    const unknownConfig = {
+      ...metricConfig,
+      type: 'unknown-future-type',
+    } as unknown as WidgetConfig;
+
+    // when
+    render(<WidgetRenderer config={unknownConfig} />);
+
+    // then – must not crash and should show something indicating it is unsupported
+    expect(
+      screen.getByText(/unsupported|unknown|not supported/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/operate/client/src/App/Notebooks/WidgetRenderer.tsx
+++ b/operate/client/src/App/Notebooks/WidgetRenderer.tsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import React from 'react';
+import {MetricWidget} from './widgets/MetricWidget';
+import {TableWidget} from './widgets/TableWidget';
+import type {WidgetConfig} from './types';
+
+type Props = {
+  config: WidgetConfig;
+};
+
+const WidgetRenderer: React.FC<Props> = ({config}) => {
+  if (config.type === 'metric') {
+    return <MetricWidget config={config} />;
+  }
+
+  if (config.type === 'table') {
+    return <TableWidget config={config} />;
+  }
+
+  return (
+    <div>
+      <p>Unsupported widget type: {(config as {type: string}).type}</p>
+    </div>
+  );
+};
+
+export {WidgetRenderer};

--- a/operate/client/src/App/Notebooks/WidgetRenderer.tsx
+++ b/operate/client/src/App/Notebooks/WidgetRenderer.tsx
@@ -9,25 +9,75 @@
 import React from 'react';
 import {MetricWidget} from './widgets/MetricWidget';
 import {TableWidget} from './widgets/TableWidget';
+import {BpmnWidget} from './widgets/BpmnWidget';
+import {ChartWidget} from './widgets/ChartWidget';
+import {TextWidget} from './widgets/TextWidget';
+import {KpiWidget} from './widgets/KpiWidget';
+import {StatusGridWidget} from './widgets/StatusGridWidget';
+import {ActivityFeedWidget} from './widgets/ActivityFeedWidget';
+import {FunnelWidget} from './widgets/FunnelWidget';
+import {TrendWidget} from './widgets/TrendWidget';
+import {WidgetFrame} from './WidgetFrame';
 import type {WidgetConfig} from './types';
 
 type Props = {
   config: WidgetConfig;
+  onRemove?: () => void;
 };
 
-const WidgetRenderer: React.FC<Props> = ({config}) => {
+function renderInner(config: WidgetConfig): React.ReactElement {
   if (config.type === 'metric') {
     return <MetricWidget config={config} />;
   }
-
   if (config.type === 'table') {
     return <TableWidget config={config} />;
   }
-
+  if (config.type === 'bpmn') {
+    return <BpmnWidget config={config} />;
+  }
+  if (config.type === 'chart') {
+    return <ChartWidget config={config} />;
+  }
+  if (config.type === 'text') {
+    return <TextWidget config={config} />;
+  }
+  if (config.type === 'kpi') {
+    return <KpiWidget config={config} />;
+  }
+  if (config.type === 'status-grid') {
+    return <StatusGridWidget config={config} />;
+  }
+  if (config.type === 'activity-feed') {
+    return <ActivityFeedWidget config={config} />;
+  }
+  if (config.type === 'funnel') {
+    return <FunnelWidget config={config} />;
+  }
+  if (config.type === 'trend') {
+    return <TrendWidget config={config} />;
+  }
   return (
     <div>
       <p>Unsupported widget type: {(config as {type: string}).type}</p>
     </div>
+  );
+}
+
+const WidgetRenderer: React.FC<Props> = ({config, onRemove}) => {
+  // Text widgets are pure narrative — no need for the frame's "show details"
+  // button (the markdown IS the content). They still get the remove button
+  // via a slim wrapper inside the slot's grid placement.
+  if (config.type === 'text') {
+    return (
+      <WidgetFrame config={config} onRemove={onRemove} hideDetails>
+        {renderInner(config)}
+      </WidgetFrame>
+    );
+  }
+  return (
+    <WidgetFrame config={config} onRemove={onRemove}>
+      {renderInner(config)}
+    </WidgetFrame>
   );
 };
 

--- a/operate/client/src/App/Notebooks/WidgetRenderer.tsx
+++ b/operate/client/src/App/Notebooks/WidgetRenderer.tsx
@@ -23,6 +23,7 @@ import type {WidgetConfig} from './types';
 type Props = {
   config: WidgetConfig;
   onRemove?: () => void;
+  onUpdate?: (next: WidgetConfig) => void;
 };
 
 function renderInner(config: WidgetConfig): React.ReactElement {
@@ -63,7 +64,7 @@ function renderInner(config: WidgetConfig): React.ReactElement {
   );
 }
 
-const WidgetRenderer: React.FC<Props> = ({config, onRemove}) => {
+const WidgetRenderer: React.FC<Props> = ({config, onRemove, onUpdate}) => {
   // Text widgets are pure narrative — no need for the frame's "show details"
   // button (the markdown IS the content). They still get the remove button
   // via a slim wrapper inside the slot's grid placement.
@@ -75,7 +76,7 @@ const WidgetRenderer: React.FC<Props> = ({config, onRemove}) => {
     );
   }
   return (
-    <WidgetFrame config={config} onRemove={onRemove}>
+    <WidgetFrame config={config} onRemove={onRemove} onUpdate={onUpdate}>
       {renderInner(config)}
     </WidgetFrame>
   );

--- a/operate/client/src/App/Notebooks/awsSigV4.ts
+++ b/operate/client/src/App/Notebooks/awsSigV4.ts
@@ -1,0 +1,166 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+/**
+ * Minimal hand-rolled AWS SigV4 signer for a single POST request.
+ * Uses the Web Crypto API (crypto.subtle) — no npm dependencies.
+ *
+ * Reference: https://docs.aws.amazon.com/general/latest/gr/sigv4_signing.html
+ */
+
+// ---------------------------------------------------------------------------
+// Low-level crypto helpers
+// ---------------------------------------------------------------------------
+
+async function sha256Hex(message: string): Promise<string> {
+  const msgBuffer = new TextEncoder().encode(message);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', msgBuffer);
+  return toHex(new Uint8Array(hashBuffer));
+}
+
+async function hmacSha256(key: Uint8Array, data: string): Promise<Uint8Array> {
+  // TypeScript's strict DOM lib types `importKey`'s 2nd arg as `ArrayBuffer`
+  // (via BufferSource), but at runtime a Uint8Array is always a valid typed
+  // array key material.  The cast silences the compile error without any
+  // runtime conversion that could confuse jsdom's SubtleCrypto.
+  const cryptoKey = await crypto.subtle.importKey(
+    'raw',
+    key as unknown as ArrayBuffer,
+    {name: 'HMAC', hash: 'SHA-256'},
+    false,
+    ['sign'],
+  );
+  const signature = await crypto.subtle.sign(
+    'HMAC',
+    cryptoKey,
+    new TextEncoder().encode(data),
+  );
+  return new Uint8Array(signature);
+}
+
+function toHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+// ---------------------------------------------------------------------------
+// Signing-key derivation
+// ---------------------------------------------------------------------------
+
+async function deriveSigningKey(
+  secretAccessKey: string,
+  dateStamp: string, // YYYYMMDD
+  region: string,
+  service: string,
+): Promise<Uint8Array> {
+  const kSecret = new TextEncoder().encode(`AWS4${secretAccessKey}`);
+  const kDate = await hmacSha256(kSecret, dateStamp);
+  const kRegion = await hmacSha256(kDate, region);
+  const kService = await hmacSha256(kRegion, service);
+  const kSigning = await hmacSha256(kService, 'aws4_request');
+  return kSigning;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export type SigV4Credentials = {
+  accessKeyId: string;
+  secretAccessKey: string;
+  region: string;
+  service: string;
+};
+
+/**
+ * Compute the Authorization header and companion headers for a POST request.
+ * Returns the full set of headers that must be sent with the request.
+ */
+export async function signRequest(
+  credentials: SigV4Credentials,
+  host: string,
+  path: string,
+  body: string,
+): Promise<Record<string, string>> {
+  const {accessKeyId, secretAccessKey, region, service} = credentials;
+
+  // Timestamps
+  const now = new Date();
+  const amzDate = now.toISOString().replace(/[:-]/g, '').slice(0, 15) + 'Z'; // YYYYMMDDTHHmmssZ
+  const dateStamp = amzDate.slice(0, 8); // YYYYMMDD
+
+  // Payload hash
+  const payloadHash = await sha256Hex(body);
+
+  // Canonical headers (must be sorted, lowercase)
+  const canonicalHeaders =
+    `content-type:application/json\n` +
+    `host:${host}\n` +
+    `x-amz-content-sha256:${payloadHash}\n` +
+    `x-amz-date:${amzDate}\n`;
+
+  const signedHeaders = 'content-type;host;x-amz-content-sha256;x-amz-date';
+
+  // Canonical request
+  //
+  // SigV4 quirk: for non-S3 services (Bedrock included), the URI in the
+  // canonical request must be **doubly URI-encoded**. The actual HTTP request
+  // path is singly encoded (e.g. "/model/arn%3A...%2F.../invoke"), but for
+  // signing we re-encode each path segment so "%3A" becomes "%253A".
+  // We split on "/" so the slashes between segments stay literal.
+  const canonicalPath = path
+    .split('/')
+    .map((segment) => encodeURIComponent(segment))
+    .join('/');
+
+  const canonicalRequest = [
+    'POST',
+    canonicalPath,
+    '', // query string (empty)
+    canonicalHeaders,
+    signedHeaders,
+    payloadHash,
+  ].join('\n');
+
+  // Credential scope
+  const credentialScope = `${dateStamp}/${region}/${service}/aws4_request`;
+
+  // String to sign
+  const hashedCanonicalRequest = await sha256Hex(canonicalRequest);
+  const stringToSign = [
+    'AWS4-HMAC-SHA256',
+    amzDate,
+    credentialScope,
+    hashedCanonicalRequest,
+  ].join('\n');
+
+  // Signature
+  const signingKey = await deriveSigningKey(
+    secretAccessKey,
+    dateStamp,
+    region,
+    service,
+  );
+  const signatureBytes = await hmacSha256(signingKey, stringToSign);
+  const signature = toHex(signatureBytes);
+
+  // Authorization header
+  const authorization =
+    `AWS4-HMAC-SHA256 Credential=${accessKeyId}/${credentialScope},` +
+    `SignedHeaders=${signedHeaders},` +
+    `Signature=${signature}`;
+
+  return {
+    'content-type': 'application/json',
+    host,
+    'x-amz-content-sha256': payloadHash,
+    'x-amz-date': amzDate,
+    Authorization: authorization,
+  };
+}

--- a/operate/client/src/App/Notebooks/index.test.tsx
+++ b/operate/client/src/App/Notebooks/index.test.tsx
@@ -1,0 +1,184 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import React from 'react';
+import {render, screen, waitFor} from 'modules/testing-library';
+import {MemoryRouter, Route, Routes} from 'react-router-dom';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {NotebookPage} from './index';
+import {saveNotebook, loadNotebook} from './persistence';
+import type {Notebook, WidgetConfig} from './types';
+
+// ---------------------------------------------------------------------------
+// Mock the LLM module — we don't want real network calls in integration tests.
+// ---------------------------------------------------------------------------
+vi.mock('./llm', () => ({
+  generateWidgets: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock WidgetRenderer so rendering widgets is trivial and deterministic.
+// ---------------------------------------------------------------------------
+vi.mock('./WidgetRenderer', () => ({
+  WidgetRenderer: ({config}: {config: WidgetConfig}) => (
+    <div data-testid={`widget-${config.id}`}>{config.title}</div>
+  ),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type WrapperProps = {children?: React.ReactNode};
+
+function createWrapper(notebookId: string = 'test-id-123') {
+  const Wrapper = ({children}: WrapperProps) => (
+    <QueryClientProvider client={getMockQueryClient()}>
+      <MemoryRouter initialEntries={[`/notebooks/${notebookId}`]}>
+        <Routes>
+          <Route path="/notebooks/:id" element={children} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+  return Wrapper;
+}
+
+const GENERATED_WIDGET: WidgetConfig = {
+  id: 'generated-widget-id',
+  type: 'metric',
+  title: 'Generated Metric',
+  query: {endpoint: '/v2/process-instances/search', method: 'POST'},
+  field: 'page.totalItems',
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('<NotebookPage />', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('should render the prompt input on an empty notebook', () => {
+    // given – no notebook in localStorage for this id
+
+    // when
+    render(<NotebookPage />, {wrapper: createWrapper('brand-new-id')});
+
+    // then – a text area or input for the prompt must be present
+    expect(
+      screen.getByRole('textbox') ?? screen.getByPlaceholderText(/prompt|ask/i),
+    ).toBeInTheDocument();
+  });
+
+  it('should auto-create a new notebook in localStorage when the id is not found', () => {
+    // given – localStorage is empty, id is unknown
+    const notebookId = 'auto-create-id';
+
+    // when
+    render(<NotebookPage />, {wrapper: createWrapper(notebookId)});
+
+    // then – persistence layer must now contain this notebook
+    const saved = loadNotebook(notebookId);
+    expect(saved).not.toBeNull();
+    expect(saved?.id).toBe(notebookId);
+    expect(saved?.title).toBe('Untitled notebook');
+    expect(saved?.widgets).toEqual([]);
+  });
+
+  it('should load an existing notebook from localStorage and render its widgets', async () => {
+    // given
+    const existingNotebook: Notebook = {
+      id: 'existing-nb',
+      title: 'My Saved Notebook',
+      widgets: [
+        {
+          id: 'existing-w-1',
+          type: 'metric',
+          title: 'Existing Widget',
+          query: {endpoint: '/v2/process-instances/search', method: 'POST'},
+        },
+      ],
+      updatedAt: Date.now(),
+    };
+    saveNotebook(existingNotebook);
+
+    // when
+    render(<NotebookPage />, {wrapper: createWrapper('existing-nb')});
+
+    // then – the pre-existing widget is rendered
+    expect(
+      await screen.findByTestId('widget-existing-w-1'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Existing Widget')).toBeInTheDocument();
+  });
+
+  it('should call generateWidgets and append returned widgets to the notebook on prompt submit', async () => {
+    // given
+    const {generateWidgets} = await import('./llm');
+    vi.mocked(generateWidgets).mockResolvedValue([GENERATED_WIDGET]);
+
+    const {user} = render(<NotebookPage />, {
+      wrapper: createWrapper('submit-test-id'),
+    });
+
+    // when – type a prompt and submit
+    const promptInput =
+      screen.getByRole('textbox') ?? screen.getByPlaceholderText(/prompt|ask/i);
+    await user.type(promptInput, 'show running instances');
+
+    const submitButton = screen.getByRole('button', {
+      name: /submit|send|run|generate/i,
+    });
+    await user.click(submitButton);
+
+    // then – widget returned by LLM appears on screen
+    expect(
+      await screen.findByTestId(`widget-${GENERATED_WIDGET.id}`),
+    ).toBeInTheDocument();
+    expect(generateWidgets).toHaveBeenCalledWith(
+      expect.stringContaining('show running instances'),
+      expect.anything(),
+    );
+  });
+
+  it('should persist the notebook to localStorage on widget add', async () => {
+    // given
+    const {generateWidgets} = await import('./llm');
+    vi.mocked(generateWidgets).mockResolvedValue([GENERATED_WIDGET]);
+    const notebookId = 'persist-test-id';
+
+    const {user} = render(<NotebookPage />, {
+      wrapper: createWrapper(notebookId),
+    });
+
+    // when
+    const promptInput =
+      screen.getByRole('textbox') ?? screen.getByPlaceholderText(/prompt|ask/i);
+    await user.type(promptInput, 'anything');
+
+    const submitButton = screen.getByRole('button', {
+      name: /submit|send|run|generate/i,
+    });
+    await user.click(submitButton);
+
+    // wait for widget to appear before asserting localStorage
+    await screen.findByTestId(`widget-${GENERATED_WIDGET.id}`);
+
+    // then – localStorage must contain the generated widget
+    await waitFor(() => {
+      const saved = loadNotebook(notebookId);
+      expect(saved).not.toBeNull();
+      expect(saved?.widgets).toHaveLength(1);
+      expect(saved?.widgets[0]?.id).toBe(GENERATED_WIDGET.id);
+    });
+  });
+});

--- a/operate/client/src/App/Notebooks/index.test.tsx
+++ b/operate/client/src/App/Notebooks/index.test.tsx
@@ -147,6 +147,7 @@ describe('<NotebookPage />', () => {
     expect(generateWidgets).toHaveBeenCalledWith(
       expect.stringContaining('show running instances'),
       expect.anything(),
+      expect.objectContaining({fromPill: expect.any(Boolean)}),
     );
   });
 

--- a/operate/client/src/App/Notebooks/index.tsx
+++ b/operate/client/src/App/Notebooks/index.tsx
@@ -1,0 +1,120 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import React, {useState} from 'react';
+import {useParams} from 'react-router-dom';
+import {InlineNotification} from '@carbon/react';
+import {generateWidgets} from './llm';
+import {loadNotebook, saveNotebook} from './persistence';
+import {PromptInput} from './PromptInput';
+import {WidgetRenderer} from './WidgetRenderer';
+import {PageContainer, NotebookTitle, WidgetsGrid} from './styled';
+import type {Notebook, WidgetConfig} from './types';
+
+const API_KEY: string =
+  (import.meta.env['VITE_ANTHROPIC_API_KEY'] as string | undefined) ?? '';
+
+function createFreshNotebook(id: string): Notebook {
+  return {
+    id,
+    title: 'Untitled notebook',
+    widgets: [],
+    updatedAt: Date.now(),
+  };
+}
+
+const NotebookPage: React.FC = () => {
+  const {id = 'default'} = useParams<{id: string}>();
+
+  const [notebook, setNotebook] = useState<Notebook>(() => {
+    const loaded = loadNotebook(id);
+    if (loaded) {
+      return loaded;
+    }
+    const fresh = createFreshNotebook(id);
+    saveNotebook(fresh);
+    return fresh;
+  });
+
+  const [prompt, setPrompt] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const handleSubmit = async () => {
+    const trimmedPrompt = prompt.trim();
+    if (!trimmedPrompt || isLoading) {
+      return;
+    }
+
+    setIsLoading(true);
+    setErrorMessage(null);
+
+    try {
+      const newWidgets: WidgetConfig[] = await generateWidgets(
+        trimmedPrompt,
+        API_KEY,
+      );
+
+      setNotebook((prev) => {
+        const isFirstPrompt =
+          prev.widgets.length === 0 && prev.title === 'Untitled notebook';
+        const updated: Notebook = {
+          ...prev,
+          title: isFirstPrompt ? trimmedPrompt.slice(0, 50) : prev.title,
+          widgets: [...prev.widgets, ...newWidgets],
+          updatedAt: Date.now(),
+        };
+        saveNotebook(updated);
+        return updated;
+      });
+
+      setPrompt('');
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : 'Failed to generate widgets.';
+      setErrorMessage(message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const hasContent = notebook.widgets.length > 0;
+  const hasCustomTitle = notebook.title !== 'Untitled notebook';
+
+  return (
+    <PageContainer>
+      {(hasContent || hasCustomTitle) && (
+        <NotebookTitle>{notebook.title}</NotebookTitle>
+      )}
+
+      {errorMessage && (
+        <InlineNotification
+          kind="error"
+          title="Error"
+          subtitle={errorMessage}
+          onCloseButtonClick={() => setErrorMessage(null)}
+        />
+      )}
+
+      <WidgetsGrid>
+        {notebook.widgets.map((widget) => (
+          <WidgetRenderer key={widget.id} config={widget} />
+        ))}
+      </WidgetsGrid>
+
+      <PromptInput
+        value={prompt}
+        onChange={setPrompt}
+        onSubmit={handleSubmit}
+        isLoading={isLoading}
+      />
+    </PageContainer>
+  );
+};
+
+export {NotebookPage};

--- a/operate/client/src/App/Notebooks/index.tsx
+++ b/operate/client/src/App/Notebooks/index.tsx
@@ -160,6 +160,24 @@ const NotebookPage: React.FC = () => {
     });
   };
 
+  /**
+   * Replace a widget's config in place. Called from the WidgetFrame edit
+   * modal. The new config has already been Zod-validated and shares the
+   * widget's original id, so React keys and the visual position are
+   * preserved.
+   */
+  const handleUpdateWidget = (widgetId: string, next: WidgetConfig) => {
+    setNotebook((prev) => {
+      const updated: Notebook = {
+        ...prev,
+        widgets: prev.widgets.map((w) => (w.id === widgetId ? next : w)),
+        updatedAt: Date.now(),
+      };
+      saveNotebook(updated);
+      return updated;
+    });
+  };
+
   const handleClearAll = () => {
     setNotebook((prev) => {
       const updated: Notebook = {
@@ -225,6 +243,7 @@ const NotebookPage: React.FC = () => {
               <WidgetRenderer
                 config={widget}
                 onRemove={() => handleRemoveWidget(widget.id)}
+                onUpdate={(next) => handleUpdateWidget(widget.id, next)}
               />
             </WidgetSlot>
           ))}

--- a/operate/client/src/App/Notebooks/index.tsx
+++ b/operate/client/src/App/Notebooks/index.tsx
@@ -8,16 +8,56 @@
 
 import React, {useState} from 'react';
 import {useParams} from 'react-router-dom';
-import {InlineNotification} from '@carbon/react';
-import {generateWidgets} from './llm';
+import {InlineNotification, Button} from '@carbon/react';
+import {TrashCan} from '@carbon/react/icons';
+import {generateWidgets, type BedrockCredentials} from './llm';
 import {loadNotebook, saveNotebook} from './persistence';
 import {PromptInput} from './PromptInput';
 import {WidgetRenderer} from './WidgetRenderer';
-import {PageContainer, NotebookTitle, WidgetsGrid} from './styled';
+import {
+  PageContainer,
+  ContentScroll,
+  NotebookTitle,
+  NotebookHeader,
+  WidgetsGrid,
+  WidgetSlot,
+} from './styled';
 import type {Notebook, WidgetConfig} from './types';
 
-const API_KEY: string =
-  (import.meta.env['VITE_ANTHROPIC_API_KEY'] as string | undefined) ?? '';
+/**
+ * Map widget type to its height tier. Used by `<WidgetSlot data-tier=…>`
+ * to opt TALL widgets into a shared 296px min-height so they line up in
+ * the same row.
+ */
+function widgetTier(
+  type: WidgetConfig['type'],
+): 'short' | 'tall' | 'hero' | 'auto' {
+  switch (type) {
+    case 'metric':
+    case 'trend':
+      return 'short';
+    case 'kpi':
+    case 'chart':
+    case 'funnel':
+    case 'activity-feed':
+      return 'tall';
+    case 'bpmn':
+    case 'status-grid':
+      return 'hero';
+    case 'table':
+    case 'text':
+    default:
+      return 'auto';
+  }
+}
+
+const BEDROCK_CREDENTIALS: BedrockCredentials = {
+  arn: (import.meta.env['VITE_AWS_BEDROCK_ARN'] as string | undefined) ?? '',
+  accessKeyId:
+    (import.meta.env['VITE_AWS_ACCESS_KEY_ID'] as string | undefined) ?? '',
+  secretAccessKey:
+    (import.meta.env['VITE_AWS_SECRET_ACCESS_KEY'] as string | undefined) ?? '',
+};
 
 function createFreshNotebook(id: string): Notebook {
   return {
@@ -44,9 +84,15 @@ const NotebookPage: React.FC = () => {
   const [prompt, setPrompt] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-
-  const handleSubmit = async () => {
-    const trimmedPrompt = prompt.trim();
+  // Pills route to static presets via {fromPill: true}; freeform → real LLM.
+  const handleSubmit = async (
+    promptOverride?: string,
+    options: {fromPill?: boolean} = {},
+  ) => {
+    // Allow callers (e.g. one-click suggestion pills) to pass an explicit
+    // prompt that bypasses local state — avoids stale-closure issues when the
+    // textarea was just populated and submitted in the same tick.
+    const trimmedPrompt = (promptOverride ?? prompt).trim();
     if (!trimmedPrompt || isLoading) {
       return;
     }
@@ -57,7 +103,8 @@ const NotebookPage: React.FC = () => {
     try {
       const newWidgets: WidgetConfig[] = await generateWidgets(
         trimmedPrompt,
-        API_KEY,
+        BEDROCK_CREDENTIALS,
+        {fromPill: options.fromPill ?? false},
       );
 
       setNotebook((prev) => {
@@ -83,29 +130,79 @@ const NotebookPage: React.FC = () => {
     }
   };
 
+  const handleRemoveWidget = (widgetId: string) => {
+    setNotebook((prev) => {
+      const updated: Notebook = {
+        ...prev,
+        widgets: prev.widgets.filter((w) => w.id !== widgetId),
+        updatedAt: Date.now(),
+      };
+      saveNotebook(updated);
+      return updated;
+    });
+  };
+
+  const handleClearAll = () => {
+    setNotebook((prev) => {
+      const updated: Notebook = {
+        ...prev,
+        title: 'Untitled notebook',
+        widgets: [],
+        updatedAt: Date.now(),
+      };
+      saveNotebook(updated);
+      return updated;
+    });
+    setErrorMessage(null);
+  };
+
   const hasContent = notebook.widgets.length > 0;
   const hasCustomTitle = notebook.title !== 'Untitled notebook';
 
   return (
     <PageContainer>
-      {(hasContent || hasCustomTitle) && (
-        <NotebookTitle>{notebook.title}</NotebookTitle>
-      )}
+      <ContentScroll>
+        {(hasContent || hasCustomTitle) && (
+          <NotebookHeader>
+            <NotebookTitle>{notebook.title}</NotebookTitle>
+            {hasContent && (
+              <Button
+                kind="ghost"
+                size="sm"
+                renderIcon={TrashCan}
+                onClick={handleClearAll}
+              >
+                Clear all widgets
+              </Button>
+            )}
+          </NotebookHeader>
+        )}
 
-      {errorMessage && (
-        <InlineNotification
-          kind="error"
-          title="Error"
-          subtitle={errorMessage}
-          onCloseButtonClick={() => setErrorMessage(null)}
-        />
-      )}
+        {errorMessage && (
+          <InlineNotification
+            kind="error"
+            title="Error"
+            subtitle={errorMessage}
+            onCloseButtonClick={() => setErrorMessage(null)}
+          />
+        )}
 
-      <WidgetsGrid>
-        {notebook.widgets.map((widget) => (
-          <WidgetRenderer key={widget.id} config={widget} />
-        ))}
-      </WidgetsGrid>
+        <WidgetsGrid>
+          {notebook.widgets.map((widget, index) => (
+            <WidgetSlot
+              key={widget.id}
+              $type={widget.type}
+              data-tier={widgetTier(widget.type)}
+              style={{animationDelay: `${index * 90}ms`}}
+            >
+              <WidgetRenderer
+                config={widget}
+                onRemove={() => handleRemoveWidget(widget.id)}
+              />
+            </WidgetSlot>
+          ))}
+        </WidgetsGrid>
+      </ContentScroll>
 
       <PromptInput
         value={prompt}

--- a/operate/client/src/App/Notebooks/index.tsx
+++ b/operate/client/src/App/Notebooks/index.tsx
@@ -25,22 +25,33 @@ import {
 import type {Notebook, WidgetConfig} from './types';
 
 /**
- * Map widget type to its height tier. Used by `<WidgetSlot data-tier=…>`
+ * Map widget config to its height tier. Used by `<WidgetSlot data-tier=…>`
  * to opt TALL widgets into a shared 296px min-height so they line up in
- * the same row.
+ * the same row. Activity-feed with activityFeedSize==='hero' upgrades to
+ * the HERO tier (full-width, 480px, internally scrollable).
  */
-function widgetTier(
-  type: WidgetConfig['type'],
-): 'short' | 'tall' | 'hero' | 'auto' {
-  switch (type) {
+function widgetTier(widget: WidgetConfig): 'short' | 'tall' | 'hero' | 'auto' {
+  if (widget.type === 'activity-feed' && widget.activityFeedSize === 'hero') {
+    return 'hero';
+  }
+  // Radar charts span the full row; pair that with HERO height so the polygon
+  // can render with a near-square aspect ratio. At TALL (296px) the radar
+  // gets squashed into a thin horizontal strip.
+  if (widget.type === 'chart' && widget.chartType === 'radar') {
+    return 'hero';
+  }
+  switch (widget.type) {
     case 'metric':
     case 'trend':
       return 'short';
-    case 'kpi':
     case 'chart':
     case 'funnel':
     case 'activity-feed':
       return 'tall';
+    case 'kpi':
+      // KPI spans the full row but only needs enough height for one strip of
+      // numbers. Auto tier lets the tile size to content, ~140px in practice.
+      return 'auto';
     case 'bpmn':
     case 'status-grid':
       return 'hero';
@@ -112,7 +123,14 @@ const NotebookPage: React.FC = () => {
           prev.widgets.length === 0 && prev.title === 'Untitled notebook';
         const updated: Notebook = {
           ...prev,
-          title: isFirstPrompt ? trimmedPrompt.slice(0, 50) : prev.title,
+          title: isFirstPrompt
+            ? // Cap the auto-derived title at 120 chars so longer prompts
+              // ("give me a deep dive dashboard for the payment process")
+              // aren't clipped mid-word.
+              trimmedPrompt.length > 120
+              ? `${trimmedPrompt.slice(0, 117).trimEnd()}…`
+              : trimmedPrompt
+            : prev.title,
           widgets: [...prev.widgets, ...newWidgets],
           updatedAt: Date.now(),
         };
@@ -192,7 +210,16 @@ const NotebookPage: React.FC = () => {
             <WidgetSlot
               key={widget.id}
               $type={widget.type}
-              data-tier={widgetTier(widget.type)}
+              $chartType={
+                widget.type === 'chart' ? widget.chartType : undefined
+              }
+              $activityFeedSize={
+                widget.type === 'activity-feed'
+                  ? (widget.activityFeedSize ?? 'tall')
+                  : undefined
+              }
+              data-tier={widgetTier(widget)}
+              data-type={widget.type}
               style={{animationDelay: `${index * 90}ms`}}
             >
               <WidgetRenderer

--- a/operate/client/src/App/Notebooks/llm.test.ts
+++ b/operate/client/src/App/Notebooks/llm.test.ts
@@ -1,0 +1,145 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {generateWidgets} from './llm';
+import type {WidgetConfig} from './types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const MOCK_WIDGET: WidgetConfig = {
+  id: 'w-abc-123',
+  type: 'metric',
+  title: 'Running Instances',
+  query: {
+    endpoint: '/v2/process-instances/search',
+    method: 'POST',
+    body: {filter: {state: 'ACTIVE'}},
+  },
+  field: 'page.totalItems',
+};
+
+/**
+ * Build the minimal Anthropic tool-use response envelope that llm.ts is
+ * expected to parse.  The LLM returns widget configs via a tool call so the
+ * JSON shape is deterministic.
+ */
+function makeAnthropicToolUseResponse(widgets: WidgetConfig[]) {
+  return {
+    id: 'msg_01',
+    type: 'message',
+    role: 'assistant',
+    content: [
+      {
+        type: 'tool_use',
+        id: 'tu_01',
+        name: 'create_widgets',
+        input: {widgets},
+      },
+    ],
+    model: 'claude-3-5-haiku-20241022',
+    stop_reason: 'tool_use',
+    usage: {input_tokens: 10, output_tokens: 20},
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('generateWidgets', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  it('should throw a clear error when apiKey is undefined', async () => {
+    // given
+    const prompt = 'show me active process instances';
+
+    // when / then
+    await expect(generateWidgets(prompt, undefined)).rejects.toThrow(
+      /api key/i,
+    );
+  });
+
+  it('should call Anthropic API with the prompt and return parsed widget configs', async () => {
+    // given
+    const prompt = 'show me active process instances';
+    const apiKey = 'sk-ant-test-key';
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => makeAnthropicToolUseResponse([MOCK_WIDGET]),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    // when
+    const result = await generateWidgets(prompt, apiKey);
+
+    // then – the request must reach the Anthropic messages endpoint
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('anthropic');
+    expect(url).toContain('messages');
+
+    // request body must carry the user prompt and a tool definition
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+    const messages = body['messages'] as Array<{role: string; content: string}>;
+    expect(messages).toBeInstanceOf(Array);
+    const userMsg = messages.find((m) => m.role === 'user');
+    expect(userMsg?.content).toContain(prompt);
+    expect(body['tools']).toBeInstanceOf(Array);
+    expect((body['tools'] as unknown[]).length).toBeGreaterThan(0);
+
+    // result is the parsed array
+    expect(result).toEqual([MOCK_WIDGET]);
+  });
+
+  it('should return an array of WidgetConfig with at least one item', async () => {
+    // given
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () =>
+        makeAnthropicToolUseResponse([
+          MOCK_WIDGET,
+          {...MOCK_WIDGET, id: 'w-2'},
+        ]),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    // when
+    const result = await generateWidgets('show me two widgets', 'sk-ant-key');
+
+    // then
+    expect(result.length).toBeGreaterThanOrEqual(1);
+    result.forEach((w) => {
+      expect(w).toHaveProperty('id');
+      expect(w).toHaveProperty('type');
+      expect(w).toHaveProperty('title');
+      expect(w).toHaveProperty('query');
+    });
+  });
+
+  it('should propagate API errors with a useful message', async () => {
+    // given
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({
+        error: {type: 'authentication_error', message: 'invalid api key'},
+      }),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    // when / then
+    await expect(generateWidgets('anything', 'bad-key')).rejects.toThrow(
+      /401|authentication|invalid/i,
+    );
+  });
+});

--- a/operate/client/src/App/Notebooks/llm.test.ts
+++ b/operate/client/src/App/Notebooks/llm.test.ts
@@ -7,7 +7,7 @@
  */
 
 import {describe, it, expect, vi, beforeEach} from 'vitest';
-import {generateWidgets} from './llm';
+import {generateWidgets, type BedrockCredentials} from './llm';
 import type {WidgetConfig} from './types';
 
 // ---------------------------------------------------------------------------
@@ -26,12 +26,18 @@ const MOCK_WIDGET: WidgetConfig = {
   field: 'page.totalItems',
 };
 
+const VALID_CREDENTIALS: BedrockCredentials = {
+  arn: 'arn:aws:bedrock:us-east-1:123456789012:inference-profile/my-profile',
+  accessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+  secretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+};
+
 /**
- * Build the minimal Anthropic tool-use response envelope that llm.ts is
- * expected to parse.  The LLM returns widget configs via a tool call so the
- * JSON shape is deterministic.
+ * Build the Bedrock/Anthropic tool-use response envelope that llm.ts is
+ * expected to parse. Bedrock returns the same JSON shape as the direct
+ * Anthropic Messages API.
  */
-function makeAnthropicToolUseResponse(widgets: WidgetConfig[]) {
+function makeToolUseResponse(widgets: WidgetConfig[]) {
   return {
     id: 'msg_01',
     type: 'message',
@@ -59,37 +65,100 @@ describe('generateWidgets', () => {
     vi.stubGlobal('fetch', vi.fn());
   });
 
-  it('should throw a clear error when apiKey is undefined', async () => {
+  it('should throw a clear error when credentials are undefined', async () => {
     // given
     const prompt = 'show me active process instances';
 
     // when / then
     await expect(generateWidgets(prompt, undefined)).rejects.toThrow(
-      /api key/i,
+      /VITE_AWS_BEDROCK_ARN/i,
     );
   });
 
-  it('should call Anthropic API with the prompt and return parsed widget configs', async () => {
+  it('should throw a clear error when arn is missing', async () => {
+    // given
+    const creds: BedrockCredentials = {
+      ...VALID_CREDENTIALS,
+      arn: '',
+    };
+
+    // when / then
+    await expect(generateWidgets('any prompt', creds)).rejects.toThrow(
+      /VITE_AWS_BEDROCK_ARN/i,
+    );
+  });
+
+  it('should throw a clear error when accessKeyId is missing', async () => {
+    // given
+    const creds: BedrockCredentials = {
+      ...VALID_CREDENTIALS,
+      accessKeyId: '',
+    };
+
+    // when / then
+    await expect(generateWidgets('any prompt', creds)).rejects.toThrow(
+      /VITE_AWS_BEDROCK_ARN/i,
+    );
+  });
+
+  it('should throw a clear error when secretAccessKey is missing', async () => {
+    // given
+    const creds: BedrockCredentials = {
+      ...VALID_CREDENTIALS,
+      secretAccessKey: '',
+    };
+
+    // when / then
+    await expect(generateWidgets('any prompt', creds)).rejects.toThrow(
+      /VITE_AWS_BEDROCK_ARN/i,
+    );
+  });
+
+  it('should throw a clear error when ARN does not match expected format', async () => {
+    // given
+    const creds: BedrockCredentials = {
+      ...VALID_CREDENTIALS,
+      arn: 'not-a-valid-arn',
+    };
+
+    // when / then
+    await expect(generateWidgets('any prompt', creds)).rejects.toThrow(
+      /invalid bedrock arn/i,
+    );
+  });
+
+  it('should call Bedrock API with the prompt and return parsed widget configs', async () => {
     // given
     const prompt = 'show me active process instances';
-    const apiKey = 'sk-ant-test-key';
     const mockFetch = vi.fn().mockResolvedValue({
       ok: true,
-      json: async () => makeAnthropicToolUseResponse([MOCK_WIDGET]),
+      json: async () => makeToolUseResponse([MOCK_WIDGET]),
     });
     vi.stubGlobal('fetch', mockFetch);
 
     // when
-    const result = await generateWidgets(prompt, apiKey);
+    const result = await generateWidgets(prompt, VALID_CREDENTIALS);
 
-    // then – the request must reach the Anthropic messages endpoint
+    // then – the request must reach the Bedrock runtime endpoint
     expect(mockFetch).toHaveBeenCalledOnce();
     const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
-    expect(url).toContain('anthropic');
-    expect(url).toContain('messages');
+    expect(url).toContain('bedrock-runtime.us-east-1.amazonaws.com');
+    expect(url).toContain('/model/');
+    expect(url).toContain('/invoke');
 
-    // request body must carry the user prompt and a tool definition
+    // method must be POST
+    expect(init.method).toBe('POST');
+
+    // Authorization header must use SigV4
+    const headers = init.headers as Record<string, string>;
+    expect(headers['Authorization']).toMatch(/^AWS4-HMAC-SHA256 /);
+
+    // request body must use bedrock-specific anthropic_version (not a header)
     const body = JSON.parse(init.body as string) as Record<string, unknown>;
+    expect(body['anthropic_version']).toBe('bedrock-2023-05-31');
+    // no "model" field — it is in the URL
+    expect(body).not.toHaveProperty('model');
+
     const messages = body['messages'] as Array<{role: string; content: string}>;
     expect(messages).toBeInstanceOf(Array);
     const userMsg = messages.find((m) => m.role === 'user');
@@ -106,15 +175,15 @@ describe('generateWidgets', () => {
     const mockFetch = vi.fn().mockResolvedValue({
       ok: true,
       json: async () =>
-        makeAnthropicToolUseResponse([
-          MOCK_WIDGET,
-          {...MOCK_WIDGET, id: 'w-2'},
-        ]),
+        makeToolUseResponse([MOCK_WIDGET, {...MOCK_WIDGET, id: 'w-2'}]),
     });
     vi.stubGlobal('fetch', mockFetch);
 
     // when
-    const result = await generateWidgets('show me two widgets', 'sk-ant-key');
+    const result = await generateWidgets(
+      'show me two widgets',
+      VALID_CREDENTIALS,
+    );
 
     // then
     expect(result.length).toBeGreaterThanOrEqual(1);
@@ -132,14 +201,72 @@ describe('generateWidgets', () => {
       ok: false,
       status: 401,
       json: async () => ({
-        error: {type: 'authentication_error', message: 'invalid api key'},
+        message: 'The security token included in the request is invalid.',
       }),
     });
     vi.stubGlobal('fetch', mockFetch);
 
     // when / then
-    await expect(generateWidgets('anything', 'bad-key')).rejects.toThrow(
-      /401|authentication|invalid/i,
-    );
+    await expect(
+      generateWidgets('anything', VALID_CREDENTIALS),
+    ).rejects.toThrow(/401|security token|invalid/i);
+  });
+
+  it('should throw when the response contains no tool_use block', async () => {
+    // given
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        content: [{type: 'text', text: 'I cannot help with that.'}],
+        stop_reason: 'end_turn',
+      }),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    // when / then
+    await expect(
+      generateWidgets('anything', VALID_CREDENTIALS),
+    ).rejects.toThrow(/tool_use/i);
+  });
+
+  it('should throw when the tool_use input fails Zod validation', async () => {
+    // given — response is valid JSON but has wrong widget shape
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        content: [
+          {
+            type: 'tool_use',
+            id: 'tu_01',
+            name: 'create_widgets',
+            input: {widgets: [{broken: true}]},
+          },
+        ],
+        stop_reason: 'tool_use',
+      }),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    // when / then
+    await expect(
+      generateWidgets('anything', VALID_CREDENTIALS),
+    ).rejects.toThrow(/malformed/i);
+  });
+
+  it('should URL-encode the ARN in the request path', async () => {
+    // given
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => makeToolUseResponse([MOCK_WIDGET]),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    // when
+    await generateWidgets('test', VALID_CREDENTIALS);
+
+    // then – colons and slashes in the ARN must be percent-encoded in the URL path
+    const [url] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const encodedArn = encodeURIComponent(VALID_CREDENTIALS.arn);
+    expect(url).toContain(encodedArn);
   });
 });

--- a/operate/client/src/App/Notebooks/llm.ts
+++ b/operate/client/src/App/Notebooks/llm.ts
@@ -8,9 +8,53 @@
 
 import {z} from 'zod';
 import {WidgetConfigSchema, type WidgetConfig} from './types';
+import {signRequest} from './awsSigV4';
+import {pickConfigs} from './presets';
 
-const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages';
-const MODEL = 'claude-sonnet-4-5';
+// ---------------------------------------------------------------------------
+// ARN parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract the AWS region from a Bedrock inference-profile or foundation-model ARN.
+ *
+ * Expected format:
+ *   arn:aws:bedrock:<region>:<account>:inference-profile/<id>
+ *   arn:aws:bedrock:<region>:<account>:foundation-model/<id>
+ *
+ * The region is the 4th colon-delimited segment (index 3).
+ */
+function extractRegionFromArn(arn: string): string {
+  // Basic structural check: must start with "arn:aws:bedrock:" and have 6 parts
+  const parts = arn.split(':');
+  if (
+    parts.length < 6 ||
+    parts[0] !== 'arn' ||
+    parts[1] !== 'aws' ||
+    parts[2] !== 'bedrock' ||
+    !parts[3]
+  ) {
+    throw new Error(
+      `Invalid Bedrock ARN: "${arn}". ` +
+        'Expected format: arn:aws:bedrock:<region>:<account>:inference-profile/<id> ' +
+        'or arn:aws:bedrock:<region>:<account>:foundation-model/<id>',
+    );
+  }
+  return parts[3];
+}
+
+// ---------------------------------------------------------------------------
+// Bedrock endpoint builder
+// ---------------------------------------------------------------------------
+
+function bedrockInvokeUrl(region: string, arn: string): string {
+  const encodedArn = encodeURIComponent(arn);
+  return `https://bedrock-runtime.${region}.amazonaws.com/model/${encodedArn}/invoke`;
+}
+
+// ---------------------------------------------------------------------------
+// Prompts & tool definition (unchanged from original)
+// ---------------------------------------------------------------------------
 
 const SYSTEM_PROMPT =
   `You are an assistant that creates dashboard widgets for the Camunda Operate monitoring UI.
@@ -20,11 +64,122 @@ Available V2 API endpoints (POST, body is JSON filter object):
 - /v2/process-definitions/search — filter: {processDefinitionId, name, ...}
 - /v2/jobs/search               — filter: {state, type, processInstanceKey, ...}
 - /v2/element-instances/search  — filter: {processInstanceKey, elementId, state, ...}
+- /v2/user-tasks/search          — filter: {state, assignee, processDefinitionId, ...}
+- GET /v2/process-definitions/{key}/xml — returns BPMN XML for a given processDefinitionKey (NUMERIC key, not the id string)
+- POST /v2/process-definitions/{key}/statistics/element-instances — returns per-flow-node counts {elementId, active, incidents, completed, canceled}
 
-Widget types: "metric" (shows a single number) or "table" (shows rows of data).
-For metric widgets, set field to a dot-path into the response (default: "page.totalItems").
-For table widgets, set columns to an array of field names from items[].
+PRE-AGGREGATED STATISTICS endpoints — prefer these over manual grouping when available:
+- POST /v2/incidents/statistics/process-instances-by-error    — incidents grouped by errorType (already aggregated; no client-side grouping needed)
+- POST /v2/incidents/statistics/process-instances-by-definition — incidents grouped by processDefinitionId
+- POST /v2/process-definitions/statistics/process-instances    — process instances grouped by definition
+- POST /v2/process-definitions/statistics/process-instances-by-version — process instances grouped by version
+
+These return arrays of {key, count} (or similar) — when used with a chart widget, set chartGroupBy to the appropriate field and the widget will plot the counts directly.
+
+DATE FILTERS work across most search endpoints with Mongo-style operators:
+- {"startDate": {"$gte": "2026-05-01T00:00:00Z", "$lt": "2026-05-08T00:00:00Z"}}
+- {"creationTime": {"$gte": ..., "$lt": ...}}
+
+Widget types:
+- "metric" — shows a single number. Set field to a dot-path into the response (default: "page.totalItems"). Set accent to communicate intent: info for activity, success for completion, warning for queues/load, error for failures/incidents.
+- "trend"  — a sparkline that fires N parallel real queries, one per time bucket, and plots the results. Use when the user asks for "over time", "trend", "history", "last 7 days/24h". Configure:
+  - trendDateField: the date column to bucket by (e.g. "startDate" for process instances, "creationTime" for incidents and jobs).
+  - trendBuckets: number of data points (5-12 is sensible; default 7). Keep N ≤ 12 to limit load.
+  - trendBucketSpan: size of each bucket — "1h", "6h", "24h", "7d". Default "24h".
+  - trendAccent: color accent — "info", "success", "warning", "error", "neutral".
+  - The query field should use the same endpoint as you would for a metric count (page.limit: 1). The widget adds date-range filters automatically per bucket.
+- "kpi"    — one tile with 3-4 numbers side by side, each with its own label, query, and accent color. Use this for "health summary", "overview tile", or "multiple stats together". Set kpis[] array with label, query, field, and accent for each cell. Set the top-level query to {endpoint: "/__notebook_kpi__", method: "GET"} as a placeholder.
+- "table"  — shows rows of data. Set columns to an array of field names from items[].
+- "bpmn"   — renders a BPMN diagram with optional live-data overlays. Set processDefinitionKey and overlay.
+  - overlay "combined": blue badge = active count, red badge = incident count per flow node (best for operational use)
+  - overlay "active":   blue badge only — shows where tokens are flowing right now
+  - overlay "incidents": red badge only — highlights stuck/errored nodes
+  - overlay "heatmap":  fills each flow node with red at varying opacity based on incident density — hottest nodes darkest. Hottest nodes also get a count badge. Use when intensity matters more than exact counts.
+  - overlay "none":     no overlays — use for educational "how does this process work" views
+- "chart"  — renders a chart by grouping items[] from the query response.
+  - chartType: "bar" for categorical comparisons, "donut" for proportions with a center KPI number, "pie" for proportional breakdowns where you want to emphasize parts-of-whole without a center, "line" for time-series or trends, "stacked-bar" for grouped breakdowns, "stacked-area" for time-series broken down by sub-category (filled stacked lines), "treemap" for hierarchical sized rectangles, "radar" for multi-axis comparisons, "meter" for progress vs. a threshold.
+  - chartGroupBy: the field name in items[] to group by (e.g. "errorType", "state", "processDefinitionId").
+  - chartValueField: optional field to sum per group (defaults to count of items in the group).
+  - chartStackBy: only for "stacked-bar" or "radar" — the secondary dimension (e.g. "state").
+  - Use page.limit: 1000 in the query body to fetch enough data to aggregate client-side.
+- "text"   — a markdown narrative cell (no data fetching). Use this to set CONTEXT or write a SHORT INTRO above a cluster of data widgets, like a section header or a bulleted list of "things to check". Set "text" to the markdown content (#, ##, **bold**, *italic*, lists, inline code supported). Keep the "query" field present but use {endpoint: "/__notebook_text__", method: "GET"} as a placeholder — text widgets ignore the query.
+  - Use sparingly: at most 1 text widget at the start of a multi-widget bundle, only when the bundle has 4+ data widgets. Don't pad with text between every widget.
+- "status-grid" — one tile per deployed process, color-coded by incident count (green=0, yellow=1-5, red=6+). Use when the user asks for a "health board", "process status", or "status of all processes". Set query to {endpoint: "/__notebook_status_grid__", method: "GET"} as a placeholder.
+- "activity-feed" — a vertical timeline of recent events. Supports two modes:
+  - Single-source (legacy): configure activityTitleField, activitySubtitleField, activityTimeField, activityKindField. Use the incidents or element-instances endpoint.
+  - Multi-source (preferred): set activitySources[] instead. Each source has: label (display name), query (its own endpoint/method/body), titleField, subtitleField (optional), timeField, and accent ("info"|"success"|"warning"|"error"|"neutral" for dot color). The widget fires one query per source in parallel, merges all results by timestamp (newest first), and renders a single interleaved timeline with colored dots per source. When the user asks for an activity timeline or "what's happening", prefer the multi-source variant so different event types (incidents, instance starts, etc.) interleave with different-colored dots. Set the root query to {endpoint: "/__notebook_activity_multi__", method: "GET"} as a placeholder when using activitySources.
+- "funnel" — a horizontal bar funnel showing conversion through BPMN process stages. Set processDefinitionKey and funnelStages[] with {label, elementId} for each stage. Stages are ordered top-to-bottom (highest volume first). Use when the user asks about "funnel", "conversion", "drop-off", or "stage volumes".
+
+When to use chart widget:
+- User asks for a breakdown, distribution, or "by [field]" → chart widget.
+- User asks for a comparison across categories → bar chart.
+- User asks about proportions, percentages, or share → donut chart (shows total in center) or pie chart (no center hole, pure proportional).
+- Pie for proportional breakdowns where you want to emphasize parts-of-whole rather than precise comparison. Donut also for proportions but with a center number — use it for KPIs you want to anchor visually.
+- Stacked area for time-series broken down by sub-category. Stacked bar for categorical breakdowns with sub-category bands.
+- User asks about trends, over time, or history → PREFER the trend widget (real data). Only use line chart if user explicitly asks for a chart style.
+- User asks for a breakdown by two dimensions or "stacked" → stacked-bar chart.
+- User asks about hierarchy, nested groups, or "treemap" → treemap chart.
+- User asks for multi-axis comparison → radar chart.
+- chartGroupBy is the field name in items[] to group by; chartValueField is optional (defaults to count of items).
+
+When the user wants BOTH a breakdown AND examples (e.g. "show incidents by error type and the latest ones"), generate a chart widget AND a table widget side-by-side (both 6 cols, in adjacent positions in the array).
+
+When to use bpmn widget:
+- User asks about a specific process, wants to see it, or asks "where are instances" → bpmn with overlay "combined"
+- User asks how a process works, to explain it, or show its structure → bpmn with overlay "none"
+- **STRONG SIGNAL — use BPMN with heatmap overlay**: when the user asks "where are instances stuck", "where are things getting stuck", "stuck instances", "incident hotspots", "what's broken in the process", or anything that maps an operational pain to a process flow → ALWAYS include a bpmn widget with overlay "heatmap" (in addition to any tables/charts). The visual location of the pain in the diagram is the headline.
+- User asks for a heatmap or live state → bpmn with overlay "heatmap"
+- For "compare X vs Y" or "all processes" → include ONE bpmn per process (combined overlay). Don't skip BPMN for comparison prompts.
+- ALWAYS include processDefinitionKey when the user mentions a process by name (e.g. "order-process", "payment-process", "shipping-process"). When the user is generic ("a process", "the worst process"), default to "order-process". The widget resolves string ids to numeric keys automatically.
+- For BPMN widgets, set query.endpoint to "/v2/process-definitions/{key}/xml" with the literal "{key}" placeholder — the widget substitutes the resolved processDefinitionKey at request time. Do NOT use /v2/process-definitions/search as the BPMN widget's main query.
+
+When the user asks for a 'health board' or 'status of all processes', use status-grid.
+
 Always generate widget ids using short alphanumeric strings.
+
+Always include a "description" field for each widget: 1-3 sentences in plain
+English that explain what the user is seeing and why this widget is useful in
+the context of the prompt. Address the user directly. Avoid restating the
+title. Do not mention API endpoints or technical details — that's exposed
+separately.
+
+Set subtitle to a short helper line (≤80 chars) that adds context: how data is sorted, what is filtered, what is live. Keep it factual, not promotional. Examples: "all open incidents · grouped by errorType", "live · blue = active, red = open incidents", "sorted by most recent · capped at 15 rows". Skip subtitle for metric widgets and text widgets — they don't need it.
+
+LAYOUT RULES — the order of the widgets array determines how the dashboard packs into rows. The grid is 12 columns wide with a 32px row gap.
+
+THREE HEIGHT TIERS, sized to compose cleanly:
+  - SHORT (132px tall, 3 cols wide): metric, trend
+      → 4 fit one row (3+3+3+3)
+      → 2 stacked vertically + gap = 132+32+132 = 296 = TALL height
+  - TALL (296px tall, 6 cols wide): kpi, chart, funnel, activity-feed
+      → 2 fit one row (6+6)
+      → Pairs vertically with 2 stacked SHORTs in the next column
+  - HERO (~480px, 12 cols wide): bpmn, status-grid
+      → Own row, full-width
+  - AUTO (variable, 12 cols wide): table, text
+      → Own row, full-width
+
+ROW COMPOSITION RULES (apply in this order):
+  1. Lead with a TEXT widget at the top of any bundle with 4+ data widgets.
+  2. Group SHORT widgets (metric + trend mix) into rows of 4. Never split — always 4 per row.
+  3. Pair TALL widgets in rows of 2 (6+6). Never put a TALL widget alone — always pair it with another TALL.
+  4. HERO and AUTO widgets each get their own full-width row.
+  5. NEVER mix a SHORT widget next to a TALL widget in the same row — visual heights don't line up.
+  6. Order rows from light → heavy: SHORTs first (header numbers), then TALLs (analytical depth), then HEROes (dramatic visuals), tables last.
+
+A well-laid-out 10-widget bundle:
+  Row 1: text                                  (full width)
+  Row 2: 4 SHORT widgets (metric/trend mix)    (3+3+3+3)
+  Row 3: 2 TALL widgets (kpi + chart)          (6+6)
+  Row 4: 2 TALL widgets (chart + chart)        (6+6)
+  Row 5: HERO (status-grid)                    (full width)
+  Row 6: HERO (bpmn)                           (full width)
+  Row 7: AUTO (table)                          (full width)
+
+If you have an ODD number of TALL widgets (e.g. 3 charts), pad with another TALL widget so the last row pairs cleanly. Two metrics + two trends (= 4 SHORTs) makes a great header row — even if the user only asked about one of those numbers, the others provide context.
+
+CRITICAL: You MUST call the create_widgets tool. Do not return any text outside the tool call. If the prompt is vague (e.g. "show me everything", "tour"), generate a comprehensive bundle of 8-12 widgets covering metrics, charts, BPMN, and tables — do NOT return a clarifying-question text response. The user wants widgets, always.
+
 Return ONLY via the create_widgets tool.`.trim();
 
 const CREATE_WIDGETS_TOOL = {
@@ -40,8 +195,32 @@ const CREATE_WIDGETS_TOOL = {
           type: 'object',
           properties: {
             id: {type: 'string'},
-            type: {type: 'string', enum: ['metric', 'table']},
+            type: {
+              type: 'string',
+              enum: [
+                'metric',
+                'table',
+                'bpmn',
+                'chart',
+                'text',
+                'kpi',
+                'status-grid',
+                'activity-feed',
+                'funnel',
+                'trend',
+              ],
+            },
             title: {type: 'string'},
+            description: {
+              type: 'string',
+              description:
+                '1-3 sentences explaining what the widget shows and why it matters. Plain English, addressed to the user.',
+            },
+            subtitle: {
+              type: 'string',
+              description:
+                'Short helper line (≤80 chars) shown below the widget title. Adds context: sort order, active filters, data currency. Skip for metric and text widgets.',
+            },
             query: {
               type: 'object',
               properties: {
@@ -53,14 +232,208 @@ const CREATE_WIDGETS_TOOL = {
             },
             field: {type: 'string'},
             columns: {type: 'array', items: {type: 'string'}},
+            accent: {
+              type: 'string',
+              enum: ['info', 'success', 'warning', 'error', 'neutral'],
+              description:
+                'Accent color for metric widgets — communicates intent: info for activity, success for completion, warning for queues/load, error for failures/incidents.',
+            },
+            kpis: {
+              type: 'array',
+              description:
+                'Array of KPI cells for kpi widgets. Each cell has its own label, query, field path, and accent color.',
+              items: {
+                type: 'object',
+                properties: {
+                  label: {type: 'string'},
+                  query: {
+                    type: 'object',
+                    properties: {
+                      endpoint: {type: 'string'},
+                      method: {type: 'string', enum: ['GET', 'POST']},
+                      body: {type: 'object'},
+                    },
+                    required: ['endpoint', 'method'],
+                  },
+                  field: {
+                    type: 'string',
+                    description:
+                      'dot-path into the response; defaults to page.totalItems',
+                  },
+                  accent: {
+                    type: 'string',
+                    enum: ['info', 'success', 'warning', 'error', 'neutral'],
+                  },
+                },
+                required: ['label', 'query'],
+              },
+            },
+            processDefinitionKey: {
+              type: 'string',
+              description:
+                'The processDefinitionKey for bpmn widgets. Required when type is "bpmn".',
+            },
+            overlay: {
+              type: 'string',
+              enum: [
+                'active',
+                'incidents',
+                'combined',
+                'stuck',
+                'none',
+                'heatmap',
+              ],
+              description:
+                'Overlay mode for bpmn widgets. Use "combined" for operational use, "heatmap" for intensity visualization, "none" for educational.',
+            },
+            chartType: {
+              type: 'string',
+              enum: [
+                'bar',
+                'line',
+                'donut',
+                'pie',
+                'stacked-bar',
+                'stacked-area',
+                'meter',
+                'treemap',
+                'radar',
+              ],
+              description:
+                'Chart style: "bar" for categorical comparisons, "donut" for proportions with a center KPI number, "pie" for pure proportional breakdown (no center), "line" for time-series, "stacked-bar" for two-dimensional breakdowns, "stacked-area" for time-series broken down by sub-category, "treemap" for hierarchical sized rectangles, "radar" for multi-axis comparison, "meter" for progress vs. threshold.',
+            },
+            chartGroupBy: {
+              type: 'string',
+              description:
+                'Field name in items[] to group by (e.g. "errorType", "state", "processDefinitionId").',
+            },
+            chartValueField: {
+              type: 'string',
+              description:
+                'Optional field to sum per group. Omit to count items per group.',
+            },
+            chartStackBy: {
+              type: 'string',
+              description:
+                'For stacked-bar or radar: the secondary field to stack/key within each group (e.g. "state").',
+            },
+            trendDateField: {
+              type: 'string',
+              description:
+                'For trend widgets: the date column to bucket by (e.g. "startDate" for process-instances, "creationTime" for incidents/jobs).',
+            },
+            trendBuckets: {
+              type: 'number',
+              description:
+                'For trend widgets: number of time buckets / data points (5-12 sensible, default 7). Keep ≤ 12 to limit parallel queries.',
+            },
+            trendBucketSpan: {
+              type: 'string',
+              description:
+                'For trend widgets: duration of each bucket — "1h", "6h", "24h", "7d". Default "24h".',
+            },
+            trendAccent: {
+              type: 'string',
+              enum: ['info', 'success', 'warning', 'error', 'neutral'],
+              description:
+                'For trend widgets: accent color for the sparkline line.',
+            },
+            activityTitleField: {
+              type: 'string',
+              description:
+                'For activity-feed: field used as the primary row title (e.g. "errorType").',
+            },
+            activitySubtitleField: {
+              type: 'string',
+              description:
+                'For activity-feed: field used as the secondary subtitle (e.g. "errorMessage").',
+            },
+            activityTimeField: {
+              type: 'string',
+              description:
+                'For activity-feed: field used as the event timestamp (e.g. "creationTime").',
+            },
+            activityKindField: {
+              type: 'string',
+              description:
+                'For activity-feed: field used to derive the dot color (e.g. "state" or "errorType"). Only used in single-source mode.',
+            },
+            activitySources: {
+              type: 'array',
+              description:
+                'For activity-feed multi-source mode: each entry describes one event stream to fetch and merge into the timeline. Preferred over single-source when showing multiple event types.',
+              items: {
+                type: 'object',
+                properties: {
+                  label: {
+                    type: 'string',
+                    description:
+                      'Display name for this source, shown as a caption above each event row (e.g. "Instance started", "Incident raised").',
+                  },
+                  query: {
+                    type: 'object',
+                    properties: {
+                      endpoint: {type: 'string'},
+                      method: {type: 'string', enum: ['GET', 'POST']},
+                      body: {type: 'object'},
+                    },
+                    required: ['endpoint', 'method'],
+                  },
+                  titleField: {
+                    type: 'string',
+                    description:
+                      'Field used as the primary event title (e.g. "processDefinitionId" or "errorType").',
+                  },
+                  subtitleField: {
+                    type: 'string',
+                    description:
+                      'Optional field used as a secondary subtitle (e.g. "errorMessage").',
+                  },
+                  timeField: {
+                    type: 'string',
+                    description:
+                      'Field used as the event timestamp for sorting (e.g. "startDate" or "creationTime").',
+                  },
+                  accent: {
+                    type: 'string',
+                    enum: ['info', 'success', 'warning', 'error', 'neutral'],
+                    description:
+                      'Dot color for this source: info=blue, success=green, warning=yellow, error=red, neutral=gray.',
+                  },
+                },
+                required: ['label', 'query', 'titleField', 'timeField'],
+              },
+            },
+            funnelStages: {
+              type: 'array',
+              description:
+                'For funnel: ordered list of BPMN stages to visualize. Each has a display label and a BPMN elementId.',
+              items: {
+                type: 'object',
+                properties: {
+                  label: {type: 'string'},
+                  elementId: {type: 'string'},
+                },
+                required: ['label', 'elementId'],
+              },
+            },
+            text: {
+              type: 'string',
+              description:
+                'Markdown content for text widgets. Required when type is "text".',
+            },
           },
-          required: ['id', 'type', 'title', 'query'],
+          required: ['id', 'type', 'title', 'description', 'query'],
         },
       },
     },
     required: ['widgets'],
   },
 } as const;
+
+// ---------------------------------------------------------------------------
+// Response parsing (unchanged from original)
+// ---------------------------------------------------------------------------
 
 type AnthropicToolUseBlock = {
   type: 'tool_use';
@@ -78,41 +451,84 @@ type AnthropicResponse = {
   stop_reason: string;
 };
 
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+type BedrockCredentials = {
+  arn: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+};
+
+// ---------------------------------------------------------------------------
+// Main function
+// ---------------------------------------------------------------------------
+
 async function generateWidgets(
   prompt: string,
-  apiKey: string | undefined,
+  credentials: BedrockCredentials | undefined,
+  options: {fromPill?: boolean} = {},
 ): Promise<WidgetConfig[]> {
-  if (!apiKey) {
+  // When the prompt comes from a curated suggestion pill, route to the
+  // static preset templates: instant, deterministic, demo-safe.
+  // Free-text prompts always go to the real Bedrock LLM below.
+  if (options.fromPill) {
+    return pickConfigs(prompt);
+  }
+
+  if (
+    !credentials?.arn ||
+    !credentials.accessKeyId ||
+    !credentials.secretAccessKey
+  ) {
     throw new Error(
-      'Anthropic API key is not configured. Set VITE_ANTHROPIC_API_KEY.',
+      'AWS Bedrock credentials are not configured. ' +
+        'Set VITE_AWS_BEDROCK_ARN, VITE_AWS_ACCESS_KEY_ID, VITE_AWS_SECRET_ACCESS_KEY.',
     );
   }
 
-  const response = await fetch(ANTHROPIC_API_URL, {
+  const {arn, accessKeyId, secretAccessKey} = credentials;
+  const region = extractRegionFromArn(arn);
+  const url = bedrockInvokeUrl(region, arn);
+  const host = `bedrock-runtime.${region}.amazonaws.com`;
+
+  // Bedrock+Anthropic request body:
+  // - No "model" field (model is in the URL).
+  // - "anthropic_version" in the body (not a header).
+  const requestBody = JSON.stringify({
+    anthropic_version: 'bedrock-2023-05-31',
+    max_tokens: 4096,
+    system: SYSTEM_PROMPT,
+    tools: [CREATE_WIDGETS_TOOL],
+    tool_choice: {type: 'tool', name: 'create_widgets'},
+    messages: [{role: 'user', content: prompt}],
+  });
+
+  const sigHeaders = await signRequest(
+    {accessKeyId, secretAccessKey, region, service: 'bedrock'},
+    host,
+    new URL(url).pathname,
+    requestBody,
+  );
+
+  const response = await fetch(url, {
     method: 'POST',
-    headers: {
-      'x-api-key': apiKey,
-      'anthropic-version': '2023-06-01',
-      'anthropic-dangerous-direct-browser-access': 'true',
-      'content-type': 'application/json',
-    },
-    body: JSON.stringify({
-      model: MODEL,
-      max_tokens: 2048,
-      system: SYSTEM_PROMPT,
-      tools: [CREATE_WIDGETS_TOOL],
-      tool_choice: {type: 'tool', name: 'create_widgets'},
-      messages: [{role: 'user', content: prompt}],
-    }),
+    headers: sigHeaders,
+    body: requestBody,
   });
 
   if (!response.ok) {
     const errorBody = (await response.json()) as {
+      message?: string;
       error?: {message?: string; type?: string};
     };
     const message =
-      errorBody.error?.message ?? errorBody.error?.type ?? 'Unknown error';
-    throw new Error(`Anthropic API error ${response.status}: ${message}`);
+      errorBody.message ??
+      errorBody.error?.message ??
+      errorBody.error?.type ??
+      'Unknown error';
+    throw new Error(`Bedrock API error ${response.status}: ${message}`);
   }
 
   const data = (await response.json()) as AnthropicResponse;
@@ -137,3 +553,4 @@ async function generateWidgets(
 }
 
 export {generateWidgets};
+export type {BedrockCredentials};

--- a/operate/client/src/App/Notebooks/llm.ts
+++ b/operate/client/src/App/Notebooks/llm.ts
@@ -68,17 +68,32 @@ Available V2 API endpoints (POST, body is JSON filter object):
 - GET /v2/process-definitions/{key}/xml — returns BPMN XML for a given processDefinitionKey (NUMERIC key, not the id string)
 - POST /v2/process-definitions/{key}/statistics/element-instances — returns per-flow-node counts {elementId, active, incidents, completed, canceled}
 
-PRE-AGGREGATED STATISTICS endpoints — prefer these over manual grouping when available:
-- POST /v2/incidents/statistics/process-instances-by-error    — incidents grouped by errorType (already aggregated; no client-side grouping needed)
-- POST /v2/incidents/statistics/process-instances-by-definition — incidents grouped by processDefinitionId
-- POST /v2/process-definitions/statistics/process-instances    — process instances grouped by definition
-- POST /v2/process-definitions/statistics/process-instances-by-version — process instances grouped by version
+PRE-AGGREGATED STATISTICS endpoints — these have STRICT body shapes and unusual response fields. Prefer the regular search endpoints with client-side grouping (using chartGroupBy on /v2/incidents/search etc.) UNLESS you carefully match these contracts:
 
-These return arrays of {key, count} (or similar) — when used with a chart widget, set chartGroupBy to the appropriate field and the widget will plot the counts directly.
+- POST /v2/incidents/statistics/process-instances-by-error
+    Body: {} (empty — does NOT accept a "filter" field). Sending {filter:...} returns 400.
+    Returns items: [{errorHashCode, errorMessage, activeInstancesWithErrorCount}]
+    For a chart, set: chartGroupBy: "errorMessage", chartValueField: "activeInstancesWithErrorCount"
+    Note: groups by full error MESSAGE (long strings), not by short errorType. For shorter labels prefer /v2/incidents/search with chartGroupBy: "errorType".
 
-DATE FILTERS work across most search endpoints with Mongo-style operators:
+- POST /v2/process-definitions/statistics/process-instances
+    Body: {} (empty).
+    Returns items: [{processDefinitionId, latestProcessDefinitionName, activeInstancesWithoutIncidentCount, activeInstancesWithIncidentCount, ...}]
+    For a chart of healthy instances: chartGroupBy: "latestProcessDefinitionName", chartValueField: "activeInstancesWithoutIncidentCount"
+
+The other statistics endpoints (-by-definition, -by-version) require specific filter shapes that are tricky — for hackday safety, prefer /v2/incidents/search and /v2/process-instances/search with chartGroupBy + page.limit: 1000.
+
+DATE FIELD NAMES — different endpoints use DIFFERENT names. Use the wrong one and the request returns 400 ("Unrecognized field"):
+- /v2/process-instances/search  → "startDate", "endDate"
+- /v2/incidents/search          → "creationTime"
+- /v2/jobs/search               → "deadline" (no creation date)
+- /v2/user-tasks/search         → "creationDate", "completionDate", "dueDate", "followUpDate"
+- /v2/element-instances/search  → "startDate", "endDate"
+
+DATE FILTERS use Mongo-style operators with the field name appropriate to that endpoint:
 - {"startDate": {"$gte": "2026-05-01T00:00:00Z", "$lt": "2026-05-08T00:00:00Z"}}
-- {"creationTime": {"$gte": ..., "$lt": ...}}
+- {"creationTime": {"$gte": ..., "$lt": ...}} (incidents only)
+- {"creationDate": {"$gte": ..., "$lt": ...}} (user-tasks only — NOT "creationTime")
 
 Widget types:
 - "metric" — shows a single number. Set field to a dot-path into the response (default: "page.totalItems"). Set accent to communicate intent: info for activity, success for completion, warning for queues/load, error for failures/incidents.
@@ -108,6 +123,7 @@ Widget types:
 - "activity-feed" — a vertical timeline of recent events. Supports two modes:
   - Single-source (legacy): configure activityTitleField, activitySubtitleField, activityTimeField, activityKindField. Use the incidents or element-instances endpoint.
   - Multi-source (preferred): set activitySources[] instead. Each source has: label (display name), query (its own endpoint/method/body), titleField, subtitleField (optional), timeField, and accent ("info"|"success"|"warning"|"error"|"neutral" for dot color). The widget fires one query per source in parallel, merges all results by timestamp (newest first), and renders a single interleaved timeline with colored dots per source. When the user asks for an activity timeline or "what's happening", prefer the multi-source variant so different event types (incidents, instance starts, etc.) interleave with different-colored dots. Set the root query to {endpoint: "/__notebook_activity_multi__", method: "GET"} as a placeholder when using activitySources.
+  - Size variant: set activityFeedSize to "hero" (full-width 480px, internally scrollable, shows up to 20 rows) when the user wants a "live activity stream", "recent activity", or a prominent hero element on the dashboard. Omit activityFeedSize (defaults to "tall") for a standard 6-col 296px feed. Hero feeds occupy their own full-width row — treat them like HERO-tier widgets in the layout rules.
 - "funnel" — a horizontal bar funnel showing conversion through BPMN process stages. Set processDefinitionKey and funnelStages[] with {label, elementId} for each stage. Stages are ordered top-to-bottom (highest volume first). Use when the user asks about "funnel", "conversion", "drop-off", or "stage volumes".
 
 When to use chart widget:
@@ -357,6 +373,12 @@ const CREATE_WIDGETS_TOOL = {
               type: 'string',
               description:
                 'For activity-feed: field used to derive the dot color (e.g. "state" or "errorType"). Only used in single-source mode.',
+            },
+            activityFeedSize: {
+              type: 'string',
+              enum: ['tall', 'hero'],
+              description:
+                'For activity-feed: "hero" makes the feed full-width (12 cols, 480px, internally scrollable, up to 20 rows). Use when the user wants a prominent live activity stream or recent activity hero element. Defaults to "tall" (6 cols, 296px).',
             },
             activitySources: {
               type: 'array',

--- a/operate/client/src/App/Notebooks/llm.ts
+++ b/operate/client/src/App/Notebooks/llm.ts
@@ -1,0 +1,139 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {z} from 'zod';
+import {WidgetConfigSchema, type WidgetConfig} from './types';
+
+const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages';
+const MODEL = 'claude-sonnet-4-5';
+
+const SYSTEM_PROMPT =
+  `You are an assistant that creates dashboard widgets for the Camunda Operate monitoring UI.
+Available V2 API endpoints (POST, body is JSON filter object):
+- /v2/process-instances/search  — filter: {state, processDefinitionId, ...}
+- /v2/incidents/search          — filter: {state, processInstanceKey, ...}
+- /v2/process-definitions/search — filter: {processDefinitionId, name, ...}
+- /v2/jobs/search               — filter: {state, type, processInstanceKey, ...}
+- /v2/element-instances/search  — filter: {processInstanceKey, elementId, state, ...}
+
+Widget types: "metric" (shows a single number) or "table" (shows rows of data).
+For metric widgets, set field to a dot-path into the response (default: "page.totalItems").
+For table widgets, set columns to an array of field names from items[].
+Always generate widget ids using short alphanumeric strings.
+Return ONLY via the create_widgets tool.`.trim();
+
+const CREATE_WIDGETS_TOOL = {
+  name: 'create_widgets',
+  description:
+    'Create an array of dashboard widgets based on the user prompt. Each widget has a type, title, and a query describing the API call to make.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      widgets: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            id: {type: 'string'},
+            type: {type: 'string', enum: ['metric', 'table']},
+            title: {type: 'string'},
+            query: {
+              type: 'object',
+              properties: {
+                endpoint: {type: 'string'},
+                method: {type: 'string', enum: ['GET', 'POST']},
+                body: {type: 'object'},
+              },
+              required: ['endpoint', 'method'],
+            },
+            field: {type: 'string'},
+            columns: {type: 'array', items: {type: 'string'}},
+          },
+          required: ['id', 'type', 'title', 'query'],
+        },
+      },
+    },
+    required: ['widgets'],
+  },
+} as const;
+
+type AnthropicToolUseBlock = {
+  type: 'tool_use';
+  id: string;
+  name: string;
+  input: unknown;
+};
+
+const ToolInputSchema = z.object({
+  widgets: z.array(WidgetConfigSchema),
+});
+
+type AnthropicResponse = {
+  content: Array<{type: string} | AnthropicToolUseBlock>;
+  stop_reason: string;
+};
+
+async function generateWidgets(
+  prompt: string,
+  apiKey: string | undefined,
+): Promise<WidgetConfig[]> {
+  if (!apiKey) {
+    throw new Error(
+      'Anthropic API key is not configured. Set VITE_ANTHROPIC_API_KEY.',
+    );
+  }
+
+  const response = await fetch(ANTHROPIC_API_URL, {
+    method: 'POST',
+    headers: {
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+      'anthropic-dangerous-direct-browser-access': 'true',
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: MODEL,
+      max_tokens: 2048,
+      system: SYSTEM_PROMPT,
+      tools: [CREATE_WIDGETS_TOOL],
+      tool_choice: {type: 'tool', name: 'create_widgets'},
+      messages: [{role: 'user', content: prompt}],
+    }),
+  });
+
+  if (!response.ok) {
+    const errorBody = (await response.json()) as {
+      error?: {message?: string; type?: string};
+    };
+    const message =
+      errorBody.error?.message ?? errorBody.error?.type ?? 'Unknown error';
+    throw new Error(`Anthropic API error ${response.status}: ${message}`);
+  }
+
+  const data = (await response.json()) as AnthropicResponse;
+  const toolUseBlock = data.content.find(
+    (block): block is AnthropicToolUseBlock => block.type === 'tool_use',
+  );
+
+  if (!toolUseBlock) {
+    throw new Error(
+      'LLM did not return a tool_use block. Cannot parse widget configs.',
+    );
+  }
+
+  const parsed = ToolInputSchema.safeParse(toolUseBlock.input);
+  if (!parsed.success) {
+    throw new Error(
+      `LLM returned malformed widget configs: ${parsed.error.message}`,
+    );
+  }
+
+  return parsed.data.widgets as WidgetConfig[];
+}
+
+export {generateWidgets};

--- a/operate/client/src/App/Notebooks/persistence.test.ts
+++ b/operate/client/src/App/Notebooks/persistence.test.ts
@@ -1,0 +1,146 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {describe, it, expect, beforeEach} from 'vitest';
+import {
+  saveNotebook,
+  loadNotebook,
+  deleteNotebook,
+  listNotebooks,
+} from './persistence';
+import type {Notebook} from './types';
+
+// Minimal in-memory localStorage substitute, reset before each test.
+// The global localStorage stub from setupTests is an object with getItem/setItem/removeItem/clear,
+// which already satisfies the contract we need here.
+
+const makeNotebook = (overrides: Partial<Notebook> = {}): Notebook => ({
+  id: 'nb-001',
+  title: 'Test Notebook',
+  widgets: [],
+  updatedAt: 1_700_000_000_000,
+  ...overrides,
+});
+
+describe('persistence', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('should save and load a notebook by id', () => {
+    // given
+    const notebook = makeNotebook({id: 'nb-save-load', title: 'My Notebook'});
+
+    // when
+    saveNotebook(notebook);
+    const loaded = loadNotebook('nb-save-load');
+
+    // then
+    expect(loaded).not.toBeNull();
+    expect(loaded?.id).toBe('nb-save-load');
+    expect(loaded?.title).toBe('My Notebook');
+    expect(loaded?.widgets).toEqual([]);
+  });
+
+  it('should return null when loading a non-existent id', () => {
+    // given – nothing saved
+
+    // when
+    const result = loadNotebook('does-not-exist');
+
+    // then
+    expect(result).toBeNull();
+  });
+
+  it('should update the index entry when saving (id, title, updatedAt, widgetCount)', () => {
+    // given
+    const notebook = makeNotebook({
+      id: 'nb-index',
+      title: 'Indexed Notebook',
+      updatedAt: 1_700_000_001_000,
+      widgets: [
+        {
+          id: 'w1',
+          type: 'metric',
+          title: 'Widget A',
+          query: {endpoint: '/v2/process-instances/search', method: 'POST'},
+        },
+        {
+          id: 'w2',
+          type: 'table',
+          title: 'Widget B',
+          query: {endpoint: '/v2/process-instances/search', method: 'POST'},
+        },
+      ],
+    });
+
+    // when
+    saveNotebook(notebook);
+    const index = listNotebooks();
+
+    // then
+    const entry = index.find((e) => e.id === 'nb-index');
+    expect(entry).toBeDefined();
+    expect(entry?.title).toBe('Indexed Notebook');
+    expect(entry?.updatedAt).toBe(1_700_000_001_000);
+    expect(entry?.widgetCount).toBe(2);
+  });
+
+  it('should remove a notebook from index and storage on delete', () => {
+    // given
+    const notebook = makeNotebook({id: 'nb-delete'});
+    saveNotebook(notebook);
+    expect(loadNotebook('nb-delete')).not.toBeNull();
+
+    // when
+    deleteNotebook('nb-delete');
+
+    // then
+    expect(loadNotebook('nb-delete')).toBeNull();
+    const index = listNotebooks();
+    expect(index.find((e) => e.id === 'nb-delete')).toBeUndefined();
+  });
+
+  it('should return all notebooks from the index sorted by updatedAt desc', () => {
+    // given
+    saveNotebook(makeNotebook({id: 'nb-old', title: 'Old', updatedAt: 1_000}));
+    saveNotebook(makeNotebook({id: 'nb-mid', title: 'Mid', updatedAt: 2_000}));
+    saveNotebook(makeNotebook({id: 'nb-new', title: 'New', updatedAt: 3_000}));
+
+    // when
+    const index = listNotebooks();
+
+    // then
+    expect(index[0]?.id).toBe('nb-new');
+    expect(index[1]?.id).toBe('nb-mid');
+    expect(index[2]?.id).toBe('nb-old');
+  });
+
+  it('should handle malformed JSON gracefully (return null, do not throw)', () => {
+    // given – inject bad JSON directly into storage
+    localStorage.setItem('operate.notebooks.v1.nb-bad', '{not valid json');
+
+    // when / then – must not throw
+    expect(() => loadNotebook('nb-bad')).not.toThrow();
+    expect(loadNotebook('nb-bad')).toBeNull();
+  });
+
+  it('should validate notebook shape with Zod and return null on schema mismatch', () => {
+    // given – valid JSON but wrong shape (missing required fields)
+    localStorage.setItem(
+      'operate.notebooks.v1.nb-schema-fail',
+      JSON.stringify({id: 'nb-schema-fail', notAValidField: true}),
+    );
+
+    // when
+    const result = loadNotebook('nb-schema-fail');
+
+    // then
+    expect(result).toBeNull();
+  });
+});

--- a/operate/client/src/App/Notebooks/persistence.ts
+++ b/operate/client/src/App/Notebooks/persistence.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {z} from 'zod';
+import {
+  NotebookSchema,
+  NotebookIndexEntrySchema,
+  type Notebook,
+  type NotebookIndexEntry,
+} from './types';
+
+const KEYS = {
+  index: 'operate.notebooks.v1.index',
+  notebook: (id: string) => `operate.notebooks.v1.${id}`,
+} as const;
+
+const NotebookIndexSchema = z.array(NotebookIndexEntrySchema);
+
+function loadIndex(): NotebookIndexEntry[] {
+  try {
+    const raw = localStorage.getItem(KEYS.index);
+    if (raw == null) {
+      return [];
+    }
+    return NotebookIndexSchema.parse(JSON.parse(raw));
+  } catch {
+    return [];
+  }
+}
+
+function saveIndex(index: NotebookIndexEntry[]): void {
+  localStorage.setItem(KEYS.index, JSON.stringify(index));
+}
+
+function saveNotebook(notebook: Notebook): void {
+  localStorage.setItem(KEYS.notebook(notebook.id), JSON.stringify(notebook));
+
+  const index = loadIndex();
+  const entry: NotebookIndexEntry = {
+    id: notebook.id,
+    title: notebook.title,
+    updatedAt: notebook.updatedAt,
+    widgetCount: notebook.widgets.length,
+  };
+
+  const existing = index.findIndex((e) => e.id === notebook.id);
+  if (existing >= 0) {
+    index[existing] = entry;
+  } else {
+    index.push(entry);
+  }
+
+  saveIndex(index);
+}
+
+function loadNotebook(id: string): Notebook | null {
+  try {
+    const raw = localStorage.getItem(KEYS.notebook(id));
+    if (raw == null) {
+      return null;
+    }
+    const parsed = JSON.parse(raw) as unknown;
+    const result = NotebookSchema.safeParse(parsed);
+    if (!result.success) {
+      return null;
+    }
+    return result.data;
+  } catch {
+    return null;
+  }
+}
+
+function deleteNotebook(id: string): void {
+  localStorage.removeItem(KEYS.notebook(id));
+  const index = loadIndex().filter((e) => e.id !== id);
+  saveIndex(index);
+}
+
+function listNotebooks(): NotebookIndexEntry[] {
+  return loadIndex().sort((a, b) => b.updatedAt - a.updatedAt);
+}
+
+export {saveNotebook, loadNotebook, deleteNotebook, listNotebooks};

--- a/operate/client/src/App/Notebooks/presets.test.ts
+++ b/operate/client/src/App/Notebooks/presets.test.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {pickConfigs} from './presets';
+
+// presets now always returns *thematically related* bundles (not single
+// widgets) so the same prompt feels generative across runs. Tests therefore
+// assert on theme/contents rather than exact length-1.
+
+describe('presets.pickConfigs', () => {
+  it('should return a multi-widget Monday morning bundle', () => {
+    // when
+    const configs = pickConfigs('Set me up with a Monday morning view');
+
+    // then
+    expect(configs.length).toBeGreaterThan(1);
+    // Monday morning bundle always contains a BPMN heatmap of order-process
+    expect(configs.some((c) => c.type === 'bpmn')).toBe(true);
+  });
+
+  it('should produce an incident-themed bundle for "list all incidents"', () => {
+    // when
+    const configs = pickConfigs('list all incidents');
+
+    // then – every widget should target the incidents domain
+    expect(configs.length).toBeGreaterThan(0);
+    const allIncidentDomain = configs.every(
+      (c) =>
+        c.query.endpoint.includes('incidents') ||
+        c.type === 'bpmn' ||
+        c.title.toLowerCase().includes('incident'),
+    );
+    expect(allIncidentDomain).toBe(true);
+  });
+
+  it('should produce an incident-themed bundle when prompt mentions incidents generically', () => {
+    // when
+    const configs = pickConfigs('how is incidents looking');
+
+    // then
+    expect(configs.length).toBeGreaterThan(0);
+    const someIncidentDomain = configs.some(
+      (c) =>
+        c.query.endpoint.includes('incidents') ||
+        c.type === 'bpmn' ||
+        c.title.toLowerCase().includes('incident'),
+    );
+    expect(someIncidentDomain).toBe(true);
+  });
+
+  it('should return a multi-widget overview as the fallback for unmatched prompts', () => {
+    // given – a prompt that matches none of the keyword patterns
+    // when
+    const configs = pickConfigs('completely unrelated text xyzzy');
+
+    // then – fallback gives a meaningful overview, not a lonely metric
+    expect(configs.length).toBeGreaterThan(1);
+    expect(configs.some((c) => c.type === 'metric')).toBe(true);
+  });
+
+  it('should return a single metric for "how many" prompts', () => {
+    // when
+    const configs = pickConfigs('how many active process instances');
+
+    // then – count prompts intentionally still yield one metric
+    expect(configs).toHaveLength(1);
+    expect(configs[0]?.type).toBe('metric');
+  });
+
+  it('should produce a jobs-themed bundle for "show me jobs"', () => {
+    // when
+    const configs = pickConfigs('show me jobs');
+
+    // then – at least one widget should target the jobs domain
+    expect(configs.length).toBeGreaterThan(0);
+    const someJobsDomain = configs.some(
+      (c) =>
+        c.query.endpoint.includes('jobs') ||
+        c.title.toLowerCase().includes('job'),
+    );
+    expect(someJobsDomain).toBe(true);
+  });
+
+  it('should route "What error types are happening most?" to the error preset (not the activity preset)', () => {
+    // given – this is the "Top errors" suggestion pill prompt. Earlier the
+    // /what.*happen/ matcher swallowed it before the error-specific matcher
+    // could run, producing recent instances instead of incidents.
+    // when
+    const configs = pickConfigs('What error types are happening most?');
+
+    // then – every widget should target the incidents/errors domain.
+    expect(configs.length).toBeGreaterThan(0);
+    const everyOneIsErrorThemed = configs.every(
+      (c) =>
+        c.query.endpoint.includes('incidents') ||
+        c.title.toLowerCase().includes('incident') ||
+        c.title.toLowerCase().includes('error'),
+    );
+    expect(everyOneIsErrorThemed).toBe(true);
+  });
+});

--- a/operate/client/src/App/Notebooks/presets.ts
+++ b/operate/client/src/App/Notebooks/presets.ts
@@ -115,6 +115,61 @@ function activeIncidentsMetric(): WidgetConfig {
   };
 }
 
+/**
+ * Age of the oldest still-active process instance. Renders as "3d 4h" by
+ * pulling the single oldest active instance's startDate and computing
+ * "now − startDate" in the metric widget.
+ */
+function oldestActiveInstanceAgeMetric(): WidgetConfig {
+  return {
+    id: uid('m-oldest-active'),
+    type: 'metric',
+    title: 'Oldest active instance',
+    description:
+      'Age of the longest-running active process instance. Computed as now − startDate of the oldest ACTIVE instance across all processes. A high value means a token has been parked for a long time and is likely stuck.',
+    query: {
+      endpoint: '/v2/process-instances/search',
+      method: 'POST',
+      body: {
+        filter: {state: 'ACTIVE'},
+        sort: [{field: 'startDate', order: 'ASC'}],
+        page: {limit: 1},
+      },
+    },
+    field: 'items.0.startDate',
+    metricFormat: 'age-from',
+    metricSubvalueField: 'items.0.processDefinitionId',
+    accent: 'warning',
+  };
+}
+
+/**
+ * Age of the most recently completed process instance. Useful as a
+ * "throughput pulse" — if it's hours old, nothing is finishing.
+ */
+function lastCompletedInstanceAgeMetric(): WidgetConfig {
+  return {
+    id: uid('m-last-completed'),
+    type: 'metric',
+    title: 'Last completion',
+    description:
+      'How long since the most recent process instance completed. A growing number suggests throughput has stalled.',
+    query: {
+      endpoint: '/v2/process-instances/search',
+      method: 'POST',
+      body: {
+        filter: {state: 'COMPLETED'},
+        sort: [{field: 'endDate', order: 'DESC'}],
+        page: {limit: 1},
+      },
+    },
+    field: 'items.0.endDate',
+    metricFormat: 'age-from',
+    metricSubvalueField: 'items.0.processDefinitionId',
+    accent: 'success',
+  };
+}
+
 function activeJobsMetric(): WidgetConfig {
   return {
     id: uid('m-jobs'),
@@ -596,6 +651,21 @@ function combinedActivityFeed(): WidgetConfig {
   };
 }
 
+/**
+ * Hero-size multi-source activity feed — same content as combinedActivityFeed()
+ * but rendered full-width at 480px with internal scroll (holds 12-20 rows).
+ * Use this as the headline widget when the user asks for a "live activity
+ * stream" or "recent activity" as a prominent hero element.
+ */
+function combinedActivityFeedHero(): WidgetConfig {
+  return {
+    ...combinedActivityFeed(),
+    id: uid('af-hero'),
+    activityFeedSize: 'hero',
+    subtitle: 'instances + incidents · newest first · 20 items · full width',
+  };
+}
+
 // =============================================================================
 // FUNNEL — process stage conversion
 // =============================================================================
@@ -723,6 +793,195 @@ function instancesByProcessStackedArea(): WidgetConfig {
       method: 'POST',
       body: {page: {limit: 1000}},
     },
+  };
+}
+
+// =============================================================================
+// LINE — incidents by error type (rendered as a line)
+// =============================================================================
+
+/**
+ * A real time-series line chart: number of process instances started today,
+ * bucketed per hour. Categorical x-axis labels (00:00 … 23:00) read naturally
+ * as time, so the line shape genuinely conveys throughput-over-time — unlike
+ * a line drawn across unordered categorical values.
+ *
+ * The chart widget bucket-keys client-side by hour-of-day from each item's
+ * `startDate`; chartValueField is unused (count of items per bucket).
+ */
+function completedTodayPerHourLine(): WidgetConfig {
+  const startOfToday = new Date();
+  startOfToday.setUTCHours(0, 0, 0, 0);
+  return {
+    id: uid('c-line-completed'),
+    type: 'chart',
+    title: 'Completions today (per hour)',
+    description:
+      'A line chart of process instances that *finished* today, bucketed by hour. The shape shows when the system is most productive — useful paired with starts-per-hour to see throughput end-to-end.',
+    subtitle: 'today · grouped by hour-of-day · COMPLETED only',
+    chartType: 'line',
+    chartGroupBy: 'endHour',
+    query: {
+      endpoint: '/v2/process-instances/search',
+      method: 'POST',
+      body: {
+        filter: {
+          state: 'COMPLETED',
+          endDate: {$gte: startOfToday.toISOString()},
+        },
+        page: {limit: 1000},
+      },
+    },
+    accent: 'success',
+  };
+}
+
+function instancesStartedTodayLine(): WidgetConfig {
+  // Server-side filter for "today" (UTC). Doing it on the server keeps the
+  // payload small and avoids fetching weeks of data.
+  const startOfToday = new Date();
+  startOfToday.setUTCHours(0, 0, 0, 0);
+  return {
+    id: uid('c-line'),
+    type: 'chart',
+    title: 'Instances started today (per hour)',
+    description:
+      "A line chart of process instances started today, bucketed by hour. The x-axis is hour-of-day, so the line's slope shows when traffic ramps up and tails off — a real throughput-over-time view.",
+    subtitle: 'today · grouped by hour-of-day',
+    chartType: 'line',
+    chartGroupBy: 'startHour',
+    query: {
+      endpoint: '/v2/process-instances/search',
+      method: 'POST',
+      body: {
+        filter: {startDate: {$gte: startOfToday.toISOString()}},
+        page: {limit: 1000},
+      },
+    },
+    accent: 'info',
+  };
+}
+
+// =============================================================================
+// TREEMAP — instances by process (area-proportional)
+// =============================================================================
+
+/**
+ * Treemap of all process instances grouped by lifecycle state. State has
+ * a small fixed cardinality (ACTIVE / COMPLETED / CANCELED / TERMINATED)
+ * with well-distributed counts in any non-trivial cluster, so the treemap
+ * always renders multiple distinguishable rectangles instead of a single
+ * dominant tile.
+ */
+/**
+ * Treemap of active jobs grouped by job `type`. Job types in any non-trivial
+ * cluster span 5–15 distinct values (one per service-task element across
+ * deployed processes), and Carbon Charts assigns a different palette color
+ * to each — so the treemap renders many distinguishable, colorful rectangles
+ * instead of two blue blobs.
+ */
+/**
+ * Treemap of all process instances grouped by their process definition.
+ * Works on any non-trivial cluster (every deployed BPMN gets a rectangle)
+ * and grows naturally with deployment scale — 3 processes give 3 colored
+ * rectangles, a real customer with 30 BPMNs gets a much richer chart.
+ *
+ * Uses ALL instances (not just ACTIVE) so even processes with no active
+ * tokens still appear, and the relative sizing reflects total volume — a
+ * better story than queue depth, which can be near-zero in a healthy
+ * cluster.
+ */
+function instancesByProcessTreemap(): WidgetConfig {
+  return {
+    id: uid('c-treemap'),
+    type: 'chart',
+    title: 'Process volume (treemap)',
+    description:
+      'Each rectangle is one process definition, sized by how many instances it has produced overall. The biggest tile is the workhorse process — most of your runtime traffic flows through it.',
+    subtitle: 'all instances · area = volume · grouped by process',
+    chartType: 'treemap',
+    chartGroupBy: 'processDefinitionId',
+    query: {
+      endpoint: '/v2/process-instances/search',
+      method: 'POST',
+      body: {page: {limit: 1000}},
+    },
+  };
+}
+
+// =============================================================================
+// RADAR — instances per process broken out by state
+// =============================================================================
+
+/**
+ * Radar of active jobs broken down by job type, with one polygon per process.
+ * Lifecycle state has only ~4 distinct values (a degenerate radar shape);
+ * job type spans 5–15 distinct values across deployed BPMNs, giving the
+ * polygon enough axes for the silhouette to actually convey something —
+ * which process is heavy on validation vs. shipping vs. charging, etc.
+ */
+/**
+ * Radar of process instances broken down by job type, with one polygon per
+ * process. We query a much bigger sample (all jobs, any state) so that even
+ * processes whose queues are momentarily empty still have data to plot —
+ * otherwise the radar shows axes but no polygon when only one process has
+ * active jobs.
+ *
+ * Polygon: processDefinitionId (one per BPMN). Axis: job `type` (one per
+ * service-task element across the deployed BPMNs — typically 5–15 axes).
+ */
+/**
+ * Radar of completed element instances grouped by process. Element instances
+ * accumulate over time (every BPMN node execution creates one), so even a
+ * quiet cluster has plenty of data and every deployed process is represented.
+ *
+ * We avoided /v2/jobs/search because the backend's JobEntity transformer
+ * NPEs on jobs whose elementId is null in the index — a server-side bug
+ * triggered by completed jobs in some cluster states.
+ *
+ * Polygon: processDefinitionId (one per BPMN). Axis: `type` (the BPMN element
+ * kind — SERVICE_TASK, USER_TASK, EXCLUSIVE_GATEWAY, …). Typically 4–8
+ * distinct types per BPMN, plenty for a meaningful polygon shape.
+ */
+function elementsByTypeRadar(): WidgetConfig {
+  return {
+    id: uid('c-radar'),
+    type: 'chart',
+    title: 'Element-type profile per process (radar)',
+    description:
+      'Each polygon is one process; each axis is a BPMN element kind (service task, user task, gateway, …). The shape reveals the structural fingerprint of each process — heavily-gatewayed flows look very different from straight pipelines.',
+    subtitle: 'completed element instances · polygons = process · axes = type',
+    chartType: 'radar',
+    chartGroupBy: 'processDefinitionId',
+    chartStackBy: 'type',
+    query: {
+      endpoint: '/v2/element-instances/search',
+      method: 'POST',
+      body: {filter: {state: 'COMPLETED'}, page: {limit: 1000}},
+    },
+  };
+}
+
+// =============================================================================
+// METER — jobs queue saturation
+// =============================================================================
+
+function jobsMeter(): WidgetConfig {
+  return {
+    id: uid('c-meter'),
+    type: 'chart',
+    title: 'Job queue saturation (meter)',
+    description:
+      'Active jobs grouped by type, rendered as a horizontal meter. Each bar shows the relative depth of one worker queue — handy for spotting outliers in saturation.',
+    subtitle: 'active jobs · grouped by type',
+    chartType: 'meter',
+    chartGroupBy: 'type',
+    query: {
+      endpoint: '/v2/jobs/search',
+      method: 'POST',
+      body: {filter: {state: 'CREATED'}, page: {limit: 1000}},
+    },
+    accent: 'warning',
   };
 }
 
@@ -953,14 +1212,16 @@ These widgets focus on failure modes. The **incident chart** breaks down errors 
     ],
   },
   {
-    // Workload / throughput / worker capacity per job type
+    // Worker capacity — drills into job queues per type. About worker pools:
+    // which ones are backlogged, which are idle. Job-centric.
     match: (p) =>
-      /workload|throughput|capacity|worker.*capacity|jobs.*by.*type/i.test(p),
+      /\bcapacity\b|worker.*capacity|jobs.*by.*type|worker.*pool|queue.*depth/i.test(
+        p,
+      ),
     build: () => [
       activeJobsMetric(),
-      activeInstancesMetric(),
-      // Bar chart grouping jobs by type — visualizes which worker pool is
-      // under-loaded vs. backed up. Real V2 query, no client-side fakery.
+      jobsTrendHourly(),
+      // Bar chart grouping jobs by type — which worker pool is backed up.
       {
         id: uid('c-jobs-by-type'),
         type: 'chart',
@@ -977,6 +1238,20 @@ These widgets focus on failure modes. The **incident chart** breaks down errors 
         accent: 'warning',
       },
       jobsTable(),
+    ],
+  },
+  {
+    // Workload / throughput — system-wide load. About instances and the
+    // overall cluster, not per-worker queues. Process-centric.
+    match: (p) => /workload|throughput|how.*busy|how.*loaded/i.test(p),
+    build: () => [
+      activeInstancesMetric(),
+      activeIncidentsMetric(),
+      completedInstancesMetric(),
+      instancesTrendDaily(),
+      instancesByProcessStackedArea(),
+      instancesByProcess(),
+      recentInstancesTable(),
     ],
   },
   {
@@ -1019,10 +1294,32 @@ These widgets focus on failure modes. The **incident chart** breaks down errors 
     ],
   },
   {
-    // Slowest / longest-running instances
+    // Slowest / longest-running instances — top-row KPIs (with creative
+    // age-based metrics), then where-they-live chart + heatmap, then the
+    // longest-running table at the bottom.
     match: (p) =>
       /slow|long.*running|longest|outlier|taking.*forever|stuck.*long/i.test(p),
     build: () => [
+      oldestActiveInstanceAgeMetric(),
+      activeInstancesMetric(),
+      lastCompletedInstanceAgeMetric(),
+      activeIncidentsMetric(),
+      {
+        id: uid('c-active-by-process'),
+        type: 'chart',
+        title: 'Active instances by process',
+        description:
+          'Where the active workload is concentrated. Process definitions with many active instances may be the source of long-running outliers.',
+        chartType: 'bar',
+        chartGroupBy: 'processDefinitionId',
+        query: {
+          endpoint: '/v2/process-instances/search',
+          method: 'POST',
+          body: {filter: {state: 'ACTIVE'}, page: {limit: 1000}},
+        },
+        accent: 'info',
+      },
+      bpmnDiagram(DEMO_PROCESS_KEY, 'active'),
       {
         id: uid('t-slowest'),
         type: 'table',
@@ -1040,22 +1337,6 @@ These widgets focus on failure modes. The **incident chart** breaks down errors 
           },
         },
         columns: ['processInstanceKey', 'processDefinitionId', 'startDate'],
-      },
-      activeInstancesMetric(),
-      {
-        id: uid('c-active-by-process'),
-        type: 'chart',
-        title: 'Active instances by process',
-        description:
-          'Where the active workload is concentrated. Process definitions with many active instances may be the source of long-running outliers.',
-        chartType: 'bar',
-        chartGroupBy: 'processDefinitionId',
-        query: {
-          endpoint: '/v2/process-instances/search',
-          method: 'POST',
-          body: {filter: {state: 'ACTIVE'}, page: {limit: 1000}},
-        },
-        accent: 'info',
       },
     ],
   },
@@ -1078,13 +1359,19 @@ These widgets focus on failure modes. The **incident chart** breaks down errors 
   // -------------------------------------------------------------------------
 
   {
-    // Explicit "list incidents" — always include the table.
+    // Explicit "list incidents" — triage layout: KPIs on top (short row),
+    // breakdown + heatmap in the middle (tall row), full incidents table at
+    // the bottom as the hero of the page.
     match: (p) =>
       /incident/i.test(p) && /\blist\b|\btable\b|\ball\b|\bshow\b/i.test(p),
     build: () => [
-      incidentsTable(),
       activeIncidentsMetric(),
+      incidentsTrendHourly(),
+      activeInstancesMetric(),
+      activeJobsMetric(),
       incidentsByErrorType(),
+      bpmnDiagram(DEMO_PROCESS_KEY, 'incidents'),
+      incidentsTable(),
     ],
   },
   {
@@ -1312,15 +1599,33 @@ These widgets focus on failure modes. The **incident chart** breaks down errors 
     build: () => [statusGridWidget(), incidentsByErrorType()],
   },
   {
-    // Multi-source activity feed / live stream
+    // Multi-source activity feed / live stream — KPI strip on top so the
+    // viewer has live counters while events flow below in the hero feed.
     match: (p) => /live.*activity|activity.*stream|recent activity/i.test(p),
-    build: () => [combinedActivityFeed(), activeIncidentsMetric()],
+    build: () => [
+      activeInstancesMetric(),
+      activeIncidentsMetric(),
+      activeJobsMetric(),
+      completedInstancesMetric(),
+      incidentsTrendHourly(),
+      jobsTrendHourly(),
+      instancesTrendDaily(),
+      processHealthKpi(),
+      combinedActivityFeedHero(),
+    ],
   },
   {
-    // Activity feed / recent events / timeline
+    // Activity feed / recent events / timeline (lighter version)
     match: (p) =>
       /\bactivity\b|recent.*events?|timeline|feed|latest.*incidents?/i.test(p),
-    build: () => [combinedActivityFeed(), activeIncidentsMetric()],
+    build: () => [
+      activeInstancesMetric(),
+      activeIncidentsMetric(),
+      activeJobsMetric(),
+      completedInstancesMetric(),
+      combinedActivityFeed(),
+      incidentsByErrorType(),
+    ],
   },
   {
     // Pie chart — proportional breakdown emphasis
@@ -1361,10 +1666,33 @@ These widgets focus on failure modes. The **incident chart** breaks down errors 
     ],
   },
   {
-    // "where are instances stuck" / "heatmap" → heatmap overlay,
-    // process-aware (detects "order"/"payment"/"shipping" in the prompt).
+    // "where are instances stuck" / "heatmap" → broader stuck-instance triage.
+    // If the prompt names a specific process, show a deep dive on that one;
+    // otherwise show heatmaps for ALL demo processes side-by-side, plus
+    // supporting KPIs and the longest-running instances table.
     match: (p) => /where.*stuck|heatmap/i.test(p),
-    build: (p) => [bpmnDiagram(detectProcessFromPrompt(p), 'heatmap')],
+    build: (p) => {
+      const named = ALL_DEMO_PROCESSES.find((key) =>
+        new RegExp(`\\b${key.split('-')[0]}\\b`, 'i').test(p),
+      );
+      if (named != null) {
+        return [
+          activeIncidentsMetric(),
+          activeInstancesMetric(),
+          activeJobsMetric(),
+          bpmnDiagram(named, 'heatmap'),
+          incidentsByErrorType(),
+          failingInstancesTable(),
+        ];
+      }
+      return [
+        activeIncidentsMetric(),
+        activeInstancesMetric(),
+        activeJobsMetric(),
+        ...ALL_DEMO_PROCESSES.map((key) => bpmnDiagram(key, 'heatmap')),
+        failingInstancesTable(),
+      ];
+    },
   },
   {
     // "show me live diagram" / "live diagram"
@@ -1406,36 +1734,47 @@ These widgets focus on failure modes. The **incident chart** breaks down errors 
       textWidget(
         `## The full notebook tour
 
-Below is **one of every widget type** the notebook can render — each one independent, each one reading live data from your Camunda cluster. Watch them cascade in: metrics, trend sparklines, a KPI tile, charts (donut, pie, stacked-bar, stacked-area), a per-process status grid, a BPMN heatmap, a combined activity stream, a conversion funnel, and a list. Hover any tile and click </> to see exactly what query produced it.`,
+Below is **one of every widget type** the notebook can render — each one independent, each one reading live data from your Camunda cluster. You'll see metrics, trend sparklines, a KPI strip, all 9 chart subtypes (bar, line, donut, pie, stacked-bar, stacked-area, meter, treemap, radar), a per-process status grid, a BPMN heatmap, a combined activity stream, a conversion funnel, and a list. Hover any tile and click </> to see exactly what query produced it.`,
         'Widget showcase',
       ),
-      // Row 2: 4 SHORT tiles (3+3+3+3) — 2 metrics + 2 trends. All 132px.
+      // Row: KPI strip (full width AUTO, ~140px)
+      processHealthKpi(),
+      // Row: 4 SHORT tiles (3+3+3+3) — metrics + trends. All 132px.
       activeInstancesMetric(),
       activeIncidentsMetric(),
       instancesTrendDaily(),
       incidentsTrendHourly(),
-      // Row 3: 4 more SHORT tiles — different metrics
+      // Row: 4 more SHORT tiles — different metrics
       activeJobsMetric(),
       completedInstancesMetric(),
       processDefinitionsMetric(),
       jobsTrendHourly(),
-      // Row 4: KPI (6) + first chart (6) — both TALL 296px
-      processHealthKpi(),
+      // Row: bar + line (6+6) — both TALL
+      incidentsByErrorType(), // bar
+      instancesStartedTodayLine(), // line
+      // Row: donut + pie (6+6) — both TALL
       instancesByState(), // donut
-      // Row 5: pie + stacked-area (6+6) — both TALL
-      instancesByStatePie(),
-      instancesByProcessStackedArea(),
-      // Row 6: stacked-bar + activity feed (6+6) — both TALL
-      instancesByProcessStacked(),
-      combinedActivityFeed(),
-      // Row 7: incidents-by-error chart + funnel (6+6) — both TALL
-      incidentsByErrorType(),
-      funnelWidget(),
-      // Row 8: status grid, full width HERO
+      instancesByStatePie(), // pie
+      // Row: stacked-bar + stacked-area (6+6)
+      instancesByProcessStacked(), // stacked-bar
+      instancesByProcessStackedArea(), // stacked-area
+      // Row: meter + treemap (6+6)
+      jobsMeter(), // meter
+      instancesByProcessTreemap(), // treemap
+      // Row: radar + funnel (6+6)
+      elementsByTypeRadar(), // radar
+      funnelWidget(), // funnel
+      // Row: completed-today line — paired in the row above with the bar.
+      completedTodayPerHourLine(),
+      // Row: hero activity stream (full width HERO)
+      combinedActivityFeedHero(), // activity-feed (hero variant)
+      // Row: status grid, full width HERO
       statusGridWidget(),
-      // Row 9: BPMN heatmap, full width HERO
+      // Row: BPMN heatmap, full width HERO
       bpmnDiagram(DEMO_PROCESS_KEY, 'heatmap'),
-      // Row 10: closing details table, full width AUTO
+      // Row: BPMN combined overlay (different variant), full width HERO
+      bpmnDiagram(DEMO_PROCESS_KEY, 'combined'),
+      // Row: closing details table, full width AUTO
       incidentsTable(),
     ],
   },

--- a/operate/client/src/App/Notebooks/presets.ts
+++ b/operate/client/src/App/Notebooks/presets.ts
@@ -1,0 +1,1495 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {WidgetConfig} from './types';
+
+// ---------------------------------------------------------------------------
+// Notebook PRESETS — static dashboard templates indexed by intent keywords.
+//
+// Used by the suggestion pills (PromptInput.tsx). When the user clicks a pill
+// the prompt routes here instead of to the real LLM — instant, deterministic,
+// curated bundles. Free-text prompts go to the real Bedrock LLM via llm.ts.
+//
+// IDs include a random suffix so re-running the same prompt produces a fresh
+// widget (otherwise React-key collisions cause the new widget to silently
+// replace the existing one).
+// ---------------------------------------------------------------------------
+
+function uid(prefix: string): string {
+  return `${prefix}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+// ---------------------------------------------------------------------------
+// Demo processes — match the BPMN files seeded by scripts/seed-demo-data.sh.
+// Each entry maps the technical processDefinitionId (used in the V2 API URL)
+// to a human-readable display name used in widget titles.
+// ---------------------------------------------------------------------------
+const DEMO_PROCESS_KEY = 'order-process'; // default fallback
+
+const PROCESS_DISPLAY_NAMES: Record<string, string> = {
+  'order-process': 'Order Process',
+  'payment-process': 'Payment Process',
+  'shipping-process': 'Shipping Process',
+};
+
+function processDisplayName(key: string): string {
+  return PROCESS_DISPLAY_NAMES[key] ?? key;
+}
+
+/**
+ * Detect a process from the prompt — returns the matching processDefinitionId
+ * or the default fallback. Used to make widget bundles process-aware.
+ */
+function detectProcessFromPrompt(prompt: string): string {
+  if (/order|fulfill|fulfillment/i.test(prompt)) {
+    return 'order-process';
+  }
+  if (/payment|pay\b|charge|billing/i.test(prompt)) {
+    return 'payment-process';
+  }
+  if (/ship|delivery|dispatch/i.test(prompt)) {
+    return 'shipping-process';
+  }
+  return DEMO_PROCESS_KEY;
+}
+
+const ALL_DEMO_PROCESSES = Object.keys(PROCESS_DISPLAY_NAMES);
+
+// =============================================================================
+// METRICS — single-number tiles
+// =============================================================================
+
+function activeInstancesMetric(): WidgetConfig {
+  return {
+    id: uid('m-active'),
+    type: 'metric',
+    title: 'Active process instances',
+    description:
+      'The total number of process instances currently running across all deployed processes. A live count that updates as instances start, complete, or fail.',
+    query: {
+      endpoint: '/v2/process-instances/search',
+      method: 'POST',
+      body: {filter: {state: 'ACTIVE'}, page: {limit: 1}},
+    },
+    field: 'page.totalItems',
+    accent: 'info',
+  };
+}
+
+function completedInstancesMetric(): WidgetConfig {
+  return {
+    id: uid('m-completed'),
+    type: 'metric',
+    title: 'Completed instances',
+    description:
+      'How many process instances have finished successfully. Useful to gauge throughput and catch unusual drops.',
+    query: {
+      endpoint: '/v2/process-instances/search',
+      method: 'POST',
+      body: {filter: {state: 'COMPLETED'}, page: {limit: 1}},
+    },
+    field: 'page.totalItems',
+    accent: 'success',
+  };
+}
+
+function activeIncidentsMetric(): WidgetConfig {
+  return {
+    id: uid('m-incidents'),
+    type: 'metric',
+    title: 'Active incidents',
+    description:
+      'Open incidents across all processes. Each incident is a stuck instance waiting for human intervention — non-zero values mean something needs attention.',
+    query: {
+      endpoint: '/v2/incidents/search',
+      method: 'POST',
+      body: {filter: {state: 'ACTIVE'}, page: {limit: 1}},
+    },
+    field: 'page.totalItems',
+    accent: 'error',
+  };
+}
+
+function activeJobsMetric(): WidgetConfig {
+  return {
+    id: uid('m-jobs'),
+    type: 'metric',
+    title: 'Active jobs',
+    description:
+      'Jobs currently waiting to be picked up by a worker. Sustained high values can indicate worker capacity problems.',
+    query: {
+      endpoint: '/v2/jobs/search',
+      method: 'POST',
+      body: {filter: {state: 'CREATED'}, page: {limit: 1}},
+    },
+    field: 'page.totalItems',
+    accent: 'warning',
+  };
+}
+
+function processDefinitionsMetric(): WidgetConfig {
+  return {
+    id: uid('m-defs'),
+    type: 'metric',
+    title: 'Deployed processes',
+    description:
+      'How many distinct process definitions are deployed in this cluster, counting all versions.',
+    query: {
+      endpoint: '/v2/process-definitions/search',
+      method: 'POST',
+      body: {page: {limit: 1}},
+    },
+    field: 'page.totalItems',
+    accent: 'neutral',
+  };
+}
+
+// =============================================================================
+// TABLES — list views
+// =============================================================================
+
+function activeInstancesTable(): WidgetConfig {
+  return {
+    id: uid('t-instances-active'),
+    type: 'table',
+    title: 'Active process instances',
+    description:
+      'Up to 25 currently running process instances, newest first. Each row shows the instance key, the process it belongs to, its state, and when it started.',
+    query: {
+      endpoint: '/v2/process-instances/search',
+      method: 'POST',
+      body: {
+        filter: {state: 'ACTIVE'},
+        sort: [{field: 'startDate', order: 'DESC'}],
+        page: {limit: 25},
+      },
+    },
+    columns: [
+      'processInstanceKey',
+      'processDefinitionId',
+      'state',
+      'startDate',
+    ],
+  };
+}
+
+function recentInstancesTable(): WidgetConfig {
+  return {
+    id: uid('t-instances-recent'),
+    type: 'table',
+    title: 'Recently started instances',
+    description:
+      'The 25 most recently started process instances regardless of state — useful for spotting just-started workloads or freshly completed runs.',
+    query: {
+      endpoint: '/v2/process-instances/search',
+      method: 'POST',
+      body: {
+        sort: [{field: 'startDate', order: 'DESC'}],
+        page: {limit: 25},
+      },
+    },
+    columns: [
+      'processInstanceKey',
+      'processDefinitionId',
+      'state',
+      'startDate',
+      'endDate',
+    ],
+  };
+}
+
+function failingInstancesTable(): WidgetConfig {
+  return {
+    id: uid('t-instances-failing'),
+    type: 'table',
+    title: 'Instances with incidents',
+    description:
+      'Process instances that currently have at least one open incident. Drill into one of these to see what failed and why.',
+    query: {
+      endpoint: '/v2/process-instances/search',
+      method: 'POST',
+      body: {
+        filter: {hasIncident: true},
+        sort: [{field: 'startDate', order: 'DESC'}],
+        page: {limit: 25},
+      },
+    },
+    columns: ['processInstanceKey', 'processDefinitionId', 'startDate'],
+  };
+}
+
+function incidentsTable(): WidgetConfig {
+  return {
+    id: uid('t-incidents'),
+    type: 'table',
+    title: 'Active incidents',
+    description:
+      'Open incidents sorted by most recent. Each row shows the failing element, the error type, and the message — exactly what you need to triage operationally.',
+    subtitle: 'sorted by most recent · capped at 15 rows',
+    query: {
+      endpoint: '/v2/incidents/search',
+      method: 'POST',
+      body: {
+        filter: {state: 'ACTIVE'},
+        sort: [{field: 'creationTime', order: 'DESC'}],
+        page: {limit: 25},
+      },
+    },
+    columns: [
+      'incidentKey',
+      'errorType',
+      'errorMessage',
+      'processDefinitionId',
+      'creationTime',
+    ],
+  };
+}
+
+function processDefinitionsTable(): WidgetConfig {
+  return {
+    id: uid('t-defs'),
+    type: 'table',
+    title: 'Deployed processes',
+    description:
+      'Every process definition deployed to this cluster. Use this when onboarding to a new system or to confirm an expected process is present.',
+    query: {
+      endpoint: '/v2/process-definitions/search',
+      method: 'POST',
+      body: {page: {limit: 25}},
+    },
+    columns: ['processDefinitionId', 'name', 'version', 'tenantId'],
+  };
+}
+
+function jobsTable(): WidgetConfig {
+  return {
+    id: uid('t-jobs'),
+    type: 'table',
+    title: 'Active jobs',
+    description:
+      'Jobs currently waiting for a worker, oldest deadline first. Useful for spotting backlogs or jobs that are about to time out.',
+    query: {
+      endpoint: '/v2/jobs/search',
+      method: 'POST',
+      body: {
+        filter: {state: 'CREATED'},
+        sort: [{field: 'deadline', order: 'ASC'}],
+        page: {limit: 25},
+      },
+    },
+    columns: ['jobKey', 'type', 'state', 'processInstanceKey', 'deadline'],
+  };
+}
+
+function userTasksTable(): WidgetConfig {
+  return {
+    id: uid('t-tasks'),
+    type: 'table',
+    title: 'Open user tasks',
+    description:
+      'Outstanding tasks awaiting a human. Newest first. Shows the task name, its assignee (if any), and the parent process — the inbox view of human-in-the-loop work.',
+    query: {
+      endpoint: '/v2/user-tasks/search',
+      method: 'POST',
+      body: {
+        filter: {state: 'CREATED'},
+        sort: [{field: 'creationDate', order: 'DESC'}],
+        page: {limit: 25},
+      },
+    },
+    columns: [
+      'userTaskKey',
+      'name',
+      'assignee',
+      'processDefinitionId',
+      'creationDate',
+    ],
+  };
+}
+
+// =============================================================================
+// CHARTS — grouped/counted visualisations
+// =============================================================================
+
+type ChartWidgetOverrides = {
+  id?: string;
+  title?: string;
+  description?: string;
+  subtitle?: string;
+  chartType?: WidgetConfig['chartType'];
+  chartGroupBy?: string;
+  chartValueField?: string;
+  endpoint?: string;
+  body?: unknown;
+};
+
+function chartWidget(overrides: ChartWidgetOverrides = {}): WidgetConfig {
+  return {
+    id: overrides.id ?? uid('c-chart'),
+    type: 'chart',
+    title: overrides.title ?? 'Chart',
+    description: overrides.description,
+    subtitle: overrides.subtitle,
+    chartType: overrides.chartType ?? 'bar',
+    chartGroupBy: overrides.chartGroupBy ?? 'state',
+    chartValueField: overrides.chartValueField,
+    query: {
+      endpoint: overrides.endpoint ?? '/v2/process-instances/search',
+      method: 'POST',
+      body: overrides.body ?? {page: {limit: 1000}},
+    },
+  };
+}
+
+function incidentsByErrorType(): WidgetConfig {
+  return chartWidget({
+    id: uid('c-inc-error'),
+    title: 'Incidents by error type',
+    description:
+      'A breakdown of all open incidents grouped by error type. Use this to identify which failure category is most prevalent and where to focus remediation.',
+    subtitle: 'all open incidents · grouped by errorType',
+    chartType: 'bar',
+    chartGroupBy: 'errorType',
+    endpoint: '/v2/incidents/search',
+    body: {page: {limit: 1000}},
+  });
+}
+
+function instancesByState(): WidgetConfig {
+  return chartWidget({
+    id: uid('c-inst-state'),
+    title: 'Instances by state',
+    description:
+      'Proportion of process instances in each lifecycle state — active, completed, canceled, and incident. A quick visual of overall cluster health.',
+    chartType: 'donut',
+    chartGroupBy: 'state',
+    endpoint: '/v2/process-instances/search',
+    body: {page: {limit: 1000}},
+  });
+}
+
+function instancesByProcess(): WidgetConfig {
+  return chartWidget({
+    id: uid('c-inst-proc'),
+    title: 'Instances by process',
+    description:
+      'Count of active process instances grouped by process definition. Use this to see which processes are driving the most workload right now.',
+    chartType: 'bar',
+    chartGroupBy: 'processDefinitionId',
+    endpoint: '/v2/process-instances/search',
+    body: {filter: {state: 'ACTIVE'}, page: {limit: 1000}},
+  });
+}
+
+// (Removed `incidentsOverTime` — it was a categorical line chart misrepresented
+// as a "trend". For real time-series of incidents/instances, use the dedicated
+// trend widget which fires N parallel real queries with date-range filters.)
+
+// =============================================================================
+// KPI — multi-number hero tile
+// =============================================================================
+
+function processHealthKpi(): WidgetConfig {
+  return {
+    id: uid('k-health'),
+    type: 'kpi',
+    title: 'Process health',
+    description:
+      'Four key indicators side-by-side: running instances, completed today, instances with incidents, and pending jobs. A single-glance health check for your cluster.',
+    subtitle: 'live counters · last updated when widget loaded',
+    // Placeholder query — KPI widgets use kpis[] for individual fetches.
+    query: {endpoint: '/__notebook_kpi__', method: 'GET'},
+    kpis: [
+      {
+        label: 'Active instances',
+        query: {
+          endpoint: '/v2/process-instances/search',
+          method: 'POST',
+          body: {filter: {state: 'ACTIVE'}, page: {limit: 1}},
+        },
+        field: 'page.totalItems',
+        accent: 'info',
+      },
+      {
+        label: 'Completed',
+        query: {
+          endpoint: '/v2/process-instances/search',
+          method: 'POST',
+          body: {filter: {state: 'COMPLETED'}, page: {limit: 1}},
+        },
+        field: 'page.totalItems',
+        accent: 'success',
+      },
+      {
+        label: 'With incidents',
+        query: {
+          endpoint: '/v2/incidents/search',
+          method: 'POST',
+          body: {filter: {state: 'ACTIVE'}, page: {limit: 1}},
+        },
+        field: 'page.totalItems',
+        accent: 'error',
+      },
+      {
+        label: 'Pending jobs',
+        query: {
+          endpoint: '/v2/jobs/search',
+          method: 'POST',
+          body: {filter: {state: 'CREATED'}, page: {limit: 1}},
+        },
+        field: 'page.totalItems',
+        accent: 'warning',
+      },
+    ],
+  };
+}
+
+// (Removed `throughputOverviewKpi` — it duplicated `processHealthKpi` and
+// its only caller used a "throughput overview" trigger phrase nobody types
+// naturally. The workload/throughput preset uses processHealthKpi instead.)
+
+// =============================================================================
+// BPMN diagram widgets
+// =============================================================================
+
+type OverlayType =
+  | 'active'
+  | 'incidents'
+  | 'combined'
+  | 'stuck'
+  | 'none'
+  | 'heatmap';
+
+// =============================================================================
+// TEXT — narrative cells for the LLM to set context above data widgets
+// =============================================================================
+
+function textWidget(text: string, title: string = 'Note'): WidgetConfig {
+  return {
+    id: uid('x-text'),
+    type: 'text',
+    title,
+    text,
+    // Placeholder query — text widgets ignore the query but the schema
+    // requires one to keep the data widgets simple.
+    query: {endpoint: '/__notebook_text__', method: 'GET'},
+  };
+}
+
+function bpmnDiagram(
+  processDefinitionKey: string = DEMO_PROCESS_KEY,
+  overlay: OverlayType = 'combined',
+): WidgetConfig {
+  const name = processDisplayName(processDefinitionKey);
+  const overlaySuffix: Record<OverlayType, string> = {
+    active: ' · Active instances',
+    incidents: ' · Incident hotspots',
+    combined: ' · Live state',
+    stuck: ' · Stuck instances',
+    none: '',
+    heatmap: ' · Incident heatmap',
+  };
+  const overlayDescription: Record<OverlayType, string> = {
+    none: `Structural diagram of the ${name} — the full flow without any live-data overlays. Useful for understanding how the process is shaped.`,
+    active: `Live diagram of the ${name} with **blue badges** showing how many instances are currently at each task. Useful for spotting where work is queueing up.`,
+    incidents: `Live diagram of the ${name} highlighting **incident hotspots** — red badges count open incidents per task.`,
+    combined: `Live diagram of the ${name}. **Blue badges** are active instance counts per task; **red badges** are open incidents. Together they show where work is — and where it's stuck.`,
+    stuck: `Live diagram of the ${name} highlighting tasks where instances are waiting — currently equivalent to the active-instance overlay until age-tracking ships in the API.`,
+    heatmap: `Live heatmap of the ${name}. Flow nodes are filled with a red gradient — pale for few incidents, deep red for many — so the worst hotspots jump out immediately. Hottest nodes also show their incident count as a badge.`,
+  };
+  const overlaySubtitle: Record<OverlayType, string> = {
+    none: 'structural view · no live data',
+    active: 'live · blue = active instance count per task',
+    incidents: 'live · red = open incidents per task',
+    combined: 'live · blue = active, red = open incidents',
+    stuck: 'live · blue = instances waiting per task',
+    heatmap: 'live · red intensity = incident density per node',
+  };
+  return {
+    id: uid('b-bpmn'),
+    type: 'bpmn',
+    title: `${name}${overlaySuffix[overlay]}`,
+    description: overlayDescription[overlay],
+    subtitle: overlaySubtitle[overlay],
+    query: {
+      endpoint: `/v2/process-definitions/${processDefinitionKey}/xml`,
+      method: 'GET',
+    },
+    processDefinitionKey,
+    overlay,
+  };
+}
+
+// =============================================================================
+// STATUS GRID — per-process health board
+// =============================================================================
+
+function statusGridWidget(): WidgetConfig {
+  return {
+    id: uid('sg-grid'),
+    type: 'status-grid',
+    title: 'Process health board',
+    description:
+      'One tile per deployed process. Green means no incidents, yellow means 1-5 open incidents, red means more than 5 — a quick visual health check for your entire cluster.',
+    subtitle: 'deployed processes · color = incident severity',
+    query: {endpoint: '/__notebook_status_grid__', method: 'GET'},
+  };
+}
+
+// =============================================================================
+// ACTIVITY FEED — timeline of recent events
+// =============================================================================
+
+/**
+ * Multi-source combined activity feed — interleaves instance starts and
+ * incident events in a single chronological timeline. Each source has a
+ * distinct accent color so event types are visually distinguishable at a
+ * glance.
+ */
+function combinedActivityFeed(): WidgetConfig {
+  return {
+    id: uid('af-combined'),
+    type: 'activity-feed',
+    title: 'Live activity stream',
+    description:
+      'An interleaved timeline of recent process instance starts (blue) and incident events (red), merged by time so you can see what happened and when across both streams.',
+    subtitle: 'instances + incidents · newest first · 12 items',
+    // Placeholder — multi-source feeds use activitySources; the root query is
+    // unused but required by the schema.
+    query: {endpoint: '/__notebook_activity_multi__', method: 'GET'},
+    activitySources: [
+      {
+        label: 'Instance started',
+        query: {
+          endpoint: '/v2/process-instances/search',
+          method: 'POST',
+          body: {
+            sort: [{field: 'startDate', order: 'DESC'}],
+            page: {limit: 12},
+          },
+        },
+        titleField: 'processDefinitionId',
+        timeField: 'startDate',
+        accent: 'info',
+      },
+      {
+        label: 'Incident raised',
+        query: {
+          endpoint: '/v2/incidents/search',
+          method: 'POST',
+          body: {
+            sort: [{field: 'creationTime', order: 'DESC'}],
+            page: {limit: 12},
+          },
+        },
+        titleField: 'errorType',
+        subtitleField: 'errorMessage',
+        timeField: 'creationTime',
+        accent: 'error',
+      },
+    ],
+  };
+}
+
+// =============================================================================
+// FUNNEL — process stage conversion
+// =============================================================================
+
+function funnelWidget(): WidgetConfig {
+  return {
+    id: uid('fn-funnel'),
+    type: 'funnel',
+    title: 'Order process — stage funnel',
+    description:
+      'Shows how many tokens have passed through each stage of the order process. The width of each bar is proportional to the total volume, making drop-off between stages immediately visible.',
+    // Real endpoint that the widget actually fires. The widget also issues a
+    // helper /v2/process-definitions/search call when the key is non-numeric
+    // (to resolve a string id like "order-process" to its numeric key).
+    query: {
+      endpoint: `/v2/process-definitions/${DEMO_PROCESS_KEY}/statistics/element-instances`,
+      method: 'POST',
+    },
+    processDefinitionKey: DEMO_PROCESS_KEY,
+    funnelStages: [
+      {label: 'Validate', elementId: 'Task_Validate'},
+      {label: 'Charge Payment', elementId: 'Task_Charge'},
+      {label: 'Reserve Inventory', elementId: 'Task_Reserve'},
+      {label: 'Ship Order', elementId: 'Task_Ship'},
+    ],
+  };
+}
+
+// =============================================================================
+// TREND — multi-bucket sparkline widgets backed by real parallel queries
+// =============================================================================
+
+function instancesTrendDaily(): WidgetConfig {
+  return {
+    id: uid('tr-instances-daily'),
+    type: 'trend',
+    title: 'New instances · last 7 days',
+    description:
+      'Daily count of new process instances over the past 7 days. Each point is a real query against the V2 API filtered by startDate. Use this to spot weekly patterns or sudden drops in throughput.',
+    query: {
+      endpoint: '/v2/process-instances/search',
+      method: 'POST',
+      body: {page: {limit: 1}},
+    },
+    trendDateField: 'startDate',
+    trendBuckets: 7,
+    trendBucketSpan: '24h',
+    trendAccent: 'info',
+  };
+}
+
+function incidentsTrendHourly(): WidgetConfig {
+  return {
+    id: uid('tr-incidents-hourly'),
+    type: 'trend',
+    title: 'Incidents · last 12 hours',
+    description:
+      'Hourly incident creation rate over the past 12 hours. Spikes indicate process failures clustering in time — useful for correlating incidents with deployments or external system outages.',
+    query: {
+      endpoint: '/v2/incidents/search',
+      method: 'POST',
+      body: {page: {limit: 1}},
+    },
+    trendDateField: 'creationTime',
+    trendBuckets: 12,
+    trendBucketSpan: '1h',
+    trendAccent: 'error',
+  };
+}
+
+function jobsTrendHourly(): WidgetConfig {
+  return {
+    id: uid('tr-jobs-hourly'),
+    type: 'trend',
+    title: 'Jobs created · last 12 hours',
+    description:
+      'Hourly job creation volume over the past 12 hours. Sustained growth may indicate worker capacity problems before they surface as timeouts.',
+    query: {
+      endpoint: '/v2/jobs/search',
+      method: 'POST',
+      body: {page: {limit: 1}},
+    },
+    trendDateField: 'creationTime',
+    trendBuckets: 12,
+    trendBucketSpan: '1h',
+    trendAccent: 'warning',
+  };
+}
+
+// =============================================================================
+// PIE — instances by state as a filled pie (no center hole)
+// =============================================================================
+
+function instancesByStatePie(): WidgetConfig {
+  return chartWidget({
+    id: uid('c-inst-pie'),
+    title: 'Instances by state (pie)',
+    description:
+      'A pie chart breaking down process instances by lifecycle state — active, completed, canceled, and incident. Emphasises parts-of-whole when you want proportions without the center hole.',
+    subtitle: 'all instances · grouped by state',
+    chartType: 'pie',
+    chartGroupBy: 'state',
+    endpoint: '/v2/process-instances/search',
+    body: {page: {limit: 1000}},
+  });
+}
+
+// =============================================================================
+// STACKED AREA — instances by process over time (stacked by state)
+// =============================================================================
+
+function instancesByProcessStackedArea(): WidgetConfig {
+  return {
+    id: uid('c-area'),
+    type: 'chart',
+    title: 'Instances by process and state (area)',
+    description:
+      'A stacked area chart showing how process instances are distributed across process definitions, with each band colored by lifecycle state. Good for spotting state trends across processes.',
+    subtitle: 'all instances · stacked by state · grouped by process',
+    chartType: 'stacked-area',
+    chartGroupBy: 'processDefinitionId',
+    chartStackBy: 'state',
+    query: {
+      endpoint: '/v2/process-instances/search',
+      method: 'POST',
+      body: {page: {limit: 1000}},
+    },
+  };
+}
+
+// =============================================================================
+// STACKED BAR — instances by process stacked by state
+// =============================================================================
+
+function instancesByProcessStacked(): WidgetConfig {
+  return {
+    id: uid('c-stacked'),
+    type: 'chart',
+    title: 'Instances by process and state',
+    description:
+      'A stacked bar chart showing the breakdown of process instances per process definition, with each bar colored by lifecycle state (active, completed, canceled, incident). Use this to spot which processes have unusually high failure rates.',
+    chartType: 'stacked-bar',
+    chartGroupBy: 'processDefinitionId',
+    chartStackBy: 'state',
+    query: {
+      endpoint: '/v2/process-instances/search',
+      method: 'POST',
+      body: {page: {limit: 1000}},
+    },
+  };
+}
+
+// =============================================================================
+// CHART-LIST — compound chart + compact list widgets
+// =============================================================================
+
+// (Removed `incidentsBreakdownAndList` and `instancesByProcessAndList` —
+// the chart-list compound widget was retired in favor of side-by-side
+// chart + table pairs. Use `incidentsByErrorType()` + `incidentsTable()`
+// or `instancesByProcess()` + `activeInstancesTable()` instead.)
+
+// =============================================================================
+// PRESETS — keyword-based bundles
+// =============================================================================
+
+type Preset = {
+  match: (prompt: string) => boolean;
+  /**
+   * Receives the original prompt so presets can detect which process the user
+   * mentioned (order/payment/shipping). Most presets ignore it; BPMN-related
+   * ones use it to make widgets process-aware.
+   */
+  build: (prompt: string) => WidgetConfig[];
+};
+
+// ---------------------------------------------------------------------------
+// Variation helpers — used so the same prompt can produce different (but
+// thematically consistent) bundles each time. Makes the demo feel live
+// rather than canned.
+// ---------------------------------------------------------------------------
+
+function pickOne<T>(items: T[]): T {
+  return items[Math.floor(Math.random() * items.length)] as T;
+}
+
+function shuffle<T>(items: T[]): T[] {
+  const copy = [...items];
+  for (let i = copy.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [copy[i], copy[j]] = [copy[j] as T, copy[i] as T];
+  }
+  return copy;
+}
+
+function sample<T>(items: T[], n: number): T[] {
+  return shuffle(items).slice(0, Math.min(n, items.length));
+}
+
+const PRESETS: Preset[] = [
+  // -------------------------------------------------------------------------
+  // Multi-widget dashboards (most cinematic — multiple widgets cascade in)
+  // -------------------------------------------------------------------------
+
+  {
+    // "Monday morning view" — the headline cinematic prompt.
+    // Always: 1 KPI hero + 2 metrics + a chart + the BPMN heatmap + a table.
+    // Each rendering picks a different *combination* of the above primitives
+    // so re-running the same prompt yields a different (but thematic) view.
+    match: (p) => /monday|morning/i.test(p),
+    build: () => {
+      const metricsPool = [
+        activeInstancesMetric,
+        activeIncidentsMetric,
+        activeJobsMetric,
+        processDefinitionsMetric,
+        completedInstancesMetric,
+      ];
+      const chartsPool = [
+        instancesByState,
+        incidentsByErrorType,
+        instancesByProcess,
+      ];
+      const tablesPool = [
+        incidentsTable,
+        activeInstancesTable,
+        failingInstancesTable,
+        recentInstancesTable,
+        combinedActivityFeed,
+      ];
+      const overlayPool: OverlayType[] = [
+        'combined',
+        'active',
+        'incidents',
+        'heatmap',
+      ];
+
+      // Pick a narrative tone — three variations so re-running feels alive.
+      const intros = [
+        `## Good morning ☕
+
+Here's the state of your processes right now. **Active incidents** are clustered in \`order-process\` — start with the heatmap below and drill into the table to triage. Numbers are live and refresh every time you reload the notebook.`,
+
+        `## Monday rundown
+
+Three things to check: (1) the **active incident count** at the top — anything > 10 is worth your attention, (2) the **BPMN heatmap** showing where instances are getting stuck, and (3) the **table** of currently running work. Everything below is live data from your cluster.`,
+
+        `## Process health snapshot
+
+The widgets below are sampled from your live cluster. Look for *red* in the BPMN heatmap (stuck nodes), spikes in the chart, and recent activity in the table. Click any tile's </> to see exactly what query produced it.`,
+      ];
+
+      const trendPool = [
+        instancesTrendDaily,
+        incidentsTrendHourly,
+        jobsTrendHourly,
+      ];
+
+      // Layout principle: group widgets by visual height so adjacent widgets
+      // on a row line up. Order:
+      //   row 1: text intro (full width)
+      //   row 2: 2 metrics + 2 trend tiles (3+3+3+3) — all 132px short
+      //   row 3: KPI tile (6) + chart (6) — both TALL
+      //   row 4: chart + chart (6+6) — both TALL — DIFFERENT charts (no dupe)
+      //   row 5: BPMN (full width)
+      //   row 6: table (full width)
+      //
+      // Use sample(chartsPool, 3) to draw 3 *distinct* charts up front,
+      // avoiding duplicates that previously slipped through pickOne+pickOne.
+      const charts = sample(chartsPool, 3).map((f) => f());
+      return [
+        textWidget(pickOne(intros), 'Monday morning'),
+        // Row 2: 4 short tiles — mix of metrics and trends so the row pops
+        ...sample(metricsPool, 2).map((f) => f()),
+        ...sample(trendPool, 2).map((f) => f()),
+        // Row 3: KPI + first chart
+        processHealthKpi(),
+        charts[0] as WidgetConfig,
+        // Row 4: two more charts (distinct from row 3 and from each other)
+        charts[1] as WidgetConfig,
+        charts[2] as WidgetConfig,
+        // Row 5: BPMN heatmap, full width — varied process for re-runs
+        bpmnDiagram(pickOne(ALL_DEMO_PROCESSES), pickOne(overlayPool)),
+        // Row 6: closing list, full width
+        pickOne(tablesPool)(),
+      ];
+    },
+  },
+  {
+    // Triage / something looks off
+    match: (p) =>
+      /triage|wrong|broken|something.*off|unhealthy|failing/i.test(p),
+    build: () => {
+      const intros = [
+        `## Triage view
+
+Something feels off. Below: a **count of open incidents**, the BPMN diagram of \`order-process\` highlighting failing nodes, and a list of stuck instances. Start with the brightest red node in the diagram and work outward.`,
+
+        `## What's broken right now
+
+These widgets focus on failure modes. The **incident chart** breaks down errors by type so you can see if one kind of failure is dominating, and the **table** lists every stuck instance — sorted newest-first so you catch the freshest fires.`,
+      ];
+      // Layout: text intro, then a chart pair on its own row, then the
+      // BPMN incidents diagram (full width), then the failure tables.
+      // The single 3-col incident metric goes alongside three other metric
+      // tiles to fill the row evenly.
+      return [
+        textWidget(pickOne(intros), 'Triage'),
+        // Row 2: 4 metric tiles — all same height
+        activeIncidentsMetric(),
+        activeInstancesMetric(),
+        activeJobsMetric(),
+        completedInstancesMetric(),
+        // Row 3: chart pair (6+6) — both 320px
+        incidentsByErrorType(),
+        instancesByState(),
+        // Row 4: BPMN incident hotspots (full width)
+        bpmnDiagram(DEMO_PROCESS_KEY, 'incidents'),
+        // Row 5: closing failure tables (each full width — they stack)
+        ...sample([failingInstancesTable, incidentsTable], 2).map((f) => f()),
+      ];
+    },
+  },
+  {
+    // Health / overview / dashboard
+    match: (p) => /overview|dashboard|health|status|summary/i.test(p),
+    build: () => {
+      const metricsPool = [
+        activeInstancesMetric,
+        activeIncidentsMetric,
+        completedInstancesMetric,
+        processDefinitionsMetric,
+        activeJobsMetric,
+      ];
+      const chartsPool = [instancesByState, incidentsByErrorType];
+      return [
+        ...sample(metricsPool, 4).map((f) => f()),
+        pickOne(chartsPool)(),
+        recentInstancesTable(),
+      ];
+    },
+  },
+  {
+    // What's happening / right now — generic "show me what's going on".
+    // Intentionally does NOT match "activity" or "live" — those route to the
+    // dedicated activity-feed preset further down. Also bails out for prompts
+    // that mention error/incident so those hit the error-themed presets.
+    match: (p) =>
+      /what.*happen|right now|currently/i.test(p) &&
+      !/error|incident|activity|live|stream|feed/i.test(p),
+    build: () => [
+      activeInstancesMetric(),
+      activeJobsMetric(),
+      activeIncidentsMetric(),
+      recentInstancesTable(),
+    ],
+  },
+  {
+    // Workload / throughput / worker capacity per job type
+    match: (p) =>
+      /workload|throughput|capacity|worker.*capacity|jobs.*by.*type/i.test(p),
+    build: () => [
+      activeJobsMetric(),
+      activeInstancesMetric(),
+      // Bar chart grouping jobs by type — visualizes which worker pool is
+      // under-loaded vs. backed up. Real V2 query, no client-side fakery.
+      {
+        id: uid('c-jobs-by-type'),
+        type: 'chart',
+        title: 'Active jobs by type',
+        description:
+          "Jobs grouped by their declared type. Use this to spot a worker pool that is falling behind: bars that tower over the rest are queues your workers can't keep up with.",
+        chartType: 'bar',
+        chartGroupBy: 'type',
+        query: {
+          endpoint: '/v2/jobs/search',
+          method: 'POST',
+          body: {filter: {state: 'CREATED'}, page: {limit: 1000}},
+        },
+        accent: 'warning',
+      },
+      jobsTable(),
+    ],
+  },
+  {
+    // User-task workload by assignee — who's overloaded?
+    match: (p) =>
+      /user.*task.*assignee|who.*has.*task|task.*workload|assignee.*workload|inbox/i.test(
+        p,
+      ),
+    build: () => [
+      {
+        id: uid('m-tasks'),
+        type: 'metric',
+        title: 'Pending user tasks',
+        description: 'Total open tasks awaiting a human across all processes.',
+        query: {
+          endpoint: '/v2/user-tasks/search',
+          method: 'POST',
+          body: {filter: {state: 'CREATED'}, page: {limit: 1}},
+        },
+        field: 'page.totalItems',
+        accent: 'warning',
+      },
+      // Bar chart of tasks per assignee — exposes who is overloaded.
+      {
+        id: uid('c-tasks-by-assignee'),
+        type: 'chart',
+        title: 'Open tasks by assignee',
+        description:
+          'Pending user tasks grouped by who they are assigned to. Tall bars are the inboxes you might want to redistribute load away from.',
+        chartType: 'bar',
+        chartGroupBy: 'assignee',
+        query: {
+          endpoint: '/v2/user-tasks/search',
+          method: 'POST',
+          body: {filter: {state: 'CREATED'}, page: {limit: 1000}},
+        },
+        accent: 'warning',
+      },
+      userTasksTable(),
+    ],
+  },
+  {
+    // Slowest / longest-running instances
+    match: (p) =>
+      /slow|long.*running|longest|outlier|taking.*forever|stuck.*long/i.test(p),
+    build: () => [
+      {
+        id: uid('t-slowest'),
+        type: 'table',
+        title: 'Longest-running active instances',
+        description:
+          'The 25 oldest still-active process instances, sorted by start date ascending. Outliers here are the ones worth investigating — long-running could mean a stuck task or genuinely complex work.',
+        subtitle: 'sorted by start date · oldest first',
+        query: {
+          endpoint: '/v2/process-instances/search',
+          method: 'POST',
+          body: {
+            filter: {state: 'ACTIVE'},
+            sort: [{field: 'startDate', order: 'ASC'}],
+            page: {limit: 25},
+          },
+        },
+        columns: ['processInstanceKey', 'processDefinitionId', 'startDate'],
+      },
+      activeInstancesMetric(),
+      {
+        id: uid('c-active-by-process'),
+        type: 'chart',
+        title: 'Active instances by process',
+        description:
+          'Where the active workload is concentrated. Process definitions with many active instances may be the source of long-running outliers.',
+        chartType: 'bar',
+        chartGroupBy: 'processDefinitionId',
+        query: {
+          endpoint: '/v2/process-instances/search',
+          method: 'POST',
+          body: {filter: {state: 'ACTIVE'}, page: {limit: 1000}},
+        },
+        accent: 'info',
+      },
+    ],
+  },
+  {
+    // Top errors / error type drill-down
+    match: (p) =>
+      /top.*error|error.*type|error.*breakdown|error.*drill|kinds.*of.*error|what.*error/i.test(
+        p,
+      ),
+    // "Top errors" — incident chart + table of recent incidents.
+    // Chart (TALL, 6 cols) drops onto its own row alone; table follows
+    // full-width. No SHORT+TALL mixing.
+    build: () => [incidentsByErrorType(), incidentsTable()],
+  },
+
+  // -------------------------------------------------------------------------
+  // Domain-themed bundles — each pool offers thematically related widgets.
+  // We sample 2-4 from the pool so the same prompt produces a different
+  // (but related) combination each run. Order matters: more-specific first.
+  // -------------------------------------------------------------------------
+
+  {
+    // Explicit "list incidents" — always include the table.
+    match: (p) =>
+      /incident/i.test(p) && /\blist\b|\btable\b|\ball\b|\bshow\b/i.test(p),
+    build: () => [
+      incidentsTable(),
+      activeIncidentsMetric(),
+      incidentsByErrorType(),
+    ],
+  },
+  {
+    // Incident-themed prompts — covers count, list, breakdown, BPMN heatmap
+    match: (p) => /incident/i.test(p),
+    build: () => {
+      const pool = [
+        activeIncidentsMetric,
+        incidentsTable,
+        failingInstancesTable,
+        incidentsByErrorType,
+        () => bpmnDiagram(DEMO_PROCESS_KEY, 'incidents'),
+      ];
+      return sample(pool, 2 + Math.floor(Math.random() * 2)).map((f) => f());
+    },
+  },
+  {
+    // Failing / stuck instances
+    match: (p) =>
+      /(failing|stuck|error)\s*(instance|process)/i.test(p) ||
+      /(instance|process).*incident/i.test(p),
+    build: () => {
+      const pool = [
+        failingInstancesTable,
+        activeIncidentsMetric,
+        incidentsByErrorType,
+        () => bpmnDiagram(DEMO_PROCESS_KEY, 'incidents'),
+      ];
+      return sample(pool, 2 + Math.floor(Math.random() * 2)).map((f) => f());
+    },
+  },
+  {
+    // User tasks — count above the table for context.
+    match: (p) => /user.*task|human.*task|todo|inbox/i.test(p),
+    build: () => [
+      {
+        id: uid('m-tasks-pending'),
+        type: 'metric',
+        title: 'Pending user tasks',
+        description: 'Total open tasks awaiting a human across all processes.',
+        query: {
+          endpoint: '/v2/user-tasks/search',
+          method: 'POST',
+          body: {filter: {state: 'CREATED'}, page: {limit: 1}},
+        },
+        field: 'page.totalItems',
+        accent: 'warning',
+      },
+      userTasksTable(),
+    ],
+  },
+  {
+    // Jobs (workers)
+    match: (p) => /job|worker|task queue/i.test(p),
+    build: () => {
+      const extra = [
+        instancesByProcess,
+        () => bpmnDiagram(DEMO_PROCESS_KEY, 'active'),
+      ];
+      return [
+        activeJobsMetric(),
+        jobsTable(),
+        ...sample(extra, Math.floor(Math.random() * 2)).map((f) => f()),
+      ];
+    },
+  },
+  {
+    // Process definitions / deployments
+    match: (p) =>
+      /process.*definition|deployment|deployed|what.*processes|which.*processes/i.test(
+        p,
+      ),
+    build: () => {
+      const pool = [
+        processDefinitionsMetric,
+        processDefinitionsTable,
+        instancesByProcess,
+      ];
+      return sample(pool, 2 + Math.floor(Math.random() * 2)).map((f) => f());
+    },
+  },
+  {
+    // Completed / finished
+    match: (p) => /completed|finished|done/i.test(p),
+    build: () => {
+      const pool = [
+        completedInstancesMetric,
+        recentInstancesTable,
+        instancesByState,
+      ];
+      return sample(pool, 2 + Math.floor(Math.random() * 2)).map((f) => f());
+    },
+  },
+  {
+    // Recently started/created INSTANCES specifically. Scoped to instance
+    // vocabulary so "latest incidents" or "newest errors" don't get caught
+    // here — those route to the incident presets above.
+    match: (p) =>
+      /(recent|latest|new|last|just.*started)\s+(process\s+)?instance/i.test(p),
+    build: () => {
+      const pool = [
+        recentInstancesTable,
+        activeInstancesMetric,
+        instancesByProcess,
+      ];
+      return sample(pool, 2 + Math.floor(Math.random() * 2)).map((f) => f());
+    },
+  },
+  {
+    // List / table of instances
+    match: (p) => /list|table|all.*instances?|show.*instances?/i.test(p),
+    build: () => {
+      const pool = [
+        activeInstancesTable,
+        recentInstancesTable,
+        activeInstancesMetric,
+      ];
+      return sample(pool, 2 + Math.floor(Math.random() * 2)).map((f) => f());
+    },
+  },
+  {
+    // Counts / how many / total — return a deterministic answer based on
+    // which subject the prompt actually mentions. Random selection here was
+    // untrustworthy: asking "how many active instances?" and getting a count
+    // of jobs is the wrong answer.
+    match: (p) => /how many|count|number of|total/i.test(p),
+    build: (p) => {
+      if (/incident/i.test(p)) {
+        return [activeIncidentsMetric()];
+      }
+      if (/job|worker/i.test(p)) {
+        return [activeJobsMetric()];
+      }
+      if (/completed|finished|done/i.test(p)) {
+        return [completedInstancesMetric()];
+      }
+      if (/process.*definition|deployed|process.*type/i.test(p)) {
+        return [processDefinitionsMetric()];
+      }
+      if (/instance|process|active|running/i.test(p)) {
+        return [activeInstancesMetric()];
+      }
+      // Default: when the user just says "how many?" or "total" with no
+      // subject, show a KPI tile with all four counts side-by-side. Always
+      // correct, always useful — better than guessing one number.
+      return [processHealthKpi()];
+    },
+  },
+
+  // -------------------------------------------------------------------------
+  // Trend widget prompts — real multi-query sparkline data
+  // -------------------------------------------------------------------------
+  {
+    match: (p) =>
+      /trend|over time|history|last (24|7|hour|day)|past (week|hour|day)/i.test(
+        p,
+      ),
+    build: () => {
+      const pool = [instancesTrendDaily, incidentsTrendHourly, jobsTrendHourly];
+      return sample(pool, 2).map((f) => f());
+    },
+  },
+
+  // -------------------------------------------------------------------------
+  // Chart-list compound widgets — chart + compact list from one fetch
+  // -------------------------------------------------------------------------
+  {
+    // "incidents grouped by error type with recent examples" — chart + table
+    match: (p) =>
+      /incidents.*breakdown.*list|breakdown.*and.*list|chart.*and.*list|grouped.*recent.*example|by error.*recent|with recent example/i.test(
+        p,
+      ),
+    build: () => [incidentsByErrorType(), incidentsTable()],
+  },
+  {
+    // "instances by process with recent examples" — chart + table
+    match: (p) =>
+      /instances.*by.*process.*and.*list|process.*and.*list|by process.*recent/i.test(
+        p,
+      ),
+    build: () => [instancesByProcess(), activeInstancesTable()],
+  },
+
+  // -------------------------------------------------------------------------
+  // Chart / distribution prompts
+  // -------------------------------------------------------------------------
+  {
+    // Incidents breakdown by error type
+    match: (p) =>
+      /incident.*by error|by error.*type|incident.*breakdown|incident.*distribution/i.test(
+        p,
+      ),
+    build: () => [incidentsByErrorType(), incidentsTable()],
+  },
+  {
+    // Instances by state (donut)
+    match: (p) =>
+      /by state|state.*breakdown|state.*distribution|instance.*state/i.test(p),
+    build: () => [instancesByState(), activeInstancesMetric()],
+  },
+  {
+    // Instances by process (bar)
+    match: (p) =>
+      /by process|process.*breakdown|process.*distribution/i.test(p),
+    build: () => [instancesByProcess(), processDefinitionsMetric()],
+  },
+  {
+    // Generic chart / breakdown / distribution
+    match: (p) => /chart|breakdown|distribution/i.test(p),
+    build: () => {
+      const pool = [instancesByState, incidentsByErrorType, instancesByProcess];
+      return sample(pool, 2).map((f) => f());
+    },
+  },
+
+  // -------------------------------------------------------------------------
+  // New widget type presets
+  // -------------------------------------------------------------------------
+  {
+    // Process health board / status grid
+    match: (p) =>
+      /status.*board|process.*health|all.*processes.*status|cluster.*status|health.*board/i.test(
+        p,
+      ),
+    build: () => [statusGridWidget(), incidentsByErrorType()],
+  },
+  {
+    // Multi-source activity feed / live stream
+    match: (p) => /live.*activity|activity.*stream|recent activity/i.test(p),
+    build: () => [combinedActivityFeed(), activeIncidentsMetric()],
+  },
+  {
+    // Activity feed / recent events / timeline
+    match: (p) =>
+      /\bactivity\b|recent.*events?|timeline|feed|latest.*incidents?/i.test(p),
+    build: () => [combinedActivityFeed(), activeIncidentsMetric()],
+  },
+  {
+    // Pie chart — proportional breakdown emphasis
+    match: (p) => /\bpie\b/i.test(p),
+    build: () => [instancesByStatePie(), activeInstancesMetric()],
+  },
+  {
+    // Stacked area chart
+    match: (p) => /area chart|stacked area|trend over.*by state/i.test(p),
+    build: () => [instancesByProcessStackedArea(), processDefinitionsMetric()],
+  },
+  {
+    // Funnel / conversion / drop-off
+    match: (p) =>
+      /funnel|conversion|drop.*off|drop-off|stage.*conversion/i.test(p),
+    build: () => [funnelWidget(), activeInstancesMetric()],
+  },
+  {
+    // Stacked bar chart
+    match: (p) =>
+      /breakdown.*by.*process.*and.*state|stacked|process.*by.*state/i.test(p),
+    build: () => [instancesByProcessStacked(), processDefinitionsMetric()],
+  },
+
+  // -------------------------------------------------------------------------
+  // BPMN diagram prompts
+  // -------------------------------------------------------------------------
+  {
+    // Compare all deployed processes side-by-side
+    match: (p) =>
+      /compare.*process|all.*process.*diagram|processes.*side/i.test(p),
+    build: () => [
+      textWidget(
+        '## Process comparison\nSide-by-side diagrams of every deployed process. Each shows live state — active instances and incident hotspots — so you can see where work and pain are concentrated.',
+        'Process comparison',
+      ),
+      ...ALL_DEMO_PROCESSES.map((key) => bpmnDiagram(key, 'combined')),
+    ],
+  },
+  {
+    // "where are instances stuck" / "heatmap" → heatmap overlay,
+    // process-aware (detects "order"/"payment"/"shipping" in the prompt).
+    match: (p) => /where.*stuck|heatmap/i.test(p),
+    build: (p) => [bpmnDiagram(detectProcessFromPrompt(p), 'heatmap')],
+  },
+  {
+    // "show me live diagram" / "live diagram"
+    match: (p) => /show.*diagram.*live|live.*diagram/i.test(p),
+    build: (p) => [bpmnDiagram(detectProcessFromPrompt(p), 'combined')],
+  },
+  {
+    // "show me how X works" / "explain process X" → structural view, no overlay
+    match: (p) =>
+      /how.*work|explain.*process|what.*process.*do|process.*structure/i.test(
+        p,
+      ),
+    build: (p) => [bpmnDiagram(detectProcessFromPrompt(p), 'none')],
+  },
+  {
+    // "show the diagram" / "show bpmn" / "diagram of" → active overlay.
+    // Intentionally narrow — bare "show me processes" should hit the
+    // process-definitions preset above, not a BPMN diagram of the default.
+    match: (p) =>
+      /\bdiagram\b|\bbpmn\b|diagram\s+of|show.*diagram|show.*bpmn/i.test(p),
+    build: (p) => [bpmnDiagram(detectProcessFromPrompt(p), 'active')],
+  },
+
+  // -------------------------------------------------------------------------
+  // KPI / health tile prompts
+  // -------------------------------------------------------------------------
+  {
+    match: (p) => /kpi|key.*metric|health.*tile|stats|status.*card/i.test(p),
+    build: () => [processHealthKpi(), incidentsTable()],
+  },
+
+  // -------------------------------------------------------------------------
+  // Showcase — one of every widget type (the cinematic demo prompt)
+  // -------------------------------------------------------------------------
+  {
+    match: (p) =>
+      /showcase|all widgets|sample|demo dashboard|everything|tour/i.test(p),
+    build: () => [
+      textWidget(
+        `## The full notebook tour
+
+Below is **one of every widget type** the notebook can render — each one independent, each one reading live data from your Camunda cluster. Watch them cascade in: metrics, trend sparklines, a KPI tile, charts (donut, pie, stacked-bar, stacked-area), a per-process status grid, a BPMN heatmap, a combined activity stream, a conversion funnel, and a list. Hover any tile and click </> to see exactly what query produced it.`,
+        'Widget showcase',
+      ),
+      // Row 2: 4 SHORT tiles (3+3+3+3) — 2 metrics + 2 trends. All 132px.
+      activeInstancesMetric(),
+      activeIncidentsMetric(),
+      instancesTrendDaily(),
+      incidentsTrendHourly(),
+      // Row 3: 4 more SHORT tiles — different metrics
+      activeJobsMetric(),
+      completedInstancesMetric(),
+      processDefinitionsMetric(),
+      jobsTrendHourly(),
+      // Row 4: KPI (6) + first chart (6) — both TALL 296px
+      processHealthKpi(),
+      instancesByState(), // donut
+      // Row 5: pie + stacked-area (6+6) — both TALL
+      instancesByStatePie(),
+      instancesByProcessStackedArea(),
+      // Row 6: stacked-bar + activity feed (6+6) — both TALL
+      instancesByProcessStacked(),
+      combinedActivityFeed(),
+      // Row 7: incidents-by-error chart + funnel (6+6) — both TALL
+      incidentsByErrorType(),
+      funnelWidget(),
+      // Row 8: status grid, full width HERO
+      statusGridWidget(),
+      // Row 9: BPMN heatmap, full width HERO
+      bpmnDiagram(DEMO_PROCESS_KEY, 'heatmap'),
+      // Row 10: closing details table, full width AUTO
+      incidentsTable(),
+    ],
+  },
+  // (Removed `throughput overview` preset — its trigger phrase was dev
+  // jargon nobody types naturally. The workload/throughput preset above
+  // covers the same intent with a broader matcher.)
+
+  // -------------------------------------------------------------------------
+  // Fallback: a varied "general overview" bundle so unmatched prompts don't
+  // feel canned. Picks 2 metrics + 1 chart + 1 BPMN/table from rotating pools.
+  // -------------------------------------------------------------------------
+  {
+    match: () => true,
+    build: () => {
+      const metricsPool = [
+        activeInstancesMetric,
+        activeIncidentsMetric,
+        activeJobsMetric,
+        completedInstancesMetric,
+        processDefinitionsMetric,
+      ];
+      const chartsPool = [
+        instancesByState,
+        incidentsByErrorType,
+        instancesByProcess,
+      ];
+      const overlayChoices: OverlayType[] = ['combined', 'active'];
+      const visualPool = [
+        () => bpmnDiagram(DEMO_PROCESS_KEY, pickOne(overlayChoices)),
+        recentInstancesTable,
+        activeInstancesTable,
+        incidentsTable,
+      ];
+      return [
+        ...sample(metricsPool, 2).map((f) => f()),
+        pickOne(chartsPool)(),
+        pickOne(visualPool)(),
+      ];
+    },
+  },
+];
+
+/**
+ * Match a prompt against the preset matchers and return the corresponding
+ * widget bundle. Synchronous and instant — these are static templates.
+ */
+function pickConfigs(prompt: string): WidgetConfig[] {
+  for (const preset of PRESETS) {
+    if (preset.match(prompt)) {
+      return preset.build(prompt);
+    }
+  }
+  // Unreachable — last preset always matches — but TypeScript-safe.
+  return [activeInstancesMetric()];
+}
+
+export {pickConfigs};

--- a/operate/client/src/App/Notebooks/styled.ts
+++ b/operate/client/src/App/Notebooks/styled.ts
@@ -454,6 +454,17 @@ const WidgetTable = styled.table`
   td {
     color: var(--cds-text-primary);
   }
+
+  /* Linkable cell values (instance keys → Operate's instance page).
+     Carbon's link blue with subtle hover underline. */
+  td a {
+    color: var(--cds-link-primary);
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
 `;
 
 const EmptyState = styled.p`

--- a/operate/client/src/App/Notebooks/styled.ts
+++ b/operate/client/src/App/Notebooks/styled.ts
@@ -28,19 +28,28 @@ import {styles} from '@carbon/elements';
 // ---------------------------------------------------------------------------
 const TILE_HEIGHT_SHORT = '132px';
 const TILE_HEIGHT_TALL = '296px';
+const TILE_HEIGHT_HERO = '480px';
 
 /**
- * Two-row grid: scrollable content area (1fr) and a fixed prompt row (auto).
- * The page itself fills the parent (PageContent is height:100%), so the
- * content area scrolls internally while the prompt stays anchored.
+ * Two-column grid: scrollable content area (1fr) on the left and a sticky
+ * 360px prompt rail on the right. The page itself fills the parent
+ * (PageContent is height:100%), so the content area scrolls internally
+ * while the prompt rail stays in view.
  */
 const PageContainer = styled.div`
   display: grid;
-  grid-template-rows: 1fr auto;
+  grid-template-columns: 1fr 520px;
   height: 100%;
   width: 100%;
-  max-width: 1400px;
+  max-width: 1600px;
   margin: 0 auto;
+
+  @media (max-width: 1100px) {
+    /* Below 1100px there's no room for both columns. Collapse to a single
+       column with the prompt back at the bottom (the way it was). */
+    grid-template-columns: 1fr;
+    grid-template-rows: 1fr auto;
+  }
 `;
 
 const ContentScroll = styled.div`
@@ -68,6 +77,16 @@ const NotebookTitle = styled.h1`
   margin: 0;
   flex: 1;
   min-width: 0;
+  /* Allow long auto-derived titles ("give me a deep dive dashboard for the
+     payment process") to wrap onto multiple lines instead of being clipped.
+     The !important overrides Carbon's productiveHeading04 mixin which sets
+     a no-wrap text style on h1 by default. */
+  white-space: normal !important;
+  overflow: visible;
+  text-overflow: unset;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  line-height: 1.25;
 `;
 
 const WidgetsGrid = styled.div`
@@ -76,10 +95,13 @@ const WidgetsGrid = styled.div`
   gap: var(--cds-spacing-05);
   flex: 1;
   align-content: start;
-  /* Dense flow lets later widgets fill earlier holes — keeps the dashboard
-     compact even when widget sizes mix. The visual order can drift slightly
-     from DOM order, which is acceptable for dashboard layouts. */
-  grid-auto-flow: dense;
+  /* Strict row order — DOM order = visual order. We do NOT use grid-auto-flow:
+     dense because it lets later widgets backfill earlier gaps. When the user
+     submits two prompts in a row, dense flow causes widgets from the second
+     prompt's "short" row to fill leftover columns from the first prompt's
+     last row, visually merging the two batches. Presets are sized so they
+     compose without internal gaps — no need for dense. */
+  grid-auto-flow: row;
 `;
 
 /**
@@ -99,24 +121,50 @@ const WidgetsGrid = styled.div`
  * a CSS rule below — so all TALLs in the same row at least floor at 296px,
  * and don't wildly disagree on height.
  */
-const WidgetSlot = styled.div<{$type: string}>`
+const WidgetSlot = styled.div<{
+  $type: string;
+  $chartType?: string;
+  $activityFeedSize?: 'tall' | 'hero';
+}>`
   grid-column: span
-    ${({$type}) =>
+    ${({$type, $chartType, $activityFeedSize}) => {
+      // Activity-feed hero variant spans full width.
+      if ($type === 'activity-feed' && $activityFeedSize === 'hero') {
+        return 12;
+      }
+      // Radar charts need a square-ish aspect ratio to render the polygon
+      // legibly; at 6 cols they get squashed into a thin sliver. Span the
+      // full row so the radar gets ~960px of width.
+      if ($type === 'chart' && $chartType === 'radar') {
+        return 12;
+      }
       // SHORT (3 cols): metric tiles + trend (which is also a metric tile
       // shape with a tiny inline sparkline)
-      $type === 'metric' || $type === 'trend'
-        ? 3
-        : $type === 'table' ||
-            $type === 'bpmn' ||
-            $type === 'text' ||
-            $type === 'status-grid'
-          ? 12
-          : $type === 'chart' ||
-              $type === 'kpi' ||
-              $type === 'activity-feed' ||
-              $type === 'funnel'
-            ? 6
-            : 6};
+      if ($type === 'metric' || $type === 'trend') {
+        return 3;
+      }
+      if (
+        $type === 'table' ||
+        $type === 'bpmn' ||
+        $type === 'text' ||
+        $type === 'status-grid'
+      ) {
+        return 12;
+      }
+      // KPI tiles always span the full width — they're a horizontal row of
+      // numbers and need every column they can get so the labels never clip.
+      if ($type === 'kpi') {
+        return 12;
+      }
+      if (
+        $type === 'chart' ||
+        $type === 'activity-feed' ||
+        $type === 'funnel'
+      ) {
+        return 6;
+      }
+      return 6;
+    }};
   min-width: 0;
 
   @media (max-width: 900px) {
@@ -144,6 +192,27 @@ const WidgetSlot = styled.div<{$type: string}>`
     overflow: hidden;
   }
 
+  /* HERO activity-feed: full-width 480px tile with internal scroll.
+     The ActivityFeed inside handles overflow via overflow-y: auto. */
+  &[data-tier='hero'][data-type='activity-feed'] > div > .cds--tile {
+    min-height: ${TILE_HEIGHT_HERO};
+    max-height: ${TILE_HEIGHT_HERO};
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  /* HERO chart (currently used for radar): full-width 480px tile so the
+     polygon can render with a near-square aspect ratio. Without this the
+     chart inherits its component-level CHART_HEIGHT (240px) and squashes. */
+  &[data-tier='hero'][data-type='chart'] > div > .cds--tile {
+    min-height: ${TILE_HEIGHT_HERO};
+    max-height: ${TILE_HEIGHT_HERO};
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
   /* Cascade fade-in on mount. The animation-delay is set inline per index. */
   animation: notebook-widget-appear 320ms cubic-bezier(0.2, 0.8, 0.2, 1)
     backwards;
@@ -161,44 +230,94 @@ const WidgetSlot = styled.div<{$type: string}>`
 `;
 
 /**
- * Anchored prompt — sits in the bottom row of the page grid so it is always
- * visible regardless of how many widgets exist or how far the content above
- * is scrolled.
+ * Right-side prompt rail. Compact: textarea on top, button below it, then
+ * pills wrap-flowing as content-sized chips. Below 1100px it becomes a
+ * bottom strip (the layout we had before).
  */
-const PromptSection = styled.div`
+const PromptSection = styled.aside`
   display: flex;
   flex-direction: column;
-  gap: var(--cds-spacing-03);
-  padding: var(--cds-spacing-04) var(--cds-spacing-07) var(--cds-spacing-05);
-  background: var(--cds-background);
-  border-top: 1px solid var(--cds-border-subtle);
+  gap: var(--cds-spacing-04);
+  padding: var(--cds-spacing-05);
+  background: var(--cds-layer);
+  border-left: 1px solid var(--cds-border-subtle);
+  /* Sit at the top of the rail, content-sized — don't stretch the section
+     to the full grid row height. */
+  align-self: start;
+
+  @media (max-width: 1100px) {
+    border-left: none;
+    border-top: 1px solid var(--cds-border-subtle);
+    background: var(--cds-background);
+    padding: var(--cds-spacing-04) var(--cds-spacing-07) var(--cds-spacing-05);
+  }
 `;
 
 /**
- * Clickable example prompts shown above the textarea so the user can see
- * what kinds of dashboards they can ask for. Each pill maps to a known
- * preset in presets.ts.
+ * Section header for the rail. Tight — just a small uppercase label so the
+ * eye finds the rail quickly without taking vertical real estate.
+ */
+const PromptSectionTitle = styled.h3`
+  ${styles.label01};
+  text-transform: uppercase;
+  letter-spacing: 0.32px;
+  color: var(--cds-text-secondary);
+  margin: 0;
+
+  @media (max-width: 1100px) {
+    display: none;
+  }
+`;
+
+const PromptSectionHint = styled.p`
+  ${styles.helperText01};
+  color: var(--cds-text-helper);
+  margin: 0 0 var(--cds-spacing-02) 0;
+
+  @media (max-width: 1100px) {
+    display: none;
+  }
+`;
+
+/**
+ * Pill row — content-sized chips that wrap. Same layout in both the rail
+ * and the bottom-strip; only the surrounding flow direction changes.
+ * Pills hover with a subtle lift, no fixed width.
  */
 const PromptSuggestions = styled.div`
   display: flex;
   flex-wrap: wrap;
-  gap: var(--cds-spacing-02);
   align-items: center;
-  margin-bottom: var(--cds-spacing-02);
+  gap: var(--cds-spacing-02);
+  margin-top: var(--cds-spacing-02);
 
   .cds--tag {
     cursor: pointer;
     transition: transform 120ms ease;
+    margin: 0;
   }
   .cds--tag:hover:not([disabled]) {
     transform: translateY(-1px);
+  }
+
+  @media (max-width: 1100px) {
+    margin-top: 0;
+    .cds--tag {
+      width: auto;
+    }
+    .cds--tag:hover:not([disabled]) {
+      transform: translateY(-1px);
+    }
   }
 `;
 
 const PromptRow = styled.div`
   display: flex;
   gap: var(--cds-spacing-03);
-  align-items: flex-end;
+  align-items: center;
+  justify-content: flex-end;
+  /* Button stays content-sized; if the InlineLoading is also rendered, the
+     loading indicator pushes the button to the right. */
 `;
 
 const WidgetTitle = styled.h4`
@@ -216,6 +335,26 @@ const WidgetSubtitle = styled.p`
   ${styles.helperText01};
   color: var(--cds-text-helper);
   margin: calc(var(--cds-spacing-03) * -1) 0 var(--cds-spacing-04) 0;
+`;
+
+/**
+ * Centering wrapper for circular charts (pie/donut). Carbon Charts renders
+ * its SVG anchored to the left of its container; without this wrapper the
+ * disk sits flush-left while the bottom legend takes the full width.
+ */
+const CircularChartWrap = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+
+  /* Carbon Charts root — let it consume full width so the inner SVG can
+     center itself; the chart layout engine reads container size and lays
+     out disk + legend within. */
+  .cds--cc--chart-wrapper {
+    width: 100%;
+  }
 `;
 
 /**
@@ -550,7 +689,10 @@ const OverlayBadgeGroup = styled.div`
  */
 const KpiGrid = styled.div`
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  /* Single-row layout: all cells share the available width. Using minmax(0, 1fr)
+     means cells shrink instead of forcing the grid to wrap, which would push
+     KPIs below the 296px TALL cap and clip them. */
+  grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
   gap: var(--cds-spacing-05);
   margin-top: var(--cds-spacing-04);
 `;
@@ -561,14 +703,16 @@ const KpiGrid = styled.div`
  */
 const KpiCell = styled.div<{$accent?: string}>`
   position: relative;
-  padding: var(--cds-spacing-04) var(--cds-spacing-04) var(--cds-spacing-04)
+  padding: var(--cds-spacing-03) var(--cds-spacing-04) var(--cds-spacing-03)
     calc(var(--cds-spacing-04) + 3px + var(--cds-spacing-03));
   background: var(--cds-layer-accent);
   border-radius: 2px;
   display: flex;
   flex-direction: column;
+  justify-content: center;
   gap: var(--cds-spacing-02);
   overflow: hidden;
+  min-width: 0;
 
   &::before {
     content: '';
@@ -675,11 +819,19 @@ const StatusTileSkeleton = styled.div`
 // ActivityFeedWidget — vertical timeline of events
 // ---------------------------------------------------------------------------
 
-const ActivityFeed = styled.div`
+const ActivityFeed = styled.div<{$scrollable?: boolean}>`
   display: flex;
   flex-direction: column;
   margin-top: var(--cds-spacing-04);
   position: relative;
+  ${({$scrollable}) =>
+    $scrollable
+      ? `
+    flex: 1;
+    overflow-y: auto;
+    min-height: 0;
+  `
+      : ''}
 `;
 
 const ActivityRow = styled.div`
@@ -779,19 +931,29 @@ const TrendSparklineArea = styled.div`
 const FunnelContainer = styled.div`
   display: flex;
   flex-direction: column;
-  gap: var(--cds-spacing-03);
-  margin-top: var(--cds-spacing-04);
+  /* Compact gap so 4 stages (bar + inline drop-off) fit within the 296px TALL
+     tile. Target: 4 × ~46px content + 3 × 4px gaps + 56px chrome ≈ 260px. */
+  gap: var(--cds-spacing-02);
+  margin-top: var(--cds-spacing-03);
+  width: 100%;
+  min-width: 0;
 `;
 
 const FunnelRow = styled.div`
   display: flex;
-  flex-direction: column;
-  gap: var(--cds-spacing-02);
+  flex-direction: row;
+  align-items: center;
+  gap: var(--cds-spacing-03);
+  width: 100%;
+  min-width: 0;
 `;
 
 const FunnelBarTrack = styled.div`
   position: relative;
-  height: 32px;
+  /* Reduced from 32px to 28px so 4 stages fit cleanly in the 296px TALL tier
+     without overflow. Label and count remain readable at this height. */
+  height: 28px;
+  flex: 1;
   background: var(--cds-layer-accent);
   border-radius: 2px;
   overflow: hidden;
@@ -831,8 +993,15 @@ const FunnelBarCount = styled.div`
 const FunnelDropoff = styled.div`
   ${styles.label01};
   color: var(--cds-text-helper);
+  /* Inline next to the bar track. Fixed width keeps bars vertically aligned
+     regardless of whether a drop-off is shown. Wide enough for "↓ 100% drop-off"
+     without clipping. */
+  flex-shrink: 0;
+  width: 96px;
   text-align: right;
-  padding-right: var(--cds-spacing-02);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 `;
 
 // ---------------------------------------------------------------------------
@@ -879,11 +1048,14 @@ export {
   WidgetsGrid,
   WidgetSlot,
   PromptSection,
+  PromptSectionTitle,
+  PromptSectionHint,
   PromptRow,
   PromptSuggestions,
   WidgetTitle,
   WidgetSubtitle,
   WidgetDivider,
+  CircularChartWrap,
   WidgetTable,
   EmptyState,
   MetricTile,

--- a/operate/client/src/App/Notebooks/styled.ts
+++ b/operate/client/src/App/Notebooks/styled.ts
@@ -600,6 +600,51 @@ const ConfigPanelBlock = styled.pre`
   overflow-y: auto;
 `;
 
+/**
+ * Editable JSON editor for the widget config modal. Same visual treatment as
+ * ConfigPanelBlock so toggling between "view" and "edit" mode doesn't shift
+ * the layout — only the underlying element (pre vs textarea) and the focus
+ * affordances change.
+ */
+const ConfigEditorTextarea = styled.textarea`
+  ${styles.code01};
+  color: var(--cds-text-primary);
+  background: var(--cds-layer-accent);
+  border: 1px solid var(--cds-border-strong);
+  border-radius: 2px;
+  padding: var(--cds-spacing-04);
+  width: 100%;
+  min-height: 320px;
+  resize: vertical;
+  font-family: var(--cds-code-01-font-family, monospace);
+  white-space: pre;
+  overflow: auto;
+  outline: none;
+
+  &:focus {
+    border-color: var(--cds-focus);
+    box-shadow: 0 0 0 1px var(--cds-focus);
+  }
+`;
+
+const ConfigEditorActions = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--cds-spacing-03);
+  margin-top: var(--cds-spacing-04);
+`;
+
+const ConfigEditorError = styled.div`
+  ${styles.bodyShort01};
+  color: var(--cds-text-error);
+  background: var(--cds-notification-background-error);
+  padding: var(--cds-spacing-03) var(--cds-spacing-04);
+  border-left: 3px solid var(--cds-support-error);
+  border-radius: 2px;
+  margin-top: var(--cds-spacing-03);
+  white-space: pre-wrap;
+`;
+
 // ---------------------------------------------------------------------------
 // BpmnWidget — diagram container + overlay badges
 // ---------------------------------------------------------------------------
@@ -1079,6 +1124,9 @@ export {
   ConfigSectionLabel,
   ConfigEndpoint,
   ConfigPanelBlock,
+  ConfigEditorTextarea,
+  ConfigEditorActions,
+  ConfigEditorError,
   BpmnDiagramContainer,
   BpmnLegend,
   BpmnLegendItem,

--- a/operate/client/src/App/Notebooks/styled.ts
+++ b/operate/client/src/App/Notebooks/styled.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import styled from 'styled-components';
+import {styles} from '@carbon/elements';
+
+const PageContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: var(--cds-spacing-05);
+  gap: var(--cds-spacing-05);
+`;
+
+const NotebookTitle = styled.h1`
+  ${styles.productiveHeading04};
+  color: var(--cds-text-primary);
+`;
+
+const WidgetsGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: var(--cds-spacing-05);
+  flex: 1;
+  overflow-y: auto;
+`;
+
+const PromptSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--cds-spacing-03);
+`;
+
+const PromptRow = styled.div`
+  display: flex;
+  gap: var(--cds-spacing-03);
+  align-items: flex-end;
+`;
+
+const WidgetTitle = styled.h4`
+  ${styles.productiveHeading02};
+  color: var(--cds-text-primary);
+  margin: 0 0 var(--cds-spacing-04) 0;
+`;
+
+const WidgetTable = styled.table`
+  width: 100%;
+  border-collapse: collapse;
+  ${styles.bodyShort01};
+
+  th,
+  td {
+    text-align: left;
+    padding: var(--cds-spacing-03) var(--cds-spacing-04);
+    border-bottom: 1px solid var(--cds-border-subtle);
+  }
+
+  th {
+    ${styles.productiveHeading01};
+    color: var(--cds-text-secondary);
+    background: var(--cds-layer-accent);
+  }
+
+  td {
+    color: var(--cds-text-primary);
+  }
+`;
+
+const EmptyState = styled.p`
+  ${styles.bodyShort01};
+  color: var(--cds-text-helper);
+  margin: 0;
+`;
+
+export {
+  PageContainer,
+  NotebookTitle,
+  WidgetsGrid,
+  PromptSection,
+  PromptRow,
+  WidgetTitle,
+  WidgetTable,
+  EmptyState,
+};

--- a/operate/client/src/App/Notebooks/styled.ts
+++ b/operate/client/src/App/Notebooks/styled.ts
@@ -6,34 +6,193 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import styled from 'styled-components';
+import styled, {createGlobalStyle} from 'styled-components';
 import {styles} from '@carbon/elements';
 
+// ---------------------------------------------------------------------------
+// Composable height tiers — every widget falls into one of three sizes that
+// stack and pair cleanly given the WidgetsGrid 32px row gap:
+//   - SHORT  132px  : metric, trend
+//   - TALL   296px  : kpi, chart, funnel, activity-feed
+//   - HERO   480px  : bpmn, status-grid
+//
+// Why these numbers? With the grid's 32px row gap:
+//   2 × SHORT + 1 gap = 132 + 32 + 132 = 296 = TALL
+//   3 × SHORT + 2 gap = 132 × 3 + 32 × 2 = 460 ≈ HERO
+//
+// Result: a column of N stacked SHORTs aligns with TALL/HERO neighbours
+// in the next column — no awkward gaps.
+//
+// Auto widgets (table, text) take their natural height and live on their own
+// 12-col row, so vertical alignment with neighbours doesn't apply.
+// ---------------------------------------------------------------------------
+const TILE_HEIGHT_SHORT = '132px';
+const TILE_HEIGHT_TALL = '296px';
+
+/**
+ * Two-row grid: scrollable content area (1fr) and a fixed prompt row (auto).
+ * The page itself fills the parent (PageContent is height:100%), so the
+ * content area scrolls internally while the prompt stays anchored.
+ */
 const PageContainer = styled.div`
+  display: grid;
+  grid-template-rows: 1fr auto;
+  height: 100%;
+  width: 100%;
+  max-width: 1400px;
+  margin: 0 auto;
+`;
+
+const ContentScroll = styled.div`
+  overflow-y: auto;
+  padding: var(--cds-spacing-07) var(--cds-spacing-07) var(--cds-spacing-05);
   display: flex;
   flex-direction: column;
-  height: 100%;
-  padding: var(--cds-spacing-05);
-  gap: var(--cds-spacing-05);
+  gap: var(--cds-spacing-06);
+`;
+
+/**
+ * Top-of-content header row: notebook title on the left, action buttons
+ * (e.g. Clear all) on the right.
+ */
+const NotebookHeader = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--cds-spacing-04);
 `;
 
 const NotebookTitle = styled.h1`
   ${styles.productiveHeading04};
   color: var(--cds-text-primary);
+  margin: 0;
+  flex: 1;
+  min-width: 0;
 `;
 
 const WidgetsGrid = styled.div`
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  grid-template-columns: repeat(12, 1fr);
   gap: var(--cds-spacing-05);
   flex: 1;
-  overflow-y: auto;
+  align-content: start;
+  /* Dense flow lets later widgets fill earlier holes — keeps the dashboard
+     compact even when widget sizes mix. The visual order can drift slightly
+     from DOM order, which is acceptable for dashboard layouts. */
+  grid-auto-flow: dense;
 `;
 
+/**
+ * Per-widget grid placement and TIER. Three height tiers compose cleanly with
+ * the 32px row gap:
+ *
+ *  - SHORT (132px, 3 cols): metric, trend
+ *  - TALL  (296px, 6 cols): kpi, chart, funnel, activity-feed
+ *  - HERO  (~480px, 12 cols): bpmn, status-grid — full-width
+ *  - AUTO  (variable, 12 cols): table, text — full-width, own row
+ *
+ * Stacking math: 2 × SHORT + gap = 132 + 32 + 132 = 296 = TALL.
+ * So a column of 2 SHORTs aligns top + bottom with 1 TALL beside them.
+ * 3 SHORTs stack to ~460px, close to a HERO.
+ *
+ * For TALL widgets we set min-height: TILE_HEIGHT_TALL on the inner Tile via
+ * a CSS rule below — so all TALLs in the same row at least floor at 296px,
+ * and don't wildly disagree on height.
+ */
+const WidgetSlot = styled.div<{$type: string}>`
+  grid-column: span
+    ${({$type}) =>
+      // SHORT (3 cols): metric tiles + trend (which is also a metric tile
+      // shape with a tiny inline sparkline)
+      $type === 'metric' || $type === 'trend'
+        ? 3
+        : $type === 'table' ||
+            $type === 'bpmn' ||
+            $type === 'text' ||
+            $type === 'status-grid'
+          ? 12
+          : $type === 'chart' ||
+              $type === 'kpi' ||
+              $type === 'activity-feed' ||
+              $type === 'funnel'
+            ? 6
+            : 6};
+  min-width: 0;
+
+  @media (max-width: 900px) {
+    grid-column: span ${({$type}) => ($type === 'metric' ? 6 : 12)};
+  }
+  @media (max-width: 600px) {
+    grid-column: span 12;
+  }
+
+  /* Each slot keeps its widget's natural height — stretching short content
+     (e.g. a sparkline) to match a tall neighbour leaves an awkward empty band.
+     For TALL widgets we floor at TILE_HEIGHT_TALL on their inner Tile so
+     adjacent TALLs in the same row at least share a minimum baseline. */
+  align-self: start;
+
+  /* Lock TALL-tier widgets to the TALL height. Both min and max are set so
+     every TALL widget (chart, KPI, funnel, activity feed) lines
+     up at 296px in the same row — no gaps, no overflow. The widget's
+     internal scrollable region (list, feed) handles content overflow. */
+  &[data-tier='tall'] > div > .cds--tile {
+    min-height: ${TILE_HEIGHT_TALL};
+    max-height: ${TILE_HEIGHT_TALL};
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  /* Cascade fade-in on mount. The animation-delay is set inline per index. */
+  animation: notebook-widget-appear 320ms cubic-bezier(0.2, 0.8, 0.2, 1)
+    backwards;
+
+  @keyframes notebook-widget-appear {
+    from {
+      opacity: 0;
+      transform: translateY(12px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+`;
+
+/**
+ * Anchored prompt — sits in the bottom row of the page grid so it is always
+ * visible regardless of how many widgets exist or how far the content above
+ * is scrolled.
+ */
 const PromptSection = styled.div`
   display: flex;
   flex-direction: column;
   gap: var(--cds-spacing-03);
+  padding: var(--cds-spacing-04) var(--cds-spacing-07) var(--cds-spacing-05);
+  background: var(--cds-background);
+  border-top: 1px solid var(--cds-border-subtle);
+`;
+
+/**
+ * Clickable example prompts shown above the textarea so the user can see
+ * what kinds of dashboards they can ask for. Each pill maps to a known
+ * preset in presets.ts.
+ */
+const PromptSuggestions = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--cds-spacing-02);
+  align-items: center;
+  margin-bottom: var(--cds-spacing-02);
+
+  .cds--tag {
+    cursor: pointer;
+    transition: transform 120ms ease;
+  }
+  .cds--tag:hover:not([disabled]) {
+    transform: translateY(-1px);
+  }
 `;
 
 const PromptRow = styled.div`
@@ -46,6 +205,93 @@ const WidgetTitle = styled.h4`
   ${styles.productiveHeading02};
   color: var(--cds-text-primary);
   margin: 0 0 var(--cds-spacing-04) 0;
+`;
+
+/**
+ * Optional helper line rendered directly below WidgetTitle.
+ * Adds context such as sort order, active filters, or data currency.
+ * Only render when config.subtitle is set.
+ */
+const WidgetSubtitle = styled.p`
+  ${styles.helperText01};
+  color: var(--cds-text-helper);
+  margin: calc(var(--cds-spacing-03) * -1) 0 var(--cds-spacing-04) 0;
+`;
+
+/**
+ * Thin horizontal rule used to visually separate sections inside a tile.
+ */
+const WidgetDivider = styled.hr`
+  border: none;
+  border-top: 1px solid var(--cds-border-subtle);
+  margin: var(--cds-spacing-05) 0 var(--cds-spacing-04) 0;
+`;
+
+// Map accent token to the corresponding Carbon CSS custom property.
+const ACCENT_COLOR: Record<string, string> = {
+  info: 'var(--cds-support-info)',
+  success: 'var(--cds-support-success)',
+  warning: 'var(--cds-support-warning)',
+  error: 'var(--cds-support-error)',
+  neutral: 'var(--cds-border-strong)',
+};
+
+/**
+ * Polished metric tile: small uppercase caption + huge value.
+ * The ::before adds a 4px accent stripe on the left edge.
+ * Pass $accent to control the stripe color (defaults to 'info').
+ */
+const MetricTile = styled.div<{$accent?: string}>`
+  position: relative;
+  padding: var(--cds-spacing-05);
+  background: var(--cds-layer);
+  border-radius: 2px;
+  /* SHORT tier — fixed so trend/metric/error/loading all measure exactly
+     the same in any row state (no min-height drift). */
+  height: ${TILE_HEIGHT_SHORT};
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: var(--cds-spacing-03);
+  overflow: hidden;
+  transition:
+    transform 160ms ease,
+    box-shadow 160ms ease;
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    width: 4px;
+    background: ${({$accent = 'info'}) =>
+      ACCENT_COLOR[$accent] ?? ACCENT_COLOR['info']};
+  }
+
+  &:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+  }
+`;
+
+const MetricCaption = styled.div`
+  ${styles.label01};
+  color: var(--cds-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.32px;
+`;
+
+const MetricValue = styled.div`
+  ${styles.productiveHeading07};
+  color: var(--cds-text-primary);
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+`;
+
+const MetricSubvalue = styled.div`
+  ${styles.helperText01};
+  color: var(--cds-text-helper);
 `;
 
 const WidgetTable = styled.table`
@@ -77,13 +323,611 @@ const EmptyState = styled.p`
   margin: 0;
 `;
 
+/**
+ * TextWidget — narrative/markdown cell. Designed to feel like editorial copy
+ * floating above the data widgets, not a card. No background, no border.
+ */
+const TextWidgetContainer = styled.div`
+  padding: var(--cds-spacing-04) 0;
+  color: var(--cds-text-primary);
+
+  h1,
+  h2,
+  h3,
+  h4 {
+    margin: 0 0 var(--cds-spacing-04) 0;
+    color: var(--cds-text-primary);
+  }
+  h1 {
+    ${styles.productiveHeading05};
+  }
+  h2 {
+    ${styles.productiveHeading04};
+  }
+  h3 {
+    ${styles.productiveHeading03};
+  }
+  h4 {
+    ${styles.productiveHeading02};
+  }
+  p {
+    ${styles.bodyLong02};
+    margin: 0 0 var(--cds-spacing-04) 0;
+    color: var(--cds-text-primary);
+  }
+  ul,
+  ol {
+    ${styles.bodyLong02};
+    margin: 0 0 var(--cds-spacing-04) var(--cds-spacing-06);
+    color: var(--cds-text-primary);
+  }
+  li {
+    margin-bottom: var(--cds-spacing-02);
+  }
+  strong {
+    font-weight: 600;
+    color: var(--cds-text-primary);
+  }
+  code {
+    ${styles.code01};
+    background: var(--cds-layer-accent);
+    padding: 0 var(--cds-spacing-02);
+    border-radius: 2px;
+  }
+  > *:last-child {
+    margin-bottom: 0;
+  }
+`;
+
+// ---------------------------------------------------------------------------
+// WidgetFrame — wrapper that reveals a "show config" action on hover, and
+// expands an inline JSON panel below the widget when toggled.
+// ---------------------------------------------------------------------------
+
+const WidgetFrameContainer = styled.div`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: var(--cds-spacing-03);
+
+  /* Show the action bar on hover or when the panel is open. */
+  &:hover .widget-actions {
+    opacity: 1;
+  }
+`;
+
+const WidgetActions = styled.div<{
+  $visible: boolean;
+}>`
+  position: absolute;
+  top: var(--cds-spacing-03);
+  right: var(--cds-spacing-03);
+  z-index: 1;
+  opacity: ${({$visible}) => ($visible ? 1 : 0)};
+  transition: opacity 120ms ease;
+`;
+
+/**
+ * Modal-content typography for the widget details modal.
+ * Description first (the LLM's natural-language summary), then the request
+ * line, then the raw config JSON.
+ */
+const ConfigDescription = styled.p`
+  ${styles.bodyLong02};
+  color: var(--cds-text-primary);
+  margin: 0 0 var(--cds-spacing-06) 0;
+`;
+
+const ConfigSectionLabel = styled.div`
+  ${styles.label01};
+  text-transform: uppercase;
+  letter-spacing: 0.32px;
+  color: var(--cds-text-secondary);
+  margin-bottom: var(--cds-spacing-03);
+`;
+
+const ConfigEndpoint = styled.div`
+  ${styles.code02};
+  color: var(--cds-text-primary);
+  word-break: break-all;
+  background: var(--cds-layer-accent);
+  padding: var(--cds-spacing-03) var(--cds-spacing-04);
+  border-left: 3px solid var(--cds-support-info);
+  border-radius: 2px;
+  margin-bottom: var(--cds-spacing-05);
+`;
+
+const ConfigPanelBlock = styled.pre`
+  ${styles.code01};
+  color: var(--cds-text-primary);
+  margin: 0;
+  background: var(--cds-layer-accent);
+  padding: var(--cds-spacing-04);
+  border-radius: 2px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 320px;
+  overflow-y: auto;
+`;
+
+// ---------------------------------------------------------------------------
+// BpmnWidget — diagram container + overlay badges
+// ---------------------------------------------------------------------------
+
+/**
+ * Legend rendered below the BPMN diagram explaining what the colors / badges
+ * mean. Compact horizontal row of dot+label pairs.
+ */
+const BpmnLegend = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--cds-spacing-05);
+  padding: var(--cds-spacing-03) var(--cds-spacing-04) 0;
+  ${styles.label02};
+  color: var(--cds-text-secondary);
+`;
+
+const BpmnLegendItem = styled.span`
+  display: inline-flex;
+  align-items: center;
+  gap: var(--cds-spacing-02);
+`;
+
+const BpmnLegendDot = styled.span<{$color: string; $intensity?: number}>`
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: ${({$color, $intensity}) =>
+    $intensity != null ? `rgba(218, 30, 40, ${$intensity})` : $color};
+`;
+
+const BpmnLegendGradient = styled.span`
+  display: inline-block;
+  width: 80px;
+  height: 10px;
+  border-radius: 2px;
+  background: linear-gradient(
+    to right,
+    rgba(218, 30, 40, 0.15),
+    rgba(218, 30, 40, 0.9)
+  );
+`;
+
+const BpmnDiagramContainer = styled.div`
+  /* HERO tier — full-width, never sits horizontally next to a smaller widget,
+     so this height doesn't need to match SHORT × N exactly. 480 reads well. */
+  height: 480px;
+  width: 100%;
+  position: relative;
+  overflow: hidden;
+  border-radius: 2px;
+
+  /* Force the bpmn-js canvas itself to fully fill — without this the canvas
+     can render shorter than the container, leaving a hard cut at the bottom.
+     The .djs-container is bpmn-js's root SVG host. */
+  > div,
+  .djs-container {
+    height: 100% !important;
+    width: 100% !important;
+  }
+`;
+
+/**
+ * Small count badge positioned absolutely inside the bpmn-js overlay container.
+ * Use --cds-support-info for active (blue) and --cds-support-error for incidents (red).
+ */
+const OverlayBadge = styled.div<{$color: string}>`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 var(--cds-spacing-02);
+  background: ${({$color}) => $color};
+  color: #fff;
+  border-radius: 10px;
+  ${styles.label01};
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  white-space: nowrap;
+  pointer-events: none;
+`;
+
+const OverlayBadgeGroup = styled.div`
+  display: flex;
+  gap: 2px;
+`;
+
+// ---------------------------------------------------------------------------
+// KpiWidget — horizontal grid of mini-metric cells inside one tile.
+// ---------------------------------------------------------------------------
+
+/**
+ * Responsive grid that lays out KPI cells side by side.
+ * auto-fit + minmax lets the grid reflow from 4-across to 2-across on narrow
+ * containers without JS.
+ */
+const KpiGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: var(--cds-spacing-05);
+  margin-top: var(--cds-spacing-04);
+`;
+
+/**
+ * Individual KPI cell: accent stripe + label + big number.
+ * Mirrors the MetricTile feel at a smaller scale.
+ */
+const KpiCell = styled.div<{$accent?: string}>`
+  position: relative;
+  padding: var(--cds-spacing-04) var(--cds-spacing-04) var(--cds-spacing-04)
+    calc(var(--cds-spacing-04) + 3px + var(--cds-spacing-03));
+  background: var(--cds-layer-accent);
+  border-radius: 2px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--cds-spacing-02);
+  overflow: hidden;
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    width: 3px;
+    background: ${({$accent = 'info'}) =>
+      ACCENT_COLOR[$accent] ?? ACCENT_COLOR['info']};
+  }
+`;
+
+// ---------------------------------------------------------------------------
+// StatusGridWidget — per-process health board
+// ---------------------------------------------------------------------------
+
+const StatusGridContainer = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: var(--cds-spacing-04);
+  margin-top: var(--cds-spacing-04);
+`;
+
+const StatusTile = styled.div<{$status: 'healthy' | 'warning' | 'critical'}>`
+  position: relative;
+  padding: var(--cds-spacing-04) var(--cds-spacing-04) var(--cds-spacing-04)
+    calc(var(--cds-spacing-04) + 4px);
+  background: var(--cds-layer-accent);
+  border-radius: 2px;
+  overflow: hidden;
+  transition:
+    transform 120ms ease,
+    box-shadow 120ms ease;
+  cursor: default;
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    width: 4px;
+    background: ${({$status}) =>
+      $status === 'healthy'
+        ? 'var(--cds-support-success)'
+        : $status === 'warning'
+          ? 'var(--cds-support-warning)'
+          : 'var(--cds-support-error)'};
+  }
+
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 3px 8px rgba(0, 0, 0, 0.1);
+  }
+`;
+
+const StatusTileName = styled.div`
+  ${styles.productiveHeading01};
+  color: var(--cds-text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+const StatusTileVersion = styled.div`
+  ${styles.label01};
+  color: var(--cds-text-secondary);
+  margin-top: var(--cds-spacing-02);
+`;
+
+const StatusTileCount = styled.div<{
+  $status: 'healthy' | 'warning' | 'critical';
+}>`
+  ${styles.productiveHeading04};
+  color: ${({$status}) =>
+    $status === 'healthy'
+      ? 'var(--cds-support-success)'
+      : $status === 'warning'
+        ? 'var(--cds-support-warning)'
+        : 'var(--cds-support-error)'};
+  margin-top: var(--cds-spacing-03);
+  font-variant-numeric: tabular-nums;
+`;
+
+const StatusTileSkeleton = styled.div`
+  background: var(--cds-layer-accent);
+  border-radius: 2px;
+  height: 80px;
+  animation: pulse 1.5s ease-in-out infinite;
+
+  @keyframes pulse {
+    0%,
+    100% {
+      opacity: 1;
+    }
+    50% {
+      opacity: 0.5;
+    }
+  }
+`;
+
+// ---------------------------------------------------------------------------
+// ActivityFeedWidget — vertical timeline of events
+// ---------------------------------------------------------------------------
+
+const ActivityFeed = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-top: var(--cds-spacing-04);
+  position: relative;
+`;
+
+const ActivityRow = styled.div`
+  display: flex;
+  gap: var(--cds-spacing-04);
+  padding-bottom: var(--cds-spacing-04);
+  position: relative;
+
+  &:last-child {
+    padding-bottom: 0;
+  }
+
+  /* Vertical connecting line between dots */
+  &:not(:last-child)::after {
+    content: '';
+    position: absolute;
+    left: 7px;
+    top: 16px;
+    bottom: 0;
+    width: 2px;
+    background: var(--cds-border-subtle);
+  }
+`;
+
+const ActivityDot = styled.div<{$color?: string}>`
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: ${({$color}) => $color ?? 'var(--cds-support-info)'};
+  margin-top: 2px;
+  z-index: 1;
+`;
+
+const ActivityContent = styled.div`
+  flex: 1;
+  min-width: 0;
+`;
+
+const ActivityTitle = styled.div`
+  ${styles.productiveHeading01};
+  color: var(--cds-text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+const ActivitySubtitle = styled.div`
+  ${styles.bodyShort01};
+  color: var(--cds-text-secondary);
+  margin-top: var(--cds-spacing-01);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+const ActivityTime = styled.div`
+  ${styles.label01};
+  color: var(--cds-text-helper);
+  margin-top: var(--cds-spacing-01);
+  white-space: nowrap;
+`;
+
+// ---------------------------------------------------------------------------
+// SparklineWrapper — small bottom margin below MetricValue
+// ---------------------------------------------------------------------------
+
+const SparklineWrapper = styled.div`
+  margin-top: var(--cds-spacing-03);
+`;
+
+// ---------------------------------------------------------------------------
+// TrendWidget — sparkline tile with label and bucket captions
+// ---------------------------------------------------------------------------
+
+/**
+ * Compact sparkline slot inside the metric-tile-shaped TrendWidget.
+ * Sits flush below the big value (parent flex gap handles spacing). The SVG
+ * is height: 24px so the trend tile's three flex children still fit within
+ * MetricTile's 132px min-height.
+ */
+const TrendSparklineArea = styled.div`
+  display: flex;
+  align-items: center;
+  margin: 0;
+
+  svg {
+    display: block;
+    max-width: 100%;
+  }
+`;
+
+// ---------------------------------------------------------------------------
+// FunnelWidget — horizontal bar funnel
+// ---------------------------------------------------------------------------
+
+const FunnelContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--cds-spacing-03);
+  margin-top: var(--cds-spacing-04);
+`;
+
+const FunnelRow = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--cds-spacing-02);
+`;
+
+const FunnelBarTrack = styled.div`
+  position: relative;
+  height: 32px;
+  background: var(--cds-layer-accent);
+  border-radius: 2px;
+  overflow: hidden;
+`;
+
+const FunnelBarFill = styled.div<{$pct: number; $colorIdx: number}>`
+  height: 100%;
+  width: ${({$pct}) => $pct}%;
+  background: ${({$colorIdx}) => {
+    const colors = ['var(--cds-support-info)', '#0353e9', '#0043ce', '#002d9c'];
+    return colors[$colorIdx % colors.length];
+  }};
+  border-radius: 2px;
+  transition: width 400ms ease;
+`;
+
+const FunnelBarLabel = styled.div`
+  position: absolute;
+  top: 50%;
+  left: var(--cds-spacing-04);
+  transform: translateY(-50%);
+  ${styles.productiveHeading01};
+  color: #fff;
+  pointer-events: none;
+`;
+
+const FunnelBarCount = styled.div`
+  position: absolute;
+  top: 50%;
+  right: var(--cds-spacing-04);
+  transform: translateY(-50%);
+  ${styles.label01};
+  color: var(--cds-text-secondary);
+  pointer-events: none;
+`;
+
+const FunnelDropoff = styled.div`
+  ${styles.label01};
+  color: var(--cds-text-helper);
+  text-align: right;
+  padding-right: var(--cds-spacing-02);
+`;
+
+// ---------------------------------------------------------------------------
+// BPMN heatmap global styles
+// ---------------------------------------------------------------------------
+
+/**
+ * Heatmap styles need to be GLOBAL because the .djs-element nodes are
+ * rendered inside the bpmn-js canvas (a sibling subtree of our wrapper),
+ * and styled-components scoping would never reach them. createGlobalStyle
+ * injects the CSS into <head> with no scope class.
+ *
+ * Five intensity buckets targeting the visible SVG shape on each flow node.
+ */
+const BpmnHeatmapStyles = createGlobalStyle`
+  .djs-element.notebook-heatmap-0 .djs-visual > :first-child {
+    fill: rgba(218, 30, 40, 0.18) !important;
+    stroke: rgba(218, 30, 40, 0.6) !important;
+  }
+  .djs-element.notebook-heatmap-1 .djs-visual > :first-child {
+    fill: rgba(218, 30, 40, 0.35) !important;
+    stroke: rgba(218, 30, 40, 0.7) !important;
+  }
+  .djs-element.notebook-heatmap-2 .djs-visual > :first-child {
+    fill: rgba(218, 30, 40, 0.55) !important;
+    stroke: rgba(218, 30, 40, 0.8) !important;
+  }
+  .djs-element.notebook-heatmap-3 .djs-visual > :first-child {
+    fill: rgba(218, 30, 40, 0.75) !important;
+    stroke: rgba(165, 14, 14, 1) !important;
+  }
+  .djs-element.notebook-heatmap-4 .djs-visual > :first-child {
+    fill: rgba(218, 30, 40, 0.92) !important;
+    stroke: rgba(165, 14, 14, 1) !important;
+    stroke-width: 2px !important;
+  }
+`;
+
 export {
   PageContainer,
+  ContentScroll,
   NotebookTitle,
+  NotebookHeader,
   WidgetsGrid,
+  WidgetSlot,
   PromptSection,
   PromptRow,
+  PromptSuggestions,
   WidgetTitle,
+  WidgetSubtitle,
+  WidgetDivider,
   WidgetTable,
   EmptyState,
+  MetricTile,
+  MetricCaption,
+  MetricValue,
+  MetricSubvalue,
+  WidgetFrameContainer,
+  WidgetActions,
+  ConfigDescription,
+  ConfigSectionLabel,
+  ConfigEndpoint,
+  ConfigPanelBlock,
+  BpmnDiagramContainer,
+  BpmnLegend,
+  BpmnLegendItem,
+  BpmnLegendDot,
+  BpmnLegendGradient,
+  OverlayBadge,
+  OverlayBadgeGroup,
+  TextWidgetContainer,
+  KpiGrid,
+  KpiCell,
+  ACCENT_COLOR,
+  StatusGridContainer,
+  StatusTile,
+  StatusTileName,
+  StatusTileVersion,
+  StatusTileCount,
+  StatusTileSkeleton,
+  ActivityFeed,
+  ActivityRow,
+  ActivityDot,
+  ActivityContent,
+  ActivityTitle,
+  ActivitySubtitle,
+  ActivityTime,
+  SparklineWrapper,
+  TrendSparklineArea,
+  FunnelContainer,
+  FunnelRow,
+  FunnelBarTrack,
+  FunnelBarFill,
+  FunnelBarLabel,
+  FunnelBarCount,
+  FunnelDropoff,
+  BpmnHeatmapStyles,
 };

--- a/operate/client/src/App/Notebooks/types.ts
+++ b/operate/client/src/App/Notebooks/types.ts
@@ -77,6 +77,19 @@ const WidgetConfigSchema = z.object({
   columns: z.array(z.string()).optional(),
   // metric-specific accent color (semantic stripe on the left edge):
   accent: AccentSchema.optional(),
+  /**
+   * How to render the metric value.
+   * - 'count' (default): format as localized integer
+   * - 'age-from': interpret the field value as a date string and render
+   *   "3d 4h" / "12m" relative to now. Useful for "oldest instance" tiles.
+   * - 'duration-ms': interpret the field value as a millisecond duration.
+   * - 'percent': format the field value as a percentage (0–1 → 0–100%).
+   */
+  metricFormat: z
+    .enum(['count', 'age-from', 'duration-ms', 'percent'])
+    .optional(),
+  /** Optional caption rendered below the value (e.g. "since 2026-04-30"). */
+  metricSubvalueField: z.string().optional(),
   // trend-specific fields (only when type === 'trend'):
   trendDateField: z.string().optional(),
   trendBuckets: z.number().optional(),
@@ -119,6 +132,9 @@ const WidgetConfigSchema = z.object({
   activityKindField: z.string().optional(),
   // Multi-source activity feed: when set, overrides the single-source fields above.
   activitySources: z.array(ActivitySourceSchema).optional(),
+  // Size variant: 'hero' spans the full 12-col row and is internally scrollable
+  // (fits 12-20 rows). Defaults to 'tall' (6 cols, 296px, overflow-hidden).
+  activityFeedSize: z.enum(['tall', 'hero']).optional(),
   // funnel-specific fields:
   funnelStages: z.array(FunnelStageSchema).optional(),
 });

--- a/operate/client/src/App/Notebooks/types.ts
+++ b/operate/client/src/App/Notebooks/types.ts
@@ -15,13 +15,112 @@ const WidgetQuerySchema = z.object({
   pathParams: z.record(z.string(), z.string()).optional(),
 });
 
+const AccentSchema = z.enum(['info', 'success', 'warning', 'error', 'neutral']);
+
+const KpiItemSchema = z.object({
+  label: z.string(),
+  query: WidgetQuerySchema,
+  /** dot-path into the response; defaults to 'page.totalItems' */
+  field: z.string().optional(),
+  accent: AccentSchema.optional(),
+});
+
+const FunnelStageSchema = z.object({
+  label: z.string(),
+  elementId: z.string(),
+});
+
+const ActivitySourceSchema = z.object({
+  label: z.string(),
+  query: WidgetQuerySchema,
+  titleField: z.string(),
+  subtitleField: z.string().optional(),
+  timeField: z.string(),
+  accent: z.enum(['info', 'success', 'warning', 'error', 'neutral']).optional(),
+});
+
 const WidgetConfigSchema = z.object({
   id: z.string(),
-  type: z.enum(['metric', 'table']),
+  type: z.enum([
+    'metric',
+    'table',
+    'bpmn',
+    'chart',
+    'text',
+    'kpi',
+    'status-grid',
+    'activity-feed',
+    'funnel',
+    'trend',
+  ]),
   title: z.string(),
+  /**
+   * One-to-three sentence natural-language summary of the widget's purpose
+   * and what the user is seeing. Authored by the LLM (or fake-LLM presets).
+   * Surfaced in the "Show config" modal so users can understand a widget
+   * without reading the JSON.
+   */
+  description: z.string().optional(),
+  /**
+   * Short helper line (≤80 chars) shown below the widget title. Adds
+   * context: how data is sorted, what's filtered, what's live.
+   * Authored by the LLM (or fake-LLM presets). Skipped on metric and text
+   * widgets where it would be redundant.
+   */
+  subtitle: z.string().optional(),
+  // Required at schema level — text widgets pass a placeholder query (see
+  // textWidget() in presets.ts). The query is ignored by widgets that don't
+  // need it. This avoids spreading optional-narrowing throughout the data
+  // widgets.
   query: WidgetQuerySchema,
   field: z.string().optional(),
   columns: z.array(z.string()).optional(),
+  // metric-specific accent color (semantic stripe on the left edge):
+  accent: AccentSchema.optional(),
+  // trend-specific fields (only when type === 'trend'):
+  trendDateField: z.string().optional(),
+  trendBuckets: z.number().optional(),
+  trendBucketSpan: z.string().optional(),
+  trendAccent: z
+    .enum(['info', 'success', 'warning', 'error', 'neutral'])
+    .optional(),
+  // chart-specific fields (only used when type === 'chart'):
+  chartType: z
+    .enum([
+      'bar',
+      'line',
+      'donut',
+      'pie',
+      'stacked-bar',
+      'stacked-area',
+      'meter',
+      'treemap',
+      'radar',
+    ])
+    .optional(),
+  chartGroupBy: z.string().optional(),
+  chartValueField: z.string().optional(),
+  chartStackBy: z.string().optional(),
+  // bpmn-specific fields (only used when type === 'bpmn'):
+  processDefinitionKey: z.string().optional(),
+  overlay: z
+    .enum(['active', 'incidents', 'combined', 'stuck', 'none', 'heatmap'])
+    .optional(),
+  // text-specific (only used when type === 'text'):
+  // Markdown content to render. Headings (#, ##), bold, italics, lists,
+  // links, and inline code are supported.
+  text: z.string().optional(),
+  // kpi-specific: array of individual metric cells shown side-by-side
+  kpis: z.array(KpiItemSchema).optional(),
+  // activity-feed-specific fields:
+  activityTitleField: z.string().optional(),
+  activitySubtitleField: z.string().optional(),
+  activityTimeField: z.string().optional(),
+  activityKindField: z.string().optional(),
+  // Multi-source activity feed: when set, overrides the single-source fields above.
+  activitySources: z.array(ActivitySourceSchema).optional(),
+  // funnel-specific fields:
+  funnelStages: z.array(FunnelStageSchema).optional(),
 });
 
 const NotebookSchema = z.object({
@@ -39,13 +138,27 @@ const NotebookIndexEntrySchema = z.object({
 });
 
 type WidgetConfig = z.infer<typeof WidgetConfigSchema>;
+type KpiItem = z.infer<typeof KpiItemSchema>;
 type Notebook = z.infer<typeof NotebookSchema>;
 type NotebookIndexEntry = z.infer<typeof NotebookIndexEntrySchema>;
+type FunnelStage = z.infer<typeof FunnelStageSchema>;
+
+type ActivitySource = z.infer<typeof ActivitySourceSchema>;
 
 export {
   WidgetConfigSchema,
   NotebookSchema,
   NotebookIndexEntrySchema,
   WidgetQuerySchema,
+  KpiItemSchema,
+  FunnelStageSchema,
+  ActivitySourceSchema,
 };
-export type {WidgetConfig, Notebook, NotebookIndexEntry};
+export type {
+  WidgetConfig,
+  KpiItem,
+  Notebook,
+  NotebookIndexEntry,
+  FunnelStage,
+  ActivitySource,
+};

--- a/operate/client/src/App/Notebooks/types.ts
+++ b/operate/client/src/App/Notebooks/types.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {z} from 'zod';
+
+const WidgetQuerySchema = z.object({
+  endpoint: z.string(),
+  method: z.enum(['GET', 'POST']),
+  body: z.unknown().optional(),
+  pathParams: z.record(z.string(), z.string()).optional(),
+});
+
+const WidgetConfigSchema = z.object({
+  id: z.string(),
+  type: z.enum(['metric', 'table']),
+  title: z.string(),
+  query: WidgetQuerySchema,
+  field: z.string().optional(),
+  columns: z.array(z.string()).optional(),
+});
+
+const NotebookSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  widgets: z.array(WidgetConfigSchema),
+  updatedAt: z.number(),
+});
+
+const NotebookIndexEntrySchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  updatedAt: z.number(),
+  widgetCount: z.number(),
+});
+
+type WidgetConfig = z.infer<typeof WidgetConfigSchema>;
+type Notebook = z.infer<typeof NotebookSchema>;
+type NotebookIndexEntry = z.infer<typeof NotebookIndexEntrySchema>;
+
+export {
+  WidgetConfigSchema,
+  NotebookSchema,
+  NotebookIndexEntrySchema,
+  WidgetQuerySchema,
+};
+export type {WidgetConfig, Notebook, NotebookIndexEntry};

--- a/operate/client/src/App/Notebooks/widgets/ActivityFeedWidget.test.tsx
+++ b/operate/client/src/App/Notebooks/widgets/ActivityFeedWidget.test.tsx
@@ -1,0 +1,261 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import React from 'react';
+import {render, screen} from 'modules/testing-library';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {http, HttpResponse} from 'msw';
+import {mockServer} from 'modules/mock-server/node';
+import {ActivityFeedWidget} from './ActivityFeedWidget';
+import type {WidgetConfig} from '../types';
+
+type Props = {children?: React.ReactNode};
+
+const Wrapper = ({children}: Props) => (
+  <QueryClientProvider client={getMockQueryClient()}>
+    {children}
+  </QueryClientProvider>
+);
+
+// ---------------------------------------------------------------------------
+// Single-source smoke tests
+// ---------------------------------------------------------------------------
+
+const singleSourceConfig: WidgetConfig = {
+  id: 'af-single-test',
+  type: 'activity-feed',
+  title: 'Recent incidents',
+  query: {
+    endpoint: '/v2/incidents/search',
+    method: 'POST',
+    body: {page: {limit: 50}},
+  },
+  activityTitleField: 'errorType',
+  activitySubtitleField: 'errorMessage',
+  activityTimeField: 'creationTime',
+};
+
+describe('<ActivityFeedWidget /> — single source', () => {
+  it('should render activity items from the response', async () => {
+    // given
+    mockServer.use(
+      http.post(
+        '/v2/incidents/search',
+        () =>
+          HttpResponse.json({
+            items: [
+              {
+                errorType: 'IO_MAPPING_ERROR',
+                errorMessage: 'mapping failed',
+                creationTime: new Date(Date.now() - 60_000).toISOString(),
+              },
+              {
+                errorType: 'JOB_NO_RETRIES',
+                errorMessage: 'no retries left',
+                creationTime: new Date(Date.now() - 120_000).toISOString(),
+              },
+            ],
+          }),
+        {once: true},
+      ),
+    );
+
+    // when
+    render(<ActivityFeedWidget config={singleSourceConfig} />, {
+      wrapper: Wrapper,
+    });
+
+    // then
+    expect(await screen.findByText('IO_MAPPING_ERROR')).toBeInTheDocument();
+    expect(screen.getByText('JOB_NO_RETRIES')).toBeInTheDocument();
+    expect(screen.getByTestId('activity-feed')).toBeInTheDocument();
+  });
+
+  it('should render the loading state while data is loading', () => {
+    // given — server never responds
+    mockServer.use(
+      http.post('/v2/incidents/search', async () => {
+        await new Promise(() => {});
+        return HttpResponse.json({});
+      }),
+    );
+
+    // when
+    render(<ActivityFeedWidget config={singleSourceConfig} />, {
+      wrapper: Wrapper,
+    });
+
+    // then
+    expect(screen.getByTestId('activity-feed-loading')).toBeInTheDocument();
+  });
+
+  it('should render the error state on fetch failure', async () => {
+    // given
+    mockServer.use(
+      http.post('/v2/incidents/search', () => HttpResponse.error(), {
+        once: true,
+      }),
+    );
+
+    // when
+    render(<ActivityFeedWidget config={singleSourceConfig} />, {
+      wrapper: Wrapper,
+    });
+
+    // then
+    expect(
+      await screen.findByTestId('activity-feed-error'),
+    ).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Multi-source smoke tests
+// ---------------------------------------------------------------------------
+
+const multiSourceConfig: WidgetConfig = {
+  id: 'af-multi-test',
+  type: 'activity-feed',
+  title: 'Live activity stream',
+  query: {endpoint: '/__notebook_activity_multi__', method: 'GET'},
+  activitySources: [
+    {
+      label: 'Instance started',
+      query: {
+        endpoint: '/v2/process-instances/search',
+        method: 'POST',
+        body: {sort: [{field: 'startDate', order: 'DESC'}], page: {limit: 12}},
+      },
+      titleField: 'processDefinitionId',
+      timeField: 'startDate',
+      accent: 'info',
+    },
+    {
+      label: 'Incident raised',
+      query: {
+        endpoint: '/v2/incidents/search',
+        method: 'POST',
+        body: {
+          sort: [{field: 'creationTime', order: 'DESC'}],
+          page: {limit: 12},
+        },
+      },
+      titleField: 'errorType',
+      subtitleField: 'errorMessage',
+      timeField: 'creationTime',
+      accent: 'error',
+    },
+  ],
+};
+
+describe('<ActivityFeedWidget /> — multi-source', () => {
+  it('should merge items from both sources into one interleaved timeline', async () => {
+    // given — two endpoints, each returning one item
+    mockServer.use(
+      http.post(
+        '/v2/process-instances/search',
+        () =>
+          HttpResponse.json({
+            items: [
+              {
+                processDefinitionId: 'order-process',
+                startDate: new Date(Date.now() - 30_000).toISOString(),
+              },
+            ],
+          }),
+        {once: true},
+      ),
+      http.post(
+        '/v2/incidents/search',
+        () =>
+          HttpResponse.json({
+            items: [
+              {
+                errorType: 'JOB_NO_RETRIES',
+                errorMessage: 'all retries exhausted',
+                creationTime: new Date(Date.now() - 90_000).toISOString(),
+              },
+            ],
+          }),
+        {once: true},
+      ),
+    );
+
+    // when
+    render(<ActivityFeedWidget config={multiSourceConfig} />, {
+      wrapper: Wrapper,
+    });
+
+    // then — items from both sources appear in the single timeline
+    expect(await screen.findByText('order-process')).toBeInTheDocument();
+    expect(screen.getByText('JOB_NO_RETRIES')).toBeInTheDocument();
+
+    // and source labels are shown
+    expect(screen.getByText('Instance started')).toBeInTheDocument();
+    expect(screen.getByText('Incident raised')).toBeInTheDocument();
+
+    // and the feed wrapper is present
+    expect(screen.getByTestId('activity-feed')).toBeInTheDocument();
+  });
+
+  it('should show skeleton rows while sources are loading', () => {
+    // given — neither endpoint responds
+    mockServer.use(
+      http.post('/v2/process-instances/search', async () => {
+        await new Promise(() => {});
+        return HttpResponse.json({});
+      }),
+      http.post('/v2/incidents/search', async () => {
+        await new Promise(() => {});
+        return HttpResponse.json({});
+      }),
+    );
+
+    // when
+    render(<ActivityFeedWidget config={multiSourceConfig} />, {
+      wrapper: Wrapper,
+    });
+
+    // then
+    expect(screen.getByTestId('activity-feed-loading')).toBeInTheDocument();
+  });
+
+  it('should render items from the successful source and show a failed count footnote when one source errors', async () => {
+    // given — instances endpoint succeeds, incidents endpoint fails
+    mockServer.use(
+      http.post(
+        '/v2/process-instances/search',
+        () =>
+          HttpResponse.json({
+            items: [
+              {
+                processDefinitionId: 'payment-process',
+                startDate: new Date(Date.now() - 10_000).toISOString(),
+              },
+            ],
+          }),
+        {once: true},
+      ),
+      http.post('/v2/incidents/search', () => HttpResponse.error(), {
+        once: true,
+      }),
+    );
+
+    // when
+    render(<ActivityFeedWidget config={multiSourceConfig} />, {
+      wrapper: Wrapper,
+    });
+
+    // then — item from the successful source is visible
+    expect(await screen.findByText('payment-process')).toBeInTheDocument();
+
+    // and a failure footnote is shown
+    expect(screen.getByText(/1 source failed/i)).toBeInTheDocument();
+  });
+});

--- a/operate/client/src/App/Notebooks/widgets/ActivityFeedWidget.tsx
+++ b/operate/client/src/App/Notebooks/widgets/ActivityFeedWidget.tsx
@@ -27,13 +27,16 @@ import {
 
 type Props = {
   config: WidgetConfig;
+  /** When true the feed uses internal scroll (hero variant). */
+  isHero?: boolean;
 };
 
 type ApiResponse = {
   items: Record<string, unknown>[];
 };
 
-const MAX_ITEMS = 12;
+const MAX_ITEMS_TALL = 12;
+const MAX_ITEMS_HERO = 20;
 
 /**
  * Returns a human-readable relative time string ("2 minutes ago", "1 hour ago").
@@ -106,12 +109,14 @@ type MultiSourceFeedProps = {
   title: string;
   subtitle?: string;
   sources: ActivitySource[];
+  isHero?: boolean;
 };
 
 const MultiSourceFeed: React.FC<MultiSourceFeedProps> = ({
   title,
   subtitle,
   sources,
+  isHero = false,
 }) => {
   const results = useQueries({
     queries: sources.map((source) => ({
@@ -190,10 +195,10 @@ const MultiSourceFeed: React.FC<MultiSourceFeedProps> = ({
     }
   });
 
+  const maxItems = isHero ? MAX_ITEMS_HERO : MAX_ITEMS_TALL;
+
   // Sort newest-first, take top N
-  const sorted = entries
-    .sort((a, b) => b.timeMs - a.timeMs)
-    .slice(0, MAX_ITEMS);
+  const sorted = entries.sort((a, b) => b.timeMs - a.timeMs).slice(0, maxItems);
 
   if (sorted.length === 0) {
     return (
@@ -216,7 +221,7 @@ const MultiSourceFeed: React.FC<MultiSourceFeedProps> = ({
     <Tile>
       <WidgetTitle>{title}</WidgetTitle>
       {subtitle && <WidgetSubtitle>{subtitle}</WidgetSubtitle>}
-      <ActivityFeed data-testid="activity-feed">
+      <ActivityFeed $scrollable={isHero} data-testid="activity-feed">
         {sorted.map((entry, i) => (
           <ActivityRow key={i}>
             <ActivityDot $color={entry.dotColor} />
@@ -246,9 +251,13 @@ const MultiSourceFeed: React.FC<MultiSourceFeedProps> = ({
 
 type SingleSourceFeedProps = {
   config: WidgetConfig;
+  isHero?: boolean;
 };
 
-const SingleSourceFeed: React.FC<SingleSourceFeedProps> = ({config}) => {
+const SingleSourceFeed: React.FC<SingleSourceFeedProps> = ({
+  config,
+  isHero = false,
+}) => {
   const {
     title,
     subtitle,
@@ -317,7 +326,7 @@ const SingleSourceFeed: React.FC<SingleSourceFeedProps> = ({config}) => {
       const db = tb != null ? new Date(tb as string).getTime() : 0;
       return db - da;
     })
-    .slice(0, MAX_ITEMS);
+    .slice(0, isHero ? MAX_ITEMS_HERO : MAX_ITEMS_TALL);
 
   if (sorted.length === 0) {
     return (
@@ -335,7 +344,7 @@ const SingleSourceFeed: React.FC<SingleSourceFeedProps> = ({config}) => {
     <Tile>
       <WidgetTitle>{title}</WidgetTitle>
       {subtitle && <WidgetSubtitle>{subtitle}</WidgetSubtitle>}
-      <ActivityFeed data-testid="activity-feed">
+      <ActivityFeed $scrollable={isHero} data-testid="activity-feed">
         {sorted.map((item, i) => {
           const titleVal = item[activityTitleField];
           const subtitleVal = item[activitySubtitleField];
@@ -370,8 +379,9 @@ const SingleSourceFeed: React.FC<SingleSourceFeedProps> = ({config}) => {
 // Public component — routes to multi-source or single-source
 // ---------------------------------------------------------------------------
 
-const ActivityFeedWidget: React.FC<Props> = ({config}) => {
-  const {activitySources, title, subtitle} = config;
+const ActivityFeedWidget: React.FC<Props> = ({config, isHero}) => {
+  const {activitySources, title, subtitle, activityFeedSize} = config;
+  const heroMode = isHero ?? activityFeedSize === 'hero';
 
   if (activitySources != null && activitySources.length > 0) {
     return (
@@ -379,11 +389,12 @@ const ActivityFeedWidget: React.FC<Props> = ({config}) => {
         title={title}
         subtitle={subtitle}
         sources={activitySources}
+        isHero={heroMode}
       />
     );
   }
 
-  return <SingleSourceFeed config={config} />;
+  return <SingleSourceFeed config={config} isHero={heroMode} />;
 };
 
 export {ActivityFeedWidget};

--- a/operate/client/src/App/Notebooks/widgets/ActivityFeedWidget.tsx
+++ b/operate/client/src/App/Notebooks/widgets/ActivityFeedWidget.tsx
@@ -1,0 +1,389 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import React from 'react';
+import {useQueries, useQuery} from '@tanstack/react-query';
+import {SkeletonText, Tile} from '@carbon/react';
+import {requestWithThrow} from 'modules/request';
+import type {WidgetConfig, ActivitySource} from '../types';
+import {
+  WidgetTitle,
+  WidgetSubtitle,
+  EmptyState,
+  ActivityFeed,
+  ActivityRow,
+  ActivityDot,
+  ActivityContent,
+  ActivityTitle,
+  ActivitySubtitle,
+  ActivityTime,
+  ACCENT_COLOR,
+} from '../styled';
+
+type Props = {
+  config: WidgetConfig;
+};
+
+type ApiResponse = {
+  items: Record<string, unknown>[];
+};
+
+const MAX_ITEMS = 12;
+
+/**
+ * Returns a human-readable relative time string ("2 minutes ago", "1 hour ago").
+ * Falls back to the raw value string if parsing fails.
+ */
+function relativeTime(value: unknown): string {
+  if (value == null) {
+    return '';
+  }
+  const date = new Date(value as string | number);
+  if (isNaN(date.getTime())) {
+    return String(value);
+  }
+
+  const diffMs = Date.now() - date.getTime();
+  const diffSec = Math.floor(diffMs / 1000);
+  if (diffSec < 60) {
+    return `${Math.max(0, diffSec)}s ago`;
+  }
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) {
+    return `${diffMin}m ago`;
+  }
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) {
+    return `${diffHr}h ago`;
+  }
+  const diffDay = Math.floor(diffHr / 24);
+  return `${diffDay}d ago`;
+}
+
+/**
+ * Derive a dot color from a known field value. Falls back to info color.
+ */
+function kindToColor(kind: unknown): string {
+  if (kind == null) {
+    return ACCENT_COLOR['info']!;
+  }
+  const s = String(kind).toUpperCase();
+  if (s === 'INCIDENT' || s === 'ERROR' || s === 'FAILED') {
+    return ACCENT_COLOR['error']!;
+  }
+  if (s === 'COMPLETED' || s === 'SUCCESS') {
+    return ACCENT_COLOR['success']!;
+  }
+  if (s === 'WARNING') {
+    return ACCENT_COLOR['warning']!;
+  }
+  return ACCENT_COLOR['info']!;
+}
+
+// ---------------------------------------------------------------------------
+// Normalized feed entry used for the merged timeline
+// ---------------------------------------------------------------------------
+
+type FeedEntry = {
+  sourceLabel: string;
+  title: string;
+  subtitle?: string;
+  time: unknown;
+  timeMs: number;
+  dotColor: string;
+};
+
+// ---------------------------------------------------------------------------
+// Multi-source feed sub-component
+// ---------------------------------------------------------------------------
+
+type MultiSourceFeedProps = {
+  title: string;
+  subtitle?: string;
+  sources: ActivitySource[];
+};
+
+const MultiSourceFeed: React.FC<MultiSourceFeedProps> = ({
+  title,
+  subtitle,
+  sources,
+}) => {
+  const results = useQueries({
+    queries: sources.map((source) => ({
+      queryKey: [
+        'notebook-activity-feed-multi',
+        source.label,
+        source.query,
+      ] as const,
+      queryFn: async () => {
+        const {response, error} = await requestWithThrow<ApiResponse>({
+          url: source.query.endpoint,
+          method: source.query.method,
+          body: source.query.body,
+        });
+        if (error) {
+          throw error;
+        }
+        return response;
+      },
+    })),
+  });
+
+  const anyPending = results.some((r) => r.status === 'pending');
+  const failedCount = results.filter((r) => r.status === 'error').length;
+
+  if (anyPending) {
+    return (
+      <Tile>
+        <WidgetTitle>{title}</WidgetTitle>
+        {subtitle && <WidgetSubtitle>{subtitle}</WidgetSubtitle>}
+        <ActivityFeed data-testid="activity-feed-loading">
+          {Array.from({length: 6}).map((_, i) => (
+            <ActivityRow key={i}>
+              <ActivityDot />
+              <ActivityContent>
+                <SkeletonText width="60%" />
+                <SkeletonText width="40%" />
+              </ActivityContent>
+            </ActivityRow>
+          ))}
+        </ActivityFeed>
+      </Tile>
+    );
+  }
+
+  // Merge all successful results into one chronological list
+  const entries: FeedEntry[] = [];
+
+  sources.forEach((source, idx) => {
+    const result = results[idx];
+    if (result?.status !== 'success') {
+      return;
+    }
+    const items = result.data?.items ?? [];
+    const dotColor =
+      source.accent != null
+        ? (ACCENT_COLOR[source.accent] ?? ACCENT_COLOR['info']!)
+        : ACCENT_COLOR['info']!;
+
+    for (const item of items) {
+      const timeVal = item[source.timeField];
+      const timeMs =
+        timeVal != null ? new Date(timeVal as string).getTime() : 0;
+      const titleVal = item[source.titleField];
+      const subtitleVal =
+        source.subtitleField != null ? item[source.subtitleField] : undefined;
+
+      entries.push({
+        sourceLabel: source.label,
+        title: titleVal != null ? String(titleVal) : '—',
+        subtitle: subtitleVal != null ? String(subtitleVal) : undefined,
+        time: timeVal,
+        timeMs: isNaN(timeMs) ? 0 : timeMs,
+        dotColor,
+      });
+    }
+  });
+
+  // Sort newest-first, take top N
+  const sorted = entries
+    .sort((a, b) => b.timeMs - a.timeMs)
+    .slice(0, MAX_ITEMS);
+
+  if (sorted.length === 0) {
+    return (
+      <Tile>
+        <WidgetTitle>{title}</WidgetTitle>
+        {subtitle && <WidgetSubtitle>{subtitle}</WidgetSubtitle>}
+        <EmptyState data-testid="activity-feed-empty">
+          No recent activity.
+        </EmptyState>
+        {failedCount > 0 && (
+          <EmptyState>
+            ({failedCount} source{failedCount > 1 ? 's' : ''} failed)
+          </EmptyState>
+        )}
+      </Tile>
+    );
+  }
+
+  return (
+    <Tile>
+      <WidgetTitle>{title}</WidgetTitle>
+      {subtitle && <WidgetSubtitle>{subtitle}</WidgetSubtitle>}
+      <ActivityFeed data-testid="activity-feed">
+        {sorted.map((entry, i) => (
+          <ActivityRow key={i}>
+            <ActivityDot $color={entry.dotColor} />
+            <ActivityContent>
+              <ActivitySubtitle>{entry.sourceLabel}</ActivitySubtitle>
+              <ActivityTitle>{entry.title}</ActivityTitle>
+              {entry.subtitle != null && (
+                <ActivitySubtitle>{entry.subtitle}</ActivitySubtitle>
+              )}
+              <ActivityTime>{relativeTime(entry.time)}</ActivityTime>
+            </ActivityContent>
+          </ActivityRow>
+        ))}
+      </ActivityFeed>
+      {failedCount > 0 && (
+        <EmptyState>
+          ({failedCount} source{failedCount > 1 ? 's' : ''} failed)
+        </EmptyState>
+      )}
+    </Tile>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Single-source feed (original behaviour, kept for backwards compat)
+// ---------------------------------------------------------------------------
+
+type SingleSourceFeedProps = {
+  config: WidgetConfig;
+};
+
+const SingleSourceFeed: React.FC<SingleSourceFeedProps> = ({config}) => {
+  const {
+    title,
+    subtitle,
+    query,
+    activityTitleField = 'errorType',
+    activitySubtitleField = 'errorMessage',
+    activityTimeField = 'creationTime',
+    activityKindField,
+  } = config;
+
+  const {data, status} = useQuery({
+    queryKey: ['notebook-activity-feed', config.id, query],
+    queryFn: async () => {
+      const {response, error} = await requestWithThrow<ApiResponse>({
+        url: query.endpoint,
+        method: query.method,
+        body: query.body,
+      });
+      if (error) {
+        throw error;
+      }
+      return response;
+    },
+  });
+
+  if (status === 'pending') {
+    return (
+      <Tile>
+        <WidgetTitle>{title}</WidgetTitle>
+        {subtitle && <WidgetSubtitle>{subtitle}</WidgetSubtitle>}
+        <ActivityFeed data-testid="activity-feed-loading">
+          {Array.from({length: 6}).map((_, i) => (
+            <ActivityRow key={i}>
+              <ActivityDot />
+              <ActivityContent>
+                <SkeletonText width="60%" />
+                <SkeletonText width="40%" />
+              </ActivityContent>
+            </ActivityRow>
+          ))}
+        </ActivityFeed>
+      </Tile>
+    );
+  }
+
+  if (status === 'error') {
+    return (
+      <Tile>
+        <WidgetTitle>{title}</WidgetTitle>
+        {subtitle && <WidgetSubtitle>{subtitle}</WidgetSubtitle>}
+        <EmptyState data-testid="activity-feed-error">
+          Could not load activity.
+        </EmptyState>
+      </Tile>
+    );
+  }
+
+  const rawItems = data?.items ?? [];
+
+  // Sort by time field descending (newest first), then limit.
+  const sorted = [...rawItems]
+    .sort((a, b) => {
+      const ta = a[activityTimeField];
+      const tb = b[activityTimeField];
+      const da = ta != null ? new Date(ta as string).getTime() : 0;
+      const db = tb != null ? new Date(tb as string).getTime() : 0;
+      return db - da;
+    })
+    .slice(0, MAX_ITEMS);
+
+  if (sorted.length === 0) {
+    return (
+      <Tile>
+        <WidgetTitle>{title}</WidgetTitle>
+        {subtitle && <WidgetSubtitle>{subtitle}</WidgetSubtitle>}
+        <EmptyState data-testid="activity-feed-empty">
+          No recent activity.
+        </EmptyState>
+      </Tile>
+    );
+  }
+
+  return (
+    <Tile>
+      <WidgetTitle>{title}</WidgetTitle>
+      {subtitle && <WidgetSubtitle>{subtitle}</WidgetSubtitle>}
+      <ActivityFeed data-testid="activity-feed">
+        {sorted.map((item, i) => {
+          const titleVal = item[activityTitleField];
+          const subtitleVal = item[activitySubtitleField];
+          const timeVal = item[activityTimeField];
+          const kindVal = activityKindField
+            ? item[activityKindField]
+            : titleVal;
+
+          const dotColor = kindToColor(kindVal);
+
+          return (
+            <ActivityRow key={i}>
+              <ActivityDot $color={dotColor} />
+              <ActivityContent>
+                <ActivityTitle>
+                  {titleVal != null ? String(titleVal) : '—'}
+                </ActivityTitle>
+                {subtitleVal != null && (
+                  <ActivitySubtitle>{String(subtitleVal)}</ActivitySubtitle>
+                )}
+                <ActivityTime>{relativeTime(timeVal)}</ActivityTime>
+              </ActivityContent>
+            </ActivityRow>
+          );
+        })}
+      </ActivityFeed>
+    </Tile>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Public component — routes to multi-source or single-source
+// ---------------------------------------------------------------------------
+
+const ActivityFeedWidget: React.FC<Props> = ({config}) => {
+  const {activitySources, title, subtitle} = config;
+
+  if (activitySources != null && activitySources.length > 0) {
+    return (
+      <MultiSourceFeed
+        title={title}
+        subtitle={subtitle}
+        sources={activitySources}
+      />
+    );
+  }
+
+  return <SingleSourceFeed config={config} />;
+};
+
+export {ActivityFeedWidget};

--- a/operate/client/src/App/Notebooks/widgets/BpmnWidget.test.tsx
+++ b/operate/client/src/App/Notebooks/widgets/BpmnWidget.test.tsx
@@ -1,0 +1,182 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import React from 'react';
+import {render, screen, waitFor} from 'modules/testing-library';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {http, HttpResponse} from 'msw';
+import {mockServer} from 'modules/mock-server/node';
+import {BpmnWidget} from './BpmnWidget';
+import type {WidgetConfig} from '../types';
+
+// ---------------------------------------------------------------------------
+// Stub the Diagram component — we test data plumbing, not BPMN rendering.
+// ---------------------------------------------------------------------------
+
+vi.mock('modules/components/Diagram', () => ({
+  Diagram: ({xml, children}: {xml: string; children?: React.ReactNode}) => (
+    <div data-testid="diagram-stub">
+      <span data-testid="diagram-xml">{xml}</span>
+      {children}
+    </div>
+  ),
+}));
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+type Props = {children?: React.ReactNode};
+
+const Wrapper = ({children}: Props) => (
+  <QueryClientProvider client={getMockQueryClient()}>
+    {children}
+  </QueryClientProvider>
+);
+
+const MOCK_XML = '<bpmn:definitions>...</bpmn:definitions>';
+
+const MOCK_STATS = {
+  items: [
+    {elementId: 'task-a', active: 3, canceled: 0, incidents: 1, completed: 10},
+    {elementId: 'task-b', active: 0, canceled: 0, incidents: 0, completed: 5},
+  ],
+};
+
+function makeBpmnConfig(overrides: Partial<WidgetConfig> = {}): WidgetConfig {
+  return {
+    id: 'w-bpmn-test',
+    type: 'bpmn',
+    title: 'Order fulfillment',
+    query: {
+      endpoint: '/v2/process-definitions/1234567890/xml',
+      method: 'GET',
+    },
+    processDefinitionKey: '1234567890',
+    overlay: 'combined',
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('<BpmnWidget />', () => {
+  it('should render a loading state while XML is loading', () => {
+    // given — XML never responds; suppress unhandled stats request (POST)
+    mockServer.use(
+      http.get('/v2/process-definitions/1234567890/xml', async () => {
+        await new Promise(() => {});
+        return new HttpResponse(MOCK_XML);
+      }),
+      http.post(
+        '/v2/process-definitions/1234567890/statistics/element-instances',
+        () => HttpResponse.json(MOCK_STATS),
+      ),
+    );
+
+    // when
+    render(<BpmnWidget config={makeBpmnConfig()} />, {wrapper: Wrapper});
+
+    // then
+    expect(screen.getByTestId('bpmn-loading')).toBeInTheDocument();
+  });
+
+  it('should render the BPMN diagram when XML loads successfully', async () => {
+    // given
+    mockServer.use(
+      http.get(
+        '/v2/process-definitions/1234567890/xml',
+        () =>
+          new HttpResponse(MOCK_XML, {headers: {'Content-Type': 'text/xml'}}),
+        {once: true},
+      ),
+      http.post(
+        '/v2/process-definitions/1234567890/statistics/element-instances',
+        () => HttpResponse.json(MOCK_STATS),
+        {once: true},
+      ),
+    );
+
+    // when
+    render(<BpmnWidget config={makeBpmnConfig()} />, {wrapper: Wrapper});
+
+    // then — title is shown and the diagram stub is rendered
+    expect(screen.getByText('Order fulfillment')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByTestId('diagram-stub')).toBeInTheDocument();
+    });
+  });
+
+  it('should render an error state when XML fetch fails', async () => {
+    // given
+    mockServer.use(
+      http.get(
+        '/v2/process-definitions/1234567890/xml',
+        () => new HttpResponse(null, {status: 404}),
+        {once: true},
+      ),
+      http.post(
+        '/v2/process-definitions/1234567890/statistics/element-instances',
+        () => HttpResponse.json(MOCK_STATS),
+      ),
+    );
+
+    // when
+    render(<BpmnWidget config={makeBpmnConfig()} />, {wrapper: Wrapper});
+
+    // then
+    await waitFor(() => {
+      expect(screen.getByText(/could not load diagram/i)).toBeInTheDocument();
+    });
+  });
+
+  it('should not fetch stats when overlay is "none"', async () => {
+    // given
+    let statsFetched = false;
+    mockServer.use(
+      http.get(
+        '/v2/process-definitions/1234567890/xml',
+        () =>
+          new HttpResponse(MOCK_XML, {headers: {'Content-Type': 'text/xml'}}),
+        {once: true},
+      ),
+      http.post(
+        '/v2/process-definitions/1234567890/statistics/element-instances',
+        () => {
+          statsFetched = true;
+          return HttpResponse.json(MOCK_STATS);
+        },
+      ),
+    );
+
+    // when
+    render(<BpmnWidget config={makeBpmnConfig({overlay: 'none'})} />, {
+      wrapper: Wrapper,
+    });
+
+    // then — diagram renders without stats
+    await waitFor(() => {
+      expect(screen.getByTestId('diagram-stub')).toBeInTheDocument();
+    });
+    expect(statsFetched).toBe(false);
+  });
+
+  it('should render an empty state when no processDefinitionKey is provided', () => {
+    // given
+    const config = makeBpmnConfig({processDefinitionKey: undefined});
+
+    // when
+    render(<BpmnWidget config={config} />, {wrapper: Wrapper});
+
+    // then
+    expect(screen.getByText(/no process definition key/i)).toBeInTheDocument();
+  });
+});

--- a/operate/client/src/App/Notebooks/widgets/BpmnWidget.tsx
+++ b/operate/client/src/App/Notebooks/widgets/BpmnWidget.tsx
@@ -1,0 +1,469 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import React, {useMemo} from 'react';
+import {observer} from 'mobx-react';
+import {useQuery} from '@tanstack/react-query';
+import {InlineLoading, Tile} from '@carbon/react';
+import {createPortal} from 'react-dom';
+import {
+  endpoints,
+  type GetProcessDefinitionStatisticsResponseBody,
+} from '@camunda/camunda-api-zod-schemas/8.10';
+import {requestWithThrow} from 'modules/request';
+import {Diagram} from 'modules/components/Diagram';
+import {useResolveProcessKey} from './useResolveProcessKey';
+import {ACTIVE_BADGE, INCIDENTS_BADGE} from 'modules/bpmn-js/badgePositions';
+import {diagramOverlaysStore} from 'modules/stores/diagramOverlays';
+import type {OverlayData} from 'modules/bpmn-js/BpmnJS';
+import type {WidgetConfig} from '../types';
+import {
+  WidgetTitle,
+  WidgetSubtitle,
+  EmptyState,
+  BpmnDiagramContainer,
+  OverlayBadge,
+  BpmnHeatmapStyles,
+  BpmnLegend,
+  BpmnLegendItem,
+  BpmnLegendDot,
+  BpmnLegendGradient,
+} from '../styled';
+
+type Props = {
+  config: WidgetConfig;
+};
+
+// ---------------------------------------------------------------------------
+// Element-instance statistics type (per flow-node)
+// ---------------------------------------------------------------------------
+
+type ElementStat = {
+  elementId: string;
+  active: number;
+  canceled: number;
+  incidents: number;
+  completed: number;
+};
+
+// ---------------------------------------------------------------------------
+// Overlay badge helpers
+// ---------------------------------------------------------------------------
+
+// IMPORTANT: diagramOverlaysStore is a global singleton — when multiple BPMN
+// widgets are mounted at once (e.g. "Compare all processes" with 3 diagrams),
+// each widget reads the full overlay array and would portal badges into every
+// container. Result without scoping: each badge appears N times on the
+// last-mounted diagram.
+//
+// Fix: scope the overlay type by widget id. Each widget's overlays then have
+// unique types in the store, and each widget filters by its own pair.
+const OVERLAY_TYPE_ACTIVE_PREFIX = 'notebook-bpmn-active::';
+const OVERLAY_TYPE_INCIDENTS_PREFIX = 'notebook-bpmn-incidents::';
+function activeTypeFor(widgetId: string) {
+  return OVERLAY_TYPE_ACTIVE_PREFIX + widgetId;
+}
+function incidentsTypeFor(widgetId: string) {
+  return OVERLAY_TYPE_INCIDENTS_PREFIX + widgetId;
+}
+
+/**
+ * Renders a badge into the DOM container that bpmn-js created for this overlay.
+ * We use createPortal so the badge is a real React element but mounted inside
+ * the bpmn-js canvas at the correct flow-node position.
+ */
+const ActiveBadge: React.FC<{container: HTMLElement; count: number}> = ({
+  container,
+  count,
+}) =>
+  createPortal(
+    <OverlayBadge $color="var(--cds-support-info)" data-testid="overlay-active">
+      {count}
+    </OverlayBadge>,
+    container,
+  );
+
+const IncidentBadge: React.FC<{container: HTMLElement; count: number}> = ({
+  container,
+  count,
+}) =>
+  createPortal(
+    <OverlayBadge
+      $color="var(--cds-support-error)"
+      data-testid="overlay-incident"
+    >
+      {count}
+    </OverlayBadge>,
+    container,
+  );
+
+// ---------------------------------------------------------------------------
+// Build OverlayData descriptors from element stats
+// ---------------------------------------------------------------------------
+
+type OverlayMode =
+  | 'active'
+  | 'incidents'
+  | 'combined'
+  | 'stuck'
+  | 'none'
+  | 'heatmap';
+
+function buildOverlayData(
+  stats: ElementStat[],
+  mode: OverlayMode,
+  widgetId: string,
+): OverlayData[] {
+  if (mode === 'none') {
+    return [];
+  }
+  const TYPE_ACTIVE = activeTypeFor(widgetId);
+  const TYPE_INCIDENTS = incidentsTypeFor(widgetId);
+
+  const overlays: OverlayData[] = [];
+
+  // For heatmap mode, only show incident badges on the hottest nodes (bucket 3+)
+  // to confirm the intensity is data-driven, not purely decorative.
+  if (mode === 'heatmap') {
+    const maxIncidents = Math.max(...stats.map((s) => s.incidents), 1);
+    for (const stat of stats) {
+      if (stat.incidents > 0) {
+        const intensity = stat.incidents / maxIncidents;
+        const bucket = Math.min(4, Math.floor(intensity * 5));
+        if (bucket >= 3) {
+          overlays.push({
+            elementId: stat.elementId,
+            type: TYPE_INCIDENTS,
+            position: INCIDENTS_BADGE,
+            payload: {count: stat.incidents},
+          });
+        }
+      }
+    }
+    return overlays;
+  }
+
+  for (const stat of stats) {
+    if (mode === 'active' || mode === 'stuck') {
+      // TODO: stuck overlay is currently equivalent to active.
+      // Productionize with age math from element-instances once that data
+      // is available from the API (e.g. oldest token creation date per element).
+      if (stat.active > 0) {
+        overlays.push({
+          elementId: stat.elementId,
+          type: TYPE_ACTIVE,
+          position: ACTIVE_BADGE,
+          payload: {count: stat.active},
+        });
+      }
+    } else if (mode === 'incidents') {
+      if (stat.incidents > 0) {
+        overlays.push({
+          elementId: stat.elementId,
+          type: TYPE_INCIDENTS,
+          position: INCIDENTS_BADGE,
+          payload: {count: stat.incidents},
+        });
+      }
+    } else if (mode === 'combined') {
+      if (stat.active > 0) {
+        overlays.push({
+          elementId: stat.elementId,
+          type: TYPE_ACTIVE,
+          position: ACTIVE_BADGE,
+          payload: {count: stat.active},
+        });
+      }
+      if (stat.incidents > 0) {
+        overlays.push({
+          elementId: stat.elementId,
+          type: TYPE_INCIDENTS,
+          position: INCIDENTS_BADGE,
+          payload: {count: stat.incidents},
+        });
+      }
+    }
+  }
+
+  return overlays;
+}
+
+/**
+ * For heatmap mode: compute [elementId, className] tuples where className is
+ * notebook-heatmap-{0..4}. Elements with 0 incidents are excluded.
+ */
+function buildHeatmapClasses(
+  stats: ElementStat[],
+): [elementId: string, className: string][] {
+  const maxIncidents = Math.max(...stats.map((s) => s.incidents), 1);
+  const result: [string, string][] = [];
+
+  for (const stat of stats) {
+    if (stat.incidents > 0) {
+      const intensity = stat.incidents / maxIncidents;
+      const bucket = Math.min(4, Math.floor(intensity * 5));
+      result.push([stat.elementId, `notebook-heatmap-${bucket}`]);
+    }
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// BpmnWidget
+// ---------------------------------------------------------------------------
+
+// Wrapped in mobx-react `observer` so the component re-renders when the
+// diagramOverlaysStore (which holds bpmn-js overlay container refs) changes.
+// Without this, the first render captures an empty store and badges never
+// portal into the diagram even though the data is loaded.
+const BpmnWidget: React.FC<Props> = observer(({config}) => {
+  const {
+    title,
+    subtitle,
+    processDefinitionKey: configKey,
+    overlay = 'combined',
+  } = config;
+
+  // The V2 XML/statistics endpoints require the *numeric* processDefinitionKey,
+  // but the LLM (and preset templates) often pass the human-readable
+  // processDefinitionId (e.g. "order-process"). The shared hook resolves the
+  // string to the numeric key, deduping requests across multiple BPMN/funnel
+  // widgets in the same bundle that point at the same process.
+  const looksNumeric = !!configKey && /^\d+$/.test(configKey);
+  const {resolvedKey, status: resolveStatus} = useResolveProcessKey(configKey);
+  const processDefinitionKey = resolvedKey;
+
+  // Fetch BPMN XML
+  const {data: xml, status: xmlStatus} = useQuery({
+    queryKey: ['notebook-bpmn-xml', processDefinitionKey],
+    enabled: !!processDefinitionKey,
+    queryFn: async () => {
+      if (!processDefinitionKey) {
+        throw new Error('No processDefinitionKey');
+      }
+      const {response, error} = await requestWithThrow<string>({
+        url: endpoints.getProcessDefinitionXml.getUrl({processDefinitionKey}),
+        method: endpoints.getProcessDefinitionXml.method,
+        responseType: 'text',
+      });
+      if (error) {
+        throw error;
+      }
+      return response;
+    },
+  });
+
+  // Fetch element-instance statistics (only when overlay is requested)
+  const {data: statsResponse} = useQuery({
+    queryKey: ['notebook-bpmn-stats', processDefinitionKey, overlay],
+    enabled: !!processDefinitionKey && overlay !== 'none',
+    queryFn: async () => {
+      if (!processDefinitionKey) {
+        throw new Error('No processDefinitionKey');
+      }
+      const {response, error} =
+        await requestWithThrow<GetProcessDefinitionStatisticsResponseBody>({
+          url: endpoints.getProcessDefinitionStatistics.getUrl({
+            processDefinitionKey,
+            statisticName: 'element-instances',
+          }),
+          method: endpoints.getProcessDefinitionStatistics.method,
+        });
+      if (error) {
+        throw error;
+      }
+      return response;
+    },
+  });
+
+  // Per-instance overlay type strings — keeps this widget's badges separate
+  // from any sibling BPMN widgets in the notebook (see comment near
+  // OVERLAY_TYPE_ACTIVE_PREFIX above).
+  const widgetId = config.id;
+  const myActiveType = activeTypeFor(widgetId);
+  const myIncidentsType = incidentsTypeFor(widgetId);
+
+  const overlayData = useMemo(() => {
+    if (!statsResponse?.items) {
+      return [];
+    }
+    return buildOverlayData(
+      statsResponse.items as ElementStat[],
+      overlay as OverlayMode,
+      widgetId,
+    );
+  }, [statsResponse, overlay, widgetId]);
+
+  // Heatmap class tuples — used when overlay === 'heatmap'
+  const heatmapClasses = useMemo(() => {
+    if (overlay !== 'heatmap' || !statsResponse?.items) {
+      return undefined;
+    }
+    return buildHeatmapClasses(statsResponse.items as ElementStat[]);
+  }, [statsResponse, overlay]);
+
+  // Highlighted element ids — elements with incidents get a visual emphasis
+  const highlightedElementIds = useMemo(() => {
+    if (
+      overlay !== 'incidents' &&
+      overlay !== 'combined' &&
+      overlay !== 'heatmap'
+    ) {
+      return undefined;
+    }
+    return statsResponse?.items
+      ?.filter((s) => (s as ElementStat).incidents > 0)
+      .map((s) => (s as ElementStat).elementId);
+  }, [statsResponse, overlay]);
+
+  // Retrieve overlay containers from the MobX store — filter by THIS widget's
+  // unique type strings so we don't pick up siblings' overlays.
+  const storeOverlays = diagramOverlaysStore.state.overlays.filter(
+    ({type}) => type === myActiveType || type === myIncidentsType,
+  );
+
+  // --- missing processDefinitionKey ---
+  if (!configKey) {
+    return (
+      <Tile>
+        <WidgetTitle>{title}</WidgetTitle>
+        {subtitle && <WidgetSubtitle>{subtitle}</WidgetSubtitle>}
+        <EmptyState>No process definition key configured.</EmptyState>
+      </Tile>
+    );
+  }
+
+  // --- resolve failed (id → numeric key lookup) ---
+  if (!looksNumeric && resolveStatus === 'error') {
+    return (
+      <Tile>
+        <WidgetTitle>{title}</WidgetTitle>
+        {subtitle && <WidgetSubtitle>{subtitle}</WidgetSubtitle>}
+        <EmptyState data-testid="bpmn-error">
+          Process &quot;{configKey}&quot; not found.
+        </EmptyState>
+      </Tile>
+    );
+  }
+
+  // --- loading (either resolving the id or fetching the xml) ---
+  if (
+    (!looksNumeric && resolveStatus === 'pending') ||
+    xmlStatus === 'pending'
+  ) {
+    return (
+      <Tile>
+        <WidgetTitle>{title}</WidgetTitle>
+        {subtitle && <WidgetSubtitle>{subtitle}</WidgetSubtitle>}
+        <InlineLoading
+          description="Loading diagram…"
+          data-testid="bpmn-loading"
+        />
+      </Tile>
+    );
+  }
+
+  // --- error ---
+  if (xmlStatus === 'error' || !xml) {
+    return (
+      <Tile>
+        <WidgetTitle>{title}</WidgetTitle>
+        {subtitle && <WidgetSubtitle>{subtitle}</WidgetSubtitle>}
+        <EmptyState data-testid="bpmn-error">
+          Could not load diagram.
+        </EmptyState>
+      </Tile>
+    );
+  }
+
+  // Legend content varies by overlay mode — explains exactly what the audience
+  // is seeing (badges, colors, intensity).
+  const renderLegend = () => {
+    if (overlay === 'none') {
+      return null;
+    }
+    if (overlay === 'heatmap') {
+      return (
+        <BpmnLegend>
+          <BpmnLegendItem>
+            <BpmnLegendGradient />
+            Incident intensity (pale → deep red)
+          </BpmnLegendItem>
+          <BpmnLegendItem>
+            <BpmnLegendDot $color="var(--cds-support-error)" />
+            Badge on hottest tasks shows incident count
+          </BpmnLegendItem>
+        </BpmnLegend>
+      );
+    }
+    return (
+      <BpmnLegend>
+        {(overlay === 'active' ||
+          overlay === 'combined' ||
+          overlay === 'stuck') && (
+          <BpmnLegendItem>
+            <BpmnLegendDot $color="var(--cds-support-info)" />
+            Active instance count
+          </BpmnLegendItem>
+        )}
+        {(overlay === 'incidents' || overlay === 'combined') && (
+          <BpmnLegendItem>
+            <BpmnLegendDot $color="var(--cds-support-error)" />
+            Open incidents
+          </BpmnLegendItem>
+        )}
+      </BpmnLegend>
+    );
+  };
+
+  return (
+    <Tile>
+      <WidgetTitle>{title}</WidgetTitle>
+      {subtitle && <WidgetSubtitle>{subtitle}</WidgetSubtitle>}
+      <BpmnDiagramContainer data-testid="bpmn-diagram-container">
+        {overlay === 'heatmap' && <BpmnHeatmapStyles />}
+        <Diagram
+          xml={xml}
+          overlaysData={overlayData}
+          highlightedElementIds={highlightedElementIds}
+          customElementClasses={heatmapClasses}
+        >
+          {storeOverlays.map((storeOverlay) => {
+            const payload = storeOverlay.payload as {count: number};
+
+            if (storeOverlay.type === myActiveType) {
+              return (
+                <ActiveBadge
+                  key={`active-${storeOverlay.elementId}`}
+                  container={storeOverlay.container}
+                  count={payload.count}
+                />
+              );
+            }
+
+            if (storeOverlay.type === myIncidentsType) {
+              return (
+                <IncidentBadge
+                  key={`incidents-${storeOverlay.elementId}`}
+                  container={storeOverlay.container}
+                  count={payload.count}
+                />
+              );
+            }
+
+            return null;
+          })}
+        </Diagram>
+      </BpmnDiagramContainer>
+      {renderLegend()}
+    </Tile>
+  );
+});
+
+export {BpmnWidget};

--- a/operate/client/src/App/Notebooks/widgets/ChartWidget.test.tsx
+++ b/operate/client/src/App/Notebooks/widgets/ChartWidget.test.tsx
@@ -1,0 +1,377 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import React from 'react';
+import {render, screen} from 'modules/testing-library';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {http, HttpResponse} from 'msw';
+import {mockServer} from 'modules/mock-server/node';
+import {ChartWidget} from './ChartWidget';
+import {buildChartData} from './chartUtils';
+import type {WidgetConfig} from '../types';
+
+// ---------------------------------------------------------------------------
+// Stub Carbon Charts so D3 is not invoked inside jsdom
+// ---------------------------------------------------------------------------
+
+vi.mock('@carbon/charts-react', () => ({
+  SimpleBarChart: ({data}: {data: unknown[]}) => (
+    <div data-testid="bar-chart-stub" data-count={data.length} />
+  ),
+  LineChart: ({data}: {data: unknown[]}) => (
+    <div data-testid="line-chart-stub" data-count={data.length} />
+  ),
+  DonutChart: ({data}: {data: unknown[]}) => (
+    <div data-testid="donut-chart-stub" data-count={data.length} />
+  ),
+  PieChart: ({data}: {data: unknown[]}) => (
+    <div data-testid="pie-chart-stub" data-count={data.length} />
+  ),
+  StackedBarChart: ({data}: {data: unknown[]}) => (
+    <div data-testid="stacked-bar-chart-stub" data-count={data.length} />
+  ),
+  StackedAreaChart: ({data}: {data: unknown[]}) => (
+    <div data-testid="stacked-area-chart-stub" data-count={data.length} />
+  ),
+  MeterChart: ({data}: {data: unknown[]}) => (
+    <div data-testid="meter-chart-stub" data-count={data.length} />
+  ),
+  TreemapChart: ({data}: {data: unknown[]}) => (
+    <div data-testid="treemap-chart-stub" data-count={data.length} />
+  ),
+  RadarChart: ({data}: {data: unknown[]}) => (
+    <div data-testid="radar-chart-stub" data-count={data.length} />
+  ),
+}));
+
+// Also stub the CSS import so Vite doesn't choke on it in test mode
+vi.mock('@carbon/charts-react/styles.css', () => ({}));
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+type Props = {children?: React.ReactNode};
+
+const Wrapper = ({children}: Props) => (
+  <QueryClientProvider client={getMockQueryClient()}>
+    {children}
+  </QueryClientProvider>
+);
+
+const barConfig: WidgetConfig = {
+  id: 'w-chart-bar-test',
+  type: 'chart',
+  title: 'Incidents by error type',
+  chartType: 'bar',
+  chartGroupBy: 'errorType',
+  query: {
+    endpoint: '/v2/incidents/search',
+    method: 'POST',
+    body: {page: {limit: 1000}},
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Unit tests for buildChartData helper
+// ---------------------------------------------------------------------------
+
+describe('buildChartData', () => {
+  it('should count items per group when no valueField is given', () => {
+    // given
+    const items = [
+      {errorType: 'IO_MAPPING_ERROR'},
+      {errorType: 'IO_MAPPING_ERROR'},
+      {errorType: 'JOB_NO_RETRIES'},
+    ];
+
+    // when
+    const result = buildChartData(items, 'errorType');
+
+    // then — sorted descending by count
+    expect(result[0]).toEqual({group: 'IO_MAPPING_ERROR', value: 2});
+    expect(result[1]).toEqual({group: 'JOB_NO_RETRIES', value: 1});
+  });
+
+  it('should sum a numeric valueField per group', () => {
+    // given
+    const items = [
+      {region: 'EU', amount: 100},
+      {region: 'US', amount: 50},
+      {region: 'EU', amount: 200},
+    ];
+
+    // when
+    const result = buildChartData(items, 'region', 'amount');
+
+    // then
+    const eu = result.find((d) => d.group === 'EU');
+    const us = result.find((d) => d.group === 'US');
+    expect(eu?.value).toBe(300);
+    expect(us?.value).toBe(50);
+  });
+
+  it('should label missing group values as (unknown)', () => {
+    // given
+    const items = [{errorType: null}, {errorType: undefined}, {}];
+
+    // when
+    const result = buildChartData(items, 'errorType');
+
+    // then
+    expect(result[0]).toEqual({group: '(unknown)', value: 3});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Component tests
+// ---------------------------------------------------------------------------
+
+describe('<ChartWidget />', () => {
+  it('should render the bar chart when data loads successfully', async () => {
+    // given
+    mockServer.use(
+      http.post(
+        '/v2/incidents/search',
+        () =>
+          HttpResponse.json({
+            page: {totalItems: 3},
+            items: [
+              {incidentKey: '1', errorType: 'IO_MAPPING_ERROR'},
+              {incidentKey: '2', errorType: 'IO_MAPPING_ERROR'},
+              {incidentKey: '3', errorType: 'JOB_NO_RETRIES'},
+            ],
+          }),
+        {once: true},
+      ),
+    );
+
+    // when
+    render(<ChartWidget config={barConfig} />, {wrapper: Wrapper});
+
+    // then — title is rendered
+    expect(
+      await screen.findByText('Incidents by error type'),
+    ).toBeInTheDocument();
+
+    // and the chart stub is mounted with 2 groups (IO_MAPPING_ERROR, JOB_NO_RETRIES)
+    const stub = await screen.findByTestId('bar-chart-stub');
+    expect(stub).toBeInTheDocument();
+    expect(stub).toHaveAttribute('data-count', '2');
+  });
+
+  it('should render a loading state while data is loading', async () => {
+    // given — server never responds
+    mockServer.use(
+      http.post('/v2/incidents/search', async () => {
+        await new Promise(() => {});
+        return HttpResponse.json({});
+      }),
+    );
+
+    // when
+    render(<ChartWidget config={barConfig} />, {wrapper: Wrapper});
+
+    // then
+    expect(screen.getByTestId('chart-loading')).toBeInTheDocument();
+  });
+
+  it('should render an error state on fetch failure', async () => {
+    // given
+    mockServer.use(
+      http.post('/v2/incidents/search', () => HttpResponse.error(), {
+        once: true,
+      }),
+    );
+
+    // when
+    render(<ChartWidget config={barConfig} />, {wrapper: Wrapper});
+
+    // then
+    expect(
+      await screen.findByText(/could not load chart/i),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('chart-error')).toBeInTheDocument();
+  });
+
+  it('should render an empty state when items array is empty', async () => {
+    // given
+    mockServer.use(
+      http.post(
+        '/v2/incidents/search',
+        () =>
+          HttpResponse.json({
+            page: {totalItems: 0},
+            items: [],
+          }),
+        {once: true},
+      ),
+    );
+
+    // when
+    render(<ChartWidget config={barConfig} />, {wrapper: Wrapper});
+
+    // then
+    expect(await screen.findByText(/no data available/i)).toBeInTheDocument();
+    expect(screen.getByTestId('chart-empty')).toBeInTheDocument();
+  });
+
+  it('should render a donut chart when chartType is donut', async () => {
+    // given
+    const donutConfig: WidgetConfig = {
+      ...barConfig,
+      id: 'w-chart-donut-test',
+      title: 'Instances by state',
+      chartType: 'donut',
+      chartGroupBy: 'state',
+      query: {
+        endpoint: '/v2/process-instances/search',
+        method: 'POST',
+        body: {page: {limit: 1000}},
+      },
+    };
+
+    mockServer.use(
+      http.post(
+        '/v2/process-instances/search',
+        () =>
+          HttpResponse.json({
+            items: [
+              {processInstanceKey: '1', state: 'ACTIVE'},
+              {processInstanceKey: '2', state: 'ACTIVE'},
+              {processInstanceKey: '3', state: 'COMPLETED'},
+            ],
+          }),
+        {once: true},
+      ),
+    );
+
+    // when
+    render(<ChartWidget config={donutConfig} />, {wrapper: Wrapper});
+
+    // then
+    expect(await screen.findByTestId('donut-chart-stub')).toBeInTheDocument();
+    expect(screen.getByTestId('donut-chart-stub')).toHaveAttribute(
+      'data-count',
+      '2',
+    );
+  });
+
+  it('should render a pie chart when chartType is pie', async () => {
+    // given
+    const pieConfig: WidgetConfig = {
+      ...barConfig,
+      id: 'w-chart-pie-test',
+      title: 'Instances by state (pie)',
+      chartType: 'pie',
+      chartGroupBy: 'state',
+      query: {
+        endpoint: '/v2/process-instances/search',
+        method: 'POST',
+        body: {page: {limit: 1000}},
+      },
+    };
+
+    mockServer.use(
+      http.post(
+        '/v2/process-instances/search',
+        () =>
+          HttpResponse.json({
+            items: [{state: 'ACTIVE'}, {state: 'ACTIVE'}, {state: 'COMPLETED'}],
+          }),
+        {once: true},
+      ),
+    );
+
+    // when
+    render(<ChartWidget config={pieConfig} />, {wrapper: Wrapper});
+
+    // then
+    expect(await screen.findByTestId('pie-chart-stub')).toBeInTheDocument();
+    expect(screen.getByTestId('pie-chart-stub')).toHaveAttribute(
+      'data-count',
+      '2',
+    );
+  });
+
+  it('should render a stacked-area chart when chartType is stacked-area', async () => {
+    // given
+    const areaConfig: WidgetConfig = {
+      ...barConfig,
+      id: 'w-chart-area-test',
+      title: 'Instances by process (area)',
+      chartType: 'stacked-area',
+      chartGroupBy: 'processDefinitionId',
+      chartStackBy: 'state',
+      query: {
+        endpoint: '/v2/process-instances/search',
+        method: 'POST',
+        body: {page: {limit: 1000}},
+      },
+    };
+
+    mockServer.use(
+      http.post(
+        '/v2/process-instances/search',
+        () =>
+          HttpResponse.json({
+            items: [
+              {processDefinitionId: 'order-process', state: 'ACTIVE'},
+              {processDefinitionId: 'order-process', state: 'COMPLETED'},
+              {processDefinitionId: 'payment-process', state: 'ACTIVE'},
+            ],
+          }),
+        {once: true},
+      ),
+    );
+
+    // when
+    render(<ChartWidget config={areaConfig} />, {wrapper: Wrapper});
+
+    // then
+    expect(
+      await screen.findByTestId('stacked-area-chart-stub'),
+    ).toBeInTheDocument();
+  });
+
+  it('should render a line chart when chartType is line', async () => {
+    // given
+    const lineConfig: WidgetConfig = {
+      ...barConfig,
+      id: 'w-chart-line-test',
+      title: 'Incidents over time',
+      chartType: 'line',
+      query: {
+        endpoint: '/v2/incidents/search',
+        method: 'POST',
+        body: {page: {limit: 1000}},
+      },
+    };
+
+    mockServer.use(
+      http.post(
+        '/v2/incidents/search',
+        () =>
+          HttpResponse.json({
+            items: [
+              {incidentKey: '1', errorType: 'IO_MAPPING_ERROR'},
+              {incidentKey: '2', errorType: 'JOB_NO_RETRIES'},
+            ],
+          }),
+        {once: true},
+      ),
+    );
+
+    // when
+    render(<ChartWidget config={lineConfig} />, {wrapper: Wrapper});
+
+    // then
+    expect(await screen.findByTestId('line-chart-stub')).toBeInTheDocument();
+  });
+});

--- a/operate/client/src/App/Notebooks/widgets/ChartWidget.tsx
+++ b/operate/client/src/App/Notebooks/widgets/ChartWidget.tsx
@@ -1,0 +1,326 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import React from 'react';
+import {useQuery} from '@tanstack/react-query';
+import {InlineLoading, Tile} from '@carbon/react';
+import {
+  SimpleBarChart,
+  LineChart,
+  DonutChart,
+  PieChart,
+  StackedBarChart,
+  StackedAreaChart,
+  MeterChart,
+  TreemapChart,
+  RadarChart,
+} from '@carbon/charts-react';
+import '@carbon/charts-react/styles.css';
+import {requestWithThrow} from 'modules/request';
+import type {WidgetConfig} from '../types';
+import {WidgetTitle, WidgetSubtitle, EmptyState} from '../styled';
+import {
+  buildChartData,
+  buildStackedChartData,
+  buildTreemapData,
+  buildRadarData,
+} from './chartUtils';
+import {
+  SEMANTIC_COLOR_SCALE,
+  HARMONIOUS_PALETTE,
+  COMMON_CHART_OPTIONS,
+  CHART_HEIGHT,
+  barOptions,
+  lineOptions,
+  stackedBarOptions,
+  donutOptions,
+} from './chartOptions';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type Props = {
+  config: WidgetConfig;
+  /** Override the chart height — used by ChartListWidget for compact mode. */
+  heightOverride?: string;
+};
+
+type ApiResponse = {
+  items: Record<string, unknown>[];
+  page?: {totalItems: number};
+};
+
+// ---------------------------------------------------------------------------
+// Local options for chart types not in chartOptions.ts
+// ---------------------------------------------------------------------------
+
+function pieOptions(height: string) {
+  return {
+    ...COMMON_CHART_OPTIONS,
+    title: '',
+    height,
+    resizable: true,
+    legend: {position: 'right' as const},
+    color: {scale: SEMANTIC_COLOR_SCALE, pairing: {option: 2}},
+  };
+}
+
+function stackedAreaOptions(groupBy: string, height: string) {
+  return {
+    ...COMMON_CHART_OPTIONS,
+    title: '',
+    height,
+    axes: {
+      left: {mapsTo: 'value', stacked: true},
+      bottom: {
+        mapsTo: 'group',
+        scaleType: 'labels' as const,
+        title: groupBy,
+      },
+    },
+    legend: {enabled: true},
+    color: {scale: SEMANTIC_COLOR_SCALE, pairing: {option: 2}},
+    data: {groupMapsTo: 'key'},
+  } as const;
+}
+
+function meterOptions(height: string) {
+  return {
+    ...COMMON_CHART_OPTIONS,
+    title: '',
+    height,
+    meter: {
+      proportional: {
+        total: undefined,
+      },
+    },
+    color: {scale: SEMANTIC_COLOR_SCALE, pairing: {option: 2}},
+  };
+}
+
+function treemapOptions(height: string) {
+  return {
+    ...COMMON_CHART_OPTIONS,
+    title: '',
+    height,
+    color: {
+      scale: SEMANTIC_COLOR_SCALE,
+      pairing: {option: 2},
+      // Provide explicit gradient colors for treemap groups that aren't in
+      // the semantic map; Carbon Charts falls back to its gradient scale.
+      gradient: {colors: HARMONIOUS_PALETTE},
+    },
+  };
+}
+
+function radarOptions(height: string) {
+  return {
+    ...COMMON_CHART_OPTIONS,
+    title: '',
+    height,
+    radar: {
+      axes: {angle: 'key', value: 'value'},
+    },
+    legend: {enabled: true},
+    color: {
+      scale: SEMANTIC_COLOR_SCALE,
+      pairing: {option: 2},
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// ChartWidget
+// ---------------------------------------------------------------------------
+
+const ChartWidget: React.FC<Props> = ({config, heightOverride}) => {
+  const {
+    title,
+    subtitle,
+    query,
+    chartType = 'bar',
+    chartGroupBy = 'state',
+    chartValueField,
+    chartStackBy = 'state',
+  } = config;
+
+  const chartHeight = heightOverride ?? CHART_HEIGHT;
+
+  const {data, status} = useQuery({
+    queryKey: ['notebook-widget', config.id, query],
+    queryFn: async () => {
+      const {response, error} = await requestWithThrow<ApiResponse>({
+        url: query.endpoint,
+        method: query.method,
+        body: query.body,
+      });
+      if (error) {
+        throw error;
+      }
+      return response;
+    },
+  });
+
+  if (status === 'pending') {
+    return (
+      <Tile>
+        <WidgetTitle>{title}</WidgetTitle>
+        {subtitle && <WidgetSubtitle>{subtitle}</WidgetSubtitle>}
+        <InlineLoading
+          description="Loading chart…"
+          data-testid="chart-loading"
+        />
+      </Tile>
+    );
+  }
+
+  if (status === 'error') {
+    return (
+      <Tile>
+        <WidgetTitle>{title}</WidgetTitle>
+        {subtitle && <WidgetSubtitle>{subtitle}</WidgetSubtitle>}
+        <EmptyState data-testid="chart-error">Could not load chart.</EmptyState>
+      </Tile>
+    );
+  }
+
+  const items = data?.items ?? [];
+
+  if (items.length === 0) {
+    return (
+      <Tile>
+        <WidgetTitle>{title}</WidgetTitle>
+        {subtitle && <WidgetSubtitle>{subtitle}</WidgetSubtitle>}
+        <EmptyState data-testid="chart-empty">No data available.</EmptyState>
+      </Tile>
+    );
+  }
+
+  if (chartType === 'stacked-bar') {
+    const stackedData = buildStackedChartData(
+      items,
+      chartGroupBy,
+      chartStackBy,
+    );
+    return (
+      <Tile>
+        <WidgetTitle>{title}</WidgetTitle>
+        {subtitle && <WidgetSubtitle>{subtitle}</WidgetSubtitle>}
+        <StackedBarChart
+          data={stackedData}
+          options={stackedBarOptions(chartGroupBy, chartHeight)}
+        />
+      </Tile>
+    );
+  }
+
+  if (chartType === 'stacked-area') {
+    const stackedData = buildStackedChartData(
+      items,
+      chartGroupBy,
+      chartStackBy,
+    );
+    return (
+      <Tile>
+        <WidgetTitle>{title}</WidgetTitle>
+        {subtitle && <WidgetSubtitle>{subtitle}</WidgetSubtitle>}
+        <StackedAreaChart
+          data={stackedData}
+          options={stackedAreaOptions(chartGroupBy, chartHeight)}
+        />
+      </Tile>
+    );
+  }
+
+  if (chartType === 'treemap') {
+    const treeData = buildTreemapData(items, chartGroupBy);
+    return (
+      <Tile>
+        <WidgetTitle>{title}</WidgetTitle>
+        {subtitle && <WidgetSubtitle>{subtitle}</WidgetSubtitle>}
+        <TreemapChart data={treeData} options={treemapOptions(chartHeight)} />
+      </Tile>
+    );
+  }
+
+  if (chartType === 'radar') {
+    const radarData = buildRadarData(items, chartGroupBy, chartStackBy);
+    return (
+      <Tile>
+        <WidgetTitle>{title}</WidgetTitle>
+        {subtitle && <WidgetSubtitle>{subtitle}</WidgetSubtitle>}
+        <RadarChart data={radarData} options={radarOptions(chartHeight)} />
+      </Tile>
+    );
+  }
+
+  if (chartType === 'meter') {
+    const chartData = buildChartData(items, chartGroupBy, chartValueField);
+    return (
+      <Tile>
+        <WidgetTitle>{title}</WidgetTitle>
+        {subtitle && <WidgetSubtitle>{subtitle}</WidgetSubtitle>}
+        <MeterChart data={chartData} options={meterOptions(chartHeight)} />
+      </Tile>
+    );
+  }
+
+  const chartData = buildChartData(items, chartGroupBy, chartValueField);
+
+  if (chartType === 'donut') {
+    const total = chartData.reduce((sum, d) => sum + d.value, 0);
+    return (
+      <Tile>
+        <WidgetTitle>{title}</WidgetTitle>
+        {subtitle && <WidgetSubtitle>{subtitle}</WidgetSubtitle>}
+        <DonutChart
+          data={chartData}
+          options={donutOptions(chartGroupBy, chartHeight, total)}
+        />
+      </Tile>
+    );
+  }
+
+  if (chartType === 'pie') {
+    return (
+      <Tile>
+        <WidgetTitle>{title}</WidgetTitle>
+        {subtitle && <WidgetSubtitle>{subtitle}</WidgetSubtitle>}
+        <PieChart data={chartData} options={pieOptions(chartHeight)} />
+      </Tile>
+    );
+  }
+
+  if (chartType === 'line') {
+    return (
+      <Tile>
+        <WidgetTitle>{title}</WidgetTitle>
+        {subtitle && <WidgetSubtitle>{subtitle}</WidgetSubtitle>}
+        <LineChart
+          data={chartData}
+          options={lineOptions(chartGroupBy, chartHeight)}
+        />
+      </Tile>
+    );
+  }
+
+  // default: bar
+  return (
+    <Tile>
+      <WidgetTitle>{title}</WidgetTitle>
+      {subtitle && <WidgetSubtitle>{subtitle}</WidgetSubtitle>}
+      <SimpleBarChart
+        data={chartData}
+        options={barOptions(chartGroupBy, chartHeight)}
+      />
+    </Tile>
+  );
+};
+
+export {ChartWidget};

--- a/operate/client/src/App/Notebooks/widgets/ChartWidget.tsx
+++ b/operate/client/src/App/Notebooks/widgets/ChartWidget.tsx
@@ -23,7 +23,12 @@ import {
 import '@carbon/charts-react/styles.css';
 import {requestWithThrow} from 'modules/request';
 import type {WidgetConfig} from '../types';
-import {WidgetTitle, WidgetSubtitle, EmptyState} from '../styled';
+import {
+  WidgetTitle,
+  WidgetSubtitle,
+  EmptyState,
+  CircularChartWrap,
+} from '../styled';
 import {
   buildChartData,
   buildStackedChartData,
@@ -61,12 +66,18 @@ type ApiResponse = {
 // ---------------------------------------------------------------------------
 
 function pieOptions(height: string) {
+  // Mirror donut's config. Carbon's pie defaults to `alignment: 'left'` which
+  // anchors the disk on the left of the SVG; setting `alignment: 'center'`
+  // (matching donutChart's default override) centers the disk while leaving
+  // the inherited bottom legend intact. Do NOT touch `pie.labels` here — that
+  // toggle has secondary effects on legend rendering in Carbon Charts 1.x.
   return {
     ...COMMON_CHART_OPTIONS,
     title: '',
     height,
     resizable: true,
-    legend: {position: 'right' as const},
+    pie: {alignment: 'center' as const},
+    legend: {position: 'bottom' as const},
     color: {scale: SEMANTIC_COLOR_SCALE, pairing: {option: 2}},
   };
 }
@@ -90,32 +101,48 @@ function stackedAreaOptions(groupBy: string, height: string) {
   } as const;
 }
 
-function meterOptions(height: string) {
+function meterOptions(height: string, total: number) {
   return {
     ...COMMON_CHART_OPTIONS,
     title: '',
     height,
     meter: {
       proportional: {
-        total: undefined,
+        total,
+        unit: '',
       },
     },
     color: {scale: SEMANTIC_COLOR_SCALE, pairing: {option: 2}},
   };
 }
 
-function treemapOptions(height: string) {
+/**
+ * Build a per-leaf color scale for treemap rendering. Carbon Charts uses
+ * `color.scale` as a `name → color` map for the treemap's children. Unknown
+ * names fall back to a single default color — that's why our shared
+ * SEMANTIC_COLOR_SCALE produced uniform blue rectangles for job types like
+ * 'validate' / 'charge' that aren't in the semantic dictionary.
+ *
+ * Cycle through HARMONIOUS_PALETTE so every distinct leaf name gets its
+ * own distinct color.
+ */
+function treemapColorScale(names: string[]): Record<string, string> {
+  const scale: Record<string, string> = {};
+  for (let i = 0; i < names.length; i++) {
+    scale[names[i]!] = HARMONIOUS_PALETTE[i % HARMONIOUS_PALETTE.length]!;
+  }
+  return scale;
+}
+
+function treemapOptions(height: string, colorScale?: Record<string, string>) {
   return {
     ...COMMON_CHART_OPTIONS,
     title: '',
     height,
-    color: {
-      scale: SEMANTIC_COLOR_SCALE,
-      pairing: {option: 2},
-      // Provide explicit gradient colors for treemap groups that aren't in
-      // the semantic map; Carbon Charts falls back to its gradient scale.
-      gradient: {colors: HARMONIOUS_PALETTE},
-    },
+    // Caller-provided per-name palette (built from leaf names in
+    // ChartWidget). See `treemapColorScale()` below for why we don't share
+    // SEMANTIC_COLOR_SCALE here.
+    color: colorScale != null ? {scale: colorScale} : undefined,
   };
 }
 
@@ -126,8 +153,13 @@ function radarOptions(height: string) {
     height,
     radar: {
       axes: {angle: 'key', value: 'value'},
+      // Carbon Charts defaults radar.alignment to 'left' (per the source's
+      // radarChart defaults), which anchors the polygon at the left edge of
+      // the SVG and leaves the right two thirds of the wide tile empty.
+      // Centering puts the polygon in the middle of the tile.
+      alignment: 'center' as const,
     },
-    legend: {enabled: true},
+    legend: {enabled: true, position: 'right' as const},
     color: {
       scale: SEMANTIC_COLOR_SCALE,
       pairing: {option: 2},
@@ -150,7 +182,11 @@ const ChartWidget: React.FC<Props> = ({config, heightOverride}) => {
     chartStackBy = 'state',
   } = config;
 
-  const chartHeight = heightOverride ?? CHART_HEIGHT;
+  // Radar gets the full HERO tier (480px tile) so the polygon can render
+  // square; bump its internal chart height to fill the tile, otherwise it
+  // renders as a thin strip at the top of the empty area.
+  const chartHeight =
+    heightOverride ?? (chartType === 'radar' ? '420px' : CHART_HEIGHT);
 
   const {data, status} = useQuery({
     queryKey: ['notebook-widget', config.id, query],
@@ -239,12 +275,36 @@ const ChartWidget: React.FC<Props> = ({config, heightOverride}) => {
   }
 
   if (chartType === 'treemap') {
-    const treeData = buildTreemapData(items, chartGroupBy);
+    // Cap distinct rectangles so the legend doesn't dominate the tile when
+    // a real cluster has 30+ process definitions. buildTreemapData already
+    // returns roots sorted by value descending, so slicing keeps the
+    // largest groups; small ones become a single "Other" bucket.
+    const TREEMAP_MAX_GROUPS = 8;
+    const allRoots = buildTreemapData(items, chartGroupBy);
+    let treeData = allRoots;
+    if (allRoots.length > TREEMAP_MAX_GROUPS) {
+      const top = allRoots.slice(0, TREEMAP_MAX_GROUPS - 1);
+      const tail = allRoots.slice(TREEMAP_MAX_GROUPS - 1);
+      const tailValue = tail.reduce(
+        (sum, r) => sum + (r.children?.[0]?.value ?? 0),
+        0,
+      );
+      treeData = [
+        ...top,
+        {name: 'Other', children: [{name: 'Other', value: tailValue}]},
+      ];
+    }
+    // Each root has one child whose name matches the root's name, so the
+    // root names give us the full per-leaf color list.
+    const colorScale = treemapColorScale(treeData.map((r) => r.name));
     return (
       <Tile>
         <WidgetTitle>{title}</WidgetTitle>
         {subtitle && <WidgetSubtitle>{subtitle}</WidgetSubtitle>}
-        <TreemapChart data={treeData} options={treemapOptions(chartHeight)} />
+        <TreemapChart
+          data={treeData}
+          options={treemapOptions(chartHeight, colorScale)}
+        />
       </Tile>
     );
   }
@@ -262,11 +322,18 @@ const ChartWidget: React.FC<Props> = ({config, heightOverride}) => {
 
   if (chartType === 'meter') {
     const chartData = buildChartData(items, chartGroupBy, chartValueField);
+    // Carbon's proportional meter needs an explicit total to compute segment
+    // widths; without it the bar renders empty. Use the sum of all values as
+    // 100% — gives a proper "share of total" stacked bar.
+    const meterTotal = chartData.reduce((sum, d) => sum + d.value, 0) || 1;
     return (
       <Tile>
         <WidgetTitle>{title}</WidgetTitle>
         {subtitle && <WidgetSubtitle>{subtitle}</WidgetSubtitle>}
-        <MeterChart data={chartData} options={meterOptions(chartHeight)} />
+        <MeterChart
+          data={chartData}
+          options={meterOptions(chartHeight, meterTotal)}
+        />
       </Tile>
     );
   }
@@ -279,10 +346,12 @@ const ChartWidget: React.FC<Props> = ({config, heightOverride}) => {
       <Tile>
         <WidgetTitle>{title}</WidgetTitle>
         {subtitle && <WidgetSubtitle>{subtitle}</WidgetSubtitle>}
-        <DonutChart
-          data={chartData}
-          options={donutOptions(chartGroupBy, chartHeight, total)}
-        />
+        <CircularChartWrap>
+          <DonutChart
+            data={chartData}
+            options={donutOptions(chartGroupBy, chartHeight, total)}
+          />
+        </CircularChartWrap>
       </Tile>
     );
   }
@@ -292,18 +361,51 @@ const ChartWidget: React.FC<Props> = ({config, heightOverride}) => {
       <Tile>
         <WidgetTitle>{title}</WidgetTitle>
         {subtitle && <WidgetSubtitle>{subtitle}</WidgetSubtitle>}
-        <PieChart data={chartData} options={pieOptions(chartHeight)} />
+        <CircularChartWrap>
+          <PieChart data={chartData} options={pieOptions(chartHeight)} />
+        </CircularChartWrap>
       </Tile>
     );
   }
 
   if (chartType === 'line') {
+    // Special case: when the preset asks to group by a synthetic time bucket
+    // ("startHour"/"endHour") the field doesn't exist on the response — we
+    // derive it client-side from the corresponding date field. This lets a
+    // line chart show real throughput-over-time without needing a server-
+    // side aggregation endpoint.
+    let lineData = chartData;
+    if (chartGroupBy === 'startHour' || chartGroupBy === 'endHour') {
+      const dateField = chartGroupBy === 'startHour' ? 'startDate' : 'endDate';
+      // Bucket items by HH:00 of their date field, then ensure all 24 hours
+      // exist (zero-filled) so the line always has a contiguous x-axis.
+      const counts = new Map<string, number>();
+      for (let h = 0; h < 24; h++) {
+        counts.set(`${String(h).padStart(2, '0')}:00`, 0);
+      }
+      for (const item of items) {
+        const raw = item[dateField];
+        if (raw == null) {
+          continue;
+        }
+        const t = new Date(raw as string);
+        if (isNaN(t.getTime())) {
+          continue;
+        }
+        const key = `${String(t.getUTCHours()).padStart(2, '0')}:00`;
+        counts.set(key, (counts.get(key) ?? 0) + 1);
+      }
+      lineData = Array.from(counts.entries()).map(([group, value]) => ({
+        group,
+        value,
+      }));
+    }
     return (
       <Tile>
         <WidgetTitle>{title}</WidgetTitle>
         {subtitle && <WidgetSubtitle>{subtitle}</WidgetSubtitle>}
         <LineChart
-          data={chartData}
+          data={lineData}
           options={lineOptions(chartGroupBy, chartHeight)}
         />
       </Tile>

--- a/operate/client/src/App/Notebooks/widgets/FunnelWidget.tsx
+++ b/operate/client/src/App/Notebooks/widgets/FunnelWidget.tsx
@@ -1,0 +1,183 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import React, {useMemo} from 'react';
+import {useQuery} from '@tanstack/react-query';
+import {InlineLoading, Tile} from '@carbon/react';
+import {
+  endpoints,
+  type GetProcessDefinitionStatisticsResponseBody,
+} from '@camunda/camunda-api-zod-schemas/8.10';
+import {requestWithThrow} from 'modules/request';
+import type {WidgetConfig} from '../types';
+import {useResolveProcessKey} from './useResolveProcessKey';
+import {
+  WidgetTitle,
+  WidgetSubtitle,
+  EmptyState,
+  FunnelContainer,
+  FunnelRow,
+  FunnelBarTrack,
+  FunnelBarFill,
+  FunnelBarLabel,
+  FunnelBarCount,
+  FunnelDropoff,
+} from '../styled';
+
+type Props = {
+  config: WidgetConfig;
+};
+
+type ElementStat = {
+  elementId: string;
+  active: number;
+  canceled: number;
+  incidents: number;
+  completed: number;
+};
+
+const FunnelWidget: React.FC<Props> = ({config}) => {
+  const {
+    title,
+    subtitle,
+    processDefinitionKey: configKey,
+    funnelStages = [],
+  } = config;
+
+  // Shared resolver — dedupes /v2/process-definitions/search across multiple
+  // BPMN/funnel widgets in the same bundle that point at the same process.
+  const looksNumeric = !!configKey && /^\d+$/.test(configKey);
+  const {resolvedKey, status: resolveStatus} = useResolveProcessKey(configKey);
+  const processDefinitionKey = resolvedKey;
+
+  const {data: statsResponse, status: statsStatus} = useQuery({
+    queryKey: ['notebook-funnel-stats', processDefinitionKey],
+    enabled: !!processDefinitionKey,
+    queryFn: async () => {
+      if (!processDefinitionKey) {
+        throw new Error('No processDefinitionKey');
+      }
+      const {response, error} =
+        await requestWithThrow<GetProcessDefinitionStatisticsResponseBody>({
+          url: endpoints.getProcessDefinitionStatistics.getUrl({
+            processDefinitionKey,
+            statisticName: 'element-instances',
+          }),
+          method: endpoints.getProcessDefinitionStatistics.method,
+        });
+      if (error) {
+        throw error;
+      }
+      return response;
+    },
+  });
+
+  const stageData = useMemo(() => {
+    if (!statsResponse?.items || funnelStages.length === 0) {
+      return [];
+    }
+
+    const statsMap = new Map<string, ElementStat>();
+    for (const s of statsResponse.items as ElementStat[]) {
+      statsMap.set(s.elementId, s);
+    }
+
+    return funnelStages.map((stage) => {
+      const stat = statsMap.get(stage.elementId);
+      const total = stat
+        ? stat.active + stat.completed + stat.canceled + stat.incidents
+        : 0;
+      return {label: stage.label, total};
+    });
+  }, [statsResponse, funnelStages]);
+
+  // --- missing config ---
+  if (!configKey || funnelStages.length === 0) {
+    return (
+      <Tile>
+        <WidgetTitle>{title}</WidgetTitle>
+        {subtitle && <WidgetSubtitle>{subtitle}</WidgetSubtitle>}
+        <EmptyState>No process or stages configured for funnel.</EmptyState>
+      </Tile>
+    );
+  }
+
+  // --- loading ---
+  if (
+    (!looksNumeric && resolveStatus === 'pending') ||
+    statsStatus === 'pending'
+  ) {
+    return (
+      <Tile>
+        <WidgetTitle>{title}</WidgetTitle>
+        {subtitle && <WidgetSubtitle>{subtitle}</WidgetSubtitle>}
+        <InlineLoading
+          description="Loading funnel…"
+          data-testid="funnel-loading"
+        />
+      </Tile>
+    );
+  }
+
+  // --- error ---
+  if ((!looksNumeric && resolveStatus === 'error') || statsStatus === 'error') {
+    return (
+      <Tile>
+        <WidgetTitle>{title}</WidgetTitle>
+        {subtitle && <WidgetSubtitle>{subtitle}</WidgetSubtitle>}
+        <EmptyState data-testid="funnel-error">
+          Could not load funnel data.
+        </EmptyState>
+      </Tile>
+    );
+  }
+
+  if (stageData.length === 0) {
+    return (
+      <Tile>
+        <WidgetTitle>{title}</WidgetTitle>
+        {subtitle && <WidgetSubtitle>{subtitle}</WidgetSubtitle>}
+        <EmptyState data-testid="funnel-empty">No stage data.</EmptyState>
+      </Tile>
+    );
+  }
+
+  const maxTotal = Math.max(...stageData.map((s) => s.total), 1);
+
+  return (
+    <Tile>
+      <WidgetTitle>{title}</WidgetTitle>
+      {subtitle && <WidgetSubtitle>{subtitle}</WidgetSubtitle>}
+      <FunnelContainer data-testid="funnel-chart">
+        {stageData.map((stage, i) => {
+          const pct = (stage.total / maxTotal) * 100;
+          const prev = stageData[i - 1];
+          const dropoff =
+            prev && prev.total > 0
+              ? Math.round(((prev.total - stage.total) / prev.total) * 100)
+              : null;
+
+          return (
+            <FunnelRow key={stage.label}>
+              <FunnelBarTrack>
+                <FunnelBarFill $pct={pct} $colorIdx={i} />
+                <FunnelBarLabel>{stage.label}</FunnelBarLabel>
+                <FunnelBarCount>{stage.total.toLocaleString()}</FunnelBarCount>
+              </FunnelBarTrack>
+              {dropoff !== null && dropoff > 0 && (
+                <FunnelDropoff>↓ {dropoff}% drop-off</FunnelDropoff>
+              )}
+            </FunnelRow>
+          );
+        })}
+      </FunnelContainer>
+    </Tile>
+  );
+};
+
+export {FunnelWidget};

--- a/operate/client/src/App/Notebooks/widgets/KpiWidget.test.tsx
+++ b/operate/client/src/App/Notebooks/widgets/KpiWidget.test.tsx
@@ -1,0 +1,148 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import React from 'react';
+import {render, screen} from 'modules/testing-library';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {http, HttpResponse} from 'msw';
+import {mockServer} from 'modules/mock-server/node';
+import {KpiWidget} from './KpiWidget';
+import type {WidgetConfig} from '../types';
+
+type Props = {children?: React.ReactNode};
+
+const Wrapper = ({children}: Props) => (
+  <QueryClientProvider client={getMockQueryClient()}>
+    {children}
+  </QueryClientProvider>
+);
+
+const kpiConfig: WidgetConfig = {
+  id: 'w-kpi-test',
+  type: 'kpi',
+  title: 'Process health',
+  query: {endpoint: '/__notebook_kpi__', method: 'GET'},
+  kpis: [
+    {
+      label: 'Active instances',
+      query: {
+        endpoint: '/v2/process-instances/search',
+        method: 'POST',
+        body: {filter: {state: 'ACTIVE'}, page: {limit: 1}},
+      },
+      field: 'page.totalItems',
+      accent: 'info',
+    },
+    {
+      label: 'With incidents',
+      query: {
+        endpoint: '/v2/incidents/search',
+        method: 'POST',
+        body: {filter: {state: 'ACTIVE'}, page: {limit: 1}},
+      },
+      field: 'page.totalItems',
+      accent: 'error',
+    },
+  ],
+};
+
+describe('<KpiWidget />', () => {
+  it('should render the title and a grid with one cell per KPI', async () => {
+    // given
+    mockServer.use(
+      http.post(
+        '/v2/process-instances/search',
+        () =>
+          HttpResponse.json({
+            page: {totalItems: 42, firstSortValues: [], lastSortValues: []},
+            items: [],
+          }),
+        {once: true},
+      ),
+      http.post(
+        '/v2/incidents/search',
+        () =>
+          HttpResponse.json({
+            page: {totalItems: 3, firstSortValues: [], lastSortValues: []},
+            items: [],
+          }),
+        {once: true},
+      ),
+    );
+
+    // when
+    render(<KpiWidget config={kpiConfig} />, {wrapper: Wrapper});
+
+    // then — title renders
+    expect(screen.getByText('Process health')).toBeInTheDocument();
+
+    // both cell labels render
+    expect(await screen.findByText('Active instances')).toBeInTheDocument();
+    expect(await screen.findByText('With incidents')).toBeInTheDocument();
+
+    // values from API render
+    expect(await screen.findByText('42')).toBeInTheDocument();
+    expect(await screen.findByText('3')).toBeInTheDocument();
+  });
+
+  it('should render loading skeletons while cells are fetching', async () => {
+    // given — servers never resolve
+    mockServer.use(
+      http.post('/v2/process-instances/search', async () => {
+        await new Promise(() => {});
+        return HttpResponse.json({});
+      }),
+      http.post('/v2/incidents/search', async () => {
+        await new Promise(() => {});
+        return HttpResponse.json({});
+      }),
+    );
+
+    // when
+    render(<KpiWidget config={kpiConfig} />, {wrapper: Wrapper});
+
+    // then — at least one loading cell is present
+    const loadingCells = screen.getAllByTestId('kpi-cell-loading');
+    expect(loadingCells.length).toBeGreaterThan(0);
+  });
+
+  it('should render a dash for cells that fail to fetch', async () => {
+    // given
+    mockServer.use(
+      http.post('/v2/process-instances/search', () => HttpResponse.error(), {
+        once: true,
+      }),
+      http.post('/v2/incidents/search', () => HttpResponse.error(), {
+        once: true,
+      }),
+    );
+
+    // when
+    render(<KpiWidget config={kpiConfig} />, {wrapper: Wrapper});
+
+    // then — error cells render an em-dash placeholder
+    const dashes = await screen.findAllByText('—');
+    expect(dashes.length).toBeGreaterThan(0);
+  });
+
+  it('should show a fallback message when kpis array is empty', () => {
+    // given
+    const emptyConfig: WidgetConfig = {
+      ...kpiConfig,
+      id: 'w-kpi-empty',
+      kpis: [],
+    };
+
+    // when
+    render(<KpiWidget config={emptyConfig} />, {wrapper: Wrapper});
+
+    // then
+    expect(screen.getByText(/no kpi items configured/i)).toBeInTheDocument();
+  });
+});

--- a/operate/client/src/App/Notebooks/widgets/KpiWidget.tsx
+++ b/operate/client/src/App/Notebooks/widgets/KpiWidget.tsx
@@ -1,0 +1,149 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import React from 'react';
+import {useQuery} from '@tanstack/react-query';
+import {SkeletonText, Tile} from '@carbon/react';
+import {requestWithThrow} from 'modules/request';
+import type {WidgetConfig, KpiItem} from '../types';
+import {
+  WidgetTitle,
+  WidgetSubtitle,
+  MetricCaption,
+  MetricValue,
+  KpiGrid,
+  KpiCell,
+} from '../styled';
+
+type Props = {
+  config: WidgetConfig;
+};
+
+// ---------------------------------------------------------------------------
+// Path traversal helper (mirrors MetricWidget)
+// ---------------------------------------------------------------------------
+
+function getByPath(obj: unknown, path: string): unknown {
+  return path
+    .split('.')
+    .reduce(
+      (acc, key) =>
+        acc != null && typeof acc === 'object'
+          ? (acc as Record<string, unknown>)[key]
+          : undefined,
+      obj,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Single KPI cell — runs its own useQuery so fetches are parallel.
+// React Query deduplicates by queryKey when multiple cells share an endpoint.
+// ---------------------------------------------------------------------------
+
+type KpiCellProps = {
+  kpi: KpiItem;
+  widgetId: string;
+  index: number;
+};
+
+const KpiCellWidget: React.FC<KpiCellProps> = ({kpi, widgetId, index}) => {
+  const field = kpi.field ?? 'page.totalItems';
+  const accent = kpi.accent ?? 'info';
+
+  const {data, status} = useQuery({
+    queryKey: [
+      'notebook-kpi',
+      widgetId,
+      index,
+      kpi.query.endpoint,
+      kpi.query.method,
+      kpi.query.body,
+    ],
+    queryFn: async () => {
+      const {response, error} = await requestWithThrow<Record<string, unknown>>(
+        {
+          url: kpi.query.endpoint,
+          method: kpi.query.method,
+          body: kpi.query.body,
+        },
+      );
+      if (error) {
+        throw error;
+      }
+      return response;
+    },
+  });
+
+  if (status === 'pending') {
+    return (
+      <KpiCell $accent={accent} data-testid="kpi-cell-loading">
+        <MetricCaption>{kpi.label}</MetricCaption>
+        <SkeletonText heading width="60px" />
+      </KpiCell>
+    );
+  }
+
+  if (status === 'error') {
+    return (
+      <KpiCell $accent={accent} data-testid="kpi-cell-error">
+        <MetricCaption>{kpi.label}</MetricCaption>
+        <MetricValue>—</MetricValue>
+      </KpiCell>
+    );
+  }
+
+  const rawValue = getByPath(data, field);
+  const displayValue =
+    typeof rawValue === 'number'
+      ? rawValue.toLocaleString()
+      : String(rawValue ?? '—');
+
+  return (
+    <KpiCell $accent={accent} data-testid="kpi-cell">
+      <MetricCaption>{kpi.label}</MetricCaption>
+      <MetricValue>{displayValue}</MetricValue>
+    </KpiCell>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// KpiWidget — the hero tile. One Tile, N cells in a CSS grid.
+// ---------------------------------------------------------------------------
+
+const KpiWidget: React.FC<Props> = ({config}) => {
+  const {title, subtitle, kpis = []} = config;
+
+  if (kpis.length === 0) {
+    return (
+      <Tile>
+        <WidgetTitle>{title}</WidgetTitle>
+        {subtitle && <WidgetSubtitle>{subtitle}</WidgetSubtitle>}
+        <p>No KPI items configured.</p>
+      </Tile>
+    );
+  }
+
+  return (
+    <Tile>
+      <WidgetTitle>{title}</WidgetTitle>
+      {subtitle && <WidgetSubtitle>{subtitle}</WidgetSubtitle>}
+      <KpiGrid data-testid="kpi-grid">
+        {kpis.map((kpi, i) => (
+          <KpiCellWidget
+            key={`${config.id}-kpi-${i}`}
+            kpi={kpi}
+            widgetId={config.id}
+            index={i}
+          />
+        ))}
+      </KpiGrid>
+    </Tile>
+  );
+};
+
+export {KpiWidget};

--- a/operate/client/src/App/Notebooks/widgets/MetricWidget.test.tsx
+++ b/operate/client/src/App/Notebooks/widgets/MetricWidget.test.tsx
@@ -1,0 +1,97 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import React from 'react';
+import {render, screen} from 'modules/testing-library';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {http, HttpResponse} from 'msw';
+import {mockServer} from 'modules/mock-server/node';
+import {MetricWidget} from './MetricWidget';
+import type {WidgetConfig} from '../types';
+
+type Props = {children?: React.ReactNode};
+
+const Wrapper = ({children}: Props) => (
+  <QueryClientProvider client={getMockQueryClient()}>
+    {children}
+  </QueryClientProvider>
+);
+
+const metricConfig: WidgetConfig = {
+  id: 'w-metric-test',
+  type: 'metric',
+  title: 'Running Instances',
+  query: {
+    endpoint: '/v2/process-instances/search',
+    method: 'POST',
+    body: {filter: {state: 'ACTIVE'}},
+  },
+  field: 'page.totalItems',
+};
+
+describe('<MetricWidget />', () => {
+  it('should render a loading skeleton while data is loading', async () => {
+    // given – server never resolves so we stay in loading state
+    mockServer.use(
+      http.post('/v2/process-instances/search', async () => {
+        // delay indefinitely for this test
+        await new Promise(() => {});
+        return HttpResponse.json({});
+      }),
+    );
+
+    // when
+    render(<MetricWidget config={metricConfig} />, {wrapper: Wrapper});
+
+    // then – a skeleton / loading indicator must be visible immediately
+    expect(
+      screen.getByRole('status', {hidden: true}) ??
+        screen.getByTestId('metric-skeleton'),
+    ).toBeInTheDocument();
+  });
+
+  it('should render the title and the value from response.page.totalItems by default', async () => {
+    // given
+    mockServer.use(
+      http.post(
+        '/v2/process-instances/search',
+        () =>
+          HttpResponse.json({
+            page: {totalItems: 42, firstSortValues: [], lastSortValues: []},
+            items: [],
+          }),
+        {once: true},
+      ),
+    );
+
+    // when
+    render(<MetricWidget config={metricConfig} />, {wrapper: Wrapper});
+
+    // then
+    expect(await screen.findByText('Running Instances')).toBeInTheDocument();
+    expect(await screen.findByText('42')).toBeInTheDocument();
+  });
+
+  it('should render an error state on fetch failure', async () => {
+    // given
+    mockServer.use(
+      http.post('/v2/process-instances/search', () => HttpResponse.error(), {
+        once: true,
+      }),
+    );
+
+    // when
+    render(<MetricWidget config={metricConfig} />, {wrapper: Wrapper});
+
+    // then
+    expect(
+      await screen.findByText(/error|failed|could not/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/operate/client/src/App/Notebooks/widgets/MetricWidget.tsx
+++ b/operate/client/src/App/Notebooks/widgets/MetricWidget.tsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import React from 'react';
+import {useQuery} from '@tanstack/react-query';
+import {Tile} from '@carbon/react';
+import {requestWithThrow} from 'modules/request';
+import type {WidgetConfig} from '../types';
+
+type Props = {
+  config: WidgetConfig;
+};
+
+function getByPath(obj: unknown, path: string): unknown {
+  return path
+    .split('.')
+    .reduce(
+      (acc, key) =>
+        acc != null && typeof acc === 'object'
+          ? (acc as Record<string, unknown>)[key]
+          : undefined,
+      obj,
+    );
+}
+
+const MetricWidget: React.FC<Props> = ({config}) => {
+  const {title, query, field = 'page.totalItems'} = config;
+
+  const {data, status} = useQuery({
+    queryKey: ['notebook-widget', config.id, query],
+    queryFn: async () => {
+      const {response, error} = await requestWithThrow<Record<string, unknown>>(
+        {
+          url: query.endpoint,
+          method: query.method,
+          body: query.body,
+        },
+      );
+      if (error) {
+        throw error;
+      }
+      return response;
+    },
+  });
+
+  if (status === 'pending') {
+    return (
+      <Tile>
+        <span role="status" data-testid="metric-skeleton">
+          Loading...
+        </span>
+      </Tile>
+    );
+  }
+
+  if (status === 'error') {
+    return (
+      <Tile>
+        <p>Could not load data for &quot;{title}&quot;.</p>
+      </Tile>
+    );
+  }
+
+  const value = getByPath(data, field);
+
+  return (
+    <Tile>
+      <p>{title}</p>
+      <p>{String(value ?? '')}</p>
+    </Tile>
+  );
+};
+
+export {MetricWidget};

--- a/operate/client/src/App/Notebooks/widgets/MetricWidget.tsx
+++ b/operate/client/src/App/Notebooks/widgets/MetricWidget.tsx
@@ -34,8 +34,55 @@ function getByPath(obj: unknown, path: string): unknown {
     );
 }
 
+function formatAgeFrom(value: unknown): string {
+  if (value == null) {
+    return '—';
+  }
+  const t = new Date(value as string).getTime();
+  if (isNaN(t)) {
+    return '—';
+  }
+  const ms = Math.max(0, Date.now() - t);
+  return formatDurationMs(ms);
+}
+
+function formatDurationMs(ms: number): string {
+  if (!isFinite(ms) || ms < 0) {
+    return '—';
+  }
+  const sec = Math.floor(ms / 1000);
+  const min = Math.floor(sec / 60);
+  const hr = Math.floor(min / 60);
+  const day = Math.floor(hr / 24);
+  if (day > 0) {
+    return `${day}d ${hr % 24}h`;
+  }
+  if (hr > 0) {
+    return `${hr}h ${min % 60}m`;
+  }
+  if (min > 0) {
+    return `${min}m`;
+  }
+  return `${sec}s`;
+}
+
+function formatPercent(value: unknown): string {
+  if (typeof value !== 'number' || !isFinite(value)) {
+    return '—';
+  }
+  const pct = value <= 1 ? value * 100 : value;
+  return `${pct.toFixed(pct >= 10 ? 0 : 1)}%`;
+}
+
 const MetricWidget: React.FC<Props> = ({config}) => {
-  const {title, query, field = 'page.totalItems', accent = 'info'} = config;
+  const {
+    title,
+    query,
+    field = 'page.totalItems',
+    accent = 'info',
+    metricFormat = 'count',
+    metricSubvalueField,
+  } = config;
 
   const {data, status} = useQuery({
     queryKey: ['notebook-widget', config.id, query],
@@ -76,15 +123,35 @@ const MetricWidget: React.FC<Props> = ({config}) => {
   }
 
   const rawValue = getByPath(data, field);
-  const numericValue =
-    typeof rawValue === 'number'
-      ? rawValue.toLocaleString()
-      : String(rawValue ?? '—');
+  let displayValue: string;
+  switch (metricFormat) {
+    case 'age-from':
+      displayValue = formatAgeFrom(rawValue);
+      break;
+    case 'duration-ms':
+      displayValue =
+        typeof rawValue === 'number' ? formatDurationMs(rawValue) : '—';
+      break;
+    case 'percent':
+      displayValue = formatPercent(rawValue);
+      break;
+    default:
+      displayValue =
+        typeof rawValue === 'number'
+          ? rawValue.toLocaleString()
+          : String(rawValue ?? '—');
+  }
+
+  const subvalueRaw =
+    metricSubvalueField != null ? getByPath(data, metricSubvalueField) : null;
+  const subvalue =
+    subvalueRaw != null && subvalueRaw !== '' ? String(subvalueRaw) : null;
 
   return (
     <MetricTile $accent={accent}>
       <MetricCaption>{title}</MetricCaption>
-      <MetricValue>{numericValue}</MetricValue>
+      <MetricValue>{displayValue}</MetricValue>
+      {subvalue != null && <MetricSubvalue>{subvalue}</MetricSubvalue>}
     </MetricTile>
   );
 };

--- a/operate/client/src/App/Notebooks/widgets/MetricWidget.tsx
+++ b/operate/client/src/App/Notebooks/widgets/MetricWidget.tsx
@@ -8,9 +8,15 @@
 
 import React from 'react';
 import {useQuery} from '@tanstack/react-query';
-import {Tile} from '@carbon/react';
+import {SkeletonText} from '@carbon/react';
 import {requestWithThrow} from 'modules/request';
 import type {WidgetConfig} from '../types';
+import {
+  MetricTile,
+  MetricCaption,
+  MetricValue,
+  MetricSubvalue,
+} from '../styled';
 
 type Props = {
   config: WidgetConfig;
@@ -29,7 +35,7 @@ function getByPath(obj: unknown, path: string): unknown {
 }
 
 const MetricWidget: React.FC<Props> = ({config}) => {
-  const {title, query, field = 'page.totalItems'} = config;
+  const {title, query, field = 'page.totalItems', accent = 'info'} = config;
 
   const {data, status} = useQuery({
     queryKey: ['notebook-widget', config.id, query],
@@ -50,29 +56,36 @@ const MetricWidget: React.FC<Props> = ({config}) => {
 
   if (status === 'pending') {
     return (
-      <Tile>
+      <MetricTile $accent={accent}>
+        <MetricCaption>{title}</MetricCaption>
         <span role="status" data-testid="metric-skeleton">
-          Loading...
+          <SkeletonText heading width="80px" />
         </span>
-      </Tile>
+      </MetricTile>
     );
   }
 
   if (status === 'error') {
     return (
-      <Tile>
-        <p>Could not load data for &quot;{title}&quot;.</p>
-      </Tile>
+      <MetricTile $accent={accent}>
+        <MetricCaption>{title}</MetricCaption>
+        <MetricValue>—</MetricValue>
+        <MetricSubvalue>Could not load data</MetricSubvalue>
+      </MetricTile>
     );
   }
 
-  const value = getByPath(data, field);
+  const rawValue = getByPath(data, field);
+  const numericValue =
+    typeof rawValue === 'number'
+      ? rawValue.toLocaleString()
+      : String(rawValue ?? '—');
 
   return (
-    <Tile>
-      <p>{title}</p>
-      <p>{String(value ?? '')}</p>
-    </Tile>
+    <MetricTile $accent={accent}>
+      <MetricCaption>{title}</MetricCaption>
+      <MetricValue>{numericValue}</MetricValue>
+    </MetricTile>
   );
 };
 

--- a/operate/client/src/App/Notebooks/widgets/Sparkline.tsx
+++ b/operate/client/src/App/Notebooks/widgets/Sparkline.tsx
@@ -1,0 +1,81 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import React from 'react';
+
+const ACCENT_COLORS: Record<string, string> = {
+  info: 'var(--cds-support-info)',
+  success: 'var(--cds-support-success)',
+  warning: 'var(--cds-support-warning)',
+  error: 'var(--cds-support-error)',
+};
+
+type Props = {
+  points: number[];
+  color?: string;
+  width?: number;
+  height?: number;
+};
+
+/**
+ * Hand-rolled inline SVG sparkline. Renders a polyline connecting the given
+ * numeric data points, scaled to fit the requested dimensions. A small filled
+ * circle marks the last (most recent) point.
+ */
+const Sparkline: React.FC<Props> = ({
+  points,
+  color = 'info',
+  width = 120,
+  height = 32,
+}) => {
+  if (points.length < 2) {
+    return null;
+  }
+
+  const strokeColor = ACCENT_COLORS[color] ?? color;
+  const padV = 3;
+
+  const minVal = Math.min(...points);
+  const maxVal = Math.max(...points);
+  const range = maxVal - minVal || 1;
+
+  // Map data index to SVG x-coordinate
+  const xScale = (i: number) => (i / (points.length - 1)) * width;
+  // Map value to SVG y-coordinate (invert: higher value = lower y)
+  const yScale = (v: number) =>
+    height - padV - ((v - minVal) / range) * (height - padV * 2);
+
+  const polylinePoints = points
+    .map((v, i) => `${xScale(i).toFixed(1)},${yScale(v).toFixed(1)}`)
+    .join(' ');
+
+  const lastX = xScale(points.length - 1);
+  const lastY = yScale(points[points.length - 1] as number);
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      aria-hidden="true"
+      style={{display: 'block', overflow: 'visible'}}
+    >
+      <polyline
+        points={polylinePoints}
+        fill="none"
+        stroke={strokeColor}
+        strokeWidth="1.5"
+        strokeLinejoin="round"
+        strokeLinecap="round"
+      />
+      <circle cx={lastX} cy={lastY} r={3} fill={strokeColor} />
+    </svg>
+  );
+};
+
+export {Sparkline};

--- a/operate/client/src/App/Notebooks/widgets/StatusGridWidget.tsx
+++ b/operate/client/src/App/Notebooks/widgets/StatusGridWidget.tsx
@@ -1,0 +1,168 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import React from 'react';
+import {useQuery} from '@tanstack/react-query';
+import {Tile} from '@carbon/react';
+import {requestWithThrow} from 'modules/request';
+import type {WidgetConfig} from '../types';
+import {
+  WidgetTitle,
+  WidgetSubtitle,
+  EmptyState,
+  StatusGridContainer,
+  StatusTile,
+  StatusTileName,
+  StatusTileVersion,
+  StatusTileCount,
+  StatusTileSkeleton,
+} from '../styled';
+
+type Props = {
+  config: WidgetConfig;
+};
+
+type ProcessDef = {
+  processDefinitionKey: string;
+  processDefinitionId: string;
+  name?: string;
+  version?: number;
+};
+
+type Incident = {
+  processDefinitionKey?: string;
+  processDefinitionId?: string;
+};
+
+function incidentStatus(count: number): 'healthy' | 'warning' | 'critical' {
+  if (count === 0) {
+    return 'healthy';
+  }
+  if (count <= 5) {
+    return 'warning';
+  }
+  return 'critical';
+}
+
+const StatusGridWidget: React.FC<Props> = ({config}) => {
+  const {title, subtitle} = config;
+
+  const {data: defsData, status: defsStatus} = useQuery({
+    queryKey: ['notebook-status-grid-defs', config.id],
+    queryFn: async () => {
+      const {response, error} = await requestWithThrow<{
+        items: ProcessDef[];
+      }>({
+        url: '/v2/process-definitions/search',
+        method: 'POST',
+        body: {page: {limit: 100}},
+      });
+      if (error) {
+        throw error;
+      }
+      return response;
+    },
+  });
+
+  const {data: incidentsData} = useQuery({
+    queryKey: ['notebook-status-grid-incidents', config.id],
+    queryFn: async () => {
+      const {response, error} = await requestWithThrow<{
+        items: Incident[];
+      }>({
+        url: '/v2/incidents/search',
+        method: 'POST',
+        body: {filter: {state: 'ACTIVE'}, page: {limit: 1000}},
+      });
+      if (error) {
+        throw error;
+      }
+      return response;
+    },
+  });
+
+  if (defsStatus === 'pending') {
+    return (
+      <Tile>
+        <WidgetTitle>{title}</WidgetTitle>
+        {subtitle && <WidgetSubtitle>{subtitle}</WidgetSubtitle>}
+        <StatusGridContainer data-testid="status-grid-loading">
+          {Array.from({length: 6}).map((_, i) => (
+            <StatusTileSkeleton key={i} />
+          ))}
+        </StatusGridContainer>
+      </Tile>
+    );
+  }
+
+  if (defsStatus === 'error') {
+    return (
+      <Tile>
+        <WidgetTitle>{title}</WidgetTitle>
+        {subtitle && <WidgetSubtitle>{subtitle}</WidgetSubtitle>}
+        <EmptyState data-testid="status-grid-error">
+          Could not load process health.
+        </EmptyState>
+      </Tile>
+    );
+  }
+
+  const defs = defsData?.items ?? [];
+
+  if (defs.length === 0) {
+    return (
+      <Tile>
+        <WidgetTitle>{title}</WidgetTitle>
+        {subtitle && <WidgetSubtitle>{subtitle}</WidgetSubtitle>}
+        <EmptyState data-testid="status-grid-empty">
+          No deployed processes.
+        </EmptyState>
+      </Tile>
+    );
+  }
+
+  // Build incident count map keyed by processDefinitionKey
+  const incidentsByKey = new Map<string, number>();
+  for (const inc of incidentsData?.items ?? []) {
+    const key = inc.processDefinitionKey ?? inc.processDefinitionId ?? '';
+    if (key) {
+      incidentsByKey.set(key, (incidentsByKey.get(key) ?? 0) + 1);
+    }
+  }
+
+  return (
+    <Tile>
+      <WidgetTitle>{title}</WidgetTitle>
+      {subtitle && <WidgetSubtitle>{subtitle}</WidgetSubtitle>}
+      <StatusGridContainer data-testid="status-grid">
+        {defs.map((def) => {
+          const count = incidentsByKey.get(def.processDefinitionKey) ?? 0;
+          const status = incidentStatus(count);
+          const displayName =
+            def.name ?? def.processDefinitionId ?? def.processDefinitionKey;
+
+          return (
+            <StatusTile
+              key={def.processDefinitionKey}
+              $status={status}
+              data-testid="status-tile"
+            >
+              <StatusTileName title={displayName}>{displayName}</StatusTileName>
+              <StatusTileVersion>v{def.version ?? 1}</StatusTileVersion>
+              <StatusTileCount $status={status}>
+                {count} incident{count !== 1 ? 's' : ''}
+              </StatusTileCount>
+            </StatusTile>
+          );
+        })}
+      </StatusGridContainer>
+    </Tile>
+  );
+};
+
+export {StatusGridWidget};

--- a/operate/client/src/App/Notebooks/widgets/TableWidget.test.tsx
+++ b/operate/client/src/App/Notebooks/widgets/TableWidget.test.tsx
@@ -1,0 +1,110 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import React from 'react';
+import {render, screen} from 'modules/testing-library';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {http, HttpResponse} from 'msw';
+import {mockServer} from 'modules/mock-server/node';
+import {TableWidget} from './TableWidget';
+import type {WidgetConfig} from '../types';
+
+type Props = {children?: React.ReactNode};
+
+const Wrapper = ({children}: Props) => (
+  <QueryClientProvider client={getMockQueryClient()}>
+    {children}
+  </QueryClientProvider>
+);
+
+const tableConfig: WidgetConfig = {
+  id: 'w-table-test',
+  type: 'table',
+  title: 'Process Instances',
+  query: {
+    endpoint: '/v2/process-instances/search',
+    method: 'POST',
+    body: {},
+  },
+  columns: ['id', 'state', 'processDefinitionId'],
+};
+
+describe('<TableWidget />', () => {
+  it('should render a DataTable with the configured columns', async () => {
+    // given
+    mockServer.use(
+      http.post(
+        '/v2/process-instances/search',
+        () =>
+          HttpResponse.json({
+            page: {totalItems: 2},
+            items: [
+              {id: 'pi-1', state: 'ACTIVE', processDefinitionId: 'proc-a'},
+              {id: 'pi-2', state: 'COMPLETED', processDefinitionId: 'proc-b'},
+            ],
+          }),
+        {once: true},
+      ),
+    );
+
+    // when
+    render(<TableWidget config={tableConfig} />, {wrapper: Wrapper});
+
+    // then – column headers derived from the columns config
+    expect(await screen.findByText('id')).toBeInTheDocument();
+    expect(await screen.findByText('state')).toBeInTheDocument();
+    expect(await screen.findByText('processDefinitionId')).toBeInTheDocument();
+
+    // and data rows
+    expect(await screen.findByText('pi-1')).toBeInTheDocument();
+    expect(await screen.findByText('ACTIVE')).toBeInTheDocument();
+  });
+
+  it('should render a loading skeleton while data is loading', async () => {
+    // given – server never responds
+    mockServer.use(
+      http.post('/v2/process-instances/search', async () => {
+        await new Promise(() => {});
+        return HttpResponse.json({});
+      }),
+    );
+
+    // when
+    render(<TableWidget config={tableConfig} />, {wrapper: Wrapper});
+
+    // then
+    expect(
+      screen.getByRole('status', {hidden: true}) ??
+        screen.getByTestId('table-skeleton'),
+    ).toBeInTheDocument();
+  });
+
+  it('should render an empty state when items array is empty', async () => {
+    // given
+    mockServer.use(
+      http.post(
+        '/v2/process-instances/search',
+        () =>
+          HttpResponse.json({
+            page: {totalItems: 0},
+            items: [],
+          }),
+        {once: true},
+      ),
+    );
+
+    // when
+    render(<TableWidget config={tableConfig} />, {wrapper: Wrapper});
+
+    // then
+    expect(
+      await screen.findByText(/no data|no results|empty|no items/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/operate/client/src/App/Notebooks/widgets/TableWidget.tsx
+++ b/operate/client/src/App/Notebooks/widgets/TableWidget.tsx
@@ -12,6 +12,7 @@ import {DataTableSkeleton, Tile} from '@carbon/react';
 import {requestWithThrow} from 'modules/request';
 import type {WidgetConfig} from '../types';
 import {WidgetTitle, WidgetSubtitle, WidgetTable, EmptyState} from '../styled';
+import {columnLabel, renderCellValue} from './tableCells';
 
 type Props = {
   config: WidgetConfig;
@@ -90,7 +91,7 @@ const TableWidget: React.FC<Props> = ({config}) => {
         <thead>
           <tr>
             {columns.map((col) => (
-              <th key={col}>{col}</th>
+              <th key={col}>{columnLabel(col)}</th>
             ))}
           </tr>
         </thead>
@@ -98,7 +99,7 @@ const TableWidget: React.FC<Props> = ({config}) => {
           {visibleItems.map((item, rowIndex) => (
             <tr key={String(item['id'] ?? rowIndex)}>
               {columns.map((col) => (
-                <td key={col}>{String(item[col] ?? '')}</td>
+                <td key={col}>{renderCellValue(col, item[col], item)}</td>
               ))}
             </tr>
           ))}

--- a/operate/client/src/App/Notebooks/widgets/TableWidget.tsx
+++ b/operate/client/src/App/Notebooks/widgets/TableWidget.tsx
@@ -1,0 +1,102 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import React from 'react';
+import {useQuery} from '@tanstack/react-query';
+import {DataTableSkeleton, Tile} from '@carbon/react';
+import {requestWithThrow} from 'modules/request';
+import type {WidgetConfig} from '../types';
+import {WidgetTitle, WidgetTable, EmptyState} from '../styled';
+
+type Props = {
+  config: WidgetConfig;
+};
+
+type ApiResponse = {
+  items: Record<string, unknown>[];
+  page?: {totalItems: number};
+};
+
+const TableWidget: React.FC<Props> = ({config}) => {
+  const {title, query, columns = []} = config;
+
+  const {data, status} = useQuery({
+    queryKey: ['notebook-widget', config.id, query],
+    queryFn: async () => {
+      const {response, error} = await requestWithThrow<ApiResponse>({
+        url: query.endpoint,
+        method: query.method,
+        body: query.body,
+      });
+      if (error) {
+        throw error;
+      }
+      return response;
+    },
+  });
+
+  if (status === 'pending') {
+    return (
+      <Tile>
+        <WidgetTitle>{title}</WidgetTitle>
+        <DataTableSkeleton
+          role="status"
+          data-testid="table-skeleton"
+          columnCount={columns.length || 3}
+          rowCount={5}
+        />
+      </Tile>
+    );
+  }
+
+  if (status === 'error') {
+    return (
+      <Tile>
+        <WidgetTitle>{title}</WidgetTitle>
+        <EmptyState>Could not load data.</EmptyState>
+      </Tile>
+    );
+  }
+
+  const items = data?.items ?? [];
+
+  if (items.length === 0) {
+    return (
+      <Tile>
+        <WidgetTitle>{title}</WidgetTitle>
+        <EmptyState>No data available.</EmptyState>
+      </Tile>
+    );
+  }
+
+  return (
+    <Tile>
+      <WidgetTitle>{title}</WidgetTitle>
+      <WidgetTable>
+        <thead>
+          <tr>
+            {columns.map((col) => (
+              <th key={col}>{col}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((item, rowIndex) => (
+            <tr key={String(item['id'] ?? rowIndex)}>
+              {columns.map((col) => (
+                <td key={col}>{String(item[col] ?? '')}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </WidgetTable>
+    </Tile>
+  );
+};
+
+export {TableWidget};

--- a/operate/client/src/App/Notebooks/widgets/TableWidget.tsx
+++ b/operate/client/src/App/Notebooks/widgets/TableWidget.tsx
@@ -11,7 +11,7 @@ import {useQuery} from '@tanstack/react-query';
 import {DataTableSkeleton, Tile} from '@carbon/react';
 import {requestWithThrow} from 'modules/request';
 import type {WidgetConfig} from '../types';
-import {WidgetTitle, WidgetTable, EmptyState} from '../styled';
+import {WidgetTitle, WidgetSubtitle, WidgetTable, EmptyState} from '../styled';
 
 type Props = {
   config: WidgetConfig;
@@ -23,7 +23,7 @@ type ApiResponse = {
 };
 
 const TableWidget: React.FC<Props> = ({config}) => {
-  const {title, query, columns = []} = config;
+  const {title, subtitle, query, columns = []} = config;
 
   const {data, status} = useQuery({
     queryKey: ['notebook-widget', config.id, query],
@@ -44,6 +44,7 @@ const TableWidget: React.FC<Props> = ({config}) => {
     return (
       <Tile>
         <WidgetTitle>{title}</WidgetTitle>
+        {subtitle && <WidgetSubtitle>{subtitle}</WidgetSubtitle>}
         <DataTableSkeleton
           role="status"
           data-testid="table-skeleton"
@@ -58,25 +59,33 @@ const TableWidget: React.FC<Props> = ({config}) => {
     return (
       <Tile>
         <WidgetTitle>{title}</WidgetTitle>
+        {subtitle && <WidgetSubtitle>{subtitle}</WidgetSubtitle>}
         <EmptyState>Could not load data.</EmptyState>
       </Tile>
     );
   }
 
   const items = data?.items ?? [];
+  const totalItems = data?.page?.totalItems ?? items.length;
 
   if (items.length === 0) {
     return (
       <Tile>
         <WidgetTitle>{title}</WidgetTitle>
+        {subtitle && <WidgetSubtitle>{subtitle}</WidgetSubtitle>}
         <EmptyState>No data available.</EmptyState>
       </Tile>
     );
   }
 
+  const MAX_ROWS = 15;
+  const visibleItems = items.slice(0, MAX_ROWS);
+  const truncated = items.length > MAX_ROWS;
+
   return (
     <Tile>
       <WidgetTitle>{title}</WidgetTitle>
+      {subtitle && <WidgetSubtitle>{subtitle}</WidgetSubtitle>}
       <WidgetTable>
         <thead>
           <tr>
@@ -86,7 +95,7 @@ const TableWidget: React.FC<Props> = ({config}) => {
           </tr>
         </thead>
         <tbody>
-          {items.map((item, rowIndex) => (
+          {visibleItems.map((item, rowIndex) => (
             <tr key={String(item['id'] ?? rowIndex)}>
               {columns.map((col) => (
                 <td key={col}>{String(item[col] ?? '')}</td>
@@ -95,6 +104,12 @@ const TableWidget: React.FC<Props> = ({config}) => {
           ))}
         </tbody>
       </WidgetTable>
+      {(truncated || items.length < totalItems) && (
+        <EmptyState style={{marginTop: 'var(--cds-spacing-04)'}}>
+          Showing first {visibleItems.length} of {totalItems.toLocaleString()}{' '}
+          rows.
+        </EmptyState>
+      )}
     </Tile>
   );
 };

--- a/operate/client/src/App/Notebooks/widgets/TextWidget.tsx
+++ b/operate/client/src/App/Notebooks/widgets/TextWidget.tsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+import type {WidgetConfig} from '../types';
+import {TextWidgetContainer} from '../styled';
+
+type Props = {
+  config: WidgetConfig;
+};
+
+/**
+ * A simple LLM-authored narrative cell. Renders markdown so the LLM can
+ * write headers, bold, italics, lists — perfect for setting context above
+ * a cluster of data widgets ("Three things you should know this morning…").
+ *
+ * Has no data fetching; query/columns/etc. on the config are ignored.
+ */
+const TextWidget: React.FC<Props> = ({config}) => {
+  const text = config.text ?? config.description ?? '';
+  return (
+    <TextWidgetContainer>
+      <ReactMarkdown>{text}</ReactMarkdown>
+    </TextWidgetContainer>
+  );
+};
+
+export {TextWidget};

--- a/operate/client/src/App/Notebooks/widgets/TrendWidget.test.tsx
+++ b/operate/client/src/App/Notebooks/widgets/TrendWidget.test.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import React from 'react';
+import {render, screen} from 'modules/testing-library';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {http, HttpResponse} from 'msw';
+import {mockServer} from 'modules/mock-server/node';
+import {TrendWidget} from './TrendWidget';
+import type {WidgetConfig} from '../types';
+
+type Props = {children?: React.ReactNode};
+
+const Wrapper = ({children}: Props) => (
+  <QueryClientProvider client={getMockQueryClient()}>
+    {children}
+  </QueryClientProvider>
+);
+
+const trendConfig: WidgetConfig = {
+  id: 'w-trend-test',
+  type: 'trend',
+  title: 'New instances · last 7 days',
+  query: {
+    endpoint: '/v2/process-instances/search',
+    method: 'POST',
+    body: {page: {limit: 1}},
+  },
+  trendDateField: 'startDate',
+  trendBuckets: 7,
+  trendBucketSpan: '24h',
+  trendAccent: 'info',
+};
+
+describe('<TrendWidget />', () => {
+  it('should render the widget title', async () => {
+    // given
+    mockServer.use(
+      http.post('/v2/process-instances/search', () =>
+        HttpResponse.json({
+          page: {totalItems: 5, firstSortValues: [], lastSortValues: []},
+          items: [],
+        }),
+      ),
+    );
+
+    // when
+    render(<TrendWidget config={trendConfig} />, {wrapper: Wrapper});
+
+    // then
+    expect(
+      await screen.findByText('New instances · last 7 days'),
+    ).toBeInTheDocument();
+  });
+
+  it('should render the title-as-caption and show a loading skeleton initially', () => {
+    // given — respond with data immediately so queries complete quickly
+    mockServer.use(
+      http.post('/v2/process-instances/search', () =>
+        HttpResponse.json({
+          page: {totalItems: 3, firstSortValues: [], lastSortValues: []},
+          items: [],
+        }),
+      ),
+    );
+
+    // when — render synchronously; before promises settle, the metric tile
+    // shows its caption and a SkeletonText placeholder for the value.
+    render(<TrendWidget config={trendConfig} />, {wrapper: Wrapper});
+
+    // then — caption is rendered (the title or subtitle as MetricCaption)
+    expect(
+      screen.getByText(trendConfig.subtitle ?? trendConfig.title),
+    ).toBeInTheDocument();
+  });
+});

--- a/operate/client/src/App/Notebooks/widgets/TrendWidget.tsx
+++ b/operate/client/src/App/Notebooks/widgets/TrendWidget.tsx
@@ -1,0 +1,281 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import React from 'react';
+import {useQuery} from '@tanstack/react-query';
+import {SkeletonText} from '@carbon/react';
+import {requestWithThrow} from 'modules/request';
+import type {WidgetConfig} from '../types';
+import {
+  MetricTile,
+  MetricCaption,
+  MetricValue,
+  TrendSparklineArea,
+} from '../styled';
+import {Sparkline} from './Sparkline';
+
+// ---------------------------------------------------------------------------
+// Time bucket helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a bucket span string like '1h', '6h', '24h', '7d' into milliseconds.
+ * Falls back to 86_400_000 (24h) for unrecognised strings.
+ */
+function parseBucketSpanMs(span: string): number {
+  const match = /^(\d+)(h|d)$/.exec(span.toLowerCase());
+  if (!match) {
+    return 86_400_000;
+  }
+  const value = parseInt(match[1] as string, 10);
+  const unit = match[2];
+  if (unit === 'h') {
+    return value * 3_600_000;
+  }
+  if (unit === 'd') {
+    return value * 86_400_000;
+  }
+  return 86_400_000;
+}
+
+type TimeWindow = {start: Date; end: Date};
+
+/**
+ * Generate `count` non-overlapping time windows of `spanMs` ending at `now`.
+ * Returns them in chronological order (oldest first, most recent last).
+ */
+function buildTimeWindows(
+  count: number,
+  spanMs: number,
+  now: Date,
+): TimeWindow[] {
+  const windows: TimeWindow[] = [];
+  const nowMs = now.getTime();
+  for (let i = count - 1; i >= 0; i--) {
+    const endMs = nowMs - i * spanMs;
+    const startMs = endMs - spanMs;
+    windows.push({start: new Date(startMs), end: new Date(endMs)});
+  }
+  return windows;
+}
+
+// ---------------------------------------------------------------------------
+// Single-bucket query component
+// ---------------------------------------------------------------------------
+
+type BucketQueryProps = {
+  widgetId: string;
+  bucketIndex: number;
+  endpoint: string;
+  method: 'GET' | 'POST';
+  baseBody: unknown;
+  dateField: string;
+  window: TimeWindow;
+};
+
+type BucketResult = {
+  count: number | null;
+  isLoading: boolean;
+  isError: boolean;
+};
+
+function useBucketQuery({
+  widgetId,
+  bucketIndex,
+  endpoint,
+  method,
+  baseBody,
+  dateField,
+  window,
+}: BucketQueryProps): BucketResult {
+  const isoStart = window.start.toISOString();
+  const isoEnd = window.end.toISOString();
+
+  // Merge the date-range filter into the base body using the V2 Mongo-style
+  // operator format confirmed in the API type definitions:
+  //   startDate: {$gte: isoStart, $lt: isoEnd}
+  const body = React.useMemo(
+    () => ({
+      ...(baseBody != null && typeof baseBody === 'object' ? baseBody : {}),
+      filter: {
+        ...((baseBody as {filter?: Record<string, unknown>} | null)?.filter ??
+          {}),
+        [dateField]: {$gte: isoStart, $lt: isoEnd},
+      },
+    }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [isoStart, isoEnd, dateField, JSON.stringify(baseBody)],
+  );
+
+  const {data, status} = useQuery({
+    queryKey: [
+      'notebook-trend-bucket',
+      widgetId,
+      bucketIndex,
+      endpoint,
+      method,
+      dateField,
+      isoStart,
+      isoEnd,
+      body,
+    ],
+    queryFn: async () => {
+      const {response, error} = await requestWithThrow<Record<string, unknown>>(
+        {
+          url: endpoint,
+          method,
+          body,
+        },
+      );
+      if (error) {
+        throw error;
+      }
+      return response;
+    },
+  });
+
+  if (status === 'pending') {
+    return {count: null, isLoading: true, isError: false};
+  }
+  if (status === 'error') {
+    return {count: null, isLoading: false, isError: true};
+  }
+
+  // Navigate page.totalItems
+  const pageData = data?.['page'] as Record<string, unknown> | undefined;
+  const totalItems = pageData?.['totalItems'];
+  const count = typeof totalItems === 'number' ? totalItems : null;
+  return {count, isLoading: false, isError: false};
+}
+
+// ---------------------------------------------------------------------------
+// TrendWidget — the hero component
+// ---------------------------------------------------------------------------
+
+type Props = {
+  config: WidgetConfig;
+};
+
+/**
+ * BucketQueryRunner is a helper that calls useBucketQuery (a hook) per bucket
+ * and surfaces the result via a render-prop callback. This preserves the
+ * Rules of Hooks (hooks can only be called at the top level of a component)
+ * by putting each bucket query inside its own component instance.
+ */
+type BucketQueryRunnerProps = BucketQueryProps & {
+  onResult: (index: number, result: BucketResult) => void;
+};
+
+const BucketQueryRunner: React.FC<BucketQueryRunnerProps> = ({
+  onResult,
+  ...props
+}) => {
+  const result = useBucketQuery(props);
+  const {bucketIndex} = props;
+  const {count, isLoading, isError} = result;
+  React.useEffect(() => {
+    onResult(bucketIndex, {count, isLoading, isError});
+  }, [bucketIndex, count, isLoading, isError, onResult]);
+  return null;
+};
+
+/**
+ * TrendWidget fires N parallel queries (one per time bucket) and renders the
+ * per-bucket counts as a Sparkline. Date-range filters use the V2 Mongo-style
+ * operator format: `{[dateField]: {$gte: isoStart, $lt: isoEnd}}`.
+ */
+const TrendWidget: React.FC<Props> = ({config}) => {
+  const {
+    title,
+    subtitle,
+    query,
+    trendDateField = 'startDate',
+    trendBuckets = 7,
+    trendBucketSpan = '24h',
+    trendAccent = 'info',
+  } = config;
+
+  const spanMs = parseBucketSpanMs(trendBucketSpan);
+  const now = React.useMemo(() => new Date(), []);
+  const windows = React.useMemo(
+    () => buildTimeWindows(trendBuckets, spanMs, now),
+    [trendBuckets, spanMs, now],
+  );
+
+  // Bucket results indexed by bucket position
+  const [results, setResults] = React.useState<BucketResult[]>(() =>
+    windows.map(() => ({count: null, isLoading: true, isError: false})),
+  );
+
+  const handleResult = React.useCallback(
+    (index: number, result: BucketResult) => {
+      setResults((prev) => {
+        const next = [...prev];
+        next[index] = result;
+        return next;
+      });
+    },
+    [],
+  );
+
+  const anyLoading = results.some((r) => r.isLoading);
+  const allError = results.every((r) => r.isError);
+
+  // Build sparkline points — use 0 for buckets that errored (partial tolerance)
+  const points = results.map((r) => (r.count != null ? r.count : 0));
+
+  const lastCount = results[results.length - 1]?.count;
+
+  // Sized identically to a metric tile: caption + value + small sparkline.
+  // 3 children inside MetricTile's flex column — adds up to ~110px content,
+  // floors to MetricTile's min-height of 132px exactly. Drops the prior
+  // "Last 7 days · ending …" footer to keep the tile's natural height in
+  // sync with sibling metric tiles in the same row.
+  return (
+    <MetricTile $accent={trendAccent}>
+      {/* Render one hidden query runner per bucket — each calls its own useQuery */}
+      {windows.map((win, i) => (
+        <BucketQueryRunner
+          key={`${config.id}-bucket-${i}`}
+          widgetId={config.id}
+          bucketIndex={i}
+          endpoint={query.endpoint}
+          method={query.method}
+          baseBody={query.body}
+          dateField={trendDateField}
+          window={win}
+          onResult={handleResult}
+        />
+      ))}
+
+      <MetricCaption>{subtitle ?? title}</MetricCaption>
+
+      {anyLoading && <SkeletonText heading width="80px" />}
+
+      {!anyLoading && allError && <MetricValue>—</MetricValue>}
+
+      {!anyLoading && !allError && (
+        <>
+          <MetricValue>
+            {lastCount != null ? lastCount.toLocaleString() : '—'}
+          </MetricValue>
+          <TrendSparklineArea>
+            <Sparkline
+              points={points}
+              color={trendAccent}
+              width={180}
+              height={24}
+            />
+          </TrendSparklineArea>
+        </>
+      )}
+    </MetricTile>
+  );
+};
+
+export {TrendWidget};

--- a/operate/client/src/App/Notebooks/widgets/chartOptions.ts
+++ b/operate/client/src/App/Notebooks/widgets/chartOptions.ts
@@ -157,12 +157,17 @@ function donutOptions(groupBy: string, height: string, total?: number) {
     height,
     resizable: true,
     donut: {
+      // Carbon Charts anchors the disk to the left of the SVG by default;
+      // explicit 'center' alignment positions it in the middle of the tile.
+      alignment: 'center' as const,
       center:
         total != null
           ? {number: total, label: toTitleCase(groupBy)}
           : {label: toTitleCase(groupBy)},
     },
-    legend: {position: 'right' as const},
+    // 'bottom' uses tile width better and avoids the legend being clipped
+    // against the right edge when group labels are long.
+    legend: {position: 'bottom' as const},
     color: {scale: SEMANTIC_COLOR_SCALE, pairing: {option: 2}},
   };
 }

--- a/operate/client/src/App/Notebooks/widgets/chartOptions.ts
+++ b/operate/client/src/App/Notebooks/widgets/chartOptions.ts
@@ -1,0 +1,179 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+/**
+ * Shared chart colors, option factories, and constants used by both
+ * ChartWidget. Extracted into a separate file so
+ * ChartWidget.tsx only exports React components (required by react-refresh).
+ */
+
+// ---------------------------------------------------------------------------
+// Color constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Semantic color scale for known group values. Carbon Charts uses this to
+ * look up a group label and return the mapped color. Unknown groups fall back
+ * to the harmonious palette below.
+ */
+const SEMANTIC_COLOR_SCALE: Record<string, string> = {
+  // State values
+  INCIDENT: '#da1e28',
+  ERROR: '#da1e28',
+  ACTIVE: '#0f62fe',
+  COMPLETED: '#24a148',
+  CANCELED: '#8d8d8d',
+  // Error type values — red family so incident charts read as semantically
+  // incident-related rather than a random rainbow.
+  IO_MAPPING_ERROR: '#da1e28',
+  JOB_NO_RETRIES: '#a2191f',
+  CALLED_ELEMENT_ERROR: '#b81921',
+  EXTRACT_VALUE_ERROR: '#ff8389',
+  CONDITION_ERROR: '#fa4d56',
+  UNHANDLED_ERROR_EVENT: '#c62828',
+  MESSAGE_SIZE_EXCEEDED: '#e53935',
+  EXECUTION_LISTENER_NO_RETRIES: '#ff6f6b',
+};
+
+/**
+ * Carbon-aligned categorical palette used as the default when a group is not
+ * in the semantic map. Six colors drawn from Carbon's data visualization
+ * palette — harmonious, readable on both light and dark backgrounds.
+ */
+const HARMONIOUS_PALETTE = [
+  '#0f62fe', // blue-60
+  '#6929c4', // purple-70
+  '#009d9a', // teal-50
+  '#198038', // green-60
+  '#ee538b', // magenta-50
+  '#b28600', // yellow-50
+];
+
+// ---------------------------------------------------------------------------
+// Common options base
+// ---------------------------------------------------------------------------
+
+const COMMON_CHART_OPTIONS = {
+  animations: true,
+  toolbar: {enabled: false},
+} as const;
+
+// ---------------------------------------------------------------------------
+// Chart height — sized so the surrounding Tile (with title + Tile padding)
+// lands at the TALL tier (296px). 240px chart + ~56px chrome = 296px.
+// ---------------------------------------------------------------------------
+
+const CHART_HEIGHT = '240px';
+
+// ---------------------------------------------------------------------------
+// Title case helper
+// ---------------------------------------------------------------------------
+
+/** Convert a camelCase/snake_case/UPPER_CASE field name to Title Case. */
+function toTitleCase(str: string): string {
+  return str
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .replace(/[_-]/g, ' ')
+    .replace(
+      /\w\S*/g,
+      (w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase(),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Chart options factories
+// ---------------------------------------------------------------------------
+
+// Carbon Charts renders its own title; we already render WidgetTitle at the
+// top of the Tile, so pass an empty string to avoid duplication.
+function barOptions(groupBy: string, height: string) {
+  return {
+    ...COMMON_CHART_OPTIONS,
+    title: '',
+    height,
+    axes: {
+      left: {mapsTo: 'value'},
+      bottom: {
+        mapsTo: 'group',
+        scaleType: 'labels' as const,
+        title: groupBy,
+      },
+    },
+    legend: {enabled: false},
+    grid: {x: {enabled: false}},
+    color: {scale: SEMANTIC_COLOR_SCALE, pairing: {option: 2}},
+  };
+}
+
+function lineOptions(groupBy: string, height: string) {
+  return {
+    ...COMMON_CHART_OPTIONS,
+    title: '',
+    height,
+    axes: {
+      left: {mapsTo: 'value'},
+      bottom: {
+        mapsTo: 'group',
+        scaleType: 'labels' as const,
+        title: groupBy,
+      },
+    },
+    legend: {enabled: false},
+    points: {enabled: true, radius: 4},
+    color: {scale: SEMANTIC_COLOR_SCALE, pairing: {option: 2}},
+  };
+}
+
+function stackedBarOptions(groupBy: string, height: string) {
+  return {
+    ...COMMON_CHART_OPTIONS,
+    title: '',
+    height,
+    axes: {
+      left: {mapsTo: 'value', stacked: true},
+      bottom: {
+        mapsTo: 'group',
+        scaleType: 'labels' as const,
+        title: groupBy,
+      },
+    },
+    legend: {enabled: true},
+    grid: {x: {enabled: false}},
+    color: {scale: SEMANTIC_COLOR_SCALE, pairing: {option: 2}},
+    // Carbon Charts stacked bar uses 'key' as the stack dimension label
+    data: {groupMapsTo: 'key'},
+  } as const;
+}
+
+function donutOptions(groupBy: string, height: string, total?: number) {
+  return {
+    ...COMMON_CHART_OPTIONS,
+    title: '',
+    height,
+    resizable: true,
+    donut: {
+      center:
+        total != null
+          ? {number: total, label: toTitleCase(groupBy)}
+          : {label: toTitleCase(groupBy)},
+    },
+    legend: {position: 'right' as const},
+    color: {scale: SEMANTIC_COLOR_SCALE, pairing: {option: 2}},
+  };
+}
+
+export {
+  SEMANTIC_COLOR_SCALE,
+  HARMONIOUS_PALETTE,
+  COMMON_CHART_OPTIONS,
+  CHART_HEIGHT,
+  barOptions,
+  lineOptions,
+  stackedBarOptions,
+  donutOptions,
+};

--- a/operate/client/src/App/Notebooks/widgets/chartUtils.ts
+++ b/operate/client/src/App/Notebooks/widgets/chartUtils.ts
@@ -116,11 +116,17 @@ function buildTreemapData(
     countMap.set(key, (countMap.get(key) ?? 0) + 1);
   }
 
-  const children = Array.from(countMap.entries())
-    .map(([name, value]) => ({name, value}))
-    .sort((a, b) => b.value - a.value);
-
-  return [{name: groupBy, children}];
+  // Return ONE ROOT PER GROUP. Carbon Charts colors children of the same
+  // root with shades of a single color — so a single root wrapping all
+  // children produced one-color treemaps. Wrapping each leaf in its own
+  // root makes Carbon treat each as a distinct color group, picking up the
+  // per-name color scale we pass in.
+  return Array.from(countMap.entries())
+    .sort((a, b) => b[1] - a[1])
+    .map(([name, value]) => ({
+      name,
+      children: [{name, value}],
+    }));
 }
 
 // ---------------------------------------------------------------------------
@@ -142,6 +148,14 @@ type RadarDataPoint = {
  * For hackday simplicity this reuses the `chartStackBy` concept: the axes
  * are the distinct values of `keyBy` across all items.
  */
+/**
+ * Cap on the number of distinct groups (legend entries / radar polygons).
+ * More than this and the legend dominates the tile, pushing the radar
+ * polygon off-screen. Top groups by total value are kept; the rest are
+ * dropped.
+ */
+const RADAR_MAX_GROUPS = 5;
+
 function buildRadarData(
   items: Record<string, unknown>[],
   groupBy: string,
@@ -169,9 +183,23 @@ function buildRadarData(
     inner.set(key, (inner.get(key) ?? 0) + 1);
   }
 
+  // Keep only the top-N groups by total count. Anything beyond that is
+  // dropped so the legend stays readable and the radar polygon has room.
+  const groupTotals = Array.from(acc.entries())
+    .map(([group, inner]) => {
+      let total = 0;
+      for (const v of inner.values()) {
+        total += v;
+      }
+      return [group, total] as const;
+    })
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, RADAR_MAX_GROUPS)
+    .map(([group]) => group);
+
   const result: RadarDataPoint[] = [];
-  for (const [group, inner] of acc.entries()) {
-    // Ensure every group has an entry for every key (zero if absent)
+  for (const group of groupTotals) {
+    const inner = acc.get(group)!;
     for (const key of allKeys) {
       result.push({group, key, value: inner.get(key) ?? 0});
     }

--- a/operate/client/src/App/Notebooks/widgets/chartUtils.ts
+++ b/operate/client/src/App/Notebooks/widgets/chartUtils.ts
@@ -1,0 +1,193 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+type ChartDataPoint = {
+  group: string;
+  value: number;
+};
+
+/**
+ * Groups an array of items by the given field name, then either counts the
+ * items per group or sums a numeric `valueField` (if provided). Returns an
+ * array of `{group, value}` points suitable for Carbon Charts.
+ */
+function buildChartData(
+  items: Record<string, unknown>[],
+  groupBy: string,
+  valueField?: string,
+): ChartDataPoint[] {
+  const acc = new Map<string, number>();
+
+  for (const item of items) {
+    const raw = item[groupBy];
+    const group = raw !== undefined && raw !== null ? String(raw) : '(unknown)';
+
+    if (valueField) {
+      const raw2 = item[valueField];
+      const num = typeof raw2 === 'number' ? raw2 : Number(raw2 ?? 0);
+      acc.set(group, (acc.get(group) ?? 0) + (isNaN(num) ? 0 : num));
+    } else {
+      acc.set(group, (acc.get(group) ?? 0) + 1);
+    }
+  }
+
+  return Array.from(acc.entries())
+    .map(([group, value]) => ({group, value}))
+    .sort((a, b) => b.value - a.value);
+}
+
+type StackedChartDataPoint = {
+  group: string;
+  key: string;
+  value: number;
+};
+
+/**
+ * Produces a two-dimensional aggregate suitable for Carbon Charts'
+ * StackedBarChart. Each data point has:
+ *   - `group`: the outer category (X axis) from `groupBy`
+ *   - `key`:   the stack dimension from `stackBy`
+ *   - `value`: count of items in this (group, key) cell
+ */
+function buildStackedChartData(
+  items: Record<string, unknown>[],
+  groupBy: string,
+  stackBy: string,
+): StackedChartDataPoint[] {
+  // acc: Map<group, Map<key, count>>
+  const acc = new Map<string, Map<string, number>>();
+
+  for (const item of items) {
+    const rawGroup = item[groupBy];
+    const rawKey = item[stackBy];
+    const group =
+      rawGroup !== undefined && rawGroup !== null
+        ? String(rawGroup)
+        : '(unknown)';
+    const key =
+      rawKey !== undefined && rawKey !== null ? String(rawKey) : '(unknown)';
+
+    if (!acc.has(group)) {
+      acc.set(group, new Map());
+    }
+    const inner = acc.get(group)!;
+    inner.set(key, (inner.get(key) ?? 0) + 1);
+  }
+
+  const result: StackedChartDataPoint[] = [];
+  for (const [group, inner] of acc.entries()) {
+    for (const [key, value] of inner.entries()) {
+      result.push({group, key, value});
+    }
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Treemap data — Carbon Charts TreemapChart format
+// ---------------------------------------------------------------------------
+
+type TreemapDataPoint = {
+  name: string;
+  value?: number;
+  children?: Array<{name: string; value: number}>;
+};
+
+/**
+ * Groups items by `groupBy` and counts them, returning a single root node
+ * with one child per group. Carbon Charts TreemapChart expects an array with
+ * one root entry whose `children` contain the leaf nodes.
+ */
+function buildTreemapData(
+  items: Record<string, unknown>[],
+  groupBy: string,
+): TreemapDataPoint[] {
+  const countMap = new Map<string, number>();
+
+  for (const item of items) {
+    const raw = item[groupBy];
+    const key = raw !== undefined && raw !== null ? String(raw) : '(unknown)';
+    countMap.set(key, (countMap.get(key) ?? 0) + 1);
+  }
+
+  const children = Array.from(countMap.entries())
+    .map(([name, value]) => ({name, value}))
+    .sort((a, b) => b.value - a.value);
+
+  return [{name: groupBy, children}];
+}
+
+// ---------------------------------------------------------------------------
+// Radar data — Carbon Charts RadarChart format
+// ---------------------------------------------------------------------------
+
+type RadarDataPoint = {
+  group: string;
+  key: string;
+  value: number;
+};
+
+/**
+ * Builds radar chart data. Each `group` value (from `groupBy`) becomes one
+ * polygon on the radar. Each `key` value (from `keyBy`, defaulting to
+ * `stackBy`) becomes an axis. Values are counts of items in each (group, key)
+ * cell.
+ *
+ * For hackday simplicity this reuses the `chartStackBy` concept: the axes
+ * are the distinct values of `keyBy` across all items.
+ */
+function buildRadarData(
+  items: Record<string, unknown>[],
+  groupBy: string,
+  keyBy: string,
+): RadarDataPoint[] {
+  // acc: Map<group, Map<key, count>>
+  const acc = new Map<string, Map<string, number>>();
+  const allKeys = new Set<string>();
+
+  for (const item of items) {
+    const rawGroup = item[groupBy];
+    const rawKey = item[keyBy];
+    const group =
+      rawGroup !== undefined && rawGroup !== null
+        ? String(rawGroup)
+        : '(unknown)';
+    const key =
+      rawKey !== undefined && rawKey !== null ? String(rawKey) : '(unknown)';
+
+    allKeys.add(key);
+    if (!acc.has(group)) {
+      acc.set(group, new Map());
+    }
+    const inner = acc.get(group)!;
+    inner.set(key, (inner.get(key) ?? 0) + 1);
+  }
+
+  const result: RadarDataPoint[] = [];
+  for (const [group, inner] of acc.entries()) {
+    // Ensure every group has an entry for every key (zero if absent)
+    for (const key of allKeys) {
+      result.push({group, key, value: inner.get(key) ?? 0});
+    }
+  }
+  return result;
+}
+
+export {
+  buildChartData,
+  buildStackedChartData,
+  buildTreemapData,
+  buildRadarData,
+};
+export type {
+  ChartDataPoint,
+  StackedChartDataPoint,
+  TreemapDataPoint,
+  RadarDataPoint,
+};

--- a/operate/client/src/App/Notebooks/widgets/tableCells.tsx
+++ b/operate/client/src/App/Notebooks/widgets/tableCells.tsx
@@ -1,0 +1,175 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import React from 'react';
+import {Link} from 'react-router-dom';
+import {Paths} from 'modules/Routes';
+
+/**
+ * Map of raw V2 API field names → human-readable column headers. Falls back
+ * to a Title Case version of the raw key when a field isn't in the map.
+ */
+const COLUMN_LABELS: Record<string, string> = {
+  processInstanceKey: 'Instance',
+  parentProcessInstanceKey: 'Parent instance',
+  processDefinitionId: 'Process',
+  processDefinitionKey: 'Process key',
+  processDefinitionVersion: 'Version',
+  incidentKey: 'Incident',
+  jobKey: 'Job',
+  userTaskKey: 'Task',
+  elementId: 'Element',
+  elementInstanceKey: 'Element instance',
+  errorType: 'Error type',
+  errorMessage: 'Message',
+  creationTime: 'Created',
+  creationDate: 'Created',
+  completionDate: 'Completed',
+  startDate: 'Started',
+  endDate: 'Ended',
+  dueDate: 'Due',
+  followUpDate: 'Follow-up',
+  deadline: 'Deadline',
+  assignee: 'Assignee',
+  candidateUser: 'Candidate user',
+  candidateGroup: 'Candidate group',
+  state: 'State',
+  type: 'Type',
+  name: 'Name',
+  retries: 'Retries',
+  priority: 'Priority',
+  tenantId: 'Tenant',
+  bpmnProcessId: 'BPMN process',
+  version: 'Version',
+};
+
+function toTitleCase(s: string): string {
+  return s
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .replace(/[_-]/g, ' ')
+    .replace(
+      /\w\S*/g,
+      (w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase(),
+    );
+}
+
+function columnLabel(field: string): string {
+  return COLUMN_LABELS[field] ?? toTitleCase(field);
+}
+
+/**
+ * Format an ISO date string as a short, readable representation. Returns the
+ * raw value if parsing fails so we never silently hide data.
+ */
+function formatDate(value: unknown): string {
+  if (value == null || value === '') {
+    return '';
+  }
+  const t = new Date(value as string);
+  if (isNaN(t.getTime())) {
+    return String(value);
+  }
+  // Short locale-independent form: "2026-05-08 12:34"
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return (
+    `${t.getFullYear()}-${pad(t.getMonth() + 1)}-${pad(t.getDate())} ` +
+    `${pad(t.getHours())}:${pad(t.getMinutes())}`
+  );
+}
+
+const DATE_FIELDS = new Set([
+  'creationTime',
+  'creationDate',
+  'completionDate',
+  'startDate',
+  'endDate',
+  'dueDate',
+  'followUpDate',
+  'deadline',
+]);
+
+const KEY_FIELDS_LINKED_TO_INSTANCE = new Set([
+  'processInstanceKey',
+  'parentProcessInstanceKey',
+]);
+
+/**
+ * Truncate long error messages to a reasonable preview, keeping the table
+ * compact. Full text is available in the hover tooltip via the title attr.
+ */
+const MAX_MESSAGE_LEN = 80;
+
+/**
+ * Render a single table cell value. Renders as:
+ *  - a router-link to the Operate process instance page for keys
+ *    (processInstanceKey, parentProcessInstanceKey)
+ *  - a formatted timestamp for known date fields
+ *  - a truncated preview (with title=full text) for errorMessage
+ *  - the raw stringified value otherwise
+ *
+ * Pure presentation — no fetching, no state. Centralised here so both the
+ * regular table widget and the hero/embedded variants format consistently.
+ */
+function renderCellValue(
+  field: string,
+  value: unknown,
+  row: Record<string, unknown>,
+): React.ReactNode {
+  if (value == null || value === '') {
+    return <span style={{color: 'var(--cds-text-helper)'}}>—</span>;
+  }
+
+  // Linkable instance keys (or the row's own processInstanceKey if the
+  // table is itself a list of incidents/jobs/tasks).
+  if (KEY_FIELDS_LINKED_TO_INSTANCE.has(field)) {
+    const id = String(value);
+    return (
+      <Link to={Paths.processInstance(id)} title={`Open instance ${id}`}>
+        {id}
+      </Link>
+    );
+  }
+
+  // For incident/job/task tables: when the row carries a processInstanceKey,
+  // make incidentKey / jobKey / userTaskKey visible AND link to the parent
+  // instance page (Operate doesn't have first-class incident/job pages, but
+  // the parent instance page is where you'd triage the row).
+  if (
+    (field === 'incidentKey' ||
+      field === 'jobKey' ||
+      field === 'userTaskKey' ||
+      field === 'elementInstanceKey') &&
+    row.processInstanceKey != null
+  ) {
+    const parentId = String(row.processInstanceKey);
+    return (
+      <Link
+        to={Paths.processInstance(parentId)}
+        title={`Open parent instance ${parentId}`}
+      >
+        {String(value)}
+      </Link>
+    );
+  }
+
+  if (DATE_FIELDS.has(field)) {
+    return formatDate(value);
+  }
+
+  const stringValue = String(value);
+
+  if (field === 'errorMessage' && stringValue.length > MAX_MESSAGE_LEN) {
+    return (
+      <span title={stringValue}>{stringValue.slice(0, MAX_MESSAGE_LEN)}…</span>
+    );
+  }
+
+  return stringValue;
+}
+
+export {columnLabel, renderCellValue};

--- a/operate/client/src/App/Notebooks/widgets/useResolveProcessKey.ts
+++ b/operate/client/src/App/Notebooks/widgets/useResolveProcessKey.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useQuery} from '@tanstack/react-query';
+import {requestWithThrow} from 'modules/request';
+
+/**
+ * Resolves a possibly-string processDefinitionId (e.g. "order-process") to
+ * its numeric processDefinitionKey via /v2/process-definitions/search.
+ *
+ * Why a shared hook?
+ *   The V2 statistics + xml endpoints require the *numeric* processDefinitionKey,
+ *   but our LLM and preset templates typically pass the human-readable id. Several
+ *   widgets (BpmnWidget, FunnelWidget, future ones) need this mapping. Without
+ *   a shared hook each widget fires its own /v2/process-definitions/search
+ *   even when they're resolving the same id, so a "Show me everything" bundle
+ *   with 2-3 BPMN widgets pointing at order-process used to fire 2-3 redundant
+ *   searches.
+ *
+ *   With this shared hook we use a single canonical TanStack Query queryKey
+ *   (`['notebook-process-resolve-key', configKey]`). Every widget that calls
+ *   this hook for the same configKey hits the same cache entry — TanStack Query
+ *   dedupes the in-flight request and serves cached results across widgets.
+ *
+ * Behaviour:
+ *   - If `configKey` already looks numeric (all digits), returns it immediately
+ *     with status='success'. No network call is made.
+ *   - Otherwise fires `/v2/process-definitions/search` filtered by
+ *     processDefinitionId, picking the highest-version match.
+ *   - Returns `{key, status, isError}` mirroring the React Query return shape
+ *     callers already expect.
+ *
+ * Cache:
+ *   The default React Query cache is fine — staleTime defaults to 0 but the
+ *   in-flight dedupe is what we care about here, not long-lived caching.
+ *   If a process is re-deployed between calls the resolver still gets the
+ *   correct latest key once the query refetches.
+ */
+function useResolveProcessKey(configKey: string | undefined): {
+  resolvedKey: string | undefined;
+  status: 'idle' | 'pending' | 'success' | 'error';
+  isError: boolean;
+} {
+  const looksNumeric = !!configKey && /^\d+$/.test(configKey);
+
+  const {data, status} = useQuery({
+    queryKey: ['notebook-process-resolve-key', configKey],
+    enabled: !!configKey && !looksNumeric,
+    queryFn: async () => {
+      if (!configKey) {
+        throw new Error('No processDefinitionKey');
+      }
+      const {response, error} = await requestWithThrow<{
+        items: Array<{
+          processDefinitionKey: string;
+          processDefinitionId: string;
+        }>;
+      }>({
+        url: '/v2/process-definitions/search',
+        method: 'POST',
+        body: {
+          filter: {processDefinitionId: configKey},
+          sort: [{field: 'version', order: 'DESC'}],
+          page: {limit: 1},
+        },
+      });
+      if (error) {
+        throw error;
+      }
+      const first = response?.items?.[0];
+      if (!first) {
+        throw new Error(`Process "${configKey}" not found`);
+      }
+      return first.processDefinitionKey;
+    },
+  });
+
+  if (looksNumeric) {
+    return {resolvedKey: configKey, status: 'success', isError: false};
+  }
+  if (!configKey) {
+    return {resolvedKey: undefined, status: 'idle', isError: false};
+  }
+  return {resolvedKey: data, status, isError: status === 'error'};
+}
+
+export {useResolveProcessKey};

--- a/operate/client/src/App/index.tsx
+++ b/operate/client/src/App/index.tsx
@@ -202,6 +202,13 @@ const routes = createRoutesFromElements(
           return {Component: OperationsLog};
         }}
       />
+      <Route
+        path={Paths.notebook()}
+        lazy={async () => {
+          const {NotebookPage} = await import('./Notebooks/index');
+          return {Component: NotebookPage};
+        }}
+      />
     </Route>
   </Route>,
 );

--- a/operate/client/src/modules/Routes.tsx
+++ b/operate/client/src/modules/Routes.tsx
@@ -62,6 +62,9 @@ const Paths = {
   batchOperation(batchOperationKey: string | null = ':batchOperationKey') {
     return `/batch-operations/${batchOperationKey}`;
   },
+  notebook(id: string = ':id') {
+    return `/notebooks/${id}`;
+  },
 } as const;
 
 function getRelativeProcessInstancePathHandler(path: string) {

--- a/operate/client/src/modules/hooks/useCurrentPage.tsx
+++ b/operate/client/src/modules/hooks/useCurrentPage.tsx
@@ -28,6 +28,7 @@ const useCurrentPage = () => {
     | 'process-details-operations-log'
     | 'process-details-instance-history'
     | 'decision-details'
+    | 'notebooks'
     | 'login'
     | undefined {
     if (matchPath(Paths.dashboard(), location.pathname) !== null) {
@@ -106,6 +107,10 @@ const useCurrentPage = () => {
 
     if (matchPath(Paths.decisionInstance(), location.pathname) !== null) {
       return 'decision-details';
+    }
+
+    if (matchPath(Paths.notebook(), location.pathname) !== null) {
+      return 'notebooks';
     }
 
     return;

--- a/operate/client/src/setupTests.tsx
+++ b/operate/client/src/setupTests.tsx
@@ -194,7 +194,9 @@ const localStorageMock = (function () {
     clear() {
       store = {};
     },
-    removeItem: vi.fn(),
+    removeItem(key: string) {
+      delete store[key];
+    },
   };
 })();
 

--- a/operate/client/vite.config.ts
+++ b/operate/client/vite.config.ts
@@ -47,20 +47,24 @@ export default defineConfig(({mode}) => ({
   server: {
     port: 3000,
     open: true,
-    proxy: {
-      '/api': 'http://localhost:8080',
-      '/v1': 'http://localhost:8080',
-      '/v2': 'http://localhost:8080',
-      '/login': {
-        target: 'http://localhost:8080',
-        bypass: (req) => (req.method !== 'POST' ? '/' : undefined),
-      },
-      '/logout': {
-        target: 'http://localhost:8080',
-        bypass: (req) => (req.method !== 'POST' ? '/' : undefined),
-      },
-      '/client-config.js': 'http://localhost:8080/operate',
-    },
+    proxy: (() => {
+      const backend =
+        process.env['VITE_BACKEND_TARGET'] ?? 'http://localhost:8080';
+      return {
+        '/api': backend,
+        '/v1': backend,
+        '/v2': backend,
+        '/login': {
+          target: backend,
+          bypass: (req) => (req.method !== 'POST' ? '/' : undefined),
+        },
+        '/logout': {
+          target: backend,
+          bypass: (req) => (req.method !== 'POST' ? '/' : undefined),
+        },
+        '/client-config.js': `${backend}/operate`,
+      };
+    })(),
   },
   build: {
     outDir,


### PR DESCRIPTION
## Summary
- Adds a Notebook page to Operate where users describe widgets in natural language
- LLM generates dashboard widgets (metrics, tables) backed by real V2 API queries
- Editable widget config, column labels, instance links, and chart support

## Hackday project
This is a hackday exploration — not intended for production merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)