### PR TITLE
feat: non start message correlation with business id as additional constraint

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.common;
 
 import static io.camunda.zeebe.util.buffer.BufferUtil.cloneBuffer;
+import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 
 import io.camunda.zeebe.el.Expression;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
@@ -374,6 +375,11 @@ public final class CatchEventBehavior {
     final DirectBuffer bpmnProcessId = cloneBuffer(context.getBpmnProcessId());
     final long elementInstanceKey = context.getElementInstanceKey();
     final long processDefinitionKey = context.getProcessDefinitionKey();
+    // Capture the process instance's businessId at subscription-open time and ship it with the
+    // OPEN command so the message partition can apply business-id-based filtering locally at
+    // correlation time. Reading PI state from another partition at correlation time would
+    // reintroduce the cross-partition chatter the design explicitly avoids.
+    final DirectBuffer businessId = wrapString(context.getBusinessId());
 
     final int subscriptionPartitionId = routingInfo.partitionForCorrelationKey(correlationKey);
 
@@ -388,6 +394,7 @@ public final class CatchEventBehavior {
     subscription.setInterrupting(event.isInterrupting());
     subscription.setTenantId(context.getTenantId());
     subscription.setRootProcessInstanceKey(rootProcessInstanceKey);
+    subscription.setBusinessId(businessId);
 
     final var subscriptionKey = keyGenerator.nextKey();
     stateWriter.appendFollowUpEvent(
@@ -402,7 +409,8 @@ public final class CatchEventBehavior {
         messageName,
         correlationKey,
         event.isInterrupting(),
-        context.getTenantId());
+        context.getTenantId(),
+        businessId);
 
     final String subscriptionMessageName = subscription.getMessageName();
     final String tenantId = subscription.getTenantId();
@@ -673,7 +681,8 @@ public final class CatchEventBehavior {
       final DirectBuffer messageName,
       final DirectBuffer correlationKey,
       final boolean closeOnCorrelate,
-      final String tenantId) {
+      final String tenantId,
+      final DirectBuffer businessId) {
     return subscriptionCommandSender.openMessageSubscription(
         subscriptionPartitionId,
         processInstanceKey,
@@ -683,7 +692,8 @@ public final class CatchEventBehavior {
         messageName,
         correlationKey,
         closeOnCorrelate,
-        tenantId);
+        tenantId,
+        businessId);
   }
 
   public record CatchEvent(ExecutableCatchEvent element, DirectBuffer messageName, Timer timer) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.engine.state.immutable.MessageStartEventSubscriptionStat
 import io.camunda.zeebe.engine.state.immutable.MessageState;
 import io.camunda.zeebe.engine.state.immutable.MessageSubscriptionState;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
+import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.Collection;
 import org.agrona.DirectBuffer;
 
@@ -123,7 +124,9 @@ public final class MessageCorrelateBehavior {
           // correlate the message only once per process
           if (!subscription.isCorrelating()
               && !correlatingSubscriptions.contains(
-                  subscription.getRecord().getBpmnProcessIdBuffer())) {
+                  subscription.getRecord().getBpmnProcessIdBuffer())
+              && businessIdMatches(
+                  messageData.businessId(), subscription.getRecord().getBusinessIdBuffer())) {
 
             final var correlatingSubscription =
                 subscription
@@ -158,7 +161,9 @@ public final class MessageCorrelateBehavior {
           // correlate the message only once per process
           if (!subscription.isCorrelating()
               && !correlatingSubscriptions.contains(
-                  subscription.getRecord().getBpmnProcessIdBuffer())) {
+                  subscription.getRecord().getBpmnProcessIdBuffer())
+              && businessIdMatches(
+                  messageData.businessId(), subscription.getRecord().getBusinessIdBuffer())) {
 
             // Just collect, don't write state yet
             correlatingSubscriptions.add(subscription.getRecord());
@@ -184,10 +189,26 @@ public final class MessageCorrelateBehavior {
                 messageData.tenantId()));
   }
 
+  /**
+   * Asymmetric business-id matching rule from the design: a message published without a business id
+   * (empty buffer) correlates regardless of the subscription's stored business id; a message with a
+   * business id only correlates to subscriptions whose stored business id matches exactly. Reading
+   * from the local {@code MessageSubscription} (not from PI state on another partition) is what
+   * keeps this a constant-time, on-partition check.
+   */
+  private boolean businessIdMatches(
+      final DirectBuffer messageBusinessId, final DirectBuffer subscriptionBusinessId) {
+    if (messageBusinessId == null || messageBusinessId.capacity() == 0) {
+      return true;
+    }
+    return BufferUtil.equals(messageBusinessId, subscriptionBusinessId);
+  }
+
   public record MessageData(
       long messageKey,
       DirectBuffer messageName,
       DirectBuffer correlationKey,
       DirectBuffer variables,
-      String tenantId) {}
+      String tenantId,
+      DirectBuffer businessId) {}
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
@@ -202,7 +202,8 @@ public final class MessageCorrelationCorrelateProcessor
         messageCorrelationRecord.getNameBuffer(),
         messageCorrelationRecord.getCorrelationKeyBuffer(),
         messageCorrelationRecord.getVariablesBuffer(),
-        messageCorrelationRecord.getTenantId());
+        messageCorrelationRecord.getTenantId(),
+        messageCorrelationRecord.getBusinessIdBuffer());
   }
 
   private Optional<Rejection> isAuthorizedForAllSubscriptions(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelator.java
@@ -12,8 +12,10 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.SideEffectWrit
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.state.immutable.MessageState;
 import io.camunda.zeebe.engine.state.message.StoredMessage;
+import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
+import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.time.InstantSource;
 import org.agrona.collections.MutableBoolean;
 
@@ -71,7 +73,8 @@ public final class MessageCorrelator {
     final boolean correlateMessage =
         message.getDeadline() > clock.millis()
             && !messageState.existMessageCorrelation(
-                messageKey, subscriptionRecord.getBpmnProcessIdBuffer());
+                messageKey, subscriptionRecord.getBpmnProcessIdBuffer())
+            && businessIdMatches(message, subscriptionRecord);
 
     if (correlateMessage) {
       subscriptionRecord.setMessageKey(messageKey).setVariables(message.getVariablesBuffer());
@@ -83,6 +86,22 @@ public final class MessageCorrelator {
     }
 
     return correlateMessage;
+  }
+
+  /**
+   * Asymmetric business-id matching rule from the design: a buffered message without a business id
+   * correlates regardless of the subscription's stored business id; a buffered message with a
+   * business id only correlates to subscriptions whose stored business id matches exactly. The
+   * subscription's business id was captured at OPEN time from the process instance, so this stays a
+   * local, on-partition check.
+   */
+  private static boolean businessIdMatches(
+      final MessageRecord message, final MessageSubscriptionRecord subscription) {
+    final var messageBusinessId = message.getBusinessIdBuffer();
+    if (messageBusinessId.capacity() == 0) {
+      return true;
+    }
+    return BufferUtil.equals(messageBusinessId, subscription.getBusinessIdBuffer());
   }
 
   private boolean sendCorrelateCommand(final MessageSubscriptionRecord subscriptionRecord) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessagePublishProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessagePublishProcessor.java
@@ -170,6 +170,7 @@ public final class MessagePublishProcessor implements TypedRecordProcessor<Messa
         messageCorrelationRecord.getNameBuffer(),
         messageCorrelationRecord.getCorrelationKeyBuffer(),
         messageCorrelationRecord.getVariablesBuffer(),
-        messageCorrelationRecord.getTenantId());
+        messageCorrelationRecord.getTenantId(),
+        messageCorrelationRecord.getBusinessIdBuffer());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionCreateProcessor.java
@@ -104,6 +104,7 @@ public final class MessageSubscriptionCreateProcessor
         subscriptionRecord.getProcessDefinitionKey(),
         subscriptionRecord.getMessageNameBuffer(),
         subscriptionRecord.isInterrupting(),
-        subscriptionRecord.getTenantId());
+        subscriptionRecord.getTenantId(),
+        subscriptionRecord.getBusinessIdBuffer());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingProcessMessageSubscriptionCheckScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingProcessMessageSubscriptionCheckScheduler.java
@@ -109,7 +109,8 @@ public final class PendingProcessMessageSubscriptionCheckScheduler
         subscription.getRecord().getMessageNameBuffer(),
         subscription.getRecord().getCorrelationKeyBuffer(),
         subscription.getRecord().isInterrupting(),
-        subscription.getRecord().getTenantId());
+        subscription.getRecord().getTenantId(),
+        subscription.getRecord().getBusinessIdBuffer());
   }
 
   private void sendCloseCommand(final ProcessMessageSubscription subscription) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSender.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSender.java
