### PR TITLE
feat: implement AI Agent status display and related functionality 

### DIFF
--- a/operate/client/package-lock.json
+++ b/operate/client/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@axe-core/playwright": "4.11.3",
         "@bpmn-io/element-template-icon-renderer": "1.0.0",
-        "@camunda/camunda-api-zod-schemas": "0.0.63",
+        "@camunda/camunda-api-zod-schemas": "0.0.65",
         "@camunda/camunda-composite-components": "0.23.3",
         "@carbon/elements": "11.87.0",
         "@carbon/react": "1.105.0",
@@ -455,9 +455,9 @@
       "license": "LicenseRef-Camunda-1.0"
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.63",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.63.tgz",
-      "integrity": "sha512-q5QgxVLfELY/WOEJjZKc4waVZ6UFzVKbQNSRyPCMvZyb9Q+DFn7Wm/JNwXLCS+UxrMsj7ROHC8IuzjE+IGAoew==",
+      "version": "0.0.65",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.65.tgz",
+      "integrity": "sha512-OxVHev5OMzki3BwrSNJ2qJa06ADN7ICP9oiXKNcbZgD7QQvjNMkw2CiZ7d29c2ApocJo8gogtiP75caaXfLZ5g==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/operate/client/package.json
+++ b/operate/client/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@axe-core/playwright": "4.11.3",
     "@bpmn-io/element-template-icon-renderer": "1.0.0",
