### PR TITLE
fix: skip tests incompatible with stable/8.9 server

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/cluster-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/cluster-api-tests.spec.ts
@@ -21,6 +21,13 @@ import {
 
 test.describe('Cluster API Tests', () => {
   test('Get Cluster Topology', async ({request}) => {
+    // eslint-disable-next-line playwright/no-conditional-in-test
+    if (process.env.FORWARD_COMPAT_MODE === 'true') {
+      test.skip(
+        true,
+        'Skipped in forward-compat mode - partition count differs on target server',
+      );
+    }
     const res = await request.get(buildUrl('/topology'), {
       headers: defaultHeaders(),
     });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/cluster-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/cluster-api-tests.spec.ts
@@ -12,6 +12,7 @@ import {
   assertUnauthorizedRequest,
   buildUrl,
   defaultHeaders,
+  isForwardCompat,
 } from '../../../utils/http';
 import {
   brokerResponseFields,
@@ -21,13 +22,10 @@ import {
 
 test.describe('Cluster API Tests', () => {
   test('Get Cluster Topology', async ({request}) => {
-    // eslint-disable-next-line playwright/no-conditional-in-test
-    if (process.env.FORWARD_COMPAT_MODE === 'true') {
-      test.skip(
-        true,
-        'Skipped in forward-compat mode - partition count differs on target server',
-      );
-    }
+    test.skip(
+      isForwardCompat,
+      'Skipped in forward-compat mode - partition count differs on target server',
+    );
     const res = await request.get(buildUrl('/topology'), {
       headers: defaultHeaders(),
     });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-ad-hoc-activities-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-ad-hoc-activities-api.spec.ts
@@ -76,6 +76,13 @@ test.describe.parallel('Element Instance Ad-hoc Activities API', () => {
   test('Activate AdHoc Activities SucceedsWithValidElements', async ({
     request,
   }) => {
+    // eslint-disable-next-line playwright/no-conditional-in-test
+    if (process.env.FORWARD_COMPAT_MODE === 'true') {
+      test.skip(
+        true,
+        'Skipped in forward-compat mode - ad-hoc activities endpoint not available on target server',
+      );
+    }
     const adHocKey = state.adHocSubProcessInstanceKeySimple as string;
 
     const body = {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-ad-hoc-activities-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-ad-hoc-activities-api.spec.ts
@@ -13,6 +13,7 @@ import {
   assertStatusCode,
   assertUnauthorizedRequest,
   buildUrl,
+  isForwardCompat,
   jsonHeaders,
 } from '../../../../utils/http';
 import {
@@ -26,6 +27,11 @@ const state: Record<string, unknown> = {};
 
 /* eslint-disable playwright/expect-expect */
 test.describe.parallel('Element Instance Ad-hoc Activities API', () => {
+  test.skip(
+    isForwardCompat,
+    'Skipped in forward-compat mode - ad-hoc activities endpoint not available on target server',
+  );
+
   test.beforeAll(async ({request}) => {
     await test.step('Deploy BPMN with ad-hoc subprocess', async () => {
       await deploy(['./resources/ad_hoc_sub_process_api_test.bpmn']);
@@ -76,13 +82,6 @@ test.describe.parallel('Element Instance Ad-hoc Activities API', () => {
   test('Activate AdHoc Activities SucceedsWithValidElements', async ({
     request,
   }) => {
-    // eslint-disable-next-line playwright/no-conditional-in-test
-    if (process.env.FORWARD_COMPAT_MODE === 'true') {
-      test.skip(
-        true,
-        'Skipped in forward-compat mode - ad-hoc activities endpoint not available on target server',
-      );
-    }
     const adHocKey = state.adHocSubProcessInstanceKeySimple as string;
 
     const body = {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message/correlate-message-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message/correlate-message-api-tests.spec.ts
@@ -12,6 +12,7 @@ import {
   jsonHeaders,
   assertRequiredFields,
   assertEqualsForKeys,
+  isForwardCompat,
   paginatedResponseFields,
 } from '../../../../utils/http';
 import {
@@ -85,13 +86,10 @@ test.describe('Correlate Message API Tests', () => {
   });
 
   test('Correlate Message Flow', async ({request}) => {
-    // eslint-disable-next-line playwright/no-conditional-in-test
-    if (process.env.FORWARD_COMPAT_MODE === 'true') {
-      test.skip(
-        true,
-        'Skipped in forward-compat mode - processInstanceKey mismatch due to partition count difference',
-      );
-    }
+    test.skip(
+      isForwardCompat,
+      'Skipped in forward-compat mode - processInstanceKey mismatch due to partition count difference',
+    );
     await test.step('Correlate Message', async () => {
       const res = await request.post(buildUrl('/messages/correlation'), {
         headers: jsonHeaders(),

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message/correlate-message-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message/correlate-message-api-tests.spec.ts
@@ -85,6 +85,13 @@ test.describe('Correlate Message API Tests', () => {
   });
 
   test('Correlate Message Flow', async ({request}) => {
+    // eslint-disable-next-line playwright/no-conditional-in-test
+    if (process.env.FORWARD_COMPAT_MODE === 'true') {
+      test.skip(
+        true,
+        'Skipped in forward-compat mode - processInstanceKey mismatch due to partition count difference',
+      );
+    }
     await test.step('Correlate Message', async () => {
       const res = await request.post(buildUrl('/messages/correlation'), {
         headers: jsonHeaders(),


### PR DESCRIPTION
## Description

- Skip "Get Cluster Topology" test (partition count differs on 8.9)
- Skip "Activate AdHoc Activities" test (endpoint not available on 8.9)
- Skip "Correlate Message Flow" test (key mismatch due to partition count)

## Related issues

related to https://camunda.slack.com/archives/C0A2AGG2Q2E/p1778556270798459
