### PR TITLE
ci: switch docker-build-helm-integration to merge_group trigger (stable/8.8)

### DIFF
--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -190,6 +190,10 @@ jobs:
           elif [[ "${{ github.event_name }}" == "merge_group" ]]; then
             # For merge queue: <maven-version>-mq<PR_NUMBER>-run<run_id>-a<run_attempt>
             PR_NUM=$(echo "${{ github.ref }}" | grep -oP '(?<=pr-)\d+')
+            if [[ -z "${PR_NUM}" ]]; then
+              echo "Failed to extract PR number from merge queue ref '${{ github.ref }}'." >&2
+              exit 1
+            fi
             echo "tag=${MAVEN_VERSION}-mq${PR_NUM}-run${{ github.run_id }}-a${{ github.run_attempt }}" >> "$GITHUB_OUTPUT"
           else
             # For manual dispatch: <maven-version>-<short-sha> (e.g., 8.8.0-SNAPSHOT-abc1234)

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -5,10 +5,13 @@
 name: Docker Build and Helm Integration Test
 
 on:
+  push:
+    branches:
+      - stable/8.8
   workflow_dispatch:
     inputs:
       version:
-        description: 'Docker image version tag (defaults to pr-<sha> or Maven version)'
+        description: 'Docker image version tag (defaults to ...-mq<PR_NUMBER>-run<run_id>-a<attempt> for merge queue, ...-dispatch-run<run_id>-a<attempt> for manual dispatch, or ...-stable-8.8-run<run_id>-a<attempt> for push to stable/8.8)'
         type: string
         required: false
       helmRepositoryBranchName:
@@ -22,7 +25,7 @@ on:
       scenario:
         description: 'Test scenario'
         type: string
-        default: 'keycloak-original'
+        default: 'alwaysgreen'
       deployment-ttl:
         description: 'Deployment TTL'
         type: string
@@ -30,14 +33,15 @@ on:
       shortname:
         description: 'Short name for the deployment'
         type: string
-        default: 'kcor'
+        default: 'agrn'
   merge_group:
     types:
       - checks_requested
 
