### PR TITLE
feat: bundle analytics-exporter in the Camunda distribution

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -210,6 +210,11 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>analytics-exporter</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>camunda-db-rdbms</artifactId>
     </dependency>
 
@@ -1110,6 +1115,9 @@
 
             <!-- App Integrations Exporter -->
             <dependency>io.camunda:app-integrations-exporter</dependency>
+
+            <!-- Analytics Exporter -->
+            <dependency>io.camunda:analytics-exporter</dependency>
           </usedDependencies>
           <ignoredUnusedDeclaredDependencies>
             <dep>com.nimbusds:oauth2-oidc-sdk</dep>


### PR DESCRIPTION
## Description

Adds the analytics exporter to our dist pom file. This ensure we package the exporter library and make it easy to use. If we don't we wouldn't have it available on our classpath.

Related to #52387 