### PR TITLE
feat: add AgentInstance schema foundation for secondary storage

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/backup/BackupPriorityConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/backup/BackupPriorityConfiguration.java
@@ -101,18 +101,17 @@ public class BackupPriorityConfiguration {
 
     final List<Prio3Backup> prio3 =
         List.of(
-            // OPERATE
-            new BatchOperationTemplate(indexPrefix, isElasticsearch),
-            new OperationTemplate(indexPrefix, isElasticsearch),
             // CAMUNDA
             new CorrelatedMessageSubscriptionTemplate(indexPrefix, isElasticsearch),
             // OPERATE
+            new BatchOperationTemplate(indexPrefix, isElasticsearch),
             new DecisionInstanceTemplate(indexPrefix, isElasticsearch),
-            new MessageSubscriptionTemplate(indexPrefix, isElasticsearch),
             new FlowNodeInstanceTemplate(indexPrefix, isElasticsearch),
             new IncidentTemplate(indexPrefix, isElasticsearch),
             new JobTemplate(indexPrefix, isElasticsearch),
+            new MessageSubscriptionTemplate(indexPrefix, isElasticsearch),
             new MessageTemplate(indexPrefix, isElasticsearch),
+            new OperationTemplate(indexPrefix, isElasticsearch),
             new PostImporterQueueTemplate(indexPrefix, isElasticsearch),
             new SequenceFlowTemplate(indexPrefix, isElasticsearch),
             new VariableTemplate(indexPrefix, isElasticsearch),
@@ -140,14 +139,14 @@ public class BackupPriorityConfiguration {
             new UsageMetricTemplate(indexPrefix, isElasticsearch),
             new UsageMetricTUTemplate(indexPrefix, isElasticsearch),
             // AUDIT LOG
-            new AuditLogTemplate(indexPrefix, isElasticsearch),
             new AuditLogCleanupIndex(indexPrefix, isElasticsearch),
+            new AuditLogTemplate(indexPrefix, isElasticsearch),
             // CAMUNDA
             new AgentInstanceTemplate(indexPrefix, isElasticsearch),
             new ClusterVariableIndex(indexPrefix, isElasticsearch),
-            new JobMetricsBatchTemplate(indexPrefix, isElasticsearch),
+            new DeployedResourceIndex(indexPrefix, isElasticsearch),
             new GlobalListenerIndex(indexPrefix, isElasticsearch),
-            new DeployedResourceIndex(indexPrefix, isElasticsearch));
+            new JobMetricsBatchTemplate(indexPrefix, isElasticsearch));
 
     LOG.debug("Prio1 are {}", prio1);
     LOG.debug("Prio2 are {}", prio2);

--- a/dist/src/main/java/io/camunda/application/commons/backup/BackupPriorityConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/backup/BackupPriorityConfiguration.java
@@ -102,6 +102,7 @@ public class BackupPriorityConfiguration {
     final List<Prio3Backup> prio3 =
         List.of(
             // CAMUNDA
+            new AgentInstanceTemplate(indexPrefix, isElasticsearch),
             new CorrelatedMessageSubscriptionTemplate(indexPrefix, isElasticsearch),
             // OPERATE
             new BatchOperationTemplate(indexPrefix, isElasticsearch),
@@ -142,7 +143,6 @@ public class BackupPriorityConfiguration {
             new AuditLogCleanupIndex(indexPrefix, isElasticsearch),
             new AuditLogTemplate(indexPrefix, isElasticsearch),
             // CAMUNDA
-            new AgentInstanceTemplate(indexPrefix, isElasticsearch),
             new ClusterVariableIndex(indexPrefix, isElasticsearch),
             new DeployedResourceIndex(indexPrefix, isElasticsearch),
             new GlobalListenerIndex(indexPrefix, isElasticsearch),

--- a/dist/src/main/java/io/camunda/application/commons/backup/BackupPriorityConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/backup/BackupPriorityConfiguration.java
@@ -35,6 +35,7 @@ import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
 import io.camunda.webapps.schema.descriptors.index.RoleIndex;
 import io.camunda.webapps.schema.descriptors.index.TenantIndex;
 import io.camunda.webapps.schema.descriptors.index.UserIndex;
+import io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.template.AuditLogTemplate;
 import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
 import io.camunda.webapps.schema.descriptors.template.CorrelatedMessageSubscriptionTemplate;
@@ -142,6 +143,7 @@ public class BackupPriorityConfiguration {
             new AuditLogTemplate(indexPrefix, isElasticsearch),
             new AuditLogCleanupIndex(indexPrefix, isElasticsearch),
             // CAMUNDA
+            new AgentInstanceTemplate(indexPrefix, isElasticsearch),
             new ClusterVariableIndex(indexPrefix, isElasticsearch),
             new JobMetricsBatchTemplate(indexPrefix, isElasticsearch),
             new GlobalListenerIndex(indexPrefix, isElasticsearch),

--- a/dist/src/test/java/io/camunda/application/commons/backup/BackupPrioritiesTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/backup/BackupPrioritiesTest.java
@@ -114,6 +114,8 @@ class BackupPrioritiesTest {
     // PRIO 3 main indices
     assertThat(iterator.next().allIndices())
         .containsExactlyInAnyOrder(
+            "camunda-agent-instance-8.10.0_",
+            "camunda-correlated-message-subscription-8.8.0_",
             "operate-batch-operation-1.0.0_",
             "operate-operation-8.4.1_",
             "operate-decision-instance-8.3.0_",
@@ -126,11 +128,14 @@ class BackupPrioritiesTest {
             "operate-sequence-flow-8.3.0_",
             "operate-variable-8.3.0_",
             "tasklist-draft-task-variable-8.3.0_",
-            "tasklist-task-variable-8.3.0_",
-            "camunda-correlated-message-subscription-8.8.0_");
+            "tasklist-task-variable-8.3.0_");
     // PRIO 3 dated indices
     assertThat(iterator.next().allIndices())
         .containsExactlyInAnyOrder(
+            "camunda-agent-instance-8.10.0_*",
+            "-camunda-agent-instance-8.10.0_",
+            "camunda-correlated-message-subscription-8.8.0_*",
+            "-camunda-correlated-message-subscription-8.8.0_",
             "operate-batch-operation-1.0.0_*",
             "-operate-batch-operation-1.0.0_",
             "operate-operation-8.4.1_*",
@@ -156,9 +161,7 @@ class BackupPrioritiesTest {
             "tasklist-draft-task-variable-8.3.0_*",
             "-tasklist-draft-task-variable-8.3.0_",
             "tasklist-task-variable-8.3.0_*",
-            "-tasklist-task-variable-8.3.0_",
-            "camunda-correlated-message-subscription-8.8.0_*",
-            "-camunda-correlated-message-subscription-8.8.0_");
+            "-tasklist-task-variable-8.3.0_");
 
     // PRIO 4 main indices
     assertThat(iterator.next().allIndices())
@@ -181,8 +184,7 @@ class BackupPrioritiesTest {
             "camunda-cluster-variable-8.9.0_",
             "camunda-job-metrics-batch-8.9.0_",
             "camunda-global-listener-8.9.0_",
-            "camunda-deployed-resource-8.10.0_",
-            "camunda-agent-instance-8.10.0_");
+            "camunda-deployed-resource-8.10.0_");
 
     // PRIO 4 dated indices
     assertThat(iterator.next().allIndices())
@@ -194,9 +196,7 @@ class BackupPrioritiesTest {
             "camunda-audit-log-8.9.0_*",
             "-camunda-audit-log-8.9.0_",
             "camunda-job-metrics-batch-8.9.0_*",
-            "-camunda-job-metrics-batch-8.9.0_",
-            "camunda-agent-instance-8.10.0_*",
-            "-camunda-agent-instance-8.10.0_");
+            "-camunda-job-metrics-batch-8.9.0_");
 
     for (final var indexList : indices) {
       assertThat(indexList.allIndices())

--- a/dist/src/test/java/io/camunda/application/commons/backup/BackupPrioritiesTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/backup/BackupPrioritiesTest.java
@@ -181,7 +181,8 @@ class BackupPrioritiesTest {
             "camunda-cluster-variable-8.9.0_",
             "camunda-job-metrics-batch-8.9.0_",
             "camunda-global-listener-8.9.0_",
-            "camunda-deployed-resource-8.10.0_");
+            "camunda-deployed-resource-8.10.0_",
+            "camunda-agent-instance-8.10.0_");
 
     // PRIO 4 dated indices
     assertThat(iterator.next().allIndices())
@@ -193,7 +194,9 @@ class BackupPrioritiesTest {
             "camunda-audit-log-8.9.0_*",
             "-camunda-audit-log-8.9.0_",
             "camunda-job-metrics-batch-8.9.0_*",
-            "-camunda-job-metrics-batch-8.9.0_");
+            "-camunda-job-metrics-batch-8.9.0_",
+            "camunda-agent-instance-8.10.0_*",
+            "-camunda-agent-instance-8.10.0_");
 
     for (final var indexList : indices) {
       assertThat(indexList.allIndices())

--- a/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerIT.java
@@ -1016,6 +1016,7 @@ public class SchemaManagerIT {
             newPrefix + "-camunda-audit-log-8.9.0_",
             newPrefix + "-camunda-audit-log-cleanup-8.9.0_",
             newPrefix + "-camunda-history-deletion-8.9.0_",
+            newPrefix + "-camunda-agent-instance-8.10.0_",
             newPrefix + "-camunda-deployed-resource-8.10.0_",
             newPrefix + "-operate-batch-operation-1.0.0_",
             newPrefix + "-operate-decision-8.3.0_",

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/IndexDescriptors.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/IndexDescriptors.java
@@ -24,6 +24,7 @@ import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
 import io.camunda.webapps.schema.descriptors.index.RoleIndex;
 import io.camunda.webapps.schema.descriptors.index.TenantIndex;
 import io.camunda.webapps.schema.descriptors.index.UserIndex;
+import io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.template.AuditLogTemplate;
 import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
 import io.camunda.webapps.schema.descriptors.template.CorrelatedMessageSubscriptionTemplate;
@@ -92,7 +93,8 @@ public class IndexDescriptors {
                 new JobMetricsBatchTemplate(indexPrefix, isElasticsearch),
                 new AuditLogCleanupIndex(indexPrefix, isElasticsearch),
                 new GlobalListenerIndex(indexPrefix, isElasticsearch),
-                new DeployedResourceIndex(indexPrefix, isElasticsearch))
+                new DeployedResourceIndex(indexPrefix, isElasticsearch),
+                new AgentInstanceTemplate(indexPrefix, isElasticsearch))
             .collect(Collectors.toMap(Object::getClass, Function.identity()));
   }
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/AgentInstanceTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/AgentInstanceTemplate.java
@@ -22,8 +22,6 @@ public class AgentInstanceTemplate extends AbstractTemplateDescriptor
   public static final String KEY = "key";
   public static final String ELEMENT_ID = "elementId";
   public static final String ELEMENT_INSTANCE_KEYS = "elementInstanceKeys";
-  public static final String PROCESS_INSTANCE_KEY = "processInstanceKey";
-  public static final String ROOT_PROCESS_INSTANCE_KEY = "rootProcessInstanceKey";
   public static final String BPMN_PROCESS_ID = "bpmnProcessId";
   public static final String PROCESS_DEFINITION_KEY = "processDefinitionKey";
   public static final String PROCESS_DEFINITION_VERSION = "processDefinitionVersion";

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/AgentInstanceTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/AgentInstanceTemplate.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.schema.descriptors.template;
+
+import io.camunda.webapps.schema.descriptors.AbstractTemplateDescriptor;
+import io.camunda.webapps.schema.descriptors.ComponentNames;
+import io.camunda.webapps.schema.descriptors.ProcessInstanceDependant;
+import io.camunda.webapps.schema.descriptors.backup.Prio4Backup;
+import java.util.Optional;
+
+public class AgentInstanceTemplate extends AbstractTemplateDescriptor
+    implements ProcessInstanceDependant, Prio4Backup {
+
+  public static final String INDEX_NAME = "agent-instance";
+  public static final String INDEX_VERSION = "8.10.0";
+
+  public static final String KEY = "key";
+  public static final String ELEMENT_ID = "elementId";
+  public static final String ELEMENT_INSTANCE_KEYS = "elementInstanceKeys";
+  public static final String PROCESS_INSTANCE_KEY = "processInstanceKey";
+  public static final String BPMN_PROCESS_ID = "bpmnProcessId";
+  public static final String PROCESS_DEFINITION_KEY = "processDefinitionKey";
+  public static final String PROCESS_DEFINITION_VERSION = "processDefinitionVersion";
+  public static final String VERSION_TAG = "versionTag";
+  public static final String TENANT_ID = "tenantId";
+  public static final String STATUS = "status";
+  public static final String MODEL = "model";
+  public static final String PROVIDER = "provider";
+  public static final String SYSTEM_PROMPT = "systemPrompt";
+  public static final String MAX_TOKENS = "maxTokens";
+  public static final String MAX_MODEL_CALLS = "maxModelCalls";
+  public static final String MAX_TOOL_CALLS = "maxToolCalls";
+  public static final String INPUT_TOKENS = "inputTokens";
+  public static final String OUTPUT_TOKENS = "outputTokens";
+  public static final String MODEL_CALLS = "modelCalls";
+  public static final String TOOL_CALLS = "toolCalls";
+  public static final String TOOLS = "tools";
+  public static final String CREATION_DATE = "creationDate";
+  public static final String LAST_UPDATED_DATE = "lastUpdatedDate";
+  public static final String COMPLETION_DATE = "completionDate";
+
+  public AgentInstanceTemplate(final String indexPrefix, final boolean isElasticsearch) {
+    super(indexPrefix, isElasticsearch);
+  }
+
+  @Override
+  public String getIndexName() {
+    return INDEX_NAME;
+  }
+
+  @Override
+  public Optional<String> getTenantIdField() {
+    return Optional.of(TENANT_ID);
+  }
+
+  @Override
+  public String getVersion() {
+    return INDEX_VERSION;
+  }
+
+  @Override
+  public String getComponentName() {
+    return ComponentNames.CAMUNDA.toString();
+  }
+}

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/AgentInstanceTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/AgentInstanceTemplate.java
@@ -23,6 +23,7 @@ public class AgentInstanceTemplate extends AbstractTemplateDescriptor
   public static final String ELEMENT_ID = "elementId";
   public static final String ELEMENT_INSTANCE_KEYS = "elementInstanceKeys";
   public static final String PROCESS_INSTANCE_KEY = "processInstanceKey";
+  public static final String ROOT_PROCESS_INSTANCE_KEY = "rootProcessInstanceKey";
   public static final String BPMN_PROCESS_ID = "bpmnProcessId";
   public static final String PROCESS_DEFINITION_KEY = "processDefinitionKey";
   public static final String PROCESS_DEFINITION_VERSION = "processDefinitionVersion";

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/AgentInstanceTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/AgentInstanceTemplate.java
@@ -10,11 +10,11 @@ package io.camunda.webapps.schema.descriptors.template;
 import io.camunda.webapps.schema.descriptors.AbstractTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.ComponentNames;
 import io.camunda.webapps.schema.descriptors.ProcessInstanceDependant;
-import io.camunda.webapps.schema.descriptors.backup.Prio4Backup;
+import io.camunda.webapps.schema.descriptors.backup.Prio3Backup;
 import java.util.Optional;
 
 public class AgentInstanceTemplate extends AbstractTemplateDescriptor
-    implements ProcessInstanceDependant, Prio4Backup {
+    implements ProcessInstanceDependant, Prio3Backup {
 
   public static final String INDEX_NAME = "agent-instance";
   public static final String INDEX_VERSION = "8.10.0";

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/agentinstance/AgentInstanceEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/agentinstance/AgentInstanceEntity.java
@@ -97,6 +97,14 @@ public final class AgentInstanceEntity
   @SinceVersion(value = "8.10.0", requireDefault = false)
   private List<Long> elementInstanceKeys;
 
+  /**
+   * Key of the top-level (root) process instance in a call-activity hierarchy. Required by {@link
+   * io.camunda.webapps.schema.descriptors.ProcessInstanceDependant} so the archiver can sweep agent
+   * instance documents across sub-process boundaries when archiving a root process instance.
+   */
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private long rootProcessInstanceKey = -1L;
+
   // Handler-computed dates — not present in AgentInstanceRecordValue
   @SinceVersion(value = "8.10.0", requireDefault = false)
   private OffsetDateTime creationDate;
@@ -320,6 +328,15 @@ public final class AgentInstanceEntity
     return this;
   }
 
+  public long getRootProcessInstanceKey() {
+    return rootProcessInstanceKey;
+  }
+
+  public AgentInstanceEntity setRootProcessInstanceKey(final long rootProcessInstanceKey) {
+    this.rootProcessInstanceKey = rootProcessInstanceKey;
+    return this;
+  }
+
   public OffsetDateTime getCreationDate() {
     return creationDate;
   }
@@ -373,6 +390,7 @@ public final class AgentInstanceEntity
         toolCalls,
         tools,
         elementInstanceKeys,
+        rootProcessInstanceKey,
         creationDate,
         lastUpdatedDate,
         completionDate);
@@ -410,6 +428,7 @@ public final class AgentInstanceEntity
         && toolCalls == that.toolCalls
         && Objects.equals(tools, that.tools)
         && Objects.equals(elementInstanceKeys, that.elementInstanceKeys)
+        && rootProcessInstanceKey == that.rootProcessInstanceKey
         && Objects.equals(creationDate, that.creationDate)
         && Objects.equals(lastUpdatedDate, that.lastUpdatedDate)
         && Objects.equals(completionDate, that.completionDate);
@@ -428,6 +447,8 @@ public final class AgentInstanceEntity
         + '\''
         + ", processInstanceKey="
         + processInstanceKey
+        + ", rootProcessInstanceKey="
+        + rootProcessInstanceKey
         + ", bpmnProcessId='"
         + bpmnProcessId
         + '\''

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/agentinstance/AgentInstanceEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/agentinstance/AgentInstanceEntity.java
@@ -1,0 +1,485 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.schema.entities.agentinstance;
+
+import io.camunda.webapps.schema.entities.ExporterEntity;
+import io.camunda.webapps.schema.entities.PartitionedEntity;
+import io.camunda.webapps.schema.entities.SinceVersion;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Secondary-storage entity for AGENT_INSTANCE records. All nested sub-objects from the protocol
+ * (definition, limits, metrics) are flattened to top-level fields to avoid nested object mapping
+ * complexity in ES/OS and keep the RDBMS model flat.
+ */
+public final class AgentInstanceEntity
+    implements ExporterEntity<AgentInstanceEntity>,
+        PartitionedEntity<AgentInstanceEntity>,
+        TenantOwned {
+
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private String id;
+
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private long key;
+
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private String elementId;
+
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private long processInstanceKey;
+
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private String bpmnProcessId;
+
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private long processDefinitionKey;
+
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private int processDefinitionVersion;
+
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private String versionTag;
+
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private String tenantId;
+
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private int partitionId;
+
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private AgentInstanceStatus status;
+
+  // Definition fields — flattened from AgentInstanceDefinitionValue
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private String model;
+
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private String provider;
+
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private String systemPrompt;
+
+  // Limits fields — flattened from AgentInstanceLimitsValue
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private long maxTokens;
+
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private int maxModelCalls;
+
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private int maxToolCalls;
+
+  // Metrics fields — flattened from AgentInstanceMetricsValue
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private long inputTokens;
+
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private long outputTokens;
+
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private int modelCalls;
+
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private int toolCalls;
+
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private List<AgentInstanceToolValue> tools;
+
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private List<Long> elementInstanceKeys;
+
+  // Handler-computed dates — not present in AgentInstanceRecordValue
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private OffsetDateTime creationDate;
+
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private OffsetDateTime lastUpdatedDate;
+
+  /** Null until the agent instance reaches the COMPLETED state. */
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private OffsetDateTime completionDate;
+
+  @Override
+  public String getId() {
+    return id;
+  }
+
+  @Override
+  public AgentInstanceEntity setId(final String id) {
+    this.id = id;
+    return this;
+  }
+
+  public long getKey() {
+    return key;
+  }
+
+  public AgentInstanceEntity setKey(final long key) {
+    this.key = key;
+    return this;
+  }
+
+  public String getElementId() {
+    return elementId;
+  }
+
+  public AgentInstanceEntity setElementId(final String elementId) {
+    this.elementId = elementId;
+    return this;
+  }
+
+  public long getProcessInstanceKey() {
+    return processInstanceKey;
+  }
+
+  public AgentInstanceEntity setProcessInstanceKey(final long processInstanceKey) {
+    this.processInstanceKey = processInstanceKey;
+    return this;
+  }
+
+  public String getBpmnProcessId() {
+    return bpmnProcessId;
+  }
+
+  public AgentInstanceEntity setBpmnProcessId(final String bpmnProcessId) {
+    this.bpmnProcessId = bpmnProcessId;
+    return this;
+  }
+
+  public long getProcessDefinitionKey() {
+    return processDefinitionKey;
+  }
+
+  public AgentInstanceEntity setProcessDefinitionKey(final long processDefinitionKey) {
+    this.processDefinitionKey = processDefinitionKey;
+    return this;
+  }
+
+  public int getProcessDefinitionVersion() {
+    return processDefinitionVersion;
+  }
+
+  public AgentInstanceEntity setProcessDefinitionVersion(final int processDefinitionVersion) {
+    this.processDefinitionVersion = processDefinitionVersion;
+    return this;
+  }
+
+  public String getVersionTag() {
+    return versionTag;
+  }
+
+  public AgentInstanceEntity setVersionTag(final String versionTag) {
+    this.versionTag = versionTag;
+    return this;
+  }
+
+  @Override
+  public String getTenantId() {
+    return tenantId;
+  }
+
+  public AgentInstanceEntity setTenantId(final String tenantId) {
+    this.tenantId = tenantId;
+    return this;
+  }
+
+  @Override
+  public int getPartitionId() {
+    return partitionId;
+  }
+
+  @Override
+  public AgentInstanceEntity setPartitionId(final int partitionId) {
+    this.partitionId = partitionId;
+    return this;
+  }
+
+  public AgentInstanceStatus getStatus() {
+    return status;
+  }
+
+  public AgentInstanceEntity setStatus(final AgentInstanceStatus status) {
+    this.status = status;
+    return this;
+  }
+
+  public String getModel() {
+    return model;
+  }
+
+  public AgentInstanceEntity setModel(final String model) {
+    this.model = model;
+    return this;
+  }
+
+  public String getProvider() {
+    return provider;
+  }
+
+  public AgentInstanceEntity setProvider(final String provider) {
+    this.provider = provider;
+    return this;
+  }
+
+  public String getSystemPrompt() {
+    return systemPrompt;
+  }
+
+  public AgentInstanceEntity setSystemPrompt(final String systemPrompt) {
+    this.systemPrompt = systemPrompt;
+    return this;
+  }
+
+  public long getMaxTokens() {
+    return maxTokens;
+  }
+
+  public AgentInstanceEntity setMaxTokens(final long maxTokens) {
+    this.maxTokens = maxTokens;
+    return this;
+  }
+
+  public int getMaxModelCalls() {
+    return maxModelCalls;
+  }
+
+  public AgentInstanceEntity setMaxModelCalls(final int maxModelCalls) {
+    this.maxModelCalls = maxModelCalls;
+    return this;
+  }
+
+  public int getMaxToolCalls() {
+    return maxToolCalls;
+  }
+
+  public AgentInstanceEntity setMaxToolCalls(final int maxToolCalls) {
+    this.maxToolCalls = maxToolCalls;
+    return this;
+  }
+
+  public long getInputTokens() {
+    return inputTokens;
+  }
+
+  public AgentInstanceEntity setInputTokens(final long inputTokens) {
+    this.inputTokens = inputTokens;
+    return this;
+  }
+
+  public long getOutputTokens() {
+    return outputTokens;
+  }
+
+  public AgentInstanceEntity setOutputTokens(final long outputTokens) {
+    this.outputTokens = outputTokens;
+    return this;
+  }
+
+  public int getModelCalls() {
+    return modelCalls;
+  }
+
+  public AgentInstanceEntity setModelCalls(final int modelCalls) {
+    this.modelCalls = modelCalls;
+    return this;
+  }
+
+  public int getToolCalls() {
+    return toolCalls;
+  }
+
+  public AgentInstanceEntity setToolCalls(final int toolCalls) {
+    this.toolCalls = toolCalls;
+    return this;
+  }
+
+  public List<AgentInstanceToolValue> getTools() {
+    return tools;
+  }
+
+  public AgentInstanceEntity setTools(final List<AgentInstanceToolValue> tools) {
+    this.tools = tools;
+    return this;
+  }
+
+  public List<Long> getElementInstanceKeys() {
+    return elementInstanceKeys;
+  }
+
+  public AgentInstanceEntity setElementInstanceKeys(final List<Long> elementInstanceKeys) {
+    this.elementInstanceKeys = elementInstanceKeys;
+    return this;
+  }
+
+  public OffsetDateTime getCreationDate() {
+    return creationDate;
+  }
+
+  public AgentInstanceEntity setCreationDate(final OffsetDateTime creationDate) {
+    this.creationDate = creationDate;
+    return this;
+  }
+
+  public OffsetDateTime getLastUpdatedDate() {
+    return lastUpdatedDate;
+  }
+
+  public AgentInstanceEntity setLastUpdatedDate(final OffsetDateTime lastUpdatedDate) {
+    this.lastUpdatedDate = lastUpdatedDate;
+    return this;
+  }
+
+  public OffsetDateTime getCompletionDate() {
+    return completionDate;
+  }
+
+  public AgentInstanceEntity setCompletionDate(final OffsetDateTime completionDate) {
+    this.completionDate = completionDate;
+    return this;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        id,
+        key,
+        elementId,
+        processInstanceKey,
+        bpmnProcessId,
+        processDefinitionKey,
+        processDefinitionVersion,
+        versionTag,
+        tenantId,
+        partitionId,
+        status,
+        model,
+        provider,
+        systemPrompt,
+        maxTokens,
+        maxModelCalls,
+        maxToolCalls,
+        inputTokens,
+        outputTokens,
+        modelCalls,
+        toolCalls,
+        tools,
+        elementInstanceKeys,
+        creationDate,
+        lastUpdatedDate,
+        completionDate);
+  }
+
+  @Override
+  public boolean equals(final Object obj) {
+    if (obj == this) {
+      return true;
+    }
+    if (obj == null || obj.getClass() != getClass()) {
+      return false;
+    }
+    final var that = (AgentInstanceEntity) obj;
+    return Objects.equals(id, that.id)
+        && key == that.key
+        && Objects.equals(elementId, that.elementId)
+        && processInstanceKey == that.processInstanceKey
+        && Objects.equals(bpmnProcessId, that.bpmnProcessId)
+        && processDefinitionKey == that.processDefinitionKey
+        && processDefinitionVersion == that.processDefinitionVersion
+        && Objects.equals(versionTag, that.versionTag)
+        && Objects.equals(tenantId, that.tenantId)
+        && partitionId == that.partitionId
+        && Objects.equals(status, that.status)
+        && Objects.equals(model, that.model)
+        && Objects.equals(provider, that.provider)
+        && Objects.equals(systemPrompt, that.systemPrompt)
+        && maxTokens == that.maxTokens
+        && maxModelCalls == that.maxModelCalls
+        && maxToolCalls == that.maxToolCalls
+        && inputTokens == that.inputTokens
+        && outputTokens == that.outputTokens
+        && modelCalls == that.modelCalls
+        && toolCalls == that.toolCalls
+        && Objects.equals(tools, that.tools)
+        && Objects.equals(elementInstanceKeys, that.elementInstanceKeys)
+        && Objects.equals(creationDate, that.creationDate)
+        && Objects.equals(lastUpdatedDate, that.lastUpdatedDate)
+        && Objects.equals(completionDate, that.completionDate);
+  }
+
+  @Override
+  public String toString() {
+    return "AgentInstanceEntity{"
+        + "id='"
+        + id
+        + '\''
+        + ", key="
+        + key
+        + ", elementId='"
+        + elementId
+        + '\''
+        + ", processInstanceKey="
+        + processInstanceKey
+        + ", bpmnProcessId='"
+        + bpmnProcessId
+        + '\''
+        + ", processDefinitionKey="
+        + processDefinitionKey
+        + ", processDefinitionVersion="
+        + processDefinitionVersion
+        + ", versionTag='"
+        + versionTag
+        + '\''
+        + ", tenantId='"
+        + tenantId
+        + '\''
+        + ", partitionId="
+        + partitionId
+        + ", status="
+        + status
+        + ", model='"
+        + model
+        + '\''
+        + ", provider='"
+        + provider
+        + '\''
+        + ", systemPrompt='"
+        + systemPrompt
+        + '\''
+        + ", maxTokens="
+        + maxTokens
+        + ", maxModelCalls="
+        + maxModelCalls
+        + ", maxToolCalls="
+        + maxToolCalls
+        + ", inputTokens="
+        + inputTokens
+        + ", outputTokens="
+        + outputTokens
+        + ", modelCalls="
+        + modelCalls
+        + ", toolCalls="
+        + toolCalls
+        + ", tools="
+        + tools
+        + ", elementInstanceKeys="
+        + elementInstanceKeys
+        + ", creationDate="
+        + creationDate
+        + ", lastUpdatedDate="
+        + lastUpdatedDate
+        + ", completionDate="
+        + completionDate
+        + '}';
+  }
+
+  public record AgentInstanceToolValue(String name, String description, String elementId) {}
+}

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/agentinstance/AgentInstanceStatus.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/agentinstance/AgentInstanceStatus.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.schema.entities.agentinstance;
+
+public enum AgentInstanceStatus {
+  INITIALIZING,
+  TOOL_DISCOVERY,
+  IDLE,
+  THINKING,
+  TOOL_CALLING,
+  COMPLETED
+}

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/template/camunda-agent-instance.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/template/camunda-agent-instance.json
@@ -17,6 +17,9 @@
       "processInstanceKey": {
         "type": "long"
       },
+      "rootProcessInstanceKey": {
+        "type": "long"
+      },
       "bpmnProcessId": {
         "type": "keyword"
       },

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/template/camunda-agent-instance.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/template/camunda-agent-instance.json
@@ -1,0 +1,101 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "id": {
+        "type": "keyword"
+      },
+      "key": {
+        "type": "long"
+      },
+      "elementId": {
+        "type": "keyword"
+      },
+      "elementInstanceKeys": {
+        "type": "long"
+      },
+      "processInstanceKey": {
+        "type": "long"
+      },
+      "bpmnProcessId": {
+        "type": "keyword"
+      },
+      "processDefinitionKey": {
+        "type": "long"
+      },
+      "processDefinitionVersion": {
+        "type": "integer"
+      },
+      "versionTag": {
+        "type": "keyword"
+      },
+      "tenantId": {
+        "type": "keyword"
+      },
+      "partitionId": {
+        "type": "integer"
+      },
+      "status": {
+        "type": "keyword"
+      },
+      "model": {
+        "type": "keyword"
+      },
+      "provider": {
+        "type": "keyword"
+      },
+      "systemPrompt": {
+        "type": "text",
+        "index": false
+      },
+      "maxTokens": {
+        "type": "long"
+      },
+      "maxModelCalls": {
+        "type": "integer"
+      },
+      "maxToolCalls": {
+        "type": "integer"
+      },
+      "inputTokens": {
+        "type": "long"
+      },
+      "outputTokens": {
+        "type": "long"
+      },
+      "modelCalls": {
+        "type": "integer"
+      },
+      "toolCalls": {
+        "type": "integer"
+      },
+      "tools": {
+        "type": "nested",
+        "properties": {
+          "name": {
+            "type": "keyword"
+          },
+          "description": {
+            "type": "text",
+            "index": false
+          },
+          "elementId": {
+            "type": "keyword"
+          }
+        }
+      },
+      "creationDate": {
+        "format": "date_time || epoch_millis",
+        "type": "date"
+      },
+      "lastUpdatedDate": {
+        "format": "date_time || epoch_millis",
+        "type": "date"
+      },
+      "completionDate": {
+        "format": "date_time || epoch_millis",
+        "type": "date"
+      }
+    }
+  }
+}

