### PR TITLE
Backup content batch deletion

### DIFF
--- a/zeebe/backup-stores/azure/pom.xml
+++ b/zeebe/backup-stores/azure/pom.xml
@@ -38,6 +38,11 @@
 
     <dependency>
       <groupId>com.azure</groupId>
+      <artifactId>azure-storage-blob-batch</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.azure</groupId>
       <artifactId>azure-core</artifactId>
     </dependency>
 

--- a/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupStore.java
+++ b/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupStore.java
@@ -12,6 +12,7 @@ import com.azure.identity.DefaultAzureCredentialBuilder;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.BlobServiceClientBuilder;
+import com.azure.storage.blob.batch.BlobBatchClientBuilder;
 import com.azure.storage.blob.models.ListBlobsOptions;
 import com.azure.storage.common.StorageSharedKeyCredential;
 import io.camunda.zeebe.backup.api.Backup;
@@ -28,7 +29,9 @@ import io.camunda.zeebe.backup.common.BackupStoreException.UnexpectedManifestSta
 import io.camunda.zeebe.backup.common.Manifest;
 import io.camunda.zeebe.backup.common.Manifest.StatusCode;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -77,7 +80,8 @@ public final class AzureBackupStore implements BackupStore {
     final boolean createContainer = isCreateContainer(config);
     containerCreated = !createContainer;
 
-    fileSetManager = new FileSetManager(blobContainerClient, createContainer);
+    final var blobBatchClient = new BlobBatchClientBuilder(client).buildClient();
+    fileSetManager = new FileSetManager(blobContainerClient, blobBatchClient, createContainer);
     manifestManager = new ManifestManager(blobContainerClient, createContainer);
   }
 
@@ -225,8 +229,11 @@ public final class AzureBackupStore implements BackupStore {
                 "Cannot delete Backup with id '%s', must be marked as deleted."
                     .formatted(id.toString()));
           }
-          fileSetManager.delete(id, SNAPSHOT_FILESET_NAME);
-          fileSetManager.delete(id, SEGMENTS_FILESET_NAME);
+          final var snapshotUrls = fileSetManager.collectBlobUrls(id, SNAPSHOT_FILESET_NAME);
+          final var segmentUrls = fileSetManager.collectBlobUrls(id, SEGMENTS_FILESET_NAME);
+          final List<String> allUrls = new ArrayList<>(snapshotUrls);
+          allUrls.addAll(segmentUrls);
+          fileSetManager.deleteBlobs(allUrls);
           manifestManager.deleteManifest(manifest);
         },
         executor);

--- a/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/FileSetManager.java
+++ b/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/FileSetManager.java
@@ -96,10 +96,6 @@ final class FileSetManager {
         responses.add(batch.deleteBlob(url));
       }
       blobBatchClient.submitBatch(batch);
-      final var failure = responses.stream().filter(r -> r.getStatusCode() / 100 != 2).findFirst();
-      if (failure.isPresent()) {
-        throw new RuntimeException("Failures detected in the blob batch deletion");
-      }
     }
   }
 

--- a/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/FileSetManager.java
+++ b/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/FileSetManager.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.backup.azure;
 
 import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.batch.BlobBatchClient;
 import com.azure.storage.blob.models.BlobErrorCode;
 import com.azure.storage.blob.models.BlobHttpHeaders;
 import com.azure.storage.blob.models.BlobRequestConditions;
