### PR TITLE
feat: add jspecify annotations to ActorFuture and Clock

### DIFF
--- a/zeebe/dynamic-config/pom.xml
+++ b/zeebe/dynamic-config/pom.xml
@@ -116,7 +116,6 @@
     <dependency>
       <groupId>org.agrona</groupId>
       <artifactId>agrona</artifactId>
-      <scope>test</scope>
     </dependency>
 
     <dependency>
@@ -166,6 +165,8 @@
           <ignoredNonTestScopedDependencies>
             <!-- When not set, we get error "Non-test scoped test only dependencies found". If we set the scope to test only, the build fails. -->
             <ignoredNonTestScopedDependency>io.camunda:zeebe-atomix-utils</ignoredNonTestScopedDependency>
+            <!-- Required by javac annotation processor for nullaway -->
+            <ignoredNonTestScopedDependency>org.agrona:agrona</ignoredNonTestScopedDependency>
           </ignoredNonTestScopedDependencies>
           <usedDependencies>
             <dependency>net.jqwik:jqwik</dependency>

--- a/zeebe/scheduler/pom.xml
+++ b/zeebe/scheduler/pom.xml
@@ -31,6 +31,10 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-commons</artifactId>
     </dependency>

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/Actor.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/Actor.java
@@ -18,6 +18,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import org.jspecify.annotations.Nullable;
 
 public abstract class Actor implements AutoCloseable, AsyncClosable, ConcurrencyControl {
 
@@ -99,7 +100,7 @@ public abstract class Actor implements AutoCloseable, AsyncClosable, Concurrency
   }
 
   @Override