--- a/webapps-schema/src/main/resources/schema/opensearch/create/template/camunda-agent-instance.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/template/camunda-agent-instance.json
@@ -17,6 +17,9 @@
       "processInstanceKey": {
         "type": "long"
       },
+      "rootProcessInstanceKey": {
+        "type": "long"
+      },
       "bpmnProcessId": {
         "type": "keyword"
       },

--- a/webapps-schema/src/main/resources/schema/opensearch/create/template/camunda-agent-instance.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/template/camunda-agent-instance.json
@@ -1,0 +1,101 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "id": {
+        "type": "keyword"
+      },
+      "key": {
+        "type": "long"
+      },
+      "elementId": {
+        "type": "keyword"
+      },
+      "elementInstanceKeys": {
+        "type": "long"
+      },
+      "processInstanceKey": {
+        "type": "long"
+      },
+      "bpmnProcessId": {
+        "type": "keyword"
+      },
+      "processDefinitionKey": {
+        "type": "long"
+      },
+      "processDefinitionVersion": {
+        "type": "integer"
+      },
+      "versionTag": {
+        "type": "keyword"
+      },
+      "tenantId": {
+        "type": "keyword"
+      },
+      "partitionId": {
+        "type": "integer"
+      },
+      "status": {
+        "type": "keyword"
+      },
+      "model": {
+        "type": "keyword"
+      },
+      "provider": {
+        "type": "keyword"
+      },
+      "systemPrompt": {
+        "type": "text",
+        "index": false
+      },
+      "maxTokens": {
+        "type": "long"
+      },
+      "maxModelCalls": {
+        "type": "integer"
+      },
+      "maxToolCalls": {
+        "type": "integer"
+      },
+      "inputTokens": {
+        "type": "long"
+      },
+      "outputTokens": {
+        "type": "long"
+      },
+      "modelCalls": {
+        "type": "integer"
+      },
+      "toolCalls": {
+        "type": "integer"
+      },
+      "tools": {
+        "type": "nested",
+        "properties": {
+          "name": {
+            "type": "keyword"
+          },
+          "description": {
+            "type": "text",
+            "index": false
+          },
+          "elementId": {
+            "type": "keyword"
+          }
+        }
+      },
+      "creationDate": {
+        "format": "date_time || epoch_millis",
+        "type": "date"
+      },
+      "lastUpdatedDate": {
+        "format": "date_time || epoch_millis",
+        "type": "date"
+      },
+      "completionDate": {
+        "format": "date_time || epoch_millis",
+        "type": "date"
+      }
+    }
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AbstractProcessInstanceArchiverJobIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AbstractProcessInstanceArchiverJobIT.java
@@ -14,6 +14,7 @@ import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.search.test.utils.SearchClientAdapter;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.ProcessInstanceDependant;
+import io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.template.AuditLogTemplate;
 import io.camunda.webapps.schema.descriptors.template.CorrelatedMessageSubscriptionTemplate;
 import io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate;
