### PR TITLE
test: inject Camunda unified config via flat properties instead of bean override

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineConnectPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineConnectPropertiesOverride.java
@@ -82,17 +82,6 @@ public class SearchEngineConnectPropertiesOverride {
 
       final SecondaryStorageDatabase<?> database;
 
-      // The Spring condition gating this bean reads camunda.data.secondary-storage.type from the
-      // Environment, while this factory reads the (possibly mutated) Camunda POJO. Callers that
-      // mutate the POJO post-condition (e.g. TestRestoreApp with type=none) can land us here with
-      // a "none" storage type; treat it as a no-op rather than failing startup.
-      // TODO we need to stop overriding the configuration POJO in the integration tests and rather
-      // use spring properties
-      if (secondaryStorage.getType() == SecondaryStorageType.none) {
-        LOGGER.warn("Unexpected: secondary storage type is set to 'none'");
-        return;
-      }
-
       switch (secondaryStorage.getType()) {
         case elasticsearch:
           {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/CamundaRdbmsTestApplication.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/CamundaRdbmsTestApplication.java
@@ -7,11 +7,10 @@
  */
 package io.camunda.it.rdbms.db.util;
 
-import static io.camunda.spring.utils.DatabaseTypeUtils.UNIFIED_CONFIG_PROPERTY_CAMUNDA_DATABASE_TYPE;
-
 import io.atomix.cluster.MemberId;
 import io.camunda.configuration.Camunda;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
+import io.camunda.container.ExtendedConfigurationBuilder;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.zeebe.qa.util.actuator.HealthActuator;
 import io.camunda.zeebe.qa.util.cluster.TestSpringApplication;
@@ -38,8 +37,6 @@ public final class CamundaRdbmsTestApplication
     super(springConfigurations);
 
     unifiedConfig = new Camunda();
-    //noinspection resource
-    withBean("camunda", unifiedConfig, Camunda.class);
   }
 
   public CamundaRdbmsTestApplication withDatabaseContainer(
@@ -98,6 +95,10 @@ public final class CamundaRdbmsTestApplication
     // we need to hook in at the last minute and set the property as it won't resolve from the
     // config bean
     withProperty("zeebe.broker.gateway.enable", true);
+    // Flatten the in-memory unified config into camunda.* properties at the latest possible point,
+    // so the rdbms URL set in start() (after the container is up) is captured. Refreshable so that
+    // fields cleared between stop/start don't remain.
+    withRefreshableProperties(ExtendedConfigurationBuilder.flatPropertiesFor(unifiedConfig));
     return super.createSpringBuilder();
   }
 
@@ -151,9 +152,8 @@ public final class CamundaRdbmsTestApplication
   }
 
   private void setSecondaryStorageToRdbms() {
-    // set environment variable camunda.data.secondary-storage.type to ensure that
-    // ConditionalOnSecondaryStorageType behaves as expected
-    super.withProperty(UNIFIED_CONFIG_PROPERTY_CAMUNDA_DATABASE_TYPE, "rdbms");
+    // The unified-config type is emitted as camunda.data.secondary-storage.type when the unified
+    // config is flattened at startup, which ConditionalOnSecondaryStorageType reads.
     unifiedConfig.getData().getSecondaryStorage().setType(SecondaryStorageType.rdbms);
     unifiedConfig
         .getData()

--- a/qa/testcontainer/src/main/java/io/camunda/container/ExtendedConfigurationBuilder.java
+++ b/qa/testcontainer/src/main/java/io/camunda/container/ExtendedConfigurationBuilder.java
@@ -8,11 +8,13 @@
 package io.camunda.container;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
@@ -22,14 +24,25 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator.Feature;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.camunda.configuration.Api;
+import io.camunda.configuration.BatchOperation;
 import io.camunda.configuration.Camunda;
 import io.camunda.configuration.Cluster;
 import io.camunda.configuration.Data;
+import io.camunda.configuration.DocumentBasedHistory;
 import io.camunda.configuration.Exporter;
+import io.camunda.configuration.Grpc;
+import io.camunda.configuration.InternalApi;
+import io.camunda.configuration.KeyStore;
+import io.camunda.configuration.LongPolling;
+import io.camunda.configuration.Membership;
 import io.camunda.configuration.Monitoring;
+import io.camunda.configuration.Network;
+import io.camunda.configuration.PostExport;
 import io.camunda.configuration.Processing;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.configuration.Security;
+import io.camunda.configuration.Ssl;
+import io.camunda.configuration.TlsCluster;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.Webapps;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
@@ -40,6 +53,7 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -48,7 +62,7 @@ import org.springframework.util.unit.DataSize;
 public class ExtendedConfigurationBuilder {
 
   public static final String CONFIG_FILE_NAME = "config.yaml";
-  private static final ObjectMapper YAML_MAPPER = createYamlMapper();
+  private static final ObjectMapper MAPPER = createMapper();
   private static final String CAMUNDA_HEADER = "camunda";
 
   private static final TypeReference<LinkedHashMap<String, Object>> MAP_TYPE =
@@ -62,20 +76,45 @@ public class ExtendedConfigurationBuilder {
     initializeUnifiedConfigDefaults();
   }
 
-  private static ObjectMapper createYamlMapper() {
+  /**
+   * Single mapper that drives both the YAML export (consumed by the Camunda Docker container) and
+   * the flat-property export (consumed by in-process test applications).
+   *
+   * <p>Reads actual stored field values, bypassing the unified-config getters whose accessor logic
+   * (validation against legacy property names, fallbacks) is irrelevant when reflecting in-memory
+   * builder state. Internal helper fields that are not part of the binding contract — e.g. {@code
+   * legacyPropertiesMap}, constructor-injected {@code prefix}/{@code databaseName} — are ignored
+   * via MixIns kept here to avoid touching production classes.
+   */
+  private static ObjectMapper createMapper() {
     final var springTypesModule = new SimpleModule("extendedTypes");
     springTypesModule.addSerializer(new DurationSerializer());
     springTypesModule.addSerializer(new DataSizeSerializer());
 
-    return new ObjectMapper(new YAMLFactory().disable(Feature.WRITE_DOC_START_MARKER))
-        .registerModule(new JavaTimeModule())
-        .registerModule(new Jdk8Module())
-        .registerModule(springTypesModule)
-        .disable(SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS)
-        .setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL)
-        .setVisibility(PropertyAccessor.ALL, Visibility.NONE)
-        .setVisibility(PropertyAccessor.GETTER, Visibility.ANY)
-        .setVisibility(PropertyAccessor.IS_GETTER, Visibility.ANY);
+    final var mapper =
+        new ObjectMapper(new YAMLFactory().disable(Feature.WRITE_DOC_START_MARKER))
+            .registerModule(new JavaTimeModule())
+            .registerModule(new Jdk8Module())
+            .registerModule(springTypesModule)
+            .disable(SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS)
+            .setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL)
+            .setVisibility(PropertyAccessor.ALL, Visibility.NONE)
+            .setVisibility(PropertyAccessor.FIELD, Visibility.ANY)
+            .setPropertyNamingStrategy(PropertyNamingStrategies.KEBAB_CASE);
+
+    mapper.addMixIn(Cluster.class, LegacyPropertiesMapMixIn.class);
+    mapper.addMixIn(Grpc.class, LegacyPropertiesMapMixIn.class);
+    mapper.addMixIn(InternalApi.class, LegacyPropertiesMapMixIn.class);
+    mapper.addMixIn(LongPolling.class, LegacyPropertiesMapMixIn.class);
+    mapper.addMixIn(Membership.class, LegacyPropertiesMapMixIn.class);
+    mapper.addMixIn(Network.class, LegacyPropertiesMapMixIn.class);
+    mapper.addMixIn(Ssl.class, LegacyPropertiesMapMixIn.class);
+    mapper.addMixIn(TlsCluster.class, LegacyPropertiesMapMixIn.class);
+    mapper.addMixIn(KeyStore.class, KeyStoreMixIn.class);
+    mapper.addMixIn(BatchOperation.class, BatchOperationMixIn.class);
+    mapper.addMixIn(DocumentBasedHistory.class, PrefixMixIn.class);
+    mapper.addMixIn(PostExport.class, PrefixMixIn.class);
+    return mapper;
   }
 
   public Camunda getUnifiedConfig() {
@@ -262,11 +301,63 @@ public class ExtendedConfigurationBuilder {
             }
             mergeConfigs(fullConfig, flatten(additionalConfigs));
 
-            return YAML_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(fullConfig);
+            return MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(fullConfig);
           } catch (final IOException e) {
             throw new RuntimeException(e);
           }
         });
