### PR TITLE
test: ensure we verify lifecycle policies set by archiver jobs

### DIFF
--- a/search/search-test-utils/src/main/java/io/camunda/search/test/utils/SearchClientAdapter.java
+++ b/search/search-test-utils/src/main/java/io/camunda/search/test/utils/SearchClientAdapter.java
@@ -20,6 +20,7 @@ import java.io.StringWriter;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -149,6 +150,41 @@ public class SearchClientAdapter {
           Requests.builder().method("GET").endpoint("_plugins/_ism/policies/" + policyName).build();
 
       return objectMapper.readTree(osClient.generic().execute(request).getBody().get().body());
+    }
+    return null;
+  }
+
+  public String getLifecyclePolicyNameForIndex(final String indexName) throws IOException {
+    if (elsClient != null) {
+      final var response = elsClient.indices().getSettings(req -> req.index(indexName));
+
+      final var state = response.result().get(indexName);
+      return Optional.ofNullable(state)
+          .map(co.elastic.clients.elasticsearch.indices.IndexState::settings)
+          .map(co.elastic.clients.elasticsearch.indices.IndexSettings::index)
+          .map(co.elastic.clients.elasticsearch.indices.IndexSettings::lifecycle)
+          .map(co.elastic.clients.elasticsearch.indices.IndexSettingsLifecycle::name)
+          .orElse(null);
+    } else if (osClient != null) {
+      final var request =
+          Requests.builder()
+              .method("GET")
+              .endpoint("_plugins/_ism/explain/" + indexName)
+              .query(Map.of("show_policy", "true"))
+              .build();
+
+      try (final var response = osClient.generic().execute(request)) {
+        final var json = objectMapper.readTree(response.getBody().get().body());
+        return Optional.ofNullable(json.get(indexName))
+            .filter(
+                explain -> {
+                  final var enabled = explain.get("enabled");
+                  return enabled != null && enabled.asBoolean();
+                })
+            .map(explain -> explain.get("policy_id"))
+            .map(JsonNode::asText)
+            .orElse(null);
+      }
     }
     return null;
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
@@ -373,7 +373,16 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
     final var timer = Timer.start();
     return AsyncRepeatUntil.repeatUntil(
             taskSupplier::moveNextBatch, count -> taskSupplier.isComplete())
-        .thenComposeAsync(docIds -> setIndexLifeCycle(destinationIndexName), executor)
+        .thenComposeAsync(
+            ignored -> {
+              // don't set the lifecycle if nothing was moved
+              // as it also might mean the index does not exist anyway
+              if (taskSupplier.getTotalArchived() > 0L) {
+                return setIndexLifeCycle(destinationIndexName);
+              }
+              return CompletableFuture.completedFuture(null);
+            },
+            executor)
         .thenApply(
             ignored -> {
               logger.trace(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
@@ -384,7 +384,16 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
     final var timer = Timer.start();
     return AsyncRepeatUntil.repeatUntil(
             taskSupplier::moveNextBatch, count -> taskSupplier.isComplete())
-        .thenComposeAsync(docIds -> setIndexLifeCycle(destinationIndexName), executor)
+        .thenComposeAsync(
+            ignored -> {
+              // don't set the lifecycle if nothing was moved
+              // as it also might mean the index does not exist anyway
+              if (taskSupplier.getTotalArchived() > 0L) {
+                return setIndexLifeCycle(destinationIndexName);
+              }
+              return CompletableFuture.completedFuture(null);
+            },
+            executor)
         .thenApply(
             ignored -> {
               logger.trace(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiverJobIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiverJobIT.java
@@ -36,13 +36,16 @@ import io.camunda.zeebe.exporter.test.ExporterTestContext;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 import org.agrona.CloseHelper;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
@@ -68,12 +71,14 @@ public abstract class ArchiverJobIT<T extends ArchiverJob<?>> {
   protected Context context;
 
   private final List<AutoCloseable> resourcesToClose = new ArrayList<>();
+  private LifecyclePolicyNameVerifier lifecyclePolicyNameVerifier;
 
   @BeforeEach
   void setup() {
     context = new ExporterTestContext().setPartitionId(PARTITION_ID);
     exporterMetrics = new CamundaExporterMetrics(context.getMeterRegistry());
     executor = Executors.newSingleThreadExecutor();
+    lifecyclePolicyNameVerifier = new LifecyclePolicyNameVerifier();
   }
 
   @AfterEach
@@ -189,6 +194,9 @@ public abstract class ArchiverJobIT<T extends ArchiverJob<?>> {
     assertThat(newIndexEntity)
         .describedAs("Expected %s to have been moved to %s", entity, dateIndex)
         .isEqualTo(entity);
+
+    lifecyclePolicyNameVerifier.verifyIndexHasLifecyclePolicy(
+        client, dateIndex, getExpectedLifecyclePolicyName());
   }
 
   protected void verifyNotMoved(
@@ -221,6 +229,10 @@ public abstract class ArchiverJobIT<T extends ArchiverJob<?>> {
         .describedAs(
             "Expected %s to still be in %s", entity, templateDescriptor.getFullQualifiedName())
         .isEqualTo(entity);
+  }
+
+  protected String getExpectedLifecyclePolicyName() {
+    return "camunda-retention-policy";
   }
 
   private ExporterResourceProvider exporterResourceProvider(final ExporterConfiguration config) {
@@ -289,6 +301,26 @@ public abstract class ArchiverJobIT<T extends ArchiverJob<?>> {
       final ExporterConfiguration config,
       final ExporterResourceProvider resourceProvider,
       final ArchiverRepository repository);
+
+  static class LifecyclePolicyNameVerifier {
+    private final Set<String> alreadyVerifiedIndexes = new HashSet<>();
+
+    void verifyIndexHasLifecyclePolicy(
+        final SearchClientAdapter client, final String indexName, final String expectedPolicy) {
+      // no need to check the same index over and over (as we're checking per-doc)
+      if (alreadyVerifiedIndexes.contains(indexName)) {
+        return;
+      }
+      Awaitility.await()
+          .atMost(Duration.ofSeconds(10L))
+          .untilAsserted(
+              () -> {
+                final var policy = client.getLifecyclePolicyNameForIndex(indexName);
+                assertThat(policy).isEqualTo(expectedPolicy);
+              });
+      alreadyVerifiedIndexes.add(indexName);
+    }
+  }
 
   interface ArchiveJobConsumer<T> {
     void accept(T job, ExporterResourceProvider resourceProvider) throws Exception;

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/UsageMetricArchiverJobIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/UsageMetricArchiverJobIT.java
@@ -24,6 +24,11 @@ import org.junit.jupiter.api.TestTemplate;
 @TestInstance(Lifecycle.PER_CLASS)
 public class UsageMetricArchiverJobIT extends ArchiverJobIT<UsageMetricArchiverJob> {
   @Override
+  protected String getExpectedLifecyclePolicyName() {
+    return "camunda-usage-metrics-retention-policy";
+  }
+
+  @Override
   UsageMetricArchiverJob createArchiveJob(
       final ExporterConfiguration config,
       final ExporterResourceProvider resourceProvider,

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/UsageMetricTUArchiverJobIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/UsageMetricTUArchiverJobIT.java
@@ -23,6 +23,11 @@ import org.junit.jupiter.api.TestTemplate;
 @TestInstance(Lifecycle.PER_CLASS)
 public class UsageMetricTUArchiverJobIT extends ArchiverJobIT<UsageMetricTUArchiverJob> {
   @Override
+  protected String getExpectedLifecyclePolicyName() {
+    return "camunda-usage-metrics-retention-policy";
+  }
+
+  @Override
   UsageMetricTUArchiverJob createArchiveJob(
       final ExporterConfiguration config,
       final ExporterResourceProvider resourceProvider,


### PR DESCRIPTION
doing this by ensuring we check when we verify if a document has been moved, that the target index has the policy set.

also fixes an edge-case with not setting lifecycle policies when archiving docs by ID

## Related issues

refs #49826
