### PR TITLE
feat: cut flaky-test gate false positives — lifecycle filter + broader baseline

### DIFF
--- a/.github/actions/detect-new-flaky-tests/README.md
+++ b/.github/actions/detect-new-flaky-tests/README.md
@@ -73,7 +73,7 @@ LEFT OUTER JOIN `ci-30-162810.prod_ci_analytics.build_status_v2` bs
   ON ts.ci_url = bs.ci_url AND ts.build_id = bs.build_id AND ts.job_name = bs.job_name
 WHERE ts.report_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 20 DAY)
   AND ts.ci_url = "https://github.com/camunda/camunda"
-  AND test_status = "flaky"
+  AND test_status IN ("flaky", "failure", "error")
   AND (
     (build_trigger = "merge_group"
       AND (build_base_ref = "refs/heads/main" OR build_base_ref LIKE "refs/heads/stable/%"))
@@ -81,19 +81,26 @@ WHERE ts.report_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 20 DAY)
     (build_trigger = "push"
       AND (build_ref = "refs/heads/main" OR build_ref LIKE "refs/heads/stable/%"))
     OR
+    (build_trigger = "schedule"
+      AND (build_ref = "refs/heads/main" OR build_ref LIKE "refs/heads/stable/%"))
+    OR
     (build_trigger = "pull_request"
       AND bs.build_ref != @pr_ref)
   )
 ```
 
-This returns every test that flaked at least once on `main`, `stable/*`, or
+This returns every test that produced an unreliable result (`flaky`,
+`failure`, or `error`) on `main`, `stable/*`, in nightly scheduled runs, or
 in any other pull request in the last 20 days. The 20-day window matches the
-range of clustered BigQuery data. PR runs are included so tests that flake
-mostly on PRs are still recognised, but the current PR's own observations are
-excluded so a new flake cannot launder itself across re-runs. The current
-PR's ref is supplied at query time via `bq query --parameter='pr_ref:STRING:refs/pull/<N>/merge'`
-(see the [workflow step](../../workflows/ci.yml)). The GCP service account key
-is fetched from Vault.
+range of clustered BigQuery data. The status filter is broad on purpose —
+`failure`/`error` rows on `main`/`stable/*` are just as much a signal of an
+unreliable test as `flaky`, and excluding them was causing false-positive
+alerts. PR runs are included so tests that flake mostly on PRs are still
+recognised, but the current PR's own observations are excluded so a new flake
+cannot launder itself across re-runs. The current PR's ref is supplied at
+query time via `bq query --parameter='pr_ref:STRING:refs/pull/<N>/merge'`
+(see the [workflow step](../../workflows/ci.yml)). The GCP service account
+key is fetched from Vault.
 
 ## Processing Steps
 
@@ -114,6 +121,13 @@ io.camunda.it.rdbms.db.processinstance.ProcessInstanceIT.shouldSelectRootExpired
 ```
 
 If the same test appears in multiple jobs, it's deduplicated (jobs are merged).
+
+JUnit lifecycle entries (`<beforeAll>`, `<afterAll>`, `<beforeEach>`,
+`<afterEach>`) are dropped at this stage. They represent class-level setup
+or teardown failures, not test methods, and BigQuery never records them, so
+comparing them against the baseline produces guaranteed false-positive
+alerts. A setup failure already fails the job through the normal path; the
+new-flaky gate has nothing useful to add for it.
 
 ### Step 2: Parse baseline flaky tests
 
@@ -261,10 +275,11 @@ bq query --project_id=ci-30-162810 --use_legacy_sql=false --format=json \
      ON ts.ci_url=bs.ci_url AND ts.build_id=bs.build_id AND ts.job_name=bs.job_name
    WHERE ts.report_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 20 DAY)
      AND ts.ci_url="https://github.com/camunda/camunda"
-     AND test_status = "flaky"
+     AND test_status IN ("flaky","failure","error")
      AND (
        (build_trigger="merge_group" AND (build_base_ref="refs/heads/main" OR build_base_ref LIKE "refs/heads/stable/%"))
        OR (build_trigger="push" AND (build_ref="refs/heads/main" OR build_ref LIKE "refs/heads/stable/%"))
+       OR (build_trigger="schedule" AND (build_ref="refs/heads/main" OR build_ref LIKE "refs/heads/stable/%"))
        OR (build_trigger="pull_request" AND bs.build_ref != @pr_ref)
      )' 2>/dev/null > /tmp/known-flaky-tests.json
 

--- a/.github/actions/detect-new-flaky-tests/README.md
+++ b/.github/actions/detect-new-flaky-tests/README.md
@@ -85,7 +85,7 @@ WHERE ts.report_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 20 DAY)
       AND (build_ref = "refs/heads/main" OR build_ref LIKE "refs/heads/stable/%"))
     OR
     (build_trigger = "pull_request"
-      AND bs.build_ref != @pr_ref)
+      AND (bs.build_ref IS NULL OR bs.build_ref != @pr_ref))
   )
 ```
 
@@ -280,7 +280,7 @@ bq query --project_id=ci-30-162810 --use_legacy_sql=false --format=json \
        (build_trigger="merge_group" AND (build_base_ref="refs/heads/main" OR build_base_ref LIKE "refs/heads/stable/%"))
        OR (build_trigger="push" AND (build_ref="refs/heads/main" OR build_ref LIKE "refs/heads/stable/%"))
        OR (build_trigger="schedule" AND (build_ref="refs/heads/main" OR build_ref LIKE "refs/heads/stable/%"))
-       OR (build_trigger="pull_request" AND bs.build_ref != @pr_ref)
+       OR (build_trigger="pull_request" AND (bs.build_ref IS NULL OR bs.build_ref != @pr_ref))
      )' 2>/dev/null > /tmp/known-flaky-tests.json
 
 # 2. Simulate PR flaky test data

--- a/.github/actions/detect-new-flaky-tests/detect_new_flaky_tests.py
+++ b/.github/actions/detect-new-flaky-tests/detect_new_flaky_tests.py
@@ -25,27 +25,24 @@ PREFIX = "[new-flaky]"
 
 
 # ---------------------------------------------------------------------------
-# Test‑name helpers (mirror the JS helpers in flaky-tests-summary-comment)
+# Test-name helpers (mirrors parseTestName in flaky-tests-summary-comment/src/helpers.js)
+# Keep both in sync when changing parsing logic.
 # ---------------------------------------------------------------------------
 
 def parse_test_name(test_name: str) -> dict:
     """Parse a fully-qualified test name into package, class, and method."""
-    # Strip trailing (params)[index] suffixes before locating the class/method
-    # split. JUnit @ParameterizedTest display names can embed dots inside [...]
-    # (e.g. "[1: RaftRule with 4 nodes.]"), which would mislead rfind(".") into
-    # treating the bracketed dot as the package separator.
-    bare = re.sub(r"(\([^)]*\))?(\[[^\]]*\])?\s*$", "", test_name)
+    # Strip trailing [index] and (params) from the full FQN *before* splitting
+    # so that dots inside display-name brackets (e.g. "[1: Rule with 4 nodes.]")
+    # don't confuse rfind(".") and produce a wrong package/class/method split.
+    bare = re.sub(r"\[.*?]\s*$", "", test_name.strip()).strip()
+    bare = re.sub(r"\(.*?\)\s*$", "", bare).strip()
+
     last_dot = bare.rfind(".")
     if last_dot == -1:
         return {"fullName": test_name.strip()}
 
-    fully_qualified_class = test_name[:last_dot]
-    method_name = test_name[last_dot + 1 :]
-
-    # Remove trailing [index]
-    method_name = re.sub(r"\[.*?]\s*$", "", method_name)
-    # Remove parameter list
-    method_name = re.sub(r"\(.*?\)\s*$", "", method_name).strip()
+    fully_qualified_class = bare[:last_dot]
+    method_name = bare[last_dot + 1:].strip()
 
     class_parts = fully_qualified_class.split(".")
     class_name = class_parts[-1]

--- a/.github/actions/detect-new-flaky-tests/detect_new_flaky_tests.py
+++ b/.github/actions/detect-new-flaky-tests/detect_new_flaky_tests.py
@@ -30,7 +30,12 @@ PREFIX = "[new-flaky]"
 
 def parse_test_name(test_name: str) -> dict:
     """Parse a fully-qualified test name into package, class, and method."""
-    last_dot = test_name.rfind(".")
+    # Strip trailing (params)[index] suffixes before locating the class/method
+    # split. JUnit @ParameterizedTest display names can embed dots inside [...]
+    # (e.g. "[1: RaftRule with 4 nodes.]"), which would mislead rfind(".") into
+    # treating the bracketed dot as the package separator.
+    bare = re.sub(r"(\([^)]*\))?(\[[^\]]*\])?\s*$", "", test_name)
+    last_dot = bare.rfind(".")
     if last_dot == -1:
         return {"fullName": test_name.strip()}
 

--- a/.github/actions/detect-new-flaky-tests/detect_new_flaky_tests.py
+++ b/.github/actions/detect-new-flaky-tests/detect_new_flaky_tests.py
@@ -83,6 +83,14 @@ def process_flaky_tests_data(raw_data: list) -> list:
 
         for test_name in test_names:
             parsed = parse_test_name(test_name)
+            # Skip JUnit lifecycle entries like <beforeAll>, <afterAll>, <beforeEach>,
+            # <afterEach>. These are class-level setup/teardown failures, not test
+            # methods. BigQuery never records them, so the baseline can't match —
+            # treating them as test methods produces guaranteed false-positive alerts.
+            method = parsed.get("methodName", "")
+            if method.startswith("<") and method.endswith(">"):
+                print(f'{PREFIX} Skipping lifecycle entry "{test_name}" (job="{job}") — not a test method')
+                continue
             key = get_test_key(parsed)
             if key in test_map:
                 existing = test_map[key]

--- a/.github/actions/flaky-tests-summary-comment/src/helpers.js
+++ b/.github/actions/flaky-tests-summary-comment/src/helpers.js
@@ -1,5 +1,13 @@
 function parseTestName(testName) {
-  const lastDotIndex = testName.lastIndexOf('.');
+  // Strip trailing [index] and (params) from the full FQN *before* splitting
+  // so that dots inside display-name brackets (e.g. "[1: Rule with 4 nodes.]")
+  // don't confuse lastIndexOf and produce a wrong package/class/method split.
+  const bare = testName.trim()
+    .replace(/\[.*?]\s*$/, '')
+    .replace(/\(.*?\)\s*$/, '')
+    .trim();
+
+  const lastDotIndex = bare.lastIndexOf('.');
 
   if (lastDotIndex === -1) {
     console.warn(`[flaky-tests] Could not parse test name: ${testName}`);
@@ -8,14 +16,8 @@ function parseTestName(testName) {
     };
   }
 
-  const fullyQualifiedClass = testName.slice(0, lastDotIndex);
-  let methodName = testName.slice(lastDotIndex + 1);
-
-  // Remove trailing [index] if it exists
-  methodName = methodName.replace(/\[.*?]\s*$/, '');
-
-  // Remove parameter list if it exists
-  methodName = methodName.replace(/\(.*?\)\s*$/, '').trim();
+  const fullyQualifiedClass = bare.slice(0, lastDotIndex);
+  const methodName = bare.slice(lastDotIndex + 1).trim();
 
   const classParts = fullyQualifiedClass.split('.');
   const className = classParts[classParts.length - 1];

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1321,7 +1321,16 @@ jobs:
 
   detect-new-flaky-tests:
     name: detect new flaky tests
-    if: always() && github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
+    # Skip backport PRs: code already gated on main, re-checking adds noise.
+    # Two conditions cover both automated (monorepo-devops-automation[bot]) and
+    # manually-named (backport-* / backport/*) backports. Direct fixes on
+    # stable/* branches by humans still run the gate.
+    if: >-
+      always()
+      && github.event_name == 'pull_request'
+      && !github.event.pull_request.head.repo.fork
+      && !startsWith(github.head_ref, 'backport')
+      && github.event.pull_request.user.login != 'monorepo-devops-automation[bot]'
     needs:
       - detect-changes
       - archunit-tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1464,10 +1464,11 @@ jobs:
                ON ts.ci_url=bs.ci_url AND ts.build_id=bs.build_id AND ts.job_name=bs.job_name
              WHERE ts.report_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 20 DAY)
                AND ts.ci_url="https://github.com/camunda/camunda"
-               AND test_status = "flaky"
+               AND test_status IN ("flaky","failure","error")
                AND (
                  (build_trigger="merge_group" AND (build_base_ref="refs/heads/main" OR build_base_ref LIKE "refs/heads/stable/%"))
                  OR (build_trigger="push" AND (build_ref="refs/heads/main" OR build_ref LIKE "refs/heads/stable/%"))
+                 OR (build_trigger="schedule" AND (build_ref="refs/heads/main" OR build_ref LIKE "refs/heads/stable/%"))
                  OR (build_trigger="pull_request" AND bs.build_ref != @pr_ref)
                )' > "$RUNNER_TEMP/known-flaky-tests.json"
           echo "known_flaky_tests_file=$RUNNER_TEMP/known-flaky-tests.json" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1478,7 +1478,7 @@ jobs:
                  (build_trigger="merge_group" AND (build_base_ref="refs/heads/main" OR build_base_ref LIKE "refs/heads/stable/%"))
                  OR (build_trigger="push" AND (build_ref="refs/heads/main" OR build_ref LIKE "refs/heads/stable/%"))
                  OR (build_trigger="schedule" AND (build_ref="refs/heads/main" OR build_ref LIKE "refs/heads/stable/%"))
-                 OR (build_trigger="pull_request" AND bs.build_ref != @pr_ref)
+                 OR (build_trigger="pull_request" AND (bs.build_ref IS NULL OR bs.build_ref != @pr_ref))
                )' > "$RUNNER_TEMP/known-flaky-tests.json"
           echo "known_flaky_tests_file=$RUNNER_TEMP/known-flaky-tests.json" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Context

Follow-up to #52685 (already merged on main). Baseline for this PR: main already has the 20-day window, PR runs in baseline, and self-laundering exclusion from #52685.

**Intended for backport to stable/8.9** (which still has the original #50691 gate — 14-day window, `flaky`-only status, no PR runs). A combined backport will be needed.

## What the analysis showed

Post-#52685 analysis — main-targeting PRs only, 5 alerts fired after #52685 merged:

| PR | Test | Root cause | Fixed by |
|---|---|---|---|
| [#52822](https://github.com/camunda/camunda/pull/52822#issuecomment-4423118593) | `S3RestoreAcceptanceIT.shouldRunRestore` | `push:flaky=1` was 48d ago (>20d window). PR `error` rows in window but status filter missed them. | This PR — status filter |
| [#52298](https://github.com/camunda/camunda/pull/52298#issuecomment-4434129396) | `FailOverReplicationTest.shouldNotReceiveEntriesOnDisconnect` | `push:flaky=1` was 28d ago. `schedule:flaky=1` was 8d ago — inside window but trigger excluded. | This PR — schedule trigger |
| [#52326](https://github.com/camunda/camunda/pull/52326#issuecomment-4427388630) | `AssignMappingToGroupTest.shouldRejectIfEmptyGroupId` | Only `flaky` row was the current PR's own run (excluded by `@pr_ref`). All prior rows were `error` — not counted. | This PR — status filter |
| [#48963](https://github.com/camunda/camunda/pull/48963#issuecomment-4441158801) | `AssignUserTaskTest.shouldAssignUserTaskWithAssigneeWithImplicitAllowOverride` | Same: `flaky=1` was self (excluded), all others `error`. | This PR — status filter |
| [#41993](https://github.com/camunda/camunda/pull/41993#issuecomment-4439278026) | `RaftFailOverIT.shouldReplicateSnapshotMultipleTimesAfterMultipleDataLoss[1: RaftRule with 4 nodes.]` | Parser bug: `.` inside `[...]` display name breaks `rfind(".")` class/method split. | This PR — parser fix |

**0 genuine new flakes detected in analysis window. All 5 false positives resolved by this PR.**

## Changes

### 1. Drop JUnit lifecycle entries (`<beforeAll>`, `<afterAll>`, `<beforeEach>`, `<afterEach>`)

`process_flaky_tests_data` skips entries whose `methodName` starts with `<` and ends with `>`. BigQuery has zero rows with `test_name` starting with `<` — confirmed empirically. Every lifecycle entry is a guaranteed false positive. Setup failures already surface through normal job failure.

Eliminates 6/45 alerts (13%) observed across the full 10-day window.

### 2. Broaden baseline status filter — `flaky` → (`flaky`, `failure`, `error`)

The `@pr_ref` self-laundering exclusion means a test's only `flaky` row is often the current PR itself (excluded). All prior observations on other PRs are frequently `error` — now counted. Also catches tests that `error`/`failure` on main but never reach the `flaky` retry path. Confirmed root cause of 3/5 post-#52685 false positives.

### 3. Add `schedule` trigger to baseline

Nightly scheduled runs on `main`/`stable/*` produce flake signal previously silently dropped. Confirmed root cause of 1/5 post-#52685 false positives (`FailOverReplicationTest` had `schedule:flaky=1` at 8 days, inside the 20-day window but excluded).

### 4. Skip gate for backport PRs

Backport PRs carry code already gated on main. Re-checking adds noise with zero value. Two conditions cover all observed patterns:
- `!startsWith(github.head_ref, 'backport')` — catches `backport-*` and `backport/*` naming
- `github.event.pull_request.user.login != 'monorepo-devops-automation[bot]'` — catches bot-opened backports regardless of branch name

Direct stable/* fixes by humans (non-backport branch, human author) still run the gate.

### 5. Fix `parse_test_name` for dots inside `[...]` display names

JUnit `@ParameterizedTest` display names can contain dots inside `[...]` (e.g. `[1: RaftRule with 4 nodes.]`). The old `rfind(".")` found the trailing dot inside the bracket instead of the package separator, producing a malformed class/method split:
- class → `io.atomix.raft.RaftFailOverIT.shouldReplicate...[1: RaftRule with 4 nodes`
- method → `]`

Baseline lookup with that key always returned empty → guaranteed false positive.

Fix: strip trailing `(params)[index]` suffixes from the full input into a `bare` string before `rfind(".")`, so the split always lands on the real package-class boundary.

### 6. Fix NULL semantics in `pull_request` baseline predicate

With `LEFT OUTER JOIN`, when `build_status_v2` has no matching row for a test run, `bs.build_ref` is `NULL`. The predicate `bs.build_ref != @pr_ref` evaluates to `NULL` (not `TRUE`) — silently excluding those test runs from the baseline. Fixed to `(bs.build_ref IS NULL OR bs.build_ref != @pr_ref)` so unmatched rows are retained. Applied in `ci.yml` and both README SQL examples.

## Coverage change

| | Known-flaky baseline | GB billed |
|---|---|---|
| Before this PR (main with #52685) | 437 | 11.67 |
| After this PR | **8 347** (19×) | 12.20 (~5%) |

## Backport note

`stable/8.9` still has the original #50691 gate (14-day window, `flaky`-only, no PR runs, no `@pr_ref`). A backport needs changes from both #52685 and this PR combined, since this PR's diff is on top of #52685's already-merged baseline.

## Test plan

- [ ] CI runs updated baseline query without errors
- [ ] PR with a lifecycle failure in surefire output logs `Skipping lifecycle entry ... — not a test method`, no alert posted for it
- [ ] Previously-flagged test (e.g. `S3RestoreAcceptanceIT.shouldRunRestore`) now found in baseline and not alerted
- [ ] Automated backport PR opened by `monorepo-devops-automation[bot]` skips the gate entirely
- [ ] Test name `shouldReplicate...[1: RaftRule with 4 nodes.]` parses correctly: class=`RaftFailOverIT`, method=`shouldReplicateSnapshotMultipleTimesAfterMultipleDataLoss`

Related: #50691 (gate) · #52685 (20d window + PR inclusion) · camunda/infra-core#12398 (clustering)