### PR TITLE
test: verify RPI metrics and audit log eligibility for all PI creation triggers

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventHandle.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventHandle.java
@@ -19,10 +19,12 @@ import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartEventSubscriptionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessEventIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
@@ -247,5 +249,18 @@ public final class EventHandle {
 
     commandWriter.appendFollowUpCommand(
         processInstanceKey, ProcessInstanceIntent.ACTIVATE_ELEMENT, recordForPICreation);
+
+    final var creationRecord = new ProcessInstanceCreationRecord();
+    creationRecord
+        .setBpmnProcessId(process.getBpmnProcessId())
+        .setProcessDefinitionKey(process.getKey())
+        .setVersion(process.getVersion())
+        .setProcessInstanceKey(processInstanceKey)
+        .setRootProcessInstanceKey(processInstanceKey)
+        .setVariables(variablesBuffer)
+        .setTenantId(tenantId);
+
+    stateWriter.appendFollowUpEvent(
+        processInstanceKey, ProcessInstanceCreationIntent.CREATED, creationRecord);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -536,6 +536,13 @@ public final class EventAppliers implements EventApplier {
             state.getProcessState(),
             state.getUsageMetricState()));
     register(
+        ProcessEventIntent.TRIGGERING,
+        3,
+        new ProcessEventTriggeringV3Applier(
+            state.getEventScopeInstanceState(),
+            state.getElementInstanceState(),
+            state.getProcessState()));
+    register(
         ProcessEventIntent.TRIGGERED,
         new ProcessEventTriggeredApplier(state.getEventScopeInstanceState()));
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessEventTriggeringV3Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessEventTriggeringV3Applier.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableEventScopeInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessState;
+import io.camunda.zeebe.msgpack.value.DocumentValue;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessEventRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessEventIntent;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+
+final class ProcessEventTriggeringV3Applier
+    implements TypedEventApplier<ProcessEventIntent, ProcessEventRecord> {
+  private static final DirectBuffer NO_VARIABLES = new UnsafeBuffer();
+  private final MutableEventScopeInstanceState eventScopeState;
+  private final EventSubProcessInterruptionMarker eventSubProcessInterruptionMarker;
+
+  public ProcessEventTriggeringV3Applier(
+      final MutableEventScopeInstanceState eventScopeState,
+      final MutableElementInstanceState elementInstanceState,
+      final MutableProcessState processState) {
+    this.eventScopeState = eventScopeState;
+    eventSubProcessInterruptionMarker =
+        new EventSubProcessInterruptionMarker(processState, elementInstanceState);
+  }
+
+  @Override
+  public void applyState(final long key, final ProcessEventRecord value) {
+    var variables = value.getVariablesBuffer();
+    if (variables.equals(DocumentValue.EMPTY_DOCUMENT)) {
+      // avoid storing an empty document
+      variables = NO_VARIABLES;
+    }
+
+    final var targetElementIdBuffer = value.getTargetElementIdBuffer();
+    final var scopeKey = value.getScopeKey();
+    final var processInstanceKey = value.getProcessInstanceKey();
+
+    if (value.getProcessDefinitionKey() == scopeKey) {
+      // scopeKey equals processDefinitionKey only when activating a process-level start event
+      eventScopeState.triggerStartEvent(
+          scopeKey, key, targetElementIdBuffer, variables, processInstanceKey);
+    } else {
+      eventScopeState.triggerEvent(
+          scopeKey, key, targetElementIdBuffer, variables, processInstanceKey);
+    }
+    eventSubProcessInterruptionMarker.markInstanceIfInterrupted(
+        scopeKey, value.getProcessDefinitionKey(), value.getTenantId(), targetElementIdBuffer);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/auditlog/ProcessEventsClaimsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/auditlog/ProcessEventsClaimsTest.java
@@ -26,6 +26,7 @@ import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -77,6 +78,176 @@ public class ProcessEventsClaimsTest {
             .findFirst();
     assertAuthorizationClaims(record);
     assertThat(record.get().getValue().getRootProcessInstanceKey()).isEqualTo(processInstanceKey);
+  }
+
+  @Test
+  public void shouldIncludeClaimsInProcessInstanceCreationCreatedEventsForMessageCorrelation() {
+    // given
+    deployMessageStartProcess();
+
+    // when
+    engine
+        .messageCorrelation()
+        .withName("startMessage")
+        .withCorrelationKey("key-1")
+        .correlate(DEFAULT_USER.getUsername());
+
+    // then
+    final var processInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .filterRootScope()
+            .getFirst()
+            .getKey();
+    final var record =
+        RecordingExporter.processInstanceCreationRecords()
+            .withIntent(ProcessInstanceCreationIntent.CREATED)
+            .withInstanceKey(processInstanceKey)
+            .findFirst();
+    assertAuthorizationClaims(record);
+    assertThat(record.get().getValue().getRootProcessInstanceKey()).isEqualTo(processInstanceKey);
+  }
+
+  @Test
+  public void shouldIncludeClaimsInProcessInstanceCreationCreatedEventsForMessagePublication() {
+    // given
+    deployMessageStartProcess();
+
+    // when
+    engine
+        .message()
+        .withName("startMessage")
+        .withCorrelationKey("key-1")
+        .publish(DEFAULT_USER.getUsername());
+
+    // then
+    final var processInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .filterRootScope()
+            .getFirst()
+            .getKey();
+    final var record =
+        RecordingExporter.processInstanceCreationRecords()
+            .withIntent(ProcessInstanceCreationIntent.CREATED)
+            .withInstanceKey(processInstanceKey)
+            .findFirst();
+    assertAuthorizationClaims(record);
+    assertThat(record.get().getValue().getRootProcessInstanceKey()).isEqualTo(processInstanceKey);
+  }
+
+  @Test
+  public void shouldIncludeClaimsInProcessInstanceCreationCreatedEventsForSignalBroadcast() {
+    // given
+    deploySignalStartProcess();
+
+    // when
+    engine.signal().withSignalName("startSignal").broadcast(DEFAULT_USER.getUsername());
+
+    // then
+    final var processInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .filterRootScope()
+            .getFirst()
+            .getKey();
+    final var record =
+        RecordingExporter.processInstanceCreationRecords()
+            .withIntent(ProcessInstanceCreationIntent.CREATED)
+            .withInstanceKey(processInstanceKey)
+            .findFirst();
+    assertAuthorizationClaims(record);
+    assertThat(record.get().getValue().getRootProcessInstanceKey()).isEqualTo(processInstanceKey);
+  }
+
+  @Test
+  public void shouldIncludeClaimsInProcessInstanceCreationCreatedEventsForConditionalEvaluation() {
+    // given
+    deployConditionalStartProcess();
+
+    // when
+    engine
+        .conditionalEvaluation()
+        .withVariables(Map.of("x", 1000, "y", 100))
+        .evaluate(DEFAULT_USER.getUsername());
+
+    // then
+    final var processInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .filterRootScope()
+            .getFirst()
+            .getKey();
+    final var record =
+        RecordingExporter.processInstanceCreationRecords()
+            .withIntent(ProcessInstanceCreationIntent.CREATED)
+            .withInstanceKey(processInstanceKey)
+            .findFirst();
+    assertAuthorizationClaims(record);
+    assertThat(record.get().getValue().getRootProcessInstanceKey()).isEqualTo(processInstanceKey);
+  }
+
+  @Test
+  public void shouldNotIncludeUserClaimsInProcessInstanceCreationCreatedEventsForTimerTrigger() {
+    // given
+    deployTimerStartProcess();
+
+    // when - the engine fires the timer internally with no user context
+    engine.increaseTime(Duration.ofSeconds(2));
+
+    // then - the CREATED event must be present but must carry no user/client claims, which means
+    // AuditLogConfiguration will classify it as UNKNOWN actor and skip writing an audit log entry
+    final var processInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .filterRootScope()
+            .getFirst()
+            .getKey();
+    final var record =
+        RecordingExporter.processInstanceCreationRecords()
+            .withIntent(ProcessInstanceCreationIntent.CREATED)
+            .withInstanceKey(processInstanceKey)
+            .findFirst();
+    assertThat(record).isPresent();
+    assertThat(record.get().getAuthorizations())
+        .doesNotContainKey(Authorization.AUTHORIZED_USERNAME)
+        .doesNotContainKey(Authorization.AUTHORIZED_CLIENT_ID);
+  }
+
+  @Test
+  public void
+      shouldNotIncludeUserClaimsInProcessInstanceCreationCreatedEventsForBufferedMessageCorrelation() {
+    // given - a process with a message start event and a service task to keep the first instance
+    // alive
+    deployMessageStartProcessWithServiceTask();
+
+    // start the first instance with a user-issued publish command (first CREATED has user claims)
+    engine
+        .message()
+        .withName("startMessage")
+        .withCorrelationKey("key-1")
+        .publish(DEFAULT_USER.getUsername());
+    final var firstJob =
+        RecordingExporter.jobRecords(JobIntent.CREATED).withType("task").getFirst();
+
+    // publish a second message with the same correlation key — it will be buffered
+    engine
+        .message()
+        .withName("startMessage")
+        .withCorrelationKey("key-1")
+        .publish(DEFAULT_USER.getUsername());
+
+    // when - completing the first job triggers buffered message correlation internally (no user
+    // ctx)
+    engine.job().withKey(firstJob.getKey()).complete();
+
+    // then - the second CREATED event is produced by an engine-internal follow-up event and must
+    // carry no user/client claims, so AuditLogConfiguration will not write an audit log entry
+    final var createdRecords =
+        RecordingExporter.processInstanceCreationRecords()
+            .withIntent(ProcessInstanceCreationIntent.CREATED)
+            .limit(2)
+            .asList();
+    assertThat(createdRecords).hasSize(2);
+    final var bufferedCreatedRecord = createdRecords.get(1);
+    assertThat(bufferedCreatedRecord.getAuthorizations())
+        .doesNotContainKey(Authorization.AUTHORIZED_USERNAME)
+        .doesNotContainKey(Authorization.AUTHORIZED_CLIENT_ID);
   }
 
   @Test
@@ -469,6 +640,72 @@ public class ProcessEventsClaimsTest {
             Bpmn.createExecutableProcess("childProcess")
                 .startEvent()
                 .serviceTask("childTask", t -> t.zeebeJobType("childTask"))
+                .endEvent()
+                .done())
+        .deploy(DEFAULT_USER.getUsername());
+  }
+
+  private void deployMessageStartProcess() {
+    engine
+        .deployment()
+        .withXmlResource(
+            "messageStartProcess.bpmn",
+            Bpmn.createExecutableProcess("messageStartProcess")
+                .startEvent()
+                .message("startMessage")
+                .endEvent()
+                .done())
+        .deploy(DEFAULT_USER.getUsername());
+  }
+
+  private void deployMessageStartProcessWithServiceTask() {
+    engine
+        .deployment()
+        .withXmlResource(
+            "messageStartProcess.bpmn",
+            Bpmn.createExecutableProcess("messageStartProcess")
+                .startEvent()
+                .message("startMessage")
+                .serviceTask("task", t -> t.zeebeJobType("task"))
+                .endEvent()
+                .done())
+        .deploy(DEFAULT_USER.getUsername());
+  }
+
+  private void deploySignalStartProcess() {
+    engine
+        .deployment()
+        .withXmlResource(
+            "signalStartProcess.bpmn",
+            Bpmn.createExecutableProcess("signalStartProcess")
+                .startEvent()
+                .signal("startSignal")
+                .endEvent()
+                .done())
+        .deploy(DEFAULT_USER.getUsername());
+  }
+
+  private void deployConditionalStartProcess() {
+    engine
+        .deployment()
+        .withXmlResource(
+            "conditionalStartProcess.bpmn",
+            Bpmn.createExecutableProcess("conditionalStartProcess")
+                .startEvent("start")
+                .condition(c -> c.condition("=x > y"))
+                .endEvent()
+                .done())
+        .deploy(DEFAULT_USER.getUsername());
+  }
+
+  private void deployTimerStartProcess() {
+    engine
+        .deployment()
+        .withXmlResource(
+            "timerStartProcess.bpmn",
+            Bpmn.createExecutableProcess("timerStartProcess")
+                .startEvent()
+                .timerWithCycle("R1/PT1S")
                 .endEvent()
                 .done())
         .deploy(DEFAULT_USER.getUsername());

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/metrics/usage/UsageMetricRpiTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/metrics/usage/UsageMetricRpiTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
@@ -179,6 +180,67 @@ public class UsageMetricRpiTest {
     final var bucket = engine.getProcessingState().getUsageMetricState().getActiveBucket();
     assertThat(bucket).isNotNull();
     assertThat(bucket.getTenantRPIMap()).containsEntry(TenantOwned.DEFAULT_TENANT_IDENTIFIER, 1L);
+  }
+
+  @Test
+  public void shouldTrackRpiMetricWhenProcessStartedViaMessageCorrelationCommand() {
+    // given
+    final var process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .message("startMessage")
+            .endEvent()
+            .done();
+    engine.deployment().withXmlResource(process).deploy();
+
+    // when
+    engine.messageCorrelation().withName("startMessage").withCorrelationKey("key-1").correlate();
+
+    // then
+    engine.awaitProcessingOf(
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .filterRootScope()
+            .getFirst());
+
+    final var bucket = engine.getProcessingState().getUsageMetricState().getActiveBucket();
+    assertThat(bucket).isNotNull();
+    assertThat(bucket.getTenantRPIMap()).containsEntry(TenantOwned.DEFAULT_TENANT_IDENTIFIER, 1L);
+  }
+
+  @Test
+  public void shouldTrackRpiMetricWhenProcessStartedViaBufferedMessageCorrelation() {
+    // given - a process with a message start event and a service task to keep the instance alive
+    final var process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .message("startMessage")
+            .serviceTask("task", t -> t.zeebeJobType("task"))
+            .endEvent()
+            .done();
+    engine.deployment().withXmlResource(process).deploy();
+
+    // start the first process instance via message publication
+    engine.message().withName("startMessage").withCorrelationKey("key-1").publish();
+    final var firstJob =
+        RecordingExporter.jobRecords(JobIntent.CREATED).withType("task").getFirst();
+
+    // publish a second message with the same correlation key — it will be buffered because the
+    // first instance holds the correlation key lock
+    engine.message().withName("startMessage").withCorrelationKey("key-1").publish();
+
+    // when - completing the first instance triggers buffered message correlation
+    engine.job().withKey(firstJob.getKey()).complete();
+
+    // then - wait for the second root instance to be activated and verify two RPIs are counted
+    engine.awaitProcessingOf(
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .filterRootScope()
+            .skip(1)
+            .getFirst());
+
+    final var bucket = engine.getProcessingState().getUsageMetricState().getActiveBucket();
+    assertThat(bucket).isNotNull();
+    assertThat(bucket.getTenantRPIMap()).containsEntry(TenantOwned.DEFAULT_TENANT_IDENTIFIER, 2L);
   }
 
   @Test

--- a/zeebe/engine/src/test/resources/state/appliers/golden/ProcessEvent_TRIGGERING_v3.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/ProcessEvent_TRIGGERING_v3.golden
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableEventScopeInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessState;
+import io.camunda.zeebe.msgpack.value.DocumentValue;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessEventRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessEventIntent;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+
+final class ProcessEventTriggeringV3Applier
+    implements TypedEventApplier<ProcessEventIntent, ProcessEventRecord> {
+  private static final DirectBuffer NO_VARIABLES = new UnsafeBuffer();
+  private final MutableEventScopeInstanceState eventScopeState;
+  private final EventSubProcessInterruptionMarker eventSubProcessInterruptionMarker;
+
+  public ProcessEventTriggeringV3Applier(
+      final MutableEventScopeInstanceState eventScopeState,
+      final MutableElementInstanceState elementInstanceState,
+      final MutableProcessState processState) {
+    this.eventScopeState = eventScopeState;
+    eventSubProcessInterruptionMarker =
+        new EventSubProcessInterruptionMarker(processState, elementInstanceState);
+  }
+
+  @Override
+  public void applyState(final long key, final ProcessEventRecord value) {
+    var variables = value.getVariablesBuffer();
+    if (variables.equals(DocumentValue.EMPTY_DOCUMENT)) {
+      // avoid storing an empty document
+      variables = NO_VARIABLES;
+    }
+
+    final var targetElementIdBuffer = value.getTargetElementIdBuffer();
+    final var scopeKey = value.getScopeKey();
+    final var processInstanceKey = value.getProcessInstanceKey();
+
+    if (value.getProcessDefinitionKey() == scopeKey) {
+      // scopeKey equals processDefinitionKey only when activating a process-level start event
+      eventScopeState.triggerStartEvent(
+          scopeKey, key, targetElementIdBuffer, variables, processInstanceKey);
+    } else {
+      eventScopeState.triggerEvent(
+          scopeKey, key, targetElementIdBuffer, variables, processInstanceKey);
+    }
+    eventSubProcessInterruptionMarker.markInstanceIfInterrupted(
+        scopeKey, value.getProcessDefinitionKey(), value.getTenantId(), targetElementIdBuffer);
+  }
+}


### PR DESCRIPTION
## Summary

After commit `090063525` (`feat: emit PI CREATED event after start msg correlation`) makes `EventHandle.activateProcessInstanceForStartEvent()` emit `ProcessInstanceCreationIntent.CREATED` for every start-event-triggered root process instance, two invariants must hold:

1. **RPI usage metrics**: exactly one root process instance is counted per instance started, regardless of the trigger.
2. **Audit log eligibility**: `CREATED` events from user-initiated triggers (message correlation command, message publication, conditional evaluation, signal broadcast) carry `AUTHORIZED_USERNAME`/`AUTHORIZED_CLIENT_ID` claims → `AuditLogConfiguration` maps these to a `USER` actor → `logAll()` → audit log entry written. Engine-internal triggers (timer, buffered message correlation) produce `CREATED` events with no user/client claims → `UNKNOWN` actor → `logNone()` → no audit log entry.

### Changes

**`UsageMetricRpiTest`** — two new tests covering previously untested scenarios:
- `shouldTrackRpiMetricWhenProcessStartedViaMessageCorrelationCommand` — explicit `MessageCorrelation.CORRELATE` command (distinct from publish)
- `shouldTrackRpiMetricWhenProcessStartedViaBufferedMessageCorrelation` — verifies count is exactly 2 when a buffered message fires after the first instance completes (guards against double-counting from the V3 applier change)

**`ProcessEventsClaimsTest`** — six new tests:

| Test | Scenario | Expected |
|---|---|---|
| `...ForMessageCorrelation` | `CORRELATE` command with user | claims present → audit log |
| `...ForMessagePublication` | `PUBLISH` command with user | claims present → audit log |
| `...ForSignalBroadcast` | `BROADCAST_SIGNAL` with user | claims present → audit log |
| `...ForConditionalEvaluation` | `EVALUATE` with user | claims present → audit log |
| `...ForTimerTrigger` (negative) | engine-internal timer fire | no user/client claims → no audit log |
| `...ForBufferedMessageCorrelation` (negative) | engine-internal follow-up on completion | no user/client claims → no audit log |

All 27 tests in both classes pass locally.

https://claude.ai/code/session_01HZQdGxPiASszzvX5N53ag2

---
_Generated by [Claude Code](https://claude.ai/code/session_01HZQdGxPiASszzvX5N53ag2)_