### PR TITLE
backport: await first backup state

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupRangeTrackingIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupRangeTrackingIT.java
@@ -149,6 +149,14 @@ final class BackupRangeTrackingIT {
               }
             });
 
+    Awaitility.await()
+        .untilAsserted(
+            () ->
+                assertThat(actuator.state().getBackupStates())
+                    .describedAs("There should be backup state for partition 1")
+                    .extracting(PartitionBackupState::getPartitionId)
+                    .contains(1));
+
     final var lastBackupBeforeLeaderChange =
         actuator.state().getBackupStates().stream()
             .filter((final PartitionBackupState state) -> state.getPartitionId() == 1)


### PR DESCRIPTION
## Description

Backport of https://github.com/camunda/camunda/pull/52459

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
