### PR TITLE
refactor: replace java.io.File with java.nio.file.Path in journal module

### DIFF
--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/Segment.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/Segment.java
@@ -274,7 +274,7 @@ final class Segment implements AutoCloseable, FlushableSegment {
 
     final var target = file.getFileMarkedForDeletion();
     try {
-      FileUtil.moveDurably(file.file().toPath(), target);
+      FileUtil.moveDurably(file.file(), target);
     } catch (final IOException e) {
       throw new JournalException(e);
     }

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/Segment.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/Segment.java
@@ -286,7 +286,7 @@ final class Segment implements AutoCloseable, FlushableSegment {
 
     final var target = file.getFileMarkedForDeletion();
     try {
-      FileUtil.moveDurably(file.file().toPath(), target);
+      FileUtil.moveDurably(file.file(), target);
     } catch (final IOException e) {
       throw new JournalException(e);
     }

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentFile.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentFile.java
@@ -18,7 +18,6 @@ package io.camunda.zeebe.journal.file;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.io.File;
 import java.nio.file.Path;
 
 /**
@@ -34,24 +33,14 @@ public final class SegmentFile {
   private static final String EXTENSION = "log";
   private static final String DELETE_EXTENSION = "deleted";
   private static final char DELETE_EXTENSION_SEPARATOR = '_';
-  private final File file;
+  private final Path file;
   private Path fileMarkedForDeletion;
 
   /**
    * @throws IllegalArgumentException if {@code file} is not a valid segment file
    */
-  SegmentFile(final File file) {
+  SegmentFile(final Path file) {
     this.file = file;
-  }
-
-  /**
-   * Returns a boolean value indicating whether the given file appears to be a parsable segment
-   * file.
-   *
-   * @throws NullPointerException if {@code file} is null
-   */
-  public static boolean isSegmentFile(final String name, final File file) {
-    return isSegmentFile(name, file.getName());
   }
 
   /**
@@ -71,6 +60,16 @@ public final class SegmentFile {
     }
 
     return fileName.startsWith(journalName);
+  }
+
+  /**
+   * Returns a boolean value indicating whether the given file appears to be a parsable segment
+   * file.
+   *
+   * @throws NullPointerException if {@code file} is null
+   */
+  public static boolean isSegmentFile(final String name, final Path file) {
+    return isSegmentFile(name, file.getFileName().toString());
   }
 
   /**
@@ -99,17 +98,14 @@ public final class SegmentFile {
     }
   }
 
-  /** Creates a segment file for the given directory, log name, segment ID, and segment version. */
-  static File createSegmentFile(final String name, final File directory, final long id) {
-    return new File(
-        directory,
-        String.format(
-            "%s%s%d%s%s",
-            checkNotNull(name, "name cannot be null"),
-            PART_SEPARATOR,
-            id,
-            EXTENSION_SEPARATOR,
-            EXTENSION));
+  /** Creates a segment file for the given directory, log name, and segment ID. */
+  static Path createSegmentFile(final String name, final Path directory, final long id) {
+    return directory.resolve(
+        checkNotNull(name, "name cannot be null")
+            + PART_SEPARATOR
+            + id
+            + EXTENSION_SEPARATOR
+            + EXTENSION);
   }
 
   /**
@@ -117,12 +113,12 @@ public final class SegmentFile {
    *
    * @return The segment file.
    */
-  File file() {
+  Path file() {
     return file;
   }
 
   String name() {
-    return file.getName();
+    return file.getFileName().toString();
   }
 
   Path getFileMarkedForDeletion() {
@@ -130,8 +126,8 @@ public final class SegmentFile {
       final String renamedFileName =
           String.format(
               "%s%c%d-%s",
-              file.getName(), DELETE_EXTENSION_SEPARATOR, deletedFileIndex++, DELETE_EXTENSION);
-      fileMarkedForDeletion = Path.of(file.getParent(), renamedFileName);
+              file.getFileName(), DELETE_EXTENSION_SEPARATOR, deletedFileIndex++, DELETE_EXTENSION);
+      fileMarkedForDeletion = file.resolveSibling(renamedFileName);
     }
     return fileMarkedForDeletion;
   }

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentFile.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentFile.java
@@ -18,7 +18,6 @@ package io.camunda.zeebe.journal.file;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.io.File;
 import java.nio.file.Path;
 import org.jspecify.annotations.Nullable;
 
@@ -35,24 +34,14 @@ public final class SegmentFile {
   private static final String EXTENSION = "log";
   private static final String DELETE_EXTENSION = "deleted";
   private static final char DELETE_EXTENSION_SEPARATOR = '_';
-  private final File file;
+  private final Path file;
   private @Nullable Path fileMarkedForDeletion;
 
   /**
    * @throws IllegalArgumentException if {@code file} is not a valid segment file
    */
-  SegmentFile(final File file) {
+  SegmentFile(final Path file) {
     this.file = file;
-  }
-
-  /**
-   * Returns a boolean value indicating whether the given file appears to be a parsable segment
-   * file.
-   *
-   * @throws NullPointerException if {@code file} is null
-   */
-  public static boolean isSegmentFile(final String name, final File file) {
-    return isSegmentFile(name, file.getName());
   }
 
   /**
@@ -72,6 +61,16 @@ public final class SegmentFile {
     }
 
     return fileName.startsWith(journalName);
+  }
+
+  /**
+   * Returns a boolean value indicating whether the given file appears to be a parsable segment
+   * file.
+   *
+   * @throws NullPointerException if {@code file} is null
+   */
+  public static boolean isSegmentFile(final String name, final Path file) {
+    return isSegmentFile(name, file.getFileName().toString());
   }
 
   /**
@@ -100,17 +99,14 @@ public final class SegmentFile {
     }
   }
 
-  /** Creates a segment file for the given directory, log name, segment ID, and segment version. */
-  static File createSegmentFile(final String name, final File directory, final long id) {
-    return new File(
-        directory,
-        String.format(
-            "%s%s%d%s%s",
-            checkNotNull(name, "name cannot be null"),
-            PART_SEPARATOR,
-            id,
-            EXTENSION_SEPARATOR,
-            EXTENSION));
+  /** Creates a segment file for the given directory, log name, and segment ID. */
+  static Path createSegmentFile(final String name, final Path directory, final long id) {
+    return directory.resolve(
+        checkNotNull(name, "name cannot be null")
+            + PART_SEPARATOR
+            + id
+            + EXTENSION_SEPARATOR
+            + EXTENSION);
   }
 
   /**
@@ -118,12 +114,12 @@ public final class SegmentFile {
    *
    * @return The segment file.
    */
-  File file() {
+  Path file() {
     return file;
   }
 
   String name() {
-    return file.getName();
+    return file.getFileName().toString();
   }
 
   Path getFileMarkedForDeletion() {
@@ -131,11 +127,8 @@ public final class SegmentFile {
       final String renamedFileName =
           String.format(
               "%s%c%d-%s",
-              file.getName(), DELETE_EXTENSION_SEPARATOR, deletedFileIndex++, DELETE_EXTENSION);
-      final var parent =
-          checkNotNull(
-              file.toPath().getParent(), "Expected file %s to have a parent, but was null", file);
-      fileMarkedForDeletion = parent.resolve(renamedFileName);
+              file.getFileName(), DELETE_EXTENSION_SEPARATOR, deletedFileIndex++, DELETE_EXTENSION);
+      fileMarkedForDeletion = file.resolveSibling(renamedFileName);
     }
     return fileMarkedForDeletion;
   }

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentFile.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentFile.java
@@ -102,11 +102,13 @@ public final class SegmentFile {
   /** Creates a segment file for the given directory, log name, and segment ID. */
   static Path createSegmentFile(final String name, final Path directory, final long id) {
     return directory.resolve(
-        checkNotNull(name, "name cannot be null")
-            + PART_SEPARATOR
-            + id
-            + EXTENSION_SEPARATOR
-            + EXTENSION);
+        String.format(
+            "%s%c%d%c%s",
+            checkNotNull(name, "name cannot be null"),
+            PART_SEPARATOR,
+            id,
+            EXTENSION_SEPARATOR,
+            EXTENSION));
   }
 
   /**
@@ -116,10 +118,6 @@ public final class SegmentFile {
    */
   Path file() {
     return file;
-  }
-
-  String name() {
-    return file.getFileName().toString();
   }
 
   Path getFileMarkedForDeletion() {

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentLoader.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentLoader.java
@@ -110,7 +110,7 @@ final class SegmentLoader {
           e);
     }
     return new UninitializedSegment(
-        new SegmentFile(segmentFile.toFile()),
+        new SegmentFile(segmentFile),
         descriptor.id(),
         descriptor.maxSegmentSize(),
         mappedSegment,
@@ -155,7 +155,7 @@ final class SegmentLoader {
       final SegmentDescriptorSerializer descriptorSerializer,
       final long lastWrittenAsqn,
       final JournalIndex journalIndex) {
-    final SegmentFile segmentFile = new SegmentFile(file.toFile());
+    final SegmentFile segmentFile = new SegmentFile(file);
     return new Segment(
         segmentFile,
         descriptor,
@@ -216,8 +216,8 @@ final class SegmentLoader {
     }
   }
 
-  private void checkDiskSpace(final Path segmentPath, final int maxSegmentSize) {
-    final var available = segmentPath.getParent().toFile().getUsableSpace();
+  private void checkDiskSpace(final Path segmentPath, final int maxSegmentSize) throws IOException {
+    final var available = Files.getFileStore(segmentPath.getParent()).getUsableSpace();
     final var required = Math.max(maxSegmentSize, minFreeDiskSpace);
     if (available < required) {
       throw new JournalException.OutOfDiskSpace(

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentLoader.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentLoader.java
@@ -112,7 +112,7 @@ final class SegmentLoader {
           e);
     }
     return new UninitializedSegment(
-        new SegmentFile(segmentFile.toFile()),
+        new SegmentFile(segmentFile),
         descriptor.id(),
         descriptor.maxSegmentSize(),
         mappedSegment,
@@ -157,7 +157,7 @@ final class SegmentLoader {
       final SegmentDescriptorSerializer descriptorSerializer,
       final long lastWrittenAsqn,
       final JournalIndex journalIndex) {
-    final SegmentFile segmentFile = new SegmentFile(file.toFile());
+    final SegmentFile segmentFile = new SegmentFile(file);
     return new Segment(
         segmentFile,
         descriptor,
@@ -218,12 +218,12 @@ final class SegmentLoader {
     }
   }
 
-  private void checkDiskSpace(final Path segmentPath, final int maxSegmentSize) {
+  private void checkDiskSpace(final Path segmentPath, final int maxSegmentSize) throws IOException {
     final var parent =
         requireNonNull(
             segmentPath.getParent(),
             () -> String.format("Expected file %s to have a parent but it was null", segmentPath));
-    final var available = parent.toFile().getUsableSpace();
+    final var available = Files.getFileStore(parent).getUsableSpace();
     final var required = Math.max(maxSegmentSize, minFreeDiskSpace);
     if (available < required) {
       throw new JournalException.OutOfDiskSpace(

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
@@ -207,7 +207,7 @@ public final class SegmentedJournal implements Journal {
 
     final var segmentPaths =
         tailSegments.values().stream()
-            .map(segment -> segment.file().file().toPath())
+            .map(segment -> segment.file().file())
             .collect(Collectors.toList());
 
     final var firstAsqn = findFirstAsqn(tailSegments);

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
@@ -220,7 +220,7 @@ public final class SegmentedJournal implements Journal {
 
     final var segmentPaths =
         tailSegments.values().stream()
-            .map(segment -> segment.file().file().toPath())
+            .map(segment -> segment.file().file())
             .collect(Collectors.toList());
 
     final var firstAsqn = findFirstAsqn(tailSegments);

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalBuilder.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalBuilder.java
@@ -22,6 +22,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import io.camunda.zeebe.journal.JournalMetaStore;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.io.File;
+import java.nio.file.Path;
 
 /** Raft log builder. */
 @SuppressWarnings("UnusedReturnValue")
@@ -38,7 +39,7 @@ public class SegmentedJournalBuilder {
   private static final int DEFAULT_PARTITION_ID = -1;
 
   protected String name = DEFAULT_NAME;
-  protected File directory = new File(DEFAULT_DIRECTORY);
+  protected Path directory = Path.of(DEFAULT_DIRECTORY);
   protected int maxSegmentSize = DEFAULT_MAX_SEGMENT_SIZE;
 
   private long freeDiskSpace = DEFAULT_MIN_FREE_DISK_SPACE;
@@ -74,7 +75,7 @@ public class SegmentedJournalBuilder {
    * @throws NullPointerException If the {@code directory} is {@code null}
    */
   public SegmentedJournalBuilder withDirectory(final String directory) {
-    return withDirectory(new File(checkNotNull(directory, "directory cannot be null")));
+    return withDirectory(Path.of(checkNotNull(directory, "directory cannot be null")));
   }
 
   /**
@@ -86,9 +87,21 @@ public class SegmentedJournalBuilder {
    * @return The journal builder.
    * @throws NullPointerException If the {@code directory} is {@code null}
    */
-  public SegmentedJournalBuilder withDirectory(final File directory) {
+  public SegmentedJournalBuilder withDirectory(final Path directory) {
     this.directory = checkNotNull(directory, "directory cannot be null");
     return this;
+  }
+
+  /**
+   * Sets the journal directory, returning the builder for method chaining.
+   *
+   * @param directory The journal directory.
+   * @return The journal builder.
+   * @deprecated Use {@link #withDirectory(Path)} instead.
+   */
+  @Deprecated
+  public SegmentedJournalBuilder withDirectory(final File directory) {
+    return withDirectory(checkNotNull(directory, "directory cannot be null").toPath());
   }
 
   /**

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalBuilder.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalBuilder.java
@@ -23,6 +23,7 @@ import static java.util.Objects.requireNonNull;
 import io.camunda.zeebe.journal.JournalMetaStore;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.io.File;
+import java.nio.file.Path;
 import org.jspecify.annotations.Nullable;
 
 /** Raft log builder. */
@@ -40,7 +41,7 @@ public class SegmentedJournalBuilder {
   private static final int DEFAULT_PARTITION_ID = -1;
 
   protected String name = DEFAULT_NAME;
-  protected File directory = new File(DEFAULT_DIRECTORY);
+  protected Path directory = Path.of(DEFAULT_DIRECTORY);
   protected int maxSegmentSize = DEFAULT_MAX_SEGMENT_SIZE;
 
   private long freeDiskSpace = DEFAULT_MIN_FREE_DISK_SPACE;
@@ -76,7 +77,7 @@ public class SegmentedJournalBuilder {
    * @throws NullPointerException If the {@code directory} is {@code null}
    */
   public SegmentedJournalBuilder withDirectory(final String directory) {
-    return withDirectory(new File(checkNotNull(directory, "directory cannot be null")));
+    return withDirectory(Path.of(checkNotNull(directory, "directory cannot be null")));
   }
 
   /**
@@ -88,9 +89,21 @@ public class SegmentedJournalBuilder {
    * @return The journal builder.
    * @throws NullPointerException If the {@code directory} is {@code null}
    */
-  public SegmentedJournalBuilder withDirectory(final File directory) {
+  public SegmentedJournalBuilder withDirectory(final Path directory) {
     this.directory = checkNotNull(directory, "directory cannot be null");
     return this;
+  }
+
+  /**
+   * Sets the journal directory, returning the builder for method chaining.
+   *
+   * @param directory The journal directory.
+   * @return The journal builder.
+   * @deprecated Use {@link #withDirectory(Path)} instead.
+   */
+  @Deprecated
+  public SegmentedJournalBuilder withDirectory(final File directory) {
+    return withDirectory(checkNotNull(directory, "directory cannot be null").toPath());
   }
 
   /**

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
@@ -13,15 +13,12 @@ import io.camunda.zeebe.journal.CorruptedJournalException;
 import io.camunda.zeebe.journal.JournalException;
 import io.camunda.zeebe.journal.JournalMetaStore;
 import io.camunda.zeebe.util.logging.ThrottledLogger;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -51,7 +48,7 @@ final class SegmentsManager implements AutoCloseable {
   private final JournalMetrics journalMetrics;
   private final JournalIndex journalIndex;
   private final int maxSegmentSize;
-  private final File directory;
+  private final Path directory;
   private final SegmentLoader segmentLoader;
   private final String name;
   private final JournalMetaStore metaStore;
@@ -61,7 +58,7 @@ final class SegmentsManager implements AutoCloseable {
   SegmentsManager(
       final JournalIndex journalIndex,
       final int maxSegmentSize,
-      final File directory,
+      final Path directory,
       final String name,
       final SegmentLoader segmentLoader,
       final JournalMetrics journalMetrics,
@@ -339,13 +336,12 @@ final class SegmentsManager implements AutoCloseable {
 
   private UninitializedSegment createUninitializedSegment(final SegmentDescriptor descriptor) {
     final var segmentFile = SegmentFile.createSegmentFile(name, directory, descriptor.id());
-    return segmentLoader.createUninitializedSegment(segmentFile.toPath(), descriptor, journalIndex);
+    return segmentLoader.createUninitializedSegment(segmentFile, descriptor, journalIndex);
   }
 
   private Segment createSegment(final SegmentDescriptor descriptor, final long lastWrittenAsqn) {
     final var segmentFile = SegmentFile.createSegmentFile(name, directory, descriptor.id());
-    return segmentLoader.createSegment(
-        segmentFile.toPath(), descriptor, lastWrittenAsqn, journalIndex);
+    return segmentLoader.createSegment(segmentFile, descriptor, lastWrittenAsqn, journalIndex);
   }
 
   /**
@@ -353,24 +349,29 @@ final class SegmentsManager implements AutoCloseable {
    *
    * @return A collection of segments for the log.
    */
-  private Collection<Segment> loadSegments() {
+  private List<Segment> loadSegments() {
     final var lastFlushedIndex = metaStore.loadLastFlushedIndex();
 
     // Ensure log directories are created.
-    //noinspection ResultOfMethodCallIgnored
-    directory.mkdirs();
+    try {
+      Files.createDirectories(directory);
+    } catch (final IOException e) {
+      throw new JournalException(
+          String.format("Failed to create journal directory '%s'", directory), e);
+    }
+
     final List<Segment> segments = new ArrayList<>();
 
-    final List<File> files = getSortedLogSegments();
+    final List<Path> files = getSortedLogSegments();
     Segment previousSegment = null;
     for (int i = 0; i < files.size(); i++) {
-      final File file = files.get(i);
+      final Path file = files.get(i);
 
       try {
-        LOG.debug("Found segment file: {}", file.getName());
+        LOG.debug("Found segment file: {}", file.getFileName());
         final Segment segment =
             segmentLoader.loadExistingSegment(
-                file.toPath(),
+                file,
                 previousSegment != null ? previousSegment.lastAsqn() : INITIAL_ASQN,
                 journalIndex);
 
@@ -411,7 +412,7 @@ final class SegmentsManager implements AutoCloseable {
 
   /** Returns true if segments after corrupted segment were deleted; false, otherwise */
   private boolean handleSegmentCorruption(
-      final List<File> files,
+      final List<Path> files,
       final List<Segment> segments,
       final int failedIndex,
       final long lastFlushedIndex) {
@@ -435,53 +436,58 @@ final class SegmentsManager implements AutoCloseable {
   }
 
   private void deleteUnflushedSegments(
-      final List<File> files, final int failedIndex, final long lastFlushedIndex) {
+      final List<Path> files, final int failedIndex, final long lastFlushedIndex) {
     LOG.debug(
         "Found corrupted segment after last ack'ed index {}. Deleting segments {} - {}",
         lastFlushedIndex,
-        files.get(failedIndex).getName(),
-        files.get(files.size() - 1).getName());
+        files.get(failedIndex).getFileName(),
+        files.get(files.size() - 1).getFileName());
 
     for (int i = failedIndex; i < files.size(); i++) {
-      final File file = files.get(i);
+      final Path file = files.get(i);
       try {
-        Files.delete(file.toPath());
+        Files.delete(file);
       } catch (final IOException e) {
         throw new JournalException(
             String.format(
-                "Failed to delete log segment '%s' when handling corruption.", file.getName()),
+                "Failed to delete log segment '%s' when handling corruption.", file.getFileName()),
             e);
       }
     }
   }
 
-  /** Returns an array of valid log segments sorted by their id which may be empty but not null. */
-  private List<File> getSortedLogSegments() {
-    final File[] files =
-        directory.listFiles(file -> file.isFile() && SegmentFile.isSegmentFile(name, file));
-
-    if (files == null) {
+  /** Returns a list of valid log segments sorted by their id which may be empty but not null. */
+  private List<Path> getSortedLogSegments() {
+    if (!Files.isDirectory(directory)) {
       throw new IllegalStateException(
           String.format(
               "Could not list files in directory '%s'. Either the path doesn't point to a directory or an I/O error occurred.",
               directory));
     }
 
-    Arrays.sort(files, Comparator.comparingInt(f -> SegmentFile.getSegmentIdFromPath(f.getName())));
-
-    return Arrays.asList(files);
+    try (final var stream = Files.list(directory)) {
+      return stream
+          .filter(p -> Files.isRegularFile(p) && SegmentFile.isSegmentFile(name, p))
+          .sorted(
+              Comparator.comparingInt(
+                  p -> SegmentFile.getSegmentIdFromPath(p.getFileName().toString())))
+          .toList();
+    } catch (final IOException e) {
+      throw new JournalException(
+          String.format("Failed to list segment files in directory '%s'", directory), e);
+    }
   }
 
   private void deleteDeferredFiles() {
     try (final DirectoryStream<Path> segmentsToDelete =
         Files.newDirectoryStream(
-            directory.toPath(),
+            directory,
             path -> SegmentFile.isDeletedSegmentFile(name, path.getFileName().toString()))) {
       segmentsToDelete.forEach(this::deleteDeferredFile);
     } catch (final IOException e) {
       LOG.warn(
           "Could not delete segment files marked for deletion in {}. This can result in unnecessary disk usage.",
-          directory.toPath(),
+          directory,
           e);
     }
   }

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
@@ -14,15 +14,12 @@ import io.camunda.zeebe.journal.CorruptedJournalException;
 import io.camunda.zeebe.journal.JournalException;
 import io.camunda.zeebe.journal.JournalMetaStore;
 import io.camunda.zeebe.util.logging.ThrottledLogger;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -53,7 +50,7 @@ final class SegmentsManager implements AutoCloseable {
   private final JournalMetrics journalMetrics;
   private final JournalIndex journalIndex;
   private final int maxSegmentSize;
-  private final File directory;
+  private final Path directory;
   private final SegmentLoader segmentLoader;
   private final String name;
   private final JournalMetaStore metaStore;
@@ -63,7 +60,7 @@ final class SegmentsManager implements AutoCloseable {
   SegmentsManager(
       final JournalIndex journalIndex,
       final int maxSegmentSize,
-      final File directory,
+      final Path directory,
       final String name,
       final SegmentLoader segmentLoader,
       final JournalMetrics journalMetrics,
@@ -341,13 +338,12 @@ final class SegmentsManager implements AutoCloseable {
 
   private UninitializedSegment createUninitializedSegment(final SegmentDescriptor descriptor) {
     final var segmentFile = SegmentFile.createSegmentFile(name, directory, descriptor.id());
-    return segmentLoader.createUninitializedSegment(segmentFile.toPath(), descriptor, journalIndex);
+    return segmentLoader.createUninitializedSegment(segmentFile, descriptor, journalIndex);
   }
 
   private Segment createSegment(final SegmentDescriptor descriptor, final long lastWrittenAsqn) {
     final var segmentFile = SegmentFile.createSegmentFile(name, directory, descriptor.id());
-    return segmentLoader.createSegment(
-        segmentFile.toPath(), descriptor, lastWrittenAsqn, journalIndex);
+    return segmentLoader.createSegment(segmentFile, descriptor, lastWrittenAsqn, journalIndex);
   }
 
   /**
@@ -355,24 +351,29 @@ final class SegmentsManager implements AutoCloseable {
    *
    * @return A collection of segments for the log.
    */
-  private Collection<Segment> loadSegments() {
+  private List<Segment> loadSegments() {
     final var lastFlushedIndex = metaStore.loadLastFlushedIndex();
 
     // Ensure log directories are created.
-    //noinspection ResultOfMethodCallIgnored
-    directory.mkdirs();
+    try {
+      Files.createDirectories(directory);
+    } catch (final IOException e) {
+      throw new JournalException(
+          String.format("Failed to create journal directory '%s'", directory), e);
+    }
+
     final List<Segment> segments = new ArrayList<>();
 
-    final List<File> files = getSortedLogSegments();
+    final List<Path> files = getSortedLogSegments();
     Segment previousSegment = null;
     for (int i = 0; i < files.size(); i++) {
-      final File file = files.get(i);
+      final Path file = files.get(i);
 
       try {
-        LOG.debug("Found segment file: {}", file.getName());
+        LOG.debug("Found segment file: {}", file.getFileName());
         final Segment segment =
             segmentLoader.loadExistingSegment(
-                file.toPath(),
+                file,
                 previousSegment != null ? previousSegment.lastAsqn() : INITIAL_ASQN,
                 journalIndex);
 
@@ -413,7 +414,7 @@ final class SegmentsManager implements AutoCloseable {
 
   /** Returns true if segments after corrupted segment were deleted; false, otherwise */
   private boolean handleSegmentCorruption(
-      final List<File> files,
+      final List<Path> files,
       final List<Segment> segments,
       final int failedIndex,
       final long lastFlushedIndex) {
@@ -437,53 +438,58 @@ final class SegmentsManager implements AutoCloseable {
   }
 
   private void deleteUnflushedSegments(
-      final List<File> files, final int failedIndex, final long lastFlushedIndex) {
+      final List<Path> files, final int failedIndex, final long lastFlushedIndex) {
     LOG.debug(
         "Found corrupted segment after last ack'ed index {}. Deleting segments {} - {}",
         lastFlushedIndex,
-        files.get(failedIndex).getName(),
-        files.get(files.size() - 1).getName());
+        files.get(failedIndex).getFileName(),
+        files.get(files.size() - 1).getFileName());
 
     for (int i = failedIndex; i < files.size(); i++) {
-      final File file = files.get(i);
+      final Path file = files.get(i);
       try {
-        Files.delete(file.toPath());
+        Files.delete(file);
       } catch (final IOException e) {
         throw new JournalException(
             String.format(
-                "Failed to delete log segment '%s' when handling corruption.", file.getName()),
+                "Failed to delete log segment '%s' when handling corruption.", file.getFileName()),
             e);
       }
     }
   }
 
-  /** Returns an array of valid log segments sorted by their id which may be empty but not null. */
-  private List<File> getSortedLogSegments() {
-    final File[] files =
-        directory.listFiles(file -> file.isFile() && SegmentFile.isSegmentFile(name, file));
-
-    if (files == null) {
+  /** Returns a list of valid log segments sorted by their id which may be empty but not null. */
+  private List<Path> getSortedLogSegments() {
+    if (!Files.isDirectory(directory)) {
       throw new IllegalStateException(
           String.format(
               "Could not list files in directory '%s'. Either the path doesn't point to a directory or an I/O error occurred.",
               directory));
     }
 
-    Arrays.sort(files, Comparator.comparingInt(f -> SegmentFile.getSegmentIdFromPath(f.getName())));
-
-    return Arrays.asList(files);
+    try (final var stream = Files.list(directory)) {
+      return stream
+          .filter(p -> Files.isRegularFile(p) && SegmentFile.isSegmentFile(name, p))
+          .sorted(
+              Comparator.comparingInt(
+                  p -> SegmentFile.getSegmentIdFromPath(p.getFileName().toString())))
+          .toList();
+    } catch (final IOException e) {
+      throw new JournalException(
+          String.format("Failed to list segment files in directory '%s'", directory), e);
+    }
   }
 
   private void deleteDeferredFiles() {
     try (final DirectoryStream<Path> segmentsToDelete =
         Files.newDirectoryStream(
-            directory.toPath(),
+            directory,
             path -> SegmentFile.isDeletedSegmentFile(name, path.getFileName().toString()))) {
       segmentsToDelete.forEach(this::deleteDeferredFile);
     } catch (final IOException e) {
       LOG.warn(
           "Could not delete segment files marked for deletion in {}. This can result in unnecessary disk usage.",
-          directory.toPath(),
+          directory,
           e);
     }
   }

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/JournalAppendTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/JournalAppendTest.java
@@ -65,7 +65,7 @@ final class JournalAppendTest {
   private SegmentedJournal openJournal(final Consumer<SegmentedJournalBuilder> option) {
     final var builder =
         SegmentedJournal.builder(meterRegistry)
-            .withDirectory(directory.resolve("data").toFile())
+            .withDirectory(directory.resolve("data"))
             .withMaxSegmentSize(1024 * 1024) // speeds up certain tests, e.g. shouldCompact
             .withMetaStore(metaStore)
             .withJournalIndexDensity(5);
@@ -89,7 +89,7 @@ final class JournalAppendTest {
     // given
     try (final var receiverJournal =
         SegmentedJournal.builder(meterRegistry)
-            .withDirectory(directory.resolve("data-2").toFile())
+            .withDirectory(directory.resolve("data-2"))
             .withJournalIndexDensity(5)
             .withMetaStore(new MockJournalMetastore())
             .build()) {
@@ -141,7 +141,7 @@ final class JournalAppendTest {
     // given
     try (final var receiverJournal =
         SegmentedJournal.builder(meterRegistry)
-            .withDirectory(directory.resolve("data-2").toFile())
+            .withDirectory(directory.resolve("data-2"))
             .withJournalIndexDensity(5)
             .withMetaStore(new MockJournalMetastore())
             .build()) {
@@ -189,7 +189,7 @@ final class JournalAppendTest {
     // given
     try (final var receiverJournal =
         SegmentedJournal.builder(meterRegistry)
-            .withDirectory(directory.resolve("data-2").toFile())
+            .withDirectory(directory.resolve("data-2"))
             .withJournalIndexDensity(5)
             .withMetaStore(new MockJournalMetastore())
             .build()) {
@@ -234,7 +234,7 @@ final class JournalAppendTest {
     // given
     try (final var receiverJournal =
         SegmentedJournal.builder(meterRegistry)
-            .withDirectory(directory.resolve("data-2").toFile())
+            .withDirectory(directory.resolve("data-2"))
             .withJournalIndexDensity(5)
             .withMetaStore(new MockJournalMetastore())
             .build()) {
@@ -257,7 +257,7 @@ final class JournalAppendTest {
     // given
     try (final var receiverJournal =
         SegmentedJournal.builder(meterRegistry)
-            .withDirectory(directory.resolve("data-2").toFile())
+            .withDirectory(directory.resolve("data-2"))
             .withJournalIndexDensity(5)
             .withMetaStore(new MockJournalMetastore())
             .build()) {
@@ -296,7 +296,7 @@ final class JournalAppendTest {
     // given
     try (final var receiverJournal =
         SegmentedJournal.builder(meterRegistry)
-            .withDirectory(directory.resolve("data-2").toFile())
+            .withDirectory(directory.resolve("data-2"))
             .withJournalIndexDensity(5)
             .withMetaStore(new MockJournalMetastore())
             .build()) {
@@ -330,7 +330,7 @@ final class JournalAppendTest {
     // given
     try (final var receiverJournal =
         SegmentedJournal.builder(meterRegistry)
-            .withDirectory(directory.resolve("data-2").toFile())
+            .withDirectory(directory.resolve("data-2"))
             .withJournalIndexDensity(5)
             .withMetaStore(new MockJournalMetastore())
             .build()) {

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/JournalAppendTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/JournalAppendTest.java
@@ -65,7 +65,7 @@ final class JournalAppendTest {
   private SegmentedJournal openJournal(final Consumer<SegmentedJournalBuilder> option) {
     final var builder =
         SegmentedJournal.builder(meterRegistry)
-            .withDirectory(directory.resolve("data").toFile())
+            .withDirectory(directory.resolve("data"))
             .withMaxSegmentSize(1024 * 1024) // speeds up certain tests, e.g. shouldCompact
             .withMetaStore(metaStore)
             .withJournalIndexDensity(5);
@@ -89,7 +89,7 @@ final class JournalAppendTest {
     // given
     try (final var receiverJournal =
         SegmentedJournal.builder(meterRegistry)
-            .withDirectory(directory.resolve("data-2").toFile())
+            .withDirectory(directory.resolve("data-2"))
             .withJournalIndexDensity(5)
             .withMetaStore(new MockJournalMetastore())
             .build()) {
@@ -141,7 +141,7 @@ final class JournalAppendTest {
     // given
     try (final var receiverJournal =
         SegmentedJournal.builder(meterRegistry)
-            .withDirectory(directory.resolve("data-2").toFile())
+            .withDirectory(directory.resolve("data-2"))
             .withJournalIndexDensity(5)
             .withMetaStore(new MockJournalMetastore())
             .build()) {
@@ -189,7 +189,7 @@ final class JournalAppendTest {
     // given
     try (final var receiverJournal =
         SegmentedJournal.builder(meterRegistry)
-            .withDirectory(directory.resolve("data-2").toFile())
+            .withDirectory(directory.resolve("data-2"))
             .withJournalIndexDensity(5)
             .withMetaStore(new MockJournalMetastore())
             .build()) {
@@ -239,7 +239,7 @@ final class JournalAppendTest {
     // given
     try (final var receiverJournal =
         SegmentedJournal.builder(meterRegistry)
-            .withDirectory(directory.resolve("data-2").toFile())
+            .withDirectory(directory.resolve("data-2"))
             .withJournalIndexDensity(5)
             .withMetaStore(new MockJournalMetastore())
             .build()) {
@@ -262,7 +262,7 @@ final class JournalAppendTest {
     // given
     try (final var receiverJournal =
         SegmentedJournal.builder(meterRegistry)
-            .withDirectory(directory.resolve("data-2").toFile())
+            .withDirectory(directory.resolve("data-2"))
             .withJournalIndexDensity(5)
             .withMetaStore(new MockJournalMetastore())
             .build()) {
@@ -301,7 +301,7 @@ final class JournalAppendTest {
     // given
     try (final var receiverJournal =
         SegmentedJournal.builder(meterRegistry)
-            .withDirectory(directory.resolve("data-2").toFile())
+            .withDirectory(directory.resolve("data-2"))
             .withJournalIndexDensity(5)
             .withMetaStore(new MockJournalMetastore())
             .build()) {
@@ -335,7 +335,7 @@ final class JournalAppendTest {
     // given
     try (final var receiverJournal =
         SegmentedJournal.builder(meterRegistry)
-            .withDirectory(directory.resolve("data-2").toFile())
+            .withDirectory(directory.resolve("data-2"))
             .withJournalIndexDensity(5)
             .withMetaStore(new MockJournalMetastore())
             .build()) {

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/JournalReaderTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/JournalReaderTest.java
@@ -16,7 +16,6 @@ import io.camunda.zeebe.util.buffer.BufferWriter;
 import io.camunda.zeebe.util.buffer.DirectBufferWriter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import org.agrona.CloseHelper;
@@ -39,11 +38,9 @@ final class JournalReaderTest {
 
   @BeforeEach
   public void setup(final @TempDir Path tempDir) {
-    final File directory = tempDir.resolve("data").toFile();
-
     journal =
         SegmentedJournal.builder(meterRegistry)
-            .withDirectory(directory)
+            .withDirectory(tempDir.resolve("data"))
             .withJournalIndexDensity(5)
             .withMetaStore(new MockJournalMetastore())
             .build();

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/JournalTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/JournalTest.java
@@ -22,12 +22,11 @@ import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.camunda.zeebe.util.buffer.DirectBufferWriter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import java.io.File;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.Consumer;
 import org.agrona.CloseHelper;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -508,8 +507,8 @@ final class JournalTest {
     recordDataWriter.wrap(new UnsafeBuffer("000".getBytes(StandardCharsets.UTF_8)));
     journal.append(recordDataWriter);
     final var secondRecord = copyRecord(journal.append(recordDataWriter));
-    final File dataFile = Objects.requireNonNull(directory.toFile().listFiles())[0];
-    final File log = Objects.requireNonNull(dataFile.listFiles())[0];
+    final Path dataFile = Files.list(directory).findFirst().orElseThrow();
+    final Path log = Files.list(dataFile).findFirst().orElseThrow();
 
     // when
     journal.close();
@@ -527,8 +526,8 @@ final class JournalTest {
     recordDataWriter.wrap(new UnsafeBuffer("000".getBytes(StandardCharsets.UTF_8)));
     final var firstRecord = copyRecord(journal.append(recordDataWriter));
     final var secondRecord = copyRecord(journal.append(recordDataWriter));
-    final File dataFile = Objects.requireNonNull(directory.toFile().listFiles())[0];
-    final File log = Objects.requireNonNull(dataFile.listFiles())[0];
+    final Path dataFile = Files.list(directory).findFirst().orElseThrow();
+    final Path log = Files.list(dataFile).findFirst().orElseThrow();
 
     // when
     journal.close();
@@ -580,7 +579,7 @@ final class JournalTest {
   private SegmentedJournal openJournal(final Consumer<SegmentedJournalBuilder> option) {
     final var builder =
         SegmentedJournal.builder(meterRegistry)
-            .withDirectory(directory.resolve("data").toFile())
+            .withDirectory(directory.resolve("data"))
             .withMaxSegmentSize(1024 * 1024) // speeds up certain tests, e.g. shouldCompact
             .withMetaStore(metaStore)
             .withJournalIndexDensity(5);

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/JournalTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/JournalTest.java
@@ -507,8 +507,14 @@ final class JournalTest {
     recordDataWriter.wrap(new UnsafeBuffer("000".getBytes(StandardCharsets.UTF_8)));
     journal.append(recordDataWriter);
     final var secondRecord = copyRecord(journal.append(recordDataWriter));
-    final Path dataFile = Files.list(directory).findFirst().orElseThrow();
-    final Path log = Files.list(dataFile).findFirst().orElseThrow();
+    final Path dataFile;
+    try (final var stream = Files.list(directory)) {
+      dataFile = stream.findFirst().orElseThrow();
+    }
+    final Path log;
+    try (final var stream = Files.list(dataFile)) {
+      log = stream.findFirst().orElseThrow();
+    }
 
     // when
     journal.close();
@@ -526,8 +532,14 @@ final class JournalTest {
     recordDataWriter.wrap(new UnsafeBuffer("000".getBytes(StandardCharsets.UTF_8)));
     final var firstRecord = copyRecord(journal.append(recordDataWriter));
     final var secondRecord = copyRecord(journal.append(recordDataWriter));
-    final Path dataFile = Files.list(directory).findFirst().orElseThrow();
-    final Path log = Files.list(dataFile).findFirst().orElseThrow();
+    final Path dataFile;
+    try (final var stream = Files.list(directory)) {
+      dataFile = stream.findFirst().orElseThrow();
+    }
+    final Path log;
+    try (final var stream = Files.list(dataFile)) {
+      log = stream.findFirst().orElseThrow();
+    }
 
     // when
     journal.close();

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/JournalTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/JournalTest.java
@@ -510,8 +510,14 @@ final class JournalTest {
         new DirectBufferWriter(new UnsafeBuffer("000".getBytes(StandardCharsets.UTF_8)));
     journal.append(recordDataWriter);
     final var secondRecord = copyRecord(journal.append(recordDataWriter));
-    final Path dataFile = Files.list(directory).findFirst().orElseThrow();
-    final Path log = Files.list(dataFile).findFirst().orElseThrow();
+    final Path dataFile;
+    try (final var stream = Files.list(directory)) {
+      dataFile = stream.findFirst().orElseThrow();
+    }
+    final Path log;
+    try (final var stream = Files.list(dataFile)) {
+      log = stream.findFirst().orElseThrow();
+    }
 
     // when
     journal.close();
@@ -530,8 +536,14 @@ final class JournalTest {
         new DirectBufferWriter(new UnsafeBuffer("000".getBytes(StandardCharsets.UTF_8)));
     final var firstRecord = copyRecord(journal.append(recordDataWriter));
     final var secondRecord = copyRecord(journal.append(recordDataWriter));
-    final Path dataFile = Files.list(directory).findFirst().orElseThrow();
-    final Path log = Files.list(dataFile).findFirst().orElseThrow();
+    final Path dataFile;
+    try (final var stream = Files.list(directory)) {
+      dataFile = stream.findFirst().orElseThrow();
+    }
+    final Path log;
+    try (final var stream = Files.list(dataFile)) {
+      log = stream.findFirst().orElseThrow();
+    }
 
     // when
     journal.close();

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/JournalTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/JournalTest.java
@@ -22,12 +22,11 @@ import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.camunda.zeebe.util.buffer.DirectBufferWriter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import java.io.File;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.Consumer;
 import org.agrona.CloseHelper;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -511,8 +510,8 @@ final class JournalTest {
         new DirectBufferWriter(new UnsafeBuffer("000".getBytes(StandardCharsets.UTF_8)));
     journal.append(recordDataWriter);
     final var secondRecord = copyRecord(journal.append(recordDataWriter));
-    final File dataFile = Objects.requireNonNull(directory.toFile().listFiles())[0];
-    final File log = Objects.requireNonNull(dataFile.listFiles())[0];
+    final Path dataFile = Files.list(directory).findFirst().orElseThrow();
+    final Path log = Files.list(dataFile).findFirst().orElseThrow();
 
     // when
     journal.close();
@@ -531,8 +530,8 @@ final class JournalTest {
         new DirectBufferWriter(new UnsafeBuffer("000".getBytes(StandardCharsets.UTF_8)));
     final var firstRecord = copyRecord(journal.append(recordDataWriter));
     final var secondRecord = copyRecord(journal.append(recordDataWriter));
-    final File dataFile = Objects.requireNonNull(directory.toFile().listFiles())[0];
-    final File log = Objects.requireNonNull(dataFile.listFiles())[0];
+    final Path dataFile = Files.list(directory).findFirst().orElseThrow();
+    final Path log = Files.list(dataFile).findFirst().orElseThrow();
 
     // when
     journal.close();
@@ -586,7 +585,7 @@ final class JournalTest {
   private SegmentedJournal openJournal(final Consumer<SegmentedJournalBuilder> option) {
     final var builder =
         SegmentedJournal.builder(meterRegistry)
-            .withDirectory(directory.resolve("data").toFile())
+            .withDirectory(directory.resolve("data"))
             .withMaxSegmentSize(1024 * 1024) // speeds up certain tests, e.g. shouldCompact
             .withMetaStore(metaStore)
             .withJournalIndexDensity(5);

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/LogCorrupter.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/LogCorrupter.java
@@ -9,13 +9,10 @@ package io.camunda.zeebe.journal.file;
 
 import io.camunda.zeebe.journal.record.JournalRecordReaderUtil;
 import io.camunda.zeebe.journal.record.SBESerializer;
-import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 public final class LogCorrupter {
 
@@ -26,51 +23,24 @@ public final class LogCorrupter {
    * @param index index of record to be corrupted
    * @return true if the specified record was successfully corrupted; otherwise, returns false
    */
-  public static boolean corruptRecord(final File file, final long index) throws IOException {
-    final byte[] bytes = new byte[Math.toIntExact(file.length())];
-    int read;
-
-    try (final BufferedInputStream in = new BufferedInputStream(new FileInputStream(file))) {
-      final int available = in.available();
-      read = in.read(bytes, 0, bytes.length);
-
-      // reached EOF
-      if (read == -1) {
-        read = available;
-      }
-    }
+  public static boolean corruptRecord(final Path file, final long index) throws IOException {
+    final byte[] bytes = Files.readAllBytes(file);
 
     if (!corruptRecord(bytes, index)) {
       return false;
     }
 
-    try (final BufferedOutputStream out = new BufferedOutputStream(new FileOutputStream(file))) {
-      out.write(bytes, 0, read);
-    }
-
+    Files.write(file, bytes);
     return true;
   }
 
-  public static void corruptDescriptor(final File file) throws IOException {
-    final byte[] bytes = new byte[SegmentDescriptorSerializer.currentEncodingLength()];
-    int read;
-
-    try (final BufferedInputStream in = new BufferedInputStream(new FileInputStream(file))) {
-      final int available = in.available();
-      read = in.read(bytes, 0, bytes.length);
-
-      // reached EOF
-      if (read == -1) {
-        read = available;
-      }
-    }
+  public static void corruptDescriptor(final Path file) throws IOException {
+    final byte[] bytes = Files.readAllBytes(file);
 
     final byte schemaId = bytes[MessageHeaderDecoder.schemaIdEncodingOffset() + 1];
     bytes[MessageHeaderDecoder.schemaIdEncodingOffset() + 1] = (byte) ~schemaId;
 
-    try (final BufferedOutputStream out = new BufferedOutputStream(new FileOutputStream(file))) {
-      out.write(bytes, 0, read);
-    }
+    Files.write(file, bytes);
   }
 
   private static boolean corruptRecord(final byte[] bytes, final long targetIndex) {

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalReaderTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalReaderTest.java
@@ -56,7 +56,7 @@ class SegmentedJournalReaderTest {
 
     journal =
         SegmentedJournal.builder(meterRegistry)
-            .withDirectory(directory.resolve("data").toFile())
+            .withDirectory(directory.resolve("data"))
             .withMaxSegmentSize(
                 entrySize * ENTRIES_PER_SEGMENT
                     + SegmentDescriptorSerializer.currentEncodingLength())

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalReaderTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalReaderTest.java
@@ -51,7 +51,7 @@ class SegmentedJournalReaderTest {
 
     journal =
         SegmentedJournal.builder(meterRegistry)
-            .withDirectory(directory.resolve("data").toFile())
+            .withDirectory(directory.resolve("data"))
             .withMaxSegmentSize(
                 entrySize * ENTRIES_PER_SEGMENT
                     + SegmentDescriptorSerializer.currentEncodingLength())

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
@@ -35,14 +35,13 @@ import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.camunda.zeebe.util.buffer.DirectBufferWriter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import java.io.File;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Objects;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
@@ -549,10 +548,9 @@ class SegmentedJournalTest {
   @Test
   void shouldContinueAppendAfterDetectingPartiallyWrittenDescriptor() throws Exception {
     // given
-    final File dataFile = directory.resolve("data").toFile();
-    assertThat(dataFile.mkdirs()).isTrue();
-    final File emptyLog = new File(dataFile, "journal-1.log");
-    assertThat(emptyLog.createNewFile()).isTrue();
+    final Path dataFile = directory.resolve("data");
+    Files.createDirectories(dataFile);
+    Files.createFile(dataFile.resolve("journal-1.log"));
 
     // when
     journal = openJournal(10);
@@ -571,9 +569,12 @@ class SegmentedJournalTest {
     // given
     journal = openJournal(1);
     journal.close();
-    final File dataFile = directory.resolve("data").toFile();
-    final File logFile =
-        Objects.requireNonNull(dataFile.listFiles(f -> f.getName().endsWith(".log")))[0];
+    final Path dataFile = directory.resolve("data");
+    final Path logFile =
+        Files.list(dataFile)
+            .filter(p -> p.getFileName().toString().endsWith(".log"))
+            .findFirst()
+            .orElseThrow();
     LogCorrupter.corruptDescriptor(logFile);
 
     // when/then
@@ -609,9 +610,12 @@ class SegmentedJournalTest {
     journal.close();
     journalFactory.metaStore().storeLastFlushedIndex(lastFlushedIndex);
 
-    final File dataFile = directory.resolve("data").toFile();
-    final File logFile =
-        Objects.requireNonNull(dataFile.listFiles(f -> f.getName().endsWith("2.log")))[0];
+    final Path dataFile = directory.resolve("data");
+    final Path logFile =
+        Files.list(dataFile)
+            .filter(p -> p.getFileName().toString().endsWith("2.log"))
+            .findFirst()
+            .orElseThrow();
     LogCorrupter.corruptDescriptor(logFile);
 
     // when/then
@@ -640,11 +644,11 @@ class SegmentedJournalTest {
     journal.reset(100);
 
     // then
-    final File logDirectory = directory.resolve("data").toFile();
+    final Path logDirectory = directory.resolve("data");
     assertThat(logDirectory)
         .isDirectoryContaining(
-            file -> SegmentFile.isDeletedSegmentFile(JOURNAL_NAME, file.getName()))
-        .isDirectoryContaining(file -> SegmentFile.isSegmentFile(JOURNAL_NAME, file.getName()));
+            p -> SegmentFile.isDeletedSegmentFile(JOURNAL_NAME, p.getFileName().toString()))
+        .isDirectoryContaining(p -> SegmentFile.isSegmentFile(JOURNAL_NAME, p));
   }
 
   @Test
@@ -714,11 +718,11 @@ class SegmentedJournalTest {
     reader.close();
 
     // then
-    final File logDirectory = directory.resolve("data").toFile();
+    final Path logDirectory = directory.resolve("data");
     assertThat(logDirectory)
         .isDirectoryNotContaining(
-            file -> SegmentFile.isDeletedSegmentFile(JOURNAL_NAME, file.getName()))
-        .isDirectoryContaining(file -> SegmentFile.isSegmentFile(JOURNAL_NAME, file.getName()));
+            p -> SegmentFile.isDeletedSegmentFile(JOURNAL_NAME, p.getFileName().toString()))
+        .isDirectoryContaining(p -> SegmentFile.isSegmentFile(JOURNAL_NAME, p));
   }
 
   @Test
@@ -731,15 +735,15 @@ class SegmentedJournalTest {
     journal.reset(100);
 
     // then
-    final File logDirectory = directory.resolve("data").toFile();
+    final Path logDirectory = directory.resolve("data");
     assertThat(logDirectory)
         .isDirectoryNotContaining(
-            file -> SegmentFile.isDeletedSegmentFile(JOURNAL_NAME, file.getName()))
-        .isDirectoryContaining(file -> SegmentFile.isSegmentFile(JOURNAL_NAME, file.getName()));
+            p -> SegmentFile.isDeletedSegmentFile(JOURNAL_NAME, p.getFileName().toString()))
+        .isDirectoryContaining(p -> SegmentFile.isSegmentFile(JOURNAL_NAME, p));
   }
 
   @Test
-  void shouldBeAbleToResetAgainWhileThePreviousFileIsNotDeleted() {
+  void shouldBeAbleToResetAgainWhileThePreviousFileIsNotDeleted() throws Exception {
     // given
     journal = openJournal(2);
     journal.append(journalFactory.entry());
@@ -751,15 +755,19 @@ class SegmentedJournalTest {
     journal.reset(200);
 
     // then
-    final File logDirectory = directory.resolve("data").toFile();
+    final Path logDirectory = directory.resolve("data");
 
     // there are two files deferred for deletion
     assertThat(
-            logDirectory.listFiles(
-                file -> SegmentFile.isDeletedSegmentFile(JOURNAL_NAME, file.getName())))
+            Files.list(logDirectory)
+                .filter(
+                    p -> SegmentFile.isDeletedSegmentFile(JOURNAL_NAME, p.getFileName().toString()))
+                .toList())
         .hasSize(2);
     assertThat(
-            logDirectory.listFiles(file -> SegmentFile.isSegmentFile(JOURNAL_NAME, file.getName())))
+            Files.list(logDirectory)
+                .filter(p -> SegmentFile.isSegmentFile(JOURNAL_NAME, p))
+                .toList())
         .hasSize(1);
   }
 
@@ -799,9 +807,9 @@ class SegmentedJournalTest {
         SegmentedJournal.builder(meterRegistry)
             .withSegmentAllocator(SegmentAllocator.defaultAllocator())
             .withMaxSegmentSize(segmentSize)
-            .withDirectory(tmpDir.toFile())
+            .withDirectory(tmpDir)
             .withMetaStore(new MockJournalMetastore());
-    final File firstSegment;
+    final Path firstSegment;
 
     // when
     try (final var journal = builder.build()) {
@@ -822,9 +830,9 @@ class SegmentedJournalTest {
         SegmentedJournal.builder(meterRegistry)
             .withSegmentAllocator(SegmentAllocator.noop())
             .withMaxSegmentSize(segmentSize)
-            .withDirectory(tmpDir.toFile())
+            .withDirectory(tmpDir)
             .withMetaStore(new MockJournalMetastore());
-    final File firstSegment;
+    final Path firstSegment;
 
     // when
     try (final var journal = builder.build()) {

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
@@ -570,11 +570,11 @@ class SegmentedJournalTest {
     journal = openJournal(1);
     journal.close();
     final Path dataFile = directory.resolve("data");
-    final Path logFile =
-        Files.list(dataFile)
-            .filter(p -> p.getFileName().toString().endsWith(".log"))
-            .findFirst()
-            .orElseThrow();
+    final Path logFile;
+    try (final var stream = Files.list(dataFile)) {
+      logFile =
+          stream.filter(p -> p.getFileName().toString().endsWith(".log")).findFirst().orElseThrow();
+    }
     LogCorrupter.corruptDescriptor(logFile);
 
     // when/then
@@ -611,11 +611,14 @@ class SegmentedJournalTest {
     journalFactory.metaStore().storeLastFlushedIndex(lastFlushedIndex);
 
     final Path dataFile = directory.resolve("data");
-    final Path logFile =
-        Files.list(dataFile)
-            .filter(p -> p.getFileName().toString().endsWith("2.log"))
-            .findFirst()
-            .orElseThrow();
+    final Path logFile;
+    try (final var stream = Files.list(dataFile)) {
+      logFile =
+          stream
+              .filter(p -> p.getFileName().toString().endsWith("2.log"))
+              .findFirst()
+              .orElseThrow();
+    }
     LogCorrupter.corruptDescriptor(logFile);
 
     // when/then
@@ -758,17 +761,20 @@ class SegmentedJournalTest {
     final Path logDirectory = directory.resolve("data");
 
     // there are two files deferred for deletion
-    assertThat(
-            Files.list(logDirectory)
-                .filter(
-                    p -> SegmentFile.isDeletedSegmentFile(JOURNAL_NAME, p.getFileName().toString()))
-                .toList())
-        .hasSize(2);
-    assertThat(
-            Files.list(logDirectory)
-                .filter(p -> SegmentFile.isSegmentFile(JOURNAL_NAME, p))
-                .toList())
-        .hasSize(1);
+    try (final var stream = Files.list(logDirectory)) {
+      assertThat(
+              stream
+                  .filter(
+                      p ->
+                          SegmentFile.isDeletedSegmentFile(
+                              JOURNAL_NAME, p.getFileName().toString()))
+                  .toList())
+          .hasSize(2);
+    }
+    try (final var stream = Files.list(logDirectory)) {
+      assertThat(stream.filter(p -> SegmentFile.isSegmentFile(JOURNAL_NAME, p)).toList())
+          .hasSize(1);
+    }
   }
 
   @Test

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
@@ -692,11 +692,11 @@ class SegmentedJournalTest {
     journal = openJournal(1);
     journal.close();
     final Path dataFile = directory.resolve("data");
-    final Path logFile =
-        Files.list(dataFile)
-            .filter(p -> p.getFileName().toString().endsWith(".log"))
-            .findFirst()
-            .orElseThrow();
+    final Path logFile;
+    try (final var stream = Files.list(dataFile)) {
+      logFile =
+          stream.filter(p -> p.getFileName().toString().endsWith(".log")).findFirst().orElseThrow();
+    }
     LogCorrupter.corruptDescriptor(logFile);
 
     // when/then
@@ -734,11 +734,14 @@ class SegmentedJournalTest {
     journalFactory.metaStore().storeLastFlushedIndex(lastFlushedIndex);
 
     final Path dataFile = directory.resolve("data");
-    final Path logFile =
-        Files.list(dataFile)
-            .filter(p -> p.getFileName().toString().endsWith("2.log"))
-            .findFirst()
-            .orElseThrow();
+    final Path logFile;
+    try (final var stream = Files.list(dataFile)) {
+      logFile =
+          stream
+              .filter(p -> p.getFileName().toString().endsWith("2.log"))
+              .findFirst()
+              .orElseThrow();
+    }
     LogCorrupter.corruptDescriptor(logFile);
 
     // when/then
@@ -881,17 +884,20 @@ class SegmentedJournalTest {
     final Path logDirectory = directory.resolve("data");
 
     // there are two files deferred for deletion
-    assertThat(
-            Files.list(logDirectory)
-                .filter(
-                    p -> SegmentFile.isDeletedSegmentFile(JOURNAL_NAME, p.getFileName().toString()))
-                .toList())
-        .hasSize(2);
-    assertThat(
-            Files.list(logDirectory)
-                .filter(p -> SegmentFile.isSegmentFile(JOURNAL_NAME, p))
-                .toList())
-        .hasSize(1);
+    try (final var stream = Files.list(logDirectory)) {
+      assertThat(
+              stream
+                  .filter(
+                      p ->
+                          SegmentFile.isDeletedSegmentFile(
+                              JOURNAL_NAME, p.getFileName().toString()))
+                  .toList())
+          .hasSize(2);
+    }
+    try (final var stream = Files.list(logDirectory)) {
+      assertThat(stream.filter(p -> SegmentFile.isSegmentFile(JOURNAL_NAME, p)).toList())
+          .hasSize(1);
+    }
   }
 
   @Test

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
@@ -35,14 +35,13 @@ import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.camunda.zeebe.util.buffer.DirectBufferWriter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import java.io.File;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Objects;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
@@ -671,10 +670,9 @@ class SegmentedJournalTest {
   @Test
   void shouldContinueAppendAfterDetectingPartiallyWrittenDescriptor() throws Exception {
     // given
-    final File dataFile = directory.resolve("data").toFile();
-    assertThat(dataFile.mkdirs()).isTrue();
-    final File emptyLog = new File(dataFile, "journal-1.log");
-    assertThat(emptyLog.createNewFile()).isTrue();
+    final Path dataFile = directory.resolve("data");
+    Files.createDirectories(dataFile);
+    Files.createFile(dataFile.resolve("journal-1.log"));
 
     // when
     journal = openJournal(10);
@@ -693,9 +691,12 @@ class SegmentedJournalTest {
     // given
     journal = openJournal(1);
     journal.close();
-    final File dataFile = directory.resolve("data").toFile();
-    final File logFile =
-        Objects.requireNonNull(dataFile.listFiles(f -> f.getName().endsWith(".log")))[0];
+    final Path dataFile = directory.resolve("data");
+    final Path logFile =
+        Files.list(dataFile)
+            .filter(p -> p.getFileName().toString().endsWith(".log"))
+            .findFirst()
+            .orElseThrow();
     LogCorrupter.corruptDescriptor(logFile);
 
     // when/then
@@ -732,9 +733,12 @@ class SegmentedJournalTest {
     journal.close();
     journalFactory.metaStore().storeLastFlushedIndex(lastFlushedIndex);
 
-    final File dataFile = directory.resolve("data").toFile();
-    final File logFile =
-        Objects.requireNonNull(dataFile.listFiles(f -> f.getName().endsWith("2.log")))[0];
+    final Path dataFile = directory.resolve("data");
+    final Path logFile =
+        Files.list(dataFile)
+            .filter(p -> p.getFileName().toString().endsWith("2.log"))
+            .findFirst()
+            .orElseThrow();
     LogCorrupter.corruptDescriptor(logFile);
 
     // when/then
@@ -763,11 +767,11 @@ class SegmentedJournalTest {
     journal.reset(100);
 
     // then
-    final File logDirectory = directory.resolve("data").toFile();
+    final Path logDirectory = directory.resolve("data");
     assertThat(logDirectory)
         .isDirectoryContaining(
-            file -> SegmentFile.isDeletedSegmentFile(JOURNAL_NAME, file.getName()))
-        .isDirectoryContaining(file -> SegmentFile.isSegmentFile(JOURNAL_NAME, file.getName()));
+            p -> SegmentFile.isDeletedSegmentFile(JOURNAL_NAME, p.getFileName().toString()))
+        .isDirectoryContaining(p -> SegmentFile.isSegmentFile(JOURNAL_NAME, p));
   }
 
   @Test
@@ -837,11 +841,11 @@ class SegmentedJournalTest {
     reader.close();
 
     // then
-    final File logDirectory = directory.resolve("data").toFile();
+    final Path logDirectory = directory.resolve("data");
     assertThat(logDirectory)
         .isDirectoryNotContaining(
-            file -> SegmentFile.isDeletedSegmentFile(JOURNAL_NAME, file.getName()))
-        .isDirectoryContaining(file -> SegmentFile.isSegmentFile(JOURNAL_NAME, file.getName()));
+            p -> SegmentFile.isDeletedSegmentFile(JOURNAL_NAME, p.getFileName().toString()))
+        .isDirectoryContaining(p -> SegmentFile.isSegmentFile(JOURNAL_NAME, p));
   }
 
   @Test
@@ -854,15 +858,15 @@ class SegmentedJournalTest {
     journal.reset(100);
 
     // then
-    final File logDirectory = directory.resolve("data").toFile();
+    final Path logDirectory = directory.resolve("data");
     assertThat(logDirectory)
         .isDirectoryNotContaining(
-            file -> SegmentFile.isDeletedSegmentFile(JOURNAL_NAME, file.getName()))
-        .isDirectoryContaining(file -> SegmentFile.isSegmentFile(JOURNAL_NAME, file.getName()));
+            p -> SegmentFile.isDeletedSegmentFile(JOURNAL_NAME, p.getFileName().toString()))
+        .isDirectoryContaining(p -> SegmentFile.isSegmentFile(JOURNAL_NAME, p));
   }
 
   @Test
-  void shouldBeAbleToResetAgainWhileThePreviousFileIsNotDeleted() {
+  void shouldBeAbleToResetAgainWhileThePreviousFileIsNotDeleted() throws Exception {
     // given
     journal = openJournal(2);
     journal.append(journalFactory.entry());
@@ -874,15 +878,19 @@ class SegmentedJournalTest {
     journal.reset(200);
 
     // then
-    final File logDirectory = directory.resolve("data").toFile();
+    final Path logDirectory = directory.resolve("data");
 
     // there are two files deferred for deletion
     assertThat(
-            logDirectory.listFiles(
-                file -> SegmentFile.isDeletedSegmentFile(JOURNAL_NAME, file.getName())))
+            Files.list(logDirectory)
+                .filter(
+                    p -> SegmentFile.isDeletedSegmentFile(JOURNAL_NAME, p.getFileName().toString()))
+                .toList())
         .hasSize(2);
     assertThat(
-            logDirectory.listFiles(file -> SegmentFile.isSegmentFile(JOURNAL_NAME, file.getName())))
+            Files.list(logDirectory)
+                .filter(p -> SegmentFile.isSegmentFile(JOURNAL_NAME, p))
+                .toList())
         .hasSize(1);
   }
 
@@ -922,9 +930,9 @@ class SegmentedJournalTest {
         SegmentedJournal.builder(meterRegistry)
             .withSegmentAllocator(SegmentAllocator.defaultAllocator())
             .withMaxSegmentSize(segmentSize)
-            .withDirectory(tmpDir.toFile())
+            .withDirectory(tmpDir)
             .withMetaStore(new MockJournalMetastore());
-    final File firstSegment;
+    final Path firstSegment;
 
     // when
     try (final var journal = builder.build()) {
@@ -945,9 +953,9 @@ class SegmentedJournalTest {
         SegmentedJournal.builder(meterRegistry)
             .withSegmentAllocator(SegmentAllocator.noop())
             .withMaxSegmentSize(segmentSize)
-            .withDirectory(tmpDir.toFile())
+            .withDirectory(tmpDir)
             .withMetaStore(new MockJournalMetastore());
-    final File firstSegment;
+    final Path firstSegment;
 
     // when
     try (final var journal = builder.build()) {

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalWriterTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalWriterTest.java
@@ -127,7 +127,7 @@ final class SegmentedJournalWriterTest {
     final var corruptedDescriptor =
         descriptor.withUpdatedIndices(
             descriptor.lastIndex(), firstSegment.descriptor().lastPosition() + 1);
-    final var segmentFile = firstSegment.file().file().toPath();
+    final var segmentFile = firstSegment.file().file();
     try (final FileChannel channel =
         FileChannel.open(segmentFile, StandardOpenOption.READ, StandardOpenOption.WRITE)) {
       final MappedByteBuffer buffer =

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsManagerTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsManagerTest.java
@@ -14,8 +14,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.zeebe.journal.CorruptedJournalException;
 import io.camunda.zeebe.test.util.junit.RegressionTest;
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -56,11 +56,11 @@ class SegmentsManagerTest {
     try (final var newSegments = journalFactory.segmentsManager(directory)) {
       newSegments.open();
       // then
-      final File logDirectory = directory.resolve("data").toFile();
+      final Path logDirectory = directory.resolve("data");
       assertThat(logDirectory)
           .isDirectoryNotContaining(
-              file -> SegmentFile.isDeletedSegmentFile(JOURNAL_NAME, file.getName()))
-          .isDirectoryContaining(file -> SegmentFile.isSegmentFile(JOURNAL_NAME, file.getName()));
+              p -> SegmentFile.isDeletedSegmentFile(JOURNAL_NAME, p.getFileName().toString()))
+          .isDirectoryContaining(p -> SegmentFile.isSegmentFile(JOURNAL_NAME, p));
     }
   }
 
@@ -71,9 +71,12 @@ class SegmentsManagerTest {
       journal.append(journalFactory.entry()).index();
     }
 
-    final File dataFile = directory.resolve("data").toFile();
-    final File logFile =
-        Objects.requireNonNull(dataFile.listFiles(f -> f.getName().endsWith(".log")))[0];
+    final Path dataFile = directory.resolve("data");
+    final Path logFile =
+        Files.list(dataFile)
+            .filter(p -> p.getFileName().toString().endsWith(".log"))
+            .findFirst()
+            .orElseThrow();
     LogCorrupter.corruptDescriptor(logFile);
 
     // when/then
@@ -91,9 +94,12 @@ class SegmentsManagerTest {
     }
     journalFactory.metaStore().storeLastFlushedIndex(index);
 
-    final File dataFile = directory.resolve("data").toFile();
-    final File logFile =
-        Objects.requireNonNull(dataFile.listFiles(f -> f.getName().endsWith("2.log")))[0];
+    final Path dataFile = directory.resolve("data");
+    final Path logFile =
+        Files.list(dataFile)
+            .filter(p -> p.getFileName().toString().endsWith("2.log"))
+            .findFirst()
+            .orElseThrow();
     LogCorrupter.corruptDescriptor(logFile);
 
     // when
@@ -111,9 +117,12 @@ class SegmentsManagerTest {
     // given
     final var journal = openJournal();
     journal.close();
-    final File dataFile = directory.resolve("data").toFile();
-    final File logFile =
-        Objects.requireNonNull(dataFile.listFiles(f -> f.getName().endsWith(".log")))[0];
+    final Path dataFile = directory.resolve("data");
+    final Path logFile =
+        Files.list(dataFile)
+            .filter(p -> p.getFileName().toString().endsWith(".log"))
+            .findFirst()
+            .orElseThrow();
     LogCorrupter.corruptDescriptor(logFile);
 
     // when
@@ -185,10 +194,9 @@ class SegmentsManagerTest {
   @Test
   void shouldHandlePartiallyWrittenDescriptor() throws Exception {
     // given
-    final File dataFile = directory.resolve("data").toFile();
-    assertThat(dataFile.mkdirs()).isTrue();
-    final File emptyLog = new File(dataFile, "journal-1.log");
-    assertThat(emptyLog.createNewFile()).isTrue();
+    final Path dataFile = directory.resolve("data");
+    Files.createDirectories(dataFile);
+    Files.createFile(dataFile.resolve("journal-1.log"));
 
     // when
     segments = journalFactory.segmentsManager(directory);

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsManagerTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsManagerTest.java
@@ -72,11 +72,11 @@ class SegmentsManagerTest {
     }
 
     final Path dataFile = directory.resolve("data");
-    final Path logFile =
-        Files.list(dataFile)
-            .filter(p -> p.getFileName().toString().endsWith(".log"))
-            .findFirst()
-            .orElseThrow();
+    final Path logFile;
+    try (final var stream = Files.list(dataFile)) {
+      logFile =
+          stream.filter(p -> p.getFileName().toString().endsWith(".log")).findFirst().orElseThrow();
+    }
     LogCorrupter.corruptDescriptor(logFile);
 
     // when/then
@@ -95,11 +95,14 @@ class SegmentsManagerTest {
     journalFactory.metaStore().storeLastFlushedIndex(index);
 
     final Path dataFile = directory.resolve("data");
-    final Path logFile =
-        Files.list(dataFile)
-            .filter(p -> p.getFileName().toString().endsWith("2.log"))
-            .findFirst()
-            .orElseThrow();
+    final Path logFile;
+    try (final var stream = Files.list(dataFile)) {
+      logFile =
+          stream
+              .filter(p -> p.getFileName().toString().endsWith("2.log"))
+              .findFirst()
+              .orElseThrow();
+    }
     LogCorrupter.corruptDescriptor(logFile);
 
     // when
@@ -118,11 +121,11 @@ class SegmentsManagerTest {
     final var journal = openJournal();
     journal.close();
     final Path dataFile = directory.resolve("data");
-    final Path logFile =
-        Files.list(dataFile)
-            .filter(p -> p.getFileName().toString().endsWith(".log"))
-            .findFirst()
-            .orElseThrow();
+    final Path logFile;
+    try (final var stream = Files.list(dataFile)) {
+      logFile =
+          stream.filter(p -> p.getFileName().toString().endsWith(".log")).findFirst().orElseThrow();
+    }
     LogCorrupter.corruptDescriptor(logFile);
 
     // when

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/TestJournalFactory.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/TestJournalFactory.java
@@ -110,13 +110,7 @@ final class TestJournalFactory {
   SegmentsManager segmentsManager(
       final Path directory, final SegmentLoader loader, final JournalMetaStore metaStore) {
     return new SegmentsManager(
-        index,
-        maxSegmentSize(),
-        directory.resolve("data").toFile(),
-        "journal",
-        loader,
-        metrics,
-        metaStore);
+        index, maxSegmentSize(), directory.resolve("data"), "journal", loader, metrics, metaStore);
   }
 
   SegmentedJournal journal(final SegmentsManager segments) {

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/util/PosixPathAssert.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/util/PosixPathAssert.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.journal.util;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
@@ -31,10 +30,6 @@ public final class PosixPathAssert extends AbstractPathAssert<PosixPathAssert> {
 
   public static PosixPathAssert assertThat(final Path path) {
     return new PosixPathAssert(path);
-  }
-
-  public static PosixPathAssert assertThat(final File file) {
-    return assertThat(file.toPath());
   }
 
   /**


### PR DESCRIPTION
## Summary

- Replaces `java.io.File` with `java.nio.file.Path` in `SegmentFile`, `SegmentsManager`, and `SegmentedJournalBuilder` (with a `@Deprecated` `File` adapter kept for backward compat)
- Replaces `File.getUsableSpace()` with `Files.getFileStore().getUsableSpace()` in `SegmentLoader.checkDiskSpace()`
- Replaces buffered IO stream stack in `LogCorrupter` with `Files.readAllBytes`/`Files.write`
- Updates all call sites in tests to use `Path` directly, eliminating `.toFile()` / `.file().toPath()` round-trips

`RandomAccessFile` is intentionally kept in `SegmentLoader.mapNewSegment()` to avoid potential performance regressions from switching to an alternative file extension strategy.

## Related issues
closes #7605