+  }
+
+  /**
+   * Exports this builder's unified configuration as flat, Spring-binding-ready property keys (e.g.
+   * {@code camunda.cluster.size=1}). Only fields whose stored value differs from a pristine {@code
+   * new Camunda()} are emitted, keeping the property set lean and predictable.
+   *
+   * <p>Values are read directly from instance fields via reflection (no getters), so accessor-side
+   * validation and legacy fallbacks in the unified-config classes do not interfere.
+   */
+  public Map<String, Object> exportConfigAsFlatProperties() {
+    return flatPropertiesFor(unifiedConfig);
+  }
+
+  /**
+   * Reflects {@code config} field-by-field, diffs it against a pristine {@code new Camunda()}, and
+   * returns a flat map of {@code camunda.*} property keys suitable for Spring's relaxed binding.
+   * List elements are emitted as {@code key[i]}; map entries as {@code key.entryKey}.
+   */
+  public static Map<String, Object> flatPropertiesFor(final Camunda config) {
+    return UnifiedConfigurationHelper.withoutValidation(
+        () -> {
+          final Map<String, Object> defaultMap = flatten(new Camunda());
+          final Map<String, Object> configuredMap = flatten(config);
+          final Map<String, Object> diff = diffMaps(defaultMap, configuredMap);
+          final Map<String, Object> flat = new LinkedHashMap<>();
+          flattenInto(diff, CAMUNDA_HEADER, flat);
+          return flat;
+        });
+  }
+
+  private static void flattenInto(
+      final Object node, final String key, final Map<String, Object> flat) {
+    if (node instanceof final Map<?, ?> map) {
+      if (map.isEmpty()) {
+        return;
+      }
+      for (final Map.Entry<?, ?> entry : map.entrySet()) {
+        final String childKey =
+            key.isEmpty() ? entry.getKey().toString() : key + "." + entry.getKey();
+        flattenInto(entry.getValue(), childKey, flat);
+      }
+    } else if (node instanceof final List<?> list) {
+      if (list.isEmpty()) {
+        return;
+      }
+      for (int i = 0; i < list.size(); i++) {
+        flattenInto(list.get(i), key + "[" + i + "]", flat);
+      }
+    } else if (node != null) {
+      flat.put(key, node);
+    }
   }
 
   /**
@@ -330,7 +421,7 @@ public class ExtendedConfigurationBuilder {
   }
 
   private static Map<String, Object> flatten(final Object value) {
-    return YAML_MAPPER.convertValue(value, MAP_TYPE);
+    return MAPPER.convertValue(value, MAP_TYPE);
   }
 
   /** Serializes {@link Duration} as an ISO-8601 string (e.g. {@code PT5M}, {@code PT0.1S}). */
