### PR TITLE
feat: Added x-properties-added-in-version: field to properties of Zeebe V2 API yaml

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/authorizations.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/authorizations.yaml
@@ -218,6 +218,7 @@ components:
         resourcePropertyName:
           description: The name of the resource property on which this authorization is based.
           type: string
+          x-added-in-version: "8.9"
         resourceType:
           description: The type of resource to add permissions to.
           allOf:
@@ -297,6 +298,7 @@ components:
           type: array
           items:
             type: string
+          x-added-in-version: "8.9"
         resourceType:
           description: The type of resource to search permissions for.
           allOf:
@@ -330,6 +332,7 @@ components:
           description: The name of the resource property the permission relates to (mutually exclusive with `resourceId`).
           nullable: true
           type: string
+          x-added-in-version: "8.9"
         permissionTypes:
           description: Specifies the types of the permissions.
           type: array

--- a/zeebe/gateway-protocol/src/main/proto/v2/authorizations.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/authorizations.yaml
@@ -218,7 +218,6 @@ components:
         resourcePropertyName:
           description: The name of the resource property on which this authorization is based.
           type: string
-          x-added-in-version: "8.9"
         resourceType:
           description: The type of resource to add permissions to.
           allOf:
@@ -235,6 +234,9 @@ components:
         - resourcePropertyName
         - resourceType
         - permissionTypes
+      x-added-in-version:
+        - propertyName: resourcePropertyName
+          addedInVersion: "8.9"
 
     AuthorizationRequest:
       x-polymorphic-schema: true
@@ -298,11 +300,13 @@ components:
           type: array
           items:
             type: string
-          x-added-in-version: "8.9"
         resourceType:
           description: The type of resource to search permissions for.
           allOf:
             - $ref: '#/components/schemas/ResourceTypeEnum'
+      x-added-in-version:
+        - propertyName: resourcePropertyNames
+          addedInVersion: "8.9"
 
     AuthorizationResult:
       required:
@@ -332,7 +336,6 @@ components:
           description: The name of the resource property the permission relates to (mutually exclusive with `resourceId`).
           nullable: true
           type: string
-          x-added-in-version: "8.9"
         permissionTypes:
           description: Specifies the types of the permissions.
           type: array
@@ -342,6 +345,9 @@ components:
           allOf:
             - $ref: '#/components/schemas/AuthorizationKey'
           description: The key of the authorization.
+      x-added-in-version:
+        - propertyName: resourcePropertyName
+          addedInVersion: "8.9"
 
     AuthorizationSearchResult:
       type: object

--- a/zeebe/gateway-protocol/src/main/proto/v2/authorizations.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/authorizations.yaml
@@ -234,7 +234,7 @@ components:
         - resourcePropertyName
         - resourceType
         - permissionTypes
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: resourcePropertyName
           addedInVersion: "8.9"
 
@@ -304,7 +304,7 @@ components:
           description: The type of resource to search permissions for.
           allOf:
             - $ref: '#/components/schemas/ResourceTypeEnum'
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: resourcePropertyNames
           addedInVersion: "8.9"
 
@@ -345,7 +345,7 @@ components:
           allOf:
             - $ref: '#/components/schemas/AuthorizationKey'
           description: The key of the authorization.
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: resourcePropertyName
           addedInVersion: "8.9"
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/batch-operations.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/batch-operations.yaml
@@ -241,7 +241,7 @@ components:
           description: Key of the batch operation.
         batchOperationType:
           $ref: '#/components/schemas/BatchOperationTypeEnum'
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: batchOperationKey
           addedInVersion: "8.8"
         - propertyName: batchOperationType
@@ -307,7 +307,7 @@ components:
           description: The ID of the actor who performed the operation.
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: actorType
           addedInVersion: "8.9"
         - propertyName: actorId
@@ -393,7 +393,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/BatchOperationError'
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: actorType
           addedInVersion: "8.9"
         - propertyName: actorId
@@ -479,7 +479,7 @@ components:
           description: The type of the batch operation.
           allOf:
             - $ref: '#/components/schemas/BatchOperationTypeFilterProperty'
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: operationType
           addedInVersion: "8.9"
 
@@ -553,7 +553,7 @@ components:
           description: The error message from the engine in case of a failed operation.
           nullable: true
           type: string
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: rootProcessInstanceKey
           addedInVersion: "8.9"
 
@@ -584,7 +584,7 @@ components:
           $ref: 'keys.yaml#/components/schemas/OperationReference'
       required:
         - filter
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: operationReference
           addedInVersion: "8.9"
 
@@ -601,7 +601,7 @@ components:
           $ref: 'keys.yaml#/components/schemas/OperationReference'
       required:
         - filter
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: operationReference
           addedInVersion: "8.9"
 
@@ -636,7 +636,7 @@ components:
       required:
         - filter
         - migrationPlan
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: operationReference
           addedInVersion: "8.9"
 
@@ -679,7 +679,7 @@ components:
       required:
         - filter
         - moveInstructions
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: operationReference
           addedInVersion: "8.9"
 
@@ -776,7 +776,7 @@ components:
             $ref: '#/components/schemas/BatchOperationTypeEnum'
         $like:
           $ref: 'filters.yaml#/components/schemas/LikeFilter'
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: "$eq"
           addedInVersion: "8.8"
         - propertyName: "$neq"

--- a/zeebe/gateway-protocol/src/main/proto/v2/batch-operations.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/batch-operations.yaml
@@ -239,8 +239,10 @@ components:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/BatchOperationKey'
           description: Key of the batch operation.
+          x-added-in-version: "8.8"
         batchOperationType:
           $ref: '#/components/schemas/BatchOperationTypeEnum'
+          x-added-in-version: "8.8"
 
     BatchOperationSearchQuerySortRequest:
       type: object
@@ -298,10 +300,12 @@ components:
           description: The type of the actor who performed the operation.
           allOf:
             - $ref: 'audit-logs.yaml#/components/schemas/AuditLogActorTypeEnum'
+          x-added-in-version: "8.9"
         actorId:
           description: The ID of the actor who performed the operation.
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
+          x-added-in-version: "8.9"
 
     BatchOperationSearchQueryResult:
       description: The batch operation search query result.
@@ -362,10 +366,12 @@ components:
           nullable: true
           allOf:
             - $ref: 'audit-logs.yaml#/components/schemas/AuditLogActorTypeEnum'
+          x-added-in-version: "8.9"
         actorId:
           type: string
           description: The ID of the actor who performed the operation. Available for batch operations created since 8.9.
           nullable: true
+          x-added-in-version: "8.9"
         operationsTotalCount:
           type: integer
           description: The total number of items contained in this batch operation.
@@ -464,6 +470,7 @@ components:
           description: The type of the batch operation.
           allOf:
             - $ref: '#/components/schemas/BatchOperationTypeFilterProperty'
+          x-added-in-version: "8.9"
 
     BatchOperationItemSearchQueryResult:
       type: object
@@ -515,6 +522,7 @@ components:
           nullable: true
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
+          x-added-in-version: "8.9"
         state:
           description: State of the item.
           type: string
@@ -561,6 +569,7 @@ components:
           description: The process instance filter.
         operationReference:
           $ref: 'keys.yaml#/components/schemas/OperationReference'
+          x-added-in-version: "8.9"
       required:
         - filter
 
@@ -575,6 +584,7 @@ components:
           description: The process instance filter.
         operationReference:
           $ref: 'keys.yaml#/components/schemas/OperationReference'
+          x-added-in-version: "8.9"
       required:
         - filter
 
@@ -606,6 +616,7 @@ components:
           description: The migration plan.
         operationReference:
           $ref: 'keys.yaml#/components/schemas/OperationReference'
+          x-added-in-version: "8.9"
       required:
         - filter
         - migrationPlan
@@ -646,6 +657,7 @@ components:
           description: Instructions for moving tokens between elements.
         operationReference:
           $ref: 'keys.yaml#/components/schemas/OperationReference'
+          x-added-in-version: "8.9"
       required:
         - filter
         - moveInstructions
@@ -729,20 +741,25 @@ components:
           description: Checks for equality with the provided value.
           allOf:
             - $ref: '#/components/schemas/BatchOperationTypeEnum'
+          x-added-in-version: "8.8"
         $neq:
           description: Checks for inequality with the provided value.
           allOf:
             - $ref: '#/components/schemas/BatchOperationTypeEnum'
+          x-added-in-version: "8.8"
         $exists:
           description: Checks if the current property exists.
           type: boolean
+          x-added-in-version: "8.8"
         $in:
           description: Checks if the property matches any of the provided values.
           type: array
           items:
             $ref: '#/components/schemas/BatchOperationTypeEnum'
+          x-added-in-version: "8.8"
         $like:
           $ref: 'filters.yaml#/components/schemas/LikeFilter'
+          x-added-in-version: "8.8"
 
     BatchOperationStateFilterProperty:
       description: BatchOperationStateEnum property with full advanced search capabilities.

--- a/zeebe/gateway-protocol/src/main/proto/v2/batch-operations.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/batch-operations.yaml
@@ -239,10 +239,13 @@ components:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/BatchOperationKey'
           description: Key of the batch operation.
-          x-added-in-version: "8.8"
         batchOperationType:
           $ref: '#/components/schemas/BatchOperationTypeEnum'
-          x-added-in-version: "8.8"
+      x-added-in-version:
+        - propertyName: batchOperationKey
+          addedInVersion: "8.8"
+        - propertyName: batchOperationType
+          addedInVersion: "8.8"
 
     BatchOperationSearchQuerySortRequest:
       type: object
@@ -300,12 +303,15 @@ components:
           description: The type of the actor who performed the operation.
           allOf:
             - $ref: 'audit-logs.yaml#/components/schemas/AuditLogActorTypeEnum'
-          x-added-in-version: "8.9"
         actorId:
           description: The ID of the actor who performed the operation.
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
-          x-added-in-version: "8.9"
+      x-added-in-version:
+        - propertyName: actorType
+          addedInVersion: "8.9"
+        - propertyName: actorId
+          addedInVersion: "8.9"
 
     BatchOperationSearchQueryResult:
       description: The batch operation search query result.
@@ -366,12 +372,10 @@ components:
           nullable: true
           allOf:
             - $ref: 'audit-logs.yaml#/components/schemas/AuditLogActorTypeEnum'
-          x-added-in-version: "8.9"
         actorId:
           type: string
           description: The ID of the actor who performed the operation. Available for batch operations created since 8.9.
           nullable: true
-          x-added-in-version: "8.9"
         operationsTotalCount:
           type: integer
           description: The total number of items contained in this batch operation.
@@ -389,6 +393,11 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/BatchOperationError'
+      x-added-in-version:
+        - propertyName: actorType
+          addedInVersion: "8.9"
+        - propertyName: actorId
+          addedInVersion: "8.9"
 
     BatchOperationError:
       required:
@@ -470,7 +479,9 @@ components:
           description: The type of the batch operation.
           allOf:
             - $ref: '#/components/schemas/BatchOperationTypeFilterProperty'
-          x-added-in-version: "8.9"
+      x-added-in-version:
+        - propertyName: operationType
+          addedInVersion: "8.9"
 
     BatchOperationItemSearchQueryResult:
       type: object
@@ -522,7 +533,6 @@ components:
           nullable: true
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
-          x-added-in-version: "8.9"
         state:
           description: State of the item.
           type: string
@@ -543,6 +553,9 @@ components:
           description: The error message from the engine in case of a failed operation.
           nullable: true
           type: string
+      x-added-in-version:
+        - propertyName: rootProcessInstanceKey
+          addedInVersion: "8.9"
 
     DecisionInstanceDeletionBatchOperationRequest:
       type: object
@@ -569,9 +582,11 @@ components:
           description: The process instance filter.
         operationReference:
           $ref: 'keys.yaml#/components/schemas/OperationReference'
-          x-added-in-version: "8.9"
       required:
         - filter
+      x-added-in-version:
+        - propertyName: operationReference
+          addedInVersion: "8.9"
 
     ProcessInstanceIncidentResolutionBatchOperationRequest:
       type: object
@@ -584,9 +599,11 @@ components:
           description: The process instance filter.
         operationReference:
           $ref: 'keys.yaml#/components/schemas/OperationReference'
-          x-added-in-version: "8.9"
       required:
         - filter
+      x-added-in-version:
+        - propertyName: operationReference
+          addedInVersion: "8.9"
 
     ProcessInstanceDeletionBatchOperationRequest:
       type: object
@@ -616,10 +633,12 @@ components:
           description: The migration plan.
         operationReference:
           $ref: 'keys.yaml#/components/schemas/OperationReference'
-          x-added-in-version: "8.9"
       required:
         - filter
         - migrationPlan
+      x-added-in-version:
+        - propertyName: operationReference
+          addedInVersion: "8.9"
 
     ProcessInstanceMigrationBatchOperationPlan:
       type: object
@@ -657,10 +676,12 @@ components:
           description: Instructions for moving tokens between elements.
         operationReference:
           $ref: 'keys.yaml#/components/schemas/OperationReference'
-          x-added-in-version: "8.9"
       required:
         - filter
         - moveInstructions
+      x-added-in-version:
+        - propertyName: operationReference
+          addedInVersion: "8.9"
 
     ProcessInstanceModificationMoveBatchOperationInstruction:
       description: |
@@ -741,25 +762,31 @@ components:
           description: Checks for equality with the provided value.
           allOf:
             - $ref: '#/components/schemas/BatchOperationTypeEnum'
-          x-added-in-version: "8.8"
         $neq:
           description: Checks for inequality with the provided value.
           allOf:
             - $ref: '#/components/schemas/BatchOperationTypeEnum'
-          x-added-in-version: "8.8"
         $exists:
           description: Checks if the current property exists.
           type: boolean
-          x-added-in-version: "8.8"
         $in:
           description: Checks if the property matches any of the provided values.
           type: array
           items:
             $ref: '#/components/schemas/BatchOperationTypeEnum'
-          x-added-in-version: "8.8"
         $like:
           $ref: 'filters.yaml#/components/schemas/LikeFilter'
-          x-added-in-version: "8.8"
+      x-added-in-version:
+        - propertyName: "$eq"
+          addedInVersion: "8.8"
+        - propertyName: "$neq"
+          addedInVersion: "8.8"
+        - propertyName: "$exists"
+          addedInVersion: "8.8"
+        - propertyName: "$in"
+          addedInVersion: "8.8"
+        - propertyName: "$like"
+          addedInVersion: "8.8"
 
     BatchOperationStateFilterProperty:
       description: BatchOperationStateEnum property with full advanced search capabilities.

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
@@ -58,40 +58,48 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/BrokerInfo'
-          x-added-in-version: "8.6"
         clusterId:
           description: The cluster Id.
           type: string
           nullable: true
-          x-added-in-version: "8.9"
         clusterSize:
           description: The number of brokers in the cluster.
           type: integer
           format: int32
           example: 3
-          x-added-in-version: "8.6"
         partitionsCount:
           description: The number of partitions are spread across the cluster.
           type: integer
           format: int32
           example: 3
-          x-added-in-version: "8.6"
         replicationFactor:
           description: The configured replication factor for this cluster.
           type: integer
           format: int32
           example: 3
-          x-added-in-version: "8.6"
         gatewayVersion:
           description: The version of the Zeebe Gateway.
           type: string
           example: 8.8.0
-          x-added-in-version: "8.6"
         lastCompletedChangeId:
           description: ID of the last completed change
           type: string
           example: "-1"
-          x-added-in-version: "8.8"
+      x-added-in-version:
+        - propertyName: brokers
+          addedInVersion: "8.6"
+        - propertyName: clusterId
+          addedInVersion: "8.9"
+        - propertyName: clusterSize
+          addedInVersion: "8.6"
+        - propertyName: partitionsCount
+          addedInVersion: "8.6"
+        - propertyName: replicationFactor
+          addedInVersion: "8.6"
+        - propertyName: gatewayVersion
+          addedInVersion: "8.6"
+        - propertyName: lastCompletedChangeId
+          addedInVersion: "8.8"
 
     BrokerInfo:
       description: Provides information on a broker node.

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
@@ -58,33 +58,40 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/BrokerInfo'
+          x-added-in-version: "8.6"
         clusterId:
           description: The cluster Id.
           type: string
           nullable: true
+          x-added-in-version: "8.9"
         clusterSize:
           description: The number of brokers in the cluster.
           type: integer
           format: int32
           example: 3
+          x-added-in-version: "8.6"
         partitionsCount:
           description: The number of partitions are spread across the cluster.
           type: integer
           format: int32
           example: 3
+          x-added-in-version: "8.6"
         replicationFactor:
           description: The configured replication factor for this cluster.
           type: integer
           format: int32
           example: 3
+          x-added-in-version: "8.6"
         gatewayVersion:
           description: The version of the Zeebe Gateway.
           type: string
           example: 8.8.0
+          x-added-in-version: "8.6"
         lastCompletedChangeId:
           description: ID of the last completed change
           type: string
           example: "-1"
+          x-added-in-version: "8.8"
 
     BrokerInfo:
       description: Provides information on a broker node.

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
@@ -85,7 +85,7 @@ components:
           description: ID of the last completed change
           type: string
           example: "-1"
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: brokers
           addedInVersion: "8.6"
         - propertyName: clusterId

--- a/zeebe/gateway-protocol/src/main/proto/v2/decision-definitions.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/decision-definitions.yaml
@@ -214,14 +214,12 @@ components:
         name:
           type: string
           description: The DMN name of the decision definition.
-          x-added-in-version: "8.8"
         isLatestVersion:
           description: |
             Whether to only return the latest version of each decision definition.
             When using this filter, pagination functionality is limited, you can only paginate forward using `after` and `limit`.
             The response contains no `startCursor` in the `page`, and requests ignore the `from` and `before` in the `page`.
           type: boolean
-          x-added-in-version: "8.9"
         version:
           type: integer
           description: The assigned version of the decision definition.
@@ -243,11 +241,18 @@ components:
         decisionRequirementsName:
           type: string
           description: The DMN name of the decision requirements that the decision definition is part of.
-          x-added-in-version: "8.9"
         decisionRequirementsVersion:
           type: integer
           description: The assigned version of the decision requirements that the decision definition is part of.
-          x-added-in-version: "8.9"
+      x-added-in-version:
+        - propertyName: name
+          addedInVersion: "8.8"
+        - propertyName: isLatestVersion
+          addedInVersion: "8.9"
+        - propertyName: decisionRequirementsName
+          addedInVersion: "8.9"
+        - propertyName: decisionRequirementsVersion
+          addedInVersion: "8.9"
 
     DecisionDefinitionSearchQueryResult:
       type: object
@@ -280,42 +285,52 @@ components:
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/DecisionDefinitionId'
           description: The DMN ID of the decision definition.
-          x-added-in-version: "8.6"
         decisionDefinitionKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/DecisionDefinitionKey'
           description: The assigned key, which acts as a unique identifier for this decision definition.
-          x-added-in-version: "8.6"
         decisionRequirementsId:
           description: the DMN ID of the decision requirements graph that the decision definition is part of.
           type: string
-          x-added-in-version: "8.6"
         decisionRequirementsKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/DecisionRequirementsKey'
           description: The assigned key of the decision requirements graph that the decision definition is part of.
-          x-added-in-version: "8.6"
         decisionRequirementsName:
           description: The DMN name of the decision requirements that the decision definition is part of.
           type: string
-          x-added-in-version: "8.9"
         decisionRequirementsVersion:
           description: The assigned version of the decision requirements that the decision definition is part of.
           type: integer
-          x-added-in-version: "8.9"
         name:
           description: The DMN name of the decision definition.
           type: string
-          x-added-in-version: "8.8"
         tenantId:
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/TenantId'
           description: The tenant ID of the decision definition.
-          x-added-in-version: "8.6"
         version:
           description: The assigned version of the decision definition.
           type: integer
-          x-added-in-version: "8.6"
+      x-added-in-version:
+        - propertyName: decisionDefinitionId
+          addedInVersion: "8.6"
+        - propertyName: decisionDefinitionKey
+          addedInVersion: "8.6"
+        - propertyName: decisionRequirementsId
+          addedInVersion: "8.6"
+        - propertyName: decisionRequirementsKey
+          addedInVersion: "8.6"
+        - propertyName: decisionRequirementsName
+          addedInVersion: "8.9"
+        - propertyName: decisionRequirementsVersion
+          addedInVersion: "8.9"
+        - propertyName: name
+          addedInVersion: "8.8"
+        - propertyName: tenantId
+          addedInVersion: "8.6"
+        - propertyName: version
+          addedInVersion: "8.6"
 
     DecisionEvaluationInstruction:
       x-polymorphic-schema: true
@@ -403,7 +418,6 @@ components:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/DecisionEvaluationKey'
           description: The unique key identifying this decision evaluation.
-          x-added-in-version: "8.8"
         decisionInstanceKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/DecisionInstanceKey'
@@ -438,6 +452,9 @@ components:
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/TenantId'
           description: The tenant ID of the evaluated decision.
+      x-added-in-version:
+        - propertyName: decisionEvaluationKey
+          addedInVersion: "8.8"
 
     EvaluatedDecisionResult:
       required:
@@ -496,4 +513,6 @@ components:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/DecisionEvaluationInstanceKey'
           description: The unique key identifying this decision evaluation instance.
-          x-added-in-version: "8.8"
+      x-added-in-version:
+        - propertyName: decisionEvaluationInstanceKey
+          addedInVersion: "8.8"

--- a/zeebe/gateway-protocol/src/main/proto/v2/decision-definitions.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/decision-definitions.yaml
@@ -244,7 +244,7 @@ components:
         decisionRequirementsVersion:
           type: integer
           description: The assigned version of the decision requirements that the decision definition is part of.
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: name
           addedInVersion: "8.8"
         - propertyName: isLatestVersion
@@ -312,7 +312,7 @@ components:
         version:
           description: The assigned version of the decision definition.
           type: integer
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: decisionDefinitionId
           addedInVersion: "8.6"
         - propertyName: decisionDefinitionKey
@@ -452,7 +452,7 @@ components:
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/TenantId'
           description: The tenant ID of the evaluated decision.
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: decisionEvaluationKey
           addedInVersion: "8.8"
 
@@ -513,6 +513,6 @@ components:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/DecisionEvaluationInstanceKey'
           description: The unique key identifying this decision evaluation instance.
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: decisionEvaluationInstanceKey
           addedInVersion: "8.8"

--- a/zeebe/gateway-protocol/src/main/proto/v2/decision-definitions.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/decision-definitions.yaml
@@ -214,12 +214,14 @@ components:
         name:
           type: string
           description: The DMN name of the decision definition.
+          x-added-in-version: "8.8"
         isLatestVersion:
           description: |
             Whether to only return the latest version of each decision definition.
             When using this filter, pagination functionality is limited, you can only paginate forward using `after` and `limit`.
             The response contains no `startCursor` in the `page`, and requests ignore the `from` and `before` in the `page`.
           type: boolean
+          x-added-in-version: "8.9"
         version:
           type: integer
           description: The assigned version of the decision definition.
@@ -241,9 +243,11 @@ components:
         decisionRequirementsName:
           type: string
           description: The DMN name of the decision requirements that the decision definition is part of.
+          x-added-in-version: "8.9"
         decisionRequirementsVersion:
           type: integer
           description: The assigned version of the decision requirements that the decision definition is part of.
+          x-added-in-version: "8.9"
 
     DecisionDefinitionSearchQueryResult:
       type: object
