### PR TITLE
feat: add agentInstaceKey to element-instances API result

### DIFF
--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -1053,6 +1053,7 @@ public final class SearchQueryResponseMapper {
         .rootProcessInstanceKey(keyToStringOrNull(instance.rootProcessInstanceKey()))
         .endDate(formatDateOrNull(instance.endDate()))
         .incidentKey(keyToStringOrNull(instance.incidentKey()))
+        .agentInstanceKey(null) // TODO: this will be filled in #51513
         .build();
   }
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/element-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/element-instances.yaml
@@ -414,6 +414,7 @@ components:
         - rootProcessInstanceKey
         - endDate
         - incidentKey
+        - agentInstanceKey
       properties:
         processDefinitionId:
           description: The process definition ID associated to this element instance.
@@ -501,6 +502,11 @@ components:
           allOf:
             - $ref: "keys.yaml#/components/schemas/IncidentKey"
           description: Incident key associated with this element instance.
+          nullable: true
+        agentInstanceKey:
+          allOf:
+            - $ref: "keys.yaml#/components/schemas/AgentInstanceKey"
+          description: The agent instance key associated with this element instance.
           nullable: true
 
     ElementInstanceStateEnum:

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ElementInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ElementInstanceQueryControllerTest.java
@@ -77,7 +77,8 @@ public class ElementInstanceQueryControllerTest extends RestControllerTest {
                    "state":"ACTIVE",
                    "hasIncident":false,
                    "incidentKey": null,
-                   "tenantId":"<default>"
+                   "tenantId":"<default>",
+                   "agentInstanceKey": null
                  }
               ],
               "page": {
@@ -130,7 +131,8 @@ public class ElementInstanceQueryControllerTest extends RestControllerTest {
                    "state":"ACTIVE",
                    "hasIncident":true,
                    "incidentKey":"1234",
-                   "tenantId":"tenantId"
+                   "tenantId":"tenantId",
+                   "agentInstanceKey": null
                  }
           """;
 


### PR DESCRIPTION
Element Instances can be associated to an Agent Instance if during their execution they make use of LLM calls. This is the case for example when using the AI Agent connectors:
- AI Agent Subprocess (based on Ad-hoc Sub-process)
- AI Agent Task (based on Service Tasks)

This pull request updates the `element-instances.yaml` schema to add support for tracking the agent instance associated with an element instance. The main change is the introduction of a new `agentInstanceKey` property, which allows the schema to reference the agent instance key for each element instance.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #52775 
