### PR TITLE
test: stabilize Tasklist Unassign click flake on 8.9 nightly E2E

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskDetailsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskDetailsPage.ts
@@ -159,7 +159,7 @@ class TaskDetailsPage {
 
   async clickUnassignButton() {
     await expect(this.unassignButton).toBeVisible({timeout: 30000});
-    await this.unassignButton.click();
+    await this.unassignButton.click({timeout: 30000});
   }
 
   async clickCompleteTaskButton() {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
@@ -130,10 +130,20 @@ test.describe('task details page', () => {
     taskPanelPage,
     taskDetailsPage,
   }) => {
-    await taskPanelPage.openTask('usertask_to_be_completed');
-
-    await expect(taskDetailsPage.assignToMeButton).toBeVisible({
-      timeout: 60000,
+    // The task list refreshes while other specs run in parallel, so the
+    // first .nth(0) click can land on a stale card whose details panel
+    // never updates. Retry the open + assert until the right panel shows
+    // the unassigned task ready for action.
+    await waitForAssertion({
+      assertion: async () => {
+        await taskPanelPage.openTask('usertask_to_be_completed');
+        await expect(taskDetailsPage.assignToMeButton).toBeVisible({
+          timeout: 20000,
+        });
+      },
+      onFailure: async () => {
+        await page.reload();
+      },
     });
     await expect(taskDetailsPage.completeTaskButton).toBeDisabled();
     await taskDetailsPage.clickAssignToMeButton();


### PR DESCRIPTION
## Summary

Stabilizes two flaky Tasklist E2E tests surfaced in the [8.9 nightly run](https://github.com/camunda/camunda/actions/runs/25646336476). No product (frontend or backend) changes — QA test stabilization only.

- **`processInstanceMigration.spec.ts:797` "Migrate parallel job-based user tasks to Camunda user tasks"** (unexpected failure, both attempts) — `TaskDetailsPage.clickUnassignButton` waits 30s for the Unassign button to be visible, then calls `.click()` with the default 10s action timeout. The migration test loops this path six times; after a prior task is completed and the next card is clicked on the left, the right panel briefly renders the Unassign button (so `toBeVisible` matches in ~385ms per trace), then re-renders during transition and the 10s click never re-finds it. Same flake hit on the [May 7 nightly](https://github.com/camunda/camunda/actions/runs/25471660596) but passed on retry; May 11 failed both attempts. Fix: give the click a 30s timeout matching the visibility wait, so Playwright's actionability retry rides out the transition.
- **`task-details.spec.ts:128` "assign and unassign task"** (flaky, passed on retry) — `taskPanelPage.openTask('usertask_to_be_completed')` clicks `.nth(0)` of the matched text, but specs run in parallel (4 workers) and the task list refreshes while the click is in flight, so the click can land on a stale card whose details panel never updates. The subsequent `expect(assignToMeButton).toBeVisible({timeout: 60000})` then hangs 60s before failing. Fix: wrap the open-and-assert in `waitForAssertion` with a `page.reload()` fallback, matching the pattern used elsewhere in the file.

## Files changed

- `pages/TaskDetailsPage.ts` — `clickUnassignButton` click timeout 10s → 30s.
- `tests/tasklist/task-details.spec.ts` — wrap `openTask` + first `assignToMeButton` assertion in `waitForAssertion`.

No overlap with PR #52670 (open against `main`), which targets different failure modes in the same migration spec (Tasklist login form, post-migration polling).

## Test plan

- [x] `playwright test tests/operate/processInstanceMigration.spec.ts --grep "Migrate parallel job-based"` passes locally against `demo/demo` (V2 mode).
- [x] `playwright test tests/tasklist/task-details.spec.ts --grep "assign and unassign task"` passes locally.
- [x] https://github.com/camunda/camunda/actions/runs/25663836852 -> all 🟢 

🤖 Generated with [Claude Code](https://claude.com/claude-code)