### PR TITLE
test: unskip dashboard tests fixed by #45129

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDashboardPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDashboardPage.ts
@@ -20,6 +20,7 @@ export class OperateDashboardPage {
   readonly instancesByProcessItem: (index: number) => Locator;
   readonly instancesByProcessItemByName: (name: string) => Locator;
   readonly incidentsByErrorItem: (index: number) => Locator;
+  readonly incidentsByErrorItemByMessage: (message: string | RegExp) => Locator;
   readonly activeInstancesBadge: Locator;
   readonly incidentInstancesBadge: Locator;
   readonly processInstancesHeading: (
@@ -58,6 +59,11 @@ export class OperateDashboardPage {
 
     this.incidentsByErrorItem = (index: number) =>
       page.getByTestId(`incident-byError-${index}`);
+
+    this.incidentsByErrorItemByMessage = (message: string | RegExp) =>
+      this.incidentsByError
+        .locator('[data-testid^="incident-byError-"]')
+        .filter({hasText: message});
 
     this.activeInstancesBadge = page
       .getByTestId('active-instances-badge')

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/dashboardIncidentGenerator.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/dashboardIncidentGenerator.bpmn
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_dashboardIncidentGenerator" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.31.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0">
+  <bpmn:process id="dashboardIncidentGenerator" name="Dashboard Incident Generator" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_13hjtls</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_13hjtls" sourceRef="StartEvent_1" targetRef="DashboardIncidentGenerator" />
+    <bpmn:endEvent id="Event_11zx0y4">
+      <bpmn:incoming>Flow_1nrs4lg</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1nrs4lg" sourceRef="DashboardIncidentGenerator" targetRef="Event_11zx0y4" />
+    <bpmn:serviceTask id="DashboardIncidentGenerator" name="Dashboard Incident Generator">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="dashboardIncidentGenerator" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_13hjtls</bpmn:incoming>
+      <bpmn:outgoing>Flow_1nrs4lg</bpmn:outgoing>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="dashboardIncidentGenerator">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_11zx0y4_di" bpmnElement="Event_11zx0y4">
+        <dc:Bounds x="422" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_05iptua_di" bpmnElement="DashboardIncidentGenerator">
+        <dc:Bounds x="270" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_13hjtls_di" bpmnElement="Flow_13hjtls">
+        <di:waypoint x="218" y="120" />
+        <di:waypoint x="270" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1nrs4lg_di" bpmnElement="Flow_1nrs4lg">
+        <di:waypoint x="370" y="120" />
+        <di:waypoint x="422" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/dashboard.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/dashboard.spec.ts
@@ -173,9 +173,7 @@ test.describe('Dashboard', () => {
       // switch to Variables before asserting on the variable value.
       await operateProcessInstancePage.clickVariablesTab();
       await expect(
-        operateProcessInstancePage.variablesList.getByText(
-          '"Incident Type A"',
-        ),
+        operateProcessInstancePage.variablesList.getByText('"Incident Type A"'),
       ).toBeVisible();
     });
 
@@ -189,9 +187,7 @@ test.describe('Dashboard', () => {
       await operateDashboardPage.clickViewInstanceLink();
       await operateProcessInstancePage.clickVariablesTab();
       await expect(
-        operateProcessInstancePage.variablesList.getByText(
-          '"Incident Type B"',
-        ),
+        operateProcessInstancePage.variablesList.getByText('"Incident Type B"'),
       ).toBeVisible();
     });
   });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/dashboard.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/dashboard.spec.ts
@@ -145,8 +145,7 @@ test.describe('Dashboard', () => {
     });
   });
 
