### PR TITLE
Persist processDefinitionPath on element migration

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -367,6 +367,11 @@ public final class EventAppliers implements EventApplier {
         new ProcessInstanceElementMigratedV4Applier(
             elementInstanceState, processState, state.getMessageState()));
     register(
+        ProcessInstanceIntent.ELEMENT_MIGRATED,
+        5,
+        new ProcessInstanceElementMigratedV5Applier(
+            elementInstanceState, processState, state.getMessageState()));
+    register(
         ProcessInstanceIntent.ANCESTOR_MIGRATED,
         new ProcessInstanceAncestorMigratedApplier(elementInstanceState));
     register(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -362,6 +362,11 @@ public final class EventAppliers implements EventApplier {
         new ProcessInstanceElementMigratedV3Applier(
             elementInstanceState, processState, state.getMessageState()));
     register(
+        ProcessInstanceIntent.ELEMENT_MIGRATED,
+        4,
+        new ProcessInstanceElementMigratedV4Applier(
+            elementInstanceState, processState, state.getMessageState()));
+    register(
         ProcessInstanceIntent.ANCESTOR_MIGRATED,
         new ProcessInstanceAncestorMigratedApplier(elementInstanceState));
     register(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementMigratedV4Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementMigratedV4Applier.java
@@ -53,7 +53,8 @@ final class ProcessInstanceElementMigratedV4Applier
               .setBpmnProcessId(value.getBpmnProcessId())
               .setVersion(value.getVersion())
               .setElementId(value.getElementId())
-              .setFlowScopeKey(value.getFlowScopeKey());
+              .setFlowScopeKey(value.getFlowScopeKey())
+              .setProcessDefinitionPath(value.getProcessDefinitionPath());
         });
 
     if (value.getBpmnElementType() == BpmnElementType.PROCESS) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementMigratedV4Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementMigratedV4Applier.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElementContainer;
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.immutable.ProcessState;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableMessageState;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.concurrent.atomic.AtomicLong;
+import org.agrona.DirectBuffer;
+
+/** Applies state changes for `ProcessInstance:Element_Migrated` */
+final class ProcessInstanceElementMigratedV4Applier
+    implements TypedEventApplier<ProcessInstanceIntent, ProcessInstanceRecord> {
+
+  private final MutableElementInstanceState elementInstanceState;
+  private final ProcessState processState;
+  private final MutableMessageState messageState;
+
+  public ProcessInstanceElementMigratedV4Applier(
+      final MutableElementInstanceState elementInstanceState,
+      final ProcessState processState,
+      final MutableMessageState messageState) {
+    this.elementInstanceState = elementInstanceState;
+    this.processState = processState;
+    this.messageState = messageState;
+  }
+
+  @Override
+  public void applyState(final long elementInstanceKey, final ProcessInstanceRecord value) {
+    if (value.getBpmnElementType() == BpmnElementType.PROCESS) {
+      migrateCorrelatedMessageStartEvent(elementInstanceKey, value);
+    }
+
+    final var previousProcessDefinitionKey = new AtomicLong();
+    elementInstanceState.updateInstance(
+        elementInstanceKey,
+        elementInstance -> {
+          previousProcessDefinitionKey.set(elementInstance.getValue().getProcessDefinitionKey());
+          elementInstance
+              .getValue()
+              .setProcessDefinitionKey(value.getProcessDefinitionKey())
+              .setBpmnProcessId(value.getBpmnProcessId())
+              .setVersion(value.getVersion())
+              .setElementId(value.getElementId())
+              .setFlowScopeKey(value.getFlowScopeKey());
+        });
+
+    if (value.getBpmnElementType() == BpmnElementType.PROCESS) {
+      elementInstanceState.deleteProcessInstanceKeyByDefinitionKey(
+          value.getProcessInstanceKey(), previousProcessDefinitionKey.get());
+      elementInstanceState.insertProcessInstanceKeyByDefinitionKey(
+          value.getProcessInstanceKey(), value.getProcessDefinitionKey());
+    }
+  }
+
+  private void migrateCorrelatedMessageStartEvent(
+      final long elementInstanceKey, final ProcessInstanceRecord value) {
+
+    final var instance = elementInstanceState.getInstance(elementInstanceKey).getValue();
+    final DirectBuffer previousBpmnProcessId = instance.getBpmnProcessIdBuffer();
+    final DirectBuffer currentBpmnProcessId = value.getBpmnProcessIdBuffer();
+    final DirectBuffer correlationKey =
+        messageState.getProcessInstanceCorrelationKey(value.getProcessInstanceKey());
+
+    if (isCorrelationKeyAbsent(correlationKey)) {
+      // no need to update correlation key relations since there isn't one
+      return;
+    }
+
+    final boolean isTargetWithMessageStartEvent =
+        processState
+            .getFlowElement(
+                value.getProcessDefinitionKey(),
+                value.getTenantId(),
+                value.getElementIdBuffer(),
+                ExecutableFlowElementContainer.class)
+            .hasMessageStartEvent();
+    final boolean hasBpmnProcessIdChanged =
+        !BufferUtil.equals(previousBpmnProcessId, currentBpmnProcessId);
+
+    if (isTargetWithMessageStartEvent && hasBpmnProcessIdChanged) {
+      // unlock the previous process instance's process id
+      messageState.removeActiveProcessInstance(previousBpmnProcessId, correlationKey);
+      // lock the new process instance's process id
+      messageState.putActiveProcessInstance(currentBpmnProcessId, correlationKey);
+    }
+
+    // clean up the correlation key relation if the target process doesn't have a message start
+    // event at all
+    if (!isTargetWithMessageStartEvent) {
+      messageState.removeActiveProcessInstance(previousBpmnProcessId, correlationKey);
+      messageState.removeProcessInstanceCorrelationKey(value.getProcessInstanceKey());
+    }
+  }
+
+  private boolean isCorrelationKeyAbsent(final DirectBuffer correlationKey) {
+    return correlationKey == null || correlationKey.capacity() == 0;
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementMigratedV5Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementMigratedV5Applier.java
@@ -57,7 +57,8 @@ final class ProcessInstanceElementMigratedV5Applier
               .setBpmnProcessId(value.getBpmnProcessId())
               .setVersion(value.getVersion())
               .setElementId(value.getElementId())
-              .setFlowScopeKey(value.getFlowScopeKey());
+              .setFlowScopeKey(value.getFlowScopeKey())
+              .setProcessDefinitionPath(value.getProcessDefinitionPath());
         });
 
     if (value.getBpmnElementType() == BpmnElementType.PROCESS) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementMigratedV5Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementMigratedV5Applier.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElementContainer;
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.immutable.ProcessState;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableMessageState;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import org.agrona.DirectBuffer;
+
+/** Applies state changes for `ProcessInstance:Element_Migrated` */
+final class ProcessInstanceElementMigratedV5Applier
+    implements TypedEventApplier<ProcessInstanceIntent, ProcessInstanceRecord> {
+
+  private final MutableElementInstanceState elementInstanceState;
+  private final ProcessState processState;
+  private final MutableMessageState messageState;
+
+  public ProcessInstanceElementMigratedV5Applier(
+      final MutableElementInstanceState elementInstanceState,
+      final ProcessState processState,
+      final MutableMessageState messageState) {
+    this.elementInstanceState = elementInstanceState;
+    this.processState = processState;
+    this.messageState = messageState;
+  }
+
+  @Override
+  public void applyState(final long elementInstanceKey, final ProcessInstanceRecord value) {
+    if (value.getBpmnElementType() == BpmnElementType.PROCESS) {
+      migrateCorrelatedMessageStartEvent(elementInstanceKey, value);
+    }
+
+    final var previousProcessDefinitionKey = new AtomicLong();
+    final var previousProcessDefinitionId = new AtomicReference<String>();
+    elementInstanceState.updateInstance(
+        elementInstanceKey,
+        elementInstance -> {
+          previousProcessDefinitionKey.set(elementInstance.getValue().getProcessDefinitionKey());
+          previousProcessDefinitionId.set(elementInstance.getValue().getBpmnProcessId());
+          elementInstance
+              .getValue()
+              .setProcessDefinitionKey(value.getProcessDefinitionKey())
+              .setBpmnProcessId(value.getBpmnProcessId())
+              .setVersion(value.getVersion())
+              .setElementId(value.getElementId())
+              .setFlowScopeKey(value.getFlowScopeKey());
+        });
+
+    if (value.getBpmnElementType() == BpmnElementType.PROCESS) {
+      elementInstanceState.deleteProcessInstanceKeyByDefinitionKey(
+          value.getProcessInstanceKey(), previousProcessDefinitionKey.get());
+      elementInstanceState.insertProcessInstanceKeyByDefinitionKey(
+          value.getProcessInstanceKey(), value.getProcessDefinitionKey());
+
+      migrateBusinessIdIndex(value, previousProcessDefinitionId.get());
+    }
+  }
+
+  private void migrateCorrelatedMessageStartEvent(
+      final long elementInstanceKey, final ProcessInstanceRecord value) {
+
+    final var instance = elementInstanceState.getInstance(elementInstanceKey).getValue();
+    final DirectBuffer previousBpmnProcessId = instance.getBpmnProcessIdBuffer();
+    final DirectBuffer currentBpmnProcessId = value.getBpmnProcessIdBuffer();
+    final DirectBuffer correlationKey =
+        messageState.getProcessInstanceCorrelationKey(value.getProcessInstanceKey());
+
+    if (isCorrelationKeyAbsent(correlationKey)) {
+      // no need to update correlation key relations since there isn't one
+      return;
+    }
+
+    final boolean isTargetWithMessageStartEvent =
+        processState
+            .getFlowElement(
+                value.getProcessDefinitionKey(),
+                value.getTenantId(),
+                value.getElementIdBuffer(),
+                ExecutableFlowElementContainer.class)
+            .hasMessageStartEvent();
+    final boolean hasBpmnProcessIdChanged =
+        !BufferUtil.equals(previousBpmnProcessId, currentBpmnProcessId);
+
+    if (isTargetWithMessageStartEvent && hasBpmnProcessIdChanged) {
+      // unlock the previous process instance's process id
+      messageState.removeActiveProcessInstance(previousBpmnProcessId, correlationKey);
+      // lock the new process instance's process id
+      messageState.putActiveProcessInstance(currentBpmnProcessId, correlationKey);
+    }
+
+    // clean up the correlation key relation if the target process doesn't have a message start
+    // event at all
+    if (!isTargetWithMessageStartEvent) {
+      messageState.removeActiveProcessInstance(previousBpmnProcessId, correlationKey);
+      messageState.removeProcessInstanceCorrelationKey(value.getProcessInstanceKey());
+    }
+  }
+
+  private boolean isCorrelationKeyAbsent(final DirectBuffer correlationKey) {
+    return correlationKey == null || correlationKey.capacity() == 0;
+  }
+
+  private void migrateBusinessIdIndex(
+      final ProcessInstanceRecord value, final String previousProcessDefinitionId) {
+    final String businessId = value.getBusinessId();
+    if (businessId.isEmpty()) {
+      return;
+    }
+    if (value.hasParentProcessInstance()) {
+      return;
+    }
+    if (Objects.equals(previousProcessDefinitionId, value.getBpmnProcessId())) {
+      // no need to update the business id index if the process definition id didn't change
+      // note that the business id, the tenant id, and the instance key never change on migration
+      return;
+    }
+    elementInstanceState.deleteProcessInstanceKeyMappingByBusinessId(
+        businessId,
+        previousProcessDefinitionId,
+        value.getTenantId(),
+        value.getProcessInstanceKey());
+    elementInstanceState.insertProcessInstanceKeyByBusinessId(
+        businessId, value.getBpmnProcessId(), value.getTenantId(), value.getProcessInstanceKey());
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementMigratedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementMigratedApplierTest.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -93,6 +94,49 @@ public class ProcessInstanceElementMigratedApplierTest {
                 processInstance.getProcessDefinitionKey()))
         .describedAs("Expect that there are no instances of the old process definition")
         .isEmpty();
+  }
+
+  @Test
+  void shouldUpdateProcessDefinitionPathOnMigrationV5() {
+    // given
+    final var elementInstanceKey = 3L;
+    final var sourceProcessDefinitionKey = 1L;
+    final var targetProcessDefinitionKey = 4L;
+    final var processInstance =
+        new ProcessInstanceRecord()
+            .setProcessDefinitionKey(sourceProcessDefinitionKey)
+            .setBpmnProcessId("process")
+            .setVersion(1)
+            .setElementId("task")
+            .setBpmnElementType(BpmnElementType.SERVICE_TASK)
+            .setProcessInstanceKey(2L)
+            .setProcessDefinitionPath(List.of(sourceProcessDefinitionKey));
+    elementInstanceState.createInstance(
+        new ElementInstance(
+            elementInstanceKey, ProcessInstanceIntent.ELEMENT_ACTIVATED, processInstance));
+
+    final var applier =
+        new ProcessInstanceElementMigratedV5Applier(
+            elementInstanceState,
+            processingState.getProcessState(),
+            processingState.getMessageState());
+
+    // when
+    final var migratedProcessInstance = new ProcessInstanceRecord();
+    migratedProcessInstance.wrap(processInstance);
+    migratedProcessInstance
+        .setProcessDefinitionKey(targetProcessDefinitionKey)
+        .setVersion(2)
+        .setBpmnProcessId("another_process")
+        .setElementId("another_task")
+        .setProcessDefinitionPath(List.of(targetProcessDefinitionKey));
+    applier.applyState(elementInstanceKey, migratedProcessInstance);
+
+    // then
+    assertThat(elementInstanceState.getInstance(elementInstanceKey).getValue())
+        .describedAs(
+            "Expect that the process definition path is updated to the target process definition")
+        .hasProcessDefinitionPath(List.of(targetProcessDefinitionKey));
   }
 
   @Test