@@ -345,6 +436,30 @@ public class ExtendedConfigurationBuilder {
         throws IOException {
       gen.writeString(value.toString());
     }
+  }
+
+  /** Hides the legacy-property-name lookup map shared by many unified-config classes. */
+  private abstract static class LegacyPropertiesMapMixIn {
+    @JsonIgnore private Map<String, String> legacyPropertiesMap;
+  }
+
+  /** {@link KeyStore} additionally has a constructor-injected {@code prefix}. */
+  private abstract static class KeyStoreMixIn {
+    @JsonIgnore private Map<String, String> legacyPropertiesMap;
+    @JsonIgnore private String prefix;
+  }
+
+  /** Hides the {@code databaseName} injected via {@link BatchOperation}'s constructor. */
+  private abstract static class BatchOperationMixIn {
+    @JsonIgnore private String databaseName;
+  }
+
+  /**
+   * Hides the {@code prefix} injected via constructor on {@link DocumentBasedHistory} / {@link
+   * PostExport}.
+   */
+  private abstract static class PrefixMixIn {
+    @JsonIgnore private String prefix;
   }
 
   /**

--- a/qa/testcontainer/src/test/java/io/camunda/container/ExtendedConfigurationBuilderTest.java
+++ b/qa/testcontainer/src/test/java/io/camunda/container/ExtendedConfigurationBuilderTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.container;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.Exporter;
+import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.util.unit.DataSize;
+
+final class ExtendedConfigurationBuilderTest {
+
+  @Test
+  void shouldEmitEmptyMapForPristineConfig() {
+    final var flat = ExtendedConfigurationBuilder.flatPropertiesFor(new Camunda());
+    assertThat(flat).isEmpty();
+  }
+
+  @Test
+  void shouldEmitOnlyChangedScalars() {
+    // given
+    final var config = new Camunda();
+    config.getCluster().setSize(3);
+    config.getCluster().setPartitionCount(7);
+
+    // when
+    final var flat = ExtendedConfigurationBuilder.flatPropertiesFor(config);
+
+    // then
+    assertThat(flat)
+        .containsEntry("camunda.cluster.size", 3)
+        .containsEntry("camunda.cluster.partition-count", 7);
+  }
+
+  @Test
+  void shouldSerializeDurationAndDataSizeAsStrings() {
+    // given
+    final var config = new Camunda();
+    config.getData().setSnapshotPeriod(Duration.ofMinutes(1));
+    config.getData().getPrimaryStorage().getLogStream().setLogSegmentSize(DataSize.ofMegabytes(16));
+
+    // when
+    final var flat = ExtendedConfigurationBuilder.flatPropertiesFor(config);
+
+    // then
+    assertThat(flat)
+        .containsEntry("camunda.data.snapshot-period", "PT1M")
+        .containsEntry("camunda.data.primary-storage.log-stream.log-segment-size", "16MB");
+  }
+
+  @Test
+  void shouldSerializeEnumsByName() {
+    // given
+    final var config = new Camunda();
+    config.getData().getSecondaryStorage().setType(SecondaryStorageType.rdbms);
+
+    // when
+    final var flat = ExtendedConfigurationBuilder.flatPropertiesFor(config);
+
+    // then
+    assertThat(flat).containsEntry("camunda.data.secondary-storage.type", "rdbms");
+  }
+
+  @Test
+  void shouldEmitListEntriesWithIndexNotation() {
+    // given
+    final var config = new Camunda();
+    config.getCluster().setInitialContactPoints(List.of("host-a:26502", "host-b:26502"));
+
+    // when
+    final var flat = ExtendedConfigurationBuilder.flatPropertiesFor(config);
+
+    // then
+    assertThat(flat)
+        .containsEntry("camunda.cluster.initial-contact-points[0]", "host-a:26502")
+        .containsEntry("camunda.cluster.initial-contact-points[1]", "host-b:26502");
+  }
+
+  @Test
+  void shouldEmitMapEntriesAsNestedKeys() {
+    // given
+    final var config = new Camunda();
+    final var exporter = new Exporter();
+    exporter.setClassName("io.camunda.test.MyExporter");
+    exporter.setArgs(Map.of("connect", Map.of("url", "http://localhost:9200")));
+    config.getData().getExporters().put("myExporter", exporter);
+
+    // when
+    final var flat = ExtendedConfigurationBuilder.flatPropertiesFor(config);
+
+    // then — exporter field names are kebab-cased, but map keys (exporter id, args) stay verbatim
+    assertThat(flat)
+        .containsEntry("camunda.data.exporters.myExporter.class-name", "io.camunda.test.MyExporter")
+        .containsEntry(
+            "camunda.data.exporters.myExporter.args.connect.url", "http://localhost:9200");
+  }
+
+  @Test
+  void shouldIgnoreInternalHelperFields() {
+    // given
+    final var config = new Camunda();
+    // mutate something so the cluster section is emitted
+    config.getCluster().setSize(2);
+
+    // when
+    final var flat = ExtendedConfigurationBuilder.flatPropertiesFor(config);
+
+    // then — no `legacyPropertiesMap` or comparable internal-helper keys leak out
+    assertThat(flat.keySet())
+        .noneMatch(k -> k.contains("legacy-properties-map"))
+        .noneMatch(k -> k.endsWith(".prefix"))
+        .noneMatch(k -> k.endsWith(".database-name"));
+  }
+}

--- a/qa/util/pom.xml
+++ b/qa/util/pom.xml
@@ -221,12 +221,16 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>configuration</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.jspecify</groupId>
       <artifactId>jspecify</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-testcontainer</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestCamundaApplication.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestCamundaApplication.java
@@ -21,6 +21,7 @@ import io.camunda.authentication.config.AuthenticationProperties;
 import io.camunda.configuration.Camunda;
 import io.camunda.configuration.EngineJob;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
+import io.camunda.container.ExtendedConfigurationBuilder;
 import io.camunda.identity.IdentityModuleConfiguration;
 import io.camunda.operate.OperateModuleConfiguration;
 import io.camunda.security.api.model.config.AuthenticationMethod;
@@ -142,8 +143,7 @@ public final class TestCamundaApplication extends TestSpringApplication<TestCamu
                 List.of(DEFAULT_MAPPING_RULE_ID)));
 
     //noinspection resource
-    withBean("camunda", unifiedConfig, Camunda.class)
-        .withBean("security-config", securityConfig, CamundaSecurityProperties.class)
+    withBean("security-config", securityConfig, CamundaSecurityProperties.class)
         .withProperty(
             AuthenticationProperties.API_UNPROTECTED,
             securityConfig.getAuthentication().getUnprotectedApi())
@@ -192,6 +192,9 @@ public final class TestCamundaApplication extends TestSpringApplication<TestCamu
     withProperty(
         "zeebe.broker.gateway.enable",
         property("zeebe.broker.gateway.enable", Boolean.class, isGatewayEnabled));
+    // Flatten the in-memory unified config into camunda.* properties at the latest possible point.
+    // Refreshable so that fields cleared between stop/start don't remain.
+    withRefreshableProperties(ExtendedConfigurationBuilder.flatPropertiesFor(unifiedConfig));
     return super.createSpringBuilder();
   }
 
@@ -310,7 +313,6 @@ public final class TestCamundaApplication extends TestSpringApplication<TestCamu
   @Override
   public TestCamundaApplication withSecondaryStorageType(final SecondaryStorageType type) {
     unifiedConfig.getData().getSecondaryStorage().setType(type);
-    withProperty("camunda.data.secondary-storage.type", type.name());
     return this;
   }
 

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestStandaloneBackupManager.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestStandaloneBackupManager.java
@@ -16,6 +16,7 @@ import io.camunda.application.commons.search.PhysicalTenantSearchClientReadersCo
 import io.camunda.application.commons.search.SearchClientReaderConfiguration;
 import io.camunda.configuration.Camunda;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
+import io.camunda.container.ExtendedConfigurationBuilder;
 import io.camunda.zeebe.qa.util.actuator.HealthActuator;
 import io.camunda.zeebe.qa.util.actuator.HealthActuator.NoopHealthActuator;
 import io.camunda.zeebe.qa.util.cluster.TestSpringApplication;
@@ -39,8 +40,6 @@ public class TestStandaloneBackupManager
         SearchClientReaderConfiguration.class);
 
     unifiedConfig = new Camunda();
-    //noinspection resource
-    withBean("camunda", unifiedConfig, Camunda.class);
   }
 
   @Override
@@ -82,6 +81,9 @@ public class TestStandaloneBackupManager
 
   @Override
   protected SpringApplicationBuilder createSpringBuilder() {
+    // Flatten the in-memory unified config into camunda.* properties at the latest possible point.
+    // Refreshable so that fields cleared between stop/start don't remain.
+    withRefreshableProperties(ExtendedConfigurationBuilder.flatPropertiesFor(unifiedConfig));
     return super.createSpringBuilder().web(WebApplicationType.NONE);
   }
 
@@ -92,15 +94,12 @@ public class TestStandaloneBackupManager
 
   /**
    * Convenience method for setting the secondary storage type in the unified configuration.
-   * Additionally, the property camunda.data.secondary-storage.type is set to ensure that
-   * ConditionalOnSecondaryStorageType behaves as expected
    *
    * @param type the secondary storage type
    * @return itself for chaining
    */
   public TestStandaloneBackupManager withSecondaryStorageType(final SecondaryStorageType type) {
     unifiedConfig.getData().getSecondaryStorage().setType(type);
-    withProperty("camunda.data.secondary-storage.type", type.name());
     return this;
   }
 }

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestStandaloneSchemaManager.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestStandaloneSchemaManager.java
@@ -12,6 +12,7 @@ import io.camunda.application.StandaloneSchemaManager;
 import io.camunda.application.commons.configuration.UnifiedConfigurationModule;
 import io.camunda.configuration.Camunda;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
