### PR TITLE
fix: skip setting flowNodeId for RETRIES_UPDATED event

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/UnhandledBpmnErrorJobElementIdIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/UnhandledBpmnErrorJobElementIdIT.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.response.Job;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that the engine-internal {@code NO_CATCH_EVENT_FOUND} sentinel (set by {@link
+ * io.camunda.zeebe.engine.processing.job.JobThrowErrorProcessor} when a BPMN error has no matching
+ * catch event) never surfaces in the jobs search API as the job's {@code elementId}.
+ *
+ * <p>The bug: when {@code RETRIES_UPDATED} fires after {@code ERROR_THROWN}, the job record still
+ * carries {@code elementId="NO_CATCH_EVENT_FOUND"}. Both {@code JobHandler} (ES/OS exporter) and
+ * {@code JobExportHandler} (RDBMS exporter) used to write that value verbatim into secondary
+ * storage, corrupting the {@code elementId} field returned by the jobs search API.
+ */
+@MultiDbTest
+public class UnhandledBpmnErrorJobElementIdIT {
+
+  private static CamundaClient camundaClient;
+
+  @Test
+  void shouldNotExposeNoCatchEventFoundMarkerAsJobElementId() {
+    final var jobType = "service-task-throw-unhandled-error";
+    final var serviceTaskId = "ServiceTaskThrowingUnhandledError";
+
+    // given - a process whose service task throws a BPMN error with no matching catch event
+    final var processModel =
+        Bpmn.createExecutableProcess("process-unhandled-error-job-element-id")
+            .startEvent("StartEvent")
+            .serviceTask(serviceTaskId, t -> t.zeebeJobType(jobType))
+            .endEvent("EndEvent")
+            .done();
+
+    camundaClient
+        .newDeployResourceCommand()
+        .addProcessModel(processModel, "process-unhandled-error-job-element-id.bpmn")
+        .send()
+        .join();
+
+    camundaClient
+        .newCreateInstanceCommand()
+        .bpmnProcessId("process-unhandled-error-job-element-id")
+        .latestVersion()
+        .send()
+        .join();
+
+    final var activatedJob =
+        Awaitility.await("the service task job is activatable")
+            .atMost(TIMEOUT_DATA_AVAILABILITY)
+            .ignoreExceptions()
+            .until(
+                () ->
+                    camundaClient
+                        .newActivateJobsCommand()
+                        .jobType(jobType)
+                        .maxJobsToActivate(1)
+                        .send()
+                        .join()
+                        .getJobs(),
+                jobs -> !jobs.isEmpty())
+            .getFirst();
+
+    // when - throw a BPMN error for which there is no catch event; the engine sets the job's
+    // elementId to the NO_CATCH_EVENT_FOUND sentinel and creates an incident
+    camundaClient
+        .newThrowErrorCommand(activatedJob.getKey())
+        .errorCode("unhandled-error-code")
+        .send()
+        .join();
+
+    // wait until the incident appears so we know ERROR_THROWN has been processed
+    Awaitility.await("incident created for unhandled BPMN error")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newIncidentSearchRequest()
+                            .filter(f -> f.jobKey(activatedJob.getKey()))
+                            .send()
+                            .join()
+                            .items())
+                    .hasSize(1));
+
+    // update retries - this triggers RETRIES_UPDATED which was the source of the leak
+    camundaClient.newUpdateRetriesCommand(activatedJob.getKey()).retries(1).send().join();
+
+    // then - the job search API must return the real service-task elementId, never the marker
+    Awaitility.await("job search reflects the RETRIES_UPDATED state")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var jobs =
+                  camundaClient
+                      .newJobSearchRequest()
+                      .filter(f -> f.jobKey(activatedJob.getKey()))
+                      .send()
+                      .join()
+                      .items();
+              assertThat(jobs).hasSize(1);
+              assertThat(jobs.stream().map(Job::getElementId).toList())
+                  .as("elementId should not be overwritten with NO_CATCH_EVENT_FOUND marker")
+                  .doesNotContain("NO_CATCH_EVENT_FOUND")
+                  .containsOnly(serviceTaskId);
+            });
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/behaviour/JobUpdateBehaviour.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/behaviour/JobUpdateBehaviour.java
@@ -53,7 +53,7 @@ public class JobUpdateBehaviour {
             jobState,
             processingStateState.getBannedInstanceState(),
             "update",
-            List.of(State.ACTIVATABLE, State.ACTIVATED, State.FAILED),
+            List.of(State.ACTIVATABLE, State.ACTIVATED, State.FAILED, State.ERROR_THROWN),
             authCheckBehavior);
     this.authCheckBehavior = authCheckBehavior;
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/JobHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/JobHandler.java
@@ -50,6 +50,8 @@ public class JobHandler implements ExportHandler<JobEntity, JobRecordValue> {
           JobIntent.MIGRATED);
   private static final Set<JobIntent> FAILED_JOB_EVENTS =
       Set.of(JobIntent.FAILED, JobIntent.ERROR_THROWN);
