### PR TITLE
feat: add generic sbe decode command to debugcli

### DIFF
--- a/debug-cli/README.md
+++ b/debug-cli/README.md
@@ -47,6 +47,22 @@ alias debug-cli="java -jar target/cdbg-${version}.jar"
     debug-cli topology -s -f /path/to/topology.meta --source /path/to/input.json
     ```
 
+#### `sbe`
+
+- **Description:**
+  Decode an SBE-encoded file to JSON using a user-provided schema.
+- **Options:**
+  - `-s`, `--schema`: Path to the SBE schema (`.xml` or `.sbeir`).
+  - `-o`, `--offset`: Byte offset where the SBE message header starts. Defaults to `0`.
+  - `-f`, `--file`: Path to the encoded input file.
+  - `FILE`: Positional alternative to `--file`.
+- **Examples:**
+
+  ```
+  debug-cli sbe --schema /path/to/protocol.xml /path/to/message.bin
+  debug-cli sbe --schema /path/to/raft-entry-schema.xml -f /path/to/default-partition-1.meta --offset 1
+  ```
+
 #### `help`
 
 - **Description:** Show help for the CLI or any subcommand.
@@ -55,6 +71,7 @@ alias debug-cli="java -jar target/cdbg-${version}.jar"
   ```
   debug-cli --help
   debug-cli topology --help
