### PR TITLE
test: stabilize two nightly E2E flakes on stable/8.8

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
@@ -334,16 +334,16 @@ class OperateProcessesPage {
       const checkbox = row.getByRole('checkbox', {
         name: /(un)?select row/i,
       });
+      // Carbon renders the checkbox inside a <label>; the visible text
+      // ("Select row") sits in a visually-hidden <span> inside that label.
+      // Clicking the span fails because the wrapping label intercepts
+      // pointer events. Click the label element itself instead, mirroring
+      // the working pattern in selectProcessInstances.
+      const label = row.locator('label.cds--checkbox-label');
 
       await expect(checkbox).toBeVisible({timeout: 30000});
       if (!(await checkbox.isChecked())) {
-        // Carbon wraps the checkbox in a label; clicking the label is the
-        // reliable cross-browser way to toggle the input. The label text
-        // toggles between "Select row" and "Unselect row" with state.
-        await row
-          .getByText(/^(un)?select row$/i)
-          .first()
-          .click({timeout: 30000});
+        await label.click({timeout: 30000});
       }
     }
   }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
@@ -310,8 +310,39 @@ class OperateProcessesPage {
   }
 
   async selectProcessCheckboxByPIK(...PIK: string[]): Promise<void> {
+    // Wait for every PIK's row to be present before clicking — the table can
+    // briefly render fewer rows than the "X results" count claims while the
+    // indexer catches up, so without this guard the first checkbox click can
+    // race the row appearing.
     for (const key of PIK) {
-      await this.page.locator(`label[for$="${key}"]`).click();
+      await expect(
+        this.page.getByTestId('cell-processInstanceKey').filter({hasText: key}),
+      ).toBeVisible({timeout: 30000});
+    }
+
+    for (const key of PIK) {
+      const row = this.page
+        .getByTestId('data-list')
+        .getByRole('row')
+        .filter({
+          has: this.page
+            .getByTestId('cell-processInstanceKey')
+            .filter({hasText: key}),
+        });
+      const checkbox = row.getByRole('checkbox', {
+        name: /(un)?select row/i,
+      });
+
+      await expect(checkbox).toBeVisible({timeout: 30000});
+      if (!(await checkbox.isChecked())) {
+        // Carbon wraps the checkbox in a label; clicking the label is the
+        // reliable cross-browser way to toggle the input. The label text
+        // toggles between "Select row" and "Unselect row" with state.
+        await row
+          .getByText(/^(un)?select row$/i)
+          .first()
+          .click({timeout: 30000});
+      }
     }
   }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