@@ -276,33 +280,42 @@ components:
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/DecisionDefinitionId'
           description: The DMN ID of the decision definition.
+          x-added-in-version: "8.6"
         decisionDefinitionKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/DecisionDefinitionKey'
           description: The assigned key, which acts as a unique identifier for this decision definition.
+          x-added-in-version: "8.6"
         decisionRequirementsId:
           description: the DMN ID of the decision requirements graph that the decision definition is part of.
           type: string
+          x-added-in-version: "8.6"
         decisionRequirementsKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/DecisionRequirementsKey'
           description: The assigned key of the decision requirements graph that the decision definition is part of.
+          x-added-in-version: "8.6"
         decisionRequirementsName:
           description: The DMN name of the decision requirements that the decision definition is part of.
           type: string
+          x-added-in-version: "8.9"
         decisionRequirementsVersion:
           description: The assigned version of the decision requirements that the decision definition is part of.
           type: integer
+          x-added-in-version: "8.9"
         name:
           description: The DMN name of the decision definition.
           type: string
+          x-added-in-version: "8.8"
         tenantId:
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/TenantId'
           description: The tenant ID of the decision definition.
+          x-added-in-version: "8.6"
         version:
           description: The assigned version of the decision definition.
           type: integer
+          x-added-in-version: "8.6"
 
     DecisionEvaluationInstruction:
       x-polymorphic-schema: true
@@ -390,6 +403,7 @@ components:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/DecisionEvaluationKey'
           description: The unique key identifying this decision evaluation.
+          x-added-in-version: "8.8"
         decisionInstanceKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/DecisionInstanceKey'
@@ -482,3 +496,4 @@ components:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/DecisionEvaluationInstanceKey'
           description: The unique key identifying this decision evaluation instance.
+          x-added-in-version: "8.8"

--- a/zeebe/gateway-protocol/src/main/proto/v2/decision-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/decision-instances.yaml
@@ -206,34 +206,43 @@ components:
           description: The key of the decision evaluation instance.
           allOf:
             - $ref: 'keys.yaml#/components/schemas/DecisionEvaluationInstanceKeyFilterProperty'
+          x-added-in-version: "8.8"
         state:
           description: The state of the decision instance.
           allOf:
             - $ref: '#/components/schemas/DecisionInstanceStateFilterProperty'
+          x-added-in-version: "8.6"
         evaluationFailure:
           type: string
           description: The evaluation failure of the decision instance.
+          x-added-in-version: "8.6"
         evaluationDate:
           description: The evaluation date of the decision instance.
           allOf:
             - $ref: 'filters.yaml#/components/schemas/DateTimeFilterProperty'
+          x-added-in-version: "8.8"
         decisionDefinitionId:
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/DecisionDefinitionId'
           description: The ID of the DMN decision.
+          x-added-in-version: "8.6"
         decisionDefinitionName:
           type: string
           description: The name of the DMN decision.
+          x-added-in-version: "8.6"
         decisionDefinitionVersion:
           type: integer
           format: int32
           description: The version of the decision.
+          x-added-in-version: "8.6"
         decisionDefinitionType:
           $ref: '#/components/schemas/DecisionDefinitionTypeEnum'
+          x-added-in-version: "8.6"
         tenantId:
           description: The tenant ID of the decision instance.
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/TenantId'
+          x-added-in-version: "8.6"
         decisionEvaluationKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/DecisionEvaluationKey'
@@ -241,30 +250,37 @@ components:
             The key of the parent decision evaluation. Note that this is not the identifier of
             an individual decision instance; the `decisionEvaluationInstanceKey` is the identifier
             for a decision instance.
+          x-added-in-version: "8.8"
         processDefinitionKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessDefinitionKey'
           description: The key of the process definition.
+          x-added-in-version: "8.6"
         processInstanceKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
           description: The key of the process instance.
+          x-added-in-version: "8.6"
         decisionDefinitionKey:
           description: The key of the decision.
           allOf:
             - $ref: 'keys.yaml#/components/schemas/DecisionDefinitionKeyFilterProperty'
+          x-added-in-version: "8.6"
         elementInstanceKey:
           description: The key of the element instance this decision instance is linked to.
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ElementInstanceKeyFilterProperty'
+          x-added-in-version: "8.8"
         rootDecisionDefinitionKey:
           description: The key of the root decision definition.
           allOf:
             - $ref: 'keys.yaml#/components/schemas/DecisionDefinitionKeyFilterProperty'
+          x-added-in-version: "8.9"
         decisionRequirementsKey:
           description: The key of the decision requirements definition.
           allOf:
             - $ref: 'keys.yaml#/components/schemas/DecisionRequirementsKeyFilterProperty'
+          x-added-in-version: "8.9"
 
     DeleteDecisionInstanceRequest:
       type: object
@@ -312,55 +328,69 @@ components:
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/DecisionDefinitionId'
           description: The ID of the DMN decision.
+          x-added-in-version: "8.6"
         decisionDefinitionKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/DecisionDefinitionKey'
           description: The key of the decision.
+          x-added-in-version: "8.6"
         decisionDefinitionName:
           type: string
           description: The name of the DMN decision.
+          x-added-in-version: "8.6"
         decisionDefinitionType:
           $ref: '#/components/schemas/DecisionDefinitionTypeEnum'
+          x-added-in-version: "8.6"
         decisionDefinitionVersion:
           type: integer
           format: int32
           description: The version of the decision.
+          x-added-in-version: "8.6"
         decisionEvaluationInstanceKey:
           $ref: 'keys.yaml#/components/schemas/DecisionEvaluationInstanceKey'
+          x-added-in-version: "8.8"
         decisionEvaluationKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/DecisionEvaluationKey'
           description: The key of the decision evaluation where this instance was created.
+          x-added-in-version: "8.8"
         elementInstanceKey:
           description: The key of the element instance this decision instance is linked to.
           nullable: true
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ElementInstanceKey'
+          x-added-in-version: "8.8"
         evaluationDate:
           type: string
           format: date-time
           description: The evaluation date of the decision instance.
+          x-added-in-version: "8.6"
         evaluationFailure:
           type: string
           nullable: true
           description: The evaluation failure of the decision instance.
+          x-added-in-version: "8.6"
         processDefinitionKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessDefinitionKey'
           nullable: true
           description: The key of the process definition.
+          x-added-in-version: "8.6"
         processInstanceKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
           nullable: true
           description: The key of the process instance.
+          x-added-in-version: "8.6"
         result:
           type: string
           description: The result of the decision instance.
+          x-added-in-version: "8.6"
         rootDecisionDefinitionKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/DecisionDefinitionKey'
           description: The key of the root decision definition.
+          x-added-in-version: "8.9"
         rootProcessInstanceKey:
           description: |
             The key of the root process instance. The root process instance is the top-level
@@ -369,12 +399,15 @@ components:
           nullable: true
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
+          x-added-in-version: "8.9"
         state:
           $ref: '#/components/schemas/DecisionInstanceStateEnum'
+          x-added-in-version: "8.6"
         tenantId:
           description: The tenant ID of the decision instance.
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/TenantId'
+          x-added-in-version: "8.6"
 
     DecisionInstanceGetQueryResult:
       allOf:
@@ -408,12 +441,15 @@ components:
         inputId:
           type: string
           description: The identifier of the decision input.
+          x-added-in-version: "8.6"
         inputName:
           type: string
           description: The name of the decision input.
+          x-added-in-version: "8.6"
         inputValue:
           description: The value of the decision input.
           type: string
+          x-added-in-version: "8.6"
 
     EvaluatedDecisionOutputItem:
       required:
@@ -438,11 +474,13 @@ components:
           description: The ID of the matched rule.
           nullable: true
           type: string
+          x-added-in-version: "8.9"
         ruleIndex:
           description: The index of the matched rule.
           nullable: true
           type: integer
           format: int32
+          x-added-in-version: "8.9"
 
     MatchedDecisionRuleItem:
       required:
@@ -455,15 +493,18 @@ components:
         ruleId:
           description: The ID of the matched rule.
           type: string
+          x-added-in-version: "8.6"
         ruleIndex:
           description: The index of the matched rule.
           type: integer
           format: int32
+          x-added-in-version: "8.6"
         evaluatedOutputs:
           description: The evaluated decision outputs.
           type: array
           items:
             $ref: '#/components/schemas/EvaluatedDecisionOutputItem'
+          x-added-in-version: "8.6"
 
     ## Enums
 
@@ -504,25 +545,31 @@ components:
           description: Checks for equality with the provided value.
           allOf:
             - $ref: "#/components/schemas/DecisionInstanceStateEnum"
+          x-added-in-version: "8.9"
         $neq:
           description: Checks for inequality with the provided value.
           allOf:
             - $ref: "#/components/schemas/DecisionInstanceStateEnum"
+          x-added-in-version: "8.9"
         $exists:
           description: Checks if the current property exists.
           type: boolean
+          x-added-in-version: "8.9"
         $in:
           description: Checks if the property matches any of the provided values.
           type: array
           items:
             $ref: "#/components/schemas/DecisionInstanceStateEnum"
+          x-added-in-version: "8.9"
         $notIn:
           description: Checks if the property matches none of the provided values.
           type: array
           items:
             $ref: "#/components/schemas/DecisionInstanceStateEnum"
+          x-added-in-version: "8.9"
         $like:
           $ref: 'filters.yaml#/components/schemas/LikeFilter'
+          x-added-in-version: "8.9"
 
     DecisionInstanceStateFilterProperty:
       description: DecisionInstanceStateEnum property with full advanced search capabilities.

--- a/zeebe/gateway-protocol/src/main/proto/v2/decision-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/decision-instances.yaml
@@ -265,7 +265,7 @@ components:
           description: The key of the decision requirements definition.
           allOf:
             - $ref: 'keys.yaml#/components/schemas/DecisionRequirementsKeyFilterProperty'
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: decisionEvaluationInstanceKey
           addedInVersion: "8.8"
         - propertyName: state
@@ -408,7 +408,7 @@ components:
           description: The tenant ID of the decision instance.
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/TenantId'
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: decisionDefinitionId
           addedInVersion: "8.6"
         - propertyName: decisionDefinitionKey
@@ -482,7 +482,7 @@ components:
         inputValue:
           description: The value of the decision input.
           type: string
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: inputId
           addedInVersion: "8.6"
         - propertyName: inputName
@@ -518,7 +518,7 @@ components:
           nullable: true
           type: integer
           format: int32
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: ruleId
           addedInVersion: "8.9"
         - propertyName: ruleIndex
@@ -544,7 +544,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/EvaluatedDecisionOutputItem'
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: ruleId
           addedInVersion: "8.6"
         - propertyName: ruleIndex
@@ -610,7 +610,7 @@ components:
             $ref: "#/components/schemas/DecisionInstanceStateEnum"
         $like:
           $ref: 'filters.yaml#/components/schemas/LikeFilter'
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: "$eq"
           addedInVersion: "8.9"
         - propertyName: "$neq"

--- a/zeebe/gateway-protocol/src/main/proto/v2/decision-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/decision-instances.yaml
@@ -206,43 +206,34 @@ components:
           description: The key of the decision evaluation instance.
           allOf:
             - $ref: 'keys.yaml#/components/schemas/DecisionEvaluationInstanceKeyFilterProperty'
-          x-added-in-version: "8.8"
         state:
           description: The state of the decision instance.
           allOf:
             - $ref: '#/components/schemas/DecisionInstanceStateFilterProperty'
-          x-added-in-version: "8.6"
         evaluationFailure:
           type: string
           description: The evaluation failure of the decision instance.
-          x-added-in-version: "8.6"
         evaluationDate:
           description: The evaluation date of the decision instance.
           allOf:
             - $ref: 'filters.yaml#/components/schemas/DateTimeFilterProperty'
-          x-added-in-version: "8.8"
         decisionDefinitionId:
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/DecisionDefinitionId'
           description: The ID of the DMN decision.
-          x-added-in-version: "8.6"
         decisionDefinitionName:
           type: string
           description: The name of the DMN decision.
-          x-added-in-version: "8.6"
         decisionDefinitionVersion:
           type: integer
           format: int32
           description: The version of the decision.
-          x-added-in-version: "8.6"
         decisionDefinitionType:
           $ref: '#/components/schemas/DecisionDefinitionTypeEnum'
-          x-added-in-version: "8.6"
         tenantId:
           description: The tenant ID of the decision instance.
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/TenantId'
-          x-added-in-version: "8.6"
         decisionEvaluationKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/DecisionEvaluationKey'
@@ -250,37 +241,63 @@ components:
             The key of the parent decision evaluation. Note that this is not the identifier of
             an individual decision instance; the `decisionEvaluationInstanceKey` is the identifier
             for a decision instance.
-          x-added-in-version: "8.8"
         processDefinitionKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessDefinitionKey'
           description: The key of the process definition.
-          x-added-in-version: "8.6"
         processInstanceKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
           description: The key of the process instance.
-          x-added-in-version: "8.6"
         decisionDefinitionKey:
           description: The key of the decision.
           allOf:
             - $ref: 'keys.yaml#/components/schemas/DecisionDefinitionKeyFilterProperty'
-          x-added-in-version: "8.6"
         elementInstanceKey:
           description: The key of the element instance this decision instance is linked to.
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ElementInstanceKeyFilterProperty'
-          x-added-in-version: "8.8"
         rootDecisionDefinitionKey:
           description: The key of the root decision definition.
           allOf:
             - $ref: 'keys.yaml#/components/schemas/DecisionDefinitionKeyFilterProperty'
-          x-added-in-version: "8.9"
         decisionRequirementsKey:
           description: The key of the decision requirements definition.
           allOf:
             - $ref: 'keys.yaml#/components/schemas/DecisionRequirementsKeyFilterProperty'
-          x-added-in-version: "8.9"
+      x-added-in-version:
+        - propertyName: decisionEvaluationInstanceKey
+          addedInVersion: "8.8"
+        - propertyName: state
+          addedInVersion: "8.6"
+        - propertyName: evaluationFailure
+          addedInVersion: "8.6"
+        - propertyName: evaluationDate
+          addedInVersion: "8.8"
+        - propertyName: decisionDefinitionId
+          addedInVersion: "8.6"
+        - propertyName: decisionDefinitionName
+          addedInVersion: "8.6"
+        - propertyName: decisionDefinitionVersion
+          addedInVersion: "8.6"
+        - propertyName: decisionDefinitionType
+          addedInVersion: "8.6"
+        - propertyName: tenantId
+          addedInVersion: "8.6"
+        - propertyName: decisionEvaluationKey
+          addedInVersion: "8.8"
+        - propertyName: processDefinitionKey
+          addedInVersion: "8.6"
+        - propertyName: processInstanceKey
+          addedInVersion: "8.6"
+        - propertyName: decisionDefinitionKey
+          addedInVersion: "8.6"
+        - propertyName: elementInstanceKey
+          addedInVersion: "8.8"
+        - propertyName: rootDecisionDefinitionKey
+          addedInVersion: "8.9"
+        - propertyName: decisionRequirementsKey
+          addedInVersion: "8.9"
 
     DeleteDecisionInstanceRequest:
       type: object
@@ -328,69 +345,55 @@ components:
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/DecisionDefinitionId'
           description: The ID of the DMN decision.
-          x-added-in-version: "8.6"
         decisionDefinitionKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/DecisionDefinitionKey'
           description: The key of the decision.
-          x-added-in-version: "8.6"
         decisionDefinitionName:
           type: string
           description: The name of the DMN decision.
-          x-added-in-version: "8.6"
         decisionDefinitionType:
           $ref: '#/components/schemas/DecisionDefinitionTypeEnum'
-          x-added-in-version: "8.6"
         decisionDefinitionVersion:
           type: integer
           format: int32
           description: The version of the decision.
-          x-added-in-version: "8.6"
         decisionEvaluationInstanceKey:
           $ref: 'keys.yaml#/components/schemas/DecisionEvaluationInstanceKey'
-          x-added-in-version: "8.8"
         decisionEvaluationKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/DecisionEvaluationKey'
           description: The key of the decision evaluation where this instance was created.
-          x-added-in-version: "8.8"
         elementInstanceKey:
           description: The key of the element instance this decision instance is linked to.
           nullable: true
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ElementInstanceKey'
-          x-added-in-version: "8.8"
         evaluationDate:
           type: string
           format: date-time
           description: The evaluation date of the decision instance.
-          x-added-in-version: "8.6"
         evaluationFailure:
           type: string
           nullable: true
           description: The evaluation failure of the decision instance.
-          x-added-in-version: "8.6"
         processDefinitionKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessDefinitionKey'
           nullable: true
           description: The key of the process definition.
-          x-added-in-version: "8.6"
         processInstanceKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
           nullable: true
           description: The key of the process instance.
-          x-added-in-version: "8.6"
         result:
           type: string
           description: The result of the decision instance.
-          x-added-in-version: "8.6"
         rootDecisionDefinitionKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/DecisionDefinitionKey'
           description: The key of the root decision definition.
-          x-added-in-version: "8.9"
         rootProcessInstanceKey:
           description: |
             The key of the root process instance. The root process instance is the top-level
@@ -399,15 +402,47 @@ components:
           nullable: true
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
-          x-added-in-version: "8.9"
         state:
           $ref: '#/components/schemas/DecisionInstanceStateEnum'
-          x-added-in-version: "8.6"
         tenantId:
           description: The tenant ID of the decision instance.
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/TenantId'
-          x-added-in-version: "8.6"
+      x-added-in-version:
+        - propertyName: decisionDefinitionId
+          addedInVersion: "8.6"
+        - propertyName: decisionDefinitionKey
+          addedInVersion: "8.6"
+        - propertyName: decisionDefinitionName
+          addedInVersion: "8.6"
+        - propertyName: decisionDefinitionType
+          addedInVersion: "8.6"
+        - propertyName: decisionDefinitionVersion
+          addedInVersion: "8.6"
+        - propertyName: decisionEvaluationInstanceKey
+          addedInVersion: "8.8"
+        - propertyName: decisionEvaluationKey
+          addedInVersion: "8.8"
+        - propertyName: elementInstanceKey
+          addedInVersion: "8.8"
+        - propertyName: evaluationDate
+          addedInVersion: "8.6"
+        - propertyName: evaluationFailure
+          addedInVersion: "8.6"
+        - propertyName: processDefinitionKey
+          addedInVersion: "8.6"
+        - propertyName: processInstanceKey
+          addedInVersion: "8.6"
+        - propertyName: result
+          addedInVersion: "8.6"
+        - propertyName: rootDecisionDefinitionKey
+          addedInVersion: "8.9"
+        - propertyName: rootProcessInstanceKey
+          addedInVersion: "8.9"
+        - propertyName: state
+          addedInVersion: "8.6"
+        - propertyName: tenantId
+          addedInVersion: "8.6"
 
     DecisionInstanceGetQueryResult:
       allOf:
@@ -441,15 +476,19 @@ components:
         inputId:
           type: string
           description: The identifier of the decision input.
-          x-added-in-version: "8.6"
         inputName:
           type: string
           description: The name of the decision input.
-          x-added-in-version: "8.6"
         inputValue:
           description: The value of the decision input.
           type: string
-          x-added-in-version: "8.6"
+      x-added-in-version:
+        - propertyName: inputId
+          addedInVersion: "8.6"
+        - propertyName: inputName
+          addedInVersion: "8.6"
+        - propertyName: inputValue
+          addedInVersion: "8.6"
 
     EvaluatedDecisionOutputItem:
       required:
@@ -474,13 +513,16 @@ components:
           description: The ID of the matched rule.
           nullable: true
           type: string
-          x-added-in-version: "8.9"
         ruleIndex:
           description: The index of the matched rule.
           nullable: true
           type: integer
           format: int32
-          x-added-in-version: "8.9"
+      x-added-in-version:
+        - propertyName: ruleId
+          addedInVersion: "8.9"
+        - propertyName: ruleIndex
+          addedInVersion: "8.9"
 
     MatchedDecisionRuleItem:
       required:
@@ -493,18 +535,22 @@ components:
         ruleId:
           description: The ID of the matched rule.
           type: string
-          x-added-in-version: "8.6"
         ruleIndex:
           description: The index of the matched rule.
           type: integer
           format: int32
-          x-added-in-version: "8.6"
         evaluatedOutputs:
           description: The evaluated decision outputs.
           type: array
           items:
             $ref: '#/components/schemas/EvaluatedDecisionOutputItem'
-          x-added-in-version: "8.6"
+      x-added-in-version:
+        - propertyName: ruleId
+          addedInVersion: "8.6"
+        - propertyName: ruleIndex
+          addedInVersion: "8.6"
+        - propertyName: evaluatedOutputs
+          addedInVersion: "8.6"
 
     ## Enums
 
@@ -545,31 +591,38 @@ components:
           description: Checks for equality with the provided value.
           allOf:
             - $ref: "#/components/schemas/DecisionInstanceStateEnum"
-          x-added-in-version: "8.9"
         $neq:
           description: Checks for inequality with the provided value.
           allOf:
             - $ref: "#/components/schemas/DecisionInstanceStateEnum"
-          x-added-in-version: "8.9"
         $exists:
           description: Checks if the current property exists.
           type: boolean
-          x-added-in-version: "8.9"
         $in:
           description: Checks if the property matches any of the provided values.
           type: array
           items:
             $ref: "#/components/schemas/DecisionInstanceStateEnum"
-          x-added-in-version: "8.9"
         $notIn:
           description: Checks if the property matches none of the provided values.
           type: array
           items:
             $ref: "#/components/schemas/DecisionInstanceStateEnum"
-          x-added-in-version: "8.9"
         $like:
           $ref: 'filters.yaml#/components/schemas/LikeFilter'
-          x-added-in-version: "8.9"
+      x-added-in-version:
+        - propertyName: "$eq"
+          addedInVersion: "8.9"
+        - propertyName: "$neq"
+          addedInVersion: "8.9"
+        - propertyName: "$exists"
+          addedInVersion: "8.9"
+        - propertyName: "$in"
+          addedInVersion: "8.9"
+        - propertyName: "$notIn"
+          addedInVersion: "8.9"
+        - propertyName: "$like"
+          addedInVersion: "8.9"
 
     DecisionInstanceStateFilterProperty:
       description: DecisionInstanceStateEnum property with full advanced search capabilities.

--- a/zeebe/gateway-protocol/src/main/proto/v2/decision-requirements.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/decision-requirements.yaml
@@ -172,7 +172,9 @@ components:
         resourceName:
           type: string
           description: The name of the resource from which the decision requirements were parsed
-          x-added-in-version: "8.8"
+      x-added-in-version:
+        - propertyName: resourceName
+          addedInVersion: "8.8"
 
     DecisionRequirementsSearchQueryResult:
       required:
@@ -201,27 +203,34 @@ components:
         decisionRequirementsId:
           type: string
           description: The DMN ID of the decision requirements.
-          x-added-in-version: "8.6"
         decisionRequirementsKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/DecisionRequirementsKey'
           description: The assigned key, which acts as a unique identifier for this decision requirements.
-          x-added-in-version: "8.6"
         decisionRequirementsName:
           type: string
           description: The DMN name of the decision requirements.
-          x-added-in-version: "8.6"
         resourceName:
           type: string
           description: The name of the resource from which this decision requirements was parsed.
-          x-added-in-version: "8.6"
         tenantId:
           description: The tenant ID of the decision requirements.
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/TenantId'
-          x-added-in-version: "8.6"
         version:
           type: integer
           format: int32
           description: The assigned version of the decision requirements.
