### PR TITLE
docs(c8run): document workflow_dispatch for feature branch builds

### DIFF
--- a/c8run/README.md
+++ b/c8run/README.md
@@ -67,6 +67,19 @@ go build -o c8run ./cmd/c8run/
 ./start.sh
 ```
 
+## Build C8Run from a feature branch (via CI)
+
+The [`c8run-build.yaml`](https://github.com/camunda/camunda/actions/workflows/c8run-build.yaml) workflow supports `workflow_dispatch`, so you can trigger a full build and package from any branch without setting up a local environment.
+
+Steps:
+
+1. Go to the [C8Run: build/test workflow](https://github.com/camunda/camunda/actions/workflows/c8run-build.yaml).
+2. Click **Run workflow**, select your feature branch, and start the run.
+3. Wait for the run to complete.
+4. Download the `camunda8-run-build-<os>` artifacts from the run summary.
+
+The workflow produces platform-specific artifacts for Linux, macOS (ARM and Intel), and Windows; the downloaded artifacts contain the corresponding `camunda8-run*` files ready to share with colleagues or customers.
+
 ### Connectors launcher
 
 C8Run automatically starts the connectors runtime through Spring Boot's `PropertiesLauncher` for connector bundles versioned 8.9.0 or newer (including snapshots). Older bundles continue to run via the legacy `JarLauncher`, so you can switch versions in `.env` without extra configuration.

--- a/c8run/docs/testing-guide.md
+++ b/c8run/docs/testing-guide.md
@@ -45,7 +45,7 @@ API and Playwright-based E2E tests live in `e2e_tests/`. These are run by C8Run 
 ### Layer 1 — In-repo smoke tests (`camunda/camunda`)
 
 **Workflow:** `.github/workflows/c8run-build.yaml`
-**Triggers:** PRs touching `c8run/**` and nightly at 23:30 UTC
+**Triggers:** PRs touching `c8run/**`, nightly at 23:30 UTC, and `workflow_dispatch` (can be triggered manually on any branch from the [Actions UI](https://github.com/camunda/camunda/actions/workflows/c8run-build.yaml) — uploads `camunda8-run-build-<os>` artifacts to the run summary)
 
 What runs:
 - Playwright tests (`c8run/e2e_tests/`) on Linux, macOS ARM, macOS Intel


### PR DESCRIPTION
## Summary

- Added a new `## Build C8Run from a feature branch (via CI)` section to `c8run/README.md`, explaining how to use the `workflow_dispatch` trigger on `c8run-build.yaml` to produce shareable artifacts from any feature branch.
- Updated the **Layer 1 — In-repo smoke tests** trigger list in `c8run/docs/testing-guide.md` to mention `workflow_dispatch` alongside the existing PR and nightly triggers.

## Why

Contributors sometimes need to share a working C8Run build from a feature branch with less technical colleagues or customers — without requiring them to set up a Go toolchain. The `c8run-build.yaml` workflow already supports `workflow_dispatch` and uploads `camunda8-run-*` artifacts for Linux, macOS (ARM + Intel), and Windows, but this capability was undocumented. These changes make it discoverable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)