### PR TITLE
Reduce daily load test run time

### DIFF
--- a/.github/scripts/post-load-test-results-to-slack.py
+++ b/.github/scripts/post-load-test-results-to-slack.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Build and post the daily load-test results table to Slack.
+
+Renders a side-by-side gRPC vs REST metrics table from the end-of-soak metric
+snapshots and posts it to the reliability-testing Slack channel via an incoming
+webhook. Invoked by the `notify-results` job of
+`.github/workflows/camunda-daily-load-tests.yml`.
+
+Metric names, descriptions, and display formats are sourced from `queries.yaml`
+(the single source of truth shared with `loadTestMetrics.sh`), so adding a metric
+there automatically adds a row here.
+
+Required environment variables:
+  GRPC_RESULTS_JSON   JSON object of {metric_name: value} for the gRPC run.
+  REST_RESULTS_JSON   JSON object of {metric_name: value} for the REST run.
+  BENCHMARK           Benchmark name, e.g. medic-daily-YYYY-MM-DD-<sha>-test.
+  SLACK_WEBHOOK_URL   Incoming-webhook URL to post to.
+  REPO                GitHub repo slug, e.g. camunda/camunda.
+  RUN_ID              GitHub Actions run id (used to link the workflow run).
+
+Optional:
+  QUERIES_YAML        Path to queries.yaml. Default:
+                      load-tests/docs/scripts/queries.yaml
+"""
+import json
+import os
+import socket
+import urllib.error
+import urllib.request
+
+import yaml
+
+grpc    = json.loads(os.environ.get('GRPC_RESULTS_JSON') or '{}')
+rest    = json.loads(os.environ.get('REST_RESULTS_JSON') or '{}')
+bench   = os.environ['BENCHMARK']
+grpc_ns = f'c8-{bench}'
+rest_ns = f'c8-{bench}-rest'
+repo    = os.environ['REPO']
+run_id  = os.environ['RUN_ID']
+webhook = os.environ['SLACK_WEBHOOK_URL']
+
+queries_yaml = os.environ.get('QUERIES_YAML', 'load-tests/docs/scripts/queries.yaml')
+
+# Extract YYYY-MM-DD from medic-daily-YYYY-MM-DD-<sha>-test
+parts = bench.split('-')
+date  = '-'.join(parts[2:5]) if len(parts) >= 5 else bench
+
+# Derive table rows from queries.yaml — single source of truth for
+# metric names, descriptions, and display formats.
+with open(queries_yaml) as f:
+    queries = yaml.safe_load(f)['queries']
+
+
+def fmt(v, q):
+    if v is None:
+        return 'n/a'
+    try:
+        n = float(v)
+    except (TypeError, ValueError):
+        return 'n/a'
+    fmt_type = q.get('format', 'float')
+    dec  = q.get('decimals', 2)
+    unit = q.get('unit') or ''
+    if fmt_type == 'integer':
+        return f'{round(n):,}'
+    elif fmt_type == 'percent':
+        return f'{n:.{dec}f}{unit or "%"}'
+    else:
+        return f'{n:.{dec}f}{(" " + unit) if unit else ""}'
+
+
+lw = max(len('Metric'), *(len(q['description']) for q in queries))
+gw = max(len('gRPC'),   *(len(fmt(grpc.get(q['name']), q)) for q in queries))
+rw = max(len('REST'),   *(len(fmt(rest.get(q['name']), q)) for q in queries))
+
+header = f"{'Metric':<{lw}}  {'gRPC':<{gw}}  {'REST':<{rw}}"
+sep    = '-' * (lw + 2 + gw + 2 + rw)
+rows   = [
+    f"{q['description']:<{lw}}  {fmt(grpc.get(q['name']), q):<{gw}}  {fmt(rest.get(q['name']), q):<{rw}}"
+    for q in queries
+]
+table  = '\n'.join([header, sep] + rows)
+
+grpc_dash = f'https://dashboard.benchmark.camunda.cloud/d/zeebe-dashboard/zeebe?var-namespace={grpc_ns}'
+rest_dash = f'https://dashboard.benchmark.camunda.cloud/d/zeebe-dashboard/zeebe?var-namespace={rest_ns}'
+run_url   = f'https://github.com/{repo}/actions/runs/{run_id}'
+
+payload = {
+    'blocks': [
+        {
+            'type': 'section',
+            'text': {
+                'type': 'mrkdwn',
+                'text': f':bar_chart: *Daily Load Test Results — {date}*\nDuration: 3 h · <{run_url}|Workflow run>',
+            },
+        },
+        {
+            'type': 'section',
+            'text': {
+                'type': 'mrkdwn',
+                'text': f'<{grpc_dash}|Grafana gRPC> · <{rest_dash}|Grafana REST>',
+            },
+        },
+        {
+            'type': 'section',
+            'text': {
+                'type': 'mrkdwn',
+                'text': '```\n' + table + '\n```',
+            },
+        },
+    ]
+}
+
+body = json.dumps(payload).encode()
+req  = urllib.request.Request(
+    webhook, data=body, headers={'Content-Type': 'application/json'}
+)
+try:
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        print(f'Slack response: {resp.status}')
+except urllib.error.HTTPError as e:
+    print(f'Slack HTTP error: {e.code} {e.read().decode()}')
+    raise
+except (urllib.error.URLError, socket.timeout) as e:
+    print(f'Slack connection error: {e}')
+    raise

--- a/.github/workflows/camunda-daily-load-tests.yml
+++ b/.github/workflows/camunda-daily-load-tests.yml
@@ -1,6 +1,11 @@
 # description: Runs a daily max-load stress test against main.
+#              After a 3-hour soak: snapshots metrics as a GitHub artifact,
+#              posts a side-by-side summary table to Slack, then immediately
+#              deletes both namespaces to reduce cost.
 #              Naming pattern: medic-daily-YYYY-MM-DD-<sha>
-# calls: camunda-load-test.yml (scenario: max)
+# calls: camunda-load-test.yml (scenario: max),
+#        camunda-load-test-metrics.yaml,
+#        camunda-delete-load-test.yml
 # type: CI
 # owner: @camunda/reliability-testing
 name: Daily Camunda Platform Load Tests
@@ -87,10 +92,132 @@ jobs:
       build-frontend: true
       load-test-load: --set global.preferRest.enabled=true
 
+  # Wait 3 hours to let both load tests reach a stable operating state before
+  # taking the metrics snapshot. Skipped if both setup jobs failed (no tests running).
+  soak:
+    name: Soak (3 hours)
+    runs-on: ubuntu-latest
+    needs: [ setup-max-load-test, setup-max-rest-load-test ]
+    if: needs.setup-max-load-test.result == 'success' || needs.setup-max-rest-load-test.result == 'success'
+    timeout-minutes: 195
+    permissions: { }
+    steps:
+      - name: Wait 3 hours for soak period
+        run: sleep 10800
+
+  # Gated on its own setup: if the gRPC setup failed, its namespace was never
+  # created, so skip metrics collection rather than query a missing namespace.
+  collect-metrics-grpc:
+    name: Collect metrics (gRPC)
+    needs: [ benchmark-data, setup-max-load-test, soak ]
+    if: needs.soak.result == 'success' && needs.setup-max-load-test.result == 'success'
+    uses: ./.github/workflows/camunda-load-test-metrics.yaml
+    secrets: inherit
+    with:
+      namespace: c8-${{ needs.benchmark-data.outputs.benchmark }}
+      duration-seconds: '10800'
+
+  collect-metrics-rest:
+    name: Collect metrics (REST)
+    needs: [ benchmark-data, setup-max-rest-load-test, soak ]
+    if: needs.soak.result == 'success' && needs.setup-max-rest-load-test.result == 'success'
+    uses: ./.github/workflows/camunda-load-test-metrics.yaml
+    secrets: inherit
+    with:
+      namespace: c8-${{ needs.benchmark-data.outputs.benchmark }}-rest
+      duration-seconds: '10800'
+
+  # Upload both metrics JSON files as a workflow artifact (90-day retention).
+  upload-metrics:
+    name: Upload metrics artifacts
+    runs-on: ubuntu-latest
+    needs: [ benchmark-data, collect-metrics-grpc, collect-metrics-rest ]
+    # Run if at least one side collected metrics; a skipped side just yields an empty file.
+    if: always() && (needs.collect-metrics-grpc.result == 'success' || needs.collect-metrics-rest.result == 'success')
+    timeout-minutes: 5
+    permissions: { }
+    steps:
+      - name: Write metrics JSON files
+        env:
+          GRPC_JSON: ${{ needs.collect-metrics-grpc.outputs.results-json }}
+          REST_JSON: ${{ needs.collect-metrics-rest.outputs.results-json }}
+        run: |
+          printf '%s' "$GRPC_JSON" > metrics-grpc.json
+          printf '%s' "$REST_JSON" > metrics-rest.json
+      - name: Upload metrics artifacts
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: daily-load-test-metrics-${{ needs.benchmark-data.outputs.benchmark }}
+          path: |
+            metrics-grpc.json
+            metrics-rest.json
+          retention-days: 90
+
+  # Post a side-by-side gRPC vs REST metrics table to Slack.
+  notify-results:
+    name: Notify Slack with results
+    runs-on: ubuntu-latest
+    needs: [ benchmark-data, collect-metrics-grpc, collect-metrics-rest ]
+    # Post if at least one side collected metrics; the skipped side renders as n/a.
+    if: always() && (needs.collect-metrics-grpc.result == 'success' || needs.collect-metrics-rest.result == 'success')
+    timeout-minutes: 5
+    permissions: { }
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Import Slack webhook from Vault
+        id: slack-secrets
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/camunda/ci/github-actions SLACK_ZEEBOT_RELIABILITY_TESTING_ALERTS_WEBHOOK_URL;
+      - name: Build and post Slack results table
+        # queries.yaml is the canonical source of metric names/labels/formats;
+        # the script reads it directly so the Slack table stays in sync.
+        env:
+          GRPC_RESULTS_JSON: ${{ needs.collect-metrics-grpc.outputs.results-json }}
+          REST_RESULTS_JSON: ${{ needs.collect-metrics-rest.outputs.results-json }}
+          BENCHMARK: ${{ needs.benchmark-data.outputs.benchmark }}
+          SLACK_WEBHOOK_URL: ${{ steps.slack-secrets.outputs.SLACK_ZEEBOT_RELIABILITY_TESTING_ALERTS_WEBHOOK_URL }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+        run: python3 .github/scripts/post-load-test-results-to-slack.py
+
+  # Delete namespaces immediately after metrics are collected to reduce cluster cost.
+  # Runs regardless of whether metrics collection succeeded or was skipped, as long
+  # as we have a valid namespace name (benchmark-data succeeded).
+  cleanup-grpc:
+    name: Cleanup gRPC namespace
+    needs: [ benchmark-data, collect-metrics-grpc ]
+    if: always() && needs.benchmark-data.result == 'success'
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/camunda-delete-load-test.yml
+    secrets: inherit
+    with:
+      namespace: c8-${{ needs.benchmark-data.outputs.benchmark }}
+
+  cleanup-rest:
+    name: Cleanup REST namespace
+    needs: [ benchmark-data, collect-metrics-rest ]
+    if: always() && needs.benchmark-data.result == 'success'
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/camunda-delete-load-test.yml
+    secrets: inherit
+    with:
+      namespace: c8-${{ needs.benchmark-data.outputs.benchmark }}-rest
+
   notify:
     name: Notify on failure
     runs-on: ubuntu-latest
-    needs: [ setup-max-load-test, setup-max-rest-load-test ]
+    needs: [ setup-max-load-test, setup-max-rest-load-test, soak, collect-metrics-grpc, collect-metrics-rest, upload-metrics, notify-results ]
     if: failure()
     timeout-minutes: 5
     permissions: { }


### PR DESCRIPTION
Daily tests previously ran with TTL: 1 day with no automated metric
collection after the test period. This
left results only in Grafana dashboards.

The new flow:
1. Set up gRPC and REST max-load tests (unchanged)
2. Soak for 3 hours to reach a stable operating state
3. Snapshot Prometheus metrics for both namespaces (10 800 s window) via the
   recently-added camunda-load-test-metrics.yaml reusable workflow
4. Upload both metrics JSON files as a GitHub artifact (90-day retention)
5. Post a side-by-side gRPC vs REST comparison table to Slack, rendered by the
   standalone `.github/scripts/post-load-test-results-to-slack.py` script, which
   reads metric names/labels/formats directly from `queries.yaml` so the table
   stays in sync with the canonical metric definitions
6. Immediately delete both namespaces to reduce cluster cost

Each metrics-collection job is gated on its own setup result, so a one-sided
setup failure skips only that side instead of querying a namespace that was
never created; `upload-metrics` and `notify-results` still run when at least
one side succeeded, so a partial run is still reported.

Cleanup always runs (if: always) as long as benchmark-data succeeded, so
namespaces are never stranded even if metrics collection or notification fails.
The TTL=1 label is kept as a safety net for any unexpected failures.

Smoke tested: metric collection + Slack table verified end-to-end against a live
3-hour run (both gRPC and REST namespaces); all metric formats
(integer/percent/rate/latency) render correctly.

https://claude.ai/code/session_015G4GHqvEHKnGmj31fH3NZr

WorkingComment: https://camunda.slack.com/archives/C0ANMGS3D4Y/p1780406938447509

Blocked by https://github.com/camunda/camunda/pull/52840