-          x-added-in-version: "8.6"
+      x-added-in-version:
+        - propertyName: decisionRequirementsId
+          addedInVersion: "8.6"
+        - propertyName: decisionRequirementsKey
+          addedInVersion: "8.6"
+        - propertyName: decisionRequirementsName
+          addedInVersion: "8.6"
+        - propertyName: resourceName
+          addedInVersion: "8.6"
+        - propertyName: tenantId
+          addedInVersion: "8.6"
+        - propertyName: version
+          addedInVersion: "8.6"

--- a/zeebe/gateway-protocol/src/main/proto/v2/decision-requirements.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/decision-requirements.yaml
@@ -172,7 +172,7 @@ components:
         resourceName:
           type: string
           description: The name of the resource from which the decision requirements were parsed
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: resourceName
           addedInVersion: "8.8"
 
@@ -221,7 +221,7 @@ components:
           type: integer
           format: int32
           description: The assigned version of the decision requirements.
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: decisionRequirementsId
           addedInVersion: "8.6"
         - propertyName: decisionRequirementsKey

--- a/zeebe/gateway-protocol/src/main/proto/v2/decision-requirements.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/decision-requirements.yaml
@@ -172,6 +172,7 @@ components:
         resourceName:
           type: string
           description: The name of the resource from which the decision requirements were parsed
+          x-added-in-version: "8.8"
 
     DecisionRequirementsSearchQueryResult:
       required:
@@ -200,21 +201,27 @@ components:
         decisionRequirementsId:
           type: string
           description: The DMN ID of the decision requirements.
+          x-added-in-version: "8.6"
         decisionRequirementsKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/DecisionRequirementsKey'
           description: The assigned key, which acts as a unique identifier for this decision requirements.
+          x-added-in-version: "8.6"
         decisionRequirementsName:
           type: string
           description: The DMN name of the decision requirements.
+          x-added-in-version: "8.6"
         resourceName:
           type: string
           description: The name of the resource from which this decision requirements was parsed.
+          x-added-in-version: "8.6"
         tenantId:
           description: The tenant ID of the decision requirements.
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/TenantId'
+          x-added-in-version: "8.6"
         version:
           type: integer
           format: int32
           description: The assigned version of the decision requirements.
+          x-added-in-version: "8.6"

--- a/zeebe/gateway-protocol/src/main/proto/v2/deployments.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/deployments.yaml
@@ -322,7 +322,9 @@ components:
           description: Deployed resource.
           allOf:
             - $ref: '#/components/schemas/DeploymentResourceResult'
-          x-added-in-version: "8.7"
+      x-added-in-version:
+        - propertyName: resource
+          addedInVersion: "8.7"
 
     DeploymentProcessResult:
       description: A deployed process.
@@ -525,7 +527,9 @@ components:
             will not be populated.
           type: boolean
           default: false
-          x-added-in-version: "8.9"
+      x-added-in-version:
+        - propertyName: deleteHistory
+          addedInVersion: "8.9"
 
     DeleteResourceResponse:
       type: object
@@ -537,7 +541,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/ResourceKey'
           description: The system-assigned key for this resource, requested to be deleted.
-          x-added-in-version: "8.9"
         batchOperation:
           nullable: true
           allOf:
@@ -548,7 +551,11 @@ components:
             This field is only populated when the request `deleteHistory` is set to `true` and the resource
             is a process definition. For other resource types (decisions, forms, generic resources),
             this field will be `null`.
-          x-added-in-version: "8.9"
+      x-added-in-version:
+        - propertyName: resourceKey
+          addedInVersion: "8.9"
+        - propertyName: batchOperation
+          addedInVersion: "8.9"
 
     ResourceResult:
       type: object
@@ -563,31 +570,38 @@ components:
         resourceName:
           description: The resource name from which this resource was parsed.
           type: string
-          x-added-in-version: "8.7"
         version:
           description: The assigned resource version.
           type: integer
           format: int32
-          x-added-in-version: "8.7"
         versionTag:
           nullable: true
           description: The version tag of this resource.
           type: string
-          x-added-in-version: "8.7"
         resourceId:
           description: The resource ID of this resource.
           type: string
-          x-added-in-version: "8.7"
         tenantId:
           description: The tenant ID of this resource.
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/TenantId'
-          x-added-in-version: "8.7"
         resourceKey:
           allOf:
             - $ref: '#/components/schemas/ResourceKey'
           description: The unique key of this resource.
-          x-added-in-version: "8.7"
+      x-added-in-version:
+        - propertyName: resourceName
+          addedInVersion: "8.7"
+        - propertyName: version
+          addedInVersion: "8.7"
+        - propertyName: versionTag
+          addedInVersion: "8.7"
+        - propertyName: resourceId
+          addedInVersion: "8.7"
+        - propertyName: tenantId
+          addedInVersion: "8.7"
+        - propertyName: resourceKey
+          addedInVersion: "8.7"
 
     ## Keys
 
@@ -630,28 +644,34 @@ components:
           description: Checks for equality with the provided value.
           allOf:
             - $ref: '#/components/schemas/DeploymentKey'
-          x-added-in-version: "8.9"
         $neq:
           description: Checks for inequality with the provided value.
           allOf:
             - $ref: '#/components/schemas/DeploymentKey'
-          x-added-in-version: "8.9"
         $exists:
           description: Checks if the current property exists.
           type: boolean
-          x-added-in-version: "8.9"
         $in:
           description: Checks if the property matches any of the provided values.
           type: array
           items:
             $ref: '#/components/schemas/DeploymentKey'
-          x-added-in-version: "8.9"
         $notIn:
           description: Checks if the property matches none of the provided values.
           type: array
           items:
             $ref: '#/components/schemas/DeploymentKey'
-          x-added-in-version: "8.9"
+      x-added-in-version:
+        - propertyName: "$eq"
+          addedInVersion: "8.9"
+        - propertyName: "$neq"
+          addedInVersion: "8.9"
+        - propertyName: "$exists"
+          addedInVersion: "8.9"
+        - propertyName: "$in"
+          addedInVersion: "8.9"
+        - propertyName: "$notIn"
+          addedInVersion: "8.9"
 
     ResourceKeyFilterProperty:
       description: ResourceKey property with full advanced search capabilities.
@@ -672,28 +692,34 @@ components:
           description: Checks for equality with the provided value.
           allOf:
             - $ref: "#/components/schemas/ResourceKey"
-          x-added-in-version: "8.9"
         $neq:
           description: Checks for inequality with the provided value.
           allOf:
             - $ref: "#/components/schemas/ResourceKey"
-          x-added-in-version: "8.9"
         $exists:
           description: Checks if the current property exists.
           type: boolean
-          x-added-in-version: "8.9"
         $in:
           description: Checks if the property matches any of the provided values.
           type: array
           items:
             $ref: "#/components/schemas/ResourceKey"
-          x-added-in-version: "8.9"
         $notIn:
           description: Checks if the property matches none of the provided values.
           type: array
           items:
             $ref: "#/components/schemas/ResourceKey"
-          x-added-in-version: "8.9"
+      x-added-in-version:
+        - propertyName: "$eq"
+          addedInVersion: "8.9"
+        - propertyName: "$neq"
+          addedInVersion: "8.9"
+        - propertyName: "$exists"
+          addedInVersion: "8.9"
+        - propertyName: "$in"
+          addedInVersion: "8.9"
+        - propertyName: "$notIn"
+          addedInVersion: "8.9"
 
     ## Resource Search
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/deployments.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/deployments.yaml
@@ -322,7 +322,7 @@ components:
           description: Deployed resource.
           allOf:
             - $ref: '#/components/schemas/DeploymentResourceResult'
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: resource
           addedInVersion: "8.7"
 
@@ -527,7 +527,7 @@ components:
             will not be populated.
           type: boolean
           default: false
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: deleteHistory
           addedInVersion: "8.9"
 
@@ -551,7 +551,7 @@ components:
             This field is only populated when the request `deleteHistory` is set to `true` and the resource
             is a process definition. For other resource types (decisions, forms, generic resources),
             this field will be `null`.
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: resourceKey
           addedInVersion: "8.9"
         - propertyName: batchOperation
@@ -589,7 +589,7 @@ components:
           allOf:
             - $ref: '#/components/schemas/ResourceKey'
           description: The unique key of this resource.
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: resourceName
           addedInVersion: "8.7"
         - propertyName: version
@@ -661,7 +661,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/DeploymentKey'
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: "$eq"
           addedInVersion: "8.9"
         - propertyName: "$neq"
@@ -709,7 +709,7 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/ResourceKey"
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: "$eq"
           addedInVersion: "8.9"
         - propertyName: "$neq"

--- a/zeebe/gateway-protocol/src/main/proto/v2/deployments.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/deployments.yaml
@@ -322,6 +322,7 @@ components:
           description: Deployed resource.
           allOf:
             - $ref: '#/components/schemas/DeploymentResourceResult'
+          x-added-in-version: "8.7"
 
     DeploymentProcessResult:
       description: A deployed process.
@@ -524,6 +525,7 @@ components:
             will not be populated.
           type: boolean
           default: false
+          x-added-in-version: "8.9"
 
     DeleteResourceResponse:
       type: object
@@ -535,6 +537,7 @@ components:
           allOf:
             - $ref: '#/components/schemas/ResourceKey'
           description: The system-assigned key for this resource, requested to be deleted.
+          x-added-in-version: "8.9"
         batchOperation:
           nullable: true
           allOf:
@@ -545,6 +548,7 @@ components:
             This field is only populated when the request `deleteHistory` is set to `true` and the resource
             is a process definition. For other resource types (decisions, forms, generic resources),
             this field will be `null`.
+          x-added-in-version: "8.9"
 
     ResourceResult:
       type: object
@@ -559,25 +563,31 @@ components:
         resourceName:
           description: The resource name from which this resource was parsed.
           type: string
+          x-added-in-version: "8.7"
         version:
           description: The assigned resource version.
           type: integer
           format: int32
+          x-added-in-version: "8.7"
         versionTag:
           nullable: true
           description: The version tag of this resource.
           type: string
+          x-added-in-version: "8.7"
         resourceId:
           description: The resource ID of this resource.
           type: string
+          x-added-in-version: "8.7"
         tenantId:
           description: The tenant ID of this resource.
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/TenantId'
+          x-added-in-version: "8.7"
         resourceKey:
           allOf:
             - $ref: '#/components/schemas/ResourceKey'
           description: The unique key of this resource.
+          x-added-in-version: "8.7"
 
     ## Keys
 
@@ -620,23 +630,28 @@ components:
           description: Checks for equality with the provided value.
           allOf:
             - $ref: '#/components/schemas/DeploymentKey'
+          x-added-in-version: "8.9"
         $neq:
           description: Checks for inequality with the provided value.
           allOf:
             - $ref: '#/components/schemas/DeploymentKey'
+          x-added-in-version: "8.9"
         $exists:
           description: Checks if the current property exists.
           type: boolean
+          x-added-in-version: "8.9"
         $in:
           description: Checks if the property matches any of the provided values.
           type: array
           items:
             $ref: '#/components/schemas/DeploymentKey'
+          x-added-in-version: "8.9"
         $notIn:
           description: Checks if the property matches none of the provided values.
           type: array
           items:
             $ref: '#/components/schemas/DeploymentKey'
+          x-added-in-version: "8.9"
 
     ResourceKeyFilterProperty:
       description: ResourceKey property with full advanced search capabilities.
@@ -657,23 +672,28 @@ components:
           description: Checks for equality with the provided value.
           allOf:
             - $ref: "#/components/schemas/ResourceKey"
+          x-added-in-version: "8.9"
         $neq:
           description: Checks for inequality with the provided value.
           allOf:
             - $ref: "#/components/schemas/ResourceKey"
+          x-added-in-version: "8.9"
         $exists:
           description: Checks if the current property exists.
           type: boolean
+          x-added-in-version: "8.9"
         $in:
           description: Checks if the property matches any of the provided values.
           type: array
           items:
             $ref: "#/components/schemas/ResourceKey"
+          x-added-in-version: "8.9"
         $notIn:
           description: Checks if the property matches none of the provided values.
           type: array
           items:
             $ref: "#/components/schemas/ResourceKey"
+          x-added-in-version: "8.9"
 
     ## Resource Search
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/documents.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/documents.yaml
@@ -112,7 +112,7 @@ paths:
                     $ref: '#/components/schemas/DocumentMetadata'
               required:
                 - files
-              x-added-in-version:
+              x-properties-added-in-version:
                 - propertyName: metadataList
                   addedInVersion: "8.8"
             encoding:
@@ -311,7 +311,7 @@ components:
           nullable: true
         metadata:
           $ref: '#/components/schemas/DocumentMetadataResponse'
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: "camunda.document.type"
           addedInVersion: "8.7"
         - propertyName: storeId
@@ -344,7 +344,7 @@ components:
         detail:
           type: string
           description: A human-readable explanation specific to this occurrence of the problem.
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: status
           addedInVersion: "8.9"
         - propertyName: title
@@ -398,7 +398,7 @@ components:
           type: object
           description: Custom properties of the document.
           additionalProperties: true
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: contentType
           addedInVersion: "8.6"
         - propertyName: fileName
@@ -455,7 +455,7 @@ components:
           type: object
           description: Custom properties of the document.
           additionalProperties: true
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: processDefinitionId
           addedInVersion: "8.7"
         - propertyName: processInstanceKey

--- a/zeebe/gateway-protocol/src/main/proto/v2/documents.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/documents.yaml
@@ -110,9 +110,11 @@ paths:
                   type: array
                   items:
                     $ref: '#/components/schemas/DocumentMetadata'
-                  x-added-in-version: "8.8"
               required:
                 - files
+              x-added-in-version:
+                - propertyName: metadataList
+                  addedInVersion: "8.8"
             encoding:
               files:
                 headers:
@@ -296,24 +298,30 @@ components:
           description: Document discriminator. Always set to "camunda".
           enum:
             - camunda
-          x-added-in-version: "8.7"
         storeId:
           type: string
           description: The ID of the document store.
-          x-added-in-version: "8.6"
         documentId:
           allOf:
             - $ref: '#/components/schemas/DocumentId'
           description: The ID of the document.
-          x-added-in-version: "8.6"
         contentHash:
           type: string
           description: The hash of the document.
           nullable: true
-          x-added-in-version: "8.7"
         metadata:
           $ref: '#/components/schemas/DocumentMetadataResponse'
-          x-added-in-version: "8.6"
+      x-added-in-version:
+        - propertyName: "camunda.document.type"
+          addedInVersion: "8.7"
+        - propertyName: storeId
+          addedInVersion: "8.6"
+        - propertyName: documentId
+          addedInVersion: "8.6"
+        - propertyName: contentHash
+          addedInVersion: "8.7"
+        - propertyName: metadata
+          addedInVersion: "8.6"
 
     DocumentCreationFailureDetail:
       type: object
@@ -330,14 +338,17 @@ components:
           type: integer
           format: int32
           description: The HTTP status code of the failure.
-          x-added-in-version: "8.9"
         title:
           type: string
           description: A short, human-readable summary of the problem type.
-          x-added-in-version: "8.9"
         detail:
           type: string
           description: A human-readable explanation specific to this occurrence of the problem.
+      x-added-in-version:
+        - propertyName: status
+          addedInVersion: "8.9"
+        - propertyName: title
+          addedInVersion: "8.9"
 
     DocumentCreationBatchResponse:
       allOf:
@@ -364,36 +375,44 @@ components:
         contentType:
           type: string
           description: The content type of the document.
-          x-added-in-version: "8.6"
         fileName:
           type: string
           description: The name of the file.
-          x-added-in-version: "8.6"
         expiresAt:
           type: string
           format: date-time
           description: The date and time when the document expires.
-          x-added-in-version: "8.6"
         size:
           type: integer
           format: int64
           description: The size of the document in bytes.
-          x-added-in-version: "8.6"
         processDefinitionId:
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/ProcessDefinitionId'
           description: The ID of the process definition that created the document.
-          x-added-in-version: "8.7"
         processInstanceKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
           description: The key of the process instance that created the document.
-          x-added-in-version: "8.7"
         customProperties:
           type: object
           description: Custom properties of the document.
           additionalProperties: true
-          x-added-in-version: "8.7"
+      x-added-in-version:
+        - propertyName: contentType
+          addedInVersion: "8.6"
+        - propertyName: fileName
+          addedInVersion: "8.6"
+        - propertyName: expiresAt
+          addedInVersion: "8.6"
+        - propertyName: size
+          addedInVersion: "8.6"
+        - propertyName: processDefinitionId
+          addedInVersion: "8.7"
+        - propertyName: processInstanceKey
+          addedInVersion: "8.7"
+        - propertyName: customProperties
+          addedInVersion: "8.7"
 
     DocumentMetadataResponse:
       description: Information about the document that is returned in responses.
@@ -427,18 +446,22 @@ components:
             - $ref: 'identifiers.yaml#/components/schemas/ProcessDefinitionId'
           description: The ID of the process definition that created the document.
           nullable: true
-          x-added-in-version: "8.7"
         processInstanceKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
           description: The key of the process instance that created the document.
           nullable: true
-          x-added-in-version: "8.7"
         customProperties:
           type: object
           description: Custom properties of the document.
           additionalProperties: true
-          x-added-in-version: "8.7"
+      x-added-in-version:
+        - propertyName: processDefinitionId
+          addedInVersion: "8.7"
+        - propertyName: processInstanceKey
+          addedInVersion: "8.7"
+        - propertyName: customProperties
+          addedInVersion: "8.7"
 
     DocumentLinkRequest:
       type: object

--- a/zeebe/gateway-protocol/src/main/proto/v2/documents.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/documents.yaml
@@ -110,6 +110,7 @@ paths:
                   type: array
                   items:
                     $ref: '#/components/schemas/DocumentMetadata'
+                  x-added-in-version: "8.8"
               required:
                 - files
             encoding:
@@ -295,19 +296,24 @@ components:
           description: Document discriminator. Always set to "camunda".
           enum:
             - camunda
+          x-added-in-version: "8.7"
         storeId:
           type: string
           description: The ID of the document store.
+          x-added-in-version: "8.6"
         documentId:
           allOf:
             - $ref: '#/components/schemas/DocumentId'
           description: The ID of the document.
+          x-added-in-version: "8.6"
         contentHash:
           type: string
           description: The hash of the document.
           nullable: true
+          x-added-in-version: "8.7"
         metadata:
           $ref: '#/components/schemas/DocumentMetadataResponse'
+          x-added-in-version: "8.6"
 
     DocumentCreationFailureDetail:
       type: object
@@ -324,9 +330,11 @@ components:
           type: integer
           format: int32
           description: The HTTP status code of the failure.
+          x-added-in-version: "8.9"
         title:
           type: string
           description: A short, human-readable summary of the problem type.
+          x-added-in-version: "8.9"
         detail:
           type: string
           description: A human-readable explanation specific to this occurrence of the problem.
@@ -356,29 +364,36 @@ components:
         contentType:
           type: string
           description: The content type of the document.
+          x-added-in-version: "8.6"
         fileName:
           type: string
           description: The name of the file.
+          x-added-in-version: "8.6"
         expiresAt:
           type: string
           format: date-time
           description: The date and time when the document expires.
+          x-added-in-version: "8.6"
         size:
           type: integer
           format: int64
           description: The size of the document in bytes.
+          x-added-in-version: "8.6"
         processDefinitionId:
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/ProcessDefinitionId'
           description: The ID of the process definition that created the document.
+          x-added-in-version: "8.7"
         processInstanceKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
           description: The key of the process instance that created the document.
+          x-added-in-version: "8.7"
         customProperties:
           type: object
           description: Custom properties of the document.
           additionalProperties: true
+          x-added-in-version: "8.7"
 
     DocumentMetadataResponse:
       description: Information about the document that is returned in responses.
@@ -412,15 +427,18 @@ components:
             - $ref: 'identifiers.yaml#/components/schemas/ProcessDefinitionId'
           description: The ID of the process definition that created the document.
           nullable: true
+          x-added-in-version: "8.7"
         processInstanceKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
           description: The key of the process instance that created the document.
           nullable: true
+          x-added-in-version: "8.7"
         customProperties:
           type: object
           description: Custom properties of the document.
           additionalProperties: true
+          x-added-in-version: "8.7"
 
     DocumentLinkRequest:
       type: object

--- a/zeebe/gateway-protocol/src/main/proto/v2/element-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/element-instances.yaml
@@ -502,7 +502,7 @@ components:
             - $ref: "keys.yaml#/components/schemas/IncidentKey"
           description: Incident key associated with this element instance.
           nullable: true
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: rootProcessInstanceKey
           addedInVersion: "8.9"
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/element-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/element-instances.yaml
@@ -493,7 +493,6 @@ components:
           nullable: true
           allOf:
             - $ref: "keys.yaml#/components/schemas/ProcessInstanceKey"
-          x-added-in-version: "8.9"
         processDefinitionKey:
           allOf:
             - $ref: "keys.yaml#/components/schemas/ProcessDefinitionKey"
@@ -503,6 +502,9 @@ components:
             - $ref: "keys.yaml#/components/schemas/IncidentKey"
           description: Incident key associated with this element instance.
           nullable: true
+      x-added-in-version:
+        - propertyName: rootProcessInstanceKey
+          addedInVersion: "8.9"
 
     ElementInstanceStateEnum:
       description: Element states

--- a/zeebe/gateway-protocol/src/main/proto/v2/element-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/element-instances.yaml
@@ -493,6 +493,7 @@ components:
           nullable: true
           allOf:
             - $ref: "keys.yaml#/components/schemas/ProcessInstanceKey"
+          x-added-in-version: "8.9"
         processDefinitionKey:
           allOf:
             - $ref: "keys.yaml#/components/schemas/ProcessDefinitionKey"

--- a/zeebe/gateway-protocol/src/main/proto/v2/filters.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/filters.yaml
@@ -21,27 +21,33 @@ components:
         $eq:
           description: Checks for equality with the provided value.
           type: string
-          x-added-in-version: "8.8"
         $neq:
           description: Checks for inequality with the provided value.
           type: string
-          x-added-in-version: "8.8"
         $exists:
           description: Checks if the current property exists.
           type: boolean
-          x-added-in-version: "8.8"
         $in:
           description: Checks if the property matches any of the provided values.
           type: array
           items:
             type: string
-          x-added-in-version: "8.8"
         $notIn:
           description: Checks if the property matches none of the provided values.
           type: array
           items:
             type: string
-          x-added-in-version: "8.8"
+      x-added-in-version:
+        - propertyName: "$eq"
+          addedInVersion: "8.8"
+        - propertyName: "$neq"
+          addedInVersion: "8.8"
+        - propertyName: "$exists"
+          addedInVersion: "8.8"
+        - propertyName: "$in"
+          addedInVersion: "8.8"
+        - propertyName: "$notIn"
+          addedInVersion: "8.8"
 
     AdvancedStringFilter:
       title: Advanced filter
@@ -52,7 +58,9 @@ components:
           properties:
             $like:
               $ref: '#/components/schemas/LikeFilter'
-              x-added-in-version: "8.8"
+          x-added-in-version:
+            - propertyName: "$like"
+              addedInVersion: "8.8"
 
     BasicStringFilterProperty:
       description: String property with basic advanced search capabilities.
