### PR TITLE
fix: wrap error-message ops in single has_child bool to enforce per-incident AND

### DIFF
--- a/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
@@ -306,13 +306,25 @@
     <!-- Error message filters -->
     <if test="filter.errorMessageOperations != null and !filter.errorMessageOperations.isEmpty()">
       <foreach collection="filter.errorMessageOperations" item="operation">
-        AND EXISTS (
-        SELECT 1
-        FROM ${prefix}INCIDENT i
-        WHERE i.PROCESS_INSTANCE_KEY = pi.PROCESS_INSTANCE_KEY
-        AND i.ERROR_MESSAGE
-        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
-        )
+        <choose>
+          <when test="operation.operator.name().equals('NOT_EXISTS')">
+            AND NOT EXISTS (
+            SELECT 1
+            FROM ${prefix}INCIDENT i
+            WHERE i.PROCESS_INSTANCE_KEY = pi.PROCESS_INSTANCE_KEY
+            AND i.ERROR_MESSAGE IS NOT NULL
+            )
+          </when>
+          <otherwise>
+            AND EXISTS (
+            SELECT 1
+            FROM ${prefix}INCIDENT i
+            WHERE i.PROCESS_INSTANCE_KEY = pi.PROCESS_INSTANCE_KEY
+            AND i.ERROR_MESSAGE
+            <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+            )
+          </otherwise>
+        </choose>
       </foreach>
     </if>
     <if

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSearchIT.java
@@ -1135,7 +1135,7 @@ public class ProcessInstanceSearchIT {
             .join();
 
     // then:
-    assertThat(result.items().size()).isEqualTo(0);
+    assertThat(result.items().size()).isEqualTo(8);
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSearchIT.java
@@ -44,6 +44,7 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @MultiDbTest
 @CompatibilityTest
@@ -1389,6 +1390,49 @@ public class ProcessInstanceSearchIT {
             .join();
 
     assertThat(result.items()).isNotEmpty();
+  }
+
+  @Test
+  @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
+  void shouldNarrowByHashCodeWhenErrorMessageInContainsSharedPrefix() {
+    // given
+    final var sharedPrefix = "Expected result of the expression";
+
+    // when
+    final var result =
+        camundaClient
+            .newProcessInstanceSearchRequest()
+            .filter(
+                f ->
+                    f.incidentErrorHashCode(INCIDENT_ERROR_HASH_CODE_V2)
+                        .errorMessage(f2 -> f2.in(List.of(sharedPrefix))))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items())
+        .hasSize(1)
+        .allSatisfy(
+            instance ->
+                assertThat(instance.getProcessDefinitionId()).isEqualTo("incident_process_v2"));
+  }
+
+  @Test
+  void shouldReturnNoResultWhenInListConflictsWithResolvedHashCode() {
+    // given
+    // when
+    final var result =
+        camundaClient
+            .newProcessInstanceSearchRequest()
+            .filter(
+                f ->
+                    f.incidentErrorHashCode(INCIDENT_ERROR_HASH_CODE_V2)
+                        .errorMessage(f2 -> f2.in(List.of(INCIDENT_ERROR_MESSAGE_V1))))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).isEmpty();
   }
 
   @Test

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/query/SearchQueryBuilders.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/query/SearchQueryBuilders.java
@@ -478,56 +478,6 @@ public final class SearchQueryBuilders {
         .toList();
   }
 