@@ -60,7 +60,8 @@ public class SubscriptionCommandSender {
       final DirectBuffer messageName,
       final DirectBuffer correlationKey,
       final boolean closeOnCorrelate,
-      final String tenantId) {
+      final String tenantId,
+      final DirectBuffer businessId) {
     return handleFollowUpCommandBasedOnPartition(
         subscriptionPartitionId,
         ValueType.MESSAGE_SUBSCRIPTION,
@@ -74,7 +75,8 @@ public class SubscriptionCommandSender {
             .setMessageName(messageName)
             .setCorrelationKey(correlationKey)
             .setInterrupting(closeOnCorrelate)
-            .setTenantId(tenantId));
+            .setTenantId(tenantId)
+            .setBusinessId(businessId));
   }
 
   /**
@@ -90,6 +92,9 @@ public class SubscriptionCommandSender {
    * @param correlationKey the correlation key for which the message should be correlated
    * @param closeOnCorrelate indicates whether the subscription should be closed after correlation
    * @param tenantId the tenant id the message subscription is created for
+   * @param businessId the business id captured from the subscribing process instance at open time;
+   *     used as a post-routing local filter on the subscription partition. May be an empty buffer
+   *     when the process instance has no business id.
    */
   public void sendDirectOpenMessageSubscription(
       final int subscriptionPartitionId,
@@ -100,7 +105,8 @@ public class SubscriptionCommandSender {
       final DirectBuffer messageName,
       final DirectBuffer correlationKey,
       final boolean closeOnCorrelate,
-      final String tenantId) {
+      final String tenantId,
+      final DirectBuffer businessId) {
     interPartitionCommandSender.sendCommand(
         subscriptionPartitionId,
         ValueType.MESSAGE_SUBSCRIPTION,
@@ -114,7 +120,8 @@ public class SubscriptionCommandSender {
             .setMessageName(messageName)
             .setCorrelationKey(correlationKey)
             .setInterrupting(closeOnCorrelate)
-            .setTenantId(tenantId));
+            .setTenantId(tenantId)
+            .setBusinessId(businessId));
   }
 
   public boolean openProcessMessageSubscription(
@@ -123,7 +130,8 @@ public class SubscriptionCommandSender {
       final long processDefinitionKey,
       final DirectBuffer messageName,
       final boolean closeOnCorrelate,
-      final String tenantId) {
+      final String tenantId,
+      final DirectBuffer businessId) {
     return handleFollowUpCommandBasedOnPartition(
         Protocol.decodePartitionId(processInstanceKey),
         ValueType.PROCESS_MESSAGE_SUBSCRIPTION,
@@ -136,7 +144,8 @@ public class SubscriptionCommandSender {
             .setMessageKey(-1)
             .setMessageName(messageName)
             .setInterrupting(closeOnCorrelate)
-            .setTenantId(tenantId));
+            .setTenantId(tenantId)
+            .setBusinessId(businessId));
   }
 
   public boolean correlateProcessMessageSubscription(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationBusinessIdMultiplePartitionsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationBusinessIdMultiplePartitionsTest.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.SubscriptionUtil;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.MessageIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.MessageRecordValue;
+import io.camunda.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.function.Predicate;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Cross-partition variant of {@link MessageCorrelationBusinessIdTest}: ensures the asymmetric
+ * business-id filter behaves identically when the process instance lives on a partition different
+ * from the message partition. The PI partition ships the business id with the OPEN command and the
+ * message partition applies the filter against the locally stored value — the design's central
+ * anti-chatter rule.
+ */
+public final class MessageCorrelationBusinessIdMultiplePartitionsTest {
+
+  private static final int PARTITION_COUNT = 3;
+  private static final String PROCESS_ID = "process";
+
+  private static final BpmnModelInstance INTERMEDIATE_CATCH_PROCESS =
+      Bpmn.createExecutableProcess(PROCESS_ID)
+          .startEvent()
+          .intermediateCatchEvent("receive-message")
+          .message(m -> m.name("message").zeebeCorrelationKeyExpression("key"))
+          .endEvent()
+          .done();
+
+  @Rule public final EngineRule engine = EngineRule.multiplePartition(PARTITION_COUNT);
+
+  @Test
+  public void shouldCorrelateMessageWithBusinessIdAcrossPartitions() {
+    // given a process instance whose correlation key routes its subscription to a specific
+    // partition; the PI itself may live on a different partition
+    engine.deployment().withXmlResource(INTERMEDIATE_CATCH_PROCESS).deploy();
+    final String correlationKey = "order-x-1";
+    final String businessId = "biz-42";
+    final long processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withBusinessId(businessId)
+            .withVariable("key", correlationKey)
+            .create();
+    final var subscription = awaitSubscriptionCreated(processInstanceKey);
+
+    // sanity: the subscription was opened on the message partition (P_K), and that partition has
+    // the business id stored locally — this is what makes the filter on-partition.
+    assertThat(subscription.getPartitionId())
+        .isEqualTo(partitionFor(correlationKey, PARTITION_COUNT));
+    assertThat(subscription.getValue().getBusinessId()).isEqualTo(businessId);
+    // and the PI lives on a different partition than its subscription — otherwise this test would
+    // silently degenerate into a single-partition scenario and would not actually exercise the
+    // cross-partition rule it claims to.
+    assertCrossPartitionRouting(processInstanceKey, subscription.getPartitionId());
+
+    // when
+    engine
+        .message()
+        .withName("message")
+        .withCorrelationKey(correlationKey)
+        .withBusinessId(businessId)
+        .publish();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+                .withElementType(BpmnElementType.PROCESS)
+                .withProcessInstanceKey(processInstanceKey)
+                .getFirst())
+        .isNotNull();
+  }
+
+  @Test
+  public void shouldNotCorrelateMessageWithMismatchedBusinessIdAcrossPartitions() {
+    // given
+    engine.deployment().withXmlResource(INTERMEDIATE_CATCH_PROCESS).deploy();
+    final String correlationKey = "order-x-2";
+    final String businessId = "biz-42";
+    final long processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withBusinessId(businessId)
+            .withVariable("key", correlationKey)
+            .create();
+    final var subscription = awaitSubscriptionCreated(processInstanceKey);
+    // sanity: same cross-partition guarantee as the positive case.
+    assertCrossPartitionRouting(processInstanceKey, subscription.getPartitionId());
+
+    // when
+    engine
+        .message()
+        .withName("message")
+        .withCorrelationKey(correlationKey)
+        .withBusinessId("other-biz")
+        .withTimeToLive(0L)
+        .publish();
+
+    // then the message lifecycle completes (EXPIRED on the message partition) without ever
+    // correlating to the PI on the other partition.
+    assertNoCorrelationUpToMessageExpiry(processInstanceKey, "message", correlationKey);
+  }
+
+  private static Record<MessageSubscriptionRecordValue> awaitSubscriptionCreated(
+      final long processInstanceKey) {
+    return RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .getFirst();
+  }
+
+  /**
+   * Bound the record stream on the EXPIRED of the specific message identified by {@code
+   * messageName} + {@code correlationKey} (a deterministic terminal the caller published, typically
+   * with TTL=0) and assert that no CORRELATING/CORRELATED records for {@code processInstanceKey}
+   * appeared up to that point.
+   */
+  private static void assertNoCorrelationUpToMessageExpiry(
+      final long processInstanceKey, final String messageName, final String correlationKey) {
+    final Predicate<Record<?>> messageExpired =
+        r ->
+            r.getIntent() == MessageIntent.EXPIRED
+                && r.getValue() instanceof final MessageRecordValue v
+                && messageName.equals(v.getName())
+                && correlationKey.equals(v.getCorrelationKey());
+    final boolean correlated =
+        RecordingExporter.records()
+            .limit(messageExpired::test)
+            .messageSubscriptionRecords()
+            .withProcessInstanceKey(processInstanceKey)
+            .withIntent(MessageSubscriptionIntent.CORRELATED)
+            .exists();
+    assertThat(correlated).isFalse();
+    final boolean correlating =
+        RecordingExporter.records()
+            .limit(messageExpired::test)
+            .messageSubscriptionRecords()
+            .withProcessInstanceKey(processInstanceKey)
+            .withIntent(MessageSubscriptionIntent.CORRELATING)
+            .exists();
+    assertThat(correlating).isFalse();
+  }
+
+  private static int partitionFor(final String correlationKey, final int count) {
+    return SubscriptionUtil.getSubscriptionPartitionId(
+        BufferUtil.wrapString(correlationKey), count);
+  }
+
+  /**
+   * Assert that the PI's partition (derived from {@code processInstanceKey}) differs from the
+   * subscription partition, so the test actually exercises the cross-partition path. If the chosen
+   * {@code correlationKey} / {@code businessId} happen to hash to the same partition, this fails
+   * loudly instead of silently degenerating into a single-partition scenario.
+   */
+  private static void assertCrossPartitionRouting(
+      final long processInstanceKey, final int subscriptionPartitionId) {
+    final int piPartitionId = Protocol.decodePartitionId(processInstanceKey);
+    assertThat(piPartitionId)
+        .as(
+            "PI partition (%d) must differ from subscription partition (%d) so the test exercises"
+                + " cross-partition correlation; otherwise pick correlationKey/businessId values"
+                + " whose hashes differ",
+            piPartitionId, subscriptionPartitionId)
+        .isNotEqualTo(subscriptionPartitionId);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationBusinessIdTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationBusinessIdTest.java
@@ -1,0 +1,397 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.MessageIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.MessageRecordValue;
+import io.camunda.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
+import java.util.function.Predicate;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Behavioral specification for using {@code businessId} as an additional, post-routing local
+ * constraint on non-start (catch / boundary / intermediate) message correlation.
+ *
+ * <p>The asymmetric rule is load-bearing and is exercised from both sides:
+ *
+ * <ul>
+ *   <li>A message published <b>without</b> a {@code businessId} correlates regardless of the
+ *       subscription's stored value.
+ *   <li>A message published <b>with</b> a {@code businessId} correlates only to subscriptions whose
+ *       stored value matches exactly — both for new-message → existing-subscription correlation and
+ *       for new-subscription → buffered-message correlation.
+ * </ul>
+ *
+ * <p>Tests cover both correlation directions (publish-then-subscribe and subscribe-then-publish), a
+ * multi-definition scenario where two processes share the same name/key but differ in business id
+ * usage, and a pin that the value captured at OPEN time is what governs later correlation.
+ */
+public final class MessageCorrelationBusinessIdTest {
+
+  private static final String PROCESS_ID = "process";
+
+  private static final BpmnModelInstance INTERMEDIATE_CATCH_PROCESS =
+      Bpmn.createExecutableProcess(PROCESS_ID)
+          .startEvent()
+          .intermediateCatchEvent("receive-message")
+          .message(m -> m.name("message").zeebeCorrelationKeyExpression("key"))
+          .endEvent()
+          .done();
+
+  @Rule public final EngineRule engine = EngineRule.singlePartition();
+
+  // --- Asymmetric rule, publish-then-subscribe is not relevant; these test
+  // --- subscribe-then-publish (the "new message → existing subscription" path).
+
+  @Test
+  public void shouldCorrelateMessageWithoutBusinessIdToSubscriptionFromProcessInstanceWithOne() {
+    // given
+    engine.deployment().withXmlResource(INTERMEDIATE_CATCH_PROCESS).deploy();
+    final long processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withBusinessId("biz-42")
+            .withVariable("key", "order-1")
+            .create();
+    awaitSubscriptionCreated(processInstanceKey);
+
+    // when
+    engine.message().withName("message").withCorrelationKey("order-1").publish();
+
+    // then
+    assertProcessCompleted(processInstanceKey);
+  }
+
+  @Test
+  public void shouldCorrelateMessageWithoutBusinessIdToSubscriptionWithoutOne() {
+    // given
+    engine.deployment().withXmlResource(INTERMEDIATE_CATCH_PROCESS).deploy();
+    final long processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable("key", "order-2")
+            .create();
+    awaitSubscriptionCreated(processInstanceKey);
+
+    // when
+    engine.message().withName("message").withCorrelationKey("order-2").publish();
+
+    // then
+    assertProcessCompleted(processInstanceKey);
+  }
+
+  @Test
+  public void shouldCorrelateMessageWithBusinessIdToSubscriptionWithMatchingOne() {
+    // given
+    engine.deployment().withXmlResource(INTERMEDIATE_CATCH_PROCESS).deploy();
+    final long processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withBusinessId("biz-42")
+            .withVariable("key", "order-3")
+            .create();
+    awaitSubscriptionCreated(processInstanceKey);
+
+    // when
+    engine
+        .message()
+        .withName("message")
+        .withCorrelationKey("order-3")
+        .withBusinessId("biz-42")
+        .publish();
+
+    // then
+    assertProcessCompleted(processInstanceKey);
+  }
+
+  @Test
+  public void shouldNotCorrelateMessageWithBusinessIdToSubscriptionWithDifferentOne() {
+    // given
+    engine.deployment().withXmlResource(INTERMEDIATE_CATCH_PROCESS).deploy();
+    final long processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withBusinessId("biz-42")
+            .withVariable("key", "order-4")
+            .create();
+    awaitSubscriptionCreated(processInstanceKey);
+
+    // when a message with a different businessId is published with a TTL of 0 so the
+    // engine processes the publish-and-discard cycle deterministically.
+    engine
+        .message()
+        .withName("message")
+        .withCorrelationKey("order-4")
+        .withBusinessId("other-biz")
+        .withTimeToLive(0L)
+        .publish();
+
+    // then the message lifecycle completes (EXPIRED) without ever correlating the subscription.
+    assertNoCorrelationUpToMessageExpiry(processInstanceKey, "message", "order-4");
+  }
+
+  @Test
+  public void shouldNotCorrelateMessageWithBusinessIdToSubscriptionWithoutOne() {
+    // given
+    engine.deployment().withXmlResource(INTERMEDIATE_CATCH_PROCESS).deploy();
+    final long processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable("key", "order-5")
+            .create();
+    awaitSubscriptionCreated(processInstanceKey);
+
+    // when
+    engine
+        .message()
+        .withName("message")
+        .withCorrelationKey("order-5")
+        .withBusinessId("biz-42")
+        .withTimeToLive(0L)
+        .publish();
+
+    // then
+    assertNoCorrelationUpToMessageExpiry(processInstanceKey, "message", "order-5");
+  }
+
+  // --- Buffered-message path: publish first, subscribe later.
+
+  @Test
+  public void shouldCorrelateBufferedMessageWithMatchingBusinessIdToNewSubscription() {
+    // given a message published before any matching subscription exists
+    engine.deployment().withXmlResource(INTERMEDIATE_CATCH_PROCESS).deploy();
+    engine
+        .message()
+        .withName("message")
+        .withCorrelationKey("order-6")
+        .withBusinessId("biz-42")
+        .withTimeToLive(Duration.ofMinutes(5))
+        .publish();
+
+    // when a process instance with the matching businessId opens the subscription
+    final long processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withBusinessId("biz-42")
+            .withVariable("key", "order-6")
+            .create();
+
+    // then the buffered message is correlated and the process completes
+    assertProcessCompleted(processInstanceKey);
+  }
+
+  @Test
+  public void shouldNotCorrelateBufferedMessageWithBusinessIdToSubscriptionWithDifferentOne() {
+    // given
+    engine.deployment().withXmlResource(INTERMEDIATE_CATCH_PROCESS).deploy();
+    engine
+        .message()
+        .withName("message")
+        .withCorrelationKey("order-7")
+        .withBusinessId("biz-42")
+        .withTimeToLive(Duration.ofMinutes(5))
+        .publish();
+
+    // when a process instance with a different businessId opens the subscription
+    final long processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withBusinessId("other-biz")
+            .withVariable("key", "order-7")
+            .create();
+    awaitSubscriptionCreated(processInstanceKey);
+
+    // then the buffered message is not consumed; we use a separate TTL=0 sentinel publish on an
+    // unrelated correlation key as a deterministic boundary to assert "no correlation happened
+    // up to this point".
+    engine
+        .message()
+        .withName("sentinel")
+        .withCorrelationKey("sentinel-key-1")
+        .withTimeToLive(0L)
+        .publish();
+    assertNoCorrelationUpToMessageExpiry(processInstanceKey, "sentinel", "sentinel-key-1");
+  }
+
+  // --- Multi-definition: one published message vs subscriptions from two different process
+  // --- definitions with different businessId values.
+
+  @Test
+  public void shouldOnlyCorrelateToSubscriptionsWithMatchingBusinessIdAcrossDefinitions() {
+    // given two distinct process definitions subscribing to the same message name + correlation
+    // key, plus three instances with different business ids
+    final var matchingProcessId = "matching-" + PROCESS_ID;
+    final var nonMatchingProcessId = "non-matching-" + PROCESS_ID;
+    engine
+        .deployment()
+        .withXmlResource(processWithIntermediateCatch(matchingProcessId))
+        .withXmlResource(processWithIntermediateCatch(nonMatchingProcessId))
+        .deploy();
+
+    final long matchingPi =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(matchingProcessId)
+            .withBusinessId("biz-42")
+            .withVariable("key", "order-8")
+            .create();
+    final long nonMatchingPi =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(nonMatchingProcessId)
+            .withBusinessId("other-biz")
+            .withVariable("key", "order-8")
+            .create();
+    awaitSubscriptionCreated(matchingPi);
+    awaitSubscriptionCreated(nonMatchingPi);
+
+    // when
+    engine
+        .message()
+        .withName("message")
+        .withCorrelationKey("order-8")
+        .withBusinessId("biz-42")
+        .publish();
+
+    // then only the matching PI completes; the non-matching one keeps waiting (the matching PI's
+    // completion is itself the deterministic terminal we bound the negative assertion on).
+    assertProcessCompleted(matchingPi);
+    assertNoCorrelationForProcessInstance(nonMatchingPi, matchingPi);
+  }
+
+  // --- Pinning: businessId captured at OPEN time governs correlation; the subscription's stored
+  // --- value is what's matched, not anything resolved at correlation time from PI state.
+
+  @Test
+  public void shouldUseBusinessIdCapturedAtSubscriptionOpenToFilterCorrelation() {
+    // given a subscription was opened from a PI with businessId "biz-42"
+    engine.deployment().withXmlResource(INTERMEDIATE_CATCH_PROCESS).deploy();
+    final long processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withBusinessId("biz-42")
+            .withVariable("key", "order-9")
+            .create();
+    final var subscriptionCreated = awaitSubscriptionCreated(processInstanceKey);
+
+    // then the subscription on the message partition carries that businessId; later correlation
+    // decisions are made against this stored value, not by re-reading PI state across partitions.
+    assertThat(subscriptionCreated.getValue().getBusinessId()).isEqualTo("biz-42");
+
+    // and an exactly matching publish correlates against that stored value
+    engine
+        .message()
+        .withName("message")
+        .withCorrelationKey("order-9")
+        .withBusinessId("biz-42")
+        .publish();
+    assertProcessCompleted(processInstanceKey);
+  }
+
+  private static BpmnModelInstance processWithIntermediateCatch(final String processId) {
+    return Bpmn.createExecutableProcess(processId)
+        .startEvent()
+        .intermediateCatchEvent("receive-message")
+        .message(m -> m.name("message").zeebeCorrelationKeyExpression("key"))
+        .endEvent()
+        .done();
+  }
+
+  private static Record<MessageSubscriptionRecordValue> awaitSubscriptionCreated(
+      final long processInstanceKey) {
+    return RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .getFirst();
+  }
+
+  private static void assertProcessCompleted(final long processInstanceKey) {
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+                .withElementType(BpmnElementType.PROCESS)
+                .withProcessInstanceKey(processInstanceKey)
+                .getFirst())
+        .isNotNull();
+  }
+
+  /**
+   * Assert that no CORRELATING/CORRELATED records for {@code processInstanceKey} appear in the
+   * record stream up to the EXPIRED of the specific message identified by {@code messageName} +
+   * {@code correlationKey}. The caller is responsible for publishing that message (typically with
+   * TTL=0) so its EXPIRED is a deterministic terminal we can bound on. Matching the specific
+   * message — rather than the first EXPIRED of any message — keeps the helper honest if multiple
+   * messages happen to expire in the same test stream.
+   */
+  private static void assertNoCorrelationUpToMessageExpiry(
+      final long processInstanceKey, final String messageName, final String correlationKey) {
+    final Predicate<Record<?>> messageExpired =
+        r ->
+            r.getIntent() == MessageIntent.EXPIRED
+                && r.getValue() instanceof final MessageRecordValue v
+                && messageName.equals(v.getName())
+                && correlationKey.equals(v.getCorrelationKey());
+    final boolean correlated =
+        RecordingExporter.records()
+            .limit(messageExpired::test)
+            .messageSubscriptionRecords()
+            .withProcessInstanceKey(processInstanceKey)
+            .withIntent(MessageSubscriptionIntent.CORRELATED)
+            .exists();
+    assertThat(correlated).isFalse();
+    final boolean correlating =
+        RecordingExporter.records()
+            .limit(messageExpired::test)
+            .messageSubscriptionRecords()
+            .withProcessInstanceKey(processInstanceKey)
+            .withIntent(MessageSubscriptionIntent.CORRELATING)
+            .exists();
+    assertThat(correlating).isFalse();
+  }
+
+  /**
+   * Assert that the {@code targetProcessInstanceKey} never had a correlation, using the {@code
+   * boundaryProcessInstanceKey}'s completion (a deterministic positive terminal) as the upper bound
+   * of the observed record stream.
+   */
+  private static void assertNoCorrelationForProcessInstance(
+      final long targetProcessInstanceKey, final long boundaryProcessInstanceKey) {
+    final boolean correlated =
+        RecordingExporter.records()
+            .limit(
+                r ->
+                    r.getIntent() == ProcessInstanceIntent.ELEMENT_COMPLETED
+                        && r.getValue() instanceof final ProcessInstanceRecordValue v
+                        && v.getProcessInstanceKey() == boundaryProcessInstanceKey
+                        && v.getBpmnElementType() == BpmnElementType.PROCESS)
+            .messageSubscriptionRecords()
+            .withProcessInstanceKey(targetProcessInstanceKey)
+            .withIntent(MessageSubscriptionIntent.CORRELATED)
+            .exists();
+    assertThat(correlated).isFalse();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
@@ -142,7 +142,8 @@ public final class MessageStreamProcessorTest {
             eq(subscription.getProcessDefinitionKey()),
             any(),
             anyBoolean(),
-            eq(TenantOwned.DEFAULT_TENANT_IDENTIFIER));
+            eq(TenantOwned.DEFAULT_TENANT_IDENTIFIER),
+            any());
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionBusinessIdPlumbingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionBusinessIdPlumbingTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Pins that the process instance's {@code businessId} is captured at message-subscription open time
+ * and shipped to the message partition together with the OPEN command, so the message partition
+ * holds it locally on the {@code MessageSubscription} record. This is a precondition for the
+ * post-routing local filter implemented in the next increment: reading the PI's {@code businessId}
+ * from a different partition at correlation time would reintroduce the cross-partition chatter the
+ * design explicitly avoids.
+ *
+ * <p>This test does not exercise any correlation-time filtering — it only validates the plumbing of
+ * the field from the PI partition through to {@code P_K}.
+ */
+public final class MessageSubscriptionBusinessIdPlumbingTest {
+
+  private static final String PROCESS_ID = "process";
+
+  private static final BpmnModelInstance INTERMEDIATE_CATCH_PROCESS =
+      Bpmn.createExecutableProcess(PROCESS_ID)
+          .startEvent()
+          .intermediateCatchEvent("receive-message")
+          .message(m -> m.name("message").zeebeCorrelationKeyExpression("key"))
+          .endEvent()
+          .done();
+
+  @Rule public final EngineRule engine = EngineRule.singlePartition();
+
+  @Test
+  public void shouldPropagateBusinessIdFromProcessInstanceToMessageSubscription() {
+    // given
+    engine.deployment().withXmlResource(INTERMEDIATE_CATCH_PROCESS).deploy();
+
+    // when
+    final long processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withBusinessId("biz-42")
+            .withVariable("key", "order-1")
+            .create();
+
+    // then
+    final var processSubscriptionCreated =
+        RecordingExporter.processMessageSubscriptionRecords(
+                ProcessMessageSubscriptionIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+    assertThat(processSubscriptionCreated.getValue().getBusinessId()).isEqualTo("biz-42");
+
+    final var subscriptionCreated =
+        RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+    assertThat(subscriptionCreated.getValue().getBusinessId()).isEqualTo("biz-42");
+  }
+
+  @Test
+  public void shouldStoreEmptyBusinessIdWhenProcessInstanceHasNone() {
+    // given
+    engine.deployment().withXmlResource(INTERMEDIATE_CATCH_PROCESS).deploy();
+
+    // when
+    final long processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable("key", "order-2")
+            .create();
+
+    // then
+    final var subscriptionCreated =
+        RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+    assertThat(subscriptionCreated.getValue().getBusinessId()).isEmpty();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSenderTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSenderTest.java
@@ -46,6 +46,7 @@ public class SubscriptionCommandSenderTest {
   private static final long DEFAULT_ELEMENT_INSTANCE_KEY = 111;
   private static final long DEFAULT_PROCESS_DEFINITION_KEY = 222;
   private static final DirectBuffer DEFAULT_MESSAGE_NAME = BufferUtil.wrapString("msg");
+  private static final DirectBuffer DEFAULT_BUSINESS_ID = BufferUtil.wrapString("");
   private static final String DEFAULT_TENANT = TenantOwned.DEFAULT_TENANT_IDENTIFIER;
   private InterPartitionCommandSender mockInterPartitionCommandSender;
   private SubscriptionCommandSender subscriptionCommandSender;
@@ -240,7 +241,8 @@ public class SubscriptionCommandSenderTest {
         DEFAULT_MESSAGE_NAME,
         DEFAULT_CORRELATION_KEY,
         true,
-        TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+        TenantOwned.DEFAULT_TENANT_IDENTIFIER,
+        DEFAULT_BUSINESS_ID);
 
     // then
     verify(mockProcessingResultBuilder).appendPostCommitTask(any());
@@ -261,7 +263,8 @@ public class SubscriptionCommandSenderTest {
         DEFAULT_MESSAGE_NAME,
         DEFAULT_CORRELATION_KEY,
         true,
-        TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+        TenantOwned.DEFAULT_TENANT_IDENTIFIER,
+        DEFAULT_BUSINESS_ID);
 
     // then
     verify(mockProcessingResultBuilder, never()).appendPostCommitTask(any());
@@ -282,7 +285,8 @@ public class SubscriptionCommandSenderTest {
         DEFAULT_MESSAGE_NAME,
         DEFAULT_CORRELATION_KEY,
         true,
-        TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+        TenantOwned.DEFAULT_TENANT_IDENTIFIER,
+        DEFAULT_BUSINESS_ID);
 
     // then
     verify(mockInterPartitionCommandSender)
@@ -306,7 +310,8 @@ public class SubscriptionCommandSenderTest {
         DEFAULT_PROCESS_DEFINITION_KEY,
         DEFAULT_MESSAGE_NAME,
         true,
-        TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+        TenantOwned.DEFAULT_TENANT_IDENTIFIER,
+        DEFAULT_BUSINESS_ID);
 
     // then
     verify(mockProcessingResultBuilder).appendPostCommitTask(any());
@@ -324,7 +329,8 @@ public class SubscriptionCommandSenderTest {
         DEFAULT_PROCESS_DEFINITION_KEY,
         DEFAULT_MESSAGE_NAME,
         true,
-        TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+        TenantOwned.DEFAULT_TENANT_IDENTIFIER,
+        DEFAULT_BUSINESS_ID);
 
     // then
     verify(mockProcessingResultBuilder, never()).appendPostCommitTask(any());

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/PublishMessageClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/PublishMessageClient.java
@@ -103,6 +103,11 @@ public final class PublishMessageClient {
     return this;
   }
 
+  public PublishMessageClient withBusinessId(final String businessId) {
+    messageRecord.setBusinessId(businessId);
+    return this;
+  }
+
   public PublishMessageClient onPartition(final int partitionId) {
     this.partitionId = partitionId;
     return this;

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-message-correlation-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-message-correlation-template.json
@@ -45,6 +45,9 @@
             },
             "requestStreamId": {
               "type": "integer"
+            },
+            "businessId": {
+              "type": "keyword"
             }
           }
         }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-message-subscription-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-message-subscription-template.json
@@ -51,6 +51,9 @@
             },
             "tenantId": {
               "type": "keyword"
+            },
+            "businessId": {
+              "type": "keyword"
             }
           }
         }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-message-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-message-template.json
@@ -39,6 +39,9 @@
             },
             "tenantId": {
               "type": "keyword"
+            },
+            "businessId": {
+              "type": "keyword"
             }
           }
         }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-message-subscription-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-message-subscription-template.json
