### PR TITLE
fix: AWS IT Cleanup

### DIFF
--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/AWSOpenSearchSetupHelper.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/AWSOpenSearchSetupHelper.java
@@ -19,6 +19,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.opensearch.client.json.JsonData;
 import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch.cluster.DeleteComponentTemplateRequest;
 import org.opensearch.client.opensearch.cluster.PutClusterSettingsRequest;
 import org.opensearch.client.opensearch.cluster.PutClusterSettingsRequest.Builder;
 import org.opensearch.client.opensearch.cluster.PutClusterSettingsResponse;
@@ -117,6 +118,15 @@ public class AWSOpenSearchSetupHelper extends OpenSearchSetupHelper {
           .deleteIndexTemplate(new DeleteIndexTemplateRequest.Builder().name(prefix + "*").build());
     } catch (final IOException e) {
       LOGGER.warn("Exception on cleaning index templates {}", prefix, e);
+    }
+
+    try {
+      client
+          .cluster()
+          .deleteComponentTemplate(
+              DeleteComponentTemplateRequest.builder().name(prefix + "*").build());
+    } catch (final IOException e) {
+      LOGGER.warn("Exception on cleaning component templates {}", prefix, e);
     }
   }
 

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
@@ -428,9 +428,7 @@ public class CamundaMultiDBExtension
       }
     }
 
-    // we need to close the test application before cleaning up
-    closeables.add(() -> setupHelper.cleanup(testPrefix));
-    closeables.add(setupHelper);
+    // cleaning up secondary storage is explicitly handled in afterAll() method
 
     Awaitility.await("Await secondary storage connection")
         .timeout(TIMEOUT_DATABASE_READINESS)
@@ -732,8 +730,21 @@ public class CamundaMultiDBExtension
       return;
     }
 
+    // 1. Stop application and other resources first (forward iteration)
     CloseHelper.quietCloseAll(closeables);
     CloseHelper.quietClose(authenticatedClientFactory);
+
+    // 2. Delete test indices now that the application has stopped writing
+    if (testPrefix != null) {
+      try {
+        setupHelper.cleanup(testPrefix);
+      } catch (final Exception e) {
+        LOGGER.warn("Failed to cleanup indices with prefix {}", testPrefix, e);
+      }
+    }
+    CloseHelper.quietClose(setupHelper);
+
+    // 3. Reset exporter to make sure it doesn't interfere with other tests
     RecordingExporter.reset();
 
     coordinationStore(context).remove(EXTENSION_COORDINATION_KEY);

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/ElasticOpenSearchSetupHelper.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/ElasticOpenSearchSetupHelper.java
@@ -146,6 +146,17 @@ public abstract class ElasticOpenSearchSetupHelper implements MultiDbSetupHelper
             return sendHttpDeleteRequest(httpClient, deleteIndexTemplatesEndpoint);
           },
           5);
+
+      // Component templates are also separate from index templates and indices. They must be
+      // deleted to allow proper recreation during subsequent test runs.
+      // https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-component-template.html
+      withRetry(
+          () -> {
+            final URI deleteComponentTemplatesEndpoint =
+                URI.create(String.format("%s/_component_template/%s*", endpoint, prefix));
+            return sendHttpDeleteRequest(httpClient, deleteComponentTemplatesEndpoint);
+          },
+          5);
     }
   }
 

--- a/search/search-test-utils/pom.xml
+++ b/search/search-test-utils/pom.xml
@@ -97,6 +97,16 @@
       <artifactId>zeebe-test-util</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.agrona</groupId>
+      <artifactId>agrona</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/search/search-test-utils/src/main/java/io/camunda/search/test/utils/AWSSearchDBExtension.java
+++ b/search/search-test-utils/src/main/java/io/camunda/search/test/utils/AWSSearchDBExtension.java
@@ -13,8 +13,12 @@ import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.search.connect.os.OpensearchConnector;
 import java.time.Duration;
 import java.util.UUID;