-    "@camunda/camunda-api-zod-schemas": "0.0.63",
+    "@camunda/camunda-api-zod-schemas": "0.0.65",
     "@camunda/camunda-composite-components": "0.23.3",
     "@carbon/elements": "11.87.0",
     "@carbon/react": "1.105.0",

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.test.tsx
@@ -1,0 +1,141 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {render, screen} from 'modules/testing-library';
+import {AgentDetails} from './index';
+import type {AgentInstance} from '@camunda/camunda-api-zod-schemas/8.10';
+
+const mockAgentInstance: AgentInstance = {
+  agentInstanceKey: '2251799813851828',
+  status: 'TOOL_CALLING',
+  definition: {
+    model: 'gpt-4',
+    provider: 'openai',
+    systemPrompt: 'You are a helpful assistant.',
+  },
+  metrics: {
+    inputTokens: 100,
+    outputTokens: 50,
+    modelCalls: 3,
+    toolCalls: 2,
+  },
+  limits: {
+    maxModelCalls: 10,
+    maxToolCalls: 5,
+    maxTokens: 1000,
+  },
+  elementId: 'Activity_1',
+  processInstanceKey: '123456789',
+  processDefinitionKey: '444555666',
+  tenantId: '<default>',
+  creationDate: '2025-01-15T10:00:00.000Z',
+  lastUpdatedDate: '2025-01-15T10:05:00.000Z',
+  completionDate: null,
+  elementInstanceKeys: ['111222333'],
+};
+
+describe('<AgentDetails />', () => {
+  it('should render AI Agent heading and status for TOOL_CALLING', () => {
+    render(
+      <AgentDetails
+        agentInstance={mockAgentInstance}
+        isLoading={false}
+        isError={false}
+      />,
+    );
+
+    expect(screen.getByText('AI Agent')).toBeInTheDocument();
+    expect(screen.getByText('Status: Calling tools')).toBeInTheDocument();
+  });
+
+  it('should render status for THINKING', () => {
+    render(
+      <AgentDetails
+        agentInstance={{...mockAgentInstance, status: 'THINKING'}}
+        isLoading={false}
+        isError={false}
+      />,
+    );
+
+    expect(screen.getByText('Status: Thinking')).toBeInTheDocument();
+  });
+
+  it('should render status for IDLE', () => {
+    render(
+      <AgentDetails
+        agentInstance={{...mockAgentInstance, status: 'IDLE'}}
+        isLoading={false}
+        isError={false}
+      />,
+    );
+
+    expect(screen.getByText('Status: Idle')).toBeInTheDocument();
+  });
+
+  it('should render status for COMPLETED', () => {
+    render(
+      <AgentDetails
+        agentInstance={{...mockAgentInstance, status: 'COMPLETED'}}
+        isLoading={false}
+        isError={false}
+      />,
+    );
+
+    expect(screen.getByText('Status: Completed')).toBeInTheDocument();
+  });
+
+  it('should render status for INITIALIZING', () => {
+    render(
+      <AgentDetails
+        agentInstance={{...mockAgentInstance, status: 'INITIALIZING'}}
+        isLoading={false}
+        isError={false}
+      />,
+    );
+
+    expect(screen.getByText('Status: Initializing')).toBeInTheDocument();
+  });
+
+  it('should render status for TOOL_DISCOVERY', () => {
+    render(
+      <AgentDetails
+        agentInstance={{...mockAgentInstance, status: 'TOOL_DISCOVERY'}}
+        isLoading={false}
+        isError={false}
+      />,
+    );
+
+    expect(screen.getByText('Status: Discovering tools')).toBeInTheDocument();
+  });
+
+  it('should render loading state', () => {
+    render(
+      <AgentDetails
+        agentInstance={undefined}
+        isLoading={true}
+        isError={false}
+      />,
+    );
+
+    expect(screen.getByText('AI Agent')).toBeInTheDocument();
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+  });
+
+  it('should render error state when fetch fails', () => {
+    render(
+      <AgentDetails
+        agentInstance={undefined}
+        isLoading={false}
+        isError={true}
+      />,
+    );
+
+    expect(screen.getByText('AI Agent')).toBeInTheDocument();
+    expect(screen.getByText('Unable to load agent status')).toBeInTheDocument();
+  });
+});

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.tsx
@@ -11,10 +11,10 @@ import type {
   AgentInstanceStatus,
 } from '@camunda/camunda-api-zod-schemas/8.10';
 import {
-  InProgress,
-  CheckmarkFilled,
   CircleDash,
   WarningFilled,
+  CheckmarkOutline,
+  Time,
 } from '@carbon/react/icons';
 import {
   AgentDetailsContainer,
@@ -39,11 +39,11 @@ function StatusIcon({status}: {status: AgentInstanceStatus}) {
     case 'THINKING':
     case 'TOOL_CALLING':
     case 'TOOL_DISCOVERY':
-      return <InProgress size={16} />;
+      return <Time size={16} />;
     case 'IDLE':
       return <CircleDash size={16} />;
     case 'COMPLETED':
-      return <CheckmarkFilled size={16} />;
+      return <CheckmarkOutline size={16} />;
     default:
       return <WarningFilled size={16} />;
   }

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.tsx
@@ -1,0 +1,104 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {
+  AgentInstance,
+  AgentInstanceStatus,
+} from '@camunda/camunda-api-zod-schemas/8.10';
+import {
+  InProgress,
+  CheckmarkFilled,
+  CircleDash,
+  WarningFilled,
+} from '@carbon/react/icons';
+import {
+  AgentDetailsContainer,
+  AgentHeading,
+  StatusRow,
+  StatusIconWrapper,
+  StatusLabel,
+} from './styled';
+
+const STATUS_LABELS: Record<AgentInstanceStatus, string> = {
+  INITIALIZING: 'Initializing',
+  THINKING: 'Thinking',
+  TOOL_CALLING: 'Calling tools',
+  TOOL_DISCOVERY: 'Discovering tools',
+  IDLE: 'Idle',
+  COMPLETED: 'Completed',
+};
+
+function StatusIcon({status}: {status: AgentInstanceStatus}) {
+  switch (status) {
+    case 'INITIALIZING':
+    case 'THINKING':
+    case 'TOOL_CALLING':
+    case 'TOOL_DISCOVERY':
+      return <InProgress size={16} />;
+    case 'IDLE':
+      return <CircleDash size={16} />;
+    case 'COMPLETED':
+      return <CheckmarkFilled size={16} />;
+    default:
+      return <WarningFilled size={16} />;
+  }
+}
+
+type AgentDetailsProps = {
+  agentInstance: AgentInstance | undefined;
+  isLoading: boolean;
+  isError: boolean;
+};
+
+const AgentDetails: React.FC<AgentDetailsProps> = ({
+  agentInstance,
+  isLoading,
+  isError,
+}) => {
+  if (isLoading) {
+    return (
+      <AgentDetailsContainer>
+        <AgentHeading>AI Agent</AgentHeading>
+        <StatusRow>
+          <StatusLabel>Loading...</StatusLabel>
+        </StatusRow>
+      </AgentDetailsContainer>
+    );
+  }
+
+  if (isError || !agentInstance) {
+    return (
+      <AgentDetailsContainer>
+        <AgentHeading>AI Agent</AgentHeading>
+        <StatusRow>
+          <StatusIconWrapper>
+            <WarningFilled size={16} />
+          </StatusIconWrapper>
+          <StatusLabel>Unable to load agent status</StatusLabel>
+        </StatusRow>
+      </AgentDetailsContainer>
+    );
+  }
+
+  const statusLabel =
+    STATUS_LABELS[agentInstance.status] ?? agentInstance.status;
+
+  return (
+    <AgentDetailsContainer data-testid="agent-details">
+      <AgentHeading>AI Agent</AgentHeading>
+      <StatusRow data-testid="agent-status-row">
+        <StatusIconWrapper>
+          <StatusIcon status={agentInstance.status} />
+        </StatusIconWrapper>
+        <StatusLabel>Status: {statusLabel}</StatusLabel>
+      </StatusRow>
+    </AgentDetailsContainer>
+  );
+};
+
+export {AgentDetails};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/styled.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/styled.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import styled from 'styled-components';
+
+const AgentDetailsContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--cds-spacing-03);
+`;
+
+const AgentHeading = styled.h5`
+  font-size: var(--cds-heading-compact-01-font-size);
+  font-weight: var(--cds-heading-compact-01-font-weight);
+  line-height: var(--cds-heading-compact-01-line-height);
+  margin: 0;
+`;
+
+const StatusRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: var(--cds-spacing-03);
+  padding: var(--cds-spacing-03) 0;
+`;
+
+const StatusIconWrapper = styled.span`
+  display: flex;
+  align-items: center;
+  color: var(--cds-icon-primary);
+`;
+
+const StatusLabel = styled.span`
+  font-size: var(--cds-body-compact-01-font-size);
+`;
+
+export {
+  AgentDetailsContainer,
+  AgentHeading,
+  StatusRow,
+  StatusIconWrapper,
+  StatusLabel,
+};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.tsx
@@ -26,6 +26,8 @@ import {getExecutionDuration} from './getExecutionDuration';
 import {EmptyMessageContainer, Container, Callout} from './styled';
 import {StructuredList} from 'modules/components/StructuredList';
 import {useProcessInstance} from 'modules/queries/processInstance/useProcessInstance';