+import io.camunda.container.ExtendedConfigurationBuilder;
 import io.camunda.zeebe.qa.util.actuator.HealthActuator;
 import io.camunda.zeebe.qa.util.actuator.HealthActuator.NoopHealthActuator;
 import io.camunda.zeebe.qa.util.cluster.TestSpringApplication;
@@ -28,8 +29,6 @@ public class TestStandaloneSchemaManager
     super(UnifiedConfigurationModule.class, StandaloneSchemaManager.class);
 
     unifiedConfig = new Camunda();
-    //noinspection resource
-    withBean("camunda", unifiedConfig, Camunda.class);
   }
 
   @Override
@@ -66,20 +65,20 @@ public class TestStandaloneSchemaManager
 
   /**
    * Convenience method for setting the secondary storage type in the unified configuration.
-   * Additionally, the environment variable camunda.data.secondary-storage.type is set to ensure
-   * that ConditionalOnSecondaryStorageType behaves as expected
    *
    * @param type the secondary storage type
    * @return itself for chaining
    */
   public TestStandaloneSchemaManager withSecondaryStorageType(final SecondaryStorageType type) {
     unifiedConfig.getData().getSecondaryStorage().setType(type);
-    withProperty("camunda.data.secondary-storage.type", type.name());
     return this;
   }
 
   @Override
   protected SpringApplicationBuilder createSpringBuilder() {
+    // Flatten the in-memory unified config into camunda.* properties at the latest possible point.
+    // Refreshable so that fields cleared between stop/start don't remain.
+    withRefreshableProperties(ExtendedConfigurationBuilder.flatPropertiesFor(unifiedConfig));
     return super.createSpringBuilder().web(WebApplicationType.NONE);
   }
 }

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestRestoreApp.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestRestoreApp.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.qa.util.cluster;
 import io.atomix.cluster.MemberId;
 import io.camunda.application.Profile;
 import io.camunda.configuration.Camunda;