+import org.agrona.CloseHelper;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.ExpandWildcard;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * {@code AWSSearchDBExtension} is an extension that manages an AWS-based OpenSearch instance,
@@ -33,6 +37,8 @@ import org.opensearch.client.opensearch.OpenSearchClient;
  * maintainer has to make sure it won't fail on a CI.
  */
 public class AWSSearchDBExtension extends SearchDBExtension {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(AWSSearchDBExtension.class);
 
   private static OpenSearchClient osClient;
 
@@ -101,14 +107,51 @@ public class AWSSearchDBExtension extends SearchDBExtension {
 
   @Override
   public void afterAll(final ExtensionContext context) throws Exception {
-    osClient.indices().delete(req -> req.index(IDX_FORM_PREFIX + "*"));
-    osClient.indices().delete(req -> req.index(CUSTOM_PREFIX + "*"));
-    osClient.indices().delete(req -> req.index(IDX_PROCESS_PREFIX + "*"));
-    osClient.indices().delete(req -> req.index(ZEEBE_IDX_PREFIX + "*"));
-    osClient.indices().delete(req -> req.index(ARCHIVER_IDX_PREFIX + "*"));
-    osClient.indices().delete(req -> req.index(BATCH_IDX_PREFIX + "*"));
-    osClient.indices().delete(req -> req.index(INCIDENT_IDX_PREFIX + "*"));
-    osClient.indices().delete(req -> req.index("*" + ENGINE_CLIENT_TEST_MARKERS + "*"));
-    osClient._transport().close();
+    final String[] prefixes = {
+      IDX_FORM_PREFIX,
+      CUSTOM_PREFIX,
+      IDX_PROCESS_PREFIX,
+      ZEEBE_IDX_PREFIX,
+      ARCHIVER_IDX_PREFIX,
+      BATCH_IDX_PREFIX,
+      INCIDENT_IDX_PREFIX,
+      IDX_DECISIONREQUIREMENTS_PREFIX,
+      IDX_BATCH_OPERATION_PREFIX,
+      HISTORY_DELETION_ID_PREFIX,
+    };
+
+    CloseHelper.quietCloseAll(
+        () -> {
+          for (final String prefix : prefixes) {
+            deleteIndicesQuietly(prefix + "*");
+            deleteIndexTemplatesQuietly(prefix + "*");
+          }
+          deleteIndicesQuietly("*" + ENGINE_CLIENT_TEST_MARKERS + "*");
+          deleteIndexTemplatesQuietly("*" + ENGINE_CLIENT_TEST_MARKERS + "*");
+        },
+        () -> osClient._transport().close());
+  }
+
+  private void deleteIndicesQuietly(final String pattern) {
+    try {
+      osClient
+          .indices()
+          .delete(
+              req ->
+                  req.index(pattern)
+                      .ignoreUnavailable(true)
+                      .allowNoIndices(true)
+                      .expandWildcards(ExpandWildcard.Open));
+    } catch (final Exception e) {
+      LOGGER.warn("Failed to delete indices matching {}", pattern, e);
+    }
+  }
+
+  private void deleteIndexTemplatesQuietly(final String pattern) {
+    try {
+      osClient.indices().deleteIndexTemplate(req -> req.name(pattern));
+    } catch (final Exception e) {
+      LOGGER.warn("Failed to delete index templates matching {}", pattern, e);
+    }
   }
 }

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/AWSSearchDBExtension.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/AWSSearchDBExtension.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;
 import java.util.UUID;
+import org.agrona.CloseHelper;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
@@ -79,7 +80,13 @@ public class AWSSearchDBExtension extends SearchDBExtension {
 
   @Override
   public void afterEach(final ExtensionContext context) throws Exception {
-    // No-Op
+    // this will swallow any errors when running each deletion if there are any
+    CloseHelper.quietCloseAll(
+        testClient::deleteIndices,
+        testClient::deleteIndexTemplates,
+        testClient::deleteComponentTemplates);
+
+    CloseHelper.quietCloseAll(testClient, client);
   }
 
   /** {@inheritDoc} */


### PR DESCRIPTION


## Description

Noted that we are leaving a lot of indexes and templates behind after each test run. This should hopefully help with cleaning them up.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

Relates to #https://github.com/camunda/camunda/issues/52967 and #52892
