### PR TITLE
test(cpt): increase container startup timeout

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/containers/CamundaContainer.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/containers/CamundaContainer.java
@@ -46,7 +46,7 @@ import org.testcontainers.utility.DockerImageName;
 
 public class CamundaContainer extends GenericContainer<CamundaContainer> {
 
-  private static final Duration DEFAULT_STARTUP_TIMEOUT = Duration.ofMinutes(1);
+  private static final Duration DEFAULT_STARTUP_TIMEOUT = Duration.ofMinutes(2);
   private static final Duration DEFAULT_READINESS_TIMEOUT = Duration.ofSeconds(10);
 
   private static final String READY_ENDPOINT = "/actuator/health/status";


### PR DESCRIPTION
## Description

Increase container startup timeout from 1 to 2 minutes for the [CPT compatibility tests](https://github.com/camunda/camunda/actions/workflows/camunda-process-test-compatibility.yml).

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

related to  #52884