@@ -79,43 +87,52 @@ components:
           description: Checks for equality with the provided value.
           type: integer
           format: int32
-          x-added-in-version: "8.8"
         $neq:
           description: Checks for inequality with the provided value.
           type: integer
           format: int32
-          x-added-in-version: "8.8"
         $exists:
           description: Checks if the current property exists.
           type: boolean
-          x-added-in-version: "8.8"
         $gt:
           description: Greater than comparison with the provided value.
           type: integer
           format: int32
-          x-added-in-version: "8.8"
         $gte:
           description: Greater than or equal comparison with the provided value.
           type: integer
           format: int32
-          x-added-in-version: "8.8"
         $lt:
           description: Lower than comparison with the provided value.
           type: integer
           format: int32
-          x-added-in-version: "8.8"
         $lte:
           description: Lower than or equal comparison with the provided value.
           type: integer
           format: int32
-          x-added-in-version: "8.8"
         $in:
           description: Checks if the property matches any of the provided values.
           type: array
           items:
             type: integer
             format: int32
-          x-added-in-version: "8.8"
+      x-added-in-version:
+        - propertyName: "$eq"
+          addedInVersion: "8.8"
+        - propertyName: "$neq"
+          addedInVersion: "8.8"
+        - propertyName: "$exists"
+          addedInVersion: "8.8"
+        - propertyName: "$gt"
+          addedInVersion: "8.8"
+        - propertyName: "$gte"
+          addedInVersion: "8.8"
+        - propertyName: "$lt"
+          addedInVersion: "8.8"
+        - propertyName: "$lte"
+          addedInVersion: "8.8"
+        - propertyName: "$in"
+          addedInVersion: "8.8"
 
     IntegerFilterProperty:
       description: Integer property with advanced search capabilities.
@@ -135,43 +152,52 @@ components:
           description: Checks for equality with the provided value.
           type: string
           format: date-time
-          x-added-in-version: "8.8"
         $neq:
           description: Checks for inequality with the provided value.
           type: string
           format: date-time
-          x-added-in-version: "8.8"
         $exists:
           description: Checks if the current property exists.
           type: boolean
-          x-added-in-version: "8.8"
         $gt:
           description: Greater than comparison with the provided value.
           type: string
           format: date-time
-          x-added-in-version: "8.8"
         $gte:
           description: Greater than or equal comparison with the provided value.
           type: string
           format: date-time
-          x-added-in-version: "8.8"
         $lt:
           description: Lower than comparison with the provided value.
           type: string
           format: date-time
-          x-added-in-version: "8.8"
         $lte:
           description: Lower than or equal comparison with the provided value.
           type: string
           format: date-time
-          x-added-in-version: "8.8"
         $in:
           description: Checks if the property matches any of the provided values.
           type: array
           items:
             type: string
             format: date-time
-          x-added-in-version: "8.8"
+      x-added-in-version:
+        - propertyName: "$eq"
+          addedInVersion: "8.8"
+        - propertyName: "$neq"
+          addedInVersion: "8.8"
+        - propertyName: "$exists"
+          addedInVersion: "8.8"
+        - propertyName: "$gt"
+          addedInVersion: "8.8"
+        - propertyName: "$gte"
+          addedInVersion: "8.8"
+        - propertyName: "$lt"
+          addedInVersion: "8.8"
+        - propertyName: "$lte"
+          addedInVersion: "8.8"
+        - propertyName: "$in"
+          addedInVersion: "8.8"
 
     DateTimeFilterProperty:
       description: Date-time property with full advanced search capabilities.

--- a/zeebe/gateway-protocol/src/main/proto/v2/filters.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/filters.yaml
@@ -21,22 +21,27 @@ components:
         $eq:
           description: Checks for equality with the provided value.
           type: string
+          x-added-in-version: "8.8"
         $neq:
           description: Checks for inequality with the provided value.
           type: string
+          x-added-in-version: "8.8"
         $exists:
           description: Checks if the current property exists.
           type: boolean
+          x-added-in-version: "8.8"
         $in:
           description: Checks if the property matches any of the provided values.
           type: array
           items:
             type: string
+          x-added-in-version: "8.8"
         $notIn:
           description: Checks if the property matches none of the provided values.
           type: array
           items:
             type: string
+          x-added-in-version: "8.8"
 
     AdvancedStringFilter:
       title: Advanced filter
@@ -47,6 +52,7 @@ components:
           properties:
             $like:
               $ref: '#/components/schemas/LikeFilter'
+              x-added-in-version: "8.8"
 
     BasicStringFilterProperty:
       description: String property with basic advanced search capabilities.
@@ -73,35 +79,43 @@ components:
           description: Checks for equality with the provided value.
           type: integer
           format: int32
+          x-added-in-version: "8.8"
         $neq:
           description: Checks for inequality with the provided value.
           type: integer
           format: int32
+          x-added-in-version: "8.8"
         $exists:
           description: Checks if the current property exists.
           type: boolean
+          x-added-in-version: "8.8"
         $gt:
           description: Greater than comparison with the provided value.
           type: integer
           format: int32
+          x-added-in-version: "8.8"
         $gte:
           description: Greater than or equal comparison with the provided value.
           type: integer
           format: int32
+          x-added-in-version: "8.8"
         $lt:
           description: Lower than comparison with the provided value.
           type: integer
           format: int32
+          x-added-in-version: "8.8"
         $lte:
           description: Lower than or equal comparison with the provided value.
           type: integer
           format: int32
+          x-added-in-version: "8.8"
         $in:
           description: Checks if the property matches any of the provided values.
           type: array
           items:
             type: integer
             format: int32
+          x-added-in-version: "8.8"
 
     IntegerFilterProperty:
       description: Integer property with advanced search capabilities.
@@ -121,35 +135,43 @@ components:
           description: Checks for equality with the provided value.
           type: string
           format: date-time
+          x-added-in-version: "8.8"
         $neq:
           description: Checks for inequality with the provided value.
           type: string
           format: date-time
+          x-added-in-version: "8.8"
         $exists:
           description: Checks if the current property exists.
           type: boolean
+          x-added-in-version: "8.8"
         $gt:
           description: Greater than comparison with the provided value.
           type: string
           format: date-time
+          x-added-in-version: "8.8"
         $gte:
           description: Greater than or equal comparison with the provided value.
           type: string
           format: date-time
+          x-added-in-version: "8.8"
         $lt:
           description: Lower than comparison with the provided value.
           type: string
           format: date-time
+          x-added-in-version: "8.8"
         $lte:
           description: Lower than or equal comparison with the provided value.
           type: string
           format: date-time
+          x-added-in-version: "8.8"
         $in:
           description: Checks if the property matches any of the provided values.
           type: array
           items:
             type: string
             format: date-time
+          x-added-in-version: "8.8"
 
     DateTimeFilterProperty:
       description: Date-time property with full advanced search capabilities.

--- a/zeebe/gateway-protocol/src/main/proto/v2/filters.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/filters.yaml
@@ -37,7 +37,7 @@ components:
           type: array
           items:
             type: string
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: "$eq"
           addedInVersion: "8.8"
         - propertyName: "$neq"
@@ -58,7 +58,7 @@ components:
           properties:
             $like:
               $ref: '#/components/schemas/LikeFilter'
-          x-added-in-version:
+          x-properties-added-in-version:
             - propertyName: "$like"
               addedInVersion: "8.8"
 
@@ -116,7 +116,7 @@ components:
           items:
             type: integer
             format: int32
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: "$eq"
           addedInVersion: "8.8"
         - propertyName: "$neq"
@@ -181,7 +181,7 @@ components:
           items:
             type: string
             format: date-time
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: "$eq"
           addedInVersion: "8.8"
         - propertyName: "$neq"

--- a/zeebe/gateway-protocol/src/main/proto/v2/form-models.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/form-models.yaml
@@ -16,23 +16,29 @@ components:
           description: The tenant ID of the form.
           allOf:
             - $ref: "identifiers.yaml#/components/schemas/TenantId"
-          x-added-in-version: "8.8"
         formId:
           description: The user-provided identifier of the form.
           allOf:
             - $ref: "identifiers.yaml#/components/schemas/FormId"
-          x-added-in-version: "8.8"
         schema:
           description: The form schema as a JSON document serialized as a string.
           type: string
-          x-added-in-version: "8.8"
         version:
           description: The version of the the deployed form.
           type: integer
           format: int64
-          x-added-in-version: "8.8"
         formKey:
           allOf:
             - $ref: "keys.yaml#/components/schemas/FormKey"
           description: The assigned key, which acts as a unique identifier for this form.
-          x-added-in-version: "8.8"
+      x-added-in-version:
+        - propertyName: tenantId
+          addedInVersion: "8.8"
+        - propertyName: formId
+          addedInVersion: "8.8"
+        - propertyName: schema
+          addedInVersion: "8.8"
+        - propertyName: version
+          addedInVersion: "8.8"
+        - propertyName: formKey
+          addedInVersion: "8.8"

--- a/zeebe/gateway-protocol/src/main/proto/v2/form-models.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/form-models.yaml
@@ -16,18 +16,23 @@ components:
           description: The tenant ID of the form.
           allOf:
             - $ref: "identifiers.yaml#/components/schemas/TenantId"
+          x-added-in-version: "8.8"
         formId:
           description: The user-provided identifier of the form.
           allOf:
             - $ref: "identifiers.yaml#/components/schemas/FormId"
+          x-added-in-version: "8.8"
         schema:
           description: The form schema as a JSON document serialized as a string.
           type: string
+          x-added-in-version: "8.8"
         version:
           description: The version of the the deployed form.
           type: integer
           format: int64
+          x-added-in-version: "8.8"
         formKey:
           allOf:
             - $ref: "keys.yaml#/components/schemas/FormKey"
           description: The assigned key, which acts as a unique identifier for this form.
+          x-added-in-version: "8.8"

--- a/zeebe/gateway-protocol/src/main/proto/v2/form-models.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/form-models.yaml
@@ -31,7 +31,7 @@ components:
           allOf:
             - $ref: "keys.yaml#/components/schemas/FormKey"
           description: The assigned key, which acts as a unique identifier for this form.
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: tenantId
           addedInVersion: "8.8"
         - propertyName: formId

--- a/zeebe/gateway-protocol/src/main/proto/v2/identifiers.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/identifiers.yaml
@@ -224,25 +224,31 @@ components:
           description: Checks for equality with the provided value.
           allOf:
             - $ref: '#/components/schemas/ElementId'
+          x-added-in-version: "8.10"
         $neq:
           description: Checks for inequality with the provided value.
           allOf:
             - $ref: '#/components/schemas/ElementId'
+          x-added-in-version: "8.10"
         $exists:
           description: Checks if the current property exists.
           type: boolean
+          x-added-in-version: "8.10"
         $in:
           description: Checks if the property matches any of the provided values.
           type: array
           items:
             $ref: '#/components/schemas/ElementId'
+          x-added-in-version: "8.10"
         $notIn:
           description: Checks if the property matches none of the provided values.
           type: array
           items:
             $ref: '#/components/schemas/ElementId'
+          x-added-in-version: "8.10"
         $like:
           $ref: 'filters.yaml#/components/schemas/LikeFilter'
+          x-added-in-version: "8.10"
 
     ProcessDefinitionIdFilterProperty:
       description: ProcessDefinitionId property with full advanced search capabilities.
@@ -263,22 +269,28 @@ components:
           description: Checks for equality with the provided value.
           allOf:
             - $ref: '#/components/schemas/ProcessDefinitionId'
+          x-added-in-version: "8.10"
         $neq:
           description: Checks for inequality with the provided value.
           allOf:
             - $ref: '#/components/schemas/ProcessDefinitionId'
+          x-added-in-version: "8.10"
         $exists:
           description: Checks if the current property exists.
           type: boolean
+          x-added-in-version: "8.10"
         $in:
           description: Checks if the property matches any of the provided values.
           type: array
           items:
             $ref: '#/components/schemas/ProcessDefinitionId'
+          x-added-in-version: "8.10"
         $notIn:
           description: Checks if the property matches none of the provided values.
           type: array
           items:
             $ref: '#/components/schemas/ProcessDefinitionId'
+          x-added-in-version: "8.10"
         $like:
           $ref: 'filters.yaml#/components/schemas/LikeFilter'
+          x-added-in-version: "8.10"

--- a/zeebe/gateway-protocol/src/main/proto/v2/identifiers.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/identifiers.yaml
@@ -243,7 +243,7 @@ components:
             $ref: '#/components/schemas/ElementId'
         $like:
           $ref: 'filters.yaml#/components/schemas/LikeFilter'
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: "$eq"
           addedInVersion: "8.10"
         - propertyName: "$neq"
@@ -295,7 +295,7 @@ components:
             $ref: '#/components/schemas/ProcessDefinitionId'
         $like:
           $ref: 'filters.yaml#/components/schemas/LikeFilter'
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: "$eq"
           addedInVersion: "8.10"
         - propertyName: "$neq"

--- a/zeebe/gateway-protocol/src/main/proto/v2/identifiers.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/identifiers.yaml
@@ -224,31 +224,38 @@ components:
           description: Checks for equality with the provided value.
           allOf:
             - $ref: '#/components/schemas/ElementId'
-          x-added-in-version: "8.10"
         $neq:
           description: Checks for inequality with the provided value.
           allOf:
             - $ref: '#/components/schemas/ElementId'
-          x-added-in-version: "8.10"
         $exists:
           description: Checks if the current property exists.
           type: boolean
-          x-added-in-version: "8.10"
         $in:
           description: Checks if the property matches any of the provided values.
           type: array
           items:
             $ref: '#/components/schemas/ElementId'
-          x-added-in-version: "8.10"
         $notIn:
           description: Checks if the property matches none of the provided values.
           type: array
           items:
             $ref: '#/components/schemas/ElementId'
-          x-added-in-version: "8.10"
         $like:
           $ref: 'filters.yaml#/components/schemas/LikeFilter'
-          x-added-in-version: "8.10"
+      x-added-in-version:
+        - propertyName: "$eq"
+          addedInVersion: "8.10"
+        - propertyName: "$neq"
+          addedInVersion: "8.10"
+        - propertyName: "$exists"
+          addedInVersion: "8.10"
+        - propertyName: "$in"
+          addedInVersion: "8.10"
+        - propertyName: "$notIn"
+          addedInVersion: "8.10"
+        - propertyName: "$like"
+          addedInVersion: "8.10"
 
     ProcessDefinitionIdFilterProperty:
       description: ProcessDefinitionId property with full advanced search capabilities.
@@ -269,28 +276,35 @@ components:
           description: Checks for equality with the provided value.
           allOf:
             - $ref: '#/components/schemas/ProcessDefinitionId'
-          x-added-in-version: "8.10"
         $neq:
           description: Checks for inequality with the provided value.
           allOf:
             - $ref: '#/components/schemas/ProcessDefinitionId'
-          x-added-in-version: "8.10"
         $exists:
           description: Checks if the current property exists.
           type: boolean
-          x-added-in-version: "8.10"
         $in:
           description: Checks if the property matches any of the provided values.
           type: array
           items:
             $ref: '#/components/schemas/ProcessDefinitionId'
-          x-added-in-version: "8.10"
         $notIn:
           description: Checks if the property matches none of the provided values.
           type: array
           items:
             $ref: '#/components/schemas/ProcessDefinitionId'
-          x-added-in-version: "8.10"
         $like:
           $ref: 'filters.yaml#/components/schemas/LikeFilter'
-          x-added-in-version: "8.10"
+      x-added-in-version:
+        - propertyName: "$eq"
+          addedInVersion: "8.10"
+        - propertyName: "$neq"
+          addedInVersion: "8.10"
+        - propertyName: "$exists"
+          addedInVersion: "8.10"
+        - propertyName: "$in"
+          addedInVersion: "8.10"
+        - propertyName: "$notIn"
+          addedInVersion: "8.10"
+        - propertyName: "$like"
+          addedInVersion: "8.10"

--- a/zeebe/gateway-protocol/src/main/proto/v2/incidents.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/incidents.yaml
@@ -210,7 +210,7 @@ components:
           description: The incident search filters.
           allOf:
             - $ref: '#/components/schemas/IncidentFilter'
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: sort
           addedInVersion: "8.6"
         - propertyName: filter
@@ -268,7 +268,7 @@ components:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/JobKeyFilterProperty'
           description: The job key, if exists, associated with this incident.
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: elementId
           addedInVersion: "8.8"
         - propertyName: incidentKey
@@ -314,7 +314,7 @@ components:
             $ref: "#/components/schemas/IncidentErrorTypeEnum"
         $like:
           $ref: "filters.yaml#/components/schemas/LikeFilter"
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: "$eq"
           addedInVersion: "8.9"
         - propertyName: "$neq"
@@ -387,7 +387,7 @@ components:
             $ref: "#/components/schemas/IncidentStateEnum"
         $like:
           $ref: "filters.yaml#/components/schemas/LikeFilter"
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: "$eq"
           addedInVersion: "8.9"
         - propertyName: "$neq"
@@ -446,7 +446,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/IncidentResult'
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: items
           addedInVersion: "8.6"
 
@@ -523,7 +523,7 @@ components:
           nullable: true
           allOf:
             - $ref: 'keys.yaml#/components/schemas/JobKey'
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: processDefinitionId
           addedInVersion: "8.6"
         - propertyName: errorType
@@ -557,7 +557,7 @@ components:
       properties:
         operationReference:
           $ref: 'keys.yaml#/components/schemas/OperationReference'
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: operationReference
           addedInVersion: "8.8"
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/incidents.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/incidents.yaml
@@ -206,10 +206,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/IncidentSearchQuerySortRequest'
+          x-added-in-version: "8.6"
         filter:
           description: The incident search filters.
           allOf:
             - $ref: '#/components/schemas/IncidentFilter'
+          x-added-in-version: "8.6"
 
     IncidentFilter:
       description: Incident search filter.
@@ -231,6 +233,7 @@ components:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
           description: The element ID associated to this incident.
+          x-added-in-version: "8.8"
         creationTime:
           allOf:
             - $ref: "filters.yaml#/components/schemas/DateTimeFilterProperty"
@@ -247,6 +250,7 @@ components:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/BasicStringFilterProperty'
           description: The assigned key, which acts as a unique identifier for this incident.
+          x-added-in-version: "8.8"
         processDefinitionKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessDefinitionKeyFilterProperty'
@@ -259,6 +263,7 @@ components:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ElementInstanceKeyFilterProperty'
           description: The element instance key associated to this incident.
+          x-added-in-version: "8.8"
         jobKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/JobKeyFilterProperty'
@@ -283,25 +288,31 @@ components:
           description: Checks for equality with the provided value.
           allOf:
             - $ref: "#/components/schemas/IncidentErrorTypeEnum"
+          x-added-in-version: "8.9"
         $neq:
           description: Checks for inequality with the provided value.
           allOf:
             - $ref: "#/components/schemas/IncidentErrorTypeEnum"
+          x-added-in-version: "8.9"
         $exists:
           description: Checks if the current property exists.
           type: boolean
+          x-added-in-version: "8.9"
         $in:
           description: Checks if the property matches any of the provided values.
           type: array
           items:
             $ref: "#/components/schemas/IncidentErrorTypeEnum"
+          x-added-in-version: "8.9"
         $notIn:
           description: Checks if the property does not match any of the provided values.
           type: array
           items:
             $ref: "#/components/schemas/IncidentErrorTypeEnum"
+          x-added-in-version: "8.9"
         $like:
           $ref: "filters.yaml#/components/schemas/LikeFilter"
+          x-added-in-version: "8.9"
 
     IncidentErrorTypeEnum:
       description: Incident error type with a defined set of values.
@@ -343,25 +354,31 @@ components:
           description: Checks for equality with the provided value.
           allOf:
             - $ref: "#/components/schemas/IncidentStateEnum"
+          x-added-in-version: "8.9"
         $neq:
           description: Checks for inequality with the provided value.
           allOf:
             - $ref: "#/components/schemas/IncidentStateEnum"
+          x-added-in-version: "8.9"
         $exists:
           description: Checks if the current property exists.
           type: boolean
+          x-added-in-version: "8.9"
         $in:
           description: Checks if the property matches any of the provided values.
           type: array
           items:
             $ref: "#/components/schemas/IncidentStateEnum"
+          x-added-in-version: "8.9"
         $notIn:
           description: Checks if the property does not match any of the provided values.
           type: array
           items:
             $ref: "#/components/schemas/IncidentStateEnum"
+          x-added-in-version: "8.9"
         $like:
           $ref: "filters.yaml#/components/schemas/LikeFilter"
+          x-added-in-version: "8.9"
 
     IncidentStateEnum:
       description: Incident states with a defined set of values.
@@ -408,6 +425,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/IncidentResult'
+          x-added-in-version: "8.6"
 
     IncidentResult:
       type: object
@@ -430,41 +448,51 @@ components:
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/ProcessDefinitionId'
           description: The process definition ID associated to this incident.
+          x-added-in-version: "8.6"
         errorType:
           description: The type of the incident error.
           allOf:
             - $ref: "#/components/schemas/IncidentErrorTypeEnum"
+          x-added-in-version: "8.6"
         errorMessage:
           type: string
           description: Error message which describes the error in more detail.
+          x-added-in-version: "8.6"
         elementId:
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/ElementId'
           description: The element ID associated to this incident.
+          x-added-in-version: "8.8"
         creationTime:
           description: The creation time of the incident.
           type: string
           format: date-time
+          x-added-in-version: "8.6"
         state:
           description: The incident state.
           allOf:
             - $ref: "#/components/schemas/IncidentStateEnum"
+          x-added-in-version: "8.6"
         tenantId:
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/TenantId'
           description: The tenant ID of the incident.
+          x-added-in-version: "8.6"
         incidentKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/IncidentKey'
           description: The assigned key, which acts as a unique identifier for this incident.
+          x-added-in-version: "8.8"
         processDefinitionKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessDefinitionKey'
           description: The process definition key associated to this incident.
+          x-added-in-version: "8.6"
         processInstanceKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
           description: The process instance key associated to this incident.
+          x-added-in-version: "8.6"
         rootProcessInstanceKey:
           description: |
             The key of the root process instance. The root process instance is the top-level
@@ -473,15 +501,18 @@ components:
           nullable: true
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
+          x-added-in-version: "8.9"
         elementInstanceKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ElementInstanceKey'
           description: The element instance key associated to this incident.
+          x-added-in-version: "8.8"
         jobKey:
           description: The job key, if exists, associated with this incident.
           nullable: true
           allOf:
             - $ref: 'keys.yaml#/components/schemas/JobKey'
+          x-added-in-version: "8.6"
 
     IncidentResolutionRequest:
       type: object
@@ -489,6 +520,7 @@ components:
       properties:
         operationReference:
           $ref: 'keys.yaml#/components/schemas/OperationReference'
+          x-added-in-version: "8.8"
 
     IncidentProcessInstanceStatisticsByErrorQuery:
       type: object

--- a/zeebe/gateway-protocol/src/main/proto/v2/incidents.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/incidents.yaml
@@ -206,12 +206,15 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/IncidentSearchQuerySortRequest'
-          x-added-in-version: "8.6"
         filter:
           description: The incident search filters.
           allOf:
             - $ref: '#/components/schemas/IncidentFilter'
-          x-added-in-version: "8.6"
+      x-added-in-version:
+        - propertyName: sort
+          addedInVersion: "8.6"
+        - propertyName: filter
+          addedInVersion: "8.6"
 
     IncidentFilter:
       description: Incident search filter.
