### PR TITLE
fix: add equals/hashCode to ExporterDescriptor to prevent exporter state loss

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/repo/ExporterDescriptor.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/repo/ExporterDescriptor.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.broker.exporter.context.ExporterConfiguration;
 import io.camunda.zeebe.exporter.api.Exporter;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * When initialising the ExporterRepository via Spring, we inject predefined beans of the
@@ -56,5 +57,21 @@ public class ExporterDescriptor {
 
   public boolean isSameTypeAs(final ExporterDescriptor other) {
     return exporterFactory.isSameTypeAs(other.exporterFactory);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof final ExporterDescriptor other)) {
+      return false;
+    }
+    return Objects.equals(getId(), other.getId());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(getId());
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStepTest.java
@@ -250,6 +250,36 @@ class ExporterDirectorPartitionTransitionStepTest {
   }
 
   @Test
+  void shouldNotRemoveStateOfConfigNotFoundExporter() {
+    // given - expB's static config was removed; it is tracked with CONFIG_NOT_FOUND
+    final String configuredExporterId = "expA";
+    final String configNotFoundExporterId = "expB";
+    final var exporterConfig =
+        getExporterConfig(
+            configuredExporterId, State.ENABLED, configNotFoundExporterId, State.CONFIG_NOT_FOUND);
+
+    // expB is absent from the repository because its static config was removed
+    final Map<String, ExporterDescriptor> exporters =
+        Map.of(configuredExporterId, new ExporterDescriptor(configuredExporterId));
+    when(exporterRepository.getExporters()).thenReturn(exporters);
+    transitionContext.setDynamicPartitionConfig(exporterConfig);
+
+    final var mockedExporterDirector = mock(ExporterDirector.class);
+    when(mockedExporterDirector.startAsync(any()))
+        .thenReturn(TestActorFuture.completedFuture(null));
+    final var exporterDirectorStep =
+        new ExporterDirectorPartitionTransitionStep((ctx, phase) -> mockedExporterDirector);
+
+    // when - director starts with no concurrent config change
+    exporterDirectorStep.prepareTransition(transitionContext, 1, Role.LEADER).join();
+    exporterDirectorStep.transitionTo(transitionContext, 1, Role.LEADER).join();
+
+    // then - expB's persisted state (position, metadata) must not be deleted
+    verify(mockedExporterDirector, never()).removeExporter(configNotFoundExporterId);
+    verify(mockedExporterDirector, never()).removeExporter(configuredExporterId);
+  }
+
+  @Test
   void shouldEnableExporterIfConfigChangedConcurrently() {
     // given
     final String enabledExporterId = "expA";


### PR DESCRIPTION
## Summary

When an exporter's static config is removed, its dynamic state is set to `CONFIG_NOT_FOUND`. The broker preserves its position in the database until the user explicitly removes it via the API.

In `ExporterDirectorPartitionTransitionStep`, `getEnabledExporterDescriptors()` is called to not only know which exporters should be started/opened, but also which can safely be removed from the state. For exporters absent from the repository, each call creates a **fresh** `ExporterDescriptor` wrapping a `BlockingExporter`. Since `ExporterDescriptor` had no `equals`/`hashCode`, `Map.containsKey` used identity comparison — the two fresh instances were considered different even though they shared the same ID, so `removeExporter` was called and the persisted exporter state (position, metadata) was permanently deleted.

The fix adds ID-based `equals`/`hashCode` to `ExporterDescriptor`. Two descriptors with the same ID represent the same logical exporter. I considered adding configuration as well, but based on our semantics, just comparing ID is the right call: two exporters are considered the same if they have the same ID.

I think it may be confusing down the line if we wanted to do object comparison in tests, but in production usage, the semantics are correct imo.

Alternative would be to explicitly compare by ID, but I don't see a huge advantage to it.

Closes #52253