### PR TITLE
feat: delete Optimize indices in load tests

### DIFF
--- a/load-tests/setup/default/Makefile
+++ b/load-tests/setup/default/Makefile
@@ -76,10 +76,10 @@ platform_values_stable := $(platform_values) -f values-stable.yaml
 all: install
 
 .PHONY: install
-install: check-deadline create-namespace create-credentials install-storage install-platform install-load-test install-elasticsearch-exporter
+install: check-deadline create-namespace create-credentials install-storage install-platform install-load-test install-elasticsearch-exporter install-optimize-cleanup
 
 .PHONY: install-stable
-install-stable: check-deadline create-namespace create-credentials install-storage install-platform-stable install-load-test install-elasticsearch-exporter
+install-stable: check-deadline create-namespace create-credentials install-storage install-platform-stable install-load-test install-elasticsearch-exporter install-optimize-cleanup
 
 # Fail fast if the namespace TTL deadline (read from resources/namespace.yaml,
 # the single source of truth) is today or in the past — the TTL cleanup
@@ -169,6 +169,11 @@ ifeq ($(secondary_storage),elasticsearch)
 else
 	@echo "Skipping Elasticsearch Prometheus Exporter installation (secondary_storage=$(secondary_storage))"
 endif
+
+.PHONY: install-optimize-cleanup
+install-optimize-cleanup:
+	@echo "Deploying Optimize indices cleanup job"
+	kubectl apply --namespace $(namespace) -f resources/opoptimize-indices-cleanup.yaml
 
 # Install/upgrade Camunda Platform helm chart
 .PHONY: install-platform

--- a/load-tests/setup/default/Makefile
+++ b/load-tests/setup/default/Makefile
@@ -173,7 +173,7 @@ endif
 .PHONY: install-optimize-cleanup
 install-optimize-cleanup:
 	@echo "Deploying Optimize indices cleanup job"
-	kubectl apply --namespace $(namespace) -f resources/opoptimize-indices-cleanup.yaml
+	kubectl apply --namespace $(namespace) -f resources/optimize-indices-cleanup.yaml
 
 # Install/upgrade Camunda Platform helm chart
 .PHONY: install-platform

--- a/load-tests/setup/default/resources/optimize-indices-cleanup.yaml
+++ b/load-tests/setup/default/resources/optimize-indices-cleanup.yaml
@@ -38,7 +38,7 @@ spec:
                   retval=$?
                   set -e
                   if [ $retval -eq 0 ]; then
-                  URL=$url
+                    URL="$url"
                     echo "Using Elasticsearch/OpenSearch URL at: $URL"
                     break
                   fi

--- a/load-tests/setup/default/resources/optimize-indices-cleanup.yaml
+++ b/load-tests/setup/default/resources/optimize-indices-cleanup.yaml
@@ -1,0 +1,57 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: optimize-indices-cleanup
+  labels:
+    app: optimize-indices-cleanup
+spec:
+  schedule: "@hourly"
+  suspend: false
+  concurrencyPolicy: Replace
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        metadata:
+          labels:
+            app: optimize-indices-cleanup
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: optimize-indices-cleanup
+            image: curlimages/curl:8.20.0
+            command: ["/bin/sh", "-c"]
+            args:
+              - |
+                #!/bin/sh
+                set -e
+
+                echo "Starting Optimize indices cleanup job..."
+
+                echo "Detecting whether we run OpenSearch or Elasticsearch..."
+                # Support both Elasticsearch and OpenSearch, we clean the first one that is available.
+                for URL in "http://elastic-hl:9200" "http://opensearch-headless:9200"
+                do
+                  echo "Checking URL: $URL"
+                  set +e
+                  curl -sf "$URL" > /dev/null
+                  retval=$?
+                  set -e
+                  if [ $retval -eq 0 ]; then
+                    echo "Using Elasticsearch/OpenSearch URL at: $URL"
+                    break
+                  fi
+                done
+
+                if [ -z $URL ]; then
+                  echo "No Elasticsearch or OpenSearch instance found. Exiting."
+                  exit 1
+                fi
+
+                for index in optimize-process-instance-refundingprocess_v8 optimize-process-instance-bankdisputehandling_v8
+                do
+                  echo "Deleting index: $index"
+                  echo "$(curl -sfi --request DELETE "$URL/$index")"
+                done
+
+                echo "Optimize indices cleanup job completed."

--- a/load-tests/setup/default/resources/optimize-indices-cleanup.yaml
+++ b/load-tests/setup/default/resources/optimize-indices-cleanup.yaml
@@ -30,20 +30,21 @@ spec:
 
                 echo "Detecting whether we run OpenSearch or Elasticsearch..."
                 # Support both Elasticsearch and OpenSearch, we clean the first one that is available.
-                for URL in "http://elastic-hl:9200" "http://opensearch-headless:9200"
+                for url in "http://elastic-hl:9200" "http://opensearch-headless:9200"
                 do
-                  echo "Checking URL: $URL"
+                  echo "Checking URL: $url"
                   set +e
-                  curl -sf "$URL" > /dev/null
+                  curl -sf "$url" > /dev/null
                   retval=$?
                   set -e
                   if [ $retval -eq 0 ]; then
+                  URL=$url
                     echo "Using Elasticsearch/OpenSearch URL at: $URL"
                     break
                   fi
                 done
 
-                if [ -z $URL ]; then
+                if [ -z "$URL" ]; then
                   echo "No Elasticsearch or OpenSearch instance found. Exiting."
                   exit 1
                 fi


### PR DESCRIPTION
## Description

This is a temporary mitigations to delete large Optimize indices from the load tests deployments until we get a proper fix for Optimize configuration.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

* https://app.incident.io/camunda/incidents/5539
* https://app.incident.io/camunda/incidents/5337