+import io.camunda.container.ExtendedConfigurationBuilder;
 import io.camunda.zeebe.qa.util.actuator.HealthActuator;
 import io.camunda.zeebe.restore.RestoreApp;
 import java.time.Instant;
@@ -35,9 +36,7 @@ public final class TestRestoreApp extends TestSpringApplication<TestRestoreApp> 
   public TestRestoreApp(final Camunda config) {
     super(RestoreApp.class);
     this.config = config;
-
-    //noinspection resource
-    withBean("config", config, Camunda.class).withAdditionalProfile(Profile.RESTORE);
+    withAdditionalProfile(Profile.RESTORE);
   }
 
   @Override
@@ -82,6 +81,9 @@ public final class TestRestoreApp extends TestSpringApplication<TestRestoreApp> 
 
   @Override
   protected SpringApplicationBuilder createSpringBuilder() {
+    // Flatten the in-memory unified config into camunda.* properties at the latest possible point.
+    // Refreshable so that fields cleared between stop/start don't linger.
+    withRefreshableProperties(ExtendedConfigurationBuilder.flatPropertiesFor(config));
     return super.createSpringBuilder().web(WebApplicationType.NONE);
   }
 

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestSpringApplication.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestSpringApplication.java
@@ -24,8 +24,10 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.Banner.Mode;
@@ -47,6 +49,7 @@ public abstract class TestSpringApplication<T extends TestSpringApplication<T>>
   private final Collection<String> additionalProfiles;
   private final Collection<ApplicationContextInitializer> additionalInitializers;
   private final ReactorResourceFactory reactorResourceFactory = new ReactorResourceFactory();
