### PR TITLE
deps: bump tomcat version to 10.1.55

### DIFF
--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -54,7 +54,7 @@
     <spring.boot.version>3.5.14</spring.boot.version>
     <spring.version>6.2.17</spring.version>
     <spring.security.version>6.5.10</spring.security.version>
-    <version.tomcat>10.1.44</version.tomcat>
+    <version.tomcat>10.1.55</version.tomcat>
     <httpclient.version>4.5.14</httpclient.version>
     <quartz.version>2.3.2</quartz.version>
     <kotlin-stdlib.version>2.1.0</kotlin-stdlib.version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -104,7 +104,7 @@
     <spring-security.version>${version.spring-security}</spring-security.version>
     <version.spring-boot>3.5.14</version.spring-boot>
     <version.logback>1.5.25</version.logback>
-    <version.tomcat>10.1.44</version.tomcat>
+    <version.tomcat>10.1.55</version.tomcat>
     <version.concurrentunit>0.4.6</version.concurrentunit>
     <version.kryo>5.6.0</version.kryo>
     <version.failsafe>2.4.4</version.failsafe>


### PR DESCRIPTION
## Description

Bumps Tomcat versions to `10.1.55`

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

n/a