-  // skipped due to bug 45129: https://github.com/camunda/camunda/issues/45129
-  test.skip('Navigate to processes view (same truncated error message)', async ({
+  test('Navigate to processes view (same truncated error message)', async ({
     operateDashboardPage,
     operateProcessInstancePage,
   }) => {
@@ -226,12 +225,7 @@ test.describe('Dashboard', () => {
     });
   });
 
-  // skipped due to bug 45129: https://github.com/camunda/camunda/issues/45129
-  // Dashboard "incidents by error" badge counts every incident of a given
-  // error type, but the filtered Process Instances page applies the truncated
-  // error message (cut at 100 chars) as a filter — so totals don't match when
-  // the message is longer.
-  test.skip('Select process instances by error message', async ({
+  test('Select process instances by error message', async ({
     operateDashboardPage,
   }) => {
     await test.step('Select first error and verify incident count', async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/dashboard.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/dashboard.spec.ts
@@ -169,8 +169,13 @@ test.describe('Dashboard', () => {
       ).toBeVisible();
 
       await operateDashboardPage.clickViewInstanceLink();
+      // Instances with an incident open on the Incidents tab by default;
+      // switch to Variables before asserting on the variable value.
+      await operateProcessInstancePage.clickVariablesTab();
       await expect(
-        operateProcessInstancePage.variableCellByName(/incident type a/i),
+        operateProcessInstancePage.variablesList.getByText(
+          '"Incident Type A"',
+        ),
       ).toBeVisible();
     });
 
@@ -182,8 +187,11 @@ test.describe('Dashboard', () => {
       ).toBeVisible();
 
       await operateDashboardPage.clickViewInstanceLink();
+      await operateProcessInstancePage.clickVariablesTab();
       await expect(
-        operateProcessInstancePage.variableCellByName(/incident type b/i),
+        operateProcessInstancePage.variablesList.getByText(
+          '"Incident Type B"',
+        ),
       ).toBeVisible();
     });
   });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/dashboard.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/dashboard.spec.ts
@@ -31,8 +31,8 @@ test.beforeAll(async ({request}) => {
     './resources/onlyIncidentsProcess_v_1.bpmn',
     './resources/orderProcess_v_1.bpmn',
     './resources/processWithAnIncident.bpmn',
-    './resources/incidentGeneratorProcess.bpmn',
     './resources/dashboardSelectionProcess_v_1.bpmn',
+    './resources/dashboardIncidentGenerator.bpmn',
   ]);
 
   await deploy([
@@ -41,9 +41,12 @@ test.beforeAll(async ({request}) => {
     './resources/onlyIncidentsProcess_v_2.bpmn',
   ]);
 
-  createWorker('incidentGenerator', true, {}, (job) => {
+  createWorker('dashboardIncidentGenerator', true, {}, (job) => {
+    // Prefix is unique to this spec so the error-message hash doesn't
+    // collide with incidents created by other specs (e.g.
+    // job-worker-statistics-test-setup.spec.ts uses the same base text).
     const BASE_ERROR_MESSAGE =
-      'This is an error message for testing purposes. This error message is very long to ensure it is truncated in the UI.';
+      '[dashboard-spec] This is an error message for testing purposes. This error message is very long to ensure it is truncated in the UI.';
 
     if (job.variables.incidentType === 'Incident Type A') {
       return job.fail(`${BASE_ERROR_MESSAGE} Type A`);
@@ -60,10 +63,10 @@ test.beforeAll(async ({request}) => {
     createInstances('orderProcess', 1, 10),
     createInstances('dashboardSelectionProcess', 1, 10),
     createSingleInstance('processWithAnIncident', 1),
-    createSingleInstance('incidentGeneratorProcess', 1, {
+    createSingleInstance('dashboardIncidentGenerator', 1, {
       incidentType: 'Incident Type A',
     }),
-    createSingleInstance('incidentGeneratorProcess', 1, {
+    createSingleInstance('dashboardIncidentGenerator', 1, {
       incidentType: 'Incident Type B',
     }),
   ]);
@@ -149,8 +152,13 @@ test.describe('Dashboard', () => {
     operateDashboardPage,
     operateProcessInstancePage,
   }) => {
+    // Scope the link selectors to this spec's [dashboard-spec] prefix so
+    // they don't match identical-suffix incidents created by other specs.
+    const typeALink = /\[dashboard-spec].*type a/i;
+    const typeBLink = /\[dashboard-spec].*type b/i;
+
     await test.step('Select incident type A and verify details', async () => {
-      await operateDashboardPage.clickIncidentByType(/type a/i);
+      await operateDashboardPage.clickIncidentByType(typeALink);
 
       await expect(
         operateDashboardPage.processInstancesHeading(1, false),
@@ -164,7 +172,7 @@ test.describe('Dashboard', () => {
 
     await test.step('Select incident type B and verify details', async () => {
       await operateDashboardPage.gotoDashboardPage();
-      await operateDashboardPage.clickIncidentByType(/type b/i);
+      await operateDashboardPage.clickIncidentByType(typeBLink);
       await expect(
         operateDashboardPage.processInstancesHeading(1, false),
       ).toBeVisible();

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/dashboard.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/dashboard.spec.ts
@@ -22,6 +22,14 @@ import {defaultAssertionOptions} from '../../utils/constants';
 
 let instanceIds: string[] = [];
 
+// Unique per beforeAll execution so multiple projects (e.g. `chromium` and
+// `operate-e2e`) running this spec against the same cluster produce
+// distinct error-message hashes — keeping the "incidents by error" rows
+// and Process Instances counts separate for each project's worker.
+const runTag = `dashboard-spec-${Math.random().toString(36).slice(2, 10)}`;
+
+const DASHBOARD_INCIDENT_BASE_MESSAGE = `[${runTag}] This is an error message for testing purposes. This error message is very long to ensure it is truncated in the UI.`;
+
 test.beforeAll(async ({request}) => {
   test.setTimeout(180000);
 
@@ -42,16 +50,10 @@ test.beforeAll(async ({request}) => {
   ]);
 
   createWorker('dashboardIncidentGenerator', true, {}, (job) => {
-    // Prefix is unique to this spec so the error-message hash doesn't
-    // collide with incidents created by other specs (e.g.
-    // job-worker-statistics-test-setup.spec.ts uses the same base text).
-    const BASE_ERROR_MESSAGE =
-      '[dashboard-spec] This is an error message for testing purposes. This error message is very long to ensure it is truncated in the UI.';
-
     if (job.variables.incidentType === 'Incident Type A') {
-      return job.fail(`${BASE_ERROR_MESSAGE} Type A`);
+      return job.fail(`${DASHBOARD_INCIDENT_BASE_MESSAGE} Type A`);
     } else {
-      return job.fail(`${BASE_ERROR_MESSAGE} Type B`);
+      return job.fail(`${DASHBOARD_INCIDENT_BASE_MESSAGE} Type B`);
     }
   });
 
@@ -152,10 +154,12 @@ test.describe('Dashboard', () => {
     operateDashboardPage,
     operateProcessInstancePage,
   }) => {
-    // Scope the link selectors to this spec's [dashboard-spec] prefix so
-    // they don't match identical-suffix incidents created by other specs.
-    const typeALink = /\[dashboard-spec].*type a/i;
-    const typeBLink = /\[dashboard-spec].*type b/i;
+    // Scope the link selectors to this beforeAll execution's runTag so
+    // they don't match incidents created by parallel project workers
+    // (e.g. `chromium` and `operate-e2e`) running this same spec, or by
+    // any other spec emitting incidents with similar text.
+    const typeALink = new RegExp(`${runTag}.*type a`, 'i');
+    const typeBLink = new RegExp(`${runTag}.*type b`, 'i');
 
     await test.step('Select incident type A and verify details', async () => {
       await operateDashboardPage.clickIncidentByType(typeALink);
@@ -236,18 +240,26 @@ test.describe('Dashboard', () => {
   test('Select process instances by error message', async ({
     operateDashboardPage,
   }) => {
-    await test.step('Select first error and verify incident count', async () => {
+    await test.step('Select dashboard-spec error and verify incident count', async () => {
       await expect(operateDashboardPage.incidentsByError).toBeVisible();
 
-      const firstInstanceByError = operateDashboardPage.incidentsByErrorItem(0);
+      // Use the row matching this beforeAll execution's runTag so the
+      // selected error population is not mutated by other specs running
+      // in parallel against the same cluster.
+      const dashboardErrorRow =
+        operateDashboardPage.incidentsByErrorItemByMessage(
+          new RegExp(runTag, 'i'),
+        );
+
+      await expect(dashboardErrorRow.first()).toBeVisible();
 
       const incidentCount = Number(
         await operateDashboardPage
-          .incidentBadgeFromItem(firstInstanceByError)
+          .incidentBadgeFromItem(dashboardErrorRow.first())
           .innerText(),
       );
 
-      await operateDashboardPage.clickItem(firstInstanceByError);
+      await operateDashboardPage.clickItem(dashboardErrorRow.first());
 
       await expect(
         operateDashboardPage.processInstancesHeading(


### PR DESCRIPTION
## Description

Re-enable two Operate dashboard E2E tests that were skipped pending [#45129](https://github.com/camunda/camunda/issues/45129) (`incidentErrorHashCode` filter param ignored on process instances search endpoint). That issue was closed yesterday by merged PR #52801, so the tests can run again:

- `Navigate to processes view (same truncated error message)`
- `Select process instances by error message`

Both are in `qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/dashboard.spec.ts`.

## Validation
https://github.com/camunda/camunda/actions/runs/25792190789 e2e all 🟢 

🤖 Generated with [Claude Code](https://claude.com/claude-code)