### PR TITLE
feat: Add bpmnProcessId to AgentInstanceRecord

### DIFF
--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceRecord.java
@@ -27,6 +27,7 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
   private final LongProperty elementInstanceKeyProp = new LongProperty("elementInstanceKey", -1L);
   private final StringProperty elementIdProp = new StringProperty("elementId", "");
   private final LongProperty processInstanceKeyProp = new LongProperty("processInstanceKey", -1L);
+  private final StringProperty bpmnProcessIdProp = new StringProperty("bpmnProcessId", "");
   private final LongProperty processDefinitionKeyProp =
       new LongProperty("processDefinitionKey", -1L);
   private final IntegerProperty processDefinitionVersionProp =
@@ -46,11 +47,12 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
       new ArrayProperty<>("tools", AgentInstanceTool::new);
 
   public AgentInstanceRecord() {
-    super(13);
+    super(14);
     declareProperty(agentInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
         .declareProperty(elementIdProp)
         .declareProperty(processInstanceKeyProp)
+        .declareProperty(bpmnProcessIdProp)
         .declareProperty(processDefinitionKeyProp)
         .declareProperty(processDefinitionVersionProp)
         .declareProperty(versionTagProp)
@@ -99,6 +101,16 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
 
   public AgentInstanceRecord setProcessInstanceKey(final long processInstanceKey) {
     processInstanceKeyProp.setValue(processInstanceKey);
+    return this;
+  }
+
+  @Override
+  public String getBpmnProcessId() {
+    return BufferUtil.bufferAsString(bpmnProcessIdProp.getValue());
+  }
+
+  public AgentInstanceRecord setBpmnProcessId(final String bpmnProcessId) {
+    bpmnProcessIdProp.setValue(bpmnProcessId);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -4670,6 +4670,7 @@ final class JsonSerializableToJsonTest {
                       .setElementInstanceKey(2251799813685249L)
                       .setElementId("invoice-data-extraction-agent")
                       .setProcessInstanceKey(2251799813685248L)
+                      .setBpmnProcessId("invoice-handling-process")
                       .setProcessDefinitionKey(2251799813685100L)
                       .setProcessDefinitionVersion(3)
                       .setVersionTag("v1.2")
@@ -4704,6 +4705,7 @@ final class JsonSerializableToJsonTest {
           "elementInstanceKey": 2251799813685249,
           "elementId": "invoice-data-extraction-agent",
           "processInstanceKey": 2251799813685248,
+          "bpmnProcessId": "invoice-handling-process",
           "processDefinitionKey": 2251799813685100,
           "processDefinitionVersion": 3,
           "versionTag": "v1.2",
@@ -4732,6 +4734,7 @@ final class JsonSerializableToJsonTest {
           "elementInstanceKey": -1,
           "elementId": "",
           "processInstanceKey": -1,
+          "bpmnProcessId": "",
           "processDefinitionKey": -1,
           "processDefinitionVersion": -1,
           "versionTag": "",

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceRecordTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceRecordTest.java
@@ -28,6 +28,7 @@ final class AgentInstanceRecordTest {
     assertThat(record.getElementInstanceKey()).isEqualTo(-1L);
     assertThat(record.getElementId()).isEmpty();
     assertThat(record.getProcessInstanceKey()).isEqualTo(-1L);
+    assertThat(record.getBpmnProcessId()).isEmpty();
     assertThat(record.getProcessDefinitionKey()).isEqualTo(-1L);
     assertThat(record.getProcessDefinitionVersion()).isEqualTo(-1);
     assertThat(record.getVersionTag()).isEmpty();
@@ -43,6 +44,7 @@ final class AgentInstanceRecordTest {
             .setElementInstanceKey(2251799813685249L)
             .setElementId("invoice-data-extraction-agent")
             .setProcessInstanceKey(2251799813685248L)
+            .setBpmnProcessId("invoice-handling-process")
             .setProcessDefinitionKey(2251799813685100L)
             .setProcessDefinitionVersion(3)
             .setVersionTag("v1.2")
@@ -57,6 +59,7 @@ final class AgentInstanceRecordTest {
     assertThat(copy.getElementInstanceKey()).isEqualTo(original.getElementInstanceKey());
     assertThat(copy.getElementId()).isEqualTo(original.getElementId());
     assertThat(copy.getProcessInstanceKey()).isEqualTo(original.getProcessInstanceKey());
+    assertThat(copy.getBpmnProcessId()).isEqualTo(original.getBpmnProcessId());
     assertThat(copy.getProcessDefinitionKey()).isEqualTo(original.getProcessDefinitionKey());
     assertThat(copy.getProcessDefinitionVersion())
         .isEqualTo(original.getProcessDefinitionVersion());

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentInstanceRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentInstanceRecord.golden
@@ -27,6 +27,7 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
   private final LongProperty elementInstanceKeyProp = new LongProperty("elementInstanceKey", -1L);
   private final StringProperty elementIdProp = new StringProperty("elementId", "");
   private final LongProperty processInstanceKeyProp = new LongProperty("processInstanceKey", -1L);
+  private final StringProperty bpmnProcessIdProp = new StringProperty("bpmnProcessId", "");
   private final LongProperty processDefinitionKeyProp =
       new LongProperty("processDefinitionKey", -1L);
   private final IntegerProperty processDefinitionVersionProp =
@@ -46,11 +47,12 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
       new ArrayProperty<>("tools", AgentInstanceTool::new);
 
   public AgentInstanceRecord() {
-    super(13);
+    super(14);
     declareProperty(agentInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
         .declareProperty(elementIdProp)
         .declareProperty(processInstanceKeyProp)
+        .declareProperty(bpmnProcessIdProp)
         .declareProperty(processDefinitionKeyProp)
         .declareProperty(processDefinitionVersionProp)
         .declareProperty(versionTagProp)
@@ -99,6 +101,16 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
 
   public AgentInstanceRecord setProcessInstanceKey(final long processInstanceKey) {
     processInstanceKeyProp.setValue(processInstanceKey);
+    return this;
+  }
+
+  @Override
+  public String getBpmnProcessId() {
+    return BufferUtil.bufferAsString(bpmnProcessIdProp.getValue());
+  }
+
+  public AgentInstanceRecord setBpmnProcessId(final String bpmnProcessId) {
+    bpmnProcessIdProp.setValue(bpmnProcessId);
     return this;
   }
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentInstanceRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentInstanceRecordValue.java
@@ -46,6 +46,11 @@ public interface AgentInstanceRecordValue extends RecordValue, ProcessInstanceRe
   long getProcessInstanceKey();
 
   /**
+   * @return the BPMN process ID of the process definition containing this agent
+   */
+  String getBpmnProcessId();
+
+  /**
    * @return the key of the process definition
    */
   @Override

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/AgentInstanceRecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/AgentInstanceRecordStream.java
@@ -37,6 +37,10 @@ public final class AgentInstanceRecordStream
     return valueFilter(v -> elementId.equals(v.getElementId()));
   }
 
+  public AgentInstanceRecordStream withBpmnProcessId(final String bpmnProcessId) {
+    return valueFilter(v -> bpmnProcessId.equals(v.getBpmnProcessId()));
+  }
+
   public AgentInstanceRecordStream withStatus(final AgentInstanceStatus status) {
     return valueFilter(v -> v.getStatus() == status);
   }


### PR DESCRIPTION
## Description

Add a `bpmnProcessId` identity field to the `AGENT_INSTANCE` record. The field is exposed on `AgentInstanceRecordValue` (`getBpmnProcessId()`) and backed by a MsgPack `StringProperty` on `AgentInstanceRecord` with default `""`. It carries the BPMN process ID (the `id` attribute of the root `<process>` element) of the process definition containing the agent.

This is protocol-level groundwork only. The engine processor that will populate the field from `elementInstanceKey` — consistent with how `elementId`, `processDefinitionKey`, `processDefinitionVersion`, `versionTag` are resolved — is intentionally deferred and tracked separately.

### Motivation

The field was present in the agreed data model in #51505 but was missed when the `AGENT_INSTANCE` record type was introduced in #52694. The Optimize team flagged this as a gap: they need the BPMN process ID for definition-level aggregation and correlation across process definition versions. Adding it now closes the gap between the agreed data model and the implementation, and unblocks downstream analytics work.

> [!NOTE]
> At the engine/protocol layer the field is named `bpmnProcessId` to stay consistent with every other record value in `zeebe/protocol` ([`UserTaskRecordValue`](https://github.com/camunda/camunda/blob/c98a7dea7fbe4d6da87cb0eca1c60a9a355c8390/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/UserTaskRecordValue.java#L78), `ProcessInstanceRecordValue`, `JobRecordValue`, `IncidentRecordValue`, …). When this field is later surfaced via the REST / Query API it should be exposed as `processDefinitionId`, mirroring the existing REST convention — compare [`UserTaskRecordValue#getBpmnProcessId()`](https://github.com/camunda/camunda/blob/c98a7dea7fbe4d6da87cb0eca1c60a9a355c8390/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/UserTaskRecordValue.java#L78) (engine) with `UserTaskResult.processDefinitionId` in [`zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml`](https://github.com/camunda/camunda/blob/df7f5b514b31813b61598d22b79071d1b436293d/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml#L595) (REST).

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #52861