### PR TITLE
feat: introduce `BrokerId` subclass of MemberId

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -113,7 +113,7 @@ public class ClusterEndpoint {
           ClusterApiUtils.mapOperationResponse(
               requestSender
                   .addMembers(
-                      new AddMembersRequest(Set.of(new MemberId(String.valueOf(id))), dryRun))
+                      new AddMembersRequest(Set.of(MemberId.from(String.valueOf(id))), dryRun))
                   .join());
       case partitions -> ResponseEntity.status(501).body("Adding partitions is not supported");
       case changes ->
@@ -132,7 +132,7 @@ public class ClusterEndpoint {
       case brokers ->
           ClusterApiUtils.mapOperationResponse(
               requestSender
-                  .removeMembers(new RemoveMembersRequest(Set.of(new MemberId(id)), dryRun))
+                  .removeMembers(new RemoveMembersRequest(Set.of(MemberId.from(id)), dryRun))
                   .join());
       case partitions -> ResponseEntity.status(501).body("Removing partitions is not supported");
       case changes -> {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/BrokerId.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/BrokerId.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.atomix.cluster;
+
+import java.util.Objects;
+import org.jspecify.annotations.Nullable;
+
+/** Guarantees that this MemberId is from a zeebe broker, not any other applications. */
+public class BrokerId extends MemberId {
+
+  BrokerId(final @Nullable String zone, final int nodeIdx, final String id) {
+    super(zone, nodeIdx, Objects.requireNonNull(id));
+    if (!buildMemberIdString(zone, nodeIdx).equals(id)) {
+      throw new IllegalArgumentException(
+          "Expected id to be consistent with zone & nodeIdx, but they are: zone=%s, nodeIdx=%d, id=%s"
+              .formatted(zone, nodeIdx, id));
+    }
+  }
+}

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/MemberId.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/MemberId.java
@@ -28,35 +28,17 @@ public class MemberId extends NodeId {
    * Null when the member is anonymous When a zone is present, this is the node index in the local
    * cluster (e.g. 0, 1, 2, 3...) If a zone is not present, it's equal to the id
    */
-  private final @Nullable Integer nodeIdx;
+  protected final @Nullable Integer nodeIdx;
 
   /** Null when the member is not zone aware */
-  private final @Nullable String zone;
+  protected final @Nullable String zone;
 
   // id must be created in the factory method as it's a required argument of the super constructor
-  private MemberId(final @Nullable String zone, final @Nullable Integer nodeIdx, final String id) {
+  protected MemberId(
+      final @Nullable String zone, final @Nullable Integer nodeIdx, final String id) {
     super(id);
     this.nodeIdx = validateNodeIdx(nodeIdx);
     this.zone = validateZone(zone);
-  }
-
-  public MemberId(final String id) {
-    super(id);
-    final var parts = id.split("/");
-    if (parts.length > 2) {
-      throw new IllegalArgumentException("Expected id to be of the form $zone/$id, but got " + id);
-    } else if (parts.length == 2) {
-      zone = parts[0];
-      nodeIdx = tryParseInt(parts[1]);
-    } else if (parts.length == 1) {
-      zone = null;
-      nodeIdx = tryParseInt(parts[0]);
-    } else {
-      throw new IllegalArgumentException(
-          "Expected id to be of the form $zone/$id or $id, but got " + id);
-    }
-    validateZone(zone);
-    validateNodeIdx(nodeIdx);
   }
 
   /**
@@ -75,7 +57,26 @@ public class MemberId extends NodeId {
    * @return node id
    */
   public static MemberId from(final String id) {
-    return new MemberId(id);
+    final Integer nodeIdx;
+    final String zone;
+    final var parts = id.split("/");
+    if (parts.length > 2) {
+      throw new IllegalArgumentException("Expected id to be of the form $zone/$id, but got " + id);
+    } else if (parts.length == 2) {
+      zone = parts[0];
+      nodeIdx = tryParseInt(parts[1]);
+    } else if (parts.length == 1) {
+      zone = null;
+      nodeIdx = tryParseInt(parts[0]);
+    } else {
+      throw new IllegalArgumentException(
+          "Expected id to be of the form $zone/$id or $id, but got " + id);
+    }
+    if (nodeIdx != null) {
+      return new BrokerId(zone, nodeIdx, id);
+    } else {
+      return new MemberId(zone, null, id);
+    }
   }
 
   /**
@@ -85,7 +86,7 @@ public class MemberId extends NodeId {
    * it is {@code "$zone/$nodeId"}. Leading/trailing whitespace is stripped from {@code zone}.
    */
   public static MemberId from(final @Nullable String zone, final int nodeId) {
-    return new MemberId(zone, nodeId, buildMemberIdString(zone, nodeId));
+    return new BrokerId(zone, nodeId, buildMemberIdString(zone, nodeId));
   }
 
   public int nodeIdx() {
@@ -106,21 +107,24 @@ public class MemberId extends NodeId {
     return Objects.equals(this.zone, zone);
   }
 
-  private static @Nullable Integer validateNodeIdx(final @Nullable Integer nodeIdx) {
+  protected static @Nullable Integer validateNodeIdx(final @Nullable Integer nodeIdx) {
     if (nodeIdx != null && nodeIdx < 0) {
       throw new IllegalArgumentException("Expected nodeIdx to be >= 0, but got " + nodeIdx);
     }
     return nodeIdx;
   }
 
-  private static @Nullable String validateZone(final @Nullable String zone) {
+  protected static @Nullable String validateZone(final @Nullable String zone) {
     if (zone != null && zone.isBlank()) {
       throw new IllegalArgumentException("Expected zone to be non-empty, but was empty");
+    }
+    if (zone != null && zone.contains("/")) {
+      throw new IllegalArgumentException("Expected zone to not contain a '/', but was " + zone);
     }
     return zone != null ? zone.strip() : null;
   }
 
-  private static String buildMemberIdString(final @Nullable String zone, final int nodeIdx) {
+  protected static String buildMemberIdString(final @Nullable String zone, final int nodeIdx) {
     if (zone == null) {
       return Integer.toString(nodeIdx);
     } else {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/NodeId.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/NodeId.java
@@ -34,7 +34,7 @@ public class NodeId extends AbstractIdentifier<String> implements Comparable<Nod
    * @param id string identifier
    */
   public NodeId(final String id) {
-    super(id);
+    super(Objects.requireNonNull(id));
   }
 
   /**

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/MemberIdTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/MemberIdTest.java
@@ -162,6 +162,7 @@ final class MemberIdTest {
   }
 
   private void assertEncodeDecode(final MemberId memberId) {
-    assertThat(MemberId.from(memberId.id())).isEqualTo(memberId);
+    final var decoded = MemberId.from(memberId.id());
+    assertThat(decoded).isEqualTo(memberId).returns(memberId.hashCode(), MemberId::hashCode);
   }
 }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/MemberIdTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/MemberIdTest.java
@@ -34,7 +34,9 @@ final class MemberIdTest {
 
     // then
 
+    assertEncodeDecode(memberId);
     assertThat(memberId)
+        .isInstanceOf(BrokerId.class)
         .returns(7, MemberId::nodeIdx)
         .returns(null, MemberId::zone)
         .returns("7", MemberId::id);
@@ -53,12 +55,23 @@ final class MemberIdTest {
   }
 
   @Test
+  void shouldThrowWhenZoneContainsASlash() {
+    // given / when / then
+    assertThatThrownBy(() -> MemberId.from("us-east1/b/7"))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> MemberId.from("us-east1/b", 7))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
   void shouldStripSurroundingWhitespaceFromZone() {
     // given / when
     final var memberId = MemberId.from("  eu-west  ", 7);
 
     // then
+    assertEncodeDecode(memberId);
     assertThat(memberId)
+        .isInstanceOf(BrokerId.class)
         .returns(7, MemberId::nodeIdx)
         .returns("eu-west", MemberId::zone)
         .returns("eu-west/7", MemberId::id);
@@ -70,7 +83,9 @@ final class MemberIdTest {
     final var memberId = MemberId.from("us-east", 7);
 
     // then
+    assertEncodeDecode(memberId);
     assertThat(memberId)
+        .isInstanceOf(BrokerId.class)
         .returns(7, MemberId::nodeIdx)
         .returns("us-east", MemberId::zone)
         .returns("us-east/7", MemberId::id);
@@ -82,7 +97,11 @@ final class MemberIdTest {
     final var memberId = MemberId.from("3");
 
     // when / then
-    assertThat(memberId).returns(3, MemberId::nodeIdx).returns(null, MemberId::zone);
+    assertEncodeDecode(memberId);
+    assertThat(memberId)
+        .isInstanceOf(BrokerId.class)
+        .returns(3, MemberId::nodeIdx)
+        .returns(null, MemberId::zone);
   }
 
   @Test
@@ -91,7 +110,9 @@ final class MemberIdTest {
     final var memberId = MemberId.from("us-east/12");
 
     // when / then
+    assertEncodeDecode(memberId);
     assertThat(memberId)
+        .isInstanceOf(BrokerId.class)
         .returns(12, MemberId::nodeIdx)
         .returns("us-east", MemberId::zone)
         .returns("us-east/12", MemberId::id);
@@ -103,6 +124,7 @@ final class MemberIdTest {
     final var memberId = MemberId.from("anonymous");
 
     // when / then
+    assertEncodeDecode(memberId);
     assertThatThrownBy(memberId::nodeIdx).isInstanceOf(IllegalStateException.class);
   }
 
@@ -137,5 +159,9 @@ final class MemberIdTest {
     // then
     assertThatThrownBy(() -> Member.builder(memberId).withZoneId("us").build())
         .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  private void assertEncodeDecode(final MemberId memberId) {
+    assertThat(MemberId.from(memberId.id())).isEqualTo(memberId);
   }
 }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/cluster/impl/RaftClusterContextTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/cluster/impl/RaftClusterContextTest.java
@@ -35,11 +35,11 @@ final class RaftClusterContextTest {
   @Test
   void shouldConfigureFromStored() {
     // given
-    final var localMember = new DefaultRaftMember(new MemberId("1"), Type.ACTIVE, Instant.now());
+    final var localMember = new DefaultRaftMember(MemberId.from("1"), Type.ACTIVE, Instant.now());
     final var remoteMembers =
         List.<RaftMember>of(
-            new DefaultRaftMember(new MemberId("2"), Type.ACTIVE, Instant.now()),
-            new DefaultRaftMember(new MemberId("3"), Type.ACTIVE, Instant.now()));
+            new DefaultRaftMember(MemberId.from("2"), Type.ACTIVE, Instant.now()),
+            new DefaultRaftMember(MemberId.from("3"), Type.ACTIVE, Instant.now()));
     final var members = Stream.concat(Stream.of(localMember), remoteMembers.stream()).toList();
 
     final var configuration = new Configuration(1, 1, Instant.now().toEpochMilli(), members);
@@ -68,11 +68,11 @@ final class RaftClusterContextTest {
   @Test
   void shouldReconfigureOverStored() {
     // given -- stored configuration that only contains the local member
-    final var localMember = new DefaultRaftMember(new MemberId("1"), Type.ACTIVE, Instant.now());
+    final var localMember = new DefaultRaftMember(MemberId.from("1"), Type.ACTIVE, Instant.now());
     final var remoteMembers =
         List.<RaftMember>of(
-            new DefaultRaftMember(new MemberId("2"), Type.ACTIVE, Instant.now()),
-            new DefaultRaftMember(new MemberId("3"), Type.ACTIVE, Instant.now()));
+            new DefaultRaftMember(MemberId.from("2"), Type.ACTIVE, Instant.now()),
+            new DefaultRaftMember(MemberId.from("3"), Type.ACTIVE, Instant.now()));
     final var members = Stream.concat(Stream.of(localMember), remoteMembers.stream()).toList();
 
     final var raft =
@@ -105,11 +105,11 @@ final class RaftClusterContextTest {
   @Test
   void shouldRemoveContextsOnReconfiguration() {
     // given -- stored configuration that contains all members
-    final var localMember = new DefaultRaftMember(new MemberId("1"), Type.ACTIVE, Instant.now());
+    final var localMember = new DefaultRaftMember(MemberId.from("1"), Type.ACTIVE, Instant.now());
     final var remoteMembers =
         List.<RaftMember>of(
-            new DefaultRaftMember(new MemberId("2"), Type.ACTIVE, Instant.now()),
-            new DefaultRaftMember(new MemberId("3"), Type.ACTIVE, Instant.now()));
+            new DefaultRaftMember(MemberId.from("2"), Type.ACTIVE, Instant.now()),
+            new DefaultRaftMember(MemberId.from("3"), Type.ACTIVE, Instant.now()));
     final var members = Stream.concat(Stream.of(localMember), remoteMembers.stream()).toList();
 
     final var raft =
@@ -136,11 +136,11 @@ final class RaftClusterContextTest {
   @Test
   void shouldUpdateMemberType() {
     // given -- stored configuration that contains all members
-    final var localMember = new DefaultRaftMember(new MemberId("1"), Type.ACTIVE, Instant.now());
+    final var localMember = new DefaultRaftMember(MemberId.from("1"), Type.ACTIVE, Instant.now());
     final var oldRemoteMembers =
         List.<RaftMember>of(
-            new DefaultRaftMember(new MemberId("2"), Type.ACTIVE, Instant.now()),
-            new DefaultRaftMember(new MemberId("3"), Type.ACTIVE, Instant.now()));
+            new DefaultRaftMember(MemberId.from("2"), Type.ACTIVE, Instant.now()),
+            new DefaultRaftMember(MemberId.from("3"), Type.ACTIVE, Instant.now()));
     final var oldMembers =
         Stream.concat(Stream.of(localMember), oldRemoteMembers.stream()).toList();
 
@@ -151,11 +151,12 @@ final class RaftClusterContextTest {
     context.bootstrap(List.of()).join();
 
     // when -- reconfigure with a new configuration only contains the local member
-    final var newLocalMember = new DefaultRaftMember(new MemberId("1"), Type.ACTIVE, Instant.now());
+    final var newLocalMember =
+        new DefaultRaftMember(MemberId.from("1"), Type.ACTIVE, Instant.now());
     final var newRemoteMembers =
         List.<RaftMember>of(
-            new DefaultRaftMember(new MemberId("2"), Type.PASSIVE, Instant.now()),
-            new DefaultRaftMember(new MemberId("3"), Type.PASSIVE, Instant.now()));
+            new DefaultRaftMember(MemberId.from("2"), Type.PASSIVE, Instant.now()),
+            new DefaultRaftMember(MemberId.from("3"), Type.PASSIVE, Instant.now()));
     final var newMembers =
         Stream.concat(Stream.of(newLocalMember), newRemoteMembers.stream()).toList();
 
@@ -176,11 +177,11 @@ final class RaftClusterContextTest {
   @Test
   void shouldCountVoteFromLocalMember() {
     // given
-    final var localMember = new DefaultRaftMember(new MemberId("1"), Type.ACTIVE, Instant.now());
+    final var localMember = new DefaultRaftMember(MemberId.from("1"), Type.ACTIVE, Instant.now());
     final var remoteMembers =
         List.<RaftMember>of(
-            new DefaultRaftMember(new MemberId("2"), Type.ACTIVE, Instant.now()),
-            new DefaultRaftMember(new MemberId("3"), Type.ACTIVE, Instant.now()));
+            new DefaultRaftMember(MemberId.from("2"), Type.ACTIVE, Instant.now()),
+            new DefaultRaftMember(MemberId.from("3"), Type.ACTIVE, Instant.now()));
     final var members = Stream.concat(Stream.of(localMember), remoteMembers.stream()).toList();
 
     final var raft =
@@ -192,7 +193,7 @@ final class RaftClusterContextTest {
     final Consumer<Boolean> callback = mock();
     final var quorum = context.getVoteQuorum(callback);
 
-    quorum.succeed(new MemberId("2"));
+    quorum.succeed(MemberId.from("2"));
 
     // then
     verify(callback).accept(true);
@@ -201,17 +202,17 @@ final class RaftClusterContextTest {
   @Test
   void shouldRequireJointConsensusVotes() {
     // given
-    final var localMember = new DefaultRaftMember(new MemberId("1"), Type.ACTIVE, Instant.now());
+    final var localMember = new DefaultRaftMember(MemberId.from("1"), Type.ACTIVE, Instant.now());
     final var oldRemoteMembers =
         List.<RaftMember>of(
-            new DefaultRaftMember(new MemberId("2"), Type.ACTIVE, Instant.now()),
-            new DefaultRaftMember(new MemberId("3"), Type.ACTIVE, Instant.now()));
+            new DefaultRaftMember(MemberId.from("2"), Type.ACTIVE, Instant.now()),
+            new DefaultRaftMember(MemberId.from("3"), Type.ACTIVE, Instant.now()));
     final var oldMembers =
         Stream.concat(Stream.of(localMember), oldRemoteMembers.stream()).toList();
     final var newRemoteMembers =
         List.<RaftMember>of(
-            new DefaultRaftMember(new MemberId("2"), Type.ACTIVE, Instant.now()),
-            new DefaultRaftMember(new MemberId("4"), Type.ACTIVE, Instant.now()));
+            new DefaultRaftMember(MemberId.from("2"), Type.ACTIVE, Instant.now()),
+            new DefaultRaftMember(MemberId.from("4"), Type.ACTIVE, Instant.now()));
     final var newMembers =
         Stream.concat(Stream.of(localMember), newRemoteMembers.stream()).toList();
 
@@ -226,23 +227,23 @@ final class RaftClusterContextTest {
     final var quorum = context.getVoteQuorum(callback);
 
     // then
-    quorum.succeed(new MemberId("4"));
+    quorum.succeed(MemberId.from("4"));
     verifyNoInteractions(callback);
 
-    quorum.succeed(new MemberId("2"));
+    quorum.succeed(MemberId.from("2"));
     verify(callback).accept(true);
   }
 
   @Test
   void shouldCalculateQuorum() {
     // given
-    final var localMember = new DefaultRaftMember(new MemberId("1"), Type.ACTIVE, Instant.now());
+    final var localMember = new DefaultRaftMember(MemberId.from("1"), Type.ACTIVE, Instant.now());
     final var remoteMembers =
         List.<RaftMember>of(
-            new DefaultRaftMember(new MemberId("2"), Type.ACTIVE, Instant.now()),
-            new DefaultRaftMember(new MemberId("3"), Type.ACTIVE, Instant.now()),
-            new DefaultRaftMember(new MemberId("4"), Type.ACTIVE, Instant.now()),
-            new DefaultRaftMember(new MemberId("5"), Type.ACTIVE, Instant.now()));
+            new DefaultRaftMember(MemberId.from("2"), Type.ACTIVE, Instant.now()),
+            new DefaultRaftMember(MemberId.from("3"), Type.ACTIVE, Instant.now()),
+            new DefaultRaftMember(MemberId.from("4"), Type.ACTIVE, Instant.now()),
+            new DefaultRaftMember(MemberId.from("5"), Type.ACTIVE, Instant.now()));
     final var members = Stream.concat(Stream.of(localMember), remoteMembers.stream()).toList();
 
     final var raft =
@@ -251,10 +252,10 @@ final class RaftClusterContextTest {
     context.bootstrap(List.of()).join();
 
     // when
-    context.getMemberContext(new MemberId("2")).setMatchIndex(2);
-    context.getMemberContext(new MemberId("3")).setMatchIndex(3);
-    context.getMemberContext(new MemberId("4")).setMatchIndex(4);
-    context.getMemberContext(new MemberId("5")).setMatchIndex(5);
+    context.getMemberContext(MemberId.from("2")).setMatchIndex(2);
+    context.getMemberContext(MemberId.from("3")).setMatchIndex(3);
+    context.getMemberContext(MemberId.from("4")).setMatchIndex(4);
+    context.getMemberContext(MemberId.from("5")).setMatchIndex(5);
 
     // then
     assertThat(context.getQuorumFor(RaftMemberContext::getMatchIndex)).hasValue(4L);
@@ -263,11 +264,11 @@ final class RaftClusterContextTest {
   @Test
   void shouldNotIncludeLocalMemberInQuorumWhenItIsNotPartOfNewConfiguration() {
     // given
-    final var localMember = new DefaultRaftMember(new MemberId("1"), Type.ACTIVE, Instant.now());
+    final var localMember = new DefaultRaftMember(MemberId.from("1"), Type.ACTIVE, Instant.now());
     final var remoteMembers =
         List.<RaftMember>of(
-            new DefaultRaftMember(new MemberId("2"), Type.ACTIVE, Instant.now()),
-            new DefaultRaftMember(new MemberId("3"), Type.ACTIVE, Instant.now()));
+            new DefaultRaftMember(MemberId.from("2"), Type.ACTIVE, Instant.now()),
+            new DefaultRaftMember(MemberId.from("3"), Type.ACTIVE, Instant.now()));
 
     final var raft =
         raftWithStoredConfiguration(
@@ -276,8 +277,8 @@ final class RaftClusterContextTest {
     context.bootstrap(List.of()).join();
 
     // when
-    context.getMemberContext(new MemberId("2")).setMatchIndex(2);
-    context.getMemberContext(new MemberId("3")).setMatchIndex(3);
+    context.getMemberContext(MemberId.from("2")).setMatchIndex(2);
+    context.getMemberContext(MemberId.from("3")).setMatchIndex(3);
 
     // then
     assertThat(context.getQuorumFor(RaftMemberContext::getMatchIndex)).hasValue(2L);
@@ -286,17 +287,17 @@ final class RaftClusterContextTest {
   @Test
   void quorumWhenNewMembersAreAhead() {
     // given
-    final var localMember = new DefaultRaftMember(new MemberId("1"), Type.ACTIVE, Instant.now());
+    final var localMember = new DefaultRaftMember(MemberId.from("1"), Type.ACTIVE, Instant.now());
     final var oldRemoteMembers =
         List.<RaftMember>of(
-            new DefaultRaftMember(new MemberId("2"), Type.ACTIVE, Instant.now()),
-            new DefaultRaftMember(new MemberId("3"), Type.ACTIVE, Instant.now()));
+            new DefaultRaftMember(MemberId.from("2"), Type.ACTIVE, Instant.now()),
+            new DefaultRaftMember(MemberId.from("3"), Type.ACTIVE, Instant.now()));
     final var oldMembers =
         Stream.concat(Stream.of(localMember), oldRemoteMembers.stream()).toList();
     final var newRemoteMembers =
         List.<RaftMember>of(
-            new DefaultRaftMember(new MemberId("2"), Type.ACTIVE, Instant.now()),
-            new DefaultRaftMember(new MemberId("4"), Type.ACTIVE, Instant.now()));
+            new DefaultRaftMember(MemberId.from("2"), Type.ACTIVE, Instant.now()),
+            new DefaultRaftMember(MemberId.from("4"), Type.ACTIVE, Instant.now()));
     final var newMembers =
         Stream.concat(Stream.of(localMember), newRemoteMembers.stream()).toList();
 
@@ -322,17 +323,17 @@ final class RaftClusterContextTest {
   @Test
   void quorumWhenOldMembersAreAhead() {
     // given
-    final var localMember = new DefaultRaftMember(new MemberId("1"), Type.ACTIVE, Instant.now());
+    final var localMember = new DefaultRaftMember(MemberId.from("1"), Type.ACTIVE, Instant.now());
     final var oldRemoteMembers =
         List.<RaftMember>of(
-            new DefaultRaftMember(new MemberId("2"), Type.ACTIVE, Instant.now()),
-            new DefaultRaftMember(new MemberId("3"), Type.ACTIVE, Instant.now()));
+            new DefaultRaftMember(MemberId.from("2"), Type.ACTIVE, Instant.now()),
+            new DefaultRaftMember(MemberId.from("3"), Type.ACTIVE, Instant.now()));
     final var oldMembers =
         Stream.concat(Stream.of(localMember), oldRemoteMembers.stream()).toList();
     final var newRemoteMembers =
         List.<RaftMember>of(
-            new DefaultRaftMember(new MemberId("4"), Type.ACTIVE, Instant.now()),
-            new DefaultRaftMember(new MemberId("5"), Type.ACTIVE, Instant.now()));
+            new DefaultRaftMember(MemberId.from("4"), Type.ACTIVE, Instant.now()),
+            new DefaultRaftMember(MemberId.from("5"), Type.ACTIVE, Instant.now()));
     final var newMembers =
         Stream.concat(Stream.of(localMember), newRemoteMembers.stream()).toList();
 
@@ -358,11 +359,11 @@ final class RaftClusterContextTest {
   @Test
   void quorumWhenClusterBecomesSingleMember() {
     // given
-    final var localMember = new DefaultRaftMember(new MemberId("1"), Type.ACTIVE, Instant.now());
+    final var localMember = new DefaultRaftMember(MemberId.from("1"), Type.ACTIVE, Instant.now());
     final var oldRemoteMembers =
         List.<RaftMember>of(
-            new DefaultRaftMember(new MemberId("2"), Type.ACTIVE, Instant.now()),
-            new DefaultRaftMember(new MemberId("3"), Type.ACTIVE, Instant.now()));
+            new DefaultRaftMember(MemberId.from("2"), Type.ACTIVE, Instant.now()),
+            new DefaultRaftMember(MemberId.from("3"), Type.ACTIVE, Instant.now()));
     final var oldMembers =
         Stream.concat(Stream.of(localMember), oldRemoteMembers.stream()).toList();
     final var newMembers = List.<RaftMember>of(localMember);
@@ -386,11 +387,11 @@ final class RaftClusterContextTest {
   @Test
   void quorumWhenClusterWasSingleMember() {
     // given
-    final var localMember = new DefaultRaftMember(new MemberId("1"), Type.ACTIVE, Instant.now());
+    final var localMember = new DefaultRaftMember(MemberId.from("1"), Type.ACTIVE, Instant.now());
     final var newRemoteMembers =
         List.<RaftMember>of(
-            new DefaultRaftMember(new MemberId("2"), Type.ACTIVE, Instant.now()),
-            new DefaultRaftMember(new MemberId("3"), Type.ACTIVE, Instant.now()));
+            new DefaultRaftMember(MemberId.from("2"), Type.ACTIVE, Instant.now()),
+            new DefaultRaftMember(MemberId.from("3"), Type.ACTIVE, Instant.now()));
     final var newMembers =
         Stream.concat(Stream.of(localMember), newRemoteMembers.stream()).toList();
     final var oldMembers = List.<RaftMember>of(localMember);
@@ -414,7 +415,7 @@ final class RaftClusterContextTest {
   @Test
   void demotedMemberIsNotVoting() {
     // given
-    final var localMember = new DefaultRaftMember(new MemberId("1"), Type.ACTIVE, Instant.now());
+    final var localMember = new DefaultRaftMember(MemberId.from("1"), Type.ACTIVE, Instant.now());
 
     final var initialConfiguration =
         new Configuration(
@@ -423,8 +424,8 @@ final class RaftClusterContextTest {
             Instant.now().toEpochMilli(),
             List.of(
                 localMember,
-                new DefaultRaftMember(new MemberId("2"), Type.ACTIVE, Instant.now()),
-                new DefaultRaftMember(new MemberId("3"), Type.ACTIVE, Instant.now())));
+                new DefaultRaftMember(MemberId.from("2"), Type.ACTIVE, Instant.now()),
+                new DefaultRaftMember(MemberId.from("3"), Type.ACTIVE, Instant.now())));
     final var raft = raftWithStoredConfiguration(initialConfiguration);
     final var context = new RaftClusterContext(localMember.memberId(), raft);
     context.bootstrap(List.of()).join();
@@ -437,20 +438,20 @@ final class RaftClusterContextTest {
             Instant.now().toEpochMilli(),
             List.of(
                 localMember,
-                new DefaultRaftMember(new MemberId("2"), Type.ACTIVE, Instant.now()),
-                new DefaultRaftMember(new MemberId("3"), Type.PASSIVE, Instant.now())),
+                new DefaultRaftMember(MemberId.from("2"), Type.ACTIVE, Instant.now()),
+                new DefaultRaftMember(MemberId.from("3"), Type.PASSIVE, Instant.now())),
             List.of());
     context.configure(newConfiguration);
 
     // then -- member 3 is no longer a voting member
     assertThat(context.getVotingMembers())
-        .containsExactly(new DefaultRaftMember(new MemberId("2"), Type.ACTIVE, Instant.now()));
+        .containsExactly(new DefaultRaftMember(MemberId.from("2"), Type.ACTIVE, Instant.now()));
   }
 
   @Test
   void shouldKeepMembersWithHighestType() {
     // given - three active members
-    final var localMember = new DefaultRaftMember(new MemberId("1"), Type.ACTIVE, Instant.now());
+    final var localMember = new DefaultRaftMember(MemberId.from("1"), Type.ACTIVE, Instant.now());
 
     final var initialConfiguration =
         new Configuration(
@@ -459,8 +460,8 @@ final class RaftClusterContextTest {
             Instant.now().toEpochMilli(),
             List.of(
                 localMember,
-                new DefaultRaftMember(new MemberId("2"), Type.ACTIVE, Instant.now()),
-                new DefaultRaftMember(new MemberId("3"), Type.ACTIVE, Instant.now())));
+                new DefaultRaftMember(MemberId.from("2"), Type.ACTIVE, Instant.now()),
+                new DefaultRaftMember(MemberId.from("3"), Type.ACTIVE, Instant.now())));
     final var raft = raftWithStoredConfiguration(initialConfiguration);
     final var context = new RaftClusterContext(localMember.memberId(), raft);
     context.bootstrap(List.of()).join();
@@ -473,8 +474,8 @@ final class RaftClusterContextTest {
             Instant.now().toEpochMilli(),
             List.of(
                 localMember,
-                new DefaultRaftMember(new MemberId("2"), Type.ACTIVE, Instant.now()),
-                new DefaultRaftMember(new MemberId("3"), Type.PASSIVE, Instant.now())),
+                new DefaultRaftMember(MemberId.from("2"), Type.ACTIVE, Instant.now()),
+                new DefaultRaftMember(MemberId.from("3"), Type.PASSIVE, Instant.now())),
             List.of());
     context.configure(newConfiguration);
 
@@ -482,8 +483,8 @@ final class RaftClusterContextTest {
     assertThat(context.getConfiguration().allMembers())
         .containsExactlyInAnyOrder(
             localMember,
-            new DefaultRaftMember(new MemberId("2"), Type.ACTIVE, Instant.now()),
-            new DefaultRaftMember(new MemberId("3"), Type.ACTIVE, Instant.now()));
+            new DefaultRaftMember(MemberId.from("2"), Type.ACTIVE, Instant.now()),
+            new DefaultRaftMember(MemberId.from("3"), Type.ACTIVE, Instant.now()));
   }
 
   private RaftContext raftWithStoredConfiguration(final Configuration configuration) {

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/partition/RaftServerReceiverSubjectsTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/partition/RaftServerReceiverSubjectsTest.java
@@ -40,7 +40,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 public class RaftServerReceiverSubjectsTest {
 
   private static final String PARTITION_GROUP = "group";
-  private static final MemberId MEMBER_ID = new MemberId("0");
+  private static final MemberId MEMBER_ID = MemberId.from("0");
   private static final PartitionId PARTITION_ID = new PartitionId(PARTITION_GROUP, 1);
   private static final PartitionMetadata METADATA =
       new PartitionMetadata(PARTITION_ID, Set.of(), Map.of(), 1, MEMBER_ID);

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/partition/RaftServerSenderSubjectsTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/partition/RaftServerSenderSubjectsTest.java
@@ -56,7 +56,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 public class RaftServerSenderSubjectsTest {
 
   private static final String PARTITION_GROUP = "group";
-  private static final MemberId MEMBER_ID = new MemberId("0");
+  private static final MemberId MEMBER_ID = MemberId.from("0");
   private static final PartitionId PARTITION_ID = new PartitionId(PARTITION_GROUP, 1);
   private static final PartitionMetadata METADATA =
       new PartitionMetadata(PARTITION_ID, Set.of(), Map.of(), 1, MEMBER_ID);

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/storage/system/MetaStoreTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/storage/system/MetaStoreTest.java
@@ -74,7 +74,7 @@ class MetaStoreTest {
     @Test
     void shouldStoreAndLoadVote() {
       // when
-      metaStore.storeVote(new MemberId("id"));
+      metaStore.storeVote(MemberId.from("id"));
 
       // then
       assertThat(metaStore.loadVote().id()).isEqualTo("id");
@@ -96,7 +96,7 @@ class MetaStoreTest {
     @Test
     void shouldLoadExistingVote() throws IOException {
       // given
-      metaStore.storeVote(new MemberId("id"));
+      metaStore.storeVote(MemberId.from("id"));
 
       // when
       metaStore.close();

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/utils/VoteQuorumTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/utils/VoteQuorumTest.java
@@ -32,7 +32,7 @@ final class VoteQuorumTest {
               callback, Set.of(MemberId.from("1"), MemberId.from("2"), MemberId.from("3")));
 
       // when
-      quorum.succeed(new MemberId("1"));
+      quorum.succeed(MemberId.from("1"));
 
       // then
       verifyNoInteractions(callback);
@@ -48,8 +48,8 @@ final class VoteQuorumTest {
               callback, Set.of(MemberId.from("1"), MemberId.from("2"), MemberId.from("3")));
 
       // when
-      quorum.succeed(new MemberId("1"));
-      quorum.succeed(new MemberId("2"));
+      quorum.succeed(MemberId.from("1"));
+      quorum.succeed(MemberId.from("2"));
 
       // then
       verify(callback, only()).accept(true);
@@ -65,8 +65,8 @@ final class VoteQuorumTest {
               callback, Set.of(MemberId.from("1"), MemberId.from("2"), MemberId.from("3")));
 
       // when
-      quorum.succeed(new MemberId("1"));
-      quorum.succeed(new MemberId("1"));
+      quorum.succeed(MemberId.from("1"));
+      quorum.succeed(MemberId.from("1"));
 
       // then
       verifyNoInteractions(callback);
@@ -82,8 +82,8 @@ final class VoteQuorumTest {
               callback, Set.of(MemberId.from("1"), MemberId.from("2"), MemberId.from("3")));
 
       // when
-      quorum.succeed(new MemberId("5"));
-      quorum.succeed(new MemberId("6"));
+      quorum.succeed(MemberId.from("5"));
+      quorum.succeed(MemberId.from("6"));
 
       // then
       verifyNoInteractions(callback);
@@ -99,9 +99,9 @@ final class VoteQuorumTest {
               callback, Set.of(MemberId.from("1"), MemberId.from("2"), MemberId.from("3")));
 
       // when
-      quorum.succeed(new MemberId("1"));
-      quorum.succeed(new MemberId("2"));
-      quorum.succeed(new MemberId("3"));
+      quorum.succeed(MemberId.from("1"));
+      quorum.succeed(MemberId.from("2"));
+      quorum.succeed(MemberId.from("3"));
 
       // then
       verify(callback, only()).accept(true);
@@ -117,8 +117,8 @@ final class VoteQuorumTest {
               callback, Set.of(MemberId.from("1"), MemberId.from("2"), MemberId.from("3")));
 
       // when
-      quorum.fail(new MemberId("1"));
-      quorum.fail(new MemberId("2"));
+      quorum.fail(MemberId.from("1"));
+      quorum.fail(MemberId.from("2"));
 
       // then
       verify(callback, only()).accept(false);
@@ -134,10 +134,10 @@ final class VoteQuorumTest {
               callback, Set.of(MemberId.from("1"), MemberId.from("2"), MemberId.from("3")));
 
       // when
-      quorum.fail(new MemberId("1"));
-      quorum.fail(new MemberId("2"));
-      quorum.succeed(new MemberId("1"));
-      quorum.succeed(new MemberId("2"));
+      quorum.fail(MemberId.from("1"));
+      quorum.fail(MemberId.from("2"));
+      quorum.succeed(MemberId.from("1"));
+      quorum.succeed(MemberId.from("2"));
 
       // then
       verify(callback, only()).accept(false);
@@ -158,8 +158,8 @@ final class VoteQuorumTest {
               Set.of(MemberId.from("1"), MemberId.from("2"), MemberId.from("3")));
 
       // when
-      quorum.succeed(new MemberId("1"));
-      quorum.succeed(new MemberId("2"));
+      quorum.succeed(MemberId.from("1"));
+      quorum.succeed(MemberId.from("2"));
 
       // then
       verify(callback, only()).accept(true);
@@ -177,10 +177,10 @@ final class VoteQuorumTest {
               Set.of(MemberId.from("4"), MemberId.from("5"), MemberId.from("6")));
 
       // when
-      quorum.succeed(new MemberId("1"));
-      quorum.succeed(new MemberId("2"));
-      quorum.succeed(new MemberId("4"));
-      quorum.succeed(new MemberId("5"));
+      quorum.succeed(MemberId.from("1"));
+      quorum.succeed(MemberId.from("2"));
+      quorum.succeed(MemberId.from("4"));
+      quorum.succeed(MemberId.from("5"));
 
       // then
       verify(callback, only()).accept(true);
@@ -198,8 +198,8 @@ final class VoteQuorumTest {
               Set.of(MemberId.from("1"), MemberId.from("2"), MemberId.from("3")));
 
       // when
-      quorum.succeed(new MemberId("1"));
-      quorum.succeed(new MemberId("4"));
+      quorum.succeed(MemberId.from("1"));
+      quorum.succeed(MemberId.from("4"));
 
       // then
       verifyNoInteractions(callback);
@@ -217,8 +217,8 @@ final class VoteQuorumTest {
               Set.of(MemberId.from("1"), MemberId.from("2"), MemberId.from("3")));
 
       // when
-      quorum.succeed(new MemberId("1"));
-      quorum.succeed(new MemberId("3"));
+      quorum.succeed(MemberId.from("1"));
+      quorum.succeed(MemberId.from("3"));
 
       // then
       verifyNoInteractions(callback);
@@ -236,8 +236,8 @@ final class VoteQuorumTest {
               Set.of(MemberId.from("1"), MemberId.from("2"), MemberId.from("3")));
 
       // when
-      quorum.fail(new MemberId("1"));
-      quorum.fail(new MemberId("4"));
+      quorum.fail(MemberId.from("1"));
+      quorum.fail(MemberId.from("4"));
 
       // then
       verify(callback, only()).accept(false);
@@ -255,11 +255,11 @@ final class VoteQuorumTest {
               Set.of(MemberId.from("1"), MemberId.from("2"), MemberId.from("3")));
 
       // when
-      quorum.fail(new MemberId("1"));
-      quorum.fail(new MemberId("4"));
-      quorum.succeed(new MemberId("1"));
-      quorum.succeed(new MemberId("2"));
-      quorum.succeed(new MemberId("3"));
+      quorum.fail(MemberId.from("1"));
+      quorum.fail(MemberId.from("4"));
+      quorum.succeed(MemberId.from("1"));
+      quorum.succeed(MemberId.from("2"));
+      quorum.succeed(MemberId.from("3"));
 
       // then
       verify(callback, only()).accept(false);

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/backup/ConcurrentBackupCompactionTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/backup/ConcurrentBackupCompactionTest.java
@@ -92,7 +92,7 @@ public class ConcurrentBackupCompactionTest extends DynamicAutoCloseable {
 
     final var partitionMetadata =
         new PartitionMetadata(
-            PartitionId.from("raft", partitionId), Set.of(), Map.of(), 1, new MemberId("1"));
+            PartitionId.from("raft", partitionId), Set.of(), Map.of(), 1, MemberId.from("1"));
     final var raftPartition =
         new RaftPartition(partitionMetadata, null, dataDirectory.toFile(), meterRegistry);
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandCheckpointTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandCheckpointTest.java
@@ -215,6 +215,6 @@ final class InterPartitionCommandCheckpointTest {
     final var messageCaptor = ArgumentCaptor.forClass(byte[].class);
     verify(communicationService)
         .unicast(eq(LEGACY_TOPIC_PREFIX + 1), messageCaptor.capture(), any(), any(), eq(true));
-    receiver.handleMessage(new MemberId("0"), messageCaptor.getValue());
+    receiver.handleMessage(MemberId.from("0"), messageCaptor.getValue());
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverTest.java
@@ -62,7 +62,7 @@ final class InterPartitionCommandReceiverTest {
     final var receiver = new InterPartitionCommandReceiverImpl(logStreamWriter);
 
     // when
-    receiver.handleMessage(new MemberId("0"), sentMessage);
+    receiver.handleMessage(MemberId.from("0"), sentMessage);
 
     // then - sent message can be written to log stream
     verify(logStreamWriter).tryWrite(any(WriteContext.class), any(LogAppendEntry.class));
@@ -95,7 +95,7 @@ final class InterPartitionCommandReceiverTest {
 
     // when
     receiver.setDiskSpaceAvailable(false);
-    receiver.handleMessage(new MemberId("0"), sentMessage);
+    receiver.handleMessage(MemberId.from("0"), sentMessage);
 
     // then
     verifyNoInteractions(logStreamWriter);
@@ -122,7 +122,7 @@ final class InterPartitionCommandReceiverTest {
     final var receiver = new InterPartitionCommandReceiverImpl(logStreamWriter);
 
     // when
-    receiver.handleMessage(new MemberId("0"), sentMessage);
+    receiver.handleMessage(MemberId.from("0"), sentMessage);
 
     // then
     final var entryCaptor = ArgumentCaptor.forClass(LogAppendEntry.class);
@@ -162,7 +162,7 @@ final class InterPartitionCommandReceiverTest {
     final var receiver = new InterPartitionCommandReceiverImpl(logStreamWriter);
 
     // when
-    receiver.handleMessage(new MemberId("0"), sentMessage);
+    receiver.handleMessage(MemberId.from("0"), sentMessage);
 
     // then
     final var entryCaptor = ArgumentCaptor.forClass(LogAppendEntry.class);
@@ -193,7 +193,7 @@ final class InterPartitionCommandReceiverTest {
     final var entryCaptor = ArgumentCaptor.forClass(LogAppendEntry.class);
 
     // when
-    receiver.handleMessage(new MemberId("0"), sentMessage);
+    receiver.handleMessage(MemberId.from("0"), sentMessage);
 
     // then
     verify(logStreamWriter).tryWrite(any(WriteContext.class), entryCaptor.capture());
@@ -219,7 +219,7 @@ final class InterPartitionCommandReceiverTest {
     final var entryCaptor = ArgumentCaptor.forClass(LogAppendEntry.class);
 
     // when
-    receiver.handleMessage(new MemberId("0"), sentMessage);
+    receiver.handleMessage(MemberId.from("0"), sentMessage);
 
     // then
     verify(logStreamWriter).tryWrite(any(WriteContext.class), entryCaptor.capture());
@@ -251,7 +251,7 @@ final class InterPartitionCommandReceiverTest {
     final var receiver = new InterPartitionCommandReceiverImpl(logStreamWriter);
 
     // when
-    receiver.handleMessage(new MemberId("0"), sentMessage);
+    receiver.handleMessage(MemberId.from("0"), sentMessage);
 
     // then
     verify(logStreamWriter)
@@ -286,7 +286,7 @@ final class InterPartitionCommandReceiverTest {
     final var receiver = new InterPartitionCommandReceiverImpl(logStreamWriter);
 
     // when
-    receiver.handleMessage(new MemberId("0"), sentMessage);
+    receiver.handleMessage(MemberId.from("0"), sentMessage);
 
     // then
     verify(logStreamWriter)

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/AwaitRedistributionCompletionTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/AwaitRedistributionCompletionTest.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 
 public class AwaitRedistributionCompletionTest extends AbstractApplierTest {
 
-  MemberId memberId = new MemberId("1");
+  MemberId memberId = MemberId.from("1");
 
   ClusterConfiguration empty = ClusterConfiguration.init();
   ClusterConfiguration validAllPartitionConfig =

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PartitionJoinApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PartitionJoinApplierTest.java
@@ -154,7 +154,7 @@ final class PartitionJoinApplierTest {
         ClusterConfiguration.init()
             .addMember(localMemberId, MemberState.initializeAsActive(Map.of()))
             .addMember(
-                new MemberId("2"),
+                MemberId.from("2"),
                 MemberState.initializeAsActive(
                     Map.of(1, PartitionState.active(1, partitionConfig))));
     final var updater =
@@ -178,7 +178,7 @@ final class PartitionJoinApplierTest {
         ClusterConfiguration.init()
             .addMember(localMemberId, MemberState.initializeAsActive(Map.of()))
             .addMember(
-                new MemberId("2"),
+                MemberId.from("2"),
                 MemberState.initializeAsActive(
                     Map.of(1, PartitionState.active(1, partitionConfig))));
     final var partitionJoinApplier =
@@ -233,7 +233,7 @@ final class PartitionJoinApplierTest {
         ClusterConfiguration.init()
             .addMember(localMemberId, MemberState.initializeAsActive(Map.of()))
             .addMember(
-                new MemberId("2"),
+                MemberId.from("2"),
                 MemberState.initializeAsActive(Map.of(1, PartitionState.active(1, config))));
 
     final var partitionJoinApplier =

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
@@ -98,7 +98,7 @@ class PartitionRestoreServiceTest {
 
     final var partitionMetadata =
         new PartitionMetadata(
-            PartitionId.from("raft", partitionId), Set.of(), Map.of(), 1, new MemberId("1"));
+            PartitionId.from("raft", partitionId), Set.of(), Map.of(), 1, MemberId.from("1"));
     final var raftPartition =
         new RaftPartition(partitionMetadata, null, dataDirectoryToRestore.toFile(), meterRegistry);
     restoreService =


### PR DESCRIPTION
## Description
To introduce some compile time safety, in this PR I added a `BrokerId` subclass of `MemberId` that is instantiated when the `MemberId` is from a broker. 
This allows us to safely replace `int nodeId` to `BrokerId brokerId` later on without the risk of adding new failure modes as `MemberId.nodeIdx` can throw if the nodeId is not set.

To do so, I first had to remove the constructor `new MemberId(String)` in favour of the existing factory method `MemberId.from(String)` that will instantiate a BrokerId when possible.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