+import {useAgentInstanceForElement} from 'modules/queries/agentInstances/useAgentInstanceForElement';
+import {AgentDetails} from './AgentDetails';
 import type {UserTask} from '@camunda/camunda-api-zod-schemas/8.10';
 
 const formatTaskLink = (
@@ -113,6 +115,12 @@ const DetailsTab: React.FC = () => {
   );
 
   const userTask = userTaskSearchResult?.items?.[0] ?? null;
+
+  const {
+    agentInstance,
+    isLoading: isAgentLoading,
+    isError: isAgentError,
+  } = useAgentInstanceForElement(selectedElementId, elementInstanceKey);
 
   const calledDecisionInstance = decisionInstanceSearchResult?.items?.find(
     (instance) =>
@@ -357,6 +365,14 @@ const DetailsTab: React.FC = () => {
         ]}
         rows={rows}
       />
+      {clientConfig.isAiAgentEnabled &&
+        (agentInstance !== undefined || isAgentLoading || isAgentError) && (
+          <AgentDetails
+            agentInstance={agentInstance}
+            isLoading={isAgentLoading}
+            isError={isAgentError}
+          />
+        )}
     </Container>
   );
 };

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.tsx
@@ -20,6 +20,7 @@ import {useJobs} from 'modules/queries/jobs/useJobs';
 import {useDecisionInstancesSearch} from 'modules/queries/decisionInstances/useDecisionInstancesSearch';
 import {isCamundaUserTask} from 'modules/bpmn-js/utils/isCamundaUserTask';
 import {useSearchUserTasks} from 'modules/queries/userTasks/useSearchUserTasks';
