### PR TITLE
 feat: add elementInstanceKeys to agent instance schema and filter 

### DIFF
--- a/webapp/client/apps/orchestration-cluster-webapp/package.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/package.json
@@ -17,7 +17,7 @@
 		"generate:svg": "svgr --typescript --no-index --out-dir src/modules/svg src/assets/svg"
 	},
 	"dependencies": {
-		"@camunda/camunda-api-zod-schemas": "0.0.64",
+		"@camunda/camunda-api-zod-schemas": "0.0.65",
 		"@camunda/camunda-composite-components": "0.23.1",
 		"@carbon/react": "1.106.0",
 		"@tanstack/react-query": "5.100.5",

--- a/webapp/client/package-lock.json
+++ b/webapp/client/package-lock.json
@@ -56,7 +56,7 @@
 		"apps/orchestration-cluster-webapp": {
 			"name": "@camunda/orchestration-cluster-webapp",
 			"dependencies": {
-				"@camunda/camunda-api-zod-schemas": "0.0.64",
+				"@camunda/camunda-api-zod-schemas": "0.0.65",
 				"@camunda/camunda-composite-components": "0.23.1",
 				"@carbon/react": "1.106.0",
 				"@tanstack/react-query": "5.100.5",
@@ -9677,13 +9677,13 @@
 			"version": "0.0.1",
 			"license": "LicenseRef-Camunda-1.0",
 			"devDependencies": {
-				"@camunda/camunda-api-zod-schemas": "0.0.64",
+				"@camunda/camunda-api-zod-schemas": "0.0.65",
 				"typescript": "6.0.3"
 			}
 		},
 		"packages/camunda-api-zod-schemas": {
 			"name": "@camunda/camunda-api-zod-schemas",
-			"version": "0.0.64",
+			"version": "0.0.65",
 			"license": "LicenseRef-Camunda-1.0",
 			"devDependencies": {
 				"@types/node": "25.6.0",

--- a/webapp/client/packages/c8-mocks/package.json
+++ b/webapp/client/packages/c8-mocks/package.json
@@ -18,7 +18,7 @@
 		"typecheck": "tsc"
 	},
 	"devDependencies": {
-		"@camunda/camunda-api-zod-schemas": "0.0.64",
+		"@camunda/camunda-api-zod-schemas": "0.0.65",
 		"typescript": "6.0.3"
 	}
 }

--- a/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
+++ b/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v0.0.65
+
+### 🚀 Enhancements
+
+- Add `elementInstanceKeys` to agent instance schema and search filter ([#52888](https://github.com/camunda/camunda/issues/52888))
+  - `elementInstanceKeys: z.array(z.string())` on `agentInstanceSchema` (response)
+  - `elementInstanceKeys: z.array(basicStringFilterSchema)` on `agentInstanceFilterSchema` (search filter)
+
+### ❤️ Contributors
+
+- Omran Abazid ([@OmranAbazid](https://github.com/OmranAbazid))
+
 ## v0.0.64
 
 ### 🚀 Enhancements

--- a/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/agent-instance.ts
+++ b/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/agent-instance.ts
@@ -62,6 +62,7 @@ const agentInstanceSchema = z.object({
 	creationDate: z.string(),
 	lastUpdatedDate: z.string(),
 	completionDate: z.string().nullable(),
+	elementInstanceKeys: z.array(z.string()),
 });
 type AgentInstance = z.infer<typeof agentInstanceSchema>;
 
@@ -76,6 +77,7 @@ const agentInstanceFilterSchema = z
 		creationDate: advancedDateTimeFilterSchema,
 		lastUpdatedDate: advancedDateTimeFilterSchema,
 		completionDate: advancedDateTimeFilterSchema,
+		elementInstanceKeys: z.array(basicStringFilterSchema),
 	})
 	.partial();
 type AgentInstanceFilter = z.infer<typeof agentInstanceFilterSchema>;

--- a/webapp/client/packages/camunda-api-zod-schemas/package.json
+++ b/webapp/client/packages/camunda-api-zod-schemas/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda/camunda-api-zod-schemas",
-	"version": "0.0.64",
+	"version": "0.0.65",
 	"license": "LicenseRef-Camunda-1.0",
 	"description": "Zod schemas and TypeScript types for Camunda 8 unified API",
 	"author": "Vinicius Goulart <vinicius.goulart@camunda.com>",


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Updates the @camunda/camunda-api-zod-schemas package to reflect the API changes from #52903, which adds elementInstanceKeys to the agent instance endpoints.


## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

related to #51926