@@ -24,10 +25,13 @@ import io.camunda.zeebe.backup.common.FileSet;
 import io.camunda.zeebe.backup.common.FileSet.NamedFile;
 import io.camunda.zeebe.backup.common.NamedFileSetImpl;
 import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 
 final class FileSetManager {
+  static final int MAX_DELETE_BLOB_BATCH_SIZE = 256;
   private static final long MB = 1024 * 1024;
   private static final ParallelTransferOptions CHUNKED_FILE_OPTS =
       new ParallelTransferOptions()
@@ -40,11 +44,16 @@ final class FileSetManager {
   // The path format is constructed by contents/partitionId/checkpointId/nodeId/nameOfFile
   private static final String PATH_FORMAT = "contents/%s/%s/%s/%s/";
   private final BlobContainerClient containerClient;
+  private final BlobBatchClient blobBatchClient;
   private final ReentrantLock containerCreationLock = new ReentrantLock();
   private volatile boolean containerCreated = false;
 
-  FileSetManager(final BlobContainerClient containerClient, final boolean createContainer) {
+  FileSetManager(
+      final BlobContainerClient containerClient,
+      final BlobBatchClient blobBatchClient,
+      final boolean createContainer) {
     this.containerClient = containerClient;
+    this.blobBatchClient = blobBatchClient;
     containerCreated = !createContainer;
   }
 
@@ -68,14 +77,23 @@ final class FileSetManager {
     }
   }
 
-  public void delete(final BackupIdentifier id, final String fileSetName) {
+  Collection<String> collectBlobUrls(final BackupIdentifier id, final String fileSetName) {
     assureContainerCreated();
     final ListBlobsOptions options = new ListBlobsOptions().setPrefix(fileSetPath(id, fileSetName));
-    containerClient
-        .listBlobs(options, null)
-        .forEach(
-            blobItem ->
-                containerClient.getBlobClient(blobItem.getName()).getBlockBlobClient().delete());
+    return containerClient.listBlobs(options, null).stream()
+        .map(blobItem -> containerClient.getBlobClient(blobItem.getName()).getBlobUrl())
+        .toList();
+  }
+
+  void deleteBlobs(final List<String> blobUrls) {
+    final int size = blobUrls.size();
+    for (int i = 0; i < size; i += MAX_DELETE_BLOB_BATCH_SIZE) {
+      final var batch = blobBatchClient.getBlobBatch();
+      for (final var url : blobUrls.subList(i, Math.min(i + MAX_DELETE_BLOB_BATCH_SIZE, size))) {
+        batch.deleteBlob(url);
+      }
+      blobBatchClient.submitBatch(batch);
+    }
   }
 
   public NamedFileSet restore(

--- a/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/FileSetManager.java
+++ b/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/FileSetManager.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.backup.azure;
 
+import com.azure.core.http.rest.Response;
 import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.batch.BlobBatchClient;
@@ -25,6 +26,7 @@ import io.camunda.zeebe.backup.common.FileSet;
 import io.camunda.zeebe.backup.common.FileSet.NamedFile;
 import io.camunda.zeebe.backup.common.NamedFileSetImpl;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.locks.ReentrantLock;
@@ -89,10 +91,15 @@ final class FileSetManager {
     final int size = blobUrls.size();
     for (int i = 0; i < size; i += MAX_DELETE_BATCH_SIZE) {
       final var batch = blobBatchClient.getBlobBatch();
+      final List<Response<Void>> responses = new ArrayList<>();
       for (final var url : blobUrls.subList(i, Math.min(i + MAX_DELETE_BATCH_SIZE, size))) {
-        batch.deleteBlob(url);
+        responses.add(batch.deleteBlob(url));
       }
       blobBatchClient.submitBatch(batch);
+      final var failure = responses.stream().filter(r -> r.getStatusCode() / 100 != 2).findFirst();
+      if (failure.isPresent()) {
+        throw new RuntimeException("Failures detected in the blob batch deletion");
+      }
     }
   }
 

--- a/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/FileSetManager.java
+++ b/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/FileSetManager.java
@@ -31,7 +31,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 
 final class FileSetManager {
-  static final int MAX_DELETE_BLOB_BATCH_SIZE = 256;
+  static final int MAX_DELETE_BATCH_SIZE = 256;
   private static final long MB = 1024 * 1024;
   private static final ParallelTransferOptions CHUNKED_FILE_OPTS =
       new ParallelTransferOptions()
@@ -87,9 +87,9 @@ final class FileSetManager {
 
   void deleteBlobs(final List<String> blobUrls) {
     final int size = blobUrls.size();
-    for (int i = 0; i < size; i += MAX_DELETE_BLOB_BATCH_SIZE) {
+    for (int i = 0; i < size; i += MAX_DELETE_BATCH_SIZE) {
       final var batch = blobBatchClient.getBlobBatch();
-      for (final var url : blobUrls.subList(i, Math.min(i + MAX_DELETE_BLOB_BATCH_SIZE, size))) {
+      for (final var url : blobUrls.subList(i, Math.min(i + MAX_DELETE_BATCH_SIZE, size))) {
         batch.deleteBlob(url);
       }
       blobBatchClient.submitBatch(batch);

--- a/zeebe/backup-stores/azure/src/test/java/io/camunda/zeebe/backup/azure/AzureBackupStoreBatchDeletionTest.java
+++ b/zeebe/backup-stores/azure/src/test/java/io/camunda/zeebe/backup/azure/AzureBackupStoreBatchDeletionTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.azure;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.BlobServiceClientBuilder;
+import com.azure.storage.blob.specialized.BlobLeaseClientBuilder;
+import io.camunda.zeebe.backup.api.BackupStatus;
+import io.camunda.zeebe.backup.api.BackupStatusCode;
+import io.camunda.zeebe.backup.azure.util.AzuriteContainer;
+import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
+import io.camunda.zeebe.backup.testkit.support.TestBackupProvider;
+import java.time.Duration;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+public class AzureBackupStoreBatchDeletionTest {
+  @Container private static final AzuriteContainer AZURITE = new AzuriteContainer();
+  private final String containerName = UUID.randomUUID().toString();
+
+  @Test
+  void shouldNotDeleteManifestOnContentException() throws Exception {
+    // given
+    final var config =
+        new AzureBackupConfig.Builder()
+            .withConnectionString(AZURITE.getConnectString())
+            .withContainerName(containerName)
+            .build();
+
+    final BlobServiceClient client = buildClient(config);
+    final BlobContainerClient containerClient = client.getBlobContainerClient(containerName);
+
+    final var backupId = new BackupIdentifierImpl(1, 2, 3);
+    final var backup = TestBackupProvider.simpleBackupWithId(backupId);
+
+    final var store = new AzureBackupStore(config, client);
+
+    try {
+      store.save(backup).join();
+      store.markDeleted(backupId).join();
+
+      // Acquire leases on segment blobs for backupId to make them undeletable
+      acquireLeasesOnSegmentBlobs(containerClient, backupId);
+
+      // when - delete fails due to leased blobs
+      store.delete(backupId).exceptionally(t -> null).join();
+
+      // then - manifest should still exist since batch deletion failed
+      assertThat(store.getStatus(backupId))
+          .succeedsWithin(Duration.ofSeconds(10))
+          .extracting(BackupStatus::statusCode)
+          .isEqualTo(BackupStatusCode.DELETED);
+    } finally {
+      store.closeAsync().join();
+    }
+  }
+
+  private void acquireLeasesOnSegmentBlobs(
+      final BlobContainerClient containerClient, final BackupIdentifierImpl backupId) {
+    final var prefix =
+        "contents/"
+            + backupId.partitionId()
+            + "/"
+            + backupId.checkpointId()
+            + "/"
+            + backupId.nodeId()
+            + "/segments/";
+
+    containerClient.listBlobs().stream()
+        .filter(blob -> blob.getName().startsWith(prefix))
+        .forEach(
+            blob -> {
+              final var blobClient = containerClient.getBlobClient(blob.getName());
+              final var leaseClient =
+                  new BlobLeaseClientBuilder().blobClient(blobClient).buildClient();
+              leaseClient.acquireLease(60);
+            });
+  }
+
+  private static BlobServiceClient buildClient(final AzureBackupConfig config) {
+    return new BlobServiceClientBuilder().connectionString(config.connectionString()).buildClient();
+  }
+}

--- a/zeebe/backup-stores/azure/src/test/java/io/camunda/zeebe/backup/azure/AzureBackupStoreDeleteTest.java
+++ b/zeebe/backup-stores/azure/src/test/java/io/camunda/zeebe/backup/azure/AzureBackupStoreDeleteTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.azure;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.azure.core.http.HttpPipeline;
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.BlobServiceVersion;
+import com.azure.storage.blob.models.BlobStorageException;
+import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
+import io.camunda.zeebe.backup.common.Manifest;
+import java.lang.reflect.Field;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+final class AzureBackupStoreDeleteTest {
+
+  @Mock private ManifestManager manifestManager;
+  @Mock private FileSetManager fileSetManager;
+  @Mock private BlobServiceClient blobServiceClient;
+
+  private AzureBackupStore store;
+  private final BackupIdentifierImpl id = new BackupIdentifierImpl(1, 2, 3L);
+
+  @BeforeEach
+  void setUp() throws Exception {
+    final var config =
+        new AzureBackupConfig.Builder()
+            .withCreateContainer(false)
+            .withContainerName("test")
+            .build();
+    final var containerClient = mock(BlobContainerClient.class);
+    when(blobServiceClient.getBlobContainerClient(anyString())).thenReturn(containerClient);
+    when(containerClient.exists()).thenReturn(true);
+    when(blobServiceClient.getHttpPipeline()).thenReturn(mock(HttpPipeline.class));
+    when(blobServiceClient.getAccountUrl()).thenReturn("https://test.blob.core.windows.net");
+    when(blobServiceClient.getServiceVersion()).thenReturn(BlobServiceVersion.getLatest());
+
+    store = new AzureBackupStore(config, blobServiceClient);
+    setField(store, "manifestManager", manifestManager);
+    setField(store, "fileSetManager", fileSetManager);
+  }
+
+  @Test
+  void shouldNotDeleteManifestWhenContentsDeletionFails() {
+    // given
+    final Manifest deletedManifest = Manifest.createFailed(id).delete();
+    when(manifestManager.getManifest(id)).thenReturn(deletedManifest);
+    when(fileSetManager.collectBlobUrls(eq(id), any()))
+        .thenReturn(List.of("https://test.blob.core.windows.net/container/contents/file1"));
+    doThrow(mock(BlobStorageException.class)).when(fileSetManager).deleteBlobs(any());
+
+    // when
+    assertThatThrownBy(() -> store.delete(id).join())
+        .hasCauseInstanceOf(BlobStorageException.class);
+
+    // then - manifest was never deleted
+    verify(manifestManager, never()).deleteManifest(any());
+  }
+
+  private static void setField(final Object target, final String name, final Object value)
+      throws Exception {
+    final Field field = target.getClass().getDeclaredField(name);
+    field.setAccessible(true);
+    field.set(target, value);
+  }
+}

--- a/zeebe/backup-stores/azure/src/test/java/io/camunda/zeebe/backup/azure/AzureBackupStoreSaveTest.java
+++ b/zeebe/backup-stores/azure/src/test/java/io/camunda/zeebe/backup/azure/AzureBackupStoreSaveTest.java
@@ -17,8 +17,10 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.azure.core.http.HttpPipeline;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.BlobServiceVersion;
 import io.camunda.zeebe.backup.api.Backup;
 import io.camunda.zeebe.backup.azure.ManifestManager.PersistedManifest;
 import io.camunda.zeebe.backup.common.BackupDescriptorImpl;
@@ -65,6 +67,9 @@ final class AzureBackupStoreSaveTest {
     final var containerClient = mock(BlobContainerClient.class);
     when(blobServiceClient.getBlobContainerClient(anyString())).thenReturn(containerClient);
     when(containerClient.exists()).thenReturn(true);
+    when(blobServiceClient.getHttpPipeline()).thenReturn(mock(HttpPipeline.class));
+    when(blobServiceClient.getAccountUrl()).thenReturn("https://test.blob.core.windows.net");
+    when(blobServiceClient.getServiceVersion()).thenReturn(BlobServiceVersion.V2020_10_02);
     final var realStore = new AzureBackupStore(config, blobServiceClient);
 
     /* Inject mocks */

--- a/zeebe/backup-stores/azure/src/test/java/io/camunda/zeebe/backup/azure/FileSetManagerTest.java
+++ b/zeebe/backup-stores/azure/src/test/java/io/camunda/zeebe/backup/azure/FileSetManagerTest.java
@@ -38,7 +38,7 @@ final class FileSetManagerTest {
 
   @Test
   void shouldSplitDeleteAcrossMultipleBatches() {
-    // given - 257 URLs exceeds MAX_DELETE_BLOB_BATCH_SIZE (256)
+    // given - 257 URLs exceeds MAX_DELETE_BATCH_SIZE (256)
     final var blobBatch = mock(BlobBatch.class);
     when(blobBatchClient.getBlobBatch()).thenReturn(blobBatch);
     final var urls =

--- a/zeebe/backup-stores/azure/src/test/java/io/camunda/zeebe/backup/azure/FileSetManagerTest.java
+++ b/zeebe/backup-stores/azure/src/test/java/io/camunda/zeebe/backup/azure/FileSetManagerTest.java
@@ -7,15 +7,19 @@
  */
 package io.camunda.zeebe.backup.azure;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.azure.core.http.rest.Response;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.batch.BlobBatch;
 import com.azure.storage.blob.batch.BlobBatchClient;
+import java.util.List;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -41,6 +45,9 @@ final class FileSetManagerTest {
     // given - 257 URLs exceeds MAX_DELETE_BATCH_SIZE (256)
     final var blobBatch = mock(BlobBatch.class);
     when(blobBatchClient.getBlobBatch()).thenReturn(blobBatch);
+    final var response = mock(Response.class);
+    when(response.getStatusCode()).thenReturn(202);
+    when(blobBatch.deleteBlob(anyString())).thenReturn(response);
     final var urls =
         IntStream.range(0, 257)
             .mapToObj(i -> "https://test.blob.core.windows.net/container/file" + i)
@@ -51,5 +58,22 @@ final class FileSetManagerTest {
 
     // then - submitBatch called twice: first 256, then 1
     verify(blobBatchClient, times(2)).submitBatch(any());
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void shouldThrowWhenBlobDeletionResponseIndicatesFailure() {
+    // given
+    final var blobBatch = mock(BlobBatch.class);
+    when(blobBatchClient.getBlobBatch()).thenReturn(blobBatch);
+    final var failedResponse = mock(Response.class);
+    when(failedResponse.getStatusCode()).thenReturn(412);
+    when(blobBatch.deleteBlob(anyString())).thenReturn(failedResponse);
+    final var url = "https://test.blob.core.windows.net/container/file1";
+
+    // when/then
+    assertThatThrownBy(() -> manager.deleteBlobs(List.of(url)))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("Failures detected in the blob batch deletion");
   }
 }

--- a/zeebe/backup-stores/azure/src/test/java/io/camunda/zeebe/backup/azure/FileSetManagerTest.java
+++ b/zeebe/backup-stores/azure/src/test/java/io/camunda/zeebe/backup/azure/FileSetManagerTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.azure;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.batch.BlobBatch;
+import com.azure.storage.blob.batch.BlobBatchClient;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+final class FileSetManagerTest {
+
+  @Mock private BlobContainerClient containerClient;
+  @Mock private BlobBatchClient blobBatchClient;
+
+  private FileSetManager manager;
+
+  @BeforeEach
+  void setUp() {
+    manager = new FileSetManager(containerClient, blobBatchClient, false);
+  }
+
+  @Test
+  void shouldSplitDeleteAcrossMultipleBatches() {
+    // given - 257 URLs exceeds MAX_DELETE_BLOB_BATCH_SIZE (256)
+    final var blobBatch = mock(BlobBatch.class);
+    when(blobBatchClient.getBlobBatch()).thenReturn(blobBatch);
+    final var urls =
+        IntStream.range(0, 257)
+            .mapToObj(i -> "https://test.blob.core.windows.net/container/file" + i)
+            .toList();
+
+    // when
+    manager.deleteBlobs(urls);
+
+    // then - submitBatch called twice: first 256, then 1
+    verify(blobBatchClient, times(2)).submitBatch(any());
+  }
+}

--- a/zeebe/backup-stores/azure/src/test/java/io/camunda/zeebe/backup/azure/FileSetManagerTest.java
+++ b/zeebe/backup-stores/azure/src/test/java/io/camunda/zeebe/backup/azure/FileSetManagerTest.java
@@ -9,16 +9,16 @@ package io.camunda.zeebe.backup.azure;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.azure.core.http.rest.Response;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.batch.BlobBatch;
 import com.azure.storage.blob.batch.BlobBatchClient;
+import com.azure.storage.blob.batch.BlobBatchStorageException;
 import java.util.List;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
@@ -45,9 +45,6 @@ final class FileSetManagerTest {
     // given - 257 URLs exceeds MAX_DELETE_BATCH_SIZE (256)
     final var blobBatch = mock(BlobBatch.class);
     when(blobBatchClient.getBlobBatch()).thenReturn(blobBatch);
-    final var response = mock(Response.class);
-    when(response.getStatusCode()).thenReturn(202);
-    when(blobBatch.deleteBlob(anyString())).thenReturn(response);
     final var urls =
         IntStream.range(0, 257)
             .mapToObj(i -> "https://test.blob.core.windows.net/container/file" + i)
@@ -66,14 +63,11 @@ final class FileSetManagerTest {
     // given
     final var blobBatch = mock(BlobBatch.class);
     when(blobBatchClient.getBlobBatch()).thenReturn(blobBatch);
-    final var failedResponse = mock(Response.class);
-    when(failedResponse.getStatusCode()).thenReturn(412);
-    when(blobBatch.deleteBlob(anyString())).thenReturn(failedResponse);
+    doThrow(mock(BlobBatchStorageException.class)).when(blobBatchClient).submitBatch(any());
     final var url = "https://test.blob.core.windows.net/container/file1";
 
     // when/then
     assertThatThrownBy(() -> manager.deleteBlobs(List.of(url)))
-        .isInstanceOf(RuntimeException.class)
-        .hasMessageContaining("Failures detected in the blob batch deletion");
+        .isInstanceOf(BlobBatchStorageException.class);
   }
 }

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/FileSetManager.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/FileSetManager.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.backup.gcs;
 
+import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.Storage;
@@ -21,6 +22,9 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
@@ -32,6 +36,7 @@ final class FileSetManager {
 
   public static final String SNAPSHOT_FILESET_NAME = "snapshot";
   public static final String SEGMENTS_FILESET_NAME = "segments";
+  static final int MAX_DELETE_BLOB_BATCH_SIZE = 100;
 
   /**
    * The path format consists of the following elements:
@@ -134,12 +139,21 @@ final class FileSetManager {
     }
   }
 
-  public void delete(final BackupIdentifier id, final String fileSetName) {
+  Collection<BlobId> collectBlobIds(final BackupIdentifier id, final String fileSetName) {
+    final var ids = new ArrayList<BlobId>();
     for (final var blob :
         client
             .list(bucketInfo.getName(), BlobListOption.prefix(fileSetPath(id, fileSetName)))
             .iterateAll()) {
-      blob.delete();
+      ids.add(blob.getBlobId());
+    }
+    return ids;
+  }
+
+  void deleteBlobs(final List<BlobId> blobIds) {
+    final int size = blobIds.size();
+    for (int i = 0; i < size; i += MAX_DELETE_BLOB_BATCH_SIZE) {
+      client.delete(blobIds.subList(i, Math.min(i + MAX_DELETE_BLOB_BATCH_SIZE, size)));
     }
   }
 

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/FileSetManager.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/FileSetManager.java
@@ -7,12 +7,15 @@
  */
 package io.camunda.zeebe.backup.gcs;
 
+import com.google.cloud.BatchResult.Callback;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.Storage.BlobListOption;
 import com.google.cloud.storage.Storage.BlobWriteOption;
+import com.google.cloud.storage.StorageBatch;
+import com.google.cloud.storage.StorageException;
 import io.camunda.zeebe.backup.api.BackupIdentifier;
 import io.camunda.zeebe.backup.api.NamedFileSet;
 import io.camunda.zeebe.backup.common.FileSet;
@@ -29,6 +32,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Semaphore;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -153,7 +157,16 @@ final class FileSetManager {
   void deleteBlobs(final List<BlobId> blobIds) {
     final int size = blobIds.size();
     for (int i = 0; i < size; i += MAX_DELETE_BATCH_SIZE) {
-      client.delete(blobIds.subList(i, Math.min(i + MAX_DELETE_BATCH_SIZE, size)));
+      final StorageBatch batch = client.batch();
+      final List<StorageException> errors = new ArrayList<>();
+      for (final var blobId : blobIds.subList(i, Math.min(i + MAX_DELETE_BATCH_SIZE, size))) {
+        batch.delete(blobId).notify(new BooleanStorageExceptionCallback(errors::add));
+      }
+      batch.submit();
+      if (!errors.isEmpty()) {
+        throw new RuntimeException(
+            "Failures detected in the blob batch deletion", errors.getFirst());
+      }
     }
   }
 
@@ -206,5 +219,17 @@ final class FileSetManager {
     return BlobInfo.newBuilder(bucketInfo, fileSetPath(id, fileSetName) + fileName)
         .setContentType("application/octet-stream")
         .build();
+  }
+
+  private record BooleanStorageExceptionCallback(Consumer<StorageException> onError)
+      implements Callback<Boolean, StorageException> {
+
+    @Override
+    public void success(final Boolean deleted) {}
+
+    @Override
+    public void error(final StorageException exception) {
+      onError.accept(exception);
+    }
   }
 }

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/FileSetManager.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/FileSetManager.java
@@ -36,7 +36,7 @@ final class FileSetManager {
 
   public static final String SNAPSHOT_FILESET_NAME = "snapshot";
   public static final String SEGMENTS_FILESET_NAME = "segments";
-  static final int MAX_DELETE_BLOB_BATCH_SIZE = 100;
+  static final int MAX_DELETE_BATCH_SIZE = 100;
 
   /**
    * The path format consists of the following elements:
@@ -152,8 +152,8 @@ final class FileSetManager {
 
   void deleteBlobs(final List<BlobId> blobIds) {
     final int size = blobIds.size();
-    for (int i = 0; i < size; i += MAX_DELETE_BLOB_BATCH_SIZE) {
-      client.delete(blobIds.subList(i, Math.min(i + MAX_DELETE_BLOB_BATCH_SIZE, size)));
+    for (int i = 0; i < size; i += MAX_DELETE_BATCH_SIZE) {
+      client.delete(blobIds.subList(i, Math.min(i + MAX_DELETE_BATCH_SIZE, size)));
     }
   }
 

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/FileSetManager.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/FileSetManager.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.backup.api.NamedFileSet;
 import io.camunda.zeebe.backup.common.FileSet;
 import io.camunda.zeebe.backup.common.FileSet.NamedFile;
 import io.camunda.zeebe.backup.common.NamedFileSetImpl;
+import io.camunda.zeebe.backup.gcs.GcsBackupStoreException.BatchOperationException;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
@@ -164,8 +165,8 @@ final class FileSetManager {
       }
       batch.submit();
       if (!errors.isEmpty()) {
-        throw new RuntimeException(
-            "Failures detected in the blob batch deletion", errors.getFirst());
+        throw new BatchOperationException(
+            "Failures detected in the blob batch deletion", errors.getFirst()) {};
       }
     }
   }

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.backup.gcs;
 
+import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.Storage;
@@ -26,7 +27,9 @@ import io.camunda.zeebe.backup.common.Manifest.StatusCode;
 import io.camunda.zeebe.backup.gcs.GcsBackupStoreException.ConfigurationException;
 import io.camunda.zeebe.backup.gcs.GcsConnectionConfig.Authentication.None;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
@@ -155,8 +158,13 @@ public final class GcsBackupStore implements BackupStore {
                 "Cannot delete Backup with id '%s', must be marked as deleted."
                     .formatted(id.toString()));
           }
-          fileSetManager.delete(id, FileSetManager.SNAPSHOT_FILESET_NAME);
-          fileSetManager.delete(id, FileSetManager.SEGMENTS_FILESET_NAME);
+          final var snapshotIds =
+              fileSetManager.collectBlobIds(id, FileSetManager.SNAPSHOT_FILESET_NAME);
+          final var segmentIds =
+              fileSetManager.collectBlobIds(id, FileSetManager.SEGMENTS_FILESET_NAME);
+          final List<BlobId> allIds = new ArrayList<>(snapshotIds);
+          allIds.addAll(segmentIds);
+          fileSetManager.deleteBlobs(allIds);
           manifestManager.deleteManifest(manifest);
         },
         executor);

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStoreException.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStoreException.java
@@ -31,4 +31,10 @@ public abstract class GcsBackupStoreException extends RuntimeException {
       super(message, cause);
     }
   }
+
+  public static class BatchOperationException extends GcsBackupStoreException {
+    public BatchOperationException(final String message, final Throwable cause) {
+      super(message, cause);
+    }
+  }
 }

--- a/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/FileSetManagerTest.java
+++ b/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/FileSetManagerTest.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
 import io.camunda.zeebe.backup.common.FileSet;
 import io.camunda.zeebe.backup.common.FileSet.NamedFile;
 import io.camunda.zeebe.backup.common.NamedFileSetImpl;
+import io.camunda.zeebe.backup.gcs.GcsBackupStoreException.BatchOperationException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -206,7 +207,7 @@ final class FileSetManagerTest {
 
     // when/then
     Assertions.assertThatThrownBy(() -> manager.deleteBlobs(List.of(blobId)))
-        .isInstanceOf(RuntimeException.class)
+        .isInstanceOf(BatchOperationException.class)
         .hasMessageContaining("Failures detected in the blob batch deletion");
   }
 

--- a/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/FileSetManagerTest.java
+++ b/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/FileSetManagerTest.java
@@ -11,10 +11,13 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
 import com.google.api.gax.paging.Page;
+import com.google.cloud.BatchResult.Callback;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageBatch;
+import com.google.cloud.storage.StorageBatchResult;
 import com.google.cloud.storage.StorageException;
 import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
 import io.camunda.zeebe.backup.common.FileSet;
@@ -29,6 +32,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executors;
+import java.util.stream.IntStream;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -156,13 +160,18 @@ final class FileSetManagerTest {
     final var mockPage = mock(Page.class);
     when(mockPage.iterateAll()).thenReturn(List.of(mockBlob));
     when(storage.list(eq("bucket"), any())).thenReturn(mockPage);
+    final var mockBatch = mock(StorageBatch.class);
+    when(storage.batch()).thenReturn(mockBatch);
+    when(mockBatch.delete(any(BlobId.class))).thenReturn(mock(StorageBatchResult.class));
 
     // when
     final var collected = manager.collectBlobIds(backupIdentifier, "filesetName");
     manager.deleteBlobs(new ArrayList<>(collected));
 
     // then
-    verify(storage).delete(List.of(blobId));
+    verify(storage).batch();
+    verify(mockBatch).delete(blobId);
+    verify(mockBatch).submit();
   }
 
   @Test
@@ -177,31 +186,47 @@ final class FileSetManagerTest {
         .hasMessageContaining("expected");
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   void shouldThrowExceptionWhenBatchDeleteThrows() {
     // given
     final var blobId = BlobId.of("bucket", "basePath/contents/1/2/3/filesetName/file");
-    when(storage.delete(List.of(blobId))).thenThrow(new StorageException(412, "expected"));
+    final var mockBatch = mock(StorageBatch.class);
+    when(storage.batch()).thenReturn(mockBatch);
+    final var mockResult = mock(StorageBatchResult.class);
+    when(mockBatch.delete(any(BlobId.class))).thenReturn(mockResult);
+    doAnswer(
+            inv -> {
+              final Callback<Boolean, StorageException> cb = inv.getArgument(0);
+              cb.error(new StorageException(412, "expected"));
+              return null;
+            })
+        .when(mockResult)
+        .notify(any());
 
     // when/then
     Assertions.assertThatThrownBy(() -> manager.deleteBlobs(List.of(blobId)))
-        .isInstanceOf(StorageException.class)
-        .hasMessageContaining("expected");
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("Failures detected in the blob batch deletion");
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   void shouldSplitDeleteAcrossMultipleBatches() {
     // given - 101 blobs exceeds MAX_DELETE_BATCH_SIZE (100)
     final var blobIds =
-        java.util.stream.IntStream.range(0, 101)
+        IntStream.range(0, 101)
             .mapToObj(i -> BlobId.of("bucket", "contents/1/2/3/file" + i))
-            .collect(java.util.stream.Collectors.toList());
+            .toList();
+    final var mockBatch = mock(StorageBatch.class);
+    when(storage.batch()).thenReturn(mockBatch);
+    when(mockBatch.delete(any(BlobId.class))).thenReturn(mock(StorageBatchResult.class));
 
     // when
     manager.deleteBlobs(blobIds);
 
     // then - two separate batch calls: first 100, then 1
-    verify(storage, times(2)).delete(any(Iterable.class));
+    verify(storage, times(2)).batch();
   }
 
   @Test

--- a/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/FileSetManagerTest.java
+++ b/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/FileSetManagerTest.java
@@ -191,7 +191,7 @@ final class FileSetManagerTest {
 
   @Test
   void shouldSplitDeleteAcrossMultipleBatches() {
-    // given - 101 blobs exceeds MAX_DELETE_BLOB_BATCH_SIZE (100)
+    // given - 101 blobs exceeds MAX_DELETE_BATCH_SIZE (100)
     final var blobIds =
         java.util.stream.IntStream.range(0, 101)
             .mapToObj(i -> BlobId.of("bucket", "contents/1/2/3/file" + i))

--- a/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/FileSetManagerTest.java
+++ b/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/FileSetManagerTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.*;
 
 import com.google.api.gax.paging.Page;
 import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageException;
@@ -23,6 +24,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -145,50 +147,61 @@ final class FileSetManagerTest {
 
   @SuppressWarnings("unchecked")
   @Test
-  void shouldDeleteFileSet() {
+  void shouldCollectAndDeleteFileSetBlobs() {
     // given
     final var backupIdentifier = new BackupIdentifierImpl(1, 2, 3);
-
+    final var blobId = BlobId.of("bucket", "basePath/contents/1/2/3/filesetName/file");
     final var mockBlob = mock(Blob.class);
+    when(mockBlob.getBlobId()).thenReturn(blobId);
     final var mockPage = mock(Page.class);
     when(mockPage.iterateAll()).thenReturn(List.of(mockBlob));
     when(storage.list(eq("bucket"), any())).thenReturn(mockPage);
 
     // when
-    manager.delete(backupIdentifier, "filesetName");
+    final var collected = manager.collectBlobIds(backupIdentifier, "filesetName");
+    manager.deleteBlobs(new ArrayList<>(collected));
 
     // then
-    verify(mockBlob).delete();
+    verify(storage).delete(List.of(blobId));
   }
 
   @Test
-  void shouldThrowExceptionOnDeleteFileSetWhenListThrows() {
+  void shouldThrowExceptionOnCollectWhenListThrows() {
     // given
     final var backupIdentifier = new BackupIdentifierImpl(1, 2, 3);
     when(storage.list(eq("bucket"), any())).thenThrow(new StorageException(412, "expected"));
 
-    // when throw
-    Assertions.assertThatThrownBy(() -> manager.delete(backupIdentifier, "filesetName"))
+    // when/then
+    Assertions.assertThatThrownBy(() -> manager.collectBlobIds(backupIdentifier, "filesetName"))
         .isInstanceOf(StorageException.class)
         .hasMessageContaining("expected");
   }
 
-  @SuppressWarnings("unchecked")
   @Test
-  void shouldThrowExceptionOnDeleteFileSetWhenBlobDeleteThrows() {
+  void shouldThrowExceptionWhenBatchDeleteThrows() {
     // given
-    final var backupIdentifier = new BackupIdentifierImpl(1, 2, 3);
+    final var blobId = BlobId.of("bucket", "basePath/contents/1/2/3/filesetName/file");
+    when(storage.delete(List.of(blobId))).thenThrow(new StorageException(412, "expected"));
 
-    final Blob mockBlob = mock(Blob.class);
-    when(mockBlob.delete()).thenThrow(new StorageException(412, "expected"));
-    final var mockPage = mock(Page.class);
-    when(mockPage.iterateAll()).thenReturn(List.of(mockBlob));
-    when(storage.list(eq("bucket"), any())).thenReturn(mockPage);
-
-    // when throw
-    Assertions.assertThatThrownBy(() -> manager.delete(backupIdentifier, "filesetName"))
+    // when/then
+    Assertions.assertThatThrownBy(() -> manager.deleteBlobs(List.of(blobId)))
         .isInstanceOf(StorageException.class)
         .hasMessageContaining("expected");
+  }
+
+  @Test
+  void shouldSplitDeleteAcrossMultipleBatches() {
+    // given - 101 blobs exceeds MAX_DELETE_BLOB_BATCH_SIZE (100)
+    final var blobIds =
+        java.util.stream.IntStream.range(0, 101)
+            .mapToObj(i -> BlobId.of("bucket", "contents/1/2/3/file" + i))
+            .collect(java.util.stream.Collectors.toList());
+
+    // when
+    manager.deleteBlobs(blobIds);
+
+    // then - two separate batch calls: first 100, then 1
+    verify(storage, times(2)).delete(any(Iterable.class));
   }
 
   @Test

--- a/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/GcsBackupStoreBatchDeletionTest.java
+++ b/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/GcsBackupStoreBatchDeletionTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.gcs;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
+import com.google.cloud.BatchResult.Callback;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageBatch;
+import com.google.cloud.storage.StorageBatchResult;
+import com.google.cloud.storage.StorageException;
+import io.camunda.zeebe.backup.api.BackupStatus;
+import io.camunda.zeebe.backup.api.BackupStatusCode;
+import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
+import io.camunda.zeebe.backup.gcs.util.GcsContainer;
+import io.camunda.zeebe.backup.testkit.support.TestBackupProvider;
+import java.time.Duration;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+public class GcsBackupStoreBatchDeletionTest {
+  @Container private static final GcsContainer GCS = new GcsContainer();
+  private static final String BUCKET_NAME = RandomStringUtils.randomAlphabetic(10).toLowerCase();
+
+  @Test
+  void shouldNotDeleteManifestOnContentException() throws Exception {
+    // given
+    final var config =
+        new GcsBackupConfig.Builder()
+            .withBucketName(BUCKET_NAME)
+            .withHost(GCS.externalEndpoint())
+            .withoutAuthentication()
+            .build();
+
+    final Storage realClient = GcsBackupStore.buildClient(config);
+    realClient.create(BucketInfo.of(BUCKET_NAME));
+
+    final Storage spyClient = spy(realClient);
+    final var store = new GcsBackupStore(config, spyClient);
+
+    final var backupId = new BackupIdentifierImpl(1, 2, 3);
+    final var backup = TestBackupProvider.simpleBackupWithId(backupId);
+
+    final var failedSegment = backup.segments().names().stream().findFirst().orElseThrow();
+    final var fullSegmentPath = "2/3/1/segments/" + failedSegment;
+
+    interceptSegmentDeletion(realClient, fullSegmentPath, spyClient);
+
+    try {
+      store.save(backup).join();
+      store.markDeleted(backupId).join();
+
+      // when - delete fails due to intercepted segment deletion error
+      store.delete(backupId).exceptionally(t -> null).join();
+
+      // then - manifest should still exist since content deletion failed
+      assertThat(store.getStatus(backupId))
+          .succeedsWithin(Duration.ofSeconds(10))
+          .extracting(BackupStatus::statusCode)
+          .isEqualTo(BackupStatusCode.DELETED);
+    } finally {
+      store.closeAsync().join();
+      realClient.close();
+    }
+  }
+
+  private static void interceptSegmentDeletion(
+      final Storage realClient, final String fullSegmentPath, final Storage spyClient) {
+    doAnswer(invocation -> createInterceptedBatch(realClient, fullSegmentPath))
+        .when(spyClient)
+        .batch();
+  }
+
+  private static StorageBatch createInterceptedBatch(
+      final Storage realClient, final String fullSegmentPath) {
+    final StorageBatch realBatch = realClient.batch();
+    final StorageBatch spyBatch = spy(realBatch);
+
+    doAnswer(
+            deleteInvocation ->
+                interceptDelete(deleteInvocation.getArgument(0), fullSegmentPath, realBatch))
+        .when(spyBatch)
+        .delete(any(BlobId.class));
+
+    return spyBatch;
+  }
+
+  private static StorageBatchResult<Boolean> interceptDelete(
+      final BlobId blobId, final String fullSegmentPath, final StorageBatch realBatch) {
+    if (blobId.getName().contains(fullSegmentPath)) {
+      return createFailingBatchResult();
+    }
+    return realBatch.delete(blobId);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static StorageBatchResult<Boolean> createFailingBatchResult() {
+    final var result = mock(StorageBatchResult.class);
+    doAnswer(
+            notifyInvocation -> {
+              final Callback<Boolean, StorageException> callback = notifyInvocation.getArgument(0);
+              callback.error(new StorageException(403, "Access Denied"));
+              return null;
+            })
+        .when(result)
+        .notify(any());
+    return result;
+  }
+}

--- a/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/GcsBackupStoreDeleteTest.java
+++ b/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/GcsBackupStoreDeleteTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.gcs;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageException;
+import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
+import io.camunda.zeebe.backup.common.Manifest;
+import java.lang.reflect.Field;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+final class GcsBackupStoreDeleteTest {
+
+  @Mock private ManifestManager manifestManager;
+  @Mock private FileSetManager fileSetManager;
+
+  private GcsBackupStore store;
+  private final BackupIdentifierImpl id = new BackupIdentifierImpl(1, 2, 3L);
+
+  @BeforeEach
+  void setUp() throws Exception {
+    final var config =
+        new GcsBackupConfig.Builder().withBucketName("bucket").withoutAuthentication().build();
+    store = new GcsBackupStore(config, mock(Storage.class));
+    setField(store, "manifestManager", manifestManager);
+    setField(store, "fileSetManager", fileSetManager);
+  }
+
+  @Test
+  void shouldNotDeleteManifestWhenContentsDeletionFails() {
+    // given
+    final Manifest deletedManifest = Manifest.createFailed(id).delete();
+    when(manifestManager.getManifest(id)).thenReturn(deletedManifest);
+    when(fileSetManager.collectBlobIds(eq(id), any()))
+        .thenReturn(List.of(BlobId.of("bucket", "contents/1/3/2/snapshot/file1")));
+    doThrow(new StorageException(500, "simulated contents deletion failure"))
+        .when(fileSetManager)
+        .deleteBlobs(any());
+
+    // when
+    assertThatThrownBy(() -> store.delete(id).join())
+        .hasCauseInstanceOf(StorageException.class)
+        .hasMessageContaining("simulated contents deletion failure");
+
+    // then - manifest was never deleted
+    verify(manifestManager, never()).deleteManifest(any());
+  }
+
+  private static void setField(final Object target, final String name, final Object value)
+      throws Exception {
+    final Field field = target.getClass().getDeclaredField(name);
+    field.setAccessible(true);
+    field.set(target, value);
+  }
+}

--- a/zeebe/backup-stores/s3/pom.xml
+++ b/zeebe/backup-stores/s3/pom.xml
@@ -162,6 +162,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>

--- a/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
+++ b/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
@@ -404,14 +404,14 @@ public final class S3BackupStore implements BackupStore {
   }
 
   private CompletableFuture<List<ObjectIdentifier>> listBackupObjects(final String prefix) {
-    return client
-        .listObjectsV2(req -> req.bucket(config.bucketName()).prefix(prefix))
-        .thenApplyAsync(
-            objects ->
-                objects.contents().stream()
-                    .map(S3Object::key)
-                    .map(key -> ObjectIdentifier.builder().key(key).build())
-                    .toList());
+    final var aggregator = new AsyncAggregatingSubscriber<ObjectIdentifier>(SCAN_PARALLELISM);
+    client
+        .listObjectsV2Paginator(req -> req.bucket(config.bucketName()).prefix(prefix))
+        .contents()
+        .map(s3Object -> ObjectIdentifier.builder().key(s3Object.key()).build())
+        .map(CompletableFuture::completedFuture)
+        .subscribe(aggregator);
+    return aggregator.result().thenApply(List::copyOf);
   }
 
   private CompletableFuture<Void> deleteBackupObjects(

--- a/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
+++ b/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
@@ -93,6 +93,7 @@ public final class S3BackupStore implements BackupStore {
   static final String METADATA_OBJECT_NAME = "metadata.json";
   private static final Logger LOG = LoggerFactory.getLogger(S3BackupStore.class);
   private static final int SCAN_PARALLELISM = 16;
+  private static final int MAX_DELETE_BATCH_SIZE = 1000;
   private final Pattern backupIdentifierPattern;
   private final S3BackupConfig config;
   private final S3AsyncClient client;
@@ -269,11 +270,11 @@ public final class S3BackupStore implements BackupStore {
             })
         .thenComposeAsync(
             manifest ->
-                listObjects(manifest, Directory.MANIFESTS)
+                listObjects(manifest, Directory.CONTENTS)
                     .thenComposeAsync(this::deleteBackupObjects)
                     .thenComposeAsync(
                         ignored ->
-                            listObjects(manifest, Directory.CONTENTS)
+                            listObjects(manifest, Directory.MANIFESTS)
                                 .thenComposeAsync(this::deleteBackupObjects)));
   }
 
@@ -423,11 +424,21 @@ public final class S3BackupStore implements BackupStore {
       // Nothing to delete, which we must handle because the delete request would be invalid
       return CompletableFuture.completedFuture(null);
     }
+    final var list = List.copyOf(objectIdentifiers);
+    final int size = list.size();
+    CompletableFuture<Void> result = CompletableFuture.completedFuture(null);
+    for (int i = 0; i < size; i += MAX_DELETE_BATCH_SIZE) {
+      final var batch = list.subList(i, Math.min(i + MAX_DELETE_BATCH_SIZE, size));
+      result = result.thenComposeAsync(ignored -> deleteBatch(batch));
+    }
+    return result;
+  }
+
+  private CompletableFuture<Void> deleteBatch(final List<ObjectIdentifier> batch) {
     return client
         .deleteObjects(
             req ->
-                req.bucket(config.bucketName())
-                    .delete(delete -> delete.objects(objectIdentifiers).quiet(true)))
+                req.bucket(config.bucketName()).delete(delete -> delete.objects(batch).quiet(true)))
         .thenApplyAsync(
             response -> {
               if (!response.errors().isEmpty()) {

--- a/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/S3BackupStoreDeleteTest.java
+++ b/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/S3BackupStoreDeleteTest.java
@@ -93,7 +93,7 @@ final class S3BackupStoreDeleteTest {
     // when
     store.delete(id).join();
 
-    // then - deleteObjects called twice: batch of 1000 then batch of 1
+    // then - deleteObjects called thrice: two batches of 1000 then batch of 1
     verify(client, times(3)).deleteObjects(any(Consumer.class));
   }
 

--- a/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/S3BackupStoreDeleteTest.java
+++ b/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/S3BackupStoreDeleteTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.s3;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsResponse;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.S3Object;
+
+@ExtendWith(MockitoExtension.class)
+final class S3BackupStoreDeleteTest {
+
+  @Mock private S3AsyncClient client;
+
+  private S3BackupStore store;
+  private final BackupIdentifierImpl id = new BackupIdentifierImpl(1, 2, 3L);
+
+  @BeforeEach
+  void setUp() {
+    final var config = new S3BackupConfig.Builder().withBucketName("test-bucket").build();
+    store = new S3BackupStore(config, client);
+  }
+
+  @Test
+  void shouldNotDeleteManifestWhenContentsDeletionFails() {
+    // given - manifest absent on both new and legacy paths -> DOES_NOT_EXIST status passes guard
+    when(client.getObject(any(Consumer.class), any(AsyncResponseTransformer.class)))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                NoSuchKeyException.builder().message("no such key").build()));
+    // contents listing returns 1 object (new path); legacy path returns empty
+    when(client.listObjectsV2(any(Consumer.class)))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                ListObjectsV2Response.builder()
+                    .contents(S3Object.builder().key("contents/2/3/1/snapshot/file1").build())
+                    .build()))
+        .thenReturn(CompletableFuture.completedFuture(ListObjectsV2Response.builder().build()));
+    // contents deletion fails
+    when(client.deleteObjects(any(Consumer.class)))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new RuntimeException("simulated contents deletion failure")));
+
+    // when
+    assertThatThrownBy(() -> store.delete(id).join())
+        .hasCauseInstanceOf(RuntimeException.class)
+        .hasMessageContaining("simulated contents deletion failure");
+
+    // then - deleteObjects called once for contents only; manifest objects never reached
+    verify(client, times(1)).deleteObjects(any(Consumer.class));
+  }
+
+  @Test
+  void shouldSplitDeleteIntoMultipleBatches() {
+    // given - manifest absent -> DOES_NOT_EXIST status passes guard
+    when(client.getObject(any(Consumer.class), any(AsyncResponseTransformer.class)))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                NoSuchKeyException.builder().message("no such key").build()));
+    // 1001 objects on new-path contents listing; all other listObjectsV2 calls return empty
+    final var objects =
+        IntStream.range(0, 1001)
+            .mapToObj(i -> S3Object.builder().key("contents/2/3/1/file" + i).build())
+            .toList();
+    when(client.listObjectsV2(any(Consumer.class)))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                ListObjectsV2Response.builder().contents(objects).build()))
+        .thenReturn(CompletableFuture.completedFuture(ListObjectsV2Response.builder().build()))
+        .thenReturn(CompletableFuture.completedFuture(ListObjectsV2Response.builder().build()))
+        .thenReturn(CompletableFuture.completedFuture(ListObjectsV2Response.builder().build()));
+    // both content batches succeed
+    when(client.deleteObjects(any(Consumer.class)))
+        .thenReturn(CompletableFuture.completedFuture(DeleteObjectsResponse.builder().build()));
+
+    // when
+    store.delete(id).join();
+
+    // then - deleteObjects called twice: batch of 1000 then batch of 1
+    verify(client, times(2)).deleteObjects(any(Consumer.class));
+  }
+}

--- a/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/S3BackupStoreDeleteTest.java
+++ b/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/S3BackupStoreDeleteTest.java
@@ -9,11 +9,13 @@ package io.camunda.zeebe.backup.s3;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.stream.IntStream;
@@ -22,12 +24,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.reactivestreams.Subscription;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.core.async.SdkPublisher;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.DeleteObjectsResponse;
-import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.S3Object;
+import software.amazon.awssdk.services.s3.paginators.ListObjectsV2Publisher;
 
 @ExtendWith(MockitoExtension.class)
 final class S3BackupStoreDeleteTest {
@@ -50,14 +54,10 @@ final class S3BackupStoreDeleteTest {
         .thenReturn(
             CompletableFuture.failedFuture(
                 NoSuchKeyException.builder().message("no such key").build()));
-    // contents listing returns 1 object (new path); legacy path returns empty
-    when(client.listObjectsV2(any(Consumer.class)))
-        .thenReturn(
-            CompletableFuture.completedFuture(
-                ListObjectsV2Response.builder()
-                    .contents(S3Object.builder().key("contents/2/3/1/snapshot/file1").build())
-                    .build()))
-        .thenReturn(CompletableFuture.completedFuture(ListObjectsV2Response.builder().build()));
+    // contents new path: 1 object; legacy path: empty
+    stubPaginatorCalls(
+        publisherOf(S3Object.builder().key("contents/2/3/1/snapshot/file1").build()),
+        emptyPublisher());
     // contents deletion fails
     when(client.deleteObjects(any(Consumer.class)))
         .thenReturn(
@@ -80,18 +80,12 @@ final class S3BackupStoreDeleteTest {
         .thenReturn(
             CompletableFuture.failedFuture(
                 NoSuchKeyException.builder().message("no such key").build()));
-    // 1001 objects on new-path contents listing; all other listObjectsV2 calls return empty
+    // contents new path: 1001 objects across two pages; all other paths: empty
     final var objects =
-        IntStream.range(0, 1001)
+        IntStream.range(0, 2001)
             .mapToObj(i -> S3Object.builder().key("contents/2/3/1/file" + i).build())
             .toList();
-    when(client.listObjectsV2(any(Consumer.class)))
-        .thenReturn(
-            CompletableFuture.completedFuture(
-                ListObjectsV2Response.builder().contents(objects).build()))
-        .thenReturn(CompletableFuture.completedFuture(ListObjectsV2Response.builder().build()))
-        .thenReturn(CompletableFuture.completedFuture(ListObjectsV2Response.builder().build()))
-        .thenReturn(CompletableFuture.completedFuture(ListObjectsV2Response.builder().build()));
+    stubPaginatorCalls(publisherOf(objects), emptyPublisher(), emptyPublisher(), emptyPublisher());
     // both content batches succeed
     when(client.deleteObjects(any(Consumer.class)))
         .thenReturn(CompletableFuture.completedFuture(DeleteObjectsResponse.builder().build()));
@@ -100,6 +94,48 @@ final class S3BackupStoreDeleteTest {
     store.delete(id).join();
 
     // then - deleteObjects called twice: batch of 1000 then batch of 1
-    verify(client, times(2)).deleteObjects(any(Consumer.class));
+    verify(client, times(3)).deleteObjects(any(Consumer.class));
+  }
+
+  /** Stubs successive listObjectsV2Paginator calls to return the given publishers in order. */
+  private void stubPaginatorCalls(final ListObjectsV2Publisher... publishers) {
+    var stub = when(client.listObjectsV2Paginator(any(Consumer.class)));
+    for (final var publisher : publishers) {
+      stub = stub.thenReturn(publisher);
+    }
+  }
+
+  private static ListObjectsV2Publisher publisherOf(final S3Object... objects) {
+    return publisherOf(List.of(objects));
+  }
+
+  private static ListObjectsV2Publisher publisherOf(final List<S3Object> objects) {
+    final var publisher = mock(ListObjectsV2Publisher.class);
+    when(publisher.contents()).thenReturn(sdkPublisherOf(objects));
+    return publisher;
+  }
+
+  private static ListObjectsV2Publisher emptyPublisher() {
+    return publisherOf(List.of());
+  }
+
+  private static SdkPublisher<S3Object> sdkPublisherOf(final List<S3Object> objects) {
+    return subscriber ->
+        subscriber.onSubscribe(
+            new Subscription() {
+              private boolean emitted = false;
+
+              @Override
+              public void request(final long n) {
+                if (!emitted) {
+                  emitted = true;
+                  objects.forEach(subscriber::onNext);
+                  subscriber.onComplete();
+                }
+              }
+
+              @Override
+              public void cancel() {}
+            });
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Support batch deletion of backup contents (segments/snapshots) for all remote backup stores (S3/GCS/Azure). Each store has it's own max batch size limit declared by their specs.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #45257 
