### PR TITLE
feat(broker): add configurable cache size for BoundedCommandCache

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/BoundedCommandCache.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/BoundedCommandCache.java
@@ -28,6 +28,11 @@ import org.agrona.collections.LongHashSet;
 public final class BoundedCommandCache {
   private static final int DEFAULT_CAPACITY = 100_000;
 
+  /** Returns the default capacity of the command cache. */
+  public static int defaultCapacity() {
+    return DEFAULT_CAPACITY;
+  }
+
   private final Lock lock = new ReentrantLock();
 
   private final int capacity;

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/BoundedScheduledCommandCache.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/BoundedScheduledCommandCache.java
@@ -21,7 +21,7 @@ import org.agrona.collections.LongHashSet;
  * A thread safe bounded command cache. It will only cache intent and key pairs for the intents it
  * was originally built with. The underlying cache map is pre-populated with a {@link
  * BoundedCommandCache} per intent. Thus, the bound of the complete cache is sum of the bounds of
- * the mapped caches, i.e. the number of intents times the cache capacity (fixed at 100,000).
+ * the mapped caches, i.e. the number of intents times the cache capacity.
  *
  * <p>NOTE: the staged cache return via {@link #stage()} is not thread-safe!
  */
@@ -40,19 +40,37 @@ public final class BoundedScheduledCommandCache implements StageableScheduledCom
   }
 
   /**
-   * Returns a bounded cache which will only cache commands for the given intents.
+   * Returns a bounded cache which will only cache commands for the given intents, using the default
+   * capacity.
    *
+   * @param metrics the metrics to report cache size changes
    * @param intents the intents to cache
    * @return a thread-safe command cache
    */
   public static BoundedScheduledCommandCache ofIntent(
       final ScheduledCommandCacheMetrics metrics, final Intent... intents) {
+    return ofIntent(metrics, BoundedCommandCache.defaultCapacity(), intents);
+  }
+
+  /**
+   * Returns a bounded cache which will only cache commands for the given intents, with a custom
+   * capacity per intent cache.
+   *
+   * @param metrics the metrics to report cache size changes
+   * @param capacity the capacity per intent cache
+   * @param intents the intents to cache
+   * @return a thread-safe command cache
+   */
+  public static BoundedScheduledCommandCache ofIntent(
+      final ScheduledCommandCacheMetrics metrics,
+      final int capacity,
+      final Intent... intents) {
     final Map<Intent, BoundedCommandCache> caches =
         Arrays.stream(intents)
             .collect(
                 Collectors.toMap(
                     Function.identity(),
-                    intent -> new BoundedCommandCache(metrics.forIntent(intent))));
+                    intent -> new BoundedCommandCache(capacity, metrics.forIntent(intent))));
     return new BoundedScheduledCommandCache(caches);
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ProcessingCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ProcessingCfg.java
@@ -17,6 +17,7 @@ public final class ProcessingCfg implements ConfigurationEntry {
   private boolean enableAsyncScheduledTasks = true;
   private Duration scheduledTaskCheckInterval = Duration.ofSeconds(1);
   private Set<Long> skipPositions;
+  private int scheduledCommandCacheCapacity = 100_000;
 
   @Override
   public void init(final BrokerCfg globalConfig, final String brokerBase) {
@@ -28,6 +29,11 @@ public final class ProcessingCfg implements ConfigurationEntry {
       throw new IllegalArgumentException(
           "scheduledTaskCheckInterval must be positive but was %s"
               .formatted(scheduledTaskCheckInterval));
+    }
+    if (scheduledCommandCacheCapacity < 1) {
+      throw new IllegalArgumentException(
+          "scheduledCommandCacheCapacity must be >= 1 but was %s"
+              .formatted(scheduledCommandCacheCapacity));
     }
   }
 
@@ -55,6 +61,14 @@ public final class ProcessingCfg implements ConfigurationEntry {
     this.skipPositions = skipPositions;
   }
 
+  public int getScheduledCommandCacheCapacity() {
+    return scheduledCommandCacheCapacity;
+  }
+
+  public void setScheduledCommandCacheCapacity(final int scheduledCommandCacheCapacity) {
+    this.scheduledCommandCacheCapacity = scheduledCommandCacheCapacity;
+  }
+
   @Override
   public String toString() {
     return "ProcessingCfg{"
@@ -64,6 +78,8 @@ public final class ProcessingCfg implements ConfigurationEntry {
         + enableAsyncScheduledTasks
         + ", scheduledTaskCheckInterval="
         + scheduledTaskCheckInterval
+        + ", scheduledCommandCacheCapacity="
+        + scheduledCommandCacheCapacity
         + '}';
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
@@ -152,9 +152,12 @@ public final class StreamProcessorTransitionStep implements PartitionTransitionS
                 engine.getCurrentPartitionCount(
                     context.getBrokerCfg().getCluster().getPartitionsCount()));
 
+    final var scheduledCommandCacheCapacity =
+        context.getBrokerCfg().getProcessing().getScheduledCommandCacheCapacity();
     final var scheduledCommandCache =
         BoundedScheduledCommandCache.ofIntent(
             new BoundedCommandCacheMetrics(context.getPartitionTransitionMeterRegistry()),
+            scheduledCommandCacheCapacity,
             TimerIntent.TRIGGER,
             JobIntent.TIME_OUT,
             JobIntent.RECUR_AFTER_BACKOFF,


### PR DESCRIPTION
When dealing with timer bombs or other scenarios that generate large numbers of scheduled commands, the hardcoded 100,000 entry capacity of BoundedCommandCache can become a bottleneck during cluster recovery. I hit this while investigating a recovery scenario where we had more timers in state than the cache could hold.

This change adds `processing.scheduledCommandCacheCapacity` as a configuration option so operators can tune the cache size to match their workload. The default stays at 100,000 to keep existing behavior unchanged.

The implementation adds:
- A new `scheduledCommandCacheCapacity` field in `ProcessingCfg` with validation
- A `defaultCapacity()` static method in `BoundedCommandCache` so the default is defined in one place
- An overloaded `ofIntent()` factory method in `BoundedScheduledCommandCache` that accepts the capacity
- Wiring in `StreamProcessorTransitionStep` to read the config and pass it through

Example configuration:

```yaml
zeebe:
  broker:
    processing:
      scheduledCommandCacheCapacity: 200000
```

Closes #48541