### PR TITLE
test: flaky modifications persist after reloading

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstanceViewModificationMode.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstanceViewModificationMode.ts
@@ -549,15 +549,20 @@ export class OperateProcessInstanceViewModificationModePage {
 
   async addNewVariable(variableIndex: string, name: string, value: string) {
     await this.addVariableModificationButton.click();
-    await expect(
-      this.page.getByTestId(`variable-newVariables[${variableIndex}]`),
-    ).toBeVisible();
-
-    await this.getNewVariableNameFieldSelector(variableIndex).clear();
-    await this.getNewVariableNameFieldSelector(variableIndex).type(name);
-    await this.page.keyboard.press('Tab');
-
-    await this.expectEditorToBeLoaded();
+    const nameField = this.getNewVariableNameFieldSelector(variableIndex);
+    // Wait for a fresh empty input — guards against matching a pre-existing row
+    // at the same index that is about to be detached by the re-render.
+    await expect(nameField).toBeVisible();
+    await expect(nameField).toHaveValue('');
+    await nameField.click();
+    await nameField.type(name);
+    const valueField = this.getNewVariableValueFieldSelector(variableIndex);
+    await valueField.click();
+    await expect(async () => {
+      expect(
+        await valueField.evaluate((el) => el.matches(':focus-within')),
+      ).toBe(true);
+    }).toPass({timeout: 10_000});
     await this.page.keyboard.insertText(value);
     await this.page.keyboard.press('Tab');
   }
@@ -606,8 +611,9 @@ export class OperateProcessInstanceViewModificationModePage {
     const jsonEditorModal =
       this.newVariableByIndex(variableIndex).jsonEditorModal;
     await expect(jsonEditorModal.header).toBeVisible();
-    await expect(jsonEditorModal.inputField).toBeVisible();
-    await expect(jsonEditorModal.inputField).toBeEnabled();
+    // await expect(jsonEditorModal.inputField).toBeVisible();
+    // await expect(jsonEditorModal.inputField).toBeEnabled();
+    await expect(this.page.getByRole('dialog').getByRole('code')).toBeVisible();
     await this.fillMonacoEditor(jsonEditorModal.inputField, json);
     await jsonEditorModal.applyButton.click();
     await this.page.keyboard.press('Tab');
@@ -617,7 +623,6 @@ export class OperateProcessInstanceViewModificationModePage {
     await this.editableExistingVariableByName(
       variableName,
     ).readModeValue.click();
-    await this.clearMonacoEditor();
 
     await this.editableExistingVariableByName(
       variableName,
@@ -625,10 +630,14 @@ export class OperateProcessInstanceViewModificationModePage {
     const jsonEditorModal =
       this.editableExistingVariableByName(variableName).jsonEditorModal;
     await expect(jsonEditorModal.header).toBeVisible();
-    await expect(jsonEditorModal.inputField).toBeVisible();
-    await expect(jsonEditorModal.inputField).toBeEnabled();
+    // await expect(jsonEditorModal.inputField).toBeVisible();
+    // await expect(jsonEditorModal.inputField).toBeEnabled();
+    await expect(this.page.getByRole('dialog').getByRole('code')).toBeVisible();
+    await jsonEditorModal.inputField.evaluate((el: HTMLElement) => el.focus());
+    await this.clearMonacoEditor();
     await this.fillMonacoEditor(jsonEditorModal.inputField, json);
     await jsonEditorModal.applyButton.click();
+    await expect(jsonEditorModal.header).toBeHidden();
     await this.editableExistingVariableByName(
       variableName,
     ).writeModeValue.click();

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts
@@ -659,6 +659,7 @@ test.describe('Process Instance Modifications', () => {
       });
 
       test('Applied modifications persist after reloading', async ({
+        page,
         operateProcessInstancePage,
         operateProcessInstanceViewModificationModePage,
       }) => {
@@ -697,39 +698,48 @@ test.describe('Process Instance Modifications', () => {
           operateProcessInstanceViewModificationModePage.modificationModeText,
         ).toBeHidden();
 
-        await operateProcessInstancePage.expandTreeItemInHistory(
-          activityFirstSubprocess,
-        );
-        await operateProcessInstancePage.clickInstanceHistoryElement(
-          activityCollectMoney,
-        );
-        await expect(
-          operateProcessInstancePage.existingVariableByName('testLocalVariable')
-            .name,
-        ).toBeVisible();
-        expect(
-          await operateProcessInstancePage
-            .existingVariableByName('testLocalVariable')
-            .value.innerText(),
-        ).toContain('"addedValue"');
+        await waitForAssertion({
+          assertion: async () => {
+            await operateProcessInstancePage.expandTreeItemInHistory(
+              activityFirstSubprocess,
+            );
+            await operateProcessInstancePage.clickInstanceHistoryElement(
+              activityCollectMoney,
+            );
+            await expect(
+              operateProcessInstancePage.existingVariableByName(
+                'testLocalVariable',
+              ).name,
+            ).toBeVisible();
+            expect(
+              await operateProcessInstancePage
+                .existingVariableByName('testLocalVariable')
+                .value.innerText(),
+            ).toContain('"addedValue"');
 
-        await operateProcessInstancePage.navigateToRootScope();
-        await expect(
-          operateProcessInstancePage.existingVariableByName(
-            'testNewMeowVariable',
-          ).name,
-        ).toBeVisible();
-        expect(
-          await operateProcessInstancePage
-            .existingVariableByName('testNewMeowVariable')
-            .value.innerText(),
-        ).toContain('7');
-        await assertJsonEqual(
-          operateProcessInstancePage.existingVariableByName(
-            'testVariableString',
-          ).value,
-          validJSONValue2,
-        );
+            await operateProcessInstancePage.navigateToRootScope();
+            await expect(
+              operateProcessInstancePage.existingVariableByName(
+                'testNewMeowVariable',
+              ).name,
+            ).toBeVisible();
+            expect(
+              await operateProcessInstancePage
+                .existingVariableByName('testNewMeowVariable')
+                .value.innerText(),
+            ).toContain('7');
+            await assertJsonEqual(
+              operateProcessInstancePage.existingVariableByName(
+                'testVariableString',
+              ).value,
+              validJSONValue2,
+            );
+          },
+          onFailure: async () => {
+            await page.reload();
+            await hideHelperModals(page);
+          },
+        });
       });
     });
   });


### PR DESCRIPTION
## Description

This PR is to fix the flaky test for modifications persist after reloading in Operate. Issues arise while trying to wait for textbox to load and so there is timeout that leads to failure.

Two race conditions in addNewVariable caused the Applied modifications persist after reloading test to flake, specifically when adding a local variable to the collectMoney subprocess scope.

Race condition 1 — name field (pre-existing): The original code called .clear() then .type(name) on the name field without waiting for the DOM row to stabilise. When switching to a subprocess scope, the variable row re-renders and the name field is briefly detached — .clear() would match a stale element at the same index, causing the name to be typed into the wrong row or dropped.

Race condition 2 — value field (introduced by the name field fix): Fixing the name field introduced a new issue. After typing the name, the code pressed Tab and only checked that the name field lost focus before calling insertText

## Fix

Name field: Wait for the specific name field to be visible and empty before interacting with it, guarding against stale rows from re-renders
Value field: Instead of Tab navigation and a weak page-wide editor check, explicitly click the value field and wait until its Monaco editor has focus using :focus-within

:focus-within is true only once Monaco's internal element is the active DOM element. toPass() polls with retry, so insertText is guaranteed to land correctly regardless of how long Monaco takes to initialise after a scope switch.

## Related issues

closes #52657

## Test plan

- [ ] Run on-demand E2E workflow against this branch: https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml
- [ ] Locally: `npx playwright test --project=operate-e2e --grep "Applied modifications persist after reloading" --workers=1 --repeat-each=20` and `npm run test -- --project=chromium tests/operate/ --workers=4 --repeat-each=2` 