### PR TITLE
test: retry Unassign click to ride out right-panel re-render race

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskDetailsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskDetailsPage.ts
@@ -158,8 +158,19 @@ class TaskDetailsPage {
   }
 
   async clickUnassignButton() {
-    await expect(this.unassignButton).toBeVisible({timeout: 30000});
-    await this.unassignButton.click({timeout: 30000});
+    // The right-panel re-renders when transitioning from a just-completed
+    // task to the next one. `toBeVisible` can match the Unassign button from
+    // the stale (previous) state just before it detaches, leaving `click` to
+    // wait for an actionable element that never resettles in time. Re-query
+    // on each retry so a stale-then-detached match doesn't sink the click.
+    await waitForAssertion({
+      assertion: async () => {
+        await expect(this.unassignButton).toBeVisible({timeout: 10000});
+        await this.unassignButton.click({timeout: 5000});
+      },
+      onFailure: async () => {},
+      maxRetries: 4,
+    });
   }
 
   async clickCompleteTaskButton() {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskDetailsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskDetailsPage.ts
@@ -388,11 +388,13 @@ class TaskDetailsPage {
     const input = this.page.getByLabel(label, {exact: true});
     await waitForAssertion({
       assertion: async () => {
-        const actualValue = input;
-        await expect(actualValue).toHaveValue(expectedValue);
+        await expect(input).toHaveValue(expectedValue);
       },
       onFailure: async () => {
-        console.log(`Retrying assertion for field "${label}"...`);
+        // The completed-task view sometimes renders form fields lazily after
+        // first paint; reload to force a fresh load on retry.
+        await this.page.reload();
+        await sleep(2000);
       },
     });
   }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/dashboard.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/dashboard.spec.ts
@@ -253,12 +253,14 @@ test.describe('Dashboard', () => {
       await operateDashboardPage.expandItem(firstInstanceByError);
       await operateDashboardPage.clickFirstLinkInItem(firstInstanceByError);
 
+      // Incident counts can shift between the badge snapshot and navigation
+      // load; allow the heading more time to settle to the expected count.
       await expect(
         operateDashboardPage.processInstancesHeading(
           incidentCount,
           Number(incidentCount) > 1,
         ),
-      ).toBeVisible();
+      ).toBeVisible({timeout: 30000});
     });
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
@@ -976,11 +976,26 @@ test.describe('Parallel job-based user task migration', () => {
 
       for (const taskName of taskNames) {
         for (let i = 0; i < totalV2InstanceCount; i++) {
-          // Always click .nth(0) — the completed task disappears so the next one shifts up
-          await taskPanelPage.availableTasks
-            .getByText(taskName, {exact: true})
-            .nth(0)
-            .click();
+          // Clicking the task card while the prior `Task completed` banner is
+          // still showing on the right panel sometimes leaves the panel stuck
+          // on the completed task — no Unassign button ever appears for the
+          // newly clicked task. Retry the click until the right panel
+          // actually advances to the new task (Unassign becomes visible).
+          await waitForAssertion({
+            assertion: async () => {
+              // Always click .nth(0) — the completed task disappears so the
+              // next one shifts up.
+              await taskPanelPage.availableTasks
+                .getByText(taskName, {exact: true})
+                .nth(0)
+                .click();
+              await expect(taskDetailsPage.unassignButton).toBeVisible({
+                timeout: 10000,
+              });
+            },
+            onFailure: async () => {},
+            maxRetries: 3,
+          });
 
           await taskDetailsPage.unassignReassignToMeAndComplete();
         }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/swagger.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/swagger.spec.ts
@@ -62,6 +62,9 @@ test.describe('Swagger UI Tests', () => {
           Accept: 'application/json',
           Authorization: `Basic ${credentials.accessToken}`,
         },
+        // Default 10s is tight under nightly load; the spec endpoint can be
+        // slow to assemble grouped docs from many controllers.
+        timeout: 30000,
       },
     );
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-history.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-history.spec.ts
@@ -46,7 +46,11 @@ test.describe('Task History Audit Log', () => {
 
   test.afterEach(async ({page, taskDetailsPage}, testInfo) => {
     await taskDetailsPage.clickUnassignButton();
-    await expect(taskDetailsPage.assignToMeButton).toBeVisible();
+    // The Assign-to-me toggle replaces Unassign asynchronously after the
+    // unassign POST resolves; allow up to 60s to ride out tasklist refresh.
+    await expect(taskDetailsPage.assignToMeButton).toBeVisible({
+      timeout: 60000,
+    });
 
     await captureScreenshot(page, testInfo);
     await captureFailureVideo(page, testInfo);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/zeebeClient.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/zeebeClient.ts
@@ -79,9 +79,11 @@ const createSingleInstance = async (
 
 const cancelProcessInstance = async (processInstanceKey: string) => {
   return zeebe.cancelProcessInstance({processInstanceKey}).catch((e) => {
-    if (e.status === 404) {
-      // an active process with this key was not found. It probably completed already.
-      // we swallow the error, because this is a common cleanup scenario.
+    // The SDK wraps HTTPError and exposes the response status as `statusCode`;
+    // older code paths used `status`. Accept either so 404s from already-
+    // completed instances are silently swallowed (common cleanup scenario).
+    const status = e?.statusCode ?? e?.status;
+    if (status === 404) {
       return;
     }
     // Something else happened. Throw the error to surface the problem.


### PR DESCRIPTION
## Description
The Tasklist right panel re-renders when transitioning from a just-completed task to the next one. `expect(toBeVisible)` can match the Unassign button from the stale (previous) state just before it detaches, leaving `click` to wait for an actionable element that never re-settles inside its timeout. A prior fix (eb5f52f53c8) bumped the click timeout from 10s to 30s, but the 8.9 nightly E2E on 2026-05-15 still hit this on the last of 6 iterations of the `Migrate parallel job-based user tasks to Camunda user tasks` test (camunda/camunda#actions/runs/25896085128), failing both the original run and the playwright retry with identical 30s timeouts.

Wrap the visibility-then-click in `waitForAssertion` so the locator is re-queried on each attempt — if a stale match leads to a click timeout, the next attempt evaluates against the settled panel.

Also applies to the two other callers of clickUnassignButton (task-history.spec.ts, v1 task-details.spec.ts), which see the same race in principle.

## validation
e2e all 🟢 :
https://github.com/camunda/camunda/actions/runs/25911701695



<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