@@ -292,13 +292,17 @@ class OperateProcessesPage {
   }
 
   static getRowByProcessInstanceKey(page: Page, keyStr: string): Locator {
+    // Match the PIK cell's text content exactly, so a key that is a substring
+    // of another visible key (rare for 16-digit keys, but possible) cannot
+    // produce an ambiguous multi-row match.
+    const escapedKey = keyStr.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     return page
       .getByTestId('data-list')
       .getByRole('row')
       .filter({
         has: page
           .getByTestId('cell-processInstanceKey')
-          .filter({hasText: keyStr}),
+          .filter({hasText: new RegExp(`^${escapedKey}$`)}),
       });
   }
   async clickVersionSortButton(): Promise<void> {
@@ -315,20 +319,18 @@ class OperateProcessesPage {
     // indexer catches up, so without this guard the first checkbox click can
     // race the row appearing.
     for (const key of PIK) {
-      await expect(
-        this.page.getByTestId('cell-processInstanceKey').filter({hasText: key}),
-      ).toBeVisible({timeout: 30000});
+      const row = OperateProcessesPage.getRowByProcessInstanceKey(
+        this.page,
+        key,
+      );
+      await expect(row).toHaveCount(1, {timeout: 30000});
     }
 
     for (const key of PIK) {
-      const row = this.page
-        .getByTestId('data-list')
-        .getByRole('row')
-        .filter({
-          has: this.page
-            .getByTestId('cell-processInstanceKey')
-            .filter({hasText: key}),
-        });
+      const row = OperateProcessesPage.getRowByProcessInstanceKey(
+        this.page,
+        key,
+      );
       const checkbox = row.getByRole('checkbox', {
         name: /(un)?select row/i,
       });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
@@ -344,6 +344,7 @@ test.describe('task details page', () => {
   });
 
   test('task completion with form from assigned to me filter', async ({
+    page,
     taskPanelPage,
     taskDetailsPage,
   }) => {
@@ -366,11 +367,25 @@ test.describe('task details page', () => {
 
     await taskPanelPage.filterBy('Completed');
     await taskPanelPage.assertCompletedHeadingVisible();
-    await taskPanelPage.openTask('User registration');
 
-    await taskDetailsPage.assertFieldValue('Name*', 'Gaius Julius Caesar');
-    await taskDetailsPage.assertFieldValue('Address*', 'Rome');
-    await taskDetailsPage.assertFieldValue('Age', '55');
+    // Multiple "User registration" tasks may be completed across tests in this
+    // file. openTask clicks .nth(0), which can land on an earlier completion
+    // (e.g. Jon/Earth from "task completion with form") before the indexer
+    // surfaces the just-completed task at the top. Re-open and re-assert on
+    // reload so we eventually inspect the right task.
+    await waitForAssertion({
+      assertion: async () => {
+        await taskPanelPage.openTask('User registration');
+        await taskDetailsPage.assertFieldValue('Name*', 'Gaius Julius Caesar');
+        await taskDetailsPage.assertFieldValue('Address*', 'Rome');
+        await taskDetailsPage.assertFieldValue('Age', '55');
+      },
+      onFailure: async () => {
+        await page.reload();
+        await taskPanelPage.filterBy('Completed');
+        await taskPanelPage.assertCompletedHeadingVisible();
+      },
+    });
   });
 
   test('task completion with prefilled form', async ({


### PR DESCRIPTION
## Summary

Addresses two failures from the [May 15 nightly run](https://github.com/camunda/camunda/actions/runs/25895056148) on `stable/8.8` that are **not** covered by the in-flight stabilization PR #52726.

- **`OperateProcessesPage.selectProcessCheckboxByPIK`**: replace the brittle `label[for$="<PIK>"]` raw selector with a row-scoped lookup, click the actual `<label class="cds--checkbox-label">` element (not the visually-hidden text span inside it, which the label intercepts pointer events for), and wait for every PIK row to be visible before clicking. Fixes `processInstancesFilters.spec.ts:90` > "Filter process instances by parent key, date range, variable, instance key and error message".
- **`task-details.spec.ts:346`** > "task completion with form from assigned to me filter": several preceding tests complete other "User registration" instances, so `openTask().nth(0)` on the Completed list can land on a stale task (Jon/Earth) before the just-completed one (Gaius/Rome) is indexed. Wrap the open + assert block in `waitForAssertion` so we reload and re-pick the top task until the values match.

## Scope

Intentionally narrow — every other failure from the May 15 run is already addressed by #52726 (e.g. `versionCells` typo, `fillDynamicList` resilience, `verifyFlowNodeMappings` timeout, deployed-form task-completion race). This PR can land independently of #52726.

## Validation

On-demand E2E run after the label-click fix (12a02b8): https://github.com/camunda/camunda/actions/runs/25918960225

Both target specs pass:
- ✓ `processInstancesFilters.spec.ts:90` (1.0m, no retry)
- ✓ `task-details.spec.ts:346` (39.8s)

Other failures in that run (`processInstanceMigration` × 3, `processInstanceHistory.spec.ts:320`) are out of scope: the migration tests are addressed by #52726, and `processInstanceHistory` is a pre-existing flake unaffected by this PR's diff.

## Test plan
- [x] `npx tsc --noEmit` — no new TS errors introduced
- [x] `npx eslint` on changed files — clean
- [x] `processInstancesFilters.spec.ts:90` passes on validation run
- [x] `task-details.spec.ts:346` passes on validation run
- [ ] Re-run nightly E2E on `stable/8.8` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)