### PR TITLE
test: stabilize four nightly API-test flakes on main (shared-cluster indexing lag)

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-statistics-time-series-job-type-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-statistics-time-series-job-type-api-tests.spec.ts
@@ -16,6 +16,7 @@ import {
   jsonHeaders,
 } from '../../../../utils/http';
 import {validateResponse} from '../../../../json-body-assertions';
+import {extendedAssertionOptions} from '../../../../utils/constants';
 import {
   createUser,
   grantUserResourceAuthorization,
@@ -23,14 +24,6 @@ import {
   StatisticsJobItem,
 } from '@requestHelpers';
 import {cleanupUsers} from 'utils/usersCleanup';
-
-// The time-series view can lag the by-types snapshot by tens of seconds on
-// a loaded shared cluster, so the cross-view count comparison needs a
-// longer budget than the default 30s.
-const timeSeriesCatchupAssertionOptions = {
-  intervals: [5_000, 10_000, 15_000, 25_000, 35_000],
-  timeout: 90_000,
-};
 
 test.describe
   .parallel('Get time-series metrics for a job type API Tests', () => {
@@ -151,7 +144,7 @@ test.describe
         expect(extendedItem.created.count).toBe(item.created.count);
         expect(extendedItem.completed.count).toBe(item.completed.count);
         expect(extendedItem.failed.count).toBe(item.failed.count);
-      }).toPass(timeSeriesCatchupAssertionOptions);
+      }).toPass(extendedAssertionOptions);
     });
   });
 
@@ -299,7 +292,7 @@ test.describe
         expect(extendedItem.created.count).toBe(item.created.count);
         expect(extendedItem.completed.count).toBe(item.completed.count);
         expect(extendedItem.failed.count).toBe(item.failed.count);
-      }).toPass(timeSeriesCatchupAssertionOptions);
+      }).toPass(extendedAssertionOptions);
     });
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-statistics-time-series-job-type-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-statistics-time-series-job-type-api-tests.spec.ts
@@ -16,7 +16,6 @@ import {
   jsonHeaders,
 } from '../../../../utils/http';
 import {validateResponse} from '../../../../json-body-assertions';
-import {defaultAssertionOptions} from '../../../../utils/constants';
 import {
   createUser,
   grantUserResourceAuthorization,
@@ -24,6 +23,14 @@ import {
   StatisticsJobItem,
 } from '@requestHelpers';
 import {cleanupUsers} from 'utils/usersCleanup';
+
+// The time-series view can lag the by-types snapshot by tens of seconds on
+// a loaded shared cluster, so the cross-view count comparison needs a
+// longer budget than the default 30s.
+const timeSeriesCatchupAssertionOptions = {
+  intervals: [5_000, 10_000, 15_000, 25_000, 35_000],
+  timeout: 90_000,
+};
 
 test.describe
   .parallel('Get time-series metrics for a job type API Tests', () => {
@@ -144,7 +151,7 @@ test.describe
         expect(extendedItem.created.count).toBe(item.created.count);
         expect(extendedItem.completed.count).toBe(item.completed.count);
         expect(extendedItem.failed.count).toBe(item.failed.count);
-      }).toPass(defaultAssertionOptions);
+      }).toPass(timeSeriesCatchupAssertionOptions);
     });
   });
 
@@ -292,7 +299,7 @@ test.describe
         expect(extendedItem.created.count).toBe(item.created.count);
         expect(extendedItem.completed.count).toBe(item.completed.count);
         expect(extendedItem.failed.count).toBe(item.failed.count);
-      }).toPass(defaultAssertionOptions);
+      }).toPass(timeSeriesCatchupAssertionOptions);
     });
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-create-batch-to-modify-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-create-batch-to-modify-api.spec.ts
@@ -23,6 +23,14 @@ import {defaultAssertionOptions} from '../../../../utils/constants';
 import {findUserTask} from '@requestHelpers';
 import {validateResponse} from 'json-body-assertions';
 
+// Batch modify is asynchronous: the API returns immediately, but the
+// resulting user-task moves can take longer than the default 30s to be
+// indexed in user-tasks/search under load.
+const postModificationAssertionOptions = {
+  intervals: [5_000, 10_000, 15_000, 25_000, 35_000],
+  timeout: 90_000,
+};
+
 /* eslint-disable playwright/expect-expect */
 test.describe.parallel('Create Process Instance Batch to Modify Tests', () => {
   test.beforeAll(async () => {
@@ -361,7 +369,7 @@ test.describe.parallel('Create Process Instance Batch to Modify Tests', () => {
         expect(secondTask).toBeDefined();
         expect(firstTask!.state).toBe('CANCELED');
         expect(secondTask!.state).toBe('CREATED');
-      }).toPass(defaultAssertionOptions);
+      }).toPass(postModificationAssertionOptions);
 
       await expect(async () => {
         const res2 = await request.post(buildUrl('/user-tasks/search'), {
@@ -394,7 +402,7 @@ test.describe.parallel('Create Process Instance Batch to Modify Tests', () => {
         expect(secondTask2).toBeDefined();
         expect(firstTask2!.state).toBe('CANCELED');
         expect(secondTask2!.state).toBe('CREATED');
-      }).toPass(defaultAssertionOptions);
+      }).toPass(postModificationAssertionOptions);
     });
 
     await cancelProcessInstance(localState.processInstanceKey1);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-create-batch-to-modify-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-create-batch-to-modify-api.spec.ts
@@ -19,17 +19,12 @@ import {
   buildUrl,
   jsonHeaders,
 } from '../../../../utils/http';
-import {defaultAssertionOptions} from '../../../../utils/constants';
+import {
+  defaultAssertionOptions,
+  extendedAssertionOptions,
+} from '../../../../utils/constants';
 import {findUserTask} from '@requestHelpers';
 import {validateResponse} from 'json-body-assertions';
-
-// Batch modify is asynchronous: the API returns immediately, but the
-// resulting user-task moves can take longer than the default 30s to be
-// indexed in user-tasks/search under load.
-const postModificationAssertionOptions = {
-  intervals: [5_000, 10_000, 15_000, 25_000, 35_000],
-  timeout: 90_000,
-};
 
 /* eslint-disable playwright/expect-expect */
 test.describe.parallel('Create Process Instance Batch to Modify Tests', () => {
@@ -369,7 +364,7 @@ test.describe.parallel('Create Process Instance Batch to Modify Tests', () => {
         expect(secondTask).toBeDefined();
         expect(firstTask!.state).toBe('CANCELED');
         expect(secondTask!.state).toBe('CREATED');
-      }).toPass(postModificationAssertionOptions);
+      }).toPass(extendedAssertionOptions);
 
       await expect(async () => {
         const res2 = await request.post(buildUrl('/user-tasks/search'), {
@@ -402,7 +397,7 @@ test.describe.parallel('Create Process Instance Batch to Modify Tests', () => {
         expect(secondTask2).toBeDefined();
         expect(firstTask2!.state).toBe('CANCELED');
         expect(secondTask2!.state).toBe('CREATED');
-      }).toPass(postModificationAssertionOptions);
+      }).toPass(extendedAssertionOptions);
     });
 
     await cancelProcessInstance(localState.processInstanceKey1);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/constants.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/constants.ts
@@ -38,6 +38,14 @@ export const defaultAssertionOptions = {
   timeout: 30_000,
 };
 
+// Use when an assertion polls on data that has to propagate through the
+// secondary-storage indexer on a loaded shared cluster (e.g. post-batch
+// user-task search, cross-view count reconciliation).
+export const extendedAssertionOptions = {
+  intervals: [5_000, 10_000, 15_000, 25_000, 35_000],
+  timeout: 90_000,
+};
+
 export const uniqueBusinessId = (prefix = 'biz'): string => {
   return `${prefix}-${generateUniqueId()}`;
 };

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/batch-operation-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/batch-operation-requestHelpers.ts
@@ -36,8 +36,8 @@ export async function cancelBatchOperation(
 // (404 → 204). Use the same generous budget that createCompletedBatchOperation
 // uses for engine catch-up.
 const batchOperationLifecycleOptions = {
-  intervals: [5_000, 10_000, 10_000, 15_000, 20_000],
-  timeout: 90_000,
+  intervals: [5_000, 10_000, 10_000, 15_000, 20_000, 30_000],
+  timeout: 180_000,
 };
 
 export async function suspendBatchOperation(
@@ -136,8 +136,8 @@ export async function expectBatchState(
 }
 
 export const postMigrationAssertionOptions = {
-  intervals: [5_000, 10_000, 15_000, 25_000, 35_000],
-  timeout: 90_000,
+  intervals: [5_000, 10_000, 15_000, 25_000, 35_000, 45_000],
+  timeout: 180_000,
 };
 
 export const notFoundDetail = (key: string) =>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/batch-operation-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/batch-operation-requestHelpers.ts
@@ -33,8 +33,8 @@ export async function cancelBatchOperation(
 
 // A freshly created batch operation can take longer than the default 30s
 // to be visible to the suspend/resume commands on a loaded shared cluster
-// (404 → 204). Use the same generous budget that createCompletedBatchOperation
-// uses for engine catch-up.
+// (404 → 204). Use a more generous budget here for batch operation lifecycle
+// actions while the engine catches up.
 const batchOperationLifecycleOptions = {
   intervals: [5_000, 10_000, 10_000, 15_000, 20_000, 30_000],
   timeout: 180_000,


### PR DESCRIPTION
## Summary

Bundles fixes for the four failing API tests in the [May 18 on-demand main API run](https://github.com/camunda/camunda/actions/runs/26023596218/job/76491328540). 1 hard fail + 3 flakes — all the same root cause: the secondary-storage view lagging the broker on a loaded shared cluster, so each assertion polled past its timeout before the expected state surfaced.

## Changes

- **`utils/constants.ts`**: add a shared `extendedAssertionOptions` (intervals up to 35s, total 90s) alongside `defaultAssertionOptions` (total 30s). Use this when polling on data that has to propagate through the secondary-storage indexer.
- **`batch-operation-requestHelpers.ts`**:
  - `batchOperationLifecycleOptions` 90s → 180s (fixes `batch-operations-cancel-api-tests.spec.ts:58` "Cancel batch operation twice" — first cancel returned 404 for the full 90s as the batch hadn't surfaced for cancellation).
  - `postMigrationAssertionOptions` 90s → 180s (fixes `process-instance-create-batch-to-migrate-api.spec.ts:138` "Success" — element id still old after 90s).
- **`process-instance-create-batch-to-modify-api.spec.ts:249`** "With Or Filters": switch the post-modify user-tasks search polls from `defaultAssertionOptions` (30s) to `extendedAssertionOptions` (90s). The May 18 run hit `toBeDefined` failures on the second instance's `first_task` after the modify had been committed.
- **`job-statistics-time-series-job-type-api-tests.spec.ts:211`** "no resolution parameter — Success": same `defaultAssertionOptions` → `extendedAssertionOptions` swap on the by-types ↔ time-series count reconciliation poll. This test hard-failed both attempts in the run with `Expected: 2 / Received: 1` — the comment in the test already calls out that the time-series view lags by-types, so the fix is just to give it a longer budget. Also applied to the matching block earlier in the file (same pattern, would flake under the same conditions).

## Validation
https://github.com/camunda/camunda/actions/runs/26025804370 -> all 🟢 

## Test plan
- [x] `npx eslint` on changed files — 0 errors
- [x] `npx tsc --noEmit` on the test suite — no new errors


🤖 Generated with [Claude Code](https://claude.com/claude-code)