### PR TITLE
feat: allow profiling duration to be overridden via env var

### DIFF
--- a/load-tests/docs/scripts/executeProfiling.sh
+++ b/load-tests/docs/scripts/executeProfiling.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -xeu
 # Usage:
 #  ./executeProfiling.sh <POD-NAME> [EVENT-TYPE] [DATABASE] [ADDITIONAL-OPTIONS]
+#  PROFILING_DURATION=200 ./executeProfiling.sh <POD-NAME> [EVENT-TYPE] [DATABASE] [ADDITIONAL-OPTIONS]
 #
 # EVENT-TYPE can be:
 #   cpu   - CPU profiling (default)
@@ -10,6 +11,9 @@
 #   elasticsearch (default), opensearch, postgresql, oracle, mysql, mssql, mariadb, none
 # ADDITIONAL-OPTIONS: Optional additional flags to pass to async-profiler (e.g., "-t" to profile threads separately)
 # See https://github.com/async-profiler/async-profiler/blob/master/docs/ProfilerOptions.md for potential options
+#
+# Environment variables:
+#   PROFILING_DURATION - profiling duration in seconds (default: 100)
 set -oxe pipefail
 
 if [ -z "$1" ]; then
@@ -87,7 +91,7 @@ fi
 PID=$(kubectl exec "$node" -- ps -ax | awk '$5 ~ /java/ {print $1}')
 
 # Run profiling
-kubectl exec "$node" -- ./data/asprof -e "$profiler_event" -d 100 -f "$containerPath/$filename" --libpath "$containerPath/libasyncProfiler.so" $additional_options "$PID"
+kubectl exec "$node" -- ./data/asprof -e "$profiler_event" -d "${PROFILING_DURATION:-100}" -f "$containerPath/$filename" --libpath "$containerPath/libasyncProfiler.so" $additional_options "$PID"
 
 # Copy result
 kubectl cp "$node:$containerPath/$filename" "$node-$filename"


### PR DESCRIPTION
## Description
Currently it was always 100, but it can be overridden via env var PROFILING_DURATION

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
