### PR TITLE
ci: unblock Renovate by removing prCreation throttle and raising branch cap

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,6 +11,7 @@
   ],
   "dependencyDashboard": true,
   "prConcurrentLimit": 50,
+  "branchConcurrentLimit": 100,
   "prHourlyLimit": 10,
   "updateNotScheduled": false,
   "schedule": [
@@ -581,7 +582,6 @@
       "description": "Prevent supply-chain-attacks by not creating branches or PRs before the minimum release age.",
       "matchPackageNames": ["*"],
       "minimumReleaseAge": "3 days",
-      "prCreation": "not-pending",
       "internalChecksFilter": "strict"
     }
   ],


### PR DESCRIPTION
## Summary

Related [slack thread](https://camunda.slack.com/archives/C071KP5BTHB/p1778585261347399)

Renovate PR throughput collapsed from ~10–16 PRs/day in April to 1–2/day since late April. Investigation traced this to two settings introduced in #50101:

- `prCreation: "not-pending"` holds each renovate branch ~24h waiting for status checks that never appear, because CI does not run on `push` to `renovate/*` branches (workflows only `push`-trigger on `main`/`stable/*`/`release-*`).
- The implicit `branchConcurrentLimit` (inherited from `prConcurrentLimit: 50`) then saturated at ~54 active branches, blocking new candidates with `branch-limit-reached` (which the Dependency Dashboard surfaces as "Rate-Limited").

### Changes

- Remove `prCreation: "not-pending"` so branches convert to PRs immediately.
- Set `branchConcurrentLimit: 100` explicitly to decouple branch capacity from PR review capacity.
- Keep the `minimumReleaseAge: 3 days` and `internalChecksFilter: "strict"` supply-chain protections.

### Expected effect

- Next Renovate run: the 30 stuck "Other Branches" open as PRs, and rate-limited candidates start creating branches again.
- Next 24–48h: open PR count temporarily spikes as the backlog flushes, then settles as auto-merge processes them.
- Steady state returns to pre-#50101 throughput.

## Test plan

- [ ] Monitor [Dependency Dashboard #12605](https://github.com/camunda/camunda/issues/12605) for the next scheduled Renovate run — confirm "Rate-Limited" count starts dropping and stuck "Other Branches" become PRs.
- [ ] Check open Renovate PR count over the next 24–48h — expect a temporary spike followed by settling as auto-merge clears the backlog.