### PR TITLE
fix: prevent archiver hang when ES failure has null cause (#52781)

### DIFF
--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
@@ -223,10 +223,15 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
               final var timer = getArchiverDeleteQueryTimer();
               startTimer.stop(timer);
               final var result = handleResponse(response, e, sourceIndexName, "delete");
-              result.ifLeft(
-                  throwable -> trackMetricForDeleteFailures(processInstanceKeys, throwable));
               result.ifRightOrLeft(deleteFuture::complete, deleteFuture::completeExceptionally);
             });
+
+    deleteFuture.exceptionally(
+        throwable -> {
+          trackMetricForDeleteFailures(processInstanceKeys, throwable);
+          return null;
+        });
+
     return deleteFuture.thenApply(ok -> null);
   }
 
@@ -236,7 +241,7 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
       final String destinationIndexName,
       final String idFieldName,
       final List<Object> processInstanceKeys) {
-    final var reindexFuture = new CompletableFuture<Void>();
+    final var reindexFuture = new CompletableFuture<Long>();
     final var reindexRequest =
         createReindexRequestWithDefaults()
             .setSourceIndices(sourceIndexName)
@@ -246,19 +251,21 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
     final var startTimer = Timer.start();
 
     ElasticsearchUtil.reindexAsync(archiverExecutor, reindexRequest, esClient)
-        .thenAccept(
-            ignore -> {
+        .whenComplete(
+            (response, e) -> {
               final var reindexTimer = getArchiverReindexQueryTimer();
               startTimer.stop(reindexTimer);
-              reindexFuture.complete(null);
-            })
-        .exceptionally(
-            (e) -> {
-              trackMetricForReindexFailures(processInstanceKeys, e);
-              reindexFuture.completeExceptionally(e);
-              return null;
+              final var result = handleResponse(response, e, sourceIndexName, "reindex");
+              result.ifRightOrLeft(reindexFuture::complete, reindexFuture::completeExceptionally);
             });
-    return reindexFuture;
+
+    reindexFuture.exceptionally(
+        e -> {
+          trackMetricForReindexFailures(processInstanceKeys, e);
+          return null;
+        });
+
+    return reindexFuture.thenApply(ok -> null);
   }
 
   private SearchRequest createFinishedBatchOperationsSearchRequest(final AggregationBuilder agg) {
@@ -455,11 +462,9 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
         "Failed while trying to reindex documents during the archival process for the following process instance keys [{}]",
         processInstanceKeys);
 
+    final Throwable cause = e.getCause() != null ? e.getCause() : e;
     metrics.recordCounts(
-        Metrics.COUNTER_NAME_REINDEX_FAILURES,
-        1,
-        "exception",
-        e.getCause().getClass().getSimpleName());
+        Metrics.COUNTER_NAME_REINDEX_FAILURES, 1, "exception", cause.getClass().getSimpleName());
   }
 
   private void trackMetricForDeleteFailures(
@@ -469,11 +474,9 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
         "Failed while trying to delete documents during the archival process for the following process instance keys [{}]",
         processInstanceKeys);
 
