### PR TITLE
fix: OS validateRepositoryExists works when location is missing

### DIFF
--- a/webapps-backup/pom.xml
+++ b/webapps-backup/pom.xml
@@ -88,5 +88,20 @@
       <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock-standalone</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents.client5</groupId>
+      <artifactId>httpclient5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents.core5</groupId>
+      <artifactId>httpcore5</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/opensearch/OpensearchBackupRepository.java
+++ b/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/opensearch/OpensearchBackupRepository.java
@@ -55,12 +55,15 @@ import org.opensearch.client.opensearch._types.OpenSearchException;
 import org.opensearch.client.opensearch.indices.GetIndexRequest;
 import org.opensearch.client.opensearch.snapshot.GetSnapshotResponse;
 import org.opensearch.client.opensearch.snapshot.SnapshotInfo;
+import org.opensearch.client.util.MissingRequiredPropertyException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class OpensearchBackupRepository implements BackupRepository {
   public static final String SNAPSHOT_MISSING_EXCEPTION_TYPE = "snapshot_missing_exception";
   public static final String REPOSITORY_MISSING_EXCEPTION_TYPE = "repository_missing_exception";
+  private static final String MISSING_REQUIRED_LOCATION_PROPERTY_MESSAGE =
+      "Missing required property 'RepositorySettings.location'";
   private static final Logger LOGGER = LoggerFactory.getLogger(OpensearchBackupRepository.class);
 
   private final OpenSearchClient openSearchClient;
@@ -122,6 +125,12 @@ public class OpensearchBackupRepository implements BackupRepository {
         final String reason = noRepositoryErrorMessage(repositoryName);
         throw new BackupException(reason);
       }
+
+      if (isKnownS3RepositoryDeserializationIssue(e)) {
+        LOGGER.debug("Repository {} exists (property 'location' missing)", repositoryName);
+        return;
+      }
+
       final String reason =
           format(
               "Exception occurred when validating existence of repository with name [%s].",
@@ -536,6 +545,24 @@ public class OpensearchBackupRepository implements BackupRepository {
       }
     }
     return null;
+  }
+
+  /**
+   * Recognizes a known case of an S3 repository that exists but is rendered with a required field
+   * 'location' missing. With opensearch-java older than 3.0.0, an error is thrown, while our
+   * expected behavior is that <code>validateRepositoryExists</code> should succeed.
+   *
+   * @param t exception thrown by the OpenSearch client
+   * @return <code>true</code> if we're in the case of missing `location` property, <code>false
+   *     </code> otherwise.
+   */
+  private boolean isKnownS3RepositoryDeserializationIssue(final Throwable t) {
+    final Throwable cause = t.getCause();
+    if (!(cause instanceof MissingRequiredPropertyException)) {
+      return false;
+    }
+
+    return MISSING_REQUIRED_LOCATION_PROPERTY_MESSAGE.equals(cause.getMessage());
   }
 
   private <R> R safe(

--- a/webapps-backup/src/test/java/io/camunda/webapps/backup/repository/opensearch/OpensearchBackupRepositoryWireMockTest.java
+++ b/webapps-backup/src/test/java/io/camunda/webapps/backup/repository/opensearch/OpensearchBackupRepositoryWireMockTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.backup.repository.opensearch;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.assertThatException;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import io.camunda.webapps.backup.repository.BackupRepositoryProps;
+import io.camunda.webapps.backup.repository.BackupRepositoryPropsRecord;
+import io.camunda.webapps.backup.repository.WebappsSnapshotNameProvider;
+import java.io.IOException;
+import org.apache.hc.core5.http.HttpHost;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opensearch.client.json.jackson.JacksonJsonpMapper;
+import org.opensearch.client.opensearch.OpenSearchAsyncClient;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.transport.httpclient5.ApacheHttpClient5Transport;
+import org.opensearch.client.transport.httpclient5.ApacheHttpClient5TransportBuilder;
+
+@WireMockTest
+class OpensearchBackupRepositoryWireMockTest {
+
+  private static final String REPOSITORY_NAME = "camunda-backup";
+  private static final String VALIDATION_ERROR_MESSAGE =
+      String.format(
+          "Exception occurred when validating existence of repository with name [%s].",
+          REPOSITORY_NAME);
+
+  private ApacheHttpClient5Transport transport;
+  private OpensearchBackupRepository repository;
+
+  @BeforeEach
+  void setup(final WireMockRuntimeInfo wmRuntimeInfo) {
+    final var host = new HttpHost("localhost", wmRuntimeInfo.getHttpPort());
+    transport =
+        ApacheHttpClient5TransportBuilder.builder(host)
+            .setMapper(new JacksonJsonpMapper())
+            .setHttpClientConfigCallback(httpClientBuilder -> httpClientBuilder)
+            .build();
+
+    final var syncClient = new OpenSearchClient(transport);
+    final var asyncClient = new OpenSearchAsyncClient(transport);
+    final var backupProps =
+        new BackupRepositoryPropsRecord(
+            "1.0",
+            REPOSITORY_NAME,
+            0,
+            BackupRepositoryProps.defaultIncompleteCheckTimeoutInSeconds());
+
+    repository =
+        new OpensearchBackupRepository(
+            syncClient, asyncClient, backupProps, new WebappsSnapshotNameProvider());
+  }
+
+  @AfterEach
+  void teardown() throws IOException {
+    if (transport != null) {
+      transport.close();
+    }
+  }
+
+  @Test
+  void validateRepositoryExistsWorksWhenLocationIsMissing() {
+    // Simulates AWS OpenSearch S3 repo response — no 'location' field
+    stubFor(
+        get(urlEqualTo(String.format("/_snapshot/%s", REPOSITORY_NAME)))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(
+                        String.format(
+                            """
+                        {
+                          "%s": {
+                            "type": "s3",
+                            "settings": {
+                              "bucket": "my-bucket",
+                              "region": "us-east-1"
+                            }
+                          }
+                        }
+                        """,
+                            REPOSITORY_NAME))));
+
+    // This should return without errors
+    assertThatNoException().isThrownBy(() -> repository.validateRepositoryExists("camunda-backup"));
+  }
+
+  @Test
+  void validateRepositoryExistsFailsWhenTypeIsMissing() {
+    stubFor(
+        get(urlEqualTo(String.format("/_snapshot/%s", REPOSITORY_NAME)))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    // field "location" present,
+                    // field "type" missing
+                    .withBody(
+                        String.format(
+                            """
+                        {
+                          "%s": {
+                            "settings": {
+                              "bucket": "my-bucket",
+                              "region": "us-east-1",
+                              "location": "somelocation"
+                            }
+                          }
+                        }
+                        """,
+                            REPOSITORY_NAME))));
+
+    // This should return without errors
+    assertThatException()
+        .isThrownBy(() -> repository.validateRepositoryExists(REPOSITORY_NAME))
+        .withMessage(VALIDATION_ERROR_MESSAGE);
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Context:
https://github.com/camunda/camunda/issues/43272

Unlike `stable/8.7`, in this debug message we are using the full response object retrieved by `getRepository()`. For this reason, I am choosing not to use a `null` deserializer (like we did in [this issue](https://github.com/camunda/camunda/pull/27225)), in favor of the handling in the `catch` block.

An alternative approach would be to replace the client call with a raw REST call to the endpoint. I am not going for this approach because this would imply work around parsing the request and handling edge cases like a proper client: in my opinion, the size of the task would not be justified by the gravity of the bug.

Next versions of Camunda are not affected, as they use a newer OpenSearch client (version >= 3.0.0).

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
