### PR TITLE
fix: prevent Tasklist archiver hang when ES callback throws (#52781)

### DIFF
--- a/tasklist/archiver/pom.xml
+++ b/tasklist/archiver/pom.xml
@@ -117,6 +117,30 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/es/ArchiverUtilElasticSearch.java
+++ b/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/es/ArchiverUtilElasticSearch.java
@@ -55,28 +55,29 @@ public class ArchiverUtilElasticSearch extends ArchiverUtilAbstract {
       final String sourceIndexName,
       final String idFieldName,
       final List<String> processInstanceKeys) {
-    final var deleteFuture = new CompletableFuture<Long>();
     final var deleteRequest =
         createDeleteByQueryRequestWithDefaults(sourceIndexName)
             .setQuery(termsQuery(idFieldName, processInstanceKeys))
             .setMaxRetries(UPDATE_RETRY_COUNT);
     final var startTimer = Timer.start();
 
-    sendDeleteRequest(deleteRequest)
-        .whenComplete(
-            (response, e) -> {
-              final var timer = getArchiverDeleteQueryTimer();
-              startTimer.stop(timer);
-
-              if (e != null) {
-                trackMetricForDeleteFailures(processInstanceKeys, e);
+    return sendDeleteRequest(deleteRequest)
+        .handle((response, e) -> handleResponse(response, e, sourceIndexName, "delete"))
+        .thenCompose(
+            result -> {
+              try {
+                startTimer.stop(getArchiverDeleteQueryTimer());
+                if (result.isLeft()) {
+                  trackMetricForDeleteFailures(processInstanceKeys, result.getLeft());
+                }
+              } catch (final Exception ex) {
+                LOGGER.warn("Failed to record metric", ex);
               }
-
-              final var result = handleResponse(response, e, sourceIndexName, "delete");
-              result.ifRightOrLeft(deleteFuture::complete, deleteFuture::completeExceptionally);
+              if (result.isLeft()) {
+                return CompletableFuture.failedFuture(result.getLeft());
+              }
+              return CompletableFuture.completedFuture(result.get());
             });
-
-    return deleteFuture;
   }
 
   @Override
@@ -85,7 +86,6 @@ public class ArchiverUtilElasticSearch extends ArchiverUtilAbstract {
       final String destinationIndexName,
       final String idFieldName,
       final List<String> processInstanceKeys) {
-    final var reindexFuture = new CompletableFuture<Long>();
     final var reindexRequest =
         createReindexRequestWithDefaults()
             .setSourceIndices(sourceIndexName)
@@ -93,21 +93,23 @@ public class ArchiverUtilElasticSearch extends ArchiverUtilAbstract {
             .setSourceQuery(termsQuery(idFieldName, processInstanceKeys));
 
     final var startTimer = Timer.start();
-    sendReindexRequest(reindexRequest)
-        .whenComplete(
-            (response, e) -> {
-              final var reindexTimer = getArchiverReindexQueryTimer();
-              startTimer.stop(reindexTimer);
-
-              if (e != null) {
-                trackMetricForReindexFailures(processInstanceKeys, e);
+    return sendReindexRequest(reindexRequest)
+        .handle((response, e) -> handleResponse(response, e, sourceIndexName, "reindex"))
+        .thenCompose(
+            result -> {
+              try {
+                startTimer.stop(getArchiverReindexQueryTimer());
+                if (result.isLeft()) {
+                  trackMetricForReindexFailures(processInstanceKeys, result.getLeft());
+                }
+              } catch (final Exception ex) {
+                LOGGER.warn("Failed to record metric", ex);
               }
-
-              final var result = handleResponse(response, e, sourceIndexName, "reindex");
-              result.ifRightOrLeft(reindexFuture::complete, reindexFuture::completeExceptionally);
+              if (result.isLeft()) {
+                return CompletableFuture.failedFuture(result.getLeft());
+              }
+              return CompletableFuture.completedFuture(result.get());
             });
-
-    return reindexFuture;
   }
 
   @Override
@@ -201,11 +203,9 @@ public class ArchiverUtilElasticSearch extends ArchiverUtilAbstract {
         "Failed reindex while trying to reindex the following process instance keys [{}]",
         processInstanceKeys);
 
+    final Throwable cause = e.getCause() != null ? e.getCause() : e;
     metrics.recordCounts(
-        Metrics.COUNTER_NAME_REINDEX_FAILURES,
-        1,
-        "exception",
-        e.getCause().getClass().getSimpleName());
+        Metrics.COUNTER_NAME_REINDEX_FAILURES, 1, "exception", cause.getClass().getSimpleName());
   }
 
   private void trackMetricForDeleteFailures(
@@ -214,11 +214,9 @@ public class ArchiverUtilElasticSearch extends ArchiverUtilAbstract {
         "Failed deletion while trying to archive the following process instance keys [{}]",
         processInstanceKeys);
 
+    final Throwable cause = e.getCause() != null ? e.getCause() : e;
     metrics.recordCounts(
-        Metrics.COUNTER_NAME_DELETE_FAILURES,
-        1,
-        "exception",
-        e.getCause().getClass().getSimpleName());
+        Metrics.COUNTER_NAME_DELETE_FAILURES, 1, "exception", cause.getClass().getSimpleName());
   }
 
   private Timer getArchiverDeleteQueryTimer() {

--- a/tasklist/archiver/src/test/java/io/camunda/tasklist/archiver/es/ArchiverUtilElasticSearchTest.java
+++ b/tasklist/archiver/src/test/java/io/camunda/tasklist/archiver/es/ArchiverUtilElasticSearchTest.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.tasklist.archiver.es;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.tasklist.Metrics;
+import io.camunda.tasklist.util.ElasticsearchUtil;
+import io.micrometer.core.instrument.Timer;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.elasticsearch.index.reindex.BulkByScrollResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Regression tests for the silent archiver hang documented in GitHub issue #52781. Verifies that
+ * futures returned by {@link ArchiverUtilElasticSearch} always complete — even when the underlying
+ * ES failure carries no {@link Throwable#getCause() cause}, when metric recording itself throws, or
+ * when any other unexpected exception occurs in the callback.
+ */
+@ExtendWith(MockitoExtension.class)
+public class ArchiverUtilElasticSearchTest {
+
+  @InjectMocks private ArchiverUtilElasticSearch underTest;
+  @Mock private Metrics metrics;
+
+  // --- delete: null cause ---
+
+  @Test
+  public void deleteDocumentsCompletesFutureWhenFailureHasNullCause() throws Exception {
+    try (final MockedStatic<ElasticsearchUtil> mockedStatic = mockStatic(ElasticsearchUtil.class);
+        final MockedStatic<Timer> mockedTimer = mockStatic(Timer.class)) {
+      mockedTimer.when(Timer::start).thenReturn(mock(Timer.Sample.class));
+      final RuntimeException noCause = new RuntimeException("ES delete failed");
+      assertThat(noCause.getCause()).isNull();
+      final CompletableFuture<BulkByScrollResponse> failed = new CompletableFuture<>();
+      failed.completeExceptionally(noCause);
+      mockedStatic
+          .when(() -> ElasticsearchUtil.deleteByQueryAsync(any(), any(), any()))
+          .thenReturn(failed);
+
+      final CompletableFuture<Long> res = underTest.deleteDocuments("idx", "id", List.of("1"));
+
+      assertThatFutureCompletesWithin(res, 5, TimeUnit.SECONDS);
+      assertThat(res).isCompletedExceptionally();
+      verify(metrics)
+          .recordCounts(
+              eq(Metrics.COUNTER_NAME_DELETE_FAILURES),
+              anyLong(),
+              eq("exception"),
+              eq("RuntimeException"));
+    }
+  }
+
+  // --- reindex: null cause ---
+
+  @Test
+  public void reindexDocumentsCompletesFutureWhenFailureHasNullCause() throws Exception {
+    try (final MockedStatic<ElasticsearchUtil> mockedStatic = mockStatic(ElasticsearchUtil.class);
+        final MockedStatic<Timer> mockedTimer = mockStatic(Timer.class)) {
+      mockedTimer.when(Timer::start).thenReturn(mock(Timer.Sample.class));
+      final RuntimeException noCause = new RuntimeException("ES reindex failed");
+      assertThat(noCause.getCause()).isNull();
+      final CompletableFuture<BulkByScrollResponse> failed = new CompletableFuture<>();
+      failed.completeExceptionally(noCause);
+      mockedStatic
+          .when(() -> ElasticsearchUtil.reindexAsync(any(), any(), any()))
+          .thenReturn(failed);
+
+      final CompletableFuture<Long> res =
+          underTest.reindexDocuments("src", "dst", "id", List.of("1"));
+
+      assertThatFutureCompletesWithin(res, 5, TimeUnit.SECONDS);
+      assertThat(res).isCompletedExceptionally();
+      verify(metrics)
+          .recordCounts(
+              eq(Metrics.COUNTER_NAME_REINDEX_FAILURES),
+              anyLong(),
+              eq("exception"),
+              eq("RuntimeException"));
+    }
+  }
+
+  // --- delete: metric tracking throws ---
+
+  @Test
+  public void deleteDocumentsCompletesFutureWhenMetricTrackingThrows() throws Exception {
+    try (final MockedStatic<ElasticsearchUtil> mockedStatic = mockStatic(ElasticsearchUtil.class);
+        final MockedStatic<Timer> mockedTimer = mockStatic(Timer.class)) {
+      mockedTimer.when(Timer::start).thenReturn(mock(Timer.Sample.class));
+      final CompletableFuture<BulkByScrollResponse> failed = new CompletableFuture<>();
+      failed.completeExceptionally(new RuntimeException("ES delete failed"));
+      mockedStatic
+          .when(() -> ElasticsearchUtil.deleteByQueryAsync(any(), any(), any()))
+          .thenReturn(failed);
+      doThrow(new RuntimeException("metric registry exploded"))
+          .when(metrics)
+          .recordCounts(
+              eq(Metrics.COUNTER_NAME_DELETE_FAILURES),
+              anyLong(),
+              eq("exception"),
+              eq("RuntimeException"));
+
+      final CompletableFuture<Long> res = underTest.deleteDocuments("idx", "id", List.of("1"));
+
+      assertThatFutureCompletesWithin(res, 5, TimeUnit.SECONDS);
+      assertThat(res).isCompletedExceptionally();
+    }
+  }
+
+  // --- reindex: metric tracking throws ---
+
+  @Test
+  public void reindexDocumentsCompletesFutureWhenMetricTrackingThrows() throws Exception {
+    try (final MockedStatic<ElasticsearchUtil> mockedStatic = mockStatic(ElasticsearchUtil.class);
+        final MockedStatic<Timer> mockedTimer = mockStatic(Timer.class)) {
+      mockedTimer.when(Timer::start).thenReturn(mock(Timer.Sample.class));
+      final CompletableFuture<BulkByScrollResponse> failed = new CompletableFuture<>();
+      failed.completeExceptionally(new RuntimeException("ES reindex failed"));
+      mockedStatic
+          .when(() -> ElasticsearchUtil.reindexAsync(any(), any(), any()))
+          .thenReturn(failed);
+      doThrow(new RuntimeException("metric registry exploded"))
+          .when(metrics)
+          .recordCounts(
+              eq(Metrics.COUNTER_NAME_REINDEX_FAILURES),
+              anyLong(),
+              eq("exception"),
+              eq("RuntimeException"));
+
+      final CompletableFuture<Long> res =
+          underTest.reindexDocuments("src", "dst", "id", List.of("1"));
+
+      assertThatFutureCompletesWithin(res, 5, TimeUnit.SECONDS);
+      assertThat(res).isCompletedExceptionally();
+    }
+  }
+
+  // --- delete: timer throws (broader protection) ---
+
+  @Test
+  public void deleteDocumentsCompletesFutureWhenTimerThrows() throws Exception {
+    try (final MockedStatic<ElasticsearchUtil> mockedStatic = mockStatic(ElasticsearchUtil.class);
+        final MockedStatic<Timer> mockedTimer = mockStatic(Timer.class)) {
+      final Timer.Sample timerSample = mock(Timer.Sample.class);
+      when(timerSample.stop(any())).thenThrow(new RuntimeException("timer exploded"));
+      mockedTimer.when(Timer::start).thenReturn(timerSample);
+      final CompletableFuture<BulkByScrollResponse> failed = new CompletableFuture<>();
+      failed.completeExceptionally(new RuntimeException("ES delete failed"));
+      mockedStatic
+          .when(() -> ElasticsearchUtil.deleteByQueryAsync(any(), any(), any()))
+          .thenReturn(failed);
+
+      final CompletableFuture<Long> res = underTest.deleteDocuments("idx", "id", List.of("1"));
+
+      assertThatFutureCompletesWithin(res, 5, TimeUnit.SECONDS);
+      assertThat(res).isCompletedExceptionally();
+    }
+  }
+
+  // --- reindex: timer throws (broader protection) ---
+
+  @Test
+  public void reindexDocumentsCompletesFutureWhenTimerThrows() throws Exception {
+    try (final MockedStatic<ElasticsearchUtil> mockedStatic = mockStatic(ElasticsearchUtil.class);
+        final MockedStatic<Timer> mockedTimer = mockStatic(Timer.class)) {
+      final Timer.Sample timerSample = mock(Timer.Sample.class);
+      when(timerSample.stop(any())).thenThrow(new RuntimeException("timer exploded"));
+      mockedTimer.when(Timer::start).thenReturn(timerSample);
+      final CompletableFuture<BulkByScrollResponse> failed = new CompletableFuture<>();
+      failed.completeExceptionally(new RuntimeException("ES reindex failed"));
+      mockedStatic
+          .when(() -> ElasticsearchUtil.reindexAsync(any(), any(), any()))
+          .thenReturn(failed);
+
+      final CompletableFuture<Long> res =
+          underTest.reindexDocuments("src", "dst", "id", List.of("1"));
+
+      assertThatFutureCompletesWithin(res, 5, TimeUnit.SECONDS);
+      assertThat(res).isCompletedExceptionally();
+    }
+  }
+
+  private static void assertThatFutureCompletesWithin(
+      final CompletableFuture<?> future, final long timeout, final TimeUnit unit) throws Exception {
+    try {
+      future.get(timeout, unit);
+    } catch (final TimeoutException timeoutException) {
+      throw new AssertionError(
+          "Future did not complete within " + timeout + " " + unit + " — archiver would hang",
+          timeoutException);
+    } catch (final CompletionException | ExecutionException ignored) {
+      // expected — caller asserts the future is completedExceptionally
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #52781.

The Tasklist ES archiver permanently stops archiving for a partition after a single Elasticsearch failure where the exception has no `cause` (common for `ElasticsearchStatusException`).

### Root cause

`deleteDocuments` and `reindexDocuments` both used a manual `CompletableFuture` completed inside a `whenComplete` callback:

```java
sendDeleteRequest(deleteRequest)
    .whenComplete((response, e) -> {
        if (e != null) {
            trackMetricForDeleteFailures(processInstanceKeys, e);  // ← throws NPE
        }
        result.ifRightOrLeft(deleteFuture::complete, deleteFuture::completeExceptionally);  // ← never reached
    });
```

`trackMetricForDeleteFailures` called `e.getCause().getClass()` unconditionally. When `getCause()` returns `null`, this throws a `NullPointerException` that escapes the lambda *before* `deleteFuture` is completed. The future stays pending forever, and the archiver loop for that partition never schedules its next run.

### Fix

Two targeted changes:

1. **Restructure to `handle` + `thenCompose`** — the framework-managed chain always completes the returned future, eliminating the manual-future pattern and the entire class of "callback throws before completion" bugs.

2. **Null-safe cause extraction** — `trackMetricForDelete/ReindexFailures` now falls back to the throwable itself when `getCause()` is `null`:
   ```java
   final Throwable cause = e.getCause() != null ? e.getCause() : e;
   ```