### PR TITLE
refactor: use `BrokerMemberId` in place of `int nodeId` where possible

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/FlowControlServiceImpl.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/FlowControlServiceImpl.java
@@ -9,19 +9,20 @@ package io.camunda.zeebe.shared.management;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.broker.system.configuration.FlowControlCfg;
 import io.camunda.zeebe.gateway.admin.BrokerAdminRequest;
 import io.camunda.zeebe.logstreams.impl.flowcontrol.LimitSerializer;
 import io.camunda.zeebe.shared.management.FlowControlEndpoint.FlowControlService;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
-import org.agrona.collections.IntHashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -90,7 +91,7 @@ public class FlowControlServiceImpl implements FlowControlService {
             .map(
                 brokerId -> {
                   final var request = new BrokerAdminRequest();
-                  request.setBrokerId(brokerId);
+                  request.setBrokerId(brokerId.nodeIdx());
                   request.setPartitionId(partitionId);
                   configureRequest.accept(request);
                   return client.sendRequest(request);
@@ -102,8 +103,12 @@ public class FlowControlServiceImpl implements FlowControlService {
   private CompletableFuture<FlowControlStatus> fetchFlowConfigOnPartition(
       final BrokerClusterState topology, final Integer partitionId) {
     final var brokerId = topology.getLeaderForPartition(partitionId);
+    if (brokerId == null) {
+      return CompletableFuture.failedFuture(
+          new IllegalStateException("No leader for partition " + partitionId));
+    }
     final var request = new BrokerAdminRequest();
-    request.setBrokerId(brokerId);
+    request.setBrokerId(brokerId.nodeIdx());
     request.setPartitionId(partitionId);
     request.getFLowControlConfiguration();
 
@@ -115,14 +120,15 @@ public class FlowControlServiceImpl implements FlowControlService {
                     partitionId, LimitSerializer.deserialize(response.getResponse().getPayload())));
   }
 
-  private IntHashSet getMembers(final BrokerClusterState topology, final Integer partitionId) {
+  private HashSet<MemberId> getMembers(
+      final BrokerClusterState topology, final Integer partitionId) {
     final var leader = topology.getLeaderForPartition(partitionId);
     final var followers =
         Optional.ofNullable(topology.getFollowersForPartition(partitionId)).orElseGet(Set::of);
     final var inactive =
         Optional.ofNullable(topology.getInactiveNodesForPartition(partitionId)).orElseGet(Set::of);
 
-    final var members = new IntHashSet(topology.getReplicationFactor());
+    final var members = new HashSet<MemberId>(topology.getReplicationFactor());
     members.add(leader);
     members.addAll(followers);
     members.addAll(inactive);

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/FlowControlServiceImpl.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/FlowControlServiceImpl.java
@@ -23,12 +23,14 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import org.jspecify.annotations.NullMarked;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
+@NullMarked
 public class FlowControlServiceImpl implements FlowControlService {
   private static final Logger LOG = LoggerFactory.getLogger(FlowControlServiceImpl.class);
   private final BrokerClient client;
@@ -124,14 +126,15 @@ public class FlowControlServiceImpl implements FlowControlService {
 
   private HashSet<BrokerMemberId> getMembers(
       final BrokerClusterState topology, final Integer partitionId) {
-    final var leader = topology.getLeaderForPartition(partitionId);
+    final var leader = Optional.ofNullable(topology.getLeaderForPartition(partitionId));
     final var followers =
         Optional.ofNullable(topology.getFollowersForPartition(partitionId)).orElseGet(Set::of);
     final var inactive =
         Optional.ofNullable(topology.getInactiveNodesForPartition(partitionId)).orElseGet(Set::of);
 
     final var members = new HashSet<BrokerMemberId>(topology.getReplicationFactor());
-    members.add(leader);
+    leader.ifPresent(members::add);
+
     members.addAll(followers);
     members.addAll(inactive);
     return members;

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/FlowControlServiceImpl.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/FlowControlServiceImpl.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.shared.management;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import io.atomix.cluster.MemberId;
+import io.atomix.cluster.BrokerMemberId;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.broker.system.configuration.FlowControlCfg;
@@ -91,6 +91,7 @@ public class FlowControlServiceImpl implements FlowControlService {
             .map(
                 brokerId -> {
                   final var request = new BrokerAdminRequest();
+                  // TODO: https://github.com/camunda/camunda/issues/52807
                   request.setBrokerId(brokerId.nodeIdx());
                   request.setPartitionId(partitionId);
                   configureRequest.accept(request);
@@ -108,6 +109,7 @@ public class FlowControlServiceImpl implements FlowControlService {
           new IllegalStateException("No leader for partition " + partitionId));
     }
     final var request = new BrokerAdminRequest();
+    // TODO: https://github.com/camunda/camunda/issues/52807
     request.setBrokerId(brokerId.nodeIdx());
     request.setPartitionId(partitionId);
     request.getFLowControlConfiguration();
@@ -120,7 +122,7 @@ public class FlowControlServiceImpl implements FlowControlService {
                     partitionId, LimitSerializer.deserialize(response.getResponse().getPayload())));
   }
 
-  private HashSet<MemberId> getMembers(
+  private HashSet<BrokerMemberId> getMembers(
       final BrokerClusterState topology, final Integer partitionId) {
     final var leader = topology.getLeaderForPartition(partitionId);
     final var followers =
@@ -128,7 +130,7 @@ public class FlowControlServiceImpl implements FlowControlService {
     final var inactive =
         Optional.ofNullable(topology.getInactiveNodesForPartition(partitionId)).orElseGet(Set::of);
 
-    final var members = new HashSet<MemberId>(topology.getReplicationFactor());
+    final var members = new HashSet<BrokerMemberId>(topology.getReplicationFactor());
     members.add(leader);
     members.addAll(followers);
     members.addAll(inactive);

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -114,6 +114,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>

--- a/service/src/main/java/io/camunda/service/TopologyServices.java
+++ b/service/src/main/java/io/camunda/service/TopologyServices.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
 import io.camunda.zeebe.util.VersionUtil;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -144,17 +145,17 @@ public final class TopologyServices extends ApiServices<TopologyServices> {
               }
 
               final var status = topology.getPartitionHealth(brokerId, partitionId);
-              if (status == null) {
-                LOGGER.debug("Unsupported null partition broker health status");
-                return;
-              }
 
               switch (status) {
                 case HEALTHY -> partition.health(Health.HEALTHY);
                 case UNHEALTHY -> partition.health(Health.UNHEALTHY);
                 case DEAD -> partition.health(Health.DEAD);
-                default ->
-                    LOGGER.debug("Unsupported partition broker health status '{}'", status.name());
+                case null, default ->
+                    LOGGER.debug(
+                        "Unsupported partition broker health status '{}'",
+                        Optional.ofNullable(status)
+                            .map(PartitionHealthStatus::name)
+                            .orElse("null"));
               }
               broker.addPartition(partition.build());
             });

--- a/service/src/main/java/io/camunda/service/TopologyServices.java
+++ b/service/src/main/java/io/camunda/service/TopologyServices.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.service;
 
+import io.atomix.cluster.MemberId;
 import io.atomix.utils.net.Address;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.service.TopologyServices.Topology.Builder;
@@ -65,8 +66,8 @@ public final class TopologyServices extends ApiServices<TopologyServices> {
         .anyMatch(
             partition -> {
               final var leader = topology.getLeaderForPartition(partition);
-              return topology.getPartitionHealth(leader, partition)
-                  == PartitionHealthStatus.HEALTHY;
+              return leader != null
+                  && topology.getPartitionHealth(leader, partition) == PartitionHealthStatus.HEALTHY;
             });
   }
 
@@ -112,19 +113,19 @@ public final class TopologyServices extends ApiServices<TopologyServices> {
   }
 
   private void addBrokerInfo(
-      final Broker.Builder broker, final Integer brokerId, final BrokerClusterState topology) {
+      final Broker.Builder broker, final MemberId brokerId, final BrokerClusterState topology) {
     final var brokerAddress = topology.getBrokerAddress(brokerId);
     final var address = Address.from(brokerAddress);
 
     broker
-        .nodeId(brokerId)
+        .nodeId(brokerId.nodeIdx())
         .host(address.host())
         .port(address.port())
         .version(topology.getBrokerVersion(brokerId));
   }
 
   private void addPartitionInfoToBrokerInfo(
-      final Broker.Builder broker, final Integer brokerId, final BrokerClusterState topology) {
+      final Broker.Builder broker, final MemberId brokerId, final BrokerClusterState topology) {
     topology
         .getPartitions()
         .forEach(
@@ -138,6 +139,11 @@ public final class TopologyServices extends ApiServices<TopologyServices> {
               }
 
               final var status = topology.getPartitionHealth(brokerId, partitionId);
+              if (status == null) {
+                LOGGER.debug("Unsupported null partition broker health status");
+                return;
+              }
+
               switch (status) {
                 case HEALTHY -> partition.health(Health.HEALTHY);
                 case UNHEALTHY -> partition.health(Health.UNHEALTHY);
@@ -150,7 +156,7 @@ public final class TopologyServices extends ApiServices<TopologyServices> {
   }
 
   private boolean setRole(
-      final Integer brokerId,
+      final MemberId brokerId,
       final Integer partitionId,
       final BrokerClusterState topology,
       final Partition.Builder partition) {
@@ -158,7 +164,7 @@ public final class TopologyServices extends ApiServices<TopologyServices> {
     final var partitionFollowers = topology.getFollowersForPartition(partitionId);
     final var partitionInactives = topology.getInactiveNodesForPartition(partitionId);
 
-    if (partitionLeader == brokerId) {
+    if (brokerId.equals(partitionLeader)) {
       partition.role(Role.LEADER);
     } else if (partitionFollowers != null && partitionFollowers.contains(brokerId)) {
       partition.role(Role.FOLLOWER);

--- a/service/src/main/java/io/camunda/service/TopologyServices.java
+++ b/service/src/main/java/io/camunda/service/TopologyServices.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.service;
 
-import io.atomix.cluster.MemberId;
+import io.atomix.cluster.BrokerMemberId;
 import io.atomix.utils.net.Address;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.service.TopologyServices.Topology.Builder;
@@ -67,7 +67,8 @@ public final class TopologyServices extends ApiServices<TopologyServices> {
             partition -> {
               final var leader = topology.getLeaderForPartition(partition);
               return leader != null
-                  && topology.getPartitionHealth(leader, partition) == PartitionHealthStatus.HEALTHY;
+                  && topology.getPartitionHealth(leader, partition)
+                      == PartitionHealthStatus.HEALTHY;
             });
   }
 
@@ -113,7 +114,9 @@ public final class TopologyServices extends ApiServices<TopologyServices> {
   }
 
   private void addBrokerInfo(
-      final Broker.Builder broker, final MemberId brokerId, final BrokerClusterState topology) {
+      final Broker.Builder broker,
+      final BrokerMemberId brokerId,
+      final BrokerClusterState topology) {
     final var brokerAddress = topology.getBrokerAddress(brokerId);
     final var address = Address.from(brokerAddress);
 
@@ -125,7 +128,9 @@ public final class TopologyServices extends ApiServices<TopologyServices> {
   }
 
   private void addPartitionInfoToBrokerInfo(
-      final Broker.Builder broker, final MemberId brokerId, final BrokerClusterState topology) {
+      final Broker.Builder broker,
+      final BrokerMemberId brokerId,
+      final BrokerClusterState topology) {
     topology
         .getPartitions()
         .forEach(
@@ -156,7 +161,7 @@ public final class TopologyServices extends ApiServices<TopologyServices> {
   }
 
   private boolean setRole(
-      final MemberId brokerId,
+      final BrokerMemberId brokerId,
       final Integer partitionId,
       final BrokerClusterState topology,
       final Partition.Builder partition) {

--- a/service/src/test/java/io/camunda/service/TopologyServiceTest.java
+++ b/service/src/test/java/io/camunda/service/TopologyServiceTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import io.atomix.cluster.MemberId;
 import io.camunda.service.TopologyServices.Broker;
 import io.camunda.service.TopologyServices.ClusterStatus;
 import io.camunda.service.TopologyServices.Health;
@@ -27,13 +28,16 @@ import io.camunda.zeebe.util.VersionUtil;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Stream;
 import org.assertj.core.api.Assertions;
+import org.jspecify.annotations.NullMarked;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mockito;
 
+@NullMarked
 public class TopologyServiceTest {
 
   private BrokerClient brokerClient;
@@ -65,11 +69,11 @@ public class TopologyServiceTest {
     final int leaderId2 = 2;
 
     when(clusterState.getPartitions()).thenReturn(List.of(partitionId1, partitionId2));
-    when(clusterState.getLeaderForPartition(partitionId1)).thenReturn(leaderId1);
-    when(clusterState.getLeaderForPartition(partitionId2)).thenReturn(leaderId2);
-    when(clusterState.getPartitionHealth(leaderId1, partitionId1))
+    when(clusterState.getLeaderForPartition(partitionId1)).thenReturn(memberId(leaderId1));
+    when(clusterState.getLeaderForPartition(partitionId2)).thenReturn(memberId(leaderId2));
+    when(clusterState.getPartitionHealth(memberId(leaderId1), partitionId1))
         .thenReturn(PartitionHealthStatus.HEALTHY);
-    when(clusterState.getPartitionHealth(leaderId2, partitionId2))
+    when(clusterState.getPartitionHealth(memberId(leaderId2), partitionId2))
         .thenReturn(PartitionHealthStatus.UNHEALTHY);
 
     // when
@@ -82,7 +86,7 @@ public class TopologyServiceTest {
     verify(topologyManager).getTopology();
     verify(clusterState).getPartitions();
     verify(clusterState).getLeaderForPartition(partitionId1);
-    verify(clusterState).getPartitionHealth(leaderId1, partitionId1);
+    verify(clusterState).getPartitionHealth(memberId(leaderId1), partitionId1);
   }
 
   @ParameterizedTest
@@ -99,10 +103,12 @@ public class TopologyServiceTest {
     final int leaderId2 = 2;
 
     when(clusterState.getPartitions()).thenReturn(List.of(partitionId1, partitionId2));
-    when(clusterState.getLeaderForPartition(partitionId1)).thenReturn(leaderId1);
-    when(clusterState.getLeaderForPartition(partitionId2)).thenReturn(leaderId2);
-    when(clusterState.getPartitionHealth(leaderId1, partitionId1)).thenReturn(unhealthyStatus);
-    when(clusterState.getPartitionHealth(leaderId2, partitionId2)).thenReturn(unhealthyStatus);
+    when(clusterState.getLeaderForPartition(partitionId1)).thenReturn(memberId(leaderId1));
+    when(clusterState.getLeaderForPartition(partitionId2)).thenReturn(memberId(leaderId2));
+    when(clusterState.getPartitionHealth(memberId(leaderId1), partitionId1))
+        .thenReturn(unhealthyStatus);
+    when(clusterState.getPartitionHealth(memberId(leaderId2), partitionId2))
+        .thenReturn(unhealthyStatus);
 
     // when
     final var status = services.getStatus().join();
@@ -114,9 +120,9 @@ public class TopologyServiceTest {
     verify(topologyManager).getTopology();
     verify(clusterState).getPartitions();
     verify(clusterState).getLeaderForPartition(partitionId1);
-    verify(clusterState).getPartitionHealth(leaderId1, partitionId1);
+    verify(clusterState).getPartitionHealth(memberId(leaderId1), partitionId1);
     verify(clusterState).getLeaderForPartition(partitionId2);
-    verify(clusterState).getPartitionHealth(leaderId2, partitionId2);
+    verify(clusterState).getPartitionHealth(memberId(leaderId2), partitionId2);
   }
 
   @Test
@@ -163,14 +169,14 @@ public class TopologyServiceTest {
 
     when(clusterState.getPartitions())
         .thenReturn(List.of(partitionId1, partitionId2, partitionId3));
-    when(clusterState.getLeaderForPartition(partitionId1)).thenReturn(leaderId1);
-    when(clusterState.getLeaderForPartition(partitionId2)).thenReturn(leaderId2);
-    when(clusterState.getLeaderForPartition(partitionId3)).thenReturn(leaderId3);
-    when(clusterState.getPartitionHealth(leaderId1, partitionId1))
+    when(clusterState.getLeaderForPartition(partitionId1)).thenReturn(memberId(leaderId1));
+    when(clusterState.getLeaderForPartition(partitionId2)).thenReturn(memberId(leaderId2));
+    when(clusterState.getLeaderForPartition(partitionId3)).thenReturn(memberId(leaderId3));
+    when(clusterState.getPartitionHealth(memberId(leaderId1), partitionId1))
         .thenReturn(PartitionHealthStatus.DEAD);
-    when(clusterState.getPartitionHealth(leaderId2, partitionId2))
+    when(clusterState.getPartitionHealth(memberId(leaderId2), partitionId2))
         .thenReturn(PartitionHealthStatus.UNHEALTHY);
-    when(clusterState.getPartitionHealth(leaderId3, partitionId3))
+    when(clusterState.getPartitionHealth(memberId(leaderId3), partitionId3))
         .thenReturn(PartitionHealthStatus.HEALTHY);
 
     // when
@@ -183,11 +189,11 @@ public class TopologyServiceTest {
     verify(topologyManager).getTopology();
     verify(clusterState).getPartitions();
     verify(clusterState).getLeaderForPartition(partitionId1);
-    verify(clusterState).getPartitionHealth(leaderId1, partitionId1);
+    verify(clusterState).getPartitionHealth(memberId(leaderId1), partitionId1);
     verify(clusterState).getLeaderForPartition(partitionId2);
-    verify(clusterState).getPartitionHealth(leaderId2, partitionId2);
+    verify(clusterState).getPartitionHealth(memberId(leaderId2), partitionId2);
     verify(clusterState).getLeaderForPartition(partitionId3);
-    verify(clusterState).getPartitionHealth(leaderId3, partitionId3);
+    verify(clusterState).getPartitionHealth(memberId(leaderId3), partitionId3);
   }
 
   @Test
@@ -252,6 +258,10 @@ public class TopologyServiceTest {
             });
   }
 
+  private static MemberId memberId(final int brokerId) {
+    return MemberId.from(brokerId);
+  }
+
   /**
    * Topology stub which returns a static topology with 3 brokers, 1 partition, replication factor
    * 3, where 0 is the leader (healthy), 1 is the follower (healthy), and 2 is inactive (unhealthy).
@@ -280,23 +290,23 @@ public class TopologyServiceTest {
     }
 
     @Override
-    public int getLeaderForPartition(final int partition) {
-      return 0;
+    public MemberId getLeaderForPartition(final int partition) {
+      return memberId(0);
     }
 
     @Override
-    public Set<Integer> getFollowersForPartition(final int partition) {
-      return Set.of(1);
+    public Set<MemberId> getFollowersForPartition(final int partition) {
+      return Set.of(memberId(1));
     }
 
     @Override
-    public Set<Integer> getInactiveNodesForPartition(final int partition) {
-      return Set.of(2);
+    public Set<MemberId> getInactiveNodesForPartition(final int partition) {
+      return Set.of(memberId(2));
     }
 
     @Override
-    public int getRandomBroker() {
-      return ThreadLocalRandom.current().nextInt(0, 3);
+    public MemberId getRandomBroker() {
+      return memberId(ThreadLocalRandom.current().nextInt(0, 3));
     }
 
     @Override
@@ -305,27 +315,27 @@ public class TopologyServiceTest {
     }
 
     @Override
-    public List<Integer> getBrokers() {
-      return List.of(0, 1, 2);
+    public List<MemberId> getBrokers() {
+      return Stream.of(0, 1, 2).map(TopologyServiceTest::memberId).toList();
     }
 
     @Override
-    public String getBrokerAddress(final int brokerId) {
-      return "localhost:" + (26501 + brokerId);
+    public String getBrokerAddress(final MemberId brokerId) {
+      return "localhost:" + (26501 + brokerId.nodeIdx());
     }
 
     @Override
-    public String getBrokerVersion(final int brokerId) {
+    public String getBrokerVersion(final MemberId brokerId) {
       return version;
     }
 
     @Override
-    public PartitionHealthStatus getPartitionHealth(final int brokerId, final int partition) {
+    public PartitionHealthStatus getPartitionHealth(final MemberId brokerId, final int partition) {
       if (partition != 1) {
         return PartitionHealthStatus.NULL_VAL;
       }
 
-      return switch (brokerId) {
+      return switch (brokerId.nodeIdx()) {
         case 0, 1 -> PartitionHealthStatus.HEALTHY;
         case 2 -> PartitionHealthStatus.UNHEALTHY;
         default -> PartitionHealthStatus.NULL_VAL;

--- a/service/src/test/java/io/camunda/service/TopologyServiceTest.java
+++ b/service/src/test/java/io/camunda/service/TopologyServiceTest.java
@@ -12,7 +12,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import io.atomix.cluster.MemberId;
+import io.atomix.cluster.BrokerMemberId;
 import io.camunda.service.TopologyServices.Broker;
 import io.camunda.service.TopologyServices.ClusterStatus;
 import io.camunda.service.TopologyServices.Health;
@@ -40,6 +40,12 @@ import org.mockito.Mockito;
 @NullMarked
 public class TopologyServiceTest {
 
+  private static final int partitionId1 = 1;
+  private static final int partitionId2 = 2;
+  private static final int partitionId3 = 3;
+  private static final BrokerMemberId leaderId1 = BrokerMemberId.from(1);
+  private static final BrokerMemberId leaderId2 = BrokerMemberId.from(2);
+  private static final BrokerMemberId leaderId3 = BrokerMemberId.from(3);
   private BrokerClient brokerClient;
   private BrokerClusterState clusterState;
   private TopologyServices services;
@@ -62,18 +68,12 @@ public class TopologyServiceTest {
 
   @Test
   void shouldReturnHealthyWhenAtLeastOnePartitionHasHealthyLeader() {
-    // given
-    final int partitionId1 = 1;
-    final int partitionId2 = 2;
-    final int leaderId1 = 1;
-    final int leaderId2 = 2;
-
     when(clusterState.getPartitions()).thenReturn(List.of(partitionId1, partitionId2));
-    when(clusterState.getLeaderForPartition(partitionId1)).thenReturn(memberId(leaderId1));
-    when(clusterState.getLeaderForPartition(partitionId2)).thenReturn(memberId(leaderId2));
-    when(clusterState.getPartitionHealth(memberId(leaderId1), partitionId1))
+    when(clusterState.getLeaderForPartition(partitionId1)).thenReturn(leaderId1);
+    when(clusterState.getLeaderForPartition(partitionId2)).thenReturn(leaderId2);
+    when(clusterState.getPartitionHealth(leaderId1, partitionId1))
         .thenReturn(PartitionHealthStatus.HEALTHY);
-    when(clusterState.getPartitionHealth(memberId(leaderId2), partitionId2))
+    when(clusterState.getPartitionHealth(leaderId2, partitionId2))
         .thenReturn(PartitionHealthStatus.UNHEALTHY);
 
     // when
@@ -86,7 +86,7 @@ public class TopologyServiceTest {
     verify(topologyManager).getTopology();
     verify(clusterState).getPartitions();
     verify(clusterState).getLeaderForPartition(partitionId1);
-    verify(clusterState).getPartitionHealth(memberId(leaderId1), partitionId1);
+    verify(clusterState).getPartitionHealth(leaderId1, partitionId1);
   }
 
   @ParameterizedTest
@@ -96,19 +96,11 @@ public class TopologyServiceTest {
       mode = EnumSource.Mode.EXCLUDE)
   void shouldReturnUnhealthyWhenNoPartitionHasHealthyLeader(
       final PartitionHealthStatus unhealthyStatus) {
-    // given
-    final int partitionId1 = 1;
-    final int partitionId2 = 2;
-    final int leaderId1 = 1;
-    final int leaderId2 = 2;
-
     when(clusterState.getPartitions()).thenReturn(List.of(partitionId1, partitionId2));
-    when(clusterState.getLeaderForPartition(partitionId1)).thenReturn(memberId(leaderId1));
-    when(clusterState.getLeaderForPartition(partitionId2)).thenReturn(memberId(leaderId2));
-    when(clusterState.getPartitionHealth(memberId(leaderId1), partitionId1))
-        .thenReturn(unhealthyStatus);
-    when(clusterState.getPartitionHealth(memberId(leaderId2), partitionId2))
-        .thenReturn(unhealthyStatus);
+    when(clusterState.getLeaderForPartition(partitionId1)).thenReturn(leaderId1);
+    when(clusterState.getLeaderForPartition(partitionId2)).thenReturn(leaderId2);
+    when(clusterState.getPartitionHealth(leaderId1, partitionId1)).thenReturn(unhealthyStatus);
+    when(clusterState.getPartitionHealth(leaderId2, partitionId2)).thenReturn(unhealthyStatus);
 
     // when
     final var status = services.getStatus().join();
@@ -120,9 +112,9 @@ public class TopologyServiceTest {
     verify(topologyManager).getTopology();
     verify(clusterState).getPartitions();
     verify(clusterState).getLeaderForPartition(partitionId1);
-    verify(clusterState).getPartitionHealth(memberId(leaderId1), partitionId1);
+    verify(clusterState).getPartitionHealth(leaderId1, partitionId1);
     verify(clusterState).getLeaderForPartition(partitionId2);
-    verify(clusterState).getPartitionHealth(memberId(leaderId2), partitionId2);
+    verify(clusterState).getPartitionHealth(leaderId2, partitionId2);
   }
 
   @Test
@@ -160,23 +152,17 @@ public class TopologyServiceTest {
   @Test
   void shouldHandleMixedPartitionHealthStatuses() {
     // given
-    final int partitionId1 = 1;
-    final int partitionId2 = 2;
-    final int partitionId3 = 3;
-    final int leaderId1 = 1;
-    final int leaderId2 = 2;
-    final int leaderId3 = 3;
 
     when(clusterState.getPartitions())
         .thenReturn(List.of(partitionId1, partitionId2, partitionId3));
-    when(clusterState.getLeaderForPartition(partitionId1)).thenReturn(memberId(leaderId1));
-    when(clusterState.getLeaderForPartition(partitionId2)).thenReturn(memberId(leaderId2));
-    when(clusterState.getLeaderForPartition(partitionId3)).thenReturn(memberId(leaderId3));
-    when(clusterState.getPartitionHealth(memberId(leaderId1), partitionId1))
+    when(clusterState.getLeaderForPartition(partitionId1)).thenReturn(leaderId1);
+    when(clusterState.getLeaderForPartition(partitionId2)).thenReturn(leaderId2);
+    when(clusterState.getLeaderForPartition(partitionId3)).thenReturn(leaderId3);
+    when(clusterState.getPartitionHealth(leaderId1, partitionId1))
         .thenReturn(PartitionHealthStatus.DEAD);
-    when(clusterState.getPartitionHealth(memberId(leaderId2), partitionId2))
+    when(clusterState.getPartitionHealth(leaderId2, partitionId2))
         .thenReturn(PartitionHealthStatus.UNHEALTHY);
-    when(clusterState.getPartitionHealth(memberId(leaderId3), partitionId3))
+    when(clusterState.getPartitionHealth(leaderId3, partitionId3))
         .thenReturn(PartitionHealthStatus.HEALTHY);
 
     // when
@@ -189,11 +175,11 @@ public class TopologyServiceTest {
     verify(topologyManager).getTopology();
     verify(clusterState).getPartitions();
     verify(clusterState).getLeaderForPartition(partitionId1);
-    verify(clusterState).getPartitionHealth(memberId(leaderId1), partitionId1);
+    verify(clusterState).getPartitionHealth(leaderId1, partitionId1);
     verify(clusterState).getLeaderForPartition(partitionId2);
-    verify(clusterState).getPartitionHealth(memberId(leaderId2), partitionId2);
+    verify(clusterState).getPartitionHealth(leaderId2, partitionId2);
     verify(clusterState).getLeaderForPartition(partitionId3);
-    verify(clusterState).getPartitionHealth(memberId(leaderId3), partitionId3);
+    verify(clusterState).getPartitionHealth(leaderId3, partitionId3);
   }
 
   @Test
@@ -258,10 +244,6 @@ public class TopologyServiceTest {
             });
   }
 
-  private static MemberId memberId(final int brokerId) {
-    return MemberId.from(brokerId);
-  }
-
   /**
    * Topology stub which returns a static topology with 3 brokers, 1 partition, replication factor
    * 3, where 0 is the leader (healthy), 1 is the follower (healthy), and 2 is inactive (unhealthy).
@@ -290,23 +272,23 @@ public class TopologyServiceTest {
     }
 
     @Override
-    public MemberId getLeaderForPartition(final int partition) {
-      return memberId(0);
+    public BrokerMemberId getLeaderForPartition(final int partition) {
+      return BrokerMemberId.from(0);
     }
 
     @Override
-    public Set<MemberId> getFollowersForPartition(final int partition) {
-      return Set.of(memberId(1));
+    public Set<BrokerMemberId> getFollowersForPartition(final int partition) {
+      return Set.of(BrokerMemberId.from(1));
     }
 
     @Override
-    public Set<MemberId> getInactiveNodesForPartition(final int partition) {
-      return Set.of(memberId(2));
+    public Set<BrokerMemberId> getInactiveNodesForPartition(final int partition) {
+      return Set.of(BrokerMemberId.from(2));
     }
 
     @Override
-    public MemberId getRandomBroker() {
-      return memberId(ThreadLocalRandom.current().nextInt(0, 3));
+    public BrokerMemberId getRandomBroker() {
+      return BrokerMemberId.from(ThreadLocalRandom.current().nextInt(0, 3));
     }
 
     @Override
@@ -315,22 +297,23 @@ public class TopologyServiceTest {
     }
 
     @Override
-    public List<MemberId> getBrokers() {
-      return Stream.of(0, 1, 2).map(TopologyServiceTest::memberId).toList();
+    public List<BrokerMemberId> getBrokers() {
+      return Stream.of(0, 1, 2).map(BrokerMemberId::from).toList();
     }
 
     @Override
-    public String getBrokerAddress(final MemberId brokerId) {
+    public String getBrokerAddress(final BrokerMemberId brokerId) {
       return "localhost:" + (26501 + brokerId.nodeIdx());
     }
 
     @Override
-    public String getBrokerVersion(final MemberId brokerId) {
+    public String getBrokerVersion(final BrokerMemberId brokerId) {
       return version;
     }
 
     @Override
-    public PartitionHealthStatus getPartitionHealth(final MemberId brokerId, final int partition) {
+    public PartitionHealthStatus getPartitionHealth(
+        final BrokerMemberId brokerId, final int partition) {
       if (partition != 1) {
         return PartitionHealthStatus.NULL_VAL;
       }

--- a/service/src/test/java/io/camunda/service/TopologyServiceTest.java
+++ b/service/src/test/java/io/camunda/service/TopologyServiceTest.java
@@ -40,12 +40,12 @@ import org.mockito.Mockito;
 @NullMarked
 public class TopologyServiceTest {
 
-  private static final int partitionId1 = 1;
-  private static final int partitionId2 = 2;
-  private static final int partitionId3 = 3;
-  private static final BrokerMemberId leaderId1 = BrokerMemberId.from(1);
-  private static final BrokerMemberId leaderId2 = BrokerMemberId.from(2);
-  private static final BrokerMemberId leaderId3 = BrokerMemberId.from(3);
+  private final int partitionId1 = 1;
+  private final int partitionId2 = 2;
+  private final int partitionId3 = 3;
+  private final BrokerMemberId leaderId1 = BrokerMemberId.from(1);
+  private final BrokerMemberId leaderId2 = BrokerMemberId.from(2);
+  private final BrokerMemberId leaderId3 = BrokerMemberId.from(3);
   private BrokerClient brokerClient;
   private BrokerClusterState clusterState;
   private TopologyServices services;

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/BrokerMemberId.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/BrokerMemberId.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.atomix.cluster;
+
+import io.camunda.zeebe.util.VisibleForTesting;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+@NullMarked
+public record BrokerMemberId(MemberId memberId) {
+  public BrokerMemberId {
+    try {
+      memberId.nodeIdx();
+    } catch (final IllegalStateException e) {
+      throw new IllegalStateException(
+          "Expected id to represent a broker, but got " + memberId.id(), e);
+    }
+  }
+
+  public static BrokerMemberId from(@Nullable final String zone, final int nodeIdx) {
+    return new BrokerMemberId(MemberId.from(zone, nodeIdx));
+  }
+
+  public static BrokerMemberId from(final String id) {
+    return new BrokerMemberId(MemberId.from(id));
+  }
+
+  public static BrokerMemberId from(final MemberId memberId) {
+    return new BrokerMemberId(memberId);
+  }
+
+  @VisibleForTesting
+  public static BrokerMemberId from(final int nodeIdx) {
+    return from(null, nodeIdx);
+  }
+
+  public int nodeIdx() {
+    return memberId.nodeIdx();
+  }
+
+  public @Nullable String zone() {
+    return memberId.zone();
+  }
+
+  public String id() {
+    return memberId.id();
+  }
+
+  public boolean isInZone(final @Nullable String zone) {
+    return memberId.isInZone(zone);
+  }
+
+  @Override
+  public String toString() {
+    return memberId.toString();
+  }
+}

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/MemberId.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/MemberId.java
@@ -16,6 +16,7 @@
  */
 package io.atomix.cluster;
 
+import io.camunda.zeebe.util.MemberIdUtil;
 import java.util.Objects;
 import java.util.UUID;
 import org.jspecify.annotations.NullMarked;
@@ -121,11 +122,7 @@ public class MemberId extends NodeId {
   }
 
   private static String buildMemberIdString(final @Nullable String zone, final int nodeIdx) {
-    if (zone == null) {
-      return Integer.toString(nodeIdx);
-    } else {
-      return validateZone(zone) + "/" + nodeIdx;
-    }
+    return MemberIdUtil.memberIdString(zone, nodeIdx);
   }
 
   private static @Nullable Integer tryParseInt(final String s) {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/MemberId.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/MemberId.java
@@ -17,6 +17,7 @@
 package io.atomix.cluster;
 
 import io.camunda.zeebe.util.MemberIdUtil;
+import io.camunda.zeebe.util.VisibleForTesting;
 import java.util.Objects;
 import java.util.UUID;
 import org.jspecify.annotations.NullMarked;
@@ -87,6 +88,11 @@ public class MemberId extends NodeId {
    */
   public static MemberId from(final @Nullable String zone, final int nodeId) {
     return new MemberId(zone, nodeId, buildMemberIdString(zone, nodeId));
+  }
+
+  @VisibleForTesting
+  public static MemberId from(final int nodeId) {
+    return from(null, nodeId);
   }
 
   public int nodeIdx() {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/NodeId.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/NodeId.java
@@ -19,8 +19,10 @@ package io.atomix.cluster;
 import io.atomix.utils.AbstractIdentifier;
 import java.util.Objects;
 import java.util.UUID;
+import org.jspecify.annotations.NullMarked;
 
 /** Node identifier. */
+@NullMarked
 public class NodeId extends AbstractIdentifier<String> implements Comparable<NodeId> {
 
   /** Constructor for serialization. */

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/BrokerMemberIdTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/BrokerMemberIdTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.atomix.cluster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+final class BrokerMemberIdTest {
+
+  @Test
+  void shouldCreateBrokerMemberIdFromNodeId() {
+    // given
+    final var brokerMemberId = BrokerMemberId.from(7);
+
+    // then
+    assertThat(brokerMemberId)
+        .returns(7, BrokerMemberId::nodeIdx)
+        .returns(null, BrokerMemberId::zone)
+        .returns("7", BrokerMemberId::id);
+  }
+
+  @Test
+  void shouldCreateBrokerMemberIdFromZoneAndNodeId() {
+    // given
+    final var brokerMemberId = BrokerMemberId.from("eu-west", 7);
+
+    // then
+    assertThat(brokerMemberId)
+        .returns(7, BrokerMemberId::nodeIdx)
+        .returns("eu-west", BrokerMemberId::zone)
+        .returns("eu-west/7", BrokerMemberId::id);
+  }
+
+  @Test
+  void shouldCreateBrokerMemberIdFromMemberId() {
+    // given
+    final var memberId = MemberId.from("eu-west/7");
+
+    // when
+    final var brokerMemberId = BrokerMemberId.from(memberId);
+
+    // then
+    assertThat(brokerMemberId)
+        .returns(7, BrokerMemberId::nodeIdx)
+        .returns("eu-west", BrokerMemberId::zone)
+        .returns("eu-west/7", BrokerMemberId::id);
+  }
+
+  @Test
+  void shouldRejectNonBrokerMemberId() {
+    // given
+    final var memberId = MemberId.from("backup");
+
+    // expect
+    assertThatThrownBy(() -> BrokerMemberId.from(memberId))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("to represent a broker");
+  }
+}

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/MemberIdTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/MemberIdTest.java
@@ -138,4 +138,9 @@ final class MemberIdTest {
     assertThatThrownBy(() -> Member.builder(memberId).withZoneId("us").build())
         .isInstanceOf(IllegalArgumentException.class);
   }
+
+  private void assertEncodeDecode(final MemberId memberId) {
+    final var decoded = MemberId.from(memberId.id());
+    assertThat(decoded).isEqualTo(memberId).returns(memberId.hashCode(), MemberId::hashCode);
+  }
 }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/MemberIdTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/MemberIdTest.java
@@ -30,7 +30,7 @@ final class MemberIdTest {
   @Test
   void shouldFormatIdWithoutZoneWhenZoneIsNull() {
     // given / when
-    final var memberId = MemberId.from(null, 7);
+    final var memberId = MemberId.from(7);
 
     // then
 

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/MemberIdTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/MemberIdTest.java
@@ -38,6 +38,7 @@ final class MemberIdTest {
         .returns(7, MemberId::nodeIdx)
         .returns(null, MemberId::zone)
         .returns("7", MemberId::id);
+    assertEncodeDecode(memberId);
   }
 
   @Test
@@ -62,6 +63,7 @@ final class MemberIdTest {
         .returns(7, MemberId::nodeIdx)
         .returns("eu-west", MemberId::zone)
         .returns("eu-west/7", MemberId::id);
+    assertEncodeDecode(memberId);
   }
 
   @Test
@@ -74,6 +76,7 @@ final class MemberIdTest {
         .returns(7, MemberId::nodeIdx)
         .returns("us-east", MemberId::zone)
         .returns("us-east/7", MemberId::id);
+    assertEncodeDecode(memberId);
   }
 
   @Test
@@ -83,6 +86,7 @@ final class MemberIdTest {
 
     // when / then
     assertThat(memberId).returns(3, MemberId::nodeIdx).returns(null, MemberId::zone);
+    assertEncodeDecode(memberId);
   }
 
   @Test
@@ -95,6 +99,7 @@ final class MemberIdTest {
         .returns(12, MemberId::nodeIdx)
         .returns("us-east", MemberId::zone)
         .returns("us-east/12", MemberId::id);
+    assertEncodeDecode(memberId);
   }
 
   @Test

--- a/zeebe/broker-client/pom.xml
+++ b/zeebe/broker-client/pom.xml
@@ -27,6 +27,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-atomix-cluster</artifactId>
     </dependency>

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerClientTopologyMetrics.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerClientTopologyMetrics.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.broker.client.api;
 
 import static io.camunda.zeebe.broker.client.api.BrokerClientMetricsDoc.PARTITION_ROLE;
 
+import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.broker.client.api.BrokerClientMetricsDoc.PartitionRoleValues;
 import io.camunda.zeebe.broker.client.api.BrokerClientMetricsDoc.TopologyKeyNames;
 import io.camunda.zeebe.util.collection.Table;
@@ -25,7 +26,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 public final class BrokerClientTopologyMetrics {
 
   private final MeterRegistry registry;
-  private final Table<Integer, Integer, AtomicInteger> brokerTopologyRole;
+  private final Table<Integer, MemberId, AtomicInteger> brokerTopologyRole;
 
   public BrokerClientTopologyMetrics(final MeterRegistry registry) {
     this.registry = Objects.requireNonNull(registry, "must specify a meter registry");
@@ -37,18 +38,18 @@ public final class BrokerClientTopologyMetrics {
    * {@code partitionId}
    */
   public void setRoleForPartition(
-      final int partitionId, final int brokerId, final PartitionRoleValues roleValue) {
+      final int partitionId, final MemberId brokerId, final PartitionRoleValues roleValue) {
     brokerTopologyRole
         .computeIfAbsent(partitionId, brokerId, this::registerBrokerTopologyRole)
         .set(roleValue.value());
   }
 
-  private AtomicInteger registerBrokerTopologyRole(final int partitionId, final int brokerId) {
+  private AtomicInteger registerBrokerTopologyRole(final int partitionId, final MemberId brokerId) {
     final var role = new AtomicInteger();
     Gauge.builder(PARTITION_ROLE.getName(), role, Number::intValue)
         .description(PARTITION_ROLE.getDescription())
         .tag(PartitionKeyNames.PARTITION.asString(), String.valueOf(partitionId))
-        .tag(TopologyKeyNames.BROKER.asString(), String.valueOf(brokerId))
+        .tag(TopologyKeyNames.BROKER.asString(), brokerId.id())
         .register(registry);
     return role;
   }

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerClientTopologyMetrics.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerClientTopologyMetrics.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.broker.client.api;
 
 import static io.camunda.zeebe.broker.client.api.BrokerClientMetricsDoc.PARTITION_ROLE;
 
-import io.atomix.cluster.MemberId;
+import io.atomix.cluster.BrokerMemberId;
 import io.camunda.zeebe.broker.client.api.BrokerClientMetricsDoc.PartitionRoleValues;
 import io.camunda.zeebe.broker.client.api.BrokerClientMetricsDoc.TopologyKeyNames;
 import io.camunda.zeebe.util.collection.Table;
@@ -26,7 +26,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 public final class BrokerClientTopologyMetrics {
 
   private final MeterRegistry registry;
-  private final Table<Integer, MemberId, AtomicInteger> brokerTopologyRole;
+  private final Table<Integer, BrokerMemberId, AtomicInteger> brokerTopologyRole;
 
   public BrokerClientTopologyMetrics(final MeterRegistry registry) {
     this.registry = Objects.requireNonNull(registry, "must specify a meter registry");
@@ -38,13 +38,14 @@ public final class BrokerClientTopologyMetrics {
    * {@code partitionId}
    */
   public void setRoleForPartition(
-      final int partitionId, final MemberId brokerId, final PartitionRoleValues roleValue) {
+      final int partitionId, final BrokerMemberId brokerId, final PartitionRoleValues roleValue) {
     brokerTopologyRole
         .computeIfAbsent(partitionId, brokerId, this::registerBrokerTopologyRole)
         .set(roleValue.value());
   }
 
-  private AtomicInteger registerBrokerTopologyRole(final int partitionId, final MemberId brokerId) {
+  private AtomicInteger registerBrokerTopologyRole(
+      final int partitionId, final BrokerMemberId brokerId) {
     final var role = new AtomicInteger();
     Gauge.builder(PARTITION_ROLE.getName(), role, Number::intValue)
         .description(PARTITION_ROLE.getDescription())

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerClusterState.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerClusterState.java
@@ -7,10 +7,14 @@
  */
 package io.camunda.zeebe.broker.client.api;
 
+import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
 import java.util.List;
 import java.util.Set;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
+@NullMarked
 public interface BrokerClusterState {
 
   int UNKNOWN_NODE_ID = -1;
@@ -25,27 +29,27 @@ public interface BrokerClusterState {
 
   int getReplicationFactor();
 
-  int getLeaderForPartition(int partition);
+  @Nullable MemberId getLeaderForPartition(int partition);
 
-  Set<Integer> getFollowersForPartition(int partition);
+  Set<MemberId> getFollowersForPartition(int partition);
 
-  Set<Integer> getInactiveNodesForPartition(int partition);
+  Set<MemberId> getInactiveNodesForPartition(int partition);
 
   /**
    * @return the node id of a random broker or {@link BrokerClusterState#UNKNOWN_NODE_ID} if no
    *     brokers are known
    */
-  int getRandomBroker();
+  @Nullable MemberId getRandomBroker();
 
   List<Integer> getPartitions();
 
-  List<Integer> getBrokers();
+  List<MemberId> getBrokers();
 
-  String getBrokerAddress(int brokerId);
+  @Nullable String getBrokerAddress(MemberId brokerId);
 
-  String getBrokerVersion(int brokerId);
+  @Nullable String getBrokerVersion(MemberId brokerId);
 
-  PartitionHealthStatus getPartitionHealth(int brokerId, int partition);
+  @Nullable PartitionHealthStatus getPartitionHealth(MemberId brokerId, int partition);
 
   long getLastCompletedChangeId();
 

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerClusterState.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerClusterState.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.broker.client.api;
 
-import io.atomix.cluster.MemberId;
+import io.atomix.cluster.BrokerMemberId;
 import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
 import java.util.List;
 import java.util.Set;
@@ -29,27 +29,27 @@ public interface BrokerClusterState {
 
   int getReplicationFactor();
 
-  @Nullable MemberId getLeaderForPartition(int partition);
+  @Nullable BrokerMemberId getLeaderForPartition(int partition);
 
-  Set<MemberId> getFollowersForPartition(int partition);
+  Set<BrokerMemberId> getFollowersForPartition(int partition);
 
-  Set<MemberId> getInactiveNodesForPartition(int partition);
+  Set<BrokerMemberId> getInactiveNodesForPartition(int partition);
 
   /**
    * @return the node id of a random broker or {@link BrokerClusterState#UNKNOWN_NODE_ID} if no
    *     brokers are known
    */
-  @Nullable MemberId getRandomBroker();
+  @Nullable BrokerMemberId getRandomBroker();
 
   List<Integer> getPartitions();
 
-  List<MemberId> getBrokers();
+  List<BrokerMemberId> getBrokers();
 
-  @Nullable String getBrokerAddress(MemberId brokerId);
+  @Nullable String getBrokerAddress(BrokerMemberId brokerId);
 
-  @Nullable String getBrokerVersion(MemberId brokerId);
+  @Nullable String getBrokerVersion(BrokerMemberId brokerId);
 
-  @Nullable PartitionHealthStatus getPartitionHealth(MemberId brokerId, int partition);
+  @Nullable PartitionHealthStatus getPartitionHealth(BrokerMemberId brokerId, int partition);
 
   long getLastCompletedChangeId();
 

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerClusterState.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerClusterState.java
@@ -17,9 +17,7 @@ import org.jspecify.annotations.Nullable;
 @NullMarked
 public interface BrokerClusterState {
 
-  int UNKNOWN_NODE_ID = -1;
-  int NODE_ID_NULL = UNKNOWN_NODE_ID - 1;
-  int PARTITION_ID_NULL = NODE_ID_NULL - 1;
+  int PARTITION_ID_NULL = -3;
 
   boolean isInitialized();
 
@@ -36,8 +34,7 @@ public interface BrokerClusterState {
   Set<BrokerMemberId> getInactiveNodesForPartition(int partition);
 
   /**
-   * @return the node id of a random broker or {@link BrokerClusterState#UNKNOWN_NODE_ID} if no
-   *     brokers are known
+   * @return the node id of a random broker or null if no brokers are known
    */
   @Nullable BrokerMemberId getRandomBroker();
 

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerTopologyListener.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerTopologyListener.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.broker.client.api;
 
-import io.atomix.cluster.MemberId;
+import io.atomix.cluster.BrokerMemberId;
 
 /**
  * Listener which will be notified when a broker is added or removed from the topology, or when a
@@ -15,9 +15,9 @@ import io.atomix.cluster.MemberId;
  */
 public interface BrokerTopologyListener {
 
-  default void brokerAdded(final MemberId memberId) {}
+  default void brokerAdded(final BrokerMemberId memberId) {}
 
-  default void brokerRemoved(final MemberId memberId) {}
+  default void brokerRemoved(final BrokerMemberId memberId) {}
 
   default void completedClusterChange() {}
 

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManager.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManager.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.broker.client.api;
 
-import io.atomix.cluster.MemberId;
+import io.atomix.cluster.BrokerMemberId;
 import io.camunda.zeebe.dynamic.config.ClusterConfigurationUpdateNotifier.ClusterConfigurationUpdateListener;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 
@@ -28,8 +28,8 @@ public interface BrokerTopologyManager extends ClusterConfigurationUpdateListene
 
   /**
    * Adds the topology listener. For each existing brokers, the listener will be notified via {@link
-   * BrokerTopologyListener#brokerAdded(MemberId)}. After that, the listener gets notified of every
-   * new broker added or removed events.
+   * BrokerTopologyListener#brokerAdded(BrokerMemberId)}. After that, the listener gets notified of
+   * every new broker added or removed events.
    *
    * @param listener the topology listener
    */

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/dto/BrokerRequest.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/dto/BrokerRequest.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.broker.client.api.dto;
 
-import io.atomix.cluster.MemberId;
+import io.atomix.cluster.BrokerMemberId;
 import io.camunda.zeebe.broker.client.api.RequestDispatchStrategy;
 import io.camunda.zeebe.broker.client.api.UnsupportedBrokerResponseException;
 import io.camunda.zeebe.protocol.impl.encoding.ErrorResponse;
@@ -39,7 +39,7 @@ public abstract class BrokerRequest<T> implements ClientRequest {
     this.templateId = templateId;
   }
 
-  public Optional<MemberId> getBrokerId() {
+  public Optional<BrokerMemberId> getBrokerId() {
     return Optional.empty();
   }
 

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/dto/BrokerRequest.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/dto/BrokerRequest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.client.api.dto;
 
+import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.broker.client.api.RequestDispatchStrategy;
 import io.camunda.zeebe.broker.client.api.UnsupportedBrokerResponseException;
 import io.camunda.zeebe.protocol.impl.encoding.ErrorResponse;
@@ -38,7 +39,7 @@ public abstract class BrokerRequest<T> implements ClientRequest {
     this.templateId = templateId;
   }
 
-  public Optional<Integer> getBrokerId() {
+  public Optional<MemberId> getBrokerId() {
     return Optional.empty();
   }
 

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerClientTopologyImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerClientTopologyImpl.java
@@ -7,18 +7,21 @@
  */
 package io.camunda.zeebe.broker.client.impl;
 
+import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
-import org.agrona.collections.Int2IntHashMap;
 import org.agrona.collections.Int2ObjectHashMap;
-import org.agrona.collections.IntArrayList;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Represents the current state of the broker cluster topology. It includes both the live state of
@@ -28,6 +31,7 @@ import org.agrona.collections.IntArrayList;
  * The configured cluster state is updated from the global {@link
  * io.camunda.zeebe.dynamic.config.state.ClusterConfiguration}.
  */
+@NullMarked
 public record BrokerClientTopologyImpl(
     LiveClusterState liveClusterState, ConfiguredClusterState configuredClusterState)
     implements BrokerClusterState {
@@ -72,24 +76,24 @@ public record BrokerClientTopologyImpl(
   }
 
   @Override
-  public int getLeaderForPartition(final int partition) {
+  public @Nullable MemberId getLeaderForPartition(final int partition) {
     return liveClusterState.partitionLeaders.get(partition);
   }
 
   @Override
-  public Set<Integer> getFollowersForPartition(final int partition) {
+  public Set<MemberId> getFollowersForPartition(final int partition) {
     return liveClusterState.partitionFollowers.getOrDefault(partition, Set.of());
   }
 
   @Override
-  public Set<Integer> getInactiveNodesForPartition(final int partition) {
+  public Set<MemberId> getInactiveNodesForPartition(final int partition) {
     return liveClusterState.partitionInactiveNodes.getOrDefault(partition, Set.of());
   }
 
   @Override
-  public int getRandomBroker() {
+  public @Nullable MemberId getRandomBroker() {
     if (liveClusterState.brokers.isEmpty()) {
-      return UNKNOWN_NODE_ID;
+      return null;
     } else {
       return liveClusterState.brokers.get(
           liveClusterState.randomBroker.nextInt(liveClusterState.brokers.size()));
@@ -102,22 +106,22 @@ public record BrokerClientTopologyImpl(
   }
 
   @Override
-  public List<Integer> getBrokers() {
+  public List<MemberId> getBrokers() {
     return liveClusterState.brokers;
   }
 
   @Override
-  public String getBrokerAddress(final int brokerId) {
+  public @Nullable String getBrokerAddress(final MemberId brokerId) {
     return liveClusterState.brokerAddresses.get(brokerId);
   }
 
   @Override
-  public String getBrokerVersion(final int brokerId) {
+  public @Nullable String getBrokerVersion(final MemberId brokerId) {
     return liveClusterState.brokerVersions.get(brokerId);
   }
 
   @Override
-  public PartitionHealthStatus getPartitionHealth(final int brokerId, final int partitionId) {
+  public PartitionHealthStatus getPartitionHealth(final MemberId brokerId, final int partitionId) {
     final var brokerHealthyPartitions = liveClusterState.partitionsHealthPerBroker.get(brokerId);
 
     if (brokerHealthyPartitions == null) {
@@ -153,82 +157,82 @@ public record BrokerClientTopologyImpl(
 
   static class LiveClusterState {
     private static final Long TERM_NONE = -1L;
-    private final Int2IntHashMap partitionLeaders;
+    private final Int2ObjectHashMap<MemberId> partitionLeaders;
     private final Int2ObjectHashMap<Long> partitionLeaderTerms;
-    private final Int2ObjectHashMap<Set<Integer>> partitionFollowers;
-    private final Int2ObjectHashMap<Set<Integer>> partitionInactiveNodes;
-    private final Int2ObjectHashMap<Int2ObjectHashMap<PartitionHealthStatus>>
+    private final Int2ObjectHashMap<Set<MemberId>> partitionFollowers;
+    private final Int2ObjectHashMap<Set<MemberId>> partitionInactiveNodes;
+    private final HashMap<MemberId, Int2ObjectHashMap<PartitionHealthStatus>>
         partitionsHealthPerBroker;
-    private final Int2ObjectHashMap<String> brokerAddresses;
-    private final Int2ObjectHashMap<String> brokerVersions;
-    private final IntArrayList brokers;
+    private final HashMap<MemberId, String> brokerAddresses;
+    private final HashMap<MemberId, String> brokerVersions;
+    private final List<MemberId> brokers;
     private final Random randomBroker;
 
     public LiveClusterState(final Collection<BrokerInfo> distributedBrokerInfos) {
-      partitionLeaders = new Int2IntHashMap(NODE_ID_NULL);
+      partitionLeaders = new Int2ObjectHashMap<>();
       partitionLeaderTerms = new Int2ObjectHashMap<>();
       partitionFollowers = new Int2ObjectHashMap<>();
       partitionInactiveNodes = new Int2ObjectHashMap<>();
-      partitionsHealthPerBroker = new Int2ObjectHashMap<>();
-      brokerAddresses = new Int2ObjectHashMap<>();
-      brokerVersions = new Int2ObjectHashMap<>();
-      brokers = new IntArrayList(5, NODE_ID_NULL);
+      partitionsHealthPerBroker = new HashMap<>();
+      brokerAddresses = new HashMap<>();
+      brokerVersions = new HashMap<>();
+      brokers = new ArrayList<>(5);
       randomBroker = new Random();
 
       distributedBrokerInfos.forEach(
           brokerInfo -> {
-            final int nodeId = brokerInfo.getNodeId();
-            brokers.add(brokerInfo.getNodeId());
+            final var memberId = MemberId.from(brokerInfo.memberIdString());
+            brokers.add(memberId);
             final String clientAddress = brokerInfo.getCommandApiAddress();
             if (clientAddress != null) {
-              brokerAddresses.put(nodeId, brokerInfo.getCommandApiAddress());
+              brokerAddresses.put(memberId, brokerInfo.getCommandApiAddress());
             }
-            brokerVersions.put(nodeId, brokerInfo.getVersion());
+            brokerVersions.put(memberId, brokerInfo.getVersion());
             brokerInfo.consumePartitions(
                 pId -> {}, // nothing to consume
-                (leaderPartitionId, term) -> setPartitionLeader(leaderPartitionId, nodeId, term),
-                followerPartitionId -> addPartitionFollower(followerPartitionId, nodeId),
-                inactivePartitionId -> addPartitionInactive(inactivePartitionId, nodeId));
+                (leaderPartitionId, term) -> setPartitionLeader(leaderPartitionId, memberId, term),
+                followerPartitionId -> addPartitionFollower(followerPartitionId, memberId),
+                inactivePartitionId -> addPartitionInactive(inactivePartitionId, memberId));
             brokerInfo.consumePartitionsHealth(
-                (partition, health) -> setPartitionHealthStatus(nodeId, partition, health));
+                (partition, health) -> setPartitionHealthStatus(memberId, partition, health));
           });
     }
 
-    void setPartitionLeader(final int partitionId, final int leaderId, final long term) {
+    void setPartitionLeader(final int partitionId, final MemberId leaderId, final long term) {
       if (partitionLeaderTerms.getOrDefault(partitionId, TERM_NONE) <= term) {
         partitionLeaders.put(partitionId, leaderId);
         partitionLeaderTerms.put(partitionId, Long.valueOf(term));
-        final Set<Integer> followers = partitionFollowers.get(partitionId);
+        final var followers = partitionFollowers.get(partitionId);
         if (followers != null) {
-          followers.removeIf(follower -> follower == leaderId);
+          followers.removeIf(follower -> follower.equals(leaderId));
         }
-        final Set<Integer> inactives = partitionInactiveNodes.get(partitionId);
+        final var inactives = partitionInactiveNodes.get(partitionId);
         if (inactives != null) {
-          inactives.removeIf(inactive -> inactive == leaderId);
+          inactives.removeIf(inactive -> inactive.equals(leaderId));
         }
       }
     }
 
     void setPartitionHealthStatus(
-        final int brokerId, final int partitionId, final PartitionHealthStatus status) {
+        final MemberId brokerId, final int partitionId, final PartitionHealthStatus status) {
       final var partitionsHealth =
           partitionsHealthPerBroker.computeIfAbsent(brokerId, integer -> new Int2ObjectHashMap<>());
       partitionsHealth.put(partitionId, status);
     }
 
-    void addPartitionFollower(final int partitionId, final int followerId) {
+    void addPartitionFollower(final int partitionId, final MemberId followerId) {
       partitionFollowers.computeIfAbsent(partitionId, HashSet::new).add(followerId);
       partitionLeaders.remove(partitionId, followerId);
-      final Set<Integer> inactives = partitionInactiveNodes.get(partitionId);
+      final var inactives = partitionInactiveNodes.get(partitionId);
       if (inactives != null) {
         inactives.remove(followerId);
       }
     }
 
-    void addPartitionInactive(final int partitionId, final int brokerId) {
+    void addPartitionInactive(final int partitionId, final MemberId brokerId) {
       partitionInactiveNodes.computeIfAbsent(partitionId, HashSet::new).add(brokerId);
       partitionLeaders.remove(partitionId, brokerId);
-      final Set<Integer> followers = partitionFollowers.get(partitionId);
+      final var followers = partitionFollowers.get(partitionId);
       if (followers != null) {
         followers.remove(brokerId);
       }

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerClientTopologyImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerClientTopologyImpl.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.broker.client.impl;
 
-import io.atomix.cluster.MemberId;
+import io.atomix.cluster.BrokerMemberId;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
@@ -76,22 +76,22 @@ public record BrokerClientTopologyImpl(
   }
 
   @Override
-  public @Nullable MemberId getLeaderForPartition(final int partition) {
+  public @Nullable BrokerMemberId getLeaderForPartition(final int partition) {
     return liveClusterState.partitionLeaders.get(partition);
   }
 
   @Override
-  public Set<MemberId> getFollowersForPartition(final int partition) {
+  public Set<BrokerMemberId> getFollowersForPartition(final int partition) {
     return liveClusterState.partitionFollowers.getOrDefault(partition, Set.of());
   }
 
   @Override
-  public Set<MemberId> getInactiveNodesForPartition(final int partition) {
+  public Set<BrokerMemberId> getInactiveNodesForPartition(final int partition) {
     return liveClusterState.partitionInactiveNodes.getOrDefault(partition, Set.of());
   }
 
   @Override
-  public @Nullable MemberId getRandomBroker() {
+  public @Nullable BrokerMemberId getRandomBroker() {
     if (liveClusterState.brokers.isEmpty()) {
       return null;
     } else {
@@ -106,22 +106,23 @@ public record BrokerClientTopologyImpl(
   }
 
   @Override
-  public List<MemberId> getBrokers() {
+  public List<BrokerMemberId> getBrokers() {
     return liveClusterState.brokers;
   }
 
   @Override
-  public @Nullable String getBrokerAddress(final MemberId brokerId) {
+  public @Nullable String getBrokerAddress(final BrokerMemberId brokerId) {
     return liveClusterState.brokerAddresses.get(brokerId);
   }
 
   @Override
-  public @Nullable String getBrokerVersion(final MemberId brokerId) {
+  public @Nullable String getBrokerVersion(final BrokerMemberId brokerId) {
     return liveClusterState.brokerVersions.get(brokerId);
   }
 
   @Override
-  public PartitionHealthStatus getPartitionHealth(final MemberId brokerId, final int partitionId) {
+  public PartitionHealthStatus getPartitionHealth(
+      final BrokerMemberId brokerId, final int partitionId) {
     final var brokerHealthyPartitions = liveClusterState.partitionsHealthPerBroker.get(brokerId);
 
     if (brokerHealthyPartitions == null) {
@@ -157,15 +158,15 @@ public record BrokerClientTopologyImpl(
 
   static class LiveClusterState {
     private static final Long TERM_NONE = -1L;
-    private final Int2ObjectHashMap<MemberId> partitionLeaders;
+    private final Int2ObjectHashMap<BrokerMemberId> partitionLeaders;
     private final Int2ObjectHashMap<Long> partitionLeaderTerms;
-    private final Int2ObjectHashMap<Set<MemberId>> partitionFollowers;
-    private final Int2ObjectHashMap<Set<MemberId>> partitionInactiveNodes;
-    private final HashMap<MemberId, Int2ObjectHashMap<PartitionHealthStatus>>
+    private final Int2ObjectHashMap<Set<BrokerMemberId>> partitionFollowers;
+    private final Int2ObjectHashMap<Set<BrokerMemberId>> partitionInactiveNodes;
+    private final HashMap<BrokerMemberId, Int2ObjectHashMap<PartitionHealthStatus>>
         partitionsHealthPerBroker;
-    private final HashMap<MemberId, String> brokerAddresses;
-    private final HashMap<MemberId, String> brokerVersions;
-    private final List<MemberId> brokers;
+    private final HashMap<BrokerMemberId, String> brokerAddresses;
+    private final HashMap<BrokerMemberId, String> brokerVersions;
+    private final List<BrokerMemberId> brokers;
     private final Random randomBroker;
 
     public LiveClusterState(final Collection<BrokerInfo> distributedBrokerInfos) {
@@ -181,7 +182,7 @@ public record BrokerClientTopologyImpl(
 
       distributedBrokerInfos.forEach(
           brokerInfo -> {
-            final var memberId = MemberId.from(brokerInfo.memberIdString());
+            final var memberId = BrokerMemberId.from(brokerInfo.getZone(), brokerInfo.getNodeId());
             brokers.add(memberId);
             final String clientAddress = brokerInfo.getCommandApiAddress();
             if (clientAddress != null) {
@@ -198,7 +199,7 @@ public record BrokerClientTopologyImpl(
           });
     }
 
-    void setPartitionLeader(final int partitionId, final MemberId leaderId, final long term) {
+    void setPartitionLeader(final int partitionId, final BrokerMemberId leaderId, final long term) {
       if (partitionLeaderTerms.getOrDefault(partitionId, TERM_NONE) <= term) {
         partitionLeaders.put(partitionId, leaderId);
         partitionLeaderTerms.put(partitionId, Long.valueOf(term));
@@ -214,13 +215,13 @@ public record BrokerClientTopologyImpl(
     }
 
     void setPartitionHealthStatus(
-        final MemberId brokerId, final int partitionId, final PartitionHealthStatus status) {
+        final BrokerMemberId brokerId, final int partitionId, final PartitionHealthStatus status) {
       final var partitionsHealth =
           partitionsHealthPerBroker.computeIfAbsent(brokerId, integer -> new Int2ObjectHashMap<>());
       partitionsHealth.put(partitionId, status);
     }
 
-    void addPartitionFollower(final int partitionId, final MemberId followerId) {
+    void addPartitionFollower(final int partitionId, final BrokerMemberId followerId) {
       partitionFollowers.computeIfAbsent(partitionId, HashSet::new).add(followerId);
       partitionLeaders.remove(partitionId, followerId);
       final var inactives = partitionInactiveNodes.get(partitionId);
@@ -229,7 +230,7 @@ public record BrokerClientTopologyImpl(
       }
     }
 
-    void addPartitionInactive(final int partitionId, final MemberId brokerId) {
+    void addPartitionInactive(final int partitionId, final BrokerMemberId brokerId) {
       partitionInactiveNodes.computeIfAbsent(partitionId, HashSet::new).add(brokerId);
       partitionLeaders.remove(partitionId, brokerId);
       final var followers = partitionFollowers.get(partitionId);

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerRequestManager.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerRequestManager.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.client.impl;
 
+import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.broker.client.api.BrokerClientMetricsDoc.AdditionalErrorCodes;
 import io.camunda.zeebe.broker.client.api.BrokerClientRequestMetrics;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
@@ -32,8 +33,8 @@ import java.time.Duration;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.function.ToIntFunction;
 import org.agrona.DirectBuffer;
 
 final class BrokerRequestManager extends Actor {
@@ -253,9 +254,8 @@ final class BrokerRequestManager extends Actor {
     }
 
     final var inactiveNodes = topology.getInactiveNodesForPartition(partitionId);
-    final var someNodesInactive = inactiveNodes != null && !inactiveNodes.isEmpty();
-    final var noPartitionLeader =
-        topology.getLeaderForPartition(partitionId) == BrokerClusterState.NODE_ID_NULL;
+    final var someNodesInactive = !inactiveNodes.isEmpty();
+    final var noPartitionLeader = topology.getLeaderForPartition(partitionId) == null;
     if (someNodesInactive && noPartitionLeader) {
       throw new PartitionInactiveException(partitionId);
     }
@@ -298,7 +298,7 @@ final class BrokerRequestManager extends Actor {
 
   private class BrokerAddressProvider implements Supplier<String> {
 
-    private final ToIntFunction<BrokerClusterState> nodeIdSelector;
+    private final Function<BrokerClusterState, MemberId> nodeIdSelector;
 
     BrokerAddressProvider() {
       this(BrokerClusterState::getRandomBroker);
@@ -308,7 +308,7 @@ final class BrokerRequestManager extends Actor {
       this(state -> state.getLeaderForPartition(partitionId));
     }
 
-    BrokerAddressProvider(final ToIntFunction<BrokerClusterState> nodeIdSelector) {
+    BrokerAddressProvider(final Function<BrokerClusterState, MemberId> nodeIdSelector) {
       this.nodeIdSelector = nodeIdSelector;
     }
 
@@ -316,7 +316,7 @@ final class BrokerRequestManager extends Actor {
     public String get() {
       final BrokerClusterState topology = topologyManager.getTopology();
       if (topology != null) {
-        return topology.getBrokerAddress(nodeIdSelector.applyAsInt(topology));
+        return topology.getBrokerAddress(nodeIdSelector.apply(topology));
       } else {
         return null;
       }

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerRequestManager.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerRequestManager.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.broker.client.impl;
 
-import io.atomix.cluster.MemberId;
+import io.atomix.cluster.BrokerMemberId;
 import io.camunda.zeebe.broker.client.api.BrokerClientMetricsDoc.AdditionalErrorCodes;
 import io.camunda.zeebe.broker.client.api.BrokerClientRequestMetrics;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
@@ -298,7 +298,7 @@ final class BrokerRequestManager extends Actor {
 
   private class BrokerAddressProvider implements Supplier<String> {
 
-    private final Function<BrokerClusterState, MemberId> nodeIdSelector;
+    private final Function<BrokerClusterState, BrokerMemberId> nodeIdSelector;
 
     BrokerAddressProvider() {
       this(BrokerClusterState::getRandomBroker);
@@ -308,7 +308,7 @@ final class BrokerRequestManager extends Actor {
       this(state -> state.getLeaderForPartition(partitionId));
     }
 
-    BrokerAddressProvider(final Function<BrokerClusterState, MemberId> nodeIdSelector) {
+    BrokerAddressProvider(final Function<BrokerClusterState, BrokerMemberId> nodeIdSelector) {
       this.nodeIdSelector = nodeIdSelector;
     }
 

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerRequestManager.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerRequestManager.java
@@ -36,6 +36,8 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import org.agrona.DirectBuffer;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 final class BrokerRequestManager extends Actor {
 
@@ -296,9 +298,10 @@ final class BrokerRequestManager extends Actor {
         Duration timeout);
   }
 
-  private class BrokerAddressProvider implements Supplier<String> {
+  @NullMarked
+  private class BrokerAddressProvider implements Supplier<@Nullable String> {
 
-    private final Function<BrokerClusterState, BrokerMemberId> nodeIdSelector;
+    private final Function<BrokerClusterState, @Nullable BrokerMemberId> nodeIdSelector;
 
     BrokerAddressProvider() {
       this(BrokerClusterState::getRandomBroker);
@@ -308,18 +311,21 @@ final class BrokerRequestManager extends Actor {
       this(state -> state.getLeaderForPartition(partitionId));
     }
 
-    BrokerAddressProvider(final Function<BrokerClusterState, BrokerMemberId> nodeIdSelector) {
+    BrokerAddressProvider(
+        final Function<BrokerClusterState, @Nullable BrokerMemberId> nodeIdSelector) {
       this.nodeIdSelector = nodeIdSelector;
     }
 
     @Override
-    public String get() {
+    public @Nullable String get() {
       final BrokerClusterState topology = topologyManager.getTopology();
       if (topology != null) {
-        return topology.getBrokerAddress(nodeIdSelector.apply(topology));
-      } else {
-        return null;
+        final var brokerId = nodeIdSelector.apply(topology);
+        if (brokerId != null) {
+          return topology.getBrokerAddress(brokerId);
+        }
       }
+      return null;
     }
   }
 }

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
@@ -170,6 +170,7 @@ public final class BrokerTopologyManagerImpl extends Actor
     if (brokerInfo == null) {
       return;
     }
+    final var brokerId = BrokerMemberId.from(brokerInfo.getZone(), brokerInfo.getNodeId());
 
     switch (eventType) {
       case MEMBER_ADDED -> {
@@ -184,7 +185,7 @@ public final class BrokerTopologyManagerImpl extends Actor
       case METADATA_CHANGED -> {
         LOG.debug(
             "Received metadata change from Broker {}, partitions {}, terms {} and health {}.",
-            BrokerMemberId.from(brokerInfo.getZone(), brokerInfo.getNodeId()).id(),
+            brokerId,
             brokerInfo.getPartitionRoles(),
             brokerInfo.getPartitionLeaderTerms(),
             brokerInfo.getPartitionHealthStatuses());
@@ -194,11 +195,7 @@ public final class BrokerTopologyManagerImpl extends Actor
         LOG.debug("Received broker was removed {}.", brokerInfo);
         removeBroker(subject);
       }
-      default ->
-          LOG.debug(
-              "Received {} for broker {}, do nothing.",
-              eventType,
-              BrokerMemberId.from(brokerInfo.getZone(), brokerInfo.getNodeId()).id());
+      default -> LOG.debug("Received {} for broker {}, do nothing.", eventType, brokerId);
     }
   }
 

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
@@ -177,7 +177,7 @@ public final class BrokerTopologyManagerImpl extends Actor
       case METADATA_CHANGED -> {
         LOG.debug(
             "Received metadata change from Broker {}, partitions {}, terms {} and health {}.",
-            brokerInfo.getNodeId(),
+            brokerInfo.memberIdString(),
             brokerInfo.getPartitionRoles(),
             brokerInfo.getPartitionLeaderTerms(),
             brokerInfo.getPartitionHealthStatuses());
@@ -188,7 +188,8 @@ public final class BrokerTopologyManagerImpl extends Actor
         removeBroker(subject);
       }
       default ->
-          LOG.debug("Received {} for broker {}, do nothing.", eventType, brokerInfo.getNodeId());
+          LOG.debug(
+              "Received {} for broker {}, do nothing.", eventType, brokerInfo.memberIdString());
     }
   }
 

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
@@ -198,7 +198,7 @@ public final class BrokerTopologyManagerImpl extends Actor
     partitions.forEach(
         partition -> {
           final var leader = topology.getLeaderForPartition(partition);
-          if (leader != BrokerClusterState.NODE_ID_NULL) {
+          if (leader != null) {
             topologyMetrics.setRoleForPartition(partition, leader, PartitionRoleValues.LEADER);
           }
 

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
@@ -7,11 +7,11 @@
  */
 package io.camunda.zeebe.broker.client.impl;
 
+import io.atomix.cluster.BrokerMemberId;
 import io.atomix.cluster.ClusterMembershipEvent;
 import io.atomix.cluster.ClusterMembershipEvent.Type;
 import io.atomix.cluster.ClusterMembershipEventListener;
 import io.atomix.cluster.Member;
-import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.broker.client.api.BrokerClientMetricsDoc.PartitionRoleValues;
 import io.camunda.zeebe.broker.client.api.BrokerClientTopologyMetrics;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
@@ -44,7 +44,7 @@ public final class BrokerTopologyManagerImpl extends Actor
 
   private final Set<BrokerTopologyListener> topologyListeners = new HashSet<>();
 
-  private final Map<MemberId, BrokerInfo> memberProperties = new HashMap<>();
+  private final Map<BrokerMemberId, BrokerInfo> memberProperties = new HashMap<>();
 
   public BrokerTopologyManagerImpl(
       final Supplier<Set<Member>> membersSupplier,
@@ -113,13 +113,14 @@ public final class BrokerTopologyManagerImpl extends Actor
   }
 
   private void addBroker(final Member member, final BrokerInfo brokerInfo) {
+    final var brokerMemberId = BrokerMemberId.from(brokerInfo.getZone(), brokerInfo.getNodeId());
     actor.run(
         () -> {
-          if (!memberProperties.containsKey(member.id())) {
-            topologyListeners.forEach(l -> l.brokerAdded(member.id()));
+          if (!memberProperties.containsKey(brokerMemberId)) {
+            topologyListeners.forEach(l -> l.brokerAdded(brokerMemberId));
           }
 
-          memberProperties.put(member.id(), brokerInfo);
+          memberProperties.put(brokerMemberId, brokerInfo);
 
           updateTopology(
               oldTopology ->
@@ -129,10 +130,16 @@ public final class BrokerTopologyManagerImpl extends Actor
   }
 
   private void removeBroker(final Member member) {
+    final var brokerInfo = BrokerInfo.fromProperties(member.properties());
+    if (brokerInfo == null) {
+      return;
+    }
+
+    final var brokerMemberId = BrokerMemberId.from(brokerInfo.getZone(), brokerInfo.getNodeId());
     actor.run(
         () -> {
-          memberProperties.remove(member.id());
-          topologyListeners.forEach(l -> l.brokerRemoved(member.id()));
+          memberProperties.remove(brokerMemberId);
+          topologyListeners.forEach(l -> l.brokerRemoved(brokerMemberId));
 
           final var oldTopology = topology;
           topology =
@@ -177,7 +184,7 @@ public final class BrokerTopologyManagerImpl extends Actor
       case METADATA_CHANGED -> {
         LOG.debug(
             "Received metadata change from Broker {}, partitions {}, terms {} and health {}.",
-            brokerInfo.memberIdString(),
+            BrokerMemberId.from(brokerInfo.getZone(), brokerInfo.getNodeId()).id(),
             brokerInfo.getPartitionRoles(),
             brokerInfo.getPartitionLeaderTerms(),
             brokerInfo.getPartitionHealthStatuses());
@@ -189,7 +196,9 @@ public final class BrokerTopologyManagerImpl extends Actor
       }
       default ->
           LOG.debug(
-              "Received {} for broker {}, do nothing.", eventType, brokerInfo.memberIdString());
+              "Received {} for broker {}, do nothing.",
+              eventType,
+              BrokerMemberId.from(brokerInfo.getZone(), brokerInfo.getNodeId()).id());
     }
   }
 

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/PartitionIdIterator.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/PartitionIdIterator.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.broker.client.impl;
 
 import static io.camunda.zeebe.protocol.Protocol.START_PARTITION_ID;
 
-import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import java.util.Iterator;
 import java.util.PrimitiveIterator.OfInt;
@@ -36,7 +35,7 @@ public final class PartitionIdIterator implements Iterator<Integer> {
 
   private boolean hasLeader(final BrokerTopologyManager topologyManager, final int p) {
     final var topology = topologyManager.getTopology();
-    return topology != null && topology.getLeaderForPartition(p) != BrokerClusterState.NODE_ID_NULL;
+    return topology != null && topology.getLeaderForPartition(p) != null;
   }
 
   @Override

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/RoundRobinDispatchStrategy.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/RoundRobinDispatchStrategy.java
@@ -52,7 +52,7 @@ public final class RoundRobinDispatchStrategy implements RequestDispatchStrategy
 
     for (int i = 0; i < topology.getPartitionsCount(); i++) {
       final int partition = partitions.partitionAtOffset(offset.getAndIncrement());
-      if (topology.getLeaderForPartition(partition) != BrokerClusterState.NODE_ID_NULL) {
+      if (topology.getLeaderForPartition(partition) != null) {
         return partition;
       }
     }

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/BrokerMemberIds.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/BrokerMemberIds.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.client;
+
+import io.atomix.cluster.BrokerMemberId;
+
+public class BrokerMemberIds {
+  public static final BrokerMemberId ZERO = BrokerMemberId.from(0);
+  public static final BrokerMemberId ONE = BrokerMemberId.from(1);
+  public static final BrokerMemberId TWO = BrokerMemberId.from(2);
+}

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerClientTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerClientTest.java
@@ -14,6 +14,7 @@ import static org.assertj.core.api.Assertions.fail;
 import io.atomix.cluster.AtomixCluster;
 import io.atomix.cluster.ClusterMembershipEvent;
 import io.atomix.cluster.ClusterMembershipEvent.Type;
+import io.atomix.cluster.MemberId;
 import io.atomix.cluster.discovery.BootstrapDiscoveryProvider;
 import io.atomix.utils.net.Address;
 import io.camunda.zeebe.broker.client.api.dto.BrokerError;
@@ -61,8 +62,8 @@ import org.junit.jupiter.api.TestInfo;
 
 public final class BrokerClientTest {
 
+  private static final MemberId ONE = MemberId.from("1");
   private final ActorScheduler actorScheduler = ActorScheduler.newActorScheduler().build();
-
   private final StubBroker broker = new StubBroker().start();
   private BrokerClient client;
   private AtomixCluster atomixCluster;
@@ -420,7 +421,7 @@ public final class BrokerClientTest {
           .untilAsserted(
               () ->
                   assertThat(topologyManager.getTopology().getLeaderForPartition(1))
-                      .isEqualTo(leaderBrokerId));
+                      .isEqualTo(MemberId.from(leaderBrokerId)));
 
       response = client.sendRequest(request).join();
     }
@@ -533,7 +534,9 @@ public final class BrokerClientTest {
         topologyManager.event(new ClusterMembershipEvent(Type.MEMBER_ADDED, otherBroker.member()));
         Awaitility.await("Topology is updated")
             .untilAsserted(
-                () -> assertThat(topologyManager.getTopology().getLeaderForPartition(1)).isOne());
+                () ->
+                    assertThat(topologyManager.getTopology().getLeaderForPartition(1))
+                        .isEqualTo(ONE));
 
         // when
         response = client.sendRequest(request).join();
@@ -562,7 +565,9 @@ public final class BrokerClientTest {
         topologyManager.event(new ClusterMembershipEvent(Type.MEMBER_ADDED, otherBroker.member()));
         Awaitility.await("Topology is updated")
             .untilAsserted(
-                () -> assertThat(topologyManager.getTopology().getLeaderForPartition(2)).isOne());
+                () ->
+                    assertThat(topologyManager.getTopology().getLeaderForPartition(2))
+                        .isEqualTo(ONE));
 
         // when
         response = client.sendRequest(request).join();
@@ -583,7 +588,9 @@ public final class BrokerClientTest {
         topologyManager.event(new ClusterMembershipEvent(Type.MEMBER_ADDED, otherBroker.member()));
         Awaitility.await("Topology is updated")
             .untilAsserted(
-                () -> assertThat(topologyManager.getTopology().getLeaderForPartition(2)).isOne());
+                () ->
+                    assertThat(topologyManager.getTopology().getLeaderForPartition(2))
+                        .isEqualTo(ONE));
 
         // when
         response = client.sendRequest(request).join();

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerClientTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerClientTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.client.api;
 
+import static io.camunda.zeebe.broker.client.BrokerMemberIds.ONE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.fail;
@@ -62,7 +63,6 @@ import org.junit.jupiter.api.TestInfo;
 
 public final class BrokerClientTest {
 
-  private static final BrokerMemberId ONE = BrokerMemberId.from("1");
   private final ActorScheduler actorScheduler = ActorScheduler.newActorScheduler().build();
   private final StubBroker broker = new StubBroker().start();
   private BrokerClient client;

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerClientTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerClientTest.java
@@ -12,9 +12,9 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.fail;
 
 import io.atomix.cluster.AtomixCluster;
+import io.atomix.cluster.BrokerMemberId;
 import io.atomix.cluster.ClusterMembershipEvent;
 import io.atomix.cluster.ClusterMembershipEvent.Type;
-import io.atomix.cluster.MemberId;
 import io.atomix.cluster.discovery.BootstrapDiscoveryProvider;
 import io.atomix.utils.net.Address;
 import io.camunda.zeebe.broker.client.api.dto.BrokerError;
@@ -62,7 +62,7 @@ import org.junit.jupiter.api.TestInfo;
 
 public final class BrokerClientTest {
 
-  private static final MemberId ONE = MemberId.from("1");
+  private static final BrokerMemberId ONE = BrokerMemberId.from("1");
   private final ActorScheduler actorScheduler = ActorScheduler.newActorScheduler().build();
   private final StubBroker broker = new StubBroker().start();
   private BrokerClient client;
@@ -421,7 +421,7 @@ public final class BrokerClientTest {
           .untilAsserted(
               () ->
                   assertThat(topologyManager.getTopology().getLeaderForPartition(1))
-                      .isEqualTo(MemberId.from(leaderBrokerId)));
+                      .isEqualTo(BrokerMemberId.from(leaderBrokerId)));
 
       response = client.sendRequest(request).join();
     }

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerClientTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerClientTest.java
@@ -113,9 +113,7 @@ public final class BrokerClientTest {
     topologyManager.event(new ClusterMembershipEvent(Type.MEMBER_ADDED, broker.member()));
     Awaitility.await("Topology is updated")
         .untilAsserted(
-            () ->
-                assertThat(topologyManager.getTopology().getLeaderForPartition(1))
-                    .isNotEqualTo(BrokerClusterState.NODE_ID_NULL));
+            () -> assertThat(topologyManager.getTopology().getLeaderForPartition(1)).isNotNull());
 
     client =
         new BrokerClientImpl(

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
@@ -557,8 +557,8 @@ final class BrokerTopologyManagerTest {
   @Test
   void shouldBackfillNewListenerWithCanonicalZoneAwareMemberId() {
     // given — broker 0 joined with a zone-aware id
-    final var broker = createBroker(0);
     final var zonedMemberId = BrokerMemberId.from("eu-west/0");
+    final var broker = createBroker(zonedMemberId);
     final var member =
         new Member(new MemberConfig().setId(zonedMemberId.memberId()).setZoneId("eu-west"));
     broker.writeIntoProperties(member.properties());
@@ -586,9 +586,13 @@ final class BrokerTopologyManagerTest {
   }
 
   private BrokerInfo createBroker(final int brokerId) {
+    return createBroker(BrokerMemberId.from(brokerId));
+  }
+
+  private BrokerInfo createBroker(final BrokerMemberId brokerId) {
     final BrokerInfo broker =
         new BrokerInfo()
-            .setNodeId(brokerId)
+            .setBrokerId(brokerId.nodeIdx(), brokerId.zone())
             .setPartitionsCount(1)
             .setClusterSize(3)
             .setReplicationFactor(3);
@@ -626,7 +630,7 @@ final class BrokerTopologyManagerTest {
   }
 
   private static BrokerMemberId memberId(final int nodeId) {
-    return BrokerMemberId.from(null, nodeId);
+    return BrokerMemberId.from(nodeId);
   }
 
   private static final class RecordingTopologyListener implements BrokerTopologyListener {

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
@@ -68,8 +68,7 @@ final class BrokerTopologyManagerTest {
   @Test
   void shouldUpdateTopologyOnBrokerAdd() {
     // given
-    final int brokerId = 1;
-    final var memberId = memberId(1);
+    final var brokerId = BrokerMemberId.from(1);
     final int partition = 1;
     final BrokerInfo broker = createBroker(brokerId);
     notifyEvent(createMemberAddedEvent(broker));
@@ -85,16 +84,15 @@ final class BrokerTopologyManagerTest {
 
     assertThat(topologyManager.getTopology().getFollowersForPartition(partition))
         .describedAs("The partition has the expected follower")
-        .containsExactly(memberId);
-    assertThat(topologyManager.getTopology().getBrokerVersion(memberId))
+        .containsExactly(brokerId);
+    assertThat(topologyManager.getTopology().getBrokerVersion(brokerId))
         .isEqualTo(broker.getVersion());
   }
 
   @Test
   void shouldUpdateTopologyOnBrokerRemove() {
     // given
-    final int brokerId = 0;
-    final var memberId = memberId(0);
+    final var brokerId = BrokerMemberId.from(0);
     final int partition = 1;
     final BrokerInfo broker = createBroker(brokerId);
     notifyEvent(createMemberAddedEvent(broker));
@@ -117,7 +115,7 @@ final class BrokerTopologyManagerTest {
     assertThat(topologyManager.getTopology().getBrokers()).isNotEmpty();
 
     assertThat(topologyManager.getTopology().getFollowersForPartition(partition))
-        .doesNotContain(memberId);
+        .doesNotContain(brokerId);
     assertThat(topologyManager.getTopology().getLeaderForPartition(partition)).isNull();
   }
 
@@ -125,62 +123,61 @@ final class BrokerTopologyManagerTest {
   void shouldUpdateLeaderWithNewTerm() {
     // given
     final int partition = 1;
-    final int oldLeaderId = 0;
+    final var oldLeaderId = BrokerMemberId.from(0);
     final BrokerInfo oldLeader = createBroker(oldLeaderId);
     oldLeader.setLeaderForPartition(partition, 1);
     notifyEvent(createMemberAddedEvent(oldLeader));
 
     assertThat(topologyManager.getTopology().getLeaderForPartition(partition))
         .describedAs("Topology has the old leader")
-        .isEqualTo(memberId(0));
+        .isEqualTo(oldLeaderId);
 
     // when
-    final int newLeaderId = 1;
+    final var newLeaderId = BrokerMemberId.from(1);
     final BrokerInfo newLeader = createBroker(newLeaderId);
     newLeader.setLeaderForPartition(partition, 2);
     notifyEvent(createMemberAddedEvent(newLeader));
 
     // then
-    assertThat(topologyManager.getTopology().getBrokers()).contains(memberId(newLeaderId));
+    assertThat(topologyManager.getTopology().getBrokers()).contains(newLeaderId);
     assertThat(topologyManager.getTopology().getLeaderForPartition(partition))
-        .isEqualTo(memberId(1));
+        .isEqualTo(newLeaderId);
   }
 
   @Test
   void shouldNotUpdateLeaderWhenFromPreviousTerm() {
     // given
     final int partition = 1;
-    final int newLeaderId = 1;
+    final var newLeaderId = BrokerMemberId.from(1);
     final BrokerInfo newLeader = createBroker(newLeaderId);
     newLeader.setLeaderForPartition(partition, 2);
     notifyEvent(createMemberAddedEvent(newLeader));
 
     assertThat(topologyManager.getTopology().getLeaderForPartition(partition))
-        .isEqualTo(memberId(1));
+        .isEqualTo(newLeaderId);
 
     // when
-    final int oldLeaderId = 0;
+    final var oldLeaderId = BrokerMemberId.from(0);
     final BrokerInfo oldLeader = createBroker(oldLeaderId);
     oldLeader.setLeaderForPartition(partition, 1);
     notifyEvent(createMemberAddedEvent(oldLeader));
 
     // then
-    assertThat(topologyManager.getTopology().getBrokers()).contains(memberId(oldLeaderId));
+    assertThat(topologyManager.getTopology().getBrokers()).contains(oldLeaderId);
     assertThat(topologyManager.getTopology().getLeaderForPartition(partition))
-        .isEqualTo(memberId(1));
+        .isEqualTo(newLeaderId);
   }
 
   @Test
   void shouldUpdateLeaderWhenPartitionReBootstrapWithLowerTerm() {
     // given
     final int partition = 1;
-    final int leaderId = 1;
+    final var leaderId = BrokerMemberId.from(1);
     final BrokerInfo leader = createBroker(leaderId);
     leader.setLeaderForPartition(partition, 2);
     notifyEvent(createMemberAddedEvent(leader));
 
-    assertThat(topologyManager.getTopology().getLeaderForPartition(partition))
-        .isEqualTo(memberId(1));
+    assertThat(topologyManager.getTopology().getLeaderForPartition(partition)).isEqualTo(leaderId);
 
     // when
     // partition shutdown/purge
@@ -188,23 +185,22 @@ final class BrokerTopologyManagerTest {
     notifyEvent(createMemberUpdateEvent(leader));
 
     // new leader starts with a lower term
-    final int newLeaderAfterRebootstrapId = 0;
+    final var newLeaderAfterRebootstrapId = BrokerMemberId.from(0);
     final BrokerInfo newLeaderAfterRebootstrap = createBroker(newLeaderAfterRebootstrapId);
     newLeaderAfterRebootstrap.setLeaderForPartition(partition, 1);
     notifyEvent(createMemberAddedEvent(newLeaderAfterRebootstrap));
 
     // then
-    assertThat(topologyManager.getTopology().getBrokers())
-        .contains(memberId(newLeaderAfterRebootstrapId));
+    assertThat(topologyManager.getTopology().getBrokers()).contains(newLeaderAfterRebootstrapId);
     assertThat(topologyManager.getTopology().getLeaderForPartition(partition))
-        .isEqualTo(memberId(newLeaderAfterRebootstrapId));
+        .isEqualTo(newLeaderAfterRebootstrapId);
   }
 
   @Test
   void shouldUpdateTopologyOnBrokerRemoveAndDirectlyRejoin() {
     // given
     final int partition = 1;
-    final int leaderId = 1;
+    final var leaderId = BrokerMemberId.from(1);
     final BrokerInfo leader = createBroker(leaderId);
     leader.setLeaderForPartition(partition, 1);
     notifyEvent(createMemberAddedEvent(leader));
@@ -220,39 +216,38 @@ final class BrokerTopologyManagerTest {
     // then
     assertThat(topologyManager.getTopology().getBrokers())
         .describedAs("the broker has rejoined the cluster")
-        .containsExactly(memberId(leaderId));
-    assertThat(topologyManager.getTopology().getLeaderForPartition(partition))
-        .isEqualTo(memberId(1));
+        .containsExactly(leaderId);
+    assertThat(topologyManager.getTopology().getLeaderForPartition(partition)).isEqualTo(leaderId);
   }
 
   @Test
   void shouldUpdateTopologyOnPartitionHealth() {
     // given
-    final int brokerId = 0;
+    final var brokerId = BrokerMemberId.from(0);
     final int partition = 0;
     final BrokerInfo broker = createBroker(brokerId);
     broker.setPartitionHealthy(partition);
     notifyEvent(createMemberAddedEvent(broker));
 
-    assertThat(topologyManager.getTopology().getPartitionHealth(memberId(brokerId), partition))
-        .as("partition %d is healthy on broker %d", partition, brokerId)
+    assertThat(topologyManager.getTopology().getPartitionHealth(brokerId, partition))
+        .as("partition %d is healthy on broker %s", partition, brokerId)
         .isEqualTo(PartitionHealthStatus.HEALTHY);
 
     // when
-    final BrokerInfo updatedBroker = createBroker(0);
+    final BrokerInfo updatedBroker = createBroker(brokerId);
     updatedBroker.setPartitionUnhealthy(partition);
     notifyEvent(createMemberUpdateEvent(updatedBroker));
 
     // then
-    assertThat(topologyManager.getTopology().getPartitionHealth(memberId(brokerId), partition))
-        .as("partition %d is unhealthy on broker %d", partition, brokerId)
+    assertThat(topologyManager.getTopology().getPartitionHealth(brokerId, partition))
+        .as("partition %d is unhealthy on broker %s", partition, brokerId)
         .isEqualTo(PartitionHealthStatus.UNHEALTHY);
   }
 
   @Test
   void shouldUpdateTopologyMetadataWhileNotDuplicatingFollower() {
     // given
-    final int brokerId = 0;
+    final var brokerId = BrokerMemberId.from(0);
     final int partition = 0;
     final BrokerInfo broker = createBroker(brokerId);
     broker.setPartitionHealthy(partition);
@@ -260,66 +255,65 @@ final class BrokerTopologyManagerTest {
 
     notifyEvent(createMemberAddedEvent(broker));
 
-    assertThat(topologyManager.getTopology().getPartitionHealth(memberId(brokerId), partition))
-        .as("partition %d is healthy on broker %d", partition, brokerId)
+    assertThat(topologyManager.getTopology().getPartitionHealth(brokerId, partition))
+        .as("partition %d is healthy on broker %s", partition, brokerId)
         .isEqualTo(PartitionHealthStatus.HEALTHY);
     assertThat(topologyManager.getTopology().getFollowersForPartition(partition))
-        .containsExactly(memberId(brokerId));
+        .containsExactly(brokerId);
 
     // when
     broker.setPartitionUnhealthy(partition);
     notifyEvent(createMemberUpdateEvent(broker));
 
-    assertThat(topologyManager.getTopology().getPartitionHealth(memberId(brokerId), partition))
-        .as("partition %d is unhealthy on broker %d", partition, brokerId)
+    assertThat(topologyManager.getTopology().getPartitionHealth(brokerId, partition))
+        .as("partition %d is unhealthy on broker %s", partition, brokerId)
         .isEqualTo(PartitionHealthStatus.UNHEALTHY);
 
     // then
     assertThat(topologyManager.getTopology().getFollowersForPartition(partition))
-        .containsExactly(memberId(brokerId));
+        .containsExactly(brokerId);
   }
 
   @Test
   void shouldUpdateTopologyMetadataWhileNotDuplicatingInactiveNodes() {
     // given
-    final int brokerId = 0;
+    final var brokerId = BrokerMemberId.from(0);
     final int partition = 0;
     final BrokerInfo broker = createBroker(brokerId);
     broker.setPartitionHealthy(partition);
     broker.setInactiveForPartition(partition);
     notifyEvent(createMemberAddedEvent(broker));
 
-    assertThat(topologyManager.getTopology().getPartitionHealth(memberId(brokerId), partition))
-        .as("partition %d is healthy on broker %d", partition, brokerId)
+    assertThat(topologyManager.getTopology().getPartitionHealth(brokerId, partition))
+        .as("partition %d is healthy on broker %s", partition, brokerId)
         .isEqualTo(PartitionHealthStatus.HEALTHY);
     assertThat(topologyManager.getTopology().getInactiveNodesForPartition(partition))
-        .containsExactly(memberId(brokerId));
+        .containsExactly(brokerId);
 
     // when
     broker.setPartitionUnhealthy(partition);
     notifyEvent(createMemberUpdateEvent(broker));
 
-    assertThat(topologyManager.getTopology().getPartitionHealth(memberId(brokerId), partition))
-        .as("partition %d is unhealthy on broker %d", partition, brokerId)
+    assertThat(topologyManager.getTopology().getPartitionHealth(brokerId, partition))
+        .as("partition %d is unhealthy on broker %s", partition, brokerId)
         .isEqualTo(PartitionHealthStatus.UNHEALTHY);
 
     // then
     assertThat(topologyManager.getTopology().getInactiveNodesForPartition(partition))
-        .containsExactly(memberId(brokerId));
+        .containsExactly(brokerId);
   }
 
   @Test
   void shouldUpdateTopologyOnLeaderRemoval() {
     // given
     final int partition = 1;
-    final int brokerId = 0;
+    final var brokerId = BrokerMemberId.from(0);
     final BrokerInfo broker = createBroker(brokerId).setLeaderForPartition(partition, partition);
 
     // when
     notifyEvent(createMemberUpdateEvent(broker));
 
-    assertThat(topologyManager.getTopology().getLeaderForPartition(partition))
-        .isEqualTo(memberId(0));
+    assertThat(topologyManager.getTopology().getLeaderForPartition(partition)).isEqualTo(brokerId);
 
     broker.setFollowerForPartition(partition);
     notifyEvent(createMemberUpdateEvent(broker));
@@ -327,7 +321,7 @@ final class BrokerTopologyManagerTest {
     // then
 
     assertThat(topologyManager.getTopology().getFollowersForPartition(partition))
-        .containsExactlyInAnyOrder(memberId(brokerId));
+        .containsExactlyInAnyOrder(brokerId);
     assertThat(topologyManager.getTopology().getLeaderForPartition(partition)).isNull();
   }
 
@@ -335,7 +329,7 @@ final class BrokerTopologyManagerTest {
   void shouldUpdateTopologyOnBrokerInactive() {
     // given
     final int partition = 0;
-    final int brokerId = 0;
+    final var brokerId = BrokerMemberId.from(0);
     final BrokerInfo broker = createBroker(brokerId);
     broker.setLeaderForPartition(partition, 1);
     notifyEvent(createMemberAddedEvent(broker));
@@ -344,8 +338,7 @@ final class BrokerTopologyManagerTest {
 
     assertThat(topologyManager.getTopology().getInactiveNodesForPartition(partition))
         .isNullOrEmpty();
-    assertThat(topologyManager.getTopology().getLeaderForPartition(partition))
-        .isEqualTo(memberId(0));
+    assertThat(topologyManager.getTopology().getLeaderForPartition(partition)).isEqualTo(brokerId);
 
     broker.setInactiveForPartition(partition);
     notifyEvent(createMemberUpdateEvent(broker));
@@ -353,7 +346,7 @@ final class BrokerTopologyManagerTest {
     // then
 
     assertThat(topologyManager.getTopology().getInactiveNodesForPartition(partition))
-        .contains(memberId(brokerId));
+        .contains(brokerId);
     assertThat(topologyManager.getTopology().getLeaderForPartition(partition)).isNull();
   }
 
@@ -363,7 +356,7 @@ final class BrokerTopologyManagerTest {
     final RecordingTopologyListener topology = new RecordingTopologyListener();
     addTopologyListener(topology);
 
-    final int brokerId = 1;
+    final var brokerId = BrokerMemberId.from(1);
     final BrokerInfo broker = createBroker(brokerId);
 
     // when
@@ -376,7 +369,7 @@ final class BrokerTopologyManagerTest {
   @Test
   void shouldNotifyListenerWithInitialState() {
     // given
-    final int brokerId = 1;
+    final var brokerId = BrokerMemberId.from(1);
     final BrokerInfo broker = createBroker(brokerId);
     notifyEvent(createMemberAddedEvent(broker));
 
@@ -394,7 +387,7 @@ final class BrokerTopologyManagerTest {
     final RecordingTopologyListener topology = new RecordingTopologyListener();
     addTopologyListener(topology);
 
-    final int brokerId = 1;
+    final var brokerId = BrokerMemberId.from(1);
     final BrokerInfo broker = createBroker(brokerId);
     notifyEvent(createMemberAddedEvent(broker));
 
@@ -432,7 +425,7 @@ final class BrokerTopologyManagerTest {
     final RecordingTopologyListener topology = new RecordingTopologyListener();
     addTopologyListener(topology);
 
-    final int brokerId = 1;
+    final var brokerId = BrokerMemberId.from(1);
     final BrokerInfo broker = createBroker(brokerId);
     notifyEvent(createMemberAddedEvent(broker));
 
@@ -451,7 +444,7 @@ final class BrokerTopologyManagerTest {
   @Test
   void shouldUpdateClusterSizeFromClusterTopology() {
     // given
-    final BrokerInfo broker = createBroker(1);
+    final BrokerInfo broker = createBroker(BrokerMemberId.from(1));
     notifyEvent(createMemberAddedEvent(broker));
 
     // when
@@ -479,7 +472,7 @@ final class BrokerTopologyManagerTest {
     actorSchedulerRule.workUntilDone();
 
     // when
-    final BrokerInfo broker = createBroker(1);
+    final BrokerInfo broker = createBroker(BrokerMemberId.from(1));
     notifyEvent(createMemberAddedEvent(broker));
 
     // then
@@ -489,7 +482,7 @@ final class BrokerTopologyManagerTest {
   @Test
   void shouldUpdatePartitionsFromClusterTopology() {
     // given
-    final var broker = createBroker(1);
+    final var broker = createBroker(BrokerMemberId.from(1));
     notifyEvent(createMemberAddedEvent(broker));
 
     // when
@@ -547,7 +540,7 @@ final class BrokerTopologyManagerTest {
     actorSchedulerRule.workUntilDone();
 
     // when
-    final var broker = createBroker(1);
+    final var broker = createBroker(BrokerMemberId.from(1));
     notifyEvent(createMemberAddedEvent(broker));
 
     // then
@@ -583,10 +576,6 @@ final class BrokerTopologyManagerTest {
   private void addTopologyListener(final BrokerTopologyListener listener) {
     topologyManager.addTopologyListener(listener);
     actorSchedulerRule.workUntilDone();
-  }
-
-  private BrokerInfo createBroker(final int brokerId) {
-    return createBroker(BrokerMemberId.from(brokerId));
   }
 
   private BrokerInfo createBroker(final BrokerMemberId brokerId) {
@@ -629,25 +618,21 @@ final class BrokerTopologyManagerTest {
     actorSchedulerRule.workUntilDone();
   }
 
-  private static BrokerMemberId memberId(final int nodeId) {
-    return BrokerMemberId.from(nodeId);
-  }
-
   private static final class RecordingTopologyListener implements BrokerTopologyListener {
 
-    private final Set<Integer> brokers = new CopyOnWriteArraySet<>();
+    private final Set<BrokerMemberId> brokers = new CopyOnWriteArraySet<>();
 
     @Override
     public void brokerAdded(final BrokerMemberId memberId) {
-      brokers.add(Integer.parseInt(memberId.id()));
+      brokers.add(memberId);
     }
 
     @Override
     public void brokerRemoved(final BrokerMemberId memberId) {
-      brokers.remove(Integer.parseInt(memberId.id()));
+      brokers.remove(memberId);
     }
 
-    Set<Integer> getBrokers() {
+    Set<BrokerMemberId> getBrokers() {
       return brokers;
     }
   }

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.broker.client.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.atomix.cluster.BrokerMemberId;
 import io.atomix.cluster.ClusterMembershipEvent;
 import io.atomix.cluster.ClusterMembershipEvent.Type;
 import io.atomix.cluster.Member;
@@ -68,7 +69,7 @@ final class BrokerTopologyManagerTest {
   void shouldUpdateTopologyOnBrokerAdd() {
     // given
     final int brokerId = 1;
-    final var memberId = MemberId.from(1);
+    final var memberId = memberId(1);
     final int partition = 1;
     final BrokerInfo broker = createBroker(brokerId);
     notifyEvent(createMemberAddedEvent(broker));
@@ -93,7 +94,7 @@ final class BrokerTopologyManagerTest {
   void shouldUpdateTopologyOnBrokerRemove() {
     // given
     final int brokerId = 0;
-    final var memberId = MemberId.from(0);
+    final var memberId = memberId(0);
     final int partition = 1;
     final BrokerInfo broker = createBroker(brokerId);
     notifyEvent(createMemberAddedEvent(broker));
@@ -557,18 +558,19 @@ final class BrokerTopologyManagerTest {
   void shouldBackfillNewListenerWithCanonicalZoneAwareMemberId() {
     // given — broker 0 joined with a zone-aware id
     final var broker = createBroker(0);
-    final var zonedMemberId = MemberId.from("eu-west/0");
-    final var member = new Member(new MemberConfig().setId(zonedMemberId).setZoneId("eu-west"));
+    final var zonedMemberId = BrokerMemberId.from("eu-west/0");
+    final var member =
+        new Member(new MemberConfig().setId(zonedMemberId.memberId()).setZoneId("eu-west"));
     broker.writeIntoProperties(member.properties());
     members.add(member);
     notifyEvent(new ClusterMembershipEvent(Type.MEMBER_ADDED, member));
 
     // when — a new listener is added after the broker is already known
-    final var capturedIds = new CopyOnWriteArrayList<MemberId>();
+    final var capturedIds = new CopyOnWriteArrayList<BrokerMemberId>();
     topologyManager.addTopologyListener(
         new BrokerTopologyListener() {
           @Override
-          public void brokerAdded(final MemberId memberId) {
+          public void brokerAdded(final BrokerMemberId memberId) {
             capturedIds.add(memberId);
           }
         });
@@ -623,8 +625,8 @@ final class BrokerTopologyManagerTest {
     actorSchedulerRule.workUntilDone();
   }
 
-  private static MemberId memberId(final int nodeId) {
-    return MemberId.from(null, nodeId);
+  private static BrokerMemberId memberId(final int nodeId) {
+    return BrokerMemberId.from(null, nodeId);
   }
 
   private static final class RecordingTopologyListener implements BrokerTopologyListener {
@@ -632,12 +634,12 @@ final class BrokerTopologyManagerTest {
     private final Set<Integer> brokers = new CopyOnWriteArraySet<>();
 
     @Override
-    public void brokerAdded(final MemberId memberId) {
+    public void brokerAdded(final BrokerMemberId memberId) {
       brokers.add(Integer.parseInt(memberId.id()));
     }
 
     @Override
-    public void brokerRemoved(final MemberId memberId) {
+    public void brokerRemoved(final BrokerMemberId memberId) {
       brokers.remove(Integer.parseInt(memberId.id()));
     }
 

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.broker.client.api;
 
-import static io.camunda.zeebe.broker.client.api.BrokerClusterState.NODE_ID_NULL;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.ClusterMembershipEvent;
@@ -69,6 +68,7 @@ final class BrokerTopologyManagerTest {
   void shouldUpdateTopologyOnBrokerAdd() {
     // given
     final int brokerId = 1;
+    final var memberId = MemberId.from(1);
     final int partition = 1;
     final BrokerInfo broker = createBroker(brokerId);
     notifyEvent(createMemberAddedEvent(broker));
@@ -84,8 +84,8 @@ final class BrokerTopologyManagerTest {
 
     assertThat(topologyManager.getTopology().getFollowersForPartition(partition))
         .describedAs("The partition has the expected follower")
-        .containsExactly(brokerId);
-    assertThat(topologyManager.getTopology().getBrokerVersion(brokerId))
+        .containsExactly(memberId);
+    assertThat(topologyManager.getTopology().getBrokerVersion(memberId))
         .isEqualTo(broker.getVersion());
   }
 
@@ -93,6 +93,7 @@ final class BrokerTopologyManagerTest {
   void shouldUpdateTopologyOnBrokerRemove() {
     // given
     final int brokerId = 0;
+    final var memberId = MemberId.from(0);
     final int partition = 1;
     final BrokerInfo broker = createBroker(brokerId);
     notifyEvent(createMemberAddedEvent(broker));
@@ -115,9 +116,8 @@ final class BrokerTopologyManagerTest {
     assertThat(topologyManager.getTopology().getBrokers()).isNotEmpty();
 
     assertThat(topologyManager.getTopology().getFollowersForPartition(partition))
-        .doesNotContain(brokerId);
-    assertThat(topologyManager.getTopology().getLeaderForPartition(partition))
-        .isEqualTo(NODE_ID_NULL);
+        .doesNotContain(memberId);
+    assertThat(topologyManager.getTopology().getLeaderForPartition(partition)).isNull();
   }
 
   @Test
@@ -131,7 +131,7 @@ final class BrokerTopologyManagerTest {
 
     assertThat(topologyManager.getTopology().getLeaderForPartition(partition))
         .describedAs("Topology has the old leader")
-        .isZero();
+        .isEqualTo(memberId(0));
 
     // when
     final int newLeaderId = 1;
@@ -140,8 +140,9 @@ final class BrokerTopologyManagerTest {
     notifyEvent(createMemberAddedEvent(newLeader));
 
     // then
-    assertThat(topologyManager.getTopology().getBrokers()).contains(newLeaderId);
-    assertThat(topologyManager.getTopology().getLeaderForPartition(partition)).isOne();
+    assertThat(topologyManager.getTopology().getBrokers()).contains(memberId(newLeaderId));
+    assertThat(topologyManager.getTopology().getLeaderForPartition(partition))
+        .isEqualTo(memberId(1));
   }
 
   @Test
@@ -153,7 +154,8 @@ final class BrokerTopologyManagerTest {
     newLeader.setLeaderForPartition(partition, 2);
     notifyEvent(createMemberAddedEvent(newLeader));
 
-    assertThat(topologyManager.getTopology().getLeaderForPartition(partition)).isOne();
+    assertThat(topologyManager.getTopology().getLeaderForPartition(partition))
+        .isEqualTo(memberId(1));
 
     // when
     final int oldLeaderId = 0;
@@ -162,8 +164,9 @@ final class BrokerTopologyManagerTest {
     notifyEvent(createMemberAddedEvent(oldLeader));
 
     // then
-    assertThat(topologyManager.getTopology().getBrokers()).contains(oldLeaderId);
-    assertThat(topologyManager.getTopology().getLeaderForPartition(partition)).isOne();
+    assertThat(topologyManager.getTopology().getBrokers()).contains(memberId(oldLeaderId));
+    assertThat(topologyManager.getTopology().getLeaderForPartition(partition))
+        .isEqualTo(memberId(1));
   }
 
   @Test
@@ -175,7 +178,8 @@ final class BrokerTopologyManagerTest {
     leader.setLeaderForPartition(partition, 2);
     notifyEvent(createMemberAddedEvent(leader));
 
-    assertThat(topologyManager.getTopology().getLeaderForPartition(partition)).isOne();
+    assertThat(topologyManager.getTopology().getLeaderForPartition(partition))
+        .isEqualTo(memberId(1));
 
     // when
     // partition shutdown/purge
@@ -189,9 +193,10 @@ final class BrokerTopologyManagerTest {
     notifyEvent(createMemberAddedEvent(newLeaderAfterRebootstrap));
 
     // then
-    assertThat(topologyManager.getTopology().getBrokers()).contains(newLeaderAfterRebootstrapId);
+    assertThat(topologyManager.getTopology().getBrokers())
+        .contains(memberId(newLeaderAfterRebootstrapId));
     assertThat(topologyManager.getTopology().getLeaderForPartition(partition))
-        .isEqualTo(newLeaderAfterRebootstrapId);
+        .isEqualTo(memberId(newLeaderAfterRebootstrapId));
   }
 
   @Test
@@ -214,8 +219,9 @@ final class BrokerTopologyManagerTest {
     // then
     assertThat(topologyManager.getTopology().getBrokers())
         .describedAs("the broker has rejoined the cluster")
-        .containsExactly(leaderId);
-    assertThat(topologyManager.getTopology().getLeaderForPartition(partition)).isOne();
+        .containsExactly(memberId(leaderId));
+    assertThat(topologyManager.getTopology().getLeaderForPartition(partition))
+        .isEqualTo(memberId(1));
   }
 
   @Test
@@ -227,7 +233,7 @@ final class BrokerTopologyManagerTest {
     broker.setPartitionHealthy(partition);
     notifyEvent(createMemberAddedEvent(broker));
 
-    assertThat(topologyManager.getTopology().getPartitionHealth(brokerId, partition))
+    assertThat(topologyManager.getTopology().getPartitionHealth(memberId(brokerId), partition))
         .as("partition %d is healthy on broker %d", partition, brokerId)
         .isEqualTo(PartitionHealthStatus.HEALTHY);
 
@@ -237,7 +243,7 @@ final class BrokerTopologyManagerTest {
     notifyEvent(createMemberUpdateEvent(updatedBroker));
 
     // then
-    assertThat(topologyManager.getTopology().getPartitionHealth(brokerId, partition))
+    assertThat(topologyManager.getTopology().getPartitionHealth(memberId(brokerId), partition))
         .as("partition %d is unhealthy on broker %d", partition, brokerId)
         .isEqualTo(PartitionHealthStatus.UNHEALTHY);
   }
@@ -253,23 +259,23 @@ final class BrokerTopologyManagerTest {
 
     notifyEvent(createMemberAddedEvent(broker));
 
-    assertThat(topologyManager.getTopology().getPartitionHealth(brokerId, partition))
+    assertThat(topologyManager.getTopology().getPartitionHealth(memberId(brokerId), partition))
         .as("partition %d is healthy on broker %d", partition, brokerId)
         .isEqualTo(PartitionHealthStatus.HEALTHY);
     assertThat(topologyManager.getTopology().getFollowersForPartition(partition))
-        .containsExactly(brokerId);
+        .containsExactly(memberId(brokerId));
 
     // when
     broker.setPartitionUnhealthy(partition);
     notifyEvent(createMemberUpdateEvent(broker));
 
-    assertThat(topologyManager.getTopology().getPartitionHealth(brokerId, partition))
+    assertThat(topologyManager.getTopology().getPartitionHealth(memberId(brokerId), partition))
         .as("partition %d is unhealthy on broker %d", partition, brokerId)
         .isEqualTo(PartitionHealthStatus.UNHEALTHY);
 
     // then
     assertThat(topologyManager.getTopology().getFollowersForPartition(partition))
-        .containsExactly(brokerId);
+        .containsExactly(memberId(brokerId));
   }
 
   @Test
@@ -282,23 +288,23 @@ final class BrokerTopologyManagerTest {
     broker.setInactiveForPartition(partition);
     notifyEvent(createMemberAddedEvent(broker));
 
-    assertThat(topologyManager.getTopology().getPartitionHealth(brokerId, partition))
+    assertThat(topologyManager.getTopology().getPartitionHealth(memberId(brokerId), partition))
         .as("partition %d is healthy on broker %d", partition, brokerId)
         .isEqualTo(PartitionHealthStatus.HEALTHY);
     assertThat(topologyManager.getTopology().getInactiveNodesForPartition(partition))
-        .containsExactly(brokerId);
+        .containsExactly(memberId(brokerId));
 
     // when
     broker.setPartitionUnhealthy(partition);
     notifyEvent(createMemberUpdateEvent(broker));
 
-    assertThat(topologyManager.getTopology().getPartitionHealth(brokerId, partition))
+    assertThat(topologyManager.getTopology().getPartitionHealth(memberId(brokerId), partition))
         .as("partition %d is unhealthy on broker %d", partition, brokerId)
         .isEqualTo(PartitionHealthStatus.UNHEALTHY);
 
     // then
     assertThat(topologyManager.getTopology().getInactiveNodesForPartition(partition))
-        .containsExactly(brokerId);
+        .containsExactly(memberId(brokerId));
   }
 
   @Test
@@ -311,7 +317,8 @@ final class BrokerTopologyManagerTest {
     // when
     notifyEvent(createMemberUpdateEvent(broker));
 
-    assertThat(topologyManager.getTopology().getLeaderForPartition(partition)).isZero();
+    assertThat(topologyManager.getTopology().getLeaderForPartition(partition))
+        .isEqualTo(memberId(0));
 
     broker.setFollowerForPartition(partition);
     notifyEvent(createMemberUpdateEvent(broker));
@@ -319,9 +326,8 @@ final class BrokerTopologyManagerTest {
     // then
 
     assertThat(topologyManager.getTopology().getFollowersForPartition(partition))
-        .containsExactlyInAnyOrder(brokerId);
-    assertThat(topologyManager.getTopology().getLeaderForPartition(partition))
-        .isEqualTo(NODE_ID_NULL);
+        .containsExactlyInAnyOrder(memberId(brokerId));
+    assertThat(topologyManager.getTopology().getLeaderForPartition(partition)).isNull();
   }
 
   @Test
@@ -337,7 +343,8 @@ final class BrokerTopologyManagerTest {
 
     assertThat(topologyManager.getTopology().getInactiveNodesForPartition(partition))
         .isNullOrEmpty();
-    assertThat(topologyManager.getTopology().getLeaderForPartition(partition)).isZero();
+    assertThat(topologyManager.getTopology().getLeaderForPartition(partition))
+        .isEqualTo(memberId(0));
 
     broker.setInactiveForPartition(partition);
     notifyEvent(createMemberUpdateEvent(broker));
@@ -345,8 +352,8 @@ final class BrokerTopologyManagerTest {
     // then
 
     assertThat(topologyManager.getTopology().getInactiveNodesForPartition(partition))
-        .contains(brokerId);
-    assertThat(topologyManager.getTopology().getLeaderForPartition(partition)).isNotZero();
+        .contains(memberId(brokerId));
+    assertThat(topologyManager.getTopology().getLeaderForPartition(partition)).isNull();
   }
 
   @Test
@@ -614,6 +621,10 @@ final class BrokerTopologyManagerTest {
   private void notifyEvent(final ClusterMembershipEvent broker) {
     topologyManager.event(broker);
     actorSchedulerRule.workUntilDone();
+  }
+
+  private static MemberId memberId(final int nodeId) {
+    return MemberId.from(null, nodeId);
   }
 
   private static final class RecordingTopologyListener implements BrokerTopologyListener {

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
@@ -599,15 +599,14 @@ final class BrokerTopologyManagerTest {
   }
 
   private Member createMemberFromBrokerInfo(final BrokerInfo broker) {
-    final Member member =
-        new Member(new MemberConfig().setId(Integer.toString(broker.getNodeId())));
+    final Member member = new Member(new MemberConfig().setId(broker.memberIdString()));
     broker.writeIntoProperties(member.properties());
     members.add(member);
     return member;
   }
 
   private ClusterMembershipEvent createMemberRemoveEvent(final BrokerInfo broker) {
-    final Member member = new Member(new MemberConfig().setId(String.valueOf(broker.getNodeId())));
+    final Member member = new Member(new MemberConfig().setId(broker.memberIdString()));
     broker.writeIntoProperties(member.properties());
     return new ClusterMembershipEvent(Type.MEMBER_REMOVED, member);
   }

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/PartitionIdIteratorTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/PartitionIdIteratorTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.broker.client.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.atomix.cluster.BrokerMemberId;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -21,7 +22,10 @@ final class PartitionIdIteratorTest {
     // given
     final var iterator = new PartitionIdIterator(1, 3, topologyManager);
     final List<Integer> ids = new ArrayList<>();
-    topologyManager.addPartition(1, 0).addPartition(2, 0).addPartition(3, 0);
+    topologyManager
+        .addPartition(1, BrokerMemberId.from(0))
+        .addPartition(2, BrokerMemberId.from(0))
+        .addPartition(3, BrokerMemberId.from(0));
 
     // when
     iterator.forEachRemaining(ids::add);
@@ -35,7 +39,7 @@ final class PartitionIdIteratorTest {
     // given
     final var iterator = new PartitionIdIterator(1, 3, topologyManager);
     final List<Integer> ids = new ArrayList<>();
-    topologyManager.addPartition(1, 0).addPartition(3, 0);
+    topologyManager.addPartition(1, BrokerMemberId.from(0)).addPartition(3, BrokerMemberId.from(0));
 
     // when
     iterator.forEachRemaining(ids::add);

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/PartitionIdIteratorTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/PartitionIdIteratorTest.java
@@ -7,9 +7,9 @@
  */
 package io.camunda.zeebe.broker.client.impl;
 
+import static io.camunda.zeebe.broker.client.BrokerMemberIds.ZERO;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.atomix.cluster.BrokerMemberId;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -22,10 +22,7 @@ final class PartitionIdIteratorTest {
     // given
     final var iterator = new PartitionIdIterator(1, 3, topologyManager);
     final List<Integer> ids = new ArrayList<>();
-    topologyManager
-        .addPartition(1, BrokerMemberId.from(0))
-        .addPartition(2, BrokerMemberId.from(0))
-        .addPartition(3, BrokerMemberId.from(0));
+    topologyManager.addPartition(1, ZERO).addPartition(2, ZERO).addPartition(3, ZERO);
 
     // when
     iterator.forEachRemaining(ids::add);
@@ -39,7 +36,7 @@ final class PartitionIdIteratorTest {
     // given
     final var iterator = new PartitionIdIterator(1, 3, topologyManager);
     final List<Integer> ids = new ArrayList<>();
-    topologyManager.addPartition(1, BrokerMemberId.from(0)).addPartition(3, BrokerMemberId.from(0));
+    topologyManager.addPartition(1, ZERO).addPartition(3, ZERO);
 
     // when
     iterator.forEachRemaining(ids::add);

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/RoundRobinDispatchStrategyTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/RoundRobinDispatchStrategyTest.java
@@ -7,9 +7,9 @@
  */
 package io.camunda.zeebe.broker.client.impl;
 
+import static io.camunda.zeebe.broker.client.BrokerMemberIds.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.atomix.cluster.BrokerMemberId;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.RoutingState;
@@ -40,10 +40,7 @@ final class RoundRobinDispatchStrategyTest {
     // given
     final var dispatchStrategy = new RoundRobinDispatchStrategy();
     final var topologyManager = new TestTopologyManager();
-    topologyManager
-        .addPartition(1, null)
-        .addPartition(2, BrokerMemberId.from(0))
-        .addPartition(3, BrokerMemberId.from(0));
+    topologyManager.addPartition(1, null).addPartition(2, ZERO).addPartition(3, ZERO);
 
     // when - then
     assertThat(dispatchStrategy.determinePartition(topologyManager)).isEqualTo(2);
@@ -56,9 +53,9 @@ final class RoundRobinDispatchStrategyTest {
     final var dispatchStrategy = new RoundRobinDispatchStrategy();
     final var topologyManager = new TestTopologyManager();
     topologyManager
-        .addPartition(1, BrokerMemberId.from(0))
-        .addPartition(2, BrokerMemberId.from(1))
-        .addPartition(3, BrokerMemberId.from(2))
+        .addPartition(1, ZERO)
+        .addPartition(2, ONE)
+        .addPartition(3, TWO)
         .withClusterConfiguration(
             ClusterConfiguration.builder()
                 .version(1)
@@ -81,9 +78,9 @@ final class RoundRobinDispatchStrategyTest {
     final var dispatchStrategy = new RoundRobinDispatchStrategy();
     final var topologyManager = new TestTopologyManager();
     topologyManager
-        .addPartition(1, BrokerMemberId.from(0))
-        .addPartition(2, BrokerMemberId.from(1))
-        .addPartition(3, BrokerMemberId.from(2))
+        .addPartition(1, ZERO)
+        .addPartition(2, ONE)
+        .addPartition(3, TWO)
         .withClusterConfiguration(
             ClusterConfiguration.builder()
                 .version(1)
@@ -106,10 +103,7 @@ final class RoundRobinDispatchStrategyTest {
   void shouldUpdateFromClusterConfiguration() {
     final var dispatchStrategy = new RoundRobinDispatchStrategy();
     final var topologyManager = new TestTopologyManager();
-    topologyManager
-        .addPartition(1, BrokerMemberId.from(0))
-        .addPartition(2, BrokerMemberId.from(1))
-        .addPartition(3, BrokerMemberId.from(2));
+    topologyManager.addPartition(1, ZERO).addPartition(2, ONE).addPartition(3, TWO);
 
     // when -- starting with routing state version 1, with active partitions 1 and 3
     topologyManager.withClusterConfiguration(

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/RoundRobinDispatchStrategyTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/RoundRobinDispatchStrategyTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.broker.client.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.atomix.cluster.BrokerMemberId;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.RoutingState;
@@ -40,9 +41,9 @@ final class RoundRobinDispatchStrategyTest {
     final var dispatchStrategy = new RoundRobinDispatchStrategy();
     final var topologyManager = new TestTopologyManager();
     topologyManager
-        .addPartition(1, BrokerClusterState.NODE_ID_NULL)
-        .addPartition(2, 0)
-        .addPartition(3, 0);
+        .addPartition(1, null)
+        .addPartition(2, BrokerMemberId.from(0))
+        .addPartition(3, BrokerMemberId.from(0));
 
     // when - then
     assertThat(dispatchStrategy.determinePartition(topologyManager)).isEqualTo(2);
@@ -55,9 +56,9 @@ final class RoundRobinDispatchStrategyTest {
     final var dispatchStrategy = new RoundRobinDispatchStrategy();
     final var topologyManager = new TestTopologyManager();
     topologyManager
-        .addPartition(1, 0)
-        .addPartition(2, 1)
-        .addPartition(3, 2)
+        .addPartition(1, BrokerMemberId.from(0))
+        .addPartition(2, BrokerMemberId.from(1))
+        .addPartition(3, BrokerMemberId.from(2))
         .withClusterConfiguration(
             ClusterConfiguration.builder()
                 .version(1)
@@ -80,9 +81,9 @@ final class RoundRobinDispatchStrategyTest {
     final var dispatchStrategy = new RoundRobinDispatchStrategy();
     final var topologyManager = new TestTopologyManager();
     topologyManager
-        .addPartition(1, 0)
-        .addPartition(2, 1)
-        .addPartition(3, 2)
+        .addPartition(1, BrokerMemberId.from(0))
+        .addPartition(2, BrokerMemberId.from(1))
+        .addPartition(3, BrokerMemberId.from(2))
         .withClusterConfiguration(
             ClusterConfiguration.builder()
                 .version(1)
@@ -105,7 +106,10 @@ final class RoundRobinDispatchStrategyTest {
   void shouldUpdateFromClusterConfiguration() {
     final var dispatchStrategy = new RoundRobinDispatchStrategy();
     final var topologyManager = new TestTopologyManager();
-    topologyManager.addPartition(1, 0).addPartition(2, 1).addPartition(3, 2);
+    topologyManager
+        .addPartition(1, BrokerMemberId.from(0))
+        .addPartition(2, BrokerMemberId.from(1))
+        .addPartition(3, BrokerMemberId.from(2));
 
     // when -- starting with routing state version 1, with active partitions 1 and 3
     topologyManager.withClusterConfiguration(

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/TestTopologyManager.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/TestTopologyManager.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.client.impl;
 
+import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyListener;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
@@ -17,6 +18,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 final class TestTopologyManager implements BrokerTopologyManager {
   private final TestBrokerClusterState topology;
@@ -70,10 +73,11 @@ final class TestTopologyManager implements BrokerTopologyManager {
     throw new UnsupportedOperationException();
   }
 
+  @NullMarked
   private static final class TestBrokerClusterState implements BrokerClusterState {
 
-    private final List<Integer> brokers = new ArrayList<>();
-    private final Map<Integer, Integer> partitionLeaders = new HashMap<>();
+    private final List<MemberId> brokers = new ArrayList<>();
+    private final Map<Integer, MemberId> partitionLeaders = new HashMap<>();
     private final List<Integer> partitions = new ArrayList<>();
 
     @Override
@@ -97,23 +101,23 @@ final class TestTopologyManager implements BrokerTopologyManager {
     }
 
     @Override
-    public int getLeaderForPartition(final int partition) {
-      return partitionLeaders.getOrDefault(partition, BrokerClusterState.NODE_ID_NULL);
+    public MemberId getLeaderForPartition(final int partition) {
+      return partitionLeaders.get(partition);
     }
 
     @Override
-    public Set<Integer> getFollowersForPartition(final int partition) {
+    public Set<MemberId> getFollowersForPartition(final int partition) {
       return Set.of();
     }
 
     @Override
-    public Set<Integer> getInactiveNodesForPartition(final int partition) {
+    public Set<MemberId> getInactiveNodesForPartition(final int partition) {
       return Set.of();
     }
 
     @Override
-    public int getRandomBroker() {
-      return 0;
+    public @Nullable MemberId getRandomBroker() {
+      return brokers.isEmpty() ? null : brokers.get(0);
     }
 
     @Override
@@ -122,22 +126,23 @@ final class TestTopologyManager implements BrokerTopologyManager {
     }
 
     @Override
-    public List<Integer> getBrokers() {
+    public List<MemberId> getBrokers() {
       return brokers;
     }
 
     @Override
-    public String getBrokerAddress(final int brokerId) {
+    public String getBrokerAddress(final MemberId brokerId) {
       return "";
     }
 
     @Override
-    public String getBrokerVersion(final int brokerId) {
+    public String getBrokerVersion(final MemberId brokerId) {
       return "";
     }
 
     @Override
-    public PartitionHealthStatus getPartitionHealth(final int brokerId, final int partition) {
+    public @Nullable PartitionHealthStatus getPartitionHealth(
+        final MemberId brokerId, final int partition) {
       return null;
     }
 
@@ -152,11 +157,11 @@ final class TestTopologyManager implements BrokerTopologyManager {
     }
 
     public void addBrokerIfAbsent(final int leaderId) {
-      brokers.add(leaderId);
+      brokers.add(MemberId.from(null, leaderId));
     }
 
     public void setPartitionLeader(final int id, final int leaderId) {
-      partitionLeaders.put(id, leaderId);
+      partitionLeaders.put(id, MemberId.from(null, leaderId));
     }
 
     public void addPartitionIfAbsent(final int id) {

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/TestTopologyManager.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/TestTopologyManager.java
@@ -33,8 +33,8 @@ final class TestTopologyManager implements BrokerTopologyManager {
     this.topology = topology;
   }
 
-  TestTopologyManager addPartition(final int id, final int leaderId) {
-    if (leaderId != BrokerClusterState.NODE_ID_NULL) {
+  TestTopologyManager addPartition(final int id, final BrokerMemberId leaderId) {
+    if (leaderId != null) {
       topology.addBrokerIfAbsent(leaderId);
       topology.setPartitionLeader(id, leaderId);
     }
@@ -156,12 +156,12 @@ final class TestTopologyManager implements BrokerTopologyManager {
       return "";
     }
 
-    public void addBrokerIfAbsent(final int leaderId) {
-      brokers.add(BrokerMemberId.from(null, leaderId));
+    public void addBrokerIfAbsent(final BrokerMemberId leaderId) {
+      brokers.add(leaderId);
     }
 
-    public void setPartitionLeader(final int id, final int leaderId) {
-      partitionLeaders.put(id, BrokerMemberId.from(null, leaderId));
+    public void setPartitionLeader(final int id, final BrokerMemberId leaderId) {
+      partitionLeaders.put(id, leaderId);
     }
 
     public void addPartitionIfAbsent(final int id) {

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/TestTopologyManager.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/TestTopologyManager.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.broker.client.impl;
 
-import io.atomix.cluster.MemberId;
+import io.atomix.cluster.BrokerMemberId;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyListener;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
@@ -76,8 +76,8 @@ final class TestTopologyManager implements BrokerTopologyManager {
   @NullMarked
   private static final class TestBrokerClusterState implements BrokerClusterState {
 
-    private final List<MemberId> brokers = new ArrayList<>();
-    private final Map<Integer, MemberId> partitionLeaders = new HashMap<>();
+    private final List<BrokerMemberId> brokers = new ArrayList<>();
+    private final Map<Integer, BrokerMemberId> partitionLeaders = new HashMap<>();
     private final List<Integer> partitions = new ArrayList<>();
 
     @Override
@@ -101,22 +101,22 @@ final class TestTopologyManager implements BrokerTopologyManager {
     }
 
     @Override
-    public MemberId getLeaderForPartition(final int partition) {
+    public BrokerMemberId getLeaderForPartition(final int partition) {
       return partitionLeaders.get(partition);
     }
 
     @Override
-    public Set<MemberId> getFollowersForPartition(final int partition) {
+    public Set<BrokerMemberId> getFollowersForPartition(final int partition) {
       return Set.of();
     }
 
     @Override
-    public Set<MemberId> getInactiveNodesForPartition(final int partition) {
+    public Set<BrokerMemberId> getInactiveNodesForPartition(final int partition) {
       return Set.of();
     }
 
     @Override
-    public @Nullable MemberId getRandomBroker() {
+    public @Nullable BrokerMemberId getRandomBroker() {
       return brokers.isEmpty() ? null : brokers.get(0);
     }
 
@@ -126,23 +126,23 @@ final class TestTopologyManager implements BrokerTopologyManager {
     }
 
     @Override
-    public List<MemberId> getBrokers() {
+    public List<BrokerMemberId> getBrokers() {
       return brokers;
     }
 
     @Override
-    public String getBrokerAddress(final MemberId brokerId) {
+    public String getBrokerAddress(final BrokerMemberId brokerId) {
       return "";
     }
 
     @Override
-    public String getBrokerVersion(final MemberId brokerId) {
+    public String getBrokerVersion(final BrokerMemberId brokerId) {
       return "";
     }
 
     @Override
     public @Nullable PartitionHealthStatus getPartitionHealth(
-        final MemberId brokerId, final int partition) {
+        final BrokerMemberId brokerId, final int partition) {
       return null;
     }
 
@@ -157,11 +157,11 @@ final class TestTopologyManager implements BrokerTopologyManager {
     }
 
     public void addBrokerIfAbsent(final int leaderId) {
-      brokers.add(MemberId.from(null, leaderId));
+      brokers.add(BrokerMemberId.from(null, leaderId));
     }
 
     public void setPartitionLeader(final int id, final int leaderId) {
-      partitionLeaders.put(id, MemberId.from(null, leaderId));
+      partitionLeaders.put(id, BrokerMemberId.from(null, leaderId));
     }
 
     public void addPartitionIfAbsent(final int id) {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.broker;
 
-import io.atomix.cluster.MemberId;
+import io.atomix.cluster.BrokerMemberId;
 import io.camunda.zeebe.broker.bootstrap.BrokerContext;
 import io.camunda.zeebe.broker.bootstrap.BrokerStartupContextImpl;
 import io.camunda.zeebe.broker.bootstrap.BrokerStartupProcess;
@@ -66,11 +66,11 @@ public final class Broker implements AutoCloseable {
     final ActorScheduler scheduler = this.systemContext.getScheduler();
     final BrokerInfo localBroker = createBrokerInfo(getConfig());
     final var cluster = getConfig().getCluster();
-    final var nodeId = MemberId.from(cluster.getZone(), cluster.getNodeId());
+    final var nodeId = BrokerMemberId.from(cluster.getZone(), cluster.getNodeId());
 
     healthCheckService =
         new BrokerHealthCheckService(
-            nodeId,
+            nodeId.memberId(),
             new HealthTreeMetrics(systemContext.getMeterRegistry(), Tag.of("partition", "none")));
 
     final var startupContext =

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -228,10 +228,7 @@ public final class Broker implements AutoCloseable {
 
     private final BrokerStartupProcess brokerStartupProcess;
 
-    private final int nodeId;
-
     private BrokerStartupActor(final BrokerStartupContextImpl startupContext) {
-      nodeId = startupContext.getBrokerInfo().getNodeId();
       startupContext.setConcurrencyControl(actor);
       brokerStartupProcess = new BrokerStartupProcess(startupContext);
     }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
@@ -142,7 +142,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
 
   @Override
   public String toString() {
-    return "BrokerStartupContextImpl{" + "broker=" + brokerInfo.getNodeId() + '}';
+    return "BrokerStartupContextImpl{" + "broker=" + brokerInfo.memberIdString() + '}';
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
@@ -178,7 +178,7 @@ public final class ZeebePartitionFactory {
     final var snapshotCopy = new RocksDBSnapshotCopy(zeebeFactory);
     final var context =
         new PartitionStartupAndTransitionContextImpl(
-            localBroker.getNodeId(),
+            MemberId.from(localBroker.memberIdString()),
             localBroker.getPartitionsCount(),
             communicationService,
             raftPartition,

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.partitioning.startup;
 
+import io.atomix.cluster.BrokerMemberId;
 import io.atomix.raft.partition.RaftPartition;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
@@ -178,7 +179,7 @@ public final class ZeebePartitionFactory {
     final var snapshotCopy = new RocksDBSnapshotCopy(zeebeFactory);
     final var context =
         new PartitionStartupAndTransitionContextImpl(
-            MemberId.from(localBroker.memberIdString()),
+            BrokerMemberId.from(localBroker.getZone(), localBroker.getNodeId()),
             localBroker.getPartitionsCount(),
             communicationService,
             raftPartition,

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyManagerImpl.java
@@ -117,7 +117,7 @@ public final class TopologyManagerImpl extends Actor
 
     final BrokerInfo brokerInfo = BrokerInfo.fromProperties(eventSource.properties());
 
-    if (brokerInfo != null && !brokerInfo.memberIdString().equals(localBroker.memberIdString())) {
+    if (brokerInfo != null && !memberIdOf(brokerInfo).equals(memberIdOf(localBroker))) {
       actor.run(
           () -> {
             switch (clusterMembershipEvent.type()) {
@@ -135,7 +135,7 @@ public final class TopologyManagerImpl extends Actor
                 LOG.debug(
                     "Received {} from member {}, was not handled.",
                     clusterMembershipEvent.type(),
-                    brokerInfo.memberIdString());
+                    memberIdOf(brokerInfo));
                 break;
             }
           });
@@ -154,8 +154,7 @@ public final class TopologyManagerImpl extends Actor
 
   private void removeIfLeader(final BrokerInfo brokerInfo, final Integer partition) {
     final BrokerInfo currentLeader = partitionLeaders.get(partition);
-    if (currentLeader != null
-        && currentLeader.memberIdString().equals(brokerInfo.memberIdString())) {
+    if (currentLeader != null && memberIdOf(currentLeader).equals(memberIdOf(brokerInfo))) {
       partitionLeaders.remove(partition);
     }
   }
@@ -164,7 +163,7 @@ public final class TopologyManagerImpl extends Actor
   private void onMetadataChanged(final BrokerInfo brokerInfo) {
     LOG.debug(
         "Received metadata change for {}, partitions {} terms {}",
-        brokerInfo.memberIdString(),
+        memberIdOf(brokerInfo),
         brokerInfo.getPartitionRoles(),
         brokerInfo.getPartitionLeaderTerms());
     brokerInfo.consumePartitions(
@@ -181,7 +180,7 @@ public final class TopologyManagerImpl extends Actor
             .filter(
                 entry -> {
                   final var broker = entry.getValue();
-                  return broker.memberIdString().equals(brokerInfo.memberIdString());
+                  return memberIdOf(broker).equals(memberIdOf(brokerInfo));
                 })
             .map(Entry::getKey)
             .toList();
@@ -200,7 +199,7 @@ public final class TopologyManagerImpl extends Actor
         LOG.debug(
             "Expected to have a non-null value for current leader term, but found null. Partition {} is likely removed from broker {}. Updating the leader anyway.",
             leaderPartitionId,
-            currentLeader.memberIdString());
+            memberIdOf(currentLeader));
       } else if (currentLeaderTerm >= term) {
         return false;
       }
@@ -266,5 +265,9 @@ public final class TopologyManagerImpl extends Actor
     for (final TopologyPartitionListener listener : topologyPartitionListeners) {
       LogUtil.catchAndLog(LOG, () -> listener.onPartitionLeaderUpdated(partitionId, leaderId));
     }
+  }
+
+  private static MemberId memberIdOf(final BrokerInfo brokerInfo) {
+    return MemberId.from(brokerInfo.getZone(), brokerInfo.getNodeId());
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyManagerImpl.java
@@ -117,7 +117,7 @@ public final class TopologyManagerImpl extends Actor
 
     final BrokerInfo brokerInfo = BrokerInfo.fromProperties(eventSource.properties());
 
-    if (brokerInfo != null && brokerInfo.getNodeId() != localBroker.getNodeId()) {
+    if (brokerInfo != null && !brokerInfo.memberIdString().equals(localBroker.memberIdString())) {
       actor.run(
           () -> {
             switch (clusterMembershipEvent.type()) {
@@ -135,7 +135,7 @@ public final class TopologyManagerImpl extends Actor
                 LOG.debug(
                     "Received {} from member {}, was not handled.",
                     clusterMembershipEvent.type(),
-                    brokerInfo.getNodeId());
+                    brokerInfo.memberIdString());
                 break;
             }
           });
@@ -154,7 +154,8 @@ public final class TopologyManagerImpl extends Actor
 
   private void removeIfLeader(final BrokerInfo brokerInfo, final Integer partition) {
     final BrokerInfo currentLeader = partitionLeaders.get(partition);
-    if (currentLeader != null && currentLeader.getNodeId() == brokerInfo.getNodeId()) {
+    if (currentLeader != null
+        && currentLeader.memberIdString().equals(brokerInfo.memberIdString())) {
       partitionLeaders.remove(partition);
     }
   }
@@ -163,7 +164,7 @@ public final class TopologyManagerImpl extends Actor
   private void onMetadataChanged(final BrokerInfo brokerInfo) {
     LOG.debug(
         "Received metadata change for {}, partitions {} terms {}",
-        brokerInfo.getNodeId(),
+        brokerInfo.memberIdString(),
         brokerInfo.getPartitionRoles(),
         brokerInfo.getPartitionLeaderTerms());
     brokerInfo.consumePartitions(
@@ -180,7 +181,7 @@ public final class TopologyManagerImpl extends Actor
             .filter(
                 entry -> {
                   final var broker = entry.getValue();
-                  return broker.getNodeId() == brokerInfo.getNodeId();
+                  return broker.memberIdString().equals(brokerInfo.memberIdString());
                 })
             .map(Entry::getKey)
             .toList();
@@ -199,7 +200,7 @@ public final class TopologyManagerImpl extends Actor
         LOG.debug(
             "Expected to have a non-null value for current leader term, but found null. Partition {} is likely removed from broker {}. Updating the leader anyway.",
             leaderPartitionId,
-            currentLeader.getNodeId());
+            currentLeader.memberIdString());
       } else if (currentLeaderTerm >= term) {
         return false;
       }
@@ -232,7 +233,7 @@ public final class TopologyManagerImpl extends Actor
                       LOG,
                       () ->
                           listener.onPartitionLeaderUpdated(
-                              partitionId, resolveMemberIdInZone(leader.getNodeId()))));
+                              partitionId, MemberId.from(leader.zone(), leader.getNodeId()))));
         });
   }
 
@@ -261,30 +262,9 @@ public final class TopologyManagerImpl extends Actor
   }
 
   private void notifyPartitionLeaderUpdated(final int partitionId, final BrokerInfo member) {
-    final var leaderId = resolveMemberIdInZone(member.getNodeId());
+    final var leaderId = MemberId.from(member.zone(), member.getNodeId());
     for (final TopologyPartitionListener listener : topologyPartitionListeners) {
       LogUtil.catchAndLog(LOG, () -> listener.onPartitionLeaderUpdated(partitionId, leaderId));
     }
-  }
-
-  private MemberId resolveMemberIdInZone(final int nodeId) {
-    return membershipService.getMembers().stream()
-        .map(Member::id)
-        .filter(
-            id -> {
-              try {
-                return id.isInZone(localBroker.getZone()) && id.nodeIdx() == nodeId;
-              } catch (final IllegalStateException e) {
-                return false;
-              }
-            })
-        .findFirst()
-        .orElseGet(
-            () -> {
-              LOG.warn(
-                  "No cluster member found for nodeId {}; falling back to bare MemberId — zone-aware routing will not work for this member",
-                  nodeId);
-              return MemberId.from(Integer.toString(nodeId));
-            });
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyManagerImpl.java
@@ -7,12 +7,12 @@
  */
 package io.camunda.zeebe.broker.partitioning.topology;
 
+import io.atomix.cluster.BrokerMemberId;
 import io.atomix.cluster.ClusterMembershipEvent;
 import io.atomix.cluster.ClusterMembershipEvent.Type;
 import io.atomix.cluster.ClusterMembershipEventListener;
 import io.atomix.cluster.ClusterMembershipService;
 import io.atomix.cluster.Member;
-import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.engine.state.QueryService;
@@ -230,9 +230,7 @@ public final class TopologyManagerImpl extends Actor
               (partitionId, leader) ->
                   LogUtil.catchAndLog(
                       LOG,
-                      () ->
-                          listener.onPartitionLeaderUpdated(
-                              partitionId, MemberId.from(leader.getZone(), leader.getNodeId()))));
+                      () -> listener.onPartitionLeaderUpdated(partitionId, memberIdOf(leader))));
         });
   }
 
@@ -261,13 +259,13 @@ public final class TopologyManagerImpl extends Actor
   }
 
   private void notifyPartitionLeaderUpdated(final int partitionId, final BrokerInfo member) {
-    final var leaderId = MemberId.from(member.getZone(), member.getNodeId());
+    final var leaderId = memberIdOf(member);
     for (final TopologyPartitionListener listener : topologyPartitionListeners) {
       LogUtil.catchAndLog(LOG, () -> listener.onPartitionLeaderUpdated(partitionId, leaderId));
     }
   }
 
-  private static MemberId memberIdOf(final BrokerInfo brokerInfo) {
-    return MemberId.from(brokerInfo.getZone(), brokerInfo.getNodeId());
+  private static BrokerMemberId memberIdOf(final BrokerInfo brokerInfo) {
+    return BrokerMemberId.from(brokerInfo.getZone(), brokerInfo.getNodeId());
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyManagerImpl.java
@@ -233,7 +233,7 @@ public final class TopologyManagerImpl extends Actor
                       LOG,
                       () ->
                           listener.onPartitionLeaderUpdated(
-                              partitionId, MemberId.from(leader.zone(), leader.getNodeId()))));
+                              partitionId, MemberId.from(leader.getZone(), leader.getNodeId()))));
         });
   }
 
@@ -262,7 +262,7 @@ public final class TopologyManagerImpl extends Actor
   }
 
   private void notifyPartitionLeaderUpdated(final int partitionId, final BrokerInfo member) {
-    final var leaderId = MemberId.from(member.zone(), member.getNodeId());
+    final var leaderId = MemberId.from(member.getZone(), member.getNodeId());
     for (final TopologyPartitionListener listener : topologyPartitionListeners) {
       LogUtil.catchAndLog(LOG, () -> listener.onPartitionLeaderUpdated(partitionId, leaderId));
     }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyPartitionListener.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyPartitionListener.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.zeebe.broker.partitioning.topology;
 
-import io.atomix.cluster.MemberId;
+import io.atomix.cluster.BrokerMemberId;
 
 public interface TopologyPartitionListener {
-  void onPartitionLeaderUpdated(int partitionId, MemberId leaderId);
+  void onPartitionLeaderUpdated(int partitionId, BrokerMemberId leaderId);
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.system.partitions;
 
+import io.atomix.cluster.MemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.partition.RaftPartition;
@@ -67,7 +68,7 @@ import java.util.stream.Collectors;
 public class PartitionStartupAndTransitionContextImpl
     implements PartitionContext, PartitionStartupContext, PartitionTransitionContext {
 
-  private final int nodeId;
+  private final MemberId memberId;
   private final List<PartitionListener> partitionListeners;
   private final List<PartitionRaftListener> partitionRaftListeners;
   private final int partitionCount;
@@ -121,7 +122,7 @@ public class PartitionStartupAndTransitionContextImpl
   private ClusterConfigurationService clusterConfigurationService;
 
   public PartitionStartupAndTransitionContextImpl(
-      final int nodeId,
+      final MemberId memberId,
       final int partitionCount,
       final ClusterCommunicationService clusterCommunicationService,
       final RaftPartition raftPartition,
@@ -144,7 +145,7 @@ public class PartitionStartupAndTransitionContextImpl
       final BrokerHealthCheckService brokerHealthCheckService,
       final SecurityConfiguration securityConfig,
       final MeterRegistry startupMeterRegistry) {
-    this.nodeId = nodeId;
+    this.memberId = memberId;
     this.partitionCount = partitionCount;
     this.clusterCommunicationService = clusterCommunicationService;
     this.raftPartition = raftPartition;
@@ -542,8 +543,8 @@ public class PartitionStartupAndTransitionContextImpl
   }
 
   @Override
-  public int getNodeId() {
-    return nodeId;
+  public MemberId getMemberId() {
+    return memberId;
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.broker.system.partitions;
 
-import io.atomix.cluster.MemberId;
+import io.atomix.cluster.BrokerMemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.partition.RaftPartition;
@@ -68,7 +68,7 @@ import java.util.stream.Collectors;
 public class PartitionStartupAndTransitionContextImpl
     implements PartitionContext, PartitionStartupContext, PartitionTransitionContext {
 
-  private final MemberId memberId;
+  private final BrokerMemberId memberId;
   private final List<PartitionListener> partitionListeners;
   private final List<PartitionRaftListener> partitionRaftListeners;
   private final int partitionCount;
@@ -122,7 +122,7 @@ public class PartitionStartupAndTransitionContextImpl
   private ClusterConfigurationService clusterConfigurationService;
 
   public PartitionStartupAndTransitionContextImpl(
-      final MemberId memberId,
+      final BrokerMemberId memberId,
       final int partitionCount,
       final ClusterCommunicationService clusterCommunicationService,
       final RaftPartition raftPartition,
@@ -543,7 +543,7 @@ public class PartitionStartupAndTransitionContextImpl
   }
 
   @Override
-  public MemberId getMemberId() {
+  public BrokerMemberId getMemberId() {
     return memberId;
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupContext.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.system.partitions;
 
+import io.atomix.cluster.MemberId;
 import io.atomix.raft.partition.RaftPartition;
 import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
 import io.camunda.zeebe.db.ZeebeDb;
@@ -19,7 +20,7 @@ import io.camunda.zeebe.snapshots.PersistedSnapshotStore;
 public interface PartitionStartupContext {
 
   // provided by application-wide dependencies
-  int getNodeId();
+  MemberId getMemberId();
 
   RaftPartition getRaftPartition();
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupContext.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.broker.system.partitions;
 
-import io.atomix.cluster.MemberId;
+import io.atomix.cluster.BrokerMemberId;
 import io.atomix.raft.partition.RaftPartition;
 import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
 import io.camunda.zeebe.db.ZeebeDb;
@@ -20,7 +20,7 @@ import io.camunda.zeebe.snapshots.PersistedSnapshotStore;
 public interface PartitionStartupContext {
 
   // provided by application-wide dependencies
-  MemberId getMemberId();
+  BrokerMemberId getMemberId();
 
   RaftPartition getRaftPartition();
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.broker.system.partitions;
 
-import io.atomix.cluster.MemberId;
+import io.atomix.cluster.BrokerMemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.atomix.raft.RaftServer.Role;
 import io.camunda.security.configuration.SecurityConfiguration;
@@ -45,7 +45,7 @@ import org.jspecify.annotations.Nullable;
 
 public interface PartitionTransitionContext extends PartitionContext {
 
-  MemberId getMemberId();
+  BrokerMemberId getMemberId();
 
   LogStream getLogStream();
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.system.partitions;
 
+import io.atomix.cluster.MemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.atomix.raft.RaftServer.Role;
 import io.camunda.security.configuration.SecurityConfiguration;
@@ -44,7 +45,7 @@ import org.jspecify.annotations.Nullable;
 
 public interface PartitionTransitionContext extends PartitionContext {
 
-  int getNodeId();
+  MemberId getMemberId();
 
   LogStream getLogStream();
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/AdminApiRequestHandlerStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/AdminApiRequestHandlerStep.java
@@ -45,8 +45,7 @@ public final class AdminApiRequestHandlerStep implements PartitionTransitionStep
             context.getAdminAccess(),
             context.getRaftPartition(),
             context.getClusterConfigurationService(),
-            context.getNodeId(),
-            context.getBrokerCfg().getCluster().getZone());
+            context.getMemberId());
     final var submitFuture = schedulingService.submitActor(handler);
     concurrencyControl.runOnCompletion(
         submitFuture,

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupServiceTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupServiceTransitionStep.java
@@ -109,7 +109,7 @@ public final class BackupServiceTransitionStep implements PartitionTransitionSte
 
     final BackupService backupManager =
         new BackupService(
-            context.getNodeId(),
+            context.getMemberId().nodeIdx(),
             context.getPartitionId(),
             context.getBackupStore(),
             context.getPersistedSnapshotStore(),

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
@@ -168,7 +168,6 @@ public final class StreamProcessorTransitionStep implements PartitionTransitionS
         .actorSchedulingService(context.getActorSchedulingService())
         .zeebeDb(context.getZeebeDb())
         .recordProcessors(recordProcessors)
-        .nodeId(context.getNodeId())
         .commandResponseWriter(context.getCommandApiService().newCommandResponseWriter())
         .maxCommandsInBatch(context.getBrokerCfg().getProcessing().getMaxCommandsInBatch())
         .maxRecoverableRetries(context.getBrokerCfg().getProcessing().getMaxRecoverableRetries())

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandler.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandler.java
@@ -23,7 +23,6 @@ import io.camunda.zeebe.transport.RequestType;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
 import io.camunda.zeebe.util.Either;
 import java.io.IOException;
-import org.jspecify.annotations.Nullable;
 
 public class AdminApiRequestHandler
     extends AsyncApiRequestHandler<ApiRequestReader, ApiResponseWriter> {
@@ -31,24 +30,21 @@ public class AdminApiRequestHandler
   private final PartitionAdminAccess adminAccess;
   private final RaftPartition raftPartition;
   private final ClusterConfigurationService clusterConfigurationService;
-  private final int nodeId;
-  private final @Nullable String zone;
+  private final MemberId memberId;
 
   public AdminApiRequestHandler(
       final AtomixServerTransport transport,
       final PartitionAdminAccess adminAccess,
       final RaftPartition raftPartition,
       final ClusterConfigurationService clusterConfigurationService,
-      final int nodeId,
-      final @Nullable String zone) {
+      final MemberId memberId) {
     super(ApiRequestReader::new, ApiResponseWriter::new);
     this.transport = transport;
     this.adminAccess = adminAccess;
 
     this.raftPartition = raftPartition;
     this.clusterConfigurationService = clusterConfigurationService;
-    this.nodeId = nodeId;
-    this.zone = zone;
+    this.memberId = memberId;
   }
 
   @Override
@@ -286,7 +282,6 @@ public class AdminApiRequestHandler
     // Fire-and-forget: return success immediately, then process asynchronously
     actor.run(
         () -> {
-          final MemberId currentMemberId = MemberId.from(zone, nodeId);
           clusterConfigurationService
               .getLatestClusterConfiguration()
               .onComplete(
@@ -307,17 +302,17 @@ public class AdminApiRequestHandler
                       return;
                     }
 
-                    if (!primaryMember.get().equals(currentMemberId)) {
+                    if (!primaryMember.get().equals(memberId)) {
                       LOG.info(
                           "Node {} is not primary for partition {} (primary is {}), initiating step-down",
-                          currentMemberId,
+                          memberId,
                           partitionId,
                           primaryMember.get());
                       raftPartition.stepDownForLeaderBalancing();
                     } else {
                       LOG.debug(
                           "Node {} is primary for partition {}, not stepping down",
-                          currentMemberId,
+                          memberId,
                           partitionId);
                     }
                   });

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandler.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandler.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.broker.transport.adminapi;
 
-import io.atomix.cluster.MemberId;
+import io.atomix.cluster.BrokerMemberId;
 import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.partition.RaftPartition;
 import io.camunda.zeebe.broker.partitioning.PartitionAdminAccess;
@@ -30,14 +30,14 @@ public class AdminApiRequestHandler
   private final PartitionAdminAccess adminAccess;
   private final RaftPartition raftPartition;
   private final ClusterConfigurationService clusterConfigurationService;
-  private final MemberId memberId;
+  private final BrokerMemberId memberId;
 
   public AdminApiRequestHandler(
       final AtomixServerTransport transport,
       final PartitionAdminAccess adminAccess,
       final RaftPartition raftPartition,
       final ClusterConfigurationService clusterConfigurationService,
-      final MemberId memberId) {
+      final BrokerMemberId memberId) {
     super(ApiRequestReader::new, ApiResponseWriter::new);
     this.transport = transport;
     this.adminAccess = adminAccess;
@@ -302,7 +302,7 @@ public class AdminApiRequestHandler
                       return;
                     }
 
-                    if (!primaryMember.get().equals(memberId)) {
+                    if (!primaryMember.get().equals(memberId.memberId())) {
                       LOG.info(
                           "Node {} is not primary for partition {} (primary is {}), initiating step-down",
                           memberId,

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandSenderService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandSenderService.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.broker.transport.partitionapi;
 
-import io.atomix.cluster.MemberId;
+import io.atomix.cluster.BrokerMemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.camunda.zeebe.backup.api.CheckpointListener;
 import io.camunda.zeebe.broker.partitioning.topology.TopologyPartitionListener;
@@ -74,7 +74,7 @@ public final class InterPartitionCommandSenderService extends Actor
   }
 
   @Override
-  public void onPartitionLeaderUpdated(final int leaderPartitionId, final MemberId leaderId) {
-    actor.submit(() -> commandSender.setCurrentLeader(leaderPartitionId, leaderId));
+  public void onPartitionLeaderUpdated(final int leaderPartitionId, final BrokerMemberId leaderId) {
+    actor.submit(() -> commandSender.setCurrentLeader(leaderPartitionId, leaderId.memberId()));
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.broker.system.partitions;
 
-import io.atomix.cluster.MemberId;
+import io.atomix.cluster.BrokerMemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.partition.RaftPartition;
@@ -479,8 +479,8 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
   }
 
   @Override
-  public MemberId getMemberId() {
-    return MemberId.from(0);
+  public BrokerMemberId getMemberId() {
+    return BrokerMemberId.from(0);
   }
 
   @Override

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.system.partitions;
 
+import io.atomix.cluster.MemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.partition.RaftPartition;
@@ -478,8 +479,8 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
   }
 
   @Override
-  public int getNodeId() {
-    return 0;
+  public MemberId getMemberId() {
+    return MemberId.from(0);
   }
 
   @Override

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandlerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandlerTest.java
@@ -12,7 +12,7 @@ import static org.mockito.Answers.RETURNS_MOCKS;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.atomix.cluster.MemberId;
+import io.atomix.cluster.BrokerMemberId;
 import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.partition.RaftPartition;
 import io.camunda.zeebe.broker.partitioning.PartitionAdminAccess;
@@ -106,7 +106,11 @@ final class AdminApiRequestHandlerTest {
         @Mock final ClusterConfigurationService clusterConfigurationService) {
       handler =
           new AdminApiRequestHandler(
-              transport, adminAccess, raftPartition, clusterConfigurationService, MemberId.from(1));
+              transport,
+              adminAccess,
+              raftPartition,
+              clusterConfigurationService,
+              BrokerMemberId.from(1));
     }
 
     @BeforeEach
@@ -150,7 +154,11 @@ final class AdminApiRequestHandlerTest {
       when(adminAccess.forPartition(partitionId)).thenReturn(Optional.of(adminAccess));
       handler =
           new AdminApiRequestHandler(
-              transport, adminAccess, raftPartition, clusterConfigurationService, MemberId.from(1));
+              transport,
+              adminAccess,
+              raftPartition,
+              clusterConfigurationService,
+              BrokerMemberId.from(1));
 
       request = new AdminRequest();
       request.setPartitionId(partitionId);
@@ -227,7 +235,11 @@ final class AdminApiRequestHandlerTest {
       when(adminAccess.forPartition(partitionId)).thenReturn(Optional.of(adminAccess));
       handler =
           new AdminApiRequestHandler(
-              transport, adminAccess, raftPartition, clusterConfigurationService, MemberId.from(1));
+              transport,
+              adminAccess,
+              raftPartition,
+              clusterConfigurationService,
+              BrokerMemberId.from(1));
 
       request = new AdminRequest();
       request.setPartitionId(partitionId);
@@ -304,7 +316,11 @@ final class AdminApiRequestHandlerTest {
       when(adminAccess.forPartition(partitionId)).thenReturn(Optional.of(adminAccess));
       handler =
           new AdminApiRequestHandler(
-              transport, adminAccess, raftPartition, clusterConfigurationService, MemberId.from(1));
+              transport,
+              adminAccess,
+              raftPartition,
+              clusterConfigurationService,
+              BrokerMemberId.from(1));
 
       request = new AdminRequest();
       request.setPartitionId(partitionId);
@@ -378,7 +394,7 @@ final class AdminApiRequestHandlerTest {
         @Mock final ClusterConfigurationService clusterConfigurationService) {
       this.raftPartition = raftPartition;
       this.clusterConfigurationService = clusterConfigurationService;
-      final MemberId memberId = MemberId.from(1);
+      final BrokerMemberId memberId = BrokerMemberId.from(1);
       handler =
           new AdminApiRequestHandler(
               transport, adminAccess, raftPartition, clusterConfigurationService, memberId);
@@ -443,11 +459,11 @@ final class AdminApiRequestHandlerTest {
       // given
       when(raftPartition.getRole()).thenReturn(Role.LEADER);
       final var partitionId = 1;
-      final var primaryMemberId = io.atomix.cluster.MemberId.from("2");
+      final var primaryBrokerMemberId = io.atomix.cluster.BrokerMemberId.from("2");
       final var clusterConfig =
           Mockito.mock(io.camunda.zeebe.dynamic.config.state.ClusterConfiguration.class);
       when(clusterConfig.getPrimaryMemberForPartition(partitionId))
-          .thenReturn(java.util.Optional.of(primaryMemberId));
+          .thenReturn(java.util.Optional.of(primaryBrokerMemberId.memberId()));
       when(clusterConfigurationService.getLatestClusterConfiguration())
           .thenReturn(
               io.camunda.zeebe.scheduler.future.CompletableActorFuture.completed(clusterConfig));
@@ -470,11 +486,12 @@ final class AdminApiRequestHandlerTest {
       // given
       when(raftPartition.getRole()).thenReturn(Role.LEADER);
       final var partitionId = 1;
-      final var primaryMemberId = io.atomix.cluster.MemberId.from("1"); // Same as nodeId
+      final var primaryBrokerMemberId =
+          io.atomix.cluster.BrokerMemberId.from("1"); // Same as nodeId
       final var clusterConfig =
           Mockito.mock(io.camunda.zeebe.dynamic.config.state.ClusterConfiguration.class);
       when(clusterConfig.getPrimaryMemberForPartition(partitionId))
-          .thenReturn(java.util.Optional.of(primaryMemberId));
+          .thenReturn(java.util.Optional.of(primaryBrokerMemberId.memberId()));
       when(clusterConfigurationService.getLatestClusterConfiguration())
           .thenReturn(
               io.camunda.zeebe.scheduler.future.CompletableActorFuture.completed(clusterConfig));

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandlerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandlerTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Answers.RETURNS_MOCKS;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.atomix.cluster.MemberId;
 import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.partition.RaftPartition;
 import io.camunda.zeebe.broker.partitioning.PartitionAdminAccess;
@@ -105,7 +106,7 @@ final class AdminApiRequestHandlerTest {
         @Mock final ClusterConfigurationService clusterConfigurationService) {
       handler =
           new AdminApiRequestHandler(
-              transport, adminAccess, raftPartition, clusterConfigurationService, 1, null);
+              transport, adminAccess, raftPartition, clusterConfigurationService, MemberId.from(1));
     }
 
     @BeforeEach
@@ -149,7 +150,7 @@ final class AdminApiRequestHandlerTest {
       when(adminAccess.forPartition(partitionId)).thenReturn(Optional.of(adminAccess));
       handler =
           new AdminApiRequestHandler(
-              transport, adminAccess, raftPartition, clusterConfigurationService, 1, null);
+              transport, adminAccess, raftPartition, clusterConfigurationService, MemberId.from(1));
 
       request = new AdminRequest();
       request.setPartitionId(partitionId);
@@ -226,7 +227,7 @@ final class AdminApiRequestHandlerTest {
       when(adminAccess.forPartition(partitionId)).thenReturn(Optional.of(adminAccess));
       handler =
           new AdminApiRequestHandler(
-              transport, adminAccess, raftPartition, clusterConfigurationService, 1, null);
+              transport, adminAccess, raftPartition, clusterConfigurationService, MemberId.from(1));
 
       request = new AdminRequest();
       request.setPartitionId(partitionId);
@@ -303,7 +304,7 @@ final class AdminApiRequestHandlerTest {
       when(adminAccess.forPartition(partitionId)).thenReturn(Optional.of(adminAccess));
       handler =
           new AdminApiRequestHandler(
-              transport, adminAccess, raftPartition, clusterConfigurationService, 1, null);
+              transport, adminAccess, raftPartition, clusterConfigurationService, MemberId.from(1));
 
       request = new AdminRequest();
       request.setPartitionId(partitionId);
@@ -369,7 +370,6 @@ final class AdminApiRequestHandlerTest {
     private final AdminApiRequestHandler handler;
     private final RaftPartition raftPartition;
     private final ClusterConfigurationService clusterConfigurationService;
-    private final int nodeId = 1;
 
     StepdownRequest(
         @Mock final AtomixServerTransport transport,
@@ -378,9 +378,10 @@ final class AdminApiRequestHandlerTest {
         @Mock final ClusterConfigurationService clusterConfigurationService) {
       this.raftPartition = raftPartition;
       this.clusterConfigurationService = clusterConfigurationService;
+      final MemberId memberId = MemberId.from(1);
       handler =
           new AdminApiRequestHandler(
-              transport, adminAccess, raftPartition, clusterConfigurationService, nodeId, null);
+              transport, adminAccess, raftPartition, clusterConfigurationService, memberId);
     }
 
     @BeforeEach

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestHandlerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestHandlerTest.java
@@ -12,7 +12,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import io.atomix.cluster.MemberId;
+import io.atomix.cluster.BrokerMemberId;
 import io.atomix.cluster.messaging.ClusterEventService;
 import io.atomix.cluster.messaging.MessagingConfig;
 import io.atomix.cluster.messaging.impl.NettyMessagingService;
@@ -98,8 +98,8 @@ public class SnapshotApiRequestHandlerTest {
     final var clusterService = mock(ClusterEventService.class);
     final var brokerTopology = mock(BrokerTopologyManager.class);
     final var clusterState = mock(BrokerClusterState.class);
-    when(clusterState.getLeaderForPartition(1)).thenReturn(MemberId.from(1));
-    when(clusterState.getBrokerAddress(MemberId.from("1"))).thenReturn(serverAddress);
+    when(clusterState.getLeaderForPartition(1)).thenReturn(BrokerMemberId.from(1));
+    when(clusterState.getBrokerAddress(BrokerMemberId.from("1"))).thenReturn(serverAddress);
     when(clusterState.getPartitions()).thenReturn(List.of(1));
 
     when(brokerTopology.getTopology()).thenReturn(clusterState);

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestHandlerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestHandlerTest.java
@@ -12,6 +12,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.atomix.cluster.MemberId;
 import io.atomix.cluster.messaging.ClusterEventService;
 import io.atomix.cluster.messaging.MessagingConfig;
 import io.atomix.cluster.messaging.impl.NettyMessagingService;
@@ -97,8 +98,8 @@ public class SnapshotApiRequestHandlerTest {
     final var clusterService = mock(ClusterEventService.class);
     final var brokerTopology = mock(BrokerTopologyManager.class);
     final var clusterState = mock(BrokerClusterState.class);
-    when(clusterState.getLeaderForPartition(1)).thenReturn(1);
-    when(clusterState.getBrokerAddress(1)).thenReturn(serverAddress);
+    when(clusterState.getLeaderForPartition(1)).thenReturn(MemberId.from(1));
+    when(clusterState.getBrokerAddress(MemberId.from("1"))).thenReturn(serverAddress);
     when(clusterState.getPartitions()).thenReturn(List.of(1));
 
     when(brokerTopology.getTopology()).thenReturn(clusterState);

--- a/zeebe/gateway-grpc/pom.xml
+++ b/zeebe/gateway-grpc/pom.xml
@@ -130,6 +130,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.gateway;
 
-import io.atomix.cluster.MemberId;
+import io.atomix.cluster.BrokerMemberId;
 import io.atomix.utils.net.Address;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.SecurityConfiguration;
@@ -121,7 +121,7 @@ public final class EndpointManager {
   }
 
   private void addBrokerInfo(
-      final Builder brokerInfo, final MemberId brokerId, final BrokerClusterState topology) {
+      final Builder brokerInfo, final BrokerMemberId brokerId, final BrokerClusterState topology) {
     final String brokerAddress = topology.getBrokerAddress(brokerId);
     final Address address = Address.from(brokerAddress);
 
@@ -134,7 +134,7 @@ public final class EndpointManager {
   }
 
   private void addPartitionInfoToBrokerInfo(
-      final Builder brokerInfo, final MemberId brokerId, final BrokerClusterState topology) {
+      final Builder brokerInfo, final BrokerMemberId brokerId, final BrokerClusterState topology) {
     topology
         .getPartitions()
         .forEach(
@@ -170,13 +170,14 @@ public final class EndpointManager {
    * @return true if it could set the role. False if no role was could be found.
    */
   private boolean setRole(
-      final MemberId brokerId,
+      final BrokerMemberId brokerId,
       final Integer partitionId,
       final BrokerClusterState topology,
       final Partition.Builder partitionBuilder) {
-    final MemberId partitionLeader = topology.getLeaderForPartition(partitionId);
-    final Set<MemberId> partitionFollowers = topology.getFollowersForPartition(partitionId);
-    final Set<MemberId> partitionInactives = topology.getInactiveNodesForPartition(partitionId);
+    final BrokerMemberId partitionLeader = topology.getLeaderForPartition(partitionId);
+    final var partitionFollowers = topology.getFollowersForPartition(partitionId);
+    final var partitionInactives =
+        topology.getInactiveNodesForPartition(partitionId);
 
     if (brokerId.equals(partitionLeader)) {
       partitionBuilder.setRole(PartitionBrokerRole.LEADER);

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
@@ -79,7 +79,6 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Function;
 
 public final class EndpointManager {
@@ -176,8 +175,7 @@ public final class EndpointManager {
       final Partition.Builder partitionBuilder) {
     final BrokerMemberId partitionLeader = topology.getLeaderForPartition(partitionId);
     final var partitionFollowers = topology.getFollowersForPartition(partitionId);
-    final var partitionInactives =
-        topology.getInactiveNodesForPartition(partitionId);
+    final var partitionInactives = topology.getInactiveNodesForPartition(partitionId);
 
     if (brokerId.equals(partitionLeader)) {
       partitionBuilder.setRole(PartitionBrokerRole.LEADER);

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.gateway;
 
+import io.atomix.cluster.MemberId;
 import io.atomix.utils.net.Address;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.SecurityConfiguration;
@@ -120,19 +121,20 @@ public final class EndpointManager {
   }
 
   private void addBrokerInfo(
-      final Builder brokerInfo, final Integer brokerId, final BrokerClusterState topology) {
+      final Builder brokerInfo, final MemberId brokerId, final BrokerClusterState topology) {
     final String brokerAddress = topology.getBrokerAddress(brokerId);
     final Address address = Address.from(brokerAddress);
 
-    brokerInfo
-        .setNodeId(brokerId)
-        .setHost(address.host())
-        .setPort(address.port())
-        .setVersion(topology.getBrokerVersion(brokerId));
+    brokerInfo.setNodeId(brokerId.nodeIdx()).setHost(address.host()).setPort(address.port());
+
+    final var brokerVersion = topology.getBrokerVersion(brokerId);
+    if (brokerVersion != null) {
+      brokerInfo.setVersion(brokerVersion);
+    }
   }
 
   private void addPartitionInfoToBrokerInfo(
-      final Builder brokerInfo, final Integer brokerId, final BrokerClusterState topology) {
+      final Builder brokerInfo, final MemberId brokerId, final BrokerClusterState topology) {
     topology
         .getPartitions()
         .forEach(
@@ -145,6 +147,11 @@ public final class EndpointManager {
               }
 
               final var status = topology.getPartitionHealth(brokerId, partitionId);
+              if (status == null) {
+                Loggers.GATEWAY_LOGGER.debug("Unsupported null partition broker health status");
+                return;
+              }
+
               switch (status) {
                 case HEALTHY -> partitionBuilder.setHealth(PartitionBrokerHealth.HEALTHY);
                 case UNHEALTHY -> partitionBuilder.setHealth(PartitionBrokerHealth.UNHEALTHY);
@@ -163,15 +170,15 @@ public final class EndpointManager {
    * @return true if it could set the role. False if no role was could be found.
    */
   private boolean setRole(
-      final Integer brokerId,
+      final MemberId brokerId,
       final Integer partitionId,
       final BrokerClusterState topology,
       final Partition.Builder partitionBuilder) {
-    final int partitionLeader = topology.getLeaderForPartition(partitionId);
-    final Set<Integer> partitionFollowers = topology.getFollowersForPartition(partitionId);
-    final Set<Integer> partitionInactives = topology.getInactiveNodesForPartition(partitionId);
+    final MemberId partitionLeader = topology.getLeaderForPartition(partitionId);
+    final Set<MemberId> partitionFollowers = topology.getFollowersForPartition(partitionId);
+    final Set<MemberId> partitionInactives = topology.getInactiveNodesForPartition(partitionId);
 
-    if (partitionLeader == brokerId) {
+    if (brokerId.equals(partitionLeader)) {
       partitionBuilder.setRole(PartitionBrokerRole.LEADER);
     } else if (partitionFollowers != null && partitionFollowers.contains(brokerId)) {
       partitionBuilder.setRole(PartitionBrokerRole.FOLLOWER);

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/BrokerAdminRequest.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/BrokerAdminRequest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.gateway.admin;
 
+import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRequest;
 import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
 import io.camunda.zeebe.protocol.Protocol;
@@ -62,10 +63,10 @@ public class BrokerAdminRequest extends BrokerRequest<AdminResponse> {
   }
 
   @Override
-  public Optional<Integer> getBrokerId() {
+  public Optional<MemberId> getBrokerId() {
     final var brokerId = request.getBrokerId();
     if (brokerId != AdminRequestEncoder.brokerIdNullValue()) {
-      return Optional.of(brokerId);
+      return Optional.of(MemberId.from(null, brokerId));
     } else {
       return Optional.empty();
     }

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/BrokerAdminRequest.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/BrokerAdminRequest.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.gateway.admin;
 
-import io.atomix.cluster.MemberId;
+import io.atomix.cluster.BrokerMemberId;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRequest;
 import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
 import io.camunda.zeebe.protocol.Protocol;
@@ -63,10 +63,10 @@ public class BrokerAdminRequest extends BrokerRequest<AdminResponse> {
   }
 
   @Override
-  public Optional<MemberId> getBrokerId() {
+  public Optional<BrokerMemberId> getBrokerId() {
     final var brokerId = request.getBrokerId();
     if (brokerId != AdminRequestEncoder.brokerIdNullValue()) {
-      return Optional.of(MemberId.from(null, brokerId));
+      return Optional.of(BrokerMemberId.from(null, brokerId));
     } else {
       return Optional.empty();
     }

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/exporting/ExportingControlService.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/exporting/ExportingControlService.java
@@ -7,16 +7,17 @@
  */
 package io.camunda.zeebe.gateway.admin.exporting;
 
+import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.gateway.admin.BrokerAdminRequest;
 import io.camunda.zeebe.gateway.admin.IncompleteTopologyException;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
-import org.agrona.collections.IntHashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,8 +72,10 @@ public class ExportingControlService implements ExportingControlApi {
     final var inactive =
         Optional.ofNullable(topology.getInactiveNodesForPartition(partitionId)).orElseGet(Set::of);
 
-    final var members = new IntHashSet(topology.getReplicationFactor());
-    members.add(leader);
+    final var members = new HashSet<MemberId>(topology.getReplicationFactor());
+    if (leader != null) {
+      members.add(leader);
+    }
     members.addAll(followers);
     members.addAll(inactive);
 
@@ -81,7 +84,7 @@ public class ExportingControlService implements ExportingControlApi {
             .map(
                 brokerId -> {
                   final var request = new BrokerAdminRequest();
-                  request.setBrokerId(brokerId);
+                  request.setBrokerId(brokerId.nodeIdx());
                   request.setPartitionId(partitionId);
                   configureRequest.accept(request);
                   return brokerClient.sendRequest(request);
@@ -104,22 +107,20 @@ public class ExportingControlService implements ExportingControlApi {
     for (final var partition : partitions) {
       final var leaderId = topology.getLeaderForPartition(partition);
 
-      if (leaderId == BrokerClusterState.UNKNOWN_NODE_ID
-          || leaderId == BrokerClusterState.NODE_ID_NULL) {
+      if (leaderId == null) {
         throw new IncompleteTopologyException(
-            "Leader %s of partition %s is not known, current topology: %s"
-                .formatted(leaderId, partition, topology));
+            "Leader of partition %s is not known, current topology: %s"
+                .formatted(partition, topology));
       }
 
       final var followers =
           Optional.ofNullable(topology.getFollowersForPartition(partition))
               .orElse(Collections.emptySet());
       for (final var follower : followers) {
-        if (follower == BrokerClusterState.UNKNOWN_NODE_ID
-            || follower == BrokerClusterState.NODE_ID_NULL) {
+        if (follower == null) {
           throw new IncompleteTopologyException(
-              "Follower %s of partition %s is not known, current topology: %s"
-                  .formatted(follower, partition, topology));
+              "Follower of partition %s is not known, current topology: %s"
+                  .formatted(partition, topology));
         }
       }
 

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/exporting/ExportingControlService.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/exporting/ExportingControlService.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.gateway.admin.exporting;
 
-import io.atomix.cluster.MemberId;
+import io.atomix.cluster.BrokerMemberId;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.gateway.admin.BrokerAdminRequest;
@@ -72,7 +72,7 @@ public class ExportingControlService implements ExportingControlApi {
     final var inactive =
         Optional.ofNullable(topology.getInactiveNodesForPartition(partitionId)).orElseGet(Set::of);
 
-    final var members = new HashSet<MemberId>(topology.getReplicationFactor());
+    final var members = new HashSet<BrokerMemberId>(topology.getReplicationFactor());
     if (leader != null) {
       members.add(leader);
     }

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterHealthIndicator.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterHealthIndicator.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.gateway.impl.probes.health;
 
 import static java.util.Objects.requireNonNull;
 
+import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
 import java.util.HashMap;
@@ -60,9 +61,12 @@ public class ClusterHealthIndicator implements HealthIndicator {
     final Map<String, PartitionHealthStatus> partitionDetails = new HashMap<>();
     partitions.forEach(
         partition -> {
-          final int broker = optClusterState.getLeaderForPartition(partition);
+          final MemberId broker = optClusterState.getLeaderForPartition(partition);
           final PartitionHealthStatus partitionHealthStatus =
-              optClusterState.getPartitionHealth(broker, partition);
+              broker != null
+                  ? Optional.ofNullable(optClusterState.getPartitionHealth(broker, partition))
+                      .orElse(PartitionHealthStatus.NULL_VAL)
+                  : PartitionHealthStatus.NULL_VAL;
           partitionDetails.put(String.format("Partition %d", partition), partitionHealthStatus);
         });
     return partitionDetails;

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterHealthIndicator.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterHealthIndicator.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.gateway.impl.probes.health;
 
 import static java.util.Objects.requireNonNull;
 
-import io.atomix.cluster.MemberId;
+import io.atomix.cluster.BrokerMemberId;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
 import java.util.HashMap;
@@ -61,7 +61,7 @@ public class ClusterHealthIndicator implements HealthIndicator {
     final Map<String, PartitionHealthStatus> partitionDetails = new HashMap<>();
     partitions.forEach(
         partition -> {
-          final MemberId broker = optClusterState.getLeaderForPartition(partition);
+          final var broker = optClusterState.getLeaderForPartition(partition);
           final PartitionHealthStatus partitionHealthStatus =
               broker != null
                   ? Optional.ofNullable(optClusterState.getPartitionHealth(broker, partition))

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterHealthIndicator.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterHealthIndicator.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.gateway.impl.probes.health;
 
 import static java.util.Objects.requireNonNull;
 
-import io.atomix.cluster.BrokerMemberId;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
 import java.util.HashMap;

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/probes/health/PartitionLeaderAwarenessHealthIndicator.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/probes/health/PartitionLeaderAwarenessHealthIndicator.java
@@ -37,9 +37,7 @@ public class PartitionLeaderAwarenessHealthIndicator implements HealthIndicator 
     } else {
       final var clusterState = optClusterState.get();
       if (clusterState.getPartitions().stream()
-          .anyMatch(
-              index ->
-                  clusterState.getLeaderForPartition(index) != BrokerClusterState.NODE_ID_NULL)) {
+          .anyMatch(index -> clusterState.getLeaderForPartition(index) != null)) {
         return Health.up().build();
       } else {
         return Health.down().build();

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/probes/health/PartitionLeaderAwarenessHealthIndicator.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/probes/health/PartitionLeaderAwarenessHealthIndicator.java
@@ -36,8 +36,10 @@ public class PartitionLeaderAwarenessHealthIndicator implements HealthIndicator 
       return Health.down().build();
     } else {
       final var clusterState = optClusterState.get();
-      if (clusterState.getPartitions().stream()
-          .anyMatch(index -> clusterState.getLeaderForPartition(index) != null)) {
+      final var hasKnownLeader =
+          clusterState.getPartitions().stream()
+              .anyMatch(index -> clusterState.getLeaderForPartition(index) != null);
+      if (hasKnownLeader) {
         return Health.up().build();
       } else {
         return Health.down().build();

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/stream/JobStreamClientImpl.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/stream/JobStreamClientImpl.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.gateway.impl.stream;
 
-import io.atomix.cluster.MemberId;
+import io.atomix.cluster.BrokerMemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.camunda.zeebe.protocol.impl.stream.job.JobActivationProperties;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
@@ -47,21 +47,21 @@ public final class JobStreamClientImpl implements JobStreamClient {
   }
 
   @Override
-  public synchronized void brokerAdded(final MemberId memberId) {
+  public synchronized void brokerAdded(final BrokerMemberId memberId) {
     if (!started) {
       return;
     }
 
-    streamService.onServerJoined(memberId);
+    streamService.onServerJoined(memberId.memberId());
   }
 
   @Override
-  public synchronized void brokerRemoved(final MemberId memberId) {
+  public synchronized void brokerRemoved(final BrokerMemberId memberId) {
     if (!started) {
       return;
     }
 
-    streamService.onServerRemoved(memberId);
+    streamService.onServerRemoved(memberId.memberId());
   }
 
   @Override

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/admin/exporting/ExportingControlServiceTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/admin/exporting/ExportingControlServiceTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
@@ -35,6 +36,8 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -98,7 +101,8 @@ public class ExportingControlServiceTest {
     final var service = new ExportingControlService(client);
 
     // when
-    when(client.sendRequest(requestTo(1, 1))).thenThrow(new RuntimeException("request failed"));
+    when(client.sendRequest(requestTo(1, MemberId.from(1))))
+        .thenThrow(new RuntimeException("request failed"));
 
     // then
     assertThatExceptionOfType(Throwable.class).isThrownBy(service::pauseExporting);
@@ -119,22 +123,45 @@ public class ExportingControlServiceTest {
         arguments(
             named(
                 "Evenly distributed",
-                ofTopology(Map.of(1, List.of(1, 2, 3), 2, List.of(2, 1, 3), 3, List.of(3, 1, 2))))),
+                ofTopology(
+                    Map.of(
+                        1,
+                        List.of(MemberId.from(1), MemberId.from(2), MemberId.from(3)),
+                        2,
+                        List.of(MemberId.from(2), MemberId.from(1), MemberId.from(3)),
+                        3,
+                        List.of(MemberId.from(3), MemberId.from(1), MemberId.from(2)))))),
         arguments(
             named(
                 "Single broker, no replication",
-                ofTopology(Map.of(1, List.of(1), 2, List.of(1), 3, List.of(1))))),
+                ofTopology(
+                    Map.of(
+                        1,
+                        List.of(MemberId.from(1)),
+                        2,
+                        List.of(MemberId.from(1)),
+                        3,
+                        List.of(MemberId.from(1)))))),
         arguments(
             named(
                 "Multiple brokers, no replication",
-                ofTopology(Map.of(1, List.of(1), 2, List.of(2), 3, List.of(3))))));
+                ofTopology(
+                    Map.of(
+                        1,
+                        List.of(MemberId.from(1)),
+                        2,
+                        List.of(MemberId.from(2)),
+                        3,
+                        List.of(MemberId.from(3)))))));
   }
 
   public static Stream<Arguments> invalidTopologies() {
     return Stream.of(
         arguments(named("Partition without members", ofTopology(3, 1, 3, Map.of(1, List.of())))),
         arguments(
-            named("Partition with missing member", ofTopology(3, 1, 3, Map.of(1, List.of(1, 2))))),
+            named(
+                "Partition with missing member",
+                ofTopology(3, 1, 3, Map.of(1, List.of(MemberId.from(1), MemberId.from(2)))))),
         arguments(named("Empty topology", ofTopology(1, 1, 1, Map.of()))));
   }
 
@@ -142,7 +169,7 @@ public class ExportingControlServiceTest {
       final int clusterSize,
       final int partitionCount,
       final int replicationFactor,
-      final Map<Integer, List<Integer>> topology) {
+      final Map<Integer, List<MemberId>> topology) {
     return new BrokerClusterState() {
       @Override
       public boolean isInitialized() {
@@ -165,22 +192,22 @@ public class ExportingControlServiceTest {
       }
 
       @Override
-      public int getLeaderForPartition(final int partition) {
+      public @Nullable MemberId getLeaderForPartition(final int partition) {
         return Optional.ofNullable(topology.get(partition))
             .filter(brokers -> !brokers.isEmpty())
             .map(List::getFirst)
-            .orElse(NODE_ID_NULL);
+            .orElse(null);
       }
 
       @Override
-      public Set<Integer> getFollowersForPartition(final int partition) {
+      public Set<MemberId> getFollowersForPartition(final int partition) {
         return topology.getOrDefault(partition, List.of()).stream()
             .skip(1)
             .collect(Collectors.toSet());
       }
 
       @Override
-      public Set<Integer> getInactiveNodesForPartition(final int partition) {
+      public Set<MemberId> getInactiveNodesForPartition(final int partition) {
         final var members = topology.getOrDefault(partition, List.of());
 
         return getBrokers().stream()
@@ -189,7 +216,7 @@ public class ExportingControlServiceTest {
       }
 
       @Override
-      public int getRandomBroker() {
+      public @Nullable MemberId getRandomBroker() {
         throw new UnsupportedOperationException();
       }
 
@@ -199,22 +226,23 @@ public class ExportingControlServiceTest {
       }
 
       @Override
-      public List<Integer> getBrokers() {
+      public List<MemberId> getBrokers() {
         return topology.values().stream().flatMap(Collection::stream).toList();
       }
 
       @Override
-      public String getBrokerAddress(final int brokerId) {
+      public @Nullable String getBrokerAddress(final @NonNull MemberId brokerId) {
         throw new UnsupportedOperationException();
       }
 
       @Override
-      public String getBrokerVersion(final int brokerId) {
+      public @Nullable String getBrokerVersion(final @NonNull MemberId brokerId) {
         throw new UnsupportedOperationException();
       }
 
       @Override
-      public PartitionHealthStatus getPartitionHealth(final int brokerId, final int partition) {
+      public PartitionHealthStatus getPartitionHealth(
+          final @NonNull MemberId brokerId, final int partition) {
         throw new UnsupportedOperationException();
       }
 
@@ -230,7 +258,7 @@ public class ExportingControlServiceTest {
     };
   }
 
-  private static BrokerClusterState ofTopology(final Map<Integer, List<Integer>> topology) {
+  private static BrokerClusterState ofTopology(final Map<Integer, List<MemberId>> topology) {
     final var brokers = topology.values().stream().flatMap(Collection::stream).distinct().count();
     final var partitions = topology.size();
     final var replicationFactor =
@@ -241,17 +269,17 @@ public class ExportingControlServiceTest {
     return ofTopology((int) brokers, partitions, replicationFactor, topology);
   }
 
-  record RequestMatcher(int partitionId, int brokerId)
+  record RequestMatcher(int partitionId, MemberId brokerId)
       implements ArgumentMatcher<BrokerRequest<Void>> {
 
-    static BrokerRequest<Void> requestTo(final int partitionId, final int brokerId) {
+    static BrokerRequest<Void> requestTo(final int partitionId, final MemberId brokerId) {
       return argThat(new RequestMatcher(partitionId, brokerId));
     }
 
     @Override
     public boolean matches(final BrokerRequest<Void> argument) {
       return argument.getPartitionId() == partitionId
-          && argument.getBrokerId().orElseThrow() == brokerId;
+          && argument.getBrokerId().orElseThrow().equals(brokerId);
     }
   }
 }

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/admin/exporting/ExportingControlServiceTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/admin/exporting/ExportingControlServiceTest.java
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.atomix.cluster.MemberId;
+import io.atomix.cluster.BrokerMemberId;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
@@ -101,7 +101,7 @@ public class ExportingControlServiceTest {
     final var service = new ExportingControlService(client);
 
     // when
-    when(client.sendRequest(requestTo(1, MemberId.from(1))))
+    when(client.sendRequest(requestTo(1, BrokerMemberId.from(1))))
         .thenThrow(new RuntimeException("request failed"));
 
     // then
@@ -126,33 +126,38 @@ public class ExportingControlServiceTest {
                 ofTopology(
                     Map.of(
                         1,
-                        List.of(MemberId.from(1), MemberId.from(2), MemberId.from(3)),
+                        List.of(
+                            BrokerMemberId.from(1), BrokerMemberId.from(2), BrokerMemberId.from(3)),
                         2,
-                        List.of(MemberId.from(2), MemberId.from(1), MemberId.from(3)),
+                        List.of(
+                            BrokerMemberId.from(2), BrokerMemberId.from(1), BrokerMemberId.from(3)),
                         3,
-                        List.of(MemberId.from(3), MemberId.from(1), MemberId.from(2)))))),
+                        List.of(
+                            BrokerMemberId.from(3),
+                            BrokerMemberId.from(1),
+                            BrokerMemberId.from(2)))))),
         arguments(
             named(
                 "Single broker, no replication",
                 ofTopology(
                     Map.of(
                         1,
-                        List.of(MemberId.from(1)),
+                        List.of(BrokerMemberId.from(1)),
                         2,
-                        List.of(MemberId.from(1)),
+                        List.of(BrokerMemberId.from(1)),
                         3,
-                        List.of(MemberId.from(1)))))),
+                        List.of(BrokerMemberId.from(1)))))),
         arguments(
             named(
                 "Multiple brokers, no replication",
                 ofTopology(
                     Map.of(
                         1,
-                        List.of(MemberId.from(1)),
+                        List.of(BrokerMemberId.from(1)),
                         2,
-                        List.of(MemberId.from(2)),
+                        List.of(BrokerMemberId.from(2)),
                         3,
-                        List.of(MemberId.from(3)))))));
+                        List.of(BrokerMemberId.from(3)))))));
   }
 
   public static Stream<Arguments> invalidTopologies() {
@@ -161,7 +166,8 @@ public class ExportingControlServiceTest {
         arguments(
             named(
                 "Partition with missing member",
-                ofTopology(3, 1, 3, Map.of(1, List.of(MemberId.from(1), MemberId.from(2)))))),
+                ofTopology(
+                    3, 1, 3, Map.of(1, List.of(BrokerMemberId.from(1), BrokerMemberId.from(2)))))),
         arguments(named("Empty topology", ofTopology(1, 1, 1, Map.of()))));
   }
 
@@ -169,7 +175,7 @@ public class ExportingControlServiceTest {
       final int clusterSize,
       final int partitionCount,
       final int replicationFactor,
-      final Map<Integer, List<MemberId>> topology) {
+      final Map<Integer, List<BrokerMemberId>> topology) {
     return new BrokerClusterState() {
       @Override
       public boolean isInitialized() {
@@ -192,7 +198,7 @@ public class ExportingControlServiceTest {
       }
 
       @Override
-      public @Nullable MemberId getLeaderForPartition(final int partition) {
+      public @Nullable BrokerMemberId getLeaderForPartition(final int partition) {
         return Optional.ofNullable(topology.get(partition))
             .filter(brokers -> !brokers.isEmpty())
             .map(List::getFirst)
@@ -200,14 +206,14 @@ public class ExportingControlServiceTest {
       }
 
       @Override
-      public Set<MemberId> getFollowersForPartition(final int partition) {
+      public Set<BrokerMemberId> getFollowersForPartition(final int partition) {
         return topology.getOrDefault(partition, List.of()).stream()
             .skip(1)
             .collect(Collectors.toSet());
       }
 
       @Override
-      public Set<MemberId> getInactiveNodesForPartition(final int partition) {
+      public Set<BrokerMemberId> getInactiveNodesForPartition(final int partition) {
         final var members = topology.getOrDefault(partition, List.of());
 
         return getBrokers().stream()
@@ -216,7 +222,7 @@ public class ExportingControlServiceTest {
       }
 
       @Override
-      public @Nullable MemberId getRandomBroker() {
+      public @Nullable BrokerMemberId getRandomBroker() {
         throw new UnsupportedOperationException();
       }
 
@@ -226,23 +232,23 @@ public class ExportingControlServiceTest {
       }
 
       @Override
-      public List<MemberId> getBrokers() {
+      public List<BrokerMemberId> getBrokers() {
         return topology.values().stream().flatMap(Collection::stream).toList();
       }
 
       @Override
-      public @Nullable String getBrokerAddress(final @NonNull MemberId brokerId) {
+      public @Nullable String getBrokerAddress(final @NonNull BrokerMemberId brokerId) {
         throw new UnsupportedOperationException();
       }
 
       @Override
-      public @Nullable String getBrokerVersion(final @NonNull MemberId brokerId) {
+      public @Nullable String getBrokerVersion(final @NonNull BrokerMemberId brokerId) {
         throw new UnsupportedOperationException();
       }
 
       @Override
       public PartitionHealthStatus getPartitionHealth(
-          final @NonNull MemberId brokerId, final int partition) {
+          final @NonNull BrokerMemberId brokerId, final int partition) {
         throw new UnsupportedOperationException();
       }
 
@@ -258,21 +264,21 @@ public class ExportingControlServiceTest {
     };
   }
 
-  private static BrokerClusterState ofTopology(final Map<Integer, List<MemberId>> topology) {
+  private static BrokerClusterState ofTopology(final Map<Integer, List<BrokerMemberId>> topology) {
     final var brokers = topology.values().stream().flatMap(Collection::stream).distinct().count();
     final var partitions = topology.size();
     final var replicationFactor =
         topology.values().stream()
             .map(Collection::size)
-            .max(Comparator.comparingInt((x) -> x))
+            .max(Comparator.comparingInt(x -> x))
             .orElseThrow();
     return ofTopology((int) brokers, partitions, replicationFactor, topology);
   }
 
-  record RequestMatcher(int partitionId, MemberId brokerId)
+  record RequestMatcher(int partitionId, BrokerMemberId brokerId)
       implements ArgumentMatcher<BrokerRequest<Void>> {
 
-    static BrokerRequest<Void> requestTo(final int partitionId, final MemberId brokerId) {
+    static BrokerRequest<Void> requestTo(final int partitionId, final BrokerMemberId brokerId) {
       return argThat(new RequestMatcher(partitionId, brokerId));
     }
 

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/topology/TopologyTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/topology/TopologyTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 
 public final class TopologyTest extends GatewayTest {
 
-  private static final BrokerMemberId broker0 = BrokerMemberId.from(0);
+  private final BrokerMemberId broker0 = BrokerMemberId.from(0);
 
   @Test
   public void shouldResponseWithInitialUnhealthyPartitions() {

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/topology/TopologyTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/topology/TopologyTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.gateway.api.topology;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.atomix.cluster.BrokerMemberId;
 import io.camunda.zeebe.gateway.api.util.GatewayTest;
 import io.camunda.zeebe.gateway.api.util.StubbedTopologyManager;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.Partition;
@@ -21,6 +22,8 @@ import java.util.Optional;
 import org.junit.Test;
 
 public final class TopologyTest extends GatewayTest {
+
+  private static final BrokerMemberId broker0 = BrokerMemberId.from(0);
 
   @Test
   public void shouldResponseWithInitialUnhealthyPartitions() {
@@ -57,7 +60,7 @@ public final class TopologyTest extends GatewayTest {
   public void shouldUpdatePartitionHealthHealthy() {
     // given
     final var topologyManager = (StubbedTopologyManager) brokerClient.getTopologyManager();
-    topologyManager.setPartitionHealthStatus(0, 1, PartitionHealthStatus.HEALTHY);
+    topologyManager.setPartitionHealthStatus(broker0, 1, PartitionHealthStatus.HEALTHY);
 
     // when
     final var response = client.topology(TopologyRequest.newBuilder().build());
@@ -71,7 +74,7 @@ public final class TopologyTest extends GatewayTest {
   public void shouldUpdatePartitionHealth() {
     // given
     final var topologyManager = (StubbedTopologyManager) brokerClient.getTopologyManager();
-    topologyManager.setPartitionHealthStatus(0, 1, PartitionHealthStatus.UNHEALTHY);
+    topologyManager.setPartitionHealthStatus(broker0, 1, PartitionHealthStatus.UNHEALTHY);
 
     // when
     final var response = client.topology(TopologyRequest.newBuilder().build());
@@ -86,8 +89,8 @@ public final class TopologyTest extends GatewayTest {
   public void shouldUpdateMultiplePartitionHealths() {
     // given
     final var topologyManager = (StubbedTopologyManager) brokerClient.getTopologyManager();
-    topologyManager.setPartitionHealthStatus(0, 1, PartitionHealthStatus.UNHEALTHY);
-    topologyManager.setPartitionHealthStatus(0, 6, PartitionHealthStatus.HEALTHY);
+    topologyManager.setPartitionHealthStatus(broker0, 1, PartitionHealthStatus.UNHEALTHY);
+    topologyManager.setPartitionHealthStatus(broker0, 6, PartitionHealthStatus.HEALTHY);
 
     // when
     final var response = client.topology(TopologyRequest.newBuilder().build());
@@ -104,7 +107,7 @@ public final class TopologyTest extends GatewayTest {
     final int partitionId = 3;
 
     final var topologyManager = (StubbedTopologyManager) brokerClient.getTopologyManager();
-    topologyManager.addPartitionInactive(partitionId, 0);
+    topologyManager.addPartitionInactive(partitionId, broker0);
 
     // when
     final TopologyResponse response = client.topology(TopologyRequest.newBuilder().build());

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterAwarenessHealthIndicatorTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterAwarenessHealthIndicatorTest.java
@@ -13,7 +13,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import io.atomix.cluster.MemberId;
+import io.atomix.cluster.BrokerMemberId;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import java.util.List;
 import java.util.Optional;
@@ -48,7 +48,7 @@ public class ClusterAwarenessHealthIndicatorTest {
   public void shouldReportUpIfListOfBrokersIsNotEmpty() {
     // given
     final BrokerClusterState mockClusterState = mock(BrokerClusterState.class);
-    when(mockClusterState.getBrokers()).thenReturn(List.of(MemberId.from(1)));
+    when(mockClusterState.getBrokers()).thenReturn(List.of(BrokerMemberId.from(1)));
 
     final Supplier<Optional<BrokerClusterState>> stateSupplier =
         () -> Optional.of(mockClusterState);

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterAwarenessHealthIndicatorTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterAwarenessHealthIndicatorTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import java.util.List;
 import java.util.Optional;
@@ -47,7 +48,7 @@ public class ClusterAwarenessHealthIndicatorTest {
   public void shouldReportUpIfListOfBrokersIsNotEmpty() {
     // given
     final BrokerClusterState mockClusterState = mock(BrokerClusterState.class);
-    when(mockClusterState.getBrokers()).thenReturn(List.of(1));
+    when(mockClusterState.getBrokers()).thenReturn(List.of(MemberId.from(1)));
 
     final Supplier<Optional<BrokerClusterState>> stateSupplier =
         () -> Optional.of(mockClusterState);

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterHealthIndicatorTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterHealthIndicatorTest.java
@@ -7,13 +7,13 @@
  */
 package io.camunda.zeebe.gateway.impl.probes.health;
 
-import static io.camunda.zeebe.broker.client.api.BrokerClusterState.PARTITION_ID_NULL;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
 import java.util.List;
@@ -49,7 +49,7 @@ public class ClusterHealthIndicatorTest {
   public void shouldReportDownIfListOfBrokersAnIsNotEmptyAndPartitionsIsEmpty() {
     // given
     final BrokerClusterState mockClusterState = mock(BrokerClusterState.class);
-    when(mockClusterState.getBrokers()).thenReturn(List.of(1));
+    when(mockClusterState.getBrokers()).thenReturn(List.of(MemberId.from(1)));
     when(mockClusterState.getPartitions()).thenReturn(List.of());
 
     final Supplier<Optional<BrokerClusterState>> stateSupplier =
@@ -68,10 +68,11 @@ public class ClusterHealthIndicatorTest {
   public void shouldReportUpIfHasHealthyPartition() {
     // given
     final BrokerClusterState mockClusterState = mock(BrokerClusterState.class);
-    when(mockClusterState.getBrokers()).thenReturn(List.of(1));
+    when(mockClusterState.getBrokers()).thenReturn(List.of(MemberId.from(1)));
     when(mockClusterState.getPartitions()).thenReturn(List.of(1));
-    when(mockClusterState.getLeaderForPartition(1)).thenReturn(1);
-    when(mockClusterState.getPartitionHealth(1, 1)).thenReturn(PartitionHealthStatus.HEALTHY);
+    when(mockClusterState.getLeaderForPartition(1)).thenReturn(MemberId.from(1));
+    when(mockClusterState.getPartitionHealth(MemberId.from(1), 1))
+        .thenReturn(PartitionHealthStatus.HEALTHY);
 
     final Supplier<Optional<BrokerClusterState>> stateSupplier =
         () -> Optional.of(mockClusterState);
@@ -88,14 +89,17 @@ public class ClusterHealthIndicatorTest {
   @Test
   public void shouldReportDegradedIfMissingPartitions() {
     final BrokerClusterState mockClusterState = mock(BrokerClusterState.class);
-    when(mockClusterState.getBrokers()).thenReturn(List.of(1));
+    when(mockClusterState.getBrokers()).thenReturn(List.of(MemberId.from(1)));
     when(mockClusterState.getPartitions()).thenReturn(List.of(1, 2, 3));
-    when(mockClusterState.getLeaderForPartition(1)).thenReturn(1);
-    when(mockClusterState.getLeaderForPartition(2)).thenReturn(2);
-    when(mockClusterState.getLeaderForPartition(3)).thenReturn(3);
-    when(mockClusterState.getPartitionHealth(1, 1)).thenReturn(PartitionHealthStatus.HEALTHY);
-    when(mockClusterState.getPartitionHealth(2, 2)).thenReturn(PartitionHealthStatus.HEALTHY);
-    when(mockClusterState.getPartitionHealth(3, 3)).thenReturn(PartitionHealthStatus.DEAD);
+    when(mockClusterState.getLeaderForPartition(1)).thenReturn(MemberId.from(1));
+    when(mockClusterState.getLeaderForPartition(2)).thenReturn(MemberId.from(2));
+    when(mockClusterState.getLeaderForPartition(3)).thenReturn(MemberId.from(3));
+    when(mockClusterState.getPartitionHealth(MemberId.from(1), 1))
+        .thenReturn(PartitionHealthStatus.HEALTHY);
+    when(mockClusterState.getPartitionHealth(MemberId.from(2), 2))
+        .thenReturn(PartitionHealthStatus.HEALTHY);
+    when(mockClusterState.getPartitionHealth(MemberId.from(3), 3))
+        .thenReturn(PartitionHealthStatus.DEAD);
 
     final Supplier<Optional<BrokerClusterState>> stateSupplier =
         () -> Optional.of(mockClusterState);
@@ -112,14 +116,17 @@ public class ClusterHealthIndicatorTest {
   @Test
   public void shouldReportUnhealthyIfMissingPartitionsAndTheOthersDegraded() {
     final BrokerClusterState mockClusterState = mock(BrokerClusterState.class);
-    when(mockClusterState.getBrokers()).thenReturn(List.of(1));
+    when(mockClusterState.getBrokers()).thenReturn(List.of(MemberId.from(1)));
     when(mockClusterState.getPartitions()).thenReturn(List.of(1, 2, 3));
-    when(mockClusterState.getLeaderForPartition(1)).thenReturn(1);
-    when(mockClusterState.getLeaderForPartition(2)).thenReturn(2);
-    when(mockClusterState.getLeaderForPartition(3)).thenReturn(3);
-    when(mockClusterState.getPartitionHealth(1, 1)).thenReturn(PartitionHealthStatus.UNHEALTHY);
-    when(mockClusterState.getPartitionHealth(2, 2)).thenReturn(PartitionHealthStatus.UNHEALTHY);
-    when(mockClusterState.getPartitionHealth(3, 3)).thenReturn(PartitionHealthStatus.DEAD);
+    when(mockClusterState.getLeaderForPartition(1)).thenReturn(MemberId.from(1));
+    when(mockClusterState.getLeaderForPartition(2)).thenReturn(MemberId.from(2));
+    when(mockClusterState.getLeaderForPartition(3)).thenReturn(MemberId.from(3));
+    when(mockClusterState.getPartitionHealth(MemberId.from(1), 1))
+        .thenReturn(PartitionHealthStatus.UNHEALTHY);
+    when(mockClusterState.getPartitionHealth(MemberId.from(2), 2))
+        .thenReturn(PartitionHealthStatus.UNHEALTHY);
+    when(mockClusterState.getPartitionHealth(MemberId.from(3), 3))
+        .thenReturn(PartitionHealthStatus.DEAD);
 
     final Supplier<Optional<BrokerClusterState>> stateSupplier =
         () -> Optional.of(mockClusterState);
@@ -136,14 +143,17 @@ public class ClusterHealthIndicatorTest {
   @Test
   public void shouldReportDegradedIfSomePartitionsDontHaveLeader() {
     final BrokerClusterState mockClusterState = mock(BrokerClusterState.class);
-    when(mockClusterState.getBrokers()).thenReturn(List.of(1));
+    when(mockClusterState.getBrokers()).thenReturn(List.of(MemberId.from(1)));
     when(mockClusterState.getPartitions()).thenReturn(List.of(1, 2, 3));
-    when(mockClusterState.getLeaderForPartition(1)).thenReturn(1);
-    when(mockClusterState.getLeaderForPartition(2)).thenReturn(2);
-    when(mockClusterState.getLeaderForPartition(3)).thenReturn(PARTITION_ID_NULL);
-    when(mockClusterState.getPartitionHealth(1, 1)).thenReturn(PartitionHealthStatus.HEALTHY);
-    when(mockClusterState.getPartitionHealth(2, 2)).thenReturn(PartitionHealthStatus.HEALTHY);
-    when(mockClusterState.getPartitionHealth(3, 3)).thenReturn(PartitionHealthStatus.UNHEALTHY);
+    when(mockClusterState.getLeaderForPartition(1)).thenReturn(MemberId.from(1));
+    when(mockClusterState.getLeaderForPartition(2)).thenReturn(MemberId.from(2));
+    when(mockClusterState.getLeaderForPartition(3)).thenReturn(null);
+    when(mockClusterState.getPartitionHealth(MemberId.from(1), 1))
+        .thenReturn(PartitionHealthStatus.HEALTHY);
+    when(mockClusterState.getPartitionHealth(MemberId.from(2), 2))
+        .thenReturn(PartitionHealthStatus.HEALTHY);
+    when(mockClusterState.getPartitionHealth(MemberId.from(3), 3))
+        .thenReturn(PartitionHealthStatus.UNHEALTHY);
 
     final Supplier<Optional<BrokerClusterState>> stateSupplier =
         () -> Optional.of(mockClusterState);

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterHealthIndicatorTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterHealthIndicatorTest.java
@@ -13,7 +13,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import io.atomix.cluster.MemberId;
+import io.atomix.cluster.BrokerMemberId;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
 import java.util.List;
@@ -49,7 +49,7 @@ public class ClusterHealthIndicatorTest {
   public void shouldReportDownIfListOfBrokersAnIsNotEmptyAndPartitionsIsEmpty() {
     // given
     final BrokerClusterState mockClusterState = mock(BrokerClusterState.class);
-    when(mockClusterState.getBrokers()).thenReturn(List.of(MemberId.from(1)));
+    when(mockClusterState.getBrokers()).thenReturn(List.of(BrokerMemberId.from(1)));
     when(mockClusterState.getPartitions()).thenReturn(List.of());
 
     final Supplier<Optional<BrokerClusterState>> stateSupplier =
@@ -68,10 +68,10 @@ public class ClusterHealthIndicatorTest {
   public void shouldReportUpIfHasHealthyPartition() {
     // given
     final BrokerClusterState mockClusterState = mock(BrokerClusterState.class);
-    when(mockClusterState.getBrokers()).thenReturn(List.of(MemberId.from(1)));
+    when(mockClusterState.getBrokers()).thenReturn(List.of(BrokerMemberId.from(1)));
     when(mockClusterState.getPartitions()).thenReturn(List.of(1));
-    when(mockClusterState.getLeaderForPartition(1)).thenReturn(MemberId.from(1));
-    when(mockClusterState.getPartitionHealth(MemberId.from(1), 1))
+    when(mockClusterState.getLeaderForPartition(1)).thenReturn(BrokerMemberId.from(1));
+    when(mockClusterState.getPartitionHealth(BrokerMemberId.from(1), 1))
         .thenReturn(PartitionHealthStatus.HEALTHY);
 
     final Supplier<Optional<BrokerClusterState>> stateSupplier =
@@ -89,16 +89,16 @@ public class ClusterHealthIndicatorTest {
   @Test
   public void shouldReportDegradedIfMissingPartitions() {
     final BrokerClusterState mockClusterState = mock(BrokerClusterState.class);
-    when(mockClusterState.getBrokers()).thenReturn(List.of(MemberId.from(1)));
+    when(mockClusterState.getBrokers()).thenReturn(List.of(BrokerMemberId.from(1)));
     when(mockClusterState.getPartitions()).thenReturn(List.of(1, 2, 3));
-    when(mockClusterState.getLeaderForPartition(1)).thenReturn(MemberId.from(1));
-    when(mockClusterState.getLeaderForPartition(2)).thenReturn(MemberId.from(2));
-    when(mockClusterState.getLeaderForPartition(3)).thenReturn(MemberId.from(3));
-    when(mockClusterState.getPartitionHealth(MemberId.from(1), 1))
+    when(mockClusterState.getLeaderForPartition(1)).thenReturn(BrokerMemberId.from(1));
+    when(mockClusterState.getLeaderForPartition(2)).thenReturn(BrokerMemberId.from(2));
+    when(mockClusterState.getLeaderForPartition(3)).thenReturn(BrokerMemberId.from(3));
+    when(mockClusterState.getPartitionHealth(BrokerMemberId.from(1), 1))
         .thenReturn(PartitionHealthStatus.HEALTHY);
-    when(mockClusterState.getPartitionHealth(MemberId.from(2), 2))
+    when(mockClusterState.getPartitionHealth(BrokerMemberId.from(2), 2))
         .thenReturn(PartitionHealthStatus.HEALTHY);
-    when(mockClusterState.getPartitionHealth(MemberId.from(3), 3))
+    when(mockClusterState.getPartitionHealth(BrokerMemberId.from(3), 3))
         .thenReturn(PartitionHealthStatus.DEAD);
 
     final Supplier<Optional<BrokerClusterState>> stateSupplier =
@@ -116,16 +116,16 @@ public class ClusterHealthIndicatorTest {
   @Test
   public void shouldReportUnhealthyIfMissingPartitionsAndTheOthersDegraded() {
     final BrokerClusterState mockClusterState = mock(BrokerClusterState.class);
-    when(mockClusterState.getBrokers()).thenReturn(List.of(MemberId.from(1)));
+    when(mockClusterState.getBrokers()).thenReturn(List.of(BrokerMemberId.from(1)));
     when(mockClusterState.getPartitions()).thenReturn(List.of(1, 2, 3));
-    when(mockClusterState.getLeaderForPartition(1)).thenReturn(MemberId.from(1));
-    when(mockClusterState.getLeaderForPartition(2)).thenReturn(MemberId.from(2));
-    when(mockClusterState.getLeaderForPartition(3)).thenReturn(MemberId.from(3));
-    when(mockClusterState.getPartitionHealth(MemberId.from(1), 1))
+    when(mockClusterState.getLeaderForPartition(1)).thenReturn(BrokerMemberId.from(1));
+    when(mockClusterState.getLeaderForPartition(2)).thenReturn(BrokerMemberId.from(2));
+    when(mockClusterState.getLeaderForPartition(3)).thenReturn(BrokerMemberId.from(3));
+    when(mockClusterState.getPartitionHealth(BrokerMemberId.from(1), 1))
         .thenReturn(PartitionHealthStatus.UNHEALTHY);
-    when(mockClusterState.getPartitionHealth(MemberId.from(2), 2))
+    when(mockClusterState.getPartitionHealth(BrokerMemberId.from(2), 2))
         .thenReturn(PartitionHealthStatus.UNHEALTHY);
-    when(mockClusterState.getPartitionHealth(MemberId.from(3), 3))
+    when(mockClusterState.getPartitionHealth(BrokerMemberId.from(3), 3))
         .thenReturn(PartitionHealthStatus.DEAD);
 
     final Supplier<Optional<BrokerClusterState>> stateSupplier =
@@ -143,16 +143,16 @@ public class ClusterHealthIndicatorTest {
   @Test
   public void shouldReportDegradedIfSomePartitionsDontHaveLeader() {
     final BrokerClusterState mockClusterState = mock(BrokerClusterState.class);
-    when(mockClusterState.getBrokers()).thenReturn(List.of(MemberId.from(1)));
+    when(mockClusterState.getBrokers()).thenReturn(List.of(BrokerMemberId.from(1)));
     when(mockClusterState.getPartitions()).thenReturn(List.of(1, 2, 3));
-    when(mockClusterState.getLeaderForPartition(1)).thenReturn(MemberId.from(1));
-    when(mockClusterState.getLeaderForPartition(2)).thenReturn(MemberId.from(2));
+    when(mockClusterState.getLeaderForPartition(1)).thenReturn(BrokerMemberId.from(1));
+    when(mockClusterState.getLeaderForPartition(2)).thenReturn(BrokerMemberId.from(2));
     when(mockClusterState.getLeaderForPartition(3)).thenReturn(null);
-    when(mockClusterState.getPartitionHealth(MemberId.from(1), 1))
+    when(mockClusterState.getPartitionHealth(BrokerMemberId.from(1), 1))
         .thenReturn(PartitionHealthStatus.HEALTHY);
-    when(mockClusterState.getPartitionHealth(MemberId.from(2), 2))
+    when(mockClusterState.getPartitionHealth(BrokerMemberId.from(2), 2))
         .thenReturn(PartitionHealthStatus.HEALTHY);
-    when(mockClusterState.getPartitionHealth(MemberId.from(3), 3))
+    when(mockClusterState.getPartitionHealth(BrokerMemberId.from(3), 3))
         .thenReturn(PartitionHealthStatus.UNHEALTHY);
 
     final Supplier<Optional<BrokerClusterState>> stateSupplier =

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/LivenessClusterAwarenessHealthIndicatorAutoConfigurationTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/LivenessClusterAwarenessHealthIndicatorAutoConfigurationTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.gateway.impl.SpringGatewayBridge;
 import java.util.List;
@@ -47,7 +48,7 @@ public class LivenessClusterAwarenessHealthIndicatorAutoConfigurationTest {
       shouldCreateHealthIndicatorThatReportsHealthBasedOnResultOfRegisteredClusterStateSupplier() {
     // given
     final BrokerClusterState mockClusterState = mock(BrokerClusterState.class);
-    when(mockClusterState.getBrokers()).thenReturn(List.of(1));
+    when(mockClusterState.getBrokers()).thenReturn(List.of(MemberId.from(1)));
 
     final Supplier<Optional<BrokerClusterState>> stateSupplier =
         () -> Optional.of(mockClusterState);

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/LivenessClusterAwarenessHealthIndicatorAutoConfigurationTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/LivenessClusterAwarenessHealthIndicatorAutoConfigurationTest.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import io.atomix.cluster.MemberId;
+import io.atomix.cluster.BrokerMemberId;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.gateway.impl.SpringGatewayBridge;
 import java.util.List;
@@ -48,7 +48,7 @@ public class LivenessClusterAwarenessHealthIndicatorAutoConfigurationTest {
       shouldCreateHealthIndicatorThatReportsHealthBasedOnResultOfRegisteredClusterStateSupplier() {
     // given
     final BrokerClusterState mockClusterState = mock(BrokerClusterState.class);
-    when(mockClusterState.getBrokers()).thenReturn(List.of(MemberId.from(1)));
+    when(mockClusterState.getBrokers()).thenReturn(List.of(BrokerMemberId.from(1)));
 
     final Supplier<Optional<BrokerClusterState>> stateSupplier =
         () -> Optional.of(mockClusterState);

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/LivenessPartitionLeaderAwarenessHealthIndicatorAutoConfigurationTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/LivenessPartitionLeaderAwarenessHealthIndicatorAutoConfigurationTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.gateway.impl.SpringGatewayBridge;
 import java.util.List;
@@ -49,7 +50,7 @@ public class LivenessPartitionLeaderAwarenessHealthIndicatorAutoConfigurationTes
     // given
     final BrokerClusterState mockClusterState = mock(BrokerClusterState.class);
     when(mockClusterState.getPartitions()).thenReturn(List.of(1));
-    when(mockClusterState.getLeaderForPartition(1)).thenReturn(42);
+    when(mockClusterState.getLeaderForPartition(1)).thenReturn(MemberId.from(42));
 
     final Supplier<Optional<BrokerClusterState>> stateSupplier =
         () -> Optional.of(mockClusterState);

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/LivenessPartitionLeaderAwarenessHealthIndicatorAutoConfigurationTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/LivenessPartitionLeaderAwarenessHealthIndicatorAutoConfigurationTest.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import io.atomix.cluster.MemberId;
+import io.atomix.cluster.BrokerMemberId;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.gateway.impl.SpringGatewayBridge;
 import java.util.List;
@@ -50,7 +50,7 @@ public class LivenessPartitionLeaderAwarenessHealthIndicatorAutoConfigurationTes
     // given
     final BrokerClusterState mockClusterState = mock(BrokerClusterState.class);
     when(mockClusterState.getPartitions()).thenReturn(List.of(1));
-    when(mockClusterState.getLeaderForPartition(1)).thenReturn(MemberId.from(42));
+    when(mockClusterState.getLeaderForPartition(1)).thenReturn(BrokerMemberId.from(42));
 
     final Supplier<Optional<BrokerClusterState>> stateSupplier =
         () -> Optional.of(mockClusterState);

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/PartitionLeaderAwarenessHealthIndicatorTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/PartitionLeaderAwarenessHealthIndicatorTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import java.util.List;
 import java.util.Optional;
@@ -48,8 +49,8 @@ public class PartitionLeaderAwarenessHealthIndicatorTest {
     // given
     final BrokerClusterState mockClusterState = mock(BrokerClusterState.class);
     when(mockClusterState.getPartitions()).thenReturn(List.of(1, 2));
-    when(mockClusterState.getLeaderForPartition(1)).thenReturn(BrokerClusterState.NODE_ID_NULL);
-    when(mockClusterState.getLeaderForPartition(2)).thenReturn(42);
+    when(mockClusterState.getLeaderForPartition(1)).thenReturn(null);
+    when(mockClusterState.getLeaderForPartition(2)).thenReturn(MemberId.from(42));
 
     final Supplier<Optional<BrokerClusterState>> stateSupplier =
         () -> Optional.of(mockClusterState);
@@ -86,8 +87,8 @@ public class PartitionLeaderAwarenessHealthIndicatorTest {
     // given
     final BrokerClusterState mockClusterState = mock(BrokerClusterState.class);
     when(mockClusterState.getPartitions()).thenReturn(List.of(1, 2));
-    when(mockClusterState.getLeaderForPartition(1)).thenReturn(BrokerClusterState.NODE_ID_NULL);
-    when(mockClusterState.getLeaderForPartition(2)).thenReturn(BrokerClusterState.NODE_ID_NULL);
+    when(mockClusterState.getLeaderForPartition(1)).thenReturn(null);
+    when(mockClusterState.getLeaderForPartition(2)).thenReturn(null);
 
     final Supplier<Optional<BrokerClusterState>> stateSupplier =
         () -> Optional.of(mockClusterState);

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/PartitionLeaderAwarenessHealthIndicatorTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/PartitionLeaderAwarenessHealthIndicatorTest.java
@@ -13,7 +13,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import io.atomix.cluster.MemberId;
+import io.atomix.cluster.BrokerMemberId;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import java.util.List;
 import java.util.Optional;
@@ -50,7 +50,7 @@ public class PartitionLeaderAwarenessHealthIndicatorTest {
     final BrokerClusterState mockClusterState = mock(BrokerClusterState.class);
     when(mockClusterState.getPartitions()).thenReturn(List.of(1, 2));
     when(mockClusterState.getLeaderForPartition(1)).thenReturn(null);
-    when(mockClusterState.getLeaderForPartition(2)).thenReturn(MemberId.from(42));
+    when(mockClusterState.getLeaderForPartition(2)).thenReturn(BrokerMemberId.from(42));
 
     final Supplier<Optional<BrokerClusterState>> stateSupplier =
         () -> Optional.of(mockClusterState);

--- a/zeebe/gateway/pom.xml
+++ b/zeebe/gateway/pom.xml
@@ -92,6 +92,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-atomix-cluster</artifactId>
     </dependency>

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedTopologyManager.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedTopologyManager.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.gateway.api.util;
 
 import static io.camunda.zeebe.protocol.Protocol.START_PARTITION_ID;
 
+import io.atomix.cluster.BrokerMemberId;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyListener;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
@@ -28,10 +29,11 @@ public final class StubbedTopologyManager implements BrokerTopologyManager {
   public StubbedTopologyManager(final int partitionsCount) {
     clusterConfiguration = ClusterConfiguration.uninitialized();
     clusterState = new TestBrokerClusterState(partitionsCount);
-    clusterState.addBroker(0, "localhost:26501");
+    clusterState.addBroker(BrokerMemberId.from(0), "localhost:26501");
     clusterState.setClusterId(UUID.randomUUID().toString());
     for (int partitionOffset = 0; partitionOffset < partitionsCount; partitionOffset++) {
-      clusterState.setPartitionLeader(START_PARTITION_ID + partitionOffset, 0, 1);
+      clusterState.setPartitionLeader(
+          START_PARTITION_ID + partitionOffset, BrokerMemberId.from(0), 1);
       clusterState.addPartition(START_PARTITION_ID + partitionOffset);
     }
   }
@@ -62,7 +64,9 @@ public final class StubbedTopologyManager implements BrokerTopologyManager {
   }
 
   public void setPartitionHealthStatus(
-      final int nodeId, final int partitionId, final PartitionHealthStatus partitionHealthStatus) {
+      final BrokerMemberId nodeId,
+      final int partitionId,
+      final PartitionHealthStatus partitionHealthStatus) {
     clusterState.setPartitionHealthStatus(nodeId, partitionId, partitionHealthStatus);
   }
 
@@ -70,7 +74,7 @@ public final class StubbedTopologyManager implements BrokerTopologyManager {
     clusterState.setClusterId(clusterId);
   }
 
-  public void addPartitionInactive(final int partitionId, final int nodeId) {
+  public void addPartitionInactive(final int partitionId, final BrokerMemberId nodeId) {
     clusterState.addPartitionInactive(partitionId, nodeId);
   }
 }

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/TestBrokerClusterState.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/TestBrokerClusterState.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.gateway.api.util;
 
 import static io.camunda.zeebe.protocol.Protocol.START_PARTITION_ID;
 
-import io.atomix.cluster.MemberId;
+import io.atomix.cluster.BrokerMemberId;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
 import io.camunda.zeebe.util.collection.Tuple;
@@ -70,30 +70,30 @@ public final class TestBrokerClusterState implements BrokerClusterState {
   }
 
   @Override
-  public MemberId getLeaderForPartition(final int partition) {
+  public BrokerMemberId getLeaderForPartition(final int partition) {
     if (!partitionLeaders.containsKey(partition)) {
       return null;
     }
     final int leaderId = partitionLeaders.get(partition).getLeft();
-    return leaderId == NODE_ID_NULL ? null : MemberId.from(null, leaderId);
+    return leaderId == NODE_ID_NULL ? null : BrokerMemberId.from(null, leaderId);
   }
 
   @Override
-  public Set<MemberId> getFollowersForPartition(final int partition) {
+  public Set<BrokerMemberId> getFollowersForPartition(final int partition) {
     return followerPartitionToNodeIds.getOrDefault(partition, Set.of()).stream()
-        .map(id -> MemberId.from(null, id))
+        .map(id -> BrokerMemberId.from(null, id))
         .collect(Collectors.toSet());
   }
 
   @Override
-  public Set<MemberId> getInactiveNodesForPartition(final int partition) {
+  public Set<BrokerMemberId> getInactiveNodesForPartition(final int partition) {
     return inactivePartitionsToNodeIds.getOrDefault(partition, Set.of()).stream()
-        .map(id -> MemberId.from(null, id))
+        .map(id -> BrokerMemberId.from(null, id))
         .collect(Collectors.toSet());
   }
 
   @Override
-  public MemberId getRandomBroker() {
+  public BrokerMemberId getRandomBroker() {
     throw new UnsupportedOperationException();
   }
 
@@ -103,22 +103,23 @@ public final class TestBrokerClusterState implements BrokerClusterState {
   }
 
   @Override
-  public List<MemberId> getBrokers() {
-    return brokerAddresses.keySet().stream().map(id -> MemberId.from(null, id)).toList();
+  public List<BrokerMemberId> getBrokers() {
+    return brokerAddresses.keySet().stream().map(id -> BrokerMemberId.from(null, id)).toList();
   }
 
   @Override
-  public String getBrokerAddress(final MemberId brokerId) {
+  public String getBrokerAddress(final BrokerMemberId brokerId) {
     return brokerAddresses.get(brokerId.nodeIdx());
   }
 
   @Override
-  public String getBrokerVersion(final MemberId brokerId) {
+  public String getBrokerVersion(final BrokerMemberId brokerId) {
     return "1.0.0"; // Default version for testing purposes;
   }
 
   @Override
-  public PartitionHealthStatus getPartitionHealth(final MemberId brokerId, final int partition) {
+  public PartitionHealthStatus getPartitionHealth(
+      final BrokerMemberId brokerId, final int partition) {
     return brokerPartitionHealthStatus.getOrDefault(
         Tuple.of(brokerId, partition), PartitionHealthStatus.UNHEALTHY);
   }

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/TestBrokerClusterState.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/TestBrokerClusterState.java
@@ -18,20 +18,21 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 @NullMarked
 public final class TestBrokerClusterState implements BrokerClusterState {
 
-  private final Map<Integer, String> brokerAddresses = new HashMap<>();
-  private final Map<Integer, Tuple<Integer, Long>> partitionLeaders = new HashMap<>();
-  private final Set<Integer> partitions = new HashSet<>();
-  private final Map<Tuple<Integer, Integer>, PartitionHealthStatus> brokerPartitionHealthStatus =
+  private final Map<BrokerMemberId, String> brokerAddresses = new HashMap<>();
+  private final Map<Integer, Tuple<@Nullable BrokerMemberId, Long>> partitionLeaders =
       new HashMap<>();
-  private final Map<Integer, Set<Integer>> inactivePartitionsToNodeIds = new HashMap<>();
-  private final Map<Integer, Set<Integer>> followerPartitionToNodeIds = new HashMap<>();
+  private final Set<Integer> partitions = new HashSet<>();
+  private final Map<Tuple<BrokerMemberId, Integer>, PartitionHealthStatus>
+      brokerPartitionHealthStatus = new HashMap<>();
+  private final Map<Integer, Set<BrokerMemberId>> inactivePartitionsToNodeIds = new HashMap<>();
+  private final Map<Integer, Set<BrokerMemberId>> followerPartitionToNodeIds = new HashMap<>();
   private String clusterId = "";
 
   public TestBrokerClusterState() {
@@ -43,7 +44,7 @@ public final class TestBrokerClusterState implements BrokerClusterState {
         .forEach(
             pId -> {
               partitions.add(pId);
-              partitionLeaders.put(pId, Tuple.of(NODE_ID_NULL, 0L));
+              partitionLeaders.put(pId, Tuple.of(null, 0L));
               inactivePartitionsToNodeIds.put(pId, new HashSet<>());
               followerPartitionToNodeIds.put(pId, new HashSet<>());
             });
@@ -70,30 +71,25 @@ public final class TestBrokerClusterState implements BrokerClusterState {
   }
 
   @Override
-  public BrokerMemberId getLeaderForPartition(final int partition) {
+  public @Nullable BrokerMemberId getLeaderForPartition(final int partition) {
     if (!partitionLeaders.containsKey(partition)) {
       return null;
     }
-    final int leaderId = partitionLeaders.get(partition).getLeft();
-    return leaderId == NODE_ID_NULL ? null : BrokerMemberId.from(null, leaderId);
+    return partitionLeaders.get(partition).getLeft();
   }
 
   @Override
   public Set<BrokerMemberId> getFollowersForPartition(final int partition) {
-    return followerPartitionToNodeIds.getOrDefault(partition, Set.of()).stream()
-        .map(id -> BrokerMemberId.from(null, id))
-        .collect(Collectors.toSet());
+    return new HashSet<>(followerPartitionToNodeIds.getOrDefault(partition, Set.of()));
   }
 
   @Override
   public Set<BrokerMemberId> getInactiveNodesForPartition(final int partition) {
-    return inactivePartitionsToNodeIds.getOrDefault(partition, Set.of()).stream()
-        .map(id -> BrokerMemberId.from(null, id))
-        .collect(Collectors.toSet());
+    return new HashSet<>(inactivePartitionsToNodeIds.getOrDefault(partition, Set.of()));
   }
 
   @Override
-  public BrokerMemberId getRandomBroker() {
+  public @Nullable BrokerMemberId getRandomBroker() {
     throw new UnsupportedOperationException();
   }
 
@@ -104,12 +100,12 @@ public final class TestBrokerClusterState implements BrokerClusterState {
 
   @Override
   public List<BrokerMemberId> getBrokers() {
-    return brokerAddresses.keySet().stream().map(id -> BrokerMemberId.from(null, id)).toList();
+    return brokerAddresses.keySet().stream().toList();
   }
 
   @Override
   public String getBrokerAddress(final BrokerMemberId brokerId) {
-    return brokerAddresses.get(brokerId.nodeIdx());
+    return brokerAddresses.get(brokerId);
   }
 
   @Override
@@ -138,11 +134,12 @@ public final class TestBrokerClusterState implements BrokerClusterState {
     this.clusterId = clusterId;
   }
 
-  public void addBroker(final int nodeId, final String address) {
+  public void addBroker(final BrokerMemberId nodeId, final String address) {
     brokerAddresses.put(nodeId, address);
   }
 
-  public void setPartitionLeader(final int partitionId, final int leaderId, final long term) {
+  public void setPartitionLeader(
+      final int partitionId, final BrokerMemberId leaderId, final long term) {
     partitionLeaders.put(partitionId, Tuple.of(leaderId, term));
   }
 
@@ -151,11 +148,13 @@ public final class TestBrokerClusterState implements BrokerClusterState {
   }
 
   public void setPartitionHealthStatus(
-      final int nodeId, final int partitionId, final PartitionHealthStatus partitionHealthStatus) {
+      final BrokerMemberId nodeId,
+      final int partitionId,
+      final PartitionHealthStatus partitionHealthStatus) {
     brokerPartitionHealthStatus.put(Tuple.of(nodeId, partitionId), partitionHealthStatus);
   }
 
-  public void addPartitionInactive(final int partitionId, final int nodeId) {
+  public void addPartitionInactive(final int partitionId, final BrokerMemberId nodeId) {
     addPartition(partitionId);
     inactivePartitionsToNodeIds.compute(
         partitionId,
@@ -181,7 +180,7 @@ public final class TestBrokerClusterState implements BrokerClusterState {
     }
   }
 
-  public void addFollowerPartition(final int partitionId, final int nodeId) {
+  public void addFollowerPartition(final int partitionId, final BrokerMemberId nodeId) {
     followerPartitionToNodeIds.compute(
         partitionId,
         (key, value) -> {

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/TestBrokerClusterState.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/TestBrokerClusterState.java
@@ -9,17 +9,20 @@ package io.camunda.zeebe.gateway.api.util;
 
 import static io.camunda.zeebe.protocol.Protocol.START_PARTITION_ID;
 
+import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
 import io.camunda.zeebe.util.collection.Tuple;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import org.jspecify.annotations.NullMarked;
 
+@NullMarked
 public final class TestBrokerClusterState implements BrokerClusterState {
 
   private final Map<Integer, String> brokerAddresses = new HashMap<>();
@@ -67,25 +70,30 @@ public final class TestBrokerClusterState implements BrokerClusterState {
   }
 
   @Override
-  public int getLeaderForPartition(final int partition) {
+  public MemberId getLeaderForPartition(final int partition) {
     if (!partitionLeaders.containsKey(partition)) {
-      return NODE_ID_NULL;
+      return null;
     }
-    return partitionLeaders.get(partition).getLeft();
+    final int leaderId = partitionLeaders.get(partition).getLeft();
+    return leaderId == NODE_ID_NULL ? null : MemberId.from(null, leaderId);
   }
 
   @Override
-  public Set<Integer> getFollowersForPartition(final int partition) {
-    return followerPartitionToNodeIds.getOrDefault(partition, Set.of());
+  public Set<MemberId> getFollowersForPartition(final int partition) {
+    return followerPartitionToNodeIds.getOrDefault(partition, Set.of()).stream()
+        .map(id -> MemberId.from(null, id))
+        .collect(Collectors.toSet());
   }
 
   @Override
-  public Set<Integer> getInactiveNodesForPartition(final int partition) {
-    return inactivePartitionsToNodeIds.getOrDefault(partition, Set.of());
+  public Set<MemberId> getInactiveNodesForPartition(final int partition) {
+    return inactivePartitionsToNodeIds.getOrDefault(partition, Set.of()).stream()
+        .map(id -> MemberId.from(null, id))
+        .collect(Collectors.toSet());
   }
 
   @Override
-  public int getRandomBroker() {
+  public MemberId getRandomBroker() {
     throw new UnsupportedOperationException();
   }
 
@@ -95,22 +103,22 @@ public final class TestBrokerClusterState implements BrokerClusterState {
   }
 
   @Override
-  public List<Integer> getBrokers() {
-    return new ArrayList<>(brokerAddresses.keySet());
+  public List<MemberId> getBrokers() {
+    return brokerAddresses.keySet().stream().map(id -> MemberId.from(null, id)).toList();
   }
 
   @Override
-  public String getBrokerAddress(final int brokerId) {
-    return brokerAddresses.get(brokerId);
+  public String getBrokerAddress(final MemberId brokerId) {
+    return brokerAddresses.get(brokerId.nodeIdx());
   }
 
   @Override
-  public String getBrokerVersion(final int brokerId) {
+  public String getBrokerVersion(final MemberId brokerId) {
     return "1.0.0"; // Default version for testing purposes;
   }
 
   @Override
-  public PartitionHealthStatus getPartitionHealth(final int brokerId, final int partition) {
+  public PartitionHealthStatus getPartitionHealth(final MemberId brokerId, final int partition) {
     return brokerPartitionHealthStatus.getOrDefault(
         Tuple.of(brokerId, partition), PartitionHealthStatus.UNHEALTHY);
   }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
@@ -128,8 +128,9 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
     return nodeId;
   }
 
-  public BrokerInfo setNodeId(final int nodeId) {
+  public BrokerInfo setBrokerId(final int nodeId, @Nullable final String zone) {
     this.nodeId = nodeId;
+    this.zone = zone;
     return this;
   }
 
@@ -198,11 +199,6 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
 
   public @Nullable String getZone() {
     return zone;
-  }
-
-  public BrokerInfo setZone(@Nullable final String zone) {
-    this.zone = zone;
-    return this;
   }
 
   public Map<DirectBuffer, DirectBuffer> getAddresses() {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
@@ -30,6 +30,7 @@ import io.camunda.zeebe.protocol.record.MessageHeaderDecoder;
 import io.camunda.zeebe.protocol.record.MessageHeaderEncoder;
 import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
 import io.camunda.zeebe.protocol.record.PartitionRole;
+import io.camunda.zeebe.util.MemberIdUtil;
 import io.camunda.zeebe.util.buffer.BufferReader;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.camunda.zeebe.util.buffer.BufferWriter;
@@ -130,6 +131,10 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
   public BrokerInfo setNodeId(final int nodeId) {
     this.nodeId = nodeId;
     return this;
+  }
+
+  public String memberIdString() {
+    return MemberIdUtil.memberIdString(zone, getNodeId());
   }
 
   public int getPartitionsCount() {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
@@ -331,7 +331,7 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
     if (bodyDecoder.versionLength() > 0) {
       bodyDecoder.wrapVersion(version);
     } else {
-      version.wrap(new byte[0]);
+      version.wrap(EMPTY_BYTE_ARRAY);
       bodyDecoder.skipVersion();
     }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
@@ -335,6 +335,7 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
     if (bodyDecoder.versionLength() > 0) {
       bodyDecoder.wrapVersion(version);
     } else {
+      version.wrap(new byte[0]);
       bodyDecoder.skipVersion();
     }
 
@@ -350,6 +351,7 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
     if (bodyDecoder.zoneLength() > 0) {
       zone = bodyDecoder.zone();
     } else {
+      zone = null;
       bodyDecoder.skipZone();
     }
 

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/BrokerInfoTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/BrokerInfoTest.java
@@ -47,11 +47,10 @@ final class BrokerInfoTest {
 
     final BrokerInfo brokerInfo =
         new BrokerInfo()
-            .setNodeId(nodeId)
+            .setBrokerId(nodeId, "eu-west-1b")
             .setPartitionsCount(partitionsCount)
             .setClusterSize(clusterSize)
-            .setReplicationFactor(replicationFactor)
-            .setZone("eu-west-1b");
+            .setReplicationFactor(replicationFactor);
 
     addresses.forEach(brokerInfo::addAddress);
     partitionRoles.forEach(brokerInfo::addPartitionRole);
@@ -81,7 +80,7 @@ final class BrokerInfoTest {
 
     final BrokerInfo brokerInfo =
         new BrokerInfo()
-            .setNodeId(nodeId)
+            .setBrokerId(nodeId, null)
             .setPartitionsCount(partitionsCount)
             .setClusterSize(clusterSize)
             .setReplicationFactor(replicationFactor);

--- a/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/brokerapi/StubBroker.java
+++ b/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/brokerapi/StubBroker.java
@@ -66,7 +66,7 @@ public final class StubBroker implements AutoCloseable {
             .setClusterSize(1)
             .setReplicationFactor(1)
             .setPartitionsCount(1)
-            .setNodeId(nodeId)
+            .setBrokerId(nodeId, null)
             .setPartitionHealthy(1)
             .setLeaderForPartition(partitionId, 1);
     brokerInfo.setVersion(VersionUtil.getVersion());

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/shared/gateway/GatewayHealthIndicatorsIntegrationTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/shared/gateway/GatewayHealthIndicatorsIntegrationTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.data.Offset.offset;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.gateway.health.Status;
 import io.camunda.zeebe.gateway.impl.SpringGatewayBridge;
@@ -89,7 +90,7 @@ public class GatewayHealthIndicatorsIntegrationTest {
 
     // given
     final BrokerClusterState mockClusterState = mock(BrokerClusterState.class);
-    when(mockClusterState.getBrokers()).thenReturn(List.of(1));
+    when(mockClusterState.getBrokers()).thenReturn(List.of(MemberId.from(1)));
 
     final Supplier<Optional<BrokerClusterState>> stateSupplier =
         () -> Optional.of(mockClusterState);
@@ -118,7 +119,7 @@ public class GatewayHealthIndicatorsIntegrationTest {
     // given
     final BrokerClusterState mockClusterState = mock(BrokerClusterState.class);
     when(mockClusterState.getPartitions()).thenReturn(List.of(1));
-    when(mockClusterState.getLeaderForPartition(1)).thenReturn(42);
+    when(mockClusterState.getLeaderForPartition(1)).thenReturn(MemberId.from(42));
 
     final Supplier<Optional<BrokerClusterState>> stateSupplier =
         () -> Optional.of(mockClusterState);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/shared/gateway/GatewayHealthIndicatorsIntegrationTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/shared/gateway/GatewayHealthIndicatorsIntegrationTest.java
@@ -12,7 +12,7 @@ import static org.assertj.core.data.Offset.offset;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import io.atomix.cluster.MemberId;
+import io.atomix.cluster.BrokerMemberId;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.gateway.health.Status;
 import io.camunda.zeebe.gateway.impl.SpringGatewayBridge;
@@ -90,7 +90,7 @@ public class GatewayHealthIndicatorsIntegrationTest {
 
     // given
     final BrokerClusterState mockClusterState = mock(BrokerClusterState.class);
-    when(mockClusterState.getBrokers()).thenReturn(List.of(MemberId.from(1)));
+    when(mockClusterState.getBrokers()).thenReturn(List.of(BrokerMemberId.from(1)));
 
     final Supplier<Optional<BrokerClusterState>> stateSupplier =
         () -> Optional.of(mockClusterState);
@@ -119,7 +119,7 @@ public class GatewayHealthIndicatorsIntegrationTest {
     // given
     final BrokerClusterState mockClusterState = mock(BrokerClusterState.class);
     when(mockClusterState.getPartitions()).thenReturn(List.of(1));
-    when(mockClusterState.getLeaderForPartition(1)).thenReturn(MemberId.from(42));
+    when(mockClusterState.getLeaderForPartition(1)).thenReturn(BrokerMemberId.from(42));
 
     final Supplier<Optional<BrokerClusterState>> stateSupplier =
         () -> Optional.of(mockClusterState);

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorBuilder.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorBuilder.java
@@ -30,7 +30,6 @@ public final class StreamProcessorBuilder {
   private final List<StreamProcessorLifecycleAware> lifecycleListeners = new ArrayList<>();
   private ActorSchedulingService actorSchedulingService;
   private ZeebeDb zeebeDb;
-  private int nodeId;
 
   private List<RecordProcessor> recordProcessors;
   private StageableScheduledCommandCache scheduledCommandCache = new NoopScheduledCommandCache();
@@ -47,11 +46,6 @@ public final class StreamProcessorBuilder {
   public StreamProcessorBuilder actorSchedulingService(
       final ActorSchedulingService actorSchedulingService) {
     this.actorSchedulingService = actorSchedulingService;
-    return this;
-  }
-
-  public StreamProcessorBuilder nodeId(final int nodeId) {
-    this.nodeId = nodeId;
     return this;
   }
 
@@ -107,10 +101,6 @@ public final class StreamProcessorBuilder {
 
   public ZeebeDb getZeebeDb() {
     return zeebeDb;
-  }
-
-  public int getNodeId() {
-    return nodeId;
   }
 
   public List<RecordProcessor> getRecordProcessors() {

--- a/zeebe/util/pom.xml
+++ b/zeebe/util/pom.xml
@@ -47,6 +47,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <scope>test</scope>

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/MemberIdUtil.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/MemberIdUtil.java
@@ -10,11 +10,11 @@ package io.camunda.zeebe.util;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
+/**
+ * Utility functions to create MemberId from zone and node-id. Cannot live in {@code atomix/cluster}
+ * due to module dependencies.
+ */
 @NullMarked
-/*
- Utility functions to create MemberId from zone & node-id. Because of module dependencies, it
- cannot live in `atomix/cluster`.
-*/
 public final class MemberIdUtil {
 
   private MemberIdUtil() {}

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/MemberIdUtil.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/MemberIdUtil.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.util;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+@NullMarked
+/*
+ Utility functions to create MemberId from zone & node-id. Because of module dependencies, it
+ cannot live in `atomix/cluster`.
+*/
+public final class MemberIdUtil {
+
+  private MemberIdUtil() {}
+
+  /**
+   * Returns the canonical string representation of a zone-aware member identifier.
+   *
+   * <p>When {@code zone} is {@code null} the result is the bare form {@code "$nodeId"}; otherwise
+   * it is {@code "$zone/$nodeId"}. Leading/trailing whitespace is stripped from {@code zone}.
+   *
+   * @throws IllegalArgumentException if {@code zone} is blank
+   */
+  public static String memberIdString(final @Nullable String zone, final int nodeId) {
+    if (zone == null) {
+      return Integer.toString(nodeId);
+    }
+    final var stripped = zone.strip();
+    if (stripped.isEmpty()) {
+      throw new IllegalArgumentException("Expected zone to be non-empty, but was empty");
+    }
+    return stripped + "/" + nodeId;
+  }
+}


### PR DESCRIPTION
## Description
A "newtype wrapper" of `MemberId` is created: `BrokerMemberId`.
This type just represent a MemberId that is tied to a broker. 
This is verified in the constructor, by checking that the nodeIdx is not null.
For context, `MemberId` can represent any nodeId in the cluster, that's why it has `MemberId.anonymized` or generally can wrap for example `MemberId{gateway}`. 
This does not change, MemberId is left untouched (as it's used for kryo serialization as well), so no changes on the wire.

`BrokerMemberId` is now used in place of `int nodeId` everywhere: this is required for the zone-awareness. The advantage of `BrokerMemberId` over a raw `MemberId` is that it guarantees that it refers to a broker.
`BrokerMemberId` can be constructed from `BrokerInfo`.

Migrated classes:
- `BrokerClusterState`:  required a lot of consumer classes to change as well. 
- `TopologyPartitionListener`: few changes

  
At the same time I added some `@NullMarked` annotations, which required to add some null checks. 
note that before we used a sentinel value for a missing nodeId, now it's just `null`. 
Adding nullness checks required adding some actual null checks that were missing.

As a refactoring, I moved the logic to construct the id from zone & nodeIdx to `zeebe-util` so the node string can be returned from a method in `BrokerInfo` (which is in `zeebe/protocol-impl`)

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #53224
