### PR TITLE
Implement create agent instance api

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -3439,7 +3439,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * <pre>
    *   CreateAgentInstanceResponse response = camundaClient
    *       .newCreateAgentInstanceCommand()
-   *       .elementInstanceKey("2251799813685248")
+   *       .elementInstanceKey(2251799813685248)
    *       .model("gpt-4o")
    *       .provider("openai")
    *       .systemPrompt("You are a helpful assistant.")

--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -35,6 +35,7 @@ import io.camunda.client.api.command.CancelBatchOperationStep1;
 import io.camunda.client.api.command.CancelProcessInstanceCommandStep1;
 import io.camunda.client.api.command.CompleteUserTaskCommandStep1;
 import io.camunda.client.api.command.CorrelateMessageCommandStep1;
+import io.camunda.client.api.command.CreateAgentInstanceCommandStep1;
 import io.camunda.client.api.command.CreateAuthorizationCommandStep1;
 import io.camunda.client.api.command.CreateBatchOperationCommandStep1;
 import io.camunda.client.api.command.CreateDocumentBatchCommandStep1;
@@ -3431,6 +3432,24 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder for the request to get a resource content as binary
    */
   ResourceContentGetRequest newResourceContentBinaryGetRequest(long resourceKey);
+
+  /**
+   * Creates a command to create a new agent instance.
+   *
+   * <pre>
+   *   CreateAgentInstanceResponse response = camundaClient
+   *       .newCreateAgentInstanceCommand()
+   *       .elementInstanceKey("2251799813685248")
+   *       .model("gpt-4o")
+   *       .provider("openai")
+   *       .systemPrompt("You are a helpful assistant.")
+   *       .send()
+   *       .join();
+   * </pre>
+   *
+   * @return a builder for creating an agent instance
+   */
+  CreateAgentInstanceCommandStep1 newCreateAgentInstanceCommand();
 
   /**
    * Creates a request to create a new global task listener.

--- a/clients/java/src/main/java/io/camunda/client/api/command/CreateAgentInstanceCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CreateAgentInstanceCommandStep1.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.command;
+
+import io.camunda.client.api.response.CreateAgentInstanceResponse;
+
+/**
+ * Represents a request to create a new agent instance.
+ *
+ * <p>Usage example:
+ *
+ * <pre>
+ *   CreateAgentInstanceResponse response = camundaClient
+ *       .newCreateAgentInstanceCommand()
+ *       .elementInstanceKey(2251799813685248L)
+ *       .model("gpt-4o")
+ *       .provider("openai")
+ *       .systemPrompt("You are a helpful assistant.")
+ *       .send()
+ *       .join();
+ * </pre>
+ */
+public interface CreateAgentInstanceCommandStep1 {
+
+  /**
+   * Sets the element instance key of the AHSP or AI Agent Task element instance.
+   *
+   * @param elementInstanceKey the key of the element instance. Must be greater than 0.
+   * @return this builder for method chaining
+   */
+  CreateAgentInstanceCommandStep2 elementInstanceKey(long elementInstanceKey);
+
+  interface CreateAgentInstanceCommandStep2 {
+
+    /**
+     * Sets the LLM model identifier for the agent instance.
+     *
+     * @param model the model identifier (for example, gpt-4o). Must not be null or empty.
+     * @return this builder for method chaining
+     */
+    CreateAgentInstanceCommandStep3 model(String model);
+  }
+
+  interface CreateAgentInstanceCommandStep3 {
+
+    /**
+     * Sets the LLM provider for the agent instance.
+     *
+     * @param provider the provider name (for example, openai). Must not be null or empty.
+     * @return this builder for method chaining
+     */
+    CreateAgentInstanceCommandStep4 provider(String provider);
+  }
+
+  interface CreateAgentInstanceCommandStep4 {
+
+    /**
+     * Sets the system prompt for the agent instance.
+     *
+     * @param systemPrompt the system prompt text. Must not be null or empty.
+     * @return this builder for method chaining
+     */
+    CreateAgentInstanceCommandStep5 systemPrompt(String systemPrompt);
+  }
+
+  interface CreateAgentInstanceCommandStep5
+      extends CreateAgentInstanceCommandStep1,
+          CreateAgentInstanceCommandStep2,
+          CreateAgentInstanceCommandStep3,
+          CreateAgentInstanceCommandStep4,
+          FinalCommandStep<CreateAgentInstanceResponse> {
+
+    /**
+     * Sets the maximum number of tokens the agent instance may use. Defaults to -1 (no limit).
+     *
+     * @param maxTokens the token limit. Use -1 for no limit.
+     * @return this builder for method chaining
+     */
+    CreateAgentInstanceCommandStep5 maxTokens(long maxTokens);
+
+    /**
+     * Sets the maximum number of LLM model calls the agent instance may make. Defaults to -1 (no
+     * limit).
+     *
+     * @param maxModelCalls the model-call limit. Use -1 for no limit.
+     * @return this builder for method chaining
+     */
+    CreateAgentInstanceCommandStep5 maxModelCalls(int maxModelCalls);
+
+    /**
+     * Sets the maximum number of tool calls the agent instance may make. Defaults to -1 (no limit).
+     *
+     * @param maxToolCalls the tool-call limit. Use -1 for no limit.
+     * @return this builder for method chaining
+     */
+    CreateAgentInstanceCommandStep5 maxToolCalls(int maxToolCalls);
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/api/response/CreateAgentInstanceResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/CreateAgentInstanceResponse.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.response;
+
+public interface CreateAgentInstanceResponse {
+
+  /**
+   * @return the system-generated key for the created agent instance
+   */
+  long getAgentInstanceKey();
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -43,6 +43,7 @@ import io.camunda.client.api.command.ClientException;
 import io.camunda.client.api.command.CompleteJobCommandStep1;
 import io.camunda.client.api.command.CompleteUserTaskCommandStep1;
 import io.camunda.client.api.command.CorrelateMessageCommandStep1;
+import io.camunda.client.api.command.CreateAgentInstanceCommandStep1;
 import io.camunda.client.api.command.CreateAuthorizationCommandStep1;
 import io.camunda.client.api.command.CreateBatchOperationCommandStep1;
 import io.camunda.client.api.command.CreateDocumentBatchCommandStep1;
@@ -225,6 +226,7 @@ import io.camunda.client.impl.command.CancelBatchOperationCommandImpl;
 import io.camunda.client.impl.command.CancelProcessInstanceCommandImpl;
 import io.camunda.client.impl.command.CompleteUserTaskCommandImpl;
 import io.camunda.client.impl.command.CorrelateMessageCommandImpl;
+import io.camunda.client.impl.command.CreateAgentInstanceCommandImpl;
 import io.camunda.client.impl.command.CreateAuthorizationCommandImpl;
 import io.camunda.client.impl.command.CreateBatchOperationCommandImpl.CreateBatchOperationCommandStep1Impl;
 import io.camunda.client.impl.command.CreateDocumentBatchCommandImpl;
@@ -1708,6 +1710,11 @@ public final class CamundaClientImpl implements CamundaClient {
   @Override
   public ResourceContentGetRequest newResourceContentBinaryGetRequest(final long resourceKey) {
     return new ResourceContentBinaryGetRequestImpl(httpClient, resourceKey);
+  }
+
+  @Override
+  public CreateAgentInstanceCommandStep1 newCreateAgentInstanceCommand() {
+    return new CreateAgentInstanceCommandImpl(httpClient, jsonMapper);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateAgentInstanceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateAgentInstanceCommandImpl.java
@@ -84,18 +84,21 @@ public class CreateAgentInstanceCommandImpl
 
   @Override
   public CreateAgentInstanceCommandStep5 maxTokens(final long maxTokens) {
+    ArgumentUtil.ensureGreaterThan("maxTokens", maxTokens, -2);
     ensureLimits().maxTokens(maxTokens);
     return this;
   }
 
   @Override
   public CreateAgentInstanceCommandStep5 maxModelCalls(final int maxModelCalls) {
+    ArgumentUtil.ensureGreaterThan("maxModelCalls", maxModelCalls, -2);
     ensureLimits().maxModelCalls(maxModelCalls);
     return this;
   }
 
   @Override
   public CreateAgentInstanceCommandStep5 maxToolCalls(final int maxToolCalls) {
+    ArgumentUtil.ensureGreaterThan("maxToolCalls", maxToolCalls, -2);
     ensureLimits().maxToolCalls(maxToolCalls);
     return this;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateAgentInstanceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateAgentInstanceCommandImpl.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.command;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.command.CreateAgentInstanceCommandStep1;
+import io.camunda.client.api.command.CreateAgentInstanceCommandStep1.CreateAgentInstanceCommandStep2;
+import io.camunda.client.api.command.CreateAgentInstanceCommandStep1.CreateAgentInstanceCommandStep3;
+import io.camunda.client.api.command.CreateAgentInstanceCommandStep1.CreateAgentInstanceCommandStep4;
+import io.camunda.client.api.command.CreateAgentInstanceCommandStep1.CreateAgentInstanceCommandStep5;
+import io.camunda.client.api.response.CreateAgentInstanceResponse;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.CreateAgentInstanceResponseImpl;
+import io.camunda.client.protocol.rest.AgentInstanceCreationRequest;
+import io.camunda.client.protocol.rest.AgentInstanceCreationResult;
+import io.camunda.client.protocol.rest.AgentInstanceDefinition;
+import io.camunda.client.protocol.rest.AgentInstanceLimits;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class CreateAgentInstanceCommandImpl
+    implements CreateAgentInstanceCommandStep1,
+        CreateAgentInstanceCommandStep2,
+        CreateAgentInstanceCommandStep3,
+        CreateAgentInstanceCommandStep4,
+        CreateAgentInstanceCommandStep5 {
+
+  private final AgentInstanceCreationRequest request;
+  private final JsonMapper jsonMapper;
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+
+  public CreateAgentInstanceCommandImpl(final HttpClient httpClient, final JsonMapper jsonMapper) {
+    this.jsonMapper = jsonMapper;
+    this.httpClient = httpClient;
+    httpRequestConfig = httpClient.newRequestConfig();
+    request = new AgentInstanceCreationRequest();
+    request.definition(new AgentInstanceDefinition());
+  }
+
+  @Override
+  public CreateAgentInstanceCommandStep2 elementInstanceKey(final long elementInstanceKey) {
+    ArgumentUtil.ensureGreaterThan("elementInstanceKey", elementInstanceKey, 0);
+    request.elementInstanceKey(String.valueOf(elementInstanceKey));
+    return this;
+  }
+
+  @Override
+  public CreateAgentInstanceCommandStep3 model(final String model) {
+    ArgumentUtil.ensureNotNullNorEmpty("model", model);
+    request.getDefinition().model(model);
+    return this;
+  }
+
+  @Override
+  public CreateAgentInstanceCommandStep4 provider(final String provider) {
+    ArgumentUtil.ensureNotNullNorEmpty("provider", provider);
+    request.getDefinition().provider(provider);
+    return this;
+  }
+
+  @Override
+  public CreateAgentInstanceCommandStep5 systemPrompt(final String systemPrompt) {
+    ArgumentUtil.ensureNotNullNorEmpty("systemPrompt", systemPrompt);
+    request.getDefinition().systemPrompt(systemPrompt);
+    return this;
+  }
+
+  @Override
+  public CreateAgentInstanceCommandStep5 maxTokens(final long maxTokens) {
+    ensureLimits().maxTokens(maxTokens);
+    return this;
+  }
+
+  @Override
+  public CreateAgentInstanceCommandStep5 maxModelCalls(final int maxModelCalls) {
+    ensureLimits().maxModelCalls(maxModelCalls);
+    return this;
+  }
+
+  @Override
+  public CreateAgentInstanceCommandStep5 maxToolCalls(final int maxToolCalls) {
+    ensureLimits().maxToolCalls(maxToolCalls);
+    return this;
+  }
+
+  @Override
+  public CreateAgentInstanceCommandStep5 requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<CreateAgentInstanceResponse> send() {
+    final HttpCamundaFuture<CreateAgentInstanceResponse> result = new HttpCamundaFuture<>();
+    final CreateAgentInstanceResponseImpl response = new CreateAgentInstanceResponseImpl();
+    httpClient.post(
+        "/agent-instances",
+        jsonMapper.toJson(request),
+        httpRequestConfig.build(),
+        AgentInstanceCreationResult.class,
+        response::setResponse,
+        result);
+    return result;
+  }
+
+  private AgentInstanceLimits ensureLimits() {
+    if (request.getLimits() == null) {
+      request.limits(new AgentInstanceLimits());
+    }
+    return request.getLimits();
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/response/CreateAgentInstanceResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/CreateAgentInstanceResponseImpl.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.response;
+
+import io.camunda.client.api.response.CreateAgentInstanceResponse;
+import io.camunda.client.protocol.rest.AgentInstanceCreationResult;
+
+public class CreateAgentInstanceResponseImpl implements CreateAgentInstanceResponse {
+
+  private long agentInstanceKey;
+
+  public CreateAgentInstanceResponse setResponse(final AgentInstanceCreationResult result) {
+    agentInstanceKey = Long.parseLong(result.getAgentInstanceKey());
+    return this;
+  }
+
+  @Override
+  public long getAgentInstanceKey() {
+    return agentInstanceKey;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/response/CreateAgentInstanceResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/CreateAgentInstanceResponseImpl.java
@@ -22,7 +22,7 @@ public class CreateAgentInstanceResponseImpl implements CreateAgentInstanceRespo
 
   private long agentInstanceKey;
 
-  public CreateAgentInstanceResponse setResponse(final AgentInstanceCreationResult result) {
+  public CreateAgentInstanceResponseImpl setResponse(final AgentInstanceCreationResult result) {
     agentInstanceKey = Long.parseLong(result.getAgentInstanceKey());
     return this;
   }

--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -40,6 +40,7 @@ import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.security.impl.AuthorizationChecker;
 import io.camunda.service.AdHocSubProcessActivityServices;
+import io.camunda.service.AgentInstanceServices;
 import io.camunda.service.ApiServicesExecutorProvider;
 import io.camunda.service.AuditLogServices;
 import io.camunda.service.AuthorizationServices;
@@ -240,6 +241,19 @@ public class CamundaServicesConfiguration {
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     return new AdHocSubProcessActivityServices(
+        brokerClient,
+        securityContextProvider,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
+  }
+
+  @Bean
+  public AgentInstanceServices agentInstanceServices(
+      final BrokerClient brokerClient,
+      final SecurityContextProvider securityContextProvider,
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+    return new AgentInstanceServices(
         brokerClient,
         securityContextProvider,
         executorProvider,

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapper.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.gateway.mapping.http.mapper;
+
+import io.camunda.gateway.mapping.http.RequestMapper;
+import io.camunda.gateway.mapping.http.util.KeyUtil;
+import io.camunda.gateway.mapping.http.validator.AgentInstanceRequestValidator;
+import io.camunda.gateway.protocol.model.simple.AgentInstanceCreationRequest;
+import io.camunda.gateway.protocol.model.simple.AgentInstanceCreationResult;
+import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
+import io.camunda.zeebe.util.Either;
+import org.jspecify.annotations.NullMarked;
+import org.springframework.http.ProblemDetail;
+
+@NullMarked
+public class AgentInstanceMapper {
+
+  private final AgentInstanceRequestValidator requestValidator;
+
+  public AgentInstanceMapper(final AgentInstanceRequestValidator requestValidator) {
+    this.requestValidator = requestValidator;
+  }
+
+  public Either<ProblemDetail, AgentInstanceRecord> toCreateAgentInstanceRecord(
+      final AgentInstanceCreationRequest request) {
+    return RequestMapper.getResult(
+        requestValidator.validateCreateRequest(request),
+        () -> {
+          final var record = new AgentInstanceRecord();
+
+          record.setElementInstanceKey(Long.parseLong(request.getElementInstanceKey()));
+
+          final var def = request.getDefinition();
+          record
+              .getDefinition()
+              .setModel(def.getModel())
+              .setProvider(def.getProvider())
+              .setSystemPrompt(def.getSystemPrompt());
+
+          if (request.getLimits() != null) {
+            final var limits = request.getLimits();
+            record
+                .getLimits()
+                .setMaxTokens(limits.getMaxTokens())
+                .setMaxModelCalls(limits.getMaxModelCalls())
+                .setMaxToolCalls(limits.getMaxToolCalls());
+          }
+
+          return record;
+        });
+  }
+
+  public AgentInstanceCreationResult toAgentInstanceCreationResult(
+      final AgentInstanceRecord record) {
+    return AgentInstanceCreationResult.Builder.create()
+        .agentInstanceKey(KeyUtil.keyToString(record.getAgentInstanceKey()))
+        .build();
+  }
+}

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapper.java
@@ -10,8 +10,9 @@ package io.camunda.gateway.mapping.http.mapper;
 import io.camunda.gateway.mapping.http.RequestMapper;
 import io.camunda.gateway.mapping.http.util.KeyUtil;
 import io.camunda.gateway.mapping.http.validator.AgentInstanceRequestValidator;
-import io.camunda.gateway.protocol.model.simple.AgentInstanceCreationRequest;
-import io.camunda.gateway.protocol.model.simple.AgentInstanceCreationResult;
+import io.camunda.gateway.protocol.model.AgentInstanceCreationRequest;
+import io.camunda.gateway.protocol.model.AgentInstanceCreationResult;
+import io.camunda.gateway.protocol.model.AgentInstanceLimits;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
 import io.camunda.zeebe.util.Either;
 import org.jspecify.annotations.NullMarked;
@@ -43,12 +44,7 @@ public class AgentInstanceMapper {
               .setSystemPrompt(def.getSystemPrompt());
 
           if (request.getLimits() != null) {
-            final var limits = request.getLimits();
-            record
-                .getLimits()
-                .setMaxTokens(limits.getMaxTokens())
-                .setMaxModelCalls(limits.getMaxModelCalls())
-                .setMaxToolCalls(limits.getMaxToolCalls());
+            fillLimits(request.getLimits(), record.getLimits());
           }
 
           return record;
@@ -60,5 +56,23 @@ public class AgentInstanceMapper {
     return AgentInstanceCreationResult.Builder.create()
         .agentInstanceKey(KeyUtil.keyToString(record.getAgentInstanceKey()))
         .build();
+  }
+
+  // Note: even if limits are marked @NotNull in AgentInstanceCreationRequest,
+  // nothing is actually preventing them from being null
+  @SuppressWarnings("ConstantValue")
+  private void fillLimits(
+      final AgentInstanceLimits requestLimits,
+      final io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceLimits
+          recordLimits) {
+    if (requestLimits.getMaxTokens() != null) {
+      recordLimits.setMaxTokens(requestLimits.getMaxTokens());
+    }
+    if (requestLimits.getMaxModelCalls() != null) {
+      recordLimits.setMaxModelCalls(requestLimits.getMaxModelCalls());
+    }
+    if (requestLimits.getMaxToolCalls() != null) {
+      recordLimits.setMaxToolCalls(requestLimits.getMaxToolCalls());
+    }
   }
 }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidator.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.gateway.mapping.http.validator;
+
+import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_EMPTY_ATTRIBUTE;
+import static io.camunda.gateway.mapping.http.validator.RequestValidator.validate;
+import static io.camunda.gateway.mapping.http.validator.RequestValidator.validateKeyFormat;
+
+import io.camunda.gateway.protocol.model.simple.AgentInstanceCreationRequest;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.jspecify.annotations.NullMarked;
+import org.springframework.http.ProblemDetail;
+
+@NullMarked
+public class AgentInstanceRequestValidator {
+
+  // Note: even if some properties are marked @NotNull in AgentInstanceCreationRequest,
+  // no validation is performed during deserialization, so it is still necessary to validate it here
+  @SuppressWarnings("ConstantValue")
+  public Optional<ProblemDetail> validateCreateRequest(final AgentInstanceCreationRequest request) {
+    return validate(
+        () -> {
+          final List<String> violations = new ArrayList<>();
+
+          if (request.getElementInstanceKey() == null) {
+            violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("elementInstanceKey"));
+          } else {
+            validateKeyFormat(request.getElementInstanceKey(), "elementInstanceKey", violations);
+          }
+
+          if (request.getDefinition() == null) {
+            violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("definition"));
+          } else {
+            final var def = request.getDefinition();
+            if (def.getModel() == null || def.getModel().isBlank()) {
+              violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("definition.model"));
+            }
+            if (def.getProvider() == null || def.getProvider().isBlank()) {
+              violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("definition.provider"));
+            }
+            if (def.getSystemPrompt() == null || def.getSystemPrompt().isBlank()) {
+              violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("definition.systemPrompt"));
+            }
+          }
+
+          return violations;
+        });
+  }
+}

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidator.java
@@ -8,11 +8,13 @@
 package io.camunda.gateway.mapping.http.validator;
 
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_EMPTY_ATTRIBUTE;
+import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_INVALID_ATTRIBUTE_VALUE;
 import static io.camunda.gateway.mapping.http.validator.RequestValidator.validate;
 import static io.camunda.gateway.mapping.http.validator.RequestValidator.validateKeyFormat;
 
-import io.camunda.gateway.protocol.model.simple.AgentInstanceCreationRequest;
+import io.camunda.gateway.protocol.model.AgentInstanceCreationRequest;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.jspecify.annotations.NullMarked;
@@ -50,7 +52,21 @@ public class AgentInstanceRequestValidator {
             }
           }
 
+          if (request.getLimits() != null) {
+            final var limits = request.getLimits();
+            violations.addAll(validateLimit("limits.maxTokens", limits.getMaxTokens()));
+            violations.addAll(validateLimit("limits.maxModelCalls", limits.getMaxModelCalls()));
+            violations.addAll(validateLimit("limits.maxToolCalls", limits.getMaxToolCalls()));
+          }
+
           return violations;
         });
+  }
+
+  private List<String> validateLimit(final String limitName, final Number limit) {
+    if (limit != null && limit.longValue() < -1) {
+      return List.of(ERROR_MESSAGE_INVALID_ATTRIBUTE_VALUE.formatted(limitName, limit, ">= -1"));
+    }
+    return Collections.emptyList();
   }
 }

--- a/service/src/main/java/io/camunda/service/AgentInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/AgentInstanceServices.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import io.camunda.security.api.model.CamundaAuthentication;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
+import io.camunda.service.security.SecurityContextProvider;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerCreateAgentInstanceRequest;
+import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
+import java.util.concurrent.CompletableFuture;
+
+public final class AgentInstanceServices extends ApiServices<AgentInstanceServices> {
+
+  public AgentInstanceServices(
+      final BrokerClient brokerClient,
+      final SecurityContextProvider securityContextProvider,
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+    super(
+        brokerClient,
+        securityContextProvider,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
+  }
+
+  public CompletableFuture<AgentInstanceRecord> createAgentInstance(
+      final AgentInstanceRecord record, final CamundaAuthentication authentication) {
+    return sendBrokerRequest(new BrokerCreateAgentInstanceRequest(record), authentication);
+  }
+}

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -396,11 +396,11 @@ components:
           description: Total output tokens produced across all model calls.
         modelCalls:
           type: integer
-          format: int64
+          format: int32
           description: Total number of LLM calls made.
         toolCalls:
           type: integer
-          format: int64
+          format: int32
           description: Total number of tool calls made.
 
     AgentInstanceLimits:
@@ -413,11 +413,11 @@ components:
       properties:
         maxModelCalls:
           type: integer
-          format: int64
+          format: int32
           description: Maximum LLM calls allowed. -1 if no limit is configured.
         maxToolCalls:
           type: integer
-          format: int64
+          format: int32
           description: Maximum tool calls allowed. -1 if no limit is configured.
         maxTokens:
           type: integer
@@ -492,12 +492,12 @@ components:
           description: Increment to apply to the total output token counter.
         modelCalls:
           type: integer
-          format: int64
+          format: int32
           minimum: 0
           description: Increment to apply to the total model call counter.
         toolCalls:
           type: integer
-          format: int64
+          format: int32
           minimum: 0
           description: Increment to apply to the total tool call counter.
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceController.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import io.camunda.gateway.mapping.http.mapper.AgentInstanceMapper;
+import io.camunda.gateway.mapping.http.validator.AgentInstanceRequestValidator;
+import io.camunda.gateway.protocol.model.AgentInstanceCreationRequest;
+import io.camunda.security.api.context.CamundaAuthenticationProvider;
+import io.camunda.service.AgentInstanceServices;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
+import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
+import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
+import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
+import java.util.concurrent.CompletableFuture;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@CamundaRestController
+@RequestMapping("/v2/agent-instances")
+public class AgentInstanceController {
+
+  private final AgentInstanceServices agentInstanceServices;
+  private final CamundaAuthenticationProvider authenticationProvider;
+  private final AgentInstanceMapper mapper;
+
+  public AgentInstanceController(
+      final AgentInstanceServices agentInstanceServices,
+      final CamundaAuthenticationProvider authenticationProvider) {
+    this.agentInstanceServices = agentInstanceServices;
+    this.authenticationProvider = authenticationProvider;
+    mapper = new AgentInstanceMapper(new AgentInstanceRequestValidator());
+  }
+
+  @CamundaPostMapping
+  public CompletableFuture<ResponseEntity<Object>> createAgentInstance(
+      @RequestBody final AgentInstanceCreationRequest request) {
+    return mapper
+        .toCreateAgentInstanceRecord(request)
+        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::create);
+  }
+
+  private CompletableFuture<ResponseEntity<Object>> create(final AgentInstanceRecord record) {
+    final var authentication = authenticationProvider.getCamundaAuthentication();
+    return RequestExecutor.executeServiceMethod(
+        () -> agentInstanceServices.createAgentInstance(record, authentication),
+        mapper::toAgentInstanceCreationResult,
+        HttpStatus.OK);
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
@@ -1,0 +1,299 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.assertArg;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.camunda.security.api.context.CamundaAuthenticationProvider;
+import io.camunda.service.AgentInstanceServices;
+import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
+
+@WebMvcTest(AgentInstanceController.class)
+class AgentInstanceControllerTest extends RestControllerTest {
+
+  private static final String AGENT_INSTANCES_URL = "/v2/agent-instances";
+  private static final long ELEMENT_INSTANCE_KEY = 2251799813685248L;
+  private static final long AGENT_INSTANCE_KEY = 9007199254741017L;
+
+  @MockitoBean private AgentInstanceServices agentInstanceServices;
+  @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
+
+  @BeforeEach
+  void setUp() {
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
+  }
+
+  @Test
+  void shouldCreateAgentInstance() {
+    // given
+    final var responseRecord = new AgentInstanceRecord();
+    responseRecord.setAgentInstanceKey(AGENT_INSTANCE_KEY);
+    when(agentInstanceServices.createAgentInstance(any(AgentInstanceRecord.class), any()))
+        .thenReturn(CompletableFuture.completedFuture(responseRecord));
+
+    final var requestBody =
+        """
+        {
+          "elementInstanceKey": "%d",
+          "definition": {
+            "model": "gpt-4o",
+            "provider": "openai",
+            "systemPrompt": "You are a helpful assistant."
+          }
+        }
+        """
+            .formatted(ELEMENT_INSTANCE_KEY);
+
+    // when / then
+    webClient
+        .post()
+        .uri(AGENT_INSTANCES_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(requestBody)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .json(
+            """
+            { "agentInstanceKey": "%d" }
+            """
+                .formatted(AGENT_INSTANCE_KEY),
+            JsonCompareMode.STRICT);
+
+    verify(agentInstanceServices)
+        .createAgentInstance(
+            assertArg(
+                record -> {
+                  assertThat(record.getElementInstanceKey()).isEqualTo(ELEMENT_INSTANCE_KEY);
+                  assertThat(record.getDefinition().getModel()).isEqualTo("gpt-4o");
+                  assertThat(record.getDefinition().getProvider()).isEqualTo("openai");
+                  assertThat(record.getDefinition().getSystemPrompt())
+                      .isEqualTo("You are a helpful assistant.");
+                  assertThat(record.getLimits().getMaxTokens()).isEqualTo(-1L);
+                  assertThat(record.getLimits().getMaxModelCalls()).isEqualTo(-1);
+                  assertThat(record.getLimits().getMaxToolCalls()).isEqualTo(-1);
+                }),
+            any());
+  }
+
+  @Test
+  void shouldCreateAgentInstanceWithExplicitLimits() {
+    // given
+    final var responseRecord = new AgentInstanceRecord();
+    responseRecord.setAgentInstanceKey(AGENT_INSTANCE_KEY);
+    when(agentInstanceServices.createAgentInstance(any(AgentInstanceRecord.class), any()))
+        .thenReturn(CompletableFuture.completedFuture(responseRecord));
+
+    final var requestBody =
+        """
+        {
+          "elementInstanceKey": "%d",
+          "definition": {
+            "model": "claude-sonnet-4-6",
+            "provider": "anthropic",
+            "systemPrompt": "You are an expert."
+          },
+          "limits": {
+            "maxTokens": 100000,
+            "maxModelCalls": 10,
+            "maxToolCalls": 50
+          }
+        }
+        """
+            .formatted(ELEMENT_INSTANCE_KEY);
+
+    // when / then
+    webClient
+        .post()
+        .uri(AGENT_INSTANCES_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(requestBody)
+        .exchange()
+        .expectStatus()
+        .isOk();
+
+    verify(agentInstanceServices)
+        .createAgentInstance(
+            assertArg(
+                record -> {
+                  assertThat(record.getLimits().getMaxTokens()).isEqualTo(100_000L);
+                  assertThat(record.getLimits().getMaxModelCalls()).isEqualTo(10);
+                  assertThat(record.getLimits().getMaxToolCalls()).isEqualTo(50);
+                }),
+            any());
+  }
+
+  @ParameterizedTest
+  @MethodSource("invalidCreateRequests")
+  void shouldRejectInvalidCreateRequest(final String requestBody, final String expectedDetail) {
+    // when / then
+    webClient
+        .post()
+        .uri(AGENT_INSTANCES_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(requestBody)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(
+            """
+            {
+              "type": "about:blank",
+              "title": "INVALID_ARGUMENT",
+              "status": 400,
+              "detail": "%s",
+              "instance": "/v2/agent-instances"
+            }
+            """
+                .formatted(expectedDetail),
+            JsonCompareMode.STRICT);
+
+    verifyNoInteractions(agentInstanceServices);
+  }
+
+  static Stream<Arguments> invalidCreateRequests() {
+    return Stream.of(
+        Arguments.of(
+            """
+            {
+              "definition": {
+                "model": "gpt-4o",
+                "provider": "openai",
+                "systemPrompt": "prompt"
+              }
+            }
+            """,
+            "No elementInstanceKey provided."),
+        Arguments.of(
+            """
+            {
+              "elementInstanceKey": null,
+              "definition": {
+                "model": "gpt-4o",
+                "provider": "openai",
+                "systemPrompt": "prompt"
+              }
+            }
+            """,
+            "No elementInstanceKey provided."),
+        Arguments.of(
+            """
+            {
+              "elementInstanceKey": "not-a-number",
+              "definition": {
+                "model": "gpt-4o",
+                "provider": "openai",
+                "systemPrompt": "prompt"
+              }
+            }
+            """,
+            "The provided elementInstanceKey 'not-a-number' is not a valid key."
+                + " Expected a numeric value."
+                + " Did you pass an entity id instead of an entity key?."),
+        Arguments.of(
+            """
+            {
+              "elementInstanceKey": "%d"
+            }
+            """
+                .formatted(ELEMENT_INSTANCE_KEY),
+            "No definition provided."),
+        Arguments.of(
+            """
+            {
+              "elementInstanceKey": "%d",
+              "definition": {
+                "provider": "openai",
+                "systemPrompt": "prompt"
+              }
+            }
+            """
+                .formatted(ELEMENT_INSTANCE_KEY),
+            "No definition.model provided."),
+        Arguments.of(
+            """
+            {
+              "elementInstanceKey": "%d",
+              "definition": {
+                "model": "gpt-4o",
+                "systemPrompt": "prompt"
+              }
+            }
+            """
+                .formatted(ELEMENT_INSTANCE_KEY),
+            "No definition.provider provided."),
+        Arguments.of(
+            """
+            {
+              "elementInstanceKey": "%d",
+              "definition": {
+                "model": "gpt-4o",
+                "provider": "openai"
+              }
+            }
+            """
+                .formatted(ELEMENT_INSTANCE_KEY),
+            "No definition.systemPrompt provided."));
+  }
+
+  @Test
+  void shouldReturn5xxOnServiceError() {
+    // given
+    when(agentInstanceServices.createAgentInstance(any(AgentInstanceRecord.class), any()))
+        .thenReturn(CompletableFuture.failedFuture(new RuntimeException("broker unavailable")));
+
+    final var requestBody =
+        """
+        {
+          "elementInstanceKey": "%d",
+          "definition": {
+            "model": "gpt-4o",
+            "provider": "openai",
+            "systemPrompt": "prompt"
+          }
+        }
+        """
+            .formatted(ELEMENT_INSTANCE_KEY);
+
+    // when / then
+    webClient
+        .post()
+        .uri(AGENT_INSTANCES_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(requestBody)
+        .exchange()
+        .expectStatus()
+        .is5xxServerError();
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.gateway.rest.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Named.named;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.assertArg;
 import static org.mockito.Mockito.verify;
@@ -149,7 +150,7 @@ class AgentInstanceControllerTest extends RestControllerTest {
             any());
   }
 
-  @ParameterizedTest
+  @ParameterizedTest(name = "[{index}] {0}")
   @MethodSource("invalidCreateRequests")
   void shouldRejectInvalidCreateRequest(final String requestBody, final String expectedDetail) {
     // when / then
@@ -184,85 +185,99 @@ class AgentInstanceControllerTest extends RestControllerTest {
   static Stream<Arguments> invalidCreateRequests() {
     return Stream.of(
         Arguments.of(
-            """
-            {
-              "definition": {
-                "model": "gpt-4o",
-                "provider": "openai",
-                "systemPrompt": "prompt"
-              }
-            }
-            """,
+            named(
+                "missing elementInstanceKey",
+                """
+                {
+                  "definition": {
+                    "model": "gpt-4o",
+                    "provider": "openai",
+                    "systemPrompt": "prompt"
+                  }
+                }
+                """),
             "No elementInstanceKey provided."),
         Arguments.of(
-            """
-            {
-              "elementInstanceKey": null,
-              "definition": {
-                "model": "gpt-4o",
-                "provider": "openai",
-                "systemPrompt": "prompt"
-              }
-            }
-            """,
+            named(
+                "null elementInstanceKey",
+                """
+                {
+                  "elementInstanceKey": null,
+                  "definition": {
+                    "model": "gpt-4o",
+                    "provider": "openai",
+                    "systemPrompt": "prompt"
+                  }
+                }
+                """),
             "No elementInstanceKey provided."),
         Arguments.of(
-            """
-            {
-              "elementInstanceKey": "not-a-number",
-              "definition": {
-                "model": "gpt-4o",
-                "provider": "openai",
-                "systemPrompt": "prompt"
-              }
-            }
-            """,
+            named(
+                "non-numeric elementInstanceKey",
+                """
+                {
+                  "elementInstanceKey": "not-a-number",
+                  "definition": {
+                    "model": "gpt-4o",
+                    "provider": "openai",
+                    "systemPrompt": "prompt"
+                  }
+                }
+                """),
             "The provided elementInstanceKey 'not-a-number' is not a valid key."
                 + " Expected a numeric value."
                 + " Did you pass an entity id instead of an entity key?."),
         Arguments.of(
-            """
-            {
-              "elementInstanceKey": "%d"
-            }
-            """
-                .formatted(ELEMENT_INSTANCE_KEY),
+            named(
+                "missing definition",
+                """
+                {
+                  "elementInstanceKey": "%d"
+                }
+                """
+                    .formatted(ELEMENT_INSTANCE_KEY)),
             "No definition provided."),
         Arguments.of(
-            """
-            {
-              "elementInstanceKey": "%d",
-              "definition": {
-                "provider": "openai",
-                "systemPrompt": "prompt"
-              }
-            }
-            """
-                .formatted(ELEMENT_INSTANCE_KEY),
+            named(
+                "missing definition.model",
+                """
+                {
+                  "elementInstanceKey": "%d",
+                  "definition": {
+                    "provider": "openai",
+                    "systemPrompt": "prompt"
+                  }
+                }
+                """
+                    .formatted(ELEMENT_INSTANCE_KEY)),
             "No definition.model provided."),
         Arguments.of(
-            """
-            {
-              "elementInstanceKey": "%d",
-              "definition": {
-                "model": "gpt-4o",
-                "systemPrompt": "prompt"
-              }
-            }
-            """
-                .formatted(ELEMENT_INSTANCE_KEY),
+            named(
+                "missing definition.provider",
+                """
+                {
+                  "elementInstanceKey": "%d",
+                  "definition": {
+                    "model": "gpt-4o",
+                    "systemPrompt": "prompt"
+                  }
+                }
+                """
+                    .formatted(ELEMENT_INSTANCE_KEY)),
             "No definition.provider provided."),
         Arguments.of(
-            """
-            {
-              "elementInstanceKey": "%d",
-              "definition": {
-                "model": "gpt-4o",
-                "provider": "openai"
-              }
-            }
-            """
-                .formatted(ELEMENT_INSTANCE_KEY),
+            named(
+                "missing definition.systemPrompt",
+                """
+                {
+                  "elementInstanceKey": "%d",
+                  "definition": {
+                    "model": "gpt-4o",
+                    "provider": "openai"
+                  }
+                }
+                """
+                    .formatted(ELEMENT_INSTANCE_KEY)),
             "No definition.systemPrompt provided."));
   }
 

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCreateAgentInstanceRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCreateAgentInstanceRequest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl.broker.request;
+
+import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
+import org.agrona.DirectBuffer;
+
+public class BrokerCreateAgentInstanceRequest extends BrokerExecuteCommand<AgentInstanceRecord> {
+
+  private final AgentInstanceRecord requestDto;
+
+  public BrokerCreateAgentInstanceRequest(final AgentInstanceRecord record) {
+    super(ValueType.AGENT_INSTANCE, AgentInstanceIntent.CREATE);
+    requestDto = record;
+    // Route to the partition that owns the element instance, decoded from the key.
+    // All keys in Zeebe encode the owning partition in their high bits.
+    request.setPartitionId(Protocol.decodePartitionId(record.getElementInstanceKey()));
+  }
+
+  @Override
+  public AgentInstanceRecord getRequestWriter() {
+    return requestDto;
+  }
+
+  @Override
+  protected AgentInstanceRecord toResponseDto(final DirectBuffer buffer) {
+    final AgentInstanceRecord responseDto = new AgentInstanceRecord();
+    responseDto.wrap(buffer);
+    return responseDto;
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypes.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypes.java
@@ -60,7 +60,8 @@ public final class ValueTypes {
           ValueType.CONDITIONAL_SUBSCRIPTION,
           ValueType.CONDITIONAL_EVALUATION,
           ValueType.EXPRESSION,
-          ValueType.GLOBAL_LISTENER);
+          ValueType.GLOBAL_LISTENER,
+          ValueType.AGENT_INSTANCE);
 
   private ValueTypes() {}
 


### PR DESCRIPTION
## Description
This pull request introduces a new feature for creating agent instances via the Java client and associated gateway/service logic. The changes add a complete command and response API for agent instance creation, including validation, mapping, and service layers, and update the protocol to ensure correct data types for model and tool call limits.

### Protocol Update:

* Updates the `agent-instances.yaml` protocol definition to change the type of `modelCalls` and `toolCalls` (and their limits) from `int64` to `int32`, ensuring alignment with the expected data types and preventing potential overflows or incompatibilities. 

### Gateway and Service Layer Support:

* Adds `AgentInstanceMapper` and `AgentInstanceRequestValidator` to map and validate HTTP requests for agent instance creation, ensuring all required fields are present and correctly formatted. [[1]](diffhunk://#diff-2c6920154784f43c29db0eee594c414c54b1f4cb857aa383133ee783caae1609R1-R63) [[2]](diffhunk://#diff-5e65a8f63b60e863688e933594e2c2f1167287d80948f3953c75a0b2f8fe01afR1-R56)
* Introduces `AgentInstanceServices` to handle the service-side logic for agent instance creation, integrating with authentication and broker client infrastructure.

### Java Client support

* Adds a new command interface (`CreateAgentInstanceCommandStep1`) and response interface (`CreateAgentInstanceResponse`) to the Java client API, enabling users to create agent instances with configurable properties such as model, provider, system prompt, and usage limits.
* Implements the command logic in `CreateAgentInstanceCommandImpl`, handling request building, validation, and HTTP communication for agent instance creation.
* Integrates the new command into the client (`CamundaClient`, `CamundaClientImpl`), allowing users to invoke `newCreateAgentInstanceCommand()` as part of the client API. 
* Implements the response handling in `CreateAgentInstanceResponseImpl`.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #51514 
