### PR TITLE
feat: display document metadata for document references variable

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/index.test.tsx
@@ -14,13 +14,13 @@ describe('<DocumentValueCell />', () => {
   it('should render a single document with filename and size', () => {
     const result: DocumentParseResult = {
       type: 'single',
-      document: {fileName: 'photo.png', size: 109748},
+      document: {fileName: 'photo.png', size: 112640},
     };
 
     render(<DocumentValueCell result={result} />);
 
     expect(screen.getByText('photo.png')).toBeInTheDocument();
-    expect(screen.getByText('110 KB')).toBeInTheDocument();
+    expect(screen.getByText('110 KiB')).toBeInTheDocument();
   });
 
   it('should render a single document without size', () => {

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/index.test.tsx
@@ -1,0 +1,93 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {render, screen} from 'modules/testing-library';
+import {DocumentValueCell} from './index';
+import type {DocumentParseResult} from './parseDocumentVariable';
+
+describe('<DocumentValueCell />', () => {
+  it('should render a single document with filename and size', () => {
+    const result: DocumentParseResult = {
+      type: 'single',
+      document: {fileName: 'photo.png', size: 109748},
+    };
+
+    render(<DocumentValueCell result={result} />);
+
+    expect(screen.getByText('photo.png')).toBeInTheDocument();
+    expect(screen.getByText('110 KB')).toBeInTheDocument();
+  });
+
+  it('should render a single document without size', () => {
+    const result: DocumentParseResult = {
+      type: 'single',
+      document: {fileName: 'report.pdf', size: undefined},
+    };
+
+    render(<DocumentValueCell result={result} />);
+
+    expect(screen.getByText('report.pdf')).toBeInTheDocument();
+    expect(screen.queryByText(/[BKM]B/)).not.toBeInTheDocument();
+  });
+
+  it('should middle-truncate a long filename', () => {
+    const longName = 'a'.repeat(40) + 'original-middle' + 'z'.repeat(40);
+    const result: DocumentParseResult = {
+      type: 'single',
+      document: {fileName: longName, size: 1000},
+    };
+
+    render(<DocumentValueCell result={result} />);
+
+    const displayed = screen.getByTestId('document-value-cell').textContent!;
+    expect(displayed).toContain('\u2026');
+    expect(displayed).not.toContain('original-middle');
+  });
+
+  it('should render a document list count', () => {
+    const result: DocumentParseResult = {
+      type: 'list',
+      documents: [
+        {fileName: 'a.pdf', size: 1000},
+        {fileName: 'b.pdf', size: 2000},
+        {fileName: 'c.pdf', size: 3000},
+      ],
+      isLowerBound: false,
+    };
+
+    render(<DocumentValueCell result={result} />);
+
+    expect(screen.getByText('3 documents')).toBeInTheDocument();
+  });
+
+  it('should render lower-bound count with plus sign', () => {
+    const result: DocumentParseResult = {
+      type: 'list',
+      documents: [
+        {fileName: 'a.pdf', size: 1000},
+        {fileName: 'b.pdf', size: 2000},
+      ],
+      isLowerBound: true,
+    };
+
+    render(<DocumentValueCell result={result} />);
+
+    expect(screen.getByText('2+ documents')).toBeInTheDocument();
+  });
+
+  it('should set the filename as title attribute for tooltip', () => {
+    const result: DocumentParseResult = {
+      type: 'single',
+      document: {fileName: 'my-important-file.pdf', size: 5000},
+    };
+
+    render(<DocumentValueCell result={result} />);
+
+    expect(screen.getByTitle('my-important-file.pdf')).toBeInTheDocument();
+  });
+});

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/index.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Document} from '@carbon/react/icons';
+import {
+  formatFileSize,
+  type DocumentParseResult,
+} from './parseDocumentVariable';
+import {
+  DocumentCellContainer,
+  DocumentIcon,
+  DocumentFileName,
+  DocumentSize,
+  DocumentCount,
+} from './styled';
+
+type Props = {
+  result: DocumentParseResult;
+};
+
+const TRUNCATION_LIMIT = 60;
+
+function middleTruncate(text: string, limit: number): string {
+  if (text.length <= limit) {
+    return text;
+  }
+  const half = Math.floor((limit - 1) / 2);
+  return text.slice(0, half) + '\u2026' + text.slice(text.length - half);
+}
+
+const DocumentValueCell: React.FC<Props> = ({result}) => {
+  if (result.type === 'single') {
+    const {fileName, size} = result.document;
+    return (
+      <DocumentCellContainer data-testid="document-value-cell">
+        <DocumentIcon>
+          <Document size={16} />
+        </DocumentIcon>
+        <DocumentFileName title={fileName}>
+          {middleTruncate(fileName, TRUNCATION_LIMIT)}
+        </DocumentFileName>
+        {size !== undefined && (
+          <DocumentSize>{formatFileSize(size)}</DocumentSize>
+        )}
+      </DocumentCellContainer>
+    );
+  }
+
+  const count = result.documents.length;
+  const suffix = count !== 1 ? 'documents' : 'document';
+  const label = result.isLowerBound
+    ? `${count}+ ${suffix}`
+    : `${count} ${suffix}`;
+
+  return (
+    <DocumentCellContainer data-testid="document-value-cell">
+      <DocumentIcon>
+        <Document size={16} />
+      </DocumentIcon>
+      <DocumentCount>{label}</DocumentCount>
+    </DocumentCellContainer>
+  );
+};
+
+export {DocumentValueCell};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/index.tsx
@@ -8,7 +8,7 @@
 
 import {Document} from '@carbon/react/icons';
 import {
-  formatFileSize,
+  toHumanReadableBytes,
   type DocumentParseResult,
 } from './parseDocumentVariable';
 import {
@@ -45,7 +45,7 @@ const DocumentValueCell: React.FC<Props> = ({result}) => {
           {middleTruncate(fileName, TRUNCATION_LIMIT)}
         </DocumentFileName>
         {size !== undefined && (
-          <DocumentSize>{formatFileSize(size)}</DocumentSize>
+          <DocumentSize>{toHumanReadableBytes(size)}</DocumentSize>
         )}
       </DocumentCellContainer>
     );

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/parseDocumentVariable.test.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/parseDocumentVariable.test.ts
@@ -6,7 +6,10 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {parseDocumentVariable, toHumanReadableBytes} from './parseDocumentVariable';
+import {
+  parseDocumentVariable,
+  toHumanReadableBytes,
+} from './parseDocumentVariable';
 
 const makeDocRef = (overrides: Record<string, unknown> = {}) => ({
   'camunda.document.type': 'camunda',
@@ -124,12 +127,11 @@ describe('parseDocumentVariable', () => {
     const truncated = fullJson.slice(0, fullJson.length - 5);
     const result = parseDocumentVariable(truncated, true);
 
-    expect(result).not.toBeNull();
-    expect(result!.type).toBe('single');
-    expect(
-      (result as {type: 'single'; document: {fileName: string}}).document
-        .fileName,
-    ).toBe('photo.png');
+    assert(
+      result !== null && result.type === 'single',
+      'Expected a single parsing result.',
+    );
+    expect(result!.document.fileName).toBe('photo.png');
   });
 
   it('should detect a truncated array of document references with lower bound', () => {
@@ -145,15 +147,12 @@ describe('parseDocumentVariable', () => {
     const truncated = fullJson.slice(0, fullJson.length - 30);
     const result = parseDocumentVariable(truncated, true);
 
-    expect(result).not.toBeNull();
-    expect(result!.type).toBe('list');
-    const listResult = result as {
-      type: 'list';
-      documents: unknown[];
-      isLowerBound: boolean;
-    };
-    expect(listResult.documents.length).toBeGreaterThanOrEqual(2);
-    expect(listResult.isLowerBound).toBe(true);
+    assert(
+      result !== null && result.type === 'list',
+      'Expected a list parsing result.',
+    );
+    expect(result.documents.length).toBeGreaterThanOrEqual(2);
+    expect(result.isLowerBound).toBe(true);
   });
 
   it('should return null for a document reference missing required fields', () => {

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/parseDocumentVariable.test.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/parseDocumentVariable.test.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {parseDocumentVariable, formatFileSize} from './parseDocumentVariable';
+import {parseDocumentVariable, toHumanReadableBytes} from './parseDocumentVariable';
 
 const makeDocRef = (overrides: Record<string, unknown> = {}) => ({
   'camunda.document.type': 'camunda',
@@ -186,27 +186,36 @@ describe('parseDocumentVariable', () => {
   });
 });
 
-describe('formatFileSize', () => {
-  it('should format bytes', () => {
-    expect(formatFileSize(0)).toBe('0 B');
-    expect(formatFileSize(427)).toBe('427 B');
-    expect(formatFileSize(999)).toBe('999 B');
+describe('toHumanReadableBytes', () => {
+  it('should handle zero bytes', () => {
+    expect(toHumanReadableBytes(0)).toBe('0 B');
   });
 
-  it('should format kilobytes', () => {
-    expect(formatFileSize(1000)).toBe('1 KB');
-    expect(formatFileSize(346000)).toBe('346 KB');
-    expect(formatFileSize(999999)).toBe('1000 KB');
+  it('should handle invalid input', () => {
+    expect(toHumanReadableBytes(NaN)).toBe('N/A');
+    expect(toHumanReadableBytes(Infinity)).toBe('N/A');
   });
 
-  it('should format megabytes', () => {
-    expect(formatFileSize(1000000)).toBe('1.0 MB');
-    expect(formatFileSize(2500000)).toBe('2.5 MB');
-    expect(formatFileSize(15000000)).toBe('15 MB');
+  it('should format bytes correctly', () => {
+    expect(toHumanReadableBytes(1024)).toBe('1 KiB');
+    expect(toHumanReadableBytes(1024 * 1024)).toBe('1 MiB');
+    expect(toHumanReadableBytes(1024 * 1024 * 1024)).toBe('1 GiB');
   });
 
-  it('should format gigabytes', () => {
-    expect(formatFileSize(1000000000)).toBe('1.0 GB');
-    expect(formatFileSize(25000000000)).toBe('25 GB');
+  it('should format decimals correctly', () => {
+    expect(toHumanReadableBytes(1536)).toBe('1.5 KiB');
+    expect(toHumanReadableBytes(2560)).toBe('2.5 KiB');
+    expect(toHumanReadableBytes(1536 * 1024)).toBe('1.5 MiB');
+    expect(toHumanReadableBytes(1280)).toBe('1.25 KiB');
+  });
+
+  it('should handle small values', () => {
+    expect(toHumanReadableBytes(1)).toBe('1 B');
+    expect(toHumanReadableBytes(512)).toBe('512 B');
+  });
+
+  it('should cap large values at GiB', () => {
+    const largeValue = Math.pow(1024, 4);
+    expect(toHumanReadableBytes(largeValue)).toBe('1024 GiB');
   });
 });

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/parseDocumentVariable.test.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/parseDocumentVariable.test.ts
@@ -1,0 +1,212 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {parseDocumentVariable, formatFileSize} from './parseDocumentVariable';
+
+const makeDocRef = (overrides: Record<string, unknown> = {}) => ({
+  'camunda.document.type': 'camunda',
+  storeId: 'in-memory',
+  documentId: 'doc-123',
+  contentHash: 'sha256:abc',
+  metadata: {
+    contentType: 'image/png',
+    fileName: 'photo.png',
+    expiresAt: null,
+    size: 109748,
+    processDefinitionId: null,
+    processInstanceKey: null,
+    customProperties: {},
+  },
+  ...overrides,
+});
+
+describe('parseDocumentVariable', () => {
+  it('should detect a single document reference', () => {
+    const value = JSON.stringify(makeDocRef());
+    const result = parseDocumentVariable(value, false);
+
+    expect(result).toEqual({
+      type: 'single',
+      document: {
+        fileName: 'photo.png',
+        size: 109748,
+      },
+    });
+  });
+
+  it('should detect an array with a single document as single', () => {
+    const value = JSON.stringify([makeDocRef()]);
+    const result = parseDocumentVariable(value, false);
+
+    expect(result).toEqual({
+      type: 'single',
+      document: {
+        fileName: 'photo.png',
+        size: 109748,
+      },
+    });
+  });
+
+  it('should detect an array of document references', () => {
+    const value = JSON.stringify([
+      makeDocRef({
+        metadata: {...makeDocRef().metadata, fileName: 'a.pdf', size: 1000},
+      }),
+      makeDocRef({
+        metadata: {...makeDocRef().metadata, fileName: 'b.json', size: 500},
+      }),
+      makeDocRef({
+        metadata: {...makeDocRef().metadata, fileName: 'c.txt', size: 200},
+      }),
+    ]);
+    const result = parseDocumentVariable(value, false);
+
+    expect(result).toEqual({
+      type: 'list',
+      documents: [
+        {fileName: 'a.pdf', size: 1000},
+        {fileName: 'b.json', size: 500},
+        {fileName: 'c.txt', size: 200},
+      ],
+      isLowerBound: false,
+    });
+  });
+
+  it('should return null for a plain string variable', () => {
+    const value = '"hello world"';
+    const result = parseDocumentVariable(value, false);
+
+    expect(result).toBeNull();
+  });
+
+  it('should return null for a regular JSON object', () => {
+    const value = JSON.stringify({foo: 'bar', baz: 123});
+    const result = parseDocumentVariable(value, false);
+
+    expect(result).toBeNull();
+  });
+
+  it('should return null for an empty array', () => {
+    const value = '[]';
+    const result = parseDocumentVariable(value, false);
+
+    expect(result).toBeNull();
+  });
+
+  it('should return null for an array of non-document objects', () => {
+    const value = JSON.stringify([{name: 'foo'}, {name: 'bar'}]);
+    const result = parseDocumentVariable(value, false);
+
+    expect(result).toBeNull();
+  });
+
+  it('should return null for a mixed array (some doc refs, some not)', () => {
+    const value = JSON.stringify([makeDocRef(), {name: 'not-a-doc'}]);
+    const result = parseDocumentVariable(value, false);
+
+    expect(result).toBeNull();
+  });
+
+  it('should return null for invalid JSON', () => {
+    const value = '{not valid json';
+    const result = parseDocumentVariable(value, false);
+
+    expect(result).toBeNull();
+  });
+
+  it('should detect a truncated single document reference', () => {
+    const fullJson = JSON.stringify(makeDocRef());
+    const truncated = fullJson.slice(0, fullJson.length - 5);
+    const result = parseDocumentVariable(truncated, true);
+
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe('single');
+    expect(
+      (result as {type: 'single'; document: {fileName: string}}).document
+        .fileName,
+    ).toBe('photo.png');
+  });
+
+  it('should detect a truncated array of document references with lower bound', () => {
+    const docs = [
+      makeDocRef({
+        metadata: {...makeDocRef().metadata, fileName: 'a.pdf', size: 1000},
+      }),
+      makeDocRef({
+        metadata: {...makeDocRef().metadata, fileName: 'b.json', size: 500},
+      }),
+    ];
+    const fullJson = JSON.stringify([...docs, makeDocRef()]);
+    const truncated = fullJson.slice(0, fullJson.length - 30);
+    const result = parseDocumentVariable(truncated, true);
+
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe('list');
+    const listResult = result as {
+      type: 'list';
+      documents: unknown[];
+      isLowerBound: boolean;
+    };
+    expect(listResult.documents.length).toBeGreaterThanOrEqual(2);
+    expect(listResult.isLowerBound).toBe(true);
+  });
+
+  it('should return null for a document reference missing required fields', () => {
+    const incomplete = {
+      'camunda.document.type': 'camunda',
+      storeId: 'gcp',
+    };
+    const value = JSON.stringify(incomplete);
+    const result = parseDocumentVariable(value, false);
+
+    expect(result).toBeNull();
+  });
+
+  it('should detect a document reference without metadata', () => {
+    const value = JSON.stringify({
+      'camunda.document.type': 'camunda',
+      storeId: 'in-memory',
+      documentId: 'doc-no-meta',
+      contentHash: 'sha256:abc',
+    });
+    const result = parseDocumentVariable(value, false);
+
+    expect(result).toEqual({
+      type: 'single',
+      document: {
+        fileName: 'doc-no-meta',
+        size: undefined,
+      },
+    });
+  });
+});
+
+describe('formatFileSize', () => {
+  it('should format bytes', () => {
+    expect(formatFileSize(0)).toBe('0 B');
+    expect(formatFileSize(427)).toBe('427 B');
+    expect(formatFileSize(999)).toBe('999 B');
+  });
+
+  it('should format kilobytes', () => {
+    expect(formatFileSize(1000)).toBe('1 KB');
+    expect(formatFileSize(346000)).toBe('346 KB');
+    expect(formatFileSize(999999)).toBe('1000 KB');
+  });
+
+  it('should format megabytes', () => {
+    expect(formatFileSize(1000000)).toBe('1.0 MB');
+    expect(formatFileSize(2500000)).toBe('2.5 MB');
+    expect(formatFileSize(15000000)).toBe('15 MB');
+  });
+
+  it('should format gigabytes', () => {
+    expect(formatFileSize(1000000000)).toBe('1.0 GB');
+    expect(formatFileSize(25000000000)).toBe('25 GB');
+  });
+});

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/parseDocumentVariable.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/parseDocumentVariable.ts
@@ -93,20 +93,34 @@ function parseDocumentVariable(
   };
 }
 
-function formatFileSize(bytes: number): string {
-  if (bytes < 1000) {
-    return `${bytes} B`;
+const UNITS = ['B', 'KiB', 'MiB', 'GiB'];
+const BYTES_BASE = 1024;
+
+/**
+ * Formats a number of bytes into a human readable string with binary prefixes (up to GiB)
+ * @param bytes - The number of bytes to format
+ * @returns Formatted string (e.g. "1.5 MiB")
+ */
+function toHumanReadableBytes(bytes: number): string {
+  if (bytes === 0) {
+    return '0 B';
   }
-  if (bytes < 1000 * 1000) {
-    return `${Math.round(bytes / 1000)} KB`;
+
+  if (!Number.isFinite(bytes)) {
+    return 'N/A';
   }
-  if (bytes < 1000 * 1000 * 1000) {
-    const mb = bytes / (1000 * 1000);
-    return `${mb >= 10 ? Math.round(mb) : mb.toFixed(1)} MB`;
-  }
-  const gb = bytes / (1000 * 1000 * 1000);
-  return `${gb >= 10 ? Math.round(gb) : gb.toFixed(1)} GB`;
+
+  const exponent = Math.min(
+    Math.floor(Math.log(bytes) / Math.log(BYTES_BASE)),
+    UNITS.length - 1,
+  );
+
+  const value = bytes / Math.pow(BYTES_BASE, exponent);
+  const unit = UNITS[exponent];
+  const formatted = value.toFixed(2).replace(/\.?0+$/, '');
+
+  return `${formatted} ${unit}`;
 }
 
-export {parseDocumentVariable, formatFileSize};
+export {parseDocumentVariable, toHumanReadableBytes};
 export type {DocumentParseResult};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/parseDocumentVariable.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/parseDocumentVariable.ts
@@ -1,0 +1,112 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {z} from 'zod';
+import {untruncateJson} from 'modules/utils/editor/untruncateJSON';
+
+type DocumentInfo = {
+  fileName: string;
+  size: number | undefined;
+};
+
+type DocumentParseResult =
+  | {type: 'single'; document: DocumentInfo}
+  | {type: 'list'; documents: DocumentInfo[]; isLowerBound: boolean};
+
+const documentReferenceSchema = z
+  .object({
+    'camunda.document.type': z.literal('camunda'),
+    documentId: z.string(),
+    metadata: z
+      .object({
+        fileName: z.string().optional(),
+        size: z.number().optional(),
+      })
+      .catchall(z.unknown())
+      .optional(),
+  })
+  .catchall(z.unknown());
+
+type DetectedDocumentReference = z.infer<typeof documentReferenceSchema>;
+
+function isDocumentReference(
+  value: unknown,
+): value is DetectedDocumentReference {
+  return documentReferenceSchema.safeParse(value).success;
+}
+
+function toDocumentInfo(ref: DetectedDocumentReference): DocumentInfo {
+  return {
+    fileName: ref.metadata?.fileName ?? ref.documentId,
+    size: ref.metadata?.size,
+  };
+}
+
+function safeJsonParse(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return undefined;
+  }
+}
+
+function parseDocumentVariable(
+  value: string,
+  isTruncated: boolean,
+): DocumentParseResult | null {
+  const {completed, collectionDepth} = isTruncated
+    ? untruncateJson(value)
+    : {completed: value, collectionDepth: 0};
+
+  const parsed = safeJsonParse(completed);
+
+  if (isDocumentReference(parsed)) {
+    return {type: 'single', document: toDocumentInfo(parsed)};
+  }
+
+  if (!Array.isArray(parsed) || parsed.length === 0) {
+    return null;
+  }
+
+  const docs = parsed.filter(isDocumentReference);
+  if (docs.length === 0) {
+    return null;
+  }
+
+  if (!isTruncated && docs.length !== parsed.length) {
+    return null;
+  }
+
+  if (docs.length === 1 && !isTruncated) {
+    return {type: 'single', document: toDocumentInfo(docs[0]!)};
+  }
+
+  return {
+    type: 'list',
+    documents: docs.map(toDocumentInfo),
+    isLowerBound: collectionDepth > 0 || docs.length < parsed.length,
+  };
+}
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1000) {
+    return `${bytes} B`;
+  }
+  if (bytes < 1000 * 1000) {
+    return `${Math.round(bytes / 1000)} KB`;
+  }
+  if (bytes < 1000 * 1000 * 1000) {
+    const mb = bytes / (1000 * 1000);
+    return `${mb >= 10 ? Math.round(mb) : mb.toFixed(1)} MB`;
+  }
+  const gb = bytes / (1000 * 1000 * 1000);
+  return `${gb >= 10 ? Math.round(gb) : gb.toFixed(1)} GB`;
+}
+
+export {parseDocumentVariable, formatFileSize};
+export type {DocumentParseResult};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/parseDocumentVariable.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/parseDocumentVariable.ts
@@ -7,6 +7,7 @@
  */
 
 import {z} from 'zod';
+import {safeJsonParse} from 'modules/utils';
 import {untruncateJson} from 'modules/utils/editor/untruncateJSON';
 
 type DocumentInfo = {
@@ -45,14 +46,6 @@ function toDocumentInfo(ref: DetectedDocumentReference): DocumentInfo {
     fileName: ref.metadata?.fileName ?? ref.documentId,
     size: ref.metadata?.size,
   };
-}
-
-function safeJsonParse(value: string): unknown {
-  try {
-    return JSON.parse(value);
-  } catch {
-    return undefined;
-  }
 }
 
 function parseDocumentVariable(

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/styled.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/styled.tsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import styled from 'styled-components';
+import {styles} from '@carbon/elements';
+
+const DocumentCellContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: var(--cds-spacing-03);
+  padding: var(--cds-spacing-02) 0;
+  min-height: 24px;
+`;
+
+const DocumentIcon = styled.span`
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  color: var(--cds-icon-secondary);
+`;
+
+const DocumentFileName = styled.span`
+  ${styles.bodyShort01};
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+const DocumentSize = styled.span`
+  ${styles.bodyShort01};
+  color: var(--cds-text-secondary);
+  flex-shrink: 0;
+`;
+
+const DocumentCount = styled.span`
+  ${styles.bodyShort01};
+  color: var(--cds-text-secondary);
+`;
+
+export {
+  DocumentCellContainer,
+  DocumentIcon,
+  DocumentFileName,
+  DocumentSize,
+  DocumentCount,
+};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/VariableValueCell.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/VariableValueCell.tsx
@@ -6,9 +6,12 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import {useMemo} from 'react';
 import {ViewFullVariableButton} from './ViewFullVariableButton';
 import {InlineJsonEditor} from 'modules/components/InlineJsonEditor';
 import {useVariable} from 'modules/queries/variables/useVariable';
+import {parseDocumentVariable} from './DocumentValueCell/parseDocumentVariable';
+import {DocumentValueCell} from './DocumentValueCell';
 
 type Props = {
   variableKey: string;
@@ -28,6 +31,15 @@ const VariableValueCell: React.FC<Props> = ({
   isProcessInstanceRunning,
 }) => {
   const {refetch} = useVariable(variableKey, {enabled: false});
+
+  const documentResult = useMemo(
+    () => parseDocumentVariable(value, Boolean(isTruncated)),
+    [value, isTruncated],
+  );
+
+  if (documentResult !== null) {
+    return <DocumentValueCell result={documentResult} />;
+  }
 
   return (
     <InlineJsonEditor

--- a/operate/client/src/modules/utils/index.test.ts
+++ b/operate/client/src/modules/utils/index.test.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {z} from 'zod';
+
+import {isValidJSON, safeJsonParse} from './index';
+
+describe('safeJsonParse', () => {
+  it('should return the parsed JSON when no schema is provided', () => {
+    expect(safeJsonParse('{"foo":"bar"}')).toEqual({foo: 'bar'});
+  });
+
+  it('should return undefined for invalid JSON', () => {
+    expect(safeJsonParse('{foo:"bar"}')).toBeUndefined();
+  });
+
+  it('should return schema-parsed data when a schema is provided', () => {
+    const schema = z.object({count: z.coerce.number()});
+
+    const parsed = safeJsonParse('{"count":"3"}', schema);
+
+    expect(parsed).toEqual({count: 3});
+  });
+
+  it('should return undefined when schema parsing fails', () => {
+    const schema = z.object({count: z.number()});
+
+    const parsed = safeJsonParse('{"count":"not a number"}', schema);
+
+    expect(parsed).toBeUndefined();
+  });
+});
+
+describe('isValidJSON', () => {
+  it('should return true for valid JSON', () => {
+    expect(isValidJSON('{"foo":"bar"}')).toBe(true);
+  });
+
+  it('should return false for invalid JSON', () => {
+    expect(isValidJSON('{foo:"bar"}')).toBe(false);
+  });
+});

--- a/operate/client/src/modules/utils/index.ts
+++ b/operate/client/src/modules/utils/index.ts
@@ -6,13 +6,35 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-function isValidJSON(text: string) {
+// This rule complains on function overloads...
+/* eslint-disable no-redeclare */
+
+import type {ZodType, output} from 'zod';
+
+function safeJsonParse(value: string): unknown | undefined;
+function safeJsonParse<Schema extends ZodType>(
+  value: string,
+  schema: Schema,
+): output<Schema> | undefined;
+function safeJsonParse<Schema extends ZodType>(
+  value: string,
+  schema?: Schema,
+): unknown | output<Schema> | undefined {
   try {
-    JSON.parse(text);
-    return true;
+    const parsed = JSON.parse(value) as unknown;
+    if (schema === undefined) {
+      return parsed;
+    }
+
+    const result = schema.safeParse(parsed);
+    return result.success ? result.data : undefined;
   } catch {
-    return false;
+    return undefined;
   }
 }
 
-export {isValidJSON};
+function isValidJSON(text: string) {
+  return safeJsonParse(text) !== undefined;
+}
+
+export {isValidJSON, safeJsonParse};


### PR DESCRIPTION
closes #52201

Co-authored-by: Copilot <copilot@github.com>

## Description

Detects document reference variables in Operate's Variables panel and renders them with a friendly UI instead of raw JSON.

**Single document** — shows a document icon, the filename (middle-truncated at 60 chars), and the file size:

`📄 my-document-with-a-very-long-na…me.pdf  110 KB`

**Document list** — shows a document icon and the count:

`📄 3 documents` or `📄 3+ documents` (when truncated)

When a variable is not a document reference, the existing inline JSON editor renders as before.

### How

- **Detection** (parseDocumentVariable.ts): Parses the variable's JSON value and validates it against a lenient Zod schema requiring `camunda.document.type: "camunda"` and `documentId`. Handles single objects, arrays, and truncated values (via the existing `untruncateJson` utility). Single-element arrays are treated as single documents. Mixed arrays (non-truncated) are rejected.
- **Rendering** (`DocumentValueCell/`): A new presentational component using Carbon's Document icon and design tokens. Long filenames use macOS-style middle truncation. Falls back to `documentId` when `metadata.fileName` is absent.
- **Integration** (VariableValueCell.tsx): A `useMemo` call attempts document detection before rendering. When detected, `DocumentValueCell` is rendered; otherwise the existing `InlineJsonEditor` takes over. Expand/edit buttons remain unchanged for non-document variables.

### Out of scope

Document filtering, search by variable type, preview/download, and expired document handling.



## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #52201