-  public ActorFuture<Void> closeAsync() {
+  public ActorFuture<@Nullable Void> closeAsync() {
     return actor.close();
   }
 
@@ -122,13 +123,13 @@ public abstract class Actor implements AutoCloseable, AsyncClosable, Concurrency
 
   @Override
   public <T> void runOnCompletion(
-      final ActorFuture<T> future, final BiConsumer<T, Throwable> callback) {
+      final ActorFuture<T> future, final BiConsumer<T, @Nullable Throwable> callback) {
     actor.runOnCompletion(future, callback);
   }
 
   @Override
   public <T> void runOnCompletion(
-      final Collection<ActorFuture<T>> actorFutures, final Consumer<Throwable> callback) {
+      final Collection<ActorFuture<T>> actorFutures, final Consumer<@Nullable Throwable> callback) {
     actor.runOnCompletion(actorFutures, callback);
   }
 

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorControl.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorControl.java
@@ -70,8 +70,8 @@ public class ActorControl implements ConcurrencyControl {
    * @param action
    * @return
    */
-  public ActorFuture<Void> call(final Runnable action) {
-    final Callable<Void> c =
+  public ActorFuture<@Nullable Void> call(final Runnable action) {
+    final Callable<@Nullable Void> c =
         () -> {
           action.run();
           return null;

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorControl.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorControl.java
@@ -20,6 +20,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import org.jspecify.annotations.Nullable;
 
 public class ActorControl implements ConcurrencyControl {
   final ActorTask task;
@@ -143,7 +144,7 @@ public class ActorControl implements ConcurrencyControl {
    */
   @Override
   public <T> void runOnCompletion(
-      final ActorFuture<T> future, final BiConsumer<T, Throwable> callback) {
+      final ActorFuture<T> future, final BiConsumer<T, @Nullable Throwable> callback) {
     ensureCalledFromWithinActor("runOnCompletion(...)");
 
     final ActorLifecyclePhase lifecyclePhase = task.getLifecyclePhase();
@@ -169,10 +170,9 @@ public class ActorControl implements ConcurrencyControl {
    */
   @Override
   public <T> void runOnCompletion(
-      final Collection<ActorFuture<T>> futures, final Consumer<Throwable> callback) {
+      final Collection<ActorFuture<T>> futures, final Consumer<@Nullable Throwable> callback) {
     if (!futures.isEmpty()) {
-      final BiConsumer<T, Throwable> futureConsumer =
-          new AllCompletedFutureConsumer<>(futures.size(), callback);
+      final var futureConsumer = new AllCompletedFutureConsumer<T>(futures.size(), callback);
 
       for (final ActorFuture<T> future : futures) {
         runOnCompletion(future, futureConsumer);
@@ -298,7 +298,7 @@ public class ActorControl implements ConcurrencyControl {
 
   private <T> void submitContinuationJob(
       final ActorFuture<T> future,
-      final BiConsumer<T, Throwable> callback,
+      final BiConsumer<T, @Nullable Throwable> callback,
       final Function<ActorJob, ActorFutureSubscription> futureSubscriptionSupplier) {
     final ActorJob continuationJob = new ActorJob();
     continuationJob.setRunnable(new FutureContinuationRunnable<>(future, callback));
@@ -316,7 +316,7 @@ public class ActorControl implements ConcurrencyControl {
     job.getTask().yieldThread();
   }
 
-  public ActorFuture<Void> close() {
+  public ActorFuture<@Nullable Void> close() {
     final ActorJob closeJob = new ActorJob();
 
     closeJob.onJobAddedToTask(task);
@@ -360,12 +360,12 @@ public class ActorControl implements ConcurrencyControl {
     return task.getLifecyclePhase();
   }
 
-  public boolean isCalledFromWithinActor(final ActorJob job) {
+  public boolean isCalledFromWithinActor(final @Nullable ActorJob job) {
     return job != null && job.getActor() == actor;
   }
 
   private ActorJob ensureCalledFromWithinActor(final String methodName) {
-    final ActorJob currentJob = ensureCalledFromActorThread(methodName).getCurrentJob();
+    final var currentJob = ensureCalledFromActorThread(methodName).getCurrentJob();
     if (!isCalledFromWithinActor(currentJob)) {
       throw new UnsupportedOperationException(
           "Incorrect usage of actor."

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorExecutor.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorExecutor.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.scheduler.ActorScheduler.ActorSchedulerBuilder;
 import io.camunda.zeebe.scheduler.ActorTask.ActorLifecyclePhase;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import java.util.concurrent.CompletableFuture;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Used to submit {@link ActorTask ActorTasks} and Blocking Actions to the scheduler's internal
@@ -30,19 +31,20 @@ public final class ActorExecutor {
    *
    * @param task the task to submit
    */
-  public ActorFuture<Void> submitCpuBound(final ActorTask task) {
+  public ActorFuture<@Nullable Void> submitCpuBound(final ActorTask task) {
     return submitTask(task, cpuBoundThreads);
   }
 
-  public ActorFuture<Void> submitIoBoundTask(final ActorTask task) {
+  public ActorFuture<@Nullable Void> submitIoBoundTask(final ActorTask task) {
     return submitTask(task, ioBoundThreads);
   }
 
-  private ActorFuture<Void> submitTask(final ActorTask task, final ActorThreadGroup threadGroup) {
+  private ActorFuture<@Nullable Void> submitTask(
+      final ActorTask task, final ActorThreadGroup threadGroup) {
     if (task.getLifecyclePhase() != ActorLifecyclePhase.CLOSED) {
       throw new IllegalStateException("ActorTask was already submitted!");
     }
-    final ActorFuture<Void> startingFuture = task.onTaskScheduled(threadGroup);
+    final ActorFuture<@Nullable Void> startingFuture = task.onTaskScheduled(threadGroup);
 
     threadGroup.submit(task);
     return startingFuture;
@@ -53,7 +55,7 @@ public final class ActorExecutor {
     ioBoundThreads.start();
   }
 
-  public CompletableFuture<Void> closeAsync() {
+  public CompletableFuture<@Nullable Void> closeAsync() {
     return CompletableFuture.allOf(ioBoundThreads.closeAsync(), cpuBoundThreads.closeAsync());
   }
 

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorScheduler.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorScheduler.java
@@ -17,6 +17,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import org.agrona.concurrent.BackoffIdleStrategy;
 import org.agrona.concurrent.IdleStrategy;
+import org.jspecify.annotations.Nullable;
 
 public final class ActorScheduler implements AutoCloseable, ActorSchedulingService {
   private final AtomicReference<SchedulerState> state = new AtomicReference<>();
@@ -35,7 +36,7 @@ public final class ActorScheduler implements AutoCloseable, ActorSchedulingServi
    * @param actor the actor to submit
    */
   @Override
-  public ActorFuture<Void> submitActor(final Actor actor) {
+  public ActorFuture<@Nullable Void> submitActor(final Actor actor) {
     return submitActor(actor, SchedulingHints.cpuBound());
   }
 
@@ -57,7 +58,8 @@ public final class ActorScheduler implements AutoCloseable, ActorSchedulingServi
    * @param schedulingHints additional scheduling hint
    */
   @Override
-  public ActorFuture<Void> submitActor(final Actor actor, final SchedulingHints schedulingHints) {
+  public ActorFuture<@Nullable Void> submitActor(
+      final Actor actor, final SchedulingHints schedulingHints) {
     checkRunningState();
 
     final ActorTask task = actor.actor.task;
@@ -83,7 +85,7 @@ public final class ActorScheduler implements AutoCloseable, ActorSchedulingServi
     }
   }
 
-  public Future<Void> stop() {
+  public Future<@Nullable Void> stop() {
     if (state.compareAndSet(SchedulerState.RUNNING, SchedulerState.TERMINATING)) {
 
       return actorTaskExecutor.closeAsync().thenRun(() -> state.set(SchedulerState.TERMINATED));

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorSchedulingService.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorSchedulingService.java
@@ -8,13 +8,14 @@
 package io.camunda.zeebe.scheduler;
 
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Service interface to schedule an actor (without exposing the full interface of {@code
  * ActorScheduler}
  */
 public interface ActorSchedulingService {
-  ActorFuture<Void> submitActor(final Actor actor);
+  ActorFuture<@Nullable Void> submitActor(final Actor actor);
 
-  ActorFuture<Void> submitActor(final Actor actor, SchedulingHints schedulingHints);
+  ActorFuture<@Nullable Void> submitActor(final Actor actor, SchedulingHints schedulingHints);
 }

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorTask.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorTask.java
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import org.agrona.concurrent.ManyToOneConcurrentLinkedQueue;
 import org.jetbrains.annotations.Async;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,15 +41,19 @@ public class ActorTask {
 
   // Start with a completed future to allow closing unscheduled tasks. The future is reset to
   // uncompleted in `onTaskScheduled`.
-  public final CompletableActorFuture<Void> closeFuture = CompletableActorFuture.completed(null);
+  public final CompletableActorFuture<@Nullable Void> closeFuture =
+      CompletableActorFuture.completed(null);
   final Actor actor;
   ActorJob currentJob;
   boolean shouldYield;
   final AtomicReference<TaskSchedulingState> schedulingState = new AtomicReference<>();
   final AtomicLong stateCount = new AtomicLong(0);
-  private final CompletableActorFuture<Void> jobClosingTaskFuture = new CompletableActorFuture<>();
-  private final CompletableActorFuture<Void> startingFuture = new CompletableActorFuture<>();
-  private final CompletableActorFuture<Void> jobStartingTaskFuture = new CompletableActorFuture<>();
+  private final CompletableActorFuture<@Nullable Void> jobClosingTaskFuture =
+      new CompletableActorFuture<>();
+  private final CompletableActorFuture<@Nullable Void> startingFuture =
+      new CompletableActorFuture<>();
+  private final CompletableActorFuture<@Nullable Void> jobStartingTaskFuture =
+      new CompletableActorFuture<>();
   private ActorThreadGroup actorThreadGroup;
   private Deque<ActorJob> fastLaneJobs = new ClosedQueue();
   private volatile ActorLifecyclePhase lifecyclePhase = ActorLifecyclePhase.CLOSED;
@@ -67,7 +72,7 @@ public class ActorTask {
   }
 
   /** called when the task is initially scheduled. */
-  public ActorFuture<Void> onTaskScheduled(final ActorThreadGroup actorThreadGroup) {
+  public ActorFuture<@Nullable Void> onTaskScheduled(final ActorThreadGroup actorThreadGroup) {
     this.actorThreadGroup = actorThreadGroup;
     // reset previous state to allow re-scheduling
     closeFuture.close();
@@ -481,7 +486,7 @@ public class ActorTask {
     return lifecyclePhase;
   }
 
-  public CompletableActorFuture<Void> getStartingFuture() {
+  public CompletableActorFuture<@Nullable Void> getStartingFuture() {
     return startingFuture;
   }
 

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorThread.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorThread.java
@@ -19,6 +19,7 @@ import java.util.concurrent.locks.LockSupport;
 import java.util.function.Consumer;
 import org.agrona.concurrent.IdleStrategy;
 import org.agrona.concurrent.ManyToManyConcurrentArrayQueue;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.MDC;
 
@@ -42,7 +43,7 @@ public class ActorThread extends Thread implements Consumer<Runnable> {
   protected ActorTaskRunnerIdleStrategy idleStrategy;
   ActorTask currentTask;
   private final ActorMetrics actorMetrics;
-  private final CompletableFuture<Void> terminationFuture = new CompletableFuture<>();
+  private final CompletableFuture<@Nullable Void> terminationFuture = new CompletableFuture<>();
   private final ActorClock clock;
   private final int threadId;
   private final TaskScheduler taskScheduler;
@@ -232,7 +233,7 @@ public class ActorThread extends Thread implements Consumer<Runnable> {
     terminationFuture.complete(null);
   }
 
-  public CompletableFuture<Void> close() {
+  public CompletableFuture<@Nullable Void> close() {
     if (STATE_HANDLE.compareAndSet(this, ActorThreadState.RUNNING, ActorThreadState.TERMINATING)) {
       return terminationFuture;
     } else {

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorThreadGroup.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorThreadGroup.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.scheduler.ActorScheduler.ActorSchedulerBuilder;
 import io.camunda.zeebe.util.Loggers;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ThreadLocalRandom;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A thread group is a group of threads which process the same kind of tasks (ie. blocking I/O vs.
@@ -76,10 +77,11 @@ public abstract class ActorThreadGroup {
     return schedulerName;
   }
 
-  public CompletableFuture<Void> closeAsync() {
+  public CompletableFuture<@Nullable Void> closeAsync() {
     Loggers.ACTOR_LOGGER.debug("Closing actor thread ground '{}'", groupName);
 
-    final CompletableFuture<Void>[] terminationFutures = new CompletableFuture[numOfThreads];
+    final CompletableFuture<@Nullable Void>[] terminationFutures =
+        new CompletableFuture[numOfThreads];
 
     for (int i = 0; i < numOfThreads; i++) {
       final ActorThread thread = threads[i];

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/AsyncClosable.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/AsyncClosable.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.scheduler;
 
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import org.jspecify.annotations.Nullable;
 
 public interface AsyncClosable {
 
@@ -18,9 +19,9 @@ public interface AsyncClosable {
    *
    * @return the future, which is completed when resources are closed
    */
-  ActorFuture<Void> closeAsync();
+  ActorFuture<@Nullable Void> closeAsync();
 
-  static ActorFuture<Void> closeHelper(final AsyncClosable closeable) {
+  static ActorFuture<@Nullable Void> closeHelper(final @Nullable AsyncClosable closeable) {
     if (closeable != null) {
       return closeable.closeAsync();
     } else {

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ConcurrencyControl.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ConcurrencyControl.java
@@ -16,7 +16,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Control interface to schedule tasks or follow-up tasks such that different tasks scheduled via
@@ -31,7 +31,8 @@ public interface ConcurrencyControl extends Executor {
    * @param callback the callback to call after the future has completed
    * @param <T> result type of the future
    */
-  <T> void runOnCompletion(final ActorFuture<T> future, final BiConsumer<T, Throwable> callback);
+  <T> void runOnCompletion(
+      final ActorFuture<T> future, final BiConsumer<T, @Nullable Throwable> callback);
 
   /**
    * Invoke the callback when the given futures are completed (successfully or exceptionally). This
@@ -45,7 +46,7 @@ public interface ConcurrencyControl extends Executor {
    *     Otherwise, it holds the exception of the last completed future.
    */
   <T> void runOnCompletion(
-      final Collection<ActorFuture<T>> futures, final Consumer<Throwable> callback);
+      final Collection<ActorFuture<T>> futures, final Consumer<@Nullable Throwable> callback);
 
   /**
    * Schedules an action to be invoked (must be called from an actor thread)
@@ -82,12 +83,12 @@ public interface ConcurrencyControl extends Executor {
    * @param <V> value type of future
    * @return new completed future object
    */
-  default <V> ActorFuture<V> createCompletedFuture() {
-    return CompletableActorFuture.completed(null);
+  default <V extends @Nullable Object> ActorFuture<V> createCompletedFuture() {
+    return CompletableActorFuture.<V>completed(null);
   }
 
   @Override
-  default void execute(@NotNull final Runnable command) {
+  default void execute(final Runnable command) {
     run(command);
   }
 }

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/clock/ActorClock.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/clock/ActorClock.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.scheduler.clock;
 import io.camunda.zeebe.scheduler.ActorThread;
 import java.time.Instant;
 import java.time.InstantSource;
+import org.jspecify.annotations.Nullable;
 
 public interface ActorClock extends InstantSource {
   boolean update();
@@ -20,7 +21,7 @@ public interface ActorClock extends InstantSource {
 
   long getNanoTime();
 
-  static ActorClock current() {
+  static @Nullable ActorClock current() {
     final ActorThread current = ActorThread.current();
     return current != null ? current.getClock() : null;
   }

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/clock/package-info.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/clock/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+@NullMarked
+package io.camunda.zeebe.scheduler.clock;
+
+import org.jspecify.annotations.NullMarked;

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/ActorFuture.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/ActorFuture.java
@@ -17,9 +17,11 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import org.jspecify.annotations.Nullable;
 
 /** interface for actor futures */
-public interface ActorFuture<V> extends Future<V>, BiConsumer<V, Throwable> {
+public interface ActorFuture<V extends @Nullable Object>
+    extends Future<V>, BiConsumer<V, @Nullable Throwable> {
   void complete(V value);
 
   void completeExceptionally(String failure, Throwable throwable);
@@ -57,7 +59,7 @@ public interface ActorFuture<V> extends Future<V>, BiConsumer<V, Throwable> {
    *
    * @param consumer the consumer which should be called after the future was completed
    */
-  void onComplete(BiConsumer<V, Throwable> consumer);
+  void onComplete(BiConsumer<V, @Nullable Throwable> consumer);
 
   /**
    * Registers a consumer, which is executed after the future was completed. The consumer is
@@ -68,7 +70,7 @@ public interface ActorFuture<V> extends Future<V>, BiConsumer<V, Throwable> {
    * @param consumer the callback which should be called after the future was completed
    * @param executor the executor on which the callback will be executed
    */
-  void onComplete(BiConsumer<V, Throwable> consumer, Executor executor);
+  void onComplete(BiConsumer<V, @Nullable Throwable> consumer, Executor executor);
 
   /**
    * Runs a callback when the future terminates successfully If the caller is not an actor, the
@@ -134,10 +136,10 @@ public interface ActorFuture<V> extends Future<V>, BiConsumer<V, Throwable> {
 
   boolean isCompletedExceptionally();
 
-  Throwable getException();
+  @Nullable Throwable getException();
 
   @Override
-  default void accept(final V value, final Throwable throwable) {
+  default void accept(final V value, final @Nullable Throwable throwable) {
     if (throwable != null) {
       completeExceptionally(throwable);
     } else {
@@ -172,7 +174,8 @@ public interface ActorFuture<V> extends Future<V>, BiConsumer<V, Throwable> {
    * Convenience wrapper over {@link #andThen(Function, Executor)} for the case where the next step
    * does not require the result of this future.
    */
-  <U> ActorFuture<U> andThen(Supplier<ActorFuture<U>> next, Executor executor);
+  <U extends @Nullable Object> ActorFuture<U> andThen(
+      Supplier<ActorFuture<U>> next, Executor executor);
 
   /**
    * Similar to {@link CompletableFuture#thenCompose(Function)} in that it applies a function to the
@@ -188,7 +191,8 @@ public interface ActorFuture<V> extends Future<V>, BiConsumer<V, Throwable> {
    *     used for further chaining.
    * @param <U> the type of the new future
    */
-  <U> ActorFuture<U> andThen(Function<V, ActorFuture<U>> next, Executor executor);
+  <U extends @Nullable Object> ActorFuture<U> andThen(
+      Function<V, ActorFuture<U>> next, Executor executor);
 
   /**
    * Similar to {@link ActorFuture#andThen(Function, Executor)}}, but it allows to return a future
@@ -202,7 +206,8 @@ public interface ActorFuture<V> extends Future<V>, BiConsumer<V, Throwable> {
    *     ActorFuture#onComplete(BiConsumer)} method.
    * @param <U> the type of the new future
    */
-  <U> ActorFuture<U> andThen(BiFunction<V, Throwable, ActorFuture<U>> next, Executor executor);
+  <U extends @Nullable Object> ActorFuture<U> andThen(
+      BiFunction<V, @Nullable Throwable, ActorFuture<U>> next, Executor executor);
 
   /**
    * Similar to {@link CompletableFuture#thenApply(Function)} in that it applies a function to the
@@ -220,7 +225,7 @@ public interface ActorFuture<V> extends Future<V>, BiConsumer<V, Throwable> {
    *     used for further chaining.
    * @param <U> the type of the new future
    */
-  <U> ActorFuture<U> thenApply(Function<V, U> next, Executor executor);
+  <U extends @Nullable Object> ActorFuture<U> thenApply(Function<V, U> next, Executor executor);
 
   /**
    * Similar to {@link CompletableFuture#thenApply(Function)} in that it applies a function to the
@@ -240,5 +245,5 @@ public interface ActorFuture<V> extends Future<V>, BiConsumer<V, Throwable> {
    *     used for further chaining.
    * @param <U> the type of the new future
    */
-  <U> ActorFuture<U> thenApply(final Function<V, U> next);
+  <U extends @Nullable Object> ActorFuture<U> thenApply(final Function<V, U> next);
 }

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/ActorFuture.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/ActorFuture.java
@@ -24,7 +24,7 @@ public interface ActorFuture<V extends @Nullable Object>
     extends Future<V>, BiConsumer<V, @Nullable Throwable> {
   void complete(V value);
 
-  void completeExceptionally(String failure, Throwable throwable);
+  void completeExceptionally(@Nullable String failure, Throwable throwable);
 
   void completeExceptionally(Throwable throwable);
 

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/ActorFuture.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/ActorFuture.java
@@ -136,7 +136,11 @@ public interface ActorFuture<V extends @Nullable Object>
 
   boolean isCompletedExceptionally();
 
-  @Nullable Throwable getException();
+  /**
+   * @return the throwable if this future completed exceptionally
+   * @throws IllegalStateException if the future is not completed exceptionally
+   */
+  Throwable getException();
 
   @Override
   default void accept(final V value, final @Nullable Throwable throwable) {

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/ActorFutureCollector.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/ActorFutureCollector.java
@@ -22,6 +22,7 @@ import java.util.function.BinaryOperator;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collector;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Aggregates a number of {@code ActorFuture} objects into a single one. The aggregated future is
@@ -37,7 +38,7 @@ import java.util.stream.Collector;
  *
  * @param <V> type of the value of each future
  */
-public final class ActorFutureCollector<V>
+public final class ActorFutureCollector<V extends @Nullable Object>
     implements Collector<ActorFuture<V>, List<ActorFuture<V>>, ActorFuture<List<V>>> {
 
   private final ConcurrencyControl concurrencyControl;
@@ -74,12 +75,11 @@ public final class ActorFutureCollector<V>
     return emptySet();
   }
 
-  private static final class CompletionWaiter<V> implements Supplier<ActorFuture<List<V>>> {
+  private static final class CompletionWaiter<V extends @Nullable Object>
+      implements Supplier<ActorFuture<List<V>>> {
     private final ConcurrencyControl concurrencyControl;
     private final List<ActorFuture<V>> pendingFutures;
     private final Either<Throwable, V>[] results;
-
-    private ActorFuture<List<V>> aggregated;
 
     private CompletionWaiter(
         final ConcurrencyControl concurrencyControl, final List<ActorFuture<V>> pendingFutures) {
@@ -90,7 +90,7 @@ public final class ActorFutureCollector<V>
 
     @Override
     public ActorFuture<List<V>> get() {
-      aggregated = concurrencyControl.createFuture();
+      final ActorFuture<List<V>> aggregated = concurrencyControl.createFuture();
 
       if (pendingFutures.isEmpty()) {
         aggregated.complete(Collections.emptyList());
@@ -101,7 +101,8 @@ public final class ActorFutureCollector<V>
           final var currentIndex = index;
           concurrencyControl.runOnCompletion(
               pendingFuture,
-              (result, error) -> handleCompletion(pendingFuture, currentIndex, result, error));
+              (result, error) ->
+                  handleCompletion(aggregated, pendingFuture, currentIndex, result, error));
         }
       }
 
@@ -109,20 +110,21 @@ public final class ActorFutureCollector<V>
     }
 
     private void handleCompletion(
+        final ActorFuture<List<V>> aggregated,
         final ActorFuture<V> pendingFuture,
         final int currentIndex,
         final V result,
-        final Throwable error) {
+        final @Nullable Throwable error) {
       pendingFutures.remove(pendingFuture);
 
       results[currentIndex] = error == null ? Either.right(result) : Either.left(error);
 
       if (pendingFutures.isEmpty()) {
-        completeAggregatedFuture();
+        completeAggregatedFuture(aggregated);
       }
     }
 
-    private void completeAggregatedFuture() {
+    private void completeAggregatedFuture(final ActorFuture<List<V>> aggregated) {
       final var aggregatedResult = stream(results).collect(Either.collector());
 
       if (aggregatedResult.isRight()) {

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/AllCompletedFutureConsumer.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/AllCompletedFutureConsumer.java
@@ -9,20 +9,22 @@ package io.camunda.zeebe.scheduler.future;
 
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import org.jspecify.annotations.Nullable;
 
-public final class AllCompletedFutureConsumer<T> implements BiConsumer<T, Throwable> {
-  private final Consumer<Throwable> callback;
+public final class AllCompletedFutureConsumer<T> implements BiConsumer<T, @Nullable Throwable> {
+  private final Consumer<@Nullable Throwable> callback;
   private int pendingFutures;
 
-  private Throwable occuredFailure = null;
+  private @Nullable Throwable occuredFailure = null;
 
-  public AllCompletedFutureConsumer(final int pendingFutures, final Consumer<Throwable> callback) {
+  public AllCompletedFutureConsumer(
+      final int pendingFutures, final Consumer<@Nullable Throwable> callback) {
     this.pendingFutures = pendingFutures;
     this.callback = callback;
   }
 
   @Override
-  public void accept(final T result, final Throwable failure) {
+  public void accept(final T result, final @Nullable Throwable failure) {
     pendingFutures -= 1;
 
     if (failure != null) {

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/CompletableActorFuture.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/CompletableActorFuture.java
@@ -206,7 +206,7 @@ public final class CompletableActorFuture<V extends @Nullable Object> implements
   }
 
   @Override
-  public void completeExceptionally(final String failure, final Throwable throwable) {
+  public void completeExceptionally(final @Nullable String failure, final Throwable throwable) {
     // important for other actors that consume this by #runOnCompletion
     ensureValidThrowable(throwable);
 
@@ -228,8 +228,7 @@ public final class CompletableActorFuture<V extends @Nullable Object> implements
   @Override
   public void completeExceptionally(final Throwable throwable) {
     ensureValidThrowable(throwable);
-    final var message = throwable.getMessage() != null ? throwable.getMessage() : "";
-    completeExceptionally(message, throwable);
+    completeExceptionally(throwable.getMessage(), throwable);
   }
 
   @Override

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/CompletableActorFuture.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/CompletableActorFuture.java
@@ -7,6 +7,9 @@
  */
 package io.camunda.zeebe.scheduler.future;
 
+import static io.camunda.zeebe.util.Nulls.uncheckedCastToNonNull;
+import static java.util.Objects.requireNonNull;
+
 import io.camunda.zeebe.scheduler.ActorControl;
 import io.camunda.zeebe.scheduler.ActorTask;
 import io.camunda.zeebe.scheduler.ActorThread;
@@ -27,10 +30,11 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import org.agrona.UnsafeApi;
 import org.agrona.concurrent.ManyToOneConcurrentLinkedQueue;
+import org.jspecify.annotations.Nullable;
 
 /** Completable future implementation that is garbage free and reusable */
 @SuppressWarnings("restriction")
-public final class CompletableActorFuture<V> implements ActorFuture<V> {
+public final class CompletableActorFuture<V extends @Nullable Object> implements ActorFuture<V> {
   private static final long STATE_OFFSET;
 
   private static final int AWAITING_RESULT = 1;
@@ -49,15 +53,15 @@ public final class CompletableActorFuture<V> implements ActorFuture<V> {
   }
 
   private long completedAt;
-  private V value;
-  private String failure;
-  private Throwable failureCause;
-  private final ManyToOneConcurrentLinkedQueue<BiConsumer<V, Throwable>> blockedCallbacks =
-      new ManyToOneConcurrentLinkedQueue<>();
+  private @Nullable V value;
+  private @Nullable String failure;
+  private @Nullable Throwable failureCause;
+  private final ManyToOneConcurrentLinkedQueue<BiConsumer<V, @Nullable Throwable>>
+      blockedCallbacks = new ManyToOneConcurrentLinkedQueue<>();
 
   private final ReentrantLock completionLock = new ReentrantLock();
   private volatile int state = CLOSED;
-  private Condition isDoneCondition;
+  private @Nullable Condition isDoneCondition;
 
   public CompletableActorFuture() {
     setAwaitingResult();
@@ -75,7 +79,7 @@ public final class CompletableActorFuture<V> implements ActorFuture<V> {
     state = COMPLETED_EXCEPTIONALLY;
   }
 
-  private void ensureValidThrowable(final Throwable throwable) {
+  private void ensureValidThrowable(final @Nullable Throwable throwable) {
     if (throwable == null) {
       throw new NullPointerException("Throwable must not be null.");
     }
@@ -86,15 +90,16 @@ public final class CompletableActorFuture<V> implements ActorFuture<V> {
     isDoneCondition = completionLock.newCondition();
   }
 
-  public static CompletableActorFuture<Void> completed() {
+  public static CompletableActorFuture<@Nullable Void> completed() {
     return CompletableActorFuture.completed(null);
   }
 
-  public static <V> CompletableActorFuture<V> completed(final V result) {
+  public static <V extends @Nullable Object> CompletableActorFuture<V> completed(final V result) {
     return new CompletableActorFuture<>(result); // cast for null result
   }
 
-  public static <V> CompletableActorFuture<V> completedExceptionally(final Throwable throwable) {
+  public static <V extends @Nullable Object> CompletableActorFuture<V> completedExceptionally(
+      final Throwable throwable) {
     return new CompletableActorFuture<>(throwable);
   }
 
@@ -108,11 +113,11 @@ public final class CompletableActorFuture<V> implements ActorFuture<V> {
    *     successfully. if one future returns an error, the computation is stopped (the rest of the
    *     Future will not be started) and the error is returned
    */
-  public static <A> ActorFuture<Void> traverseIgnoring(
+  public static <A> ActorFuture<@Nullable Void> traverseIgnoring(
       final Collection<A> collection,
-      final Function<A, ActorFuture<Void>> function,
+      final Function<A, ActorFuture<@Nullable Void>> function,
       final Executor executor) {
-    ActorFuture<Void> future = completed();
+    ActorFuture<@Nullable Void> future = completed();
     for (final A a : collection) {
       future = future.andThen(unused -> function.apply(a), executor);
     }
@@ -163,7 +168,7 @@ public final class CompletableActorFuture<V> implements ActorFuture<V> {
           if (remaining <= 0) {
             throw new TimeoutException("Timeout after: " + timeout + " " + unit);
           }
-          remaining = isDoneCondition.awaitNanos(unit.toNanos(timeout));
+          remaining = requireNonNull(isDoneCondition).awaitNanos(unit.toNanos(timeout));
         }
       } finally {
         completionLock.unlock();
@@ -173,7 +178,8 @@ public final class CompletableActorFuture<V> implements ActorFuture<V> {
     if (isCompletedExceptionally()) {
       throw new ExecutionException(failure, failureCause);
     } else {
-      return value;
+      // value is set by complete() before this state is reachable
+      return uncheckedCastToNonNull(value);
     }
   }
 
@@ -222,7 +228,8 @@ public final class CompletableActorFuture<V> implements ActorFuture<V> {
   @Override
   public void completeExceptionally(final Throwable throwable) {
     ensureValidThrowable(throwable);
-    completeExceptionally(throwable.getMessage(), throwable);
+    final var message = throwable.getMessage() != null ? throwable.getMessage() : "";
+    completeExceptionally(message, throwable);
   }
 
   @Override
@@ -241,7 +248,7 @@ public final class CompletableActorFuture<V> implements ActorFuture<V> {
   }
 
   @Override
-  public void onComplete(final BiConsumer<V, Throwable> consumer) {
+  public void onComplete(final BiConsumer<V, @Nullable Throwable> consumer) {
     if (ActorThread.isCalledFromActorThread()) {
       final ActorControl actorControl = ActorControl.current();
       actorControl.runOnCompletion(this, consumer);
@@ -259,7 +266,8 @@ public final class CompletableActorFuture<V> implements ActorFuture<V> {
   }
 
   @Override
-  public void onComplete(final BiConsumer<V, Throwable> consumer, final Executor executor) {
+  public void onComplete(
+      final BiConsumer<V, @Nullable Throwable> consumer, final Executor executor) {
     // There is a possible race condition that the future is completed before adding the consumer to
     // blockedCallBacks. Then the consumer will never get executed. To ensure that the
     // consumer is executed we check if the future is done, and trigger the consumer. However, if
@@ -269,7 +277,7 @@ public final class CompletableActorFuture<V> implements ActorFuture<V> {
     // this extra overhead would be acceptable.
 
     final AtomicBoolean executedOnce = new AtomicBoolean(false);
-    final BiConsumer<V, Throwable> checkedConsumer =
+    final BiConsumer<V, @Nullable Throwable> checkedConsumer =
         (res, error) ->
             executor.execute(
                 () -> {
@@ -300,7 +308,7 @@ public final class CompletableActorFuture<V> implements ActorFuture<V> {
   }
 
   @Override
-  public Throwable getException() {
+  public @Nullable Throwable getException() {
     if (!isCompletedExceptionally()) {
       throw new IllegalStateException(
           "Cannot call getException(); future is not completed exceptionally.");
@@ -323,7 +331,7 @@ public final class CompletableActorFuture<V> implements ActorFuture<V> {
   }
 
   @Override
-  public <U> ActorFuture<U> andThen(
+  public <U extends @Nullable Object> ActorFuture<U> andThen(
       final Function<V, ActorFuture<U>> next, final Executor executor) {
     return andThen(
         (v, err) -> {
@@ -342,7 +350,7 @@ public final class CompletableActorFuture<V> implements ActorFuture<V> {
 
   @Override
   public <U> ActorFuture<U> andThen(
-      final BiFunction<V, Throwable, ActorFuture<U>> next, final Executor executor) {
+      final BiFunction<V, @Nullable Throwable, ActorFuture<U>> next, final Executor executor) {
     final ActorFuture<U> nextFuture = new CompletableActorFuture<>();
     onComplete(
         (thisResult, thisError) -> {
@@ -444,9 +452,10 @@ public final class CompletableActorFuture<V> implements ActorFuture<V> {
     }
 
     if (otherFuture.isCompletedExceptionally()) {
-      completeExceptionally(otherFuture.failureCause);
+      completeExceptionally(requireNonNull(otherFuture.failureCause));
     } else {
-      complete(otherFuture.value);
+      // value is set by complete() before this state is reachable
+      complete(uncheckedCastToNonNull(otherFuture.value));
     }
   }
 

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/CompletableActorFuture.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/CompletableActorFuture.java
@@ -308,13 +308,13 @@ public final class CompletableActorFuture<V extends @Nullable Object> implements
   }
 
   @Override
-  public @Nullable Throwable getException() {
+  public Throwable getException() {
     if (!isCompletedExceptionally()) {
       throw new IllegalStateException(
           "Cannot call getException(); future is not completed exceptionally.");
     }
 
-    return failureCause;
+    return uncheckedCastToNonNull(failureCause);
   }
 
   @Override

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/FutureContinuationRunnable.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/FutureContinuationRunnable.java
@@ -9,13 +9,14 @@ package io.camunda.zeebe.scheduler.future;
 
 import java.util.function.BiConsumer;
 import org.agrona.LangUtil;
+import org.jspecify.annotations.Nullable;
 
 public final class FutureContinuationRunnable<T> implements Runnable {
   private final ActorFuture<T> future;
-  private final BiConsumer<T, Throwable> consumer;
+  private final BiConsumer<T, @Nullable Throwable> consumer;
 
   public FutureContinuationRunnable(
-      final ActorFuture<T> future, final BiConsumer<T, Throwable> consumer) {
+      final ActorFuture<T> future, final BiConsumer<T, @Nullable Throwable> consumer) {
     this.future = future;
     this.consumer = consumer;
   }

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/package-info.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+@NullMarked
+package io.camunda.zeebe.scheduler.future;
+
+import org.jspecify.annotations.NullMarked;

--- a/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/testing/TestActorFuture.java
+++ b/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/testing/TestActorFuture.java
@@ -51,7 +51,7 @@ public final class TestActorFuture<V extends @Nullable Object> implements ActorF
   }
 
   @Override
-  public void completeExceptionally(final String failure, final Throwable throwable) {
+  public void completeExceptionally(final @Nullable String failure, final Throwable throwable) {
     completeExceptionally(throwable);
   }
 

--- a/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/testing/TestActorFuture.java
+++ b/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/testing/TestActorFuture.java
@@ -24,6 +24,8 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import org.agrona.LangUtil;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Implementation of {@code ActorFuture} for use in tests. The main goal is to use this in tests
@@ -34,11 +36,12 @@ import org.agrona.LangUtil;
  *
  * @param <V>
  */
-public final class TestActorFuture<V> implements ActorFuture<V> {
+@NullMarked
+public final class TestActorFuture<V extends @Nullable Object> implements ActorFuture<V> {
 
   private final CountDownLatch countDownLatch = new CountDownLatch(1);
-  private final List<BiConsumer<V, Throwable>> onCompleteCallbacks = new ArrayList<>();
-  private Either<Throwable, V> result;
+  private final List<BiConsumer<V, @Nullable Throwable>> onCompleteCallbacks = new ArrayList<>();
+  private @Nullable Either<Throwable, V> result;
 
   @Override
   public void complete(final V value) {
@@ -87,7 +90,7 @@ public final class TestActorFuture<V> implements ActorFuture<V> {
   }
 
   @Override
-  public void onComplete(final BiConsumer<V, Throwable> consumer) {
+  public void onComplete(final BiConsumer<V, @Nullable Throwable> consumer) {
     onCompleteCallbacks.add(consumer);
 
     if (isDone()) {
@@ -173,7 +176,7 @@ public final class TestActorFuture<V> implements ActorFuture<V> {
     onCompleteCallbacks.forEach(this::triggerOnCompleteListener);
   }
 
-  private void triggerOnCompleteListener(final BiConsumer<V, Throwable> consumer) {
+  private void triggerOnCompleteListener(final BiConsumer<V, @Nullable Throwable> consumer) {
     result.ifRightOrLeft(
         value -> consumer.accept(value, null), error -> consumer.accept(null, error));
   }
@@ -194,6 +197,7 @@ public final class TestActorFuture<V> implements ActorFuture<V> {
   }
 
   @Override
+  @SuppressWarnings("NullAway")
   public V get() throws InterruptedException, ExecutionException {
     countDownLatch.await();
 
@@ -205,6 +209,7 @@ public final class TestActorFuture<V> implements ActorFuture<V> {
   }
 
   @Override
+  @SuppressWarnings("NullAway")
   public V get(final long timeout, final TimeUnit unit)
       throws InterruptedException, ExecutionException, TimeoutException {
     if (!countDownLatch.await(timeout, unit)) {

--- a/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/testing/TestActorFuture.java
+++ b/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/testing/TestActorFuture.java
@@ -99,7 +99,8 @@ public final class TestActorFuture<V extends @Nullable Object> implements ActorF
   }
 
   @Override
-  public void onComplete(final BiConsumer<V, Throwable> consumer, final Executor executor) {
+  public void onComplete(
+      final BiConsumer<V, @Nullable Throwable> consumer, final Executor executor) {
     onComplete((res, error) -> executor.execute(() -> consumer.accept(res, error)));
   }
 
@@ -110,16 +111,21 @@ public final class TestActorFuture<V extends @Nullable Object> implements ActorF
 
   @Override
   public Throwable getException() {
-    return result != null && result.isLeft() ? result.getLeft() : null;
+    if (result != null && result.isLeft()) {
+      return result.getLeft();
+    } else {
+      throw new IllegalStateException("Future is not completed exceptionally: " + result);
+    }
   }
 
   @Override
-  public <U> ActorFuture<U> andThen(final Supplier<ActorFuture<U>> next, final Executor executor) {
+  public <U extends @Nullable Object> ActorFuture<U> andThen(
+      final Supplier<ActorFuture<U>> next, final Executor executor) {
     return andThen(ignored -> next.get(), executor);
   }
 
   @Override
-  public <U> ActorFuture<U> andThen(
+  public <U extends @Nullable Object> ActorFuture<U> andThen(
       final Function<V, ActorFuture<U>> next, final Executor executor) {
     return andThen(
         (v, err) -> {
@@ -135,8 +141,8 @@ public final class TestActorFuture<V extends @Nullable Object> implements ActorF
   }
 
   @Override
-  public <U> ActorFuture<U> andThen(
-      final BiFunction<V, Throwable, ActorFuture<U>> next, final Executor executor) {
+  public <U extends @Nullable Object> ActorFuture<U> andThen(
+      final BiFunction<V, @Nullable Throwable, ActorFuture<U>> next, final Executor executor) {
     final ActorFuture<U> nextFuture = new CompletableActorFuture<>();
     onComplete(
         (thisResult, thisError) -> {
@@ -148,7 +154,8 @@ public final class TestActorFuture<V extends @Nullable Object> implements ActorF
   }
 
   @Override
-  public <U> ActorFuture<U> thenApply(final Function<V, U> next, final Executor executor) {
+  public <U extends @Nullable Object> ActorFuture<U> thenApply(
+      final Function<V, U> next, final Executor executor) {
     final ActorFuture<U> nextFuture = new TestActorFuture<>();
     onComplete(
         (value, error) -> {
@@ -168,7 +175,7 @@ public final class TestActorFuture<V extends @Nullable Object> implements ActorF
   }
 
   @Override
-  public <U> ActorFuture<U> thenApply(final Function<V, U> next) {
+  public <U extends @Nullable Object> ActorFuture<U> thenApply(final Function<V, U> next) {
     return thenApply(next, Runnable::run);
   }
 

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/ServerTransport.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/ServerTransport.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.transport;
 
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import org.jspecify.annotations.Nullable;
 
 public interface ServerTransport extends ServerOutput, AutoCloseable {
 
@@ -19,7 +20,7 @@ public interface ServerTransport extends ServerOutput, AutoCloseable {
    * @param requestType the type of request that should be handled
    * @param requestHandler the handler which should be called.
    */
-  ActorFuture<Void> subscribe(
+  ActorFuture<@Nullable Void> subscribe(
       int partitionId, RequestType requestType, RequestHandler requestHandler);
 
   /**
@@ -29,5 +30,5 @@ public interface ServerTransport extends ServerOutput, AutoCloseable {
    * @param partitionId the partition, from which we should unsubscribe
    * @param requestType
    */
-  ActorFuture<Void> unsubscribe(int partitionId, RequestType requestType);
+  ActorFuture<@Nullable Void> unsubscribe(int partitionId, RequestType requestType);
 }

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/impl/AtomixServerTransport.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/impl/AtomixServerTransport.java
@@ -22,6 +22,7 @@ import org.agrona.collections.Int2ObjectHashMap;
 import org.agrona.collections.Long2ObjectHashMap;
 import org.agrona.concurrent.IdGenerator;
 import org.agrona.concurrent.UnsafeBuffer;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 
 public class AtomixServerTransport extends Actor implements ServerTransport {
@@ -68,7 +69,7 @@ public class AtomixServerTransport extends Actor implements ServerTransport {
   }
 
   @Override
-  public ActorFuture<Void> subscribe(
+  public ActorFuture<@Nullable Void> subscribe(
       final int partitionId, final RequestType requestType, final RequestHandler requestHandler) {
     return actor.call(
         () -> {
@@ -80,7 +81,8 @@ public class AtomixServerTransport extends Actor implements ServerTransport {
   }
 
   @Override
-  public ActorFuture<Void> unsubscribe(final int partitionId, final RequestType requestType) {
+  public ActorFuture<@Nullable Void> unsubscribe(
+      final int partitionId, final RequestType requestType) {
     return actor.call(() -> removeRequestHandlers(partitionId, requestType));
   }
 

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamConsumer.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamConsumer.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.transport.stream.api;
 
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import org.agrona.DirectBuffer;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Represents a consumer of a stream which can consume data pushed from the server. The data is
@@ -24,5 +25,5 @@ public interface ClientStreamConsumer {
    *
    * @param payload the data to be consumed by the client
    */
-  ActorFuture<Void> push(DirectBuffer payload);
+  ActorFuture<@Nullable Void> push(DirectBuffer payload);
 }

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamService.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamService.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.Collection;
 import java.util.Optional;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Manages an instance of {@link ClientStreamer}. Intended to be the main entry point when setting
@@ -30,7 +31,7 @@ public interface ClientStreamService<M extends BufferWriter> extends AsyncClosab
    * Starts the service, optionally with the given actor scheduling service. Assumes the scheduling
    * service is already running.
    */
-  ActorFuture<Void> start(final ActorSchedulingService schedulingService);
+  ActorFuture<@Nullable Void> start(final ActorSchedulingService schedulingService);
 
   /**
    * A callback to be invoked when a new streaming server is added. Implementations should be

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamer.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamer.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.util.CloseableSilently;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import org.agrona.DirectBuffer;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Allows to add and remove client streams.
@@ -46,5 +47,5 @@ public interface ClientStreamer<M extends BufferWriter> extends CloseableSilentl
    * @param streamId unique id of the stream
    * @return a future which will be completed after the stream is removed
    */
-  ActorFuture<Void> remove(final ClientStreamId streamId);
+  ActorFuture<@Nullable Void> remove(final ClientStreamId streamId);
 }

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/api/RemoteStreamService.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/api/RemoteStreamService.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.Collection;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A remote stream service that manages streams from the Gateways.
@@ -25,7 +26,7 @@ public interface RemoteStreamService<M, P extends BufferWriter>
   ActorFuture<RemoteStreamer<M, P>> start(
       ActorSchedulingService actorSchedulingService, ConcurrencyControl concurrencyControl);
 
-  ActorFuture<Void> closeAsync(ConcurrencyControl concurrencyControl);
+  ActorFuture<@Nullable Void> closeAsync(ConcurrencyControl concurrencyControl);
 
   /** Returns all registered remote streams. */
   Collection<RemoteStreamInfo<M>> streams();

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamApiHandler.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamApiHandler.java
@@ -33,7 +33,7 @@ final class ClientStreamApiHandler {
   CompletableFuture<StreamResponse> handlePushRequest(final PushStreamRequest request) {
     final CompletableFuture<StreamResponse> responseFuture = new CompletableFuture<>();
 
-    final ActorFuture<Void> payloadPushed = new CompletableActorFuture<>();
+    final ActorFuture<@Nullable Void> payloadPushed = new CompletableActorFuture<>();
     clientStreamManager.onPayloadReceived(request, payloadPushed);
     payloadPushed.onComplete((ok, error) -> handlePayloadPushed(responseFuture, error), executor);
 

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.HashSet;
 import java.util.Set;
 import org.agrona.DirectBuffer;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -87,7 +88,7 @@ final class ClientStreamManager<M extends BufferWriter> {
   }
 
   public void onPayloadReceived(
-      final PushStreamRequest pushStreamRequest, final ActorFuture<Void> responseFuture) {
+      final PushStreamRequest pushStreamRequest, final ActorFuture<@Nullable Void> responseFuture) {
     final var streamId = pushStreamRequest.streamId();
     final var payload = pushStreamRequest.payload();
 

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamPusher.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamPusher.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Queue;
 import java.util.UUID;
 import org.agrona.DirectBuffer;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,7 +61,7 @@ final class ClientStreamPusher {
   void push(
       final AggregatedClientStream<?> stream,
       final DirectBuffer payload,
-      final ActorFuture<Void> future) {
+      final ActorFuture<@Nullable Void> future) {
     final var streams = stream.clientStreams().values();
     if (streams.isEmpty()) {
       future.completeExceptionally(
@@ -80,7 +81,7 @@ final class ClientStreamPusher {
       final UUID streamId,
       final Queue<ClientStreamImpl<?>> targets,
       final DirectBuffer buffer,
-      final ActorFuture<Void> future,
+      final ActorFuture<@Nullable Void> future,
       final List<Throwable> errors) {
     final var clientStream = targets.poll();
     if (clientStream == null) {
@@ -104,7 +105,8 @@ final class ClientStreamPusher {
             });
   }
 
-  private ActorFuture<Void> push(final ClientStreamImpl<?> stream, final DirectBuffer payload) {
+  private ActorFuture<@Nullable Void> push(
+      final ClientStreamImpl<?> stream, final DirectBuffer payload) {
     try {
       return stream.clientStreamConsumer().push(payload);
     } catch (final Exception e) {
@@ -112,7 +114,8 @@ final class ClientStreamPusher {
     }
   }
 
-  private void failOnStreamExhausted(final ActorFuture<Void> future, final List<Throwable> errors) {
+  private void failOnStreamExhausted(
+      final ActorFuture<@Nullable Void> future, final List<Throwable> errors) {
     final StreamExhaustedException error =
         new StreamExhaustedException(
             "Failed to push data to all available clients. No more clients left to retry.");

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamServiceImpl.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamServiceImpl.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 import java.util.Optional;
 import java.util.function.Function;
 import org.agrona.DirectBuffer;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Implementation for both {@link ClientStreamer} and {@link ClientStreamService}.
@@ -84,12 +85,12 @@ public final class ClientStreamServiceImpl<M extends BufferWriter> extends Actor
   }
 
   @Override
-  public ActorFuture<Void> remove(final ClientStreamId streamId) {
+  public ActorFuture<@Nullable Void> remove(final ClientStreamId streamId) {
     return actor.call(() -> clientStreamManager.remove(streamId));
   }
 
   @Override
-  public ActorFuture<Void> start(final ActorSchedulingService schedulingService) {
+  public ActorFuture<@Nullable Void> start(final ActorSchedulingService schedulingService) {
     return schedulingService.submitActor(this);
   }
 

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamServiceImpl.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamServiceImpl.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.stream.Stream;
+import org.jspecify.annotations.Nullable;
 
 public class RemoteStreamServiceImpl<M, P extends BufferWriter>
     implements RemoteStreamService<M, P> {
@@ -58,8 +59,8 @@ public class RemoteStreamServiceImpl<M, P extends BufferWriter>
   }
 
   @Override
-  public ActorFuture<Void> closeAsync(final ConcurrencyControl executor) {
-    final CompletableActorFuture<Void> closed = new CompletableActorFuture<>();
+  public ActorFuture<@Nullable Void> closeAsync(final ConcurrencyControl executor) {
+    final CompletableActorFuture<@Nullable Void> closed = new CompletableActorFuture<>();
     final var streamerClosed = streamer.closeAsync();
     final var serverClosed = apiServer.closeAsync();
     final var combined =

--- a/zeebe/util/pom.xml
+++ b/zeebe/util/pom.xml
@@ -47,6 +47,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <scope>test</scope>

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/Nulls.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/Nulls.java
@@ -5,20 +5,15 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.zeebe.scheduler.retry;
+package io.camunda.zeebe.util;
 
 import org.jspecify.annotations.Nullable;
 
-public final class RetryLimitExceededException extends RuntimeException {
+public final class Nulls {
+  private Nulls() {}
 
-  private final int retryLimit;
-
-  public RetryLimitExceededException(final int retryLimit, final @Nullable Throwable cause) {
-    super("Retry limit of " + retryLimit + " exceeded", cause);
-    this.retryLimit = retryLimit;
-  }
-
-  public int getRetryLimit() {
-    return retryLimit;
+  @SuppressWarnings("NullAway")
+  public static <V extends @Nullable Object> V uncheckedCastToNonNull(@Nullable final V value) {
+    return value;
   }
 }


### PR DESCRIPTION
## Description
Added `@NullMarked` and `@Nullable` to ActorFutures and `Clock`. Adding jspecify to the entire scheduler package requires a lot of cast as nulls are used extensively for performance reasons.
However, we rarely touch the code there, so it's more impactful to add annotations to the APIs used by the other modules.
As a result, there are changes required in `zeebe-transport` as all of its packages are allready supporting jspecify.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

relates #53263
