### PR TITLE
fix: Corrected wrong x-added-in-version for GET /resources/{resourceKey}/content/binary, 8.11 -> 8.10

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/deployments.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/deployments.yaml
@@ -166,7 +166,7 @@ paths:
                 $ref: "problem-detail.yaml#/components/schemas/ProblemDetail"
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
-      x-added-in-version: "8.11"
+      x-added-in-version: "8.10"
 
   /resources/search:
     post:


### PR DESCRIPTION
## Description

Corrected wrong `x-added-in-version` for `GET /resources/{resourceKey}/content/binary`, `8.11 -> 8.10`.
`x-added-in-version` can't be 8.11 till 8.10 is released.

## Related issues

closes #52924
