### PR TITLE
[API spec] Allow searching agent instances by element instance key

### DIFF
--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -1053,7 +1053,6 @@ public final class SearchQueryResponseMapper {
         .rootProcessInstanceKey(keyToStringOrNull(instance.rootProcessInstanceKey()))
         .endDate(formatDateOrNull(instance.endDate()))
         .incidentKey(keyToStringOrNull(instance.incidentKey()))
-        .agentInstanceKey(null) // TODO: this will be filled in #51513
         .build();
   }
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -270,6 +270,7 @@ components:
         - creationDate
         - lastUpdatedDate
         - completionDate
+        - elementInstanceKeys
       properties:
         agentInstanceKey:
           description: The unique key for this agent instance.
@@ -323,6 +324,12 @@ components:
           format: date-time
           nullable: true
           description: The date when this agent instance completed. Null while the agent is still running.
+        elementInstanceKeys:
+          description: The keys of all element instances associated with this agent instance.
+          type: array
+          items:
+            allOf:
+                - $ref: 'keys.yaml#/components/schemas/ElementInstanceKey'
 
     AgentInstanceDefinition:
       description: The static definition of an agent instance, set once at creation.

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -239,6 +239,14 @@ components:
           description: The completion date of the agent instance.
           allOf:
             - $ref: 'filters.yaml#/components/schemas/DateTimeFilterProperty'
+        elementInstanceKeys:
+            description: |-
+              The keys of element instances associated with this agent instance.
+              If multiple keys are provided, the filter matches agent instances associated with all of the provided keys at the same time.
+            type: array
+            items:
+              allOf:
+                - $ref: 'keys.yaml#/components/schemas/ElementInstanceKeyFilterProperty'
 
     AgentInstanceSearchQueryResult:
       description: Agent instance search response.

--- a/zeebe/gateway-protocol/src/main/proto/v2/element-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/element-instances.yaml
@@ -414,7 +414,6 @@ components:
         - rootProcessInstanceKey
         - endDate
         - incidentKey
-        - agentInstanceKey
       properties:
         processDefinitionId:
           description: The process definition ID associated to this element instance.
@@ -502,11 +501,6 @@ components:
           allOf:
             - $ref: "keys.yaml#/components/schemas/IncidentKey"
           description: Incident key associated with this element instance.
-          nullable: true
-        agentInstanceKey:
-          allOf:
-            - $ref: "keys.yaml#/components/schemas/AgentInstanceKey"
-          description: The agent instance key associated with this element instance.
           nullable: true
 
     ElementInstanceStateEnum:

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ElementInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ElementInstanceQueryControllerTest.java
@@ -77,8 +77,7 @@ public class ElementInstanceQueryControllerTest extends RestControllerTest {
                    "state":"ACTIVE",
                    "hasIncident":false,
                    "incidentKey": null,
-                   "tenantId":"<default>",
-                   "agentInstanceKey": null
+                   "tenantId":"<default>"
                  }
               ],
               "page": {
@@ -131,8 +130,7 @@ public class ElementInstanceQueryControllerTest extends RestControllerTest {
                    "state":"ACTIVE",
                    "hasIncident":true,
                    "incidentKey":"1234",
-                   "tenantId":"tenantId",
-                   "agentInstanceKey": null
+                   "tenantId":"tenantId"
                  }
           """;
 


### PR DESCRIPTION
## Description

This pull request updates the agent instance and element instance data models in the Zeebe gateway protocol to improve how associations between these entities are represented. The main focus is on removing the single `agentInstanceKey` field from element instances and instead representing associations via arrays of keys on agent instances, which allows for more flexible relationships.

**Schema and Model Updates:**

*Agent Instance Schema Changes:*
- Added an `elementInstanceKeys` array to the `AgentInstanceSearchQuery` and `AgentInstance` schemas to represent all associated element instances, supporting queries for agent instances linked to multiple element instances at once.
- Updated required properties in the agent instance schema to include `elementInstanceKeys`.

*Element Instance Schema Changes:*
- Removed the `agentInstanceKey` property from the `ElementInstance` schema, eliminating the direct one-to-many association in favor of the new array-based approach on agent instances. 

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #52888 
