### PR TITLE
feat: make ES/OS schema initialization physical-tenant aware

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineConnectPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineConnectPropertiesOverride.java
@@ -56,6 +56,10 @@ public class SearchEngineConnectPropertiesOverride {
   @Bean
   @Primary
   public SearchEngineConnectProperties searchEngineConnectProperties() {
+    return searchEngineConnectProperties(camunda);
+  }
+
+  public SearchEngineConnectProperties searchEngineConnectProperties(final Camunda camunda) {
     final SearchEngineConnectProperties override = new SearchEngineConnectProperties();
     BeanUtils.copyProperties(legacySearchEngineConnectProperties, override);
     new Converter(camunda).applyTo(override);

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineConnectPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineConnectPropertiesOverride.java
@@ -56,13 +56,9 @@ public class SearchEngineConnectPropertiesOverride {
   @Bean
   @Primary
   public SearchEngineConnectProperties searchEngineConnectProperties() {
-    return searchEngineConnectProperties(unifiedConfiguration.getCamunda());
-  }
-
-  public SearchEngineConnectProperties searchEngineConnectProperties(final Camunda camunda) {
     final SearchEngineConnectProperties override = new SearchEngineConnectProperties();
     BeanUtils.copyProperties(legacySearchEngineConnectProperties, override);
-    new Converter(camunda).applyTo(override);
+    new Converter(unifiedConfiguration.getCamunda()).applyTo(override);
     return override;
   }
 

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineConnectPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineConnectPropertiesOverride.java
@@ -43,20 +43,20 @@ public class SearchEngineConnectPropertiesOverride {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(SearchEngineConnectPropertiesOverride.class);
 
-  private final Camunda camunda;
+  private final UnifiedConfiguration unifiedConfiguration;
   private final LegacySearchEngineConnectProperties legacySearchEngineConnectProperties;
 
   public SearchEngineConnectPropertiesOverride(
       final UnifiedConfiguration unifiedConfiguration,
       final LegacySearchEngineConnectProperties legacySearchEngineConnectProperties) {
-    camunda = unifiedConfiguration.getCamunda();
+    this.unifiedConfiguration = unifiedConfiguration;
     this.legacySearchEngineConnectProperties = legacySearchEngineConnectProperties;
   }
 
   @Bean
   @Primary
   public SearchEngineConnectProperties searchEngineConnectProperties() {
-    return searchEngineConnectProperties(camunda);
+    return searchEngineConnectProperties(unifiedConfiguration.getCamunda());
   }
 
   public SearchEngineConnectProperties searchEngineConnectProperties(final Camunda camunda) {

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineIndexPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineIndexPropertiesOverride.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.configuration.beanoverrides;
 
+import io.camunda.configuration.Camunda;
 import io.camunda.configuration.DocumentBasedSecondaryStorageDatabase;
 import io.camunda.configuration.SecondaryStorage;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
@@ -44,11 +45,14 @@ public class SearchEngineIndexPropertiesOverride {
   @Bean
   @Primary
   public SearchEngineIndexProperties searchEngineIndexProperties() {
+    return searchEngineIndexProperties(unifiedConfiguration.getCamunda());
+  }
+
+  public SearchEngineIndexProperties searchEngineIndexProperties(final Camunda camunda) {
     final SearchEngineIndexProperties override = new SearchEngineIndexProperties();
     BeanUtils.copyProperties(legacySearchEngineIndexProperties, override);
 
-    final SecondaryStorage secondaryStorage =
-        unifiedConfiguration.getCamunda().getData().getSecondaryStorage();
+    final SecondaryStorage secondaryStorage = camunda.getData().getSecondaryStorage();
 
     final DocumentBasedSecondaryStorageDatabase database =
         (secondaryStorage.getType() == SecondaryStorageType.elasticsearch)

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineIndexPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineIndexPropertiesOverride.java
@@ -51,7 +51,11 @@ public class SearchEngineIndexPropertiesOverride {
   public SearchEngineIndexProperties searchEngineIndexProperties(final Camunda camunda) {
     final SearchEngineIndexProperties override = new SearchEngineIndexProperties();
     BeanUtils.copyProperties(legacySearchEngineIndexProperties, override);
+    applyTo(camunda, override);
+    return override;
+  }
 
+  public static void applyTo(final Camunda camunda, final SearchEngineIndexProperties override) {
     final SecondaryStorage secondaryStorage = camunda.getData().getSecondaryStorage();
 
     final DocumentBasedSecondaryStorageDatabase database =
@@ -74,7 +78,5 @@ public class SearchEngineIndexPropertiesOverride {
     if (!database.getRefreshIntervalByIndexName().isEmpty()) {
       override.setRefreshIntervalByIndexName(database.getRefreshIntervalByIndexName());
     }
-
-    return override;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineIndexPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineIndexPropertiesOverride.java
@@ -45,13 +45,9 @@ public class SearchEngineIndexPropertiesOverride {
   @Bean
   @Primary
   public SearchEngineIndexProperties searchEngineIndexProperties() {
-    return searchEngineIndexProperties(unifiedConfiguration.getCamunda());
-  }
-
-  public SearchEngineIndexProperties searchEngineIndexProperties(final Camunda camunda) {
     final SearchEngineIndexProperties override = new SearchEngineIndexProperties();
     BeanUtils.copyProperties(legacySearchEngineIndexProperties, override);
-    applyTo(camunda, override);
+    applyTo(unifiedConfiguration.getCamunda(), override);
     return override;
   }
 

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineRetentionPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineRetentionPropertiesOverride.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.configuration.beanoverrides;
 
+import io.camunda.configuration.Camunda;
 import io.camunda.configuration.DocumentBasedSecondaryStorageDatabase;
 import io.camunda.configuration.Retention;
 import io.camunda.configuration.SecondaryStorage;
@@ -46,25 +47,29 @@ public class SearchEngineRetentionPropertiesOverride {
   @Bean
   @Primary
   public SearchEngineRetentionProperties searchEngineRetentionProperties() {
+    return searchEngineRetentionProperties(unifiedConfiguration.getCamunda());
+  }
+
+  public SearchEngineRetentionProperties searchEngineRetentionProperties(final Camunda camunda) {
     final SearchEngineRetentionProperties override = new SearchEngineRetentionProperties();
     BeanUtils.copyProperties(legacySearchEngineRetentionProperties, override);
 
-    populateFromRetention(override);
-    populateFromSecondaryStorage(override);
+    populateFromRetention(camunda, override);
+    populateFromSecondaryStorage(camunda, override);
 
     return override;
   }
 
-  private void populateFromRetention(final SearchEngineRetentionProperties override) {
-    final Retention retention =
-        unifiedConfiguration.getCamunda().getData().getSecondaryStorage().getRetention();
+  private void populateFromRetention(
+      final Camunda camunda, final SearchEngineRetentionProperties override) {
+    final Retention retention = camunda.getData().getSecondaryStorage().getRetention();
     override.setEnabled(retention.isEnabled());
     override.setMinimumAge(retention.getMinimumAge());
   }
 
-  private void populateFromSecondaryStorage(final SearchEngineRetentionProperties override) {
-    final SecondaryStorage secondaryStorage =
-        unifiedConfiguration.getCamunda().getData().getSecondaryStorage();
+  private void populateFromSecondaryStorage(
+      final Camunda camunda, final SearchEngineRetentionProperties override) {
+    final SecondaryStorage secondaryStorage = camunda.getData().getSecondaryStorage();
 
     final DocumentBasedSecondaryStorageDatabase database =
         switch (secondaryStorage.getType()) {

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineRetentionPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineRetentionPropertiesOverride.java
@@ -47,13 +47,9 @@ public class SearchEngineRetentionPropertiesOverride {
   @Bean
   @Primary
   public SearchEngineRetentionProperties searchEngineRetentionProperties() {
-    return searchEngineRetentionProperties(unifiedConfiguration.getCamunda());
-  }
-
-  public SearchEngineRetentionProperties searchEngineRetentionProperties(final Camunda camunda) {
     final SearchEngineRetentionProperties override = new SearchEngineRetentionProperties();
     BeanUtils.copyProperties(legacySearchEngineRetentionProperties, override);
-    applyTo(camunda, override);
+    applyTo(unifiedConfiguration.getCamunda(), override);
     return override;
   }
 

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineRetentionPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineRetentionPropertiesOverride.java
@@ -53,21 +53,24 @@ public class SearchEngineRetentionPropertiesOverride {
   public SearchEngineRetentionProperties searchEngineRetentionProperties(final Camunda camunda) {
     final SearchEngineRetentionProperties override = new SearchEngineRetentionProperties();
     BeanUtils.copyProperties(legacySearchEngineRetentionProperties, override);
-
-    populateFromRetention(camunda, override);
-    populateFromSecondaryStorage(camunda, override);
-
+    applyTo(camunda, override);
     return override;
   }
 
-  private void populateFromRetention(
+  public static void applyTo(
+      final Camunda camunda, final SearchEngineRetentionProperties override) {
+    populateFromRetention(camunda, override);
+    populateFromSecondaryStorage(camunda, override);
+  }
+
+  private static void populateFromRetention(
       final Camunda camunda, final SearchEngineRetentionProperties override) {
     final Retention retention = camunda.getData().getSecondaryStorage().getRetention();
     override.setEnabled(retention.isEnabled());
     override.setMinimumAge(retention.getMinimumAge());
   }
 
-  private void populateFromSecondaryStorage(
+  private static void populateFromSecondaryStorage(
       final Camunda camunda, final SearchEngineRetentionProperties override) {
     final SecondaryStorage secondaryStorage = camunda.getData().getSecondaryStorage();
 

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineSchemaManagerPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineSchemaManagerPropertiesOverride.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.configuration.beanoverrides;
 
+import io.camunda.configuration.Camunda;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.beans.LegacySearchEngineSchemaManagerProperties;
@@ -44,11 +45,16 @@ public class SearchEngineSchemaManagerPropertiesOverride {
   @Bean
   @Primary
   public SearchEngineSchemaManagerProperties searchEngineSchemaManagerProperties() {
+    return searchEngineSchemaManagerProperties(unifiedConfiguration.getCamunda());
+  }
+
+  public SearchEngineSchemaManagerProperties searchEngineSchemaManagerProperties(
+      final Camunda camunda) {
     final SearchEngineSchemaManagerProperties override = new SearchEngineSchemaManagerProperties();
     BeanUtils.copyProperties(legacySearchEngineSchemaManagerProperties, override);
 
     override.setVersionCheckRestrictionEnabled(
-        unifiedConfiguration.getCamunda().getSystem().getUpgrade().getEnableVersionCheck());
+        camunda.getSystem().getUpgrade().getEnableVersionCheck());
 
     /* Clean-up properties */
     unifiedConfiguration

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineSchemaManagerPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineSchemaManagerPropertiesOverride.java
@@ -52,7 +52,12 @@ public class SearchEngineSchemaManagerPropertiesOverride {
       final Camunda camunda) {
     final SearchEngineSchemaManagerProperties override = new SearchEngineSchemaManagerProperties();
     BeanUtils.copyProperties(legacySearchEngineSchemaManagerProperties, override);
+    applyTo(camunda, override);
+    return override;
+  }
 
+  public static void applyTo(
+      final Camunda camunda, final SearchEngineSchemaManagerProperties override) {
     override.setVersionCheckRestrictionEnabled(
         camunda.getSystem().getUpgrade().getEnableVersionCheck());
 
@@ -65,7 +70,5 @@ public class SearchEngineSchemaManagerPropertiesOverride {
             secondaryStorage -> {
               override.setPerformCleanup(secondaryStorage.isPerformCleanup());
             });
-
-    return override;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineSchemaManagerPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineSchemaManagerPropertiesOverride.java
@@ -57,8 +57,7 @@ public class SearchEngineSchemaManagerPropertiesOverride {
         camunda.getSystem().getUpgrade().getEnableVersionCheck());
 
     /* Clean-up properties */
-    unifiedConfiguration
-        .getCamunda()
+    camunda
         .getData()
         .getSecondaryStorage()
         .elasticsearchOrOpensearch()

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineSchemaManagerPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineSchemaManagerPropertiesOverride.java
@@ -45,14 +45,9 @@ public class SearchEngineSchemaManagerPropertiesOverride {
   @Bean
   @Primary
   public SearchEngineSchemaManagerProperties searchEngineSchemaManagerProperties() {
-    return searchEngineSchemaManagerProperties(unifiedConfiguration.getCamunda());
-  }
-
-  public SearchEngineSchemaManagerProperties searchEngineSchemaManagerProperties(
-      final Camunda camunda) {
     final SearchEngineSchemaManagerProperties override = new SearchEngineSchemaManagerProperties();
     BeanUtils.copyProperties(legacySearchEngineSchemaManagerProperties, override);
-    applyTo(camunda, override);
+    applyTo(unifiedConfiguration.getCamunda(), override);
     return override;
   }
 

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchEngineDatabaseConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchEngineDatabaseConfiguration.java
@@ -8,18 +8,25 @@
 package io.camunda.application.commons.search;
 
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
+import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineIndexPropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineRetentionPropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineSchemaManagerPropertiesOverride;
 import io.camunda.configuration.beans.SearchEngineConnectProperties;
 import io.camunda.configuration.beans.SearchEngineIndexProperties;
 import io.camunda.configuration.beans.SearchEngineRetentionProperties;
 import io.camunda.configuration.beans.SearchEngineSchemaManagerProperties;
 import io.camunda.configuration.conditions.ConditionalOnSecondaryStorageType;
+import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
 import io.camunda.search.connect.configuration.DatabaseConfig;
 import io.camunda.search.connect.configuration.DatabaseType;
 import io.camunda.search.schema.config.SearchEngineConfiguration;
 import io.camunda.zeebe.broker.Broker;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.micrometer.core.instrument.MeterRegistry;
+import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -31,15 +38,35 @@ import org.springframework.context.annotation.Configuration;
 public class SearchEngineDatabaseConfiguration {
 
   @Bean
+  public Map<String, SearchEngineConfiguration> searchEngineConfigurationsByTenant(
+      final PhysicalTenantResolver physicalTenantResolver,
+      final SearchEngineConnectPropertiesOverride connectOverride,
+      final SearchEngineIndexPropertiesOverride indexOverride,
+      final SearchEngineRetentionPropertiesOverride retentionOverride,
+      final SearchEngineSchemaManagerPropertiesOverride schemaManagerOverride) {
+    return physicalTenantResolver.mapValues(
+        tenantCamunda ->
+            SearchEngineConfiguration.of(
+                b ->
+                    b.connect(connectOverride.searchEngineConnectProperties(tenantCamunda))
+                        .index(indexOverride.searchEngineIndexProperties(tenantCamunda))
+                        .retention(retentionOverride.searchEngineRetentionProperties(tenantCamunda))
+                        .schemaManager(
+                            schemaManagerOverride.searchEngineSchemaManagerProperties(
+                                tenantCamunda))));
+  }
+
+  @Bean
   public SearchEngineSchemaInitializer searchEngineSchemaInitializer(
-      final SearchEngineConfiguration searchEngineConfiguration,
+      @Qualifier("searchEngineConfigurationsByTenant")
+          final Map<String, SearchEngineConfiguration> searchEngineConfigurationsByTenant,
       final MeterRegistry meterRegistry,
       @Autowired(required = false)
           final Broker broker, // if present, then it will ensure that the broker is started first
       @Autowired(required = false) final BrokerCfg brokerCfg) {
     final boolean isGatewayEnabled = brokerCfg == null || brokerCfg.getGateway().isEnable();
     return new SearchEngineSchemaInitializer(
-        searchEngineConfiguration, meterRegistry, isGatewayEnabled);
+        searchEngineConfigurationsByTenant, meterRegistry, isGatewayEnabled);
   }
 
   @Bean

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchEngineDatabaseConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchEngineDatabaseConfiguration.java
@@ -21,6 +21,7 @@ import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
 import io.camunda.search.connect.configuration.DatabaseConfig;
 import io.camunda.search.connect.configuration.DatabaseType;
 import io.camunda.search.schema.config.SearchEngineConfiguration;
+import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import io.camunda.zeebe.broker.Broker;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -60,13 +61,18 @@ public class SearchEngineDatabaseConfiguration {
   public SearchEngineSchemaInitializer searchEngineSchemaInitializer(
       @Qualifier("searchEngineConfigurationsByTenant")
           final Map<String, SearchEngineConfiguration> searchEngineConfigurationsByTenant,
+      @Qualifier("physicalTenantScopedIndexDescriptors")
+          final Map<String, IndexDescriptors> physicalTenantScopedIndexDescriptors,
       final MeterRegistry meterRegistry,
       @Autowired(required = false)
           final Broker broker, // if present, then it will ensure that the broker is started first
       @Autowired(required = false) final BrokerCfg brokerCfg) {
     final boolean isGatewayEnabled = brokerCfg == null || brokerCfg.getGateway().isEnable();
     return new SearchEngineSchemaInitializer(
-        searchEngineConfigurationsByTenant, meterRegistry, isGatewayEnabled);
+        searchEngineConfigurationsByTenant,
+        physicalTenantScopedIndexDescriptors,
+        meterRegistry,
+        isGatewayEnabled);
   }
 
   @Bean

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchEngineDatabaseConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchEngineDatabaseConfiguration.java
@@ -7,8 +7,10 @@
  */
 package io.camunda.application.commons.search;
 
+import io.camunda.cluster.PhysicalTenantIds;
+import io.camunda.configuration.Camunda;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
-import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride.Converter;
 import io.camunda.configuration.beanoverrides.SearchEngineIndexPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineRetentionPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineSchemaManagerPropertiesOverride;
@@ -25,6 +27,8 @@ import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import io.camunda.zeebe.broker.Broker;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.micrometer.core.instrument.MeterRegistry;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -41,17 +45,23 @@ public class SearchEngineDatabaseConfiguration {
   @Bean
   public Map<String, SearchEngineConfiguration> searchEngineConfigurationsByTenant(
       final PhysicalTenantResolver physicalTenantResolver,
-      final SearchEngineConnectPropertiesOverride connectOverride,
-      final SearchEngineIndexPropertiesOverride indexOverride,
-      final SearchEngineRetentionPropertiesOverride retentionOverride,
-      final SearchEngineSchemaManagerPropertiesOverride schemaManagerOverride) {
-    return physicalTenantResolver.mapValues(
-        tenantCamunda ->
-            buildConfiguration(
-                connectOverride.searchEngineConnectProperties(tenantCamunda),
-                indexOverride.searchEngineIndexProperties(tenantCamunda),
-                retentionOverride.searchEngineRetentionProperties(tenantCamunda),
-                schemaManagerOverride.searchEngineSchemaManagerProperties(tenantCamunda)));
+      final SearchEngineConnectProperties searchEngineConnectProperties,
+      final SearchEngineIndexProperties searchEngineIndexProperties,
+      final SearchEngineRetentionProperties searchEngineRetentionProperties,
+      final SearchEngineSchemaManagerProperties searchEngineSchemaManagerProperties) {
+    final var byTenant = new LinkedHashMap<String, SearchEngineConfiguration>();
+    for (final String tenantId : physicalTenantResolver.known()) {
+      byTenant.put(
+          tenantId,
+          PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID.equals(tenantId)
+              ? buildConfiguration(
+                  searchEngineConnectProperties,
+                  searchEngineIndexProperties,
+                  searchEngineRetentionProperties,
+                  searchEngineSchemaManagerProperties)
+              : convert(physicalTenantResolver.forPhysicalTenant(tenantId)));
+    }
+    return Collections.unmodifiableMap(byTenant);
   }
 
   @Bean
@@ -83,6 +93,17 @@ public class SearchEngineDatabaseConfiguration {
         searchEngineIndexProperties,
         searchEngineRetentionProperties,
         searchEngineSchemaManagerProperties);
+  }
+
+  private static SearchEngineConfiguration convert(final Camunda tenantCamunda) {
+    final var index = new SearchEngineIndexProperties();
+    SearchEngineIndexPropertiesOverride.applyTo(tenantCamunda, index);
+    final var retention = new SearchEngineRetentionProperties();
+    SearchEngineRetentionPropertiesOverride.applyTo(tenantCamunda, retention);
+    final var schemaManager = new SearchEngineSchemaManagerProperties();
+    SearchEngineSchemaManagerPropertiesOverride.applyTo(tenantCamunda, schemaManager);
+    return buildConfiguration(
+        new Converter(tenantCamunda).convert(), index, retention, schemaManager);
   }
 
   private static SearchEngineConfiguration buildConfiguration(

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchEngineDatabaseConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchEngineDatabaseConfiguration.java
@@ -47,14 +47,11 @@ public class SearchEngineDatabaseConfiguration {
       final SearchEngineSchemaManagerPropertiesOverride schemaManagerOverride) {
     return physicalTenantResolver.mapValues(
         tenantCamunda ->
-            SearchEngineConfiguration.of(
-                b ->
-                    b.connect(connectOverride.searchEngineConnectProperties(tenantCamunda))
-                        .index(indexOverride.searchEngineIndexProperties(tenantCamunda))
-                        .retention(retentionOverride.searchEngineRetentionProperties(tenantCamunda))
-                        .schemaManager(
-                            schemaManagerOverride.searchEngineSchemaManagerProperties(
-                                tenantCamunda))));
+            buildConfiguration(
+                connectOverride.searchEngineConnectProperties(tenantCamunda),
+                indexOverride.searchEngineIndexProperties(tenantCamunda),
+                retentionOverride.searchEngineRetentionProperties(tenantCamunda),
+                schemaManagerOverride.searchEngineSchemaManagerProperties(tenantCamunda)));
   }
 
   @Bean
@@ -81,18 +78,26 @@ public class SearchEngineDatabaseConfiguration {
       final SearchEngineIndexProperties searchEngineIndexProperties,
       final SearchEngineRetentionProperties searchEngineRetentionProperties,
       final SearchEngineSchemaManagerProperties searchEngineSchemaManagerProperties) {
+    return buildConfiguration(
+        searchEngineConnectProperties,
+        searchEngineIndexProperties,
+        searchEngineRetentionProperties,
+        searchEngineSchemaManagerProperties);
+  }
+
+  private static SearchEngineConfiguration buildConfiguration(
+      final SearchEngineConnectProperties connect,
+      final SearchEngineIndexProperties index,
+      final SearchEngineRetentionProperties retention,
+      final SearchEngineSchemaManagerProperties schemaManager) {
 
     // Override schema creation if database type is "none"
-    final DatabaseType databaseType = searchEngineConnectProperties.getTypeEnum();
+    final DatabaseType databaseType = connect.getTypeEnum();
     if (DatabaseConfig.NONE.equalsIgnoreCase(databaseType.name())) {
-      searchEngineSchemaManagerProperties.setCreateSchema(false);
+      schemaManager.setCreateSchema(false);
     }
 
     return SearchEngineConfiguration.of(
-        b ->
-            b.connect(searchEngineConnectProperties)
-                .index(searchEngineIndexProperties)
-                .retention(searchEngineRetentionProperties)
-                .schemaManager(searchEngineSchemaManagerProperties));
+        b -> b.connect(connect).index(index).retention(retention).schemaManager(schemaManager));
   }
 }

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchEngineSchemaInitializer.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchEngineSchemaInitializer.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.application.commons.search;
 
+import static java.util.stream.Collectors.toUnmodifiableMap;
+
 import io.camunda.exporter.adapters.ClientAdapter;
 import io.camunda.search.schema.SchemaManager;
 import io.camunda.search.schema.SchemaManagerContainer;
@@ -16,6 +18,7 @@ import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import io.camunda.zeebe.util.VisibleForTesting;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -25,35 +28,70 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
 
 public class SearchEngineSchemaInitializer implements InitializingBean, SchemaManagerContainer {
+  private static final int MAX_PARALLEL_SCHEMA_INITS = 4;
   private static final Logger LOGGER = LoggerFactory.getLogger(SearchEngineSchemaInitializer.class);
-  private final SearchEngineConfiguration searchEngineConfiguration;
   private final SchemaManagerMetrics schemaManagerMetrics;
   private final boolean awaitSchemaInitialization;
   private final AtomicBoolean isShutdown = new AtomicBoolean(false);
-  private final AtomicBoolean initialized = new AtomicBoolean(false);
+  private final Map<String, SearchEngineConfiguration> configs;
+  private final Map<String, IndexDescriptors> descriptors;
+  private final Map<String, AtomicBoolean> initialized;
 
   public SearchEngineSchemaInitializer(
-      final SearchEngineConfiguration searchEngineConfiguration,
+      final Map<String, SearchEngineConfiguration> configsByTenant,
       final MeterRegistry meterRegistry,
       final boolean awaitSchemaInitialization) {
-    this.searchEngineConfiguration = searchEngineConfiguration;
     schemaManagerMetrics = new SchemaManagerMetrics(meterRegistry);
     this.awaitSchemaInitialization = awaitSchemaInitialization;
+
+    configs = configsByTenant;
+    descriptors =
+        configs.entrySet().stream()
+            .collect(
+                toUnmodifiableMap(
+                    Map.Entry::getKey,
+                    e ->
+                        new IndexDescriptors(
+                            e.getValue().connect().getIndexPrefix(),
+                            e.getValue().connect().getTypeEnum().isElasticSearch())));
+    initialized =
+        configs.keySet().stream()
+            .collect(toUnmodifiableMap(id -> id, id -> new AtomicBoolean(false)));
   }
 
   @Override
   public void afterPropertiesSet() throws Exception {
-    LOGGER.info("Initializing search engine schema...");
-    final var executor = Executors.newSingleThreadExecutor();
+    LOGGER.info(
+        "Initializing search engine schema for {} physical tenant(s): {}",
+        configs.size(),
+        configs.keySet());
+
+    final int parallelism = Math.min(configs.size(), MAX_PARALLEL_SCHEMA_INITS);
+    final ExecutorService executor =
+        Executors.newFixedThreadPool(
+            parallelism,
+            runnable -> {
+              final Thread t = new Thread(runnable, "schema-init");
+              t.setDaemon(true);
+              return t;
+            });
+
     if (!addShutdownHook(executor)) {
       // skipping schema initialization as JVM is shutting down
       return;
     }
-    final var future = CompletableFuture.runAsync(this::startupSchemaManager, executor);
+
+    final CompletableFuture<?>[] futures =
+        configs.keySet().stream()
+            .map(
+                id -> CompletableFuture.runAsync(() -> startupSchemaManagerForTenant(id), executor))
+            .toArray(CompletableFuture[]::new);
+    final CompletableFuture<Void> all = CompletableFuture.allOf(futures);
+
     if (awaitSchemaInitialization) {
-      synchronousSchemaInitialization(future, executor);
+      synchronousSchemaInitialization(all, executor);
     } else {
-      asyncSchemaInitialization(future, executor);
+      asyncSchemaInitialization(all, executor);
     }
   }
 
@@ -99,24 +137,31 @@ public class SearchEngineSchemaInitializer implements InitializingBean, SchemaMa
         });
   }
 
-  private void startupSchemaManager() {
-    final var indexDescriptors =
-        new IndexDescriptors(
-            searchEngineConfiguration.connect().getIndexPrefix(),
-            searchEngineConfiguration.connect().getTypeEnum().isElasticSearch());
-    try (final ClientAdapter clientAdapter = ClientAdapter.of(searchEngineConfiguration.connect());
+  private void startupSchemaManagerForTenant(final String physicalTenantId) {
+    if (isShutdown.get()) {
+      return;
+    }
+
+    final SearchEngineConfiguration cfg = configs.get(physicalTenantId);
+    final IndexDescriptors descSet = descriptors.get(physicalTenantId);
+
+    try (final ClientAdapter clientAdapter = ClientAdapter.of(cfg.connect());
         final SchemaManager schemaManager =
             new SchemaManager(
                     clientAdapter.getSearchEngineClient(),
-                    indexDescriptors.indices(),
-                    indexDescriptors.templates(),
-                    searchEngineConfiguration,
+                    descSet.indices(),
+                    descSet.templates(),
+                    cfg,
                     clientAdapter.objectMapper())
                 .withMetrics(schemaManagerMetrics)) {
       schemaManager.startup();
-      initialized.set(true);
+      initialized.get(physicalTenantId).set(true);
+      LOGGER.info("Schema initialised for physical tenant '{}'", physicalTenantId);
     } catch (final IOException e) {
-      LOGGER.debug("Failed to close the search client", e);
+      LOGGER.debug("Failed to close the search client for tenant '{}'", physicalTenantId, e);
+    } catch (final Exception e) {
+      LOGGER.error("Schema initialisation failed for physical tenant '{}'", physicalTenantId, e);
+      throw e;
     }
   }
 
@@ -146,14 +191,29 @@ public class SearchEngineSchemaInitializer implements InitializingBean, SchemaMa
     }
   }
 
+  public IndexDescriptors forTenant(final String physicalTenantId) {
+    final IndexDescriptors d = descriptors.get(physicalTenantId);
+    if (d == null) {
+      throw new IllegalArgumentException("Unknown physical tenant: " + physicalTenantId);
+    }
+    return d;
+  }
+
+  @Override
+  public boolean isInitialized(final String physicalTenantId) {
+    final AtomicBoolean flag = initialized.get(physicalTenantId);
+    return flag != null && flag.get();
+  }
+
   /**
-   * Returns true if the schema initialization completed successfully. This can be used by dependent
-   * components to check if they should proceed with their initialization.
+   * Returns true if the schema initialization completed successfully for <em>all</em> physical
+   * tenants. This can be used by dependent components to check if they should proceed with their
+   * initialization.
    *
-   * @return true if schema initialization completed successfully, false otherwise
+   * @return true if schema initialization completed successfully for all tenants, false otherwise
    */
   @Override
   public boolean isInitialized() {
-    return initialized.get();
+    return !initialized.isEmpty() && initialized.values().stream().allMatch(AtomicBoolean::get);
   }
 }

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchEngineSchemaInitializer.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchEngineSchemaInitializer.java
@@ -18,6 +18,7 @@ import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import io.camunda.zeebe.util.VisibleForTesting;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
@@ -143,24 +144,51 @@ public class SearchEngineSchemaInitializer implements InitializingBean, SchemaMa
     final SearchEngineConfiguration cfg = configs.get(physicalTenantId);
     final IndexDescriptors descSet = descriptors.get(physicalTenantId);
 
-    try (final ClientAdapter clientAdapter = ClientAdapter.of(cfg.connect());
-        final SchemaManager schemaManager =
-            new SchemaManager(
-                    clientAdapter.getSearchEngineClient(),
-                    descSet.indices(),
-                    descSet.templates(),
-                    cfg,
-                    clientAdapter.objectMapper())
-                .withMetrics(schemaManagerMetrics)) {
-      schemaManager.startup();
-      initialized.get(physicalTenantId).set(true);
-      LOGGER.info("Schema initialised for physical tenant '{}'", physicalTenantId);
+    initializeTenantSchema(
+        physicalTenantId,
+        () -> {
+          try (final ClientAdapter clientAdapter = ClientAdapter.of(cfg.connect());
+              final SchemaManager schemaManager =
+                  new SchemaManager(
+                          clientAdapter.getSearchEngineClient(),
+                          descSet.indices(),
+                          descSet.templates(),
+                          cfg,
+                          clientAdapter.objectMapper())
+                      .withMetrics(schemaManagerMetrics)) {
+            schemaManager.startup();
+            initialized.get(physicalTenantId).set(true);
+            LOGGER.info("Schema initialized for physical tenant '{}'", physicalTenantId);
+          }
+        });
+  }
+
+  /**
+   * Runs a tenant's schema startup and classifies failures: an {@link IOException} raised after the
+   * tenant was marked initialized can only stem from closing the search client and is benign; any
+   * other failure is a real initialization failure and must propagate.
+   */
+  @VisibleForTesting
+  void initializeTenantSchema(final String physicalTenantId, final TenantSchemaStartup startup) {
+    try {
+      startup.run();
     } catch (final IOException e) {
-      LOGGER.debug("Failed to close the search client for tenant '{}'", physicalTenantId, e);
-    } catch (final Exception e) {
-      LOGGER.error("Schema initialisation failed for physical tenant '{}'", physicalTenantId, e);
+      if (isInitialized(physicalTenantId)) {
+        LOGGER.debug("Failed to close the search client for tenant '{}'", physicalTenantId, e);
+        return;
+      }
+      LOGGER.error("Schema initialization failed for physical tenant '{}'", physicalTenantId, e);
+      throw new UncheckedIOException(e);
+    } catch (final RuntimeException e) {
+      LOGGER.error("Schema initialization failed for physical tenant '{}'", physicalTenantId, e);
       throw e;
     }
+  }
+
+  @VisibleForTesting
+  @FunctionalInterface
+  interface TenantSchemaStartup {
+    void run() throws IOException;
   }
 
   /**

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchEngineSchemaInitializer.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchEngineSchemaInitializer.java
@@ -30,7 +30,7 @@ import org.springframework.beans.factory.InitializingBean;
 
 public class SearchEngineSchemaInitializer implements InitializingBean, SchemaManagerContainer {
   private static final Logger LOGGER = LoggerFactory.getLogger(SearchEngineSchemaInitializer.class);
-  private final SchemaManagerMetrics schemaManagerMetrics;
+  private final MeterRegistry meterRegistry;
   private final boolean awaitSchemaInitialization;
   private final AtomicBoolean isShutdown = new AtomicBoolean(false);
   private final Map<String, SearchEngineConfiguration> configs;
@@ -42,7 +42,7 @@ public class SearchEngineSchemaInitializer implements InitializingBean, SchemaMa
       final Map<String, IndexDescriptors> descriptorsByTenant,
       final MeterRegistry meterRegistry,
       final boolean awaitSchemaInitialization) {
-    schemaManagerMetrics = new SchemaManagerMetrics(meterRegistry);
+    this.meterRegistry = meterRegistry;
     this.awaitSchemaInitialization = awaitSchemaInitialization;
 
     configs = configsByTenant;
@@ -135,7 +135,7 @@ public class SearchEngineSchemaInitializer implements InitializingBean, SchemaMa
                     indexDescriptors.templates(),
                     configuration,
                     clientAdapter.objectMapper())
-                .withMetrics(schemaManagerMetrics)) {
+                .withMetrics(new SchemaManagerMetrics(meterRegistry, physicalTenantId))) {
       schemaManager.startup();
       initialized.get(physicalTenantId).set(true);
     } catch (final IOException e) {

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchEngineSchemaInitializer.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchEngineSchemaInitializer.java
@@ -19,7 +19,6 @@ import io.camunda.zeebe.util.VisibleForTesting;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
@@ -112,11 +111,7 @@ public class SearchEngineSchemaInitializer implements InitializingBean, SchemaMa
     future.whenCompleteAsync(
         (result, error) -> {
           if (error != null) {
-            LOGGER.error(
-                "Failed to initialize search engine schema; physical tenants without an"
-                    + " initialized schema: {}",
-                uninitializedTenantIds(),
-                error);
+            LOGGER.warn("Failed to initialize search engine schema", error);
           } else {
             LOGGER.info("Search engine schema initialization complete.");
           }
@@ -129,56 +124,26 @@ public class SearchEngineSchemaInitializer implements InitializingBean, SchemaMa
       return;
     }
 
-    final SearchEngineConfiguration cfg = configs.get(physicalTenantId);
-    final IndexDescriptors descSet = descriptors.get(physicalTenantId);
+    final SearchEngineConfiguration configuration = configs.get(physicalTenantId);
+    final IndexDescriptors indexDescriptors = descriptors.get(physicalTenantId);
 
-    initializeTenantSchema(
-        physicalTenantId,
-        () -> {
-          try (final ClientAdapter clientAdapter = ClientAdapter.of(cfg.connect());
-              final SchemaManager schemaManager =
-                  new SchemaManager(
-                          clientAdapter.getSearchEngineClient(),
-                          descSet.indices(),
-                          descSet.templates(),
-                          cfg,
-                          clientAdapter.objectMapper())
-                      .withMetrics(schemaManagerMetrics)) {
-            schemaManager.startup();
-            initialized.get(physicalTenantId).set(true);
-            LOGGER.info("Schema initialized for physical tenant '{}'", physicalTenantId);
-          }
-        });
-  }
-
-  @VisibleForTesting
-  void initializeTenantSchema(final String physicalTenantId, final TenantSchemaStartup startup) {
-    try {
-      startup.run();
+    try (final ClientAdapter clientAdapter = ClientAdapter.of(configuration.connect());
+        final SchemaManager schemaManager =
+            new SchemaManager(
+                    clientAdapter.getSearchEngineClient(),
+                    indexDescriptors.indices(),
+                    indexDescriptors.templates(),
+                    configuration,
+                    clientAdapter.objectMapper())
+                .withMetrics(schemaManagerMetrics)) {
+      schemaManager.startup();
+      initialized.get(physicalTenantId).set(true);
     } catch (final IOException e) {
-      if (isInitialized(physicalTenantId)) {
-        LOGGER.debug("Failed to close the search client for tenant '{}'", physicalTenantId, e);
-        return;
+      if (!isInitialized(physicalTenantId)) {
+        throw new UncheckedIOException(e);
       }
-      LOGGER.error("Schema initialization failed for physical tenant '{}'", physicalTenantId, e);
-      throw new UncheckedIOException(e);
-    } catch (final RuntimeException e) {
-      LOGGER.error("Schema initialization failed for physical tenant '{}'", physicalTenantId, e);
-      throw e;
+      LOGGER.debug("Failed to close the search client", e);
     }
-  }
-
-  @VisibleForTesting
-  @FunctionalInterface
-  interface TenantSchemaStartup {
-    void run() throws IOException;
-  }
-
-  private List<String> uninitializedTenantIds() {
-    return initialized.entrySet().stream()
-        .filter(entry -> !entry.getValue().get())
-        .map(Map.Entry::getKey)
-        .toList();
   }
 
   /**

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchEngineSchemaInitializer.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchEngineSchemaInitializer.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.util.VisibleForTesting;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
@@ -28,6 +29,18 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
 
+/**
+ * Initializes the search engine schema for every physical tenant at startup, running up to {@link
+ * #MAX_PARALLEL_SCHEMA_INITS} tenant initializations in parallel.
+ *
+ * <p>Failure semantics: in synchronous mode (gateway enabled) any single tenant failure aborts
+ * application startup; in asynchronous mode a failure is logged at error level together with the
+ * tenants left without an initialized schema, and {@link #isInitialized()} / {@link
+ * #isInitialized(String)} keep reporting {@code false} for them. The RDBMS counterpart ({@code
+ * DefaultRdbmsSchemaManagerRegistry}) still initializes tenants sequentially; converging both sides
+ * on parallel per-tenant orchestration is tracked in
+ * https://github.com/camunda/camunda/issues/54299.
+ */
 public class SearchEngineSchemaInitializer implements InitializingBean, SchemaManagerContainer {
   private static final int MAX_PARALLEL_SCHEMA_INITS = 4;
   private static final Logger LOGGER = LoggerFactory.getLogger(SearchEngineSchemaInitializer.class);
@@ -128,7 +141,11 @@ public class SearchEngineSchemaInitializer implements InitializingBean, SchemaMa
     future.whenCompleteAsync(
         (result, error) -> {
           if (error != null) {
-            LOGGER.warn("Failed to initialize search engine schema", error);
+            LOGGER.error(
+                "Failed to initialize search engine schema; physical tenants without an"
+                    + " initialized schema: {}",
+                uninitializedTenantIds(),
+                error);
           } else {
             LOGGER.info("Search engine schema initialization complete.");
           }
@@ -189,6 +206,13 @@ public class SearchEngineSchemaInitializer implements InitializingBean, SchemaMa
   @FunctionalInterface
   interface TenantSchemaStartup {
     void run() throws IOException;
+  }
+
+  private List<String> uninitializedTenantIds() {
+    return initialized.entrySet().stream()
+        .filter(entry -> !entry.getValue().get())
+        .map(Map.Entry::getKey)
+        .toList();
   }
 
   /**

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchEngineSchemaInitializer.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchEngineSchemaInitializer.java
@@ -29,20 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
 
-/**
- * Initializes the search engine schema for every physical tenant at startup, running up to {@link
- * #MAX_PARALLEL_SCHEMA_INITS} tenant initializations in parallel.
- *
- * <p>Failure semantics: in synchronous mode (gateway enabled) any single tenant failure aborts
- * application startup; in asynchronous mode a failure is logged at error level together with the
- * tenants left without an initialized schema, and {@link #isInitialized()} / {@link
- * #isInitialized(String)} keep reporting {@code false} for them. The RDBMS counterpart ({@code
- * DefaultRdbmsSchemaManagerRegistry}) still initializes tenants sequentially; converging both sides
- * on parallel per-tenant orchestration is tracked in
- * https://github.com/camunda/camunda/issues/54299.
- */
 public class SearchEngineSchemaInitializer implements InitializingBean, SchemaManagerContainer {
-  private static final int MAX_PARALLEL_SCHEMA_INITS = 4;
   private static final Logger LOGGER = LoggerFactory.getLogger(SearchEngineSchemaInitializer.class);
   private final SchemaManagerMetrics schemaManagerMetrics;
   private final boolean awaitSchemaInitialization;
@@ -56,11 +43,6 @@ public class SearchEngineSchemaInitializer implements InitializingBean, SchemaMa
       final Map<String, IndexDescriptors> descriptorsByTenant,
       final MeterRegistry meterRegistry,
       final boolean awaitSchemaInitialization) {
-    if (!configsByTenant.keySet().equals(descriptorsByTenant.keySet())) {
-      throw new IllegalStateException(
-          "Physical tenant ids of the search engine configurations %s and the index descriptors %s do not match"
-              .formatted(configsByTenant.keySet(), descriptorsByTenant.keySet()));
-    }
     schemaManagerMetrics = new SchemaManagerMetrics(meterRegistry);
     this.awaitSchemaInitialization = awaitSchemaInitialization;
 
@@ -78,33 +60,22 @@ public class SearchEngineSchemaInitializer implements InitializingBean, SchemaMa
         configs.size(),
         configs.keySet());
 
-    final int parallelism = Math.min(configs.size(), MAX_PARALLEL_SCHEMA_INITS);
-    final ExecutorService executor =
-        Executors.newFixedThreadPool(
-            parallelism,
-            runnable -> {
-              final Thread t = new Thread(runnable, "schema-init");
-              t.setDaemon(true);
-              return t;
-            });
-
+    final var executor = Executors.newSingleThreadExecutor();
     if (!addShutdownHook(executor)) {
       // skipping schema initialization as JVM is shutting down
       return;
     }
 
-    final CompletableFuture<?>[] futures =
-        configs.keySet().stream()
-            .map(
-                id -> CompletableFuture.runAsync(() -> startupSchemaManagerForTenant(id), executor))
-            .toArray(CompletableFuture[]::new);
-    final CompletableFuture<Void> all = CompletableFuture.allOf(futures);
-
+    final var future = CompletableFuture.runAsync(this::startupSchemaManagers, executor);
     if (awaitSchemaInitialization) {
-      synchronousSchemaInitialization(all, executor);
+      synchronousSchemaInitialization(future, executor);
     } else {
-      asyncSchemaInitialization(all, executor);
+      asyncSchemaInitialization(future, executor);
     }
+  }
+
+  private void startupSchemaManagers() {
+    configs.keySet().forEach(this::startupSchemaManagerForTenant);
   }
 
   @VisibleForTesting
@@ -180,11 +151,6 @@ public class SearchEngineSchemaInitializer implements InitializingBean, SchemaMa
         });
   }
 
-  /**
-   * Runs a tenant's schema startup and classifies failures: an {@link IOException} raised after the
-   * tenant was marked initialized can only stem from closing the search client and is benign; any
-   * other failure is a real initialization failure and must propagate.
-   */
   @VisibleForTesting
   void initializeTenantSchema(final String physicalTenantId, final TenantSchemaStartup startup) {
     try {

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchEngineSchemaInitializer.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchEngineSchemaInitializer.java
@@ -39,21 +39,19 @@ public class SearchEngineSchemaInitializer implements InitializingBean, SchemaMa
 
   public SearchEngineSchemaInitializer(
       final Map<String, SearchEngineConfiguration> configsByTenant,
+      final Map<String, IndexDescriptors> descriptorsByTenant,
       final MeterRegistry meterRegistry,
       final boolean awaitSchemaInitialization) {
+    if (!configsByTenant.keySet().equals(descriptorsByTenant.keySet())) {
+      throw new IllegalStateException(
+          "Physical tenant ids of the search engine configurations %s and the index descriptors %s do not match"
+              .formatted(configsByTenant.keySet(), descriptorsByTenant.keySet()));
+    }
     schemaManagerMetrics = new SchemaManagerMetrics(meterRegistry);
     this.awaitSchemaInitialization = awaitSchemaInitialization;
 
     configs = configsByTenant;
-    descriptors =
-        configs.entrySet().stream()
-            .collect(
-                toUnmodifiableMap(
-                    Map.Entry::getKey,
-                    e ->
-                        new IndexDescriptors(
-                            e.getValue().connect().getIndexPrefix(),
-                            e.getValue().connect().getTypeEnum().isElasticSearch())));
+    descriptors = descriptorsByTenant;
     initialized =
         configs.keySet().stream()
             .collect(toUnmodifiableMap(id -> id, id -> new AtomicBoolean(false)));
@@ -189,14 +187,6 @@ public class SearchEngineSchemaInitializer implements InitializingBean, SchemaMa
       LOGGER.debug("JVM is shutting down, cannot add the schema initializer shutdown hook", e);
       return false;
     }
-  }
-
-  public IndexDescriptors forTenant(final String physicalTenantId) {
-    final IndexDescriptors d = descriptors.get(physicalTenantId);
-    if (d == null) {
-      throw new IllegalArgumentException("Unknown physical tenant: " + physicalTenantId);
-    }
-    return d;
   }
 
   @Override

--- a/dist/src/test/java/io/camunda/application/commons/search/SearchEngineDatabaseConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/search/SearchEngineDatabaseConfigurationTest.java
@@ -11,16 +11,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.configuration.Camunda;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
-import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
-import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride.Converter;
 import io.camunda.configuration.beanoverrides.SearchEngineIndexPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineRetentionPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineSchemaManagerPropertiesOverride;
-import io.camunda.configuration.beans.LegacySearchEngineConnectProperties;
-import io.camunda.configuration.beans.LegacySearchEngineIndexProperties;
-import io.camunda.configuration.beans.LegacySearchEngineRetentionProperties;
-import io.camunda.configuration.beans.LegacySearchEngineSchemaManagerProperties;
 import io.camunda.configuration.beans.SearchEngineConnectProperties;
 import io.camunda.configuration.beans.SearchEngineIndexProperties;
 import io.camunda.configuration.beans.SearchEngineRetentionProperties;
@@ -42,26 +37,20 @@ class SearchEngineDatabaseConfigurationTest {
   }
 
   private static Map<String, SearchEngineConfiguration> configsByTenant(final Camunda camunda) {
-    final UnifiedConfiguration unifiedConfig = new UnifiedConfiguration();
-    final var connectOverride =
-        new SearchEngineConnectPropertiesOverride(
-            unifiedConfig, new LegacySearchEngineConnectProperties());
-    final var indexOverride =
-        new SearchEngineIndexPropertiesOverride(
-            unifiedConfig, new LegacySearchEngineIndexProperties());
-    final var retentionOverride =
-        new SearchEngineRetentionPropertiesOverride(
-            unifiedConfig, new LegacySearchEngineRetentionProperties());
-    final var schemaManagerOverride =
-        new SearchEngineSchemaManagerPropertiesOverride(
-            unifiedConfig, new LegacySearchEngineSchemaManagerProperties());
+    final var connect = new Converter(camunda).convert();
+    final var index = new SearchEngineIndexProperties();
+    SearchEngineIndexPropertiesOverride.applyTo(camunda, index);
+    final var retention = new SearchEngineRetentionProperties();
+    SearchEngineRetentionPropertiesOverride.applyTo(camunda, retention);
+    final var schemaManager = new SearchEngineSchemaManagerProperties();
+    SearchEngineSchemaManagerPropertiesOverride.applyTo(camunda, schemaManager);
     return new SearchEngineDatabaseConfiguration()
         .searchEngineConfigurationsByTenant(
             PhysicalTenantResolver.of(new MockEnvironment(), camunda),
-            connectOverride.searchEngineConnectProperties(camunda),
-            indexOverride.searchEngineIndexProperties(camunda),
-            retentionOverride.searchEngineRetentionProperties(camunda),
-            schemaManagerOverride.searchEngineSchemaManagerProperties(camunda));
+            connect,
+            index,
+            retention,
+            schemaManager);
   }
 
   @Test

--- a/dist/src/test/java/io/camunda/application/commons/search/SearchEngineDatabaseConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/search/SearchEngineDatabaseConfigurationTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.search;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
+import io.camunda.configuration.UnifiedConfiguration;
+import io.camunda.configuration.UnifiedConfigurationHelper;
+import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineIndexPropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineRetentionPropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineSchemaManagerPropertiesOverride;
+import io.camunda.configuration.beans.LegacySearchEngineConnectProperties;
+import io.camunda.configuration.beans.LegacySearchEngineIndexProperties;
+import io.camunda.configuration.beans.LegacySearchEngineRetentionProperties;
+import io.camunda.configuration.beans.LegacySearchEngineSchemaManagerProperties;
+import io.camunda.configuration.beans.SearchEngineConnectProperties;
+import io.camunda.configuration.beans.SearchEngineIndexProperties;
+import io.camunda.configuration.beans.SearchEngineRetentionProperties;
+import io.camunda.configuration.beans.SearchEngineSchemaManagerProperties;
+import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
+import io.camunda.search.schema.config.SearchEngineConfiguration;
+import java.util.Map;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
+
+class SearchEngineDatabaseConfigurationTest {
+
+  @BeforeAll
+  @AfterAll
+  static void clearStaticEnvironment() {
+    UnifiedConfigurationHelper.setCustomEnvironment(null);
+  }
+
+  private static Map<String, SearchEngineConfiguration> configsByTenant(final Camunda camunda) {
+    final UnifiedConfiguration unifiedConfig = new UnifiedConfiguration();
+    return new SearchEngineDatabaseConfiguration()
+        .searchEngineConfigurationsByTenant(
+            PhysicalTenantResolver.of(new MockEnvironment(), camunda),
+            new SearchEngineConnectPropertiesOverride(
+                unifiedConfig, new LegacySearchEngineConnectProperties()),
+            new SearchEngineIndexPropertiesOverride(
+                unifiedConfig, new LegacySearchEngineIndexProperties()),
+            new SearchEngineRetentionPropertiesOverride(
+                unifiedConfig, new LegacySearchEngineRetentionProperties()),
+            new SearchEngineSchemaManagerPropertiesOverride(
+                unifiedConfig, new LegacySearchEngineSchemaManagerProperties()));
+  }
+
+  @Test
+  void shouldDisableSchemaCreationForNoneType() {
+    // given — the "none" type can only be supplied via the properties directly; the unified
+    // per-tenant configuration path rejects it up-front, but both paths share the same guard
+    final SearchEngineConnectProperties connect = new SearchEngineConnectProperties();
+    connect.setType("none");
+    final SearchEngineSchemaManagerProperties schemaManager =
+        new SearchEngineSchemaManagerProperties();
+    schemaManager.setCreateSchema(true);
+
+    // when
+    final SearchEngineConfiguration config =
+        new SearchEngineDatabaseConfiguration()
+            .searchEngineConfiguration(
+                connect,
+                new SearchEngineIndexProperties(),
+                new SearchEngineRetentionProperties(),
+                schemaManager);
+
+    // then
+    assertThat(config.schemaManager().isCreateSchema()).isFalse();
+  }
+
+  @Test
+  void shouldKeepSchemaCreationForElasticsearchTenant() {
+    // given
+    final Camunda camunda = new Camunda();
+    camunda.getData().getSecondaryStorage().setType(SecondaryStorageType.elasticsearch);
+
+    // when
+    final Map<String, SearchEngineConfiguration> configs = configsByTenant(camunda);
+
+    // then
+    assertThat(configs.get("default").schemaManager().isCreateSchema()).isTrue();
+  }
+}

--- a/dist/src/test/java/io/camunda/application/commons/search/SearchEngineDatabaseConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/search/SearchEngineDatabaseConfigurationTest.java
@@ -58,8 +58,7 @@ class SearchEngineDatabaseConfigurationTest {
 
   @Test
   void shouldDisableSchemaCreationForNoneType() {
-    // given — the "none" type can only be supplied via the properties directly; the unified
-    // per-tenant configuration path rejects it up-front, but both paths share the same guard
+    // given
     final SearchEngineConnectProperties connect = new SearchEngineConnectProperties();
     connect.setType("none");
     final SearchEngineSchemaManagerProperties schemaManager =

--- a/dist/src/test/java/io/camunda/application/commons/search/SearchEngineDatabaseConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/search/SearchEngineDatabaseConfigurationTest.java
@@ -43,17 +43,25 @@ class SearchEngineDatabaseConfigurationTest {
 
   private static Map<String, SearchEngineConfiguration> configsByTenant(final Camunda camunda) {
     final UnifiedConfiguration unifiedConfig = new UnifiedConfiguration();
+    final var connectOverride =
+        new SearchEngineConnectPropertiesOverride(
+            unifiedConfig, new LegacySearchEngineConnectProperties());
+    final var indexOverride =
+        new SearchEngineIndexPropertiesOverride(
+            unifiedConfig, new LegacySearchEngineIndexProperties());
+    final var retentionOverride =
+        new SearchEngineRetentionPropertiesOverride(
+            unifiedConfig, new LegacySearchEngineRetentionProperties());
+    final var schemaManagerOverride =
+        new SearchEngineSchemaManagerPropertiesOverride(
+            unifiedConfig, new LegacySearchEngineSchemaManagerProperties());
     return new SearchEngineDatabaseConfiguration()
         .searchEngineConfigurationsByTenant(
             PhysicalTenantResolver.of(new MockEnvironment(), camunda),
-            new SearchEngineConnectPropertiesOverride(
-                unifiedConfig, new LegacySearchEngineConnectProperties()),
-            new SearchEngineIndexPropertiesOverride(
-                unifiedConfig, new LegacySearchEngineIndexProperties()),
-            new SearchEngineRetentionPropertiesOverride(
-                unifiedConfig, new LegacySearchEngineRetentionProperties()),
-            new SearchEngineSchemaManagerPropertiesOverride(
-                unifiedConfig, new LegacySearchEngineSchemaManagerProperties()));
+            connectOverride.searchEngineConnectProperties(camunda),
+            indexOverride.searchEngineIndexProperties(camunda),
+            retentionOverride.searchEngineRetentionProperties(camunda),
+            schemaManagerOverride.searchEngineSchemaManagerProperties(camunda));
   }
 
   @Test

--- a/dist/src/test/java/io/camunda/application/commons/search/SearchEngineSchemaInitializerTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/search/SearchEngineSchemaInitializerTest.java
@@ -11,22 +11,80 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
+import io.camunda.configuration.UnifiedConfiguration;
+import io.camunda.configuration.UnifiedConfigurationHelper;
+import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineIndexPropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineRetentionPropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineSchemaManagerPropertiesOverride;
+import io.camunda.configuration.beans.LegacySearchEngineConnectProperties;
+import io.camunda.configuration.beans.LegacySearchEngineIndexProperties;
+import io.camunda.configuration.beans.LegacySearchEngineRetentionProperties;
+import io.camunda.configuration.beans.LegacySearchEngineSchemaManagerProperties;
+import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
+import io.camunda.search.schema.config.SearchEngineConfiguration;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.lang.reflect.Field;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
 
 class SearchEngineSchemaInitializerTest {
 
+  @BeforeAll
+  @AfterAll
+  static void clearStaticEnvironment() {
+    // Avoid leaking a previous test's environment into these unit tests.
+    UnifiedConfigurationHelper.setCustomEnvironment(null);
+  }
+
+  /** Builds an initializer with a single synthesized {@code default} tenant for an ES backend. */
   private SearchEngineSchemaInitializer createInitializer() {
-    return new SearchEngineSchemaInitializer(null, new SimpleMeterRegistry(), true);
+    final Camunda camunda = new Camunda();
+    camunda.getData().getSecondaryStorage().setType(SecondaryStorageType.elasticsearch);
+    camunda.getData().getSecondaryStorage().getElasticsearch().setUrl("http://localhost:9200");
+    final PhysicalTenantResolver resolver =
+        PhysicalTenantResolver.of(new MockEnvironment(), camunda);
+    return new SearchEngineSchemaInitializer(configsFor(resolver), new SimpleMeterRegistry(), true);
+  }
+
+  private static Map<String, SearchEngineConfiguration> configsFor(
+      final PhysicalTenantResolver resolver) {
+    final UnifiedConfiguration unifiedConfig = new UnifiedConfiguration();
+    final SearchEngineConnectPropertiesOverride connectOverride =
+        new SearchEngineConnectPropertiesOverride(
+            unifiedConfig, new LegacySearchEngineConnectProperties());
+    final SearchEngineIndexPropertiesOverride indexOverride =
+        new SearchEngineIndexPropertiesOverride(
+            unifiedConfig, new LegacySearchEngineIndexProperties());
+    final SearchEngineRetentionPropertiesOverride retentionOverride =
+        new SearchEngineRetentionPropertiesOverride(
+            unifiedConfig, new LegacySearchEngineRetentionProperties());
+    final SearchEngineSchemaManagerPropertiesOverride schemaManagerOverride =
+        new SearchEngineSchemaManagerPropertiesOverride(
+            unifiedConfig, new LegacySearchEngineSchemaManagerProperties());
+    return resolver.mapValues(
+        tenantCamunda ->
+            SearchEngineConfiguration.of(
+                b ->
+                    b.connect(connectOverride.searchEngineConnectProperties(tenantCamunda))
+                        .index(indexOverride.searchEngineIndexProperties(tenantCamunda))
+                        .retention(retentionOverride.searchEngineRetentionProperties(tenantCamunda))
+                        .schemaManager(
+                            schemaManagerOverride.searchEngineSchemaManagerProperties(
+                                tenantCamunda))));
   }
 
   /** Sets the private {@code isShutdown} flag on the initializer via reflection. */
@@ -212,6 +270,105 @@ class SearchEngineSchemaInitializerTest {
       // then — wait a bit for the whenCompleteAsync callback to run
       executor.awaitTermination(2, TimeUnit.SECONDS);
       assertThat(executor.isShutdown()).isTrue();
+    }
+  }
+
+  @Nested
+  class PerTenantResolution {
+
+    @Test
+    void shouldSynthesizeDefaultTenantWhenNoneDeclared() {
+      // given
+      final Camunda camunda = new Camunda();
+      camunda.getData().getSecondaryStorage().setType(SecondaryStorageType.elasticsearch);
+      camunda.getData().getSecondaryStorage().getElasticsearch().setIndexPrefix("default-prefix");
+      final PhysicalTenantResolver resolver =
+          PhysicalTenantResolver.of(new MockEnvironment(), camunda);
+
+      // when
+      final SearchEngineSchemaInitializer initializer =
+          new SearchEngineSchemaInitializer(configsFor(resolver), new SimpleMeterRegistry(), true);
+
+      // then
+      assertThat(initializer.isInitialized("default")).isFalse();
+      assertThat(initializer.isInitialized()).isFalse();
+      assertThat(initializer.forTenant("default").indices()).isNotEmpty();
+    }
+
+    @Test
+    void shouldThrowForUnknownTenant() {
+      // given
+      final SearchEngineSchemaInitializer initializer = createInitializer();
+
+      // when/then
+      assertThatThrownBy(() -> initializer.forTenant("unknown"))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("unknown");
+    }
+
+    @Test
+    void shouldReportPerTenantReadiness() throws Exception {
+      // given
+      final SearchEngineSchemaInitializer initializer = createInitializer();
+
+      // initially neither no-arg nor per-tenant readiness is true
+      assertThat(initializer.isInitialized()).isFalse();
+      assertThat(initializer.isInitialized("default")).isFalse();
+
+      // when — flip the per-tenant flag via reflection (simulating a successful init)
+      final Field field = SearchEngineSchemaInitializer.class.getDeclaredField("initialized");
+      field.setAccessible(true);
+      @SuppressWarnings("unchecked")
+      final java.util.Map<String, AtomicBoolean> map =
+          (java.util.Map<String, AtomicBoolean>) field.get(initializer);
+      map.get("default").set(true);
+
+      // then
+      assertThat(initializer.isInitialized("default")).isTrue();
+      assertThat(initializer.isInitialized()).isTrue();
+    }
+
+    @Test
+    void shouldReturnFalseForNoArgWhenNotAllTenantsReady() throws Exception {
+      // given — two explicitly declared tenants (default + tenantb), only one ready.
+      // We declare `default` explicitly to suppress the resolver's synthesized default entry,
+      // which would otherwise leave a third tenant permanently un-ready.
+      final MockEnvironment env = new MockEnvironment();
+      env.getPropertySources()
+          .addFirst(
+              new org.springframework.core.env.MapPropertySource(
+                  "test",
+                  java.util.Map.of(
+                      "camunda.physical-tenants.default.data.secondary-storage.type",
+                      "elasticsearch",
+                      "camunda.physical-tenants.tenantb.data.secondary-storage.type",
+                      "elasticsearch")));
+      final Camunda camunda = new Camunda();
+      camunda.getData().getSecondaryStorage().setType(SecondaryStorageType.elasticsearch);
+      camunda.getData().getSecondaryStorage().getElasticsearch().setUrl("http://es:9200");
+      final PhysicalTenantResolver resolver = PhysicalTenantResolver.of(env, camunda);
+      final SearchEngineSchemaInitializer initializer =
+          new SearchEngineSchemaInitializer(configsFor(resolver), new SimpleMeterRegistry(), true);
+
+      // when — flip readiness on only one tenant
+      final Field field = SearchEngineSchemaInitializer.class.getDeclaredField("initialized");
+      field.setAccessible(true);
+      @SuppressWarnings("unchecked")
+      final java.util.Map<String, AtomicBoolean> map =
+          (java.util.Map<String, AtomicBoolean>) field.get(initializer);
+      assertThat(map).containsOnlyKeys("default", "tenantb");
+      map.get("default").set(true);
+
+      // then
+      assertThat(initializer.isInitialized("default")).isTrue();
+      assertThat(initializer.isInitialized("tenantb")).isFalse();
+      assertThat(initializer.isInitialized()).isFalse();
+
+      // when — flip the second tenant
+      map.get("tenantb").set(true);
+
+      // then
+      assertThat(initializer.isInitialized()).isTrue();
     }
   }
 }

--- a/dist/src/test/java/io/camunda/application/commons/search/SearchEngineSchemaInitializerTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/search/SearchEngineSchemaInitializerTest.java
@@ -49,11 +49,9 @@ class SearchEngineSchemaInitializerTest {
   @BeforeAll
   @AfterAll
   static void clearStaticEnvironment() {
-    // Avoid leaking a previous test's environment into these unit tests.
     UnifiedConfigurationHelper.setCustomEnvironment(null);
   }
 
-  /** Builds an initializer with a single synthesized {@code default} tenant for an ES backend. */
   private SearchEngineSchemaInitializer createInitializer() {
     final Camunda camunda = new Camunda();
     camunda.getData().getSecondaryStorage().setType(SecondaryStorageType.elasticsearch);
@@ -69,7 +67,6 @@ class SearchEngineSchemaInitializerTest {
         configsFor(resolver), descriptorsFor(resolver), new SimpleMeterRegistry(), true);
   }
 
-  /** Builds the per-tenant descriptors the same way the production bean does. */
   private static Map<String, IndexDescriptors> descriptorsFor(
       final PhysicalTenantResolver resolver) {
     return new SearchClientReaderConfiguration().physicalTenantScopedIndexDescriptors(resolver);
@@ -102,7 +99,6 @@ class SearchEngineSchemaInitializerTest {
                                 tenantCamunda))));
   }
 
-  /** Sets the private {@code isShutdown} flag on the initializer via reflection. */
   private static void setShutdown(
       final SearchEngineSchemaInitializer initializer, final boolean value) {
     try {
@@ -138,13 +134,13 @@ class SearchEngineSchemaInitializerTest {
       // when
       initializer.synchronousSchemaInitialization(future, executor);
 
-      // then — no exception thrown, executor is closed
+      // then
       assertThat(executor.isShutdown()).isTrue();
     }
 
     @Test
     void shouldNotInterruptThreadOnShutdownTriggeredInterrupt() throws Exception {
-      // given — simulate shutdown-triggered interrupt
+      // given
       final var initializer = createInitializer();
       executor = Executors.newSingleThreadExecutor();
       setShutdown(initializer, true);
@@ -152,36 +148,36 @@ class SearchEngineSchemaInitializerTest {
       // Use an incomplete future so that future.get() blocks and sees the interrupt flag
       final var blockingFuture = new CompletableFuture<Void>();
 
-      // when — interrupt the thread so future.get() throws InterruptedException
+      // when
       Thread.currentThread().interrupt();
       initializer.synchronousSchemaInitialization(blockingFuture, executor);
 
-      // then — thread should NOT be interrupted (shutdown swallows the interrupt)
+      // then
       assertThat(Thread.currentThread().isInterrupted()).isFalse();
       assertThat(executor.isShutdown()).isTrue();
     }
 
     @Test
     void shouldReInterruptThreadOnNonShutdownInterrupt() throws Exception {
-      // given — NOT a shutdown, something else interrupted
+      // given
       final var initializer = createInitializer();
       executor = Executors.newSingleThreadExecutor();
       // isShutdown remains false (default)
 
       final var blockingFuture = new CompletableFuture<Void>();
 
-      // when — interrupt the current thread so future.get() throws InterruptedException
+      // when
       Thread.currentThread().interrupt();
       initializer.synchronousSchemaInitialization(blockingFuture, executor);
 
-      // then — thread should be re-interrupted
+      // then
       assertThat(Thread.currentThread().isInterrupted()).isTrue();
       assertThat(executor.isShutdown()).isTrue();
     }
 
     @Test
     void shouldSuppressExceptionDuringShutdown() {
-      // given — shutdown is in progress and the future fails with a non-interrupt exception.
+      // given
       // CompletableFuture.get() wraps the cause in ExecutionException, which falls into
       // the catch(Exception) block where isShutdown=true causes a silent return.
       final var initializer = createInitializer();
@@ -191,7 +187,7 @@ class SearchEngineSchemaInitializerTest {
       final var future = new CompletableFuture<Void>();
       future.completeExceptionally(new RuntimeException("ES connection failed"));
 
-      // when/then — should not throw, exception is suppressed during shutdown
+      // when/then
       assertThatNoException()
           .isThrownBy(() -> initializer.synchronousSchemaInitialization(future, executor));
       assertThat(executor.isShutdown()).isTrue();
@@ -199,7 +195,7 @@ class SearchEngineSchemaInitializerTest {
 
     @Test
     void shouldPropagateExceptionWhenNotShutdown() {
-      // given — NOT a shutdown, the future fails with a real error.
+      // given
       // CompletableFuture.get() wraps the cause in ExecutionException.
       final var initializer = createInitializer();
       executor = Executors.newSingleThreadExecutor();
@@ -209,7 +205,7 @@ class SearchEngineSchemaInitializerTest {
       final var future = new CompletableFuture<Void>();
       future.completeExceptionally(cause);
 
-      // when/then — ExecutionException wrapping the cause should propagate
+      // when/then
       assertThatThrownBy(() -> initializer.synchronousSchemaInitialization(future, executor))
           .isInstanceOf(ExecutionException.class)
           .hasCause(cause);
@@ -232,7 +228,7 @@ class SearchEngineSchemaInitializerTest {
         // expected
       }
 
-      // then — executor must be closed regardless
+      // then
       assertThat(executor.isShutdown()).isTrue();
     }
 
@@ -248,7 +244,7 @@ class SearchEngineSchemaInitializerTest {
       // when
       initializer.synchronousSchemaInitialization(blockingFuture, executor);
 
-      // then — executor must be closed regardless
+      // then
       assertThat(executor.isShutdown()).isTrue();
     }
   }
@@ -266,7 +262,7 @@ class SearchEngineSchemaInitializerTest {
       // when
       initializer.asyncSchemaInitialization(future, executor);
 
-      // then — wait a bit for the whenCompleteAsync callback to run
+      // then
       executor.awaitTermination(2, TimeUnit.SECONDS);
       assertThat(executor.isShutdown()).isTrue();
     }
@@ -282,7 +278,7 @@ class SearchEngineSchemaInitializerTest {
       // when
       initializer.asyncSchemaInitialization(future, executor);
 
-      // then — wait a bit for the whenCompleteAsync callback to run
+      // then
       executor.awaitTermination(2, TimeUnit.SECONDS);
       assertThat(executor.isShutdown()).isTrue();
     }
@@ -293,7 +289,7 @@ class SearchEngineSchemaInitializerTest {
 
     @Test
     void shouldPropagateIoExceptionFromStartupAsFailure() {
-      // given — tenant not initialized, so an IOException is a startup failure, not a close leak
+      // given
       final SearchEngineSchemaInitializer initializer = createInitializer();
 
       // when/then
@@ -310,7 +306,7 @@ class SearchEngineSchemaInitializerTest {
 
     @Test
     void shouldTolerateIoExceptionFromClosingTheClient() throws Exception {
-      // given — the startup marks the tenant initialized before close throws
+      // given
       final SearchEngineSchemaInitializer initializer = createInitializer();
       final Field field = SearchEngineSchemaInitializer.class.getDeclaredField("initialized");
       field.setAccessible(true);
@@ -371,35 +367,14 @@ class SearchEngineSchemaInitializerTest {
     }
 
     @Test
-    void shouldRejectMismatchedTenantKeySets() {
-      // given
-      final Camunda camunda = new Camunda();
-      camunda.getData().getSecondaryStorage().setType(SecondaryStorageType.elasticsearch);
-      final PhysicalTenantResolver resolver =
-          PhysicalTenantResolver.of(new MockEnvironment(), camunda);
-
-      // when/then — descriptors keyed by a different tenant id than the configs
-      assertThatThrownBy(
-              () ->
-                  new SearchEngineSchemaInitializer(
-                      configsFor(resolver),
-                      Map.of("other", new IndexDescriptors("prefix", true)),
-                      new SimpleMeterRegistry(),
-                      true))
-          .isInstanceOf(IllegalStateException.class)
-          .hasMessageContaining("do not match");
-    }
-
-    @Test
     void shouldReportPerTenantReadiness() throws Exception {
       // given
       final SearchEngineSchemaInitializer initializer = createInitializer();
 
-      // initially neither no-arg nor per-tenant readiness is true
       assertThat(initializer.isInitialized()).isFalse();
       assertThat(initializer.isInitialized("default")).isFalse();
 
-      // when — flip the per-tenant flag via reflection (simulating a successful init)
+      // when
       final Field field = SearchEngineSchemaInitializer.class.getDeclaredField("initialized");
       field.setAccessible(true);
       @SuppressWarnings("unchecked")
@@ -414,9 +389,7 @@ class SearchEngineSchemaInitializerTest {
 
     @Test
     void shouldReturnFalseForNoArgWhenNotAllTenantsReady() throws Exception {
-      // given — two explicitly declared tenants (default + tenantb), only one ready.
-      // We declare `default` explicitly to suppress the resolver's synthesized default entry,
-      // which would otherwise leave a third tenant permanently un-ready.
+      // given
       final MockEnvironment env = new MockEnvironment();
       env.getPropertySources()
           .addFirst(
@@ -427,10 +400,8 @@ class SearchEngineSchemaInitializerTest {
                       "elasticsearch",
                       "camunda.physical-tenants.tenantb.data.secondary-storage.type",
                       "elasticsearch",
-                      // authorization off => no per-tenant security.initialization block required
                       "camunda.physical-tenants.tenantb.security.authorization.enabled",
                       "false",
-                      // distinct prefix so both tenants may share the same connection
                       "camunda.physical-tenants.tenantb.data.secondary-storage.elasticsearch.index-prefix",
                       "tenantb")));
       final Camunda camunda = new Camunda();
@@ -439,7 +410,7 @@ class SearchEngineSchemaInitializerTest {
       final PhysicalTenantResolver resolver = PhysicalTenantResolver.of(env, camunda);
       final SearchEngineSchemaInitializer initializer = newInitializer(resolver);
 
-      // when — flip readiness on only one tenant
+      // when
       final Field field = SearchEngineSchemaInitializer.class.getDeclaredField("initialized");
       field.setAccessible(true);
       @SuppressWarnings("unchecked")
@@ -453,7 +424,7 @@ class SearchEngineSchemaInitializerTest {
       assertThat(initializer.isInitialized("tenantb")).isFalse();
       assertThat(initializer.isInitialized()).isFalse();
 
-      // when — flip the second tenant
+      // when
       map.get("tenantb").set(true);
 
       // then

--- a/dist/src/test/java/io/camunda/application/commons/search/SearchEngineSchemaInitializerTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/search/SearchEngineSchemaInitializerTest.java
@@ -25,6 +25,7 @@ import io.camunda.configuration.beans.LegacySearchEngineRetentionProperties;
 import io.camunda.configuration.beans.LegacySearchEngineSchemaManagerProperties;
 import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
 import io.camunda.search.schema.config.SearchEngineConfiguration;
+import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.lang.reflect.Field;
 import java.util.Map;
@@ -57,7 +58,19 @@ class SearchEngineSchemaInitializerTest {
     camunda.getData().getSecondaryStorage().getElasticsearch().setUrl("http://localhost:9200");
     final PhysicalTenantResolver resolver =
         PhysicalTenantResolver.of(new MockEnvironment(), camunda);
-    return new SearchEngineSchemaInitializer(configsFor(resolver), new SimpleMeterRegistry(), true);
+    return newInitializer(resolver);
+  }
+
+  private static SearchEngineSchemaInitializer newInitializer(
+      final PhysicalTenantResolver resolver) {
+    return new SearchEngineSchemaInitializer(
+        configsFor(resolver), descriptorsFor(resolver), new SimpleMeterRegistry(), true);
+  }
+
+  /** Builds the per-tenant descriptors the same way the production bean does. */
+  private static Map<String, IndexDescriptors> descriptorsFor(
+      final PhysicalTenantResolver resolver) {
+    return new SearchClientReaderConfiguration().physicalTenantScopedIndexDescriptors(resolver);
   }
 
   private static Map<String, SearchEngineConfiguration> configsFor(
@@ -286,24 +299,31 @@ class SearchEngineSchemaInitializerTest {
           PhysicalTenantResolver.of(new MockEnvironment(), camunda);
 
       // when
-      final SearchEngineSchemaInitializer initializer =
-          new SearchEngineSchemaInitializer(configsFor(resolver), new SimpleMeterRegistry(), true);
+      final SearchEngineSchemaInitializer initializer = newInitializer(resolver);
 
       // then
       assertThat(initializer.isInitialized("default")).isFalse();
       assertThat(initializer.isInitialized()).isFalse();
-      assertThat(initializer.forTenant("default").indices()).isNotEmpty();
     }
 
     @Test
-    void shouldThrowForUnknownTenant() {
+    void shouldRejectMismatchedTenantKeySets() {
       // given
-      final SearchEngineSchemaInitializer initializer = createInitializer();
+      final Camunda camunda = new Camunda();
+      camunda.getData().getSecondaryStorage().setType(SecondaryStorageType.elasticsearch);
+      final PhysicalTenantResolver resolver =
+          PhysicalTenantResolver.of(new MockEnvironment(), camunda);
 
-      // when/then
-      assertThatThrownBy(() -> initializer.forTenant("unknown"))
-          .isInstanceOf(IllegalArgumentException.class)
-          .hasMessageContaining("unknown");
+      // when/then — descriptors keyed by a different tenant id than the configs
+      assertThatThrownBy(
+              () ->
+                  new SearchEngineSchemaInitializer(
+                      configsFor(resolver),
+                      Map.of("other", new IndexDescriptors("prefix", true)),
+                      new SimpleMeterRegistry(),
+                      true))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("do not match");
     }
 
     @Test
@@ -342,13 +362,18 @@ class SearchEngineSchemaInitializerTest {
                       "camunda.physical-tenants.default.data.secondary-storage.type",
                       "elasticsearch",
                       "camunda.physical-tenants.tenantb.data.secondary-storage.type",
-                      "elasticsearch")));
+                      "elasticsearch",
+                      // authorization off => no per-tenant security.initialization block required
+                      "camunda.physical-tenants.tenantb.security.authorization.enabled",
+                      "false",
+                      // distinct prefix so both tenants may share the same connection
+                      "camunda.physical-tenants.tenantb.data.secondary-storage.elasticsearch.index-prefix",
+                      "tenantb")));
       final Camunda camunda = new Camunda();
       camunda.getData().getSecondaryStorage().setType(SecondaryStorageType.elasticsearch);
       camunda.getData().getSecondaryStorage().getElasticsearch().setUrl("http://es:9200");
       final PhysicalTenantResolver resolver = PhysicalTenantResolver.of(env, camunda);
-      final SearchEngineSchemaInitializer initializer =
-          new SearchEngineSchemaInitializer(configsFor(resolver), new SimpleMeterRegistry(), true);
+      final SearchEngineSchemaInitializer initializer = newInitializer(resolver);
 
       // when — flip readiness on only one tenant
       final Field field = SearchEngineSchemaInitializer.class.getDeclaredField("initialized");

--- a/dist/src/test/java/io/camunda/application/commons/search/SearchEngineSchemaInitializerTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/search/SearchEngineSchemaInitializerTest.java
@@ -27,6 +27,8 @@ import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
 import io.camunda.search.schema.config.SearchEngineConfiguration;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.lang.reflect.Field;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -283,6 +285,68 @@ class SearchEngineSchemaInitializerTest {
       // then — wait a bit for the whenCompleteAsync callback to run
       executor.awaitTermination(2, TimeUnit.SECONDS);
       assertThat(executor.isShutdown()).isTrue();
+    }
+  }
+
+  @Nested
+  class TenantStartupFailureClassification {
+
+    @Test
+    void shouldPropagateIoExceptionFromStartupAsFailure() {
+      // given — tenant not initialized, so an IOException is a startup failure, not a close leak
+      final SearchEngineSchemaInitializer initializer = createInitializer();
+
+      // when/then
+      assertThatThrownBy(
+              () ->
+                  initializer.initializeTenantSchema(
+                      "default",
+                      () -> {
+                        throw new IOException("startup failed");
+                      }))
+          .isInstanceOf(UncheckedIOException.class)
+          .hasRootCauseMessage("startup failed");
+    }
+
+    @Test
+    void shouldTolerateIoExceptionFromClosingTheClient() throws Exception {
+      // given — the startup marks the tenant initialized before close throws
+      final SearchEngineSchemaInitializer initializer = createInitializer();
+      final Field field = SearchEngineSchemaInitializer.class.getDeclaredField("initialized");
+      field.setAccessible(true);
+      @SuppressWarnings("unchecked")
+      final Map<String, AtomicBoolean> map = (Map<String, AtomicBoolean>) field.get(initializer);
+
+      // when
+      assertThatNoException()
+          .isThrownBy(
+              () ->
+                  initializer.initializeTenantSchema(
+                      "default",
+                      () -> {
+                        map.get("default").set(true);
+                        throw new IOException("close failed");
+                      }));
+
+      // then
+      assertThat(initializer.isInitialized("default")).isTrue();
+    }
+
+    @Test
+    void shouldPropagateRuntimeExceptionFromStartup() {
+      // given
+      final SearchEngineSchemaInitializer initializer = createInitializer();
+
+      // when/then
+      assertThatThrownBy(
+              () ->
+                  initializer.initializeTenantSchema(
+                      "default",
+                      () -> {
+                        throw new IllegalStateException("boom");
+                      }))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessage("boom");
     }
   }
 

--- a/dist/src/test/java/io/camunda/application/commons/search/SearchEngineSchemaInitializerTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/search/SearchEngineSchemaInitializerTest.java
@@ -13,16 +13,14 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.configuration.Camunda;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
-import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
-import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride.Converter;
 import io.camunda.configuration.beanoverrides.SearchEngineIndexPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineRetentionPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineSchemaManagerPropertiesOverride;
-import io.camunda.configuration.beans.LegacySearchEngineConnectProperties;
-import io.camunda.configuration.beans.LegacySearchEngineIndexProperties;
-import io.camunda.configuration.beans.LegacySearchEngineRetentionProperties;
-import io.camunda.configuration.beans.LegacySearchEngineSchemaManagerProperties;
+import io.camunda.configuration.beans.SearchEngineIndexProperties;
+import io.camunda.configuration.beans.SearchEngineRetentionProperties;
+import io.camunda.configuration.beans.SearchEngineSchemaManagerProperties;
 import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
 import io.camunda.search.schema.config.SearchEngineConfiguration;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
@@ -72,29 +70,21 @@ class SearchEngineSchemaInitializerTest {
 
   private static Map<String, SearchEngineConfiguration> configsFor(
       final PhysicalTenantResolver resolver) {
-    final UnifiedConfiguration unifiedConfig = new UnifiedConfiguration();
-    final SearchEngineConnectPropertiesOverride connectOverride =
-        new SearchEngineConnectPropertiesOverride(
-            unifiedConfig, new LegacySearchEngineConnectProperties());
-    final SearchEngineIndexPropertiesOverride indexOverride =
-        new SearchEngineIndexPropertiesOverride(
-            unifiedConfig, new LegacySearchEngineIndexProperties());
-    final SearchEngineRetentionPropertiesOverride retentionOverride =
-        new SearchEngineRetentionPropertiesOverride(
-            unifiedConfig, new LegacySearchEngineRetentionProperties());
-    final SearchEngineSchemaManagerPropertiesOverride schemaManagerOverride =
-        new SearchEngineSchemaManagerPropertiesOverride(
-            unifiedConfig, new LegacySearchEngineSchemaManagerProperties());
     return resolver.mapValues(
-        tenantCamunda ->
-            SearchEngineConfiguration.of(
-                b ->
-                    b.connect(connectOverride.searchEngineConnectProperties(tenantCamunda))
-                        .index(indexOverride.searchEngineIndexProperties(tenantCamunda))
-                        .retention(retentionOverride.searchEngineRetentionProperties(tenantCamunda))
-                        .schemaManager(
-                            schemaManagerOverride.searchEngineSchemaManagerProperties(
-                                tenantCamunda))));
+        tenantCamunda -> {
+          final var index = new SearchEngineIndexProperties();
+          SearchEngineIndexPropertiesOverride.applyTo(tenantCamunda, index);
+          final var retention = new SearchEngineRetentionProperties();
+          SearchEngineRetentionPropertiesOverride.applyTo(tenantCamunda, retention);
+          final var schemaManager = new SearchEngineSchemaManagerProperties();
+          SearchEngineSchemaManagerPropertiesOverride.applyTo(tenantCamunda, schemaManager);
+          return SearchEngineConfiguration.of(
+              b ->
+                  b.connect(new Converter(tenantCamunda).convert())
+                      .index(index)
+                      .retention(retention)
+                      .schemaManager(schemaManager));
+        });
   }
 
   private static void setShutdown(

--- a/dist/src/test/java/io/camunda/application/commons/search/SearchEngineSchemaInitializerTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/search/SearchEngineSchemaInitializerTest.java
@@ -27,8 +27,6 @@ import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
 import io.camunda.search.schema.config.SearchEngineConfiguration;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.lang.reflect.Field;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -281,68 +279,6 @@ class SearchEngineSchemaInitializerTest {
       // then
       executor.awaitTermination(2, TimeUnit.SECONDS);
       assertThat(executor.isShutdown()).isTrue();
-    }
-  }
-
-  @Nested
-  class TenantStartupFailureClassification {
-
-    @Test
-    void shouldPropagateIoExceptionFromStartupAsFailure() {
-      // given
-      final SearchEngineSchemaInitializer initializer = createInitializer();
-
-      // when/then
-      assertThatThrownBy(
-              () ->
-                  initializer.initializeTenantSchema(
-                      "default",
-                      () -> {
-                        throw new IOException("startup failed");
-                      }))
-          .isInstanceOf(UncheckedIOException.class)
-          .hasRootCauseMessage("startup failed");
-    }
-
-    @Test
-    void shouldTolerateIoExceptionFromClosingTheClient() throws Exception {
-      // given
-      final SearchEngineSchemaInitializer initializer = createInitializer();
-      final Field field = SearchEngineSchemaInitializer.class.getDeclaredField("initialized");
-      field.setAccessible(true);
-      @SuppressWarnings("unchecked")
-      final Map<String, AtomicBoolean> map = (Map<String, AtomicBoolean>) field.get(initializer);
-
-      // when
-      assertThatNoException()
-          .isThrownBy(
-              () ->
-                  initializer.initializeTenantSchema(
-                      "default",
-                      () -> {
-                        map.get("default").set(true);
-                        throw new IOException("close failed");
-                      }));
-
-      // then
-      assertThat(initializer.isInitialized("default")).isTrue();
-    }
-
-    @Test
-    void shouldPropagateRuntimeExceptionFromStartup() {
-      // given
-      final SearchEngineSchemaInitializer initializer = createInitializer();
-
-      // when/then
-      assertThatThrownBy(
-              () ->
-                  initializer.initializeTenantSchema(
-                      "default",
-                      () -> {
-                        throw new IllegalStateException("boom");
-                      }))
-          .isInstanceOf(IllegalStateException.class)
-          .hasMessage("boom");
     }
   }
 

--- a/schema-manager/src/main/java/io/camunda/search/schema/SchemaManagerContainer.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/SchemaManagerContainer.java
@@ -8,5 +8,7 @@
 package io.camunda.search.schema;
 
 public interface SchemaManagerContainer {
+  boolean isInitialized(final String physicalTenantId);
+
   boolean isInitialized();
 }

--- a/schema-manager/src/main/java/io/camunda/search/schema/metrics/SchemaManagerMetrics.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/metrics/SchemaManagerMetrics.java
@@ -9,6 +9,7 @@ package io.camunda.search.schema.metrics;
 
 import io.camunda.zeebe.util.CloseableSilently;
 import io.camunda.zeebe.util.micrometer.MicrometerUtil;
+import io.camunda.zeebe.util.micrometer.PartitionKeyNames;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 
@@ -29,7 +30,7 @@ public class SchemaManagerMetrics {
         Timer.builder(NAMESPACE + ".init.time")
             .description("Duration of initializing the schema in the secondary storage");
     if (physicalTenantId != null) {
-      builder.tag("physicalTenant", physicalTenantId);
+      builder.tag(PartitionKeyNames.PHYSICAL_TENANT.asString(), physicalTenantId);
     }
     schemaInitTimer = builder.register(meterRegistry);
   }

--- a/schema-manager/src/main/java/io/camunda/search/schema/metrics/SchemaManagerMetrics.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/metrics/SchemaManagerMetrics.java
@@ -20,11 +20,18 @@ public class SchemaManagerMetrics {
   private final Timer schemaInitTimer;
 
   public SchemaManagerMetrics(final MeterRegistry meterRegistry) {
+    this(meterRegistry, null);
+  }
+
+  public SchemaManagerMetrics(final MeterRegistry meterRegistry, final String physicalTenantId) {
     this.meterRegistry = meterRegistry;
-    schemaInitTimer =
+    final var builder =
         Timer.builder(NAMESPACE + ".init.time")
-            .description("Duration of initializing the schema in the secondary storage")
-            .register(meterRegistry);
+            .description("Duration of initializing the schema in the secondary storage");
+    if (physicalTenantId != null) {
+      builder.tag("physicalTenant", physicalTenantId);
+    }
+    schemaInitTimer = builder.register(meterRegistry);
   }
 
   public CloseableSilently startSchemaInitTimer() {


### PR DESCRIPTION
## Description

Makes ES/OS schema initialization physical-tenant aware, following the same pattern as the merged RDBMS physical-tenant support (`PhysicalTenantResolver.mapValues(...)` → `Map<physicalTenantId, ...>` beans, per-tenant readiness on the registry interface).

### What changed

- **Per-tenant configuration map**: `SearchEngineDatabaseConfiguration` builds a `Map<String, SearchEngineConfiguration>` via `PhysicalTenantResolver`, converting non-default tenants statelessly (static `applyTo`/`Converter` mappings, no override beans involved) while the default tenant keeps the root property beans so legacy property support is unchanged. Both paths go through one shared builder, so the `type=none` → `createSchema=false` guard applies everywhere.
- **Sequential per-tenant schema init**: `SearchEngineSchemaInitializer` initializes each tenant's schema sequentially and fail-fast, matching `DefaultRdbmsSchemaManagerRegistry` — one failing tenant aborts the remaining ones. Parallel orchestration is deferred to #54299 for both backends. The initializer consumes the existing `physicalTenantScopedIndexDescriptors` bean instead of deriving its own descriptors.
- **Per-tenant readiness**: `SchemaManagerContainer` gains `isInitialized(String physicalTenantId)`; the no-arg `isInitialized()` now means "all tenants ready".

### Metrics

- `camunda.schema.init.time` is now constructed per tenant and tagged with `physicalTenant` (the default tenant's timer gains the `physicalTenant=default` tag).

### Failure semantics

- Any tenant failure surfaces immediately: it aborts the remaining tenants and, in synchronous mode (gateway enabled), application startup.
- A startup `IOException` is no longer swallowed as a "failed to close client" debug message — it propagates as a real initialization failure; only post-success close failures are tolerated.

### Drive-by fixes

- `SearchEngineSchemaManagerPropertiesOverride` read `performCleanup` from the root configuration instead of the tenant's — per-tenant cleanup settings now take effect.
- `SearchEngineConnectPropertiesOverride` resolved the root `Camunda` eagerly at construction; it now defers to the bean method so the parameterized per-tenant path never touches root config.

## Checklist

- [x] Unit tests for per-tenant readiness and the none-type guard
- [x] Full repo compiles; `configuration` module tests green (954)