@@ -233,7 +236,6 @@ components:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
           description: The element ID associated to this incident.
-          x-added-in-version: "8.8"
         creationTime:
           allOf:
             - $ref: "filters.yaml#/components/schemas/DateTimeFilterProperty"
@@ -250,7 +252,6 @@ components:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/BasicStringFilterProperty'
           description: The assigned key, which acts as a unique identifier for this incident.
-          x-added-in-version: "8.8"
         processDefinitionKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessDefinitionKeyFilterProperty'
@@ -263,11 +264,17 @@ components:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ElementInstanceKeyFilterProperty'
           description: The element instance key associated to this incident.
-          x-added-in-version: "8.8"
         jobKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/JobKeyFilterProperty'
           description: The job key, if exists, associated with this incident.
+      x-added-in-version:
+        - propertyName: elementId
+          addedInVersion: "8.8"
+        - propertyName: incidentKey
+          addedInVersion: "8.8"
+        - propertyName: elementInstanceKey
+          addedInVersion: "8.8"
 
     IncidentErrorTypeFilterProperty:
       description: IncidentErrorTypeEnum with full advanced search capabilities.
@@ -288,31 +295,38 @@ components:
           description: Checks for equality with the provided value.
           allOf:
             - $ref: "#/components/schemas/IncidentErrorTypeEnum"
-          x-added-in-version: "8.9"
         $neq:
           description: Checks for inequality with the provided value.
           allOf:
             - $ref: "#/components/schemas/IncidentErrorTypeEnum"
-          x-added-in-version: "8.9"
         $exists:
           description: Checks if the current property exists.
           type: boolean
-          x-added-in-version: "8.9"
         $in:
           description: Checks if the property matches any of the provided values.
           type: array
           items:
             $ref: "#/components/schemas/IncidentErrorTypeEnum"
-          x-added-in-version: "8.9"
         $notIn:
           description: Checks if the property does not match any of the provided values.
           type: array
           items:
             $ref: "#/components/schemas/IncidentErrorTypeEnum"
-          x-added-in-version: "8.9"
         $like:
           $ref: "filters.yaml#/components/schemas/LikeFilter"
-          x-added-in-version: "8.9"
+      x-added-in-version:
+        - propertyName: "$eq"
+          addedInVersion: "8.9"
+        - propertyName: "$neq"
+          addedInVersion: "8.9"
+        - propertyName: "$exists"
+          addedInVersion: "8.9"
+        - propertyName: "$in"
+          addedInVersion: "8.9"
+        - propertyName: "$notIn"
+          addedInVersion: "8.9"
+        - propertyName: "$like"
+          addedInVersion: "8.9"
 
     IncidentErrorTypeEnum:
       description: Incident error type with a defined set of values.
@@ -354,31 +368,38 @@ components:
           description: Checks for equality with the provided value.
           allOf:
             - $ref: "#/components/schemas/IncidentStateEnum"
-          x-added-in-version: "8.9"
         $neq:
           description: Checks for inequality with the provided value.
           allOf:
             - $ref: "#/components/schemas/IncidentStateEnum"
-          x-added-in-version: "8.9"
         $exists:
           description: Checks if the current property exists.
           type: boolean
-          x-added-in-version: "8.9"
         $in:
           description: Checks if the property matches any of the provided values.
           type: array
           items:
             $ref: "#/components/schemas/IncidentStateEnum"
-          x-added-in-version: "8.9"
         $notIn:
           description: Checks if the property does not match any of the provided values.
           type: array
           items:
             $ref: "#/components/schemas/IncidentStateEnum"
-          x-added-in-version: "8.9"
         $like:
           $ref: "filters.yaml#/components/schemas/LikeFilter"
-          x-added-in-version: "8.9"
+      x-added-in-version:
+        - propertyName: "$eq"
+          addedInVersion: "8.9"
+        - propertyName: "$neq"
+          addedInVersion: "8.9"
+        - propertyName: "$exists"
+          addedInVersion: "8.9"
+        - propertyName: "$in"
+          addedInVersion: "8.9"
+        - propertyName: "$notIn"
+          addedInVersion: "8.9"
+        - propertyName: "$like"
+          addedInVersion: "8.9"
 
     IncidentStateEnum:
       description: Incident states with a defined set of values.
@@ -425,7 +446,9 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/IncidentResult'
-          x-added-in-version: "8.6"
+      x-added-in-version:
+        - propertyName: items
+          addedInVersion: "8.6"
 
     IncidentResult:
       type: object
@@ -448,51 +471,41 @@ components:
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/ProcessDefinitionId'
           description: The process definition ID associated to this incident.
-          x-added-in-version: "8.6"
         errorType:
           description: The type of the incident error.
           allOf:
             - $ref: "#/components/schemas/IncidentErrorTypeEnum"
-          x-added-in-version: "8.6"
         errorMessage:
           type: string
           description: Error message which describes the error in more detail.
-          x-added-in-version: "8.6"
         elementId:
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/ElementId'
           description: The element ID associated to this incident.
-          x-added-in-version: "8.8"
         creationTime:
           description: The creation time of the incident.
           type: string
           format: date-time
-          x-added-in-version: "8.6"
         state:
           description: The incident state.
           allOf:
             - $ref: "#/components/schemas/IncidentStateEnum"
-          x-added-in-version: "8.6"
         tenantId:
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/TenantId'
           description: The tenant ID of the incident.
-          x-added-in-version: "8.6"
         incidentKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/IncidentKey'
           description: The assigned key, which acts as a unique identifier for this incident.
-          x-added-in-version: "8.8"
         processDefinitionKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessDefinitionKey'
           description: The process definition key associated to this incident.
-          x-added-in-version: "8.6"
         processInstanceKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
           description: The process instance key associated to this incident.
-          x-added-in-version: "8.6"
         rootProcessInstanceKey:
           description: |
             The key of the root process instance. The root process instance is the top-level
@@ -501,18 +514,42 @@ components:
           nullable: true
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
-          x-added-in-version: "8.9"
         elementInstanceKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ElementInstanceKey'
           description: The element instance key associated to this incident.
-          x-added-in-version: "8.8"
         jobKey:
           description: The job key, if exists, associated with this incident.
           nullable: true
           allOf:
             - $ref: 'keys.yaml#/components/schemas/JobKey'
-          x-added-in-version: "8.6"
+      x-added-in-version:
+        - propertyName: processDefinitionId
+          addedInVersion: "8.6"
+        - propertyName: errorType
+          addedInVersion: "8.6"
+        - propertyName: errorMessage
+          addedInVersion: "8.6"
+        - propertyName: elementId
+          addedInVersion: "8.8"
+        - propertyName: creationTime
+          addedInVersion: "8.6"
+        - propertyName: state
+          addedInVersion: "8.6"
+        - propertyName: tenantId
+          addedInVersion: "8.6"
+        - propertyName: incidentKey
+          addedInVersion: "8.8"
+        - propertyName: processDefinitionKey
+          addedInVersion: "8.6"
+        - propertyName: processInstanceKey
+          addedInVersion: "8.6"
+        - propertyName: rootProcessInstanceKey
+          addedInVersion: "8.9"
+        - propertyName: elementInstanceKey
+          addedInVersion: "8.8"
+        - propertyName: jobKey
+          addedInVersion: "8.6"
 
     IncidentResolutionRequest:
       type: object
@@ -520,7 +557,9 @@ components:
       properties:
         operationReference:
           $ref: 'keys.yaml#/components/schemas/OperationReference'
-          x-added-in-version: "8.8"
+      x-added-in-version:
+        - propertyName: operationReference
+          addedInVersion: "8.8"
 
     IncidentProcessInstanceStatisticsByErrorQuery:
       type: object

--- a/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
@@ -313,6 +313,7 @@ components:
             The tenant filtering strategy - determines whether to use provided tenant IDs or
             assigned tenant IDs from the authenticated principal's authorized tenants.
           default: PROVIDED
+          x-added-in-version: "8.9"
       required:
         - type
         - maxJobsToActivate
@@ -419,8 +420,10 @@ components:
             - $ref: 'keys.yaml#/components/schemas/ElementInstanceKey'
         kind:
           $ref: '#/components/schemas/JobKindEnum'
+          x-added-in-version: "8.8"
         listenerEventType:
           $ref: '#/components/schemas/JobListenerEventTypeEnum'
+          x-added-in-version: "8.8"
         userTask:
           description: |
             User task properties, if the job is a user task.
@@ -428,8 +431,10 @@ components:
           nullable: true
           allOf:
             - $ref: '#/components/schemas/UserTaskProperties'
+          x-added-in-version: "8.8"
         tags:
           $ref: 'identifiers.yaml#/components/schemas/TagSet'
+          x-added-in-version: "8.8"
         rootProcessInstanceKey:
           description: |
             The key of the root process instance. The root process instance is the top-level
@@ -438,6 +443,7 @@ components:
           nullable: true
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
+          x-added-in-version: "8.9"
 
     UserTaskProperties:
       required:
@@ -639,10 +645,12 @@ components:
           description: When the job was created. Field is present for jobs created after 8.9.
           allOf:
             - $ref: 'filters.yaml#/components/schemas/DateTimeFilterProperty'
+          x-added-in-version: "8.9"
         lastUpdateTime:
           description: When the job was last updated. Field is present for jobs created after 8.9.
           allOf:
             - $ref: 'filters.yaml#/components/schemas/DateTimeFilterProperty'
+          x-added-in-version: "8.9"
 
     JobSearchQueryResult:
       description: Job search response.
@@ -759,6 +767,7 @@ components:
           nullable: true
           allOf:
             - $ref: "keys.yaml#/components/schemas/ProcessInstanceKey"
+          x-added-in-version: "8.9"
         retries:
           description: The amount of retries left to this job.
           type: integer
@@ -778,11 +787,13 @@ components:
           nullable: true
           type: string
           format: date-time
+          x-added-in-version: "8.9"
         lastUpdateTime:
           description: When the job was last updated. Field is present for jobs created after 8.9.
           nullable: true
           type: string
           format: date-time
+          x-added-in-version: "8.9"
 
     JobFailRequest:
       type: object
@@ -841,6 +852,7 @@ components:
           nullable: true
         result:
           $ref: '#/components/schemas/JobResult'
+          x-added-in-version: "8.8"
 
     JobResult:
       description: >
@@ -982,6 +994,7 @@ components:
           $ref: '#/components/schemas/JobChangeset'
         operationReference:
           $ref: "keys.yaml#/components/schemas/OperationReference"
+          x-added-in-version: "8.8"
       required:
         - changeset
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
@@ -317,7 +317,7 @@ components:
         - type
         - maxJobsToActivate
         - timeout
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: tenantFilter
           addedInVersion: "8.9"
 
@@ -441,7 +441,7 @@ components:
           nullable: true
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: kind
           addedInVersion: "8.8"
         - propertyName: listenerEventType
@@ -657,7 +657,7 @@ components:
           description: When the job was last updated. Field is present for jobs created after 8.9.
           allOf:
             - $ref: 'filters.yaml#/components/schemas/DateTimeFilterProperty'
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: creationTime
           addedInVersion: "8.9"
         - propertyName: lastUpdateTime
@@ -802,7 +802,7 @@ components:
           nullable: true
           type: string
           format: date-time
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: rootProcessInstanceKey
           addedInVersion: "8.9"
         - propertyName: creationTime
@@ -867,7 +867,7 @@ components:
           nullable: true
         result:
           $ref: '#/components/schemas/JobResult'
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: result
           addedInVersion: "8.8"
 
@@ -1013,7 +1013,7 @@ components:
           $ref: "keys.yaml#/components/schemas/OperationReference"
       required:
         - changeset
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: operationReference
           addedInVersion: "8.8"
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
@@ -313,11 +313,13 @@ components:
             The tenant filtering strategy - determines whether to use provided tenant IDs or
             assigned tenant IDs from the authenticated principal's authorized tenants.
           default: PROVIDED
-          x-added-in-version: "8.9"
       required:
         - type
         - maxJobsToActivate
         - timeout
+      x-added-in-version:
+        - propertyName: tenantFilter
+          addedInVersion: "8.9"
 
     JobActivationResult:
       description: The list of activated jobs
@@ -420,10 +422,8 @@ components:
             - $ref: 'keys.yaml#/components/schemas/ElementInstanceKey'
         kind:
           $ref: '#/components/schemas/JobKindEnum'
-          x-added-in-version: "8.8"
         listenerEventType:
           $ref: '#/components/schemas/JobListenerEventTypeEnum'
-          x-added-in-version: "8.8"
         userTask:
           description: |
             User task properties, if the job is a user task.
@@ -431,10 +431,8 @@ components:
           nullable: true
           allOf:
             - $ref: '#/components/schemas/UserTaskProperties'
-          x-added-in-version: "8.8"
         tags:
           $ref: 'identifiers.yaml#/components/schemas/TagSet'
-          x-added-in-version: "8.8"
         rootProcessInstanceKey:
           description: |
             The key of the root process instance. The root process instance is the top-level
@@ -443,7 +441,17 @@ components:
           nullable: true
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
-          x-added-in-version: "8.9"
+      x-added-in-version:
+        - propertyName: kind
+          addedInVersion: "8.8"
+        - propertyName: listenerEventType
+          addedInVersion: "8.8"
+        - propertyName: userTask
+          addedInVersion: "8.8"
+        - propertyName: tags
+          addedInVersion: "8.8"
+        - propertyName: rootProcessInstanceKey
+          addedInVersion: "8.9"
 
     UserTaskProperties:
       required:
@@ -645,12 +653,15 @@ components:
           description: When the job was created. Field is present for jobs created after 8.9.
           allOf:
             - $ref: 'filters.yaml#/components/schemas/DateTimeFilterProperty'
-          x-added-in-version: "8.9"
         lastUpdateTime:
           description: When the job was last updated. Field is present for jobs created after 8.9.
           allOf:
             - $ref: 'filters.yaml#/components/schemas/DateTimeFilterProperty'
-          x-added-in-version: "8.9"
+      x-added-in-version:
+        - propertyName: creationTime
+          addedInVersion: "8.9"
+        - propertyName: lastUpdateTime
+          addedInVersion: "8.9"
 
     JobSearchQueryResult:
       description: Job search response.
@@ -767,7 +778,6 @@ components:
           nullable: true
           allOf:
             - $ref: "keys.yaml#/components/schemas/ProcessInstanceKey"
-          x-added-in-version: "8.9"
         retries:
           description: The amount of retries left to this job.
           type: integer
@@ -787,13 +797,18 @@ components:
           nullable: true
           type: string
           format: date-time
-          x-added-in-version: "8.9"
         lastUpdateTime:
           description: When the job was last updated. Field is present for jobs created after 8.9.
           nullable: true
           type: string
           format: date-time
-          x-added-in-version: "8.9"
+      x-added-in-version:
+        - propertyName: rootProcessInstanceKey
+          addedInVersion: "8.9"
+        - propertyName: creationTime
+          addedInVersion: "8.9"
+        - propertyName: lastUpdateTime
+          addedInVersion: "8.9"
 
     JobFailRequest:
       type: object
@@ -852,7 +867,9 @@ components:
           nullable: true
         result:
           $ref: '#/components/schemas/JobResult'
-          x-added-in-version: "8.8"
+      x-added-in-version:
+        - propertyName: result
+          addedInVersion: "8.8"
 
     JobResult:
       description: >
@@ -994,9 +1011,11 @@ components:
           $ref: '#/components/schemas/JobChangeset'
         operationReference:
           $ref: "keys.yaml#/components/schemas/OperationReference"
-          x-added-in-version: "8.8"
       required:
         - changeset
+      x-added-in-version:
+        - propertyName: operationReference
+          addedInVersion: "8.8"
 
     JobChangeset:
       description: JSON object with changed job attribute values. The job cannot be completed or failed with this endpoint, use the complete job or fail job endpoints instead.

--- a/zeebe/gateway-protocol/src/main/proto/v2/keys.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/keys.yaml
@@ -196,28 +196,34 @@ components:
           description: Checks for equality with the provided value.
           allOf:
             - $ref: "#/components/schemas/ProcessDefinitionKey"
-          x-added-in-version: "8.8"
         $neq:
           description: Checks for inequality with the provided value.
           allOf:
             - $ref: "#/components/schemas/ProcessDefinitionKey"
-          x-added-in-version: "8.8"
         $exists:
           description: Checks if the current property exists.
           type: boolean
-          x-added-in-version: "8.8"
         $in:
           description: Checks if the property matches any of the provided values.
           type: array
           items:
             $ref: "#/components/schemas/ProcessDefinitionKey"
-          x-added-in-version: "8.8"
         $notIn:
           description: Checks if the property matches none of the provided values.
           type: array
           items:
             $ref: "#/components/schemas/ProcessDefinitionKey"
-          x-added-in-version: "8.8"
+      x-added-in-version:
+        - propertyName: "$eq"
+          addedInVersion: "8.8"
+        - propertyName: "$neq"
+          addedInVersion: "8.8"
+        - propertyName: "$exists"
+          addedInVersion: "8.8"
+        - propertyName: "$in"
+          addedInVersion: "8.8"
+        - propertyName: "$notIn"
+          addedInVersion: "8.8"
 
     ProcessInstanceKeyFilterProperty:
       description: ProcessInstanceKey property with full advanced search capabilities.
@@ -238,28 +244,34 @@ components:
           description: Checks for equality with the provided value.
           allOf:
             - $ref: "#/components/schemas/ProcessInstanceKey"
-          x-added-in-version: "8.8"
         $neq:
           description: Checks for inequality with the provided value.
           allOf:
             - $ref: "#/components/schemas/ProcessInstanceKey"
-          x-added-in-version: "8.8"
         $exists:
           description: Checks if the current property exists.
           type: boolean
-          x-added-in-version: "8.8"
         $in:
           description: Checks if the property matches any of the provided values.
           type: array
           items:
             $ref: "#/components/schemas/ProcessInstanceKey"
-          x-added-in-version: "8.8"
         $notIn:
           description: Checks if the property matches none of the provided values.
           type: array
           items:
             $ref: "#/components/schemas/ProcessInstanceKey"
-          x-added-in-version: "8.8"
+      x-added-in-version:
+        - propertyName: "$eq"
+          addedInVersion: "8.8"
+        - propertyName: "$neq"
+          addedInVersion: "8.8"
+        - propertyName: "$exists"
+          addedInVersion: "8.8"
+        - propertyName: "$in"
+          addedInVersion: "8.8"
+        - propertyName: "$notIn"
+          addedInVersion: "8.8"
 
     ElementInstanceKeyFilterProperty:
       description: ElementInstanceKey property with full advanced search capabilities.
@@ -280,28 +292,34 @@ components:
           description: Checks for equality with the provided value.
           allOf:
             - $ref: "#/components/schemas/ElementInstanceKey"
-          x-added-in-version: "8.8"
         $neq:
           description: Checks for inequality with the provided value.
           allOf:
             - $ref: "#/components/schemas/ElementInstanceKey"
-          x-added-in-version: "8.8"
         $exists:
           description: Checks if the current property exists.
           type: boolean
-          x-added-in-version: "8.8"
         $in:
           description: Checks if the property matches any of the provided values.
           type: array
           items:
             $ref: "#/components/schemas/ElementInstanceKey"
-          x-added-in-version: "8.8"
         $notIn:
           description: Checks if the property matches none of the provided values.
           type: array
           items:
             $ref: "#/components/schemas/ElementInstanceKey"
-          x-added-in-version: "8.8"
+      x-added-in-version:
+        - propertyName: "$eq"
+          addedInVersion: "8.8"
+        - propertyName: "$neq"
+          addedInVersion: "8.8"
+        - propertyName: "$exists"
+          addedInVersion: "8.8"
+        - propertyName: "$in"
+          addedInVersion: "8.8"
+        - propertyName: "$notIn"
+          addedInVersion: "8.8"
 
     JobKeyFilterProperty:
       description: JobKey property with full advanced search capabilities.
@@ -322,28 +340,34 @@ components:
           description: Checks for equality with the provided value.
           allOf:
             - $ref: '#/components/schemas/JobKey'
-          x-added-in-version: "8.8"
         $neq:
           description: Checks for inequality with the provided value.
           allOf:
             - $ref: '#/components/schemas/JobKey'
-          x-added-in-version: "8.8"
         $exists:
           description: Checks if the current property exists.
           type: boolean
-          x-added-in-version: "8.8"
         $in:
           description: Checks if the property matches any of the provided values.
           type: array
           items:
             $ref: '#/components/schemas/JobKey'
-          x-added-in-version: "8.8"
         $notIn:
           description: Checks if the property matches none of the provided values.
           type: array
           items:
             $ref: '#/components/schemas/JobKey'
-          x-added-in-version: "8.8"
+      x-added-in-version:
+        - propertyName: "$eq"
+          addedInVersion: "8.8"
+        - propertyName: "$neq"
+          addedInVersion: "8.8"
+        - propertyName: "$exists"
+          addedInVersion: "8.8"
+        - propertyName: "$in"
+          addedInVersion: "8.8"
+        - propertyName: "$notIn"
+          addedInVersion: "8.8"
 
     DecisionDefinitionKeyFilterProperty:
       description: DecisionDefinitionKey property with full advanced search capabilities.
@@ -364,28 +388,34 @@ components:
           description: Checks for equality with the provided value.
           allOf:
             - $ref: "#/components/schemas/DecisionDefinitionKey"
-          x-added-in-version: "8.8"
         $neq:
           description: Checks for inequality with the provided value.
           allOf:
             - $ref: "#/components/schemas/DecisionDefinitionKey"
-          x-added-in-version: "8.8"
         $exists:
           description: Checks if the current property exists.
           type: boolean
-          x-added-in-version: "8.8"
         $in:
           description: Checks if the property matches any of the provided values.
           type: array
           items:
             $ref: "#/components/schemas/DecisionDefinitionKey"
-          x-added-in-version: "8.8"
         $notIn:
           description: Checks if the property matches none of the provided values.
           type: array
           items:
             $ref: "#/components/schemas/DecisionDefinitionKey"
-          x-added-in-version: "8.8"
+      x-added-in-version:
+        - propertyName: "$eq"
+          addedInVersion: "8.8"
+        - propertyName: "$neq"
+          addedInVersion: "8.8"
+        - propertyName: "$exists"
+          addedInVersion: "8.8"
+        - propertyName: "$in"
+          addedInVersion: "8.8"
+        - propertyName: "$notIn"
+          addedInVersion: "8.8"
 
     ScopeKeyFilterProperty:
       description: |
@@ -482,28 +512,34 @@ components:
           description: Checks for equality with the provided value.
           allOf:
             - $ref: "#/components/schemas/DecisionEvaluationInstanceKey"
-          x-added-in-version: "8.9"
         $neq:
           description: Checks for inequality with the provided value.
           allOf:
             - $ref: "#/components/schemas/DecisionEvaluationInstanceKey"
-          x-added-in-version: "8.9"
         $exists:
           description: Checks if the current property exists.
           type: boolean
-          x-added-in-version: "8.9"
         $in:
           description: Checks if the property matches any of the provided values.
           type: array
           items:
             $ref: "#/components/schemas/DecisionEvaluationInstanceKey"
-          x-added-in-version: "8.9"
         $notIn:
           description: Checks if the property matches none of the provided values.
           type: array
           items:
             $ref: "#/components/schemas/DecisionEvaluationInstanceKey"
