### PR TITLE
test: stabilize dashboard "Select process instances by name" against shared-cluster load

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDashboardPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDashboardPage.ts
@@ -18,6 +18,7 @@ export class OperateDashboardPage {
   readonly instancesByProcess: Locator;
   readonly incidentsByError: Locator;
   readonly instancesByProcessItem: (index: number) => Locator;
+  readonly instancesByProcessItemByName: (name: string) => Locator;
   readonly incidentsByErrorItem: (index: number) => Locator;
   readonly activeInstancesBadge: Locator;
   readonly incidentInstancesBadge: Locator;
@@ -49,6 +50,11 @@ export class OperateDashboardPage {
 
     this.instancesByProcessItem = (index: number) =>
       page.getByTestId(`instances-by-process-definition-${index}`);
+
+    this.instancesByProcessItemByName = (name: string) =>
+      this.instancesByProcess
+        .locator('[data-testid^="instances-by-process-definition-"]')
+        .filter({hasText: name});
 
     this.incidentsByErrorItem = (index: number) =>
       page.getByTestId(`incident-byError-${index}`);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/dashboardSelectionProcess_v_1.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/dashboardSelectionProcess_v_1.bpmn
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.6.2">
+  <bpmn:process id="dashboardSelectionProcess" name="Dashboard Selection Process" isExecutable="true">
+    <bpmn:startEvent id="start" name="start">
+      <bpmn:outgoing>SequenceFlow_1sz6737</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1sz6737" sourceRef="start" targetRef="dashboardSelectionTask" />
+    <bpmn:sequenceFlow id="SequenceFlow_1oh45y7" sourceRef="dashboardSelectionTask" targetRef="end" />
+    <bpmn:endEvent id="end" name="end">
+      <bpmn:incoming>SequenceFlow_1oh45y7</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:serviceTask id="dashboardSelectionTask" name="Dashboard selection task">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="dashboardSelectionTask" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1sz6737</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1oh45y7</bpmn:outgoing>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="dashboardSelectionProcess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="start">
+        <dc:Bounds x="173" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="180" y="138" width="22" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1sz6737_di" bpmnElement="SequenceFlow_1sz6737">
+        <di:waypoint x="209" y="120" />
+        <di:waypoint x="502" y="120" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="260" y="105" width="0" height="0" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1oh45y7_di" bpmnElement="SequenceFlow_1oh45y7">
+        <di:waypoint x="602" y="120" />
+        <di:waypoint x="867" y="120" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="648" y="105" width="0" height="0" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_0gbv3sc_di" bpmnElement="end">
+        <dc:Bounds x="867" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="876" y="138" width="18" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_0sryj72_di" bpmnElement="dashboardSelectionTask">
+        <dc:Bounds x="502" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/dashboard.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/dashboard.spec.ts
@@ -32,6 +32,7 @@ test.beforeAll(async ({request}) => {
     './resources/orderProcess_v_1.bpmn',
     './resources/processWithAnIncident.bpmn',
     './resources/incidentGeneratorProcess.bpmn',
+    './resources/dashboardSelectionProcess_v_1.bpmn',
   ]);
 
   await deploy([
@@ -57,6 +58,7 @@ test.beforeAll(async ({request}) => {
     createInstances('onlyIncidentsProcess', 1, 10),
     createInstances('onlyIncidentsProcess', 2, 5),
     createInstances('orderProcess', 1, 10),
+    createInstances('dashboardSelectionProcess', 1, 10),
     createSingleInstance('processWithAnIncident', 1),
     createSingleInstance('incidentGeneratorProcess', 1, {
       incidentType: 'Incident Type A',
@@ -69,8 +71,8 @@ test.beforeAll(async ({request}) => {
   const allInstances = instancesList.flatMap((instances) => instances);
   instanceIds = allInstances.map((instance) => instance.processInstanceKey);
 
-  // Wait for instances to be created (40 total: 4+8+10+5+10+1+1+1 = 40)
-  await waitForProcessInstances(request, instanceIds, 40);
+  // Wait for instances to be created (50 total: 4+8+10+5+10+10+1+1+1 = 50)
+  await waitForProcessInstances(request, instanceIds, 50);
 });
 
 test.beforeEach(async ({page, loginPage, operateHomePage}) => {
@@ -179,33 +181,36 @@ test.describe('Dashboard', () => {
     page,
     operateDashboardPage,
   }) => {
-    await test.step('Select first process and verify total count', async () => {
-      // Dashboard badge counts and the filtered Process Instances heading
-      // are computed from independent queries, so they can disagree under
-      // active load. Retry the read + click + verify cycle if the count on
-      // the next page doesn't match what we read from the badges.
+    // Use a process definition created exclusively by this spec so the
+    // badge counts and the filtered Process Instances heading reference
+    // a stable population unaffected by other tests running in parallel.
+    const PROCESS_NAME = 'Dashboard Selection Process';
+
+    await test.step('Select dashboard selection process and verify total count', async () => {
       await waitForAssertion({
         assertion: async () => {
           await expect(operateDashboardPage.instancesByProcess).toBeVisible();
 
-          const firstInstanceByProcess =
-            operateDashboardPage.instancesByProcessItem(0);
+          const processRow =
+            operateDashboardPage.instancesByProcessItemByName(PROCESS_NAME);
+
+          await expect(processRow).toBeVisible();
 
           const incidentCount = Number(
             await operateDashboardPage
-              .incidentBadgeFromItem(firstInstanceByProcess)
+              .incidentBadgeFromItem(processRow)
               .innerText(),
           );
 
           const runningInstanceCount = Number(
             await operateDashboardPage
-              .activeBadgeFromItem(firstInstanceByProcess)
+              .activeBadgeFromItem(processRow)
               .innerText(),
           );
 
           const totalInstanceCount = incidentCount + runningInstanceCount;
 
-          await operateDashboardPage.clickItem(firstInstanceByProcess);
+          await operateDashboardPage.clickItem(processRow);
 
           await expect(
             operateDashboardPage.processInstancesHeading(


### PR DESCRIPTION
## Summary

The Operate dashboard test `Select process instances by name` reads the active + incident badges from the **first row** of the "Instances by Process" panel, clicks it, and asserts the filtered Process Instances page heading shows the same count.

On a shared CI cluster, the first row is always the busiest process (typically `orderProcess`), which many other suites also create instances of. New instances arrive between the badge read and the filtered page render, so the heading count is strictly greater than the badge sum. Recent failure:

```
Locator: getByRole('heading', { name: 'Process Instances - 1310 results' })
Expected: visible — Timeout: 10000ms
element(s) not found
```
(badge sum = 1310, actual heading = 1371)

## Fix

Add a spec-owned BPMN (`dashboardSelectionProcess_v_1.bpmn`) with a unique job type that no worker is registered for, deploy it in `beforeAll`, and look up the row by process name (`Dashboard Selection Process`) instead of sort position. Since no other suite touches this process definition, the badge sum and the heading count stay consistent under load.

### Files

- `resources/dashboardSelectionProcess_v_1.bpmn` — new BPMN (start → service task `dashboardSelectionTask` → end)
- `pages/OperateDashboardPage.ts` — new helper `instancesByProcessItemByName(name)`
- `tests/operate/dashboard.spec.ts` — deploy + 10 instances; lookup by name; expected total bumped 40 → 50

## Test plan
https://github.com/camunda/camunda/actions/runs/25787190766 -> `Select process instances by name` passed on first run 

- [ ] CI green for `dashboard.spec.ts` on the shared cluster
- [ ] Manually re-run the workflow that previously failed with the 1310/1371 mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)