### PR TITLE
feat: create FE AI skills

### DIFF
--- a/.claude/skills/frontend-feature/SKILL.md
+++ b/.claude/skills/frontend-feature/SKILL.md
@@ -79,13 +79,14 @@ When a feature is not ready for users but code needs to merge to `main`, gate it
 
 ## Local checks before commit
 
-Run from `webapp/client/apps/orchestration-cluster-webapp/`:
+Run these commands:
 
-```bash
-npm run typecheck        # TypeScript across all tsconfigs
-npm run lint             # ESLint + Prettier
-npm run test:unit        # Vitest browser mode (headless Chromium)
-```
+    # From webapp/client/
+    npm run lint             # ESLint + Prettier (workspace)
+
+    # From webapp/client/apps/orchestration-cluster-webapp/
+    npm run typecheck        # TypeScript across all tsconfigs
+    npm run test:unit        # Vitest browser mode (headless Chromium)
 
 ## Canonical docs
 

--- a/.claude/skills/frontend-feature/SKILL.md
+++ b/.claude/skills/frontend-feature/SKILL.md
@@ -1,0 +1,99 @@
+---
+
+name: frontend-feature
+description: Use when creating new pages, components, modules, or features in the orchestration cluster webapp at webapp/client/apps/orchestration-cluster-webapp/. Use when adding routes, data loading, forms, API integration, or UI components. Trigger whenever someone is building or modifying frontend feature code in webapp/client/, even for small changes like adding a column, filter, or panel.
+
+---
+
+# Frontend Feature Development
+
+Reference for building features in `@camunda/orchestration-cluster-webapp` — the unified React frontend replacing Operate, Tasklist, and Admin. The app uses React 19, TypeScript, Vite, TanStack Router (file-based), TanStack Query, MobX (theme + session), Carbon Design System, and SCSS.
+
+## Key rules
+
+- Use Carbon Design System components (`@carbon/react`). Introducing alternative UI libraries fragments the design language and creates maintenance burden.
+- Use `#/` path aliases for all imports — `#/modules/*`, `#/assets/*`, `#/pages/*`. They are resolved by Vite and the relevant tsconfig.
+- Prefer **types** from `@camunda/camunda-api-zod-schemas` to type API responses — trust the API contract. Use Zod schema validation only for **user input** (forms, URL search params, path params). For general validation needs beyond API contracts, use Zod directly.
+- Routes go in `src/routes/` (file-based, TanStack Router); pages go in `src/pages/`; reusable logic goes in `src/modules/`. A module owns one small concern — not an entire page. Keep internal structure flat; cap depth at `modules/<thing>/components/<Component>/`.
+- Follow filename conventions: `use*.ts(x)` for hooks, `*.store.ts` for stores, `PascalCase.tsx` for components, `*.test.ts(x)` for tests.
+- Use a single `export {}` block at the end of each file — no inline `export` on declarations. Only export symbols that are actually imported by other files. Don't export internal helpers, types used only within the same file, or constants that nothing else references. This keeps the public surface minimal and scannable.
+- YAGNI — don't build abstractions for hypothetical future use. Three similar lines beat a premature wrapper. Wait until a real requirement forces the shape.
+
+## Code style
+
+- **Booleans**: prefix with `is` (e.g., `isLoading`, `isVisible`).
+- **Constants**: `SCREAMING_SNAKE_CASE` (e.g., `MAX_RETRY_COUNT`).
+- **Components**: `PascalCase` (e.g., `DashboardHeader`).
+- **Comments**: avoid them. Code should explain itself. When a comment is necessary, explain *why*, not *how*.
+- **Memoize derived data**: when creating new values inside a component (e.g., `.map()`, `.filter()`, transformations), always wrap in `useMemo` to avoid recomputing on every render.
+- **SCSS spacing**: use Carbon design token CSS variables for spacing (e.g., `$spacing-05`, `var(--cds-spacing-05)`). Never hardcode pixel or rem values for layout spacing.
+
+## Building a feature
+
+A feature spans three folders in `apps/orchestration-cluster-webapp/src/`:
+
+1. **`modules/`** — components, hooks, stores, utilities. Each module owns one focused concern (`http`, `errors`, `theme`, `login`). A module is a reusable building block — not a full feature. Pages compose modules; modules don't mirror pages. Components go in a `components/` subfolder; everything else sits at the module root. Reuse existing modules before creating new ones.
+2. **`pages/`** — one file per page with co-located styles (`*.module.scss`) and tests. Pages are glue: receive data as props, orchestrate module components. No `fetch`, no business logic.
+3. **`routes/`** — TanStack Router file-based routes. File path = URL path. Auth-gated routes go under `_auth/`. The route owns the loader, `pendingComponent`, and `errorComponent`.
+
+Default to a new route for anything a user can navigate to. Skip a route only for transient overlays (toasts, hover cards), non-linkable modals (confirmations), or in-page tabs sharing the same data (encode as `?tab=...` search param).
+
+## URL as state
+
+The URL holds the page's state. Components read from it, not from each other.
+
+- **Route params**: entity identity (`/_auth/processes/$processKey`).
+- **Search params**: view state — filters, sort, cursor, selection, active tab, modal-open flag.
+- **Local React state**: ephemeral UI only — open menu, input draft, hover, focus.
+
+Validate all URL inputs with Zod. Use `validateSearch` for search params and `parseParams` for path params. Reuse schemas from `@camunda/camunda-api-zod-schemas` when the URL slice maps to an API contract; otherwise co-locate the schema in the route file.
+
+## Data loading
+
+Uses TanStack Router loaders + TanStack Query. Three tiers in descending order of preference:
+
+1. **Route loader + suspense queries** — `queryClient.ensureQueryData` in the loader, `useSuspenseQuery` in the component. Same `queryOptions` constant for both.
+2. **Route loader + `pendingComponent`** — same as above, but fire-and-forget the loader (don't `await`) and add a `pendingComponent` skeleton so the page doesn't freeze.
+3. **Streamed promises + granular skeletons** — `await` the fast query, fire-and-forget the slow one, wrap the slow slice in its own `<Suspense>`.
+
+`queryOptions` constants live in `#/modules/http/queries.ts` — the central query dictionary. API endpoint definitions (URL + method + types) live in `#/modules/http/endpoints.ts`. Do not co-locate queries or endpoints with individual modules; keep them in one place so the full set is visible and discoverable. Error handling defaults to `errorComponent` on the route. 401s are handled centrally by the `request()` wrapper (cache clear + login redirect).
+
+## Before starting a feature
+
+Work through these Camunda-specific considerations. They shape the page architecture:
+
+- **API schemas**: check if the endpoints exist in `@camunda/camunda-api-zod-schemas`. If not, add them as part of your work.
+- **Pagination**: most list endpoints paginate. Default to infinite scroll with `useSuspenseInfiniteQuery`. Trust `hasMoreTotalItems`, not `totalItems`. Prefer cursor-based pagination over offset for performance.
+- **Permissions**: authorization is server-side. For actions, leave the button visible; surface a toast on 403. For data loads, render a forbidden state (page-level or section-level). A 403 can also mean a feature is disabled for the deployment.
+- **Eventual consistency**: reads from secondary storage are eventually consistent. If the OpenAPI spec flags `x-eventually-consistent`, poll with `refetchInterval`. Default to pessimistic UI — reach for optimistic updates only with an explicit reconciliation plan.
+- **Batch operations**: POST returns a `batchOperationKey`. Poll `GET /v2/batch-operations/{key}` for state. Show a toast confirming submission, poll in the background, surface the result when it lands. Never block the page on the poll.
+- **Multi-tenancy**: deployment-level toggle. Render tenant picker, columns, and filters only when it's on. Always pass the active tenant in requests when enabled.
+
+## Forms
+
+Decision rule: use plain HTML `<form>` for simple forms. Reach for react-final-form when the form needs schema-based validation or form/field meta state (`dirty`, `touched`, submission state, field arrays). Validate on submit (whole form) and on blur (single field) — never on every keystroke. Reuse Zod schemas from `@camunda/camunda-api-zod-schemas` where the form maps to an API contract.
+
+## Feature flags
+
+When a feature is not ready for users but code needs to merge to `main`, gate it behind a flag. Export a boolean `const` from `src/modules/feature-flags.ts`, `SCREAMING_SNAKE_CASE`, default `false`. Gate at the highest possible level — route, page, or nav item — not deep in modules. Remove flags in a dedicated cleanup PR once the feature ships.
+
+## Local checks before commit
+
+Run from `webapp/client/apps/orchestration-cluster-webapp/`:
+
+```bash
+npm run typecheck        # TypeScript across all tsconfigs
+npm run lint             # ESLint + Prettier
+npm run test:unit        # Vitest browser mode (headless Chromium)
+```
+
+## Canonical docs
+
+- `docs/monorepo-docs/frontend/orchestration-cluster-webapp.md` — tech stack, layout, scripts, testing overview.
+- `docs/monorepo-docs/frontend/data-loading.md` — TanStack Router + Query patterns with full examples.
+- `docs/monorepo-docs/frontend/forms.md` — form library guidance.
+- `docs/monorepo-docs/frontend/development-process/creating-a-new-page.md` — step-by-step with checklist.
+- `docs/monorepo-docs/frontend/development-process/before-starting.md` — pre-feature considerations.
+- `docs/monorepo-docs/frontend/development-process/extending-an-existing-page.md` — incremental changes.
+- `docs/monorepo-docs/frontend/development-process/working-on-large-feature.md` — PR splitting and feature flags.
+- `docs/monorepo-docs/frontend/code-style.md` — naming, exports, comments.

--- a/.claude/skills/frontend-integration-test/SKILL.md
+++ b/.claude/skills/frontend-integration-test/SKILL.md
@@ -1,0 +1,250 @@
+---
+
+name: frontend-integration-test
+description: Use when writing, modifying, or debugging Playwright-based tests in the orchestration cluster webapp — integration tests, visual regression tests, or accessibility tests. Use when working with MSW network-level mocking via @msw/playwright, Page Object Models, axe-core accessibility checks, or screenshot comparisons. Trigger whenever someone is working in the test/ directory of the OC webapp at webapp/client/apps/orchestration-cluster-webapp/test/.
+
+---
+
+# Frontend Integration, Visual, and Accessibility Testing
+
+Playwright tests in `@camunda/orchestration-cluster-webapp` cover three categories — integration, visual regression, and accessibility — across 7 Playwright projects. Tests run against the built app served by `vite preview` on port 3003. MSW intercepts HTTP at the network level via `@msw/playwright`, so no real backend is needed.
+
+## Key rules
+
+- Import `test` and `expect` from `#/pw-modules/test-extend`, not from `@playwright/test`. The custom `test` fixture auto-starts MSW network interception per test and provides the `makeAxeBuilder` fixture for accessibility checks.
+- Use endpoint mocks from `#/shared-test-modules/mock-handlers` with `network.use()`. Each mock is an individually named export (e.g., `mockCurrentUserEndpoint`, `mockLoginEndpoint`) created with `createEndpointMock` — both unit and Playwright tests use the same definitions. All endpoint mocks must be defined in `apps/orchestration-cluster-webapp/shared-test-modules/mock-handlers.ts` — never create `createEndpointMock` calls inline in test files.
+- Prefer testing library selectors: `page.getByRole()`, `page.getByLabel()`, `page.getByText()`. Playwright includes these out of the box. They enforce accessible markup and survive structural changes. Avoid `page.locator('.css-class')` and `page.getByTestId()`.
+- Place tests in the correct category directory: `test/integration/` for MSW-mocked user flows, `test/visual/` for screenshot comparisons, `test/a11y/` for accessibility checks.
+- Use Page Object Model for page interactions — one class per page under `test/pages/`. Encapsulate navigation, locators, and composite actions (e.g., `fillCredentials(username, password)`) so tests read as user stories, not DOM queries. Page objects are registered as Playwright fixtures in `test/pw-modules/test-extend.ts` and destructured from the test parameters — **NEVER import page object classes in test files**. Test files must not contain any `import {LoginPage}` or `import {SomePage}` statements.
+
+```ts
+// WRONG — never do this in a test file
+import {LoginPage} from '../pages/Login.page';
+const loginPage = new LoginPage(page);
+
+// CORRECT — destructure from test parameters
+test('should ...', async ({loginPage, network, page}) => {
+  await loginPage.goto();
+});
+```
+- Visual tests require a containerized browser for consistent cross-machine rendering (`CONTAINERIZED_BROWSER=true` runs the official `mcr.microsoft.com/playwright` Docker image).
+- Accessibility tests check both light and dark themes automatically — the Playwright config runs a11y tests through `a11y-light` and `a11y-dark` projects.
+
+## Test categories
+
+### Integration tests (`test/integration/`)
+
+Test user flows across pages and components: navigation, data loading, error states, multi-step interactions. Mock the backend with MSW via the `network` fixture. Use page objects from fixtures — never import and instantiate them manually.
+
+```ts
+import {test, expect} from '#/pw-modules/test-extend';
+import {mockCurrentUserEndpoint, mockLoginEndpoint} from '#/shared-test-modules/mock-handlers';
+import {HttpResponse} from 'msw';
+
+test('should redirect to the initial page on success', async ({network, page, loginPage}) => {
+  network.use(
+    mockCurrentUserEndpoint({successResponse: new HttpResponse(null, {status: 401})}),
+    mockLoginEndpoint({successResponse: new HttpResponse(null, {status: 200})}),
+  );
+
+  await loginPage.goto();
+
+  network.use(mockCurrentUserEndpoint({successResponse: HttpResponse.json({})}));
+
+  await loginPage.fillCredentials('demo', 'demo');
+  await loginPage.submitButton.click();
+
+  await expect(page).toHaveURL('/');
+});
+```
+
+### Visual regression tests (`test/visual/`)
+
+Screenshot comparison via `expect(page).toHaveScreenshot()`. Four projects cover light/dark themes and desktop/tablet viewports. Always use the containerized browser for deterministic rendering.
+
+```ts
+import {test, expect} from '#/pw-modules/test-extend';
+
+test('should match snapshot', async ({page}) => {
+  await page.goto('/some-page');
+  await expect(page).toHaveScreenshot('some-page.png', {fullPage: true});
+});
+```
+
+### Accessibility tests (`test/a11y/`)
+
+Playwright + `@axe-core/playwright`. Use the `makeAxeBuilder` fixture and assert zero violations. The Playwright config runs every a11y test in both light and dark themes automatically.
+
+```ts
+import {test, expect} from '#/pw-modules/test-extend';
+
+test('should have no a11y violations', async ({makeAxeBuilder, page}) => {
+  await page.goto('/some-page');
+  const results = await makeAxeBuilder().analyze();
+  expect(results.violations).toEqual([]);
+});
+```
+
+## Fixtures
+
+The custom `test` from `#/pw-modules/test-extend` provides these fixtures:
+
+| Fixture | Auto | Description |
+|---|---|---|
+| `network` | yes | MSW interception via `@msw/playwright`. Starts before each test, stops after. Use `network.use()` to add handlers. |
+| `handlers` | no (option) | Pre-configure MSW handlers at suite level via `test.use({handlers: [...]})`. Useful when every test in a file shares the same mock setup. |
+| `makeAxeBuilder` | no | Creates an `AxeBuilder` instance scoped to the current page. Call `makeAxeBuilder().analyze()` to run the audit. |
+| `loginPage` | no | Page object for the login page. Every page object follows this pattern — registered as a fixture, destructured in tests. |
+
+The `network` fixture errors on unhandled requests (except HTML page navigations), so tests fail fast if they hit an un-mocked endpoint. This is intentional — it catches missing mocks early.
+
+Endpoint mocks are functions — always call them with a config object containing `successResponse`:
+
+```ts
+// Correct
+mockCurrentUserEndpoint({successResponse: HttpResponse.json({})})
+mockLoginEndpoint({successResponse: new HttpResponse(null, {status: 200})})
+
+// Wrong — bare reference, dot-chained, or wrong key names
+mockCurrentUserEndpoint
+mockLoginEndpoint.success()
+mockLoginEndpoint({serverResponse: ...})  // wrong key
+```
+
+`network.use()` is synchronous and takes handlers as spread arguments, not an array:
+
+```ts
+// Correct
+network.use(
+  mockCurrentUserEndpoint({successResponse: HttpResponse.json({})}),
+  mockLoginEndpoint({successResponse: new HttpResponse(null, {status: 200})}),
+);
+
+// Wrong
+await network.use([...]);
+```
+
+Do not use `// given / when / then` comments in frontend tests — that is a Java backend convention. Structure tests by visual grouping instead.
+
+## Page Object Model
+
+Encapsulate page interactions in classes under `test/pages/`. Every page object must have a `goto()` method for navigation. Use getter-based locators and composite actions (multi-step user operations like filling a form). Tests navigate via `loginPage.goto()`, never via `page.goto('/login')` directly.
+
+```ts
+// test/pages/Login.page.ts
+import {type Page} from '@playwright/test';
+
+class LoginPage {
+  private page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  async goto() {
+    await this.page.goto('/login');
+  }
+
+  get usernameInput() {
+    return this.page.getByLabel(/username/i);
+  }
+
+  get passwordInput() {
+    return this.page.getByLabel(/^password$/i);
+  }
+
+  get submitButton() {
+    return this.page.getByRole('button', {name: /login/i});
+  }
+
+  get errorMessage() {
+    return this.page.getByRole('alert').filter({hasText: /.+/});
+  }
+
+  async fillCredentials(username: string, password: string) {
+    await this.usernameInput.fill(username);
+    await this.passwordInput.fill(password);
+  }
+}
+
+export {LoginPage};
+```
+
+### Registering page objects as fixtures
+
+Page objects are never imported directly in test files. Register them as Playwright fixtures in `test/pw-modules/test-extend.ts`:
+
+```ts
+// test/pw-modules/test-extend.ts (excerpt)
+import {LoginPage} from '#/pages/Login.page';
+
+type Fixtures = {
+  // ...existing fixtures...
+  loginPage: LoginPage;
+};
+
+const test = base.extend<Fixtures>({
+  // ...existing fixtures...
+  loginPage: async ({page}, use) => {
+    await use(new LoginPage(page));
+  },
+});
+```
+
+Usage in tests — destructure from the test parameters:
+
+```ts
+import {test, expect} from '#/pw-modules/test-extend';
+import {mockCurrentUserEndpoint, mockLoginEndpoint} from '#/shared-test-modules/mock-handlers';
+import {HttpResponse} from 'msw';
+
+test('should show an error for wrong credentials', async ({network, loginPage}) => {
+  network.use(
+    mockCurrentUserEndpoint({successResponse: new HttpResponse(null, {status: 401})}),
+    mockLoginEndpoint({successResponse: new HttpResponse(null, {status: 401})}),
+  );
+
+  await loginPage.goto();
+  await loginPage.fillCredentials('demo', 'wrong-password');
+  await loginPage.submitButton.click();
+
+  await expect(loginPage.errorMessage).toContainText(/username and password do not match/i);
+});
+```
+
+## Playwright config overview
+
+The config at `playwright.config.ts` defines 7 projects:
+
+| Project | Category | Theme | Viewport |
+|---|---|---|---|
+| `visual-light` | visual | light | desktop |
+| `visual-dark` | visual | dark | desktop |
+| `visual-light-tablet` | visual | light | tablet |
+| `visual-dark-tablet` | visual | dark | tablet |
+| `a11y-light` | a11y | light | desktop |
+| `a11y-dark` | a11y | dark | desktop |
+| `integration` | integration | — | desktop |
+
+Tests match by directory: `visual/**/*.test.ts`, `a11y/**/*.test.ts`, `integration/**/*.test.ts`. The app is served via `npx vite preview` on port 3003 (build must exist first). Retries are 2x on CI, traces and screenshots are captured on failure.
+
+## Commands
+
+Run from `webapp/client/apps/orchestration-cluster-webapp/`:
+
+```bash
+npm run test:integration    # Integration tests (MSW-mocked flows)
+npm run test:visual         # Visual regression (requires Docker for containerized browser)
+npm run test:a11y           # Accessibility (light + dark themes)
+```
+
+## Template references
+
+- `test/integration/about.test.ts` — integration test with MSW.
+- `test/visual/login.test.ts` — visual regression test.
+- `test/a11y/about.test.ts` — accessibility test.
+- `test/pages/Login.page.ts` — Page Object Model.
+- `test/pw-modules/test-extend.ts` — custom `test` fixture source.
+- `shared-test-modules/mock-endpoint.ts` — `createEndpointMock` factory source.
+- `shared-test-modules/mock-handlers.ts` — shared endpoint mock definitions.
+- `docs/monorepo-docs/frontend/testing.md` — full testing guide.

--- a/.claude/skills/frontend-integration-test/SKILL.md
+++ b/.claude/skills/frontend-integration-test/SKILL.md
@@ -27,6 +27,7 @@ test('should ...', async ({loginPage, network, page}) => {
   await loginPage.goto();
 });
 ```
+
 - Visual tests require a containerized browser for consistent cross-machine rendering (`CONTAINERIZED_BROWSER=true` runs the official `mcr.microsoft.com/playwright` Docker image).
 - Accessibility tests check both light and dark themes automatically — the Playwright config runs a11y tests through `a11y-light` and `a11y-dark` projects.
 
@@ -89,12 +90,12 @@ test('should have no a11y violations', async ({makeAxeBuilder, page}) => {
 
 The custom `test` from `#/pw-modules/test-extend` provides these fixtures:
 
-| Fixture | Auto | Description |
-|---|---|---|
-| `network` | yes | MSW interception via `@msw/playwright`. Starts before each test, stops after. Use `network.use()` to add handlers. |
-| `handlers` | no (option) | Pre-configure MSW handlers at suite level via `test.use({handlers: [...]})`. Useful when every test in a file shares the same mock setup. |
-| `makeAxeBuilder` | no | Creates an `AxeBuilder` instance scoped to the current page. Call `makeAxeBuilder().analyze()` to run the audit. |
-| `loginPage` | no | Page object for the login page. Every page object follows this pattern — registered as a fixture, destructured in tests. |
+|     Fixture      |    Auto     |                                                                Description                                                                |
+|------------------|-------------|-------------------------------------------------------------------------------------------------------------------------------------------|
+| `network`        | yes         | MSW interception via `@msw/playwright`. Starts before each test, stops after. Use `network.use()` to add handlers.                        |
+| `handlers`       | no (option) | Pre-configure MSW handlers at suite level via `test.use({handlers: [...]})`. Useful when every test in a file shares the same mock setup. |
+| `makeAxeBuilder` | no          | Creates an `AxeBuilder` instance scoped to the current page. Call `makeAxeBuilder().analyze()` to run the audit.                          |
+| `loginPage`      | no          | Page object for the login page. Every page object follows this pattern — registered as a fixture, destructured in tests.                  |
 
 The `network` fixture errors on unhandled requests (except HTML page navigations), so tests fail fast if they hit an un-mocked endpoint. This is intentional — it catches missing mocks early.
 
@@ -216,15 +217,15 @@ test('should show an error for wrong credentials', async ({network, loginPage}) 
 
 The config at `playwright.config.ts` defines 7 projects:
 
-| Project | Category | Theme | Viewport |
-|---|---|---|---|
-| `visual-light` | visual | light | desktop |
-| `visual-dark` | visual | dark | desktop |
-| `visual-light-tablet` | visual | light | tablet |
-| `visual-dark-tablet` | visual | dark | tablet |
-| `a11y-light` | a11y | light | desktop |
-| `a11y-dark` | a11y | dark | desktop |
-| `integration` | integration | — | desktop |
+|        Project        |  Category   | Theme | Viewport |
+|-----------------------|-------------|-------|----------|
+| `visual-light`        | visual      | light | desktop  |
+| `visual-dark`         | visual      | dark  | desktop  |
+| `visual-light-tablet` | visual      | light | tablet   |
+| `visual-dark-tablet`  | visual      | dark  | tablet   |
+| `a11y-light`          | a11y        | light | desktop  |
+| `a11y-dark`           | a11y        | dark  | desktop  |
+| `integration`         | integration | —     | desktop  |
 
 Tests match by directory: `visual/**/*.test.ts`, `a11y/**/*.test.ts`, `integration/**/*.test.ts`. The app is served via `npx vite preview` on port 3003 (build must exist first). Retries are 2x on CI, traces and screenshots are captured on failure.
 
@@ -248,3 +249,4 @@ npm run test:a11y           # Accessibility (light + dark themes)
 - `shared-test-modules/mock-endpoint.ts` — `createEndpointMock` factory source.
 - `shared-test-modules/mock-handlers.ts` — shared endpoint mock definitions.
 - `docs/monorepo-docs/frontend/testing.md` — full testing guide.
+

--- a/.claude/skills/frontend-migrator/SKILL.md
+++ b/.claude/skills/frontend-migrator/SKILL.md
@@ -50,12 +50,12 @@ Rewrite tests using the new patterns (Vitest browser mode, MSW via worker fixtur
 
 ### 6. Run local checks
 
-```bash
-# From webapp/client/apps/orchestration-cluster-webapp/
-npm run typecheck
-npm run lint
-npm run test:unit
-```
+    # From webapp/client/
+    npm run lint
+
+    # From webapp/client/apps/orchestration-cluster-webapp/
+    npm run typecheck
+    npm run test:unit
 
 ## Pattern transformations
 

--- a/.claude/skills/frontend-migrator/SKILL.md
+++ b/.claude/skills/frontend-migrator/SKILL.md
@@ -1,0 +1,208 @@
+---
+
+name: frontend-migrator
+description: Use when migrating, porting, rewriting, or moving frontend code from operate/client/ or tasklist/client/ to the orchestration cluster webapp at webapp/client/apps/orchestration-cluster-webapp/. Trigger whenever someone mentions migrating a legacy page, component, or module to the new unified frontend, converting React Router to TanStack Router, replacing MobX stores with TanStack Query or URL state, rewriting styled-components as SCSS modules, or converting legacy test patterns to Vitest browser mode. Also use when someone asks how a legacy pattern maps to the new architecture, even for small questions like "how would I write this Operate component in the new app?" or "what's the equivalent of this Tasklist store in the unified frontend?"
+
+---
+
+# Frontend Migration: Legacy to Orchestration Cluster Webapp
+
+The orchestration cluster webapp (`webapp/client/apps/orchestration-cluster-webapp/`) is replacing the legacy Operate, Tasklist, and Admin frontends. Migration is a **rewrite using new patterns**, not a code port. The legacy code is the specification of *what* the feature does; the new code follows a different architecture for *how*.
+
+This skill is the translation layer. It maps legacy patterns to their target equivalents so you produce code that fits the new codebase from the start. For target conventions (modules/pages/routes structure, data loading tiers, forms, feature flags), defer to the `frontend-feature` skill. For test-writing details, defer to `frontend-unit-test` and `frontend-integration-test`.
+
+## Migration workflow
+
+### 1. Understand the legacy feature's intent
+
+Read the legacy code and extract *what it does for users*, not how it's implemented. Identify:
+
+- What data does it display? Where does that data come from (which API endpoints)?
+- What actions can the user take? What side effects do those actions trigger?
+- What URL does the page live at? What parameters does it accept?
+- What states does it handle? (loading, empty, error, forbidden, pagination)
+
+Focus on behavior. The implementation details (MobX stores, styled-components, React Router hooks) are all going to change.
+
+### 2. Check API endpoint availability
+
+Look up every endpoint the legacy feature calls in `@camunda/camunda-api-zod-schemas`. The legacy code typically imports from this package already — check its `import` statements. If an endpoint is missing from the schema package, it needs to be added before or alongside the migration.
+
+### 3. Map to modules / pages / routes
+
+Decide how the feature decomposes in the new architecture. The general rule:
+
+- **One route file** per navigable URL, under `src/routes/_auth/<product>/`
+- **One page component** per route, in `src/pages/`
+- **Modules** for reusable logic, in `src/modules/<concern>/` — not one module per page, but one per *concern* (e.g., `processes`, `incidents`, `variables`)
+
+Produce the code directly. If the decomposition is genuinely ambiguous (e.g., a legacy page that mixes two concerns and could become one page or two), flag it for the user with your recommendation and reasoning.
+
+Dependencies flow one way: **routes → pages → modules**. A module must never import from a route file or a page file. If a type (like search param schemas) needs to be shared between a route and a module, define it in the module and import it into the route — not the other way around.
+
+### 4. Transform patterns
+
+This is the core of the migration. Each legacy pattern has a target equivalent — apply them systematically. The summary is below; see `references/pattern-mapping.md` for side-by-side code examples.
+
+### 5. Write tests
+
+Rewrite tests using the new patterns (Vitest browser mode, MSW via worker fixture, `expect.element()`). Don't port legacy test code — the testing infrastructure is fundamentally different. See the testing transformation table below and `references/pattern-mapping.md` for full before/after examples.
+
+### 6. Run local checks
+
+```bash
+# From webapp/client/apps/orchestration-cluster-webapp/
+npm run typecheck
+npm run lint
+npm run test:unit
+```
+
+## Pattern transformations
+
+### Routing
+
+| Legacy | Target |
+|--------|--------|
+| `createBrowserRouter` + `createRoutesFromElements` | TanStack Router file-based routes |
+| `lazy={() => import('./Page')}` with `Component` export | `createFileRoute` in a file under `src/routes/` |
+| `Paths.processes()` path builder object | File path *is* the URL — `src/routes/_auth/operate/processes/index.tsx` |
+| `useParams()` / `useSearchParams()` | `useParams({ from: '/route-path' })` / `useSearch({ from: '/route-path' })` (typed, validated) |
+| `useNavigate()` + `navigate(path)` | `useNavigate()` from `@tanstack/react-router` or `<Link>` |
+| `useOutletContext()` for parent data | Shared `queryOptions` — child re-calls the same query (TanStack Query deduplicates) |
+| `<Navigate to={path} />` redirect | `throw redirect({ to: path })` in `beforeLoad` |
+| `ErrorBoundary` per route | `errorComponent` on the route definition |
+
+Auth-gated routes go under `_auth/` (pathless layout route). Product routes go under `_auth/operate/` or `_auth/tasklist/`.
+
+### Data fetching
+
+| Legacy | Target |
+|--------|--------|
+| `use*.query.ts` files scattered across modules | Centralized `queryOptions` in `#/modules/http/queries.ts` |
+| Endpoint URL construction inline in hooks | `Request` factories in `#/modules/http/endpoints.ts` |
+| `requestAndParse()` / `requestWithThrow()` | `request()` from `#/modules/http/request` |
+| `useQuery` / `useInfiniteQuery` in components | `useSuspenseQuery` / `useSuspenseInfiniteQuery` in components |
+| No data prefetching | `queryClient.ensureQueryData(queries.xxx())` in route `beforeLoad` |
+| `document.title` in `useEffect` | `head()` function on the route |
+| `refetchInterval` for polling | Same — `refetchInterval` on the query options |
+
+The pattern is: define the endpoint in `endpoints.ts`, wrap it in `queryOptions` in `queries.ts`, prefetch in the route loader, consume with `useSuspenseQuery` in the page component. This replaces the legacy pattern where each feature scattered its own query hooks.
+
+### State management
+
+This is where most legacy code diverges from the target. Legacy apps use MobX stores for everything — server cache, UI state, filters, form drafts. The target splits state across purpose-built mechanisms:
+
+| What the MobX store holds | Target mechanism | Why |
+|---------------------------|------------------|-----|
+| Server data (fetched from API) | TanStack Query via `queries.ts` | Automatic caching, deduplication, background refresh, garbage collection |
+| Filters, sort order, pagination cursor | URL search params with Zod `validateSearch` | Linkable, shareable, survives refresh, back/forward navigation works |
+| Selected items, active tab | URL search params | Same reasons — if the user can share the URL and expect the same view, it belongs in the URL |
+| Modal open/close, menu open, input draft | `useState` | Ephemeral — losing it on navigation is fine |
+| Authentication session | MobX store (`authentication.store.ts`) | Already exists in the target, keep it |
+| Theme preference | MobX store | Already exists in the target, keep it |
+
+When you encounter a MobX store in legacy code, don't port it. Decompose it by asking: "Would a user want to bookmark or share this state?" If yes → URL. If it's server data → TanStack Query. If it's ephemeral → `useState`.
+
+### Styling
+
+| Legacy | Target |
+|--------|--------|
+| `styled-components` (`styled.div`, `styled(Tile)`) | SCSS Modules (`.module.scss`) |
+| `css` helper from styled-components | Regular SCSS |
+| Transient props (`$isActive`) | CSS class toggling or data attributes |
+| `@carbon/elements` `styles.productiveHeading02` | `@carbon/type` SCSS mixins (`@include type.type-style('productive-heading-02')`) |
+| Hardcoded `px` / `rem` values | Carbon spacing tokens (`var(--cds-spacing-05)`, `$spacing-05`) |
+| Carbon token CSS vars (`--cds-border-subtle-01`) | Same — keep using Carbon CSS custom properties |
+
+SCSS modules use bracket notation for class access: `className={styles['container']!}`. The `!` is a TypeScript non-null assertion because CSS module types are optional by default.
+
+### Component structure
+
+| Legacy | Target |
+|--------|--------|
+| `export default Component` or `export {Component}` inline | `export {Component}` block at end of file |
+| `const Component: React.FC = () => ...` | `function Component() { ... }` or `const Component: React.FC = () => ...` (both OK, function declarations preferred) |
+| `index.tsx` as main file in component dir | `PascalCase.tsx` named file (no barrel files) |
+| Import via directory (`./Dashboard`) | Import via file (`#/modules/dashboard/Dashboard`) |
+| `React.memo()` wrapping | `useMemo` for derived data inside components; `React.memo` only when profiling shows a need |
+| `observer()` from mobx-react-lite (for MobX) | Remove — no MobX observation needed for server state or URL state |
+
+### Error handling
+
+| Legacy | Target |
+|--------|--------|
+| Try/catch in components | `errorComponent` on the route handles render errors |
+| Manual 401 checks | Centralized in `request()` — clears query cache, disables session |
+| `notificationsStore.displayNotification()` | Build a notification module when needed, or use Carbon's `InlineNotification` inline |
+| `<ErrorBoundary>` per route | `errorComponent` per route (TanStack Router's built-in mechanism) |
+
+### Testing
+
+This is the biggest divergence. Legacy tests use jsdom + Testing Library globals + `vi.mock()`. The target uses a real Chromium browser + MSW-only mocking + no global `screen`.
+
+| Legacy | Target |
+|--------|--------|
+| `import {render, screen} from 'modules/testing-library'` | `import {it} from '#/vitest-modules/test-extend'` + `import {render} from 'vitest-browser-react'` or `renderWithRouter` |
+| `screen.findByRole()` / `screen.getByRole()` | `screen.getByRole()` from render return value |
+| `await screen.findByText('...')` | `await expect.element(screen.getByText('...')).toBeVisible()` |
+| `waitFor(() => expect(...))` | `await expect.element(...)` — retries automatically |
+| `screen.queryByText('...')` for absence | `await expect.element(screen.getByText('...')).not.toBeVisible()` |
+| `vi.mock('../../stores/auth')` | MSW endpoint mocks — mock the HTTP, not the module |
+| `nodeMockServer.use(http.post(...))` | `worker.use(mockEndpoint({successResponse: ...}))` |
+| `mockFetchProcesses().withSuccess(data)` | `mockProcessesEndpoint({successResponse: HttpResponse.json(data)})` |
+| `MemoryRouter` + `QueryClientProvider` wrapper | `renderWithRouter('/path')` — creates real TanStack Router + QueryClient |
+| `getMockQueryClient()` | Built into `renderWithRouter` |
+| `user.click()` from userEvent | `screen.getByRole('button').click()` — direct locator interaction |
+| `// given / when / then` comments | No section comments — use blank lines for visual grouping |
+
+Endpoint mocks live in `shared-test-modules/mock-handlers.ts`. If the mock you need doesn't exist, add it there using `createEndpointMock()` — never create mocks inline in test files.
+
+### i18n
+
+**Legacy (Operate):** No i18n — all strings are hardcoded in English. There are no `i18next` imports, translation files, or `useTranslation()` calls.
+
+**Target:** The orchestration cluster webapp uses `i18next` + `react-i18next`. When migrating from Operate, wrap user-facing strings in `t('key')` via `useTranslation()` and add translation keys to the appropriate namespace in `src/modules/i18n/`. Check the target's namespace structure before adding keys.
+
+## Handling partial migrations
+
+Not every migration is a full page. You might be adding a single component, column, filter, or panel to a page that already exists in the orchestration webapp.
+
+For partial work:
+- Skip route creation — the route already exists
+- Check if a module already exists for the concern — extend it rather than creating a new one
+- Follow the same pattern transformations for the piece you're adding
+- If the page component needs new data, add the query to `queries.ts` and the endpoint to `endpoints.ts`
+
+## Common pitfalls
+
+**Porting MobX stores verbatim.** This is the most common mistake. Legacy stores mix server cache, UI state, and derived data in one class. In the target, these concerns are separated. Decompose the store, don't port it.
+
+**Scattering query definitions.** Legacy apps have `use*.query.ts` files next to each feature. The target centralizes all queries in `#/modules/http/queries.ts` and all endpoints in `endpoints.ts`. This makes the full API surface visible in one place.
+
+**Using `vi.mock()`.** Legacy tests mock MobX stores and modules with `vi.mock()`. The target mocks HTTP responses with MSW. If you need to control what a component sees, control it at the network level. The only acceptable use of `vi.mock()` is for things like `vi.useFakeTimers()` where there's no HTTP-level alternative.
+
+**Creating inline MSW handlers in test files.** Don't write `http.post('*/v2/...', () => HttpResponse.json(...))` directly in tests. All endpoint mocks must be defined in `shared-test-modules/mock-handlers.ts` using `createEndpointMock()` and consumed via `worker.use(mockXxxEndpoint({successResponse: ...}))`. If the mock you need doesn't exist yet, add it to `shared-test-modules/mock-handlers.ts` — never inline it.
+
+**Using `waitFor` or `findBy*`.** These don't exist in Vitest browser mode. Use `await expect.element(...)` which retries automatically.
+
+**Creating barrel files.** The target doesn't use `index.ts` barrel files. Import files directly using `#/` path aliases.
+
+**Putting fetch logic in page components.** Data fetching belongs in route loaders (`beforeLoad` or `loader`). Page components consume data via `useSuspenseQuery`, they don't initiate fetches.
+
+**Using styled-components.** Even if the legacy code uses them, the target uses SCSS modules exclusively. Rewrite, don't port.
+
+**Checking `isLoading` / `isError` on `useSuspenseQuery`.** Unlike `useQuery`, `useSuspenseQuery` never returns loading or error states — it suspends the component (handled by `<Suspense>` or the route's `pendingComponent`) and throws on errors (handled by `errorComponent`). If you need inline loading/error handling within a component, use `useQuery` instead, but prefer `useSuspenseQuery` with route-level boundaries as the default.
+
+**Porting `useEffect` for navigation.** Legacy code uses `useEffect(() => navigate(...))` for conditional redirects. The target uses `throw redirect()` in `beforeLoad` — it's synchronous relative to the route lifecycle and avoids the flash of the wrong page.
+
+## Canonical docs
+
+- `docs/monorepo-docs/frontend/orchestration-cluster-webapp.md` — tech stack, layout, scripts
+- `docs/monorepo-docs/frontend/data-loading.md` — TanStack Router + Query patterns
+- `docs/monorepo-docs/frontend/forms.md` — form library guidance
+- `docs/monorepo-docs/frontend/testing.md` — unit, integration, a11y, visual testing
+- `docs/monorepo-docs/frontend/code-style.md` — naming, exports, comments
+- `docs/monorepo-docs/frontend/development-process/creating-a-new-page.md` — page creation checklist
+- `docs/monorepo-docs/frontend/development-process/before-starting.md` — pre-feature considerations
+- `docs/monorepo-docs/frontend/legacy-components.md` — legacy app overview + migration epic link
+- `references/pattern-mapping.md` — detailed side-by-side code examples for every transformation

--- a/.claude/skills/frontend-migrator/references/pattern-mapping.md
+++ b/.claude/skills/frontend-migrator/references/pattern-mapping.md
@@ -1,0 +1,587 @@
+# Pattern Mapping: Legacy to Orchestration Cluster Webapp
+
+Side-by-side code examples for each pattern transformation. Use this as a reference when migrating specific code — find the legacy pattern you're looking at, then apply the target equivalent.
+
+## Table of contents
+
+1. [Routing](#routing)
+2. [Data fetching](#data-fetching)
+3. [State management](#state-management)
+4. [Styling](#styling)
+5. [Component structure](#component-structure)
+6. [Testing](#testing)
+
+---
+
+## Routing
+
+### Route definition
+
+**Legacy (React Router):**
+```tsx
+// operate/client/src/App/index.tsx
+import {Paths} from 'modules/Routes';
+
+<Route
+  path={Paths.processes()}
+  lazy={async () => {
+    const {Processes} = await import('./Processes/index');
+    return {Component: Processes};
+  }}
+/>
+```
+
+**Target (TanStack Router file-based):**
+```tsx
+// src/routes/_auth/operate/processes/index.tsx
+import {createFileRoute} from '@tanstack/react-router';
+import {ProcessesPage} from '#/pages/ProcessesPage';
+
+const Route = createFileRoute('/_auth/operate/processes/')({
+  component: ProcessesPage,
+});
+
+export {Route};
+```
+
+The file path `src/routes/_auth/operate/processes/index.tsx` *is* the URL `/operate/processes`. No path builder object needed.
+
+### Route with data loading
+
+**Legacy:**
+```tsx
+// Page component fetches its own data
+function Dashboard() {
+  const {data} = useProcessDefinitionStatistics();
+  // ...
+}
+```
+
+**Target:**
+```tsx
+// src/routes/_auth/operate/dashboard/index.tsx
+import {createFileRoute} from '@tanstack/react-router';
+import {queries} from '#/modules/http/queries';
+import {DashboardPage} from '#/pages/DashboardPage';
+
+const Route = createFileRoute('/_auth/operate/dashboard/')({
+  beforeLoad: async ({context: {queryClient}}) => {
+    await queryClient.ensureQueryData(queries.getProcessDefinitionStatistics());
+  },
+  component: DashboardPage,
+  pendingComponent: DashboardSkeleton,
+  errorComponent: DashboardError,
+  head: () => ({meta: [{title: 'Dashboard | Camunda'}]}),
+});
+
+export {Route};
+```
+
+### Route params
+
+**Legacy:**
+```tsx
+// operate/client/src/modules/Routes.tsx
+processInstance: (id?: string) => `/processes/${id ?? ':processInstanceId'}`;
+
+// In component:
+const {processInstanceId} = useParams<{processInstanceId: string}>();
+```
+
+**Target:**
+```tsx
+// File: src/routes/_auth/operate/processes/$processInstanceId/index.tsx
+// The $ prefix makes it a param segment automatically.
+
+const Route = createFileRoute('/_auth/operate/processes/$processInstanceId/')({
+  component: ProcessInstancePage,
+});
+
+// In component:
+const {processInstanceId} = useParams({from: '/_auth/operate/processes/$processInstanceId/'});
+```
+
+### Search params with validation
+
+**Legacy:**
+```tsx
+const [searchParams, setSearchParams] = useSearchParams();
+const filter = searchParams.get('filter') ?? 'all';
+```
+
+**Target:**
+```tsx
+// In the route file:
+import {z} from 'zod';
+
+const searchSchema = z.object({
+  filter: z.enum(['all', 'active', 'incidents']).catch('all'),
+  sort: z.enum(['name', 'version']).catch('name'),
+});
+
+const Route = createFileRoute('/_auth/operate/processes/')({
+  validateSearch: searchSchema,
+  component: ProcessesPage,
+});
+
+// In the page component:
+const {filter, sort} = useSearch({from: '/_auth/operate/processes/'});
+// Fully typed, validated, with defaults from .catch()
+```
+
+### Redirects
+
+**Legacy:**
+```tsx
+useEffect(() => {
+  if (!isAuthenticated) {
+    navigate('/login');
+  }
+}, [isAuthenticated]);
+```
+
+**Target:**
+```tsx
+// In the route's beforeLoad:
+beforeLoad: async ({context: {queryClient}}) => {
+  const {response} = await request(endpoints.getCurrentUser());
+  if (response === null) {
+    throw redirect({to: '/login'});
+  }
+}
+```
+
+---
+
+## Data fetching
+
+### Endpoint definition
+
+**Legacy (scattered across modules):**
+```tsx
+// operate/client/src/modules/api/v2/variables/searchVariables.ts
+const searchVariables = async (payload: QueryVariablesRequestBody) => {
+  return requestWithThrow<QueryVariablesResponseBody>({
+    url: endpoints.queryVariables.getUrl(),
+    method: endpoints.queryVariables.method,
+    body: payload,
+  });
+};
+```
+
+**Target (centralized):**
+```tsx
+// src/modules/http/endpoints.ts — ALL endpoints in one file
+import {endpoints as apiEndpoints} from '@camunda/camunda-api-zod-schemas/8.10';
+
+function searchVariables(body: QueryVariablesRequestBody): Request {
+  return new Request(getFullURL(apiEndpoints.queryVariables.getUrl()), {
+    ...BASE_REQUEST_OPTIONS,
+    method: apiEndpoints.queryVariables.method,
+    body: JSON.stringify(body),
+    headers: {'Content-Type': 'application/json'},
+  });
+}
+
+export {searchVariables};
+```
+
+### Query definition
+
+**Legacy (scattered `use*.query.ts` files):**
+```tsx
+// operate/client/src/modules/queries/variables/useVariables.ts
+function useVariables(filters: Filters) {
+  return useInfiniteQuery({
+    queryKey: queryKeys.variables.searchWithFilter(filters),
+    queryFn: async ({pageParam}) => {
+      const {response, error} = await searchVariables({...filters, ...pageParam});
+      if (response !== null) return response;
+      throw error;
+    },
+  });
+}
+```
+
+**Target (centralized `queries.ts`):**
+```tsx
+// src/modules/http/queries.ts — ALL query options in one file
+import {queryOptions} from '@tanstack/react-query';
+import * as endpoints from './endpoints';
+import {request} from './request';
+
+const queryKeys = {
+  variables: {
+    searchWithFilter: (filters: Filters) => ['variables', 'search', filters] as const,
+  },
+} as const;
+
+const queries = {
+  searchVariables: (filters: Filters) =>
+    queryOptions({
+      queryKey: queryKeys.variables.searchWithFilter(filters),
+      queryFn: async () => {
+        const {response, error} = await request(endpoints.searchVariables(filters));
+        if (error !== null) {
+          throw error;
+        }
+        return response.json() as Promise<QueryVariablesResponseBody>;
+      },
+    }),
+};
+
+export {queries, queryKeys};
+```
+
+### Using queries in components
+
+**Legacy:**
+```tsx
+function VariablesList({processInstanceId}: Props) {
+  const {data, fetchNextPage, hasNextPage} = useVariables({processInstanceId});
+  // ...
+}
+```
+
+**Target:**
+```tsx
+function VariablesList({processInstanceId}: Props) {
+  const {data} = useSuspenseQuery(queries.searchVariables({processInstanceId}));
+  // The route's beforeLoad already prefetched this data,
+  // so useSuspenseQuery resolves instantly on first render.
+}
+```
+
+**`useSuspenseQuery` vs `useQuery`**: `useSuspenseQuery` never returns `isLoading` or `isError` — it suspends for loading (handled by `<Suspense>` or the route's `pendingComponent`) and throws for errors (handled by `errorComponent`). This is the default choice. Reach for `useQuery` only when you need inline loading/error states within a single component.
+
+---
+
+## State management
+
+### MobX store holding server data → TanStack Query
+
+**Legacy:**
+```tsx
+// MobX store that fetches and caches process instances
+class ProcessInstancesStore {
+  processInstances: ProcessInstance[] = [];
+  isLoading = false;
+
+  constructor() {
+    makeObservable(this, {
+      processInstances: observable,
+      isLoading: observable,
+      fetchInstances: action,
+    });
+  }
+
+  async fetchInstances(filters: Filters) {
+    this.isLoading = true;
+    const {response} = await requestWithThrow(api.queryProcessInstances(filters));
+    if (response !== null) {
+      this.processInstances = await response.json();
+    }
+    this.isLoading = false;
+  }
+}
+```
+
+**Target:** Delete the store entirely. Add to `queries.ts`:
+```tsx
+const queries = {
+  searchProcessInstances: (filters: Filters) =>
+    queryOptions({
+      queryKey: queryKeys.processInstances.search(filters),
+      queryFn: async () => {
+        const {response, error} = await request(endpoints.searchProcessInstances(filters));
+        if (error !== null) throw error;
+        return response.json() as Promise<QueryProcessInstancesResponseBody>;
+      },
+    }),
+};
+```
+
+Components consume it with `useSuspenseQuery(queries.searchProcessInstances(filters))`. Loading state is handled by the route's `pendingComponent`. Error state by the route's `errorComponent`.
+
+### MobX store holding filter state → URL search params
+
+**Legacy:**
+```tsx
+class FiltersStore {
+  status = 'all';
+  sortBy = 'startDate';
+
+  constructor() {
+    makeObservable(this, {
+      status: observable,
+      sortBy: observable,
+      setStatus: action,
+      setSortBy: action,
+    });
+  }
+
+  setStatus(status: string) { this.status = status; }
+  setSortBy(sortBy: string) { this.sortBy = sortBy; }
+}
+```
+
+**Target:** Delete the store. Define search params on the route:
+```tsx
+// In the route file
+const searchSchema = z.object({
+  status: z.enum(['all', 'active', 'incidents', 'completed']).catch('all'),
+  sortBy: z.enum(['startDate', 'endDate', 'processName']).catch('startDate'),
+});
+
+const Route = createFileRoute('/_auth/operate/processes/')({
+  validateSearch: searchSchema,
+  component: ProcessesPage,
+});
+```
+
+Components read with `useSearch({ from: '/_auth/operate/processes/' })` and update with `navigate({ search: { status: 'active' } })`.
+
+---
+
+## Styling
+
+### styled-components → SCSS modules
+
+**Legacy (`styled.ts`):**
+```tsx
+import styled, {css} from 'styled-components';
+import {Tile as BaseTile} from '@carbon/react';
+import {styles} from '@carbon/elements';
+
+const Container = styled.div`
+  padding: var(--cds-spacing-05);
+  display: grid;
+  gap: var(--cds-spacing-05);
+`;
+
+const Tile = styled(BaseTile)`
+  ${styles.bodyCompact01};
+  border: 1px solid var(--cds-border-subtle-01);
+`;
+
+const Title = styled.h2<{$isActive: boolean}>`
+  ${styles.productiveHeading02};
+  color: ${({$isActive}) =>
+    $isActive ? 'var(--cds-text-primary)' : 'var(--cds-text-secondary)'};
+`;
+```
+
+**Target (`PageName.module.scss` + component):**
+```scss
+// ProcessesPage.module.scss
+@use '@carbon/layout' as layout;
+@use '@carbon/type' as type;
+
+.container {
+  padding: layout.$spacing-05;
+  display: grid;
+  gap: layout.$spacing-05;
+}
+
+.tile {
+  @include type.type-style('body-compact-01');
+  border: 1px solid var(--cds-border-subtle-01);
+}
+
+.title {
+  @include type.type-style('productive-heading-02');
+  color: var(--cds-text-primary);
+
+  &[data-inactive] {
+    color: var(--cds-text-secondary);
+  }
+}
+```
+
+```tsx
+// ProcessesPage.tsx
+import styles from './ProcessesPage.module.scss';
+import {Tile} from '@carbon/react';
+
+function ProcessesPage() {
+  return (
+    <div className={styles['container']!}>
+      <Tile className={styles['tile']!}>
+        <h2
+          className={styles['title']!}
+          data-inactive={!isActive || undefined}
+        >
+          {title}
+        </h2>
+      </Tile>
+    </div>
+  );
+}
+
+export {ProcessesPage};
+```
+
+Transient props (`$isActive`) become data attributes or conditional class names. Carbon tokens stay the same — they're CSS custom properties either way.
+
+---
+
+## Component structure
+
+### Exports
+
+**Legacy:**
+```tsx
+// Some files use default export
+export default Dashboard;
+
+// Some use inline named export
+export const Dashboard: React.FC = () => { ... };
+
+// Some use named export for React Router lazy loading
+export {Dashboard as Component};
+```
+
+**Target — always a block export at the end:**
+```tsx
+function Dashboard() {
+  // ...
+}
+
+export {Dashboard};
+```
+
+### File naming
+
+**Legacy:**
+```
+App/Dashboard/index.tsx        → import from './Dashboard'
+App/Dashboard/styled.ts        → styled-components
+App/Dashboard/index.test.tsx   → co-located test
+```
+
+**Target:**
+```
+pages/DashboardPage.tsx             → import from '#/pages/DashboardPage'
+pages/DashboardPage.module.scss     → co-located SCSS module
+pages/DashboardPage.test.tsx        → co-located test
+```
+
+No barrel files, no `index.tsx`, direct file imports with `#/` path aliases.
+
+---
+
+## Testing
+
+### Basic component test
+
+**Legacy (jsdom + Testing Library):**
+```tsx
+import {render, screen, waitFor} from 'modules/testing-library';
+import {MemoryRouter} from 'react-router-dom';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/getMockQueryClient';
+import {Dashboard} from './index';
+
+const Wrapper = ({children}: {children: React.ReactNode}) => (
+  <QueryClientProvider client={getMockQueryClient()}>
+    <MemoryRouter>{children}</MemoryRouter>
+  </QueryClientProvider>
+);
+
+describe('Dashboard', () => {
+  it('should render process statistics', async () => {
+    mockFetchProcessDefinitionStatistics().withSuccess(mockData);
+
+    render(<Dashboard />, {wrapper: Wrapper});
+
+    expect(await screen.findByText('10 running instances')).toBeInTheDocument();
+  });
+});
+```
+
+**Target (Vitest browser mode):**
+```tsx
+import {it} from '#/vitest-modules/test-extend';
+import {renderWithRouter} from '#/vitest-modules/render-with-router';
+import {mockProcessDefinitionStatisticsEndpoint} from '#/shared-test-modules/mock-handlers';
+import {describe, expect} from 'vitest';
+import {HttpResponse} from 'msw';
+
+describe('<Dashboard />', () => {
+  it('should render process statistics', async ({worker}) => {
+    worker.use(
+      mockProcessDefinitionStatisticsEndpoint({
+        successResponse: HttpResponse.json(mockData),
+      }),
+    );
+
+    const screen = await renderWithRouter('/operate/dashboard');
+
+    await expect
+      .element(screen.getByText('10 running instances'))
+      .toBeVisible();
+  });
+});
+```
+
+Key differences:
+- `it` from `#/vitest-modules/test-extend` (not from `vitest`)
+- `worker` fixture provides MSW (not `nodeMockServer`)
+- `renderWithRouter('/path')` replaces `MemoryRouter` + `QueryClientProvider` wrapper
+- `render()` / `renderWithRouter()` returns `screen` — no global `screen` import
+- `await expect.element(...)` replaces `await screen.findByText(...)` + `toBeInTheDocument()`
+- No `waitFor` — `expect.element()` retries automatically
+- Endpoint mocks from `shared-test-modules/mock-handlers` — not fluent builder mocks
+- Never create inline `http.post(...)` / `http.get(...)` handlers in test files — all endpoint mocks must be defined in `shared-test-modules/mock-handlers.ts` using `createEndpointMock()` from `shared-test-modules/mock-endpoint`. If a mock doesn't exist, add it there first.
+
+### Testing absence of elements
+
+**Legacy:**
+```tsx
+expect(screen.queryByText('Error')).not.toBeInTheDocument();
+```
+
+**Target:**
+```tsx
+await expect.element(screen.getByText('Error')).not.toBeVisible();
+```
+
+There is no `queryByText` in Vitest browser mode.
+
+### User interactions
+
+**Legacy:**
+```tsx
+const {user} = render(<Form />, {wrapper: Wrapper});
+await user.click(screen.getByRole('button', {name: /submit/i}));
+await user.type(screen.getByLabelText('Name'), 'Alice');
+```
+
+**Target:**
+```tsx
+const screen = await renderWithRouter('/form');
+await screen.getByRole('button', {name: /submit/i}).click();
+await screen.getByLabelText('Name').fill('Alice');
+```
+
+No `user` fixture — interact directly via locators. `.fill()` replaces `.type()`.
+
+### Standalone component test (no routing context)
+
+**Target:**
+```tsx
+import {render} from 'vitest-browser-react';
+import {it} from '#/vitest-modules/test-extend';
+import {describe, expect} from 'vitest';
+import {StatusBadge} from './StatusBadge';
+
+describe('<StatusBadge />', () => {
+  it('should render the active status', async () => {
+    const screen = await render(<StatusBadge status="active" />);
+
+    await expect.element(screen.getByText('Active')).toBeVisible();
+  });
+});
+```
+
+Use `render` from `vitest-browser-react` for components that don't need routing. Use `renderWithRouter` for anything that uses `<Link>`, `useNavigate`, or route hooks.

--- a/.claude/skills/frontend-migrator/references/pattern-mapping.md
+++ b/.claude/skills/frontend-migrator/references/pattern-mapping.md
@@ -18,6 +18,7 @@ Side-by-side code examples for each pattern transformation. Use this as a refere
 ### Route definition
 
 **Legacy (React Router):**
+
 ```tsx
 // operate/client/src/App/index.tsx
 import {Paths} from 'modules/Routes';
@@ -32,6 +33,7 @@ import {Paths} from 'modules/Routes';
 ```
 
 **Target (TanStack Router file-based):**
+
 ```tsx
 // src/routes/_auth/operate/processes/index.tsx
 import {createFileRoute} from '@tanstack/react-router';
@@ -49,6 +51,7 @@ The file path `src/routes/_auth/operate/processes/index.tsx` *is* the URL `/oper
 ### Route with data loading
 
 **Legacy:**
+
 ```tsx
 // Page component fetches its own data
 function Dashboard() {
@@ -58,6 +61,7 @@ function Dashboard() {
 ```
 
 **Target:**
+
 ```tsx
 // src/routes/_auth/operate/dashboard/index.tsx
 import {createFileRoute} from '@tanstack/react-router';
@@ -80,6 +84,7 @@ export {Route};
 ### Route params
 
 **Legacy:**
+
 ```tsx
 // operate/client/src/modules/Routes.tsx
 processInstance: (id?: string) => `/processes/${id ?? ':processInstanceId'}`;
@@ -89,6 +94,7 @@ const {processInstanceId} = useParams<{processInstanceId: string}>();
 ```
 
 **Target:**
+
 ```tsx
 // File: src/routes/_auth/operate/processes/$processInstanceId/index.tsx
 // The $ prefix makes it a param segment automatically.
@@ -104,12 +110,14 @@ const {processInstanceId} = useParams({from: '/_auth/operate/processes/$processI
 ### Search params with validation
 
 **Legacy:**
+
 ```tsx
 const [searchParams, setSearchParams] = useSearchParams();
 const filter = searchParams.get('filter') ?? 'all';
 ```
 
 **Target:**
+
 ```tsx
 // In the route file:
 import {z} from 'zod';
@@ -132,6 +140,7 @@ const {filter, sort} = useSearch({from: '/_auth/operate/processes/'});
 ### Redirects
 
 **Legacy:**
+
 ```tsx
 useEffect(() => {
   if (!isAuthenticated) {
@@ -141,6 +150,7 @@ useEffect(() => {
 ```
 
 **Target:**
+
 ```tsx
 // In the route's beforeLoad:
 beforeLoad: async ({context: {queryClient}}) => {
@@ -158,6 +168,7 @@ beforeLoad: async ({context: {queryClient}}) => {
 ### Endpoint definition
 
 **Legacy (scattered across modules):**
+
 ```tsx
 // operate/client/src/modules/api/v2/variables/searchVariables.ts
 const searchVariables = async (payload: QueryVariablesRequestBody) => {
@@ -170,6 +181,7 @@ const searchVariables = async (payload: QueryVariablesRequestBody) => {
 ```
 
 **Target (centralized):**
+
 ```tsx
 // src/modules/http/endpoints.ts — ALL endpoints in one file
 import {endpoints as apiEndpoints} from '@camunda/camunda-api-zod-schemas/8.10';
@@ -189,6 +201,7 @@ export {searchVariables};
 ### Query definition
 
 **Legacy (scattered `use*.query.ts` files):**
+
 ```tsx
 // operate/client/src/modules/queries/variables/useVariables.ts
 function useVariables(filters: Filters) {
@@ -204,6 +217,7 @@ function useVariables(filters: Filters) {
 ```
 
 **Target (centralized `queries.ts`):**
+
 ```tsx
 // src/modules/http/queries.ts — ALL query options in one file
 import {queryOptions} from '@tanstack/react-query';
@@ -236,6 +250,7 @@ export {queries, queryKeys};
 ### Using queries in components
 
 **Legacy:**
+
 ```tsx
 function VariablesList({processInstanceId}: Props) {
   const {data, fetchNextPage, hasNextPage} = useVariables({processInstanceId});
@@ -244,6 +259,7 @@ function VariablesList({processInstanceId}: Props) {
 ```
 
 **Target:**
+
 ```tsx
 function VariablesList({processInstanceId}: Props) {
   const {data} = useSuspenseQuery(queries.searchVariables({processInstanceId}));
@@ -261,6 +277,7 @@ function VariablesList({processInstanceId}: Props) {
 ### MobX store holding server data → TanStack Query
 
 **Legacy:**
+
 ```tsx
 // MobX store that fetches and caches process instances
 class ProcessInstancesStore {
@@ -287,6 +304,7 @@ class ProcessInstancesStore {
 ```
 
 **Target:** Delete the store entirely. Add to `queries.ts`:
+
 ```tsx
 const queries = {
   searchProcessInstances: (filters: Filters) =>
@@ -306,6 +324,7 @@ Components consume it with `useSuspenseQuery(queries.searchProcessInstances(filt
 ### MobX store holding filter state → URL search params
 
 **Legacy:**
+
 ```tsx
 class FiltersStore {
   status = 'all';
@@ -326,6 +345,7 @@ class FiltersStore {
 ```
 
 **Target:** Delete the store. Define search params on the route:
+
 ```tsx
 // In the route file
 const searchSchema = z.object({
@@ -348,6 +368,7 @@ Components read with `useSearch({ from: '/_auth/operate/processes/' })` and upda
 ### styled-components → SCSS modules
 
 **Legacy (`styled.ts`):**
+
 ```tsx
 import styled, {css} from 'styled-components';
 import {Tile as BaseTile} from '@carbon/react';
@@ -372,6 +393,7 @@ const Title = styled.h2<{$isActive: boolean}>`
 ```
 
 **Target (`PageName.module.scss` + component):**
+
 ```scss
 // ProcessesPage.module.scss
 @use '@carbon/layout' as layout;
@@ -430,6 +452,7 @@ Transient props (`$isActive`) become data attributes or conditional class names.
 ### Exports
 
 **Legacy:**
+
 ```tsx
 // Some files use default export
 export default Dashboard;
@@ -442,6 +465,7 @@ export {Dashboard as Component};
 ```
 
 **Target — always a block export at the end:**
+
 ```tsx
 function Dashboard() {
   // ...
@@ -453,6 +477,7 @@ export {Dashboard};
 ### File naming
 
 **Legacy:**
+
 ```
 App/Dashboard/index.tsx        → import from './Dashboard'
 App/Dashboard/styled.ts        → styled-components
@@ -460,6 +485,7 @@ App/Dashboard/index.test.tsx   → co-located test
 ```
 
 **Target:**
+
 ```
 pages/DashboardPage.tsx             → import from '#/pages/DashboardPage'
 pages/DashboardPage.module.scss     → co-located SCSS module
@@ -475,6 +501,7 @@ No barrel files, no `index.tsx`, direct file imports with `#/` path aliases.
 ### Basic component test
 
 **Legacy (jsdom + Testing Library):**
+
 ```tsx
 import {render, screen, waitFor} from 'modules/testing-library';
 import {MemoryRouter} from 'react-router-dom';
@@ -500,6 +527,7 @@ describe('Dashboard', () => {
 ```
 
 **Target (Vitest browser mode):**
+
 ```tsx
 import {it} from '#/vitest-modules/test-extend';
 import {renderWithRouter} from '#/vitest-modules/render-with-router';
@@ -537,11 +565,13 @@ Key differences:
 ### Testing absence of elements
 
 **Legacy:**
+
 ```tsx
 expect(screen.queryByText('Error')).not.toBeInTheDocument();
 ```
 
 **Target:**
+
 ```tsx
 await expect.element(screen.getByText('Error')).not.toBeVisible();
 ```
@@ -551,6 +581,7 @@ There is no `queryByText` in Vitest browser mode.
 ### User interactions
 
 **Legacy:**
+
 ```tsx
 const {user} = render(<Form />, {wrapper: Wrapper});
 await user.click(screen.getByRole('button', {name: /submit/i}));
@@ -558,6 +589,7 @@ await user.type(screen.getByLabelText('Name'), 'Alice');
 ```
 
 **Target:**
+
 ```tsx
 const screen = await renderWithRouter('/form');
 await screen.getByRole('button', {name: /submit/i}).click();
@@ -569,6 +601,7 @@ No `user` fixture — interact directly via locators. `.fill()` replaces `.type(
 ### Standalone component test (no routing context)
 
 **Target:**
+
 ```tsx
 import {render} from 'vitest-browser-react';
 import {it} from '#/vitest-modules/test-extend';

--- a/.claude/skills/frontend-unit-test/SKILL.md
+++ b/.claude/skills/frontend-unit-test/SKILL.md
@@ -1,0 +1,144 @@
+---
+
+name: frontend-unit-test
+description: Use when writing, modifying, or debugging unit tests in the orchestration cluster webapp at webapp/client/apps/orchestration-cluster-webapp/. Use when working with Vitest browser mode, MSW mocking, vitest-browser-react rendering, or any *.test.tsx file in the OC webapp's src/ directory. Trigger whenever someone needs to create, fix, or understand a frontend unit test in webapp/client/.
+
+---
+
+# Frontend Unit Testing
+
+Unit tests in `@camunda/orchestration-cluster-webapp` run in a **real Chromium browser** via Vitest Browser Mode — not jsdom or happy-dom. This matters because components render in an actual DOM with real layout, events, and browser APIs. MSW intercepts all HTTP at the service worker level.
+
+This is fundamentally different from the `@testing-library/react` + `vi.mock()` approach used in the legacy Operate and Tasklist frontends. If you're familiar with those patterns, read the key rules carefully — several habits from the legacy apps will produce broken or flaky tests here.
+
+## Key rules
+
+- Import `it` from `#/vitest-modules/test-extend`, not from `vitest`. The custom fixture auto-starts an MSW service worker before each test and resets/stops it after. Importing from `vitest` directly means no MSW interception — HTTP calls will fail or hit real endpoints.
+- Use `render()` from `vitest-browser-react`, not from `@testing-library/react`. The vitest-browser-react renderer is designed for browser-mode Vitest and handles the real DOM lifecycle correctly. Do NOT import `screen` from `@testing-library/react` — it does not exist in this setup.
+- For components that need routing context (pages, components using `<Link>`, `useNavigate`, route hooks), use `renderWithRouter(initialLocation)` from `#/vitest-modules/render-with-router` instead of bare `render()`. It creates a real TanStack Router with a memory history — no mocking needed.
+- Both `render()` and `renderWithRouter()` return the `screen` object — you MUST capture the return value: `const screen = await renderWithRouter('/login')`. There is no global `screen` import.
+- Use `expect.element()` for DOM assertions — it retries automatically until the assertion passes or times out. This replaces the `waitFor` / `findBy*` / `screen.findByRole` patterns you may know from Testing Library. There is no `waitFor` here.
+- Mock HTTP through the `worker` fixture using endpoint mocks from `#/shared-test-modules/mock-handlers`. Each mock is an individually named export (e.g., `mockCurrentUserEndpoint`, `mockLoginEndpoint`) created with `createEndpointMock` from `#/shared-test-modules/mock-endpoint`. Both unit and Playwright tests use the same definitions. All endpoint mocks must be defined in `apps/orchestration-cluster-webapp/shared-test-modules/mock-handlers.ts` — never create `createEndpointMock` calls inline in test files. Never use `vi.mock()` for API calls; it couples tests to implementation details and breaks on refactors.
+- Prefer testing library selectors: `getByRole`, `getByLabelText`, `getByText`. They enforce accessible markup and survive structural refactors. Avoid `querySelector` and `getByTestId` — they test DOM structure, not behavior.
+- Co-locate test files with source: `src/modules/foo/bar.test.tsx` sits next to `bar.tsx`.
+- Prefix test names with `should` (e.g., `it('should display an error on invalid credentials')`).
+- Do not mock the router. Use `renderWithRouter(initialLocation)` from `#/vitest-modules/render-with-router` when the component needs routing context. It creates a real TanStack Router backed by an in-memory history — the component receives real route params, search params, and navigation.
+- Avoid `vi.mock()` in general. Prefer MSW and real implementations. Vitest mocks couple tests to internals and break on refactors. Reach for them only when there is no practical alternative, such as faking time with `vi.useFakeTimers`.
+- Do not use `// given / when / then` comments — that is a Java backend convention. Structure tests by visual grouping (blank lines between setup, action, and assertion).
+
+## MSW mocking
+
+Endpoint mocks live in `#/shared-test-modules/endpoints` as a shared dictionary. Each entry is created with `createEndpointMock` from `#/shared-test-modules/mock-endpoint`, which builds a typed MSW handler factory for a given endpoint + HTTP method.
+
+Two shapes:
+
+- **With Zod schema validation**: pass `schema`, `successResponse`, and `failureResponse`. The handler validates the request body against the schema and returns the failure response if it doesn't match.
+- **Without validation**: pass only `successResponse`. The handler always returns the success response.
+
+The `worker` fixture is injected by the custom `it` and auto-resets between tests — no manual `worker.resetHandlers()` needed.
+
+## Test structure
+
+### Testing a standalone component (no routing context)
+
+```tsx
+import {render} from 'vitest-browser-react';
+import {it} from '#/vitest-modules/test-extend';
+import {mockUsersEndpoint} from '#/shared-test-modules/mock-handlers';
+import {describe, expect} from 'vitest';
+import {HttpResponse} from 'msw';
+import {UserList} from './UserList';
+
+describe('<UserList />', () => {
+  it('should render users from the API', async ({worker}) => {
+    worker.use(
+      mockUsersEndpoint({
+        successResponse: HttpResponse.json([
+          {name: 'Alice'},
+          {name: 'Bob'},
+        ]),
+      }),
+    );
+
+    const screen = await render(<UserList />);
+
+    await expect.element(screen.getByRole('cell', {name: 'Alice'})).toBeVisible();
+    await expect.element(screen.getByRole('cell', {name: 'Bob'})).toBeVisible();
+  });
+});
+```
+
+### Testing a page or component that needs routing context
+
+Use `renderWithRouter(initialLocation)` — it creates a real TanStack Router with memory history, so route params, search params, and navigation all work.
+
+```tsx
+import {it} from '#/vitest-modules/test-extend';
+import {renderWithRouter} from '#/vitest-modules/render-with-router';
+import {mockCurrentUserEndpoint} from '#/shared-test-modules/mock-handlers';
+import {describe, expect} from 'vitest';
+import {HttpResponse} from 'msw';
+
+describe('<Login />', () => {
+  it('should not allow the form to be submitted with empty fields', async ({worker}) => {
+    worker.use(
+      mockCurrentUserEndpoint({successResponse: new HttpResponse(null, {status: 401})}),
+    );
+
+    const screen = await renderWithRouter('/login');
+
+    await screen.getByRole('button', {name: /login/i}).click();
+
+    await expect.element(screen.getByLabelText(/username/i)).toBeInvalid();
+    await expect.element(screen.getByLabelText(/^password$/i)).toBeInvalid();
+  });
+});
+```
+
+## Assertion patterns
+
+```ts
+// Visibility
+await expect.element(screen.getByRole('button', {name: /submit/i})).toBeVisible();
+
+// Text content
+await expect.element(screen.getByRole('heading')).toHaveTextContent('Dashboard');
+
+// Attributes
+await expect.element(screen.getByRole('link', {name: 'Docs'})).toHaveAttribute('href', '/docs');
+
+// Absence — element should not be in the document
+await expect.element(screen.getByText('Loading...')).not.toBeVisible();
+```
+
+`expect.element()` is always async and retries — no need to wrap in `waitFor` or use `findBy*`.
+
+## Common gotchas
+
+- **No `waitFor` or `findBy*`**: `expect.element()` handles async natively. Writing `await waitFor(() => ...)` will error — it doesn't exist in this setup.
+- **No `queryByText` / `queryByRole`**: these don't exist. Use `getByText` / `getByRole` with `expect.element(...).not.toBeVisible()` for absence checks.
+- **No `user` fixture**: there is no `userEvent` or `user` fixture. Interact directly via locators: `screen.getByRole('button').click()`, `screen.getByLabelText('Name').fill('value')`.
+- **Endpoint mocks are functions**: always call them with a config object — `mockCurrentUserEndpoint({successResponse: HttpResponse.json({})})`, not `mockCurrentUserEndpoint` bare.
+- **No jsdom APIs**: tests run in a real browser, so `document.querySelector` technically works but defeats the purpose. Use `screen.getBy*` queries.
+- **`msw/browser`, not `msw/node`**: the MSW worker runs in the browser via `setupWorker`. If you see imports from `msw/node`, that's wrong.
+- **No `vi.mock()` for HTTP**: it silently breaks in browser mode and is the wrong abstraction anyway. Use MSW.
+- **`render()` returns `screen`**: unlike Testing Library where `screen` is a global import, here `render()` returns the screen object. Use `const screen = await render(<Comp />)`. Same for `renderWithRouter()` — `const screen = await renderWithRouter('/path')`.
+
+## Commands
+
+Run from `webapp/client/apps/orchestration-cluster-webapp/`:
+
+```bash
+npm run test:unit       # Headless Chromium — CI and local
+npm run test:unit:ui    # Visible browser — useful for debugging
+```
+
+## Template references
+
+- `src/pages/login.test.tsx` — page-level test using `renderWithRouter`.
+- `src/modules/mock-test.test.tsx` — component test with MSW mocking.
+- `src/vitest-modules/test-extend.ts` — custom `it` fixture source.
+- `src/vitest-modules/render-with-router.tsx` — `renderWithRouter` utility source.
+- `shared-test-modules/mock-endpoint.ts` — `createEndpointMock` factory source.
+- `shared-test-modules/mock-handlers.ts` — shared endpoint mock definitions.
+- `docs/monorepo-docs/frontend/testing.md` — full testing guide.

--- a/.claude/skills/frontend-unit-test/SKILL.md
+++ b/.claude/skills/frontend-unit-test/SKILL.md
@@ -142,3 +142,4 @@ npm run test:unit:ui    # Visible browser — useful for debugging
 - `shared-test-modules/mock-endpoint.ts` — `createEndpointMock` factory source.
 - `shared-test-modules/mock-handlers.ts` — shared endpoint mock definitions.
 - `docs/monorepo-docs/frontend/testing.md` — full testing guide.
+

--- a/.claude/skills/operate-frontend/SKILL.md
+++ b/.claude/skills/operate-frontend/SKILL.md
@@ -1,0 +1,403 @@
+---
+
+name: operate-frontend
+description: Use when fixing bugs, making changes, writing tests, or understanding code in the Operate legacy frontend at operate/client/. Trigger for any work touching operate/client/src/, including component changes, test modifications, API hook updates, styled-components edits, MobX store changes, or React Router route adjustments. Also use when someone asks about Operate frontend patterns, conventions, or architecture. This is the legacy process monitoring UI being phased out in favor of the orchestration cluster webapp.
+
+---
+
+# Operate Legacy Frontend
+
+Operate is the process monitoring frontend at `operate/client/`. It is **legacy code being phased out** — the orchestration cluster webapp at `webapp/client/` is replacing it. Work in Operate should be limited to bug fixes, small adjustments, and maintenance. For substantial new features, build them in the new app instead (see the `frontend-feature` and `frontend-migrator` skills).
+
+Follow the existing conventions described here. Don't introduce new architectural patterns — consistency matters more than modernization in a codebase that's winding down.
+
+## Tech stack
+
+| Category | Technology |
+|---|---|
+| UI framework | React 18, React DOM 18 |
+| Language | TypeScript 5.9 (strict mode) |
+| Bundler | Vite 8 |
+| Routing | react-router-dom 7 (React Router v6 API) |
+| Server state | TanStack React Query 5 |
+| Client state | MobX 6 + mobx-react / mobx-react-lite |
+| Styling | styled-components 6, Carbon Design System (`@carbon/react`, `@carbon/elements`) |
+| Forms | React Final Form + final-form-arrays |
+| Testing | Vitest (jsdom) + Testing Library + MSW 2, Playwright (E2E) |
+| BPMN/DMN | bpmn-js 18, dmn-js 17 |
+| Code editor | Monaco Editor (`@monaco-editor/react`) |
+
+## Project structure
+
+```
+operate/client/src/
+  index.tsx                          # Entry point, renders <App />
+  App/                               # App shell + page components
+    index.tsx                        # Router, providers, route tree
+    Layout/                          # App shell (header, sidebar, content)
+    Dashboard/                       # Dashboard page
+    Processes/                       # Process instances list
+    ProcessInstance/                  # Process instance detail (BPMN + tabs)
+    Decisions/                       # Decision instances list
+    DecisionInstance/                 # Decision instance detail
+    BatchOperations/                 # Batch operations list + detail
+    OperationsLog/                   # Operations log
+    Login/                           # Login page
+    RedirectDeprecatedRoutes.tsx     # Migrates old /instances URLs
+  modules/                           # Shared concerns
+    api/v2/                          # API endpoint functions (one per endpoint)
+    queries/                         # React Query hooks (useQuery, useInfiniteQuery)
+    mutations/                       # React Query mutations (useMutation)
+    react-query/                     # QueryClient provider + config
+    stores/                          # MobX stores (UI state)
+    hooks/                           # Custom React hooks
+    components/                      # Shared UI components
+    mock-server/                     # MSW setup (node for tests)
+    mocks/                           # Mock data + mock request builders
+    request/                         # HTTP request utilities
+    Routes.tsx                       # Centralized path builders (Paths, Locations)
+    testing-library.ts               # Custom render() with userEvent
+    types/                           # Shared TypeScript types
+    utils/                           # General utilities
+```
+
+Components follow a consistent directory layout: `index.tsx` (component), `styled.ts` (styled-components), `index.test.tsx` (tests). Some components place tests in a `tests/` subdirectory instead.
+
+## Routing
+
+Routes are defined in `src/App/index.tsx` using React Router v6's `createBrowserRouter` with `createRoutesFromElements`. Every page-level route is lazy-loaded:
+
+```tsx
+<Route
+  path={Paths.processes()}
+  lazy={async () => {
+    const {Processes} = await import('./Processes/index');
+    return {Component: Processes};
+  }}
+/>
+```
+
+### Path builders
+
+All route paths are centralized in `modules/Routes.tsx` via the `Paths` object. Never hardcode path strings — always use `Paths`:
+
+```tsx
+import {Paths} from 'modules/Routes';
+
+Paths.processes()
+Paths.processInstance('123')
+Paths.processInstance()
+Paths.decisionInstance('456')
+Paths.batchOperation('789')
+```
+
+The `Locations` object builds `{pathname, search}` objects with default filter params:
+
+```tsx
+import {Locations} from 'modules/Routes';
+
+Locations.processes()
+Locations.decisions()
+```
+
+### Route params and search params
+
+Route params use `useParams` with a type argument:
+
+```tsx
+const {processInstanceId} = useParams<{processInstanceId: string}>();
+```
+
+The `useProcessInstancePageParams` hook in `App/ProcessInstance/` wraps this for the process instance detail pages — use it instead of calling `useParams` directly in that context.
+
+Search params drive filter state. The `useFilters` hook in `modules/hooks/useFilters.tsx` provides `getFilters()` and `setFilters()` that read/write URL search params via `useNavigate` and `useLocation`. Filters are fully URL-driven — no MobX store for filter state.
+
+### Authentication guards
+
+All authenticated routes are wrapped in `AuthenticationCheck` (redirects to `/login` if not logged in) and `AuthorizationCheck` (redirects to `/forbidden` if user lacks permissions). These are composed in the dashboard route's `lazy` loader. If you add a new authenticated route, nest it under the dashboard route in the route tree — don't duplicate the guards.
+
+### Error boundaries
+
+A single `PageErrorBoundary` is attached to the root route via React Router's `ErrorBoundary` prop. It uses `useRouteError()` to render error details. Individual pages don't define their own error boundaries — the root one catches everything.
+
+## Data fetching
+
+Data fetching has three layers. Follow this architecture — don't bypass it.
+
+### Layer 1: API functions (`modules/api/v2/`)
+
+Each endpoint gets a thin typed function. Endpoints come from `@camunda/camunda-api-zod-schemas/8.10`:
+
+```tsx
+import {endpoints, type QueryProcessInstancesRequestBody, type QueryProcessInstancesResponseBody}
+  from '@camunda/camunda-api-zod-schemas/8.10';
+import {requestWithThrow} from 'modules/request';
+```
+
+`requestWithThrow` returns `{response, error}` — a discriminated union, not a thrown exception (despite the name). `response` is the parsed data on success, `null` on failure. `error` is a `RequestError` on failure, `null` on success. The underlying `request` function handles 401s automatically by disabling the session.
+
+There is also `requestAndParse` — this is an older utility used by a few legacy stores. Don't use it for new code; use `requestWithThrow`.
+
+### Layer 2: React Query hooks (`modules/queries/`)
+
+Query hooks wrap the API functions. Query keys are centralized in `modules/queries/queryKeys.ts`:
+
+```tsx
+const useProcessInstance = () => {
+  const {processInstanceId} = useProcessInstancePageParams();
+  return useQuery({
+```
+
+The standard pattern: destructure `{response, error}` from the API function, return `response` on success, `throw error` on failure. React Query catches the thrown error and surfaces it via `query.error`.
+
+### Layer 3: Components
+
+Components call the query hooks directly. There is no route-level data prefetching — components initiate their own fetches:
+
+```tsx
+function ProcessInstanceHeader() {
+  const {data: processInstance, isLoading} = useProcessInstance();
+  if (isLoading) return <SkeletonText />;
+}
+```
+
+### Mutations
+
+Mutations follow the same `{response, error}` pattern. Some mutations poll for eventual consistency using `queryClient.fetchQuery` with `retry: true`:
+
+```tsx
+await queryClient.fetchQuery({
+  queryKey: queryKeys.processInstance.get(key),
+  queryFn: async () => {
+    const {response} = await fetchProcessInstance(key);
+    if (response.state === 'ACTIVE') throw new Error('Still running');
+    return response;
+  },
+  retry: true,
+  retryDelay: 1000,
+});
+```
+
+### Polling
+
+Live data uses `refetchInterval` on query hooks (standard interval is 5000ms). Conditional polling is common — only poll when the instance is running or active.
+
+## State management
+
+State is split across three mechanisms. When you encounter state, identify which category it belongs to:
+
+| What | Where | Why |
+|------|-------|-----|
+| Server data (API responses) | React Query via `modules/queries/` | Automatic caching, deduplication, background refresh |
+| Filters, sort, pagination, element selection | URL search params via `useFilters`, `useSearchParams` | Shareable, survives refresh, back/forward works |
+| UI mode (modification mode, panel visibility, selection, theme) | MobX stores in `modules/stores/` | Ephemeral client-side state that doesn't belong in the URL |
+
+### MobX stores
+
+There are ~20 MobX stores. The important ones:
+
+| Store | What it manages |
+|-------|-----------------|
+| `authentication` | Session state, login/logout flow |
+| `modifications` | Process instance modification mode (add/cancel/move tokens, variable edits) |
+| `notifications` | Toast notification queue (max 5 visible) |
+| `instancesSelection` | Selected process instances for batch operations |
+| `processInstanceMigration` | Migration wizard state |
+| `panelStates` | UI panel open/closed state |
+| `batchModification` | Batch modification mode |
+| `currentTheme` | Light/dark theme preference |
+
+Components that read MobX stores must be wrapped with `observer()`:
+
+```tsx
+import {observer} from 'mobx-react';
+import {panelStatesStore} from 'modules/stores/panelStates';
+
+const MyComponent = observer(() => {
+  const isOpen = panelStatesStore.isFiltersOpen;
+});
+
+export {MyComponent};
+```
+
+Don't wrap components that don't access stores — `observer()` adds overhead.
+
+## Styling
+
+All component styling uses styled-components. There are no SCSS modules in this codebase — don't introduce them. Don't use inline `style={{}}` props either — all styling belongs in a `styled.ts` file.
+
+### File convention
+
+Each component directory has a `styled.ts` file exporting styled components:
+
+```tsx
+import styled, {css} from 'styled-components';
+import {Tile as BaseTile} from '@carbon/react';
+import {styles} from '@carbon/elements';
+```
+
+### Key patterns
+
+- **Wrapping Carbon components**: `styled(CarbonComponent)` applies additional styles on top of Carbon's defaults.
+- **Respect Carbon's defaults**: Carbon components ship with intentional styling — colors, spacing, typography, interactive states. Before applying any style that changes a Carbon component's visual defaults, you must first tell the user what you're about to override and why it's risky — even if the user explicitly asked for the change, because they may not realize it touches Carbon defaults. Explain what the override is (e.g., "This would set a custom height on SkeletonText, overriding Carbon's built-in sizing"), suggest the Carbon-native alternative if one exists (e.g., a prop, a token, a different component), and ask the user to confirm before proceeding. Only apply the override after the user says to go ahead.
+- **Carbon tokens**: typography via `@carbon/elements` `styles` object (`${styles.productiveHeading02}`), spacing/color via CSS custom properties (`var(--cds-spacing-05)`, `var(--cds-text-primary)`).
+- **Transient props**: use the `$` prefix (`$isActive`, `$size`) to avoid passing props to the DOM. Type them with generics: `styled.div<{$isActive: boolean}>`.
+- **`css` helper**: use for conditional style blocks inside template literals.
+
+## Component structure
+
+- **File naming**: `index.tsx` for the component, `styled.ts` for styles, `index.test.tsx` for tests.
+- **Exports**: always use named exports at the end of the file: `export {MyComponent}`. Never `export default`.
+- **`observer()` wrapping**: wrap the component function, not the export: `const Comp = observer(() => {...}); export {Comp};`
+- **`React.FC` typing**: most components use `const Component: React.FC<Props> = ({...}) => {...}`.
+- **No comments**: don't generate code comments. The code should be self-explanatory. If something needs a comment, the code itself should be rewritten to be clearer instead.
+
+## Testing
+
+Tests use Vitest with jsdom, `@testing-library/react`, and MSW v2 for API mocking.
+
+### Custom render
+
+Import `render` from `modules/testing-library`, not from `@testing-library/react` directly. It bundles a pre-configured `userEvent` instance:
+
+```tsx
+import {render, screen, waitFor} from 'modules/testing-library';
+
+const {user} = render(<MyComponent />, {wrapper: getWrapper()});
+await user.click(screen.getByRole('button', {name: /submit/i}));
+```
+
+### Test wrapper
+
+Tests that render components needing context use a wrapper function composing `QueryClientProvider` + `MemoryRouter`:
+
+```tsx
+import {QueryClientProvider} from '@tanstack/react-query';
+import {MemoryRouter, Routes, Route} from 'react-router-dom';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {Paths} from 'modules/Routes';
+
+const getWrapper = (initialPath = Paths.processes()) => {
+  const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => (
+    <QueryClientProvider client={getMockQueryClient()}>
+      <MemoryRouter initialEntries={[initialPath]}>
+        <Routes>
+          <Route path={Paths.processes()} element={children} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+  return Wrapper;
+};
+```
+
+`getMockQueryClient()` creates a `QueryClient` with `retry: false`, `gcTime: Infinity`, `staleTime: Infinity` — no retries, no cache expiration, always fresh.
+
+### API mocking
+
+Each endpoint has a typed mock builder in `modules/mocks/api/`. The fluent builder pattern:
+
+```tsx
+import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
+
+mockFetchProcessInstance().withSuccess(processInstanceData);
+
+mockFetchProcessInstance().withServerError(404);
+
+mockFetchProcessInstance().withDelay(processInstanceData);
+
+mockFetchProcessInstance().withNetworkError();
+```
+
+All handlers except `withNetworkError` are registered with `{once: true}` — they're consumed on first match, then removed. This lets you chain multiple setups for sequential requests in the same test. The MSW server resets all handlers in `afterEach` via `setupTests.tsx`.
+
+To create a new mock, use `mockGetRequest`, `mockPostRequest`, etc. from `modules/mocks/api/mockRequest.ts`:
+
+```tsx
+import {mockPostRequest} from 'modules/mocks/api/mockRequest';
+import type {MyResponseType} from '@camunda/camunda-api-zod-schemas/8.10';
+
+const mockSearchMyEntity = (contextPath = '') =>
+  mockPostRequest<MyResponseType>(`${contextPath}/v2/my-entities/search`);
+```
+
+### Test data factories
+
+Use factory functions from `modules/mocks/` to create typed test data:
+
+```tsx
+import {createUser} from 'modules/mocks/user';
+import {createProcessDefinition} from 'modules/mocks/processDefinition';
+
+mockMe().withSuccess(createUser());
+mockSearchProcessDefinitions().withSuccess(searchResult([createProcessDefinition({name: 'Test'})]));
+```
+
+### Assertion patterns
+
+```tsx
+expect(screen.getByRole('button', {name: /cancel/i})).toBeInTheDocument();
+
+expect(await screen.findByText('10 running instances')).toBeInTheDocument();
+
+expect(screen.queryByText('Error')).not.toBeInTheDocument();
+
+await waitFor(() => {
+  expect(screen.getByRole('cell', {name: 'completed'})).toBeInTheDocument();
+});
+
+const row = screen.getByRole('row', {name: /my-process/i});
+expect(within(row).getByText('v2')).toBeInTheDocument();
+```
+
+### Store cleanup
+
+All MobX stores are reset automatically in `afterEach` via `resetAllStores()` in `setupTests.tsx`. You don't need to reset stores manually in tests unless you need a mid-test reset.
+
+## Forms
+
+Forms use React Final Form. Two main patterns:
+
+1. **Filter forms**: use `<Form>` with field components that sync to URL search params via `useFilters`.
+
+2. **Modal/editing forms**: standard `<Form onSubmit={...}>` with `<Field>` components and explicit submit buttons. Variable editing uses `FieldArray` from `final-form-arrays`.
+
+## Commands
+
+Run from `operate/client/`:
+
+```bash
+npm start              # Dev server on :3000 (proxies API to :8080)
+npm test               # Unit tests (Vitest, jsdom)
+npm run lint           # TypeScript check + ESLint + Prettier
+npm run ts-check       # TypeScript only (tsc -b)
+npm run build          # Production build
+npm run knip           # Dead code/dependency analysis
+```
+
+## Common pitfalls
+
+- **Mock handler consumption**: `.withSuccess()` handlers are `{once: true}` — if a component makes the same request twice, the second call gets no handler. Chain two `.withSuccess()` calls or use a non-one-shot approach.
+- **Missing `observer()`**: if a component reads a MobX store but isn't wrapped in `observer()`, it won't re-render when the store changes. Symptoms: stale UI, tests that pass individually but fail in sequence.
+- **`requestAndParse` vs `requestWithThrow`**: `requestAndParse` is legacy. Use `requestWithThrow` for all new code. They have different return shapes — don't mix them up.
+- **No i18n**: all strings are hardcoded in English. Don't add `i18next` or translation files.
+- **No SCSS modules**: styling is entirely styled-components. Don't introduce `.module.scss` files.
+- **No data prefetching**: components fetch their own data via query hooks. There are no route-level loaders. Don't add them — that's the new app's pattern.
+
+## Boundaries
+
+**Follow existing conventions:**
+- styled-components for styling
+- React Final Form for forms
+- `mockFetchX().withSuccess()` pattern for test mocking
+- Named exports, `index.tsx` entry files
+- `Paths` object for all route paths
+
+**Don't introduce:**
+- SCSS modules or CSS modules
+- i18n / translation files
+- TanStack Router or file-based routing
+- Route-level data loaders / prefetching
+- New UI component libraries
+
+**For substantial new features:** use the `frontend-migrator` skill to build them in the orchestration cluster webapp instead. Operate is winding down — invest engineering effort in the replacement.

--- a/.claude/skills/operate-frontend/SKILL.md
+++ b/.claude/skills/operate-frontend/SKILL.md
@@ -13,19 +13,19 @@ Follow the existing conventions described here. Don't introduce new architectura
 
 ## Tech stack
 
-| Category | Technology |
-|---|---|
-| UI framework | React 18, React DOM 18 |
-| Language | TypeScript 5.9 (strict mode) |
-| Bundler | Vite 8 |
-| Routing | react-router-dom 7 (React Router v6 API) |
-| Server state | TanStack React Query 5 |
-| Client state | MobX 6 + mobx-react / mobx-react-lite |
-| Styling | styled-components 6, Carbon Design System (`@carbon/react`, `@carbon/elements`) |
-| Forms | React Final Form + final-form-arrays |
-| Testing | Vitest (jsdom) + Testing Library + MSW 2, Playwright (E2E) |
-| BPMN/DMN | bpmn-js 18, dmn-js 17 |
-| Code editor | Monaco Editor (`@monaco-editor/react`) |
+|   Category   |                                   Technology                                    |
+|--------------|---------------------------------------------------------------------------------|
+| UI framework | React 18, React DOM 18                                                          |
+| Language     | TypeScript 5.9 (strict mode)                                                    |
+| Bundler      | Vite 8                                                                          |
+| Routing      | react-router-dom 7 (React Router v6 API)                                        |
+| Server state | TanStack React Query 5                                                          |
+| Client state | MobX 6 + mobx-react / mobx-react-lite                                           |
+| Styling      | styled-components 6, Carbon Design System (`@carbon/react`, `@carbon/elements`) |
+| Forms        | React Final Form + final-form-arrays                                            |
+| Testing      | Vitest (jsdom) + Testing Library + MSW 2, Playwright (E2E)                      |
+| BPMN/DMN     | bpmn-js 18, dmn-js 17                                                           |
+| Code editor  | Monaco Editor (`@monaco-editor/react`)                                          |
 
 ## Project structure
 
@@ -186,26 +186,26 @@ Live data uses `refetchInterval` on query hooks (standard interval is 5000ms). C
 
 State is split across three mechanisms. When you encounter state, identify which category it belongs to:
 
-| What | Where | Why |
-|------|-------|-----|
-| Server data (API responses) | React Query via `modules/queries/` | Automatic caching, deduplication, background refresh |
-| Filters, sort, pagination, element selection | URL search params via `useFilters`, `useSearchParams` | Shareable, survives refresh, back/forward works |
-| UI mode (modification mode, panel visibility, selection, theme) | MobX stores in `modules/stores/` | Ephemeral client-side state that doesn't belong in the URL |
+|                              What                               |                         Where                         |                            Why                             |
+|-----------------------------------------------------------------|-------------------------------------------------------|------------------------------------------------------------|
+| Server data (API responses)                                     | React Query via `modules/queries/`                    | Automatic caching, deduplication, background refresh       |
+| Filters, sort, pagination, element selection                    | URL search params via `useFilters`, `useSearchParams` | Shareable, survives refresh, back/forward works            |
+| UI mode (modification mode, panel visibility, selection, theme) | MobX stores in `modules/stores/`                      | Ephemeral client-side state that doesn't belong in the URL |
 
 ### MobX stores
 
 There are ~20 MobX stores. The important ones:
 
-| Store | What it manages |
-|-------|-----------------|
-| `authentication` | Session state, login/logout flow |
-| `modifications` | Process instance modification mode (add/cancel/move tokens, variable edits) |
-| `notifications` | Toast notification queue (max 5 visible) |
-| `instancesSelection` | Selected process instances for batch operations |
-| `processInstanceMigration` | Migration wizard state |
-| `panelStates` | UI panel open/closed state |
-| `batchModification` | Batch modification mode |
-| `currentTheme` | Light/dark theme preference |
+|           Store            |                               What it manages                               |
+|----------------------------|-----------------------------------------------------------------------------|
+| `authentication`           | Session state, login/logout flow                                            |
+| `modifications`            | Process instance modification mode (add/cancel/move tokens, variable edits) |
+| `notifications`            | Toast notification queue (max 5 visible)                                    |
+| `instancesSelection`       | Selected process instances for batch operations                             |
+| `processInstanceMigration` | Migration wizard state                                                      |
+| `panelStates`              | UI panel open/closed state                                                  |
+| `batchModification`        | Batch modification mode                                                     |
+| `currentTheme`             | Light/dark theme preference                                                 |
 
 Components that read MobX stores must be wrapped with `observer()`:
 

--- a/.codeowners
+++ b/.codeowners
@@ -198,6 +198,13 @@ mwnw*                       @camunda/monorepo-devops-team
 # Engine-expert skill
 /.claude/skills/engine-expert/ @korthout @camunda/core-features
 
+# Frontend skills
+/.claude/skills/frontend-feature/          @camunda/core-features
+/.claude/skills/frontend-integration-test/ @camunda/core-features
+/.claude/skills/frontend-migrator/         @camunda/core-features
+/.claude/skills/frontend-unit-test/        @camunda/core-features
+/.claude/skills/operate-frontend/          @camunda/core-features
+
 # optimize / BI team
 /zeebe/exporter-filter/        @camunda/core-features
 

--- a/.github/agents/frontend.agent.md
+++ b/.github/agents/frontend.agent.md
@@ -1,0 +1,113 @@
+---
+name: "frontend-agent"
+description: "Frontend development specialist for the orchestration cluster webapp and legacy Operate frontend. Helps build features, write tests, debug UI issues, migrate code from legacy Operate/Tasklist frontends, maintain the legacy Operate frontend at operate/client/, and follow project conventions."
+tools:
+  [
+    "edit",
+    "search",
+    "vscode/getProjectSetupInfo",
+    "vscode/installExtension",
+    "vscode/newWorkspace",
+    "vscode/runCommand",
+    "execute/getTerminalOutput",
+    "execute/runInTerminal",
+    "read/terminalLastCommand",
+    "read/terminalSelection",
+    "execute/createAndRunTask",
+    "execute/runTask",
+    "read/getTaskOutput",
+    "search/usages",
+    "vscode/vscodeAPI",
+    "read/problems",
+    "search/changes",
+    "web/fetch",
+    "web/githubRepo",
+    "todo",
+  ]
+model: GPT-5.3-Codex (copilot)
+target: vscode
+---
+
+# Frontend Agent
+
+You are the **Frontend Development Specialist** for the orchestration cluster webapp — the unified React frontend replacing the legacy Operate, Tasklist, and Admin UIs. You help engineers build features, write tests, debug issues, and follow project conventions.
+
+## Your Role
+
+- You specialize in the `@camunda/orchestration-cluster-webapp` codebase at `webapp/client/`
+- You understand the tech stack: React 19, TypeScript, Vite, TanStack Router (file-based), TanStack Query, MobX (theme + session), Carbon Design System, Vitest Browser Mode, Playwright, MSW
+- Your output: clean, convention-following code that fits the existing architecture
+
+## Project Knowledge
+
+- **Tech Stack:** React 19, TypeScript, Vite, TanStack Router, TanStack Query, MobX, Carbon (`@carbon/react`), SCSS
+- **Testing:** Vitest Browser Mode + MSW (unit), Playwright + MSW (integration/visual/a11y)
+- **File Structure:**
+  - `webapp/client/apps/orchestration-cluster-webapp/src/modules/` — reusable building blocks
+  - `webapp/client/apps/orchestration-cluster-webapp/src/pages/` — page compositions
+  - `webapp/client/apps/orchestration-cluster-webapp/src/routes/` — TanStack Router file-based routes
+  - `webapp/client/apps/orchestration-cluster-webapp/test/` — Playwright tests (integration, visual, a11y)
+  - `webapp/client/packages/camunda-api-zod-schemas/` — API types and Zod schemas
+  - `docs/monorepo-docs/frontend/` — canonical frontend documentation
+
+## Core Loop
+
+**Follow this sequence when making changes:**
+
+1. **Lint** → `npm run lint`
+2. **Typecheck** → `npm run typecheck`
+3. **Unit test** → `npm run test:unit`
+4. **Integration test** → `npm run test:integration` (when touching user flows)
+5. **Iterate** → Fix issues, re-validate, repeat
+
+Run all commands from `webapp/client/apps/orchestration-cluster-webapp/`.
+
+## Commands You Can Run
+
+| Command                    | Purpose                                       |
+| -------------------------- | --------------------------------------------- |
+| `npm ci`                   | Install dependencies (from `webapp/client/`)  |
+| `npm run dev:oc`           | Dev server on `:3000` (from `webapp/client/`) |
+| `npm run lint`             | ESLint + Prettier                             |
+| `npm run typecheck`        | TypeScript check across all tsconfigs         |
+| `npm run test:unit`        | Unit tests — Vitest in headless Chromium      |
+| `npm run test:unit:ui`     | Unit tests — visible browser for debugging    |
+| `npm run test:integration` | Playwright integration tests (MSW-mocked)     |
+| `npm run test:a11y`        | Playwright accessibility tests (light + dark) |
+| `npm run test:visual`      | Playwright visual regression (needs Docker)   |
+| `npm run generate:svg`     | Convert SVGs to React components              |
+
+## Progressive Disclosure
+
+For detailed guidance, consult the frontend docs:
+
+- `docs/monorepo-docs/frontend/orchestration-cluster-webapp.md` — tech stack, scripts, testing overview
+- `docs/monorepo-docs/frontend/development-process/creating-a-new-page.md` — building pages step-by-step
+- `docs/monorepo-docs/frontend/development-process/before-starting.md` — pre-feature considerations
+- `docs/monorepo-docs/frontend/data-loading.md` — TanStack Router + Query patterns
+- `docs/monorepo-docs/frontend/testing.md` — unit, integration, a11y, and visual testing
+- `docs/monorepo-docs/frontend/forms.md` — form library guidance
+- `docs/monorepo-docs/frontend/code-style.md` — naming, exports, comments
+
+## Migration from Legacy Frontends
+
+When migrating code from `operate/client/` or `tasklist/client/` to the orchestration cluster webapp, consult the migration skill for pattern transformations:
+
+- `.claude/skills/frontend-migrator/` — maps legacy patterns (React Router, MobX stores, styled-components, jsdom tests) to target patterns (TanStack Router, TanStack Query, SCSS modules, Vitest browser mode)
+- `references/pattern-mapping.md` — side-by-side code examples for every transformation
+
+Key principles: migration is a rewrite (not a code port), dependencies flow routes → pages → modules, and MobX stores should be decomposed by purpose (server data → TanStack Query, filters → URL params, ephemeral UI → useState).
+
+## Legacy Operate Frontend
+
+When fixing bugs, writing tests, or making small changes in the legacy Operate frontend at `operate/client/`, consult the operate-frontend skill:
+
+- `.claude/skills/operate-frontend/` — conventions for the legacy codebase (styled-components, MobX, React Router, Testing Library + MSW mock builders)
+
+Operate is being phased out in favor of the orchestration cluster webapp. Limit work to bug fixes and maintenance. Follow existing patterns — don't modernize the architecture. Substantial new features should go to the orchestration cluster webapp instead.
+
+## Boundaries
+
+- **Always:** Run lint + typecheck, use Carbon components, follow the modules/pages/routes structure, co-locate tests with source (unit) or in `test/` (Playwright), use MSW for mocking, use `#/` path aliases, use single export block at end of file
+- **Ask first:** Adding new npm dependencies, modifying shared packages (`packages/`), changing route structure, adding new API schemas to `@camunda/camunda-api-zod-schemas`
+- **Never:** Introduce alternative UI libraries, skip linting, use jsdom for unit tests, use `vi.mock()` for HTTP calls, modify `routeTree.gen.ts` (auto-generated), use inline `export` on declarations

--- a/.github/agents/frontend.agent.md
+++ b/.github/agents/frontend.agent.md
@@ -54,13 +54,13 @@ You are the **Frontend Development Specialist** for the orchestration cluster we
 
 **Follow this sequence when making changes:**
 
-1. **Lint** → `npm run lint`
+1. **Lint** → `npm run lint` (from `webapp/client/`)
 2. **Typecheck** → `npm run typecheck`
 3. **Unit test** → `npm run test:unit`
 4. **Integration test** → `npm run test:integration` (when touching user flows)
 5. **Iterate** → Fix issues, re-validate, repeat
 
-Run all commands from `webapp/client/apps/orchestration-cluster-webapp/`.
+Run lint from `webapp/client/`. Run the remaining commands from `webapp/client/apps/orchestration-cluster-webapp/`.
 
 ## Commands You Can Run
 
@@ -68,7 +68,7 @@ Run all commands from `webapp/client/apps/orchestration-cluster-webapp/`.
 | -------------------------- | --------------------------------------------- |
 | `npm ci`                   | Install dependencies (from `webapp/client/`)  |
 | `npm run dev:oc`           | Dev server on `:3000` (from `webapp/client/`) |
-| `npm run lint`             | ESLint + Prettier                             |
+| `npm run lint`             | ESLint + Prettier (from `webapp/client/`)     |
 | `npm run typecheck`        | TypeScript check across all tsconfigs         |
 | `npm run test:unit`        | Unit tests — Vitest in headless Chromium      |
 | `npm run test:unit:ui`     | Unit tests — visible browser for debugging    |

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -28,22 +28,23 @@ module.
 
 ### Key Modules
 
-|     Module      |                        Description                        |
-|-----------------|-----------------------------------------------------------|
-| `zeebe/`        | Core process engine (broker, engine, protocol, exporters) |
-| `zeebe/gateway` | gRPC gateway                                              |
-| `operate/`      | Process monitoring webapp                                 |
-| `tasklist/`     | User task management webapp                               |
-| `identity/`     | Authentication and authorization                          |
-| `optimize/`     | Process analytics (skipped with `-Dquickly`)              |
-| `db/`           | Database layer (rdbms, rdbms-schema)                      |
-| `search/`       | Search client abstraction (Elasticsearch, OpenSearch)     |
-| `service/`      | Internal services                                         |
-| `clients/`      | Client libraries (Java, Spring Boot starters)             |
-| `gateways/`     | Gateway implementations (HTTP mapping, MCP)               |
-| `security/`     | Security core, protocol, validation                       |
-| `qa/`           | Cross-component acceptance tests                          |
-| `testing/`      | Process testing libraries                                 |
+| Module           | Description                                               |
+| ---------------- | --------------------------------------------------------- |
+| `zeebe/`         | Core process engine (broker, engine, protocol, exporters) |
+| `zeebe/gateway`  | gRPC gateway                                              |
+| `operate/`       | Process monitoring webapp                                 |
+| `tasklist/`      | User task management webapp                               |
+| `identity/`      | Authentication and authorization                          |
+| `optimize/`      | Process analytics (skipped with `-Dquickly`)              |
+| `db/`            | Database layer (rdbms, rdbms-schema)                      |
+| `search/`        | Search client abstraction (Elasticsearch, OpenSearch)     |
+| `service/`       | Internal services                                         |
+| `clients/`       | Client libraries (Java, Spring Boot starters)             |
+| `gateways/`      | Gateway implementations (HTTP mapping, MCP)               |
+| `security/`      | Security core, protocol, validation                       |
+| `qa/`            | Cross-component acceptance tests                          |
+| `webapp/client/` | Orchestration cluster unified frontend                    |
+| `testing/`       | Process testing libraries                                 |
 
 ## Build Commands
 
@@ -102,7 +103,7 @@ Types: `build`, `ci`, `deps`, `docs`, `feat`, `fix`, `merge`, `perf`, `refactor`
 `test`
 
 - Separate behavioral changes from structural/refactoring changes into distinct commits
-- Commit messages should explain *why*, not just *what* changed
+- Commit messages should explain _why_, not just _what_ changed
 - Do not use commit scopes — commitlint enforces `scope-empty`. Use `fix: ...` not `fix(ci): ...`
 
 ## Pull Request Conventions
@@ -150,8 +151,7 @@ changes. Skipping formatting reliably breaks the `Java checks` CI job.
 
 Additional instruction files are auto-loaded when you edit matching paths:
 
-- Frontend code (`client/` directories) → `.github/instructions/frontend.instructions.md`
+- Frontend code (`client/` directories, `webapp/client/`) → `.github/instructions/frontend.instructions.md`
 - MCP gateway (`gateways/gateway-mcp/`) → `.github/instructions/gateway-mcp-tools.instructions.md`
 - Load tests (`load-tests/`, load test workflows) →
   `.github/instructions/load-tests.instructions.md`
-

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -28,8 +28,8 @@ module.
 
 ### Key Modules
 
-| Module           | Description                                               |
-| ---------------- | --------------------------------------------------------- |
+|      Module      |                        Description                        |
+|------------------|-----------------------------------------------------------|
 | `zeebe/`         | Core process engine (broker, engine, protocol, exporters) |
 | `zeebe/gateway`  | gRPC gateway                                              |
 | `operate/`       | Process monitoring webapp                                 |
@@ -155,3 +155,4 @@ Additional instruction files are auto-loaded when you edit matching paths:
 - MCP gateway (`gateways/gateway-mcp/`) → `.github/instructions/gateway-mcp-tools.instructions.md`
 - Load tests (`load-tests/`, load test workflows) →
   `.github/instructions/load-tests.instructions.md`
+

--- a/.github/instructions/frontend.instructions.md
+++ b/.github/instructions/frontend.instructions.md
@@ -69,9 +69,9 @@ see `docs/monorepo-docs/frontend/`.
 # From webapp/client/
 npm ci                    # Install dependencies (workspace)
 npm run dev:oc            # Dev server on :3000
+npm run lint              # ESLint + Prettier
 
 # From webapp/client/apps/orchestration-cluster-webapp/
-npm run lint              # ESLint + Prettier
 npm run typecheck         # TypeScript across all tsconfigs
 npm run test:unit         # Vitest browser mode (headless Chromium)
 npm run test:integration  # Playwright integration tests (MSW-mocked)

--- a/.github/instructions/frontend.instructions.md
+++ b/.github/instructions/frontend.instructions.md
@@ -1,11 +1,13 @@
 ---
-applyTo: "operate/client/**,tasklist/client/**,identity/client/**,optimize/client/**"
+applyTo: "operate/client/**,tasklist/client/**,identity/client/**,optimize/client/**,webapp/client/**"
 ---
 
 # Frontend Development Conventions
 
-The webapps (Operate, Tasklist, Identity, Optimize) each have a separate frontend under their
-`client/` directory. Read the module's `client/README.md` before making changes.
+The frontends live under `client/` directories. The orchestration cluster webapp at `webapp/client/`
+is the unified frontend replacing the legacy apps. Read `webapp/client/README.md` and
+`docs/monorepo-docs/frontend/frontend.md` before working on the unified app. For the legacy apps
+(Operate, Tasklist, Identity, Optimize), read the module's `client/README.md` before making changes.
 
 ## Tech Stack
 
@@ -57,3 +59,28 @@ yarn start            # Start dev server
   conventions despite sharing the same tech stack.
 - Tasklist uses Stylelint for CSS/SCSS; run `npm run stylelint` before committing style changes.
 - Frontends are built as part of the Maven build by default. Skip with `-PskipFrontendBuild`.
+
+## Orchestration Cluster Webapp (npm)
+
+The unified frontend at `webapp/client/apps/orchestration-cluster-webapp/`. For full conventions,
+see `docs/monorepo-docs/frontend/`.
+
+```bash
+# From webapp/client/
+npm ci                    # Install dependencies (workspace)
+npm run dev:oc            # Dev server on :3000
+
+# From webapp/client/apps/orchestration-cluster-webapp/
+npm run lint              # ESLint + Prettier
+npm run typecheck         # TypeScript across all tsconfigs
+npm run test:unit         # Vitest browser mode (headless Chromium)
+npm run test:integration  # Playwright integration tests (MSW-mocked)
+npm run test:a11y         # Playwright accessibility (light + dark)
+npm run test:visual       # Playwright visual regression (needs Docker)
+```
+
+- Tech stack: React 19, TypeScript, Vite, TanStack Router, TanStack Query, Carbon, MSW
+- Unit tests use Vitest Browser Mode (real Chromium), not jsdom. See `.claude/skills/frontend-unit-test/`.
+- Playwright tests (integration, visual, a11y) use MSW via `@msw/playwright`. See `.claude/skills/frontend-integration-test/`.
+- Follow the modules/pages/routes architecture. See `.claude/skills/frontend-feature/`.
+- For migrating legacy Operate/Tasklist code to the unified app, see `.claude/skills/frontend-migrator/`.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -146,6 +146,13 @@
 # Engine-expert skill
 /.claude/skills/engine-expert/  @korthout @camunda/core-features
 
+# Frontend skills
+/.claude/skills/frontend-feature/          @camunda/core-features
+/.claude/skills/frontend-integration-test/ @camunda/core-features
+/.claude/skills/frontend-migrator/         @camunda/core-features
+/.claude/skills/frontend-unit-test/        @camunda/core-features
+/.claude/skills/operate-frontend/          @camunda/core-features
+
 # MCP gateway
 /gateways/gateway-mcp @camunda/connectors-agentic-ai
 

--- a/webapp/client/apps/orchestration-cluster-webapp/src/modules/feature-flags.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/modules/feature-flags.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+export {};


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR adds the FE agent and FE skills for the unified webapp.

The skills I added are:
- Webapp FE skill
- Webapp unit test skill
- Webapp integration test skill
- Webapp migration skill
- Operate legacy FE skill

I think the best way to review this PR is to do a quick scan of the skills MD files and then do some testing of what code the agent produces. We can always tweak the skills as we migrate Tasklist.


## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #51326