-          x-added-in-version: "8.9"
+      x-added-in-version:
+        - propertyName: "$eq"
+          addedInVersion: "8.9"
+        - propertyName: "$neq"
+          addedInVersion: "8.9"
+        - propertyName: "$exists"
+          addedInVersion: "8.9"
+        - propertyName: "$in"
+          addedInVersion: "8.9"
+        - propertyName: "$notIn"
+          addedInVersion: "8.9"
 
     AgentInstanceKeyFilterProperty:
       description: AgentInstanceKey property with full advanced search capabilities.

--- a/zeebe/gateway-protocol/src/main/proto/v2/keys.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/keys.yaml
@@ -196,23 +196,28 @@ components:
           description: Checks for equality with the provided value.
           allOf:
             - $ref: "#/components/schemas/ProcessDefinitionKey"
+          x-added-in-version: "8.8"
         $neq:
           description: Checks for inequality with the provided value.
           allOf:
             - $ref: "#/components/schemas/ProcessDefinitionKey"
+          x-added-in-version: "8.8"
         $exists:
           description: Checks if the current property exists.
           type: boolean
+          x-added-in-version: "8.8"
         $in:
           description: Checks if the property matches any of the provided values.
           type: array
           items:
             $ref: "#/components/schemas/ProcessDefinitionKey"
+          x-added-in-version: "8.8"
         $notIn:
           description: Checks if the property matches none of the provided values.
           type: array
           items:
             $ref: "#/components/schemas/ProcessDefinitionKey"
+          x-added-in-version: "8.8"
 
     ProcessInstanceKeyFilterProperty:
       description: ProcessInstanceKey property with full advanced search capabilities.
@@ -233,23 +238,28 @@ components:
           description: Checks for equality with the provided value.
           allOf:
             - $ref: "#/components/schemas/ProcessInstanceKey"
+          x-added-in-version: "8.8"
         $neq:
           description: Checks for inequality with the provided value.
           allOf:
             - $ref: "#/components/schemas/ProcessInstanceKey"
+          x-added-in-version: "8.8"
         $exists:
           description: Checks if the current property exists.
           type: boolean
+          x-added-in-version: "8.8"
         $in:
           description: Checks if the property matches any of the provided values.
           type: array
           items:
             $ref: "#/components/schemas/ProcessInstanceKey"
+          x-added-in-version: "8.8"
         $notIn:
           description: Checks if the property matches none of the provided values.
           type: array
           items:
             $ref: "#/components/schemas/ProcessInstanceKey"
+          x-added-in-version: "8.8"
 
     ElementInstanceKeyFilterProperty:
       description: ElementInstanceKey property with full advanced search capabilities.
@@ -270,23 +280,28 @@ components:
           description: Checks for equality with the provided value.
           allOf:
             - $ref: "#/components/schemas/ElementInstanceKey"
+          x-added-in-version: "8.8"
         $neq:
           description: Checks for inequality with the provided value.
           allOf:
             - $ref: "#/components/schemas/ElementInstanceKey"
+          x-added-in-version: "8.8"
         $exists:
           description: Checks if the current property exists.
           type: boolean
+          x-added-in-version: "8.8"
         $in:
           description: Checks if the property matches any of the provided values.
           type: array
           items:
             $ref: "#/components/schemas/ElementInstanceKey"
+          x-added-in-version: "8.8"
         $notIn:
           description: Checks if the property matches none of the provided values.
           type: array
           items:
             $ref: "#/components/schemas/ElementInstanceKey"
+          x-added-in-version: "8.8"
 
     JobKeyFilterProperty:
       description: JobKey property with full advanced search capabilities.
@@ -307,23 +322,28 @@ components:
           description: Checks for equality with the provided value.
           allOf:
             - $ref: '#/components/schemas/JobKey'
+          x-added-in-version: "8.8"
         $neq:
           description: Checks for inequality with the provided value.
           allOf:
             - $ref: '#/components/schemas/JobKey'
+          x-added-in-version: "8.8"
         $exists:
           description: Checks if the current property exists.
           type: boolean
+          x-added-in-version: "8.8"
         $in:
           description: Checks if the property matches any of the provided values.
           type: array
           items:
             $ref: '#/components/schemas/JobKey'
+          x-added-in-version: "8.8"
         $notIn:
           description: Checks if the property matches none of the provided values.
           type: array
           items:
             $ref: '#/components/schemas/JobKey'
+          x-added-in-version: "8.8"
 
     DecisionDefinitionKeyFilterProperty:
       description: DecisionDefinitionKey property with full advanced search capabilities.
@@ -344,23 +364,28 @@ components:
           description: Checks for equality with the provided value.
           allOf:
             - $ref: "#/components/schemas/DecisionDefinitionKey"
+          x-added-in-version: "8.8"
         $neq:
           description: Checks for inequality with the provided value.
           allOf:
             - $ref: "#/components/schemas/DecisionDefinitionKey"
+          x-added-in-version: "8.8"
         $exists:
           description: Checks if the current property exists.
           type: boolean
+          x-added-in-version: "8.8"
         $in:
           description: Checks if the property matches any of the provided values.
           type: array
           items:
             $ref: "#/components/schemas/DecisionDefinitionKey"
+          x-added-in-version: "8.8"
         $notIn:
           description: Checks if the property matches none of the provided values.
           type: array
           items:
             $ref: "#/components/schemas/DecisionDefinitionKey"
+          x-added-in-version: "8.8"
 
     ScopeKeyFilterProperty:
       description: |
@@ -457,23 +482,28 @@ components:
           description: Checks for equality with the provided value.
           allOf:
             - $ref: "#/components/schemas/DecisionEvaluationInstanceKey"
+          x-added-in-version: "8.9"
         $neq:
           description: Checks for inequality with the provided value.
           allOf:
             - $ref: "#/components/schemas/DecisionEvaluationInstanceKey"
+          x-added-in-version: "8.9"
         $exists:
           description: Checks if the current property exists.
           type: boolean
+          x-added-in-version: "8.9"
         $in:
           description: Checks if the property matches any of the provided values.
           type: array
           items:
             $ref: "#/components/schemas/DecisionEvaluationInstanceKey"
+          x-added-in-version: "8.9"
         $notIn:
           description: Checks if the property matches none of the provided values.
           type: array
           items:
             $ref: "#/components/schemas/DecisionEvaluationInstanceKey"
+          x-added-in-version: "8.9"
 
     AgentInstanceKeyFilterProperty:
       description: AgentInstanceKey property with full advanced search capabilities.

--- a/zeebe/gateway-protocol/src/main/proto/v2/keys.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/keys.yaml
@@ -213,7 +213,7 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/ProcessDefinitionKey"
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: "$eq"
           addedInVersion: "8.8"
         - propertyName: "$neq"
@@ -261,7 +261,7 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/ProcessInstanceKey"
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: "$eq"
           addedInVersion: "8.8"
         - propertyName: "$neq"
@@ -309,7 +309,7 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/ElementInstanceKey"
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: "$eq"
           addedInVersion: "8.8"
         - propertyName: "$neq"
@@ -357,7 +357,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/JobKey'
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: "$eq"
           addedInVersion: "8.8"
         - propertyName: "$neq"
@@ -405,7 +405,7 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/DecisionDefinitionKey"
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: "$eq"
           addedInVersion: "8.8"
         - propertyName: "$neq"
@@ -529,7 +529,7 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/DecisionEvaluationInstanceKey"
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: "$eq"
           addedInVersion: "8.9"
         - propertyName: "$neq"

--- a/zeebe/gateway-protocol/src/main/proto/v2/licenses.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/licenses.yaml
@@ -44,10 +44,13 @@ components:
         isCommercial:
           description: Will be false when a license contains a non-commerical=true property
           type: boolean
-          x-added-in-version: "8.8"
         expiresAt:
           nullable: true
           description: The date when the Camunda license expires
           type: string
           format: date-time
-          x-added-in-version: "8.8"
+      x-added-in-version:
+        - propertyName: isCommercial
+          addedInVersion: "8.8"
+        - propertyName: expiresAt
+          addedInVersion: "8.8"

--- a/zeebe/gateway-protocol/src/main/proto/v2/licenses.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/licenses.yaml
@@ -49,7 +49,7 @@ components:
           description: The date when the Camunda license expires
           type: string
           format: date-time
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: isCommercial
           addedInVersion: "8.8"
         - propertyName: expiresAt

--- a/zeebe/gateway-protocol/src/main/proto/v2/licenses.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/licenses.yaml
@@ -44,8 +44,10 @@ components:
         isCommercial:
           description: Will be false when a license contains a non-commerical=true property
           type: boolean
+          x-added-in-version: "8.8"
         expiresAt:
           nullable: true
           description: The date when the Camunda license expires
           type: string
           format: date-time
+          x-added-in-version: "8.8"

--- a/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
@@ -375,7 +375,7 @@ components:
             Null when the property is absent.
         tenantId:
           $ref: 'identifiers.yaml#/components/schemas/TenantId'
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: rootProcessInstanceKey
           addedInVersion: "8.9"
         - propertyName: messageSubscriptionType
@@ -505,7 +505,7 @@ components:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
           description: Filter by inbound connector type extracted from the `inbound.type` zeebe:property.
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: messageSubscriptionKey
           addedInVersion: "8.8"
         - propertyName: processDefinitionKey
@@ -626,7 +626,7 @@ components:
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/TenantId'
           description: The tenant ID associated with this correlated message subscription.
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: rootProcessInstanceKey
           addedInVersion: "8.9"
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
@@ -318,7 +318,6 @@ components:
           nullable: true
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
-          x-added-in-version: "8.9"
         elementId:
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/ElementId'
@@ -345,7 +344,6 @@ components:
           description: The correlation key of the message subscription.
         messageSubscriptionType:
           $ref: '#/components/schemas/MessageSubscriptionTypeEnum'
-          x-added-in-version: "8.10"
         toolProperties:
           type: object
           additionalProperties:
@@ -354,34 +352,44 @@ components:
             The subset of `zeebe:properties` extension properties whose keys start with the
             `io.camunda.tool:` prefix, extracted from the BPMN element associated with this
             subscription. Empty object when no matching properties are defined.
-          x-added-in-version: "8.10"
         processDefinitionName:
           type: string
           nullable: true
           description: The name of the process definition associated with this message subscription.
-          x-added-in-version: "8.10"
         processDefinitionVersion:
           type: integer
           format: int32
           nullable: true
           description: The version of the process definition associated with this message subscription.
-          x-added-in-version: "8.10"
         toolName:
           type: string
           nullable: true
           description: |
             Tool name extracted from the `io.camunda.tool:name` zeebe:property.
             Null when the property is absent.
-          x-added-in-version: "8.10"
         inboundConnectorType:
           type: string
           nullable: true
           description: |
             Inbound connector type extracted from the `inbound.type` zeebe:property.
             Null when the property is absent.
-          x-added-in-version: "8.10"
         tenantId:
           $ref: 'identifiers.yaml#/components/schemas/TenantId'
+      x-added-in-version:
+        - propertyName: rootProcessInstanceKey
+          addedInVersion: "8.9"
+        - propertyName: messageSubscriptionType
+          addedInVersion: "8.10"
+        - propertyName: toolProperties
+          addedInVersion: "8.10"
+        - propertyName: processDefinitionName
+          addedInVersion: "8.10"
+        - propertyName: processDefinitionVersion
+          addedInVersion: "8.10"
+        - propertyName: toolName
+          addedInVersion: "8.10"
+        - propertyName: inboundConnectorType
+          addedInVersion: "8.10"
 
     MessageSubscriptionSearchQuerySortRequest:
       type: object
@@ -434,57 +442,46 @@ components:
           allOf:
             - $ref: '#/components/schemas/MessageSubscriptionKeyFilterProperty'
           description: The message subscription key associated with this message subscription.
-          x-added-in-version: "8.8"
         processDefinitionKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessDefinitionKeyFilterProperty'
           description: The process definition key associated with this correlated message subscription. This only works for data created with 8.9 and later.
-          x-added-in-version: "8.9"
         processDefinitionId:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
           description: The process definition ID associated with this message subscription.
-          x-added-in-version: "8.8"
         processInstanceKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKeyFilterProperty'
           description: The process instance key associated with this message subscription.
-          x-added-in-version: "8.8"
         elementId:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
           description: The element ID associated with this message subscription.
-          x-added-in-version: "8.8"
         elementInstanceKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ElementInstanceKeyFilterProperty'
           description: The element instance key associated with this message subscription.
-          x-added-in-version: "8.8"
         messageSubscriptionState:
           allOf:
             - $ref: '#/components/schemas/MessageSubscriptionStateFilterProperty'
           description: The message subscription state.
-          x-added-in-version: "8.8"
         lastUpdatedDate:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/DateTimeFilterProperty'
           description: The last updated date of the message subscription.
-          x-added-in-version: "8.8"
         messageName:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
           description: The name of the message associated with the message subscription.
-          x-added-in-version: "8.8"
         correlationKey:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
           description: The correlation key of the message subscription.
-          x-added-in-version: "8.8"
         tenantId:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
           description: The unique external tenant ID.
-          x-added-in-version: "8.8"
         messageSubscriptionType:
           allOf:
             - $ref: '#/components/schemas/MessageSubscriptionTypeFilterProperty'
@@ -492,27 +489,55 @@ components:
             The type of message subscription to filter by. When omitted, both
             `START_EVENT` and `PROCESS_EVENT` are returned. Only available for data
             created with Camunda 8.10 or later.
-          x-added-in-version: "8.10"
         processDefinitionName:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
           description: The name of the process definition associated with this message subscription.
-          x-added-in-version: "8.10"
         processDefinitionVersion:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/IntegerFilterProperty'
           description: The version of the process definition associated with this message subscription.
-          x-added-in-version: "8.10"
         toolName:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
           description: Filter by tool name extracted from the `io.camunda.tool:name` zeebe:property.
-          x-added-in-version: "8.10"
         inboundConnectorType:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
           description: Filter by inbound connector type extracted from the `inbound.type` zeebe:property.
-          x-added-in-version: "8.10"
+      x-added-in-version:
+        - propertyName: messageSubscriptionKey
+          addedInVersion: "8.8"
+        - propertyName: processDefinitionKey
+          addedInVersion: "8.9"
+        - propertyName: processDefinitionId
+          addedInVersion: "8.8"
+        - propertyName: processInstanceKey
+          addedInVersion: "8.8"
+        - propertyName: elementId
+          addedInVersion: "8.8"
+        - propertyName: elementInstanceKey
+          addedInVersion: "8.8"
+        - propertyName: messageSubscriptionState
+          addedInVersion: "8.8"
+        - propertyName: lastUpdatedDate
+          addedInVersion: "8.8"
+        - propertyName: messageName
+          addedInVersion: "8.8"
+        - propertyName: correlationKey
+          addedInVersion: "8.8"
+        - propertyName: tenantId
+          addedInVersion: "8.8"
+        - propertyName: messageSubscriptionType
+          addedInVersion: "8.10"
+        - propertyName: processDefinitionName
+          addedInVersion: "8.10"
+        - propertyName: processDefinitionVersion
+          addedInVersion: "8.10"
+        - propertyName: toolName
+          addedInVersion: "8.10"
+        - propertyName: inboundConnectorType
+          addedInVersion: "8.10"
 
     CorrelatedMessageSubscriptionSearchQueryResult:
       required:
@@ -593,7 +618,6 @@ components:
           nullable: true
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
-          x-added-in-version: "8.9"
         subscriptionKey:
           allOf:
             - $ref: '#/components/schemas/MessageSubscriptionKey'
@@ -602,6 +626,9 @@ components:
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/TenantId'
           description: The tenant ID associated with this correlated message subscription.
+      x-added-in-version:
+        - propertyName: rootProcessInstanceKey
+          addedInVersion: "8.9"
 
     CorrelatedMessageSubscriptionSearchQuery:
       type: object

--- a/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
@@ -318,6 +318,7 @@ components:
           nullable: true
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
+          x-added-in-version: "8.9"
         elementId:
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/ElementId'
@@ -344,6 +345,7 @@ components:
           description: The correlation key of the message subscription.
         messageSubscriptionType:
           $ref: '#/components/schemas/MessageSubscriptionTypeEnum'
+          x-added-in-version: "8.10"
         toolProperties:
           type: object
           additionalProperties:
@@ -352,27 +354,32 @@ components:
             The subset of `zeebe:properties` extension properties whose keys start with the
             `io.camunda.tool:` prefix, extracted from the BPMN element associated with this
             subscription. Empty object when no matching properties are defined.
+          x-added-in-version: "8.10"
         processDefinitionName:
           type: string
           nullable: true
           description: The name of the process definition associated with this message subscription.
+          x-added-in-version: "8.10"
         processDefinitionVersion:
           type: integer
           format: int32
           nullable: true
           description: The version of the process definition associated with this message subscription.
+          x-added-in-version: "8.10"
         toolName:
           type: string
           nullable: true
           description: |
             Tool name extracted from the `io.camunda.tool:name` zeebe:property.
             Null when the property is absent.
+          x-added-in-version: "8.10"
         inboundConnectorType:
           type: string
           nullable: true
           description: |
             Inbound connector type extracted from the `inbound.type` zeebe:property.
             Null when the property is absent.
+          x-added-in-version: "8.10"
         tenantId:
           $ref: 'identifiers.yaml#/components/schemas/TenantId'
 
@@ -427,46 +434,57 @@ components:
           allOf:
             - $ref: '#/components/schemas/MessageSubscriptionKeyFilterProperty'
           description: The message subscription key associated with this message subscription.
+          x-added-in-version: "8.8"
         processDefinitionKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessDefinitionKeyFilterProperty'
           description: The process definition key associated with this correlated message subscription. This only works for data created with 8.9 and later.
+          x-added-in-version: "8.9"
         processDefinitionId:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
           description: The process definition ID associated with this message subscription.
+          x-added-in-version: "8.8"
         processInstanceKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKeyFilterProperty'
           description: The process instance key associated with this message subscription.
+          x-added-in-version: "8.8"
         elementId:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
           description: The element ID associated with this message subscription.
+          x-added-in-version: "8.8"
         elementInstanceKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ElementInstanceKeyFilterProperty'
           description: The element instance key associated with this message subscription.
+          x-added-in-version: "8.8"
         messageSubscriptionState:
           allOf:
             - $ref: '#/components/schemas/MessageSubscriptionStateFilterProperty'
           description: The message subscription state.
+          x-added-in-version: "8.8"
         lastUpdatedDate:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/DateTimeFilterProperty'
           description: The last updated date of the message subscription.
+          x-added-in-version: "8.8"
         messageName:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
           description: The name of the message associated with the message subscription.
+          x-added-in-version: "8.8"
         correlationKey:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
           description: The correlation key of the message subscription.
+          x-added-in-version: "8.8"
         tenantId:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
           description: The unique external tenant ID.
+          x-added-in-version: "8.8"
         messageSubscriptionType:
           allOf:
             - $ref: '#/components/schemas/MessageSubscriptionTypeFilterProperty'
@@ -474,22 +492,27 @@ components:
             The type of message subscription to filter by. When omitted, both
             `START_EVENT` and `PROCESS_EVENT` are returned. Only available for data
             created with Camunda 8.10 or later.
+          x-added-in-version: "8.10"
         processDefinitionName:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
           description: The name of the process definition associated with this message subscription.
+          x-added-in-version: "8.10"
         processDefinitionVersion:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/IntegerFilterProperty'
           description: The version of the process definition associated with this message subscription.
+          x-added-in-version: "8.10"
         toolName:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
           description: Filter by tool name extracted from the `io.camunda.tool:name` zeebe:property.
+          x-added-in-version: "8.10"
         inboundConnectorType:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
           description: Filter by inbound connector type extracted from the `inbound.type` zeebe:property.
+          x-added-in-version: "8.10"
 
     CorrelatedMessageSubscriptionSearchQueryResult:
       required:
@@ -570,6 +593,7 @@ components:
           nullable: true
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
+          x-added-in-version: "8.9"
         subscriptionKey:
           allOf:
             - $ref: '#/components/schemas/MessageSubscriptionKey'

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
@@ -859,6 +859,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ProcessInstanceCreationRuntimeInstruction'
+          x-added-in-version: "8.8"
         tenantId:
           description: |
             The tenant id of the process definition.
@@ -893,8 +894,10 @@ components:
             type: string
         tags:
           $ref: 'identifiers.yaml#/components/schemas/TagSet'
+          x-added-in-version: "8.8"
         businessId:
           $ref: 'identifiers.yaml#/components/schemas/BusinessId'
+          x-added-in-version: "8.9"
 
     ProcessInstanceCreationStartInstruction:
       type: object
@@ -987,11 +990,13 @@ components:
             needs a process instance key (e.g. CancelProcessInstanceRequest).
         tags:
           $ref: 'identifiers.yaml#/components/schemas/TagSet'
+          x-added-in-version: "8.8"
         businessId:
           nullable: true
           description: Business id as provided on creation.
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/BusinessId'
+          x-added-in-version: "8.9"
 
     ProcessInstanceSearchQuerySortRequest:
       type: object
@@ -1044,38 +1049,47 @@ components:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/DateTimeFilterProperty'
           description: The start date.
+          x-added-in-version: "8.6"
         endDate:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/DateTimeFilterProperty'
           description: The end date.
+          x-added-in-version: "8.6"
         state:
           allOf:
             - $ref: '#/components/schemas/ProcessInstanceStateFilterProperty'
           description: The process instance state.
+          x-added-in-version: "8.8"
         hasIncident:
           type: boolean
           description: Whether this process instance has a related incident or not.
+          x-added-in-version: "8.8"
         tenantId:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
           description: The tenant id.
+          x-added-in-version: "8.6"
         variables:
           description: The process instance variables.
           type: array
           items:
             $ref: 'variables.yaml#/components/schemas/VariableValueFilterProperty'
+          x-added-in-version: "8.8"
         processInstanceKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKeyFilterProperty'
           description: The key of this process instance.
+          x-added-in-version: "8.8"
         parentProcessInstanceKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKeyFilterProperty'
           description: The parent process instance key.
+          x-added-in-version: "8.6"
         parentElementInstanceKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ElementInstanceKeyFilterProperty'
           description: The parent element instance key.
+          x-added-in-version: "8.8"
         batchOperationId:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
@@ -1085,38 +1099,48 @@ components:
             **Deprecated**: Use `batchOperationKey` instead. This field will be removed in a future release.
             If both `batchOperationId` and `batchOperationKey` are provided, the request will be rejected with a 400 error.
           deprecated: true
+          x-added-in-version: "8.6"
         batchOperationKey:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
           description: The batch operation key.
+          x-added-in-version: "8.8"
         errorMessage:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
           description: The error message related to the process.
+          x-added-in-version: "8.6"
         hasRetriesLeft:
           description: Whether the process has failed jobs with retries left.
           type: boolean
+          x-added-in-version: "8.8"
         elementInstanceState:
           allOf:
             - $ref: 'element-instances.yaml#/components/schemas/ElementInstanceStateFilterProperty'
           description: The state of the element instances associated with the process instance.
+          x-added-in-version: "8.8"
         elementId:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
           description: The element id associated with the process instance.
+          x-added-in-version: "8.8"
         hasElementInstanceIncident:
           description: Whether the element instance has an incident or not.
           type: boolean
+          x-added-in-version: "8.8"
         incidentErrorHashCode:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/IntegerFilterProperty'
           description: The incident error hash code, associated with this process.
