### PR TITLE
Fix max size validation.

### DIFF
--- a/zeebe/broker/pom.xml
+++ b/zeebe/broker/pom.xml
@@ -263,6 +263,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-atomix-cluster</artifactId>
       <version>${project.version}</version>

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/RocksDbResourcesStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/RocksDbResourcesStep.java
@@ -49,6 +49,14 @@ final class RocksDbResourcesStep extends AbstractBrokerStartupStep {
                         .getLocalMember()
                         .id(),
                     brokerStartupContext.getBrokerConfiguration());
+            final RuntimeInfo runtimeInfo = new RuntimeInfo(partitionsPerBroker);
+            // after having the number of partitions per broker from the topology we can validate
+            // the config.
+            brokerStartupContext
+                .getBrokerConfiguration()
+                .getExperimental()
+                .getRocksdb()
+                .validateRocksDbMemory(runtimeInfo.partitionCount());
             final var resources =
                 RocksDbResources.of(
                     brokerStartupContext
@@ -56,7 +64,7 @@ final class RocksDbResourcesStep extends AbstractBrokerStartupStep {
                         .getExperimental()
                         .getRocksdb()
                         .createRocksDbConfiguration(),
-                    new RuntimeInfo(partitionsPerBroker));
+                    runtimeInfo);
             brokerStartupContext.setRocksDbResources(resources);
             startupFuture.complete(brokerStartupContext);
           } catch (final Exception e) {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -282,7 +282,14 @@ public final class SystemContext {
 
     Optional.of(experimental)
         .map(ExperimentalCfg::getRocksdb)
-        .ifPresent(c -> validateRocksDbConfig(c, cluster.getPartitionsCount()));
+        .ifPresent(
+            c ->
+                validateRocksDbConfig(
+                    c,
+                    (int)
+                        Math.ceil(
+                            (double) (cluster.getPartitionsCount() * cluster.getReplicationFactor())
+                                / cluster.getClusterSize())));
   }
 
   private void validateDataConfig(final DataCfg dataCfg) {
@@ -659,8 +666,9 @@ public final class SystemContext {
     listeners.setUserTask(validListeners);
   }
 
-  private void validateRocksDbConfig(final RocksdbCfg rocksdbCfg, final int partitionsCount) {
-    rocksdbCfg.validateRocksDbMemory(partitionsCount);
+  private void validateRocksDbConfig(
+      final RocksdbCfg rocksdbCfg, final int partitionsPerBrokerCount) {
+    rocksdbCfg.validateRocksDbMemory(partitionsPerBrokerCount);
   }
 
   private void validateBackupSchedulerConfig(final BackupCfg backupSchedulerCfg) {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -35,7 +35,6 @@ import io.camunda.zeebe.broker.system.configuration.DataCfg;
 import io.camunda.zeebe.broker.system.configuration.DiskCfg.FreeSpaceCfg;
 import io.camunda.zeebe.broker.system.configuration.ExperimentalCfg;
 import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
-import io.camunda.zeebe.broker.system.configuration.RocksdbCfg;
 import io.camunda.zeebe.broker.system.configuration.SecurityCfg;
 import io.camunda.zeebe.broker.system.configuration.backup.AzureBackupStoreConfig;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupCfg;
@@ -279,17 +278,6 @@ public final class SystemContext {
         .map(ExperimentalCfg::getEngine)
         .map(EngineCfg::getGlobalListeners)
         .ifPresent(this::validateListenersConfig);
-
-    Optional.of(experimental)
-        .map(ExperimentalCfg::getRocksdb)
-        .ifPresent(
-            c ->
-                validateRocksDbConfig(
-                    c,
-                    (int)
-                        Math.ceil(
-                            (double) (cluster.getPartitionsCount() * cluster.getReplicationFactor())
-                                / cluster.getClusterSize())));
   }
 
   private void validateDataConfig(final DataCfg dataCfg) {
@@ -664,11 +652,6 @@ public final class SystemContext {
     }
 
     listeners.setUserTask(validListeners);
-  }
-
-  private void validateRocksDbConfig(
-      final RocksdbCfg rocksdbCfg, final int partitionsPerBrokerCount) {
-    rocksdbCfg.validateRocksDbMemory(partitionsPerBrokerCount);
   }
 
   private void validateBackupSchedulerConfig(final BackupCfg backupSchedulerCfg) {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/RocksdbCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/RocksdbCfg.java
@@ -128,22 +128,16 @@ public final class RocksdbCfg implements ConfigurationEntry {
     if (blockCacheBytes <= totalMemorySize) {
       return;
     }
-    switch (memoryAllocationStrategy) {
-      case BROKER, PARTITION ->
-          LOGGER.warn(
-              "Requested RocksDB memory ({} bytes / {} MB) exceeds total system memory ({} bytes / {} MB). "
-                  + "Memory allocation strategy: {}. Partitions count: {}. "
-                  + "Consider reducing the value of CAMUNDA_DATA_PRIMARYSTORAGE_ROCKSDB_MEMORYLIMIT.",
-              blockCacheBytes,
-              blockCacheBytes / (1024 * 1024),
-              totalMemorySize,
-              totalMemorySize / (1024 * 1024),
-              getMemoryAllocationStrategy(),
-              partitionsCount);
-      // if FRACTION:
-      default ->
-          throw new IllegalStateException("Unexpected value: CAMUNDA_DATA_PRIMARYSTORAGE_ROCKSDB_MEMORYFRACTION should be within [0,1]");
-    }
+    LOGGER.warn(
+        "Requested RocksDB memory ({} bytes / {} MB) exceeds total system memory ({} bytes / {} MB). "
+            + "Memory allocation strategy: {}. Partitions count: {}. "
+            + "Consider reducing the value of CAMUNDA_DATA_PRIMARYSTORAGE_ROCKSDB_MEMORYLIMIT.",
+        blockCacheBytes,
+        blockCacheBytes / (1024 * 1024),
+        totalMemorySize,
+        totalMemorySize / (1024 * 1024),
+        getMemoryAllocationStrategy(),
+        partitionsCount);
   }
 
   private void warnIfTooHighFraction() {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/RocksdbCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/RocksdbCfg.java
@@ -124,20 +124,20 @@ public final class RocksdbCfg implements ConfigurationEntry {
   }
 
   void validateExpectedRocksDBMemoryUsageDoesNotExceedSystemMemory(
-      final long totalMemorySize, final long blockCacheBytes, final int partitionsCount) {
+      final long totalMemorySize, final long blockCacheBytes, final int partitionsPerBrokerCount) {
     if (blockCacheBytes <= totalMemorySize) {
       return;
     }
     LOGGER.warn(
         "Requested RocksDB memory ({} bytes / {} MB) exceeds total system memory ({} bytes / {} MB). "
-            + "Memory allocation strategy: {}. Partitions count: {}. "
+            + "Memory allocation strategy: {}. Partitions per broker count: {}. "
             + "Consider reducing the value of CAMUNDA_DATA_PRIMARYSTORAGE_ROCKSDB_MEMORYLIMIT.",
         blockCacheBytes,
         blockCacheBytes / (1024 * 1024),
         totalMemorySize,
         totalMemorySize / (1024 * 1024),
         getMemoryAllocationStrategy(),
-        partitionsCount);
+        partitionsPerBrokerCount);
   }
 
   private void warnIfTooHighFraction() {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/RocksdbCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/RocksdbCfg.java
@@ -125,19 +125,18 @@ public final class RocksdbCfg implements ConfigurationEntry {
 
   void validateExpectedRocksDBMemoryUsageDoesNotExceedSystemMemory(
       final long totalMemorySize, final long blockCacheBytes, final int partitionsPerBrokerCount) {
-    if (blockCacheBytes <= totalMemorySize) {
-      return;
+    if (blockCacheBytes > totalMemorySize) {
+      LOGGER.warn(
+          "Requested RocksDB memory ({} bytes / {} MB) exceeds total system memory ({} bytes / {} MB). "
+              + "Memory allocation strategy: {}. Partitions per broker count: {}. "
+              + "Consider reducing the value of CAMUNDA_DATA_PRIMARYSTORAGE_ROCKSDB_MEMORYLIMIT.",
+          blockCacheBytes,
+          blockCacheBytes / (1024 * 1024),
+          totalMemorySize,
+          totalMemorySize / (1024 * 1024),
+          getMemoryAllocationStrategy(),
+          partitionsPerBrokerCount);
     }
-    LOGGER.warn(
-        "Requested RocksDB memory ({} bytes / {} MB) exceeds total system memory ({} bytes / {} MB). "
-            + "Memory allocation strategy: {}. Partitions per broker count: {}. "
-            + "Consider reducing the value of CAMUNDA_DATA_PRIMARYSTORAGE_ROCKSDB_MEMORYLIMIT.",
-        blockCacheBytes,
-        blockCacheBytes / (1024 * 1024),
-        totalMemorySize,
-        totalMemorySize / (1024 * 1024),
-        getMemoryAllocationStrategy(),
-        partitionsPerBrokerCount);
   }
 
   private void warnIfTooHighFraction() {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/RocksdbCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/RocksdbCfg.java
@@ -84,7 +84,7 @@ public final class RocksdbCfg implements ConfigurationEntry {
       // correctly set, and if so, we validate the allocated memory does not go above the threshold.
       validateMaxMemoryFraction(totalMemorySize, blockCacheBytes);
       // validate that the allocated memory does not exceed total system memory.
-      validateMemoryDoesNotExceedSystemMemory(
+      validateExpectedRocksDBMemoryUsageDoesNotExceedSystemMemory(
           totalMemorySize, blockCacheBytes, partitionsPerBrokerCount);
     }
 
@@ -123,28 +123,26 @@ public final class RocksdbCfg implements ConfigurationEntry {
     }
   }
 
-  void validateMemoryDoesNotExceedSystemMemory(
+  void validateExpectedRocksDBMemoryUsageDoesNotExceedSystemMemory(
       final long totalMemorySize, final long blockCacheBytes, final int partitionsCount) {
-    if (blockCacheBytes > totalMemorySize) {
-      final String configHint =
-          switch (memoryAllocationStrategy) {
-            case BROKER, PARTITION ->
-                "Consider reducing the value of CAMUNDA_DATA_PRIMARYSTORAGE_ROCKSDB_MEMORYLIMIT.";
-            case FRACTION ->
-                throw new IllegalStateException(
-                    "Unexpected value: FRACTION should be within [0,1]");
-          };
-      throw new IllegalArgumentException(
-          String.format(
-              "Requested RocksDB memory (%d bytes / %d MB) exceeds total system memory (%d bytes / %d MB). "
-                  + "Memory allocation strategy: %s. Partitions count: %d. %s",
+    if (blockCacheBytes <= totalMemorySize) {
+      return;
+    }
+    switch (memoryAllocationStrategy) {
+      case BROKER, PARTITION ->
+          LOGGER.warn(
+              "Requested RocksDB memory ({} bytes / {} MB) exceeds total system memory ({} bytes / {} MB). "
+                  + "Memory allocation strategy: {}. Partitions count: {}. "
+                  + "Consider reducing the value of CAMUNDA_DATA_PRIMARYSTORAGE_ROCKSDB_MEMORYLIMIT.",
               blockCacheBytes,
               blockCacheBytes / (1024 * 1024),
               totalMemorySize,
               totalMemorySize / (1024 * 1024),
               getMemoryAllocationStrategy(),
-              partitionsCount,
-              configHint));
+              partitionsCount);
+      // if FRACTION:
+      default ->
+          throw new IllegalStateException("Unexpected value: CAMUNDA_DATA_PRIMARYSTORAGE_ROCKSDB_MEMORYFRACTION should be within [0,1]");
     }
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCacheTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCacheTest.java
@@ -12,8 +12,12 @@ import static org.assertj.core.api.Assertions.*;
 
 import io.camunda.zeebe.broker.system.configuration.RocksdbCfg;
 import io.camunda.zeebe.db.impl.rocksdb.RocksDbConfiguration.MemoryAllocationStrategy;
+import io.camunda.zeebe.test.util.logging.RecordingAppender;
 import java.lang.management.ManagementFactory;
 import java.util.stream.Stream;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.Logger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -287,6 +291,11 @@ class RocksDbSharedCacheTest {
       final MemoryAllocationStrategy strategy,
       final int partitionsCount,
       final long totalSystemMemory) {
+    final var recorder = new RecordingAppender();
+    final var logger = (Logger) LogManager.getLogger(RocksdbCfg.class);
+    recorder.start();
+    logger.addAppender(recorder);
+
     // given
     rocksdbCfg.setMemoryLimit(DataSize.ofBytes(memoryLimitBytes));
     rocksdbCfg.setMemoryAllocationStrategy(strategy);
@@ -294,6 +303,18 @@ class RocksDbSharedCacheTest {
     // when/then
     try (final var ignored = mockMemoryEnvironment(totalSystemMemory)) {
       assertThatNoException().isThrownBy(() -> rocksdbCfg.validateRocksDbMemory(partitionsCount));
+      assertThat(recorder.getAppendedEvents())
+          .anySatisfy(
+              event -> {
+                assertThat(event.getLevel()).isEqualTo(Level.WARN);
+                assertThat(event.getMessage().getFormattedMessage())
+                    .contains("Requested RocksDB memory")
+                    .contains("Memory allocation strategy: " + strategy)
+                    .contains("Partitions count: " + partitionsCount);
+              });
+    } finally {
+      logger.removeAppender(recorder);
+      recorder.stop();
     }
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCacheTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCacheTest.java
@@ -310,7 +310,7 @@ class RocksDbSharedCacheTest {
                 assertThat(event.getMessage().getFormattedMessage())
                     .contains("Requested RocksDB memory")
                     .contains("Memory allocation strategy: " + strategy)
-                    .contains("Partitions count: " + partitionsCount);
+                    .contains("Partitions per broker count: " + partitionsCount);
               });
     } finally {
       logger.removeAppender(recorder);

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCacheTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCacheTest.java
@@ -272,55 +272,28 @@ class RocksDbSharedCacheTest {
   static Stream<Arguments> provideExceedsTotalSystemMemoryScenarios() {
     return Stream.of(
         // 512MB limit with PARTITION strategy, 1 partition, 256MB total system memory
-        Arguments.of(
-            512L * 1024 * 1024,
-            MemoryAllocationStrategy.PARTITION,
-            1,
-            256L * 1024 * 1024,
-            new String[] {"512 MB", "256 MB", "PARTITION"}),
+        Arguments.of(512L * 1024 * 1024, MemoryAllocationStrategy.PARTITION, 1, 256L * 1024 * 1024),
         // 512MB limit with BROKER strategy, 1 partition, 256MB total system memory
-        Arguments.of(
-            512L * 1024 * 1024,
-            MemoryAllocationStrategy.BROKER,
-            1,
-            256L * 1024 * 1024,
-            new String[] {"BROKER"}),
+        Arguments.of(512L * 1024 * 1024, MemoryAllocationStrategy.BROKER, 1, 256L * 1024 * 1024),
         // 128MB per partition with 4 partitions = 512MB, 256MB total system memory
         Arguments.of(
-            128L * 1024 * 1024,
-            MemoryAllocationStrategy.PARTITION,
-            4,
-            256L * 1024 * 1024,
-            new String[] {"512 MB", "256 MB", "Partitions count: 4"}));
+            128L * 1024 * 1024, MemoryAllocationStrategy.PARTITION, 4, 256L * 1024 * 1024));
   }
 
   @ParameterizedTest
   @MethodSource("provideExceedsTotalSystemMemoryScenarios")
-  void shouldThrowIfRequestedMemoryExceedsTotalSystemMemory(
+  void shouldNotThrowButWarnIfRequestedMemoryExceedsTotalSystemMemory(
       final long memoryLimitBytes,
       final MemoryAllocationStrategy strategy,
       final int partitionsCount,
-      final long totalSystemMemory,
-      final String[] expectedMessageParts) {
+      final long totalSystemMemory) {
     // given
     rocksdbCfg.setMemoryLimit(DataSize.ofBytes(memoryLimitBytes));
     rocksdbCfg.setMemoryAllocationStrategy(strategy);
 
     // when/then
     try (final var ignored = mockMemoryEnvironment(totalSystemMemory)) {
-      final var throwable = catchThrowable(() -> rocksdbCfg.validateRocksDbMemory(partitionsCount));
-
-      var assertion =
-          assertThat(throwable)
-              .isInstanceOf(IllegalArgumentException.class)
-              .hasMessageContaining("Requested RocksDB memory")
-              .hasMessageContaining("exceeds total system memory")
-              .hasMessageContaining(
-                  "Consider reducing the value of CAMUNDA_DATA_PRIMARYSTORAGE_ROCKSDB_MEMORYLIMIT");
-
-      for (final String part : expectedMessageParts) {
-        assertion = assertion.hasMessageContaining(part);
-      }
+      assertThatNoException().isThrownBy(() -> rocksdbCfg.validateRocksDbMemory(partitionsCount));
     }
   }
 }


### PR DESCRIPTION
## Description

This PR fixes the bug that we do the rocks db memory validation with distinct partitions instead of number of partitions per broker. This is done by moving the validation to the moment where the fetch the partitions per broker from the broker topology. 

Additionally the the max rocksDB memory limit check for `PARTITION` and `BROKER` are now warnings instead of a illegal state exception.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes https://github.com/camunda/camunda/issues/52953
