### PR TITLE
[PoC]: Nested JSON editor options

### DIFF
--- a/operate/client/src/App/Processes/ListView/Filters/OptionalFiltersFormGroup.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/OptionalFiltersFormGroup.tsx
@@ -8,7 +8,8 @@
 
 import {observer} from 'mobx-react';
 import {useEffect, useState} from 'react';
-import {useLocation, type Location} from 'react-router-dom';
+import {useLocation, useMatch, type Location} from 'react-router-dom';
+import {Paths} from 'modules/Routes';
 import {type FieldValidator} from 'final-form';
 import {Close} from '@carbon/react/icons';
 import intersection from 'lodash/intersection';
@@ -140,6 +141,7 @@ const OptionalFiltersFormGroup: React.FC<Props> = observer(
   ({visibleFilters, onVisibleFilterChange}) => {
     const location = useLocation() as LocationType;
     const form = useForm();
+    const isOnVariablesRoute = useMatch(Paths.processesVariables()) !== null;
     const hasActiveVariableFilters =
       MULTI_VARIABLE_FILTER && variableFilterStore.hasActiveFilters;
 
@@ -160,7 +162,9 @@ const OptionalFiltersFormGroup: React.FC<Props> = observer(
               ...('endDateFrom' in filters && 'endDateTo' in filters
                 ? ['endDateRange']
                 : []),
-              ...(hasActiveVariableFilters ? ['variable'] : []),
+              ...(hasActiveVariableFilters || isOnVariablesRoute
+                ? ['variable']
+                : []),
             ] as OptionalFilter[]),
           ]),
         );
@@ -170,6 +174,7 @@ const OptionalFiltersFormGroup: React.FC<Props> = observer(
       location.search,
       onVisibleFilterChange,
       hasActiveVariableFilters,
+      isOnVariablesRoute,
     ]);
 
     const [isStartDateRangeModalOpen, setIsStartDateRangeModalOpen] =

--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterModal.test.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterModal.test.tsx
@@ -311,6 +311,24 @@ describe('<VariableFilterModal />', () => {
     expect(screen.queryByText('Value is required')).not.toBeInTheDocument();
   });
 