+  private static final Set<JobIntent> INTENTS_RETAINING_ELEMENT_ID =
+      Set.of(JobIntent.FAILED, JobIntent.ERROR_THROWN, JobIntent.RETRIES_UPDATED);
 
   protected final String indexName;
 
@@ -132,9 +134,11 @@ public class JobHandler implements ExportHandler<JobEntity, JobRecordValue> {
       entity.setDeadline(DateUtil.toOffsetDateTime(Instant.ofEpochMilli(jobDeadline)));
     }
 
-    if (FAILED_JOB_EVENTS.contains(record.getIntent())) {
-      // set flowNodeId to null to not overwrite it (because zeebe puts an error message there)
+    if (INTENTS_RETAINING_ELEMENT_ID.contains(record.getIntent())) {
       entity.setFlowNodeId(null);
+    }
+
+    if (FAILED_JOB_EVENTS.contains(record.getIntent())) {
       if (recordValue.getRetries() > 0) {
         entity.setJobFailedWithRetriesLeft(true);
       } else {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/JobHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/JobHandlerTest.java
@@ -343,6 +343,33 @@ final class JobHandlerTest {
   }
 
   @Test
+  void shouldNotUpdateFlowNodeIdOnRetriesUpdated() {
+    // given
+    final long recordKey = 789;
+    final var recordValue =
+        ImmutableJobRecordValue.builder()
+            .withElementId("serviceTask")
+            .withRetries(3)
+            .withJobKind(JobKind.BPMN_ELEMENT)
+            .build();
+    final Record<JobRecordValue> record =
+        factory.generateRecord(
+            ValueType.JOB,
+            r ->
+                r.withIntent(JobIntent.RETRIES_UPDATED)
+                    .withKey(recordKey)
+                    .withValueType(ValueType.JOB)
+                    .withValue(recordValue));
+    final var entity = new JobEntity().setId(String.valueOf(recordKey));
+
+    // when
+    underTest.updateEntity(record, entity);
+
+    // then - flowNodeId is null so flush() won't overwrite the stored value
+    assertThat(entity.getFlowNodeId()).isNull();
+  }
+
+  @Test
   void testUpdateEntityWithFailedIntentAndRetriesLeft() {
     // given
     final long recordKey = 789;

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/JobExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/JobExportHandler.java
@@ -24,6 +24,11 @@ import java.util.Set;
 
 public class JobExportHandler implements RdbmsExportHandler<JobRecordValue> {
 
+  private static final Set<JobIntent> FAILED_JOB_EVENTS =
+      Set.of(JobIntent.FAILED, JobIntent.ERROR_THROWN);
+  private static final Set<JobIntent> INTENTS_RETAINING_ELEMENT_ID =
+      Set.of(JobIntent.FAILED, JobIntent.ERROR_THROWN, JobIntent.RETRIES_UPDATED);
+
   private static final Set<JobIntent> EXPORTABLE_INTENTS =
       Set.of(
           JobIntent.CREATED,
@@ -107,8 +112,11 @@ public class JobExportHandler implements RdbmsExportHandler<JobRecordValue> {
       builder.deadline(DateUtil.toOffsetDateTime(value.getDeadline()));
     }
 
-    if (intent.equals(JobIntent.FAILED) || intent.equals(JobIntent.ERROR_THROWN)) {
+    if (INTENTS_RETAINING_ELEMENT_ID.contains(intent)) {
       builder.elementId(null);
+    }
+
+    if (FAILED_JOB_EVENTS.contains(intent)) {
       builder.hasFailedWithRetriesLeft(value.getRetries() > 0);
     }
     return builder.build();


### PR DESCRIPTION
## Description

- add unit and integration tests to validate elementId handling for unhandled BPMN errors
- skip setting flowNodeId for RETRIES_UPDATED event

## Related issues

closes https://github.com/camunda/camunda/issues/52366