@@ -54,6 +54,9 @@
             },
             "rootProcessInstanceKey": {
               "type": "long"
+            },
+            "businessId": {
+              "type": "keyword"
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-message-correlation-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-message-correlation-template.json
@@ -51,6 +51,9 @@
             },
             "requestStreamId": {
               "type": "integer"
+            },
+            "businessId": {
+              "type": "keyword"
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-message-subscription-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-message-subscription-template.json
@@ -57,6 +57,9 @@
             },
             "tenantId": {
               "type": "keyword"
+            },
+            "businessId": {
+              "type": "keyword"
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-message-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-message-template.json
@@ -45,6 +45,9 @@
             },
             "tenantId": {
               "type": "keyword"
+            },
+            "businessId": {
+              "type": "keyword"
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-message-subscription-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-message-subscription-template.json
@@ -60,6 +60,9 @@
             },
             "rootProcessInstanceKey": {
               "type": "long"
+            },
+            "businessId": {
+              "type": "keyword"
             }
           }
         }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageCorrelationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageCorrelationRecord.java
@@ -36,6 +36,7 @@ public final class MessageCorrelationRecord extends UnifiedRecordValue
   private static final StringValue PROCESS_INSTANCE_KEY_KEY = new StringValue("processInstanceKey");
   private static final StringValue PROCESS_DEFINITION_KEY_KEY =
       new StringValue("processDefinitionKey");