@@ -33,6 +34,7 @@ import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.webapps.schema.entities.JobEntity;
 import io.camunda.webapps.schema.entities.SequenceFlowEntity;
 import io.camunda.webapps.schema.entities.VariableEntity;
+import io.camunda.webapps.schema.entities.agentinstance.AgentInstanceEntity;
 import io.camunda.webapps.schema.entities.auditlog.AuditLogEntity;
 import io.camunda.webapps.schema.entities.dmn.DecisionInstanceEntity;
 import io.camunda.webapps.schema.entities.flownode.FlowNodeInstanceEntity;
@@ -499,7 +501,10 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
             List.of(auditLogEntity(processInstance))),
         new DependentEntities(
             resourceProvider.getIndexTemplateDescriptor(TaskTemplate.class),
-            List.of(taskEntity(processInstance))));
+            List.of(taskEntity(processInstance))),
+        new DependentEntities(
+            resourceProvider.getIndexTemplateDescriptor(AgentInstanceTemplate.class),
+            List.of(agentInstanceEntity(processInstance))));
   }
 
   private ProcessInstanceForListViewEntity processInstanceForListViewEntity(final String endDate) {
@@ -638,6 +643,14 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
   private TaskEntity taskEntity(final ProcessInstanceForListViewEntity processInstance) {
     final TaskEntity entity = create(TaskEntity::new);
     entity.setProcessInstanceId(String.valueOf(processInstance.getKey()));
+    entity.setRootProcessInstanceKey(processInstance.getKey());
+    return entity;
+  }
+
+  private AgentInstanceEntity agentInstanceEntity(
+      final ProcessInstanceForListViewEntity processInstance) {
+    final AgentInstanceEntity entity = create(AgentInstanceEntity::new);
+    entity.setProcessInstanceKey(processInstance.getKey());
     entity.setRootProcessInstanceKey(processInstance.getKey());
     return entity;
   }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
@@ -1091,13 +1091,13 @@ final class ElasticsearchArchiverRepositoryIT {
         .untilAsserted(
             () ->
                 verify(
-                        indicesClientSpy, times(20) // number of index templates
+                        indicesClientSpy, times(21) // number of index templates
                         )
                     .putSettings(captor.capture()));
 
     final var putIndicesSettingsRequests = captor.getAllValues();
     assertThat(putIndicesSettingsRequests)
-        .hasSize(20)
+        .hasSize(21)
         .allSatisfy(
             request -> {
               assertThat(request.index()).hasSize(1);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
@@ -1189,7 +1189,7 @@ final class OpenSearchArchiverRepositoryIT {
                 verify(
                         genericClientSpy,
                         times(
-                            40) // number of index templates * 2 (for change policy requests and add
+                            42) // number of index templates * 2 (for change policy requests and add
                         // policy requests)
                         )
                     .executeAsync(captor.capture()));
@@ -1197,7 +1197,7 @@ final class OpenSearchArchiverRepositoryIT {
     final var putIndicesSettingsRequests = captor.getAllValues();
     assertThat(putIndicesSettingsRequests)
         .filteredOn(req -> req.getEndpoint().contains("_ism/add"))
-        .hasSize(20)
+        .hasSize(21)
         .allSatisfy(
             request -> {
               final var indexPattern =


### PR DESCRIPTION
## Description

Part 1 of 3 for [#51512](https://github.com/camunda/camunda/issues/51512) — delivering secondary-storage schema support for `AGENT_INSTANCE` records produced by the Zeebe engine.

### Rationale

The Zeebe engine now produces `AGENT_INSTANCE` records (`CREATED` / `UPDATED` / `COMPLETED`) as part of the AI agent feature introduced in 8.10.0. These records need to flow into secondary storage so that the Query API can serve them. Before any export handler can write agent instance data, the schema layer — the canonical entity model and the Elasticsearch/OpenSearch index template — must exist and be reviewed independently.

This PR delivers that schema foundation. It has zero runtime dependency on handler logic, which means it:
- Unblocks the Optimize team who need the index template to start their own work
- Gives PR-2 (Camunda Exporter handler) and PR-3 (RDBMS full stack) a stable, reviewed contract to code against
- Allows schema review to happen independently of handler logic

### What is in scope

- **Entity model** (`AgentInstanceEntity`)
  - Flattens all nested protocol sub-objects (`definition`, `limits`, `metrics`) into top-level fields
  - `tools` is a typed `List<AgentInstanceToolValue>` nested record
  - `elementInstanceKeys` is `List<Long>`, forward-compatible with future multi-key associations
  - Handler-computed date fields (`creationDate`, `lastUpdatedDate`, `completionDate`) as `@Nullable OffsetDateTime`
  - `rootProcessInstanceKey` (Long, nullable) — required by `ProcessInstanceDependant` so `ProcessInstanceArchiverJob` can cascade-delete agent instance documents when the owning root process instance is archived

- **Index template descriptor** (`AgentInstanceTemplate`)
  - All field-name constants and `INDEX_VERSION = "8.10.0"`
  - Implements `ProcessInstanceDependant` to participate in history-deletion archive cascade
  - Implements `Prio4Backup` to participate in cluster backup/restore

- **Index mappings** — ES and OS JSON templates (`camunda-agent-instance.json`)
  - `systemPrompt` mapped as `text` with `index: false` (display-only, not searchable)
  - `tools` mapped as `nested` object with `name` (keyword), `description` (text/index:false), `elementId` (keyword)
  - `elementInstanceKeys` and `rootProcessInstanceKey` as `long`
  - All date fields as `date_time || epoch_millis`
  - `dynamic: strict`

- **Infrastructure wiring**
  - Registered in `IndexDescriptors` — the central registry that drives template creation at startup
  - Registered in `BackupPriorityConfiguration` at Prio4 — so the backup/restore infrastructure includes agent instance data in cluster snapshots

- **Test assertion updates** — four test classes that enumerate all known indices/templates exhaustively were updated to account for the new template:
  - `ElasticsearchArchiverRepositoryIT` and `OpenSearchArchiverRepositoryIT` — ILM index counts incremented
  - `AbstractProcessInstanceArchiverJobIT` — agent instance entry added to process-instance-dependent entity list
  - `SchemaManagerIT.shouldCreateHarmonizedSchema` — `camunda-agent-instance-8.10.0_` added to the hardcoded full index name list

- **Housekeeping** — sorted index descriptors alphabetically within each commented section in `BackupPriorityConfiguration`; consolidated the fragmented `prio3` OPERATE block that had a duplicate `// OPERATE` comment

### What is out of scope (covered by follow-up PRs)

| Excluded | Covered by |
|----------|------------|
| Camunda Exporter handler (`AgentInstanceHandler`) that writes to ES/OS | PR-2 `feat/51512-agent-instance-camunda-exporter` |
| RDBMS schema (Liquibase), mapper, writer, and RDBMS Exporter handler | PR-3 `feat/51512-agent-instance-rdbms` |
| REST API layer — `GET /agent-instances`, `POST /agent-instances/search` | #51510 |

### Test coverage

The test assertion updates above are required for CI — those four test classes act as exhaustive registries and fail on any unregistered index addition.

Additionally, two reflection-based tests in `webapps-schema` pick up the new types automatically with no changes needed:

- **`EntityTest`** — asserts every field in every `ExporterEntity` subclass carries `@SinceVersion`. `AgentInstanceEntity` is included automatically.
- **`IndexDescriptorTest`** — asserts the version string format for every `IndexDescriptor` implementation. `AgentInstanceTemplate` is included automatically.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

Part 1 of 3 for #51512 — this PR does **not** close the issue. The issue will be closed once PR-2 (Camunda Exporter handler) and PR-3 (RDBMS full stack) are merged.