### PR TITLE
fix: rename console.overrideConfiguration to console.configuration for 8.10 preview env

### DIFF
--- a/.ci/preview-environments/charts/c8sm/values.yaml
+++ b/.ci/preview-environments/charts/c8sm/values.yaml
@@ -129,7 +129,7 @@ camunda-platform:
     #   registry: camunda/console
     # Overrides the default service URL because the preview environment
     # is exposed through its own (separate)ingress controller.
-    overrideConfiguration: |
+    configuration: |
       camunda:
         console:
           managed:


### PR DESCRIPTION
## What went wrong

PR #52959 bumped the `camunda-platform` Helm chart dependency for the 8.10 preview environment from `14.0.0-alpha5` to `15.0.0-alpha1`, but did not update `values.yaml` to match the breaking API change introduced in that version.

The chart `15.0.0-alpha1` removed the `console.overrideConfiguration` key and replaced it with `console.configuration`. The chart enforces this via a hard constraint in `constraints.tpl` that calls `fail` (hard template error, exit code 1) whenever the old key is present — so every deploy attempt fails before any Kubernetes resource is created.

Failing job: https://github.com/camunda/camunda/actions/runs/26019605597/job/76479331426

Error:
```
[camunda][error] The Helm values file key "console.overrideConfiguration" has been removed.
For more details, please check Camunda Helm chart documentation.
```

## Changes

Rename `console.overrideConfiguration` → `console.configuration` in `.ci/preview-environments/charts/c8sm/values.yaml`. The value content is unchanged — `console.configuration` in 15.x uses the same `tplvalues.render` helper, so the Go-templated YAML string for console URL overrides works identically.

## Related

Caused by: #52959