### PR TITLE
docs: mention migration to jspecify in AGENTS.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -72,6 +72,9 @@ Note: `-Dquickly` skips tests, checks, and Optimize. Add `-DskipTests=false` to 
 - Enforced by the Maven Spotless plugin (Google Java Format).
 - Follow conventions in `CONTRIBUTING.md` and the
   [Zeebe Code Style wiki](https://github.com/camunda/camunda/wiki/Code-Style).
+- Repository is currently being migrated to use jspecify nullness annotations.
+  Please add `@Nullable` and `@NullMarked` annotations in classes where they are missing in order to increase coverage.
+  You should do that in a separate `refactor: ` commit.
 
 ## Testing Conventions
 


### PR DESCRIPTION
## Description
Mention the ongoing migration to jspecify nullness annotations in AGENTS.md so that agents can help out by increasing the coverage.

I edited the Code Style wiki as well, but I think that is not picked up at all by the agent.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
