### PR TITLE
fix: opensearch 3.6.0 missing getMillis()

### DIFF
--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/TaskStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/TaskStoreOpenSearch.java
@@ -858,7 +858,7 @@ public class TaskStoreOpenSearch implements TaskStore {
                     + "}else{"
                     + "doc['"
                     + field
-                    + "'].value.getMillis().toString()"
+                    + "'].value.toInstant().toEpochMilli().toString()"
                     + "}"));
     return s ->
         s.script(


### PR DESCRIPTION
## Description

Issue identified in opensearch `3.6.0`
Replace `.getMillis()` with `.toInstant().toEpochMilli()`
Backwards compatible with `2.19.x` opensearch

## Related issues

closes #52851

slack discussion ([ref](https://camunda.slack.com/archives/C08MRKHJ0CD/p1778577137170889))
