### PR TITLE
fix: add additionalProperties to getResourceContent response schema

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/deployments.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/deployments.yaml
@@ -112,6 +112,7 @@ paths:
             application/json:
               schema:
                 type: object
+                additionalProperties: true
         "404":
           description: An RPA resource with the given key was not found.
           content:


### PR DESCRIPTION
## What

Adds `additionalProperties: true` to the `getResourceContent` 200 response schema.

## Why

PR #52086 changed `GET /resources/{resourceKey}/content` from `application/octet-stream` to `application/json` with a bare `{type: object}` schema (no properties, no `additionalProperties`). This causes problems for SDK code generators:

| SDK | Result with bare `{type: object}` | Result with `additionalProperties: true` |
|-----|-----------------------------------|------------------------------------------|
| **C#** | Empty class `GetResourceContentResponse` (no fields, unusable) | `Dictionary<string, object>` |
| **TypeScript** | `{ [key: string]: unknown }` (correct by default) | `{ [key: string]: unknown }` (same) |
| **Python** | Empty model class (no fields) | `dict[str, Any]` with dict-like access |

A bare `{type: object}` is semantically ambiguous in OpenAPI 3.0 — it could mean "an object with no properties allowed" or "an object with any properties." Adding `additionalProperties: true` makes the intent explicit: this endpoint returns arbitrary JSON content.

## Change

```yaml
# Before
schema:
  type: object

# After
schema:
  type: object
  additionalProperties: true
```

Single line added in `zeebe/gateway-protocol/src/main/proto/v2/deployments.yaml`.

## Related

- Upstream PR that introduced the bare schema: #52086
- C# SDK generator fix for the same issue: [orchestration-cluster-api-csharp#173](https://github.com/camunda/orchestration-cluster-api-csharp/pull/173)