### PR TITLE
feat: add queue tag to command distribution metrics

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/DistributionMetrics.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/DistributionMetrics.java
@@ -8,17 +8,19 @@
 package io.camunda.zeebe.engine.metrics;
 
 import io.camunda.zeebe.util.micrometer.StatefulGauge;
-import io.micrometer.common.docs.KeyName;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 public final class DistributionMetrics {
 
+  private static final String NO_QUEUE = "NONE";
+
   private final MeterRegistry meterRegistry;
-  private final Map<Integer, PartitionDistributionMetrics> partitionMetrics =
+  private final Map<MetricKey, PartitionDistributionMetrics> partitionMetrics =
       new ConcurrentHashMap<>();
 
   // Metrics
@@ -60,20 +62,20 @@ public final class DistributionMetrics {
     activeDistributionsGauge.decrement();
   }
 
-  public void addPendingDistribution(final int targetPartitionId) {
-    getPartitionMetrics(targetPartitionId).addPendingDistribution();
+  public void addPendingDistribution(final int targetPartitionId, final String queueId) {
+    getPartitionMetrics(targetPartitionId, queueId).addPendingDistribution();
   }
 
-  public void removePendingDistribution(final int targetPartitionId) {
-    getPartitionMetrics(targetPartitionId).removePendingDistribution();
+  public void removePendingDistribution(final int targetPartitionId, final String queueId) {
+    getPartitionMetrics(targetPartitionId, queueId).removePendingDistribution();
   }
 
-  public void addInflightDistribution(final int targetPartitionId) {
-    getPartitionMetrics(targetPartitionId).addInflightDistribution();
+  public void addInflightDistribution(final int targetPartitionId, final String queueId) {
+    getPartitionMetrics(targetPartitionId, queueId).addInflightDistribution();
   }
 
-  public void removeInflightDistribution(final int targetPartitionId) {
-    getPartitionMetrics(targetPartitionId).removeInflightDistribution();
+  public void removeInflightDistribution(final int targetPartitionId, final String queueId) {
+    getPartitionMetrics(targetPartitionId, queueId).removeInflightDistribution();
   }
 
   /**
@@ -83,8 +85,8 @@ public final class DistributionMetrics {
    * @param originPartitionId the source partition id of the distribution (where the distribution
    *     was started)
    */
-  public void sentAcknowledgeDistribution(final int originPartitionId) {
-    getPartitionMetrics(originPartitionId).sentAcknowledgeDistribution();
+  public void sentAcknowledgeDistribution(final int originPartitionId, final String queueId) {
+    getPartitionMetrics(originPartitionId, queueId).sentAcknowledgeDistribution();
   }
 
   /**
@@ -94,8 +96,8 @@ public final class DistributionMetrics {
    * @param targetPartitionId the source partition id of the distribution (where the distribution
    *     was started)
    */
-  public void receivedAcknowledgeDistribution(final int targetPartitionId) {
-    getPartitionMetrics(targetPartitionId).receivedAcknowledgeDistribution();
+  public void receivedAcknowledgeDistribution(final int targetPartitionId, final String queueId) {
+    getPartitionMetrics(targetPartitionId, queueId).receivedAcknowledgeDistribution();
   }
 
   /**
@@ -105,19 +107,30 @@ public final class DistributionMetrics {
    *
    * @param targetPartitionId the target partition id of the distribution
    */
-  public void retryInflightDistribution(final int targetPartitionId) {
-    getPartitionMetrics(targetPartitionId).retryInflightDistribution();
+  public void retryInflightDistribution(final int targetPartitionId, final String queueId) {
+    getPartitionMetrics(targetPartitionId, queueId).retryInflightDistribution();
   }
 
-  private PartitionDistributionMetrics getPartitionMetrics(final int targetPartitionId) {
+  private PartitionDistributionMetrics getPartitionMetrics(
+      final int targetPartitionId, final String queueId) {
     return partitionMetrics.computeIfAbsent(
-        targetPartitionId, id -> new PartitionDistributionMetrics(id, meterRegistry));
+        new MetricKey(targetPartitionId, normalizeQueueId(queueId)),
+        key ->
+            new PartitionDistributionMetrics(
+                key.targetPartitionId(), key.queueId(), meterRegistry));
   }
+
+  private static String normalizeQueueId(final String queueId) {
+    return queueId == null ? NO_QUEUE : queueId;
+  }
+
+  private record MetricKey(int targetPartitionId, String queueId) {}
 
   private static class PartitionDistributionMetrics {
 
     private final MeterRegistry meterRegistry;
     private final int targetPartitionId;
+    private final String queueId;
 
     // Metrics
     private final StatefulGauge pendingDistributionsGauge;
@@ -127,34 +140,35 @@ public final class DistributionMetrics {
     private final Counter sentAcknowledgeDistributionsCounter;
 
     public PartitionDistributionMetrics(
-        final int targetPartitionId, final MeterRegistry meterRegistry) {
+        final int targetPartitionId, final String queueId, final MeterRegistry meterRegistry) {
       this.targetPartitionId = targetPartitionId;
+      this.queueId = Objects.requireNonNull(queueId);
       this.meterRegistry = meterRegistry;
 
       pendingDistributionsGauge =
           StatefulGauge.builder(DistributionMetricsDoc.PENDING_COMMAND_DISTRIBUTIONS.getName())
               .description(DistributionMetricsDoc.PENDING_COMMAND_DISTRIBUTIONS.getDescription())
-              .tags(DistributionMetricsKeyNames.tags(targetPartitionId))
+              .tags(tags())
               .register(meterRegistry);
 
       inflightDistributionsGauge =
           StatefulGauge.builder(DistributionMetricsDoc.INFLIGHT_COMMAND_DISTRIBUTIONS.getName())
               .description(DistributionMetricsDoc.INFLIGHT_COMMAND_DISTRIBUTIONS.getDescription())
-              .tags(DistributionMetricsKeyNames.tags(targetPartitionId))
+              .tags(tags())
               .register(meterRegistry);
 
       retryInflightDistributionsCounter =
           Counter.builder(DistributionMetricsDoc.RETRY_INFLIGHT_COMMAND_DISTRIBUTIONS.getName())
               .description(
                   DistributionMetricsDoc.RETRY_INFLIGHT_COMMAND_DISTRIBUTIONS.getDescription())
-              .tags(DistributionMetricsKeyNames.tags(targetPartitionId))
+              .tags(tags())
               .register(meterRegistry);
 
       sentAcknowledgeDistributionsCounter =
           Counter.builder(DistributionMetricsDoc.SENT_ACKNOWLEDGE_COMMAND_DISTRIBUTIONS.getName())
               .description(
                   DistributionMetricsDoc.SENT_ACKNOWLEDGE_COMMAND_DISTRIBUTIONS.getDescription())
-              .tags(DistributionMetricsKeyNames.tags(targetPartitionId))
+              .tags(tags())
               .register(meterRegistry);
 
       receivedAcknowledgeDistributionsCounter =
@@ -163,8 +177,12 @@ public final class DistributionMetrics {
               .description(
                   DistributionMetricsDoc.RECEIVED_ACKNOWLEDGE_COMMAND_DISTRIBUTIONS
                       .getDescription())
-              .tags(DistributionMetricsKeyNames.tags(targetPartitionId))
+              .tags(tags())
               .register(meterRegistry);
+    }
+
+    private Tags tags() {
+      return DistributionMetricsDoc.DistributionMetricKeyNames.tags(targetPartitionId, queueId);
     }
 
     public void resetGauges() {
@@ -198,20 +216,6 @@ public final class DistributionMetrics {
 
     public void receivedAcknowledgeDistribution() {
       receivedAcknowledgeDistributionsCounter.increment();
-    }
-
-    public enum DistributionMetricsKeyNames implements KeyName {
-      /** The ID of the partition associated to the metric */
-      TARGET_PARTITION {
-        @Override
-        public String asString() {
-          return "targetPartition";
-        }
-      };
-
-      public static Tags tags(final int partitionId) {
-        return Tags.of(TARGET_PARTITION.asString(), String.valueOf(partitionId));
-      }
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/DistributionMetricsDoc.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/DistributionMetricsDoc.java
@@ -168,10 +168,18 @@ public enum DistributionMetricsDoc implements ExtendedMeterDocumentation {
       public String asString() {
         return "targetPartition";
       }
+    },
+
+    QUEUE {
+      @Override
+      public String asString() {
+        return "queue";
+      }
     };
 
-    public static Tags targetPartitionTags(final int targetPartitionId) {
-      return Tags.of(TARGET_PARTITION.asString(), String.valueOf(targetPartitionId));
+    public static Tags tags(final int targetPartitionId, final String queue) {
+      return Tags.of(
+          TARGET_PARTITION.asString(), String.valueOf(targetPartitionId), QUEUE.asString(), queue);
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionAcknowledgeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionAcknowledgeProcessor.java
@@ -43,8 +43,11 @@ public class CommandDistributionAcknowledgeProcessor
     final var distributionKey = record.getKey();
     final var recordValue = record.getValue();
     final var partitionId = recordValue.getPartitionId();
+    final var queueId = distributionState.getQueueIdForDistribution(distributionKey);
 
-    commandDistributionBehavior.getMetrics().receivedAcknowledgeDistribution(partitionId);
+    commandDistributionBehavior
+        .getMetrics()
+        .receivedAcknowledgeDistribution(partitionId, queueId.orElse(null));
 
     if (!distributionState.hasPendingDistribution(distributionKey, partitionId)) {
       rejectionWriter.appendRejection(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
@@ -109,14 +109,14 @@ public final class CommandDistributionBehavior implements StreamProcessorLifecyc
     getDistributionState()
         .foreachPendingDistribution(
             (distributionKey, record) -> {
-              getMetrics().addPendingDistribution(record.getPartitionId());
+              getMetrics().addPendingDistribution(record.getPartitionId(), record.getQueueId());
               return true;
             });
 
     getDistributionState()
         .foreachRetriableDistribution(
             (distributionKey, record) -> {
-              getMetrics().addInflightDistribution(record.getPartitionId());
+              getMetrics().addInflightDistribution(record.getPartitionId(), record.getQueueId());
               return true;
             });
   }
@@ -204,7 +204,7 @@ public final class CommandDistributionBehavior implements StreamProcessorLifecyc
     final var distributionQueue = Optional.ofNullable(distributionRecord.getQueueId());
     distributionQueue.ifPresent(queue -> enqueueDistribution(queue, partition, distributionKey));
 
-    getMetrics().addPendingDistribution(partition);
+    getMetrics().addPendingDistribution(partition, distributionRecord.getQueueId());
 
     final var canDistributeImmediately =
         distributionQueue
@@ -286,7 +286,7 @@ public final class CommandDistributionBehavior implements StreamProcessorLifecyc
             .setQueueId(queueId)
             .setIntent(intent));
 
-    getMetrics().addInflightDistribution(partition);
+    getMetrics().addInflightDistribution(partition, queueId);
 
     if (executeSideEffect) {
       // This getter makes a hard copy of the command value, which we need to send the command to
@@ -326,6 +326,7 @@ public final class CommandDistributionBehavior implements StreamProcessorLifecyc
             .setIntent(command.getIntent());
 
     final int receiverPartitionId = Protocol.decodePartitionId(distributionKey);
+    final var queueId = distributionState.getQueueIdForDistribution(distributionKey);
     sideEffectWriter.appendSideEffect(
         () -> {
           interPartitionCommandSender.sendCommand(
@@ -337,7 +338,7 @@ public final class CommandDistributionBehavior implements StreamProcessorLifecyc
           return true;
         });
 
-    getMetrics().sentAcknowledgeDistribution(receiverPartitionId);
+    getMetrics().sentAcknowledgeDistribution(receiverPartitionId, queueId.orElse(null));
   }
 
   private <T extends UnifiedRecordValue> void requestContinuation(
@@ -381,16 +382,16 @@ public final class CommandDistributionBehavior implements StreamProcessorLifecyc
   public void onAcknowledgeDistribution(
       final long distributionKey, final CommandDistributionRecord recordValue) {
     final var partitionId = recordValue.getPartitionId();
+    final var queueId = distributionState.getQueueIdForDistribution(distributionKey);
 
     // finish the distribution for the partition that acknowledged the distribution
     stateWriter.appendFollowUpEvent(
         distributionKey, CommandDistributionIntent.ACKNOWLEDGED, recordValue);
 
-    getMetrics().removeInflightDistribution(partitionId);
-    getMetrics().removePendingDistribution(partitionId);
+    getMetrics().removeInflightDistribution(partitionId, queueId.orElse(null));
+    getMetrics().removePendingDistribution(partitionId, queueId.orElse(null));
 
     // Distribute next in queue if the distribution was part of a queue
-    final var queueId = distributionState.getQueueIdForDistribution(distributionKey);
     queueId.ifPresent(queue -> distributeNextInQueue(queue, partitionId));
 
     // Finish the distribution if there are no more pending distributions
@@ -421,7 +422,9 @@ public final class CommandDistributionBehavior implements StreamProcessorLifecyc
   public void onScheduledRetry(
       final long distributionKey, final CommandDistributionRecord distributionRecord) {
 
-    getMetrics().retryInflightDistribution(distributionRecord.getPartitionId());
+    getMetrics()
+        .retryInflightDistribution(
+            distributionRecord.getPartitionId(), distributionRecord.getQueueId());
 
     getCommandSender()
         .sendCommand(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/CommandDistributionMetricsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/CommandDistributionMetricsTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.metrics;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -112,6 +113,20 @@ public class CommandDistributionMetricsTest {
             metrics -> assertThat(metrics.active).isEqualTo(2),
             metrics -> assertThat(metrics.pending).isEqualTo(2),
             metrics -> assertThat(metrics.inflight).isEqualTo(1));
+    assertThat(
+            getGaugeValue(
+                1,
+                "zeebe.command.distributions.pending",
+                2,
+                DistributionQueue.DEPLOYMENT.getQueueId()))
+        .isEqualTo(2);
+    assertThat(
+            getGaugeValue(
+                1,
+                "zeebe.command.distributions.inflight",
+                2,
+                DistributionQueue.DEPLOYMENT.getQueueId()))
+        .isOne();
 
     // when
     engine.resumeProcessing(2);
@@ -227,6 +242,20 @@ public class CommandDistributionMetricsTest {
 
   private double getGaugeValue(final int partition, final String metricName) {
     final var gauge = engine.getMeterRegistry(partition).find(metricName).gauge();
+    return gauge != null ? gauge.value() : 0.0;
+  }
+
+  private double getGaugeValue(
+      final int partition,
+      final String metricName,
+      final int targetPartition,
+      final String queue) {
+    final var gauge =
+        engine
+            .getMeterRegistry(partition)
+            .find(metricName)
+            .tags("targetPartition", String.valueOf(targetPartition), "queue", queue)
+            .gauge();
     return gauge != null ? gauge.value() : 0.0;
   }
 


### PR DESCRIPTION
## Description
Adds the command distribution queue id as a `queue` tag on partition-scoped distribution metrics, so blocked queues can be identified during incidents.

Fixes #44787

## Testing
- `git diff --check`
- `./mvnw -pl zeebe/engine org.apache.maven.plugins:maven-compiler-plugin:3.14.1:compile -DskipTests -DskipITs`
- `./mvnw -pl zeebe/engine org.apache.maven.plugins:maven-compiler-plugin:3.14.1:testCompile -DskipITs`
- `./mvnw -pl zeebe/engine org.apache.maven.plugins:maven-surefire-plugin:3.5.2:test -Dtest=CommandDistributionMetricsTest -DskipITs`

Note: the normal lifecycle compile currently fails before compilation because `maven-checkstyle-plugin` cannot resolve `io.camunda:zeebe-build-tools:8.10.0-SNAPSHOT` from the configured snapshot repositories in this checkout.