+    final Throwable cause = e.getCause() != null ? e.getCause() : e;
     metrics.recordCounts(
-        Metrics.COUNTER_NAME_DELETE_FAILURES,
-        1,
-        "exception",
-        e.getCause().getClass().getSimpleName());
+        Metrics.COUNTER_NAME_DELETE_FAILURES, 1, "exception", cause.getClass().getSimpleName());
   }
 
   private Either<Throwable, Long> handleResponse(

--- a/operate/archiver/src/test/java/io/camunda/operate/archiver/ElasticsearchArchiveRepositoryTest.java
+++ b/operate/archiver/src/test/java/io/camunda/operate/archiver/ElasticsearchArchiveRepositoryTest.java
@@ -10,8 +10,10 @@ package io.camunda.operate.archiver;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.mockStatic;
@@ -32,6 +34,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
@@ -170,8 +175,9 @@ public class ElasticsearchArchiveRepositoryTest {
       try (final MockedStatic<Timer> mockedTimer = mockStatic(Timer.class)) {
         final Timer.Sample timer = mock(Timer.Sample.class);
         mockedTimer.when(Timer::start).thenReturn(timer);
-        final CompletableFuture<Void> failedFuture = new CompletableFuture<>();
-        failedFuture.completeExceptionally(new Exception("test error"));
+        final CompletableFuture<BulkByScrollResponse> failedFuture = new CompletableFuture<>();
+        final String errorMsg = "test error";
+        failedFuture.completeExceptionally(new Exception(errorMsg));
         mockedStatic
             .when(() -> ElasticsearchUtil.reindexAsync(any(), any(), any()))
             .thenReturn(failedFuture);
@@ -180,9 +186,134 @@ public class ElasticsearchArchiveRepositoryTest {
         try {
           res.join();
         } catch (final Exception e) {
-          assertThat(e.getMessage()).isEqualTo("java.lang.Exception: test error");
+          assertThat(e.getMessage()).contains(errorMsg);
         }
       }
+    }
+  }
+
+  @Test
+  public void testReindexDocumentsErrorWithNullCauseCompletesFuture() throws Exception {
+    try (final MockedStatic<ElasticsearchUtil> mockedStatic = mockStatic(ElasticsearchUtil.class)) {
+      try (final MockedStatic<Timer> mockedTimer = mockStatic(Timer.class)) {
+        final Timer.Sample timer = mock(Timer.Sample.class);
+        mockedTimer.when(Timer::start).thenReturn(timer);
+        final CompletableFuture<Void> failedFuture = new CompletableFuture<>();
+        final RuntimeException noCauseException = new RuntimeException("no-cause failure");
+        assertThat(noCauseException.getCause()).isNull();
+        failedFuture.completeExceptionally(noCauseException);
+        mockedStatic
+            .when(() -> ElasticsearchUtil.reindexAsync(any(), any(), any()))
+            .thenReturn(failedFuture);
+
+        final CompletableFuture<Void> res =
+            underTest.reindexDocuments("sourceIndex", "destinationIndex", "id", List.of());
+
+        assertThatFutureCompletesWithin(res, 5, TimeUnit.SECONDS);
+        assertThat(res).isCompletedExceptionally();
+        verify(metrics)
+            .recordCounts(
+                eq(Metrics.COUNTER_NAME_REINDEX_FAILURES),
+                anyLong(),
+                eq("exception"),
+                eq("RuntimeException"));
+      }
+    }
+  }
+
+  @Test
+  public void testReindexDocumentsMetricFailureDoesNotHangFuture() throws Exception {
+    try (final MockedStatic<ElasticsearchUtil> mockedStatic = mockStatic(ElasticsearchUtil.class)) {
+      try (final MockedStatic<Timer> mockedTimer = mockStatic(Timer.class)) {
+        final Timer.Sample timer = mock(Timer.Sample.class);
+        mockedTimer.when(Timer::start).thenReturn(timer);
+        final CompletableFuture<Void> failedFuture = new CompletableFuture<>();
+        failedFuture.completeExceptionally(new RuntimeException("no-cause failure"));
+        mockedStatic
+            .when(() -> ElasticsearchUtil.reindexAsync(any(), any(), any()))
+            .thenReturn(failedFuture);
+        doThrow(new RuntimeException("metric registry exploded"))
+            .when(metrics)
+            .recordCounts(
+                eq(Metrics.COUNTER_NAME_REINDEX_FAILURES),
+                anyLong(),
+                eq("exception"),
+                eq("RuntimeException"));
+
+        final CompletableFuture<Void> res =
+            underTest.reindexDocuments("sourceIndex", "destinationIndex", "id", List.of());
+
+        assertThatFutureCompletesWithin(res, 5, TimeUnit.SECONDS);
+        assertThat(res).isCompletedExceptionally();
+      }
+    }
+  }
+
+  @Test
+  public void testDeleteDocumentsErrorWithNullCauseCompletesFuture() throws Exception {
+    try (final MockedStatic<ElasticsearchUtil> mockedStatic = mockStatic(ElasticsearchUtil.class)) {
+      try (final MockedStatic<Timer> mockedTimer = mockStatic(Timer.class)) {
+        final Timer.Sample timer = mock(Timer.Sample.class);
+        mockedTimer.when(Timer::start).thenReturn(timer);
+        final CompletableFuture<BulkByScrollResponse> failedFuture = new CompletableFuture<>();
+        final RuntimeException noCauseException = new RuntimeException("no-cause delete failure");
+        assertThat(noCauseException.getCause()).isNull();
+        failedFuture.completeExceptionally(noCauseException);
+        mockedStatic
+            .when(() -> ElasticsearchUtil.deleteAsync(any(), any(), any()))
+            .thenReturn(failedFuture);
+
+        final CompletableFuture<Void> res = underTest.deleteDocuments("index", "id", List.of());
+
+        assertThatFutureCompletesWithin(res, 5, TimeUnit.SECONDS);
+        assertThat(res).isCompletedExceptionally();
+        verify(metrics)
+            .recordCounts(
+                eq(Metrics.COUNTER_NAME_DELETE_FAILURES),
+                anyLong(),
+                eq("exception"),
+                eq("RuntimeException"));
+      }
+    }
+  }
+
+  @Test
+  public void testDeleteDocumentsMetricFailureDoesNotHangFuture() throws Exception {
+    try (final MockedStatic<ElasticsearchUtil> mockedStatic = mockStatic(ElasticsearchUtil.class)) {
+      try (final MockedStatic<Timer> mockedTimer = mockStatic(Timer.class)) {
+        final Timer.Sample timer = mock(Timer.Sample.class);
+        mockedTimer.when(Timer::start).thenReturn(timer);
+        final CompletableFuture<BulkByScrollResponse> failedFuture = new CompletableFuture<>();
+        failedFuture.completeExceptionally(new RuntimeException("no-cause delete failure"));
+        mockedStatic
+            .when(() -> ElasticsearchUtil.deleteAsync(any(), any(), any()))
+            .thenReturn(failedFuture);
+        doThrow(new RuntimeException("metric registry exploded"))
+            .when(metrics)
+            .recordCounts(
+                eq(Metrics.COUNTER_NAME_DELETE_FAILURES),
+                anyLong(),
+                eq("exception"),
+                eq("RuntimeException"));
+
+        final CompletableFuture<Void> res = underTest.deleteDocuments("index", "id", List.of());
+
+        assertThatFutureCompletesWithin(res, 5, TimeUnit.SECONDS);
+        assertThat(res).isCompletedExceptionally();
+      }
+    }
+  }
+
+  private static void assertThatFutureCompletesWithin(
+      final CompletableFuture<?> future, final long timeout, final TimeUnit unit) throws Exception {
+    try {
+      future.get(timeout, unit);
+    } catch (final TimeoutException timeoutException) {
+      throw new AssertionError(
+          "Future did not complete within " + timeout + " " + unit + " — archiver would hang",
+          timeoutException);
+    } catch (final CompletionException | java.util.concurrent.ExecutionException ignored) {
+      // expected — caller asserts the future is completedExceptionally
     }
   }
 

--- a/operate/archiver/src/test/java/io/camunda/operate/archiver/ElasticsearchArchiveRepositoryTest.java
+++ b/operate/archiver/src/test/java/io/camunda/operate/archiver/ElasticsearchArchiveRepositoryTest.java
@@ -198,7 +198,7 @@ public class ElasticsearchArchiveRepositoryTest {
       try (final MockedStatic<Timer> mockedTimer = mockStatic(Timer.class)) {
         final Timer.Sample timer = mock(Timer.Sample.class);
         mockedTimer.when(Timer::start).thenReturn(timer);
-        final CompletableFuture<Void> failedFuture = new CompletableFuture<>();
+        final CompletableFuture<BulkByScrollResponse> failedFuture = new CompletableFuture<>();
         final RuntimeException noCauseException = new RuntimeException("no-cause failure");
         assertThat(noCauseException.getCause()).isNull();
         failedFuture.completeExceptionally(noCauseException);
@@ -227,7 +227,7 @@ public class ElasticsearchArchiveRepositoryTest {
       try (final MockedStatic<Timer> mockedTimer = mockStatic(Timer.class)) {
         final Timer.Sample timer = mock(Timer.Sample.class);
         mockedTimer.when(Timer::start).thenReturn(timer);
-        final CompletableFuture<Void> failedFuture = new CompletableFuture<>();
+        final CompletableFuture<BulkByScrollResponse> failedFuture = new CompletableFuture<>();
         failedFuture.completeExceptionally(new RuntimeException("no-cause failure"));
         mockedStatic
             .when(() -> ElasticsearchUtil.reindexAsync(any(), any(), any()))

--- a/tasklist/archiver/pom.xml
+++ b/tasklist/archiver/pom.xml
@@ -117,6 +117,30 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/es/ArchiverUtilElasticSearch.java
+++ b/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/es/ArchiverUtilElasticSearch.java
@@ -67,14 +67,15 @@ public class ArchiverUtilElasticSearch extends ArchiverUtilAbstract {
             (response, e) -> {
               final var timer = getArchiverDeleteQueryTimer();
               startTimer.stop(timer);
-
-              if (e != null) {
-                trackMetricForDeleteFailures(processInstanceKeys, e);
-              }
-
               final var result = handleResponse(response, e, sourceIndexName, "delete");
               result.ifRightOrLeft(deleteFuture::complete, deleteFuture::completeExceptionally);
             });
+
+    deleteFuture.exceptionally(
+        e -> {
+          trackMetricForDeleteFailures(processInstanceKeys, e);
+          return null;
+        });
 
     return deleteFuture;
   }
@@ -98,14 +99,15 @@ public class ArchiverUtilElasticSearch extends ArchiverUtilAbstract {
             (response, e) -> {
               final var reindexTimer = getArchiverReindexQueryTimer();
               startTimer.stop(reindexTimer);
-
-              if (e != null) {
-                trackMetricForReindexFailures(processInstanceKeys, e);
-              }
-
               final var result = handleResponse(response, e, sourceIndexName, "reindex");
               result.ifRightOrLeft(reindexFuture::complete, reindexFuture::completeExceptionally);
             });
+
+    reindexFuture.exceptionally(
+        e -> {
+          trackMetricForReindexFailures(processInstanceKeys, e);
+          return null;
+        });
 
     return reindexFuture;
   }
@@ -201,11 +203,9 @@ public class ArchiverUtilElasticSearch extends ArchiverUtilAbstract {
         "Failed reindex while trying to reindex the following process instance keys [{}]",
         processInstanceKeys);
 
+    final Throwable cause = e.getCause() != null ? e.getCause() : e;
     metrics.recordCounts(
-        Metrics.COUNTER_NAME_REINDEX_FAILURES,
-        1,
-        "exception",
-        e.getCause().getClass().getSimpleName());
+        Metrics.COUNTER_NAME_REINDEX_FAILURES, 1, "exception", cause.getClass().getSimpleName());
   }
 
   private void trackMetricForDeleteFailures(
@@ -214,11 +214,9 @@ public class ArchiverUtilElasticSearch extends ArchiverUtilAbstract {
         "Failed deletion while trying to archive the following process instance keys [{}]",
         processInstanceKeys);
 
+    final Throwable cause = e.getCause() != null ? e.getCause() : e;
     metrics.recordCounts(
-        Metrics.COUNTER_NAME_DELETE_FAILURES,
-        1,
-        "exception",
-        e.getCause().getClass().getSimpleName());
+        Metrics.COUNTER_NAME_DELETE_FAILURES, 1, "exception", cause.getClass().getSimpleName());
   }
 
   private Timer getArchiverDeleteQueryTimer() {

--- a/tasklist/archiver/src/test/java/io/camunda/tasklist/archiver/es/ArchiverUtilElasticSearchTest.java
+++ b/tasklist/archiver/src/test/java/io/camunda/tasklist/archiver/es/ArchiverUtilElasticSearchTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.tasklist.archiver.es;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.tasklist.Metrics;
+import io.camunda.tasklist.util.ElasticsearchUtil;
+import io.micrometer.core.instrument.Timer;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.elasticsearch.index.reindex.BulkByScrollResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Regression coverage for the silent archiver hang documented in GitHub issue #52781. Verifies that
+ * the futures returned by {@link ArchiverUtilElasticSearch} always complete — even when the
+ * underlying ES failure carries no {@link Throwable#getCause() cause} and when metric recording
+ * itself throws.
+ */
+@ExtendWith(MockitoExtension.class)
+public class ArchiverUtilElasticSearchTest {
+
+  @InjectMocks private ArchiverUtilElasticSearch underTest;
+  @Mock private Metrics metrics;
+
+  @Test
+  public void deleteDocumentsCompletesFutureWhenFailureHasNullCause() throws Exception {
+    try (final MockedStatic<ElasticsearchUtil> mockedStatic = mockStatic(ElasticsearchUtil.class);
+        final MockedStatic<Timer> mockedTimer = mockStatic(Timer.class)) {
+      mockedTimer.when(Timer::start).thenReturn(mock(Timer.Sample.class));
+      final RuntimeException noCause = new RuntimeException("ES delete failed");
+      assertThat(noCause.getCause()).isNull();
+      final CompletableFuture<BulkByScrollResponse> failed = new CompletableFuture<>();
+      failed.completeExceptionally(noCause);
+      mockedStatic
+          .when(() -> ElasticsearchUtil.deleteByQueryAsync(any(), any(), any()))
+          .thenReturn(failed);
+
+      final CompletableFuture<Long> res = underTest.deleteDocuments("idx", "id", List.of("1"));
+
+      assertThatFutureCompletesWithin(res, 5, TimeUnit.SECONDS);
+      assertThat(res).isCompletedExceptionally();
+      verify(metrics)
+          .recordCounts(
+              eq(Metrics.COUNTER_NAME_DELETE_FAILURES),
+              anyLong(),
+              eq("exception"),
+              eq("RuntimeException"));
+    }
+  }
+
+  @Test
+  public void reindexDocumentsCompletesFutureWhenFailureHasNullCause() throws Exception {
+    try (final MockedStatic<ElasticsearchUtil> mockedStatic = mockStatic(ElasticsearchUtil.class);
+        final MockedStatic<Timer> mockedTimer = mockStatic(Timer.class)) {
+      mockedTimer.when(Timer::start).thenReturn(mock(Timer.Sample.class));
+      final RuntimeException noCause = new RuntimeException("ES reindex failed");
+      assertThat(noCause.getCause()).isNull();
+      final CompletableFuture<BulkByScrollResponse> failed = new CompletableFuture<>();
+      failed.completeExceptionally(noCause);
+      mockedStatic
+          .when(() -> ElasticsearchUtil.reindexAsync(any(), any(), any()))
+          .thenReturn(failed);
+
+      final CompletableFuture<Long> res =
+          underTest.reindexDocuments("src", "dst", "id", List.of("1"));
+
+      assertThatFutureCompletesWithin(res, 5, TimeUnit.SECONDS);
+      assertThat(res).isCompletedExceptionally();
+      verify(metrics)
+          .recordCounts(
+              eq(Metrics.COUNTER_NAME_REINDEX_FAILURES),
+              anyLong(),
+              eq("exception"),
+              eq("RuntimeException"));
+    }
+  }
+
+  @Test
+  public void deleteDocumentsCompletesFutureWhenMetricTrackingThrows() throws Exception {
+    try (final MockedStatic<ElasticsearchUtil> mockedStatic = mockStatic(ElasticsearchUtil.class);
+        final MockedStatic<Timer> mockedTimer = mockStatic(Timer.class)) {
+      mockedTimer.when(Timer::start).thenReturn(mock(Timer.Sample.class));
+      final CompletableFuture<BulkByScrollResponse> failed = new CompletableFuture<>();
+      failed.completeExceptionally(new RuntimeException("ES delete failed"));
+      mockedStatic
+          .when(() -> ElasticsearchUtil.deleteByQueryAsync(any(), any(), any()))
+          .thenReturn(failed);
+      doThrow(new RuntimeException("metric registry exploded"))
+          .when(metrics)
+          .recordCounts(
+              eq(Metrics.COUNTER_NAME_DELETE_FAILURES),
+              anyLong(),
+              eq("exception"),
+              eq("RuntimeException"));
+
+      final CompletableFuture<Long> res = underTest.deleteDocuments("idx", "id", List.of("1"));
+
+      assertThatFutureCompletesWithin(res, 5, TimeUnit.SECONDS);
+      assertThat(res).isCompletedExceptionally();
+    }
+  }
+
+  @Test
+  public void reindexDocumentsCompletesFutureWhenMetricTrackingThrows() throws Exception {
+    try (final MockedStatic<ElasticsearchUtil> mockedStatic = mockStatic(ElasticsearchUtil.class);
+        final MockedStatic<Timer> mockedTimer = mockStatic(Timer.class)) {
+      mockedTimer.when(Timer::start).thenReturn(mock(Timer.Sample.class));
+      final CompletableFuture<BulkByScrollResponse> failed = new CompletableFuture<>();
+      failed.completeExceptionally(new RuntimeException("ES reindex failed"));
+      mockedStatic
+          .when(() -> ElasticsearchUtil.reindexAsync(any(), any(), any()))
+          .thenReturn(failed);
+      doThrow(new RuntimeException("metric registry exploded"))
+          .when(metrics)
+          .recordCounts(
+              eq(Metrics.COUNTER_NAME_REINDEX_FAILURES),
+              anyLong(),
+              eq("exception"),
+              eq("RuntimeException"));
+
+      final CompletableFuture<Long> res =
+          underTest.reindexDocuments("src", "dst", "id", List.of("1"));
+
+      assertThatFutureCompletesWithin(res, 5, TimeUnit.SECONDS);
+      assertThat(res).isCompletedExceptionally();
+    }
+  }
+
+  private static void assertThatFutureCompletesWithin(
+      final CompletableFuture<?> future, final long timeout, final TimeUnit unit) throws Exception {
+    try {
+      future.get(timeout, unit);
+    } catch (final TimeoutException timeoutException) {
+      throw new AssertionError(
+          "Future did not complete within " + timeout + " " + unit + " — archiver would hang",
+          timeoutException);
+    } catch (final CompletionException | ExecutionException ignored) {
+      // expected — caller asserts the future is completedExceptionally
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Fixes #52781: the Tasklist process-instance archiver permanently stopped archiving for a partition after a single Elasticsearch delete/reindex failure whose exception had no `cause`, leaving `allOf(...)` waiting forever and the archiver loop dead until restart.
- Root cause: `trackMetricFor{Delete,Reindex}Failures` dereferenced `e.getCause()` to label the counter, and the resulting NPE escaped the `whenComplete` lambda before the result future was completed.
- Fix restructures `deleteDocuments` / `reindexDocuments` so metric tracking attaches as an independent `.exceptionally()` stage on the result future — it cannot reach the completion path. Trackers fall back to the exception itself when `getCause()` is null so the metric still records a meaningful class.
- Operate ES `reindexDocuments` now also routes through `handleResponse` for consistency with `deleteDocuments`; previously, reindex bulk failures were silently ignored.

Covers both the **Tasklist** and **Operate** archivers. Tasklist OS and Operate OS implementations don't have the buggy metric trackers, so no code changes there; verified that their `whenComplete` paths don't dereference `getCause()` either.

## Test plan

- [x] `ArchiverUtilElasticSearchTest` (new): null-cause delete/reindex completes future, metric records the exception's own class, metric-tracker throw doesn't hang the future
- [x] `ElasticsearchArchiveRepositoryTest` (extended): same coverage for Operate ES
- [x] `mvn -pl tasklist/archiver,operate/archiver -am test` → 22 archiver tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)