### PR TITLE
ci: enable preview environment smoke testing for 8.10

### DIFF
--- a/.ci/preview-environments/charts/c8sm/Chart.lock
+++ b/.ci/preview-environments/charts/c8sm/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 1.8.7
 - name: camunda-platform
   repository: https://helm.camunda.io
-  version: 14.0.0-alpha5
-digest: sha256:41162344298445ac01c93f226f3b27cd04c45e24b8fbb6102f6eeb5427c14305
-generated: "2026-03-30T22:45:08.703809069Z"
+  version: 15.0.0-alpha1
+digest: sha256:ee899ea2eeed0ea6742921dae5a38eab7f8502d411791e94903d2b9fec9b9037
+generated: "2026-05-13T16:34:55.369666+02:00"

--- a/.ci/preview-environments/charts/c8sm/Chart.yaml
+++ b/.ci/preview-environments/charts/c8sm/Chart.yaml
@@ -14,4 +14,4 @@ dependencies:
   version: 1.8.7
 - name: camunda-platform
   repository: https://helm.camunda.io
-  version: 14.0.0-alpha5 #TODO: Update helm version once 8.10.0-alpha1 released, and re-enable 8.10 smoke tests in preview-env-smoke-test.yml
+  version: 15.0.0-alpha1

--- a/.github/workflows/preview-env-smoke-test.yml
+++ b/.github/workflows/preview-env-smoke-test.yml
@@ -59,11 +59,7 @@ jobs:
 
   deploy-8-10:
     name: Deploy 8.10 Preview Environment
-    # TODO(2026-05-11): Re-enable for scheduled/all runs once 8.10 helm chart (>=14.0.1) is released.
-    # if: contains(fromJSON('["all", "8.10", ""]'), inputs.version)
-    # Currently disabled because there is no 8.10 helm chart yet; deploy always fails.
-    # To test manually, use workflow_dispatch with version='8.10'.
-    if: inputs.version == '8.10'
+    if: contains(fromJSON('["all", "8.10", ""]'), inputs.version)
     uses: ./.github/workflows/preview-env-build-and-deploy.yml
     secrets: inherit
     with:


### PR DESCRIPTION
Reference: https://camunda.slack.com/archives/C090HGYE5T2/p1777316857686999

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
