### PR TITLE
fix: pass version in c8run E2E dispatch payload and add checkout

### DIFF
--- a/.github/workflows/trigger-c8run-e2e-tests.yml
+++ b/.github/workflows/trigger-c8run-e2e-tests.yml
@@ -1,5 +1,5 @@
 # description: Runs c8-cross-component-e2e-tests on C8Run.
-# test location: https://github.com/camunda/c8-cross-component-e2e-tests/tree/main/tests/c8Run-8.9
+# test location: https://github.com/camunda/c8-cross-component-e2e-tests/tree/main/tests/c8Run-8.10
 # type: CI
 # owner: @camunda/qa-engineering
 name: Trigger c8-cross-component-e2e-tests
@@ -16,11 +16,20 @@ jobs:
     name: Trigger c8Run E2E Tests in c8-cross-component-e2e-tests
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    permissions: {}
+    permissions:
+      contents: read
     defaults:
       run:
         shell: bash
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Extract minor version
+        id: version
+        run: |
+          version=$(grep '^CAMUNDA_VERSION=' c8run/.env | cut -d= -f2 | grep -oP '^\d+\.\d+')
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
       - name: Generate a GitHub token for camunda/camunda repo
         id: github-token
         uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@main
@@ -44,7 +53,7 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer $GITHUB_TOKEN" \
             https://api.github.com/repos/camunda/c8-cross-component-e2e-tests/dispatches \
-            -d '{"event_type": "run-c8run-tests", "client_payload": {"source_repo": "${{ github.repository }}", "source_sha": "${{ github.sha }}"}}'
+            -d '{"event_type": "run-c8run-tests", "client_payload": {"source_repo": "${{ github.repository }}", "source_sha": "${{ github.sha }}", "version": "${{ steps.version.outputs.version }}"}}'
 
       - name: Observe build status
         if: always()


### PR DESCRIPTION
## Problem

> ⚠️ https://github.com/camunda/c8-cross-component-e2e-tests/pull/2341 — must be merged first (or simultaneously) so the receiver can handle the new version field.

`trigger-c8run-e2e-tests.yml` fires a `repository_dispatch` to `camunda/c8-cross-component-e2e-tests` on every PR touching `c8run/**`. The dispatch payload only carried `source_repo` and `source_sha` — no version info:

```yaml
-d '{"event_type": "run-c8run-tests", "client_payload": {"source_repo": "...", "source_sha": "..."}}'
```

The receiver (`playwright_c8Run_tests_pr_trigger_linux.yml`) had no way to know which branch triggered it, so it hardcoded the test suite version to `"8.9"`. This meant **every** c8run PR — on `main` (8.10), `stable/8.9`, `stable/8.8` — always ran against `tests/c8Run-8.9/`. The `tests/c8Run-8.10/` folder in `c8-cross-component-e2e-tests` existed and was complete but was never used by PR checks, only by the nightly workflow.

Additionally, the `observe-build-status` step at the end of the job referenced `./.github/actions/observe-build-status` (a local action), but the repo was never checked out — causing it to silently fail on every run (`continue-on-error: true` hid this).

## Fix

1. Added `actions/checkout` (fixes `observe-build-status` too)
2. Extracted the minor version from `c8run/.env` at the source SHA:
   ```bash
   version=$(grep '^CAMUNDA_VERSION=' c8run/.env | cut -d= -f2 | grep -oP '^\d+\.\d+')
   # e.g. 8.10.0-alpha1 → 8.10, on stable/8.9: 8.9.x → 8.9
   ```
3. Passed `version` in the dispatch payload
4. Updated the stale `# test location` comment to `c8Run-8.10`
5. Fixed `permissions: {}` → `permissions: contents: read` to allow checkout

The receiver in `c8-cross-component-e2e-tests` uses this value to select the correct test folder, with a fallback to `8.9` for stable branches not yet backported.

## Companion PR

camunda/c8-cross-component-e2e-tests#2341 — must be merged first (or simultaneously) so the receiver can handle the new `version` field.

## Follow-up

Backport to `stable/8.9` so that branch also sends the correct version in the payload (without the backport it falls back to `8.9`, which is still correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)