+  private static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
 
   private final StringProperty nameProp = new StringProperty(NAME_KEY);
   private final StringProperty correlationKeyProp = new StringProperty(CORRELATION_KEY_KEY);
@@ -51,9 +52,10 @@ public final class MessageCorrelationRecord extends UnifiedRecordValue
       new LongProperty(PROCESS_INSTANCE_KEY_KEY, -1L);
   private final LongProperty processDefinitionKeyProp =
       new LongProperty(PROCESS_DEFINITION_KEY_KEY, -1L);
+  private final StringProperty businessIdProp = new StringProperty(BUSINESS_ID_KEY, "");
 
   public MessageCorrelationRecord() {
-    super(8);
+    super(10);
     declareProperty(nameProp)
         .declareProperty(correlationKeyProp)
         .declareProperty(variablesProp)
@@ -62,7 +64,8 @@ public final class MessageCorrelationRecord extends UnifiedRecordValue
         .declareProperty(requestIdProp)
         .declareProperty(requestStreamIdProp)
         .declareProperty(processInstanceKeyProp)
-        .declareProperty(processDefinitionKeyProp);
+        .declareProperty(processDefinitionKeyProp)
+        .declareProperty(businessIdProp);
   }
 
   public void wrap(final MessageCorrelationRecord record) {
@@ -71,6 +74,7 @@ public final class MessageCorrelationRecord extends UnifiedRecordValue
     setVariables(record.getVariablesBuffer());
     setTenantId(record.getTenantId());
     setProcessInstanceKey(record.getProcessInstanceKey());
+    setBusinessId(record.getBusinessIdBuffer());
   }
 
   @Override
