### PR TITLE
feat: use HTTP 406 for non-rpa resources

### DIFF
--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/GatewayErrorMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/GatewayErrorMapper.java
@@ -110,6 +110,7 @@ public class GatewayErrorMapper {
       case UNKNOWN, INTERNAL -> HttpStatus.INTERNAL_SERVER_ERROR;
       case FORBIDDEN -> HttpStatus.FORBIDDEN;
       case NOT_FOUND -> HttpStatus.NOT_FOUND;
+      case NOT_ACCEPTABLE -> HttpStatus.NOT_ACCEPTABLE;
       case UNAUTHORIZED -> HttpStatus.UNAUTHORIZED;
       case ALREADY_EXISTS, INVALID_STATE -> HttpStatus.CONFLICT;
       case INVALID_ARGUMENT -> HttpStatus.BAD_REQUEST;

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ResourceDeployIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ResourceDeployIT.java
@@ -106,7 +106,7 @@ class ResourceDeployIT {
   }
 
   @Test
-  void shouldReturnNotFoundForGetContentOnNonRpaResource() {
+  void shouldReturnNotAcceptableForGetContentOnNonRpaResource() {
     // given - /content endpoint only serves resources with type "rpa"
 
     // when
@@ -116,7 +116,7 @@ class ResourceDeployIT {
     // then
     final var problemException =
         assertThatExceptionOfType(ProblemException.class).isThrownBy(execute).actual();
-    assertThat(problemException.code()).isEqualTo(404);
+    assertThat(problemException.code()).isEqualTo(406);
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ResourceDeployWithoutSecondaryStorageIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ResourceDeployWithoutSecondaryStorageIT.java
@@ -113,7 +113,7 @@ class ResourceDeployWithoutSecondaryStorageIT {
   }
 
   @Test
-  void shouldReturnNotFoundForGetContentOnNonRpaResource() {
+  void shouldReturnNotAcceptableForGetContentOnNonRpaResource() {
     // given - /content endpoint only serves resources with type "rpa"
 
     // when
@@ -123,7 +123,7 @@ class ResourceDeployWithoutSecondaryStorageIT {
     // then
     final var problemException =
         assertThatExceptionOfType(ProblemException.class).isThrownBy(execute).actual();
-    assertThat(problemException.code()).isEqualTo(404);
+    assertThat(problemException.code()).isEqualTo(406);
   }
 
   @Test

--- a/service/src/main/java/io/camunda/service/ResourceServices.java
+++ b/service/src/main/java/io/camunda/service/ResourceServices.java
@@ -231,8 +231,17 @@ public final class ResourceServices extends ApiServices<ResourceServices> {
   private void validateResourceType(
       final String entityResourceType, final String resourceTypeFilter, final long resourceKey) {
     if (resourceTypeFilter != null && !resourceTypeFilter.equalsIgnoreCase(entityResourceType)) {
-      throw resourceNotFoundException(resourceKey);
+      throw resourceTypeNotAcceptableException(resourceKey, entityResourceType, resourceTypeFilter);
     }
+  }
+
+  private static ServiceException resourceTypeNotAcceptableException(
+      final long resourceKey, final String actualType, final String expectedType) {
+    return new ServiceException(
+        String.format(
+            "Resource with key '%d' is of type '%s', expected '%s'",
+            resourceKey, actualType, expectedType),
+        ServiceException.Status.NOT_ACCEPTABLE);
   }
 
   private static ServiceException resourceNotFoundException(final long resourceKey) {

--- a/service/src/main/java/io/camunda/service/exception/ServiceException.java
+++ b/service/src/main/java/io/camunda/service/exception/ServiceException.java
@@ -37,6 +37,7 @@ public class ServiceException extends RuntimeException {
     ABORTED,
     INTERNAL,
     NOT_FOUND,
+    NOT_ACCEPTABLE,
     ALREADY_EXISTS,
     INVALID_STATE,
     UNKNOWN

--- a/zeebe/gateway-protocol/src/main/proto/v2/deployments.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/deployments.yaml
@@ -114,7 +114,13 @@ paths:
                 type: object
                 additionalProperties: true
         "404":
-          description: An RPA resource with the given key was not found.
+          description: A resource with the given key was not found.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "problem-detail.yaml#/components/schemas/ProblemDetail"
+        "406":
+          description: The resource exists but is not an RPA resource.
           content:
             application/problem+json:
               schema:

--- a/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
@@ -357,6 +357,8 @@ paths:
     $ref: 'deployments.yaml#/paths/~1resources~1{resourceKey}'
   /resources/{resourceKey}/content:
     $ref: 'deployments.yaml#/paths/~1resources~1{resourceKey}~1content'
+  /resources/{resourceKey}/content/binary:
+    $ref: 'deployments.yaml#/paths/~1resources~1{resourceKey}~1content~1binary'
   /resources/{resourceKey}/deletion:
     $ref: 'deployments.yaml#/paths/~1resources~1{resourceKey}~1deletion'
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ResourceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ResourceControllerTest.java
@@ -20,6 +20,7 @@ import io.camunda.service.ResourceServices;
 import io.camunda.service.ResourceServices.DeployResourcesRequest;
 import io.camunda.service.ResourceServices.ResourceDeletionRequest;
 import io.camunda.service.exception.ErrorMapper;
+import io.camunda.service.exception.ServiceException;
 import io.camunda.zeebe.broker.client.api.dto.BrokerError;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRejection;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
@@ -687,6 +688,41 @@ public class ResourceControllerTest extends RestControllerTest {
               "status": 404,
               "title": "NOT_FOUND",
               "detail": "Command 'FETCH' rejected with code 'NOT_FOUND': Resource not found",
+              "instance": "%s"
+            }
+            """
+                .formatted(url),
+            JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void getResourceContentShouldYieldNotAcceptableWhenResourceIsNotRpa() {
+    // given
+    when(resourceServices.getContentByKeyFilteredByType(eq(1L), eq("rpa"), any()))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new ServiceException(
+                    "Resource with key '1' is of type 'bpmn', expected 'rpa'",
+                    ServiceException.Status.NOT_ACCEPTABLE)));
+    final var url = GET_RESOURCE_CONTENT_ENDPOINT.formatted(1);
+
+    // when / then
+    webClient
+        .get()
+        .uri(url)
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.NOT_ACCEPTABLE)
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(
+            """
+            {
+              "type": "about:blank",
+              "status": 406,
+              "title": "NOT_ACCEPTABLE",
+              "detail": "Resource with key '1' is of type 'bpmn', expected 'rpa'",
               "instance": "%s"
             }
             """


### PR DESCRIPTION
## Description

- add unit and integration tests for NOT_ACCEPTABLE response on non-RPA resources
- add NOT_ACCEPTABLE status and improve resource type validation
- add binary content endpoint and new error response for resourceKey

## Related issues

closes https://github.com/camunda/camunda/issues/52739
