### PR TITLE
Persist processDefinitionPath on element migration

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -354,6 +354,11 @@ public final class EventAppliers implements EventApplier {
         new ProcessInstanceElementMigratedV3Applier(
             elementInstanceState, processState, state.getMessageState()));
     register(
+        ProcessInstanceIntent.ELEMENT_MIGRATED,
+        4,
+        new ProcessInstanceElementMigratedV4Applier(
+            elementInstanceState, processState, state.getMessageState()));
+    register(
         ProcessInstanceIntent.ANCESTOR_MIGRATED,
         new ProcessInstanceAncestorMigratedApplier(elementInstanceState));
     register(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementMigratedV4Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementMigratedV4Applier.java
@@ -57,7 +57,8 @@ final class ProcessInstanceElementMigratedV4Applier
               .setBpmnProcessId(value.getBpmnProcessId())
               .setVersion(value.getVersion())
               .setElementId(value.getElementId())
-              .setFlowScopeKey(value.getFlowScopeKey());
+              .setFlowScopeKey(value.getFlowScopeKey())
+              .setProcessDefinitionPath(value.getProcessDefinitionPath());
         });
 
     if (value.getBpmnElementType() == BpmnElementType.PROCESS) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementMigratedV4Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementMigratedV4Applier.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElementContainer;
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.immutable.ProcessState;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableMessageState;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import org.agrona.DirectBuffer;
+
+/** Applies state changes for `ProcessInstance:Element_Migrated` */
+final class ProcessInstanceElementMigratedV4Applier
+    implements TypedEventApplier<ProcessInstanceIntent, ProcessInstanceRecord> {
+
+  private final MutableElementInstanceState elementInstanceState;
+  private final ProcessState processState;
+  private final MutableMessageState messageState;
+
+  public ProcessInstanceElementMigratedV4Applier(
+      final MutableElementInstanceState elementInstanceState,
+      final ProcessState processState,
+      final MutableMessageState messageState) {
+    this.elementInstanceState = elementInstanceState;
+    this.processState = processState;
+    this.messageState = messageState;
+  }
+
+  @Override
+  public void applyState(final long elementInstanceKey, final ProcessInstanceRecord value) {
+    if (value.getBpmnElementType() == BpmnElementType.PROCESS) {
+      migrateCorrelatedMessageStartEvent(elementInstanceKey, value);
+    }
+
+    final var previousProcessDefinitionKey = new AtomicLong();
+    final var previousProcessDefinitionId = new AtomicReference<String>();
+    elementInstanceState.updateInstance(
+        elementInstanceKey,
+        elementInstance -> {
+          previousProcessDefinitionKey.set(elementInstance.getValue().getProcessDefinitionKey());
+          previousProcessDefinitionId.set(elementInstance.getValue().getBpmnProcessId());
+          elementInstance
+              .getValue()
+              .setProcessDefinitionKey(value.getProcessDefinitionKey())
+              .setBpmnProcessId(value.getBpmnProcessId())
+              .setVersion(value.getVersion())
+              .setElementId(value.getElementId())
+              .setFlowScopeKey(value.getFlowScopeKey());
+        });
+
+    if (value.getBpmnElementType() == BpmnElementType.PROCESS) {
+      elementInstanceState.deleteProcessInstanceKeyByDefinitionKey(
+          value.getProcessInstanceKey(), previousProcessDefinitionKey.get());
+      elementInstanceState.insertProcessInstanceKeyByDefinitionKey(
+          value.getProcessInstanceKey(), value.getProcessDefinitionKey());
+
+      migrateBusinessIdIndex(value, previousProcessDefinitionId.get());
+    }
+  }
+
+  private void migrateCorrelatedMessageStartEvent(
+      final long elementInstanceKey, final ProcessInstanceRecord value) {
+
+    final var instance = elementInstanceState.getInstance(elementInstanceKey).getValue();
+    final DirectBuffer previousBpmnProcessId = instance.getBpmnProcessIdBuffer();
+    final DirectBuffer currentBpmnProcessId = value.getBpmnProcessIdBuffer();
+    final DirectBuffer correlationKey =
+        messageState.getProcessInstanceCorrelationKey(value.getProcessInstanceKey());
+
+    if (isCorrelationKeyAbsent(correlationKey)) {
+      // no need to update correlation key relations since there isn't one
+      return;
+    }
+
+    final boolean isTargetWithMessageStartEvent =
+        processState
+            .getFlowElement(
+                value.getProcessDefinitionKey(),
+                value.getTenantId(),
+                value.getElementIdBuffer(),
+                ExecutableFlowElementContainer.class)
+            .hasMessageStartEvent();
+    final boolean hasBpmnProcessIdChanged =
+        !BufferUtil.equals(previousBpmnProcessId, currentBpmnProcessId);
+
+    if (isTargetWithMessageStartEvent && hasBpmnProcessIdChanged) {
+      // unlock the previous process instance's process id
+      messageState.removeActiveProcessInstance(previousBpmnProcessId, correlationKey);
+      // lock the new process instance's process id
+      messageState.putActiveProcessInstance(currentBpmnProcessId, correlationKey);
+    }
+
+    // clean up the correlation key relation if the target process doesn't have a message start
+    // event at all
+    if (!isTargetWithMessageStartEvent) {
+      messageState.removeActiveProcessInstance(previousBpmnProcessId, correlationKey);
+      messageState.removeProcessInstanceCorrelationKey(value.getProcessInstanceKey());
+    }
+  }
+
+  private boolean isCorrelationKeyAbsent(final DirectBuffer correlationKey) {
+    return correlationKey == null || correlationKey.capacity() == 0;
+  }
+
+  private void migrateBusinessIdIndex(
+      final ProcessInstanceRecord value, final String previousProcessDefinitionId) {
+    final String businessId = value.getBusinessId();
+    if (businessId.isEmpty()) {
+      return;
+    }
+    if (value.hasParentProcessInstance()) {
+      return;
+    }
+    if (Objects.equals(previousProcessDefinitionId, value.getBpmnProcessId())) {
+      // no need to update the business id index if the process definition id didn't change
+      // note that the business id, the tenant id, and the instance key never change on migration
+      return;
+    }
+    elementInstanceState.deleteProcessInstanceKeyMappingByBusinessId(
+        businessId,
+        previousProcessDefinitionId,
+        value.getTenantId(),
+        value.getProcessInstanceKey());
+    elementInstanceState.insertProcessInstanceKeyByBusinessId(
+        businessId, value.getBpmnProcessId(), value.getTenantId(), value.getProcessInstanceKey());
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementMigratedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementMigratedApplierTest.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -93,6 +94,49 @@ public class ProcessInstanceElementMigratedApplierTest {
                 processInstance.getProcessDefinitionKey()))
         .describedAs("Expect that there are no instances of the old process definition")
         .isEmpty();
+  }
+
+  @Test
+  void shouldUpdateProcessDefinitionPathOnMigrationV4() {
+    // given
+    final var elementInstanceKey = 3L;
+    final var sourceProcessDefinitionKey = 1L;
+    final var targetProcessDefinitionKey = 4L;
+    final var processInstance =
+        new ProcessInstanceRecord()
+            .setProcessDefinitionKey(sourceProcessDefinitionKey)
+            .setBpmnProcessId("process")
+            .setVersion(1)
+            .setElementId("task")
+            .setBpmnElementType(BpmnElementType.SERVICE_TASK)
+            .setProcessInstanceKey(2L)
+            .setProcessDefinitionPath(List.of(sourceProcessDefinitionKey));
+    elementInstanceState.createInstance(
+        new ElementInstance(
+            elementInstanceKey, ProcessInstanceIntent.ELEMENT_ACTIVATED, processInstance));
+
+    final var applier =
+        new ProcessInstanceElementMigratedV4Applier(
+            elementInstanceState,
+            processingState.getProcessState(),
+            processingState.getMessageState());
+
+    // when
+    final var migratedProcessInstance = new ProcessInstanceRecord();
+    migratedProcessInstance.wrap(processInstance);
+    migratedProcessInstance
+        .setProcessDefinitionKey(targetProcessDefinitionKey)
+        .setVersion(2)
+        .setBpmnProcessId("another_process")
+        .setElementId("another_task")
+        .setProcessDefinitionPath(List.of(targetProcessDefinitionKey));
+    applier.applyState(elementInstanceKey, migratedProcessInstance);
+
+    // then
+    assertThat(elementInstanceState.getInstance(elementInstanceKey).getValue())
+        .describedAs(
+            "Expect that the process definition path is updated to the target process definition")
+        .hasProcessDefinitionPath(List.of(targetProcessDefinitionKey));
   }
 
   @Test