@@ -175,6 +179,26 @@ public final class MessageCorrelationRecord extends UnifiedRecordValue
 
   public MessageCorrelationRecord setProcessDefinitionKey(final long processDefinitionKey) {
     processDefinitionKeyProp.setValue(processDefinitionKey);
+    return this;
+  }
+
+  @Override
+  public String getBusinessId() {
+    return bufferAsString(businessIdProp.getValue());
+  }
+
+  @JsonIgnore
+  public DirectBuffer getBusinessIdBuffer() {
+    return businessIdProp.getValue();
+  }
+
+  public MessageCorrelationRecord setBusinessId(final String businessId) {
+    businessIdProp.setValue(businessId);
+    return this;
+  }
+
+  public MessageCorrelationRecord setBusinessId(final DirectBuffer businessId) {
+    businessIdProp.setValue(businessId);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageRecord.java
@@ -31,6 +31,7 @@ public final class MessageRecord extends UnifiedRecordValue implements MessageRe
   private static final StringValue VARIABLES_KEY = new StringValue("variables");
   private static final StringValue MESSAGE_ID_KEY = new StringValue("messageId");
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
+  private static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
 
   private final StringProperty nameProp = new StringProperty(NAME_KEY);
   private final StringProperty correlationKeyProp = new StringProperty(CORRELATION_KEY_KEY);
@@ -41,16 +42,18 @@ public final class MessageRecord extends UnifiedRecordValue implements MessageRe
   private final StringProperty messageIdProp = new StringProperty(MESSAGE_ID_KEY, "");
   private final StringProperty tenantIdProp =
       new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  private final StringProperty businessIdProp = new StringProperty(BUSINESS_ID_KEY, "");
 
   public MessageRecord() {
-    super(7);
+    super(8);
     declareProperty(nameProp)
         .declareProperty(correlationKeyProp)
         .declareProperty(timeToLiveProp)
         .declareProperty(variablesProp)
         .declareProperty(messageIdProp)
         .declareProperty(deadlineProp)
-        .declareProperty(tenantIdProp);
+        .declareProperty(tenantIdProp)
+        .declareProperty(businessIdProp);
   }
 
   public void wrap(final MessageRecord record) {
@@ -61,6 +64,7 @@ public final class MessageRecord extends UnifiedRecordValue implements MessageRe
     setVariables(record.getVariablesBuffer());
     setMessageId(record.getMessageIdBuffer());
     setTenantId(record.getTenantId());
+    setBusinessId(record.getBusinessIdBuffer());
   }
 
   public boolean hasMessageId() {
@@ -169,6 +173,26 @@ public final class MessageRecord extends UnifiedRecordValue implements MessageRe
 
   public MessageRecord setTenantId(final String tenantId) {
     tenantIdProp.setValue(tenantId);
+    return this;
+  }
+
+  @Override
+  public String getBusinessId() {
+    return bufferAsString(businessIdProp.getValue());
+  }
+
+  @JsonIgnore
+  public DirectBuffer getBusinessIdBuffer() {
+    return businessIdProp.getValue();
+  }
+
+  public MessageRecord setBusinessId(final String businessId) {
+    businessIdProp.setValue(businessId);
+    return this;
+  }
+
+  public MessageRecord setBusinessId(final DirectBuffer businessId) {
+    businessIdProp.setValue(businessId);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageSubscriptionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageSubscriptionRecord.java
@@ -37,6 +37,7 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
   private static final StringValue INTERRUPTING_KEY = new StringValue("interrupting");
   private static final StringValue VARIABLES_KEY = new StringValue("variables");
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
+  private static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
 
   private final LongProperty processInstanceKeyProp = new LongProperty(PROCESS_INSTANCE_KEY_KEY);
   private final LongProperty elementInstanceKeyProp = new LongProperty(ELEMENT_INSTANCE_KEY_KEY);
@@ -51,9 +52,10 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
   private final DocumentProperty variablesProp = new DocumentProperty(VARIABLES_KEY);
   private final StringProperty tenantIdProp =
       new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  private final StringProperty businessIdProp = new StringProperty(BUSINESS_ID_KEY, "");
 
   public MessageSubscriptionRecord() {
-    super(10);
+    super(11);
     declareProperty(processInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
         .declareProperty(processDefinitionKeyProp)
@@ -63,7 +65,8 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
         .declareProperty(interruptingProp)
         .declareProperty(bpmnProcessIdProp)
         .declareProperty(variablesProp)
-        .declareProperty(tenantIdProp);
+        .declareProperty(tenantIdProp)
+        .declareProperty(businessIdProp);
   }
 
   public void wrap(final MessageSubscriptionRecord record) {
@@ -77,6 +80,7 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
     setBpmnProcessId(record.getBpmnProcessIdBuffer());
     setVariables(record.getVariablesBuffer());
     setTenantId(record.getTenantId());
+    setBusinessId(record.getBusinessIdBuffer());
   }
 
   @JsonIgnore
@@ -196,6 +200,26 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
 
   public MessageSubscriptionRecord setTenantId(final String tenantId) {
     tenantIdProp.setValue(tenantId);
+    return this;
+  }
+
+  @Override
+  public String getBusinessId() {
+    return bufferAsString(businessIdProp.getValue());
+  }
+
+  @JsonIgnore
+  public DirectBuffer getBusinessIdBuffer() {
+    return businessIdProp.getValue();
+  }
+
+  public MessageSubscriptionRecord setBusinessId(final String businessId) {
+    businessIdProp.setValue(businessId);
+    return this;
+  }
+
+  public MessageSubscriptionRecord setBusinessId(final DirectBuffer businessId) {
+    businessIdProp.setValue(businessId);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/ProcessMessageSubscriptionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/ProcessMessageSubscriptionRecord.java
@@ -42,6 +42,7 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
   private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
       new StringValue("rootProcessInstanceKey");
+  private static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
 
   private final IntegerProperty subscriptionPartitionIdProp =
       new IntegerProperty(SUBSCRIPTION_PARTITION_ID_KEY);
@@ -60,9 +61,10 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
       new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   private final LongProperty rootProcessInstanceKeyProp =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1L);
+  private final StringProperty businessIdProp = new StringProperty(BUSINESS_ID_KEY, "");
 
   public ProcessMessageSubscriptionRecord() {
-    super(13);
+    super(14);
     declareProperty(subscriptionPartitionIdProp)
         .declareProperty(processInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
@@ -75,7 +77,8 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
         .declareProperty(correlationKeyProp)
         .declareProperty(elementIdProp)
         .declareProperty(tenantIdProp)
-        .declareProperty(rootProcessInstanceKeyProp);
+        .declareProperty(rootProcessInstanceKeyProp)
+        .declareProperty(businessIdProp);
   }
 
   public void wrap(final ProcessMessageSubscriptionRecord record) {
@@ -92,6 +95,7 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
     setElementId(record.getElementIdBuffer());
     setTenantId(record.getTenantId());
     setRootProcessInstanceKey(record.getRootProcessInstanceKey());
+    setBusinessId(record.getBusinessIdBuffer());
   }
 
   @JsonIgnore
@@ -246,6 +250,26 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
 
   public ProcessMessageSubscriptionRecord setTenantId(final String tenantId) {
     tenantIdProp.setValue(tenantId);
+    return this;
+  }
+
+  @Override
+  public String getBusinessId() {
+    return BufferUtil.bufferAsString(businessIdProp.getValue());
+  }
+
+  @JsonIgnore
+  public DirectBuffer getBusinessIdBuffer() {
+    return businessIdProp.getValue();
+  }
+
+  public ProcessMessageSubscriptionRecord setBusinessId(final String businessId) {
+    businessIdProp.setValue(businessId);
+    return this;
+  }
+
+  public ProcessMessageSubscriptionRecord setBusinessId(final DirectBuffer businessId) {
+    businessIdProp.setValue(businessId);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -1249,7 +1249,8 @@ final class JsonSerializableToJsonTest {
                   .setTimeToLive(timeToLive)
                   .setDeadline(22L)
                   .setMessageId(wrapString(messageId))
-                  .setTenantId("foo");
+                  .setTenantId("foo")
+                  .setBusinessId("biz-42");
             },
         """
                 {
@@ -1261,7 +1262,8 @@ final class JsonSerializableToJsonTest {
                   "messageId": "test-id",
                   "name": "test-message",
                   "deadline": 22,
-                  "tenantId": "foo"
+                  "tenantId": "foo",
+                  "businessId": "biz-42"
                 }
                 """
       },
@@ -1291,7 +1293,8 @@ final class JsonSerializableToJsonTest {
                   "messageId": "",
                   "name": "test-message",
                   "deadline": -1,
-                  "tenantId": "<default>"
+                  "tenantId": "<default>",
+                  "businessId": ""
                 }
                 """
       },
@@ -1402,7 +1405,8 @@ final class JsonSerializableToJsonTest {
                   .setMessageName(wrapString(messageName))
                   .setProcessInstanceKey(processInstanceKey)
                   .setCorrelationKey(wrapString(correlationKey))
-                  .setVariables(VARIABLES_MSGPACK);
+                  .setVariables(VARIABLES_MSGPACK)
+                  .setBusinessId("biz-42");
             },
         """
                 {
@@ -1417,7 +1421,8 @@ final class JsonSerializableToJsonTest {
                     "foo": "bar"
                   },
                   "interrupting": true,
-                  "tenantId": "<default>"
+                  "tenantId": "<default>",
+                  "businessId": "biz-42"
                 }
                 """
       },
@@ -1447,7 +1452,8 @@ final class JsonSerializableToJsonTest {
                   "messageKey": -1,
                   "variables": {},
                   "interrupting": true,
-                  "tenantId": "<default>"
+                  "tenantId": "<default>",
+                  "businessId": ""
                 }
                 """
       },
@@ -1482,7 +1488,8 @@ final class JsonSerializableToJsonTest {
                   .setVariables(VARIABLES_MSGPACK)
                   .setCorrelationKey(wrapString(correlationKey))
                   .setElementId(wrapString("A"))
-                  .setRootProcessInstanceKey(rootProcessInstanceKey);
+                  .setRootProcessInstanceKey(rootProcessInstanceKey)
+                  .setBusinessId("biz-42");
             },
         """
                 {
@@ -1499,7 +1506,8 @@ final class JsonSerializableToJsonTest {
                   "elementId": "A",
                   "interrupting": true,
                   "tenantId": "<default>",
-                  "rootProcessInstanceKey": 5678
+                  "rootProcessInstanceKey": 5678,
+                  "businessId": "biz-42"
                 }
                 """
       },
@@ -1533,7 +1541,8 @@ final class JsonSerializableToJsonTest {
                   "elementId": "",
                   "interrupting": true,
                   "tenantId": "<default>",
-                  "rootProcessInstanceKey": -1
+                  "rootProcessInstanceKey": -1,
+                  "businessId": ""
                 }
                 """
       },
@@ -3123,7 +3132,8 @@ final class JsonSerializableToJsonTest {
                   .setMessageKey(messageKey)
                   .setRequestId(requestId)
                   .setRequestStreamId(requestStreamId)
-                  .setProcessDefinitionKey(5L);
+                  .setProcessDefinitionKey(5L)
+                  .setBusinessId("biz-42");
             },
         """
                 {
@@ -3137,7 +3147,8 @@ final class JsonSerializableToJsonTest {
                   "messageKey": 2,
                   "requestId": 3,
                   "requestStreamId": 4,
-                  "processDefinitionKey": 5
+                  "processDefinitionKey": 5,
+                  "businessId": "biz-42"
                 }
                 """
       },
@@ -3332,7 +3343,8 @@ final class JsonSerializableToJsonTest {
                   "messageKey": -1,
                   "requestId": -1,
                   "requestStreamId": -1,
-                  "processDefinitionKey": -1
+                  "processDefinitionKey": -1,
+                  "businessId": ""
                 }
                 """
       },

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageBusinessIdSerializationTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageBusinessIdSerializationTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the contract of the optional {@code businessId} field on the three message records carrying
+ * it: the default representation is an empty string (not null), and {@code wrap} both copies the
+ * field from a source that has one and resets it when the source has none. All three invariants are
+ * load-bearing for the asymmetric "no businessId on the message ⇒ no constraint" semantics — a null
+ * leak, a missing copy, or a stale value carried over from a pooled record would silently change
+ * correlation behavior.
+ */
+final class MessageBusinessIdSerializationTest {
+
+  @Test
+  void shouldDefaultMessageRecordBusinessIdToEmptyString() {
+    // given
+    final var record = new MessageRecord();
+
+    // then
+    assertThat(record.getBusinessId()).isEmpty();
+  }
+
+  @Test
+  void shouldDefaultMessageSubscriptionRecordBusinessIdToEmptyString() {
+    // given
+    final var record = new MessageSubscriptionRecord();
+
+    // then
+    assertThat(record.getBusinessId()).isEmpty();
+  }
+
+  @Test
+  void shouldDefaultProcessMessageSubscriptionRecordBusinessIdToEmptyString() {
+    // given
+    final var record = new ProcessMessageSubscriptionRecord();
+
+    // then
+    assertThat(record.getBusinessId()).isEmpty();
+  }
+
+  @Test
+  void shouldCopyMessageRecordBusinessIdWhenWrappingRecordWithBusinessId() {
+    // given
+    final var source =
+        new MessageRecord()
+            .setName("msg")
+            .setCorrelationKey("k")
+            .setTimeToLive(0L)
+            .setBusinessId("biz-42");
+    final var target = new MessageRecord();
+
+    // when
+    target.wrap(source);
+
+    // then
+    assertThat(target.getBusinessId()).isEqualTo("biz-42");
+  }
+
+  @Test
+  void shouldCopyMessageSubscriptionRecordBusinessIdWhenWrappingRecordWithBusinessId() {
+    // given
+    final var source =
+        new MessageSubscriptionRecord()
+            .setProcessInstanceKey(1L)
+            .setElementInstanceKey(2L)
+            .setBusinessId("biz-42");
+    final var target = new MessageSubscriptionRecord();
+
+    // when
+    target.wrap(source);
+
+    // then
+    assertThat(target.getBusinessId()).isEqualTo("biz-42");
+  }
+
+  @Test
+  void shouldCopyProcessMessageSubscriptionRecordBusinessIdWhenWrappingRecordWithBusinessId() {
+    // given
+    final var source =
+        new ProcessMessageSubscriptionRecord()
+            .setSubscriptionPartitionId(1)
+            .setProcessInstanceKey(2L)
+            .setElementInstanceKey(3L)
+            .setBusinessId("biz-42");
+    final var target = new ProcessMessageSubscriptionRecord();
+
+    // when
+    target.wrap(source);
+
+    // then
+    assertThat(target.getBusinessId()).isEqualTo("biz-42");
+  }
+
+  @Test
+  void shouldResetMessageRecordBusinessIdWhenWrappingRecordWithoutBusinessId() {
+    // given
+    final var source = new MessageRecord().setName("msg").setCorrelationKey("k").setTimeToLive(0L);
+    final var target = new MessageRecord().setBusinessId("biz-from-previous-use");
+
+    // when
+    target.wrap(source);
+
+    // then
+    assertThat(target.getBusinessId()).isEmpty();
+  }
+
+  @Test
+  void shouldResetMessageSubscriptionRecordBusinessIdWhenWrappingRecordWithoutBusinessId() {
+    // given
+    final var source =
+        new MessageSubscriptionRecord().setProcessInstanceKey(1L).setElementInstanceKey(2L);
+    final var target = new MessageSubscriptionRecord().setBusinessId("biz-from-previous-use");
+
+    // when
+    target.wrap(source);
+
+    // then
+    assertThat(target.getBusinessId()).isEmpty();
+  }
+
+  @Test
+  void shouldResetProcessMessageSubscriptionRecordBusinessIdWhenWrappingRecordWithoutBusinessId() {
+    // given
+    final var source =
+        new ProcessMessageSubscriptionRecord()
+            .setSubscriptionPartitionId(1)
+            .setProcessInstanceKey(2L)
+            .setElementInstanceKey(3L);
+    final var target =
+        new ProcessMessageSubscriptionRecord().setBusinessId("biz-from-previous-use");
+
+    // when
+    target.wrap(source);
+
+    // then
+    assertThat(target.getBusinessId()).isEmpty();
+  }
+}

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/MessageCorrelationRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/MessageCorrelationRecord.golden
@@ -36,6 +36,7 @@ public final class MessageCorrelationRecord extends UnifiedRecordValue
   private static final StringValue PROCESS_INSTANCE_KEY_KEY = new StringValue("processInstanceKey");
   private static final StringValue PROCESS_DEFINITION_KEY_KEY =
       new StringValue("processDefinitionKey");
+  private static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
 
   private final StringProperty nameProp = new StringProperty(NAME_KEY);
   private final StringProperty correlationKeyProp = new StringProperty(CORRELATION_KEY_KEY);
@@ -51,9 +52,10 @@ public final class MessageCorrelationRecord extends UnifiedRecordValue
       new LongProperty(PROCESS_INSTANCE_KEY_KEY, -1L);
   private final LongProperty processDefinitionKeyProp =
       new LongProperty(PROCESS_DEFINITION_KEY_KEY, -1L);
+  private final StringProperty businessIdProp = new StringProperty(BUSINESS_ID_KEY, "");
 
   public MessageCorrelationRecord() {
-    super(8);
+    super(10);
     declareProperty(nameProp)
         .declareProperty(correlationKeyProp)
         .declareProperty(variablesProp)
@@ -62,7 +64,8 @@ public final class MessageCorrelationRecord extends UnifiedRecordValue
         .declareProperty(requestIdProp)
         .declareProperty(requestStreamIdProp)
         .declareProperty(processInstanceKeyProp)
-        .declareProperty(processDefinitionKeyProp);
+        .declareProperty(processDefinitionKeyProp)
+        .declareProperty(businessIdProp);
   }
 
   public void wrap(final MessageCorrelationRecord record) {
@@ -71,6 +74,7 @@ public final class MessageCorrelationRecord extends UnifiedRecordValue
     setVariables(record.getVariablesBuffer());
     setTenantId(record.getTenantId());
     setProcessInstanceKey(record.getProcessInstanceKey());
+    setBusinessId(record.getBusinessIdBuffer());
   }
 
   @Override
@@ -175,6 +179,26 @@ public final class MessageCorrelationRecord extends UnifiedRecordValue
 
   public MessageCorrelationRecord setProcessDefinitionKey(final long processDefinitionKey) {
     processDefinitionKeyProp.setValue(processDefinitionKey);
+    return this;
+  }
+
+  @Override
+  public String getBusinessId() {
+    return bufferAsString(businessIdProp.getValue());
+  }
+
+  @JsonIgnore
+  public DirectBuffer getBusinessIdBuffer() {
+    return businessIdProp.getValue();
+  }
+
+  public MessageCorrelationRecord setBusinessId(final String businessId) {
+    businessIdProp.setValue(businessId);
+    return this;
+  }
+
+  public MessageCorrelationRecord setBusinessId(final DirectBuffer businessId) {
+    businessIdProp.setValue(businessId);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/MessageRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/MessageRecord.golden
@@ -31,6 +31,7 @@ public final class MessageRecord extends UnifiedRecordValue implements MessageRe
   private static final StringValue VARIABLES_KEY = new StringValue("variables");
   private static final StringValue MESSAGE_ID_KEY = new StringValue("messageId");
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
+  private static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
 
   private final StringProperty nameProp = new StringProperty(NAME_KEY);
   private final StringProperty correlationKeyProp = new StringProperty(CORRELATION_KEY_KEY);
@@ -41,16 +42,18 @@ public final class MessageRecord extends UnifiedRecordValue implements MessageRe
   private final StringProperty messageIdProp = new StringProperty(MESSAGE_ID_KEY, "");
   private final StringProperty tenantIdProp =
       new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  private final StringProperty businessIdProp = new StringProperty(BUSINESS_ID_KEY, "");
 
   public MessageRecord() {
-    super(7);
+    super(8);
     declareProperty(nameProp)
         .declareProperty(correlationKeyProp)
         .declareProperty(timeToLiveProp)
         .declareProperty(variablesProp)
         .declareProperty(messageIdProp)
         .declareProperty(deadlineProp)
-        .declareProperty(tenantIdProp);
+        .declareProperty(tenantIdProp)
+        .declareProperty(businessIdProp);
   }
 
   public void wrap(final MessageRecord record) {
@@ -61,6 +64,7 @@ public final class MessageRecord extends UnifiedRecordValue implements MessageRe
     setVariables(record.getVariablesBuffer());
     setMessageId(record.getMessageIdBuffer());
     setTenantId(record.getTenantId());
+    setBusinessId(record.getBusinessIdBuffer());
   }
 
   public boolean hasMessageId() {
@@ -169,6 +173,27 @@ public final class MessageRecord extends UnifiedRecordValue implements MessageRe
 
   public MessageRecord setTenantId(final String tenantId) {
     tenantIdProp.setValue(tenantId);
+    return this;
+  }
+
+  @Override
+  public String getBusinessId() {
+    return bufferAsString(businessIdProp.getValue());
+  }
+
+  @JsonIgnore
+  public DirectBuffer getBusinessIdBuffer() {
+    return businessIdProp.getValue();
+  }
+
+
+  public MessageRecord setBusinessId(final String businessId) {
+    businessIdProp.setValue(businessId);
+    return this;
+  }
+
+  public MessageRecord setBusinessId(final DirectBuffer businessId) {
+    businessIdProp.setValue(businessId);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/MessageSubscriptionRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/MessageSubscriptionRecord.golden
@@ -37,6 +37,7 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
   private static final StringValue INTERRUPTING_KEY = new StringValue("interrupting");
   private static final StringValue VARIABLES_KEY = new StringValue("variables");
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
+  private static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
 
   private final LongProperty processInstanceKeyProp = new LongProperty(PROCESS_INSTANCE_KEY_KEY);
   private final LongProperty elementInstanceKeyProp = new LongProperty(ELEMENT_INSTANCE_KEY_KEY);
@@ -51,9 +52,10 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
   private final DocumentProperty variablesProp = new DocumentProperty(VARIABLES_KEY);
   private final StringProperty tenantIdProp =
       new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  private final StringProperty businessIdProp = new StringProperty(BUSINESS_ID_KEY, "");
 
   public MessageSubscriptionRecord() {
-    super(10);
+    super(11);
     declareProperty(processInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
         .declareProperty(processDefinitionKeyProp)
@@ -63,7 +65,8 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
         .declareProperty(interruptingProp)
         .declareProperty(bpmnProcessIdProp)
         .declareProperty(variablesProp)
-        .declareProperty(tenantIdProp);
+        .declareProperty(tenantIdProp)
+        .declareProperty(businessIdProp);
   }
 
   public void wrap(final MessageSubscriptionRecord record) {
@@ -77,6 +80,7 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
     setBpmnProcessId(record.getBpmnProcessIdBuffer());
     setVariables(record.getVariablesBuffer());
     setTenantId(record.getTenantId());
+    setBusinessId(record.getBusinessIdBuffer());
   }
 
   @JsonIgnore
@@ -196,6 +200,27 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
 
   public MessageSubscriptionRecord setTenantId(final String tenantId) {
     tenantIdProp.setValue(tenantId);
+    return this;
+  }
+
+  @Override
+  public String getBusinessId() {
+    return bufferAsString(businessIdProp.getValue());
+  }
+
+  @JsonIgnore
+  public DirectBuffer getBusinessIdBuffer() {
+    return businessIdProp.getValue();
+  }
+
+
+  public MessageSubscriptionRecord setBusinessId(final String businessId) {
+    businessIdProp.setValue(businessId);
+    return this;
+  }
+
+  public MessageSubscriptionRecord setBusinessId(final DirectBuffer businessId) {
+    businessIdProp.setValue(businessId);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessMessageSubscriptionRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessMessageSubscriptionRecord.golden
@@ -42,6 +42,7 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
   private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
       new StringValue("rootProcessInstanceKey");
+  private static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
 
   private final IntegerProperty subscriptionPartitionIdProp =
       new IntegerProperty(SUBSCRIPTION_PARTITION_ID_KEY);
@@ -60,9 +61,10 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
       new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   private final LongProperty rootProcessInstanceKeyProp =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1L);
+  private final StringProperty businessIdProp = new StringProperty(BUSINESS_ID_KEY, "");
 
   public ProcessMessageSubscriptionRecord() {
-    super(13);
+    super(14);
     declareProperty(subscriptionPartitionIdProp)
         .declareProperty(processInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
@@ -75,7 +77,8 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
         .declareProperty(correlationKeyProp)
         .declareProperty(elementIdProp)
         .declareProperty(tenantIdProp)
-        .declareProperty(rootProcessInstanceKeyProp);
+        .declareProperty(rootProcessInstanceKeyProp)
+        .declareProperty(businessIdProp);
   }
 
   public void wrap(final ProcessMessageSubscriptionRecord record) {
@@ -92,6 +95,7 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
     setElementId(record.getElementIdBuffer());
     setTenantId(record.getTenantId());
     setRootProcessInstanceKey(record.getRootProcessInstanceKey());
+    setBusinessId(record.getBusinessIdBuffer());
   }
 
   @JsonIgnore
@@ -246,6 +250,27 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
 
   public ProcessMessageSubscriptionRecord setTenantId(final String tenantId) {
     tenantIdProp.setValue(tenantId);
+    return this;
+  }
+
+  @Override
+  public String getBusinessId() {
+    return BufferUtil.bufferAsString(businessIdProp.getValue());
+  }
+
+  @JsonIgnore
+  public DirectBuffer getBusinessIdBuffer() {
+    return businessIdProp.getValue();
+  }
+
+
+  public ProcessMessageSubscriptionRecord setBusinessId(final String businessId) {
+    businessIdProp.setValue(businessId);
+    return this;
+  }
+
+  public ProcessMessageSubscriptionRecord setBusinessId(final DirectBuffer businessId) {
+    businessIdProp.setValue(businessId);
     return this;
   }
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/MessageCorrelationRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/MessageCorrelationRecordValue.java
@@ -53,4 +53,15 @@ public interface MessageCorrelationRecordValue
    * @return the request stream id of the initial correlate command
    */
   int getRequestStreamId();
+
+  /**
+   * The optional business id used to additionally constrain message correlation. When non-empty, a
+   * correlation only succeeds against subscriptions whose stored business id matches. When empty,
+   * business id is not used as a constraint and the message correlates regardless of the
+   * subscription's stored business id.
+   *
+   * @return the business id, or an empty string if not set
+   * @since 8.10
+   */
+  String getBusinessId();
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/MessageRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/MessageRecordValue.java
@@ -57,4 +57,15 @@ public interface MessageRecordValue extends RecordValueWithVariables, TenantOwne
    *     set, it returns -1 instead.
    */
   long getDeadline();
+
+  /**
+   * The optional business id associated with the published message. When set, it acts as an
+   * additional correlation constraint: the message only correlates to subscriptions whose stored
+   * business id matches. A message published without a business id correlates to any subscription
+   * regardless of the subscription's stored business id.
+   *
+   * @return the business id, or an empty string if not set
+   * @since 8.10
+   */
+  String getBusinessId();
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/MessageSubscriptionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/MessageSubscriptionRecordValue.java
@@ -71,4 +71,20 @@ public interface MessageSubscriptionRecordValue
    *     returns {@code false} if the event is non-interrupting.
    */
   boolean isInterrupting();
+
+  /**
+   * The business id captured from the subscribing process instance at the time the subscription was
+   * opened. Used as an additional, post-routing local filter on the message partition: when a
+   * published message carries a business id, only subscriptions whose stored business id matches
+   * will correlate. A subscription opened from a process instance without a business id stores an
+   * empty string.
+   *
+   * <p>This value is captured at OPEN time on the process instance partition and shipped to the
+   * message partition with the subscription. It is not retroactively updated if the process
+   * instance's business id is assigned later.
+   *
+   * @return the business id, or an empty string if not set
+   * @since 8.10
+   */
+  String getBusinessId();
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessMessageSubscriptionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessMessageSubscriptionRecordValue.java
@@ -88,4 +88,14 @@ public interface ProcessMessageSubscriptionRecordValue
    * @return the key of the root process instance, or {@code -1} if not set
    */
   long getRootProcessInstanceKey();
+
+  /**
+   * The business id captured from the subscribing process instance at the time the subscription was
+   * opened. It is shipped to the message partition together with the OPEN command so the message
+   * partition can apply business-id-based filtering locally at correlation time.
+   *
+   * @return the business id, or an empty string if not set
+   * @since 8.10
+   */
+  String getBusinessId();
 }


### PR DESCRIPTION
## Description

This PR implements **Business ID as an additional, post-routing local constraint for non-start message correlation** in Zeebe (catch events, boundary events, intermediate message events).

### Problem

Previously, non-start message correlation matched subscriptions solely on message name + correlation key. There was no way to further narrow correlation to a specific process instance using its Business ID.

### Solution

The `businessId` field is now captured from the process instance at subscription-open time and shipped with the `OPEN` command to the message partition, where it is stored locally on the `MessageSubscription` record. At correlation time, the message partition applies an **asymmetric local filter**:

- A message published **without** a `businessId` correlates to all matching subscriptions regardless of their stored Business ID (backward-compatible).
- A message published **with** a `businessId` only correlates to subscriptions whose locally stored Business ID matches exactly.

This design deliberately avoids cross-partition reads at correlation time — the Business ID is resolved once (at OPEN time) and stored on the message partition, keeping the filter a constant-time, on-partition check.

### Changes

- **`CatchEventBehavior`** — captures the process instance's `businessId` at subscription-open time and includes it in the `OPEN` command.
- **`SubscriptionCommandSender`** — propagates `businessId` through `openMessageSubscription` and related methods.
- **`MessageCorrelateBehavior` / `MessageCorrelator`** — applies the asymmetric `businessIdMatches` filter during both the new-message-to-existing-subscription and new-subscription-to-buffered-message correlation paths.
- **Protocol records** (`MessageRecord`, `MessageSubscriptionRecord`, `ProcessMessageSubscriptionRecord`, `MessageCorrelationRecord`) — adds the optional `businessId` field (defaults to empty string) with proper `wrap()` copy semantics to prevent stale values on pooled records.
- **Elasticsearch / OpenSearch exporter templates** — adds `businessId` as a `keyword` field to message, message-subscription, process-message-subscription, and message-correlation index templates.

### Tests

- **`MessageCorrelationBusinessIdTest`** — single-partition behavioral spec covering both correlation directions (subscribe-then-publish and publish-then-subscribe), the asymmetric rule from both sides, multi-definition scenarios, and a pin that the value captured at OPEN time governs later correlation.
- **`MessageCorrelationBusinessIdMultiplePartitionsTest`** — cross-partition variant ensuring the filter behaves identically when the process instance and the message live on different partitions.
- **`MessageSubscriptionBusinessIdPlumbingTest`** — pins that the `businessId` is correctly plumbed from the PI partition through to the message partition's stored `MessageSubscription`.
- **`MessageBusinessIdSerializationTest`** — pins default-to-empty-string, `wrap()` copy, and stale-value reset invariants on all three protocol records.

### Backward Compatibility

All existing processes and API calls that do not supply a `businessId` continue to work unchanged. The new field defaults to an empty string, and the asymmetric matching rule means a message without a `businessId` always correlates normally.

## Checklist

- [ ] Enable backports when necessary (e.g., for bug fixes, CI changes, or documentation changes).
- [ ] If this PR modifies the C8 Orchestration Cluster E2E Test Suite, the relevant tests have been run via the on-demand workflow before requesting review.

## Related issues

closes #53389