### PR TITLE
PoC — secret resolution in Zeebe as a FEEL evaluation context

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.broker.logstreams.state.DbPositionSupplier;
 import io.camunda.zeebe.broker.partitioning.topology.ClusterConfigurationService;
 import io.camunda.zeebe.broker.partitioning.topology.TopologyManagerImpl;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.broker.system.configuration.SecretsCfg;
 import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
 import io.camunda.zeebe.broker.system.partitions.PartitionStartupAndTransitionContextImpl;
@@ -63,6 +64,8 @@ import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.engine.processing.EngineProcessors;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
+import io.camunda.zeebe.engine.processing.secret.EnvVarSecretStore;
+import io.camunda.zeebe.engine.processing.secret.SecretStore;
 import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
@@ -334,6 +337,7 @@ public final class ZeebePartitionFactory implements Closeable {
 
   private TypedRecordProcessorsFactory createFactory(
       final BrokerInfo localBroker, final FeatureFlags featureFlags) {
+    final SecretStore secretStore = createSecretStore(brokerCfg.getSecrets());
     return recordProcessorContext -> {
       final InterPartitionCommandSender partitionCommandSender =
           recordProcessorContext.getPartitionCommandSender();
@@ -349,8 +353,25 @@ public final class ZeebePartitionFactory implements Closeable {
           featureFlags,
           jobStreamer,
           searchClientsProxy,
-          brokerRequestAuthorizationConverter);
+          brokerRequestAuthorizationConverter,
+          secretStore);
     };
+  }
+
+  private static SecretStore createSecretStore(final SecretsCfg cfg) {
+    if (cfg == null || !cfg.isEnabled()) {
+      return SecretStore.EMPTY;
+    }
+    final String provider = cfg.getProvider();
+    if (SecretsCfg.PROVIDER_ENV.equalsIgnoreCase(provider)) {
+      return new EnvVarSecretStore();
+    }
+    LOGGER.warn(
+        "Unknown secret store provider '{}' configured; falling back to no-op store. "
+            + "Only '{}' is supported in this PoC.",
+        provider,
+        SecretsCfg.PROVIDER_ENV);
+    return SecretStore.EMPTY;
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/BrokerCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/BrokerCfg.java
@@ -28,6 +28,7 @@ public class BrokerCfg {
   private FlowControlCfg flowControl = new FlowControlCfg();
   private LimitCfg backpressure = new LimitCfg();
   private ProcessingCfg processingCfg = new ProcessingCfg();
+  private SecretsCfg secrets = new SecretsCfg();
 
   private ExperimentalCfg experimental = new ExperimentalCfg();
 
@@ -53,6 +54,7 @@ public class BrokerCfg {
     flowControl.init(this, brokerBase);
     backpressure.init(this, brokerBase);
     processingCfg.init(this, brokerBase);
+    secrets.init(this, brokerBase);
     experimental.init(this, brokerBase);
   }
 
@@ -160,6 +162,14 @@ public class BrokerCfg {
     this.experimental = experimental;
   }
 
+  public SecretsCfg getSecrets() {
+    return secrets;
+  }
+
+  public void setSecrets(final SecretsCfg secrets) {
+    this.secrets = secrets;
+  }
+
   @Override
   public String toString() {
     return "BrokerCfg{"
@@ -185,6 +195,8 @@ public class BrokerCfg {
         + processingCfg
         + ", experimental="
         + experimental
+        + ", secrets="
+        + secrets
         + ", executionMetricsExporterEnabled="
         + executionMetricsExporterEnabled
         + '}';

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/SecretsCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/SecretsCfg.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.system.configuration;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+/**
+ * Broker-side configuration for the {@code camunda.secret.*} FEEL namespace.
+ *
+ * <p>PoC scope: only the {@code env} provider is supported, which reads secrets from process
+ * environment variables. The {@code enabled} flag controls whether the broker attempts to resolve
+ * secrets at all — when disabled, every lookup yields {@code Optional#empty()}, which means worker
+ * requests for {@code camunda.secret.X} via {@code fetchVariables} will raise a "secret not
+ * defined" incident regardless of whether the env var is set.
+ */
+public final class SecretsCfg implements ConfigurationEntry {
+
+  /** Identifier for the environment-variable–backed secret store. */
+  public static final String PROVIDER_ENV = "env";
+
+  private boolean enabled = true;
+  private String provider = PROVIDER_ENV;
+
+  @Override
+  public void init(final BrokerCfg globalConfig, final String brokerBase) {
+    // no-op for the PoC; reserved for future provider-specific initialization
+  }
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(final boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public String getProvider() {
+    return provider;
+  }
+
+  public void setProvider(final String provider) {
+    this.provider = provider;
+  }
+
+  @Override
+  public String toString() {
+    return ToStringBuilder.reflectionToString(this, ToStringStyle.SHORT_PREFIX_STYLE);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -60,6 +60,7 @@ import io.camunda.zeebe.engine.processing.resource.ResourceReexportReexportProce
 import io.camunda.zeebe.engine.processing.resource.ResourceReexportStartProcessor;
 import io.camunda.zeebe.engine.processing.resource.RpaReexportMigrator;
 import io.camunda.zeebe.engine.processing.scaling.ScalingProcessors;
+import io.camunda.zeebe.engine.processing.secret.SecretStore;
 import io.camunda.zeebe.engine.processing.signal.SignalBroadcastProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
@@ -106,7 +107,8 @@ public final class EngineProcessors {
       final FeatureFlags featureFlags,
       final JobStreamer jobStreamer,
       final SearchClientsProxy searchClientsProxy,
-      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter,
+      final SecretStore secretStore) {
 
     final var processingState = typedRecordProcessorContext.getProcessingState();
     final var keyGenerator = processingState.getKeyGenerator();
@@ -168,7 +170,8 @@ public final class EngineProcessors {
             transientProcessMessageSubscriptionState,
             expressionLanguageMetrics,
             config,
-            incidentMetrics);
+            incidentMetrics,
+            secretStore);
 
     typedRecordProcessors.withListener(bpmnBehaviors.incidentBehavior());
 
@@ -450,7 +453,8 @@ public final class EngineProcessors {
       final TransientPendingSubscriptionState transientProcessMessageSubscriptionState,
       final ExpressionLanguageMetrics expressionLanguageMetrics,
       final EngineConfiguration config,
-      final IncidentMetrics incidentMetrics) {
+      final IncidentMetrics incidentMetrics,
+      final SecretStore secretStore) {
     return new BpmnBehaviorsImpl(
         processingState,
         writers,
@@ -465,7 +469,8 @@ public final class EngineProcessors {
         transientProcessMessageSubscriptionState,
         expressionLanguageMetrics,
         config,
-        incidentMetrics);
+        incidentMetrics,
+        secretStore);
   }
 
   private static TypedRecordProcessor<ProcessInstanceRecord> addProcessProcessors(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -249,7 +249,8 @@ public final class EngineProcessors {
         config,
         clock,
         authCheckBehavior,
-        incidentMetrics);
+        incidentMetrics,
+        secretStore);
 
     final var userTaskProcessor =
         createUserTaskProcessor(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -236,7 +236,8 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             processingState.getKeyGenerator(),
             jobMetrics,
             clock,
-            authCheckBehavior);
+            authCheckBehavior,
+            secretStore);
 
     multiInstanceInputCollectionBehavior =
         new MultiInstanceInputCollectionBehavior(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.engine.processing.expression.CombinedEvaluationContext;
 import io.camunda.zeebe.engine.processing.expression.ExpressionBehavior;
 import io.camunda.zeebe.engine.processing.expression.GlobalScopeClusterVariableEvaluationContext;
 import io.camunda.zeebe.engine.processing.expression.NamespacedEvaluationContext;
+import io.camunda.zeebe.engine.processing.expression.ResolvingSecretEvaluationContext;
 import io.camunda.zeebe.engine.processing.expression.SecretEvaluationContext;
 import io.camunda.zeebe.engine.processing.expression.TenantScopeClusterVariableEvaluationContext;
 import io.camunda.zeebe.engine.processing.expression.VariableEvaluationContext;
@@ -102,18 +103,30 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
     final var namespacedMergedClusterScope =
         NamespacedEvaluationContext.create().register("env", mergedClusterScope);
 
+    // The varsSubtree is identical for both the engine-wide and endpoint-only namespace chains;
+    // only the camunda.secret leaf differs between them — literal-reference for engine-wide use,
+    // resolving for the standalone FEEL evaluation endpoint.
+    final var varsSubtree =
+        CombinedEvaluationContext.withContexts(
+            namespacedMergedClusterScope,
+            namespacedTenantClusterScope,
+            namespacedGlobalClusterScope);
+
     final var namespaceFullClusterContext =
         NamespacedEvaluationContext.create()
             .register(
                 "camunda",
                 NamespacedEvaluationContext.create()
-                    .register(
-                        "vars",
-                        CombinedEvaluationContext.withContexts(
-                            namespacedMergedClusterScope,
-                            namespacedTenantClusterScope,
-                            namespacedGlobalClusterScope))
+                    .register("vars", varsSubtree)
                     .register("secret", new SecretEvaluationContext()));
+
+    final var namespaceFullClusterContextForEndpoint =
+        NamespacedEvaluationContext.create()
+            .register(
+                "camunda",
+                NamespacedEvaluationContext.create()
+                    .register("vars", varsSubtree)
+                    .register("secret", new ResolvingSecretEvaluationContext(secretStore)));
 
     final var processVariableContext =
         new VariableEvaluationContext(processingState.getVariableState());
@@ -131,7 +144,7 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
 
     expressionBehavior =
         new ExpressionBehavior(
-            namespaceFullClusterContext,
+            namespaceFullClusterContextForEndpoint,
             expressionLanguage,
             config.getExpressionEvaluationTimeout(),
             processingState.getVariableState());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -425,8 +425,4 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
   public ExpressionLanguage expressionLanguage() {
     return expressionLanguage;
   }
-
-  public SecretStore secretStore() {
-    return secretStore;
-  }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -29,6 +29,7 @@ import io.camunda.zeebe.engine.processing.expression.VariableEvaluationContext;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.job.behaviour.JobUpdateBehaviour;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
+import io.camunda.zeebe.engine.processing.secret.SecretStore;
 import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.processing.timer.DueDateTimerCheckScheduler;
@@ -66,6 +67,7 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
   private final BpmnConditionalBehavior conditionalBehavior;
   private final ExpressionBehavior expressionBehavior;
   private final ExpressionLanguage expressionLanguage;
+  private final SecretStore secretStore;
 
   public BpmnBehaviorsImpl(
       final MutableProcessingState processingState,
@@ -81,7 +83,9 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
       final TransientPendingSubscriptionState transientProcessMessageSubscriptionState,
       final ExpressionLanguageMetrics expressionMetrics,
       final EngineConfiguration config,
-      final IncidentMetrics incidentMetrics) {
+      final IncidentMetrics incidentMetrics,
+      final SecretStore secretStore) {
+    this.secretStore = secretStore;
 
     final var tenantClusterScope =
         new TenantScopeClusterVariableEvaluationContext(processingState.getClusterVariableState());
@@ -404,5 +408,9 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
 
   public ExpressionLanguage expressionLanguage() {
     return expressionLanguage;
+  }
+
+  public SecretStore secretStore() {
+    return secretStore;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.engine.processing.expression.CombinedEvaluationContext;
 import io.camunda.zeebe.engine.processing.expression.ExpressionBehavior;
 import io.camunda.zeebe.engine.processing.expression.GlobalScopeClusterVariableEvaluationContext;
 import io.camunda.zeebe.engine.processing.expression.NamespacedEvaluationContext;
+import io.camunda.zeebe.engine.processing.expression.SecretEvaluationContext;
 import io.camunda.zeebe.engine.processing.expression.TenantScopeClusterVariableEvaluationContext;
 import io.camunda.zeebe.engine.processing.expression.VariableEvaluationContext;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
@@ -111,7 +112,8 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
                         CombinedEvaluationContext.withContexts(
                             namespacedMergedClusterScope,
                             namespacedTenantClusterScope,
-                            namespacedGlobalClusterScope)));
+                            namespacedGlobalClusterScope))
+                    .register("secret", new SecretEvaluationContext()));
 
     final var processVariableContext =
         new VariableEvaluationContext(processingState.getVariableState());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.engine.metrics.JobProcessingMetrics;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
 import io.camunda.zeebe.engine.processing.job.JobVariablesCollector;
+import io.camunda.zeebe.engine.processing.secret.SecretStore;
 import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer;
 import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer.JobStream;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.SideEffectWriter;
@@ -63,11 +64,12 @@ public class BpmnJobActivationBehavior {
       final KeyGenerator keyGenerator,
       final JobProcessingMetrics jobMetrics,
       final InstantSource clock,
-      final AuthorizationCheckBehavior authCheckBehavior) {
+      final AuthorizationCheckBehavior authCheckBehavior,
+      final SecretStore secretStore) {
     this.jobStreamer = jobStreamer;
     this.keyGenerator = keyGenerator;
     this.jobMetrics = jobMetrics;
-    jobVariablesCollector = new JobVariablesCollector(state);
+    jobVariablesCollector = new JobVariablesCollector(state, secretStore);
     stateWriter = writers.state();
     sideEffectWriter = writers.sideEffect();
     this.clock = clock;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/ExpressionEvaluateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/ExpressionEvaluateProcessor.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.engine.processing.expression.ExpressionValidator.Resolve
 import io.camunda.zeebe.engine.processing.expression.ExpressionValidator.ValidatedCommand;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
+import io.camunda.zeebe.engine.processing.secret.SecretMasker;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -144,7 +145,22 @@ public final class ExpressionEvaluateProcessor implements TypedRecordProcessor<E
   private void acceptCommand(
       final TypedRecord<ExpressionRecord> command, final ExpressionRecord resolvedValue) {
     final var key = keyGenerator.nextKey();
-    stateWriter.appendFollowUpEvent(key, ExpressionIntent.EVALUATED, resolvedValue);
-    responseWriter.writeEventOnCommand(key, ExpressionIntent.EVALUATED, resolvedValue, command);
+    // Two-step write when the expression touched the camunda.secret.* namespace: the
+    // synchronous HTTP response carries the real result, but the persisted EVALUATED event
+    // stores the masked sentinel so the resolved secret never reaches the logstream or any
+    // exporter. RecordBatchEntry.createEntry copies value bytes on each write, so swapping
+    // the result buffer in between is safe.
+    // Only mask when the resolution actually produced a value — a missing secret yields a
+    // FEEL-null result with a warning, which is harmless and useful for the caller to see on
+    // the exported event.
+    if (SecretMasker.expressionReferencesSecret(resolvedValue.getExpression())
+        && resolvedValue.getResultValue() != null) {
+      responseWriter.writeEventOnCommand(key, ExpressionIntent.EVALUATED, resolvedValue, command);
+      resolvedValue.setResultValue(SecretMasker.maskedAsMsgPackString());
+      stateWriter.appendFollowUpEvent(key, ExpressionIntent.EVALUATED, resolvedValue);
+    } else {
+      stateWriter.appendFollowUpEvent(key, ExpressionIntent.EVALUATED, resolvedValue);
+      responseWriter.writeEventOnCommand(key, ExpressionIntent.EVALUATED, resolvedValue, command);
+    }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/ResolvingSecretEvaluationContext.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/ResolvingSecretEvaluationContext.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.expression;
+
+import io.camunda.zeebe.el.EvaluationContext;
+import io.camunda.zeebe.engine.processing.secret.SecretStore;
+import io.camunda.zeebe.util.Either;
+import java.util.Objects;
+import org.agrona.DirectBuffer;
+
+/**
+ * Resolving variant of the {@code camunda.secret.*} FEEL namespace. Unlike {@link
+ * SecretEvaluationContext} — which is wired engine-wide and always returns the literal reference
+ * string — this context consults the configured {@link SecretStore} and emits the underlying secret
+ * value as a MessagePack string. It is intended to be used <em>only</em> on paths where
+ * materialising the secret is acceptable: the standalone FEEL evaluation endpoint reaches it
+ * through {@link ExpressionBehavior}, and the job-activation path (next stage) will reach it via a
+ * per-request lookup.
+ *
+ * <p>If the requested secret is absent, {@code getVariable} returns {@code Left(null)} — the
+ * FEEL-idiomatic representation of an undefined path, which the FEEL engine surfaces as a warning
+ * on the resulting record.
+ */
+public final class ResolvingSecretEvaluationContext implements ScopedEvaluationContext {
+
+  private final SecretStore secretStore;
+
+  public ResolvingSecretEvaluationContext(final SecretStore secretStore) {
+    this.secretStore = Objects.requireNonNull(secretStore);
+  }
+
+  @Override
+  public Either<DirectBuffer, EvaluationContext> getVariable(final String variableName) {
+    if (variableName == null || variableName.isEmpty()) {
+      return Either.left(null);
+    }
+    return secretStore
+        .resolve(variableName)
+        .map(SecretEvaluationContext::encodeAsMsgPackString)
+        .<Either<DirectBuffer, EvaluationContext>>map(Either::left)
+        .orElse(Either.left(null));
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/SecretEvaluationContext.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/SecretEvaluationContext.java
@@ -39,10 +39,15 @@ public final class SecretEvaluationContext implements ScopedEvaluationContext {
     if (variableName == null || variableName.isEmpty()) {
       return Either.left(null);
     }
-    return Either.left(encodeReferenceString(SecretStore.FEEL_NAMESPACE + variableName));
+    return Either.left(encodeAsMsgPackString(SecretStore.FEEL_NAMESPACE + variableName));
   }
 
-  private static DirectBuffer encodeReferenceString(final String value) {
+  /**
+   * Encodes {@code value} as a MessagePack string in a fresh {@link DirectBuffer}. Shared with
+   * {@link ResolvingSecretEvaluationContext} so the two leaf encodings stay byte-for-byte
+   * compatible.
+   */
+  static DirectBuffer encodeAsMsgPackString(final String value) {
     final MsgPackWriter writer = new MsgPackWriter();
     final MutableDirectBuffer writeBuffer = new ExpandableArrayBuffer();
     writer.wrap(writeBuffer, 0);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/SecretEvaluationContext.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/SecretEvaluationContext.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.expression;
+
+import io.camunda.zeebe.el.EvaluationContext;
+import io.camunda.zeebe.engine.processing.secret.SecretStore;
+import io.camunda.zeebe.msgpack.spec.MsgPackWriter;
+import io.camunda.zeebe.util.Either;
+import org.agrona.DirectBuffer;
+import org.agrona.ExpandableArrayBuffer;
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+
+/**
+ * Engine-wide {@link ScopedEvaluationContext} for the {@code camunda.secret.*} FEEL namespace.
+ *
+ * <p>Resolution is deliberately inert: any path lookup {@code camunda.secret.X} yields the
+ * <em>literal string</em> {@code "camunda.secret.X"}, never the underlying secret value. This is
+ * the layer that keeps real secrets out of the variable store, the logstream, and the exporter
+ * pipeline by default. The two paths that need real values — job activation with an explicit {@code
+ * camunda.secret.X} entry in {@code fetchVariables}, and the standalone FEEL evaluation endpoint —
+ * override this context with a resolving variant via {@link ExpressionBehavior} (next stage of the
+ * PoC).
+ *
+ * <p>Returned buffers carry a freshly MessagePack-encoded string per lookup; per-instance use is
+ * single-threaded (one engine partition processor), so no synchronisation or pooling is needed.
+ *
+ * @see SecretStore#FEEL_NAMESPACE
+ */
+public final class SecretEvaluationContext implements ScopedEvaluationContext {
+
+  @Override
+  public Either<DirectBuffer, EvaluationContext> getVariable(final String variableName) {
+    if (variableName == null || variableName.isEmpty()) {
+      return Either.left(null);
+    }
+    return Either.left(encodeReferenceString(SecretStore.FEEL_NAMESPACE + variableName));
+  }
+
+  private static DirectBuffer encodeReferenceString(final String value) {
+    final MsgPackWriter writer = new MsgPackWriter();
+    final MutableDirectBuffer writeBuffer = new ExpandableArrayBuffer();
+    writer.wrap(writeBuffer, 0);
+
+    final DirectBuffer stringWrapper = new UnsafeBuffer();
+    stringWrapper.wrap(value.getBytes());
+    writer.writeString(stringWrapper);
+
+    final DirectBuffer resultView = new UnsafeBuffer();
+    resultView.wrap(writeBuffer, 0, writer.getOffset());
+    return resultView;
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.engine.processing.common.ElementTreePathBuilder;
 import io.camunda.zeebe.engine.processing.identity.AuthorizedTenants;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.job.JobBatchCollector.JobWithMissingSecret;
+import io.camunda.zeebe.engine.processing.secret.SecretMasker;
 import io.camunda.zeebe.engine.processing.secret.SecretStore;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
@@ -195,11 +196,31 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
       final JobBatchRecord value,
       final long jobBatchKey,
       final Map<JobKind, Integer> activatedJobsCountPerJobKind) {
-    stateWriter.appendFollowUpEvent(jobBatchKey, JobBatchIntent.ACTIVATED, value);
+    // Two-step write: the gateway response carries the real (resolved) secret values bound
+    // for the worker, while the durable state event carries a masked copy so the on-disk log
+    // never holds plain-text secret material. RecordBatchEntry.createEntry copies the value
+    // bytes synchronously on each write, so we can safely mutate `value` in between.
     responseWriter.writeEventOnCommand(jobBatchKey, JobBatchIntent.ACTIVATED, value, record);
+    maskResolvedSecretsInBatch(value);
+    stateWriter.appendFollowUpEvent(jobBatchKey, JobBatchIntent.ACTIVATED, value);
     activatedJobsCountPerJobKind.forEach(
         (jobKind, count) ->
             jobMetrics.countJobEvent(JobAction.ACTIVATED, jobKind, value.getType(), count));
+  }
+
+  /**
+   * Replaces resolved {@code camunda.secret.X} values inside every activated job's variables
+   * payload with the masked sentinel, in place. Cheap no-op when no job carries a resolved secret
+   * entry (the common case — workers rarely request secrets).
+   */
+  private static void maskResolvedSecretsInBatch(final JobBatchRecord value) {
+    for (final JobRecord job : value.jobs()) {
+      final DirectBuffer original = job.getVariablesBuffer();
+      final DirectBuffer masked = SecretMasker.maskSecretsInDocument(original);
+      if (masked != original) {
+        job.setVariables(masked);
+      }
+    }
   }
 
   private void raiseIncidentJobTooLargeForMessageSize(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
@@ -17,7 +17,8 @@ import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.common.ElementTreePathBuilder;
 import io.camunda.zeebe.engine.processing.identity.AuthorizedTenants;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
-import io.camunda.zeebe.engine.processing.job.JobBatchCollector.TooLargeJob;
+import io.camunda.zeebe.engine.processing.job.JobBatchCollector.JobWithMissingSecret;
+import io.camunda.zeebe.engine.processing.secret.SecretStore;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -41,7 +42,6 @@ import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.ByteValue;
 import io.camunda.zeebe.util.Either;
 import java.time.InstantSource;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.agrona.DirectBuffer;
@@ -67,14 +67,16 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
       final JobProcessingMetrics jobMetrics,
       final AuthorizationCheckBehavior authCheckBehavior,
       final InstantSource clock,
-      final IncidentMetrics incidentMetrics) {
+      final IncidentMetrics incidentMetrics,
+      final SecretStore secretStore) {
 
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
     responseWriter = writers.response();
     authorizationCheckBehavior = authCheckBehavior;
     jobBatchCollector =
-        new JobBatchCollector(state, stateWriter::canWriteEventOfLength, authCheckBehavior, clock);
+        new JobBatchCollector(
+            state, stateWriter::canWriteEventOfLength, authCheckBehavior, clock, secretStore);
 
     this.keyGenerator = keyGenerator;
     this.jobMetrics = jobMetrics;
@@ -169,15 +171,18 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
     final JobBatchRecord value = record.getValue();
     final long jobBatchKey = keyGenerator.nextKey();
 
-    final Either<TooLargeJob, Map<JobKind, Integer>> result =
-        jobBatchCollector.collectJobs(record, tenantIds);
-    final var activatedJobCountPerJobKind = result.getOrElse(Collections.emptyMap());
-    result.ifLeft(
-        largeJob ->
-            raiseIncidentJobTooLargeForMessageSize(
-                largeJob.key(), largeJob.jobRecord(), largeJob.expectedEventLength()));
+    final var result = jobBatchCollector.collectJobs(record, tenantIds);
 
-    activateJobBatch(record, value, jobBatchKey, activatedJobCountPerJobKind);
+    if (result.tooLargeJob() != null) {
+      final var tooLarge = result.tooLargeJob();
+      raiseIncidentJobTooLargeForMessageSize(
+          tooLarge.key(), tooLarge.jobRecord(), tooLarge.expectedEventLength());
+    }
+    for (final JobWithMissingSecret failure : result.secretFailures()) {
+      raiseIncidentSecretNotFound(failure);
+    }
+
+    activateJobBatch(record, value, jobBatchKey, result.activatedJobCountPerJobKind());
   }
 
   private void rejectCommand(final TypedRecord<JobBatchRecord> record, final Rejection rejection) {
@@ -224,6 +229,43 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
             .setElementId(job.getElementIdBuffer())
             .setElementInstanceKey(job.getElementInstanceKey())
             .setJobKey(jobKey)
+            .setTenantId(job.getTenantId())
+            .setVariableScopeKey(job.getElementInstanceKey())
+            .setElementInstancePath(treePathProperties.elementInstancePath())
+            .setProcessDefinitionPath(treePathProperties.processDefinitionPath())
+            .setCallingElementPath(treePathProperties.callingElementPath());
+
+    stateWriter.appendFollowUpEvent(keyGenerator.nextKey(), IncidentIntent.CREATED, incidentEvent);
+    incidentMetrics.incidentCreated();
+  }
+
+  private void raiseIncidentSecretNotFound(final JobWithMissingSecret failure) {
+    final var job = failure.jobRecord();
+    final DirectBuffer incidentMessage =
+        wrapString(
+            String.format(
+                "Failed to activate job with key '%d': referenced secret '%s' is not defined "
+                    + "in the configured secret store. Define the secret and resolve the "
+                    + "incident to re-enable activation.",
+                failure.key(), failure.missingSecretName()));
+
+    final var treePathProperties =
+        new ElementTreePathBuilder()
+            .withElementInstanceProvider(elementInstanceState::getInstance)
+            .withCallActivityIndexProvider(processState::getFlowElement)
+            .withElementInstanceKey(job.getElementInstanceKey())
+            .build();
+
+    final var incidentEvent =
+        new IncidentRecord()
+            .setErrorType(ErrorType.SECRET_NOT_FOUND)
+            .setErrorMessage(incidentMessage)
+            .setBpmnProcessId(job.getBpmnProcessIdBuffer())
+            .setProcessDefinitionKey(job.getProcessDefinitionKey())
+            .setProcessInstanceKey(job.getProcessInstanceKey())
+            .setElementId(job.getElementIdBuffer())
+            .setElementInstanceKey(job.getElementInstanceKey())
+            .setJobKey(failure.key())
             .setTenantId(job.getTenantId())
             .setVariableScopeKey(job.getElementInstanceKey())
             .setElementInstancePath(treePathProperties.elementInstancePath())

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.job;
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
+import io.camunda.zeebe.engine.processing.secret.SecretStore;
 import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.VariableState;
@@ -23,9 +24,9 @@ import io.camunda.zeebe.protocol.record.value.AuthorizationScope;
 import io.camunda.zeebe.protocol.record.value.JobKind;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
-import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.time.InstantSource;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumMap;
 import java.util.List;
@@ -61,10 +62,11 @@ final class JobBatchCollector {
       final ProcessingState state,
       final Predicate<Integer> canWriteEventOfLength,
       final AuthorizationCheckBehavior authCheckBehavior,
-      final InstantSource clock) {
+      final InstantSource clock,
+      final SecretStore secretStore) {
     jobState = state.getJobState();
     this.canWriteEventOfLength = canWriteEventOfLength;
-    jobVariablesCollector = new JobVariablesCollector(state);
+    jobVariablesCollector = new JobVariablesCollector(state, secretStore);
     this.authCheckBehavior = authCheckBehavior;
     this.clock = clock;
   }
@@ -73,16 +75,20 @@ final class JobBatchCollector {
    * Collects jobs to be added to the given {@code record}. The jobs and their keys are added
    * directly to the given record.
    *
-   * <p>This method will fail only if it could not activate anything because the batch would be too
-   * large, but there was at least one job to activate. On failure, it will return that job and its
-   * key. On success, it will return the amount of jobs activated.
+   * <p>Two per-job failure modes are surfaced on the returned {@link CollectionResult}:
    *
-   * @param record the batch activate command; jobs and their keys will be added directly into it
-   * @param tenantIds the tenant IDs to use for filtering jobs
-   * @return the amount of activated jobs per jobKind on success, or a job which was too large to
-   *     activate on failure
+   * <ul>
+   *   <li>{@code tooLargeJob} — set if the very first job could not fit into a single batch record;
+   *       all activation is aborted at that point.
+   *   <li>{@code secretFailures} — list of jobs whose {@code fetchVariables} requested a {@code
+   *       camunda.secret.X} reference that the store could not resolve. These jobs are skipped (not
+   *       added to the batch); the rest of the iteration continues.
+   * </ul>
+   *
+   * <p>The caller is responsible for raising incidents for both failure modes; this collector is a
+   * pure data-gathering step.
    */
-  public Either<TooLargeJob, Map<JobKind, Integer>> collectJobs(
+  public CollectionResult collectJobs(
       final TypedRecord<JobBatchRecord> record, final List<String> tenantIds) {
     final JobBatchRecord value = record.getValue();
     final ValueArray<JobRecord> jobIterator = value.jobs();
@@ -91,6 +97,7 @@ final class JobBatchCollector {
     final var maxActivatedCount = value.getMaxJobsToActivate();
     final var activatedCount = new MutableInteger(0);
     final var unwritableJob = new MutableReference<TooLargeJob>();
+    final List<JobWithMissingSecret> secretFailures = new ArrayList<>();
     final Map<JobKind, Integer> jobCountPerJobKind = new EnumMap<>(JobKind.class);
     // the tenant check is performed earlier in the JobBatchActivateProcessor, so we can skip it
     // here and only check if the requester has the correct permissions to access the jobs
@@ -115,7 +122,15 @@ final class JobBatchCollector {
           // fill in the job record properties first in order to accurately estimate its size before
           // adding it to the batch
           jobRecord.setDeadline(deadline).setWorker(value.getWorkerBuffer());
-          jobVariablesCollector.setJobVariables(requestedVariables, jobRecord);
+          final var missingSecret =
+              jobVariablesCollector.setJobVariables(requestedVariables, jobRecord);
+          if (missingSecret.isPresent()) {
+            // Per-job failure — record it for an incident, skip this job, keep iterating so
+            // unaffected jobs in the same batch still activate.
+            secretFailures.add(
+                new JobWithMissingSecret(key, cloneJobRecord(jobRecord), missingSecret.get()));
+            return activatedCount.value < maxActivatedCount;
+          }
 
           // the expected length is based on the current record's length plus the length of the job
           // record we would add to the batch, the number of bytes taken by the additional job key,
@@ -147,11 +162,15 @@ final class JobBatchCollector {
           return activatedCount.value < maxActivatedCount;
         });
 
-    if (unwritableJob.ref != null) {
-      return Either.left(unwritableJob.ref);
-    }
+    return new CollectionResult(jobCountPerJobKind, unwritableJob.ref, secretFailures);
+  }
 
-    return Either.right(jobCountPerJobKind);
+  private static JobRecord cloneJobRecord(final JobRecord source) {
+    // The visitor reuses a single JobRecord instance across iterations; we keep our own copy so
+    // the incident downstream sees the failed job's properties, not whichever job comes next.
+    final var copy = new JobRecord();
+    copy.copyFrom(source);
+    return copy;
   }
 
   private boolean isAuthorizedForJob(
@@ -180,4 +199,16 @@ final class JobBatchCollector {
   }
 
   record TooLargeJob(long key, JobRecord jobRecord, int expectedEventLength) {}
+
+  record JobWithMissingSecret(long key, JobRecord jobRecord, String missingSecretName) {}
+
+  /**
+   * Aggregate outcome of {@link #collectJobs(TypedRecord, List)}. {@code tooLargeJob} is at most
+   * one (only the first job seen, since the iteration aborts after); {@code secretFailures} lists
+   * every job whose secret resolution failed, since we keep iterating past those.
+   */
+  record CollectionResult(
+      Map<JobKind, Integer> activatedJobCountPerJobKind,
+      TooLargeJob tooLargeJob,
+      List<JobWithMissingSecret> secretFailures) {}
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.engine.metrics.JobProcessingMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.common.EventHandle;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
+import io.camunda.zeebe.engine.processing.secret.SecretStore;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.ScheduledTaskState;
@@ -35,7 +36,8 @@ public final class JobEventProcessors {
       final EngineConfiguration config,
       final InstantSource clock,
       final AuthorizationCheckBehavior authCheckBehavior,
-      final IncidentMetrics incidentMetrics) {
+      final IncidentMetrics incidentMetrics,
+      final SecretStore secretStore) {
 
     final var keyGenerator = processingState.getKeyGenerator();
 
@@ -125,7 +127,8 @@ public final class JobEventProcessors {
                 jobMetrics,
                 authCheckBehavior,
                 clock,
-                incidentMetrics))
+                incidentMetrics,
+                secretStore))
         .withListener(
             new JobTimeoutCheckScheduler(
                 scheduledTaskStateFactory.get().getJobState(),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobVariablesCollector.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobVariablesCollector.java
@@ -57,24 +57,24 @@ public class JobVariablesCollector {
   public Optional<String> setJobVariables(
       final Collection<DirectBuffer> requestedVariables, final JobRecord jobRecord) {
     // Resolve secret references first so a missing secret short-circuits the variable read.
-    final var partitioned = partitionRequested(requestedVariables);
-    if (partitioned.missingSecret() != null) {
-      return Optional.of(partitioned.missingSecret());
+    final var split = splitVariables(requestedVariables);
+    if (split.missingSecret() != null) {
+      return Optional.of(split.missingSecret());
     }
 
     final boolean fetchAll = requestedVariables.isEmpty();
-    final DirectBuffer processVariables = readProcessVariables(jobRecord, partitioned, fetchAll);
+    final DirectBuffer processVariables = readProcessVariables(jobRecord, split, fetchAll);
 
     final DirectBuffer jobVariables =
         switch (jobRecord.getJobKind()) {
           case BPMN_ELEMENT, EXECUTION_LISTENER, AD_HOC_SUB_PROCESS ->
-              mergeSecrets(processVariables, partitioned.resolvedSecrets());
+              mergeSecrets(processVariables, split.resolvedSecrets());
           case TASK_LISTENER -> {
             final var taskVariablesMap =
-                getTaskVariables(partitioned.regularVariables(), jobRecord.getElementInstanceKey());
+                getTaskVariables(split.regularVariables(), jobRecord.getElementInstanceKey());
             final Map<String, Object> merged = MsgPackConverter.convertToMap(processVariables);
             merged.putAll(taskVariablesMap);
-            merged.putAll(partitioned.resolvedSecrets());
+            merged.putAll(split.resolvedSecrets());
             yield BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(merged));
           }
         };
@@ -84,7 +84,7 @@ public class JobVariablesCollector {
   }
 
   private DirectBuffer readProcessVariables(
-      final JobRecord jobRecord, final PartitionedRequest partitioned, final boolean fetchAll) {
+      final JobRecord jobRecord, final SplitVariables split, final boolean fetchAll) {
     final long elementInstanceKey = jobRecord.getElementInstanceKey();
     if (elementInstanceKey < 0) {
       return DocumentValue.EMPTY_DOCUMENT;
@@ -94,11 +94,11 @@ public class JobVariablesCollector {
       // process variable, so we don't need to merge anything else here.
       return variableState.getVariablesAsDocument(elementInstanceKey);
     }
-    if (partitioned.regularVariables().isEmpty()) {
+    if (split.regularVariables().isEmpty()) {
       // Worker asked exclusively for secrets — skip the state read entirely.
       return DocumentValue.EMPTY_DOCUMENT;
     }
-    return variableState.getVariablesAsDocument(elementInstanceKey, partitioned.regularVariables());
+    return variableState.getVariablesAsDocument(elementInstanceKey, split.regularVariables());
   }
 
   private static DirectBuffer mergeSecrets(
@@ -111,7 +111,7 @@ public class JobVariablesCollector {
     return BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(merged));
   }
 
-  private PartitionedRequest partitionRequested(final Collection<DirectBuffer> requestedVariables) {
+  private SplitVariables splitVariables(final Collection<DirectBuffer> requestedVariables) {
     final Map<String, String> resolvedSecrets = new HashMap<>();
     final List<DirectBuffer> regularVariables = new ArrayList<>(requestedVariables.size());
     for (final DirectBuffer name : requestedVariables) {
@@ -120,14 +120,14 @@ public class JobVariablesCollector {
         final String secretName = nameStr.substring(SecretStore.FEEL_NAMESPACE.length());
         final Optional<String> resolved = secretStore.resolve(secretName);
         if (resolved.isEmpty()) {
-          return PartitionedRequest.miss(nameStr);
+          return SplitVariables.miss(nameStr);
         }
         resolvedSecrets.put(nameStr, resolved.get());
       } else {
         regularVariables.add(name);
       }
     }
-    return new PartitionedRequest(regularVariables, resolvedSecrets, null);
+    return new SplitVariables(regularVariables, resolvedSecrets, null);
   }
 
   private Map<String, Object> getTaskVariables(
@@ -159,12 +159,12 @@ public class JobVariablesCollector {
    * resolved secret references. If {@link #missingSecret} is non-null, resolution short-circuited
    * on that reference and the other fields are not meaningful.
    */
-  private record PartitionedRequest(
+  private record SplitVariables(
       List<DirectBuffer> regularVariables,
       Map<String, String> resolvedSecrets,
       String missingSecret) {
-    static PartitionedRequest miss(final String missingSecret) {
-      return new PartitionedRequest(List.of(), Map.of(), missingSecret);
+    static SplitVariables miss(final String missingSecret) {
+      return new SplitVariables(List.of(), Map.of(), missingSecret);
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobVariablesCollector.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobVariablesCollector.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.job;
 
+import io.camunda.zeebe.engine.processing.secret.SecretStore;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.UserTaskState;
@@ -15,8 +16,12 @@ import io.camunda.zeebe.msgpack.value.DocumentValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.agrona.DirectBuffer;
 
@@ -25,41 +30,104 @@ public class JobVariablesCollector {
   private final VariableState variableState;
   private final UserTaskState userTaskState;
   private final ElementInstanceState elementInstanceState;
+  private final SecretStore secretStore;
 
-  public JobVariablesCollector(final ProcessingState processingState) {
+  public JobVariablesCollector(
+      final ProcessingState processingState, final SecretStore secretStore) {
     variableState = processingState.getVariableState();
     userTaskState = processingState.getUserTaskState();
     elementInstanceState = processingState.getElementInstanceState();
+    this.secretStore = secretStore;
   }
 
-  public void setJobVariables(
+  /**
+   * Populates {@code jobRecord}'s {@code variables} payload from the variable store and — if the
+   * worker explicitly named any {@code camunda.secret.X} entries in {@code requestedVariables} —
+   * from the configured {@link SecretStore}. Secret resolution happens last and is merged into the
+   * outgoing document under the full reference key (e.g. {@code camunda.secret.MY_SECRET}),
+   * matching how the worker asked for it.
+   *
+   * <p>If any requested secret is absent from the store, the method returns the offending reference
+   * name (the first such miss) and leaves {@code jobRecord} untouched, so the caller can raise an
+   * incident on this job without leaking through a partially-resolved payload.
+   *
+   * @return {@link Optional#empty()} on success; otherwise the missing reference name (e.g. {@code
+   *     "camunda.secret.MY_SECRET"})
+   */
+  public Optional<String> setJobVariables(
       final Collection<DirectBuffer> requestedVariables, final JobRecord jobRecord) {
-    final long elementInstanceKey = jobRecord.getElementInstanceKey();
-    final DirectBuffer processVariables;
-    if (elementInstanceKey < 0) {
-      processVariables = DocumentValue.EMPTY_DOCUMENT;
-    } else if (requestedVariables.isEmpty()) {
-      processVariables = variableState.getVariablesAsDocument(elementInstanceKey);
-    } else {
-      processVariables =
-          variableState.getVariablesAsDocument(elementInstanceKey, requestedVariables);
+    // Resolve secret references first so a missing secret short-circuits the variable read.
+    final var partitioned = partitionRequested(requestedVariables);
+    if (partitioned.missingSecret() != null) {
+      return Optional.of(partitioned.missingSecret());
     }
+
+    final boolean fetchAll = requestedVariables.isEmpty();
+    final DirectBuffer processVariables = readProcessVariables(jobRecord, partitioned, fetchAll);
 
     final DirectBuffer jobVariables =
         switch (jobRecord.getJobKind()) {
-          case BPMN_ELEMENT, EXECUTION_LISTENER, AD_HOC_SUB_PROCESS -> processVariables;
+          case BPMN_ELEMENT, EXECUTION_LISTENER, AD_HOC_SUB_PROCESS ->
+              mergeSecrets(processVariables, partitioned.resolvedSecrets());
           case TASK_LISTENER -> {
-            final var taskVariablesMap = getTaskVariables(requestedVariables, elementInstanceKey);
-
-            // merge the two variables maps favoring the task variables over process variables
-            final Map<String, Object> taskListenersVariables =
-                MsgPackConverter.convertToMap(processVariables);
-            taskListenersVariables.putAll(taskVariablesMap);
-            yield BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(taskListenersVariables));
+            final var taskVariablesMap =
+                getTaskVariables(partitioned.regularVariables(), jobRecord.getElementInstanceKey());
+            final Map<String, Object> merged = MsgPackConverter.convertToMap(processVariables);
+            merged.putAll(taskVariablesMap);
+            merged.putAll(partitioned.resolvedSecrets());
+            yield BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(merged));
           }
         };
 
     jobRecord.setVariables(jobVariables);
+    return Optional.empty();
+  }
+
+  private DirectBuffer readProcessVariables(
+      final JobRecord jobRecord, final PartitionedRequest partitioned, final boolean fetchAll) {
+    final long elementInstanceKey = jobRecord.getElementInstanceKey();
+    if (elementInstanceKey < 0) {
+      return DocumentValue.EMPTY_DOCUMENT;
+    }
+    if (fetchAll) {
+      // No name filter — the worker wants everything; secret namespace is never persisted as a
+      // process variable, so we don't need to merge anything else here.
+      return variableState.getVariablesAsDocument(elementInstanceKey);
+    }
+    if (partitioned.regularVariables().isEmpty()) {
+      // Worker asked exclusively for secrets — skip the state read entirely.
+      return DocumentValue.EMPTY_DOCUMENT;
+    }
+    return variableState.getVariablesAsDocument(elementInstanceKey, partitioned.regularVariables());
+  }
+
+  private static DirectBuffer mergeSecrets(
+      final DirectBuffer document, final Map<String, String> secrets) {
+    if (secrets.isEmpty()) {
+      return document;
+    }
+    final Map<String, Object> merged = MsgPackConverter.convertToMap(document);
+    merged.putAll(secrets);
+    return BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(merged));
+  }
+
+  private PartitionedRequest partitionRequested(final Collection<DirectBuffer> requestedVariables) {
+    final Map<String, String> resolvedSecrets = new HashMap<>();
+    final List<DirectBuffer> regularVariables = new ArrayList<>(requestedVariables.size());
+    for (final DirectBuffer name : requestedVariables) {
+      final String nameStr = BufferUtil.bufferAsString(name);
+      if (nameStr.startsWith(SecretStore.FEEL_NAMESPACE)) {
+        final String secretName = nameStr.substring(SecretStore.FEEL_NAMESPACE.length());
+        final Optional<String> resolved = secretStore.resolve(secretName);
+        if (resolved.isEmpty()) {
+          return PartitionedRequest.miss(nameStr);
+        }
+        resolvedSecrets.put(nameStr, resolved.get());
+      } else {
+        regularVariables.add(name);
+      }
+    }
+    return new PartitionedRequest(regularVariables, resolvedSecrets, null);
   }
 
   private Map<String, Object> getTaskVariables(
@@ -84,5 +152,19 @@ public class JobVariablesCollector {
     return taskVariablesMap.entrySet().stream()
         .filter(e -> requestedVariables.contains(BufferUtil.wrapString(e.getKey())))
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  /**
+   * Result of splitting the worker's {@code fetchVariables} list into regular variables and
+   * resolved secret references. If {@link #missingSecret} is non-null, resolution short-circuited
+   * on that reference and the other fields are not meaningful.
+   */
+  private record PartitionedRequest(
+      List<DirectBuffer> regularVariables,
+      Map<String, String> resolvedSecrets,
+      String missingSecret) {
+    static PartitionedRequest miss(final String missingSecret) {
+      return new PartitionedRequest(List.of(), Map.of(), missingSecret);
+    }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/secret/EnvVarSecretStore.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/secret/EnvVarSecretStore.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.secret;
+
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.regex.Pattern;
+
+/**
+ * {@link SecretStore} backed by process environment variables.
+ *
+ * <p>The bare secret name is used as the environment variable name verbatim (no prefix). For
+ * safety, only identifier-shaped names (matching {@link #VALID_NAME}) are looked up; any other name
+ * resolves to {@link Optional#empty()} to avoid shell or path injection via the FEEL expression
+ * text.
+ */
+public final class EnvVarSecretStore implements SecretStore {
+
+  /** Identifier-style names only — same shape as POSIX-portable env var names. */
+  public static final Pattern VALID_NAME = Pattern.compile("[A-Za-z_][A-Za-z0-9_]*");
+
+  private final Function<String, String> lookup;
+
+  public EnvVarSecretStore() {
+    this(System::getenv);
+  }
+
+  /** Visible for testing — allows injecting an in-memory env-var source. */
+  EnvVarSecretStore(final Function<String, String> lookup) {
+    this.lookup = lookup;
+  }
+
+  @Override
+  public Optional<String> resolve(final String secretName) {
+    if (secretName == null || !VALID_NAME.matcher(secretName).matches()) {
+      return Optional.empty();
+    }
+    return Optional.ofNullable(lookup.apply(secretName));
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/secret/SecretMasker.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/secret/SecretMasker.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.secret;
+
+import io.camunda.zeebe.msgpack.spec.MsgPackWriter;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.Map;
+import org.agrona.DirectBuffer;
+import org.agrona.ExpandableArrayBuffer;
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+
+/**
+ * Redacts resolved secret values before they reach the durable logstream or any exporter. Used by
+ * the job-activation and FEEL-evaluation processors to write a masked copy of the event record
+ * alongside the real-valued response, so the worker (or HTTP caller) sees the underlying secret
+ * while the on-disk record carries only {@link #MASKED_VALUE}.
+ */
+public final class SecretMasker {
+
+  /** The string written in place of any masked secret value. */
+  public static final String MASKED_VALUE = "***";
+
+  private SecretMasker() {}
+
+  /**
+   * Returns a fresh MessagePack-encoded variables document in which every top-level entry whose key
+   * starts with {@link SecretStore#FEEL_NAMESPACE} has had its value replaced by {@link
+   * #MASKED_VALUE}. Buffers with no such entries are returned unchanged. The returned buffer is
+   * always a fresh allocation when masking occurred — safe to retain across processor calls.
+   */
+  public static DirectBuffer maskSecretsInDocument(final DirectBuffer document) {
+    if (document == null || document.capacity() == 0) {
+      return document;
+    }
+    final Map<String, Object> map = MsgPackConverter.convertToMap(document);
+    boolean changed = false;
+    for (final var entry : map.entrySet()) {
+      if (entry.getKey().startsWith(SecretStore.FEEL_NAMESPACE)) {
+        entry.setValue(MASKED_VALUE);
+        changed = true;
+      }
+    }
+    if (!changed) {
+      return document;
+    }
+    return BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(map));
+  }
+
+  /**
+   * Returns true if {@code expression} could resolve to a secret value at the standalone FEEL
+   * evaluation endpoint, meaning the persisted {@code resultValue} should be masked before it
+   * reaches the logstream. Uses a substring check on the namespace prefix rather than a real FEEL
+   * parse — cheaper, and any false positive simply masks a value that would have been a harmless
+   * reference string anyway.
+   */
+  public static boolean expressionReferencesSecret(final String expression) {
+    return expression != null && expression.contains(SecretStore.FEEL_NAMESPACE);
+  }
+
+  /**
+   * Returns a freshly-encoded MessagePack string buffer holding {@link #MASKED_VALUE}. Used by the
+   * FEEL evaluation processor to stamp over a {@code resultValue} that originated from a
+   * secret-resolving evaluation before the persistence path serializes it.
+   */
+  public static DirectBuffer maskedAsMsgPackString() {
+    final MsgPackWriter writer = new MsgPackWriter();
+    final MutableDirectBuffer writeBuffer = new ExpandableArrayBuffer();
+    writer.wrap(writeBuffer, 0);
+
+    final DirectBuffer stringWrapper = new UnsafeBuffer();
+    stringWrapper.wrap(MASKED_VALUE.getBytes());
+    writer.writeString(stringWrapper);
+
+    final DirectBuffer resultView = new UnsafeBuffer();
+    resultView.wrap(writeBuffer, 0, writer.getOffset());
+    return resultView;
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/secret/SecretStore.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/secret/SecretStore.java
@@ -26,10 +26,20 @@ import java.util.Optional;
 public interface SecretStore {
 
   /**
+   * FEEL namespace prefix for secret references, including the trailing dot.
+   *
+   * <p>A FEEL path expression {@code camunda.secret.X} is rendered as the literal string {@code
+   * "camunda.secret.X"} whenever it is evaluated outside the two materializing paths (job
+   * activation {@code fetchVariables} and the standalone FEEL evaluation endpoint). The export
+   * masker (later stage) recognises the same prefix to redact reference substrings on the way out.
+   */
+  String FEEL_NAMESPACE = "camunda.secret.";
+
+  /**
    * Returns the secret value for {@code secretName}, or {@link Optional#empty()} if no secret by
    * that name is defined.
    *
-   * @param secretName the bare secret name (the suffix after {@code camunda.secret.}); never {@code
+   * @param secretName the bare secret name (the suffix after {@link #FEEL_NAMESPACE}); never {@code
    *     null}
    */
   Optional<String> resolve(String secretName);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/secret/SecretStore.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/secret/SecretStore.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.secret;
+
+import java.util.Optional;
+
+/**
+ * SPI for resolving secret values referenced via the {@code camunda.secret.*} FEEL namespace.
+ *
+ * <p>The PoC ships a single implementation ({@link EnvVarSecretStore}) backed by process
+ * environment variables. Implementations must be safe to call synchronously from the engine
+ * processing thread — i.e. fast, non-blocking, and free of I/O that could stall stream processing.
+ *
+ * <p>Resolved values are kept in memory only and never written to the variable store. The {@code
+ * camunda.secret.*} namespace is intentionally inert in normal FEEL evaluation (input mappings,
+ * output mappings, gateway conditions, …): in those contexts a path lookup yields the literal
+ * reference string, not the secret value. The store is consulted only when a job worker lists a
+ * {@code camunda.secret.X} entry in {@code fetchVariables} or when the standalone FEEL evaluation
+ * endpoint is invoked with such a reference.
+ */
+public interface SecretStore {
+
+  /**
+   * Returns the secret value for {@code secretName}, or {@link Optional#empty()} if no secret by
+   * that name is defined.
+   *
+   * @param secretName the bare secret name (the suffix after {@code camunda.secret.}); never {@code
+   *     null}
+   */
+  Optional<String> resolve(String secretName);
+
+  /** A {@link SecretStore} that resolves nothing — useful for tests and for the disabled state. */
+  SecretStore EMPTY = name -> Optional.empty();
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/IncidentCreatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/IncidentCreatedApplier.java
@@ -29,10 +29,25 @@ final class IncidentCreatedApplier implements TypedEventApplier<IncidentIntent, 
   public void applyState(final long incidentKey, final IncidentRecord value) {
     incidentState.createIncident(incidentKey, value);
 
-    if (ErrorType.MESSAGE_SIZE_EXCEEDED == value.getErrorType() && value.getJobKey() != -1) {
+    if (isJobBlockingIncident(value)) {
       final var jobKey = value.getJobKey();
       final var jobRecord = jobState.getJob(jobKey);
       jobState.disable(jobKey, jobRecord);
     }
+  }
+
+  /**
+   * Returns true if the incident must take its target job out of the activatable pool. Currently
+   * applies to two batch-activation failures that cannot be resolved by worker retry: the job
+   * payload is too large to ship, or a referenced {@code camunda.secret.X} cannot be resolved by
+   * the secret store. Without disabling, the next activation request would re-enter the same
+   * failure path and raise duplicate incidents.
+   */
+  private static boolean isJobBlockingIncident(final IncidentRecord value) {
+    if (value.getJobKey() == -1) {
+      return false;
+    }
+    final var errorType = value.getErrorType();
+    return errorType == ErrorType.MESSAGE_SIZE_EXCEEDED || errorType == ErrorType.SECRET_NOT_FOUND;
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/perf/TestEngine.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/perf/TestEngine.java
@@ -12,6 +12,7 @@ import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.zeebe.engine.processing.EngineProcessors;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
+import io.camunda.zeebe.engine.processing.secret.SecretStore;
 import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer;
 import io.camunda.zeebe.engine.state.DefaultZeebeDbFactory;
 import io.camunda.zeebe.engine.util.ProcessingExporterTransistor;
@@ -89,7 +90,8 @@ public final class TestEngine {
                             featureFlags,
                             JobStreamer.noop(),
                             SearchClientsProxy.noop(),
-                            new BrokerRequestAuthorizationConverter(new SecurityConfiguration()))
+                            new BrokerRequestAuthorizationConverter(new SecurityConfiguration()),
+                            SecretStore.EMPTY)
                         .withListener(
                             new ProcessingExporterTransistor(
                                 testStreams.getLogStream(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/ResolveFeelExpressionWithSecretTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/ResolveFeelExpressionWithSecretTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.expression;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.processing.secret.SecretStore;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.intent.ExpressionIntent;
+import io.camunda.zeebe.protocol.record.intent.VariableIntent;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Standalone FEEL evaluation endpoint behaviour for {@code camunda.secret.*} references.
+ * Materialises the underlying secret value from the configured {@link SecretStore} on this path
+ * only — every other engine-side FEEL evaluation continues to see literal reference strings.
+ */
+public class ResolveFeelExpressionWithSecretTest {
+
+  private static final Map<String, String> SECRETS =
+      Map.of(
+          "SLACK_BOT_TOKEN", "xoxb-real-token",
+          "STRIPE_API_KEY", "sk_test_real");
+
+  // In-memory SecretStore for the test JVM. Bound to a class-level constant so the EngineRule
+  // sees a deterministic backend regardless of which env vars happen to be set on the host.
+  private static final SecretStore TEST_STORE = name -> Optional.ofNullable(SECRETS.get(name));
+
+  @ClassRule
+  public static final EngineRule ENGINE = EngineRule.singlePartition().withSecretStore(TEST_STORE);
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldResolveSecretToRealValue() {
+    // when
+    final var record =
+        ENGINE.expression().withExpression("=camunda.secret.SLACK_BOT_TOKEN").resolve();
+
+    // then — the synchronous endpoint response carries the underlying secret value, not the
+    // literal reference string that the engine-wide context would produce.
+    Assertions.assertThat(record)
+        .hasIntent(ExpressionIntent.EVALUATED)
+        .hasRecordType(RecordType.EVENT);
+    assertThat(record.getValue().getResultValue()).isEqualTo("xoxb-real-token");
+  }
+
+  @Test
+  public void shouldResolveCompoundExpressionWithSecret() {
+    // when — the canonical "Bearer <secret>" connector idiom evaluated at the endpoint
+    final var record =
+        ENGINE
+            .expression()
+            .withExpression("=\"Bearer \" + camunda.secret.STRIPE_API_KEY")
+            .resolve();
+
+    // then — concatenation runs against the resolved value, not the reference string
+    Assertions.assertThat(record)
+        .hasIntent(ExpressionIntent.EVALUATED)
+        .hasRecordType(RecordType.EVENT);
+    assertThat(record.getValue().getResultValue()).isEqualTo("Bearer sk_test_real");
+  }
+
+  @Test
+  public void shouldReturnNullForMissingSecret() {
+    // when
+    final var record =
+        ENGINE.expression().withExpression("=camunda.secret.DOES_NOT_EXIST").resolve();
+
+    // then — undefined path resolves to FEEL null with a warning surfaced on the record, matching
+    // how cluster-variable misses are reported by the same endpoint
+    Assertions.assertThat(record)
+        .hasIntent(ExpressionIntent.EVALUATED)
+        .hasRecordType(RecordType.EVENT);
+    assertThat(record.getValue().getResultValue()).isNull();
+    assertThat(record.getValue().getWarnings()).isNotEmpty();
+  }
+
+  @Test
+  public void shouldNotMaterializeSecretInsideEngineEvenWhenStoreIsConfigured() {
+    // given — same secret store as the endpoint, but evaluation runs through an input mapping
+    // (engine-wide FEEL path), which must keep using the literal-reference context.
+    final var process =
+        Bpmn.createExecutableProcess("PROCESS_ENGINE_BOUNDARY")
+            .startEvent()
+            .serviceTask(
+                "TASK",
+                t ->
+                    t.zeebeJobType("noop")
+                        .zeebeInputExpression("camunda.secret.SLACK_BOT_TOKEN", "token"))
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final var processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId("PROCESS_ENGINE_BOUNDARY").create();
+
+    // then — the variable still carries the harmless reference string; the resolving context
+    // configured for the endpoint never bleeds into the variable-store path.
+    final var tokenVar =
+        RecordingExporter.variableRecords(VariableIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withName("token")
+            .getFirst();
+
+    assertThat(tokenVar.getValue().getValue()).isEqualTo("\"camunda.secret.SLACK_BOT_TOKEN\"");
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/ResolveFeelExpressionWithSecretTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/ResolveFeelExpressionWithSecretTest.java
@@ -48,21 +48,28 @@ public class ResolveFeelExpressionWithSecretTest {
       new RecordingExporterTestWatcher();
 
   @Test
-  public void shouldResolveSecretToRealValue() {
+  public void shouldMaskResolvedSecretValueOnPersistedEvent() {
     // when
     final var record =
         ENGINE.expression().withExpression("=camunda.secret.SLACK_BOT_TOKEN").resolve();
 
-    // then — the synchronous endpoint response carries the underlying secret value, not the
-    // literal reference string that the engine-wide context would produce.
+    // then — the persisted EVALUATED event (which is what exporters see) carries the masked
+    // sentinel rather than the real secret value. The HTTP response received by the caller is
+    // written from a separate copy of the record before masking — we verify the on-disk
+    // behaviour here because that's what's observable via the recording exporter; the
+    // response-side real-value flow is exercised by the integration tests at the gateway
+    // layer.
     Assertions.assertThat(record)
         .hasIntent(ExpressionIntent.EVALUATED)
         .hasRecordType(RecordType.EVENT);
-    assertThat(record.getValue().getResultValue()).isEqualTo("xoxb-real-token");
+    assertThat(record.getValue().getResultValue()).isEqualTo("***");
+    // Warnings stay empty — proving the resolution actually succeeded against the store, and
+    // the masked value is the post-resolution sentinel, not a "not found" symptom.
+    assertThat(record.getValue().getWarnings()).isEmpty();
   }
 
   @Test
-  public void shouldResolveCompoundExpressionWithSecret() {
+  public void shouldMaskCompoundExpressionResultOnPersistedEvent() {
     // when — the canonical "Bearer <secret>" connector idiom evaluated at the endpoint
     final var record =
         ENGINE
@@ -70,11 +77,14 @@ public class ResolveFeelExpressionWithSecretTest {
             .withExpression("=\"Bearer \" + camunda.secret.STRIPE_API_KEY")
             .resolve();
 
-    // then — concatenation runs against the resolved value, not the reference string
+    // then — even though the response sees "Bearer sk_test_real", the on-disk event carries
+    // the masked sentinel. The full result is replaced, not just the secret slot, since the
+    // PoC mask is the whole resultValue when the expression touches the namespace.
     Assertions.assertThat(record)
         .hasIntent(ExpressionIntent.EVALUATED)
         .hasRecordType(RecordType.EVENT);
-    assertThat(record.getValue().getResultValue()).isEqualTo("Bearer sk_test_real");
+    assertThat(record.getValue().getResultValue()).isEqualTo("***");
+    assertThat(record.getValue().getWarnings()).isEmpty();
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/SecretEvaluationContextTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/SecretEvaluationContextTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.expression;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import org.junit.jupiter.api.Test;
+
+final class SecretEvaluationContextTest {
+
+  private final SecretEvaluationContext context = new SecretEvaluationContext();
+
+  @Test
+  void shouldReturnLiteralReferenceForKnownSecretName() {
+    // when
+    final var result = context.getVariable("MY_SECRET");
+
+    // then — the leaf lookup is a terminal value (Left), and it carries the namespace-prefixed
+    // reference string instead of the real secret.
+    assertThat(result.isLeft()).isTrue();
+    assertThat(MsgPackConverter.convertToJson(result.getLeft()))
+        .isEqualTo("\"camunda.secret.MY_SECRET\"");
+  }
+
+  @Test
+  void shouldRoundTripAnyIdentifierStyleName() {
+    final var snake = context.getVariable("snake_case_value");
+    final var leading = context.getVariable("_LEADING");
+    final var mixed = context.getVariable("MixedCase42");
+
+    assertThat(MsgPackConverter.convertToJson(snake.getLeft()))
+        .isEqualTo("\"camunda.secret.snake_case_value\"");
+    assertThat(MsgPackConverter.convertToJson(leading.getLeft()))
+        .isEqualTo("\"camunda.secret._LEADING\"");
+    assertThat(MsgPackConverter.convertToJson(mixed.getLeft()))
+        .isEqualTo("\"camunda.secret.MixedCase42\"");
+  }
+
+  @Test
+  void shouldReturnLeftNullForEmptyName() {
+    // FEEL never asks with an empty segment, but defend against it anyway — Left(null) means
+    // "no value at this name" per the EvaluationContext contract.
+    final var result = context.getVariable("");
+
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isNull();
+  }
+
+  @Test
+  void shouldReturnLeftNullForNullName() {
+    final var result = context.getVariable(null);
+
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isNull();
+  }
+
+  @Test
+  void shouldBeProcessScopeAgnostic() {
+    // The literal-reference behavior is the same regardless of which process instance asks.
+    assertThat(context.processScoped(42L)).isSameAs(context);
+  }
+
+  @Test
+  void shouldBeTenantScopeAgnostic() {
+    assertThat(context.tenantScoped("tenant-a")).isSameAs(context);
+  }
+
+  @Test
+  void shouldNotMaterializeSecretValueEvenIfNameLooksLikeOne() {
+    // The context never consults a SecretStore. Even names that happen to match env vars in the
+    // test JVM resolve to their literal reference, not the underlying value.
+    final var anyEnvVarName = "PATH";
+
+    final var result = context.getVariable(anyEnvVarName);
+
+    assertThat(MsgPackConverter.convertToJson(result.getLeft()))
+        .isEqualTo("\"camunda.secret.PATH\"");
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/SecretFeelNamespaceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/SecretFeelNamespaceTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.expression;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.VariableIntent;
+import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * End-to-end coverage for the engine-wide {@code camunda.secret.*} FEEL namespace. The PoC's rule
+ * is that secret references evaluated outside the two materialising paths (job activation via
+ * {@code fetchVariables} and the standalone FEEL evaluation endpoint) yield the literal reference
+ * string instead of the underlying secret value. This guarantees real secrets never land in the
+ * variable store, regardless of how the BPMN author wires them.
+ */
+public class SecretFeelNamespaceTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Test
+  public void inputMappingShouldPersistLiteralReferenceString() {
+    // given — a service task whose input mapping binds a variable directly to a secret reference
+    final var process =
+        Bpmn.createExecutableProcess("PROCESS_SECRET_INPUT")
+            .startEvent()
+            .serviceTask(
+                "TASK",
+                t ->
+                    t.zeebeJobType("noop")
+                        .zeebeInputExpression("camunda.secret.SLACK_BOT_TOKEN", "token"))
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final var processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId("PROCESS_SECRET_INPUT").create();
+
+    // then — the persisted variable is the harmless reference string, not the real secret
+    final Record<VariableRecordValue> tokenVar =
+        RecordingExporter.variableRecords(VariableIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withName("token")
+            .getFirst();
+
+    assertThat(tokenVar.getValue().getValue()).isEqualTo("\"camunda.secret.SLACK_BOT_TOKEN\"");
+  }
+
+  @Test
+  public void compoundExpressionShouldKeepReferenceSubstringIntact() {
+    // given — a common connector idiom: build an Authorization header from a secret reference
+    final var process =
+        Bpmn.createExecutableProcess("PROCESS_SECRET_COMPOUND")
+            .startEvent()
+            .serviceTask(
+                "TASK",
+                t ->
+                    t.zeebeJobType("noop")
+                        .zeebeInputExpression(
+                            "\"Bearer \" + camunda.secret.STRIPE_API_KEY", "authHeader"))
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final var processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId("PROCESS_SECRET_COMPOUND").create();
+
+    // then — concatenation leaves the reference substring intact, ready for late substitution
+    // when the worker explicitly fetches the secret in a later stage.
+    final Record<VariableRecordValue> authVar =
+        RecordingExporter.variableRecords(VariableIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withName("authHeader")
+            .getFirst();
+
+    assertThat(authVar.getValue().getValue()).isEqualTo("\"Bearer camunda.secret.STRIPE_API_KEY\"");
+  }
+
+  @Test
+  public void jobTypeExpressionShouldResolveToReferenceNotSecretValue() {
+    // given — a defensive case: someone writes the job type as a secret reference. The worker
+    // must NOT see the real secret value as the job type (and the job-type field is exported).
+    final var process =
+        Bpmn.createExecutableProcess("PROCESS_SECRET_JOB_TYPE")
+            .startEvent()
+            .serviceTask("TASK", t -> t.zeebeJobTypeExpression("camunda.secret.SOME_NAME"))
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final var processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId("PROCESS_SECRET_JOB_TYPE").create();
+
+    // then
+    final var job =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst()
+            .getValue();
+
+    Assertions.assertThat(job).hasType("camunda.secret.SOME_NAME");
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivateJobsWithSecretsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivateJobsWithSecretsTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import io.camunda.zeebe.engine.processing.secret.SecretStore;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
+import io.camunda.zeebe.protocol.record.value.ErrorType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Job activation behaviour for the {@code camunda.secret.*} FEEL namespace. The broker resolves a
+ * secret value only when the worker explicitly lists the full reference name in {@code
+ * fetchVariables} — every other path keeps the literal reference string from the variable store.
+ */
+public class ActivateJobsWithSecretsTest {
+
+  private static final Map<String, String> SECRETS = Map.of("SLACK_BOT_TOKEN", "xoxb-real-token");
+
+  private static final SecretStore TEST_STORE = name -> Optional.ofNullable(SECRETS.get(name));
+
+  @ClassRule
+  public static final EngineRule ENGINE = EngineRule.singlePartition().withSecretStore(TEST_STORE);
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldMaterializeSecretWhenWorkerExplicitlyFetchesIt() {
+    // given — service task with no special configuration; the secret reference will be added
+    // by the worker's fetchVariables list, not by the BPMN model.
+    final String jobType = "secret-job-A";
+    final var process =
+        Bpmn.createExecutableProcess("PROCESS_FETCH_SECRET")
+            .startEvent()
+            .serviceTask("TASK", t -> t.zeebeJobType(jobType))
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+    ENGINE.processInstance().ofBpmnProcessId("PROCESS_FETCH_SECRET").create();
+
+    // when — worker pulls one job and asks for the secret by its full reference name
+    final var batch =
+        ENGINE
+            .jobs()
+            .withType(jobType)
+            .withFetchVariables("camunda.secret.SLACK_BOT_TOKEN")
+            .withMaxJobsToActivate(1)
+            .activate();
+
+    // then — the activation response carries the real secret value at the same key the worker
+    // asked for. The variable store itself was never touched.
+    assertThat(batch.getIntent()).isEqualTo(JobBatchIntent.ACTIVATED);
+    assertThat(batch.getValue().getJobs()).hasSize(1);
+    assertThat(batch.getValue().getJobs().getFirst().getVariables())
+        .containsExactly(entry("camunda.secret.SLACK_BOT_TOKEN", "xoxb-real-token"));
+  }
+
+  @Test
+  public void shouldNotMaterializeSecretsWhenWorkerDoesNotFetchThem() {
+    // given — an input mapping persists a reference string into the variable store. The worker
+    // does NOT list it in fetchVariables, so no resolution should happen.
+    final String jobType = "secret-job-B";
+    final var process =
+        Bpmn.createExecutableProcess("PROCESS_NO_FETCH")
+            .startEvent()
+            .serviceTask(
+                "TASK",
+                t ->
+                    t.zeebeJobType(jobType)
+                        .zeebeInputExpression("camunda.secret.SLACK_BOT_TOKEN", "token"))
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+    ENGINE.processInstance().ofBpmnProcessId("PROCESS_NO_FETCH").create();
+
+    // when — worker fetches the regular variable that holds the literal reference
+    final var batch =
+        ENGINE
+            .jobs()
+            .withType(jobType)
+            .withFetchVariables("token")
+            .withMaxJobsToActivate(1)
+            .activate();
+
+    // then — variable comes through as the literal reference string; no env-var lookup happened
+    assertThat(batch.getIntent()).isEqualTo(JobBatchIntent.ACTIVATED);
+    assertThat(batch.getValue().getJobs()).hasSize(1);
+    assertThat(batch.getValue().getJobs().getFirst().getVariables())
+        .containsExactly(entry("token", "camunda.secret.SLACK_BOT_TOKEN"));
+  }
+
+  @Test
+  public void shouldRaiseIncidentForMissingSecret() {
+    // given — two distinct task types so we can show that the missing-secret failure is
+    // per-job and does not block the rest of the batch.
+    final String missingType = "secret-job-missing";
+    final var process =
+        Bpmn.createExecutableProcess("PROCESS_MISSING_SECRET")
+            .startEvent()
+            .serviceTask("TASK", t -> t.zeebeJobType(missingType))
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+    final var processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId("PROCESS_MISSING_SECRET").create();
+
+    // when — worker requests a secret that is not in the test store
+    final var batch =
+        ENGINE
+            .jobs()
+            .withType(missingType)
+            .withFetchVariables("camunda.secret.DOES_NOT_EXIST")
+            .withMaxJobsToActivate(1)
+            .activate();
+
+    // then — the missing-secret job is not in the activation response, and an incident is
+    // raised against it with the SECRET_NOT_FOUND error type and the offending reference name in
+    // the message.
+    assertThat(batch.getValue().getJobs()).isEmpty();
+
+    final var incident =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst()
+            .getValue();
+
+    assertThat(incident.getErrorType()).isEqualTo(ErrorType.SECRET_NOT_FOUND);
+    assertThat(incident.getErrorMessage()).contains("camunda.secret.DOES_NOT_EXIST");
+    assertThat(incident.getJobKey()).isPositive();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivateJobsWithSecretsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivateJobsWithSecretsTest.java
@@ -43,7 +43,7 @@ public class ActivateJobsWithSecretsTest {
       new RecordingExporterTestWatcher();
 
   @Test
-  public void shouldMaterializeSecretWhenWorkerExplicitlyFetchesIt() {
+  public void shouldMaskResolvedSecretValueOnPersistedActivationEvent() {
     // given — service task with no special configuration; the secret reference will be added
     // by the worker's fetchVariables list, not by the BPMN model.
     final String jobType = "secret-job-A";
@@ -66,12 +66,14 @@ public class ActivateJobsWithSecretsTest {
             .withMaxJobsToActivate(1)
             .activate();
 
-    // then — the activation response carries the real secret value at the same key the worker
-    // asked for. The variable store itself was never touched.
+    // then — the persisted ACTIVATED event (what exporters see) carries the masked sentinel
+    // at the secret's reference key. The presence of the key itself proves the resolution ran
+    // — without it, fetchVariables would not have produced an entry. The unmasked value
+    // travels separately to the worker via the gateway response path.
     assertThat(batch.getIntent()).isEqualTo(JobBatchIntent.ACTIVATED);
     assertThat(batch.getValue().getJobs()).hasSize(1);
     assertThat(batch.getValue().getJobs().getFirst().getVariables())
-        .containsExactly(entry("camunda.secret.SLACK_BOT_TOKEN", "xoxb-real-token"));
+        .containsExactly(entry("camunda.secret.SLACK_BOT_TOKEN", "***"));
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
@@ -13,7 +13,8 @@ import io.camunda.security.configuration.SecurityConfigurations;
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.identity.AuthenticatedAuthorizedTenants;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
-import io.camunda.zeebe.engine.processing.job.JobBatchCollector.TooLargeJob;
+import io.camunda.zeebe.engine.processing.job.JobBatchCollector.CollectionResult;
+import io.camunda.zeebe.engine.processing.secret.SecretStore;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.MockTypedRecord;
 import io.camunda.zeebe.engine.util.ProcessingStateExtension;
@@ -34,8 +35,6 @@ import io.camunda.zeebe.stream.api.StreamClock.ControllableStreamClock;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.impl.ControllableStreamClockImpl;
 import io.camunda.zeebe.test.util.MsgPackUtil;
-import io.camunda.zeebe.test.util.asserts.EitherAssert;
-import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.time.Duration;
 import java.time.Instant;
@@ -72,7 +71,9 @@ final class JobBatchCollectorTest {
             state,
             SecurityConfigurations.unauthenticatedAndUnauthorized(),
             new EngineConfiguration());
-    collector = new JobBatchCollector(state, lengthEvaluator, authorizationCheckBehavior, clock);
+    collector =
+        new JobBatchCollector(
+            state, lengthEvaluator, authorizationCheckBehavior, clock, SecretStore.EMPTY);
   }
 
   @Test
@@ -85,15 +86,16 @@ final class JobBatchCollectorTest {
 
     // when - set up the evaluator to only accept the first job
     lengthEvaluator.canWriteEventOfLength = (length) -> toggle.getAndSet(false);
-    final Either<TooLargeJob, Map<JobKind, Integer>> result =
+    final CollectionResult result =
         collector.collectJobs(record, List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER));
 
     // then
     final JobBatchRecord batchRecord = record.getValue();
-    EitherAssert.assertThat(result)
+    assertThat(result.activatedJobCountPerJobKind())
         .as("should have activated only one job successfully")
-        .right()
         .isEqualTo(Map.of(JobKind.BPMN_ELEMENT, 1));
+    assertThat(result.tooLargeJob()).isNull();
+    assertThat(result.secretFailures()).isEmpty();
     JobBatchRecordValueAssert.assertThat(batchRecord)
         .hasOnlyJobKeys(jobs.getFirst().key)
         .isTruncated();
@@ -108,15 +110,17 @@ final class JobBatchCollectorTest {
 
     // when - set up the evaluator to accept no jobs
     lengthEvaluator.canWriteEventOfLength = (length) -> false;
-    final Either<TooLargeJob, Map<JobKind, Integer>> result =
+    final CollectionResult result =
         collector.collectJobs(record, List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER));
 
     // then
     final JobBatchRecord batchRecord = record.getValue();
-    EitherAssert.assertThat(result)
+    assertThat(result.tooLargeJob())
         .as("should return excessively large job")
-        .left()
+        .isNotNull()
         .hasFieldOrPropertyWithValue("key", jobs.getFirst().key);
+    assertThat(result.activatedJobCountPerJobKind()).isEmpty();
+    assertThat(result.secretFailures()).isEmpty();
     JobBatchRecordValueAssert.assertThat(batchRecord).hasNoJobKeys().hasNoJobs().isTruncated();
   }
 
@@ -171,15 +175,16 @@ final class JobBatchCollectorTest {
     record.getValue().setMaxJobsToActivate(1);
 
     // when
-    final Either<TooLargeJob, Map<JobKind, Integer>> result =
+    final CollectionResult result =
         collector.collectJobs(record, List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER));
 
     // then
     final JobBatchRecord batchRecord = record.getValue();
-    EitherAssert.assertThat(result)
+    assertThat(result.activatedJobCountPerJobKind())
         .as("should collect only the first job")
-        .right()
         .isEqualTo(Map.of(JobKind.BPMN_ELEMENT, 1));
+    assertThat(result.tooLargeJob()).isNull();
+    assertThat(result.secretFailures()).isEmpty();
     JobBatchRecordValueAssert.assertThat(batchRecord)
         .hasJobKeys(jobs.getFirst().key)
         .isNotTruncated();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secret/EnvVarSecretStoreTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secret/EnvVarSecretStoreTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.secret;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+final class EnvVarSecretStoreTest {
+
+  private static EnvVarSecretStore storeBackedBy(final Map<String, String> env) {
+    return new EnvVarSecretStore(env::get);
+  }
+
+  @Test
+  void shouldResolveDefinedSecret() {
+    // given
+    final var store = storeBackedBy(Map.of("SLACK_BOT_TOKEN", "xoxb-secret"));
+
+    // when
+    final Optional<String> resolved = store.resolve("SLACK_BOT_TOKEN");
+
+    // then
+    assertThat(resolved).contains("xoxb-secret");
+  }
+
+  @Test
+  void shouldReturnEmptyForUndefinedSecret() {
+    // given
+    final var store = storeBackedBy(Map.of());
+
+    // when / then
+    assertThat(store.resolve("MISSING")).isEmpty();
+  }
+
+  @Test
+  void shouldReturnEmptyForNullName() {
+    final var store = storeBackedBy(Map.of("X", "v"));
+
+    assertThat(store.resolve(null)).isEmpty();
+  }
+
+  @Test
+  void shouldRejectNamesWithIllegalCharacters() {
+    // given — the underlying map would happily return values for these names; the store guards.
+    final var store =
+        storeBackedBy(
+            Map.of(
+                "with.dot", "v1",
+                "with/slash", "v2",
+                "with space", "v3",
+                "with$dollar", "v4",
+                "", "v5"));
+
+    // when / then — any non-identifier-shaped name resolves to empty, never the env value
+    assertThat(store.resolve("with.dot")).isEmpty();
+    assertThat(store.resolve("with/slash")).isEmpty();
+    assertThat(store.resolve("with space")).isEmpty();
+    assertThat(store.resolve("with$dollar")).isEmpty();
+    assertThat(store.resolve("")).isEmpty();
+  }
+
+  @Test
+  void shouldAcceptIdentifierShapedNames() {
+    // given
+    final var store =
+        storeBackedBy(
+            Map.of(
+                "A", "a",
+                "_LEADING_UNDERSCORE", "b",
+                "snake_case_123", "c",
+                "MixedCase42", "d"));
+
+    // when / then
+    assertThat(store.resolve("A")).contains("a");
+    assertThat(store.resolve("_LEADING_UNDERSCORE")).contains("b");
+    assertThat(store.resolve("snake_case_123")).contains("c");
+    assertThat(store.resolve("MixedCase42")).contains("d");
+  }
+
+  @Test
+  void shouldRejectNamesStartingWithDigit() {
+    final var store = storeBackedBy(Map.of("1FOO", "v"));
+
+    assertThat(store.resolve("1FOO")).isEmpty();
+  }
+
+  @Test
+  void emptyStoreShouldResolveNothing() {
+    assertThat(SecretStore.EMPTY.resolve("ANY")).isEmpty();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secret/SecretMaskerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secret/SecretMaskerTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.secret;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+
+final class SecretMaskerTest {
+
+  @Test
+  void shouldReplaceTopLevelSecretValuesWithMaskedSentinel() {
+    // given — a msgpack document mixing a regular variable and a resolved secret entry, the
+    // shape JobVariablesCollector produces when a worker fetches a secret.
+    final var doc = encode(Map.of("name", "alice", "camunda.secret.SLACK_BOT_TOKEN", "xoxb-real"));
+
+    // when
+    final var masked = SecretMasker.maskSecretsInDocument(doc);
+
+    // then — the secret-keyed value is replaced; the unrelated variable is untouched.
+    final var decoded = MsgPackConverter.convertToMap(masked);
+    assertThat(decoded).containsEntry("name", "alice");
+    assertThat(decoded).containsEntry("camunda.secret.SLACK_BOT_TOKEN", "***");
+  }
+
+  @Test
+  void shouldMaskMultipleSecretsInOneDocument() {
+    final var doc =
+        encode(
+            new LinkedHashMap<String, Object>() {
+              {
+                put("camunda.secret.A", "a-value");
+                put("camunda.secret.B", "b-value");
+                put("other", "unchanged");
+              }
+            });
+
+    final var masked = SecretMasker.maskSecretsInDocument(doc);
+
+    final var decoded = MsgPackConverter.convertToMap(masked);
+    assertThat(decoded)
+        .containsEntry("camunda.secret.A", "***")
+        .containsEntry("camunda.secret.B", "***")
+        .containsEntry("other", "unchanged");
+  }
+
+  @Test
+  void shouldReturnSameBufferWhenNoSecretKeysPresent() {
+    // given — the common case: a regular variable document with no resolved secret entries.
+    final var doc = encode(Map.of("name", "alice", "amount", 42));
+
+    // when
+    final var masked = SecretMasker.maskSecretsInDocument(doc);
+
+    // then — masker short-circuits and returns the original buffer reference, avoiding the
+    // msgpack round-trip on every activation.
+    assertThat(masked).isSameAs(doc);
+  }
+
+  @Test
+  void shouldOnlyMatchExactNamespacePrefix() {
+    // given — keys whose names happen to contain "camunda.secret." but don't START with it,
+    // and a key that has the prefix but no suffix. The matcher must use startsWith, not
+    // contains, to avoid false positives.
+    final var doc =
+        encode(Map.of("about-camunda.secret.token", "value", "camunda.secret.X", "real"));
+
+    final var masked = SecretMasker.maskSecretsInDocument(doc);
+
+    final var decoded = MsgPackConverter.convertToMap(masked);
+    assertThat(decoded)
+        .containsEntry("about-camunda.secret.token", "value")
+        .containsEntry("camunda.secret.X", "***");
+  }
+
+  @Test
+  void shouldReturnInputWhenDocumentIsNullOrEmpty() {
+    assertThat(SecretMasker.maskSecretsInDocument(null)).isNull();
+    assertThat(SecretMasker.maskSecretsInDocument(new UnsafeBuffer()))
+        .matches(b -> b.capacity() == 0);
+  }
+
+  @Test
+  void shouldRecogniseSecretReferenceInExpressionText() {
+    assertThat(SecretMasker.expressionReferencesSecret("=camunda.secret.FOO")).isTrue();
+    assertThat(SecretMasker.expressionReferencesSecret("=\"Bearer \" + camunda.secret.FOO"))
+        .isTrue();
+    assertThat(SecretMasker.expressionReferencesSecret("=42")).isFalse();
+    assertThat(SecretMasker.expressionReferencesSecret("camunda.vars.cluster.KEY")).isFalse();
+    assertThat(SecretMasker.expressionReferencesSecret(null)).isFalse();
+  }
+
+  @Test
+  void maskedStringBufferDecodesToMaskedValue() {
+    final var buf = SecretMasker.maskedAsMsgPackString();
+    assertThat(MsgPackConverter.convertToJson(buf)).isEqualTo("\"***\"");
+  }
+
+  private static org.agrona.DirectBuffer encode(final Map<String, ?> map) {
+    return new UnsafeBuffer(MsgPackConverter.convertToMsgPack(map));
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secret/SecretsEndToEndScenarioTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secret/SecretsEndToEndScenarioTest.java
@@ -1,0 +1,285 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.secret;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.intent.ExpressionIntent;
+import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
+import io.camunda.zeebe.protocol.record.intent.VariableIntent;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * End-to-end scenarios for the {@code camunda.secret.*} PoC, mirroring real-world connector idioms.
+ * Each test composes multiple stages (mapping, activation, masking) to prove the five pieces of the
+ * feature behave correctly together, not just in isolation.
+ *
+ * <p>Run alongside the per-stage tests; failures here indicate composition problems even when the
+ * unit-level coverage is green.
+ */
+public class SecretsEndToEndScenarioTest {
+
+  /**
+   * Realistic secret store contents — values are intentionally distinctive so the {@link
+   * #auditExportsCarryNoRealSecretValues} sweep can grep records for them and fail loudly if any
+   * exporter would see them.
+   */
+  private static final String SLACK_TOKEN_VALUE = "xoxb-REAL-SLACK-TOKEN-do-not-leak";
+
+  private static final String STRIPE_KEY_VALUE = "sk_test_REAL-STRIPE-KEY-do-not-leak";
+  private static final String HMAC_SECRET_VALUE = "REAL-HMAC-SECRET-do-not-leak";
+
+  private static final Map<String, String> SECRETS =
+      Map.of(
+          "SLACK_BOT_TOKEN", SLACK_TOKEN_VALUE,
+          "STRIPE_API_KEY", STRIPE_KEY_VALUE,
+          "SLACK_SIGNING_SECRET", HMAC_SECRET_VALUE);
+
+  private static final SecretStore TEST_STORE = name -> Optional.ofNullable(SECRETS.get(name));
+
+  @ClassRule
+  public static final EngineRule ENGINE = EngineRule.singlePartition().withSecretStore(TEST_STORE);
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  // ----- Scenario 1: Slack outbound connector ------------------------------------------------
+
+  @Test
+  public void slackOutboundConnectorPattern() {
+    // Models the BPMN shape from the spec discussion: an input mapping that binds the secret
+    // reference to a `token` variable, plus a worker that lists both the regular variable and
+    // the secret reference itself in fetchVariables. This is what a real connector outbound
+    // worker does — it reads the connector-shaped variable plus the explicit secret.
+    final String jobType = "io.camunda:slack-outbound";
+    final var process =
+        Bpmn.createExecutableProcess("SLACK_OUTBOUND")
+            .startEvent()
+            .serviceTask(
+                "POST_MESSAGE",
+                t ->
+                    t.zeebeJobType(jobType)
+                        .zeebeInputExpression("camunda.secret.SLACK_BOT_TOKEN", "token"))
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+    final var processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId("SLACK_OUTBOUND").create();
+
+    // Worker pulls the job, fetching the local `token` variable (will be the literal reference)
+    // AND the secret reference name (will be resolved at activation time).
+    final var batch =
+        ENGINE
+            .jobs()
+            .withType(jobType)
+            .withFetchVariables("token", "camunda.secret.SLACK_BOT_TOKEN")
+            .withMaxJobsToActivate(1)
+            .activate();
+
+    // The persisted ACTIVATED event masks the resolved secret value but keeps the regular
+    // variable that holds the literal reference exactly as the input mapping persisted it.
+    assertThat(batch.getIntent()).isEqualTo(JobBatchIntent.ACTIVATED);
+    final var activatedJobVars = batch.getValue().getJobs().getFirst().getVariables();
+    assertThat(activatedJobVars)
+        .containsEntry("token", "camunda.secret.SLACK_BOT_TOKEN")
+        .containsEntry("camunda.secret.SLACK_BOT_TOKEN", SecretMasker.MASKED_VALUE);
+
+    // The variable store side: the only persisted variable is `token`, holding the harmless
+    // reference string. The secret namespace never enters the variable store — confirmed by
+    // checking that no VariableRecord exists for the secret key.
+    final var tokenVariable =
+        RecordingExporter.variableRecords(VariableIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withName("token")
+            .getFirst()
+            .getValue();
+    assertThat(tokenVariable.getValue()).isEqualTo("\"camunda.secret.SLACK_BOT_TOKEN\"");
+
+    // The secret namespace never reaches the variable store as a variable name. We don't
+    // sweep with a blocking limit here — the implicit guarantee is that only the input
+    // mapping writes variables on this path, and that mapping target is `token`. The audit
+    // sweep test below catches any composition surprise across the full record set.
+  }
+
+  // ----- Scenario 2: Stripe-style compound auth header ---------------------------------------
+
+  @Test
+  public void stripeCompoundAuthHeaderPattern() {
+    // The connector author concatenates a literal prefix with the secret reference. Per stage 2,
+    // the concatenation runs in the literal-reference context, so the persisted variable is the
+    // harmless "Bearer camunda.secret.STRIPE_API_KEY" string. The worker is expected to fetch the
+    // raw secret separately and assemble the real auth header on its own side.
+    final String jobType = "io.camunda:stripe-charge";
+    final var process =
+        Bpmn.createExecutableProcess("STRIPE_COMPOUND")
+            .startEvent()
+            .serviceTask(
+                "CHARGE",
+                t ->
+                    t.zeebeJobType(jobType)
+                        .zeebeInputExpression(
+                            "\"Bearer \" + camunda.secret.STRIPE_API_KEY", "authHeader")
+                        .zeebeInputExpression("orderAmount", "amount"))
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+    final var processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId("STRIPE_COMPOUND")
+            .withVariable("orderAmount", 4200)
+            .create();
+
+    final var batch =
+        ENGINE
+            .jobs()
+            .withType(jobType)
+            .withFetchVariables("authHeader", "amount", "camunda.secret.STRIPE_API_KEY")
+            .withMaxJobsToActivate(1)
+            .activate();
+
+    final var vars = batch.getValue().getJobs().getFirst().getVariables();
+    assertThat(vars)
+        .contains(
+            entry("authHeader", "Bearer camunda.secret.STRIPE_API_KEY"),
+            entry("camunda.secret.STRIPE_API_KEY", SecretMasker.MASKED_VALUE));
+    // amount comes through unchanged from the start variable; check the numeric value loosely
+    // since msgpack→Jackson decoding may surface it as int or long depending on size.
+    assertThat(vars).extractingByKey("amount").asString().isEqualTo("4200");
+
+    // The persisted variable store keeps the compound reference verbatim — no env-var lookup
+    // ever happened on this path.
+    final var authHeaderVar =
+        RecordingExporter.variableRecords(VariableIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withName("authHeader")
+            .getFirst()
+            .getValue();
+    assertThat(authHeaderVar.getValue()).isEqualTo("\"Bearer camunda.secret.STRIPE_API_KEY\"");
+  }
+
+  // ----- Scenario 3: FEEL endpoint analog for inbound HMAC verification ---------------------
+
+  @Test
+  public void inboundHmacResolutionViaFeelEndpoint() {
+    // The Slack inbound HMAC use case from the spec discussion lives in connector-runtime, but
+    // the path it uses to resolve secrets is the same standalone FEEL evaluation endpoint we
+    // expose from the broker. This test stands in for that flow: call the endpoint, get the
+    // real value out (the connector runtime would use it to verify the HMAC signature), and
+    // confirm the on-disk record has the masked sentinel so the audit story holds.
+    final var record =
+        ENGINE.expression().withExpression("=camunda.secret.SLACK_SIGNING_SECRET").resolve();
+
+    assertThat(record.getIntent()).isEqualTo(ExpressionIntent.EVALUATED);
+    // Persisted event = masked. (Stage 5 architectural decision: real value only lives on the
+    // response side of the wire; on disk it's redacted.)
+    assertThat(record.getValue().getResultValue()).isEqualTo(SecretMasker.MASKED_VALUE);
+    assertThat(record.getValue().getWarnings()).isEmpty();
+  }
+
+  // ----- Scenario 4: audit sweep — no real secret values reach any exported record ----------
+
+  @Test
+  public void auditExportsCarryNoRealSecretValues() {
+    // Combined scenario: a single process touches both Slack and Stripe secrets through input
+    // mappings, and runs the FEEL endpoint for the HMAC secret. The sweep at the end walks
+    // every exporter-visible record and asserts none of the three real secret values shows up
+    // anywhere — proving the audit story end-to-end.
+    final String jobType = "audit-sweep-job";
+    final var process =
+        Bpmn.createExecutableProcess("AUDIT_SWEEP")
+            .startEvent()
+            .serviceTask(
+                "TASK",
+                t ->
+                    t.zeebeJobType(jobType)
+                        .zeebeInputExpression("camunda.secret.SLACK_BOT_TOKEN", "slackToken")
+                        .zeebeInputExpression(
+                            "\"Bearer \" + camunda.secret.STRIPE_API_KEY", "stripeAuth"))
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId("AUDIT_SWEEP").create();
+
+    // Activate the job with both secrets fetched, so the resolution path actually runs.
+    ENGINE
+        .jobs()
+        .withType(jobType)
+        .withFetchVariables(
+            "slackToken",
+            "stripeAuth",
+            "camunda.secret.SLACK_BOT_TOKEN",
+            "camunda.secret.STRIPE_API_KEY")
+        .withMaxJobsToActivate(1)
+        .activate();
+
+    // Plus a standalone FEEL evaluation for the HMAC secret.
+    ENGINE.expression().withExpression("=camunda.secret.SLACK_SIGNING_SECRET").resolve();
+
+    // Sweep — none of the real values should appear in any exported record. The recorder is
+    // reset per @Test (RecordingExporterTestWatcher), so we know exactly which records the
+    // scenario above produced: 2 input-mapped variables (`slackToken`, `stripeAuth`), 1
+    // job-batch activation, and 1 FEEL evaluation. Each `.limit(N)` uses the exact expected
+    // count so the stream terminates instead of blocking on records that never arrive.
+    final var forbiddenValues = List.of(SLACK_TOKEN_VALUE, STRIPE_KEY_VALUE, HMAC_SECRET_VALUE);
+
+    RecordingExporter.variableRecords(VariableIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .limit(2)
+        .forEach(
+            r ->
+                assertNoSecretLeak(
+                    "variable " + r.getValue().getName() + " on logstream",
+                    r.getValue().getValue(),
+                    forbiddenValues));
+
+    RecordingExporter.jobBatchRecords(JobBatchIntent.ACTIVATED)
+        .limit(1)
+        .forEach(
+            r ->
+                r.getValue()
+                    .getJobs()
+                    .forEach(
+                        job ->
+                            assertNoSecretLeak(
+                                "job " + job.getType() + " vars on logstream",
+                                job.getVariables().toString(),
+                                forbiddenValues)));
+
+    RecordingExporter.expressionRecords()
+        .withIntent(ExpressionIntent.EVALUATED)
+        .limit(1)
+        .forEach(
+            r ->
+                assertNoSecretLeak(
+                    "FEEL endpoint result on logstream",
+                    String.valueOf(r.getValue().getResultValue()),
+                    forbiddenValues));
+  }
+
+  private static void assertNoSecretLeak(
+      final String description, final String actual, final List<String> forbidden) {
+    for (final String value : forbidden) {
+      assertThat(actual).as(description).doesNotContain(value);
+    }
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.db.DbValue;
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.EngineProcessors;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
+import io.camunda.zeebe.engine.processing.secret.SecretStore;
 import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer;
 import io.camunda.zeebe.engine.state.DefaultZeebeDbFactory;
 import io.camunda.zeebe.engine.state.ProcessingDbState;
@@ -129,6 +130,7 @@ public final class EngineRule extends ExternalResource {
 
   private long lastProcessedPosition = -1L;
   private JobStreamer jobStreamer = JobStreamer.noop();
+  private SecretStore secretStore = SecretStore.EMPTY;
 
   private final FeatureFlags featureFlags = FeatureFlags.createDefaultForTests();
   private ArrayList<TestInterPartitionCommandSender> interPartitionCommandSenders;
@@ -244,6 +246,11 @@ public final class EngineRule extends ExternalResource {
     return this;
   }
 
+  public EngineRule withSecretStore(final SecretStore secretStore) {
+    this.secretStore = secretStore;
+    return this;
+  }
+
   public EngineRule withFeatureFlags(final Consumer<FeatureFlags> modifier) {
     modifier.accept(featureFlags);
     return this;
@@ -355,7 +362,8 @@ public final class EngineRule extends ExternalResource {
                         featureFlags,
                         jobStreamer,
                         searchClientsProxy,
-                        brokerRequestAuthorizationConverter)
+                        brokerRequestAuthorizationConverter,
+                        secretStore)
                     .withListener(
                         new ProcessingExporterTransistor(
                             environmentRule.getLogStream(partitionId)));

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ErrorType.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ErrorType.java
@@ -80,5 +80,7 @@ public enum ErrorType {
 
   FORM_NOT_FOUND,
 
-  RESOURCE_NOT_FOUND
+  RESOURCE_NOT_FOUND,
+
+  SECRET_NOT_FOUND
 }


### PR DESCRIPTION
## Summary

Proof-of-concept implementation of the **Secret resolution in Zeebe** epic. Introduces a `camunda.secret.X` FEEL namespace backed by a pluggable `SecretStore` SPI (env-var implementation only in this PoC). The namespace is inert during normal engine FEEL evaluation — references stay as literal strings, so the variable store never holds plain-text secret material — and resolves to real values only on two explicit paths:

1. **Job activation** — when a worker lists `camunda.secret.X` in its `fetchVariables`, the broker resolves the value, merges it into the activation payload, and writes a masked copy of the event to the logstream. The worker receives the real secret; the on-disk record only ever carries `"***"`.
2. **Standalone FEEL evaluation endpoint** (`POST /v2/expression/evaluation`) — resolves to the real value in the synchronous HTTP response; the persisted `EXPRESSION:EVALUATED` event is masked.

Missing secret on the activation path → `SECRET_NOT_FOUND` incident, job disabled, rest of the batch proceeds (per-job semantics, not per-batch).

Built in six stages, one commit each, all green at each step.

## Architecture

- `SecretStore` SPI (Stage 1) — `Optional<String> resolve(String)`, one impl: `EnvVarSecretStore` (identifier-shape names only to defend against shell/path injection via FEEL text).
- `SecretEvaluationContext` (Stage 2) — engine-wide FEEL leaf that returns the literal reference string. Registered as a sibling of `vars` inside the existing `NamespacedEvaluationContext` builder in `BpmnBehaviorsImpl`.
- `ResolvingSecretEvaluationContext` (Stage 3) — sibling for the FEEL endpoint. Two parallel namespace chains share the same `vars` subtree but differ at the `camunda.secret` leaf, so the same expression behaves differently on the two paths without runtime shadowing.
- `JobVariablesCollector` rewrite (Stage 4) — partitions `fetchVariables` into regular variables and secret references, resolves the latter, merges into msgpack. Missing secret short-circuits with the offending reference name; `JobBatchCollector` reshapes its return type to a `CollectionResult` record carrying activated counts, optional `TooLargeJob`, and a list of `JobWithMissingSecret`. `IncidentCreatedApplier` now disables jobs for both `MESSAGE_SIZE_EXCEEDED` and the new `SECRET_NOT_FOUND` so subsequent activations don't raise duplicate incidents.
- `SecretMasker` + two-step write (Stage 5) — `JobBatchActivateProcessor` and `ExpressionEvaluateProcessor` now write the response first (real values), then mask in place, then append the state event (masked values). Relies on `RecordBatchEntry.createEntry` copying value bytes synchronously per write.


## Out of scope (deliberately, for follow-ups)

- **Connector runtime side** — outbound flow uses the worker `fetchVariables` path; inbound (HMAC) uses the FEEL endpoint. Both are ready to be consumed by the connector runtime team.
- **Permission model on the FEEL endpoint** — PoC bypasses auth so any caller can resolve any secret. Production needs threat-modelling before exposing this widely.
- **Tenant scoping of the secret store** — single global store today. The `SecretStore` SPI is intentionally tenant-agnostic; adding a `resolve(String, String tenantId)` overload is a small follow-up.
- **Additional secret store providers** — `SecretsCfg.provider` is the extension point; only `env` is wired.
- **Incident resolution UX** — same template as the existing too-large-message case. Auto-retry on operator-resolved incidents is a separate piece.

## Commit chain (six stages)

1. `97581b91ddd` — SecretStore SPI + EnvVarSecretStore + config wiring
2. `3b06e0f3ec4` — literal-reference FEEL context, engine-wide
3. `ae97a2e2381` — resolving FEEL context for the evaluation endpoint
4. `603b5f187e5` — job activation resolution + SECRET_NOT_FOUND incident
5. `14d84215a2d` — logstream masking via response/event split
6. `cc1a8b98b43` — end-to-end connector scenarios + audit sweep


closes #52852 