### PR TITLE
refactor: fail fast topology check to be handled by awaitility's retries

### DIFF
--- a/qa/testcontainer/src/main/java/io/camunda/container/ZeebeTopologyWaitStrategy.java
+++ b/qa/testcontainer/src/main/java/io/camunda/container/ZeebeTopologyWaitStrategy.java
@@ -313,10 +313,7 @@ public class ZeebeTopologyWaitStrategy extends AbstractWaitStrategy {
   }
 
   private Topology getTopology(final CamundaClient client) {
-    return client
-        .newTopologyRequest()
-        .send()
-        .join(startupTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return client.newTopologyRequest().send().join(5, TimeUnit.SECONDS);
   }
 
   private static final class TopologyHolder {

--- a/qa/testcontainer/src/main/java/io/camunda/container/ZeebeTopologyWaitStrategy.java
+++ b/qa/testcontainer/src/main/java/io/camunda/container/ZeebeTopologyWaitStrategy.java
@@ -209,6 +209,7 @@ public class ZeebeTopologyWaitStrategy extends AbstractWaitStrategy {
 
       try {
         Awaitility.await()
+            .ignoreExceptions()
             .pollInterval(Duration.ofSeconds(1))
             .atMost(startupTimeout)
             .until(

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/backup/BackupCompatibilityAcceptance.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/backup/BackupCompatibilityAcceptance.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.configuration.Camunda;
+import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.container.CamundaContainer.BrokerContainer;
 import io.camunda.container.ZeebeTopologyWaitStrategy;
 import io.camunda.management.backups.BackupInfo;
@@ -364,17 +365,17 @@ public interface BackupCompatibilityAcceptance {
   }
 
   private BrokerContainer createOldBroker(final String storeBasePath) {
-    final var imageName = DockerImageName.parse("camunda/zeebe").withTag(previousVersion());
+    final var imageName = DockerImageName.parse("camunda/camunda").withTag(previousVersion());
     final var broker =
         new BrokerContainer(imageName)
             .withNetwork(getNetwork())
+            .withUnifiedConfig(
+                cfg -> cfg.getData().getSecondaryStorage().setType(SecondaryStorageType.none))
             .withLogConsumer(
                 new Slf4jLogConsumer(LoggerFactory.getLogger(BackupCompatibilityAcceptance.class))
                     .withPrefix(imageName.asCanonicalNameString()))
             .withEmbeddedGateway()
             .withTopologyCheck(new ZeebeTopologyWaitStrategy(1, 1, 1))
-            .withEnv("CAMUNDA_DATABASE_TYPE", "NONE")
-            .withEnv("CAMUNDA_DATA_SECONDARYSTORAGE_TYPE", "NONE")
             .withEnv("CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI", "true");
 
     // Apply backup store specific env vars


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

- Remove the topology timeout and let it be handled by Awaitility's retries
- Change `camunda/zeebe:8.9` to `camunda/camunda:8.9` for the previous broker version. Not sure if this entirely makes a difference however running the workflow multiple times I didn't get a flake where with the Zeebe image I did

Likely the container startup time is cause by GH job resource contention.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

ref #51914 