+  it('should show value error for contains operator with empty value', async () => {
+    const onApply = vi.fn();
+    const {user} = render(
+      <VariableFilterModal {...baseMockProps} onApply={onApply} />,
+    );
+
+    await user.type(
+      screen.getAllByPlaceholderText('Variable name')[0]!,
+      'myVar',
+    );
+    await user.click(screen.getByRole('combobox', {name: 'Operator'}));
+    await user.click(screen.getByText('contains'));
+    await user.click(screen.getByRole('button', {name: 'Apply'}));
+
+    expect(screen.getByText('Value is required')).toBeInTheDocument();
+    expect(onApply).not.toHaveBeenCalled();
+  });
+
   it('should apply successfully when all conditions are valid', async () => {
     const onApply = vi.fn();
     const {user} = render(

--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterModal.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterModal.tsx
@@ -28,7 +28,7 @@ type RowErrors = {
 const validateCondition = (condition: DraftCondition): RowErrors => {
   const errors: RowErrors = {};
 
-  if (!condition.name.trim()) {
+  if (!condition.name?.trim()) {
     errors.name = 'Variable name is required';
   }
 
@@ -36,7 +36,7 @@ const validateCondition = (condition: DraftCondition): RowErrors => {
     condition.operator !== 'exists' &&
     condition.operator !== 'doesNotExist'
   ) {
-    if (!condition.value.trim()) {
+    if (!condition.value?.trim()) {
       errors.value = 'Value is required';
     } else if (condition.operator === 'oneOf') {
       let parsed: unknown;

--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterModal.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterModal.tsx
@@ -6,19 +6,46 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {useState} from 'react';
-import {Button, Modal, Stack} from '@carbon/react';
-import {Add} from '@carbon/react/icons';
+import {lazy, Suspense, useCallback, useEffect, useState} from 'react';
+import {Button, Dropdown, Modal, Stack} from '@carbon/react';
+import {Add, ArrowLeft} from '@carbon/react/icons';
 import {Form} from 'react-final-form';
 import {FieldArray} from 'react-final-form-arrays';
 import arrayMutators from 'final-form-arrays';
+import {observer} from 'mobx-react-lite';
 import {isValidJSON} from 'modules/utils';
+import {EDITOR_MODE_TOGGLE} from 'modules/feature-flags';
+import {editorModeStore, type EditorMode} from 'modules/stores/editorMode';
 import {VariableFilterRow} from './VariableFilterRow';
 import type {VariableCondition} from 'modules/stores/variableFilter';
 import type {DraftCondition} from './constants';
-import {Description, ModalContent} from './styled';
+import {
+  BackButtonContent,
+  Description,
+  DimmedParentModalStyle,
+  ExpandedEditorHeader,
+  ExpandedEditorSection,
+  ModalContent,
+  ModeToggleContainer,
+} from './styled';
+
+const JSONEditor = lazy(async () => {
+  const [{loadMonaco}, {JSONEditor}] = await Promise.all([
+    import('modules/loadMonaco'),
+    import('modules/components/JSONEditor'),
+  ]);
+  loadMonaco();
+  return {default: JSONEditor};
+});
 
 const MAX_CONDITIONS = 5;
+
+const EDITOR_MODE_OPTIONS: {id: EditorMode; label: string}[] = [
+  {id: 'default', label: 'Default (Portal Modal)'},
+  {id: 'inline', label: 'Full-Width Expandable'},
+  {id: 'step', label: 'Step-Based Transition'},
+  {id: 'slideOver', label: 'Expanded Modal'},
+];
 
 type RowErrors = {
   name?: string;
@@ -78,90 +105,344 @@ const createDraft = (): DraftCondition => ({
   value: '',
 });
 
-const VariableFilterModal: React.FC<Props> = ({
-  isOpen,
-  initialConditions,
-  onApply,
-  onClose,
-}) => {
-  const [initialDraftConditions] = useState<DraftCondition[]>(() =>
-    initialConditions.length > 0
-      ? initialConditions.map((c) => ({...c}))
-      : [createDraft()],
-  );
-
-  const handleSubmit = (
-    values: FormValues,
-  ): {conditions: RowErrors[]} | undefined => {
-    const conditionErrors = values.conditions.map(validateCondition);
-    if (conditionErrors.some(hasErrors)) {
-      return {conditions: conditionErrors};
-    }
-    onApply(
-      values.conditions.map(({operator, name, value}): VariableCondition => {
-        if (operator === 'exists' || operator === 'doesNotExist') {
-          return {name, operator, value: ''};
-        }
-        return {name, operator, value: value ?? ''};
-      }),
+const VariableFilterModal: React.FC<Props> = observer(
+  ({isOpen, initialConditions, onApply, onClose}) => {
+    const editorMode = EDITOR_MODE_TOGGLE ? editorModeStore.mode : 'default';
+    const [initialDraftConditions] = useState<DraftCondition[]>(() =>
+      initialConditions.length > 0
+        ? initialConditions.map((c) => ({...c}))
+        : [createDraft()],
     );
-    return undefined;
-  };
 
-  return (
-    <Form<FormValues>
-      onSubmit={handleSubmit}
-      initialValues={{conditions: initialDraftConditions}}
-      mutators={{...arrayMutators}}
-    >
-      {({handleSubmit: submitForm}) => (
-        <Modal
-          open={isOpen}
-          modalHeading="Filter by Variable"
-          primaryButtonText="Apply"
-          secondaryButtonText="Cancel"
-          onRequestSubmit={submitForm}
-          onRequestClose={onClose}
-          onSecondarySubmit={onClose}
-          preventCloseOnClickOutside
-          size="md"
-        >
-          <ModalContent>
-            <Stack gap={5}>
-              <Description>
-                Define one or more conditions to filter process instances by
-                variable values. All conditions are combined with AND logic.
-              </Description>
-              <FieldArray<DraftCondition> name="conditions">
-                {({fields}) => (
-                  <Stack gap={4}>
-                    {fields.map((fieldName, index) => (
-                      <VariableFilterRow
-                        key={fieldName}
-                        fieldName={fieldName}
-                        rowIndex={index}
-                        onDelete={() => fields.remove(index)}
-                        isDeleteHidden={fields.length === 1}
+    const [isJsonEditorOpen, setIsJsonEditorOpen] = useState(false);
+    const handleJsonEditorOpen = useCallback(
+      () => setIsJsonEditorOpen(true),
+      [],
+    );
+    const handleJsonEditorClose = useCallback(
+      () => setIsJsonEditorOpen(false),
+      [],
+    );
+
+    // Option A: Inline mode
+    const [expandedRowIndex, setExpandedRowIndex] = useState<number | null>(
+      null,
+    );
+
+    // Option B: Step mode
+    const [editingRowIndex, setEditingRowIndex] = useState<number | null>(null);
+    const [editedValue, setEditedValue] = useState('');
+
+    // Option C: Slide-over mode
+    const [slideOverRowIndex, setSlideOverRowIndex] = useState<number | null>(
+      null,
+    );
+    const [slideOverValue, setSlideOverValue] = useState('');
+
+    // Reset mode-specific state when mode changes
+    useEffect(() => {
+      setExpandedRowIndex(null);
+      setEditingRowIndex(null);
+      setSlideOverRowIndex(null);
+    }, [editorMode]);
+
+    const handleSubmit = (
+      values: FormValues,
+    ): {conditions: RowErrors[]} | undefined => {
+      const conditionErrors = values.conditions.map(validateCondition);
+      if (conditionErrors.some(hasErrors)) {
+        return {conditions: conditionErrors};
+      }
+      onApply(
+        values.conditions.map(({operator, name, value}): VariableCondition => {
+          if (operator === 'exists' || operator === 'doesNotExist') {
+            return {name, operator, value: ''};
+          }
+          return {name, operator, value: value ?? ''};
+        }),
+      );
+      return undefined;
+    };
+
+    return (
+      <Form<FormValues>
+        onSubmit={handleSubmit}
+        initialValues={{conditions: initialDraftConditions}}
+        mutators={{...arrayMutators}}
+      >
+        {({handleSubmit: submitForm, form}) => (
+          <Modal
+            open={isOpen}
+            modalHeading={
+              editorMode === 'step' && editingRowIndex !== null
+                ? (() => {
+                    const variableName = form
+                      .getState()
+                      .values?.['conditions']?.[editingRowIndex]?.name?.trim();
+                    return variableName
+                      ? `Edit value: ${variableName}`
+                      : 'Edit Variable Value';
+                  })()
+                : 'Filter by Variable'
+            }
+            primaryButtonText={
+              (editorMode === 'step' && editingRowIndex !== null) ||
+              (editorMode === 'slideOver' && slideOverRowIndex !== null)
+                ? 'Save value'
+                : 'Apply'
+            }
+            secondaryButtonText="Cancel"
+            onRequestSubmit={() => {
+              if (editorMode === 'step' && editingRowIndex !== null) {
+                (
+                  form as {change: (name: string, value: string) => void}
+                ).change(`conditions[${editingRowIndex}].value`, editedValue);
+                setEditingRowIndex(null);
+              } else if (
+                editorMode === 'slideOver' &&
+                slideOverRowIndex !== null
+              ) {
+                (
+                  form as {change: (name: string, value: string) => void}
+                ).change(
+                  `conditions[${slideOverRowIndex}].value`,
+                  slideOverValue,
+                );
+                setSlideOverRowIndex(null);
+              } else {
+                submitForm();
+              }
+            }}
+            onRequestClose={() => {
+              if (editorMode === 'step' && editingRowIndex !== null) {
+                setEditingRowIndex(null);
+              } else if (
+                editorMode === 'slideOver' &&
+                slideOverRowIndex !== null
+              ) {
+                setSlideOverRowIndex(null);
+              } else {
+                onClose();
+              }
+            }}
+            onSecondarySubmit={() => {
+              if (editorMode === 'step' && editingRowIndex !== null) {
+                setEditingRowIndex(null);
+              } else if (
+                editorMode === 'slideOver' &&
+                slideOverRowIndex !== null
+              ) {
+                setSlideOverRowIndex(null);
+              } else {
+                onClose();
+              }
+            }}
+            preventCloseOnClickOutside
+            selectorsFloatingMenus={['.variable-filter-json-editor']}
+            size={
+              editorMode === 'slideOver' && slideOverRowIndex !== null
+                ? 'lg'
+                : 'md'
+            }
+            className={
+              isJsonEditorOpen ? 'variable-filter-modal--dimmed' : undefined
+            }
+          >
+            <DimmedParentModalStyle />
+            <ModalContent>
+              {editorMode === 'step' && editingRowIndex !== null ? (
+                <Stack gap={5}>
+                  <Button
+                    kind="ghost"
+                    size="sm"
+                    onClick={() => setEditingRowIndex(null)}
+                  >
+                    <BackButtonContent>
+                      <ArrowLeft size={16} />
+                      Back to conditions
+                    </BackButtonContent>
+                  </Button>
+                  <Suspense fallback={<div>Loading editor...</div>}>
+                    <JSONEditor
+                      value={editedValue}
+                      onChange={setEditedValue}
+                      height="45vh"
+                    />
+                  </Suspense>
+                </Stack>
+              ) : (
+                <Stack gap={5}>
+                  <Description>
+                    Define one or more conditions to filter process instances by
+                    variable values. All conditions are combined with AND logic.
+                  </Description>
+                  <FieldArray<DraftCondition> name="conditions">
+                    {({fields}) => (
+                      <Stack gap={4}>
+                        {fields.map((fieldName, index) => (
+                          <VariableFilterRow
+                            key={fieldName}
+                            fieldName={fieldName}
+                            rowIndex={index}
+                            onDelete={() => {
+                              if (expandedRowIndex === index) {
+                                setExpandedRowIndex(null);
+                              }
+                              if (slideOverRowIndex === index) {
+                                setSlideOverRowIndex(null);
+                              }
+                              fields.remove(index);
+                            }}
+                            isDeleteHidden={fields.length === 1}
+                            onJsonEditorOpen={handleJsonEditorOpen}
+                            onJsonEditorClose={handleJsonEditorClose}
+                            onExpandRow={(i) => setExpandedRowIndex(i)}
+                            onEditValue={(i) => {
+                              const val =
+                                form.getState().values?.['conditions']?.[i]
+                                  ?.value ?? '';
+                              setEditedValue(val);
+                              setEditingRowIndex(i);
+                            }}
+                            onSlideOverOpen={(i) => {
+                              const val =
+                                form.getState().values?.['conditions']?.[i]
+                                  ?.value ?? '';
+                              setSlideOverValue(val);
+                              setSlideOverRowIndex(i);
+                            }}
+                          />
+                        ))}
+                        <Button
+                          kind="ghost"
+                          size="sm"
+                          renderIcon={Add}
+                          disabled={(fields.length ?? 0) >= MAX_CONDITIONS}
+                          onClick={() => fields.push(createDraft())}
+                        >
+                          Add condition
+                        </Button>
+                      </Stack>
+                    )}
+                  </FieldArray>
+                  {editorMode === 'inline' && (
+                    <ExpandedEditorSection $isOpen={expandedRowIndex !== null}>
+                      {expandedRowIndex !== null && (
+                        <>
+                          <ExpandedEditorHeader>
+                            <h4>
+                              {(() => {
+                                const variableName = form
+                                  .getState()
+                                  .values?.[
+                                    'conditions'
+                                  ]?.[expandedRowIndex]?.name?.trim();
+                                return variableName
+                                  ? `Edit value: ${variableName}`
+                                  : 'Edit Variable Value';
+                              })()}
+                            </h4>
+                            <Button
+                              kind="ghost"
+                              size="sm"
+                              onClick={() => setExpandedRowIndex(null)}
+                            >
+                              Done
+                            </Button>
+                          </ExpandedEditorHeader>
+                          <Suspense fallback={<div>Loading editor...</div>}>
+                            <JSONEditor
+                              value={
+                                form.getState().values?.['conditions']?.[
+                                  expandedRowIndex
+                                ]?.value ?? ''
+                              }
+                              onChange={(val: string) => {
+                                (
+                                  form as {
+                                    change: (
+                                      name: string,
+                                      value: string,
+                                    ) => void;
+                                  }
+                                ).change(
+                                  `conditions[${expandedRowIndex}].value`,
+                                  val,
+                                );
+                              }}
+                              height="35vh"
+                            />
+                          </Suspense>
+                        </>
+                      )}
+                    </ExpandedEditorSection>
+                  )}
+                  {editorMode === 'slideOver' && (
+                    <ExpandedEditorSection $isOpen={slideOverRowIndex !== null}>
+                      {slideOverRowIndex !== null && (
+                        <>
+                          <ExpandedEditorHeader>
+                            <h4>
+                              {(() => {
+                                const variableName = form
+                                  .getState()
+                                  .values?.[
+                                    'conditions'
+                                  ]?.[slideOverRowIndex]?.name?.trim();
+                                return variableName
+                                  ? `Edit value: ${variableName}`
+                                  : 'Edit Variable Value';
+                              })()}
+                            </h4>
+                            <Button
+                              kind="ghost"
+                              size="sm"
+                              onClick={() => setSlideOverRowIndex(null)}
+                            >
+                              Done
+                            </Button>
+                          </ExpandedEditorHeader>
+                          <Suspense fallback={<div>Loading editor...</div>}>
+                            <JSONEditor
+                              value={slideOverValue}
+                              onChange={setSlideOverValue}
+                              height="35vh"
+                            />
+                          </Suspense>
+                        </>
+                      )}
+                    </ExpandedEditorSection>
+                  )}
+                  {EDITOR_MODE_TOGGLE && (
+                    <ModeToggleContainer>
+                      <Dropdown
+                        id="editor-mode-toggle"
+                        titleText="UX Mode (PoC)"
+                        label="Select editor mode"
+                        size="sm"
+                        items={EDITOR_MODE_OPTIONS}
+                        itemToString={(item) => item?.label ?? ''}
+                        selectedItem={
+                          EDITOR_MODE_OPTIONS.find(
+                            (opt) => opt.id === editorMode,
+                          ) ?? EDITOR_MODE_OPTIONS[0]!
+                        }
+                        onChange={({selectedItem}) => {
+                          if (selectedItem) {
+                            editorModeStore.setMode(selectedItem.id);
+                          }
+                        }}
                       />
-                    ))}
-                    <Button
-                      kind="ghost"
-                      size="sm"
-                      renderIcon={Add}
-                      disabled={(fields.length ?? 0) >= MAX_CONDITIONS}
-                      onClick={() => fields.push(createDraft())}
-                    >
-                      Add condition
-                    </Button>
-                  </Stack>
-                )}
-              </FieldArray>
-            </Stack>
-          </ModalContent>
-        </Modal>
-      )}
-    </Form>
-  );
-};
+                    </ModeToggleContainer>
+                  )}
+                </Stack>
+              )}
+            </ModalContent>
+          </Modal>
+        )}
+      </Form>
+    );
+  },
+);
 
 export {VariableFilterModal};

--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterRow.test.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterRow.test.tsx
@@ -43,7 +43,7 @@ describe('<VariableFilterRow />', () => {
         fieldName="conditions[0]"
         rowIndex={0}
         onDelete={vi.fn()}
-        isDeleteHidden={true}
+        isDeleteHidden
       />,
       {wrapper: getWrapper()},
     );
@@ -61,7 +61,7 @@ describe('<VariableFilterRow />', () => {
         fieldName="conditions[0]"
         rowIndex={0}
         onDelete={vi.fn()}
-        isDeleteHidden={true}
+        isDeleteHidden
       />,
       {wrapper: getWrapper({operator: 'exists'})},
     );
@@ -77,14 +77,13 @@ describe('<VariableFilterRow />', () => {
         fieldName="conditions[0]"
         rowIndex={0}
         onDelete={vi.fn()}
-        isDeleteHidden={true}
+        isDeleteHidden
       />,
       {wrapper: getWrapper()},
     );
-
-    expect(screen.getByTestId('delete-variable-filter-0')).toHaveStyle({
-      visibility: 'hidden',
-    });
+    expect(
+      screen.getByTestId('delete-variable-filter-test-id'),
+    ).not.toBeVisible();
   });
 
   it('should show delete button when isDeleteHidden is false', () => {
@@ -98,9 +97,7 @@ describe('<VariableFilterRow />', () => {
       {wrapper: getWrapper()},
     );
 
-    expect(screen.getByTestId('delete-variable-filter-0')).toHaveStyle({
-      visibility: 'visible',
-    });
+    expect(screen.getByTestId('delete-variable-filter-test-id')).toBeVisible();
   });
 
   it('should update name input when user types', async () => {
@@ -109,7 +106,7 @@ describe('<VariableFilterRow />', () => {
         fieldName="conditions[0]"
         rowIndex={0}
         onDelete={vi.fn()}
-        isDeleteHidden={true}
+        isDeleteHidden
       />,
       {wrapper: getWrapper()},
     );
@@ -125,7 +122,7 @@ describe('<VariableFilterRow />', () => {
         fieldName="conditions[0]"
         rowIndex={0}
         onDelete={vi.fn()}
-        isDeleteHidden={true}
+        isDeleteHidden
       />,
       {wrapper: getWrapper({name: 'status'})},
     );
@@ -158,7 +155,7 @@ describe('<VariableFilterRow />', () => {
         fieldName="conditions[0]"
         rowIndex={0}
         onDelete={vi.fn()}
-        isDeleteHidden={true}
+        isDeleteHidden
       />,
       {wrapper: getWrapper()},
     );
@@ -177,7 +174,7 @@ describe('<VariableFilterRow />', () => {
         fieldName="conditions[0]"
         rowIndex={0}
         onDelete={vi.fn()}
-        isDeleteHidden={true}
+        isDeleteHidden
       />,
       {wrapper: getWrapper({operator: 'exists'})},
     );

--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterRow.test.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterRow.test.tsx
@@ -44,6 +44,8 @@ describe('<VariableFilterRow />', () => {
         rowIndex={0}
         onDelete={vi.fn()}
         isDeleteHidden
+        onJsonEditorOpen={vi.fn()}
+        onJsonEditorClose={vi.fn()}
       />,
       {wrapper: getWrapper()},
     );
@@ -62,6 +64,8 @@ describe('<VariableFilterRow />', () => {
         rowIndex={0}
         onDelete={vi.fn()}
         isDeleteHidden
+        onJsonEditorOpen={vi.fn()}
+        onJsonEditorClose={vi.fn()}
       />,
       {wrapper: getWrapper({operator: 'exists'})},
     );
@@ -78,6 +82,8 @@ describe('<VariableFilterRow />', () => {
         rowIndex={0}
         onDelete={vi.fn()}
         isDeleteHidden
+        onJsonEditorOpen={vi.fn()}
+        onJsonEditorClose={vi.fn()}
       />,
       {wrapper: getWrapper()},
     );
@@ -91,6 +97,8 @@ describe('<VariableFilterRow />', () => {
         rowIndex={0}
         onDelete={vi.fn()}
         isDeleteHidden={false}
+        onJsonEditorOpen={vi.fn()}
+        onJsonEditorClose={vi.fn()}
       />,
       {wrapper: getWrapper()},
     );
@@ -105,6 +113,8 @@ describe('<VariableFilterRow />', () => {
         rowIndex={0}
         onDelete={vi.fn()}
         isDeleteHidden
+        onJsonEditorOpen={vi.fn()}
+        onJsonEditorClose={vi.fn()}
       />,
       {wrapper: getWrapper()},
     );
@@ -121,6 +131,8 @@ describe('<VariableFilterRow />', () => {
         rowIndex={0}
         onDelete={vi.fn()}
         isDeleteHidden
+        onJsonEditorOpen={vi.fn()}
+        onJsonEditorClose={vi.fn()}
       />,
       {wrapper: getWrapper({name: 'status'})},
     );
@@ -138,6 +150,8 @@ describe('<VariableFilterRow />', () => {
         rowIndex={0}
         onDelete={onDelete}
         isDeleteHidden={false}
+        onJsonEditorOpen={vi.fn()}
+        onJsonEditorClose={vi.fn()}
       />,
       {wrapper: getWrapper()},
     );
@@ -154,6 +168,8 @@ describe('<VariableFilterRow />', () => {
         rowIndex={0}
         onDelete={vi.fn()}
         isDeleteHidden
+        onJsonEditorOpen={vi.fn()}
+        onJsonEditorClose={vi.fn()}
       />,
       {wrapper: getWrapper()},
     );
@@ -166,6 +182,25 @@ describe('<VariableFilterRow />', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('should call onJsonEditorOpen when editor icon is clicked', async () => {
+    const onJsonEditorOpen = vi.fn();
+    const {user} = render(
+      <VariableFilterRow
+        fieldName="conditions[0]"
+        rowIndex={0}
+        onDelete={vi.fn()}
+        isDeleteHidden
+        onJsonEditorOpen={onJsonEditorOpen}
+        onJsonEditorClose={vi.fn()}
+      />,
+      {wrapper: getWrapper({name: 'status'})},
+    );
+
+    await user.click(screen.getByRole('button', {name: 'Open JSON editor'}));
+
+    expect(onJsonEditorOpen).toHaveBeenCalledTimes(1);
+  });
+
   it('should show value field after switching back from exists to equals', async () => {
     const {user} = render(
       <VariableFilterRow
@@ -173,6 +208,8 @@ describe('<VariableFilterRow />', () => {
         rowIndex={0}
         onDelete={vi.fn()}
         isDeleteHidden
+        onJsonEditorOpen={vi.fn()}
+        onJsonEditorClose={vi.fn()}
       />,
       {wrapper: getWrapper({operator: 'exists'})},
     );

--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterRow.test.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterRow.test.tsx
@@ -81,9 +81,7 @@ describe('<VariableFilterRow />', () => {
       />,
       {wrapper: getWrapper()},
     );
-    expect(
-      screen.getByTestId('delete-variable-filter-test-id'),
-    ).not.toBeVisible();
+    expect(screen.getByTestId('delete-variable-filter-0')).not.toBeVisible();
   });
 
   it('should show delete button when isDeleteHidden is false', () => {
@@ -97,7 +95,7 @@ describe('<VariableFilterRow />', () => {
       {wrapper: getWrapper()},
     );
 
-    expect(screen.getByTestId('delete-variable-filter-test-id')).toBeVisible();
+    expect(screen.getByTestId('delete-variable-filter-0')).toBeVisible();
   });
 
   it('should update name input when user types', async () => {

--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterRow.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterRow.tsx
@@ -6,13 +6,15 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {useState} from 'react';
+import {useRef, useState} from 'react';
 import {Dropdown, TextInput} from '@carbon/react';
 import {Close, Maximize} from '@carbon/react/icons';
 import {createPortal} from 'react-dom';
 import {Field, useForm} from 'react-final-form';
 import {JSONEditorModal} from 'modules/components/JSONEditorModal';
 import {IconTextInput} from 'modules/components/IconInput';
+import {EDITOR_MODE_TOGGLE} from 'modules/feature-flags';
+import {editorModeStore} from 'modules/stores/editorMode';
 import type {VariableFilterOperator} from 'modules/stores/variableFilter';
 import {VARIABLE_FILTER_OPERATORS} from './constants';
 import {FilterRow, ValueFieldContainer, DeleteButton} from './styled';
@@ -22,6 +24,11 @@ type Props = {
   onDelete: () => void;
   isDeleteHidden: boolean;
   rowIndex: number;
+  onJsonEditorOpen: () => void;
+  onJsonEditorClose: () => void;
+  onExpandRow?: (index: number) => void;
+  onEditValue?: (index: number) => void;
+  onSlideOverOpen?: (index: number) => void;
 };
 
 const getValuePlaceholder = (operator: VariableFilterOperator): string => {
@@ -40,9 +47,16 @@ const VariableFilterRow: React.FC<Props> = ({
   onDelete,
   isDeleteHidden,
   rowIndex,
+  onJsonEditorOpen,
+  onJsonEditorClose,
+  onExpandRow,
+  onEditValue,
+  onSlideOverOpen,
 }) => {
   const [isJsonEditorOpen, setIsJsonEditorOpen] = useState(false);
   const form = useForm();
+  const iconButtonRef = useRef<HTMLButtonElement>(null);
+  const editorMode = EDITOR_MODE_TOGGLE ? editorModeStore.mode : 'default';
 
   return (
     <FilterRow>
@@ -118,48 +132,93 @@ const VariableFilterRow: React.FC<Props> = ({
                       dirtySinceLastSubmit: true,
                     }}
                   >
-                    {({input, meta}) => (
-                      <>
-                        <IconTextInput
-                          id={input.name}
-                          name={input.name}
-                          labelText="Value"
-                          hideLabel
-                          placeholder={getValuePlaceholder(operatorInput.value)}
-                          value={input.value}
-                          onChange={input.onChange}
-                          onBlur={input.onBlur}
-                          invalid={
-                            !meta.dirtySinceLastSubmit &&
-                            meta.submitError !== undefined
-                          }
-                          invalidText={
-                            meta.dirtySinceLastSubmit
-                              ? undefined
-                              : meta.submitError
-                          }
-                          size="sm"
-                          Icon={Maximize}
-                          buttonLabel="Open JSON editor"
-                          onIconClick={() => setIsJsonEditorOpen(true)}
-                          data-testid={`variable-filter-value-${rowIndex}`}
-                        />
-                        {isJsonEditorOpen &&
-                          createPortal(
-                            <JSONEditorModal
-                              isVisible={isJsonEditorOpen}
-                              title="Edit Variable Value"
-                              value={input.value}
-                              onClose={() => setIsJsonEditorOpen(false)}
-                              onApply={(value) => {
-                                input.onChange(value ?? '');
-                                setIsJsonEditorOpen(false);
-                              }}
-                            />,
-                            document.body,
-                          )}
-                      </>
-                    )}
+                    {({input, meta}) => {
+                      const handleIconClick = () => {
+                        if (editorMode === 'inline') {
+                          onExpandRow?.(rowIndex);
+                        } else if (editorMode === 'step') {
+                          onEditValue?.(rowIndex);
+                        } else if (editorMode === 'slideOver') {
+                          onSlideOverOpen?.(rowIndex);
+                        } else {
+                          setIsJsonEditorOpen(true);
+                          onJsonEditorOpen();
+                        }
+                      };
+
+                      return (
+                        <>
+                          <IconTextInput
+                            id={input.name}
+                            name={input.name}
+                            labelText="Value"
+                            hideLabel
+                            placeholder={getValuePlaceholder(
+                              operatorInput.value,
+                            )}
+                            value={input.value}
+                            onChange={input.onChange}
+                            onBlur={input.onBlur}
+                            invalid={
+                              !meta.dirtySinceLastSubmit &&
+                              meta.submitError !== undefined
+                            }
+                            invalidText={
+                              meta.dirtySinceLastSubmit
+                                ? undefined
+                                : meta.submitError
+                            }
+                            size="sm"
+                            Icon={Maximize}
+                            buttonLabel="Open JSON editor"
+                            buttonRef={iconButtonRef}
+                            onIconClick={handleIconClick}
+                            data-testid={`variable-filter-value-${rowIndex}`}
+                          />
+                          {editorMode === 'default' &&
+                            isJsonEditorOpen &&
+                            createPortal(
+                              <div className="variable-filter-json-editor">
+                                <JSONEditorModal
+                                  isVisible={isJsonEditorOpen}
+                                  title={(() => {
+                                    const variableName = form
+                                      .getState()
+                                      .values?.[
+                                        'conditions'
+                                      ]?.[rowIndex]?.name?.trim();
+                                    return variableName
+                                      ? `Edit value: ${variableName}`
+                                      : 'Edit Variable Value';
+                                  })()}
+                                  modalLabel={(() => {
+                                    const variableName = form
+                                      .getState()
+                                      .values?.[
+                                        'conditions'
+                                      ]?.[rowIndex]?.name?.trim();
+                                    return variableName
+                                      ? `Variable: ${variableName}`
+                                      : undefined;
+                                  })()}
+                                  launcherButtonRef={iconButtonRef}
+                                  value={input.value}
+                                  onClose={() => {
+                                    setIsJsonEditorOpen(false);
+                                    onJsonEditorClose();
+                                  }}
+                                  onApply={(value) => {
+                                    input.onChange(value ?? '');
+                                    setIsJsonEditorOpen(false);
+                                    onJsonEditorClose();
+                                  }}
+                                />
+                              </div>,
+                              document.body,
+                            )}
+                        </>
+                      );
+                    }}
                   </Field>
                 )}
               </ValueFieldContainer>

--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/index.test.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/index.test.tsx
@@ -6,16 +6,57 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {render, screen} from 'modules/testing-library';
+import {render, screen, waitFor} from 'modules/testing-library';
+import {MemoryRouter, Route, Routes, useLocation} from 'react-router-dom';
+import {Paths} from 'modules/Routes';
 import {VariableFilter} from '.';
 import {variableFilterStore} from 'modules/stores/variableFilter';
+
+const LocationDisplay: React.FC = () => {
+  const location = useLocation();
+  return (
+    <div data-testid="location-display">
+      {location.pathname}
+      {location.search}
+    </div>
+  );
+};
+
+const getWrapper = (initialPath = Paths.processes()) => {
+  const Wrapper: React.FC<{children: React.ReactNode}> = ({children}) => (
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Routes>
+        <Route
+          path={Paths.processes()}
+          element={
+            <>
+              {children}
+              <LocationDisplay />
+            </>
+          }
+        />
+        <Route
+          path={Paths.processesVariables()}
+          element={
+            <>
+              {children}
+              <LocationDisplay />
+            </>
+          }
+        />
+      </Routes>
+    </MemoryRouter>
+  );
+  return Wrapper;
+};
 
 describe('<VariableFilter />', () => {
   beforeEach(() => {
     variableFilterStore.reset();
   });
+
   it('should show "Add conditions" label when no conditions are set', () => {
-    render(<VariableFilter />);
+    render(<VariableFilter />, {wrapper: getWrapper()});
 
     expect(
       screen.getByRole('button', {name: 'Add conditions'}),
@@ -27,7 +68,7 @@ describe('<VariableFilter />', () => {
       {name: 'status', operator: 'equals', value: '"active"'},
     ]);
 
-    render(<VariableFilter />);
+    render(<VariableFilter />, {wrapper: getWrapper()});
 
     expect(
       screen.getByRole('button', {name: 'Edit conditions'}),
@@ -40,14 +81,14 @@ describe('<VariableFilter />', () => {
       {name: 'retries', operator: 'exists', value: ''},
     ]);
 
-    render(<VariableFilter />);
+    render(<VariableFilter />, {wrapper: getWrapper()});
 
     expect(screen.getByText('status equals "active"')).toBeInTheDocument();
     expect(screen.getByText('retries exists')).toBeInTheDocument();
   });
 
   it('should not render condition list when no conditions are set', () => {
-    render(<VariableFilter />);
+    render(<VariableFilter />, {wrapper: getWrapper()});
 
     expect(
       screen.queryByRole('list', {name: 'Active variable filters'}),
@@ -55,7 +96,7 @@ describe('<VariableFilter />', () => {
   });
 
   it('should open the modal when the button is clicked', async () => {
-    const {user} = render(<VariableFilter />);
+    const {user} = render(<VariableFilter />, {wrapper: getWrapper()});
 
     await user.click(screen.getByRole('button', {name: 'Add conditions'}));
 
@@ -65,7 +106,7 @@ describe('<VariableFilter />', () => {
   });
 
   it('should update conditions on apply', async () => {
-    const {user} = render(<VariableFilter />);
+    const {user} = render(<VariableFilter />, {wrapper: getWrapper()});
 
     await user.click(screen.getByRole('button', {name: 'Add conditions'}));
 
@@ -89,7 +130,7 @@ describe('<VariableFilter />', () => {
   });
 
   it('should not update conditions on cancel', async () => {
-    const {user} = render(<VariableFilter />);
+    const {user} = render(<VariableFilter />, {wrapper: getWrapper()});
 
     await user.click(screen.getByRole('button', {name: 'Add conditions'}));
     await user.click(screen.getByRole('button', {name: 'Cancel'}));
@@ -101,7 +142,7 @@ describe('<VariableFilter />', () => {
   });
 
   it('should reset draft rows when modal is reopened after adding unsaved rows', async () => {
-    const {user} = render(<VariableFilter />);
+    const {user} = render(<VariableFilter />, {wrapper: getWrapper()});
 
     await user.click(screen.getByRole('button', {name: 'Add conditions'}));
     await user.click(screen.getByRole('button', {name: 'Add condition'}));
@@ -111,5 +152,50 @@ describe('<VariableFilter />', () => {
     await user.click(screen.getByRole('button', {name: 'Add conditions'}));
 
     expect(screen.getAllByPlaceholderText('Variable name')).toHaveLength(1);
+  });
+
+  it('should open modal when rendered at /processes/variables', () => {
+    render(<VariableFilter />, {
+      wrapper: getWrapper(Paths.processesVariables()),
+    });
+
+    expect(
+      screen.getByRole('dialog', {name: 'Filter by Variable'}),
+    ).toBeInTheDocument();
+  });
+
+  it('should preserve search params when opening modal', async () => {
+    const {user} = render(<VariableFilter />, {
+      wrapper: getWrapper(`${Paths.processes()}?active=true&incidents=true`),
+    });
+
+    await user.click(screen.getByRole('button', {name: 'Add conditions'}));
+
+    expect(
+      screen.getByRole('dialog', {name: 'Filter by Variable'}),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('location-display')).toHaveTextContent(
+      '/processes/variables?active=true&incidents=true',
+    );
+  });
+
+  it('should preserve search params when closing modal', async () => {
+    const {user} = render(<VariableFilter />, {
+      wrapper: getWrapper(
+        `${Paths.processesVariables()}?active=true&incidents=true`,
+      ),
+    });
+
+    expect(
+      screen.getByRole('dialog', {name: 'Filter by Variable'}),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', {name: 'Cancel'}));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('location-display')).toHaveTextContent(
+        '/processes?active=true&incidents=true',
+      );
+    });
   });
 });

--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/index.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/index.tsx
@@ -6,10 +6,11 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {useState} from 'react';
 import {observer} from 'mobx-react';
+import {useMatch, useNavigate, useLocation} from 'react-router-dom';
 import {Button} from '@carbon/react';
 import {Edit} from '@carbon/react/icons';
+import {Paths} from 'modules/Routes';
 import {Title} from 'modules/components/FiltersPanel/styled';
 import {
   variableFilterStore,
@@ -29,12 +30,28 @@ const getConditionLabel = (condition: VariableCondition): string => {
 };
 
 const VariableFilter: React.FC = observer(() => {
-  const [isModalOpen, setIsModalOpen] = useState(false);
+  const isModalOpen = useMatch(Paths.processesVariables()) !== null;
+  const navigate = useNavigate();
+  const location = useLocation();
   const {conditions} = variableFilterStore;
+
+  const openModal = () => {
+    navigate({
+      pathname: Paths.processesVariables(),
+      search: location.search,
+    });
+  };
+
+  const closeModal = () => {
+    navigate({
+      pathname: Paths.processes(),
+      search: location.search,
+    });
+  };
 
   const handleApply = (newConditions: VariableCondition[]) => {
     variableFilterStore.setConditions(newConditions);
-    setIsModalOpen(false);
+    closeModal();
   };
 
   return (
@@ -55,7 +72,7 @@ const VariableFilter: React.FC = observer(() => {
         kind="ghost"
         size="sm"
         renderIcon={Edit}
-        onClick={() => setIsModalOpen(true)}
+        onClick={openModal}
         data-testid="open-variable-filter-modal"
       >
         {conditions.length === 0 ? 'Add conditions' : 'Edit conditions'}
@@ -66,7 +83,7 @@ const VariableFilter: React.FC = observer(() => {
         isOpen={isModalOpen}
         initialConditions={conditions}
         onApply={handleApply}
-        onClose={() => setIsModalOpen(false)}
+        onClose={closeModal}
       />
     </>
   );

--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/index.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/index.tsx
@@ -20,12 +20,21 @@ import {VARIABLE_FILTER_OPERATORS} from './constants';
 import {VariableFilterModal} from './VariableFilterModal';
 import {ConditionList, ConditionItem} from './styled';
 
+const MAX_VALUE_LENGTH = 50;
+
+const truncateValue = (value: string): string => {
+  if (value.length <= MAX_VALUE_LENGTH) {
+    return value;
+  }
+  return `${value.slice(0, MAX_VALUE_LENGTH)}…`;
+};
+
 const getConditionLabel = (condition: VariableCondition): string => {
   const config = VARIABLE_FILTER_OPERATORS.find(
     (op) => op.id === condition.operator,
   );
   return config?.requiresValue
-    ? `${condition.name} ${config.label} ${condition.value}`
+    ? `${condition.name} ${config.label} ${truncateValue(condition.value)}`
     : `${condition.name} ${config?.label ?? condition.operator}`;
 };
 

--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/styled.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/styled.tsx
@@ -9,6 +9,7 @@
 import styled from 'styled-components';
 import {IconButton as BaseIconButton} from '@carbon/react';
 import {styles} from '@carbon/elements';
+import {IconContainer, IconButton} from 'modules/components/IconInput/styled';
 
 const ModalContent = styled.div`
   min-height: 350px;
@@ -28,6 +29,16 @@ const FilterRow = styled.div`
 
 const ValueFieldContainer = styled.div`
   position: relative;
+
+  ${IconContainer} {
+    top: 0;
+    bottom: auto;
+    right: var(--cds-spacing-08);
+
+    ${IconButton} {
+      margin-top: 0;
+    }
+  }
 `;
 
 const DeleteButton = styled(BaseIconButton)<{$hidden?: boolean}>`

--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/styled.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/styled.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import styled from 'styled-components';
+import styled, {createGlobalStyle} from 'styled-components';
 import {IconButton as BaseIconButton} from '@carbon/react';
 import {styles} from '@carbon/elements';
 import {IconContainer, IconButton} from 'modules/components/IconInput/styled';
@@ -33,11 +33,18 @@ const ValueFieldContainer = styled.div`
   ${IconContainer} {
     top: 0;
     bottom: auto;
-    right: var(--cds-spacing-08);
 
     ${IconButton} {
       margin-top: 0;
     }
+  }
+`;
+
+const DimmedParentModalStyle = createGlobalStyle`
+  .variable-filter-modal--dimmed .cds--modal-container {
+    opacity: 0.3;
+    pointer-events: none;
+    transition: opacity 150ms ease-in-out;
   }
 `;
 
@@ -54,6 +61,48 @@ const ConditionList = styled.ul`
 
 const ConditionItem = styled.li`
   ${styles.bodyShort01};
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  word-break: break-all;
+`;
+
+const ModeToggleContainer = styled.div`
+  margin-top: var(--cds-spacing-05);
+  padding-top: var(--cds-spacing-05);
+  border-top: 1px solid var(--cds-border-subtle);
+  opacity: 0.7;
+`;
+
+const BackButtonContent = styled.span`
+  display: inline-flex;
+  align-items: center;
+  gap: var(--cds-spacing-02);
+`;
+
+const ExpandedEditorSection = styled.div<{$isOpen: boolean}>`
+  overflow: hidden;
+  max-height: ${({$isOpen}) => ($isOpen ? '50vh' : '0')};
+  opacity: ${({$isOpen}) => ($isOpen ? 1 : 0)};
+  transition:
+    max-height 300ms ease-in-out,
+    opacity 200ms ease-in-out;
+  border-top: ${({$isOpen}) =>
+    $isOpen ? '1px solid var(--cds-border-subtle)' : 'none'};
+  margin-top: ${({$isOpen}) => ($isOpen ? 'var(--cds-spacing-05)' : '0')};
+`;
+
+const ExpandedEditorHeader = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--cds-spacing-03) 0;
+
+  h4 {
+    margin: 0;
+    ${styles.headingCompact01};
+  }
 `;
 
 export {
@@ -64,4 +113,9 @@ export {
   DeleteButton,
   ConditionList,
   ConditionItem,
+  DimmedParentModalStyle,
+  ModeToggleContainer,
+  BackButtonContent,
+  ExpandedEditorSection,
+  ExpandedEditorHeader,
 };

--- a/operate/client/src/App/Processes/ListView/InstancesTable/InstancesTableWrapper.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/InstancesTableWrapper.tsx
@@ -23,6 +23,7 @@ import {useSearchParams} from 'react-router-dom';
 import {variableFilterStore} from 'modules/stores/variableFilter';
 import {processInstancesSelectionStore} from 'modules/stores/instancesSelection';
 import {useEffect, useMemo} from 'react';
+import {MULTI_VARIABLE_FILTER} from 'modules/feature-flags';
 
 const ROW_HEIGHT = 34;
 const SCROLL_STEP_SIZE = 5 * ROW_HEIGHT;
@@ -46,7 +47,10 @@ const InstancesTableWrapper: React.FC = observer(() => {
   const hasIncidentsFilter = searchParams.get('incidents') === 'true';
 
   const variable = variableFilterStore.variable;
-  const filter = useProcessInstancesSearchFilter(variable);
+  const conditions = MULTI_VARIABLE_FILTER
+    ? variableFilterStore.conditions
+    : undefined;
+  const filter = useProcessInstancesSearchFilter(variable, conditions);
   const sort = useProcessInstancesSearchSort();
 
   const enablePeriodicRefetch =

--- a/operate/client/src/App/Processes/index.tsx
+++ b/operate/client/src/App/Processes/index.tsx
@@ -7,7 +7,10 @@
  */
 
 import {observer} from 'mobx-react';
+import {Outlet, useLocation, useMatch, useNavigate} from 'react-router-dom';
 import {processInstanceMigrationStore} from 'modules/stores/processInstanceMigration';
+import {Paths} from 'modules/Routes';
+import {MULTI_VARIABLE_FILTER} from 'modules/feature-flags';
 import {MigrationView} from './MigrationView';
 import {ListView} from './ListView';
 import {useEffect} from 'react';
@@ -15,9 +18,22 @@ import {useCallbackPrompt} from 'modules/hooks/useCallbackPrompt';
 import {Modal} from '@carbon/react';
 
 const Processes: React.FC = observer(() => {
+  const isOnVariablesRoute = useMatch(Paths.processesVariables()) !== null;
+  const navigate = useNavigate();
+  const location = useLocation();
+
   useEffect(() => {
     return processInstanceMigrationStore.reset;
   }, []);
+
+  useEffect(() => {
+    if (isOnVariablesRoute && !MULTI_VARIABLE_FILTER) {
+      navigate(
+        {pathname: Paths.processes(), search: location.search},
+        {replace: true},
+      );
+    }
+  }, [isOnVariablesRoute, navigate, location.search]);
 
   const {isNavigationInterrupted, confirmNavigation, cancelNavigation} =
     useCallbackPrompt({
@@ -31,6 +47,7 @@ const Processes: React.FC = observer(() => {
       ) : (
         <ListView />
       )}
+      <Outlet />
 
       {processInstanceMigrationStore.isEnabled && isNavigationInterrupted && (
         <Modal

--- a/operate/client/src/App/index.tsx
+++ b/operate/client/src/App/index.tsx
@@ -93,7 +93,9 @@ const routes = createRoutesFromElements(
           const {Processes} = await import('./Processes/index');
           return {Component: Processes};
         }}
-      />
+      >
+        <Route path="variables" element={null} />
+      </Route>
       <Route
         path={Paths.processInstance(undefined, true)}
         lazy={async () => {

--- a/operate/client/src/modules/Routes.tsx
+++ b/operate/client/src/modules/Routes.tsx
@@ -20,6 +20,9 @@ const Paths = {
   processes() {
     return '/processes';
   },
+  processesVariables() {
+    return '/processes/variables';
+  },
   processInstance(
     processInstanceId: string | null = ':processInstanceId',
     isParent = false,

--- a/operate/client/src/modules/components/IconInput/IconTextInput.tsx
+++ b/operate/client/src/modules/components/IconInput/IconTextInput.tsx
@@ -19,6 +19,7 @@ interface Props extends React.ComponentProps<typeof BaseTextInput> {
   onIconClick: () => void;
   buttonLabel: string;
   tooltipPosition?: React.ComponentProps<typeof BaseIconButton>['align'];
+  buttonRef?: React.Ref<HTMLButtonElement>;
 }
 
 const IconTextInput: React.FC<Props> = ({
@@ -27,6 +28,7 @@ const IconTextInput: React.FC<Props> = ({
   onIconClick,
   buttonLabel,
   tooltipPosition = 'top-end',
+  buttonRef,
   ...props
 }) => {
   return (
@@ -34,6 +36,7 @@ const IconTextInput: React.FC<Props> = ({
       <TextInput invalid={invalid} {...props} />
       <IconContainer>
         <IconButton
+          ref={buttonRef}
           kind="ghost"
           size="sm"
           onClick={onIconClick}

--- a/operate/client/src/modules/components/JSONEditorModal/index.tsx
+++ b/operate/client/src/modules/components/JSONEditorModal/index.tsx
@@ -38,6 +38,8 @@ type Props = {
   editModeTitle?: string;
   readOnly?: boolean;
   allowModeToggle?: boolean;
+  launcherButtonRef?: React.RefObject<HTMLButtonElement | null>;
+  modalLabel?: React.ReactNode;
 };
 
 const JSONEditorModal: React.FC<Props> = observer(
@@ -50,6 +52,8 @@ const JSONEditorModal: React.FC<Props> = observer(
     editModeTitle,
     readOnly = false,
     allowModeToggle = false,
+    launcherButtonRef,
+    modalLabel,
   }) => {
     const [editedValue, setEditedValue] = useState(value);
     const [isValid, setIsValid] = useState(true);
@@ -96,6 +100,8 @@ const JSONEditorModal: React.FC<Props> = observer(
       <Modal
         open={isVisible}
         modalHeading={isInEditMode && editModeTitle ? editModeTitle : title}
+        modalLabel={modalLabel}
+        launcherButtonRef={launcherButtonRef}
         onRequestClose={() => {
           onClose?.();
         }}

--- a/operate/client/src/modules/feature-flags.ts
+++ b/operate/client/src/modules/feature-flags.ts
@@ -6,6 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-const MULTI_VARIABLE_FILTER = false;
+const MULTI_VARIABLE_FILTER = true;
+const EDITOR_MODE_TOGGLE = true;
 
-export {MULTI_VARIABLE_FILTER};
+export {MULTI_VARIABLE_FILTER, EDITOR_MODE_TOGGLE};

--- a/operate/client/src/modules/hooks/processInstancesSearch.test.ts
+++ b/operate/client/src/modules/hooks/processInstancesSearch.test.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {buildVariableEntry, parseOneOfValues} from './processInstancesSearch';
+import type {VariableCondition} from 'modules/stores/variableFilter';
+
+const makeCondition = (
+  overrides: Partial<VariableCondition> = {},
+): VariableCondition => ({
+  name: 'status',
+  operator: 'equals',
+  value: '"active"',
+  ...overrides,
+});
+
+describe('buildVariableEntry', () => {
+  it('should build equals entry as plain string value', () => {
+    expect(
+      buildVariableEntry(
+        makeCondition({operator: 'equals', value: '"active"'}),
+      ),
+    ).toEqual({
+      name: 'status',
+      value: '"active"',
+    });
+  });
+
+  it('should build notEqual entry as {$neq}', () => {
+    expect(
+      buildVariableEntry(
+        makeCondition({operator: 'notEqual', value: '"inactive"'}),
+      ),
+    ).toEqual({
+      name: 'status',
+      value: {$neq: '"inactive"'},
+    });
+  });
+
+  it('should build contains entry as {$like: "*value*"}', () => {
+    expect(
+      buildVariableEntry(
+        makeCondition({operator: 'contains', value: 'active'}),
+      ),
+    ).toEqual({
+      name: 'status',
+      value: {$like: '*active*'},
+    });
+  });
+
+  it('should build oneOf entry as {$in: [...]} from JSON array', () => {
+    expect(
+      buildVariableEntry(
+        makeCondition({operator: 'oneOf', value: '["active","pending"]'}),
+      ),
+    ).toEqual({
+      name: 'status',
+      value: {$in: ['"active"', '"pending"']},
+    });
+  });
+
+  it('should build exists entry as {$exists: true}', () => {
+    expect(
+      buildVariableEntry(makeCondition({operator: 'exists', value: ''})),
+    ).toEqual({
+      name: 'status',
+      value: {$exists: true},
+    });
+  });
+
+  it('should build doesNotExist entry as {$exists: false}', () => {
+    expect(
+      buildVariableEntry(makeCondition({operator: 'doesNotExist', value: ''})),
+    ).toEqual({
+      name: 'status',
+      value: {$exists: false},
+    });
+  });
+});
+
+describe('parseOneOfValues', () => {
+  it('should parse a JSON array of strings and JSON-stringify each value', () => {
+    expect(parseOneOfValues('["a","b","c"]')).toEqual(['"a"', '"b"', '"c"']);
+  });
+
+  it('should fall back to comma-split for non-JSON input', () => {
+    expect(parseOneOfValues('a, b, c')).toEqual(['a', 'b', 'c']);
+  });
+
+  it('should filter out empty entries from comma-split', () => {
+    expect(parseOneOfValues('a,,b')).toEqual(['a', 'b']);
+  });
+
+  it('should handle a JSON array of numbers by converting to strings', () => {
+    expect(parseOneOfValues('[1,2,3]')).toEqual(['1', '2', '3']);
+  });
+});
+
+describe('buildVariableEntry — multi-condition', () => {
+  it('should produce one entry per condition with mixed operators', () => {
+    const conditions: VariableCondition[] = [
+      {name: 'status', operator: 'equals', value: '"active"'},
+      {name: 'region', operator: 'contains', value: 'eu'},
+      {name: 'priority', operator: 'exists', value: ''},
+    ];
+
+    expect(conditions.map(buildVariableEntry)).toEqual([
+      {name: 'status', value: '"active"'},
+      {name: 'region', value: {$like: '*eu*'}},
+      {name: 'priority', value: {$exists: true}},
+    ]);
+  });
+
+  it('should produce byte-equivalent output to legacy path for single equals', () => {
+    const condition: VariableCondition = {
+      name: 'myVar',
+      operator: 'equals',
+      value: '"hello"',
+    };
+
+    const mvfResult = buildVariableEntry(condition);
+
+    const legacyResult = {
+      name: 'myVar',
+      value: '"hello"',
+    };
+
+    expect(mvfResult).toEqual(legacyResult);
+  });
+});

--- a/operate/client/src/modules/hooks/processInstancesSearch.test.ts
+++ b/operate/client/src/modules/hooks/processInstancesSearch.test.ts
@@ -11,12 +11,13 @@ import type {VariableCondition} from 'modules/stores/variableFilter';
 
 const makeCondition = (
   overrides: Partial<VariableCondition> = {},
-): VariableCondition => ({
-  name: 'status',
-  operator: 'equals',
-  value: '"active"',
-  ...overrides,
-});
+): VariableCondition =>
+  ({
+    name: 'status',
+    operator: 'equals',
+    value: '"active"',
+    ...overrides,
+  }) as VariableCondition;
 
 describe('buildVariableEntry', () => {
   it('should build equals entry as plain string value', () => {

--- a/operate/client/src/modules/hooks/processInstancesSearch.ts
+++ b/operate/client/src/modules/hooks/processInstancesSearch.ts
@@ -13,30 +13,80 @@ import {
 import {useMemo} from 'react';
 import {useSearchParams} from 'react-router-dom';
 import {getValidVariableValues} from 'modules/utils/filter/getValidVariableValues';
-import type {Variable} from 'modules/stores/variableFilter';
+import type {Variable, VariableCondition} from 'modules/stores/variableFilter';
+import {MULTI_VARIABLE_FILTER} from 'modules/feature-flags';
+import type {QueryProcessInstancesRequestBody} from '@camunda/camunda-api-zod-schemas/8.10';
 
-function useProcessInstancesSearchFilter(variable?: Variable) {
+type VariableEntry = NonNullable<
+  NonNullable<QueryProcessInstancesRequestBody['filter']>['variables']
+>[number];
+
+function useProcessInstancesSearchFilter(
+  variable?: Variable,
+  conditions?: VariableCondition[],
+) {
   const [searchParams] = useSearchParams();
 
   return useMemo(() => {
     const filter = parseProcessInstancesSearchFilter(searchParams);
 
-    if (filter && variable?.name && variable?.values) {
-      const parsed = (getValidVariableValues(variable.values) ?? []).map((v) =>
-        JSON.stringify(v),
-      );
-      if (parsed.length > 0) {
-        filter.variables = [
-          {
-            name: variable?.name,
-            value: parsed.length === 1 ? parsed[0]! : {$in: parsed},
-          },
-        ];
+    if (MULTI_VARIABLE_FILTER) {
+      if (filter && conditions && conditions.length > 0) {
+        filter.variables = conditions.map(buildVariableEntry);
+      }
+    } else {
+      if (filter && variable?.name && variable?.values) {
+        const parsed = (getValidVariableValues(variable.values) ?? []).map(
+          (v) => JSON.stringify(v),
+        );
+        if (parsed.length > 0) {
+          filter.variables = [
+            {
+              name: variable.name,
+              value: parsed.length === 1 ? parsed[0]! : {$in: parsed},
+            },
+          ];
+        }
       }
     }
 
     return filter;
-  }, [searchParams, variable]);
+  }, [searchParams, variable, conditions]);
+}
+
+function buildVariableEntry(condition: VariableCondition): VariableEntry {
+  switch (condition.operator) {
+    case 'equals':
+      return {name: condition.name, value: condition.value};
+    case 'notEqual':
+      return {name: condition.name, value: {$neq: condition.value}};
+    case 'contains':
+      return {name: condition.name, value: {$like: `*${condition.value}*`}};
+    case 'oneOf':
+      return {
+        name: condition.name,
+        value: {$in: parseOneOfValues(condition.value)},
+      };
+    case 'exists':
+      return {name: condition.name, value: {$exists: true}};
+    case 'doesNotExist':
+      return {name: condition.name, value: {$exists: false}};
+  }
+}
+
+function parseOneOfValues(raw: string): string[] {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (Array.isArray(parsed)) {
+      return parsed.map((v) => JSON.stringify(v));
+    }
+  } catch {
+    // fall through to comma-split
+  }
+  return raw
+    .split(',')
+    .map((v) => v.trim())
+    .filter(Boolean);
 }
 
 function useProcessInstancesSearchSort() {
@@ -48,4 +98,9 @@ function useProcessInstancesSearchSort() {
   );
 }
 
-export {useProcessInstancesSearchFilter, useProcessInstancesSearchSort};
+export {
+  useProcessInstancesSearchFilter,
+  useProcessInstancesSearchSort,
+  buildVariableEntry,
+  parseOneOfValues,
+};

--- a/operate/client/src/modules/hooks/useCurrentPage.tsx
+++ b/operate/client/src/modules/hooks/useCurrentPage.tsx
@@ -34,6 +34,10 @@ const useCurrentPage = () => {
       return 'dashboard';
     }
 
+    if (matchPath(Paths.processesVariables(), location.pathname) !== null) {
+      return 'processes';
+    }
+
     if (matchPath(Paths.processes(), location.pathname) !== null) {
       return 'processes';
     }

--- a/operate/client/src/modules/stores/editorMode.ts
+++ b/operate/client/src/modules/stores/editorMode.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {makeAutoObservable} from 'mobx';
+import {getStateLocally, storeStateLocally} from 'modules/utils/localStorage';
+
+type EditorMode = 'default' | 'inline' | 'step' | 'slideOver';
+
+const VALID_MODES: EditorMode[] = ['default', 'inline', 'step', 'slideOver'];
+const STORAGE_KEY = 'editorMode';
+
+const storedMode: string = getStateLocally()[STORAGE_KEY];
+
+class EditorModeStore {
+  state: {mode: EditorMode} = {
+    mode: VALID_MODES.includes(storedMode as EditorMode)
+      ? (storedMode as EditorMode)
+      : 'default',
+  };
+
+  constructor() {
+    makeAutoObservable(this);
+  }
+
+  get mode(): EditorMode {
+    return this.state.mode;
+  }
+
+  setMode = (mode: EditorMode) => {
+    this.state.mode = mode;
+    storeStateLocally({[STORAGE_KEY]: mode});
+  };
+
+  reset = () => {
+    this.state.mode = 'default';
+  };
+}
+
+const editorModeStore = new EditorModeStore();
+
+export {editorModeStore};
+export type {EditorMode};


### PR DESCRIPTION
## Description

Showcase nested JSON editor UX improvements.
Options evaluation can be found [here](https://www.figma.com/board/Fl7zimOTwnG7QLJDuHrKpt/MVF?node-id=0-1&t=Hwsp4brWkIecROCj-1)

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
