### PR TITLE
feat: add optional time anchor to load-test metrics workflow

### DIFF
--- a/.github/workflows/camunda-load-test-metrics.yaml
+++ b/.github/workflows/camunda-load-test-metrics.yaml
@@ -17,6 +17,11 @@ on:
         required: false
         type: string
         default: '600'
+      at:
+        description: 'Optional Prometheus `time` anchor (RFC3339, e.g. 2026-05-09T12:00:00Z, or Unix timestamp). Queries end at this instant instead of "now" — use to snapshot a run whose namespace TTL has already expired.'
+        required: false
+        type: string
+        default: ''
   workflow_call:
     inputs:
       namespace:
@@ -28,6 +33,11 @@ on:
         required: false
         type: string
         default: '600'
+      at:
+        description: 'Optional Prometheus `time` anchor (RFC3339 or Unix timestamp). When set, queries end at this instant instead of "now".'
+        required: false
+        type: string
+        default: ''
     outputs:
       results-json:
         description: 'JSON object {name: number, ...} from loadTestMetrics.sh stdout (queries that scrape no data are omitted)'
@@ -51,6 +61,7 @@ jobs:
     env:
       NAMESPACE: ${{ inputs.namespace }}
       DURATION_SECONDS: ${{ inputs.duration-seconds }}
+      AT: ${{ inputs.at }}
     outputs:
       results-json: ${{ steps.run-queries.outputs.results-json }}
     steps:
@@ -90,6 +101,7 @@ jobs:
             "$DURATION_SECONDS" \
             "$PROM_URL" \
             "--user $PROM_USER:$PROM_PASS" \
+            "$AT" \
             > /tmp/results-raw.json
           rc=$?
           if [[ $rc -ne 0 ]]; then
@@ -121,6 +133,7 @@ jobs:
 
             const namespace = process.env.NAMESPACE;
             const durationSeconds = parseInt(process.env.DURATION_SECONDS, 10);
+            const at = process.env.AT || '';
 
             // queries.yaml drives row order, description, and formatting.
             const queriesDoc = JSON.parse(
@@ -173,7 +186,7 @@ jobs:
             const body = [
               `## 🔍 Load Test Metrics`,
               '',
-              `Namespace: \`${namespace}\` · Window: ${durationSeconds}s`,
+              `Namespace: \`${namespace}\` · Window: ${durationSeconds}s${at ? ` ending at \`${at}\`` : ''}`,
               '',
               ...tableLines,
               '',

--- a/load-tests/docs/scripts/loadTestMetrics.sh
+++ b/load-tests/docs/scripts/loadTestMetrics.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 
 usage() {
   cat <<'EOF'
-Usage: loadTestMetrics.sh <namespace> [duration_seconds] [endpoint] [extra_curl_opts]
+Usage: loadTestMetrics.sh <namespace> [duration_seconds] [endpoint] [extra_curl_opts] [time_anchor]
 
 Arguments:
   namespace          Substituted for $NAMESPACE in queries (required).
@@ -16,6 +16,12 @@ Arguments:
                      (assumes a `kubectl port-forward` is open in another terminal).
   extra_curl_opts    Free-form curl options string, e.g. `--user "u:p"`.
                      Pass "" if not needed. Default: "".
+  time_anchor        Optional Prometheus `time` parameter — RFC3339 (e.g.
+                     2026-05-09T12:00:00Z) or Unix timestamp. When set, every
+                     query's range ends at this instant instead of "now". Useful
+                     for snapshotting runs whose namespace TTL has already
+                     expired (Prometheus retains scraped data past namespace
+                     deletion). Default: unset (queries end at "now").
 
 Options:
   -h, --help         Show this help message.
@@ -29,6 +35,12 @@ Examples:
     "$NAMESPACE" "$DURATION_SECONDS" \
     "https://ci-monitor.benchmark.camunda.cloud" \
     "--user $PROM_USER:$PROM_PASS" > /tmp/results.json
+
+  # Historical snapshot of an already-cleaned-up namespace:
+  ./loadTestMetrics.sh c8-foo-20260508 3600 \
+    "https://ci-monitor.benchmark.camunda.cloud" \
+    "--user $PROM_USER:$PROM_PASS" \
+    2026-05-09T12:00:00Z > /tmp/results.json
 EOF
 }
 
@@ -48,6 +60,7 @@ NAMESPACE="$1"
 DURATION_SECONDS="${2:-600}"
 ENDPOINT="${3:-http://localhost:9090}"
 EXTRA_OPTS="${4-}"
+TIME_ANCHOR="${5-}"
 
 if (( ${#NAMESPACE} > 63 )) || ! [[ "$NAMESPACE" =~ ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ ]]; then
   echo "Error: namespace '$NAMESPACE' must be a valid Kubernetes DNS label (max 63 characters; lowercase alphanumeric or '-', and must start and end with an alphanumeric character)." >&2
@@ -80,6 +93,13 @@ done
 # array is empty (bash 3.2 + set -u would otherwise raise "unbound variable").
 read -ra EXTRA_OPTS_ARR <<<"$EXTRA_OPTS"
 
+# Build the optional time anchor as a separate curl arg array so we can expand
+# it conditionally (empty arrays + `set -u` would otherwise error).
+declare -a TIME_ARGS=()
+if [[ -n "$TIME_ANCHOR" ]]; then
+  TIME_ARGS=(--data-urlencode "time=$TIME_ANCHOR")
+fi
+
 ### --- Run queries ---
 
 count=$(yq '.queries | length' "$QUERIES_FILE")
@@ -94,7 +114,8 @@ for i in $(seq 0 $((count - 1))); do
 
   resp=$(curl -sf -G ${EXTRA_OPTS_ARR[@]+"${EXTRA_OPTS_ARR[@]}"} \
         "${ENDPOINT}/api/v1/query" \
-        --data-urlencode "query=$promql" 2>/dev/null) || continue
+        --data-urlencode "query=$promql" \
+        ${TIME_ARGS[@]+"${TIME_ARGS[@]}"} 2>/dev/null) || continue
 
   [[ "$(jq -r '.status' <<<"$resp" 2>/dev/null || echo error)" == "success" ]] || continue
 


### PR DESCRIPTION
## Description

When a load-test namespace is auto-cleaned via its TTL before someone gets back to snapshot metrics, the previous workflow's relative-only window (`[duration-seconds]` ending at *now*) returns an empty result. Prometheus retains the scraped data past namespace deletion, so the fix is to let the workflow query an arbitrary instant.

Adds a new optional `at` input (RFC3339 or Unix timestamp) on both `workflow_dispatch` and `workflow_call`, plumbed through to `loadTestMetrics.sh` as a 5th positional arg. When set, the script forwards it as the Prometheus `time` parameter so each query's range ends at that instant instead of *now*. The summary renders the anchor alongside the namespace/window for clarity. Default behavior unchanged — existing callers and CI jobs are unaffected.

**Smoke-tested** on https://github.com/camunda/camunda/actions/runs/25719108637 — historic snapshot of a load test whose namespace was already TTL-cleaned, anchored to `2026-05-09T12:00:00Z`, returned a full metrics table (vs. empty `{}` from the unanchored run https://github.com/camunda/camunda/actions/runs/25716454828).

## Checklist

- [x] No backport needed (additive feature, default behavior unchanged)
- [ ] N/A — does not modify the C8 Orchestration Cluster E2E Test Suite

## Related issues

N/A — quality-of-life improvement found while operating load tests.