+  private final Set<String> refreshableKeys = new HashSet<>();
 
   public TestSpringApplication(final Class<?>... springApplications) {
     this(new HashMap<>(), new HashMap<>(), new ArrayList<>(), springApplications);
@@ -166,6 +169,22 @@ public abstract class TestSpringApplication<T extends TestSpringApplication<T>>
   @Override
   public T withAdditionalProfile(final String profile) {
     additionalProfiles.add(profile);
+    return self();
+  }
+
+  /**
+   * Replaces a set of properties that should be re-derived from in-memory builder state on every
+   * {@link #start()}. Keys set in a previous call are removed before the new {@code properties} are
+   * applied, so fields that disappear between restarts (e.g. an exporter cleared from the unified
+   * config) do not remain in Spring's property sources. Properties added via {@link #withProperty}
+   * or {@link io.camunda.zeebe.qa.util.cluster.TestApplication#withAdditionalProperties} are not
+   * tracked here and persist across restarts as before.
+   */
+  public T withRefreshableProperties(final Map<String, Object> properties) {
+    refreshableKeys.forEach(propertyOverrides::remove);
+    refreshableKeys.clear();
+    propertyOverrides.putAll(properties);
+    refreshableKeys.addAll(properties.keySet());
     return self();
   }
 

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
@@ -21,6 +21,7 @@ import io.camunda.configuration.beans.BrokerBasedProperties;
 import io.camunda.configuration.beans.SearchEngineConnectProperties;
 import io.camunda.configuration.beans.SearchEngineIndexProperties;
 import io.camunda.configuration.beans.SearchEngineRetentionProperties;
+import io.camunda.container.ExtendedConfigurationBuilder;
 import io.camunda.security.api.model.config.AuthenticationMethod;
 import io.camunda.security.configuration.ConfiguredMappingRule;
 import io.camunda.security.configuration.ConfiguredUser;
@@ -77,8 +78,7 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
         "org.springframework.boot.security.autoconfigure.web.servlet.ServletWebSecurityAutoConfiguration,"
             + "org.springframework.boot.security.autoconfigure.actuate.web.servlet.ManagementWebSecurityAutoConfiguration");
 
-    //noinspection resource
-    withBean("camunda", unifiedConfig, Camunda.class).withAdditionalProfile(Profile.BROKER);
+    withAdditionalProfile(Profile.BROKER);
 
     securityConfig = new CamundaSecurityProperties();
     securityConfig.getAuthorizations().setEnabled(false);
@@ -160,6 +160,10 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
     withProperty(
         "zeebe.broker.gateway.enable",
         property("zeebe.broker.gateway.enable", Boolean.class, isGatewayEnabled));
