### PR TITLE
test: poll dashboard Statistics invariant to avoid badge-update race

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/dashboard.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/dashboard.spec.ts
@@ -18,6 +18,7 @@ import {waitForProcessInstances} from 'utils/incidentsHelper';
 import {navigateToApp} from '@pages/UtilitiesPage';
 import {captureScreenshot, captureFailureVideo} from '@setup';
 import {waitForAssertion} from '../../utils/waitForAssertion';
+import {defaultAssertionOptions} from '../../utils/constants';
 
 let instanceIds: string[] = [];
 
@@ -86,19 +87,27 @@ test.afterEach(async ({page}, testInfo) => {
 test.describe('Dashboard', () => {
   test('Statistics', async ({operateDashboardPage}) => {
     await test.step('Verify total count equals sum of active and incident instances', async () => {
-      const incidentInstancesCount = Number(
-        await operateDashboardPage.incidentInstancesBadge.innerText(),
-      );
-      const activeProcessInstancesCount = Number(
-        await operateDashboardPage.activeInstancesBadge.innerText(),
-      );
-      const totalInstancesCount = operateDashboardPage.totalInstancesLink;
-
-      await expect(totalInstancesCount).toHaveText(
-        `${
-          incidentInstancesCount + activeProcessInstancesCount
-        } Running Process Instances in total`,
-      );
+      // The three badges (active, incident, total) update on independent
+      // polling intervals while other tests in this suite keep creating
+      // process instances, so reading the parts and then asserting the
+      // sum can fail when the system snapshot shifts between reads.
+      // Re-read all three values atomically on each poll iteration and
+      // verify the invariant holds for a consistent snapshot.
+      await expect
+        .poll(async () => {
+          const incident = Number(
+            await operateDashboardPage.incidentInstancesBadge.innerText(),
+          );
+          const active = Number(
+            await operateDashboardPage.activeInstancesBadge.innerText(),
+          );
+          const total =
+            await operateDashboardPage.totalInstancesLink.innerText();
+          return (
+            total === `${incident + active} Running Process Instances in total`
+          );
+        }, defaultAssertionOptions)
+        .toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary

Investigated a failure from on-demand run https://github.com/camunda/camunda/actions/runs/25682482876:

```
[chromium] › tests/operate/dashboard.spec.ts:87:3 › Dashboard › Statistics
Error: expect(locator).toHaveText(expected) failed
Locator:  getByTestId('total-instances-link')
Expected: "1587 Running Process Instances in total"
Received: "1692 Running Process Instances in total"
  - 9 × locator resolved to "1594 Running Process Instances in total"
  - 5 × locator resolved to "1692 Running Process Instances in total"
```

The test reads `incident.innerText()`, then `active.innerText()`, then asserts `total == incident + active`. All three badges update on independent polling intervals while other tests in this describe block (and parallel tests in the suite) continuously create process instances — so the dashboard snapshot shifts between the three reads, and the running total has already climbed past `incident + active` by the time the assertion fires.

The evidence makes that clear: the test captured one snapshot of the parts at one moment, but by the assertion the total badge had already moved on.

## Fix

Wrap all three reads in a single `expect.poll` so each iteration captures a consistent snapshot, and the test only needs the invariant to hold once within the 30s budget.

```ts
await expect.poll(async () => {
  const incident = Number(await operateDashboardPage.incidentInstancesBadge.innerText());
  const active = Number(await operateDashboardPage.activeInstancesBadge.innerText());
  const total = await operateDashboardPage.totalInstancesLink.innerText();
  return total === `${incident + active} Running Process Instances in total`;
}, defaultAssertionOptions).toBe(true);
```

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npx eslint\` clean (only pre-existing skip warnings)
- [x] \`npx playwright test tests/operate/dashboard.spec.ts -g "Statistics" --repeat-each=3\` — 3/3 passed locally with no flakes
- [ ] On-demand run: https://github.com/camunda/camunda/actions/runs/25685496233 -> e2e all 🟢 

🤖 Generated with [Claude Code](https://claude.com/claude-code)
