### PR TITLE
test: make version-sort assertions order-agnostic within v1 tie

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesTable.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesTable.spec.ts
@@ -192,6 +192,11 @@ test.describe('Process Instances Table', () => {
 
     await test.step('Check sorting of processes by process version DESC', async () => {
       await operateProcessesPage.clickVersionSortButton();
+      // The two v1 instances tie on version, and Operate's tie-break is
+      // environment-dependent (start date DESC when timestamps differ;
+      // process-instance-key when they don't). Only assert what the test
+      // is actually verifying — the primary sort: v2 at the top, both v1
+      // instances below in any order.
       await expect
         .poll(
           () => operateProcessesPage.processInstancesTable.nth(0).innerText(),
@@ -199,33 +204,41 @@ test.describe('Process Instances Table', () => {
         )
         .toContain(instanceIds[2].toString());
       await expect
-        .poll(
-          () => operateProcessesPage.processInstancesTable.nth(1).innerText(),
-          defaultAssertionOptions,
-        )
-        .toContain(instanceIds[0].toString());
-      await expect
-        .poll(
-          () => operateProcessesPage.processInstancesTable.nth(2).innerText(),
-          defaultAssertionOptions,
-        )
-        .toContain(instanceIds[1].toString());
+        .poll(async () => {
+          const row1 = await operateProcessesPage.processInstancesTable
+            .nth(1)
+            .innerText();
+          const row2 = await operateProcessesPage.processInstancesTable
+            .nth(2)
+            .innerText();
+          const combined = `${row1}||${row2}`;
+          return (
+            combined.includes(instanceIds[0].toString()) &&
+            combined.includes(instanceIds[1].toString())
+          );
+        }, defaultAssertionOptions)
+        .toBe(true);
     });
 
     await test.step('Check sorting of processes by process version ASC', async () => {
       await operateProcessesPage.clickVersionSortButton();
+      // Mirror of the DESC check: both v1 instances at the top in any
+      // order, v2 at the bottom.
       await expect
-        .poll(
-          () => operateProcessesPage.processInstancesTable.nth(0).innerText(),
-          defaultAssertionOptions,
-        )
-        .toContain(instanceIds[0].toString());
-      await expect
-        .poll(
-          () => operateProcessesPage.processInstancesTable.nth(1).innerText(),
-          defaultAssertionOptions,
-        )
-        .toContain(instanceIds[1].toString());
+        .poll(async () => {
+          const row0 = await operateProcessesPage.processInstancesTable
+            .nth(0)
+            .innerText();
+          const row1 = await operateProcessesPage.processInstancesTable
+            .nth(1)
+            .innerText();
+          const combined = `${row0}||${row1}`;
+          return (
+            combined.includes(instanceIds[0].toString()) &&
+            combined.includes(instanceIds[1].toString())
+          );
+        }, defaultAssertionOptions)
+        .toBe(true);
       await expect
         .poll(
           () => operateProcessesPage.processInstancesTable.nth(2).innerText(),


### PR DESCRIPTION
## Summary

Follow-up to #52779. The "Sorting of process instances" test made hard-coded assumptions about Operate's tie-break behavior for rows sharing a version, which doesn't match how the product actually behaves.

Evidence from two environments:
- **Run 93 CI snapshot** (\`qa/.../processInstancesTable.spec.ts:117\`): two v1 rows have timestamps 1s apart (14:30:41 vs 14:30:40), and the product orders them by **start date DESC** (newer first).
- **Local reproduction** (2-partition cluster): both v1 rows have the same timestamp at second resolution (18:08:33), and the product orders them by **process-instance-key ASC**.

The test was asserting start date ASC within tie — which matches neither.

## Fix

Since the step is verifying the *primary* sort by version (not the tie-break rule), only assert what matters:
- **version DESC**: v2 at \`nth(0)\`; both v1 keys appear in \`{nth(1), nth(2)}\` in any order
- **version ASC**: both v1 keys appear in \`{nth(0), nth(1)}\` in any order; v2 at \`nth(2)\`

## Test plan

- [x] \`npx tsc --noEmit\` — clean
- [x] \`npx eslint\` on changed file — only the pre-existing skip warning, no new errors
- [x] \`npx playwright test ... -g "Sorting of process instances" --repeat-each=3\` — 3/3 passed locally with no flakes
- [ ] On-demand run: https://github.com/camunda/camunda/actions/runs/25682482876
`Sorting of process instances` passed, other tests failed due to flakiness and will be fixed in a sepaarte PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