-# Cancel in-progress runs when a new commit enters the merge queue for the same ref
+# Limit workflow to 1 concurrent run per ref (branch) and trigger event (push/schedule/etc): new commit -> old runs are canceled to save costs
+# Exception for main + stable/* branches: complete builds for every commit needed for confidence
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ format('{0}-{1}-{2}', github.workflow, github.event_name, (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/')) && github.sha || github.ref) }}
   cancel-in-progress: true
 
 env:
@@ -55,9 +59,11 @@ jobs:
     name: Check Run Conditions
     runs-on: ubuntu-latest
     timeout-minutes: 1
+    continue-on-error: ${{ github.event_name == 'merge_group' }}
     permissions: { }
     if: >
       github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'push' ||
       github.event_name == 'merge_group'
     steps:
       - run: echo "Workflow conditions met, proceeding with build"
@@ -68,6 +74,7 @@ jobs:
     permissions: { }
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    continue-on-error: ${{ github.event_name == 'merge_group' }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -97,6 +104,7 @@ jobs:
     permissions: { }
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    continue-on-error: ${{ github.event_name == 'merge_group' }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -126,6 +134,7 @@ jobs:
     permissions: { }
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    continue-on-error: ${{ github.event_name == 'merge_group' }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -158,6 +167,7 @@ jobs:
     permissions: { }
     runs-on: gcp-perf-core-8-default
     timeout-minutes: 30
+    continue-on-error: ${{ github.event_name == 'merge_group' }}
     outputs:
       image-tag: ${{ steps.set-image-tag.outputs.tag }}
     steps:
@@ -189,16 +199,18 @@ jobs:
             echo "tag=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
           elif [[ "${{ github.event_name }}" == "merge_group" ]]; then
             # For merge queue: <maven-version>-mq<PR_NUMBER>-run<run_id>-a<run_attempt>
-            PR_NUM=$(echo "${{ github.ref }}" | grep -oP '(?<=pr-)\d+')
+            PR_NUM=$(sed -nE 's|^refs/heads/gh-readonly-queue/.+/pr-([0-9]+)-.*$|\1|p' <<< "${{ github.ref }}")
             if [[ -z "${PR_NUM}" ]]; then
-              echo "Failed to extract PR number from merge queue ref '${{ github.ref }}'." >&2
+              echo "Failed to resolve a single PR number from merge_group ref: '${{ github.ref }}'" >&2
               exit 1
             fi
             echo "tag=${MAVEN_VERSION}-mq${PR_NUM}-run${{ github.run_id }}-a${{ github.run_attempt }}" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            # For manual dispatch: <maven-version>-dispatch-run<run_id>-a<run_attempt> (e.g., 8.8.0-SNAPSHOT-dispatch-run12345678-a1)
+            echo "tag=${MAVEN_VERSION}-dispatch-run${{ github.run_id }}-a${{ github.run_attempt }}" >> "$GITHUB_OUTPUT"
           else
-            # For manual dispatch: <maven-version>-<short-sha> (e.g., 8.8.0-SNAPSHOT-abc1234)
-            SHA_SHORT="${GITHUB_SHA::7}"
-            echo "tag=${MAVEN_VERSION}-${SHA_SHORT}" >> "$GITHUB_OUTPUT"
+            # For push to stable/8.8: <maven-version>-stable-8.8-run<run_id>-a<run_attempt> (e.g., 8.8.0-SNAPSHOT-stable-8.8-run12345678-a1)
+            echo "tag=${MAVEN_VERSION}-stable-8.8-run${{ github.run_id }}-a${{ github.run_attempt }}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Download Operate frontend artifact
@@ -264,6 +276,7 @@ jobs:
     permissions: { }
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    continue-on-error: ${{ github.event_name == 'merge_group' }}
     outputs:
       identifier: ${{ steps.format.outputs.identifier }}
     steps:
@@ -292,8 +305,8 @@ jobs:
       test-enabled: true
       e2e-enabled: true
       deployment-ttl: ${{ inputs.deployment-ttl || '' }}
-      scenario: ${{ inputs.scenario || 'keycloak-original' }}
-      shortname: ${{ inputs.shortname || 'kcor' }}
+      scenario: ${{ inputs.scenario || 'alwaysgreen' }}
+      shortname: ${{ inputs.shortname || 'agrn' }}
       always-delete-namespace: true
       flows: install
       extra-values: |
@@ -318,6 +331,7 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 3
+    continue-on-error: ${{ github.event_name == 'merge_group' }}
     permissions: { }
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -31,21 +31,13 @@ on:
         description: 'Short name for the deployment'
         type: string
         default: 'kcor'
-  pull_request:
-    paths:
-      - ".github/workflows/docker-build-helm-integration.yml"
-      - "camunda.Dockerfile"
-      - "dist/**"
-      - "zeebe/**"
-      - "operate/**"
-      - "tasklist/**"
-      - "identity/**"
-      - "optimize/**"
-      - "parent/pom.xml"
+  merge_group:
+    types:
+      - checks_requested
 
-# Cancel in-progress runs when a new commit is pushed to the same PR
+# Cancel in-progress runs when a new commit enters the merge queue for the same ref
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:
@@ -66,8 +58,7 @@ jobs:
     permissions: { }
     if: >
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' &&
-       !contains(github.event.pull_request.labels.*.name, 'skip-always-green'))
+      github.event_name == 'merge_group'
     steps:
       - run: echo "Workflow conditions met, proceeding with build"
   # Parallel frontend builds
@@ -196,9 +187,10 @@ jobs:
           if [[ -n "${{ inputs.version }}" ]]; then
             # Use explicitly provided version
             echo "tag=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
-          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            # For PRs: <maven-version>-pr<PR_NUMBER>-run<run_id>-a<run_attempt>
-            echo "tag=${MAVEN_VERSION}-pr${{ github.event.pull_request.number }}-run${{ github.run_id }}-a${{ github.run_attempt }}" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.event_name }}" == "merge_group" ]]; then
+            # For merge queue: <maven-version>-mq<PR_NUMBER>-run<run_id>-a<run_attempt>
+            PR_NUM=$(echo "${{ github.ref }}" | grep -oP '(?<=pr-)\d+')
+            echo "tag=${MAVEN_VERSION}-mq${PR_NUM}-run${{ github.run_id }}-a${{ github.run_attempt }}" >> "$GITHUB_OUTPUT"
           else
             # For manual dispatch: <maven-version>-<short-sha> (e.g., 8.8.0-SNAPSHOT-abc1234)
             SHA_SHORT="${GITHUB_SHA::7}"


### PR DESCRIPTION
## Summary

Switches `docker-build-helm-integration.yml` from `pull_request` to `merge_group` trigger so the workflow only runs when a PR enters the merge queue, not on every PR push.

**Changes:**
- Replaced `pull_request` trigger (with paths) with `merge_group: types: [checks_requested]`
- Updated `concurrency.group` to use `github.ref` instead of `github.event.pull_request.number || github.ref`
- Updated `should-run` gate condition: replaced PR/label check with `merge_group`
- Updated `set-image-tag` step: replaced `pull_request` case with `merge_group` case using tag format `...-mq<PR_NUMBER>-run<run_id>-a<attempt>`

**Note:** `merge_group` does not support path filters natively — the workflow will run for all PRs entering the queue regardless of changed files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BZiCbGuK2g4Qmys9DVfFyM)_