--- a/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_ELEMENT_MIGRATED_v4.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_ELEMENT_MIGRATED_v4.golden
@@ -57,7 +57,8 @@ final class ProcessInstanceElementMigratedV4Applier
               .setBpmnProcessId(value.getBpmnProcessId())
               .setVersion(value.getVersion())
               .setElementId(value.getElementId())
-              .setFlowScopeKey(value.getFlowScopeKey());
+              .setFlowScopeKey(value.getFlowScopeKey())
+              .setProcessDefinitionPath(value.getProcessDefinitionPath());
         });
 
     if (value.getBpmnElementType() == BpmnElementType.PROCESS) {

--- a/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_ELEMENT_MIGRATED_v4.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_ELEMENT_MIGRATED_v4.golden
@@ -1,0 +1,139 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElementContainer;
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.immutable.ProcessState;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableMessageState;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import org.agrona.DirectBuffer;
+
+/** Applies state changes for `ProcessInstance:Element_Migrated` */
+final class ProcessInstanceElementMigratedV4Applier
+    implements TypedEventApplier<ProcessInstanceIntent, ProcessInstanceRecord> {
+
+  private final MutableElementInstanceState elementInstanceState;
+  private final ProcessState processState;
+  private final MutableMessageState messageState;
+
+  public ProcessInstanceElementMigratedV4Applier(
+      final MutableElementInstanceState elementInstanceState,
+      final ProcessState processState,
+      final MutableMessageState messageState) {
+    this.elementInstanceState = elementInstanceState;
+    this.processState = processState;
+    this.messageState = messageState;
+  }
+
+  @Override
+  public void applyState(final long elementInstanceKey, final ProcessInstanceRecord value) {
+    if (value.getBpmnElementType() == BpmnElementType.PROCESS) {
+      migrateCorrelatedMessageStartEvent(elementInstanceKey, value);
+    }
+
+    final var previousProcessDefinitionKey = new AtomicLong();
+    final var previousProcessDefinitionId = new AtomicReference<String>();
+    elementInstanceState.updateInstance(
+        elementInstanceKey,
+        elementInstance -> {
+          previousProcessDefinitionKey.set(elementInstance.getValue().getProcessDefinitionKey());
+          previousProcessDefinitionId.set(elementInstance.getValue().getBpmnProcessId());
+          elementInstance
+              .getValue()
+              .setProcessDefinitionKey(value.getProcessDefinitionKey())
+              .setBpmnProcessId(value.getBpmnProcessId())
+              .setVersion(value.getVersion())
+              .setElementId(value.getElementId())
+              .setFlowScopeKey(value.getFlowScopeKey());
+        });
+
+    if (value.getBpmnElementType() == BpmnElementType.PROCESS) {
+      elementInstanceState.deleteProcessInstanceKeyByDefinitionKey(
+          value.getProcessInstanceKey(), previousProcessDefinitionKey.get());
+      elementInstanceState.insertProcessInstanceKeyByDefinitionKey(
+          value.getProcessInstanceKey(), value.getProcessDefinitionKey());
+
+      migrateBusinessIdIndex(value, previousProcessDefinitionId.get());
+    }
+  }
+
+  private void migrateCorrelatedMessageStartEvent(
+      final long elementInstanceKey, final ProcessInstanceRecord value) {
+
+    final var instance = elementInstanceState.getInstance(elementInstanceKey).getValue();
+    final DirectBuffer previousBpmnProcessId = instance.getBpmnProcessIdBuffer();
+    final DirectBuffer currentBpmnProcessId = value.getBpmnProcessIdBuffer();
+    final DirectBuffer correlationKey =
+        messageState.getProcessInstanceCorrelationKey(value.getProcessInstanceKey());
+
+    if (isCorrelationKeyAbsent(correlationKey)) {
+      // no need to update correlation key relations since there isn't one
+      return;
+    }
+
+    final boolean isTargetWithMessageStartEvent =
+        processState
+            .getFlowElement(
+                value.getProcessDefinitionKey(),
+                value.getTenantId(),
+                value.getElementIdBuffer(),
+                ExecutableFlowElementContainer.class)
+            .hasMessageStartEvent();
+    final boolean hasBpmnProcessIdChanged =
+        !BufferUtil.equals(previousBpmnProcessId, currentBpmnProcessId);
+
+    if (isTargetWithMessageStartEvent && hasBpmnProcessIdChanged) {
+      // unlock the previous process instance's process id
+      messageState.removeActiveProcessInstance(previousBpmnProcessId, correlationKey);
+      // lock the new process instance's process id
+      messageState.putActiveProcessInstance(currentBpmnProcessId, correlationKey);
+    }
+
+    // clean up the correlation key relation if the target process doesn't have a message start
+    // event at all
+    if (!isTargetWithMessageStartEvent) {
+      messageState.removeActiveProcessInstance(previousBpmnProcessId, correlationKey);
+      messageState.removeProcessInstanceCorrelationKey(value.getProcessInstanceKey());
+    }
+  }
+
+  private boolean isCorrelationKeyAbsent(final DirectBuffer correlationKey) {
+    return correlationKey == null || correlationKey.capacity() == 0;
+  }
+
+  private void migrateBusinessIdIndex(
+      final ProcessInstanceRecord value, final String previousProcessDefinitionId) {
+    final String businessId = value.getBusinessId();
+    if (businessId.isEmpty()) {
+      return;
+    }
+    if (value.hasParentProcessInstance()) {
+      return;
+    }
+    if (Objects.equals(previousProcessDefinitionId, value.getBpmnProcessId())) {
+      // no need to update the business id index if the process definition id didn't change
+      // note that the business id, the tenant id, and the instance key never change on migration
+      return;
+    }
+    elementInstanceState.deleteProcessInstanceKeyMappingByBusinessId(
+        businessId,
+        previousProcessDefinitionId,
+        value.getTenantId(),
+        value.getProcessInstanceKey());
+    elementInstanceState.insertProcessInstanceKeyByBusinessId(
+        businessId, value.getBpmnProcessId(), value.getTenantId(), value.getProcessInstanceKey());
+  }
+}


### PR DESCRIPTION
## Description

`ProcessInstanceElementMigratedApplier` updates element instance state on migration but never persists the new `processDefinitionPath`. The correct path is already on the record, so the fix is applier-only.

This PR adds `ProcessInstanceElementMigratedV4Applier` — identical to V3 plus a `setProcessDefinitionPath` call — and registers it in `EventAppliers`. A new version (rather than amending V3) preserves replay determinism, since V3 shipped in 8.9.0.

The stored path is internal-only, so there is no user-visible regression today. With the corrected path, the existing `ResourceDeletionDeleteProcessor` guard becomes sufficient to block deletion of a process definition still referenced by migrated instances.

## Checklist

- [x] Backports enabled. 8.8 / 8.9 are affected, but backports must land **after** this ships in the 8.10.0 initial release to avoid breaking the upgrade-replay path.

## Related issues

closes #52746