### PR TITLE
docs: create docs for remaining FE docs sections

### DIFF
--- a/docs/monorepo-docs/frontend/adr/adr.md
+++ b/docs/monorepo-docs/frontend/adr/adr.md
@@ -1,3 +1,17 @@
 # Architecture Decision Records
 
-_Content coming soon._
+An Architecture Decision Record (ADR) is a short document that
+captures a single architectural decision, the context behind it, the
+alternatives that were considered, and the consequences that follow.
+The goal is to give future engineers a clear answer to "why was this
+built this way?" without having to dig through Slack threads or old
+Google Docs. ADRs live in `webapp/client/adrs/`. Only write an ADR
+when the decision is final.
+
+## Creating an ADR
+
+Use the Camunda
+[create-architecture-decision](https://github.com/camunda/.github/blob/main/skills/create-architecture-decision/SKILL.md)
+AI skill. It guides you through the full workflow: source review,
+decision framing, drafting, file naming, and cross-referencing. Use it
+as the default way to create ADRs.

--- a/docs/monorepo-docs/frontend/code-reviews.md
+++ b/docs/monorepo-docs/frontend/code-reviews.md
@@ -1,3 +1,37 @@
 # Code reviews
 
-_Content coming soon._
+Our baseline is the Camunda-wide review guide in
+[CONTRIBUTING.md](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#reviewing-a-pull-request)
+and the
+[Pull Requests and Code Reviews wiki](https://github.com/camunda/camunda/wiki/Pull-Requests-and-Code-Reviews).
+This page adds frontend-specific expectations.
+
+## Reviewer responsibility
+
+You share ownership of the code you approve. Approving a PR means you
+are confident it meets our standards and does what the PR and issue
+description say it does.
+
+## What to check
+
+- Code follows project conventions: data loading, routing, modules,
+  forms, and testing patterns from the sibling docs in this section.
+- The PR does what the issue and PR description describe. The PR might contain small unrelated improvements but the reviewer should ensure they are minor and do not overwhelm the PR.
+- No leftover AI artifacts: redundant comments, unnecessary
+  abstractions, dead code.
+- Tests cover the change meaningfully.
+
+## Manual testing
+
+Before approving, run the feature locally:
+
+- Check the happy path end to end.
+- Try 1-2 error cases (network failure, invalid input, 403, empty
+  state).
+
+## Emoji code
+
+We use the emoji code documented in
+[CONTRIBUTING.md](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#review-emoji-code)
+to express the intent of review comments (required change, suggestion,
+question, etc.).

--- a/docs/monorepo-docs/frontend/code-style.md
+++ b/docs/monorepo-docs/frontend/code-style.md
@@ -1,3 +1,49 @@
 # Code style
 
-_Content coming soon._
+General style conventions for the orchestration-cluster webapp
+codebase. Linting and formatting are enforced by the shared
+`@camunda/lint-config` package.
+
+## YAGNI
+
+Don't build what you don't need yet. No abstractions for hypothetical
+future use. Wait until a real requirement forces the shape. Three
+similar lines beat a premature wrapper.
+
+## Naming
+
+- **Booleans**: prefix with `is` (e.g. `isLoading`, `isVisible`).
+- **Constants**: `SCREAMING_SNAKE_CASE` (e.g. `MAX_RETRY_COUNT`).
+- **Components**: `PascalCase` (e.g. `DashboardHeader`).
+
+## Exports
+
+Use a single export block at the end of the file. Do not use inline
+`export` on declarations.
+
+```ts
+// good
+function parseInput(raw: string) { ... }
+function formatOutput(data: Data) { ... }
+
+export {parseInput, formatOutput};
+
+// avoid
+export function parseInput(raw: string) { ... }
+export function formatOutput(data: Data) { ... }
+```
+
+## Comments
+
+Avoid comments. The code should be readable enough to explain itself.
+When a comment is necessary, explain why, not how.
+
+```ts
+// good
+// The API returns dates as Unix seconds, not milliseconds.
+const timestamp = raw * 1000;
+
+// bad
+// Multiply raw by 1000.
+const timestamp = raw * 1000;
+```

--- a/docs/monorepo-docs/frontend/code-style.md
+++ b/docs/monorepo-docs/frontend/code-style.md
@@ -12,7 +12,7 @@ similar lines beat a premature wrapper.
 
 ## Naming
 
-- **Booleans**: prefix with `is` (e.g. `isLoading`, `isVisible`).
+- **Booleans**: prefix with `is` or `has` (e.g. `isLoading`, `isVisible`, `hasIncident`).
 - **Constants**: `SCREAMING_SNAKE_CASE` (e.g. `MAX_RETRY_COUNT`).
 - **Components**: `PascalCase` (e.g. `DashboardHeader`).
 

--- a/docs/monorepo-docs/frontend/development-process/working-on-large-feature.md
+++ b/docs/monorepo-docs/frontend/development-process/working-on-large-feature.md
@@ -1,3 +1,99 @@
 # Working on a large feature
 
-_Content coming soon._
+How to ship a feature that spans multiple pages, modules, or weeks of
+work. The per-PR mechanics still follow
+[Creating a new page](./creating-a-new-page.md) and
+[Extending an existing page](./extending-an-existing-page.md); this
+page covers how to break the work down and keep unfinished features
+off for users.
+
+## Overview
+
+Large features merged as a single PR are hard to review for both
+humans and agents, risky to merge, and delay value delivery. Split the
+work into smaller PRs that each stand on their own.
+
+## Split into smaller PRs
+
+Each PR should be a meaningful, self-contained unit, not "part 1 of 5"
+but a slice that adds value or lays necessary groundwork. It should
+build, pass tests, and be reviewable in isolation.
+
+How to slice:
+
+- **By layer**: schemas/types first, then modules, then page, then
+  route wiring.
+- **By user-visible unit**: one filter, one column, one panel, one
+  flow per PR.
+- **By dependency order**: shared modules before consumers.
+
+When in doubt, err on the side of smaller. A PR that is too small is
+still easy to review. A PR that is too large is not.
+
+## Feature flags
+
+When the feature is not ready to be enabled for users but code needs
+to merge to `main`, gate it behind a feature flag.
+
+### Creating a flag
+
+Export a boolean `const` from
+`src/modules/feature-flags.ts`. Use `SCREAMING_SNAKE_CASE` and
+default to `false`.
+
+```ts
+// src/modules/feature-flags.ts
+export const ENABLE_PROCESS_MIGRATION = false;
+```
+
+### Using a flag
+
+Gate at the highest possible level: route registration, page
+component, or navigation item. Do not scatter flag checks deep inside
+modules.
+
+```tsx
+import { ENABLE_PROCESS_MIGRATION } from "#/modules/feature-flags";
+
+function ProcessActions() {
+  return (
+    <>
+      {ENABLE_PROCESS_MIGRATION && <MigrateButton />}
+    </>
+  );
+}
+```
+
+### Large refactors behind a flag
+
+When a feature rewrites a significant portion of an existing page or
+module, copy the affected code and build the new version alongside the
+old one. Toggle between them with the feature flag. This keeps PRs
+small and focused: reviewers see only the new code, not a giant diff
+of interleaved changes. The cleanup PR that removes the flag also
+deletes the old copy.
+
+### Removing a flag
+
+Once the feature ships and is validated, remove the flag in a
+dedicated cleanup PR:
+
+1. Set the flag to `true` and verify everything works.
+2. Remove the `const` from `feature-flags.ts`.
+3. Remove all conditional branches that read it.
+4. Delete any dead code that was behind the negative branch.
+
+Do not leave flags lingering. If removal is deferred, file a tracking
+issue and link it from a comment next to the flag.
+
+## Checklist
+
+Before opening each PR in a large feature:
+
+- [ ] PR is a self-contained slice, not a partial dump.
+- [ ] Feature flag added in `src/modules/feature-flags.ts` if the
+      feature is not ready to enable.
+- [ ] Flag gating lives at route or page level, not deep in modules.
+- [ ] No leftover flags without a tracking issue for removal.
+- [ ] PR follows the per-PR checklist from
+      [Creating a new page](./creating-a-new-page.md#checklist).

--- a/docs/monorepo-docs/frontend/legacy-components.md
+++ b/docs/monorepo-docs/frontend/legacy-components.md
@@ -1,3 +1,22 @@
 # Legacy components
 
-_Content coming soon._
+The legacy frontends still ship independently and will eventually be
+integrated into the unified orchestration-cluster webapp.
+
+## Projects
+
+- **`operate/client`**: process monitoring.
+- **`tasklist/client`**: user task management.
+- **`identity/client`** (also known as Admin): authentication,
+  authorization and general cluster admin features.
+
+Each project has its own standards, tooling, and conventions. When
+working on them, follow the conventions already established in that
+project, not the ones documented in this section.
+
+## Migration
+
+These components will be progressively migrated into
+`@camunda/orchestration-cluster-webapp`. For the current status, see
+the unification epic
+([camunda/camunda#51305](https://github.com/camunda/camunda/issues/51305)).

--- a/docs/monorepo-docs/frontend/testing.md
+++ b/docs/monorepo-docs/frontend/testing.md
@@ -1,3 +1,141 @@
 # Testing
 
-_Content coming soon._
+Testing in `@camunda/orchestration-cluster-webapp`. For the scripts
+that run each suite, see the
+[Scripts table](./orchestration-cluster-webapp.md#scripts).
+
+## Stack
+
+| Type              | Tool                                 | Location              | Script                     |
+| ----------------- | ------------------------------------ | --------------------- | -------------------------- |
+| Unit              | Vitest browser mode (Playwright)     | `src/**/*.test.ts(x)` | `npm run test:unit`        |
+| Integration       | Playwright + MSW (`@msw/playwright`) | `test/integration/`   | `npm run test:integration` |
+| Accessibility     | Playwright + `@axe-core/playwright`  | `test/a11y/`          | `npm run test:a11y`        |
+| Visual regression | Playwright + containerized browser   | `test/visual/`        | `npm run test:visual`      |
+
+## Mocking the backend
+
+[MSW](https://mswjs.io/) is the only backend mock layer. Two
+entrypoints depending on the test type:
+
+- **Unit tests**: MSW `setupWorker` (browser mode), auto-started by
+  the custom `it` fixture from `#/vitest-modules/test-extend`.
+- **Playwright tests**: MSW via `@msw/playwright`, auto-started by
+  the `network` fixture from `#/pw-modules/test-extend`.
+
+Both use `createEndpointMock` from
+`#/shared-test-modules/mock-endpoint` to build typed request handlers.
+All endpoint mocks are defined in `#/shared-test-modules/endpoints` as
+a shared dictionary, so every test (unit and Playwright) reuses the
+same mock definitions.
+
+Unit test example:
+
+```ts
+import { it } from "#/vitest-modules/test-extend";
+import { endpoints } from "#/shared-test-modules/endpoints";
+import { HttpResponse } from "msw";
+
+it("should render users", async ({ worker }) => {
+  worker.use(
+    endpoints.users({
+      successResponse: HttpResponse.json([{ name: "Alice" }]),
+    }),
+  );
+  // render and assert...
+});
+```
+
+Playwright test example:
+
+```ts
+import { test, expect } from "#/pw-modules/test-extend";
+import { endpoints } from "#/shared-test-modules/endpoints";
+import { HttpResponse } from "msw";
+
+test("should render users", async ({ network, page }) => {
+  network.use(
+    endpoints.users({
+      successResponse: HttpResponse.json([{ name: "Alice" }]),
+    }),
+  );
+  await page.goto("/users");
+  await expect(page.getByText("Alice")).toBeVisible();
+});
+```
+
+## Prefer testing library selectors
+
+Both Vitest browser mode and Playwright include testing library
+selectors out of the box. Use `getByRole`, `getByLabelText`, and
+`getByText` over raw DOM queries like `querySelector` or `getByTestId`.
+They enforce accessible markup and make tests resilient to structural
+changes.
+
+```ts
+// good
+screen.getByRole("button", { name: /submit/i });
+screen.getByLabelText(/username/i);
+
+// avoid
+screen.querySelector("button.submit-btn");
+screen.getByTestId("submit-button");
+```
+
+## Avoid vitest mocks
+
+Prefer MSW and real implementations over `vi.mock` and
+module mocks. Vitest mocks couple tests to implementation details and
+break on refactors. Reach for them only when there is no practical
+alternative, such as faking time with `vi.useFakeTimers`.
+
+## Unit vs. integration tests
+
+### Unit tests
+
+Test a single component, hook, or utility in isolation. Render with
+`vitest-browser-react` `render()`. Use MSW to mock HTTP when the
+component fetches data.
+
+Do not mock the router. The only exception is when the component uses
+`<Link>`, `useNavigate`, or another router hook that fails without a
+provider. In that case wrap in a minimal router provider, nothing more.
+
+### Integration tests
+
+Test a feature across UI sections and pages: navigation, data loading,
+error states, user flows that span multiple components. Run against the
+built app via Playwright. Always mock the backend with MSW via the
+`network` fixture.
+
+## Accessibility tests
+
+Playwright + `@axe-core/playwright`. Two Playwright projects run every
+a11y test in both light and dark themes. Use the `makeAxeBuilder`
+fixture and assert that `violations` is empty.
+
+```ts
+import { test, expect } from "#/pw-modules/test-extend";
+
+test("should have no a11y violations", async ({ makeAxeBuilder, page }) => {
+  await page.goto("/some-page");
+  const results = await makeAxeBuilder().analyze();
+  expect(results.violations).toEqual([]);
+});
+```
+
+## Visual regression tests
+
+Playwright `toHaveScreenshot`. Four projects cover light/dark and
+desktop/tablet combinations. Set `CONTAINERIZED_BROWSER=true` to run
+inside the official `mcr.microsoft.com/playwright` Docker image for
+stable cross-machine rendering.
+
+```ts
+import { test, expect } from "#/pw-modules/test-extend";
+
+test("should match snapshot", async ({ page }) => {
+  await page.goto("/some-page");
+  await expect(page).toHaveScreenshot("some-page.png", { fullPage: true });
+});
+```

--- a/docs/monorepo-docs/frontend/using-ai.md
+++ b/docs/monorepo-docs/frontend/using-ai.md
@@ -19,7 +19,8 @@ automated agents reviewing your PRs.
   the orchestration-cluster webapp and knows our conventions. The agent
   is currently being developed and will be available soon.
 - Break the problem down before prompting. Smaller, well-scoped
-  prompts produce better results than "implement this feature."
+  prompts produce better results than "implement this feature." Use
+  plan mode to get the agent's help with the breakdown.
 - Review each response critically. Check for unnecessary abstractions,
   dead code, wrong patterns, and deviations from project conventions.
 - Iterate. Push back on the agent when the solution is not good

--- a/docs/monorepo-docs/frontend/using-ai.md
+++ b/docs/monorepo-docs/frontend/using-ai.md
@@ -1,3 +1,39 @@
 # Using AI
 
-_Content coming soon._
+Camunda follows an AI-first approach. Follow the company AI policies
+and apply the guidelines below when using AI for frontend work.
+
+## Your responsibility
+
+AI writes code, you own the result. Your job is to steer agents toward
+a good solution, not accept the first thing that compiles. Apply
+critical thinking, iterate, and refine.
+
+A PR should look as if AI was not involved. If it doesn't, you are
+shifting review burden to other engineers and wasting cycles from
+automated agents reviewing your PRs.
+
+## Working with agents
+
+- Use the frontend agent for frontend work. It is purpose-built for
+  the orchestration-cluster webapp and knows our conventions. The agent
+  is currently being developed and will be available soon.
+- Break the problem down before prompting. Smaller, well-scoped
+  prompts produce better results than "implement this feature."
+- Review each response critically. Check for unnecessary abstractions,
+  dead code, wrong patterns, and deviations from project conventions.
+- Iterate. Push back on the agent when the solution is not good
+  enough. Ask it to simplify, restructure, or try a different
+  approach.
+- Use the project docs (this site) as context for the agent so it
+  follows our conventions.
+
+## Before opening a PR
+
+- Code follows project conventions (see sibling docs).
+- No leftover boilerplate, redundant comments, or over-engineered
+  abstractions typical of AI output.
+- You can explain what your code does.
+- Tests are meaningful, not just "make the build pass."
+- The diff is clean and reviewable, same standard as hand-written
+  code.


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR adds docs for the remaining sections

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

related https://github.com/camunda/camunda/issues/51327
