### PR TITLE
test: Reduce loglevels for AC Tests to "debug"

### DIFF
--- a/qa/acceptance-tests/src/test/resources/log4j2.xml
+++ b/qa/acceptance-tests/src/test/resources/log4j2.xml
@@ -28,9 +28,9 @@
     <Logger name="io.camunda.db.rdbms" level="debug"/>
     <Logger name="io.camunda.exporter.rdbms" level="info"/>
     <Logger name="io.camunda.zeebe.engine.processing.batchoperation" level="debug"/>
-    <Logger name="io.camunda.exporter.tasks.batchoperations" level="trace"/>
-    <Logger name="io.camunda.exporter.handlers.batchoperation" level="trace"/>
-    <Logger name="io.camunda.zeebe.broker.exporter" level="trace"/>
+    <Logger name="io.camunda.exporter.tasks.batchoperations" level="debug"/>
+    <Logger name="io.camunda.exporter.handlers.batchoperation" level="debug"/>
+    <Logger name="io.camunda.zeebe.broker.exporter" level="debug"/>
     <Logger name="io.camunda.zeebe.gateway.rest" level="debug"/>
 
     <Root level="${sys:root.logging.level:-INFO}">


### PR DESCRIPTION
This pull request updates the logging configuration for several components in the system, changing their log levels from `trace` to `debug` in the `log4j2.xml` configuration file. This change reduces the verbosity of logs for these components, which can help make logs more readable and improve performance in non-debug scenarios.

Logging configuration updates:

* Changed log level from `trace` to `debug` for `io.camunda.exporter.tasks.batchoperations` in `log4j2.xml`.
* Changed log level from `trace` to `debug` for `io.camunda.exporter.handlers.batchoperation` in `log4j2.xml`.
* Changed log level from `trace` to `debug` for `io.camunda.zeebe.broker.exporter` in `log4j2.xml`.