### PR TITLE
fix: `checkForStraightThroughProcessingLoop` can cause exponential re-exploration

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/StraightThroughProcessingLoopValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/StraightThroughProcessingLoopValidator.java
@@ -30,9 +30,11 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 
 public final class StraightThroughProcessingLoopValidator {
@@ -129,11 +131,16 @@ public final class StraightThroughProcessingLoopValidator {
       final ExecutableProcess executableProcess,
       final List<ExecutableProcess> executableProcesses) {
     final var straightThroughElements = getStraightThroughElementsInProcess(executableProcess);
+    // A node enters this set once it has been proven loop-free, so subsequent DFS calls can skip
+    // it. Without this, processes with complex topologies cause exponential re-exploration of the
+    // same subgraph — see issue #53120.
+    final Set<ExecutableFlowNode> visited = new HashSet<>();
 
     for (final ExecutableFlowNode element : straightThroughElements) {
       final var potentialLoop = new LinkedList<ExecutableFlowNode>();
       final var result =
-          checkForStraightThroughProcessingLoop(potentialLoop, element, executableProcesses);
+          checkForStraightThroughProcessingLoop(
+              potentialLoop, element, executableProcesses, visited);
       if (result.isLeft()) {
         final String failureMessage =
             createFailureMessage(resource, executableProcess, result.getLeft());
@@ -194,7 +201,8 @@ public final class StraightThroughProcessingLoopValidator {
   private static Either<List<ExecutableFlowNode>, ?> checkForStraightThroughProcessingLoop(
       final LinkedList<ExecutableFlowNode> potentialLoop,
       final ExecutableFlowNode element,
-      final List<ExecutableProcess> executableProcesses) {
+      final List<ExecutableProcess> executableProcesses,
+      final Set<ExecutableFlowNode> visited) {
 
     if (foundLoop(potentialLoop, element)) {
       // It could happen that we detect a loop which doesn't involve the first element we checked.
@@ -204,10 +212,14 @@ public final class StraightThroughProcessingLoopValidator {
       // describing the loop.
       loop.add(element);
       return Either.left(loop);
+    } else if (visited.contains(element)) {
+      // This node has already been fully explored, skipping it
+      return Either.right(null);
     } else if (STRAIGHT_THROUGH_PROCESSING_ELEMENT_TYPES.containsKey(element.getElementType())) {
       final var isElementStraightThrough =
           STRAIGHT_THROUGH_PROCESSING_ELEMENT_TYPES.get(element.getElementType()).apply(element);
       if (!isElementStraightThrough) {
+        visited.add(element);
         return Either.right(null);
       }
 
@@ -221,7 +233,8 @@ public final class StraightThroughProcessingLoopValidator {
       Either<List<ExecutableFlowNode>, ?> isPartOfLoop = Either.right(null);
       for (final ExecutableFlowNode nextElement : getNextElements(element, executableProcesses)) {
         isPartOfLoop =
-            checkForStraightThroughProcessingLoop(potentialLoop, nextElement, executableProcesses);
+            checkForStraightThroughProcessingLoop(
+                potentialLoop, nextElement, executableProcesses, visited);
         if (isPartOfLoop.isLeft()) {
           break;
         }
@@ -229,11 +242,13 @@ public final class StraightThroughProcessingLoopValidator {
 
       if (isPartOfLoop.isRight()) {
         potentialLoop.remove(element);
+        visited.add(element);
       }
       return isPartOfLoop;
 
     } else {
       // No loops have been found. We can return an Either.Right to indicate success.
+      visited.add(element);
       return Either.right(null);
     }
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/StraightThroughProcessingLoopPerformanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/StraightThroughProcessingLoopPerformanceTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.validation;
+
+import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.zeebe.el.ExpressionLanguage;
+import io.camunda.zeebe.el.ExpressionLanguageFactory;
+import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowNode;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableProcess;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableSequenceFlow;
+import io.camunda.zeebe.engine.processing.deployment.model.transformation.BpmnTransformer;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.AbstractFlowNodeBuilder;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentResource;
+import java.time.InstantSource;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+final class StraightThroughProcessingLoopPerformanceTest {
+
+  private final ExpressionLanguage expressionLanguage =
+      ExpressionLanguageFactory.createExpressionLanguage(
+          new ZeebeFeelEngineClock(InstantSource.system()));
+  private final BpmnTransformer transformer = new BpmnTransformer(expressionLanguage);
+
+  @Test
+  void shouldRecurseIntoDeepGatewayAtMostOncePerProcess() {
+    final var diamonds = 10;
+    final var deepGatewayId = "join-" + (diamonds - 1);
+    final var model = diamondChain(diamonds);
+    final var process = transformer.transformDefinitions(model).getFirst();
+
+    final var deepGateway = process.getElementById(deepGatewayId, ExecutableFlowNode.class);
+    final var spyDeepGateway = spy(deepGateway);
+    rewireIncomingFlowsToSpy(process, deepGateway, spyDeepGateway);
+
+    final var resource =
+        new DeploymentResource()
+            .setResourceName(wrapString("perf.bpmn"))
+            .setResource(wrapString(Bpmn.convertToString(model)));
+    final var result = StraightThroughProcessingLoopValidator.validate(resource, List.of(process));
+
+    assertThat(result.isRight())
+        .as("Acyclic diamond chain must validate without a false-positive loop")
+        .isTrue();
+
+    // Each descending recursion of checkForStraightThroughProcessingLoop into deepGateway
+    // calls deepGateway.getOutgoing() exactly once (via getNextElements). Memoized short-
+    // circuits at the visited.contains check return without reaching getOutgoing.
+    // Pre-fix (no memoization): 2^(N-1) = 512 visits via brt-0-a's DFS alone, plus more
+    // from other roots — easily thousands of calls.
+    verify(spyDeepGateway, times(1)).getOutgoing();
+  }
+
+  private BpmnModelInstance diamondChain(final int diamonds) {
+    AbstractFlowNodeBuilder<?, ?> builder =
+        Bpmn.createExecutableProcess("perf-process").startEvent("start");
+    for (int i = 0; i < diamonds; i++) {
+      final String fork = "fork-" + i;
+      final String join = "join-" + i;
+      builder =
+          builder
+              .parallelGateway(fork)
+              .businessRuleTask(
+                  "brt-" + i + "-a",
+                  t -> t.zeebeCalledDecisionId("decision-id").zeebeResultVariable("result"))
+              .parallelGateway(join)
+              .moveToNode(fork)
+              .businessRuleTask(
+                  "brt-" + i + "-b",
+                  t -> t.zeebeCalledDecisionId("decision-id").zeebeResultVariable("result"))
+              .connectTo(join);
+    }
+    return builder.endEvent().done();
+  }
+
+  private static void rewireIncomingFlowsToSpy(
+      final ExecutableProcess process,
+      final ExecutableFlowNode original,
+      final ExecutableFlowNode spy) {
+    for (final ExecutableFlowElement element : process.getFlowElements()) {
+      if (element instanceof final ExecutableSequenceFlow sf && sf.getTarget() == original) {
+        sf.setTarget(spy);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

`StraightThroughProcessingLoopValidator` used to start DFS exploration from every `REJECTED_ELEMENT_TYPES` node in the process. That triggered the exponential blowup.

### Fix
Introduced `final Set<ExecutableFlowNode> visited = new HashSet<>();` so we can skip already visited nodes and avoid exponential blowup.

## Checklist

<!--- Please delete options that are not relevant. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #53120
