### PR TITLE
refactor: revert workaround deactivating UC validation

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/UnifiedConfigurationHelper.java
+++ b/configuration/src/main/java/io/camunda/configuration/UnifiedConfigurationHelper.java
@@ -17,7 +17,6 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,8 +35,6 @@ public class UnifiedConfigurationHelper {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(UnifiedConfigurationHelper.class);
   private static final ConversionService CONVERSION_SERVICE = new ApplicationConversionService();
-  private static final ThreadLocal<Integer> SKIP_VALIDATION_SEMAPHORE =
-      ThreadLocal.withInitial(() -> 0);
 
   private static Environment environment;
 
@@ -166,10 +163,6 @@ public class UnifiedConfigurationHelper {
         isSensitiveData);
   }
 
-  private static boolean isValidationSkipped() {
-    return SKIP_VALIDATION_SEMAPHORE.get() > 0;
-  }
-
   private static <T> T validateLegacyConfiguration(
       final String newProperty,
       final T newValue,
@@ -177,13 +170,6 @@ public class UnifiedConfigurationHelper {
       final BackwardsCompatibilityMode backwardsCompatibilityMode,
       final Set<String> legacyProperties,
       final boolean isSensitiveData) {
-
-    // Skip validations entirely, if we're building the UC object as an artifact to pass to a test
-    // container. In these cases, as the configuration goes to a container, we do not want to
-    // validate it against the local current environment.
-    if (isValidationSkipped()) {
-      return newValue;
-    }
 
     // If the environment is not set, it is assumed that the helper is used
     // in a non-Spring context, and the validation of backward compatibility
@@ -360,10 +346,6 @@ public class UnifiedConfigurationHelper {
       final BackwardsCompatibilityMode backwardsCompatibilityMode,
       final Set<Set<String>> legacyProperties,
       final boolean isSensitiveData) {
-
-    if (isValidationSkipped()) {
-      return newValue;
-    }
 
     // If the environment is not set, it is assumed that the helper is used
     // in a non-Spring context, and the validation of backward compatibility
@@ -827,15 +809,6 @@ public class UnifiedConfigurationHelper {
 
   public static void setCustomEnvironment(final Environment environment) {
     UnifiedConfigurationHelper.environment = environment;
-  }
-
-  public static <T> T withoutValidation(final Supplier<T> block) {
-    SKIP_VALIDATION_SEMAPHORE.set(SKIP_VALIDATION_SEMAPHORE.get() + 1);
-    try {
-      return block.get();
-    } finally {
-      SKIP_VALIDATION_SEMAPHORE.set(SKIP_VALIDATION_SEMAPHORE.get() - 1);
-    }
   }
 
   public enum BackwardsCompatibilityMode {

--- a/qa/testcontainer/src/main/java/io/camunda/container/ExtendedConfigurationBuilder.java
+++ b/qa/testcontainer/src/main/java/io/camunda/container/ExtendedConfigurationBuilder.java
@@ -43,7 +43,6 @@ import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.configuration.Security;
 import io.camunda.configuration.Ssl;
 import io.camunda.configuration.TlsCluster;
-import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.Webapps;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
@@ -285,27 +284,24 @@ public class ExtendedConfigurationBuilder {
    * included, avoiding serialization bloat from eagerly initialized nested objects.
    */
   public String exportConfigAsString() {
-    return UnifiedConfigurationHelper.withoutValidation(
-        () -> {
-          try {
-            // Compute the diff between the configured Camunda bean and a pristine default instance.
-            // This avoids serializing hundreds of default properties that can interfere with the
-            // Docker image's own defaults (e.g. secondary-storage type, thread counts, etc.).
-            final Map<String, Object> defaultMap = flatten(createDefaultCamunda());
-            final Map<String, Object> configuredMap = flatten(unifiedConfig);
-            final Map<String, Object> diff = diffMaps(defaultMap, configuredMap);
+    try {
+      // Compute the diff between the configured Camunda bean and a pristine default instance.
+      // This avoids serializing hundreds of default properties that can interfere with the
+      // Docker image's own defaults (e.g. secondary-storage type, thread counts, etc.).
+      final Map<String, Object> defaultMap = flatten(createDefaultCamunda());
+      final Map<String, Object> configuredMap = flatten(unifiedConfig);
+      final Map<String, Object> diff = diffMaps(defaultMap, configuredMap);
 
-            final Map<String, Object> fullConfig = new LinkedHashMap<>();
-            if (!diff.isEmpty()) {
-              fullConfig.put(CAMUNDA_HEADER, diff);
-            }
-            mergeConfigs(fullConfig, flatten(additionalConfigs));
+      final Map<String, Object> fullConfig = new LinkedHashMap<>();
+      if (!diff.isEmpty()) {
+        fullConfig.put(CAMUNDA_HEADER, diff);
+      }
+      mergeConfigs(fullConfig, flatten(additionalConfigs));
 
-            return MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(fullConfig);
-          } catch (final IOException e) {
-            throw new RuntimeException(e);
-          }
-        });
+      return MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(fullConfig);
+    } catch (final IOException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   /**
@@ -326,15 +322,12 @@ public class ExtendedConfigurationBuilder {
    * List elements are emitted as {@code key[i]}; map entries as {@code key.entryKey}.
    */
   public static Map<String, Object> flatPropertiesFor(final Camunda config) {
-    return UnifiedConfigurationHelper.withoutValidation(
-        () -> {
-          final Map<String, Object> defaultMap = flatten(new Camunda());
-          final Map<String, Object> configuredMap = flatten(config);
-          final Map<String, Object> diff = diffMaps(defaultMap, configuredMap);
-          final Map<String, Object> flat = new LinkedHashMap<>();
-          flattenInto(diff, CAMUNDA_HEADER, flat);
-          return flat;
-        });
+    final Map<String, Object> defaultMap = flatten(new Camunda());
+    final Map<String, Object> configuredMap = flatten(config);
+    final Map<String, Object> diff = diffMaps(defaultMap, configuredMap);
+    final Map<String, Object> flat = new LinkedHashMap<>();
+    flattenInto(diff, CAMUNDA_HEADER, flat);
+    return flat;
   }
 
   private static void flattenInto(


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
The workaround is not needed anymore after https://github.com/camunda/camunda/pull/52920

Data layer Nightly tests: https://github.com/camunda/camunda/actions/runs/25797862903

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