+          x-added-in-version: "8.8"
         tags:
           $ref: 'identifiers.yaml#/components/schemas/TagSet'
+          x-added-in-version: "8.8"
         businessId:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
           description: The business id associated with the process instance.
+          x-added-in-version: "8.9"
 
     ProcessDefinitionStatisticsFilter:
       description: Process definition statistics search filter.
@@ -1170,22 +1194,27 @@ components:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
           description: The process definition id.
+          x-added-in-version: "8.8"
         processDefinitionName:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
           description: The process definition name.
+          x-added-in-version: "8.8"
         processDefinitionVersion:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/IntegerFilterProperty'
           description: The process definition version.
+          x-added-in-version: "8.6"
         processDefinitionVersionTag:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
           description: The process definition version tag.
+          x-added-in-version: "8.8"
         processDefinitionKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessDefinitionKeyFilterProperty'
           description: The process definition key.
+          x-added-in-version: "8.8"
 
     ProcessInstanceFilter:
       description: Process instance search filter.
@@ -1228,6 +1257,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/ProcessInstanceFilterFields'
+              x-added-in-version: "8.8"
 
     ProcessInstanceSearchQueryResult:
       description: Process instance search response.
@@ -1266,52 +1296,65 @@ components:
       properties:
         processDefinitionId:
           $ref: 'identifiers.yaml#/components/schemas/ProcessDefinitionId'
+          x-added-in-version: "8.8"
         processDefinitionName:
           type: string
           nullable: true
           description: The process definition name.
+          x-added-in-version: "8.6"
         processDefinitionVersion:
           type: integer
           format: int32
           description: The process definition version.
+          x-added-in-version: "8.6"
         processDefinitionVersionTag:
           description: The process definition version tag.
           nullable: true
           type: string
+          x-added-in-version: "8.8"
         startDate:
           type: string
           format: date-time
           description: The start time of the process instance.
+          x-added-in-version: "8.6"
         endDate:
           description: The completion or termination time of the process instance.
           nullable: true
           type: string
           format: date-time
+          x-added-in-version: "8.6"
         state:
           $ref: '#/components/schemas/ProcessInstanceStateEnum'
+          x-added-in-version: "8.6"
         hasIncident:
           type: boolean
           description: Whether this process instance has a related incident or not.
+          x-added-in-version: "8.8"
         tenantId:
           $ref: 'identifiers.yaml#/components/schemas/TenantId'
+          x-added-in-version: "8.6"
         processInstanceKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
           description: The key of this process instance.
+          x-added-in-version: "8.8"
         processDefinitionKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessDefinitionKey'
           description: The process definition key.
+          x-added-in-version: "8.6"
         parentProcessInstanceKey:
           description: The parent process instance key.
           nullable: true
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
+          x-added-in-version: "8.8"
         parentElementInstanceKey:
           description: The parent element instance key.
           nullable: true
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ElementInstanceKey'
+          x-added-in-version: "8.8"
         rootProcessInstanceKey:
           description: |
             The key of the root process instance. The root process instance is the top-level
@@ -1320,13 +1363,16 @@ components:
           nullable: true
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
+          x-added-in-version: "8.9"
         tags:
           $ref: 'identifiers.yaml#/components/schemas/TagSet'
+          x-added-in-version: "8.8"
         businessId:
           description: The business id associated with this process instance.
           nullable: true
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/BusinessId'
+          x-added-in-version: "8.9"
 
     CancelProcessInstanceRequest:
       type: object
@@ -1402,6 +1448,7 @@ components:
           nullable: true
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
+          x-added-in-version: "8.9"
         processDefinitionKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessDefinitionKey'
@@ -1459,10 +1506,12 @@ components:
           description: The element id to migrate from.
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/ElementId'
+          x-added-in-version: "8.6"
         targetElementId:
           description: The element id to migrate into.
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/ElementId'
+          x-added-in-version: "8.6"
       required:
         - sourceElementId
         - targetElementId
@@ -1483,6 +1532,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ProcessInstanceModificationMoveInstruction'
+          x-added-in-version: "8.9"
         terminateInstructions:
           description: Instructions describing which elements to terminate.
           type: array
@@ -1686,6 +1736,7 @@ components:
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/ElementId'
           description: The id of the elements to terminate. The element instances are determined at runtime.
+          x-added-in-version: "8.9"
       required:
         - elementId
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
@@ -895,7 +895,7 @@ components:
           $ref: 'identifiers.yaml#/components/schemas/TagSet'
         businessId:
           $ref: 'identifiers.yaml#/components/schemas/BusinessId'
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: runtimeInstructions
           addedInVersion: "8.8"
         - propertyName: tags
@@ -999,7 +999,7 @@ components:
           description: Business id as provided on creation.
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/BusinessId'
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: tags
           addedInVersion: "8.8"
         - propertyName: businessId
@@ -1129,7 +1129,7 @@ components:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
           description: The business id associated with the process instance.
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: startDate
           addedInVersion: "8.6"
         - propertyName: endDate
@@ -1237,7 +1237,7 @@ components:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessDefinitionKeyFilterProperty'
           description: The process definition key.
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: processDefinitionId
           addedInVersion: "8.8"
         - propertyName: processDefinitionName
@@ -1290,7 +1290,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/ProcessInstanceFilterFields'
-          x-added-in-version:
+          x-properties-added-in-version:
             - propertyName: "$or"
               addedInVersion: "8.8"
 
@@ -1392,7 +1392,7 @@ components:
           nullable: true
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/BusinessId'
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: processDefinitionId
           addedInVersion: "8.8"
         - propertyName: processDefinitionName
@@ -1514,7 +1514,7 @@ components:
           description: The element id for this sequence flow, as provided in the BPMN process.
         tenantId:
           $ref: 'identifiers.yaml#/components/schemas/TenantId'
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: rootProcessInstanceKey
           addedInVersion: "8.9"
 
@@ -1567,7 +1567,7 @@ components:
       required:
         - sourceElementId
         - targetElementId
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: sourceElementId
           addedInVersion: "8.6"
         - propertyName: targetElementId
@@ -1594,7 +1594,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ProcessInstanceModificationTerminateInstruction'
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: moveInstructions
           addedInVersion: "8.9"
 
@@ -1797,7 +1797,7 @@ components:
           description: The id of the elements to terminate. The element instances are determined at runtime.
       required:
         - elementId
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: elementId
           addedInVersion: "8.9"
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
@@ -859,7 +859,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ProcessInstanceCreationRuntimeInstruction'
-          x-added-in-version: "8.8"
         tenantId:
           description: |
             The tenant id of the process definition.
@@ -894,10 +893,15 @@ components:
             type: string
         tags:
           $ref: 'identifiers.yaml#/components/schemas/TagSet'
-          x-added-in-version: "8.8"
         businessId:
           $ref: 'identifiers.yaml#/components/schemas/BusinessId'
-          x-added-in-version: "8.9"
+      x-added-in-version:
+        - propertyName: runtimeInstructions
+          addedInVersion: "8.8"
+        - propertyName: tags
+          addedInVersion: "8.8"
+        - propertyName: businessId
+          addedInVersion: "8.9"
 
     ProcessInstanceCreationStartInstruction:
       type: object
@@ -990,13 +994,16 @@ components:
             needs a process instance key (e.g. CancelProcessInstanceRequest).
         tags:
           $ref: 'identifiers.yaml#/components/schemas/TagSet'
-          x-added-in-version: "8.8"
         businessId:
           nullable: true
           description: Business id as provided on creation.
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/BusinessId'
-          x-added-in-version: "8.9"
+      x-added-in-version:
+        - propertyName: tags
+          addedInVersion: "8.8"
+        - propertyName: businessId
+          addedInVersion: "8.9"
 
     ProcessInstanceSearchQuerySortRequest:
       type: object
@@ -1049,47 +1056,38 @@ components:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/DateTimeFilterProperty'
           description: The start date.
-          x-added-in-version: "8.6"
         endDate:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/DateTimeFilterProperty'
           description: The end date.
-          x-added-in-version: "8.6"
         state:
           allOf:
             - $ref: '#/components/schemas/ProcessInstanceStateFilterProperty'
           description: The process instance state.
-          x-added-in-version: "8.8"
         hasIncident:
           type: boolean
           description: Whether this process instance has a related incident or not.
-          x-added-in-version: "8.8"
         tenantId:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
           description: The tenant id.
-          x-added-in-version: "8.6"
         variables:
           description: The process instance variables.
           type: array
           items:
             $ref: 'variables.yaml#/components/schemas/VariableValueFilterProperty'
-          x-added-in-version: "8.8"
         processInstanceKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKeyFilterProperty'
           description: The key of this process instance.
-          x-added-in-version: "8.8"
         parentProcessInstanceKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKeyFilterProperty'
           description: The parent process instance key.
-          x-added-in-version: "8.6"
         parentElementInstanceKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ElementInstanceKeyFilterProperty'
           description: The parent element instance key.
-          x-added-in-version: "8.8"
         batchOperationId:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
@@ -1099,48 +1097,77 @@ components:
             **Deprecated**: Use `batchOperationKey` instead. This field will be removed in a future release.
             If both `batchOperationId` and `batchOperationKey` are provided, the request will be rejected with a 400 error.
           deprecated: true
-          x-added-in-version: "8.6"
         batchOperationKey:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
           description: The batch operation key.
-          x-added-in-version: "8.8"
         errorMessage:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
           description: The error message related to the process.
-          x-added-in-version: "8.6"
         hasRetriesLeft:
           description: Whether the process has failed jobs with retries left.
           type: boolean
-          x-added-in-version: "8.8"
         elementInstanceState:
           allOf:
             - $ref: 'element-instances.yaml#/components/schemas/ElementInstanceStateFilterProperty'
           description: The state of the element instances associated with the process instance.
-          x-added-in-version: "8.8"
         elementId:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
           description: The element id associated with the process instance.
-          x-added-in-version: "8.8"
         hasElementInstanceIncident:
           description: Whether the element instance has an incident or not.
           type: boolean
-          x-added-in-version: "8.8"
         incidentErrorHashCode:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/IntegerFilterProperty'
           description: The incident error hash code, associated with this process.
-          x-added-in-version: "8.8"
         tags:
           $ref: 'identifiers.yaml#/components/schemas/TagSet'
-          x-added-in-version: "8.8"
         businessId:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
           description: The business id associated with the process instance.
-          x-added-in-version: "8.9"
+      x-added-in-version:
+        - propertyName: startDate
+          addedInVersion: "8.6"
+        - propertyName: endDate
+          addedInVersion: "8.6"
+        - propertyName: state
+          addedInVersion: "8.8"
+        - propertyName: hasIncident
+          addedInVersion: "8.8"
+        - propertyName: tenantId
+          addedInVersion: "8.6"
+        - propertyName: variables
+          addedInVersion: "8.8"
+        - propertyName: processInstanceKey
+          addedInVersion: "8.8"
+        - propertyName: parentProcessInstanceKey
+          addedInVersion: "8.6"
+        - propertyName: parentElementInstanceKey
+          addedInVersion: "8.8"
+        - propertyName: batchOperationId
+          addedInVersion: "8.6"
+        - propertyName: batchOperationKey
+          addedInVersion: "8.8"
+        - propertyName: errorMessage
+          addedInVersion: "8.6"
+        - propertyName: hasRetriesLeft
+          addedInVersion: "8.8"
+        - propertyName: elementInstanceState
+          addedInVersion: "8.8"
+        - propertyName: elementId
+          addedInVersion: "8.8"
+        - propertyName: hasElementInstanceIncident
+          addedInVersion: "8.8"
+        - propertyName: incidentErrorHashCode
+          addedInVersion: "8.8"
+        - propertyName: tags
+          addedInVersion: "8.8"
+        - propertyName: businessId
+          addedInVersion: "8.9"
 
     ProcessDefinitionStatisticsFilter:
       description: Process definition statistics search filter.
@@ -1194,27 +1221,33 @@ components:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
           description: The process definition id.
-          x-added-in-version: "8.8"
         processDefinitionName:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
           description: The process definition name.
-          x-added-in-version: "8.8"
         processDefinitionVersion:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/IntegerFilterProperty'
           description: The process definition version.
-          x-added-in-version: "8.6"
         processDefinitionVersionTag:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
           description: The process definition version tag.
-          x-added-in-version: "8.8"
         processDefinitionKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessDefinitionKeyFilterProperty'
           description: The process definition key.
-          x-added-in-version: "8.8"
+      x-added-in-version:
+        - propertyName: processDefinitionId
+          addedInVersion: "8.8"
+        - propertyName: processDefinitionName
+          addedInVersion: "8.8"
+        - propertyName: processDefinitionVersion
+          addedInVersion: "8.6"
+        - propertyName: processDefinitionVersionTag
+          addedInVersion: "8.8"
+        - propertyName: processDefinitionKey
+          addedInVersion: "8.8"
 
     ProcessInstanceFilter:
       description: Process instance search filter.
@@ -1257,7 +1290,9 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/ProcessInstanceFilterFields'
-              x-added-in-version: "8.8"
+          x-added-in-version:
+            - propertyName: "$or"
+              addedInVersion: "8.8"
 
     ProcessInstanceSearchQueryResult:
       description: Process instance search response.
@@ -1296,65 +1331,52 @@ components:
       properties:
         processDefinitionId:
           $ref: 'identifiers.yaml#/components/schemas/ProcessDefinitionId'
-          x-added-in-version: "8.8"
         processDefinitionName:
           type: string
           nullable: true
           description: The process definition name.
-          x-added-in-version: "8.6"
         processDefinitionVersion:
           type: integer
           format: int32
           description: The process definition version.
-          x-added-in-version: "8.6"
         processDefinitionVersionTag:
           description: The process definition version tag.
           nullable: true
           type: string
-          x-added-in-version: "8.8"
         startDate:
           type: string
           format: date-time
           description: The start time of the process instance.
-          x-added-in-version: "8.6"
         endDate:
           description: The completion or termination time of the process instance.
           nullable: true
           type: string
           format: date-time
-          x-added-in-version: "8.6"
         state:
           $ref: '#/components/schemas/ProcessInstanceStateEnum'
-          x-added-in-version: "8.6"
         hasIncident:
           type: boolean
           description: Whether this process instance has a related incident or not.
-          x-added-in-version: "8.8"
         tenantId:
           $ref: 'identifiers.yaml#/components/schemas/TenantId'
-          x-added-in-version: "8.6"
         processInstanceKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
           description: The key of this process instance.
-          x-added-in-version: "8.8"
         processDefinitionKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessDefinitionKey'
           description: The process definition key.
-          x-added-in-version: "8.6"
         parentProcessInstanceKey:
           description: The parent process instance key.
           nullable: true
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
-          x-added-in-version: "8.8"
         parentElementInstanceKey:
           description: The parent element instance key.
           nullable: true
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ElementInstanceKey'
-          x-added-in-version: "8.8"
         rootProcessInstanceKey:
           description: |
             The key of the root process instance. The root process instance is the top-level
@@ -1363,16 +1385,46 @@ components:
           nullable: true
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
-          x-added-in-version: "8.9"
         tags:
           $ref: 'identifiers.yaml#/components/schemas/TagSet'
-          x-added-in-version: "8.8"
         businessId:
           description: The business id associated with this process instance.
           nullable: true
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/BusinessId'
-          x-added-in-version: "8.9"
+      x-added-in-version:
+        - propertyName: processDefinitionId
+          addedInVersion: "8.8"
+        - propertyName: processDefinitionName
+          addedInVersion: "8.6"
+        - propertyName: processDefinitionVersion
+          addedInVersion: "8.6"
+        - propertyName: processDefinitionVersionTag
+          addedInVersion: "8.8"
+        - propertyName: startDate
+          addedInVersion: "8.6"
+        - propertyName: endDate
+          addedInVersion: "8.6"
+        - propertyName: state
+          addedInVersion: "8.6"
+        - propertyName: hasIncident
+          addedInVersion: "8.8"
+        - propertyName: tenantId
+          addedInVersion: "8.6"
+        - propertyName: processInstanceKey
+          addedInVersion: "8.8"
+        - propertyName: processDefinitionKey
+          addedInVersion: "8.6"
+        - propertyName: parentProcessInstanceKey
+          addedInVersion: "8.8"
+        - propertyName: parentElementInstanceKey
+          addedInVersion: "8.8"
+        - propertyName: rootProcessInstanceKey
+          addedInVersion: "8.9"
+        - propertyName: tags
+          addedInVersion: "8.8"
+        - propertyName: businessId
+          addedInVersion: "8.9"
 
     CancelProcessInstanceRequest:
       type: object
@@ -1448,7 +1500,6 @@ components:
           nullable: true
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
-          x-added-in-version: "8.9"
         processDefinitionKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessDefinitionKey'
@@ -1463,6 +1514,9 @@ components:
           description: The element id for this sequence flow, as provided in the BPMN process.
         tenantId:
           $ref: 'identifiers.yaml#/components/schemas/TenantId'
+      x-added-in-version:
+        - propertyName: rootProcessInstanceKey
+          addedInVersion: "8.9"
 
     ProcessInstanceElementStatisticsQueryResult:
       description: Process instance element statistics query response.
@@ -1506,15 +1560,18 @@ components:
           description: The element id to migrate from.
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/ElementId'
-          x-added-in-version: "8.6"
         targetElementId:
           description: The element id to migrate into.
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/ElementId'
-          x-added-in-version: "8.6"
       required:
         - sourceElementId
         - targetElementId
+      x-added-in-version:
+        - propertyName: sourceElementId
+          addedInVersion: "8.6"
+        - propertyName: targetElementId
+          addedInVersion: "8.6"
 
     ProcessInstanceModificationInstruction:
       type: object
@@ -1532,12 +1589,14 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ProcessInstanceModificationMoveInstruction'
-          x-added-in-version: "8.9"
         terminateInstructions:
           description: Instructions describing which elements to terminate.
           type: array
           items:
             $ref: '#/components/schemas/ProcessInstanceModificationTerminateInstruction'
+      x-added-in-version:
+        - propertyName: moveInstructions
+          addedInVersion: "8.9"
 
     ProcessInstanceModificationActivateInstruction:
       description: Instruction describing an element to activate.
@@ -1736,9 +1795,11 @@ components:
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/ElementId'
           description: The id of the elements to terminate. The element instances are determined at runtime.
-          x-added-in-version: "8.9"
       required:
         - elementId
+      x-added-in-version:
+        - propertyName: elementId
+          addedInVersion: "8.9"
 
     ProcessInstanceModificationTerminateByKeyInstruction:
       description: Instruction providing the key of the element instance to terminate.

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
@@ -814,6 +814,13 @@ components:
           $ref: 'identifiers.yaml#/components/schemas/TagSet'
         businessId:
           $ref: 'identifiers.yaml#/components/schemas/BusinessId'
+      x-properties-added-in-version:
+        - propertyName: runtimeInstructions
+          addedInVersion: "8.8"
+        - propertyName: tags
+          addedInVersion: "8.8"
+        - propertyName: businessId
+          addedInVersion: "8.9"
 
     ProcessInstanceCreationInstructionByKey:
       type: object
@@ -944,6 +951,9 @@ components:
           example: Activity_106kb
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/ElementId'
+      x-properties-added-in-version:
+        - propertyName: type
+          addedInVersion: "8.9"
 
     CreateProcessInstanceResult:
       x-semantic-provider:

--- a/zeebe/gateway-protocol/src/main/proto/v2/search-models.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/search-models.yaml
@@ -9,6 +9,7 @@ components:
           description: Pagination criteria.
           allOf:
             - $ref: '#/components/schemas/SearchQueryPageRequest'
+          x-added-in-version: "8.6"
 
     SearchQueryPageRequest:
       x-polymorphic-schema: true
@@ -40,12 +41,14 @@ components:
           type: integer
           format: int32
           minimum: 0
+          x-added-in-version: "8.6"
         limit:
           description: The maximum number of items to return in one request.
           type: integer
           format: int32
           default: 100
           minimum: 1
+          x-added-in-version: "8.8"
 
     CursorForwardPagination:
       type: object
@@ -57,6 +60,7 @@ components:
           description: Use the `endCursor` value from the previous response to fetch the next page of results.
           allOf:
             - $ref: 'cursors.yaml#/components/schemas/EndCursor'
+          x-added-in-version: "8.8"
         limit:
           description: The maximum number of items to return in one request.
           type: integer
@@ -75,6 +79,7 @@ components:
           description: Use the `startCursor` value from the previous response to fetch the previous page of results.
           allOf:
             - $ref: 'cursors.yaml#/components/schemas/StartCursor'
+          x-added-in-version: "8.8"
         limit:
           description: The maximum number of items to return in one request.
           type: integer
@@ -90,6 +95,7 @@ components:
       properties:
         page:
           $ref: '#/components/schemas/SearchQueryPageResponse'
+          x-added-in-version: "8.6"
 
     SortOrderEnum:
       description: The order in which to sort the related field.
@@ -119,13 +125,16 @@ components:
           description: |
             Indicates whether the `totalItems` value has been capped due to system limits. When true, `totalItems` is a lower bound and the actual number of matching items is greater than the reported value.
           type: boolean
+          x-added-in-version: "8.8"
         startCursor:
           description: The cursor value for getting the previous page of results. Use this in the `before` field of an ensuing request.
           nullable: true
           allOf:
             - $ref: 'cursors.yaml#/components/schemas/StartCursor'
+          x-added-in-version: "8.8"
         endCursor:
           description: The cursor value for getting the next page of results. Use this in the `after` field of an ensuing request.
           nullable: true
           allOf:
             - $ref: 'cursors.yaml#/components/schemas/EndCursor'
+          x-added-in-version: "8.8"

--- a/zeebe/gateway-protocol/src/main/proto/v2/search-models.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/search-models.yaml
@@ -53,7 +53,7 @@ components:
         - propertyName: from
           addedInVersion: "8.6"
         - propertyName: limit
-          addedInVersion: "8.8"
+          addedInVersion: "8.6"
 
     CursorForwardPagination:
       type: object
@@ -75,6 +75,8 @@ components:
       x-properties-added-in-version:
         - propertyName: after
           addedInVersion: "8.8"
+        - propertyName: limit
+          addedInVersion: "8.6"
 
     CursorBackwardPagination:
       type: object

--- a/zeebe/gateway-protocol/src/main/proto/v2/search-models.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/search-models.yaml
@@ -9,7 +9,7 @@ components:
           description: Pagination criteria.
           allOf:
             - $ref: '#/components/schemas/SearchQueryPageRequest'
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: page
           addedInVersion: "8.6"
 
@@ -49,7 +49,7 @@ components:
           format: int32
           default: 100
           minimum: 1
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: from
           addedInVersion: "8.6"
         - propertyName: limit
@@ -72,7 +72,7 @@ components:
           default: 100
           minimum: 1
           maximum: 10000
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: after
           addedInVersion: "8.8"
 
@@ -93,7 +93,7 @@ components:
           default: 100
           minimum: 1
           maximum: 10000
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: before
           addedInVersion: "8.8"
 
@@ -104,7 +104,7 @@ components:
       properties:
         page:
           $ref: '#/components/schemas/SearchQueryPageResponse'
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: page
           addedInVersion: "8.6"
 
@@ -146,7 +146,7 @@ components:
           nullable: true
           allOf:
             - $ref: 'cursors.yaml#/components/schemas/EndCursor'
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: hasMoreTotalItems
           addedInVersion: "8.8"
         - propertyName: startCursor

