### PR TITLE
Backport 52064 to stable/8.8

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -90,6 +90,7 @@ import org.springframework.security.config.Customizer;
 import org.springframework.security.config.ObjectPostProcessor;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
@@ -132,6 +133,7 @@ import org.springframework.security.web.authentication.logout.LogoutSuccessHandl
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.security.web.csrf.CsrfFilter;
 import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.security.web.firewall.StrictHttpFirewall;
 import org.springframework.security.web.header.writers.CrossOriginEmbedderPolicyHeaderWriter.CrossOriginEmbedderPolicy;
 import org.springframework.security.web.header.writers.CrossOriginOpenerPolicyHeaderWriter.CrossOriginOpenerPolicy;
 import org.springframework.security.web.header.writers.CrossOriginResourcePolicyHeaderWriter.CrossOriginResourcePolicy;
@@ -212,6 +214,21 @@ public class WebSecurityConfig {
       "camunda_authentication_external_requests";
   private static final KeyValues CAMUNDA_AUTHENTICATION_OBSERVATION_DOMAIN_IDENTITY_TAGS =
       KeyValues.of("domain", "identity");
+
+  /**
+   * Allows encoded slashes ({@code %2F}) in request URIs. Required for entity IDs containing
+   * forward slashes (e.g., OIDC group IDs like {@code /myGroup} from Keycloak). Without this, the
+   * default {@link StrictHttpFirewall} rejects any request whose URI contains {@code %2F} with a
+   * 400 error before it reaches any controller.
+   *
+   * @see <a href="https://github.com/camunda/camunda/issues/45215">Issue #45215</a>
+   */
+  @Bean
+  public WebSecurityCustomizer encodedSlashFirewallCustomizer() {
+    final var firewall = new StrictHttpFirewall();
+    firewall.setAllowUrlEncodedSlash(true);
+    return web -> web.httpFirewall(firewall);
+  }
 
   @Bean
   @Order(ORDER_UNPROTECTED)

--- a/dist/src/main/java/io/camunda/application/commons/rest/TomcatEncodedSlashConfig.java
+++ b/dist/src/main/java/io/camunda/application/commons/rest/TomcatEncodedSlashConfig.java
@@ -14,13 +14,17 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
- * Configures Tomcat to pass encoded slashes ({@code %2F}) through to the application instead of
- * rejecting them with a 400 error. This is required to support entity IDs that contain forward
- * slashes (e.g., OIDC group IDs like {@code /myGroup} from Keycloak).
+ * Configures Tomcat to decode encoded slashes ({@code %2F}) instead of rejecting them with a 400
+ * error. This is required to support entity IDs that contain forward slashes (e.g., OIDC group IDs
+ * like {@code /myGroup} from Keycloak).
  *
- * <p>Spring Boot's {@code PathPatternParser} matches on raw/encoded URI segments and only decodes
- * for {@code @PathVariable} binding, so {@code %2F} stays intact during route matching and is
- * decoded to {@code /} when bound to the Java parameter.
+ * <p>Uses {@link EncodedSolidusHandling#DECODE} rather than {@code PASS_THROUGH} because Tomcat
+ * 10.1+ rejects {@code %2F} during path normalization even in {@code PASS_THROUGH} mode. {@code
+ * DECODE} converts {@code %2F} → {@code /} at the connector level, before the normalization check.
+ *
+ * <p>Note: Spring Security's {@code StrictHttpFirewall} also rejects {@code %2F} independently. The
+ * firewall fix lives in {@code WebSecurityConfig.encodedSlashFirewallCustomizer()} (authentication
+ * module), configured via {@code WebSecurityCustomizer}.
  *
  * @see <a href="https://github.com/camunda/camunda/issues/45215">Issue #45215</a>
  */
@@ -32,7 +36,6 @@ public class TomcatEncodedSlashConfig {
     return factory ->
         factory.addConnectorCustomizers(
             connector ->
-                connector.setEncodedSolidusHandling(
-                    EncodedSolidusHandling.PASS_THROUGH.getValue()));
+                connector.setEncodedSolidusHandling(EncodedSolidusHandling.DECODE.getValue()));
   }
 }