-  public static <C extends List<Operation<String>>>
-      List<SearchQuery> stringMatchPhraseWithHasChildOperations(
-          final String field, final C operations, final String childType) {
-
-    if (operations == null || operations.isEmpty()) {
-      return List.of();
-    }
-
-    return operations.stream()
-        .map(
-            op ->
-                switch (op.operator()) {
-                  case EQUALS -> hasChildQuery(childType, matchPhrase(field, op.value()));
-
-                  case NOT_EQUALS ->
-                      hasChildQuery(
-                          childType,
-                          bool(b ->
-                                  b.must(List.of(exists(field)))
-                                      .mustNot(List.of(matchPhrase(field, op.value()))))
-                              .toSearchQuery());
-
-                  case EXISTS ->
-                      hasChildQuery(
-                          childType, bool(b -> b.must(List.of(exists(field)))).toSearchQuery());
-
-                  case NOT_EXISTS ->
-                      hasChildQuery(
-                          childType,
-                          bool(b -> b.must(List.of(exists(field))).mustNot(List.of(exists(field))))
-                              .toSearchQuery());
-
-                  case IN ->
-                      hasChildQuery(
-                          childType,
-                          or(
-                              op.values().stream()
-                                  .map(value -> matchPhrase(field, value))
-                                  .toList()));
-
-                  case LIKE ->
-                      hasChildQuery(
-                          childType,
-                          wildcardQuery(field, Objects.requireNonNull(op.value()).toLowerCase()));
-
-                  default -> throw unexpectedOperation("String", op.operator());
-                })
-        .toList();
-  }
-
   public static <C extends List<Operation<String>>> SearchQuery stringMatchPhraseInSingleHasChild(
       final String field, final C operations, final String childType) {
 

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/query/SearchQueryBuilders.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/query/SearchQueryBuilders.java
@@ -528,6 +528,45 @@ public final class SearchQueryBuilders {
         .toList();
   }
 
+  public static <C extends List<Operation<String>>> SearchQuery stringMatchPhraseInSingleHasChild(
+      final String field, final C operations, final String childType) {
+
+    if (operations == null || operations.isEmpty()) {
+      return null;
+    }
+
+    final List<SearchQuery> innerClauses =
+        operations.stream()
+            .map(
+                op ->
+                    switch (op.operator()) {
+                      case EQUALS -> matchPhrase(field, op.value());
+
+                      case NOT_EQUALS ->
+                          bool(b ->
+                                  b.must(List.of(exists(field)))
+                                      .mustNot(List.of(matchPhrase(field, op.value()))))
+                              .toSearchQuery();
+
+                      case EXISTS -> bool(b -> b.must(List.of(exists(field)))).toSearchQuery();
+
+                      case NOT_EXISTS ->
+                          bool(b -> b.must(List.of(exists(field))).mustNot(List.of(exists(field))))
+                              .toSearchQuery();
+
+                      case IN ->
+                          or(op.values().stream().map(value -> matchPhrase(field, value)).toList());
+
+                      case LIKE ->
+                          wildcardQuery(field, Objects.requireNonNull(op.value()).toLowerCase());
+
+                      default -> throw unexpectedOperation("String", op.operator());
+                    })
+            .toList();
+
+    return hasChildQuery(childType, bool(b -> b.must(innerClauses)).toSearchQuery());
+  }
+
   private static String formatDate(final OffsetDateTime dateTime) {
     return DATE_TIME_FORMATTER.format(dateTime);
   }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/query/SearchQueryBuilders.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/query/SearchQueryBuilders.java
@@ -501,8 +501,7 @@ public final class SearchQueryBuilders {
                       case EXISTS -> bool(b -> b.must(List.of(exists(field)))).toSearchQuery();
 
                       case NOT_EXISTS ->
-                          bool(b -> b.must(List.of(exists(field))).mustNot(List.of(exists(field))))
-                              .toSearchQuery();
+                          bool(b -> b.mustNot(List.of(exists(field)))).toSearchQuery();
 
                       case IN ->
                           or(op.values().stream().map(value -> matchPhrase(field, value)).toList());

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/query/SearchQueryBuilders.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/query/SearchQueryBuilders.java
@@ -485,35 +485,35 @@ public final class SearchQueryBuilders {
       return null;
     }
 
-    final List<SearchQuery> innerClauses =
-        operations.stream()
-            .map(
-                op ->
-                    switch (op.operator()) {
-                      case EQUALS -> matchPhrase(field, op.value());
+    final List<SearchQuery> innerClauses = new ArrayList<>();
+    final List<SearchQuery> allClauses = new ArrayList<>();
 
-                      case NOT_EQUALS ->
-                          bool(b ->
-                                  b.must(List.of(exists(field)))
-                                      .mustNot(List.of(matchPhrase(field, op.value()))))
-                              .toSearchQuery();
+    for (final var op : operations) {
+      switch (op.operator()) {
+        case EQUALS -> innerClauses.add(matchPhrase(field, op.value()));
+        case NOT_EQUALS ->
+            innerClauses.add(
+                bool(b ->
+                        b.must(List.of(exists(field)))
+                            .mustNot(List.of(matchPhrase(field, op.value()))))
+                    .toSearchQuery());
+        case EXISTS -> innerClauses.add(bool(b -> b.must(List.of(exists(field)))).toSearchQuery());
+        case NOT_EXISTS -> allClauses.add(not(hasChildQuery(childType, exists(field))));
+        case IN ->
+            innerClauses.add(
+                or(op.values().stream().map(value -> matchPhrase(field, value)).toList()));
+        case LIKE ->
+            innerClauses.add(
+                wildcardQuery(field, Objects.requireNonNull(op.value()).toLowerCase()));
+        default -> throw unexpectedOperation("String", op.operator());
+      }
+    }
 
-                      case EXISTS -> bool(b -> b.must(List.of(exists(field)))).toSearchQuery();
+    if (!innerClauses.isEmpty()) {
+      allClauses.add(hasChildQuery(childType, bool(b -> b.must(innerClauses)).toSearchQuery()));
+    }
 
-                      case NOT_EXISTS ->
-                          bool(b -> b.mustNot(List.of(exists(field)))).toSearchQuery();
-
-                      case IN ->
-                          or(op.values().stream().map(value -> matchPhrase(field, value)).toList());
-
-                      case LIKE ->
-                          wildcardQuery(field, Objects.requireNonNull(op.value()).toLowerCase());
-
-                      default -> throw unexpectedOperation("String", op.operator());
-                    })
-            .toList();
-
-    return hasChildQuery(childType, bool(b -> b.must(innerClauses)).toSearchQuery());
+    return and(allClauses);
   }
 
   private static String formatDate(final OffsetDateTime dateTime) {

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/utils/IncidentErrorHashCodeNormalizer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/utils/IncidentErrorHashCodeNormalizer.java
@@ -69,60 +69,9 @@ public class IncidentErrorHashCodeNormalizer {
     final boolean hasHash = hashOps != null && !hashOps.isEmpty();
     final boolean hasMsg = msgOps != null && !msgOps.isEmpty();
 
-    if (hasHash && hasMsg) {
-      final boolean hasLike =
-          msgOps.stream().anyMatch(op -> op != null && op.operator() == Operator.LIKE);
-      if (hasLike) {
-        if (hasInvalidErrorMessages(msgOps)) {
-          logDropReason("process instance filter", "invalid error message operations", msgOps);
-          return Optional.empty();
-        }
-        return normalizeOrFilters(
-            filter.toBuilder().replaceErrorMessageOperations(dedupeErrorMessages(msgOps)).build(),
-            resourceAccessChecks,
-            visited);
-      }
-      final var inOp = msgOps.stream().filter(op -> op.operator() == Operator.IN).findFirst();
-      if (inOp.isPresent()) {
-        final var resolvedOpt = resolveErrorMessage(hashOps, resourceAccessChecks);
-        if (resolvedOpt.isEmpty()) {
-          logDropReason(
-              "process instance filter",
-              "could not resolve error message from hashOps for IN op",
-              hashOps,
-              msgOps);
-          return Optional.empty();
-        }
-        final String resolved = resolvedOpt.get();
-        final List<String> values = new ArrayList<>(inOp.get().values());
-        if (!values.contains(resolved)) {
-          values.add(resolved);
-        }
-        return normalizeOrFilters(
-            filter.toBuilder().replaceErrorMessageOperations(List.of(Operation.in(values))).build(),
-            resourceAccessChecks,
-            visited);
-      }
-      final var resolvedOpt = resolveErrorMessage(hashOps, resourceAccessChecks);
-      if (resolvedOpt.isEmpty()) {
-        logDropReason(
-            "process instance filter", "could not resolve error message from hashOps", hashOps);
-        return Optional.empty();
-      }
-      if (anyOpDoesNotMatch(msgOps, resolvedOpt.get())) {
-        logDropReason(
-            "process instance filter",
-            "resolved error message does not match msgOps",
-            msgOps,
-            resolvedOpt.get());
-        return Optional.empty();
-      }
-      return normalizeOrFilters(
-          filter.toBuilder()
-              .replaceErrorMessageOperations(List.of(Operation.eq(resolvedOpt.get())))
-              .build(),
-          resourceAccessChecks,
-          visited);
+    if (hasMsg && hasInvalidErrorMessages(msgOps)) {
+      logDropReason("process instance filter", "invalid error message operations", msgOps);
+      return Optional.empty();
     }
     if (hasHash) {
       final var resolvedOpt = resolveErrorMessage(hashOps, resourceAccessChecks);
@@ -131,18 +80,13 @@ public class IncidentErrorHashCodeNormalizer {
             "process instance filter", "could not resolve error message from hashOps", hashOps);
         return Optional.empty();
       }
+      final var combined = prependResolvedEq(resolvedOpt.get(), msgOps);
       return normalizeOrFilters(
-          filter.toBuilder()
-              .replaceErrorMessageOperations(List.of(Operation.eq(resolvedOpt.get())))
-              .build(),
+          filter.toBuilder().replaceErrorMessageOperations(combined).build(),
           resourceAccessChecks,
           visited);
     }
     if (hasMsg) {
-      if (hasInvalidErrorMessages(msgOps)) {
-        logDropReason("process instance filter", "invalid error message operations", msgOps);
-        return Optional.empty();
-      }
       return normalizeOrFilters(
           filter.toBuilder().replaceErrorMessageOperations(dedupeErrorMessages(msgOps)).build(),
           resourceAccessChecks,
@@ -194,60 +138,9 @@ public class IncidentErrorHashCodeNormalizer {
     final boolean hasHash = hashOps != null && !hashOps.isEmpty();
     final boolean hasMsg = msgOps != null && !msgOps.isEmpty();
 
-    if (hasHash && hasMsg) {
-      final boolean hasLike =
-          msgOps.stream().anyMatch(op -> op != null && op.operator() == Operator.LIKE);
-      if (hasLike) {
-        if (hasInvalidErrorMessages(msgOps)) {
-          logDropReason("process definition filter", "invalid error message operations", msgOps);
-          return Optional.empty();
-        }
-        return normalizeOrFilters(
-            filter.toBuilder().replaceErrorMessageOperations(dedupeErrorMessages(msgOps)).build(),
-            resourceAccessChecks,
-            visited);
-      }
-      final var inOp = msgOps.stream().filter(op -> op.operator() == Operator.IN).findFirst();
-      if (inOp.isPresent()) {
-        final var resolvedOpt = resolveErrorMessage(hashOps, resourceAccessChecks);
-        if (resolvedOpt.isEmpty()) {
-          logDropReason(
-              "process definition filter",
-              "could not resolve error message from hashOps for IN op",
-              hashOps,
-              msgOps);
-          return Optional.empty();
-        }
-        final String resolved = resolvedOpt.get();
-        final List<String> values = new ArrayList<>(inOp.get().values());
-        if (!values.contains(resolved)) {
-          values.add(resolved);
-        }
-        return normalizeOrFilters(
-            filter.toBuilder().replaceErrorMessageOperations(List.of(Operation.in(values))).build(),
-            resourceAccessChecks,
-            visited);
-      }
-      final var resolvedOpt = resolveErrorMessage(hashOps, resourceAccessChecks);
-      if (resolvedOpt.isEmpty()) {
-        logDropReason(
-            "process definition filter", "could not resolve error message from hashOps", hashOps);
-        return Optional.empty();
-      }
-      if (anyOpDoesNotMatch(msgOps, resolvedOpt.get())) {
-        logDropReason(
-            "process definition filter",
-            "resolved error message does not match msgOps",
-            msgOps,
-            resolvedOpt.get());
-        return Optional.empty();
-      }
-      return normalizeOrFilters(
-          filter.toBuilder()
-              .replaceErrorMessageOperations(List.of(Operation.eq(resolvedOpt.get())))
-              .build(),
-          resourceAccessChecks,
-          visited);
+    if (hasMsg && hasInvalidErrorMessages(msgOps)) {
+      logDropReason("process definition filter", "invalid error message operations", msgOps);
+      return Optional.empty();
     }
     if (hasHash) {
       final var resolvedOpt = resolveErrorMessage(hashOps, resourceAccessChecks);
@@ -256,18 +149,13 @@ public class IncidentErrorHashCodeNormalizer {
             "process definition filter", "could not resolve error message from hashOps", hashOps);
         return Optional.empty();
       }
+      final var combined = prependResolvedEq(resolvedOpt.get(), msgOps);
       return normalizeOrFilters(
-          filter.toBuilder()
-              .replaceErrorMessageOperations(List.of(Operation.eq(resolvedOpt.get())))
-              .build(),
+          filter.toBuilder().replaceErrorMessageOperations(combined).build(),
           resourceAccessChecks,
           visited);
     }
     if (hasMsg) {
-      if (hasInvalidErrorMessages(msgOps)) {
-        logDropReason("process definition filter", "invalid error message operations", msgOps);
-        return Optional.empty();
-      }
       return normalizeOrFilters(
           filter.toBuilder().replaceErrorMessageOperations(dedupeErrorMessages(msgOps)).build(),
           resourceAccessChecks,
@@ -319,25 +207,34 @@ public class IncidentErrorHashCodeNormalizer {
     return Optional.of(resolved);
   }
 
-  private boolean anyOpDoesNotMatch(final List<Operation<String>> ops, final String value) {
-    if (ops == null || ops.isEmpty()) {
-      return true;
-    }
-    for (final var op : ops) {
-      if (op == null || op.value() == null || !value.equals(op.value())) {
-        return true;
-      }
-    }
-    return false;
-  }
-
   private boolean hasInvalidErrorMessages(final List<Operation<String>> ops) {
     if (ops == null || ops.isEmpty()) {
       return true;
     }
     for (final var op : ops) {
-      if ((op.operator() != Operator.EXISTS && op.operator() != Operator.NOT_EXISTS)
-          && (op.value() == null || op.value().isBlank())) {
+      if (op == null) {
+        return true;
+      }
+      final var operator = op.operator();
+      if (operator == null) {
+        return true;
+      }
+      if (operator == Operator.EXISTS || operator == Operator.NOT_EXISTS) {
+        continue;
+      }
+      if (operator == Operator.IN || operator == Operator.NOT_IN) {
+        final var values = op.values();
+        if (values == null || values.isEmpty()) {
+          return true;
+        }
+        for (final var v : values) {
+          if (v == null || v.isBlank()) {
+            return true;
+          }
+        }
+        continue;
+      }
+      if (op.value() == null || Objects.requireNonNull(op.value()).isBlank()) {
         return true;
       }
     }
@@ -351,6 +248,16 @@ public class IncidentErrorHashCodeNormalizer {
     } else {
       LOG.warn("Dropping {}: {}", filterType, reason);
     }
+  }
+
+  private static List<Operation<String>> prependResolvedEq(
+      final String resolved, final List<Operation<String>> existing) {
+    final List<Operation<String>> combined = new ArrayList<>();
+    combined.add(Operation.eq(resolved));
+    if (existing != null && !existing.isEmpty()) {
+      combined.addAll(existing);
+    }
+    return combined;
   }
 
   private List<Operation<String>> dedupeErrorMessages(final List<Operation<String>> ops) {

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessDefinitionStatisticsFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessDefinitionStatisticsFilterTransformer.java
@@ -13,7 +13,7 @@ import static io.camunda.search.clients.query.SearchQueryBuilders.hasChildQuery;
 import static io.camunda.search.clients.query.SearchQueryBuilders.hasParentQuery;
 import static io.camunda.search.clients.query.SearchQueryBuilders.longOperations;
 import static io.camunda.search.clients.query.SearchQueryBuilders.or;
-import static io.camunda.search.clients.query.SearchQueryBuilders.stringMatchPhraseWithHasChildOperations;
+import static io.camunda.search.clients.query.SearchQueryBuilders.stringMatchPhraseInSingleHasChild;
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringOperations;
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
 import static io.camunda.search.clients.query.SearchQueryBuilders.term;
@@ -127,10 +127,10 @@ public class ProcessDefinitionStatisticsFilterTransformer
     ofNullable(filter.hasIncident()).ifPresent(value -> queries.add(term(INCIDENT, value)));
     Optional.of(stringOperations(TENANT_ID, filter.tenantIdOperations()))
         .ifPresent(queries::addAll);
-    Optional.of(
-            stringMatchPhraseWithHasChildOperations(
+    Optional.ofNullable(
+            stringMatchPhraseInSingleHasChild(
                 ERROR_MSG, filter.errorMessageOperations(), ACTIVITIES_JOIN_RELATION))
-        .ifPresent(queries::addAll);
+        .ifPresent(queries::add);
     ofNullable(getProcessVariablesQuery(filter.variableFilters())).ifPresent(queries::add);
     queries.addAll(stringOperations(BATCH_OPERATION_IDS, filter.batchOperationIdOperations()));
     ofNullable(filter.hasRetriesLeft()).ifPresent(value -> queries.add(hasRetriesLeftQuery(value)));

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessInstanceFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessInstanceFilterTransformer.java
@@ -82,8 +82,8 @@ public final class ProcessInstanceFilterTransformer
     }
 
     if (filter.errorMessageOperations() != null && !filter.errorMessageOperations().isEmpty()) {
-      queries.addAll(
-          stringMatchPhraseWithHasChildOperations(
+      queries.add(
+          stringMatchPhraseInSingleHasChild(
               ERROR_MSG, filter.errorMessageOperations(), ACTIVITIES_JOIN_RELATION));
     }
 

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/reader/utils/IncidentErrorHashCodeNormalizerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/reader/utils/IncidentErrorHashCodeNormalizerTest.java
@@ -176,22 +176,23 @@ class IncidentErrorHashCodeNormalizerTest {
   }
 
   @Test
-  void shouldNormalizeToDedupeErrorMessageWhenHashAndMatchingErrorMessageSupplied() {
+  void shouldPrependCanonicalEqWhenHashAndErrorMessageInSupplied() {
     final var filter =
         new ProcessInstanceFilter.Builder()
             .incidentErrorHashCodeOperations(List.of(Operation.eq(1234)))
-            .errorMessageOperations(List.of(Operation.eq("Resolved")))
+            .errorMessageOperations(List.of(Operation.in(List.of("sharedPrefix"))))
             .build();
     when(incidentReader.findErrorMessageByErrorHashCodes(eq(List.of(Operation.eq(1234))), any()))
         .thenReturn("Resolved");
     final var result =
         normalizer.normalizeAndValidateProcessInstanceFilter(filter, resourceAccessChecks);
     assertThat(result).isPresent();
-    assertThat(result.get().errorMessageOperations()).containsExactly(Operation.eq("Resolved"));
+    assertThat(result.get().errorMessageOperations())
+        .containsExactly(Operation.eq("Resolved"), Operation.in(List.of("sharedPrefix")));
   }
 
   @Test
-  void shouldReturnEmptyWhenHashAndErrorMessageSuppliedButNotEqual() {
+  void shouldPrependCanonicalEqAndKeepUserOpsEvenWhenContradicting() {
     final var filter =
         new ProcessInstanceFilter.Builder()
             .incidentErrorHashCodeOperations(List.of(Operation.eq(1234)))
@@ -201,7 +202,9 @@ class IncidentErrorHashCodeNormalizerTest {
         .thenReturn("Resolved");
     final var result =
         normalizer.normalizeAndValidateProcessInstanceFilter(filter, resourceAccessChecks);
-    assertThat(result).isEmpty();
+    assertThat(result).isPresent();
+    assertThat(result.get().errorMessageOperations())
+        .containsExactly(Operation.eq("Resolved"), Operation.eq("Other"));
   }
 
   @Test
@@ -407,22 +410,23 @@ class IncidentErrorHashCodeNormalizerTest {
   }
 
   @Test
-  void shouldNormalizeToDedupeErrorMessageWhenHashAndMatchingErrorMessageSuppliedDefStat() {
+  void shouldPrependCanonicalEqWhenHashAndErrorMessageInSuppliedDefStat() {
     final var filter =
         new ProcessDefinitionStatisticsFilter.Builder(1L)
             .incidentErrorHashCodeOperations(List.of(Operation.eq(1234)))
-            .errorMessageOperations(List.of(Operation.eq("Resolved")))
+            .errorMessageOperations(List.of(Operation.in(List.of("sharedPrefix"))))
             .build();
     when(incidentReader.findErrorMessageByErrorHashCodes(eq(List.of(Operation.eq(1234))), any()))
         .thenReturn("Resolved");
     final var result =
         normalizer.normalizeAndValidateProcessDefinitionFilter(filter, resourceAccessChecks);
     assertThat(result).isPresent();
-    assertThat(result.get().errorMessageOperations()).containsExactly(Operation.eq("Resolved"));
+    assertThat(result.get().errorMessageOperations())
+        .containsExactly(Operation.eq("Resolved"), Operation.in(List.of("sharedPrefix")));
   }
 
   @Test
-  void shouldReturnEmptyWhenHashAndErrorMessageSuppliedButNotEqualDefStat() {
+  void shouldPrependCanonicalEqAndKeepUserOpsEvenWhenContradictingDefStat() {
     final var filter =
         new ProcessDefinitionStatisticsFilter.Builder(1L)
             .incidentErrorHashCodeOperations(List.of(Operation.eq(1234)))
@@ -432,7 +436,9 @@ class IncidentErrorHashCodeNormalizerTest {
         .thenReturn("Resolved");
     final var result =
         normalizer.normalizeAndValidateProcessDefinitionFilter(filter, resourceAccessChecks);
-    assertThat(result).isEmpty();
+    assertThat(result).isPresent();
+    assertThat(result.get().errorMessageOperations())
+        .containsExactly(Operation.eq("Resolved"), Operation.eq("Other"));
   }
 
   @Test

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/ProcessInstanceQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/ProcessInstanceQueryTransformerTest.java
@@ -399,22 +399,24 @@ public final class ProcessInstanceQueryTransformerTest extends AbstractTransform
     assertIsSearchTermQuery(
         boolQuery.must().get(0).queryOption(), "joinRelation", "processInstance");
 
-    // Second must clause: should be a has_child query for errorMessage.
     assertThat(boolQuery.must().get(1).queryOption())
         .isInstanceOf(SearchHasChildQuery.class)
         .satisfies(
             queryOption -> {
-              // Cast the queryOption to SearchHasChildQuery
               final SearchHasChildQuery hasChildQuery = (SearchHasChildQuery) queryOption;
               assertThat(hasChildQuery.type()).isEqualTo("activity");
-              // Assert that the inner query is a match query on "errorMessage" with our
-              // expected value.
               assertThat(hasChildQuery.query().queryOption())
                   .isInstanceOfSatisfying(
-                      SearchMatchPhraseQuery.class,
-                      (searchMatchQuery) -> {
-                        assertThat(searchMatchQuery.field()).isEqualTo("errorMessage");
-                        assertThat(searchMatchQuery.query()).isEqualTo(expectedError);
+                      SearchBoolQuery.class,
+                      innerBool -> {
+                        assertThat(innerBool.must()).hasSize(1);
+                        assertThat(innerBool.must().get(0).queryOption())
+                            .isInstanceOfSatisfying(
+                                SearchMatchPhraseQuery.class,
+                                searchMatchQuery -> {
+                                  assertThat(searchMatchQuery.field()).isEqualTo("errorMessage");
+                                  assertThat(searchMatchQuery.query()).isEqualTo(expectedError);
+                                });
                       });
             });
   }


### PR DESCRIPTION
## Description

Fixes [#45129](https://github.com/camunda/camunda/issues/45129): when a caller supplies both `incidentErrorHashCode` and `errorMessage` filters, the combined error-message operations were emitted as **separate** `has_child` queries joined by a top-level `must`. This allowed a process instance whose incidents collectively satisfied the conditions (one incident matching the hash, a different incident matching the error-message term) to slip through — breaking the intent of per-incident AND semantics.

This is a follow-up to the original attempt on branch #52489. That branch narrowed process-instance search to the resolved error message, but still emitted multiple sibling `has_child` queries when hash and `errorMessage` ops were combined. This PR replaces the multiple `has_child` queries with a **single `has_child(bool{must:[...]})`** so all conditions are evaluated against the same incident document.

RDBMS parity gap (strict `=`/`IN` vs. ES/OS `match_phrase` substring) tracked as a separate follow-up in #52798.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #45129