+  debug-cli sbe --help
   ```
 
 ## License

--- a/debug-cli/src/main/java/io/camunda/debug/cli/Main.java
+++ b/debug-cli/src/main/java/io/camunda/debug/cli/Main.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.debug.cli;
 
+import io.camunda.debug.cli.sbe.SbeCommand;
 import io.camunda.debug.cli.state.StateCommand;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
@@ -20,7 +21,8 @@ import picocli.CommandLine.Command;
       CommandLine.HelpCommand.class,
       TopologyMetaCommand.class,
       RaftCommand.class,
-      StateCommand.class
+      StateCommand.class,
+      SbeCommand.class
     })
 public class Main {
 

--- a/debug-cli/src/main/java/io/camunda/debug/cli/RaftCommand.java
+++ b/debug-cli/src/main/java/io/camunda/debug/cli/RaftCommand.java
@@ -8,17 +8,13 @@
 package io.camunda.debug.cli;
 
 import io.atomix.raft.storage.serializer.MetaStoreSerializer;
-import java.nio.ByteBuffer;
-import java.nio.channels.FileChannel;
+import io.camunda.debug.cli.sbe.SbeJsonDecoder;
 import java.nio.file.Path;
 import java.util.concurrent.Callable;
-import org.agrona.concurrent.UnsafeBuffer;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Spec;
-import uk.co.real_logic.sbe.ir.IrDecoder;
-import uk.co.real_logic.sbe.json.JsonPrinter;
 
 @Command(name = "raft", description = "Print raft metadata files")
 public class RaftCommand extends CommonOptions implements Callable<Integer> {
@@ -52,52 +48,14 @@ public class RaftCommand extends CommonOptions implements Callable<Integer> {
       spec.commandLine().getErr().println("Reading file: " + file + "\n");
     }
 
-    final long fileSize;
-    try (final var fc = FileChannel.open(file, java.nio.file.StandardOpenOption.READ)) {
-      fileSize = fc.size();
-      if (fileSize > Integer.MAX_VALUE) {
-        throw new IllegalArgumentException("File is too large to process: " + fileSize + " bytes");
-      }
-      final var metadataContentBuffer =
-          ByteBuffer.allocate((int) fileSize).order(MetaStoreSerializer.ENDIANESS);
-      final int bytesRead = fc.read(metadataContentBuffer, 0);
-      if (bytesRead != fileSize) {
-        throw new RuntimeException(
-            "Failed to read the entire file. Expected "
-                + fileSize
-                + " bytes, but read "
-                + bytesRead
-                + " bytes.");
-      }
-      metadataContentBuffer.flip();
-
-      final var version = metadataContentBuffer.get();
-      if (version != MetaStoreSerializer.VERSION) {
-        throw new RuntimeException("Invalid version encoded in the metadata file: " + version);
-      }
-      final UnsafeBuffer metadataWithoutVersion = new UnsafeBuffer();
-      metadataWithoutVersion.wrap(
-          metadataContentBuffer,
-          MetaStoreSerializer.VERSION_LENGTH,
-          metadataContentBuffer.capacity() - MetaStoreSerializer.VERSION_LENGTH);
-
-      final byte[] irBytes;
-      try (final var irFileResource =
-          getClass().getClassLoader().getResourceAsStream("sbe/raft-entry-schema.sbeir")) {
-        if (irFileResource == null) {
-          throw new RuntimeException("Failed to get resource raft-entry-schema.sbeir");
-        }
-
-        irBytes = irFileResource.readAllBytes();
-      }
-
-      try (final IrDecoder irDecoder = new IrDecoder(ByteBuffer.wrap(irBytes))) {
-        final var ir = irDecoder.decode();
-        final StringBuilder output = new StringBuilder();
-        new JsonPrinter(ir).print(output, metadataWithoutVersion, 0);
-        return output.toString();
-      }
+    final var buffer = SbeJsonDecoder.readFile(file);
+    final var version = buffer.getByte(0);
+    if (version != MetaStoreSerializer.VERSION) {
+      throw new RuntimeException("Invalid version encoded in the metadata file: " + version);
     }
+
+    final var ir = SbeJsonDecoder.loadIrFromResource(getClass(), "sbe/raft-entry-schema.sbeir");
+    return SbeJsonDecoder.toJson(buffer, ir, MetaStoreSerializer.VERSION_LENGTH);
   }
 
   @Override

--- a/debug-cli/src/main/java/io/camunda/debug/cli/sbe/SbeCommand.java
+++ b/debug-cli/src/main/java/io/camunda/debug/cli/sbe/SbeCommand.java
@@ -85,13 +85,11 @@ public class SbeCommand implements Callable<Integer> {
   private Ir resolveSchema() throws Exception {
     if (Files.exists(schema)) {
       final var normalizedSchema = schema.toAbsolutePath().normalize();
-      final var ir = SbeJsonDecoder.loadIr(schema);
       spec.commandLine().getErr().println("Schema used: filesystem path " + normalizedSchema);
-      return ir;
+      return SbeJsonDecoder.loadIr(schema);
     }
 
-    final var ir = SbeJsonDecoder.loadIrFromResource(getClass(), schema.toString());
     spec.commandLine().getErr().println("Schema used: classpath resource " + schema);
-    return ir;
+    return SbeJsonDecoder.loadIrFromResource(getClass(), schema.toString());
   }
 }

--- a/debug-cli/src/main/java/io/camunda/debug/cli/sbe/SbeCommand.java
+++ b/debug-cli/src/main/java/io/camunda/debug/cli/sbe/SbeCommand.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.debug.cli.sbe;
 
-import java.nio.file.NoSuchFileException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.Callable;
 import picocli.CommandLine.Command;
@@ -51,12 +51,7 @@ public class SbeCommand implements Callable<Integer> {
   public Integer call() {
     try {
       final var inputFile = resolveInputFile();
-      Ir ir;
-      try {
-        ir = SbeJsonDecoder.loadIr(schema);
-      } catch (final NoSuchFileException e) {
-        ir = SbeJsonDecoder.loadIrFromResource(getClass(), schema.toString());
-      }
+      final var ir = resolveSchema();
       final var json = SbeJsonDecoder.toJson(inputFile, ir, offset);
 
       spec.commandLine().getOut().println(json);
@@ -81,10 +76,22 @@ public class SbeCommand implements Callable<Integer> {
 
     if (verbose) {
       spec.commandLine().getErr().println("Reading file: " + resolvedFile);
-      spec.commandLine().getErr().println("Schema used: " + schema);
       spec.commandLine().getErr().println("Offset used: " + offset);
     }
 
     return resolvedFile;
+  }
+
+  private Ir resolveSchema() throws Exception {
+    if (Files.exists(schema)) {
+      final var normalizedSchema = schema.toAbsolutePath().normalize();
+      final var ir = SbeJsonDecoder.loadIr(schema);
+      spec.commandLine().getErr().println("Schema used: filesystem path " + normalizedSchema);
+      return ir;
+    }
+
+    final var ir = SbeJsonDecoder.loadIrFromResource(getClass(), schema.toString());
+    spec.commandLine().getErr().println("Schema used: classpath resource " + schema);
+    return ir;
   }
 }

--- a/debug-cli/src/main/java/io/camunda/debug/cli/sbe/SbeCommand.java
+++ b/debug-cli/src/main/java/io/camunda/debug/cli/sbe/SbeCommand.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.debug.cli.sbe;
+
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+import picocli.CommandLine.Spec;
+import uk.co.real_logic.sbe.ir.Ir;
+
+@Command(name = "sbe", description = "Decode an SBE-encoded file using a provided schema")
+public class SbeCommand implements Callable<Integer> {
+
+  @Spec CommandSpec spec;
+
+  @Option(
+      names = {"-f", "--file"},
+      description = "Path to the SBE-encoded file")
+  private Path file;
+
+  @Parameters(index = "0", arity = "0..1", description = "Path to the SBE-encoded file")
+  private Path positionalFile;
+
+  @Option(
+      names = {"-s", "--schema"},
+      description = "Path to the SBE schema (.xml or .sbeir)",
+      required = true)
+  private Path schema;
+
+  @Option(
+      names = {"-o", "--offset"},
+      description = "Byte offset where the SBE message header starts",
+      defaultValue = "0")
+  private long offset;
+
+  @Option(
+      names = {"-v", "--verbose"},
+      description = "Enable verbose output")
+  private boolean verbose;
+
+  @Override
+  public Integer call() {
+    try {
+      final var inputFile = resolveInputFile();
+      Ir ir;
+      try {
+        ir = SbeJsonDecoder.loadIr(schema);
+      } catch (final NoSuchFileException e) {
+        ir = SbeJsonDecoder.loadIrFromResource(getClass(), schema.toString());
+      }
+      final var json = SbeJsonDecoder.toJson(inputFile, ir, offset);
+
+      spec.commandLine().getOut().println(json);
+      return 0;
+    } catch (final Exception e) {
+      e.printStackTrace(spec.commandLine().getErr());
+      return 2;
+    }
+  }
+
+  private Path resolveInputFile() {
+    if (file != null && positionalFile != null) {
+      throw new IllegalArgumentException(
+          "Provide the input file either as a positional parameter or with --file");
+    }
+
+    final var resolvedFile = file != null ? file : positionalFile;
+    if (resolvedFile == null) {
+      throw new IllegalArgumentException(
+          "Missing input file, provide it as a positional parameter or with --file");
+    }
+
+    if (verbose) {
+      spec.commandLine().getErr().println("Reading file: " + resolvedFile);
+      spec.commandLine().getErr().println("Schema used: " + schema);
+      spec.commandLine().getErr().println("Offset used: " + offset);
+    }
+
+    return resolvedFile;
+  }
+}

--- a/debug-cli/src/main/java/io/camunda/debug/cli/sbe/SbeCommand.java
+++ b/debug-cli/src/main/java/io/camunda/debug/cli/sbe/SbeCommand.java
@@ -85,11 +85,15 @@ public class SbeCommand implements Callable<Integer> {
   private Ir resolveSchema() throws Exception {
     if (Files.exists(schema)) {
       final var normalizedSchema = schema.toAbsolutePath().normalize();
-      spec.commandLine().getErr().println("Schema used: filesystem path " + normalizedSchema);
+      if (verbose) {
+        spec.commandLine().getErr().println("Schema used: filesystem path " + normalizedSchema);
+      }
       return SbeJsonDecoder.loadIr(schema);
     }
 
-    spec.commandLine().getErr().println("Schema used: classpath resource " + schema);
+    if (verbose) {
+      spec.commandLine().getErr().println("Schema used: classpath resource " + schema);
+    }
     return SbeJsonDecoder.loadIrFromResource(getClass(), schema.toString());
   }
 }

--- a/debug-cli/src/main/java/io/camunda/debug/cli/sbe/SbeCommand.java
+++ b/debug-cli/src/main/java/io/camunda/debug/cli/sbe/SbeCommand.java
@@ -91,9 +91,18 @@ public class SbeCommand implements Callable<Integer> {
       return SbeJsonDecoder.loadIr(schema);
     }
 
+    final var schemaName = schema.toString();
+    if (!schemaName.endsWith(".sbeir")) {
+      throw new IllegalArgumentException(
+          "Schema not found on filesystem: "
+              + schema
+              + ". XML schemas must be provided as a valid filesystem path. "
+              + "Use a pre-compiled .sbeir file for classpath schemas.");
+    }
+
     if (verbose) {
       spec.commandLine().getErr().println("Schema used: classpath resource " + schema);
     }
-    return SbeJsonDecoder.loadIrFromResource(getClass(), schema.toString());
+    return SbeJsonDecoder.loadIrFromResource(getClass(), schemaName);
   }
 }

--- a/debug-cli/src/main/java/io/camunda/debug/cli/sbe/SbeJsonDecoder.java
+++ b/debug-cli/src/main/java/io/camunda/debug/cli/sbe/SbeJsonDecoder.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.debug.cli.sbe;
+
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.xml.sax.InputSource;
+import uk.co.real_logic.sbe.ir.Ir;
+import uk.co.real_logic.sbe.ir.IrDecoder;
+import uk.co.real_logic.sbe.json.JsonPrinter;
+import uk.co.real_logic.sbe.xml.IrGenerator;
+import uk.co.real_logic.sbe.xml.ParserOptions;
+import uk.co.real_logic.sbe.xml.XmlSchemaParser;
+
+public final class SbeJsonDecoder {
+
+  private SbeJsonDecoder() {}
+
+  public static Ir loadIr(final Path schema) throws Exception {
+    final var schemaFileName = schema.getFileName().toString();
+    if (schemaFileName.endsWith(".sbeir")) {
+      try (final var irDecoder = new IrDecoder(ByteBuffer.wrap(Files.readAllBytes(schema)))) {
+        return irDecoder.decode();
+      }
+    }
+
+    final var parserOptions = ParserOptions.builder().stopOnError(true).xIncludeAware(true).build();
+    try (final var inputStream = Files.newInputStream(schema)) {
+      final var inputSource = new InputSource(inputStream);
+      inputSource.setSystemId(schema.toUri().toString());
+      final var messageSchema = XmlSchemaParser.parse(inputSource, parserOptions);
+      return new IrGenerator().generate(messageSchema, schemaFileName);
+    }
+  }
+
+  public static Ir loadIrFromResource(final Class<?> resourceOwner, final String resourceName)
+      throws Exception {
+    try (final var irFileResource =
+        resourceOwner.getClassLoader().getResourceAsStream(resourceName)) {
+      if (irFileResource == null) {
+        throw new IllegalArgumentException("Failed to get resource " + resourceName);
+      }
+
+      try (final var irDecoder = new IrDecoder(ByteBuffer.wrap(irFileResource.readAllBytes()))) {
+        return irDecoder.decode();
+      }
+    }
+  }
+
+  public static UnsafeBuffer readFile(final Path inputFile) throws Exception {
+    final long fileSize = Files.size(inputFile);
+    if (fileSize > Integer.MAX_VALUE) {
+      throw new IllegalArgumentException("File is too large to process: " + fileSize + " bytes");
+    }
+
+    return new UnsafeBuffer(Files.readAllBytes(inputFile));
+  }
+
+  public static String toJson(final Path inputFile, final Ir ir, final long offset)
+      throws Exception {
+    return toJson(readFile(inputFile), ir, offset);
+  }
+
+  public static String toJson(final DirectBuffer buffer, final Ir ir, final long offset) {
+    final var output = new StringBuilder();
+    new JsonPrinter(ir).print(output, buffer, validateOffset(offset, buffer.capacity()));
+    return output.toString();
+  }
+
+  private static int validateOffset(final long offset, final int length) {
+    if (offset < 0) {
+      throw new IllegalArgumentException("Offset must be greater than or equal to 0");
+    }
+
+    if (offset >= length) {
+      throw new IllegalArgumentException(
+          "Offset " + offset + " is outside the file size of " + length + " bytes");
+    }
+
+    return Math.toIntExact(offset);
+  }
+}

--- a/debug-cli/src/main/java/io/camunda/debug/cli/sbe/SbeJsonDecoder.java
+++ b/debug-cli/src/main/java/io/camunda/debug/cli/sbe/SbeJsonDecoder.java
@@ -7,8 +7,10 @@
  */
 package io.camunda.debug.cli.sbe;
 
+import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -26,32 +28,30 @@ public final class SbeJsonDecoder {
 
   public static Ir loadIr(final Path schema) throws Exception {
     final var schemaFileName = schema.getFileName().toString();
-    if (schemaFileName.endsWith(".sbeir")) {
-      try (final var irDecoder = new IrDecoder(ByteBuffer.wrap(Files.readAllBytes(schema)))) {
-        return irDecoder.decode();
+    if (isIrSchema(schemaFileName)) {
+      try (final var inputStream = Files.newInputStream(schema)) {
+        return decodeIr(inputStream.readAllBytes());
       }
     }
 
-    final var parserOptions = ParserOptions.builder().stopOnError(true).xIncludeAware(true).build();
     try (final var inputStream = Files.newInputStream(schema)) {
-      final var inputSource = new InputSource(inputStream);
-      inputSource.setSystemId(schema.toUri().toString());
-      final var messageSchema = XmlSchemaParser.parse(inputSource, parserOptions);
-      return new IrGenerator().generate(messageSchema, schemaFileName);
+      return generateIr(inputStream, schema.toUri().toString(), schemaFileName);
     }
   }
 
   public static Ir loadIrFromResource(final Class<?> resourceOwner, final String resourceName)
       throws Exception {
-    try (final var irFileResource =
-        resourceOwner.getClassLoader().getResourceAsStream(resourceName)) {
-      if (irFileResource == null) {
-        throw new IllegalArgumentException("Failed to get resource " + resourceName);
+    final var resource = resourceOwner.getClassLoader().getResource(resourceName);
+    if (resource == null) {
+      throw new NoSuchFileException(resourceName, null, "Schema was not found on the classpath");
+    }
+
+    try (final var resourceStream = resource.openStream()) {
+      if (isIrSchema(resourceName)) {
+        return decodeIr(resourceStream.readAllBytes());
       }
 
-      try (final var irDecoder = new IrDecoder(ByteBuffer.wrap(irFileResource.readAllBytes()))) {
-        return irDecoder.decode();
-      }
+      return generateIr(resourceStream, resource.toExternalForm(), resourceName);
     }
   }
 
@@ -73,6 +73,26 @@ public final class SbeJsonDecoder {
     final var output = new StringBuilder();
     new JsonPrinter(ir).print(output, buffer, validateOffset(offset, buffer.capacity()));
     return output.toString();
+  }
+
+  private static Ir generateIr(
+      final InputStream inputStream, final String systemId, final String schemaName)
+      throws Exception {
+    final var parserOptions = ParserOptions.builder().stopOnError(true).xIncludeAware(true).build();
+    final var inputSource = new InputSource(inputStream);
+    inputSource.setSystemId(systemId);
+    final var messageSchema = XmlSchemaParser.parse(inputSource, parserOptions);
+    return new IrGenerator().generate(messageSchema, schemaName);
+  }
+
+  private static Ir decodeIr(final byte[] irBytes) throws Exception {
+    try (final var irDecoder = new IrDecoder(ByteBuffer.wrap(irBytes))) {
+      return irDecoder.decode();
+    }
+  }
+
+  private static boolean isIrSchema(final String schemaName) {
+    return schemaName.endsWith(".sbeir");
   }
 
   private static int validateOffset(final long offset, final int length) {

--- a/debug-cli/src/main/java/io/camunda/debug/cli/sbe/SbeJsonDecoder.java
+++ b/debug-cli/src/main/java/io/camunda/debug/cli/sbe/SbeJsonDecoder.java
@@ -43,7 +43,8 @@ public final class SbeJsonDecoder {
       throws Exception {
     final var resource = resourceOwner.getClassLoader().getResource(resourceName);
     if (resource == null) {
-      throw new NoSuchFileException(resourceName, null, "Schema was not found on the classpath");
+      throw new NoSuchFileException(
+          resourceName, null, ".xml or .sbeir schema was not found on the classpath");
     }
 
     try (final var resourceStream = resource.openStream()) {

--- a/debug-cli/src/test/java/io/camunda/debug/cli/SbeCommandTest.java
+++ b/debug-cli/src/test/java/io/camunda/debug/cli/SbeCommandTest.java
@@ -112,33 +112,6 @@ public class SbeCommandTest {
         .contains("Offset used: 1");
   }
 
-  @Test
-  public void shouldDecodeUsingClasspathXmlSchemaWhenFilesystemPathDoesNotExist() throws Exception {
-    // given
-    final var resourceUrl = getClass().getClassLoader().getResource("default-partition-1.conf");
-    assertThat(resourceUrl).isNotNull();
-    final var filePath = Path.of(resourceUrl.toURI());
-
-    // when
-    final int exitCode =
-        commandLine.execute(
-            "sbe",
-            "--schema",
-            "raft-entry-schema.xml",
-            "--offset",
-            "1",
-            "--verbose",
-            filePath.toString());
-
-    // then
-    assertThat(exitCode).isZero();
-    assertThat(out.toString().trim()).isEqualTo(EXPECTED_CONFIGURATION.trim());
-    assertThat(err.toString())
-        .contains("Reading file: " + filePath)
-        .contains("Schema used: classpath resource raft-entry-schema.xml")
-        .contains("Offset used: 1");
-  }
-
   private Path schemaPath() {
     final var schemaPath =
         Path.of(

--- a/debug-cli/src/test/java/io/camunda/debug/cli/SbeCommandTest.java
+++ b/debug-cli/src/test/java/io/camunda/debug/cli/SbeCommandTest.java
@@ -47,12 +47,15 @@ public class SbeCommandTest {
 """;
 
   private CommandLine commandLine;
+  private StringWriter err;
   private StringWriter out;
 
   @BeforeEach
   public void setup() {
+    err = new StringWriter();
     out = new StringWriter();
-    commandLine = new CommandLine(new Main()).setOut(new PrintWriter(out));
+    commandLine =
+        new CommandLine(new Main()).setErr(new PrintWriter(err)).setOut(new PrintWriter(out));
   }
 
   @Test
@@ -83,11 +86,11 @@ public class SbeCommandTest {
   }
 
   @Test
-  public void shouldDecodeSbeFileProvidedAsPositionalParameter() {
+  public void shouldDecodeSbeFileProvidedAsPositionalParameter() throws Exception {
     // given
     final var resourceUrl = getClass().getClassLoader().getResource("default-partition-1.conf");
     assertThat(resourceUrl).isNotNull();
-    final var filePath = Path.of(resourceUrl.getPath());
+    final var filePath = Path.of(resourceUrl.toURI());
 
     // when
     final int exitCode =
@@ -97,6 +100,25 @@ public class SbeCommandTest {
     // then
     assertThat(exitCode).isZero();
     assertThat(out.toString().trim()).isEqualTo(EXPECTED_CONFIGURATION.trim());
+  }
+
+  @Test
+  public void shouldDecodeUsingClasspathXmlSchemaWhenFilesystemPathDoesNotExist() throws Exception {
+    // given
+    final var resourceUrl = getClass().getClassLoader().getResource("default-partition-1.conf");
+    assertThat(resourceUrl).isNotNull();
+    final var filePath = Path.of(resourceUrl.toURI());
+
+    // when
+    final int exitCode =
+        commandLine.execute(
+            "sbe", "--schema", "raft-entry-schema.xml", "--offset", "1", filePath.toString());
+
+    // then
+    assertThat(exitCode).isZero();
+    assertThat(out.toString().trim()).isEqualTo(EXPECTED_CONFIGURATION.trim());
+    assertThat(err.toString().trim())
+        .isEqualTo("Schema used: classpath resource raft-entry-schema.xml");
   }
 
   private Path schemaPath() {

--- a/debug-cli/src/test/java/io/camunda/debug/cli/SbeCommandTest.java
+++ b/debug-cli/src/test/java/io/camunda/debug/cli/SbeCommandTest.java
@@ -95,11 +95,21 @@ public class SbeCommandTest {
     // when
     final int exitCode =
         commandLine.execute(
-            "sbe", "--schema", schemaPath().toString(), "--offset", "1", filePath.toString());
+            "sbe",
+            "--schema",
+            schemaPath().toString(),
+            "--offset",
+            "1",
+            "--verbose",
+            filePath.toString());
 
     // then
     assertThat(exitCode).isZero();
     assertThat(out.toString().trim()).isEqualTo(EXPECTED_CONFIGURATION.trim());
+    assertThat(err.toString())
+        .contains("Reading file: " + filePath)
+        .contains("Schema used: filesystem path " + schemaPath())
+        .contains("Offset used: 1");
   }
 
   @Test
@@ -112,13 +122,21 @@ public class SbeCommandTest {
     // when
     final int exitCode =
         commandLine.execute(
-            "sbe", "--schema", "raft-entry-schema.xml", "--offset", "1", filePath.toString());
+            "sbe",
+            "--schema",
+            "raft-entry-schema.xml",
+            "--offset",
+            "1",
+            "--verbose",
+            filePath.toString());
 
     // then
     assertThat(exitCode).isZero();
     assertThat(out.toString().trim()).isEqualTo(EXPECTED_CONFIGURATION.trim());
-    assertThat(err.toString().trim())
-        .isEqualTo("Schema used: classpath resource raft-entry-schema.xml");
+    assertThat(err.toString())
+        .contains("Reading file: " + filePath)
+        .contains("Schema used: classpath resource raft-entry-schema.xml")
+        .contains("Offset used: 1");
   }
 
   private Path schemaPath() {

--- a/debug-cli/src/test/java/io/camunda/debug/cli/SbeCommandTest.java
+++ b/debug-cli/src/test/java/io/camunda/debug/cli/SbeCommandTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.debug.cli;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.file.Path;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+public class SbeCommandTest {
+
+  private static final String EXPECTED_CONFIGURATION =
+"""
+{
+    "index": 88,
+    "term": 70,
+    "timestamp": 1759391170100,
+    "force": "FALSE",
+    "newMembers": [
+    {
+        "type": "ACTIVE",
+        "updated": 1759391120782,
+        "memberId": "0"
+    },
+    {
+        "type": "ACTIVE",
+        "updated": 1759391170100,
+        "memberId": "1"
+    }],
+    "oldMembers": [
+    {
+        "type": "ACTIVE",
+        "updated": 1759391120782,
+        "memberId": "0"
+    }]
+}
+""";
+
+  private CommandLine commandLine;
+  private StringWriter out;
+
+  @BeforeEach
+  public void setup() {
+    out = new StringWriter();
+    commandLine = new CommandLine(new Main()).setOut(new PrintWriter(out));
+  }
+
+  @Test
+  public void shouldDecodeSbeFileProvidedWithFileOption() throws Exception {
+    // given
+    final var resourceUrl = getClass().getClassLoader().getResource("default-partition-1.meta");
+    assertThat(resourceUrl).isNotNull();
+    final var filePath = Path.of(resourceUrl.toURI());
+
+    // when
+    final int exitCode =
+        commandLine.execute(
+            "sbe",
+            "--schema",
+            schemaPath().toString(),
+            "--offset",
+            "1",
+            "--file",
+            filePath.toString());
+
+    // then
+    assertThat(exitCode).isZero();
+    final var output = new ObjectMapper().readValue(out.toString(), TestRaftMetadata.class);
+    assertThat(output.term()).isEqualTo(2L);
+    assertThat(output.lastFlushedIndex()).isEqualTo(96L);
+    assertThat(output.votedFor()).isEqualTo("0");
+    assertThat(output.commitIndex()).isEqualTo(96L);
+  }
+
+  @Test
+  public void shouldDecodeSbeFileProvidedAsPositionalParameter() {
+    // given
+    final var resourceUrl = getClass().getClassLoader().getResource("default-partition-1.conf");
+    assertThat(resourceUrl).isNotNull();
+    final var filePath = Path.of(resourceUrl.getPath());
+
+    // when
+    final int exitCode =
+        commandLine.execute(
+            "sbe", "--schema", schemaPath().toString(), "--offset", "1", filePath.toString());
+
+    // then
+    assertThat(exitCode).isZero();
+    assertThat(out.toString().trim()).isEqualTo(EXPECTED_CONFIGURATION.trim());
+  }
+
+  private Path schemaPath() {
+    final var schemaPath =
+        Path.of(
+                "..",
+                "zeebe",
+                "atomix",
+                "cluster",
+                "src",
+                "main",
+                "resources",
+                "raft-entry-schema.xml")
+            .toAbsolutePath()
+            .normalize();
+    assertThat(schemaPath).exists();
+    return schemaPath;
+  }
+
+  record TestRaftMetadata(long term, long lastFlushedIndex, String votedFor, long commitIndex) {}
+}

--- a/zeebe/broker/pom.xml
+++ b/zeebe/broker/pom.xml
@@ -450,6 +450,18 @@
   </dependencies>
 
   <build>
+    <resources>
+      <resource>
+        <directory>${project.basedir}/src/main/resources</directory>
+      </resource>
+      <resource>
+        <directory>${project.build.directory}/generated-sources</directory>
+        <includes>
+          <include>**/*.sbeir</include>
+          <include>**/*.xml</include>
+        </includes>
+      </resource>
+    </resources>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/zeebe/protocol/pom.xml
+++ b/zeebe/protocol/pom.xml
@@ -103,6 +103,18 @@
   </dependencies>
 
   <build>
+    <resources>
+      <resource>
+        <directory>${project.basedir}/src/main/resources</directory>
+      </resource>
+      <resource>
+        <directory>${project.build.directory}/generated-sources</directory>
+        <includes>
+          <include>**/*.sbeir</include>
+          <include>**/*.xml</include>
+        </includes>
+      </resource>
+    </resources>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/zeebe/snapshot/pom.xml
+++ b/zeebe/snapshot/pom.xml
@@ -107,6 +107,18 @@
   </dependencies>
 
   <build>
+    <resources>
+      <resource>
+        <directory>${project.basedir}/src/main/resources</directory>
+      </resource>
+      <resource>
+        <directory>${project.build.directory}/generated-sources</directory>
+        <includes>
+          <include>**/*.sbeir</include>
+          <include>**/*.xml</include>
+        </includes>
+      </resource>
+    </resources>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/zeebe/transport/pom.xml
+++ b/zeebe/transport/pom.xml
@@ -109,6 +109,16 @@
         <filtering>true</filtering>
         <directory>src/main/resources</directory>
       </resource>
+      <resource>
+        <directory>${project.basedir}/src/main/resources</directory>
+      </resource>
+      <resource>
+        <directory>${project.build.directory}/generated-sources</directory>
+        <includes>
+          <include>**/*.sbeir</include>
+          <include>**/*.xml</include>
+        </includes>
+      </resource>
     </resources>
 
     <plugins>

--- a/zeebe/transport/pom.xml
+++ b/zeebe/transport/pom.xml
@@ -110,9 +110,6 @@
         <directory>src/main/resources</directory>
       </resource>
       <resource>
-        <directory>${project.basedir}/src/main/resources</directory>
-      </resource>
-      <resource>
         <directory>${project.build.directory}/generated-sources</directory>
         <includes>
           <include>**/*.sbeir</include>


### PR DESCRIPTION
## Description

Adds a generic \`sbe\` command to the debug CLI that can decode any SBE-encoded file given a schema.

**Schema loading:**
- Filesystem path to an \`.xml\` or \`.sbeir\` schema — XML schemas with \`xi:include\` directives are supported since the parser resolves relative paths from the file's location.
- Classpath resource name (only \`.sbeir\`) — XML is not supported from the classpath because \`xi:include\` cannot resolve relative paths across JAR boundaries.

**Offset parameter:** SBE files that prepend a version header (e.g. broker snapshot files) require skipping the header bytes before the SBE message starts. The \`--offset\` flag handles this.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #