### PR TITLE
test: serialize get-process-instance-statistics-by-error API tests

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/incident/get-process-instance-statistics-by-error-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/incident/get-process-instance-statistics-by-error-api-tests.spec.ts
@@ -31,8 +31,7 @@ import {
 } from '@requestHelpers';
 import {cleanupUsers} from 'utils/usersCleanup';
 
-test.describe
-  .parallel('Get Process Instance Statistics By Error API Tests', () => {
+test.describe('Get Process Instance Statistics By Error API Tests', () => {
   let userWithResourcesAuthorizationToSendRequest: {
     username: string;
     name: string;


### PR DESCRIPTION
## Summary

Fixes the failing tests in the [May 18 main RDBMS nightly](https://github.com/camunda/camunda/actions/runs/26010097336/job/76449290787) (MariaDB 11.8 job).

All three failing tests live in `get-process-instance-statistics-by-error-api-tests.spec.ts`. Each shows 0ms runtime and fails inside the file's \`beforeAll\` (line 57) with one of:

- \`apiRequestContext.post: Request context disposed.\`
- \`apiRequestContext.post: Fixture { request } from beforeAll cannot be reused in a test.\`

This is the classic symptom of \`test.describe.parallel\` queuing more tests than available CI workers: per-test \`request\` fixtures get reused for a subsequent test's \`beforeAll\`, and by then the first test has already disposed the context.

The sibling `get-process-instance-statistics-by-definition-api-tests.spec.ts` has the same shape and happened to pass in this run, but it can hit the same race. For now this PR fixes only the file that failed today.


## Change

Drop `test.describe.parallel` → use the default \`test.describe\`. Tests within the describe now share a single worker and a single \`beforeAll\` execution; the file itself still runs in parallel with other test files.

## Validation
https://github.com/camunda/camunda/actions/runs/26024953382, statistics tests passed. Failing tests will be addressed in https://github.com/camunda/camunda/pull/53379

## Test plan
- [x] `npx eslint` on changed file — clean (existing warnings unrelated)
- [ ] Re-run nightly RDBMS API tests on `main` after merge — confirm `get-process-instance-statistics-by-error-api-tests.spec.ts` passes on the MariaDB matrix entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)