### PR TITLE
fix: migrate Nexus vault keys to Terraform-managed credentials

### DIFF
--- a/.github/actions/setup-c8run/action.yml
+++ b/.github/actions/setup-c8run/action.yml
@@ -87,8 +87,8 @@ runs:
         roleId: ${{ inputs.vault-role-id }}
         secretId: ${{ inputs.vault-secret-id }}
         secrets: |
-          secret/data/products/distribution/ci NEXUS_USERNAME;
-          secret/data/products/distribution/ci NEXUS_PASSWORD;
+          secret/data/products/distribution/ci/nexus USER | NEXUS_USERNAME;
+          secret/data/products/distribution/ci/nexus PASSWORD | NEXUS_PASSWORD;
 
     - name: print architecture
       run: arch

--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -222,8 +222,8 @@ jobs:
           roleId: ${{ secrets.VAULT_ROLE_ID }}
           secretId: ${{ secrets.VAULT_SECRET_ID }}
           secrets: |
-            secret/data/products/distribution/ci NEXUS_USERNAME;
-            secret/data/products/distribution/ci NEXUS_PASSWORD;
+            secret/data/products/distribution/ci/nexus USER | NEXUS_USERNAME;
+            secret/data/products/distribution/ci/nexus PASSWORD | NEXUS_PASSWORD;
             secret/data/products/distribution/ci SLACK_DISTRO_BOT_WEBHOOK;
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/.github/workflows/c8run-rdbms-regression-test.yml
+++ b/.github/workflows/c8run-rdbms-regression-test.yml
@@ -73,8 +73,8 @@ jobs:
           roleId: ${{ secrets.VAULT_ROLE_ID }}
           secretId: ${{ secrets.VAULT_SECRET_ID }}
           secrets: |
-            secret/data/products/qa/ci/common NEXUS_USERNAME;
-            secret/data/products/qa/ci/common NEXUS_PASSWORD;
+            secret/data/products/qa/ci/nexus USER | NEXUS_USERNAME;
+            secret/data/products/qa/ci/nexus PASSWORD | NEXUS_PASSWORD;
 
       - name: Build c8run
         working-directory: ./c8run

--- a/.github/workflows/c8run-release.yaml
+++ b/.github/workflows/c8run-release.yaml
@@ -126,8 +126,8 @@ jobs:
           roleId: ${{ secrets.VAULT_ROLE_ID }}
           secretId: ${{ secrets.VAULT_SECRET_ID }}
           secrets: |
-            secret/data/products/distribution/ci NEXUS_USERNAME;
-            secret/data/products/distribution/ci NEXUS_PASSWORD;
+            secret/data/products/distribution/ci/nexus USER | NEXUS_USERNAME;
+            secret/data/products/distribution/ci/nexus PASSWORD | NEXUS_PASSWORD;
             secret/data/products/distribution/ci APPLE_CERTIFICATE;
             secret/data/products/distribution/ci APPLE_CERTIFICATE_PASSWORD;
             secret/data/products/distribution/ci APPLE_DEVELOPER_ID;


### PR DESCRIPTION
## Description

Migrate vault-action secrets from old shared LDAP-based keys to dedicated Terraform-managed Nexus credentials (provisioned via `camunda/infra-core#12687`).

### Changes

| File | Old path | New path |
|------|----------|----------|
| `.github/actions/setup-c8run/action.yml` | `distribution/ci NEXUS_USERNAME/PASSWORD` | `distribution/ci/nexus USER\|PASSWORD` |
| `.github/workflows/c8run-build.yaml` | `distribution/ci NEXUS_USERNAME/PASSWORD` | `distribution/ci/nexus USER\|PASSWORD` |
| `.github/workflows/c8run-release.yaml` | `distribution/ci NEXUS_USERNAME/PASSWORD` | `distribution/ci/nexus USER\|PASSWORD` |
| `.github/workflows/c8run-rdbms-regression-test.yml` | `qa/ci/common NEXUS_USERNAME/PASSWORD` | `qa/ci/nexus USER\|PASSWORD` |

Vault-action aliases ensure downstream environment variable names (`NEXUS_USERNAME`, `NEXUS_PASSWORD`) remain unchanged — no impact on consuming steps.

### Notes

- Non-Nexus secrets under `distribution/ci` (Slack, GitHub App, Apple codesigning) are **not** affected
- No Harbor/Docker credential abuse found — all Nexus references are used exclusively for Maven artifact downloads

related to camunda/team-infrastructure#1033