### PR TITLE
fix: resolve flaky processInstanceHistory e2e test for incident history

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceHistory.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceHistory.spec.ts
@@ -97,20 +97,17 @@ test.describe('Process Instance History', () => {
     await test.step('Open Process Instances Page', async () => {
       await waitForAssertion({
         assertion: async () => {
-          await expect(async () => {
-            await operateFiltersPanelPage.selectProcess('IncidentProcess');
-          }).toPass({intervals: [5_000], timeout: 60_000});
+          await operateFiltersPanelPage.selectProcess('IncidentProcess');
+          await operateFiltersPanelPage.selectVersion('1');
         },
         onFailure: async () => {
           await page.reload();
         },
       });
-      await operateFiltersPanelPage.selectVersion('1');
     });
 
     await test.step('Wait for incident to appear', async () => {
       await operateFiltersPanelPage.clickActiveInstancesCheckbox();
-      await page.waitForTimeout(5000);
       await operateFiltersPanelPage.displayOptionalFilter(
         'Process Instance Key(s)',
       );
@@ -128,6 +125,9 @@ test.describe('Process Instance History', () => {
         },
         onFailure: async () => {
           await page.reload();
+          await operateFiltersPanelPage.selectProcess('IncidentProcess');
+          await operateFiltersPanelPage.selectVersion('1');
+          await operateFiltersPanelPage.clickActiveInstancesCheckbox();
           await operateFiltersPanelPage.displayOptionalFilter(
             'Process Instance Key(s)',
           );
@@ -152,9 +152,6 @@ test.describe('Process Instance History', () => {
         },
         onFailure: async () => {
           await page.reload();
-          await operateFiltersPanelPage.displayOptionalFilter('Variable');
-          await operateFiltersPanelPage.fillVariableNameFilter('wuf');
-          await operateFiltersPanelPage.fillVariableValueFilter('1');
         },
       });
 
@@ -183,24 +180,22 @@ test.describe('Process Instance History', () => {
     });
 
     await test.step('Verify incident is resolved in Instance History', async () => {
-      await page.waitForTimeout(12000);
       await waitForAssertion({
         assertion: async () => {
           await expect(operateProcessInstancePage.incidentsTab).toBeHidden();
+          await operateProcessInstancePage.verifyHistoryItemsStatus(
+            mainProcessName,
+            ['ACTIVE'],
+          );
+          await operateProcessInstancePage.verifyHistoryItemsStatus(
+            incidentItemName,
+            ['COMPLETED'],
+          );
         },
         onFailure: async () => {
           await page.reload();
         },
       });
-
-      await operateProcessInstancePage.verifyHistoryItemsStatus(
-        mainProcessName,
-        ['ACTIVE'],
-      );
-      await operateProcessInstancePage.verifyHistoryItemsStatus(
-        incidentItemName,
-        ['COMPLETED'],
-      );
     });
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceHistory.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceHistory.spec.ts
@@ -183,6 +183,11 @@ test.describe('Process Instance History', () => {
       await waitForAssertion({
         assertion: async () => {
           await expect(operateProcessInstancePage.incidentsTab).toBeHidden();
+          await expect(
+            operateProcessInstancePage.instanceHistory
+              .getByRole('treeitem')
+              .first(),
+          ).toBeVisible();
           await operateProcessInstancePage.verifyHistoryItemsStatus(
             mainProcessName,
             ['ACTIVE'],


### PR DESCRIPTION
Remove hard-coded waitForTimeout calls (5s and 12s) that were racing against non-deterministic Operate import lag. Fix broken onFailure callbacks that lost filter state after page reload. Move history status assertions inside the waitForAssertion retry block so stale UI state is retried rather than failing hard. Remove toPass anti-pattern nested inside waitForAssertion that could spin for 3x60s.

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes https://github.com/camunda/camunda/issues/52660
