### PR TITLE
test: fix two nightly E2E failures on main

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/hto-user-flows.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/hto-user-flows.spec.ts
@@ -148,7 +148,12 @@ test.describe('HTO User Flow Tests', () => {
       await taskDetailsPage.clickAssignToMeButton();
       await taskDetailsPage.fillTextInput('Name*', 'Test User');
       await taskDetailsPage.clickCompleteTaskButton();
-      await expect(taskDetailsPage.taskCompletedBanner).toBeVisible();
+      // Default 10s timeout races indexing of the completed task on slower
+      // CI runners; mirror the 60s used by the deployed-form completion
+      // tests in task-details.spec.ts.
+      await expect(taskDetailsPage.taskCompletedBanner).toBeVisible({
+        timeout: 60000,
+      });
 
       await navigateToApp(page, 'operate');
       await loginPage.login('demo', 'demo');

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts
@@ -357,7 +357,13 @@ test.describe('Process Instance Modifications', () => {
       );
       await operateProcessInstancePage.clickDialogCancel();
 
-      await operateProcessInstancePage.navigateToRootScope();
+      // After closing the dialog we are still scoped to the added "Never
+      // fails" token, where the modification we just deleted lived. Its
+      // `newVariables[0]` row should be gone here. The previous version of
+      // this test navigated to the root scope before asserting hidden — but
+      // root still has its own pending `test3:1` modification (added in the
+      // first step), so that row remains visible there and the assertion
+      // always failed.
       await expect(
         operateProcessInstancePage.getVariableTestId('newVariables[0]'),
       ).toBeHidden({timeout: 30000});


### PR DESCRIPTION
## Summary

Fixes the failing test and stabilizes the flaky test from the [May 18 main nightly](https://github.com/camunda/camunda/actions/runs/26010629800).

### `processInstanceModifications.spec.ts:332` — failing
> A variable modification from a specific scope can be removed from the Apply Modifications dialog

The test:
1. Adds `test3:1` at root scope (`Without Incidents Process`).
2. Navigates to the added `Never fails` token in the history tree.
3. Adds another `test3:1` at that added-token scope.
4. Opens the Apply Modifications dialog and deletes the `Never fails`-scoped one.
5. Closes the dialog, then **`navigateToRootScope()`**, then asserts `variable-newVariables[0]` is hidden.

But root still has its own pending `test3:1` from step 1 — that row stays visible at root, so the `toBeHidden` always fails in CI (it passed locally by timing chance). The pre-refactor version of this test asserted hidden at the *same* scope where the deleted modification lived (the added token), which is where the assertion is meaningful. Drop the `navigateToRootScope()` to restore that behavior; the subsequent dialog re-open still validates the remaining modification has scope `Without Incidents Process`.

### `hto-user-flows.spec.ts:125` — flaky
> Form.js Integration with User Task

`expect(taskDetailsPage.taskCompletedBanner).toBeVisible()` used the default 10s timeout. Tasklist indexing of a just-completed task races that on slower CI runners — failed initial run, passed retry. Bump to 60s, mirroring the deployed-form task-completion tests in `task-details.spec.ts`.


## Validation
https://github.com/camunda/camunda/actions/runs/26023596218 -> e2e all 🟢 

## Test plan
- [x] `npx tsc --noEmit` — no new TS errors introduced
- [x] `npx eslint` on changed files — clean
- [x] `processInstanceModifications.spec.ts:332` passes locally (full `Add variable modifications` describe block, 4 tests, all green)
- [x] `hto-user-flows.spec.ts:125` passes locally
- [ ] Re-run nightly E2E on `main` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)