### PR TITLE
refactor: add auth fixture

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/fixtures.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/fixtures.ts
@@ -79,7 +79,7 @@ type PlaywrightFixtures = {
   suppressHelperModals: void;
 };
 
-const test = base.extend<PlaywrightFixtures>({
+const publicTest = base.extend<PlaywrightFixtures>({
   suppressHelperModals: [
     async ({page}, use) => {
       await page.addInitScript(() => {
@@ -217,7 +217,7 @@ type AuthWorkerFixtures = {
   loginState: {cookies: Cookie[]; csrfToken: string};
 };
 
-const authedTest = test.extend<NonNullable<unknown>, AuthWorkerFixtures>({
+const test = publicTest.extend<NonNullable<unknown>, AuthWorkerFixtures>({
   loginUser: [
     {
       username: process.env.TEST_USERNAME ?? 'demo',
@@ -250,4 +250,4 @@ const authedTest = test.extend<NonNullable<unknown>, AuthWorkerFixtures>({
   },
 });
 
-export {test, authedTest};
+export {test, publicTest};

--- a/qa/c8-orchestration-cluster-e2e-test-suite/fixtures.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/fixtures.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {test as base} from '@playwright/test';
+import {test as base, type Cookie} from '@playwright/test';
 import AxeBuilder from '@axe-core/playwright';
 import {OperateHomePage} from '@pages/OperateHomePage';
 import {TaskPanelPage} from '@pages/TaskPanelPage';
@@ -212,4 +212,42 @@ const test = base.extend<PlaywrightFixtures>({
   },
 });
 
-export {test};
+type AuthWorkerFixtures = {
+  loginUser: {username: string; password: string};
+  loginState: {cookies: Cookie[]; csrfToken: string};
+};
+
+const authedTest = test.extend<NonNullable<unknown>, AuthWorkerFixtures>({
+  loginUser: [
+    {
+      username: process.env.TEST_USERNAME ?? 'demo',
+      password: process.env.TEST_PASSWORD ?? 'demo',
+    },
+    {scope: 'worker'},
+  ],
+  loginState: [
+    async ({browser, loginUser}, use) => {
+      const baseURL =
+        process.env.CORE_APPLICATION_URL ?? 'http://localhost:8080';
+      const context = await browser.newContext();
+      const response = await context.request.post(`${baseURL}/login`, {
+        form: loginUser,
+      });
+      const csrfToken = response.headers()['x-csrf-token'] ?? '';
+      const cookies = await context.cookies();
+      await context.close();
+      await use({cookies, csrfToken});
+    },
+    {scope: 'worker'},
+  ],
+  page: async ({context, loginState}, use) => {
+    await context.addCookies(loginState.cookies);
+    await context.addInitScript((csrfToken) => {
+      sessionStorage.setItem('X-CSRF-TOKEN', csrfToken);
+    }, loginState.csrfToken);
+    const page = await context.newPage();
+    await use(page);
+  },
+});
+
+export {test, authedTest};

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/UtilitiesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/UtilitiesPage.ts
@@ -31,6 +31,15 @@ export async function navigateToApp(
   }
 }
 
+export async function navigateToAppHome(
+  page: Page,
+  appName: string,
+): Promise<void> {
+  await page.goto(
+    `${process.env.CORE_APPLICATION_URL}/${appName.toLowerCase()}/`,
+  );
+}
+
 export async function hideHelperModals(page: Page): Promise<void> {
   await page.addInitScript(() => {
     window.localStorage.setItem(

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/hto-user-flows.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/hto-user-flows.spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {expect} from '@playwright/test';
-import {test} from 'fixtures';
+import {publicTest as test} from 'fixtures';
 import {createInstances, deploy} from 'utils/zeebeClient';
 import {completeTaskWithRetry, navigateToApp} from '@pages/UtilitiesPage';
 import {sleep} from 'utils/sleep';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/identity-users-flows.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/identity-users-flows.spec.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {test} from 'fixtures';
+import {publicTest as test} from 'fixtures';
 import {expect} from '@playwright/test';
 import {captureScreenshot, captureFailureVideo} from '@setup';
 import {relativizePath, Paths} from 'utils/relativizePath';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/login.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/login.spec.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {test} from '@fixtures';
+import {publicTest as test} from '@fixtures';
 import {navigateToApp} from '@pages/UtilitiesPage';
 import {expect} from '@playwright/test';
 import {captureScreenshot, captureFailureVideo} from '@setup';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/audit-log.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/audit-log.spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {expect} from '@playwright/test';
-import {test} from 'fixtures';
+import {publicTest as test} from 'fixtures';
 import {relativizePath, Paths} from 'utils/relativizePath';
 import {navigateToApp} from '@pages/UtilitiesPage';
 import {captureScreenshot, captureFailureVideo} from '@setup';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/authorizations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/authorizations.spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {expect} from '@playwright/test';
-import {test} from 'fixtures';
+import {publicTest as test} from 'fixtures';
 import {
   LOGIN_CREDENTIALS,
   createTestData,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/create-new-user.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/create-new-user.spec.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {test} from 'fixtures';
+import {publicTest as test} from 'fixtures';
 import {navigateToApp} from '@pages/UtilitiesPage';
 import {expect} from '@playwright/test';
 import {captureScreenshot, captureFailureVideo} from '@setup';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/global-task-listeners.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/global-task-listeners.spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {expect} from '@playwright/test';
-import {test} from 'fixtures';
+import {publicTest as test} from 'fixtures';
 import {relativizePath, Paths} from 'utils/relativizePath';
 import {navigateToApp} from '@pages/UtilitiesPage';
 import {captureScreenshot, captureFailureVideo} from '@setup';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/groups.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/groups.spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {expect} from '@playwright/test';
-import {test} from 'fixtures';
+import {publicTest as test} from 'fixtures';
 import {relativizePath, Paths} from 'utils/relativizePath';
 import {navigateToApp} from '@pages/UtilitiesPage';
 import {captureScreenshot, captureFailureVideo} from '@setup';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/login.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/login.spec.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {test} from 'fixtures';
+import {publicTest as test} from 'fixtures';
 import {navigateToApp} from '@pages/UtilitiesPage';
 import {expect} from '@playwright/test';
 import {captureScreenshot, captureFailureVideo} from '@setup';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/mapping-rules.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/mapping-rules.spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {expect} from '@playwright/test';
-import {test} from 'fixtures';
+import {publicTest as test} from 'fixtures';
 import {relativizePath, Paths} from 'utils/relativizePath';
 import {navigateToApp} from '@pages/UtilitiesPage';
 import {captureScreenshot, captureFailureVideo} from '@setup';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/mcp-processes.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/mcp-processes.spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {expect} from '@playwright/test';
-import {test} from 'fixtures';
+import {publicTest as test} from 'fixtures';
 import {deploy} from 'utils/zeebeClient';
 import {relativizePath, Paths} from 'utils/relativizePath';
 import {navigateToApp} from '@pages/UtilitiesPage';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/roles.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/roles.spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {expect} from '@playwright/test';
-import {test} from 'fixtures';
+import {publicTest as test} from 'fixtures';
 import {relativizePath, Paths} from 'utils/relativizePath';
 import {LOGIN_CREDENTIALS, createTestData} from 'utils/constants';
 import {navigateToApp} from '@pages/UtilitiesPage';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/tenants.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/tenants.spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {expect} from '@playwright/test';
-import {test} from 'fixtures';
+import {publicTest as test} from 'fixtures';
 import {LOGIN_CREDENTIALS, createTestData} from 'utils/constants';
 import {navigateToApp} from '@pages/UtilitiesPage';
 import {waitForItemInList} from 'utils/waitForItemInList';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/users.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/users.spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {expect} from '@playwright/test';
-import {test} from 'fixtures';
+import {publicTest as test} from 'fixtures';
 import {relativizePath, Paths} from 'utils/relativizePath';
 import {LOGIN_CREDENTIALS, createTestData} from 'utils/constants';
 import {waitForItemInList} from 'utils/waitForItemInList';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/auditLog.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/auditLog.spec.ts
@@ -6,10 +6,10 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {test} from 'fixtures';
+import {authedTest as test} from 'fixtures';
 import {expect} from '@playwright/test';
 import {deploy, createSingleInstance} from 'utils/zeebeClient';
-import {navigateToApp} from '@pages/UtilitiesPage';
+import {navigateToAppHome} from '@pages/UtilitiesPage';
 import {captureScreenshot, captureFailureVideo} from '@setup';
 import {waitForProcessInstances} from 'utils/incidentsHelper';
 
@@ -36,9 +36,8 @@ test.beforeAll(async ({request}) => {
 });
 
 test.describe('Audit Log (Operations Log)', () => {
-  test.beforeEach(async ({page, loginPage, operateHomePage}) => {
-    await navigateToApp(page, 'operate');
-    await loginPage.login('demo', 'demo');
+  test.beforeEach(async ({page, operateHomePage}) => {
+    await navigateToAppHome(page, 'operate');
     await expect(operateHomePage.operateBanner).toBeVisible();
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/auditLog.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/auditLog.spec.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {authedTest as test} from 'fixtures';
+import {test} from 'fixtures';
 import {expect} from '@playwright/test';
 import {deploy, createSingleInstance} from 'utils/zeebeClient';
 import {navigateToAppHome} from '@pages/UtilitiesPage';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/batchMoveModification.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/batchMoveModification.spec.ts
@@ -6,12 +6,12 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {test} from '@fixtures';
+import {authedTest as test} from '@fixtures';
 import {expect} from '@playwright/test';
 import {deploy, createInstances} from 'utils/zeebeClient';
 import {captureScreenshot, captureFailureVideo} from '@setup';
 import {
-  navigateToApp,
+  navigateToAppHome,
   hideHelperModals,
   gotoProcessesPage,
 } from '@pages/UtilitiesPage';
@@ -30,9 +30,8 @@ test.beforeAll(async () => {
 });
 
 test.describe('Process Instance Batch Modification', () => {
-  test.beforeEach(async ({page, loginPage, operateHomePage}) => {
-    await navigateToApp(page, 'operate');
-    await loginPage.login('demo', 'demo');
+  test.beforeEach(async ({page, operateHomePage}) => {
+    await navigateToAppHome(page, 'operate');
     await expect(operateHomePage.operateBanner).toBeVisible();
     await hideHelperModals(page);
   });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/batchMoveModification.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/batchMoveModification.spec.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {authedTest as test} from '@fixtures';
+import {test} from '@fixtures';
 import {expect} from '@playwright/test';
 import {deploy, createInstances} from 'utils/zeebeClient';
 import {captureScreenshot, captureFailureVideo} from '@setup';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/batchOperations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/batchOperations.spec.ts
@@ -6,11 +6,11 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {test} from 'fixtures';
+import {authedTest as test} from 'fixtures';
 import {expect} from '@playwright/test';
 import {deploy} from 'utils/zeebeClient';
 import {captureScreenshot, captureFailureVideo} from '@setup';
-import {navigateToApp} from '@pages/UtilitiesPage';
+import {navigateToAppHome} from '@pages/UtilitiesPage';
 import {
   createCancellationBatch,
   expectBatchState,
@@ -28,9 +28,8 @@ test.beforeAll(async () => {
 });
 
 test.describe('Batch Operations', () => {
-  test.beforeEach(async ({page, loginPage, operateHomePage}) => {
-    await navigateToApp(page, 'operate');
-    await loginPage.login('demo', 'demo');
+  test.beforeEach(async ({page, operateHomePage}) => {
+    await navigateToAppHome(page, 'operate');
     await expect(operateHomePage.operateBanner).toBeVisible();
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/batchOperations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/batchOperations.spec.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {authedTest as test} from 'fixtures';
+import {test} from 'fixtures';
 import {expect} from '@playwright/test';
 import {deploy} from 'utils/zeebeClient';
 import {captureScreenshot, captureFailureVideo} from '@setup';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/callActivities.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/callActivities.spec.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {authedTest as test} from 'fixtures';
+import {test} from 'fixtures';
 import {expect} from '@playwright/test';
 import {deploy, createSingleInstance} from 'utils/zeebeClient';
 import {captureScreenshot, captureFailureVideo} from '@setup';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/callActivities.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/callActivities.spec.ts
@@ -6,11 +6,11 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {test} from 'fixtures';
+import {authedTest as test} from 'fixtures';
 import {expect} from '@playwright/test';
 import {deploy, createSingleInstance} from 'utils/zeebeClient';
 import {captureScreenshot, captureFailureVideo} from '@setup';
-import {navigateToApp} from '@pages/UtilitiesPage';
+import {navigateToAppHome} from '@pages/UtilitiesPage';
 import {sleep} from 'utils/sleep';
 
 type ProcessDeployment = {
@@ -36,9 +36,8 @@ test.beforeAll(async () => {
 test.describe('Call Activities', () => {
   test.describe.configure({retries: 0});
 
-  test.beforeEach(async ({page, loginPage, operateHomePage}) => {
-    await navigateToApp(page, 'operate');
-    await loginPage.login('demo', 'demo');
+  test.beforeEach(async ({page, operateHomePage}) => {
+    await navigateToAppHome(page, 'operate');
     await expect(operateHomePage.operateBanner).toBeVisible();
     await operateHomePage.clickProcessesTab();
   });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/childProcessInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/childProcessInstanceMigration.spec.ts
@@ -6,11 +6,11 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {test} from 'fixtures';
+import {authedTest as test} from 'fixtures';
 import {expect} from '@playwright/test';
 import {deploy, createInstances} from 'utils/zeebeClient';
 import {captureScreenshot, captureFailureVideo} from '@setup';
-import {navigateToApp} from '@pages/UtilitiesPage';
+import {navigateToAppHome} from '@pages/UtilitiesPage';
 import {sleep} from 'utils/sleep';
 import {waitForAssertion} from 'utils/waitForAssertion';
 import {ProcessDeployment as ProcessDeploymentDTO} from '@camunda8/sdk/dist/c8/lib/C8Dto';
@@ -93,9 +93,8 @@ test.beforeAll(async () => {
 });
 
 test.describe('Child Process Instance Migration', () => {
-  test.beforeEach(async ({page, loginPage, operateHomePage}) => {
-    await navigateToApp(page, 'operate');
-    await loginPage.login('demo', 'demo');
+  test.beforeEach(async ({page, operateHomePage}) => {
+    await navigateToAppHome(page, 'operate');
     await expect(operateHomePage.operateBanner).toBeVisible();
     await operateHomePage.clickProcessesTab();
   });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/childProcessInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/childProcessInstanceMigration.spec.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {authedTest as test} from 'fixtures';
+import {test} from 'fixtures';
 import {expect} from '@playwright/test';
 import {deploy, createInstances} from 'utils/zeebeClient';
 import {captureScreenshot, captureFailureVideo} from '@setup';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/dashboard.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/dashboard.spec.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {test} from 'fixtures';
+import {authedTest as test} from 'fixtures';
 import {expect} from '@playwright/test';
 import {
   deploy,
@@ -15,7 +15,7 @@ import {
   createWorker,
 } from 'utils/zeebeClient';
 import {waitForProcessInstances} from 'utils/incidentsHelper';
-import {navigateToApp} from '@pages/UtilitiesPage';
+import {navigateToAppHome} from '@pages/UtilitiesPage';
 import {captureScreenshot, captureFailureVideo} from '@setup';
 import {waitForAssertion} from '../../utils/waitForAssertion';
 import {defaultAssertionOptions} from '../../utils/constants';
@@ -80,9 +80,8 @@ test.beforeAll(async ({request}) => {
   await waitForProcessInstances(request, instanceIds, 50);
 });
 
-test.beforeEach(async ({page, loginPage, operateHomePage}) => {
-  await navigateToApp(page, 'operate');
-  await loginPage.login('demo', 'demo');
+test.beforeEach(async ({page, operateHomePage}) => {
+  await navigateToAppHome(page, 'operate');
   await expect(operateHomePage.operateBanner).toBeVisible();
 });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/dashboard.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/dashboard.spec.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {authedTest as test} from 'fixtures';
+import {test} from 'fixtures';
 import {expect} from '@playwright/test';
 import {
   deploy,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionInstances.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionInstances.spec.ts
@@ -6,11 +6,11 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {test} from 'fixtures';
+import {authedTest as test} from 'fixtures';
 import {expect} from '@playwright/test';
 import {captureScreenshot, captureFailureVideo} from '@setup';
 import {deploy} from 'utils/zeebeClient';
-import {navigateToApp} from '@pages/UtilitiesPage';
+import {navigateToAppHome} from '@pages/UtilitiesPage';
 import {sleep} from 'utils/sleep';
 
 interface DecisionInfo {
@@ -51,9 +51,8 @@ test.describe('Decision Instances', () => {
     await sleep(2000);
   });
 
-  test.beforeEach(async ({page, loginPage, operateHomePage}) => {
-    await navigateToApp(page, 'operate');
-    await loginPage.login('demo', 'demo');
+  test.beforeEach(async ({page, operateHomePage}) => {
+    await navigateToAppHome(page, 'operate');
     await expect(operateHomePage.operateBanner).toBeVisible();
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionInstances.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionInstances.spec.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {authedTest as test} from 'fixtures';
+import {test} from 'fixtures';
 import {expect} from '@playwright/test';
 import {captureScreenshot, captureFailureVideo} from '@setup';
 import {deploy} from 'utils/zeebeClient';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionNavigation.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionNavigation.spec.ts
@@ -6,11 +6,11 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {test} from 'fixtures';
+import {authedTest as test} from 'fixtures';
 import {expect} from '@playwright/test';
 import {deploy, createSingleInstance} from 'utils/zeebeClient';
 import {captureScreenshot, captureFailureVideo} from '@setup';
-import {navigateToApp} from '@pages/UtilitiesPage';
+import {navigateToAppHome} from '@pages/UtilitiesPage';
 import {sleep} from 'utils/sleep';
 
 type ProcessInstance = {
@@ -32,9 +32,8 @@ test.beforeAll(async () => {
 });
 
 test.describe('Decision Navigation', () => {
-  test.beforeEach(async ({page, loginPage, operateHomePage}) => {
-    await navigateToApp(page, 'operate');
-    await loginPage.login('demo', 'demo');
+  test.beforeEach(async ({page, operateHomePage}) => {
+    await navigateToAppHome(page, 'operate');
     await expect(operateHomePage.operateBanner).toBeVisible();
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionNavigation.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionNavigation.spec.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {authedTest as test} from 'fixtures';
+import {test} from 'fixtures';
 import {expect} from '@playwright/test';
 import {deploy, createSingleInstance} from 'utils/zeebeClient';
 import {captureScreenshot, captureFailureVideo} from '@setup';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/login.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/login.spec.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {test} from 'fixtures';
+import {publicTest as test} from 'fixtures';
 import {navigateToApp} from '@pages/UtilitiesPage';
 import {expect} from '@playwright/test';
 import {captureScreenshot, captureFailureVideo} from '@setup';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/miSubprocessModifications.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/miSubprocessModifications.spec.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {test} from 'fixtures';
+import {authedTest as test} from 'fixtures';
 import {expect} from '@playwright/test';
 import {
   deploy,
@@ -14,7 +14,7 @@ import {
   cancelProcessInstance,
 } from 'utils/zeebeClient';
 import {captureScreenshot, captureFailureVideo} from '@setup';
-import {navigateToApp, hideHelperModals} from '@pages/UtilitiesPage';
+import {navigateToAppHome, hideHelperModals} from '@pages/UtilitiesPage';
 import {sleep} from 'utils/sleep';
 import {waitForAssertion} from 'utils/waitForAssertion';
 
@@ -108,9 +108,8 @@ test.afterAll(async () => {
 });
 
 test.describe('Multi-Instance Subprocess Modifications', () => {
-  test.beforeEach(async ({page, loginPage, operateHomePage}) => {
-    await navigateToApp(page, 'operate');
-    await loginPage.login('demo', 'demo');
+  test.beforeEach(async ({page, operateHomePage}) => {
+    await navigateToAppHome(page, 'operate');
     await expect(operateHomePage.operateBanner).toBeVisible();
     await hideHelperModals(page);
   });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/miSubprocessModifications.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/miSubprocessModifications.spec.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {authedTest as test} from 'fixtures';
+import {test} from 'fixtures';
 import {expect} from '@playwright/test';
 import {
   deploy,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/multiInstanceSelection.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/multiInstanceSelection.spec.ts
@@ -6,11 +6,11 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {test} from 'fixtures';
+import {authedTest as test} from 'fixtures';
 import {expect} from '@playwright/test';
 import {deploy, createSingleInstance, createWorker} from 'utils/zeebeClient';
 import {captureScreenshot, captureFailureVideo} from '@setup';
-import {navigateToApp} from '@pages/UtilitiesPage';
+import {navigateToAppHome} from '@pages/UtilitiesPage';
 import {waitForIncidents} from 'utils/incidentsHelper';
 
 type ProcessInstance = {
@@ -51,9 +51,8 @@ test.beforeAll(async ({request}) => {
 
 test.describe('Multi Instance Flow Node Selection', () => {
   test.beforeEach(
-    async ({page, loginPage, operateHomePage, operateProcessInstancePage}) => {
-      await navigateToApp(page, 'operate');
-      await loginPage.login('demo', 'demo');
+    async ({page, operateHomePage, operateProcessInstancePage}) => {
+      await navigateToAppHome(page, 'operate');
       await expect(operateHomePage.operateBanner).toBeVisible();
 
       await operateProcessInstancePage.gotoProcessInstancePage({

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/multiInstanceSelection.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/multiInstanceSelection.spec.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {authedTest as test} from 'fixtures';
+import {test} from 'fixtures';
 import {expect} from '@playwright/test';
 import {deploy, createSingleInstance, createWorker} from 'utils/zeebeClient';
 import {captureScreenshot, captureFailureVideo} from '@setup';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {authedTest as test} from 'fixtures';
+import {test} from 'fixtures';
 import {expect} from '@playwright/test';
 import {randomUUID} from 'crypto';
 import {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {test} from 'fixtures';
+import {authedTest as test} from 'fixtures';
 import {expect} from '@playwright/test';
 import {randomUUID} from 'crypto';
 import {
@@ -15,7 +15,7 @@ import {
   createSingleInstance,
 } from 'utils/zeebeClient';
 import {captureScreenshot, captureFailureVideo} from '@setup';
-import {navigateToApp} from '@pages/UtilitiesPage';
+import {navigateToAppHome} from '@pages/UtilitiesPage';
 import {waitForAssertion} from 'utils/waitForAssertion';
 import {sleep} from 'utils/sleep';
 
@@ -60,9 +60,8 @@ test.beforeAll(async () => {
 });
 
 test.describe('Operations', () => {
-  test.beforeEach(async ({page, loginPage, operateHomePage}) => {
-    await navigateToApp(page, 'operate');
-    await loginPage.login('demo', 'demo');
+  test.beforeEach(async ({page, operateHomePage}) => {
+    await navigateToAppHome(page, 'operate');
     await expect(operateHomePage.operateBanner).toBeVisible();
     await operateHomePage.clickProcessesTab();
   });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceAuditLog.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceAuditLog.spec.ts
@@ -6,10 +6,10 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {test} from 'fixtures';
+import {authedTest as test} from 'fixtures';
 import {expect} from '@playwright/test';
 import {deploy, createSingleInstance} from 'utils/zeebeClient';
-import {navigateToApp} from '@pages/UtilitiesPage';
+import {navigateToAppHome} from '@pages/UtilitiesPage';
 import {captureScreenshot, captureFailureVideo} from '@setup';
 import {waitForProcessInstances} from 'utils/incidentsHelper';
 
@@ -36,9 +36,8 @@ test.beforeAll(async ({request}) => {
 });
 
 test.describe('Process Instance Audit Log', () => {
-  test.beforeEach(async ({page, loginPage, operateHomePage}) => {
-    await navigateToApp(page, 'operate');
-    await loginPage.login('demo', 'demo');
+  test.beforeEach(async ({page, operateHomePage}) => {
+    await navigateToAppHome(page, 'operate');
     await expect(operateHomePage.operateBanner).toBeVisible();
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceAuditLog.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceAuditLog.spec.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {authedTest as test} from 'fixtures';
+import {test} from 'fixtures';
 import {expect} from '@playwright/test';
 import {deploy, createSingleInstance} from 'utils/zeebeClient';
 import {navigateToAppHome} from '@pages/UtilitiesPage';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceHistory.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceHistory.spec.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {test} from 'fixtures';
+import {authedTest as test} from 'fixtures';
 import {expect} from '@playwright/test';
 import {
   deploy,
@@ -14,7 +14,7 @@ import {
   // searchByProcessInstanceKey,
 } from 'utils/zeebeClient';
 import {captureScreenshot, captureFailureVideo} from '@setup';
-import {navigateToApp} from '@pages/UtilitiesPage';
+import {navigateToAppHome} from '@pages/UtilitiesPage';
 import {waitForAssertion} from 'utils/waitForAssertion';
 
 type ProcessInstance = {processInstanceKey: number};
@@ -60,9 +60,8 @@ test.beforeAll(async () => {
 });
 
 test.describe('Process Instance History', () => {
-  test.beforeEach(async ({page, loginPage, operateHomePage}) => {
-    await navigateToApp(page, 'operate');
-    await loginPage.login('demo', 'demo');
+  test.beforeEach(async ({page, operateHomePage}) => {
+    await navigateToAppHome(page, 'operate');
     await expect(operateHomePage.operateBanner).toBeVisible();
     await operateHomePage.clickProcessesTab();
   });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceHistory.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceHistory.spec.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {authedTest as test} from 'fixtures';
+import {test} from 'fixtures';
 import {expect} from '@playwright/test';
 import {
   deploy,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceIncidents.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceIncidents.spec.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {authedTest as test} from 'fixtures';
+import {test} from 'fixtures';
 import {expect} from '@playwright/test';
 import {deploy, createInstances, createSingleInstance} from 'utils/zeebeClient';
 import {captureScreenshot, captureFailureVideo} from '@setup';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceIncidents.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceIncidents.spec.ts
@@ -6,11 +6,11 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {test} from 'fixtures';
+import {authedTest as test} from 'fixtures';
 import {expect} from '@playwright/test';
 import {deploy, createInstances, createSingleInstance} from 'utils/zeebeClient';
 import {captureScreenshot, captureFailureVideo} from '@setup';
-import {navigateToApp} from '@pages/UtilitiesPage';
+import {navigateToAppHome} from '@pages/UtilitiesPage';
 import {DATE_REGEX} from 'utils/constants';
 import {sleep} from 'utils/sleep';
 import {waitForAssertion} from '../../utils/waitForAssertion';
@@ -57,9 +57,8 @@ test.beforeAll(async () => {
 });
 
 test.describe('Process Instance', () => {
-  test.beforeEach(async ({page, loginPage, operateHomePage}) => {
-    await navigateToApp(page, 'operate');
-    await loginPage.login('demo', 'demo');
+  test.beforeEach(async ({page, operateHomePage}) => {
+    await navigateToAppHome(page, 'operate');
     await expect(operateHomePage.operateBanner).toBeVisible();
   });
 
@@ -360,9 +359,8 @@ test.beforeAll(async () => {
 });
 
 test.describe('Process Instance Incident', () => {
-  test.beforeEach(async ({page, loginPage, operateHomePage}) => {
-    await navigateToApp(page, 'operate');
-    await loginPage.login('demo', 'demo');
+  test.beforeEach(async ({page, operateHomePage}) => {
+    await navigateToAppHome(page, 'operate');
     await expect(operateHomePage.operateBanner).toBeVisible();
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceListeners.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceListeners.spec.ts
@@ -6,11 +6,11 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {test} from 'fixtures';
+import {authedTest as test} from 'fixtures';
 import {expect} from '@playwright/test';
 import {deploy, createSingleInstance, createWorker} from 'utils/zeebeClient';
 import {captureScreenshot, captureFailureVideo} from '@setup';
-import {navigateToApp} from '@pages/UtilitiesPage';
+import {navigateToAppHome} from '@pages/UtilitiesPage';
 import {sleep} from 'utils/sleep';
 import {completeUserTask, findUserTask} from '@requestHelpers';
 import {waitForAssertion} from 'utils/waitForAssertion';
@@ -55,9 +55,8 @@ test.beforeAll(async () => {
 });
 
 test.describe('Process Instance Listeners', () => {
-  test.beforeEach(async ({page, loginPage, operateHomePage}) => {
-    await navigateToApp(page, 'operate');
-    await loginPage.login('demo', 'demo');
+  test.beforeEach(async ({page, operateHomePage}) => {
+    await navigateToAppHome(page, 'operate');
     await expect(operateHomePage.operateBanner).toBeVisible();
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceListeners.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceListeners.spec.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {authedTest as test} from 'fixtures';
+import {test} from 'fixtures';
 import {expect} from '@playwright/test';
 import {deploy, createSingleInstance, createWorker} from 'utils/zeebeClient';
 import {captureScreenshot, captureFailureVideo} from '@setup';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {test} from 'fixtures';
+import {authedTest as test} from 'fixtures';
 import {expect} from '@playwright/test';
 import {
   deploy,
@@ -14,7 +14,7 @@ import {
   cancelProcessInstance,
 } from 'utils/zeebeClient';
 import {captureScreenshot, captureFailureVideo} from '@setup';
-import {navigateToApp} from '@pages/UtilitiesPage';
+import {navigateToAppHome} from '@pages/UtilitiesPage';
 import {sleep} from 'utils/sleep';
 import {waitForAssertion} from 'utils/waitForAssertion';
 import {
@@ -83,9 +83,8 @@ test.describe.serial('Process Instance Migration', () => {
     await sleep(2000);
   });
 
-  test.beforeEach(async ({page, loginPage, operateHomePage}) => {
-    await navigateToApp(page, 'operate');
-    await loginPage.login('demo', 'demo');
+  test.beforeEach(async ({page, operateHomePage}) => {
+    await navigateToAppHome(page, 'operate');
     await expect(operateHomePage.operateBanner).toBeVisible();
     await operateHomePage.clickProcessesTab();
   });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {authedTest as test} from 'fixtures';
+import {test} from 'fixtures';
 import {expect} from '@playwright/test';
 import {
   deploy,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts
@@ -6,11 +6,11 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {test} from 'fixtures';
+import {authedTest as test} from 'fixtures';
 import {expect} from '@playwright/test';
 import {deploy, createSingleInstance} from 'utils/zeebeClient';
 import {captureScreenshot, captureFailureVideo} from '@setup';
-import {navigateToApp, hideHelperModals} from '@pages/UtilitiesPage';
+import {navigateToAppHome, hideHelperModals} from '@pages/UtilitiesPage';
 import {waitForAssertion} from 'utils/waitForAssertion';
 import {assertJsonEqual} from '../../utils/assertJsonEqual';
 
@@ -77,7 +77,6 @@ test.describe('Process Instance Modifications', () => {
     test.beforeEach(
       async ({
         page,
-        loginPage,
         operateHomePage,
         operateProcessInstancePage,
         operateProcessInstanceViewModificationModePage,
@@ -86,8 +85,7 @@ test.describe('Process Instance Modifications', () => {
           test: 123,
           foo: 'bar',
         });
-        await navigateToApp(page, 'operate');
-        await loginPage.login('demo', 'demo');
+        await navigateToAppHome(page, 'operate');
         await expect(operateHomePage.operateBanner).toBeVisible();
         await hideHelperModals(page);
         await operateProcessInstancePage.gotoProcessInstancePage({
@@ -198,7 +196,6 @@ test.describe('Process Instance Modifications', () => {
     test.beforeEach(
       async ({
         page,
-        loginPage,
         operateHomePage,
         operateProcessInstancePage,
         operateProcessInstanceViewModificationModePage,
@@ -207,8 +204,7 @@ test.describe('Process Instance Modifications', () => {
           test: 123,
           foo: 'bar',
         });
-        await navigateToApp(page, 'operate');
-        await loginPage.login('demo', 'demo');
+        await navigateToAppHome(page, 'operate');
         await expect(operateHomePage.operateBanner).toBeVisible();
         await hideHelperModals(page);
         await operateProcessInstancePage.gotoProcessInstancePage({
@@ -380,19 +376,13 @@ test.describe('Process Instance Modifications', () => {
     let instance: ProcessInstance;
 
     test.beforeEach(
-      async ({
-        page,
-        loginPage,
-        operateHomePage,
-        operateProcessInstancePage,
-      }) => {
+      async ({page, operateHomePage, operateProcessInstancePage}) => {
         instance = await createSingleInstance('Process_EmbeddedSubprocess', 1, {
           meow: 0,
           testVariableNumber: 123,
           testVariableString: 'bar',
         });
-        await navigateToApp(page, 'operate');
-        await loginPage.login('demo', 'demo');
+        await navigateToAppHome(page, 'operate');
         await expect(operateHomePage.operateBanner).toBeVisible();
         await hideHelperModals(page);
         await operateProcessInstancePage.gotoProcessInstancePage({

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {authedTest as test} from 'fixtures';
+import {test} from 'fixtures';
 import {expect} from '@playwright/test';
 import {deploy, createSingleInstance} from 'utils/zeebeClient';
 import {captureScreenshot, captureFailureVideo} from '@setup';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceVariables.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceVariables.spec.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {test} from 'fixtures';
+import {authedTest as test} from 'fixtures';
 import {expect} from '@playwright/test';
 import {
   deploy,
@@ -16,7 +16,7 @@ import {
   createWorker,
 } from 'utils/zeebeClient';
 import {captureScreenshot, captureFailureVideo} from '@setup';
-import {navigateToApp} from '@pages/UtilitiesPage';
+import {navigateToAppHome} from '@pages/UtilitiesPage';
 import {expectInViewport} from 'utils/expectInViewport';
 import {sleep} from 'utils/sleep';
 
@@ -54,9 +54,8 @@ test.beforeAll(async () => {
 });
 
 test.describe('Process Instance Variables', () => {
-  test.beforeEach(async ({page, loginPage, operateHomePage}) => {
-    await navigateToApp(page, 'operate');
-    await loginPage.login('demo', 'demo');
+  test.beforeEach(async ({page, operateHomePage}) => {
+    await navigateToAppHome(page, 'operate');
     await expect(operateHomePage.operateBanner).toBeVisible();
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceVariables.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceVariables.spec.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {authedTest as test} from 'fixtures';
+import {test} from 'fixtures';
 import {expect} from '@playwright/test';
 import {
   deploy,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {authedTest as test} from 'fixtures';
+import {test} from 'fixtures';
 import {expect} from '@playwright/test';
 import {deploy, createInstances, createSingleInstance} from 'utils/zeebeClient';
 import {captureScreenshot, captureFailureVideo} from '@setup';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
@@ -6,11 +6,11 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {test} from 'fixtures';
+import {authedTest as test} from 'fixtures';
 import {expect} from '@playwright/test';
 import {deploy, createInstances, createSingleInstance} from 'utils/zeebeClient';
 import {captureScreenshot, captureFailureVideo} from '@setup';
-import {navigateToApp} from '@pages/UtilitiesPage';
+import {navigateToAppHome} from '@pages/UtilitiesPage';
 import {waitForAssertion} from 'utils/waitForAssertion';
 import {sleep} from '../../utils/sleep';
 
@@ -68,9 +68,8 @@ test.beforeAll(async () => {
 });
 
 test.describe('Process Instances Filters', () => {
-  test.beforeEach(async ({page, loginPage, operateHomePage}) => {
-    await navigateToApp(page, 'operate');
-    await loginPage.login('demo', 'demo');
+  test.beforeEach(async ({page, operateHomePage}) => {
+    await navigateToAppHome(page, 'operate');
     await expect(operateHomePage.operateBanner).toBeVisible();
     await operateHomePage.clickProcessesTab();
   });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesTable.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesTable.spec.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {authedTest as test} from 'fixtures';
+import {test} from 'fixtures';
 import {expect} from '@playwright/test';
 import {deploy, createInstances, createSingleInstance} from 'utils/zeebeClient';
 import {captureScreenshot, captureFailureVideo} from '@setup';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesTable.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesTable.spec.ts
@@ -6,11 +6,11 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {test} from 'fixtures';
+import {authedTest as test} from 'fixtures';
 import {expect} from '@playwright/test';
 import {deploy, createInstances, createSingleInstance} from 'utils/zeebeClient';
 import {captureScreenshot, captureFailureVideo} from '@setup';
-import {navigateToApp} from '@pages/UtilitiesPage';
+import {navigateToAppHome} from '@pages/UtilitiesPage';
 import {waitForAssertion} from 'utils/waitForAssertion';
 import {sleep} from 'utils/sleep';
 import {defaultAssertionOptions} from '../../utils/constants';
@@ -102,9 +102,8 @@ test.beforeAll(async ({request}) => {
 });
 
 test.describe('Process Instances Table', () => {
-  test.beforeEach(async ({page, loginPage, operateHomePage}) => {
-    await navigateToApp(page, 'operate');
-    await loginPage.login('demo', 'demo');
+  test.beforeEach(async ({page, operateHomePage}) => {
+    await navigateToAppHome(page, 'operate');
     await expect(operateHomePage.operateBanner).toBeVisible();
     await operateHomePage.clickProcessesTab();
   });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processes.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processes.spec.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {authedTest as test} from 'fixtures';
+import {test} from 'fixtures';
 import {expect} from '@playwright/test';
 import {deploy, createSingleInstance} from 'utils/zeebeClient';
 import {captureScreenshot, captureFailureVideo} from '@setup';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processes.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processes.spec.ts
@@ -6,11 +6,11 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {test} from 'fixtures';
+import {authedTest as test} from 'fixtures';
 import {expect} from '@playwright/test';
 import {deploy, createSingleInstance} from 'utils/zeebeClient';
 import {captureScreenshot, captureFailureVideo} from '@setup';
-import {navigateToApp} from '@pages/UtilitiesPage';
+import {navigateToAppHome} from '@pages/UtilitiesPage';
 import {waitForAssertion} from 'utils/waitForAssertion';
 import {sleep} from 'utils/sleep';
 
@@ -66,9 +66,8 @@ test.beforeAll(async () => {
 });
 
 test.describe('Processes', () => {
-  test.beforeEach(async ({page, loginPage, operateHomePage}) => {
-    await navigateToApp(page, 'operate');
-    await loginPage.login('demo', 'demo');
+  test.beforeEach(async ({page, operateHomePage}) => {
+    await navigateToAppHome(page, 'operate');
     await expect(operateHomePage.operateBanner).toBeVisible();
     await operateHomePage.clickProcessesTab();
   });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/swagger.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/swagger.spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {expect} from '@playwright/test';
-import {test} from 'fixtures';
+import {publicTest as test} from 'fixtures';
 import {credentials} from '../../utils/http';
 import {LOGIN_CREDENTIALS} from '../../utils/constants';
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/login.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/login.spec.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {test} from 'fixtures';
+import {publicTest as test} from 'fixtures';
 import {navigateToApp} from '@pages/UtilitiesPage';
 import {expect} from '@playwright/test';
 import {captureScreenshot, captureFailureVideo} from '@setup';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/processes-page.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/processes-page.spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {expect} from '@playwright/test';
-import {test} from 'fixtures';
+import {publicTest as test} from 'fixtures';
 import {deploy} from 'utils/zeebeClient';
 import {navigateToApp} from '@pages/UtilitiesPage';
 import {sleep} from 'utils/sleep';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/settings.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/settings.spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {expect} from '@playwright/test';
-import {test} from 'fixtures';
+import {publicTest as test} from 'fixtures';
 import {navigateToApp} from '@pages/UtilitiesPage';
 import {captureFailureVideo, captureScreenshot} from '@setup';
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
@@ -8,7 +8,7 @@
 
 import {expect} from '@playwright/test';
 import {waitForAssertion} from 'utils/waitForAssertion';
-import {test} from 'fixtures';
+import {publicTest as test} from 'fixtures';
 import {deploy, createInstances} from 'utils/zeebeClient';
 import {navigateToApp} from '@pages/UtilitiesPage';
 import {sleep} from 'utils/sleep';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-history.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-history.spec.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {test} from 'fixtures';
+import {publicTest as test} from 'fixtures';
 import {expect} from '@playwright/test';
 import {deploy, createSingleInstance} from 'utils/zeebeClient';
 import {navigateToApp} from '@pages/UtilitiesPage';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-panel.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-panel.spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {expect} from '@playwright/test';
-import {test} from 'fixtures';
+import {publicTest as test} from 'fixtures';
 import {deploy, createInstances} from 'utils/zeebeClient';
 import {sleep} from 'utils/sleep';
 import {captureScreenshot, captureFailureVideo} from '@setup';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/user-task-permission-management.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/user-task-permission-management.spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {expect} from '@playwright/test';
-import {test} from 'fixtures';
+import {publicTest as test} from 'fixtures';
 import {deploy, createSingleInstance} from 'utils/zeebeClient';
 import {sleep} from 'utils/sleep';
 import {captureScreenshot, captureFailureVideo} from '@setup';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/variables.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/variables.spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {expect} from '@playwright/test';
-import {test} from 'fixtures';
+import {publicTest as test} from 'fixtures';
 import {deploy, createInstances} from 'utils/zeebeClient';
 import {captureScreenshot, captureFailureVideo} from '@setup';
 import {navigateToApp} from '@pages/UtilitiesPage';


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Replaces per-test UI login with a worker-scoped programmatic auth fixture across the Operate e2e suite. Eliminates ~3-5s of UI form interaction per test, removes a class of  timing flakes around LoginPage.usernameInput waits, and lays the pattern for follow-up migration of Tasklist and Identity specs.

## Related issues

closes #53141 
