### PR TITLE
fix: prevent archiver hang via defensive try-catch in callbacks (#52781)

### DIFF
--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
@@ -218,14 +218,7 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
 
     final var startTimer = Timer.start();
     return ElasticsearchUtil.deleteAsync(deleteRequest, archiverExecutor, esClient)
-        .<Long>handle(
-            (response, e) -> {
-              final var result = handleResponse(response, e, sourceIndexName, "delete");
-              if (result.isLeft()) {
-                throw new CompletionException(result.getLeft());
-              }
-              return result.get();
-            })
+        .handle((response, e) -> handleResponse(response, e, sourceIndexName, "delete"))
         .whenComplete(
             (result, e) -> {
               try {
@@ -234,6 +227,7 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
                 LOGGER.warn("Failed to record delete timer for index [{}]", sourceIndexName, ex);
               }
             })
+        .<Long>thenCompose(this::unwrapEither)
         .whenComplete(
             (val, e) -> {
               if (e != null) {
@@ -261,14 +255,7 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
 
     final var startTimer = Timer.start();
     return ElasticsearchUtil.reindexAsync(archiverExecutor, reindexRequest, esClient)
-        .<Long>handle(
-            (response, e) -> {
-              final var result = handleResponse(response, e, sourceIndexName, "reindex");
-              if (result.isLeft()) {
-                throw new CompletionException(result.getLeft());
-              }
-              return result.get();
-            })
+        .handle((response, e) -> handleResponse(response, e, sourceIndexName, "reindex"))
         .whenComplete(
             (result, e) -> {
               try {
@@ -277,6 +264,7 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
                 LOGGER.warn("Failed to record reindex timer for index [{}]", sourceIndexName, ex);
               }
             })
+        .<Long>thenCompose(this::unwrapEither)
         .whenComplete(
             (val, e) -> {
               if (e != null) {
@@ -501,6 +489,14 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
         Metrics.COUNTER_NAME_DELETE_FAILURES, 1, "exception", cause.getClass().getSimpleName());
   }
 
+  private <T> CompletableFuture<T> unwrapEither(final Either<Throwable, T> result) {
+    if (result.isLeft()) {
+      return CompletableFuture.failedFuture(result.getLeft());
+    }
+    return CompletableFuture.completedFuture(result.get());
+  }
+
+  /** Strips the {@link CompletionException} wrapper added by {@code thenCompose}. */
   private static Throwable unwrapCompletion(final Throwable e) {
     return e instanceof CompletionException && e.getCause() != null ? e.getCause() : e;
   }

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
@@ -221,11 +221,7 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
         .whenComplete(
             (response, e) -> {
               try {
-                final var timer = getArchiverDeleteQueryTimer();
-                startTimer.stop(timer);
                 final var result = handleResponse(response, e, sourceIndexName, "delete");
-                result.ifLeft(
-                    throwable -> trackMetricForDeleteFailures(processInstanceKeys, throwable));
                 result.ifRightOrLeft(deleteFuture::complete, deleteFuture::completeExceptionally);
               } catch (final Exception unexpected) {
                 LOGGER.error(
@@ -234,6 +230,21 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
                     unexpected);
                 if (!deleteFuture.isDone()) {
                   deleteFuture.completeExceptionally(unexpected);
+                }
+              } finally {
+                try {
+                  final var timer = getArchiverDeleteQueryTimer();
+                  startTimer.stop(timer);
+                } catch (final Exception timerEx) {
+                  LOGGER.warn(
+                      "Failed to record delete timer for index [{}]", sourceIndexName, timerEx);
+                }
+                if (deleteFuture.isCompletedExceptionally()) {
+                  try {
+                    trackMetricForDeleteFailures(processInstanceKeys, e);
+                  } catch (final Exception metricEx) {
+                    LOGGER.warn("Failed to record delete failure metric", metricEx);
+                  }
                 }
               }
             });
@@ -259,11 +270,7 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
         .whenComplete(
             (response, e) -> {
               try {
-                final var reindexTimer = getArchiverReindexQueryTimer();
-                startTimer.stop(reindexTimer);
                 final var result = handleResponse(response, e, sourceIndexName, "reindex");
-                result.ifLeft(
-                    throwable -> trackMetricForReindexFailures(processInstanceKeys, throwable));
                 result.ifRightOrLeft(reindexFuture::complete, reindexFuture::completeExceptionally);
               } catch (final Exception unexpected) {
                 LOGGER.error(
@@ -272,6 +279,21 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
                     unexpected);
                 if (!reindexFuture.isDone()) {
                   reindexFuture.completeExceptionally(unexpected);
+                }
+              } finally {
+                try {
+                  final var reindexTimer = getArchiverReindexQueryTimer();
+                  startTimer.stop(reindexTimer);
+                } catch (final Exception timerEx) {
+                  LOGGER.warn(
+                      "Failed to record reindex timer for index [{}]", sourceIndexName, timerEx);
+                }
+                if (reindexFuture.isCompletedExceptionally()) {
+                  try {
+                    trackMetricForReindexFailures(processInstanceKeys, e);
+                  } catch (final Exception metricEx) {
+                    LOGGER.warn("Failed to record reindex failure metric", metricEx);
+                  }
                 }
               }
             });

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
@@ -37,7 +37,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.function.Function;
 import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest;
 import org.elasticsearch.action.search.SearchRequest;
@@ -219,26 +218,21 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
     final var startTimer = Timer.start();
     return ElasticsearchUtil.deleteAsync(deleteRequest, archiverExecutor, esClient)
         .handle((response, e) -> handleResponse(response, e, sourceIndexName, "delete"))
-        .whenComplete(
-            (result, e) -> {
+        .thenCompose(
+            result -> {
               try {
                 startTimer.stop(getArchiverDeleteQueryTimer());
-              } catch (final Exception ex) {
-                LOGGER.warn("Failed to record delete timer for index [{}]", sourceIndexName, ex);
-              }
-            })
-        .<Long>thenCompose(this::unwrapEither)
-        .whenComplete(
-            (val, e) -> {
-              if (e != null) {
-                try {
-                  trackMetricForDeleteFailures(processInstanceKeys, unwrapCompletion(e));
-                } catch (final Exception ex) {
-                  LOGGER.warn("Failed to record delete failure metric", ex);
+                if (result.isLeft()) {
+                  trackMetricForDeleteFailures(processInstanceKeys, result.getLeft());
                 }
+              } catch (final Throwable ex) {
+                LOGGER.warn("Failed to record metric", ex);
               }
-            })
-        .thenApply(ok -> null);
+              if (result.isLeft()) {
+                return CompletableFuture.failedFuture(result.getLeft());
+              }
+              return CompletableFuture.completedFuture(null);
+            });
   }
 
   @Override
@@ -256,26 +250,21 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
     final var startTimer = Timer.start();
     return ElasticsearchUtil.reindexAsync(archiverExecutor, reindexRequest, esClient)
         .handle((response, e) -> handleResponse(response, e, sourceIndexName, "reindex"))
-        .whenComplete(
-            (result, e) -> {
+        .thenCompose(
+            result -> {
               try {
                 startTimer.stop(getArchiverReindexQueryTimer());
-              } catch (final Exception ex) {
-                LOGGER.warn("Failed to record reindex timer for index [{}]", sourceIndexName, ex);
-              }
-            })
-        .<Long>thenCompose(this::unwrapEither)
-        .whenComplete(
-            (val, e) -> {
-              if (e != null) {
-                try {
-                  trackMetricForReindexFailures(processInstanceKeys, unwrapCompletion(e));
-                } catch (final Exception ex) {
-                  LOGGER.warn("Failed to record reindex failure metric", ex);
+                if (result.isLeft()) {
+                  trackMetricForReindexFailures(processInstanceKeys, result.getLeft());
                 }
+              } catch (final Throwable ex) {
+                LOGGER.warn("Failed to record metric", ex);
               }
-            })
-        .thenApply(ok -> null);
+              if (result.isLeft()) {
+                return CompletableFuture.failedFuture(result.getLeft());
+              }
+              return CompletableFuture.completedFuture(null);
+            });
   }
 
   private SearchRequest createFinishedBatchOperationsSearchRequest(final AggregationBuilder agg) {
@@ -487,18 +476,6 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
     final Throwable cause = e.getCause() != null ? e.getCause() : e;
     metrics.recordCounts(
         Metrics.COUNTER_NAME_DELETE_FAILURES, 1, "exception", cause.getClass().getSimpleName());
-  }
-
-  private <T> CompletableFuture<T> unwrapEither(final Either<Throwable, T> result) {
-    if (result.isLeft()) {
-      return CompletableFuture.failedFuture(result.getLeft());
-    }
-    return CompletableFuture.completedFuture(result.get());
-  }
-
-  /** Strips the {@link CompletionException} wrapper added by {@code thenCompose}. */
-  private static Throwable unwrapCompletion(final Throwable e) {
-    return e instanceof CompletionException && e.getCause() != null ? e.getCause() : e;
   }
 
   private Either<Throwable, Long> handleResponse(

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
@@ -220,12 +220,22 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
     ElasticsearchUtil.deleteAsync(deleteRequest, archiverExecutor, esClient)
         .whenComplete(
             (response, e) -> {
-              final var timer = getArchiverDeleteQueryTimer();
-              startTimer.stop(timer);
-              final var result = handleResponse(response, e, sourceIndexName, "delete");
-              result.ifLeft(
-                  throwable -> trackMetricForDeleteFailures(processInstanceKeys, throwable));
-              result.ifRightOrLeft(deleteFuture::complete, deleteFuture::completeExceptionally);
+              try {
+                final var timer = getArchiverDeleteQueryTimer();
+                startTimer.stop(timer);
+                final var result = handleResponse(response, e, sourceIndexName, "delete");
+                result.ifLeft(
+                    throwable -> trackMetricForDeleteFailures(processInstanceKeys, throwable));
+                result.ifRightOrLeft(deleteFuture::complete, deleteFuture::completeExceptionally);
+              } catch (final Exception unexpected) {
+                LOGGER.error(
+                    "Unexpected error in delete callback for index [{}]",
+                    sourceIndexName,
+                    unexpected);
+                if (!deleteFuture.isDone()) {
+                  deleteFuture.completeExceptionally(unexpected);
+                }
+              }
             });
     return deleteFuture.thenApply(ok -> null);
   }
@@ -236,7 +246,7 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
       final String destinationIndexName,
       final String idFieldName,
       final List<Object> processInstanceKeys) {
-    final var reindexFuture = new CompletableFuture<Void>();
+    final var reindexFuture = new CompletableFuture<Long>();
     final var reindexRequest =
         createReindexRequestWithDefaults()
             .setSourceIndices(sourceIndexName)
@@ -246,19 +256,26 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
     final var startTimer = Timer.start();
 
     ElasticsearchUtil.reindexAsync(archiverExecutor, reindexRequest, esClient)
-        .thenAccept(
-            ignore -> {
-              final var reindexTimer = getArchiverReindexQueryTimer();
-              startTimer.stop(reindexTimer);
-              reindexFuture.complete(null);
-            })
-        .exceptionally(
-            (e) -> {
-              trackMetricForReindexFailures(processInstanceKeys, e);
-              reindexFuture.completeExceptionally(e);
-              return null;
+        .whenComplete(
+            (response, e) -> {
+              try {
+                final var reindexTimer = getArchiverReindexQueryTimer();
+                startTimer.stop(reindexTimer);
+                final var result = handleResponse(response, e, sourceIndexName, "reindex");
+                result.ifLeft(
+                    throwable -> trackMetricForReindexFailures(processInstanceKeys, throwable));
+                result.ifRightOrLeft(reindexFuture::complete, reindexFuture::completeExceptionally);
+              } catch (final Exception unexpected) {
+                LOGGER.error(
+                    "Unexpected error in reindex callback for index [{}]",
+                    sourceIndexName,
+                    unexpected);
+                if (!reindexFuture.isDone()) {
+                  reindexFuture.completeExceptionally(unexpected);
+                }
+              }
             });
-    return reindexFuture;
+    return reindexFuture.thenApply(ok -> null);
   }
 
   private SearchRequest createFinishedBatchOperationsSearchRequest(final AggregationBuilder agg) {
@@ -455,11 +472,9 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
         "Failed while trying to reindex documents during the archival process for the following process instance keys [{}]",
         processInstanceKeys);
 
+    final Throwable cause = e.getCause() != null ? e.getCause() : e;
     metrics.recordCounts(
-        Metrics.COUNTER_NAME_REINDEX_FAILURES,
-        1,
-        "exception",
-        e.getCause().getClass().getSimpleName());
+        Metrics.COUNTER_NAME_REINDEX_FAILURES, 1, "exception", cause.getClass().getSimpleName());
   }
 
   private void trackMetricForDeleteFailures(
@@ -469,11 +484,9 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
         "Failed while trying to delete documents during the archival process for the following process instance keys [{}]",
         processInstanceKeys);
 
+    final Throwable cause = e.getCause() != null ? e.getCause() : e;
     metrics.recordCounts(
-        Metrics.COUNTER_NAME_DELETE_FAILURES,
-        1,
-        "exception",
-        e.getCause().getClass().getSimpleName());
+        Metrics.COUNTER_NAME_DELETE_FAILURES, 1, "exception", cause.getClass().getSimpleName());
   }
 
   private Either<Throwable, Long> handleResponse(

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
@@ -37,6 +37,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.function.Function;
 import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest;
 import org.elasticsearch.action.search.SearchRequest;
@@ -210,50 +211,40 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
       final String sourceIndexName,
       final String idFieldName,
       final List<Object> processInstanceKeys) {
-    final var deleteFuture = new CompletableFuture<Long>();
     final var deleteRequest =
         createDeleteByQueryRequestWithDefaults(sourceIndexName)
             .setQuery(termsQuery(idFieldName, processInstanceKeys))
             .setMaxRetries(UPDATE_RETRY_COUNT);
 
     final var startTimer = Timer.start();
-    ElasticsearchUtil.deleteAsync(deleteRequest, archiverExecutor, esClient)
-        .whenComplete(
+    return ElasticsearchUtil.deleteAsync(deleteRequest, archiverExecutor, esClient)
+        .<Long>handle(
             (response, e) -> {
-              Throwable failure = e;
+              final var result = handleResponse(response, e, sourceIndexName, "delete");
+              if (result.isLeft()) {
+                throw new CompletionException(result.getLeft());
+              }
+              return result.get();
+            })
+        .whenComplete(
+            (result, e) -> {
               try {
-                final var result = handleResponse(response, e, sourceIndexName, "delete");
-                if (result.isLeft()) {
-                  failure = result.getLeft();
-                }
-                result.ifRightOrLeft(deleteFuture::complete, deleteFuture::completeExceptionally);
-              } catch (final Exception unexpected) {
-                failure = unexpected;
-                LOGGER.error(
-                    "Unexpected error in delete callback for index [{}]",
-                    sourceIndexName,
-                    unexpected);
-                if (!deleteFuture.isDone()) {
-                  deleteFuture.completeExceptionally(unexpected);
-                }
-              } finally {
+                startTimer.stop(getArchiverDeleteQueryTimer());
+              } catch (final Exception ex) {
+                LOGGER.warn("Failed to record delete timer for index [{}]", sourceIndexName, ex);
+              }
+            })
+        .whenComplete(
+            (val, e) -> {
+              if (e != null) {
                 try {
-                  final var timer = getArchiverDeleteQueryTimer();
-                  startTimer.stop(timer);
-                } catch (final Exception timerEx) {
-                  LOGGER.warn(
-                      "Failed to record delete timer for index [{}]", sourceIndexName, timerEx);
-                }
-                if (deleteFuture.isCompletedExceptionally() && failure != null) {
-                  try {
-                    trackMetricForDeleteFailures(processInstanceKeys, failure);
-                  } catch (final Exception metricEx) {
-                    LOGGER.warn("Failed to record delete failure metric", metricEx);
-                  }
+                  trackMetricForDeleteFailures(processInstanceKeys, unwrapCompletion(e));
+                } catch (final Exception ex) {
+                  LOGGER.warn("Failed to record delete failure metric", ex);
                 }
               }
-            });
-    return deleteFuture.thenApply(ok -> null);
+            })
+        .thenApply(ok -> null);
   }
 
   @Override
@@ -262,7 +253,6 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
       final String destinationIndexName,
       final String idFieldName,
       final List<Object> processInstanceKeys) {
-    final var reindexFuture = new CompletableFuture<Long>();
     final var reindexRequest =
         createReindexRequestWithDefaults()
             .setSourceIndices(sourceIndexName)
@@ -270,44 +260,34 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
             .setSourceQuery(termsQuery(idFieldName, processInstanceKeys));
 
     final var startTimer = Timer.start();
-
-    ElasticsearchUtil.reindexAsync(archiverExecutor, reindexRequest, esClient)
-        .whenComplete(
+    return ElasticsearchUtil.reindexAsync(archiverExecutor, reindexRequest, esClient)
+        .<Long>handle(
             (response, e) -> {
-              Throwable failure = e;
+              final var result = handleResponse(response, e, sourceIndexName, "reindex");
+              if (result.isLeft()) {
+                throw new CompletionException(result.getLeft());
+              }
+              return result.get();
+            })
+        .whenComplete(
+            (result, e) -> {
               try {
-                final var result = handleResponse(response, e, sourceIndexName, "reindex");
-                if (result.isLeft()) {
-                  failure = result.getLeft();
-                }
-                result.ifRightOrLeft(reindexFuture::complete, reindexFuture::completeExceptionally);
-              } catch (final Exception unexpected) {
-                failure = unexpected;
-                LOGGER.error(
-                    "Unexpected error in reindex callback for index [{}]",
-                    sourceIndexName,
-                    unexpected);
-                if (!reindexFuture.isDone()) {
-                  reindexFuture.completeExceptionally(unexpected);
-                }
-              } finally {
+                startTimer.stop(getArchiverReindexQueryTimer());
+              } catch (final Exception ex) {
+                LOGGER.warn("Failed to record reindex timer for index [{}]", sourceIndexName, ex);
+              }
+            })
+        .whenComplete(
+            (val, e) -> {
+              if (e != null) {
                 try {
-                  final var reindexTimer = getArchiverReindexQueryTimer();
-                  startTimer.stop(reindexTimer);
-                } catch (final Exception timerEx) {
-                  LOGGER.warn(
-                      "Failed to record reindex timer for index [{}]", sourceIndexName, timerEx);
-                }
-                if (reindexFuture.isCompletedExceptionally() && failure != null) {
-                  try {
-                    trackMetricForReindexFailures(processInstanceKeys, failure);
-                  } catch (final Exception metricEx) {
-                    LOGGER.warn("Failed to record reindex failure metric", metricEx);
-                  }
+                  trackMetricForReindexFailures(processInstanceKeys, unwrapCompletion(e));
+                } catch (final Exception ex) {
+                  LOGGER.warn("Failed to record reindex failure metric", ex);
                 }
               }
-            });
-    return reindexFuture.thenApply(ok -> null);
+            })
+        .thenApply(ok -> null);
   }
 
   private SearchRequest createFinishedBatchOperationsSearchRequest(final AggregationBuilder agg) {
@@ -519,6 +499,10 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
     final Throwable cause = e.getCause() != null ? e.getCause() : e;
     metrics.recordCounts(
         Metrics.COUNTER_NAME_DELETE_FAILURES, 1, "exception", cause.getClass().getSimpleName());
+  }
+
+  private static Throwable unwrapCompletion(final Throwable e) {
+    return e instanceof CompletionException && e.getCause() != null ? e.getCause() : e;
   }
 
   private Either<Throwable, Long> handleResponse(

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
@@ -220,10 +220,15 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
     ElasticsearchUtil.deleteAsync(deleteRequest, archiverExecutor, esClient)
         .whenComplete(
             (response, e) -> {
+              Throwable failure = e;
               try {
                 final var result = handleResponse(response, e, sourceIndexName, "delete");
+                if (result.isLeft()) {
+                  failure = result.getLeft();
+                }
                 result.ifRightOrLeft(deleteFuture::complete, deleteFuture::completeExceptionally);
               } catch (final Exception unexpected) {
+                failure = unexpected;
                 LOGGER.error(
                     "Unexpected error in delete callback for index [{}]",
                     sourceIndexName,
@@ -239,9 +244,9 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
                   LOGGER.warn(
                       "Failed to record delete timer for index [{}]", sourceIndexName, timerEx);
                 }
-                if (deleteFuture.isCompletedExceptionally()) {
+                if (deleteFuture.isCompletedExceptionally() && failure != null) {
                   try {
-                    trackMetricForDeleteFailures(processInstanceKeys, e);
+                    trackMetricForDeleteFailures(processInstanceKeys, failure);
                   } catch (final Exception metricEx) {
                     LOGGER.warn("Failed to record delete failure metric", metricEx);
                   }
@@ -269,10 +274,15 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
     ElasticsearchUtil.reindexAsync(archiverExecutor, reindexRequest, esClient)
         .whenComplete(
             (response, e) -> {
+              Throwable failure = e;
               try {
                 final var result = handleResponse(response, e, sourceIndexName, "reindex");
+                if (result.isLeft()) {
+                  failure = result.getLeft();
+                }
                 result.ifRightOrLeft(reindexFuture::complete, reindexFuture::completeExceptionally);
               } catch (final Exception unexpected) {
+                failure = unexpected;
                 LOGGER.error(
                     "Unexpected error in reindex callback for index [{}]",
                     sourceIndexName,
@@ -288,9 +298,9 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
                   LOGGER.warn(
                       "Failed to record reindex timer for index [{}]", sourceIndexName, timerEx);
                 }
-                if (reindexFuture.isCompletedExceptionally()) {
+                if (reindexFuture.isCompletedExceptionally() && failure != null) {
                   try {
-                    trackMetricForReindexFailures(processInstanceKeys, e);
+                    trackMetricForReindexFailures(processInstanceKeys, failure);
                   } catch (final Exception metricEx) {
                     LOGGER.warn("Failed to record reindex failure metric", metricEx);
                   }

--- a/operate/archiver/src/test/java/io/camunda/operate/archiver/ElasticsearchArchiveRepositoryTest.java
+++ b/operate/archiver/src/test/java/io/camunda/operate/archiver/ElasticsearchArchiveRepositoryTest.java
@@ -302,14 +302,14 @@ public class ElasticsearchArchiveRepositoryTest {
   public void testDeleteDocumentsCompletesFutureWhenTimerThrows() throws Exception {
     try (final MockedStatic<ElasticsearchUtil> mockedStatic = mockStatic(ElasticsearchUtil.class);
         final MockedStatic<Timer> mockedTimer = mockStatic(Timer.class)) {
-      mockedTimer.when(Timer::start).thenReturn(mock(Timer.Sample.class));
+      final Timer.Sample timerSample = mock(Timer.Sample.class);
+      when(timerSample.stop(any())).thenThrow(new RuntimeException("timer exploded"));
+      mockedTimer.when(Timer::start).thenReturn(timerSample);
       final CompletableFuture<BulkByScrollResponse> failedFuture = new CompletableFuture<>();
       failedFuture.completeExceptionally(new RuntimeException("ES failed"));
       mockedStatic
           .when(() -> ElasticsearchUtil.deleteAsync(any(), any(), any()))
           .thenReturn(failedFuture);
-      // metrics.getTimer() returns null → startTimer.stop(null) throws NPE before
-      // handleResponse or metric tracking ever runs
 
       final CompletableFuture<Void> res = underTest.deleteDocuments("index", "id", List.of());
 
@@ -322,7 +322,9 @@ public class ElasticsearchArchiveRepositoryTest {
   public void testReindexDocumentsCompletesFutureWhenTimerThrows() throws Exception {
     try (final MockedStatic<ElasticsearchUtil> mockedStatic = mockStatic(ElasticsearchUtil.class);
         final MockedStatic<Timer> mockedTimer = mockStatic(Timer.class)) {
-      mockedTimer.when(Timer::start).thenReturn(mock(Timer.Sample.class));
+      final Timer.Sample timerSample = mock(Timer.Sample.class);
+      when(timerSample.stop(any())).thenThrow(new RuntimeException("timer exploded"));
+      mockedTimer.when(Timer::start).thenReturn(timerSample);
       final CompletableFuture<BulkByScrollResponse> failedFuture = new CompletableFuture<>();
       failedFuture.completeExceptionally(new RuntimeException("ES failed"));
       mockedStatic

--- a/operate/archiver/src/test/java/io/camunda/operate/archiver/ElasticsearchArchiveRepositoryTest.java
+++ b/operate/archiver/src/test/java/io/camunda/operate/archiver/ElasticsearchArchiveRepositoryTest.java
@@ -10,8 +10,10 @@ package io.camunda.operate.archiver;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.mockStatic;
@@ -32,6 +34,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
@@ -170,8 +175,9 @@ public class ElasticsearchArchiveRepositoryTest {
       try (final MockedStatic<Timer> mockedTimer = mockStatic(Timer.class)) {
         final Timer.Sample timer = mock(Timer.Sample.class);
         mockedTimer.when(Timer::start).thenReturn(timer);
-        final CompletableFuture<Void> failedFuture = new CompletableFuture<>();
-        failedFuture.completeExceptionally(new Exception("test error"));
+        final CompletableFuture<BulkByScrollResponse> failedFuture = new CompletableFuture<>();
+        final String errorMsg = "test error";
+        failedFuture.completeExceptionally(new Exception(errorMsg));
         mockedStatic
             .when(() -> ElasticsearchUtil.reindexAsync(any(), any(), any()))
             .thenReturn(failedFuture);
@@ -180,9 +186,167 @@ public class ElasticsearchArchiveRepositoryTest {
         try {
           res.join();
         } catch (final Exception e) {
-          assertThat(e.getMessage()).isEqualTo("java.lang.Exception: test error");
+          assertThat(e.getMessage()).contains(errorMsg);
         }
       }
+    }
+  }
+
+  // --- Regression tests for #52781: archiver hang ---
+
+  @Test
+  public void testDeleteDocumentsErrorWithNullCauseCompletesFuture() throws Exception {
+    try (final MockedStatic<ElasticsearchUtil> mockedStatic = mockStatic(ElasticsearchUtil.class);
+        final MockedStatic<Timer> mockedTimer = mockStatic(Timer.class)) {
+      mockedTimer.when(Timer::start).thenReturn(mock(Timer.Sample.class));
+      final RuntimeException noCauseException = new RuntimeException("no-cause delete failure");
+      assertThat(noCauseException.getCause()).isNull();
+      final CompletableFuture<BulkByScrollResponse> failedFuture = new CompletableFuture<>();
+      failedFuture.completeExceptionally(noCauseException);
+      mockedStatic
+          .when(() -> ElasticsearchUtil.deleteAsync(any(), any(), any()))
+          .thenReturn(failedFuture);
+
+      final CompletableFuture<Void> res = underTest.deleteDocuments("index", "id", List.of());
+
+      assertThatFutureCompletesWithin(res, 5, TimeUnit.SECONDS);
+      assertThat(res).isCompletedExceptionally();
+      verify(metrics)
+          .recordCounts(
+              eq(Metrics.COUNTER_NAME_DELETE_FAILURES),
+              anyLong(),
+              eq("exception"),
+              eq("RuntimeException"));
+    }
+  }
+
+  @Test
+  public void testDeleteDocumentsMetricFailureDoesNotHangFuture() throws Exception {
+    try (final MockedStatic<ElasticsearchUtil> mockedStatic = mockStatic(ElasticsearchUtil.class);
+        final MockedStatic<Timer> mockedTimer = mockStatic(Timer.class)) {
+      mockedTimer.when(Timer::start).thenReturn(mock(Timer.Sample.class));
+      final CompletableFuture<BulkByScrollResponse> failedFuture = new CompletableFuture<>();
+      failedFuture.completeExceptionally(new RuntimeException("no-cause delete failure"));
+      mockedStatic
+          .when(() -> ElasticsearchUtil.deleteAsync(any(), any(), any()))
+          .thenReturn(failedFuture);
+      doThrow(new RuntimeException("metric registry exploded"))
+          .when(metrics)
+          .recordCounts(
+              eq(Metrics.COUNTER_NAME_DELETE_FAILURES),
+              anyLong(),
+              eq("exception"),
+              eq("RuntimeException"));
+
+      final CompletableFuture<Void> res = underTest.deleteDocuments("index", "id", List.of());
+
+      assertThatFutureCompletesWithin(res, 5, TimeUnit.SECONDS);
+      assertThat(res).isCompletedExceptionally();
+    }
+  }
+
+  @Test
+  public void testReindexDocumentsErrorWithNullCauseCompletesFuture() throws Exception {
+    try (final MockedStatic<ElasticsearchUtil> mockedStatic = mockStatic(ElasticsearchUtil.class);
+        final MockedStatic<Timer> mockedTimer = mockStatic(Timer.class)) {
+      mockedTimer.when(Timer::start).thenReturn(mock(Timer.Sample.class));
+      final RuntimeException noCauseException = new RuntimeException("no-cause failure");
+      assertThat(noCauseException.getCause()).isNull();
+      final CompletableFuture<BulkByScrollResponse> failedFuture = new CompletableFuture<>();
+      failedFuture.completeExceptionally(noCauseException);
+      mockedStatic
+          .when(() -> ElasticsearchUtil.reindexAsync(any(), any(), any()))
+          .thenReturn(failedFuture);
+
+      final CompletableFuture<Void> res =
+          underTest.reindexDocuments("sourceIndex", "destinationIndex", "id", List.of());
+
+      assertThatFutureCompletesWithin(res, 5, TimeUnit.SECONDS);
+      assertThat(res).isCompletedExceptionally();
+      verify(metrics)
+          .recordCounts(
+              eq(Metrics.COUNTER_NAME_REINDEX_FAILURES),
+              anyLong(),
+              eq("exception"),
+              eq("RuntimeException"));
+    }
+  }
+
+  @Test
+  public void testReindexDocumentsMetricFailureDoesNotHangFuture() throws Exception {
+    try (final MockedStatic<ElasticsearchUtil> mockedStatic = mockStatic(ElasticsearchUtil.class);
+        final MockedStatic<Timer> mockedTimer = mockStatic(Timer.class)) {
+      mockedTimer.when(Timer::start).thenReturn(mock(Timer.Sample.class));
+      final CompletableFuture<BulkByScrollResponse> failedFuture = new CompletableFuture<>();
+      failedFuture.completeExceptionally(new RuntimeException("no-cause failure"));
+      mockedStatic
+          .when(() -> ElasticsearchUtil.reindexAsync(any(), any(), any()))
+          .thenReturn(failedFuture);
+      doThrow(new RuntimeException("metric registry exploded"))
+          .when(metrics)
+          .recordCounts(
+              eq(Metrics.COUNTER_NAME_REINDEX_FAILURES),
+              anyLong(),
+              eq("exception"),
+              eq("RuntimeException"));
+
+      final CompletableFuture<Void> res =
+          underTest.reindexDocuments("sourceIndex", "destinationIndex", "id", List.of());
+
+      assertThatFutureCompletesWithin(res, 5, TimeUnit.SECONDS);
+      assertThat(res).isCompletedExceptionally();
+    }
+  }
+
+  @Test
+  public void testDeleteDocumentsCompletesFutureWhenTimerThrows() throws Exception {
+    try (final MockedStatic<ElasticsearchUtil> mockedStatic = mockStatic(ElasticsearchUtil.class);
+        final MockedStatic<Timer> mockedTimer = mockStatic(Timer.class)) {
+      mockedTimer.when(Timer::start).thenReturn(mock(Timer.Sample.class));
+      final CompletableFuture<BulkByScrollResponse> failedFuture = new CompletableFuture<>();
+      failedFuture.completeExceptionally(new RuntimeException("ES failed"));
+      mockedStatic
+          .when(() -> ElasticsearchUtil.deleteAsync(any(), any(), any()))
+          .thenReturn(failedFuture);
+      // metrics.getTimer() returns null → startTimer.stop(null) throws NPE before
+      // handleResponse or metric tracking ever runs
+
+      final CompletableFuture<Void> res = underTest.deleteDocuments("index", "id", List.of());
+
+      assertThatFutureCompletesWithin(res, 5, TimeUnit.SECONDS);
+      assertThat(res).isCompletedExceptionally();
+    }
+  }
+
+  @Test
+  public void testReindexDocumentsCompletesFutureWhenTimerThrows() throws Exception {
+    try (final MockedStatic<ElasticsearchUtil> mockedStatic = mockStatic(ElasticsearchUtil.class);
+        final MockedStatic<Timer> mockedTimer = mockStatic(Timer.class)) {
+      mockedTimer.when(Timer::start).thenReturn(mock(Timer.Sample.class));
+      final CompletableFuture<BulkByScrollResponse> failedFuture = new CompletableFuture<>();
+      failedFuture.completeExceptionally(new RuntimeException("ES failed"));
+      mockedStatic
+          .when(() -> ElasticsearchUtil.reindexAsync(any(), any(), any()))
+          .thenReturn(failedFuture);
+
+      final CompletableFuture<Void> res =
+          underTest.reindexDocuments("sourceIndex", "destinationIndex", "id", List.of());
+
+      assertThatFutureCompletesWithin(res, 5, TimeUnit.SECONDS);
+      assertThat(res).isCompletedExceptionally();
+    }
+  }
+
+  private static void assertThatFutureCompletesWithin(
+      final CompletableFuture<?> future, final long timeout, final TimeUnit unit) throws Exception {
+    try {
+      future.get(timeout, unit);
+    } catch (final TimeoutException timeoutException) {
+      throw new AssertionError(
+          "Future did not complete within " + timeout + " " + unit + " — archiver would hang",
+          timeoutException);
+    } catch (final CompletionException | java.util.concurrent.ExecutionException ignored) {
+      // expected — caller asserts the future is completedExceptionally
     }
   }
 

--- a/tasklist/archiver/pom.xml
+++ b/tasklist/archiver/pom.xml
@@ -117,6 +117,30 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/es/ArchiverUtilElasticSearch.java
+++ b/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/es/ArchiverUtilElasticSearch.java
@@ -65,15 +65,22 @@ public class ArchiverUtilElasticSearch extends ArchiverUtilAbstract {
     sendDeleteRequest(deleteRequest)
         .whenComplete(
             (response, e) -> {
-              final var timer = getArchiverDeleteQueryTimer();
-              startTimer.stop(timer);
-
-              if (e != null) {
-                trackMetricForDeleteFailures(processInstanceKeys, e);
+              try {
+                final var timer = getArchiverDeleteQueryTimer();
+                startTimer.stop(timer);
+                final var result = handleResponse(response, e, sourceIndexName, "delete");
+                result.ifLeft(
+                    throwable -> trackMetricForDeleteFailures(processInstanceKeys, throwable));
+                result.ifRightOrLeft(deleteFuture::complete, deleteFuture::completeExceptionally);
+              } catch (final Exception unexpected) {
+                LOGGER.error(
+                    "Unexpected error in delete callback for index [{}]",
+                    sourceIndexName,
+                    unexpected);
+                if (!deleteFuture.isDone()) {
+                  deleteFuture.completeExceptionally(unexpected);
+                }
               }
-
-              final var result = handleResponse(response, e, sourceIndexName, "delete");
-              result.ifRightOrLeft(deleteFuture::complete, deleteFuture::completeExceptionally);
             });
 
     return deleteFuture;
@@ -96,15 +103,22 @@ public class ArchiverUtilElasticSearch extends ArchiverUtilAbstract {
     sendReindexRequest(reindexRequest)
         .whenComplete(
             (response, e) -> {
-              final var reindexTimer = getArchiverReindexQueryTimer();
-              startTimer.stop(reindexTimer);
-
-              if (e != null) {
-                trackMetricForReindexFailures(processInstanceKeys, e);
+              try {
+                final var reindexTimer = getArchiverReindexQueryTimer();
+                startTimer.stop(reindexTimer);
+                final var result = handleResponse(response, e, sourceIndexName, "reindex");
+                result.ifLeft(
+                    throwable -> trackMetricForReindexFailures(processInstanceKeys, throwable));
+                result.ifRightOrLeft(reindexFuture::complete, reindexFuture::completeExceptionally);
+              } catch (final Exception unexpected) {
+                LOGGER.error(
+                    "Unexpected error in reindex callback for index [{}]",
+                    sourceIndexName,
+                    unexpected);
+                if (!reindexFuture.isDone()) {
+                  reindexFuture.completeExceptionally(unexpected);
+                }
               }
-
-              final var result = handleResponse(response, e, sourceIndexName, "reindex");
-              result.ifRightOrLeft(reindexFuture::complete, reindexFuture::completeExceptionally);
             });
 
     return reindexFuture;
@@ -201,11 +215,9 @@ public class ArchiverUtilElasticSearch extends ArchiverUtilAbstract {
         "Failed reindex while trying to reindex the following process instance keys [{}]",
         processInstanceKeys);
 
+    final Throwable cause = e.getCause() != null ? e.getCause() : e;
     metrics.recordCounts(
-        Metrics.COUNTER_NAME_REINDEX_FAILURES,
-        1,
-        "exception",
-        e.getCause().getClass().getSimpleName());
+        Metrics.COUNTER_NAME_REINDEX_FAILURES, 1, "exception", cause.getClass().getSimpleName());
   }
 
   private void trackMetricForDeleteFailures(
@@ -214,11 +226,9 @@ public class ArchiverUtilElasticSearch extends ArchiverUtilAbstract {
         "Failed deletion while trying to archive the following process instance keys [{}]",
         processInstanceKeys);
 
+    final Throwable cause = e.getCause() != null ? e.getCause() : e;
     metrics.recordCounts(
-        Metrics.COUNTER_NAME_DELETE_FAILURES,
-        1,
-        "exception",
-        e.getCause().getClass().getSimpleName());
+        Metrics.COUNTER_NAME_DELETE_FAILURES, 1, "exception", cause.getClass().getSimpleName());
   }
 
   private Timer getArchiverDeleteQueryTimer() {

--- a/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/es/ArchiverUtilElasticSearch.java
+++ b/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/es/ArchiverUtilElasticSearch.java
@@ -66,11 +66,7 @@ public class ArchiverUtilElasticSearch extends ArchiverUtilAbstract {
         .whenComplete(
             (response, e) -> {
               try {
-                final var timer = getArchiverDeleteQueryTimer();
-                startTimer.stop(timer);
                 final var result = handleResponse(response, e, sourceIndexName, "delete");
-                result.ifLeft(
-                    throwable -> trackMetricForDeleteFailures(processInstanceKeys, throwable));
                 result.ifRightOrLeft(deleteFuture::complete, deleteFuture::completeExceptionally);
               } catch (final Exception unexpected) {
                 LOGGER.error(
@@ -79,6 +75,21 @@ public class ArchiverUtilElasticSearch extends ArchiverUtilAbstract {
                     unexpected);
                 if (!deleteFuture.isDone()) {
                   deleteFuture.completeExceptionally(unexpected);
+                }
+              } finally {
+                try {
+                  final var timer = getArchiverDeleteQueryTimer();
+                  startTimer.stop(timer);
+                } catch (final Exception timerEx) {
+                  LOGGER.warn(
+                      "Failed to record delete timer for index [{}]", sourceIndexName, timerEx);
+                }
+                if (deleteFuture.isCompletedExceptionally()) {
+                  try {
+                    trackMetricForDeleteFailures(processInstanceKeys, e);
+                  } catch (final Exception metricEx) {
+                    LOGGER.warn("Failed to record delete failure metric", metricEx);
+                  }
                 }
               }
             });
@@ -104,11 +115,7 @@ public class ArchiverUtilElasticSearch extends ArchiverUtilAbstract {
         .whenComplete(
             (response, e) -> {
               try {
-                final var reindexTimer = getArchiverReindexQueryTimer();
-                startTimer.stop(reindexTimer);
                 final var result = handleResponse(response, e, sourceIndexName, "reindex");
-                result.ifLeft(
-                    throwable -> trackMetricForReindexFailures(processInstanceKeys, throwable));
                 result.ifRightOrLeft(reindexFuture::complete, reindexFuture::completeExceptionally);
               } catch (final Exception unexpected) {
                 LOGGER.error(
@@ -117,6 +124,21 @@ public class ArchiverUtilElasticSearch extends ArchiverUtilAbstract {
                     unexpected);
                 if (!reindexFuture.isDone()) {
                   reindexFuture.completeExceptionally(unexpected);
+                }
+              } finally {
+                try {
+                  final var reindexTimer = getArchiverReindexQueryTimer();
+                  startTimer.stop(reindexTimer);
+                } catch (final Exception timerEx) {
+                  LOGGER.warn(
+                      "Failed to record reindex timer for index [{}]", sourceIndexName, timerEx);
+                }
+                if (reindexFuture.isCompletedExceptionally()) {
+                  try {
+                    trackMetricForReindexFailures(processInstanceKeys, e);
+                  } catch (final Exception metricEx) {
+                    LOGGER.warn("Failed to record reindex failure metric", metricEx);
+                  }
                 }
               }
             });

--- a/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/es/ArchiverUtilElasticSearch.java
+++ b/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/es/ArchiverUtilElasticSearch.java
@@ -63,14 +63,7 @@ public class ArchiverUtilElasticSearch extends ArchiverUtilAbstract {
     final var startTimer = Timer.start();
 
     return sendDeleteRequest(deleteRequest)
-        .<Long>handle(
-            (response, e) -> {
-              final var result = handleResponse(response, e, sourceIndexName, "delete");
-              if (result.isLeft()) {
-                throw new CompletionException(result.getLeft());
-              }
-              return result.get();
-            })
+        .handle((response, e) -> handleResponse(response, e, sourceIndexName, "delete"))
         .whenComplete(
             (result, e) -> {
               try {
@@ -79,6 +72,7 @@ public class ArchiverUtilElasticSearch extends ArchiverUtilAbstract {
                 LOGGER.warn("Failed to record delete timer for index [{}]", sourceIndexName, ex);
               }
             })
+        .<Long>thenCompose(this::unwrapEither)
         .whenComplete(
             (val, e) -> {
               if (e != null) {
@@ -105,14 +99,7 @@ public class ArchiverUtilElasticSearch extends ArchiverUtilAbstract {
 
     final var startTimer = Timer.start();
     return sendReindexRequest(reindexRequest)
-        .<Long>handle(
-            (response, e) -> {
-              final var result = handleResponse(response, e, sourceIndexName, "reindex");
-              if (result.isLeft()) {
-                throw new CompletionException(result.getLeft());
-              }
-              return result.get();
-            })
+        .handle((response, e) -> handleResponse(response, e, sourceIndexName, "reindex"))
         .whenComplete(
             (result, e) -> {
               try {
@@ -121,6 +108,7 @@ public class ArchiverUtilElasticSearch extends ArchiverUtilAbstract {
                 LOGGER.warn("Failed to record reindex timer for index [{}]", sourceIndexName, ex);
               }
             })
+        .<Long>thenCompose(this::unwrapEither)
         .whenComplete(
             (val, e) -> {
               if (e != null) {
@@ -183,6 +171,14 @@ public class ArchiverUtilElasticSearch extends ArchiverUtilAbstract {
         .setSlices(AUTO_SLICES);
   }
 
+  private <T> CompletableFuture<T> unwrapEither(final Either<Throwable, T> result) {
+    if (result.isLeft()) {
+      return CompletableFuture.failedFuture(result.getLeft());
+    }
+    return CompletableFuture.completedFuture(result.get());
+  }
+
+  /** Strips the {@link CompletionException} wrapper added by {@code thenCompose}. */
   private static Throwable unwrapCompletion(final Throwable e) {
     return e instanceof CompletionException && e.getCause() != null ? e.getCause() : e;
   }

--- a/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/es/ArchiverUtilElasticSearch.java
+++ b/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/es/ArchiverUtilElasticSearch.java
@@ -24,6 +24,7 @@ import io.camunda.tasklist.util.ElasticsearchUtil;
 import io.micrometer.core.instrument.Timer;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
@@ -55,51 +56,39 @@ public class ArchiverUtilElasticSearch extends ArchiverUtilAbstract {
       final String sourceIndexName,
       final String idFieldName,
       final List<String> processInstanceKeys) {
-    final var deleteFuture = new CompletableFuture<Long>();
     final var deleteRequest =
         createDeleteByQueryRequestWithDefaults(sourceIndexName)
             .setQuery(termsQuery(idFieldName, processInstanceKeys))
             .setMaxRetries(UPDATE_RETRY_COUNT);
     final var startTimer = Timer.start();
 
-    sendDeleteRequest(deleteRequest)
-        .whenComplete(
+    return sendDeleteRequest(deleteRequest)
+        .<Long>handle(
             (response, e) -> {
-              Throwable failure = e;
+              final var result = handleResponse(response, e, sourceIndexName, "delete");
+              if (result.isLeft()) {
+                throw new CompletionException(result.getLeft());
+              }
+              return result.get();
+            })
+        .whenComplete(
+            (result, e) -> {
               try {
-                final var result = handleResponse(response, e, sourceIndexName, "delete");
-                if (result.isLeft()) {
-                  failure = result.getLeft();
-                }
-                result.ifRightOrLeft(deleteFuture::complete, deleteFuture::completeExceptionally);
-              } catch (final Exception unexpected) {
-                failure = unexpected;
-                LOGGER.error(
-                    "Unexpected error in delete callback for index [{}]",
-                    sourceIndexName,
-                    unexpected);
-                if (!deleteFuture.isDone()) {
-                  deleteFuture.completeExceptionally(unexpected);
-                }
-              } finally {
+                startTimer.stop(getArchiverDeleteQueryTimer());
+              } catch (final Exception ex) {
+                LOGGER.warn("Failed to record delete timer for index [{}]", sourceIndexName, ex);
+              }
+            })
+        .whenComplete(
+            (val, e) -> {
+              if (e != null) {
                 try {
-                  final var timer = getArchiverDeleteQueryTimer();
-                  startTimer.stop(timer);
-                } catch (final Exception timerEx) {
-                  LOGGER.warn(
-                      "Failed to record delete timer for index [{}]", sourceIndexName, timerEx);
-                }
-                if (deleteFuture.isCompletedExceptionally() && failure != null) {
-                  try {
-                    trackMetricForDeleteFailures(processInstanceKeys, failure);
-                  } catch (final Exception metricEx) {
-                    LOGGER.warn("Failed to record delete failure metric", metricEx);
-                  }
+                  trackMetricForDeleteFailures(processInstanceKeys, unwrapCompletion(e));
+                } catch (final Exception ex) {
+                  LOGGER.warn("Failed to record delete failure metric", ex);
                 }
               }
             });
-
-    return deleteFuture;
   }
 
   @Override
@@ -108,7 +97,6 @@ public class ArchiverUtilElasticSearch extends ArchiverUtilAbstract {
       final String destinationIndexName,
       final String idFieldName,
       final List<String> processInstanceKeys) {
-    final var reindexFuture = new CompletableFuture<Long>();
     final var reindexRequest =
         createReindexRequestWithDefaults()
             .setSourceIndices(sourceIndexName)
@@ -116,44 +104,33 @@ public class ArchiverUtilElasticSearch extends ArchiverUtilAbstract {
             .setSourceQuery(termsQuery(idFieldName, processInstanceKeys));
 
     final var startTimer = Timer.start();
-    sendReindexRequest(reindexRequest)
-        .whenComplete(
+    return sendReindexRequest(reindexRequest)
+        .<Long>handle(
             (response, e) -> {
-              Throwable failure = e;
+              final var result = handleResponse(response, e, sourceIndexName, "reindex");
+              if (result.isLeft()) {
+                throw new CompletionException(result.getLeft());
+              }
+              return result.get();
+            })
+        .whenComplete(
+            (result, e) -> {
               try {
-                final var result = handleResponse(response, e, sourceIndexName, "reindex");
-                if (result.isLeft()) {
-                  failure = result.getLeft();
-                }
-                result.ifRightOrLeft(reindexFuture::complete, reindexFuture::completeExceptionally);
-              } catch (final Exception unexpected) {
-                failure = unexpected;
-                LOGGER.error(
-                    "Unexpected error in reindex callback for index [{}]",
-                    sourceIndexName,
-                    unexpected);
-                if (!reindexFuture.isDone()) {
-                  reindexFuture.completeExceptionally(unexpected);
-                }
-              } finally {
+                startTimer.stop(getArchiverReindexQueryTimer());
+              } catch (final Exception ex) {
+                LOGGER.warn("Failed to record reindex timer for index [{}]", sourceIndexName, ex);
+              }
+            })
+        .whenComplete(
+            (val, e) -> {
+              if (e != null) {
                 try {
-                  final var reindexTimer = getArchiverReindexQueryTimer();
-                  startTimer.stop(reindexTimer);
-                } catch (final Exception timerEx) {
-                  LOGGER.warn(
-                      "Failed to record reindex timer for index [{}]", sourceIndexName, timerEx);
-                }
-                if (reindexFuture.isCompletedExceptionally() && failure != null) {
-                  try {
-                    trackMetricForReindexFailures(processInstanceKeys, failure);
-                  } catch (final Exception metricEx) {
-                    LOGGER.warn("Failed to record reindex failure metric", metricEx);
-                  }
+                  trackMetricForReindexFailures(processInstanceKeys, unwrapCompletion(e));
+                } catch (final Exception ex) {
+                  LOGGER.warn("Failed to record reindex failure metric", ex);
                 }
               }
             });
-
-    return reindexFuture;
   }
 
   @Override
@@ -204,6 +181,10 @@ public class ArchiverUtilElasticSearch extends ArchiverUtilAbstract {
         .setScroll(TimeValue.timeValueMillis(INTERNAL_SCROLL_KEEP_ALIVE_MS))
         .setAbortOnVersionConflict(false)
         .setSlices(AUTO_SLICES);
+  }
+
+  private static Throwable unwrapCompletion(final Throwable e) {
+    return e instanceof CompletionException && e.getCause() != null ? e.getCause() : e;
   }
 
   private Either<Throwable, Long> handleResponse(

--- a/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/es/ArchiverUtilElasticSearch.java
+++ b/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/es/ArchiverUtilElasticSearch.java
@@ -24,7 +24,6 @@ import io.camunda.tasklist.util.ElasticsearchUtil;
 import io.micrometer.core.instrument.Timer;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
@@ -64,24 +63,20 @@ public class ArchiverUtilElasticSearch extends ArchiverUtilAbstract {
 
     return sendDeleteRequest(deleteRequest)
         .handle((response, e) -> handleResponse(response, e, sourceIndexName, "delete"))
-        .whenComplete(
-            (result, e) -> {
+        .thenCompose(
+            result -> {
               try {
                 startTimer.stop(getArchiverDeleteQueryTimer());
-              } catch (final Exception ex) {
-                LOGGER.warn("Failed to record delete timer for index [{}]", sourceIndexName, ex);
-              }
-            })
-        .<Long>thenCompose(this::unwrapEither)
-        .whenComplete(
-            (val, e) -> {
-              if (e != null) {
-                try {
-                  trackMetricForDeleteFailures(processInstanceKeys, unwrapCompletion(e));
-                } catch (final Exception ex) {
-                  LOGGER.warn("Failed to record delete failure metric", ex);
+                if (result.isLeft()) {
+                  trackMetricForDeleteFailures(processInstanceKeys, result.getLeft());
                 }
+              } catch (final Throwable ex) {
+                LOGGER.warn("Failed to record metric", ex);
               }
+              if (result.isLeft()) {
+                return CompletableFuture.failedFuture(result.getLeft());
+              }
+              return CompletableFuture.completedFuture(result.get());
             });
   }
 
@@ -100,24 +95,20 @@ public class ArchiverUtilElasticSearch extends ArchiverUtilAbstract {
     final var startTimer = Timer.start();
     return sendReindexRequest(reindexRequest)
         .handle((response, e) -> handleResponse(response, e, sourceIndexName, "reindex"))
-        .whenComplete(
-            (result, e) -> {
+        .thenCompose(
+            result -> {
               try {
                 startTimer.stop(getArchiverReindexQueryTimer());
-              } catch (final Exception ex) {
-                LOGGER.warn("Failed to record reindex timer for index [{}]", sourceIndexName, ex);
-              }
-            })
-        .<Long>thenCompose(this::unwrapEither)
-        .whenComplete(
-            (val, e) -> {
-              if (e != null) {
-                try {
-                  trackMetricForReindexFailures(processInstanceKeys, unwrapCompletion(e));
-                } catch (final Exception ex) {
-                  LOGGER.warn("Failed to record reindex failure metric", ex);
+                if (result.isLeft()) {
+                  trackMetricForReindexFailures(processInstanceKeys, result.getLeft());
                 }
+              } catch (final Throwable ex) {
+                LOGGER.warn("Failed to record metric", ex);
               }
+              if (result.isLeft()) {
+                return CompletableFuture.failedFuture(result.getLeft());
+              }
+              return CompletableFuture.completedFuture(result.get());
             });
   }
 
@@ -169,18 +160,6 @@ public class ArchiverUtilElasticSearch extends ArchiverUtilAbstract {
         .setScroll(TimeValue.timeValueMillis(INTERNAL_SCROLL_KEEP_ALIVE_MS))
         .setAbortOnVersionConflict(false)
         .setSlices(AUTO_SLICES);
-  }
-
-  private <T> CompletableFuture<T> unwrapEither(final Either<Throwable, T> result) {
-    if (result.isLeft()) {
-      return CompletableFuture.failedFuture(result.getLeft());
-    }
-    return CompletableFuture.completedFuture(result.get());
-  }
-
-  /** Strips the {@link CompletionException} wrapper added by {@code thenCompose}. */
-  private static Throwable unwrapCompletion(final Throwable e) {
-    return e instanceof CompletionException && e.getCause() != null ? e.getCause() : e;
   }
 
   private Either<Throwable, Long> handleResponse(

--- a/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/es/ArchiverUtilElasticSearch.java
+++ b/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/es/ArchiverUtilElasticSearch.java
@@ -65,10 +65,15 @@ public class ArchiverUtilElasticSearch extends ArchiverUtilAbstract {
     sendDeleteRequest(deleteRequest)
         .whenComplete(
             (response, e) -> {
+              Throwable failure = e;
               try {
                 final var result = handleResponse(response, e, sourceIndexName, "delete");
+                if (result.isLeft()) {
+                  failure = result.getLeft();
+                }
                 result.ifRightOrLeft(deleteFuture::complete, deleteFuture::completeExceptionally);
               } catch (final Exception unexpected) {
+                failure = unexpected;
                 LOGGER.error(
                     "Unexpected error in delete callback for index [{}]",
                     sourceIndexName,
@@ -84,9 +89,9 @@ public class ArchiverUtilElasticSearch extends ArchiverUtilAbstract {
                   LOGGER.warn(
                       "Failed to record delete timer for index [{}]", sourceIndexName, timerEx);
                 }
-                if (deleteFuture.isCompletedExceptionally()) {
+                if (deleteFuture.isCompletedExceptionally() && failure != null) {
                   try {
-                    trackMetricForDeleteFailures(processInstanceKeys, e);
+                    trackMetricForDeleteFailures(processInstanceKeys, failure);
                   } catch (final Exception metricEx) {
                     LOGGER.warn("Failed to record delete failure metric", metricEx);
                   }
@@ -114,10 +119,15 @@ public class ArchiverUtilElasticSearch extends ArchiverUtilAbstract {
     sendReindexRequest(reindexRequest)
         .whenComplete(
             (response, e) -> {
+              Throwable failure = e;
               try {
                 final var result = handleResponse(response, e, sourceIndexName, "reindex");
+                if (result.isLeft()) {
+                  failure = result.getLeft();
+                }
                 result.ifRightOrLeft(reindexFuture::complete, reindexFuture::completeExceptionally);
               } catch (final Exception unexpected) {
+                failure = unexpected;
                 LOGGER.error(
                     "Unexpected error in reindex callback for index [{}]",
                     sourceIndexName,
@@ -133,9 +143,9 @@ public class ArchiverUtilElasticSearch extends ArchiverUtilAbstract {
                   LOGGER.warn(
                       "Failed to record reindex timer for index [{}]", sourceIndexName, timerEx);
                 }
-                if (reindexFuture.isCompletedExceptionally()) {
+                if (reindexFuture.isCompletedExceptionally() && failure != null) {
                   try {
-                    trackMetricForReindexFailures(processInstanceKeys, e);
+                    trackMetricForReindexFailures(processInstanceKeys, failure);
                   } catch (final Exception metricEx) {
                     LOGGER.warn("Failed to record reindex failure metric", metricEx);
                   }

--- a/tasklist/archiver/src/test/java/io/camunda/tasklist/archiver/es/ArchiverUtilElasticSearchTest.java
+++ b/tasklist/archiver/src/test/java/io/camunda/tasklist/archiver/es/ArchiverUtilElasticSearchTest.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.tasklist.archiver.es;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.tasklist.Metrics;
+import io.camunda.tasklist.util.ElasticsearchUtil;
+import io.micrometer.core.instrument.Timer;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.elasticsearch.index.reindex.BulkByScrollResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Regression tests for the silent archiver hang documented in GitHub issue #52781. Verifies that
+ * futures returned by {@link ArchiverUtilElasticSearch} always complete — even when the underlying
+ * ES failure carries no {@link Throwable#getCause() cause}, when metric recording itself throws, or
+ * when any other unexpected exception occurs in the callback.
+ */
+@ExtendWith(MockitoExtension.class)
+public class ArchiverUtilElasticSearchTest {
+
+  @InjectMocks private ArchiverUtilElasticSearch underTest;
+  @Mock private Metrics metrics;
+
+  // --- delete: null cause ---
+
+  @Test
+  public void deleteDocumentsCompletesFutureWhenFailureHasNullCause() throws Exception {
+    try (final MockedStatic<ElasticsearchUtil> mockedStatic = mockStatic(ElasticsearchUtil.class);
+        final MockedStatic<Timer> mockedTimer = mockStatic(Timer.class)) {
+      mockedTimer.when(Timer::start).thenReturn(mock(Timer.Sample.class));
+      final RuntimeException noCause = new RuntimeException("ES delete failed");
+      assertThat(noCause.getCause()).isNull();
+      final CompletableFuture<BulkByScrollResponse> failed = new CompletableFuture<>();
+      failed.completeExceptionally(noCause);
+      mockedStatic
+          .when(() -> ElasticsearchUtil.deleteByQueryAsync(any(), any(), any()))
+          .thenReturn(failed);
+
+      final CompletableFuture<Long> res = underTest.deleteDocuments("idx", "id", List.of("1"));
+
+      assertThatFutureCompletesWithin(res, 5, TimeUnit.SECONDS);
+      assertThat(res).isCompletedExceptionally();
+      verify(metrics)
+          .recordCounts(
+              eq(Metrics.COUNTER_NAME_DELETE_FAILURES),
+              anyLong(),
+              eq("exception"),
+              eq("RuntimeException"));
+    }
+  }
+
+  // --- reindex: null cause ---
+
+  @Test
+  public void reindexDocumentsCompletesFutureWhenFailureHasNullCause() throws Exception {
+    try (final MockedStatic<ElasticsearchUtil> mockedStatic = mockStatic(ElasticsearchUtil.class);
+        final MockedStatic<Timer> mockedTimer = mockStatic(Timer.class)) {
+      mockedTimer.when(Timer::start).thenReturn(mock(Timer.Sample.class));
+      final RuntimeException noCause = new RuntimeException("ES reindex failed");
+      assertThat(noCause.getCause()).isNull();
+      final CompletableFuture<BulkByScrollResponse> failed = new CompletableFuture<>();
+      failed.completeExceptionally(noCause);
+      mockedStatic
+          .when(() -> ElasticsearchUtil.reindexAsync(any(), any(), any()))
+          .thenReturn(failed);
+
+      final CompletableFuture<Long> res =
+          underTest.reindexDocuments("src", "dst", "id", List.of("1"));
+
+      assertThatFutureCompletesWithin(res, 5, TimeUnit.SECONDS);
+      assertThat(res).isCompletedExceptionally();
+      verify(metrics)
+          .recordCounts(
+              eq(Metrics.COUNTER_NAME_REINDEX_FAILURES),
+              anyLong(),
+              eq("exception"),
+              eq("RuntimeException"));
+    }
+  }
+
+  // --- delete: metric tracking throws ---
+
+  @Test
+  public void deleteDocumentsCompletesFutureWhenMetricTrackingThrows() throws Exception {
+    try (final MockedStatic<ElasticsearchUtil> mockedStatic = mockStatic(ElasticsearchUtil.class);
+        final MockedStatic<Timer> mockedTimer = mockStatic(Timer.class)) {
+      mockedTimer.when(Timer::start).thenReturn(mock(Timer.Sample.class));
+      final CompletableFuture<BulkByScrollResponse> failed = new CompletableFuture<>();
+      failed.completeExceptionally(new RuntimeException("ES delete failed"));
+      mockedStatic
+          .when(() -> ElasticsearchUtil.deleteByQueryAsync(any(), any(), any()))
+          .thenReturn(failed);
+      doThrow(new RuntimeException("metric registry exploded"))
+          .when(metrics)
+          .recordCounts(
+              eq(Metrics.COUNTER_NAME_DELETE_FAILURES),
+              anyLong(),
+              eq("exception"),
+              eq("RuntimeException"));
+
+      final CompletableFuture<Long> res = underTest.deleteDocuments("idx", "id", List.of("1"));
+
+      assertThatFutureCompletesWithin(res, 5, TimeUnit.SECONDS);
+      assertThat(res).isCompletedExceptionally();
+    }
+  }
+
+  // --- reindex: metric tracking throws ---
+
+  @Test
+  public void reindexDocumentsCompletesFutureWhenMetricTrackingThrows() throws Exception {
+    try (final MockedStatic<ElasticsearchUtil> mockedStatic = mockStatic(ElasticsearchUtil.class);
+        final MockedStatic<Timer> mockedTimer = mockStatic(Timer.class)) {
+      mockedTimer.when(Timer::start).thenReturn(mock(Timer.Sample.class));
+      final CompletableFuture<BulkByScrollResponse> failed = new CompletableFuture<>();
+      failed.completeExceptionally(new RuntimeException("ES reindex failed"));
+      mockedStatic
+          .when(() -> ElasticsearchUtil.reindexAsync(any(), any(), any()))
+          .thenReturn(failed);
+      doThrow(new RuntimeException("metric registry exploded"))
+          .when(metrics)
+          .recordCounts(
+              eq(Metrics.COUNTER_NAME_REINDEX_FAILURES),
+              anyLong(),
+              eq("exception"),
+              eq("RuntimeException"));
+
+      final CompletableFuture<Long> res =
+          underTest.reindexDocuments("src", "dst", "id", List.of("1"));
+
+      assertThatFutureCompletesWithin(res, 5, TimeUnit.SECONDS);
+      assertThat(res).isCompletedExceptionally();
+    }
+  }
+
+  // --- delete: timer throws (broader protection) ---
+
+  @Test
+  public void deleteDocumentsCompletesFutureWhenTimerThrows() throws Exception {
+    try (final MockedStatic<ElasticsearchUtil> mockedStatic = mockStatic(ElasticsearchUtil.class);
+        final MockedStatic<Timer> mockedTimer = mockStatic(Timer.class)) {
+      mockedTimer.when(Timer::start).thenReturn(mock(Timer.Sample.class));
+      final CompletableFuture<BulkByScrollResponse> failed = new CompletableFuture<>();
+      failed.completeExceptionally(new RuntimeException("ES delete failed"));
+      mockedStatic
+          .when(() -> ElasticsearchUtil.deleteByQueryAsync(any(), any(), any()))
+          .thenReturn(failed);
+      // metrics.getTimer() returns null → timer.stop(null) will throw NPE inside the callback
+      // before handleResponse or metric tracking even runs
+
+      final CompletableFuture<Long> res = underTest.deleteDocuments("idx", "id", List.of("1"));
+
+      assertThatFutureCompletesWithin(res, 5, TimeUnit.SECONDS);
+      assertThat(res).isCompletedExceptionally();
+    }
+  }
+
+  // --- reindex: timer throws (broader protection) ---
+
+  @Test
+  public void reindexDocumentsCompletesFutureWhenTimerThrows() throws Exception {
+    try (final MockedStatic<ElasticsearchUtil> mockedStatic = mockStatic(ElasticsearchUtil.class);
+        final MockedStatic<Timer> mockedTimer = mockStatic(Timer.class)) {
+      mockedTimer.when(Timer::start).thenReturn(mock(Timer.Sample.class));
+      final CompletableFuture<BulkByScrollResponse> failed = new CompletableFuture<>();
+      failed.completeExceptionally(new RuntimeException("ES reindex failed"));
+      mockedStatic
+          .when(() -> ElasticsearchUtil.reindexAsync(any(), any(), any()))
+          .thenReturn(failed);
+
+      final CompletableFuture<Long> res =
+          underTest.reindexDocuments("src", "dst", "id", List.of("1"));
+
+      assertThatFutureCompletesWithin(res, 5, TimeUnit.SECONDS);
+      assertThat(res).isCompletedExceptionally();
+    }
+  }
+
+  private static void assertThatFutureCompletesWithin(
+      final CompletableFuture<?> future, final long timeout, final TimeUnit unit) throws Exception {
+    try {
+      future.get(timeout, unit);
+    } catch (final TimeoutException timeoutException) {
+      throw new AssertionError(
+          "Future did not complete within " + timeout + " " + unit + " — archiver would hang",
+          timeoutException);
+    } catch (final CompletionException | ExecutionException ignored) {
+      // expected — caller asserts the future is completedExceptionally
+    }
+  }
+}

--- a/tasklist/archiver/src/test/java/io/camunda/tasklist/archiver/es/ArchiverUtilElasticSearchTest.java
+++ b/tasklist/archiver/src/test/java/io/camunda/tasklist/archiver/es/ArchiverUtilElasticSearchTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import io.camunda.tasklist.Metrics;
 import io.camunda.tasklist.util.ElasticsearchUtil;
@@ -163,14 +164,14 @@ public class ArchiverUtilElasticSearchTest {
   public void deleteDocumentsCompletesFutureWhenTimerThrows() throws Exception {
     try (final MockedStatic<ElasticsearchUtil> mockedStatic = mockStatic(ElasticsearchUtil.class);
         final MockedStatic<Timer> mockedTimer = mockStatic(Timer.class)) {
-      mockedTimer.when(Timer::start).thenReturn(mock(Timer.Sample.class));
+      final Timer.Sample timerSample = mock(Timer.Sample.class);
+      when(timerSample.stop(any())).thenThrow(new RuntimeException("timer exploded"));
+      mockedTimer.when(Timer::start).thenReturn(timerSample);
       final CompletableFuture<BulkByScrollResponse> failed = new CompletableFuture<>();
       failed.completeExceptionally(new RuntimeException("ES delete failed"));
       mockedStatic
           .when(() -> ElasticsearchUtil.deleteByQueryAsync(any(), any(), any()))
           .thenReturn(failed);
-      // metrics.getTimer() returns null → timer.stop(null) will throw NPE inside the callback
-      // before handleResponse or metric tracking even runs
 
       final CompletableFuture<Long> res = underTest.deleteDocuments("idx", "id", List.of("1"));
 
@@ -185,7 +186,9 @@ public class ArchiverUtilElasticSearchTest {
   public void reindexDocumentsCompletesFutureWhenTimerThrows() throws Exception {
     try (final MockedStatic<ElasticsearchUtil> mockedStatic = mockStatic(ElasticsearchUtil.class);
         final MockedStatic<Timer> mockedTimer = mockStatic(Timer.class)) {
-      mockedTimer.when(Timer::start).thenReturn(mock(Timer.Sample.class));
+      final Timer.Sample timerSample = mock(Timer.Sample.class);
+      when(timerSample.stop(any())).thenThrow(new RuntimeException("timer exploded"));
+      mockedTimer.when(Timer::start).thenReturn(timerSample);
       final CompletableFuture<BulkByScrollResponse> failed = new CompletableFuture<>();
       failed.completeExceptionally(new RuntimeException("ES reindex failed"));
       mockedStatic


### PR DESCRIPTION
## Summary

Alternative approach to #52818. Fixes #52781.

PR #52818 fixes the specific `getCause()` NPE by moving metric tracking to a separate `.exceptionally()` stage. However, **other code in the same callback** (`getArchiverDeleteQueryTimer()`, `startTimer.stop()`, `handleResponse()`) can also throw and cause the identical hang.

### This PR: defensive try-catch guaranteeing future completion

Instead of restructuring the async pipeline, this fix wraps the **entire** `whenComplete` body in `try-catch` with a last-resort `completeExceptionally` fallback. This eliminates the **whole class** of hang bugs — not just the `getCause()` NPE.

### Advantages over #52818
| | #52818 (`.exceptionally()` stage) | This PR (try-catch) |
|---|---|---|
| Fixes `getCause()` NPE | ✅ | ✅ |
| Fixes timer/handleResponse throws | ❌ | ✅ |
| Metric label stability | ⚠️ Changes labels (passes wrapped exception) | ✅ Same labels as before (passes `handleResponse` result) |
| Structural change | Moves metric tracking to new pipeline stage | Minimal — adds guard around existing code |

### Changes
- Wrap `whenComplete` callbacks in try-catch guaranteeing future completion
- Fix `getCause()` null-safety in `trackMetricFor{Delete,Reindex}Failures`
- Route Operate `reindexDocuments` through `handleResponse` (was silently ignoring bulk failures)
- Add regression tests for null-cause, metric-throws, and timer-throws scenarios

Covers both **Tasklist** and **Operate** ES archivers. OpenSearch implementations do not have the buggy metric trackers.

## Test plan

- [x] `ArchiverUtilElasticSearchTest` (new, 6 tests): null-cause, metric-throws, timer-throws for both delete and reindex
- [x] `ElasticsearchArchiveRepositoryTest` (extended, +8 tests): same coverage for Operate ES
- [x] All 21 archiver tests pass

🤖 Generated with [Copilot](https://github.com/features/copilot)