### PR TITLE
ci: tweak Renovate configs for internal NPM packages

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -599,6 +599,42 @@
         "dmn-js-shared"
       ],
       "minimumReleaseAge": "0 days"
+    },
+    {
+      "description": "Group bpmn-js related packages.",
+      "matchManagers": [
+        "npm"
+      ],
+      "matchPackageNames": [
+        "bpmn-js**",
+        "bpmn-moddle",
+        "@bpmn-io/element-template-icon-renderer",
+        "@bpmn-io/element-templates-icons-renderer"
+      ],
+      "groupName": "bpmn-js",
+      "groupSlug": "bpmn-js"
+    },
+    {
+      "description": "Group dmn-js related packages.",
+      "matchManagers": [
+        "npm"
+      ],
+      "matchPackageNames": [
+        "dmn-js**"
+      ],
+      "groupName": "dmn-js",
+      "groupSlug": "dmn-js"
+    },
+    {
+      "description": "Group form-js related packages.",
+      "matchManagers": [
+        "npm"
+      ],
+      "matchPackageNames": [
+        "@bpmn-io/form-js**"
+      ],
+      "groupName": "form-js",
+      "groupSlug": "form-js"
     }
   ],
   "dockerfile": {

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -583,6 +583,22 @@
       "matchPackageNames": ["*"],
       "minimumReleaseAge": "3 days",
       "internalChecksFilter": "strict"
+    },
+    {
+      "description": "Disable release cooldown for trusted first-party and bpmn-io ecosystem packages.",
+      "matchPackageNames": [
+        "@camunda{/,}**",
+        "@bpmn-io{/,}**",
+        "bpmn-js",
+        "bpmn-js-disable-collapsed-subprocess",
+        "bpmn-moddle",
+        "dmn-js",
+        "dmn-js-decision-table",
+        "dmn-js-drd",
+        "dmn-js-literal-expression",
+        "dmn-js-shared"
+      ],
+      "minimumReleaseAge": "0 days"
     }
   ],
   "dockerfile": {


### PR DESCRIPTION
## Description

On this PR I'm disabling the cool down for our internal NPM deps and and I group the `bpmn-js`, `dmn-js` and `form-js` package updates