### PR TITLE
fix: pass version in c8run E2E dispatch payload, add checkout

### DIFF
--- a/.github/workflows/trigger-c8run-e2e-tests.yml
+++ b/.github/workflows/trigger-c8run-e2e-tests.yml
@@ -16,11 +16,20 @@ jobs:
     name: Trigger c8Run E2E Tests in c8-cross-component-e2e-tests
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    permissions: {}
+    permissions:
+      contents: read
     defaults:
       run:
         shell: bash
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Extract minor version
+        id: version
+        run: |
+          version=$(grep '^CAMUNDA_VERSION=' c8run/.env | cut -d= -f2 | grep -oP '^\d+\.\d+')
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
       - name: Generate a GitHub token for camunda/camunda repo
         id: github-token
         uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@main
@@ -44,7 +53,7 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer $GITHUB_TOKEN" \
             https://api.github.com/repos/camunda/c8-cross-component-e2e-tests/dispatches \
-            -d '{"event_type": "run-c8run-tests", "client_payload": {"source_repo": "${{ github.repository }}", "source_sha": "${{ github.sha }}"}}'
+            -d '{"event_type": "run-c8run-tests", "client_payload": {"source_repo": "${{ github.repository }}", "source_sha": "${{ github.sha }}", "version": "${{ steps.version.outputs.version }}"}}'
 
       - name: Observe build status
         if: always()


### PR DESCRIPTION
Backport of camunda/camunda#52918 to `stable/8.9`.

## What

Adds `version` to the `repository_dispatch` payload sent to `c8-cross-component-e2e-tests`, so the receiver selects the correct test folder (`tests/c8Run-8.9/`) instead of relying on a hardcoded fallback.

On this branch, `c8run/.env` contains `CAMUNDA_VERSION=8.9.x`, so the grep extracts `8.9` — the receiver will resolve `8.9` and run `tests/c8Run-8.9/`.

Also adds `actions/checkout` (fixing the silently broken `observe-build-status` step) and sets `permissions: contents: read`.

## Context

See camunda/camunda#52918 and camunda/c8-cross-component-e2e-tests#2341 for full context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)