--- a/zeebe/gateway-protocol/src/main/proto/v2/search-models.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/search-models.yaml
@@ -9,7 +9,9 @@ components:
           description: Pagination criteria.
           allOf:
             - $ref: '#/components/schemas/SearchQueryPageRequest'
-          x-added-in-version: "8.6"
+      x-added-in-version:
+        - propertyName: page
+          addedInVersion: "8.6"
 
     SearchQueryPageRequest:
       x-polymorphic-schema: true
@@ -41,14 +43,17 @@ components:
           type: integer
           format: int32
           minimum: 0
-          x-added-in-version: "8.6"
         limit:
           description: The maximum number of items to return in one request.
           type: integer
           format: int32
           default: 100
           minimum: 1
-          x-added-in-version: "8.8"
+      x-added-in-version:
+        - propertyName: from
+          addedInVersion: "8.6"
+        - propertyName: limit
+          addedInVersion: "8.8"
 
     CursorForwardPagination:
       type: object
@@ -60,7 +65,6 @@ components:
           description: Use the `endCursor` value from the previous response to fetch the next page of results.
           allOf:
             - $ref: 'cursors.yaml#/components/schemas/EndCursor'
-          x-added-in-version: "8.8"
         limit:
           description: The maximum number of items to return in one request.
           type: integer
@@ -68,6 +72,9 @@ components:
           default: 100
           minimum: 1
           maximum: 10000
+      x-added-in-version:
+        - propertyName: after
+          addedInVersion: "8.8"
 
     CursorBackwardPagination:
       type: object
@@ -79,7 +86,6 @@ components:
           description: Use the `startCursor` value from the previous response to fetch the previous page of results.
           allOf:
             - $ref: 'cursors.yaml#/components/schemas/StartCursor'
-          x-added-in-version: "8.8"
         limit:
           description: The maximum number of items to return in one request.
           type: integer
@@ -87,6 +93,9 @@ components:
           default: 100
           minimum: 1
           maximum: 10000
+      x-added-in-version:
+        - propertyName: before
+          addedInVersion: "8.8"
 
     SearchQueryResponse:
       type: object
@@ -95,7 +104,9 @@ components:
       properties:
         page:
           $ref: '#/components/schemas/SearchQueryPageResponse'
-          x-added-in-version: "8.6"
+      x-added-in-version:
+        - propertyName: page
+          addedInVersion: "8.6"
 
     SortOrderEnum:
       description: The order in which to sort the related field.
@@ -125,16 +136,20 @@ components:
           description: |
             Indicates whether the `totalItems` value has been capped due to system limits. When true, `totalItems` is a lower bound and the actual number of matching items is greater than the reported value.
           type: boolean
-          x-added-in-version: "8.8"
         startCursor:
           description: The cursor value for getting the previous page of results. Use this in the `before` field of an ensuing request.
           nullable: true
           allOf:
             - $ref: 'cursors.yaml#/components/schemas/StartCursor'
-          x-added-in-version: "8.8"
         endCursor:
           description: The cursor value for getting the next page of results. Use this in the `after` field of an ensuing request.
           nullable: true
           allOf:
             - $ref: 'cursors.yaml#/components/schemas/EndCursor'
-          x-added-in-version: "8.8"
+      x-added-in-version:
+        - propertyName: hasMoreTotalItems
+          addedInVersion: "8.8"
+        - propertyName: startCursor
+          addedInVersion: "8.8"
+        - propertyName: endCursor
+          addedInVersion: "8.8"

--- a/zeebe/gateway-protocol/src/main/proto/v2/system.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/system.yaml
@@ -193,12 +193,16 @@ components:
           $ref: '#/components/schemas/JobMetricsConfigurationResponse'
         components:
           $ref: '#/components/schemas/ComponentsConfigurationResponse'
+          x-added-in-version: "8.10"
         deployment:
           $ref: '#/components/schemas/DeploymentConfigurationResponse'
+          x-added-in-version: "8.10"
         authentication:
           $ref: '#/components/schemas/AuthenticationConfigurationResponse'
+          x-added-in-version: "8.10"
         cloud:
           $ref: '#/components/schemas/CloudConfigurationResponse'
+          x-added-in-version: "8.10"
 
     JobMetricsConfigurationResponse:
       description: Configuration for job metrics collection and export.

--- a/zeebe/gateway-protocol/src/main/proto/v2/system.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/system.yaml
@@ -193,16 +193,21 @@ components:
           $ref: '#/components/schemas/JobMetricsConfigurationResponse'
         components:
           $ref: '#/components/schemas/ComponentsConfigurationResponse'
-          x-added-in-version: "8.10"
         deployment:
           $ref: '#/components/schemas/DeploymentConfigurationResponse'
-          x-added-in-version: "8.10"
         authentication:
           $ref: '#/components/schemas/AuthenticationConfigurationResponse'
-          x-added-in-version: "8.10"
         cloud:
           $ref: '#/components/schemas/CloudConfigurationResponse'
-          x-added-in-version: "8.10"
+      x-added-in-version:
+        - propertyName: components
+          addedInVersion: "8.10"
+        - propertyName: deployment
+          addedInVersion: "8.10"
+        - propertyName: authentication
+          addedInVersion: "8.10"
+        - propertyName: cloud
+          addedInVersion: "8.10"
 
     JobMetricsConfigurationResponse:
       description: Configuration for job metrics collection and export.

--- a/zeebe/gateway-protocol/src/main/proto/v2/system.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/system.yaml
@@ -199,7 +199,7 @@ components:
           $ref: '#/components/schemas/AuthenticationConfigurationResponse'
         cloud:
           $ref: '#/components/schemas/CloudConfigurationResponse'
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: components
           addedInVersion: "8.10"
         - propertyName: deployment

--- a/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
@@ -497,7 +497,6 @@ components:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/IntegerFilterProperty'
           description: The priority of the user task.
-          x-added-in-version: "8.8"
         elementId:
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/ElementId'
@@ -508,7 +507,6 @@ components:
           description: >
             The task name. This only works for data created with 8.8 and onwards.
             Instances from prior versions don't contain this data and cannot be found.
-          x-added-in-version: "8.8"
         candidateGroup:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
@@ -521,7 +519,6 @@ components:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
           description: Tenant ID of this user task.
-          x-added-in-version: "8.8"
         processDefinitionId:
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/ProcessDefinitionIdFilterProperty'
@@ -530,39 +527,32 @@ components:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/DateTimeFilterProperty'
           description: The user task creation date.
-          x-added-in-version: "8.8"
         completionDate:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/DateTimeFilterProperty'
           description: The user task completion date.
-          x-added-in-version: "8.8"
         followUpDate:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/DateTimeFilterProperty'
           description: The user task follow-up date.
-          x-added-in-version: "8.8"
         dueDate:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/DateTimeFilterProperty'
           description: The user task due date.
-          x-added-in-version: "8.8"
         processInstanceVariables:
           type: array
           description: The variables of the process instance.
           items:
             $ref: 'variables.yaml#/components/schemas/VariableValueFilterProperty'
-          x-added-in-version: "8.8"
         localVariables:
           type: array
           description: The local variables of the user task.
           items:
             $ref: 'variables.yaml#/components/schemas/VariableValueFilterProperty'
-          x-added-in-version: "8.8"
         userTaskKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/UserTaskKey'
           description: The key for this user task.
-          x-added-in-version: "8.8"
         processDefinitionKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessDefinitionKeyFilterProperty'
@@ -575,10 +565,33 @@ components:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ElementInstanceKey'
           description: The key of the element instance.
-          x-added-in-version: "8.8"
         tags:
           $ref: 'identifiers.yaml#/components/schemas/TagSet'
-          x-added-in-version: "8.9"
+      x-added-in-version:
+        - propertyName: priority
+          addedInVersion: "8.8"
+        - propertyName: name
+          addedInVersion: "8.8"
+        - propertyName: tenantId
+          addedInVersion: "8.8"
+        - propertyName: creationDate
+          addedInVersion: "8.8"
+        - propertyName: completionDate
+          addedInVersion: "8.8"
+        - propertyName: followUpDate
+          addedInVersion: "8.8"
+        - propertyName: dueDate
+          addedInVersion: "8.8"
+        - propertyName: processInstanceVariables
+          addedInVersion: "8.8"
+        - propertyName: localVariables
+          addedInVersion: "8.8"
+        - propertyName: userTaskKey
+          addedInVersion: "8.8"
+        - propertyName: elementInstanceKey
+          addedInVersion: "8.8"
+        - propertyName: tags
+          addedInVersion: "8.9"
 
     UserTaskSearchQueryResult:
       description: User task search query response.
@@ -626,113 +639,92 @@ components:
           nullable: true
           type: string
           description: The name for this user task.
-          x-added-in-version: "8.8"
         state:
           $ref: '#/components/schemas/UserTaskStateEnum'
-          x-added-in-version: "8.6"
         assignee:
           nullable: true
           description: The assignee of the user task.
           type: string
-          x-added-in-version: "8.6"
         elementId:
           description: The element ID of the user task.
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/ElementId'
-          x-added-in-version: "8.6"
         candidateGroups:
           type: array
           description: The candidate groups for this user task.
           items:
             type: string
-          x-added-in-version: "8.8"
         candidateUsers:
           type: array
           description: The candidate users for this user task.
           items:
             type: string
-          x-added-in-version: "8.8"
         processDefinitionId:
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/ProcessDefinitionId'
           description: The ID of the process definition.
-          x-added-in-version: "8.6"
         creationDate:
           type: string
           description: The creation date of a user task.
           format: date-time
-          x-added-in-version: "8.6"
         completionDate:
           description: The completion date of a user task.
           nullable: true
           type: string
           format: date-time
-          x-added-in-version: "8.6"
         followUpDate:
           description: The follow date of a user task.
           nullable: true
           type: string
           format: date-time
-          x-added-in-version: "8.6"
         dueDate:
           description: The due date of a user task.
           nullable: true
           type: string
           format: date-time
-          x-added-in-version: "8.6"
         tenantId:
           $ref: 'identifiers.yaml#/components/schemas/TenantId'
-          x-added-in-version: "8.8"
         externalFormReference:
           description: The external form reference.
           nullable: true
           type: string
-          x-added-in-version: "8.6"
         processDefinitionVersion:
           type: integer
           description: The version of the process definition.
           format: int32
-          x-added-in-version: "8.6"
         customHeaders:
           type: object
           description: Custom headers for the user task.
           additionalProperties:
             type: string
-          x-added-in-version: "8.6"
         priority:
           type: integer
           description: The priority of a user task. The higher the value the higher the priority.
           minimum: 0
           maximum: 100
           default: 50
-          x-added-in-version: "8.6"
         userTaskKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/UserTaskKey'
           description: The key of the user task.
-          x-added-in-version: "8.8"
         elementInstanceKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ElementInstanceKey'
           description: The key of the element instance.
-          x-added-in-version: "8.6"
         processName:
           type: string
           description: |
             The name of the process definition.
             This is `null` if the process has no name defined.
           nullable: true
-          x-added-in-version: "8.8"
         processDefinitionKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessDefinitionKey'
           description: The key of the process definition.
-          x-added-in-version: "8.6"
         processInstanceKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
           description: The key of the process instance.
-          x-added-in-version: "8.6"
         rootProcessInstanceKey:
           description: |
             The key of the root process instance. The root process instance is the top-level
@@ -741,16 +733,62 @@ components:
           nullable: true
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
-          x-added-in-version: "8.9"
         formKey:
           description: The key of the form.
           nullable: true
           allOf:
             - $ref: 'keys.yaml#/components/schemas/FormKey'
-          x-added-in-version: "8.6"
         tags:
           $ref: 'identifiers.yaml#/components/schemas/TagSet'
-          x-added-in-version: "8.9"
+      x-added-in-version:
+        - propertyName: name
+          addedInVersion: "8.8"
+        - propertyName: state
+          addedInVersion: "8.6"
+        - propertyName: assignee
+          addedInVersion: "8.6"
+        - propertyName: elementId
+          addedInVersion: "8.6"
+        - propertyName: candidateGroups
+          addedInVersion: "8.8"
+        - propertyName: candidateUsers
+          addedInVersion: "8.8"
+        - propertyName: processDefinitionId
+          addedInVersion: "8.6"
+        - propertyName: creationDate
+          addedInVersion: "8.6"
+        - propertyName: completionDate
+          addedInVersion: "8.6"
+        - propertyName: followUpDate
+          addedInVersion: "8.6"
+        - propertyName: dueDate
+          addedInVersion: "8.6"
+        - propertyName: tenantId
+          addedInVersion: "8.8"
+        - propertyName: externalFormReference
+          addedInVersion: "8.6"
+        - propertyName: processDefinitionVersion
+          addedInVersion: "8.6"
+        - propertyName: customHeaders
+          addedInVersion: "8.6"
+        - propertyName: priority
+          addedInVersion: "8.6"
+        - propertyName: userTaskKey
+          addedInVersion: "8.8"
+        - propertyName: elementInstanceKey
+          addedInVersion: "8.6"
+        - propertyName: processName
+          addedInVersion: "8.8"
+        - propertyName: processDefinitionKey
+          addedInVersion: "8.6"
+        - propertyName: processInstanceKey
+          addedInVersion: "8.6"
+        - propertyName: rootProcessInstanceKey
+          addedInVersion: "8.9"
+        - propertyName: formKey
+          addedInVersion: "8.6"
+        - propertyName: tags
+          addedInVersion: "8.9"
 
     UserTaskCompletionRequest:
       type: object
@@ -856,7 +894,9 @@ components:
           default: 50
           maximum: 100
           nullable: true
-          x-added-in-version: "8.6"
+      x-added-in-version:
+        - propertyName: priority
+          addedInVersion: "8.6"
 
     UserTaskVariableSearchQuerySortRequest:
       type: object
@@ -976,25 +1016,31 @@ components:
           description: Checks for equality with the provided value.
           allOf:
             - $ref: "#/components/schemas/UserTaskStateEnum"
-          x-added-in-version: "8.8"
         $neq:
           description: Checks for inequality with the provided value.
           allOf:
             - $ref: "#/components/schemas/UserTaskStateEnum"
-          x-added-in-version: "8.8"
         $exists:
           description: Checks if the current property exists.
           type: boolean
-          x-added-in-version: "8.8"
         $in:
           description: Checks if the property matches any of the provided values.
           type: array
           items:
             $ref: "#/components/schemas/UserTaskStateEnum"
-          x-added-in-version: "8.8"
         $like:
           $ref: "filters.yaml#/components/schemas/LikeFilter"
-          x-added-in-version: "8.8"
+      x-added-in-version:
+        - propertyName: "$eq"
+          addedInVersion: "8.8"
+        - propertyName: "$neq"
+          addedInVersion: "8.8"
+        - propertyName: "$exists"
+          addedInVersion: "8.8"
+        - propertyName: "$in"
+          addedInVersion: "8.8"
+        - propertyName: "$like"
+          addedInVersion: "8.8"
 
     UserTaskAuditLogFilter:
       description: The user task audit log search filters.

--- a/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
@@ -497,6 +497,7 @@ components:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/IntegerFilterProperty'
           description: The priority of the user task.
+          x-added-in-version: "8.8"
         elementId:
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/ElementId'
@@ -507,6 +508,7 @@ components:
           description: >
             The task name. This only works for data created with 8.8 and onwards.
             Instances from prior versions don't contain this data and cannot be found.
+          x-added-in-version: "8.8"
         candidateGroup:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
@@ -519,6 +521,7 @@ components:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
           description: Tenant ID of this user task.
+          x-added-in-version: "8.8"
         processDefinitionId:
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/ProcessDefinitionIdFilterProperty'
@@ -527,32 +530,39 @@ components:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/DateTimeFilterProperty'
           description: The user task creation date.
+          x-added-in-version: "8.8"
         completionDate:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/DateTimeFilterProperty'
           description: The user task completion date.
+          x-added-in-version: "8.8"
         followUpDate:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/DateTimeFilterProperty'
           description: The user task follow-up date.
+          x-added-in-version: "8.8"
         dueDate:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/DateTimeFilterProperty'
           description: The user task due date.
+          x-added-in-version: "8.8"
         processInstanceVariables:
           type: array
           description: The variables of the process instance.
           items:
             $ref: 'variables.yaml#/components/schemas/VariableValueFilterProperty'
+          x-added-in-version: "8.8"
         localVariables:
           type: array
           description: The local variables of the user task.
           items:
             $ref: 'variables.yaml#/components/schemas/VariableValueFilterProperty'
+          x-added-in-version: "8.8"
         userTaskKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/UserTaskKey'
           description: The key for this user task.
+          x-added-in-version: "8.8"
         processDefinitionKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessDefinitionKeyFilterProperty'
@@ -565,8 +575,10 @@ components:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ElementInstanceKey'
           description: The key of the element instance.
+          x-added-in-version: "8.8"
         tags:
           $ref: 'identifiers.yaml#/components/schemas/TagSet'
+          x-added-in-version: "8.9"
 
     UserTaskSearchQueryResult:
       description: User task search query response.
@@ -614,92 +626,113 @@ components:
           nullable: true
           type: string
           description: The name for this user task.
+          x-added-in-version: "8.8"
         state:
           $ref: '#/components/schemas/UserTaskStateEnum'
+          x-added-in-version: "8.6"
         assignee:
           nullable: true
           description: The assignee of the user task.
           type: string
+          x-added-in-version: "8.6"
         elementId:
           description: The element ID of the user task.
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/ElementId'
+          x-added-in-version: "8.6"
         candidateGroups:
           type: array
           description: The candidate groups for this user task.
           items:
             type: string
+          x-added-in-version: "8.8"
         candidateUsers:
           type: array
           description: The candidate users for this user task.
           items:
             type: string
+          x-added-in-version: "8.8"
         processDefinitionId:
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/ProcessDefinitionId'
           description: The ID of the process definition.
+          x-added-in-version: "8.6"
         creationDate:
           type: string
           description: The creation date of a user task.
           format: date-time
+          x-added-in-version: "8.6"
         completionDate:
           description: The completion date of a user task.
           nullable: true
           type: string
           format: date-time
+          x-added-in-version: "8.6"
         followUpDate:
           description: The follow date of a user task.
           nullable: true
           type: string
           format: date-time
+          x-added-in-version: "8.6"
         dueDate:
           description: The due date of a user task.
           nullable: true
           type: string
           format: date-time
+          x-added-in-version: "8.6"
         tenantId:
           $ref: 'identifiers.yaml#/components/schemas/TenantId'
+          x-added-in-version: "8.8"
         externalFormReference:
           description: The external form reference.
           nullable: true
           type: string
+          x-added-in-version: "8.6"
         processDefinitionVersion:
           type: integer
           description: The version of the process definition.
           format: int32
+          x-added-in-version: "8.6"
         customHeaders:
           type: object
           description: Custom headers for the user task.
           additionalProperties:
             type: string
+          x-added-in-version: "8.6"
         priority:
           type: integer
           description: The priority of a user task. The higher the value the higher the priority.
           minimum: 0
           maximum: 100
           default: 50
+          x-added-in-version: "8.6"
         userTaskKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/UserTaskKey'
           description: The key of the user task.
+          x-added-in-version: "8.8"
         elementInstanceKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ElementInstanceKey'
           description: The key of the element instance.
+          x-added-in-version: "8.6"
         processName:
           type: string
           description: |
             The name of the process definition.
             This is `null` if the process has no name defined.
           nullable: true
+          x-added-in-version: "8.8"
         processDefinitionKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessDefinitionKey'
           description: The key of the process definition.
+          x-added-in-version: "8.6"
         processInstanceKey:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
           description: The key of the process instance.
+          x-added-in-version: "8.6"
         rootProcessInstanceKey:
           description: |
             The key of the root process instance. The root process instance is the top-level
@@ -708,13 +741,16 @@ components:
           nullable: true
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
+          x-added-in-version: "8.9"
         formKey:
           description: The key of the form.
           nullable: true
           allOf:
             - $ref: 'keys.yaml#/components/schemas/FormKey'
+          x-added-in-version: "8.6"
         tags:
           $ref: 'identifiers.yaml#/components/schemas/TagSet'
+          x-added-in-version: "8.9"
 
     UserTaskCompletionRequest:
       type: object
@@ -820,6 +856,7 @@ components:
           default: 50
           maximum: 100
           nullable: true
+          x-added-in-version: "8.6"
 
     UserTaskVariableSearchQuerySortRequest:
       type: object
@@ -939,20 +976,25 @@ components:
           description: Checks for equality with the provided value.
           allOf:
             - $ref: "#/components/schemas/UserTaskStateEnum"
+          x-added-in-version: "8.8"
         $neq:
           description: Checks for inequality with the provided value.
           allOf:
             - $ref: "#/components/schemas/UserTaskStateEnum"
+          x-added-in-version: "8.8"
         $exists:
           description: Checks if the current property exists.
           type: boolean
+          x-added-in-version: "8.8"
         $in:
           description: Checks if the property matches any of the provided values.
           type: array
           items:
             $ref: "#/components/schemas/UserTaskStateEnum"
+          x-added-in-version: "8.8"
         $like:
           $ref: "filters.yaml#/components/schemas/LikeFilter"
+          x-added-in-version: "8.8"
 
     UserTaskAuditLogFilter:
       description: The user task audit log search filters.

--- a/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
@@ -567,7 +567,7 @@ components:
           description: The key of the element instance.
         tags:
           $ref: 'identifiers.yaml#/components/schemas/TagSet'
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: priority
           addedInVersion: "8.8"
         - propertyName: name
@@ -740,7 +740,7 @@ components:
             - $ref: 'keys.yaml#/components/schemas/FormKey'
         tags:
           $ref: 'identifiers.yaml#/components/schemas/TagSet'
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: name
           addedInVersion: "8.8"
         - propertyName: state
@@ -894,7 +894,7 @@ components:
           default: 50
           maximum: 100
           nullable: true
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: priority
           addedInVersion: "8.6"
 
@@ -1030,7 +1030,7 @@ components:
             $ref: "#/components/schemas/UserTaskStateEnum"
         $like:
           $ref: "filters.yaml#/components/schemas/LikeFilter"
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: "$eq"
           addedInVersion: "8.8"
         - propertyName: "$neq"

--- a/zeebe/gateway-protocol/src/main/proto/v2/variables.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/variables.yaml
@@ -255,7 +255,9 @@ components:
           nullable: true
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
-          x-added-in-version: "8.9"
+      x-added-in-version:
+        - propertyName: rootProcessInstanceKey
+          addedInVersion: "8.9"
 
     VariableValueFilterProperty:
       type: object

--- a/zeebe/gateway-protocol/src/main/proto/v2/variables.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/variables.yaml
@@ -255,7 +255,7 @@ components:
           nullable: true
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
-      x-added-in-version:
+      x-properties-added-in-version:
         - propertyName: rootProcessInstanceKey
           addedInVersion: "8.9"
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/variables.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/variables.yaml
@@ -255,6 +255,7 @@ components:
           nullable: true
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
+          x-added-in-version: "8.9"
 
     VariableValueFilterProperty:
       type: object


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
API changes between server versions have impacts on customer application migration, expected behavioural, and type-safety.

We want to communicate this explicitly and clearly in SDKs and in the API Documentation on docs.camunda.io.

In this step we added `x-properties-added-in-version ` to every property (response/request field) whose version doesn't match it's endpoint.

## Related issues
#46745