+import {IS_AI_AGENT_ENABLED} from 'modules/feature-flags';
 import {getClientConfig} from 'modules/utils/getClientConfig';
 import {mergePathname} from 'modules/request/mergePathname';
 import {getExecutionDuration} from './getExecutionDuration';
@@ -365,7 +366,7 @@ const DetailsTab: React.FC = () => {
         ]}
         rows={rows}
       />
-      {clientConfig.isAiAgentEnabled &&
+      {IS_AI_AGENT_ENABLED &&
         (agentInstance !== undefined || isAgentLoading || isAgentError) && (
           <AgentDetails
             agentInstance={agentInstance}

--- a/operate/client/src/modules/feature-flags.ts
+++ b/operate/client/src/modules/feature-flags.ts
@@ -7,5 +7,6 @@
  */
 
 const MULTI_VARIABLE_FILTER = false;
+const IS_AI_AGENT_ENABLED = false;
 
-export {MULTI_VARIABLE_FILTER};
+export {IS_AI_AGENT_ENABLED, MULTI_VARIABLE_FILTER};

--- a/operate/client/src/modules/mocks/api/v2/agentInstances/fetchAgentInstance.ts
+++ b/operate/client/src/modules/mocks/api/v2/agentInstances/fetchAgentInstance.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {mockGetRequest} from '../../mockRequest';
+import {
+  endpoints,
+  type GetAgentInstanceResponseBody,
+} from '@camunda/camunda-api-zod-schemas/8.10';
+
+const mockFetchAgentInstance = (agentInstanceKey: string, contextPath = '') =>
+  mockGetRequest<GetAgentInstanceResponseBody>(
+    `${contextPath}${endpoints.getAgentInstance.getUrl({
+      agentInstanceKey,
+    })}`,
+  );
+
+export {mockFetchAgentInstance};

--- a/operate/client/src/modules/mocks/api/v2/agentInstances/searchAgentInstances.ts
+++ b/operate/client/src/modules/mocks/api/v2/agentInstances/searchAgentInstances.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {mockPostRequest} from '../../mockRequest';
+import {
+  type QueryAgentInstancesResponseBody,
+  endpoints,
+} from '@camunda/camunda-api-zod-schemas/8.10';
+
+const mockSearchAgentInstances = (contextPath = '') =>
+  mockPostRequest<QueryAgentInstancesResponseBody>(
+    `${contextPath}${endpoints.searchAgentInstances.getUrl()}`,
+  );
+
+export {mockSearchAgentInstances};

--- a/operate/client/src/modules/queries/agentInstances/useAgentInstanceForElement.ts
+++ b/operate/client/src/modules/queries/agentInstances/useAgentInstanceForElement.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {getClientConfig} from 'modules/utils/getClientConfig';
+import {IS_AI_AGENT_ENABLED} from 'modules/feature-flags';
 import {useProcessInstanceAgentInstances} from './useProcessInstanceAgentInstances';
 import {useAgentInstancesSearch} from './useAgentInstancesSearch';
 
@@ -14,8 +14,6 @@ const useAgentInstanceForElement = (
   selectedElementId: string | null,
   elementInstanceKey: string | null,
 ) => {
-  const {isAiAgentEnabled} = getClientConfig();
-
   const {
     data: activeAgentInstancesResult,
     isLoading: isLoadingActive,
@@ -29,7 +27,7 @@ const useAgentInstanceForElement = (
     : undefined;
 
   const needsFallback =
-    isAiAgentEnabled &&
+    IS_AI_AGENT_ENABLED &&
     cachedAgentInstance === undefined &&
     !!elementInstanceKey;
 

--- a/operate/client/src/modules/queries/agentInstances/useAgentInstanceForElement.ts
+++ b/operate/client/src/modules/queries/agentInstances/useAgentInstanceForElement.ts
@@ -16,6 +16,7 @@ const useAgentInstanceForElement = (
 ) => {
   const {
     data: activeAgentInstancesResult,
+    isSuccess,
     isLoading: isLoadingActive,
     isError: isErrorActive,
   } = useProcessInstanceAgentInstances();
@@ -28,6 +29,7 @@ const useAgentInstanceForElement = (
 
   const needsFallback =
     IS_AI_AGENT_ENABLED &&
+    isSuccess &&
     cachedAgentInstance === undefined &&
     !!elementInstanceKey;
 

--- a/operate/client/src/modules/queries/agentInstances/useAgentInstanceForElement.ts
+++ b/operate/client/src/modules/queries/agentInstances/useAgentInstanceForElement.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {getClientConfig} from 'modules/utils/getClientConfig';
+import {useProcessInstanceAgentInstances} from './useProcessInstanceAgentInstances';
+import {useAgentInstancesSearch} from './useAgentInstancesSearch';
+
+const useAgentInstanceForElement = (
+  selectedElementId: string | null,
+  elementInstanceKey: string | null,
+) => {
+  const {isAiAgentEnabled} = getClientConfig();
+
+  const {
+    data: activeAgentInstancesResult,
+    isLoading: isLoadingActive,
+    isError: isErrorActive,
+  } = useProcessInstanceAgentInstances();
+
+  const cachedAgentInstance = selectedElementId
+    ? activeAgentInstancesResult?.items?.find(
+        (agent) => agent.elementId === selectedElementId,
+      )
+    : undefined;
+
+  const needsFallback =
+    isAiAgentEnabled &&
+    cachedAgentInstance === undefined &&
+    !!elementInstanceKey;
+
+  const {
+    data: fallbackAgentInstanceResult,
+    isLoading: isLoadingFallback,
+    isError: isErrorFallback,
+  } = useAgentInstancesSearch(
+    {
+      filter: {
+        elementInstanceKeys: [{$eq: elementInstanceKey ?? ''}],
+      },
+      page: {limit: 1},
+    },
+    {
+      enabled: needsFallback,
+      refetchInterval: 5000,
+    },
+  );
+
+  const agentInstance =
+    cachedAgentInstance ?? fallbackAgentInstanceResult?.items?.[0];
+
+  return {
+    agentInstance,
+    isLoading: isLoadingActive || (needsFallback && isLoadingFallback),
+    isError: isErrorActive || (needsFallback && isErrorFallback),
+  };
+};
+
+export {useAgentInstanceForElement};

--- a/operate/client/src/modules/queries/agentInstances/useProcessInstanceAgentInstances.ts
+++ b/operate/client/src/modules/queries/agentInstances/useProcessInstanceAgentInstances.ts
@@ -8,7 +8,7 @@
 
 import type {AgentInstance} from '@camunda/camunda-api-zod-schemas/8.10';
 import {useProcessInstancePageParams} from 'App/ProcessInstance/useProcessInstancePageParams';
-import {getClientConfig} from 'modules/utils/getClientConfig';
+import {IS_AI_AGENT_ENABLED} from 'modules/feature-flags';
 import {useAgentInstancesSearch} from './useAgentInstancesSearch';
 
 const ACTIVE_STATUSES: AgentInstance['status'][] = [
@@ -21,7 +21,6 @@ const ACTIVE_STATUSES: AgentInstance['status'][] = [
 
 const useProcessInstanceAgentInstances = () => {
   const {processInstanceId} = useProcessInstancePageParams();
-  const {isAiAgentEnabled} = getClientConfig();
 
   return useAgentInstancesSearch(
     {
@@ -31,7 +30,7 @@ const useProcessInstanceAgentInstances = () => {
       },
     },
     {
-      enabled: isAiAgentEnabled && !!processInstanceId,
+      enabled: IS_AI_AGENT_ENABLED && !!processInstanceId,
       refetchInterval: 5000,
     },
   );

--- a/operate/client/src/modules/queries/agentInstances/useProcessInstanceAgentInstances.ts
+++ b/operate/client/src/modules/queries/agentInstances/useProcessInstanceAgentInstances.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {AgentInstance} from '@camunda/camunda-api-zod-schemas/8.10';
+import {useProcessInstancePageParams} from 'App/ProcessInstance/useProcessInstancePageParams';
+import {getClientConfig} from 'modules/utils/getClientConfig';
+import {useAgentInstancesSearch} from './useAgentInstancesSearch';
+
+const ACTIVE_STATUSES: AgentInstance['status'][] = [
+  'INITIALIZING',
+  'TOOL_DISCOVERY',
+  'THINKING',
+  'TOOL_CALLING',
+  'IDLE',
+];
+
+const useProcessInstanceAgentInstances = () => {
+  const {processInstanceId} = useProcessInstancePageParams();
+  const {isAiAgentEnabled} = getClientConfig();
+
+  return useAgentInstancesSearch(
+    {
+      filter: {
+        processInstanceKey: processInstanceId ?? '',
+        status: {$in: ACTIVE_STATUSES},
+      },
+    },
+    {
+      enabled: isAiAgentEnabled && !!processInstanceId,
+      refetchInterval: 5000,
+    },
+  );
+};
+
+export {useProcessInstanceAgentInstances};

--- a/operate/client/src/modules/utils/getClientConfig.ts
+++ b/operate/client/src/modules/utils/getClientConfig.ts
@@ -22,6 +22,7 @@ const ClientConfigSchema = z.object({
   resourcePermissionsEnabled: z.boolean().optional().default(false),
   multiTenancyEnabled: z.boolean().optional().default(false),
   databaseType: z.string().optional().default('document-store'),
+  isAiAgentEnabled: z.boolean().optional().default(false),
 });
 
 const DEFAULT_CLIENT_CONFIG = ClientConfigSchema.safeParse({}).data!;

--- a/operate/client/src/modules/utils/getClientConfig.ts
+++ b/operate/client/src/modules/utils/getClientConfig.ts
@@ -22,7 +22,6 @@ const ClientConfigSchema = z.object({
   resourcePermissionsEnabled: z.boolean().optional().default(false),
   multiTenancyEnabled: z.boolean().optional().default(false),
   databaseType: z.string().optional().default('document-store'),
-  isAiAgentEnabled: z.boolean().optional().default(false),
 });
 
 const DEFAULT_CLIENT_CONFIG = ClientConfigSchema.safeParse({}).data!;


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Add an AI Agent status section to the process instance Details tab, gated behind an `isAiAgentEnabled` feature flag.

When a user clicks on an element in the process instance diagram, the status section displays the current agent status (Initializing, Thinking, Calling tools, Discovering tools, Idle, Completed) with a corresponding icon.

### Approach

Agent instance resolution uses a two-tier strategy via `useAgentInstanceForElement`:

1. **Preload**: `useProcessInstanceAgentInstances` loads all active agent instances for the current process instance (polls every 5s). This is cached by React Query and shared across components — positioning it for future use in BPMN diagram overlays.
2. **Cache lookup**: When an element is selected, check the cached results for a matching `elementId`.
3. **Fallback**: If no match is found by `elementId`, search agent instances filtered by `elementInstanceKeys` to find the agent instance for the selected element.

### New files

- `AgentDetails/` — presentational component rendering agent status with icon
- `useAgentInstanceForElement` — hook encapsulating the two-tier resolution logic
- `useProcessInstanceAgentInstances` — hook preloading active agents for the process instance (follows the same self-contained pattern as `useElementInstancesStatistics`)
- Search/fetch mocks for agent instances


## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #51926