+    // Flatten the in-memory unified config into camunda.* properties at the latest possible point,
+    // so every withClusterConfig/withDataConfig/... call made up to now is captured. Refreshable
+    // so that fields cleared between stop/start (e.g. an exporter removed) don't remain.
+    withRefreshableProperties(ExtendedConfigurationBuilder.flatPropertiesFor(unifiedConfig));
     return super.createSpringBuilder();
   }
 
@@ -335,8 +339,6 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
 
   /**
    * Convenience method for setting the secondary storage type in the unified configuration.
-   * Additionally, the environment variable camunda.data.secondary-storage.type is set to ensure
-   * that ConditionalOnSecondaryStorageType behaves as expected
    *
    * @param type the secondary storage type
    * @return itself for chaining
@@ -344,7 +346,6 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
   @Override
   public TestStandaloneBroker withSecondaryStorageType(final SecondaryStorageType type) {
     unifiedConfig.getData().getSecondaryStorage().setType(type);
-    withProperty("camunda.data.secondary-storage.type", type.name());
     return this;
   }
 

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneGateway.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneGateway.java
@@ -12,9 +12,11 @@ import io.camunda.application.Profile;
 import io.camunda.application.commons.CommonsModuleConfiguration;
 import io.camunda.application.commons.security.CamundaSecurityConfiguration.CamundaSecurityProperties;
 import io.camunda.configuration.Camunda;
+import io.camunda.container.ExtendedConfigurationBuilder;
 import io.camunda.zeebe.gateway.GatewayModuleConfiguration;
 import io.camunda.zeebe.test.util.socket.SocketUtil;
 import java.util.function.Consumer;
+import org.springframework.boot.builder.SpringApplicationBuilder;
 
 /** Encapsulates an instance of the {@link GatewayModuleConfiguration} Spring application. */
 public final class TestStandaloneGateway extends TestSpringApplication<TestStandaloneGateway>
@@ -36,8 +38,7 @@ public final class TestStandaloneGateway extends TestSpringApplication<TestStand
         .getNetwork()
         .getInternalApi()
         .setPort(SocketUtil.getNextAddress().getPort());
-    //noinspection resource
-    withBean("camunda", unifiedConfig, Camunda.class).withAdditionalProfile(Profile.GATEWAY);
+    withAdditionalProfile(Profile.GATEWAY);
 
     securityConfig = new CamundaSecurityProperties();
     securityConfig.getAuthentication().setUnprotectedApi(true);
@@ -90,6 +91,15 @@ public final class TestStandaloneGateway extends TestSpringApplication<TestStand
       case CLUSTER -> unifiedConfig.getCluster().getNetwork().getInternalApi().getPort();
       default -> super.mappedPort(port);
     };