--- a/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_ELEMENT_MIGRATED_v4.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_ELEMENT_MIGRATED_v4.golden
@@ -53,7 +53,8 @@ final class ProcessInstanceElementMigratedV4Applier
               .setBpmnProcessId(value.getBpmnProcessId())
               .setVersion(value.getVersion())
               .setElementId(value.getElementId())
-              .setFlowScopeKey(value.getFlowScopeKey());
+              .setFlowScopeKey(value.getFlowScopeKey())
+              .setProcessDefinitionPath(value.getProcessDefinitionPath());
         });
 
     if (value.getBpmnElementType() == BpmnElementType.PROCESS) {

--- a/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_ELEMENT_MIGRATED_v4.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_ELEMENT_MIGRATED_v4.golden
@@ -1,0 +1,110 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElementContainer;
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.immutable.ProcessState;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableMessageState;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.concurrent.atomic.AtomicLong;
+import org.agrona.DirectBuffer;
+
+/** Applies state changes for `ProcessInstance:Element_Migrated` */
+final class ProcessInstanceElementMigratedV4Applier
+    implements TypedEventApplier<ProcessInstanceIntent, ProcessInstanceRecord> {
+
+  private final MutableElementInstanceState elementInstanceState;
+  private final ProcessState processState;
+  private final MutableMessageState messageState;
+
+  public ProcessInstanceElementMigratedV4Applier(
+      final MutableElementInstanceState elementInstanceState,
+      final ProcessState processState,
+      final MutableMessageState messageState) {
+    this.elementInstanceState = elementInstanceState;
+    this.processState = processState;
+    this.messageState = messageState;
+  }
+
+  @Override
+  public void applyState(final long elementInstanceKey, final ProcessInstanceRecord value) {
+    if (value.getBpmnElementType() == BpmnElementType.PROCESS) {
+      migrateCorrelatedMessageStartEvent(elementInstanceKey, value);
+    }
+
+    final var previousProcessDefinitionKey = new AtomicLong();
+    elementInstanceState.updateInstance(
+        elementInstanceKey,
+        elementInstance -> {
+          previousProcessDefinitionKey.set(elementInstance.getValue().getProcessDefinitionKey());
+          elementInstance
+              .getValue()
+              .setProcessDefinitionKey(value.getProcessDefinitionKey())
+              .setBpmnProcessId(value.getBpmnProcessId())
+              .setVersion(value.getVersion())
+              .setElementId(value.getElementId())
+              .setFlowScopeKey(value.getFlowScopeKey());
+        });
+
+    if (value.getBpmnElementType() == BpmnElementType.PROCESS) {
+      elementInstanceState.deleteProcessInstanceKeyByDefinitionKey(
+          value.getProcessInstanceKey(), previousProcessDefinitionKey.get());
+      elementInstanceState.insertProcessInstanceKeyByDefinitionKey(
+          value.getProcessInstanceKey(), value.getProcessDefinitionKey());
+    }
+  }
+
+  private void migrateCorrelatedMessageStartEvent(
+      final long elementInstanceKey, final ProcessInstanceRecord value) {
+
+    final var instance = elementInstanceState.getInstance(elementInstanceKey).getValue();
+    final DirectBuffer previousBpmnProcessId = instance.getBpmnProcessIdBuffer();
+    final DirectBuffer currentBpmnProcessId = value.getBpmnProcessIdBuffer();
+    final DirectBuffer correlationKey =
+        messageState.getProcessInstanceCorrelationKey(value.getProcessInstanceKey());
+
+    if (isCorrelationKeyAbsent(correlationKey)) {
+      // no need to update correlation key relations since there isn't one
+      return;
+    }
+
+    final boolean isTargetWithMessageStartEvent =
+        processState
+            .getFlowElement(
+                value.getProcessDefinitionKey(),
+                value.getTenantId(),
+                value.getElementIdBuffer(),
+                ExecutableFlowElementContainer.class)
+            .hasMessageStartEvent();
+    final boolean hasBpmnProcessIdChanged =
+        !BufferUtil.equals(previousBpmnProcessId, currentBpmnProcessId);
+
+    if (isTargetWithMessageStartEvent && hasBpmnProcessIdChanged) {
+      // unlock the previous process instance's process id
+      messageState.removeActiveProcessInstance(previousBpmnProcessId, correlationKey);
+      // lock the new process instance's process id
+      messageState.putActiveProcessInstance(currentBpmnProcessId, correlationKey);
+    }
+
+    // clean up the correlation key relation if the target process doesn't have a message start
+    // event at all
+    if (!isTargetWithMessageStartEvent) {
+      messageState.removeActiveProcessInstance(previousBpmnProcessId, correlationKey);
+      messageState.removeProcessInstanceCorrelationKey(value.getProcessInstanceKey());
+    }
+  }
+
+  private boolean isCorrelationKeyAbsent(final DirectBuffer correlationKey) {
+    return correlationKey == null || correlationKey.capacity() == 0;
+  }
+}

--- a/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_ELEMENT_MIGRATED_v5.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_ELEMENT_MIGRATED_v5.golden
@@ -57,7 +57,8 @@ final class ProcessInstanceElementMigratedV5Applier
               .setBpmnProcessId(value.getBpmnProcessId())
               .setVersion(value.getVersion())
               .setElementId(value.getElementId())
-              .setFlowScopeKey(value.getFlowScopeKey());
+              .setFlowScopeKey(value.getFlowScopeKey())
+              .setProcessDefinitionPath(value.getProcessDefinitionPath());
         });
 
     if (value.getBpmnElementType() == BpmnElementType.PROCESS) {

--- a/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_ELEMENT_MIGRATED_v5.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_ELEMENT_MIGRATED_v5.golden
@@ -1,0 +1,139 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElementContainer;
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.immutable.ProcessState;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableMessageState;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import org.agrona.DirectBuffer;
+
+/** Applies state changes for `ProcessInstance:Element_Migrated` */
+final class ProcessInstanceElementMigratedV5Applier
+    implements TypedEventApplier<ProcessInstanceIntent, ProcessInstanceRecord> {
+
+  private final MutableElementInstanceState elementInstanceState;
+  private final ProcessState processState;
+  private final MutableMessageState messageState;
+
+  public ProcessInstanceElementMigratedV5Applier(
+      final MutableElementInstanceState elementInstanceState,
+      final ProcessState processState,
+      final MutableMessageState messageState) {
+    this.elementInstanceState = elementInstanceState;
+    this.processState = processState;
+    this.messageState = messageState;
+  }
+
+  @Override
+  public void applyState(final long elementInstanceKey, final ProcessInstanceRecord value) {
+    if (value.getBpmnElementType() == BpmnElementType.PROCESS) {
+      migrateCorrelatedMessageStartEvent(elementInstanceKey, value);
+    }
+
+    final var previousProcessDefinitionKey = new AtomicLong();
+    final var previousProcessDefinitionId = new AtomicReference<String>();
+    elementInstanceState.updateInstance(
+        elementInstanceKey,
+        elementInstance -> {
+          previousProcessDefinitionKey.set(elementInstance.getValue().getProcessDefinitionKey());
+          previousProcessDefinitionId.set(elementInstance.getValue().getBpmnProcessId());
+          elementInstance
+              .getValue()
+              .setProcessDefinitionKey(value.getProcessDefinitionKey())
+              .setBpmnProcessId(value.getBpmnProcessId())
+              .setVersion(value.getVersion())
+              .setElementId(value.getElementId())
+              .setFlowScopeKey(value.getFlowScopeKey());
+        });
+
+    if (value.getBpmnElementType() == BpmnElementType.PROCESS) {
+      elementInstanceState.deleteProcessInstanceKeyByDefinitionKey(
+          value.getProcessInstanceKey(), previousProcessDefinitionKey.get());
+      elementInstanceState.insertProcessInstanceKeyByDefinitionKey(
+          value.getProcessInstanceKey(), value.getProcessDefinitionKey());
+
+      migrateBusinessIdIndex(value, previousProcessDefinitionId.get());
+    }
+  }
+
+  private void migrateCorrelatedMessageStartEvent(
+      final long elementInstanceKey, final ProcessInstanceRecord value) {
+
+    final var instance = elementInstanceState.getInstance(elementInstanceKey).getValue();
+    final DirectBuffer previousBpmnProcessId = instance.getBpmnProcessIdBuffer();
+    final DirectBuffer currentBpmnProcessId = value.getBpmnProcessIdBuffer();
+    final DirectBuffer correlationKey =
+        messageState.getProcessInstanceCorrelationKey(value.getProcessInstanceKey());
+
+    if (isCorrelationKeyAbsent(correlationKey)) {
+      // no need to update correlation key relations since there isn't one
+      return;
+    }
+
+    final boolean isTargetWithMessageStartEvent =
+        processState
+            .getFlowElement(
+                value.getProcessDefinitionKey(),
+                value.getTenantId(),
+                value.getElementIdBuffer(),
+                ExecutableFlowElementContainer.class)
+            .hasMessageStartEvent();
+    final boolean hasBpmnProcessIdChanged =
+        !BufferUtil.equals(previousBpmnProcessId, currentBpmnProcessId);
+
+    if (isTargetWithMessageStartEvent && hasBpmnProcessIdChanged) {
+      // unlock the previous process instance's process id
+      messageState.removeActiveProcessInstance(previousBpmnProcessId, correlationKey);
+      // lock the new process instance's process id
+      messageState.putActiveProcessInstance(currentBpmnProcessId, correlationKey);
+    }
+
+    // clean up the correlation key relation if the target process doesn't have a message start
+    // event at all
+    if (!isTargetWithMessageStartEvent) {
+      messageState.removeActiveProcessInstance(previousBpmnProcessId, correlationKey);
+      messageState.removeProcessInstanceCorrelationKey(value.getProcessInstanceKey());
+    }
+  }
+
+  private boolean isCorrelationKeyAbsent(final DirectBuffer correlationKey) {
+    return correlationKey == null || correlationKey.capacity() == 0;
+  }
+
+  private void migrateBusinessIdIndex(
+      final ProcessInstanceRecord value, final String previousProcessDefinitionId) {
+    final String businessId = value.getBusinessId();
+    if (businessId.isEmpty()) {
+      return;
+    }
+    if (value.hasParentProcessInstance()) {
+      return;
+    }
+    if (Objects.equals(previousProcessDefinitionId, value.getBpmnProcessId())) {
+      // no need to update the business id index if the process definition id didn't change
+      // note that the business id, the tenant id, and the instance key never change on migration
+      return;
+    }
+    elementInstanceState.deleteProcessInstanceKeyMappingByBusinessId(
+        businessId,
+        previousProcessDefinitionId,
+        value.getTenantId(),
+        value.getProcessInstanceKey());
+    elementInstanceState.insertProcessInstanceKeyByBusinessId(
+        businessId, value.getBpmnProcessId(), value.getTenantId(), value.getProcessInstanceKey());
+  }
+}


### PR DESCRIPTION
## Description

Fixes a bug where `ProcessInstanceElementMigratedApplier` did not persist `processDefinitionPath` on element migration, leaving descendant element instances pointing at the source process definition.

This PR introduces two new appliers so the fix is byte-identical across every branch that will ship it (see #52938 for the full plan):

- **V4** — mirrors V2's body plus the `setProcessDefinitionPath` call. No businessId-index migration logic. Same source on `stable/8.8`, `stable/8.9`, and `main`.
- **V5** — mirrors V3's body (keeps the businessId-index migration logic introduced in V3) plus the `setProcessDefinitionPath` call. Ships only on `main` and `stable/8.9`.

V5 is the latest registered applier for `ProcessInstance:ELEMENT_MIGRATED` on `main`.

## Checklist

- [x] Enable backport to `stable/8.9` (`backport stable/8.9` label).

## Related issues

closes #52746
relates to #52938
follow-up to #52939 (revert of #52747)
companion: #52921 (universal V4 on `stable/8.8`)