--- a/dist/src/test/java/io/camunda/application/commons/rest/TomcatEncodedSlashConfigTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/rest/TomcatEncodedSlashConfigTest.java
@@ -21,7 +21,7 @@ import org.springframework.boot.web.server.WebServerFactoryCustomizer;
 class TomcatEncodedSlashConfigTest {
 
   @Test
-  void shouldConfigurePassthroughForEncodedSlashes() {
+  void shouldConfigureDecodeForEncodedSlashes() {
     // given
     final var config = new TomcatEncodedSlashConfig();
     final WebServerFactoryCustomizer<TomcatServletWebServerFactory> customizer =
@@ -37,6 +37,6 @@ class TomcatEncodedSlashConfigTest {
 
     final var connector = mock(Connector.class);
     captor.getValue().customize(connector);
-    verify(connector).setEncodedSolidusHandling(EncodedSolidusHandling.PASS_THROUGH.getValue());
+    verify(connector).setEncodedSolidusHandling(EncodedSolidusHandling.DECODE.getValue());
   }
 }

--- a/dist/src/test/java/io/camunda/application/it/EncodedSlashIntegrationIT.java
+++ b/dist/src/test/java/io/camunda/application/it/EncodedSlashIntegrationIT.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.application.commons.rest.TomcatEncodedSlashConfig;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import org.apache.tomcat.util.buf.EncodedSolidusHandling;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.boot.web.embedded.tomcat.TomcatConnectorCustomizer;
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.firewall.StrictHttpFirewall;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Integration test for <a href="https://github.com/camunda/camunda/issues/45215">#45215</a>.
+ * Verifies the two backend layers this PR changes — the Tomcat connector and the Spring Security
+ * firewall — accept requests whose URI contains {@code %2F}, instead of rejecting them with 400.
+ *
+ * <p>This boots a real embedded Tomcat with Spring Security enabled — NOT a MockMvc test, because
+ * MockMvc bypasses Tomcat's {@code EncodedSolidusHandling} check.
+ *
+ * <p>The Tomcat layer is configured via a {@link WebServerFactoryCustomizer} bean (mirroring
+ * production wiring in {@link TomcatEncodedSlashConfig}), not via the {@code
+ * server.tomcat.encoded-solidus-handling} property.
+ *
+ * <p><b>Scope:</b> this fix targets the {@code consolidated-auth} profile's {@code
+ * WebSecurityConfig}. Optimize defines independent Spring Security configurations ({@code
+ * CCSaaSSecurityConfigurerAdapter}, {@code CCSMSecurityConfigurerAdapter}) running in their own
+ * application contexts; an equivalent customizer would be needed there if Optimize ever exposes
+ * path-variable entity IDs sourced from OIDC.
+ *
+ * <p><b>What this test does NOT assert:</b> the exact value of {@code @PathVariable} after binding.
+ * On stable/8.8 the production matching strategy is {@code AntPathMatcher} (set in {@code
+ * application.properties}), which collapses {@code //} during URI normalization and may strip the
+ * leading {@code /} from the path-bound entity ID. End-to-end behavior on 8.8 — including the value
+ * Camunda stores for the assigned group — must be verified manually with the reproduction script in
+ * PR #52064.
+ */
+@SpringBootTest(
+    webEnvironment = WebEnvironment.RANDOM_PORT,
+    classes = EncodedSlashIntegrationIT.TestConfig.class)
+class EncodedSlashIntegrationIT {
+
+  @LocalServerPort private int port;
+
+  @Test
+  void shouldAcceptEncodedSlashAtTomcatAndFirewallLayers() throws Exception {
+    // given — a group ID with a forward slash, encoded as %2F (what the Identity UI sends)
+    // when
+    final var response = sendPut("/v2/roles/admin/groups/%2FmyGroup");
+
+    // then — neither Tomcat nor Spring Security's StrictHttpFirewall rejects the request with 400
+    assertThat(response.statusCode())
+        .as("Tomcat (DECODE) and StrictHttpFirewall (allowUrlEncodedSlash) should let %2F through")
+        .isNotEqualTo(400);
+  }
+
+  @Test
+  void shouldAcceptNestedEncodedSlashesAtTomcatAndFirewallLayers() throws Exception {
+    // given — nested Keycloak group: /org/team/engineering
+    final var response = sendPut("/v2/roles/admin/groups/%2Forg%2Fteam%2Fengineering");
+
+    // then
+    assertThat(response.statusCode()).isNotEqualTo(400);
+  }
+
+  @Test
+  void shouldAcceptEncodedSlashOnGetEndpoint() throws Exception {
+    // given
+    final var response = sendGet("/v2/groups/%2FmyGroup");
+
+    // then
+    assertThat(response.statusCode()).isNotEqualTo(400);
+  }
+
+  @Test
+  void shouldHandleNormalGroupIdWithoutSlash() throws Exception {
+    // given — a normal group ID (no slashes) should still be routed and bound correctly
+    final var response = sendPut("/v2/roles/admin/groups/normalGroup");
+
+    // then
+    assertThat(response.statusCode()).isEqualTo(200);
+    assertThat(response.body()).isEqualTo("normalGroup");
+  }
+
+  private HttpResponse<String> sendPut(final String path) throws Exception {
+    return sendRequest(path, "PUT");
+  }
+
+  private HttpResponse<String> sendGet(final String path) throws Exception {
+    return sendRequest(path, "GET");
+  }
+
+  private HttpResponse<String> sendRequest(final String path, final String method)
+      throws Exception {
+    try (var client = HttpClient.newHttpClient()) {
+      final var request =
+          HttpRequest.newBuilder()
+              .uri(URI.create("http://localhost:" + port + path))
+              .method(method, HttpRequest.BodyPublishers.noBody())
+              .build();
+      return client.send(request, HttpResponse.BodyHandlers.ofString());
+    }
+  }
+
+  /**
+   * Minimal Spring Boot context: embedded Tomcat + Spring Security + test controller. Mirrors the
+   * two production beans that must cooperate for encoded slashes to work:
+   *
+   * <ol>
+   *   <li>{@link TomcatEncodedSlashConfig} — Tomcat connector layer
+   *   <li>{@code WebSecurityConfig.encodedSlashFirewallCustomizer()} — Spring Security layer
+   * </ol>
+   *
+   * <p>We don't import the full {@code WebSecurityConfig} because it requires the entire Camunda
+   * service layer. Instead we replicate just the firewall customizer bean inline.
+   */
+  @SpringBootConfiguration
+  @EnableAutoConfiguration
+  @EnableWebSecurity
+  static class TestConfig {
+
+    /** Tomcat layer: allow %2F through instead of rejecting with 400. */
+    @Bean
+    public WebServerFactoryCustomizer<TomcatServletWebServerFactory> encodedSlashCustomizer() {
+      return factory ->
+          factory.addConnectorCustomizers(
+              (TomcatConnectorCustomizer)
+                  connector -> {
+                    // DECODE converts %2F → / at the Tomcat level (before Spring MVC).
+                    // PASS_THROUGH keeps %2F in the URI but Tomcat 10.1+ still rejects it during
+                    // path normalization. DECODE avoids this by decoding before the check.
+                    connector.setEncodedSolidusHandling(EncodedSolidusHandling.DECODE.getValue());
+                  });
+    }
+
+    /** Spring Security layer: allow %2F through the firewall. */
+    @Bean
+    public WebSecurityCustomizer encodedSlashFirewallCustomizer() {
+      final var firewall = new StrictHttpFirewall();
+      firewall.setAllowUrlEncodedSlash(true);
+      return web -> web.httpFirewall(firewall);
+    }
+
+    @Bean
+    public SecurityFilterChain permitAll(final HttpSecurity http) throws Exception {
+      return http.authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+          .csrf(csrf -> csrf.disable())
+          .build();
+    }
+
+    @Bean
+    public EncodedSlashTestController encodedSlashTestController() {
+      return new EncodedSlashTestController();
+    }
+  }
+
+  /** Stub controller that echoes the decoded {@code @PathVariable} value. */
+  @RestController
+  static class EncodedSlashTestController {
+
+    @PutMapping("/v2/roles/{roleId}/groups/{groupId}")
+    public ResponseEntity<String> assignGroup(
+        @PathVariable final String roleId, @PathVariable final String groupId) {
+      return ResponseEntity.ok(groupId);
+    }
+
+    @GetMapping("/v2/groups/{groupId}")
+    public ResponseEntity<String> getGroup(@PathVariable final String groupId) {
+      return ResponseEntity.ok(groupId);
+    }
+  }
+}


### PR DESCRIPTION
## Description

⤵️ Backport of #52064 → `stable/8.8`

relates to camunda/camunda#45215 #48668 #45215

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
