### PR TITLE
fix: define resource ID for msg sub get by key

### DIFF
--- a/service/src/main/java/io/camunda/service/MessageSubscriptionServices.java
+++ b/service/src/main/java/io/camunda/service/MessageSubscriptionServices.java
@@ -17,6 +17,7 @@ import io.camunda.search.query.CorrelatedMessageSubscriptionQuery;
 import io.camunda.search.query.MessageSubscriptionQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.api.model.CamundaAuthentication;
+import io.camunda.security.auth.Authorization;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
@@ -61,7 +62,10 @@ public class MessageSubscriptionServices
             searchClient
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
-                        authentication, MESSAGE_SUBSCRIPTION_READ_AUTHORIZATION))
+                        authentication,
+                        Authorization.withAuthorization(
+                            MESSAGE_SUBSCRIPTION_READ_AUTHORIZATION,
+                            MessageSubscriptionEntity::processDefinitionId)))
                 .getMessageSubscription(key));
   }
 

--- a/service/src/test/java/io/camunda/service/MessageSubscriptionServiceTest.java
+++ b/service/src/test/java/io/camunda/service/MessageSubscriptionServiceTest.java
@@ -8,16 +8,24 @@
 package io.camunda.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.camunda.search.clients.MessageSubscriptionSearchClient;
+import io.camunda.search.entities.MessageSubscriptionEntity;
+import io.camunda.search.exception.ResourceAccessDeniedException;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.api.model.CamundaAuthentication;
+import io.camunda.service.authorization.Authorizations;
+import io.camunda.service.exception.ServiceException;
+import io.camunda.service.exception.ServiceException.Status;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.instancio.Instancio;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -54,5 +62,39 @@ public class MessageSubscriptionServiceTest {
 
     // then
     assertThat(searchQueryResult).isEqualTo(result);
+  }
+
+  @Test
+  void shouldReturnMessageSubscriptionByKey() {
+    // given
+    final var entity = Instancio.create(MessageSubscriptionEntity.class);
+    when(client.getMessageSubscription(any(Long.class))).thenReturn(entity);
+
+    // when
+    final var result = services.getByKey(1L, authentication);
+
+    // then
+    assertThat(result).isEqualTo(entity);
+  }
+
+  @Test
+  void getByKeyShouldThrowForbiddenExceptionIfNotAuthorized() {
+    // given
+    when(client.getMessageSubscription(any(Long.class)))
+        .thenThrow(
+            new ResourceAccessDeniedException(
+                Authorizations.MESSAGE_SUBSCRIPTION_READ_AUTHORIZATION));
+
+    // when
+    final ThrowingCallable executeGetByKey = () -> services.getByKey(1L, authentication);
+
+    // then
+    final var exception =
+        (ServiceException)
+            assertThatThrownBy(executeGetByKey).isInstanceOf(ServiceException.class).actual();
+    assertThat(exception.getMessage())
+        .isEqualTo(
+            "Unauthorized to perform operation 'READ_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION'");
+    assertThat(exception.getStatus()).isEqualTo(Status.FORBIDDEN);
   }
 }


### PR DESCRIPTION
## Description

Defines the resource ID to use for message subscription get-by-key service calls. Otherwise, the permission check routine has no resource ID to check permission against for the defined resource. 

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #49153 