+  }
+
+  @Override
+  protected SpringApplicationBuilder createSpringBuilder() {
+    // Flatten the in-memory unified config into camunda.* properties at the latest possible point,
+    // so every withClusterConfig/withUnifiedConfig/... call made up to now is captured. Refreshable
+    // so that fields cleared between stop/start don't remain.
+    withRefreshableProperties(ExtendedConfigurationBuilder.flatPropertiesFor(unifiedConfig));
+    return super.createSpringBuilder();
   }
 
   /**

--- a/zeebe/qa/util/src/test/java/io/camunda/zeebe/qa/util/cluster/RefreshablePropertiesTest.java
+++ b/zeebe/qa/util/src/test/java/io/camunda/zeebe/qa/util/cluster/RefreshablePropertiesTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.qa.util.cluster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.container.ExtendedConfigurationBuilder;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("resource")
+final class RefreshablePropertiesTest {
+
+  @Test
+  void shouldRemoveStaleUnifiedConfigKeysOnRestart() {
+    // given a broker with the recording exporter enabled
+    final var broker = new TestStandaloneBroker().withRecordingExporter(true);
+
+    // simulate the first start: createSpringBuilder() is called as part of start(); since we don't
+    // want to actually boot Spring here, we instead invoke the same hook directly by re-emitting
+    // the flat properties via withRefreshableProperties, mirroring what createSpringBuilder() does.
+    broker.withRefreshableProperties(
+        ExtendedConfigurationBuilder.flatPropertiesFor(broker.unifiedConfig()));
+
+    final var classNameKey =
+        "camunda.data.exporters." + TestStandaloneBroker.RECORDING_EXPORTER_ID + ".class-name";
+    assertThat(
+            broker.property(
+                classNameKey,
+                String.class,
+                /* fallback to a sentinel to distinguish absent from null */
+                "<absent>"))
+        .as("recording exporter class-name should be exposed on first start")
+        .isNotEqualTo("<absent>");
+
+    // when the exporter is removed and the broker is "restarted"
+    broker.withRecordingExporter(false);
+    broker.withRefreshableProperties(
+        ExtendedConfigurationBuilder.flatPropertiesFor(broker.unifiedConfig()));
+
+    // then the previously-emitted exporter property is gone
+    assertThat(broker.property(classNameKey, String.class, "<absent>"))
+        .as("recording exporter class-name should be cleared on restart with the exporter removed")
+        .isEqualTo("<absent>");
+  }
+
+  @Test
+  void shouldNotClearUserSetPropertiesOnRefresh() {
+    // given a broker with a user-set property that is not part of unified config
+    final var broker = new TestStandaloneBroker();
+    broker.withProperty("camunda.security.authorizations.enabled", true);
+
+    // when refreshable properties are applied and then re-applied
+    broker.withRefreshableProperties(
+        ExtendedConfigurationBuilder.flatPropertiesFor(broker.unifiedConfig()));
+    broker.withRefreshableProperties(
+        ExtendedConfigurationBuilder.flatPropertiesFor(broker.unifiedConfig()));
+
+    // then the user-set property survives both refreshes
+    assertThat(broker.property("camunda.security.authorizations.enabled", Boolean.class, false))
+        .as("user-set property should not be tracked as refreshable")
+        .isTrue();
+  }
+
+  @Test
+  void shouldOverrideStaleKeysWithNewValuesOnRefresh() {
+    // given a broker with an initial cluster size
+    final var broker = new TestStandaloneBroker();
+    broker.withClusterConfig(c -> c.setSize(2));
+    broker.withRefreshableProperties(
+        ExtendedConfigurationBuilder.flatPropertiesFor(broker.unifiedConfig()));
+    assertThat(broker.property("camunda.cluster.size", Integer.class, 0)).isEqualTo(2);
+
+    // when the cluster size is changed and refresh runs again
+    broker.withClusterConfig(c -> c.setSize(5));
+    broker.withRefreshableProperties(
+        ExtendedConfigurationBuilder.flatPropertiesFor(broker.unifiedConfig()));
+
+    // then the new value is reflected (and the old one is replaced, not left behind)
+    assertThat(broker.property("camunda.cluster.size", Integer.class, 0)).isEqualTo(5);
+  }
+
+  @Test
+  void shouldEmitEmptyMapAfterClearingAllUnifiedConfigChanges() {
+    // given a broker with various unified-config changes and a refresh applied
+    final var broker = new TestStandaloneBroker();
+    broker.withClusterConfig(c -> c.setSize(3));
+    broker.withDataConfig(d -> d.setExporters(Map.of()));
+    broker.withRefreshableProperties(
+        ExtendedConfigurationBuilder.flatPropertiesFor(broker.unifiedConfig()));
+    assertThat(broker.property("camunda.cluster.size", Integer.class, 0)).isEqualTo(3);
+
+    // when all the changes are reset to defaults and refresh runs again
+    broker.withClusterConfig(c -> c.setSize(1));
+    broker.withRefreshableProperties(
+        ExtendedConfigurationBuilder.flatPropertiesFor(broker.unifiedConfig()));
+
+    // then the previously-set size is no longer present
+    assertThat(broker.property("camunda.cluster.size", Integer.class, /* sentinel */ -1))
+        .as("size now matches pristine default and should not be emitted")
+        .isEqualTo(-1);
+  }
+}


### PR DESCRIPTION
## Summary

Replace `withBean("camunda", unifiedConfig, Camunda.class)` in the test-application classes with flat-property injection so Spring constructs the `Camunda` bean through its normal `@ConfigurationProperties` binding path.

**Why this matters.** Injecting the POJO bean directly bypassed Spring's property-binding pipeline. Anything that reads `camunda.*` through the `Environment` — `@ConditionalOnProperty`, `ConfigurationPropertyName`-based scans, the relaxed-binding mechanism, etc. — saw nothing in tests. The new path puts the configured state into the environment as real properties, so property-driven knobs are now triggerable from tests just like in production.

**Follow-up unlocked.**
- `PhysicalTenantResolver` (configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolver.java) discovers tenants by walking `IterableConfigurationPropertySource` for `camunda.physical-tenants.<id>.*` keys and binds them via Spring's `Binder`. We can now extend the test apps to cover this end-to-end.
- The YAML export used by `CamundaContainer` was reworked to use the same field-based mapper as the flat properties — getters are no longer involved on either path. The workaround in #52627 (which kept getters on the YAML side) can be reverted.