### PR TITLE
feat: export AgentInstance records via CamundaExporter

### DIFF
--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/agentinstance/AgentInstanceStatus.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/agentinstance/AgentInstanceStatus.java
@@ -8,6 +8,7 @@
 package io.camunda.webapps.schema.entities.agentinstance;
 
 public enum AgentInstanceStatus {
+  UNKNOWN,
   INITIALIZING,
   TOOL_DISCOVERY,
   IDLE,

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter;
 
+import static io.camunda.zeebe.protocol.record.ValueType.AGENT_INSTANCE;
 import static io.camunda.zeebe.protocol.record.ValueType.AUTHORIZATION;
 import static io.camunda.zeebe.protocol.record.ValueType.BATCH_OPERATION_CHUNK;
 import static io.camunda.zeebe.protocol.record.ValueType.BATCH_OPERATION_CREATION;
@@ -417,7 +418,8 @@ public class CamundaExporter implements Exporter {
             CLUSTER_VARIABLE,
             HISTORY_DELETION,
             JOB_METRICS_BATCH,
-            GLOBAL_LISTENER);
+            GLOBAL_LISTENER,
+            AGENT_INSTANCE);
 
     @Override
     public boolean acceptType(final RecordType recordType) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -16,6 +16,7 @@ import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.errorhandling.Error;
 import io.camunda.exporter.errorhandling.ErrorHandler;
 import io.camunda.exporter.errorhandling.ErrorHandlers;
+import io.camunda.exporter.handlers.AgentInstanceHandler;
 import io.camunda.exporter.handlers.AuditLogHandler;
 import io.camunda.exporter.handlers.AuthorizationCreatedUpdatedHandler;
 import io.camunda.exporter.handlers.AuthorizationDeletedHandler;
@@ -113,6 +114,7 @@ import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
 import io.camunda.webapps.schema.descriptors.index.RoleIndex;
 import io.camunda.webapps.schema.descriptors.index.TenantIndex;
 import io.camunda.webapps.schema.descriptors.index.UserIndex;
+import io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.template.AuditLogTemplate;
 import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
 import io.camunda.webapps.schema.descriptors.template.CorrelatedMessageSubscriptionTemplate;
@@ -333,6 +335,8 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
                 indexDescriptors.get(MappingRuleIndex.class).getFullQualifiedName()),
             new MappingRuleDeletedHandler(
                 indexDescriptors.get(MappingRuleIndex.class).getFullQualifiedName()),
+            new AgentInstanceHandler(
+                indexDescriptors.get(AgentInstanceTemplate.class).getFullQualifiedName()),
             new JobHandler(indexDescriptors.get(JobTemplate.class).getFullQualifiedName()),
             new MigratedVariableHandler(
                 indexDescriptors.get(VariableTemplate.class).getFullQualifiedName()),

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AgentInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AgentInstanceHandler.java
@@ -32,9 +32,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class AgentInstanceHandler
     implements ExportHandler<AgentInstanceEntity, AgentInstanceRecordValue> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(AgentInstanceHandler.class);
 
   private static final Set<AgentInstanceIntent> HANDLED_INTENTS =
       Set.of(
@@ -149,6 +153,12 @@ public class AgentInstanceHandler
       case TOOL_CALLING -> AgentInstanceStatus.TOOL_CALLING;
       case TOOL_DISCOVERY -> AgentInstanceStatus.TOOL_DISCOVERY;
       case COMPLETED -> AgentInstanceStatus.COMPLETED;
+      default -> {
+        LOGGER.warn(
+            "Received unexpected AgentInstanceStatus: {}, will be mapped to UNKNOWN",
+            protocolStatus);
+        yield AgentInstanceStatus.UNKNOWN;
+      }
     };
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AgentInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AgentInstanceHandler.java
@@ -124,6 +124,10 @@ public class AgentInstanceHandler
 
   @Override
   public void flush(final AgentInstanceEntity entity, final BatchRequest batchRequest) {
+    // `creationDate` is intentionally excluded: it is handler-derived from
+    // `record.getTimestamp()` and only populated by `updateEntity()` on the CREATED
+    // intent. Including it here would overwrite the existing index value with null on
+    // every UPDATED / COMPLETED event.
     final Map<String, Object> updateFields = new HashMap<>();
     updateFields.put(STATUS, entity.getStatus());
     updateFields.put(INPUT_TOKENS, entity.getInputTokens());
@@ -133,9 +137,7 @@ public class AgentInstanceHandler
     updateFields.put(TOOLS, entity.getTools());
     updateFields.put(ELEMENT_INSTANCE_KEYS, entity.getElementInstanceKeys());
     updateFields.put(LAST_UPDATED_DATE, entity.getLastUpdatedDate());
-    if (entity.getCompletionDate() != null) {
-      updateFields.put(COMPLETION_DATE, entity.getCompletionDate());
-    }
+    updateFields.put(COMPLETION_DATE, entity.getCompletionDate());
     batchRequest.upsert(indexName, entity.getId(), entity, updateFields);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AgentInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AgentInstanceHandler.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.COMPLETION_DATE;
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.ELEMENT_INSTANCE_KEYS;
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.INPUT_TOKENS;
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.LAST_UPDATED_DATE;
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.MODEL_CALLS;
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.OUTPUT_TOKENS;
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.STATUS;
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.TOOLS;
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.TOOL_CALLS;
+
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.entities.agentinstance.AgentInstanceEntity;
+import io.camunda.webapps.schema.entities.agentinstance.AgentInstanceEntity.AgentInstanceToolValue;
+import io.camunda.webapps.schema.entities.agentinstance.AgentInstanceStatus;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.AgentInstanceRecordValue;
+import io.camunda.zeebe.util.DateUtil;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class AgentInstanceHandler
+    implements ExportHandler<AgentInstanceEntity, AgentInstanceRecordValue> {
+
+  private static final Set<AgentInstanceIntent> HANDLED_INTENTS =
+      Set.of(
+          AgentInstanceIntent.CREATED, AgentInstanceIntent.UPDATED, AgentInstanceIntent.COMPLETED);
+
+  private final String indexName;
+
+  public AgentInstanceHandler(final String indexName) {
+    this.indexName = indexName;
+  }
+
+  @Override
+  public ValueType getHandledValueType() {
+    return ValueType.AGENT_INSTANCE;
+  }
+
+  @Override
+  public Class<AgentInstanceEntity> getEntityType() {
+    return AgentInstanceEntity.class;
+  }
+
+  @Override
+  public boolean handlesRecord(final Record<AgentInstanceRecordValue> record) {
+    final AgentInstanceIntent intent = (AgentInstanceIntent) record.getIntent();
+    return HANDLED_INTENTS.contains(intent);
+  }
+
+  @Override
+  public List<String> generateIds(final Record<AgentInstanceRecordValue> record) {
+    return List.of(String.valueOf(record.getKey()));
+  }
+
+  @Override
+  public AgentInstanceEntity createNewEntity(final String id) {
+    return new AgentInstanceEntity().setId(id);
+  }
+
+  @Override
+  public void updateEntity(
+      final Record<AgentInstanceRecordValue> record, final AgentInstanceEntity entity) {
+    final AgentInstanceRecordValue value = record.getValue();
+    final AgentInstanceIntent intent = (AgentInstanceIntent) record.getIntent();
+    final OffsetDateTime timestamp =
+        DateUtil.toOffsetDateTime(Instant.ofEpochMilli(record.getTimestamp()));
+
+    entity
+        .setKey(record.getKey())
+        .setPartitionId(record.getPartitionId())
+        .setElementId(value.getElementId())
+        .setProcessInstanceKey(value.getProcessInstanceKey())
+        // `value.getRootProcessInstanceKey()` is not yet available in the record, so we set it to
+        // -1 for now. Once it is available, this line should be updated to use the actual value.
+        // tracked by: https://github.com/camunda/camunda/issues/53236
+        .setRootProcessInstanceKey(-1)
+        .setBpmnProcessId(value.getBpmnProcessId())
+        .setProcessDefinitionKey(value.getProcessDefinitionKey())
+        .setProcessDefinitionVersion(value.getProcessDefinitionVersion())
+        .setVersionTag(value.getVersionTag())
+        .setTenantId(value.getTenantId())
+        .setStatus(mapStatus(value.getStatus()))
+        .setModel(value.getDefinition().getModel())
+        .setProvider(value.getDefinition().getProvider())
+        .setSystemPrompt(value.getDefinition().getSystemPrompt())
+        .setMaxTokens(value.getLimits().getMaxTokens())
+        .setMaxModelCalls(value.getLimits().getMaxModelCalls())
+        .setMaxToolCalls(value.getLimits().getMaxToolCalls())
+        .setInputTokens(value.getMetrics().getInputTokens())
+        .setOutputTokens(value.getMetrics().getOutputTokens())
+        .setModelCalls(value.getMetrics().getModelCalls())
+        .setToolCalls(value.getMetrics().getToolCalls())
+        .setTools(mapTools(value.getTools()))
+        // once record will return `getElementInstanceKeys()` the line below should be adjusted
+        .setElementInstanceKeys(List.of(value.getElementInstanceKey()))
+        .setLastUpdatedDate(timestamp);
+
+    if (intent == AgentInstanceIntent.CREATED) {
+      entity.setCreationDate(timestamp);
+    }
+    if (intent == AgentInstanceIntent.COMPLETED) {
+      entity.setCompletionDate(timestamp);
+    }
+  }
+
+  @Override
+  public void flush(final AgentInstanceEntity entity, final BatchRequest batchRequest) {
+    final Map<String, Object> updateFields = new HashMap<>();
+    updateFields.put(STATUS, entity.getStatus());
+    updateFields.put(INPUT_TOKENS, entity.getInputTokens());
+    updateFields.put(OUTPUT_TOKENS, entity.getOutputTokens());
+    updateFields.put(MODEL_CALLS, entity.getModelCalls());
+    updateFields.put(TOOL_CALLS, entity.getToolCalls());
+    updateFields.put(TOOLS, entity.getTools());
+    updateFields.put(ELEMENT_INSTANCE_KEYS, entity.getElementInstanceKeys());
+    updateFields.put(LAST_UPDATED_DATE, entity.getLastUpdatedDate());
+    if (entity.getCompletionDate() != null) {
+      updateFields.put(COMPLETION_DATE, entity.getCompletionDate());
+    }
+    batchRequest.upsert(indexName, entity.getId(), entity, updateFields);
+  }
+
+  @Override
+  public String getIndexName() {
+    return indexName;
+  }
+
+  private static AgentInstanceStatus mapStatus(
+      final io.camunda.zeebe.protocol.record.value.AgentInstanceStatus protocolStatus) {
+    return switch (protocolStatus) {
+      case INITIALIZING -> AgentInstanceStatus.INITIALIZING;
+      case IDLE -> AgentInstanceStatus.IDLE;
+      case THINKING -> AgentInstanceStatus.THINKING;
+      case TOOL_CALLING -> AgentInstanceStatus.TOOL_CALLING;
+      case TOOL_DISCOVERY -> AgentInstanceStatus.TOOL_DISCOVERY;
+      case COMPLETED -> AgentInstanceStatus.COMPLETED;
+    };
+  }
+
+  private static List<AgentInstanceToolValue> mapTools(
+      final List<? extends AgentInstanceRecordValue.AgentInstanceToolValue> protocolTools) {
+    return protocolTools.stream()
+        .map(t -> new AgentInstanceToolValue(t.getName(), t.getDescription(), t.getElementId()))
+        .toList();
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentInstanceHandlerTest.java
@@ -337,7 +337,9 @@ final class AgentInstanceHandlerTest {
     expectedUpdateFields.put(TOOLS, entity.getTools());
     expectedUpdateFields.put(ELEMENT_INSTANCE_KEYS, entity.getElementInstanceKeys());
     expectedUpdateFields.put(LAST_UPDATED_DATE, entity.getLastUpdatedDate());
-    // completionDate absent: UPDATED intent does not set it
+    // completionDate is null on UPDATED intent but still written so the upsert script
+    // payload is identical across intents (no-op when null overwrites null in the index).
+    expectedUpdateFields.put(COMPLETION_DATE, null);
 
     verify(mockRequest, times(1)).upsert(indexName, entity.getId(), entity, expectedUpdateFields);
   }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentInstanceHandlerTest.java
@@ -53,65 +53,38 @@ final class AgentInstanceHandlerTest {
   private final AgentInstanceHandler underTest = new AgentInstanceHandler(indexName);
 
   @Test
-  void testGetHandledValueType() {
+  void shouldReturnCorrectHandlerMetadata() {
     assertThat(underTest.getHandledValueType()).isEqualTo(ValueType.AGENT_INSTANCE);
-  }
-
-  @Test
-  void testGetEntityType() {
     assertThat(underTest.getEntityType()).isEqualTo(AgentInstanceEntity.class);
+    assertThat(underTest.getIndexName()).isEqualTo(indexName);
   }
 
-  @ParameterizedTest
+  @ParameterizedTest(name = "[{index}] Should handle \''{0}\'' record")
   @EnumSource(
       value = AgentInstanceIntent.class,
       names = {"CREATED", "UPDATED", "COMPLETED"},
       mode = Mode.INCLUDE)
   void shouldHandleRecord(final AgentInstanceIntent intent) {
-    // given
-    final Record<AgentInstanceRecordValue> record = generateRecord(intent);
-
-    // when - then
-    assertThat(underTest.handlesRecord(record)).isTrue();
+    assertThat(underTest.handlesRecord(generateRecord(intent))).isTrue();
   }
 
-  @ParameterizedTest
+  @ParameterizedTest(name = "[{index}] Should not handle \''{0}\'' record")
   @EnumSource(
       value = AgentInstanceIntent.class,
       names = {"CREATED", "UPDATED", "COMPLETED"},
       mode = Mode.EXCLUDE)
   void shouldNotHandleRecord(final AgentInstanceIntent intent) {
-    // given
-    final Record<AgentInstanceRecordValue> record = generateRecord(intent);
-
-    // when - then
-    assertThat(underTest.handlesRecord(record)).isFalse();
+    assertThat(underTest.handlesRecord(generateRecord(intent))).isFalse();
   }
 
   @Test
-  void testGenerateIds() {
+  void shouldGenerateIdFromRecordKey() {
     // given
     final Record<AgentInstanceRecordValue> record =
         factory.generateRecord(ValueType.AGENT_INSTANCE);
 
-    // when
-    final var ids = underTest.generateIds(record);
-
-    // then
-    assertThat(ids).containsExactly(String.valueOf(record.getKey()));
-  }
-
-  @Test
-  void testCreateNewEntity() {
-    // given
-    final String id = "id";
-
-    // when
-    final var entity = underTest.createNewEntity(id);
-
-    // then
-    assertThat(entity).isNotNull();
-    assertThat(entity.getId()).isEqualTo(id);
+    // when - then
+    assertThat(underTest.generateIds(record)).containsExactly(String.valueOf(record.getKey()));
   }
 
   @Test
@@ -227,77 +200,48 @@ final class AgentInstanceHandlerTest {
   }
 
   @Test
-  void shouldUpdateEntityOnUpdated() {
-    // given
-    final long recordKey = 100L;
-    final var recordValue = buildMinimalRecordValue(recordKey);
-
-    final Record<AgentInstanceRecordValue> record =
+  void shouldPreserveCreationDateAcrossSubsequentIntents() {
+    // given — CREATED sets the creation date on the entity
+    final var entity = new AgentInstanceEntity().setId("1");
+    final Record<AgentInstanceRecordValue> createdRecord =
         factory.generateRecord(
             ValueType.AGENT_INSTANCE,
-            r ->
-                r.withIntent(AgentInstanceIntent.UPDATED)
-                    .withKey(recordKey)
-                    .withValue(recordValue));
+            r -> r.withIntent(AgentInstanceIntent.CREATED).withValue(buildMinimalRecordValue(1L)));
+    underTest.updateEntity(createdRecord, entity);
+    final var creationDate = entity.getCreationDate();
+    assertThat(creationDate).isNotNull();
 
-    // pre-populate creationDate as if set by a prior CREATED event
-    final var existingCreationDate = DateUtil.toOffsetDateTime(Instant.now().minusSeconds(60));
-    final var entity =
-        new AgentInstanceEntity()
-            .setId(String.valueOf(recordKey))
-            .setCreationDate(existingCreationDate);
+    // when — UPDATED applied to the same entity
+    final Record<AgentInstanceRecordValue> updatedRecord =
+        factory.generateRecord(
+            ValueType.AGENT_INSTANCE,
+            r -> r.withIntent(AgentInstanceIntent.UPDATED).withValue(buildMinimalRecordValue(1L)));
+    underTest.updateEntity(updatedRecord, entity);
 
-    // when
-    underTest.updateEntity(record, entity);
-
-    // then
-    final var expectedTimestamp =
-        DateUtil.toOffsetDateTime(Instant.ofEpochMilli(record.getTimestamp()));
-
-    assertThat(entity.getLastUpdatedDate()).isEqualTo(expectedTimestamp);
-    assertThat(entity.getCreationDate()).isEqualTo(existingCreationDate);
+    // then — creation date preserved, last updated advanced, completion still absent
+    assertThat(entity.getCreationDate()).isEqualTo(creationDate);
+    assertThat(entity.getLastUpdatedDate()).isAfterOrEqualTo(creationDate);
     assertThat(entity.getCompletionDate()).isNull();
-  }
 
-  @Test
-  void shouldUpdateEntityOnCompleted() {
-    // given
-    final long recordKey = 100L;
-    final var recordValue =
+    // when — COMPLETED applied to the same entity
+    final var completedValue =
         ImmutableAgentInstanceRecordValue.builder()
-            .from(buildMinimalRecordValue(recordKey))
+            .from(buildMinimalRecordValue(1L))
             .withStatus(io.camunda.zeebe.protocol.record.value.AgentInstanceStatus.COMPLETED)
             .build();
-
-    final Record<AgentInstanceRecordValue> record =
+    final Record<AgentInstanceRecordValue> completedRecord =
         factory.generateRecord(
             ValueType.AGENT_INSTANCE,
-            r ->
-                r.withIntent(AgentInstanceIntent.COMPLETED)
-                    .withKey(recordKey)
-                    .withValue(recordValue));
+            r -> r.withIntent(AgentInstanceIntent.COMPLETED).withValue(completedValue));
+    underTest.updateEntity(completedRecord, entity);
 
-    // pre-populate creationDate as if set by a prior CREATED event
-    final var existingCreationDate = DateUtil.toOffsetDateTime(Instant.now().minusSeconds(120));
-    final var entity =
-        new AgentInstanceEntity()
-            .setId(String.valueOf(recordKey))
-            .setCreationDate(existingCreationDate);
-
-    // when
-    underTest.updateEntity(record, entity);
-
-    // then
-    final var expectedTimestamp =
-        DateUtil.toOffsetDateTime(Instant.ofEpochMilli(record.getTimestamp()));
-
+    // then — creation date still untouched, completion date now set
+    assertThat(entity.getCreationDate()).isEqualTo(creationDate);
+    assertThat(entity.getCompletionDate()).isNotNull();
     assertThat(entity.getStatus()).isEqualTo(AgentInstanceStatus.COMPLETED);
-    assertThat(entity.getCompletionDate()).isEqualTo(expectedTimestamp);
-    assertThat(entity.getLastUpdatedDate()).isEqualTo(expectedTimestamp);
-    assertThat(entity.getCreationDate()).isEqualTo(existingCreationDate);
   }
 
-  @ParameterizedTest
+  @ParameterizedTest(name = "[{index}] Should map protocol status \''{0}\' to entity status")
   @EnumSource(io.camunda.zeebe.protocol.record.value.AgentInstanceStatus.class)
   void shouldMapAllProtocolStatuses(
       final io.camunda.zeebe.protocol.record.value.AgentInstanceStatus protocolStatus) {
@@ -322,23 +266,34 @@ final class AgentInstanceHandlerTest {
   }
 
   @Test
-  void shouldUpsertEntityOnFlush() {
-    // given
-    final String entityId = "100";
-    final var tools = List.of(new AgentInstanceToolValue("tool", "does stuff", "toolElement"));
-    final var entity =
-        new AgentInstanceEntity()
-            .setId(entityId)
-            .setStatus(AgentInstanceStatus.THINKING)
-            .setInputTokens(10L)
-            .setOutputTokens(5L)
-            .setModelCalls(1)
-            .setToolCalls(0)
-            .setTools(tools)
-            .setElementInstanceKeys(List.of(200L))
-            .setLastUpdatedDate(DateUtil.toOffsetDateTime(Instant.now()));
+  void shouldFlushUpdateFieldsWithValuesPopulatedByUpdateEntity() {
+    // given — entity populated via updateEntity, not hand-constructed, to catch field-name drift
+    final var recordValue =
+        ImmutableAgentInstanceRecordValue.builder()
+            .from(buildMinimalRecordValue(1L))
+            .withStatus(io.camunda.zeebe.protocol.record.value.AgentInstanceStatus.THINKING)
+            .withMetrics(
+                ImmutableAgentInstanceMetricsValue.builder()
+                    .withInputTokens(42L)
+                    .withOutputTokens(17L)
+                    .withModelCalls(3)
+                    .withToolCalls(1)
+                    .build())
+            .build();
+    final Record<AgentInstanceRecordValue> record =
+        factory.generateRecord(
+            ValueType.AGENT_INSTANCE,
+            r -> r.withIntent(AgentInstanceIntent.UPDATED).withKey(1L).withValue(recordValue));
+    final var entity = new AgentInstanceEntity().setId("1");
+    underTest.updateEntity(record, entity);
 
-    final Map<String, Object> expectedUpdateFields = new LinkedHashMap<>();
+    final BatchRequest mockRequest = Mockito.mock(BatchRequest.class);
+
+    // when
+    underTest.flush(entity, mockRequest);
+
+    // then — updateFields keys match template constants; values come from entity (not hardcoded)
+    final var expectedUpdateFields = new LinkedHashMap<String, Object>();
     expectedUpdateFields.put(STATUS, entity.getStatus());
     expectedUpdateFields.put(INPUT_TOKENS, entity.getInputTokens());
     expectedUpdateFields.put(OUTPUT_TOKENS, entity.getOutputTokens());
@@ -347,14 +302,9 @@ final class AgentInstanceHandlerTest {
     expectedUpdateFields.put(TOOLS, entity.getTools());
     expectedUpdateFields.put(ELEMENT_INSTANCE_KEYS, entity.getElementInstanceKeys());
     expectedUpdateFields.put(LAST_UPDATED_DATE, entity.getLastUpdatedDate());
+    // completionDate absent: UPDATED intent does not set it
 
-    final BatchRequest mockRequest = Mockito.mock(BatchRequest.class);
-
-    // when
-    underTest.flush(entity, mockRequest);
-
-    // then
-    verify(mockRequest, times(1)).upsert(indexName, entityId, entity, expectedUpdateFields);
+    verify(mockRequest, times(1)).upsert(indexName, entity.getId(), entity, expectedUpdateFields);
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentInstanceHandlerTest.java
@@ -1,0 +1,418 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.COMPLETION_DATE;
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.ELEMENT_INSTANCE_KEYS;
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.INPUT_TOKENS;
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.LAST_UPDATED_DATE;
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.MODEL_CALLS;
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.OUTPUT_TOKENS;
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.STATUS;
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.TOOLS;
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.TOOL_CALLS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate;
+import io.camunda.webapps.schema.entities.agentinstance.AgentInstanceEntity;
+import io.camunda.webapps.schema.entities.agentinstance.AgentInstanceEntity.AgentInstanceToolValue;
+import io.camunda.webapps.schema.entities.agentinstance.AgentInstanceStatus;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.AgentInstanceRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableAgentInstanceDefinitionValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableAgentInstanceLimitsValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableAgentInstanceMetricsValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableAgentInstanceRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableAgentInstanceToolValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import io.camunda.zeebe.util.DateUtil;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.EnumSource.Mode;
+import org.mockito.Mockito;
+
+final class AgentInstanceHandlerTest {
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final String indexName = AgentInstanceTemplate.INDEX_NAME;
+
+  private final AgentInstanceHandler underTest = new AgentInstanceHandler(indexName);
+
+  @Test
+  void testGetHandledValueType() {
+    assertThat(underTest.getHandledValueType()).isEqualTo(ValueType.AGENT_INSTANCE);
+  }
+
+  @Test
+  void testGetEntityType() {
+    assertThat(underTest.getEntityType()).isEqualTo(AgentInstanceEntity.class);
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = AgentInstanceIntent.class,
+      names = {"CREATED", "UPDATED", "COMPLETED"},
+      mode = Mode.INCLUDE)
+  void shouldHandleRecord(final AgentInstanceIntent intent) {
+    // given
+    final Record<AgentInstanceRecordValue> record = generateRecord(intent);
+
+    // when - then
+    assertThat(underTest.handlesRecord(record)).isTrue();
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = AgentInstanceIntent.class,
+      names = {"CREATED", "UPDATED", "COMPLETED"},
+      mode = Mode.EXCLUDE)
+  void shouldNotHandleRecord(final AgentInstanceIntent intent) {
+    // given
+    final Record<AgentInstanceRecordValue> record = generateRecord(intent);
+
+    // when - then
+    assertThat(underTest.handlesRecord(record)).isFalse();
+  }
+
+  @Test
+  void testGenerateIds() {
+    // given
+    final Record<AgentInstanceRecordValue> record =
+        factory.generateRecord(ValueType.AGENT_INSTANCE);
+
+    // when
+    final var ids = underTest.generateIds(record);
+
+    // then
+    assertThat(ids).containsExactly(String.valueOf(record.getKey()));
+  }
+
+  @Test
+  void testCreateNewEntity() {
+    // given
+    final String id = "id";
+
+    // when
+    final var entity = underTest.createNewEntity(id);
+
+    // then
+    assertThat(entity).isNotNull();
+    assertThat(entity.getId()).isEqualTo(id);
+  }
+
+  @Test
+  void shouldUpdateEntityOnCreated() {
+    // given
+    final long recordKey = 100L;
+    final int partitionId = 1;
+    final long elementInstanceKey = 200L;
+    final String elementId = "elementId";
+    final long processInstanceKey = 300L;
+    final String bpmnProcessId = "myProcess";
+    final long processDefinitionKey = 400L;
+    final int processDefinitionVersion = 2;
+    final String versionTag = "v2";
+    final String tenantId = "<default>";
+    final String model = "gpt-4o";
+    final String provider = "openai";
+    final String systemPrompt = "You are a helpful assistant.";
+    final long maxTokens = 1000L;
+    final int maxModelCalls = 10;
+    final int maxToolCalls = 5;
+    final long inputTokens = 50L;
+    final long outputTokens = 30L;
+    final int modelCalls = 2;
+    final int toolCalls = 1;
+
+    final var toolValue =
+        ImmutableAgentInstanceToolValue.builder()
+            .withName("search")
+            .withDescription("Search the web")
+            .withElementId("searchElement")
+            .build();
+
+    final var recordValue =
+        ImmutableAgentInstanceRecordValue.builder()
+            .withAgentInstanceKey(recordKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withElementId(elementId)
+            .withProcessInstanceKey(processInstanceKey)
+            .withBpmnProcessId(bpmnProcessId)
+            .withProcessDefinitionKey(processDefinitionKey)
+            .withProcessDefinitionVersion(processDefinitionVersion)
+            .withVersionTag(versionTag)
+            .withTenantId(tenantId)
+            .withStatus(io.camunda.zeebe.protocol.record.value.AgentInstanceStatus.INITIALIZING)
+            .withDefinition(
+                ImmutableAgentInstanceDefinitionValue.builder()
+                    .withModel(model)
+                    .withProvider(provider)
+                    .withSystemPrompt(systemPrompt)
+                    .build())
+            .withLimits(
+                ImmutableAgentInstanceLimitsValue.builder()
+                    .withMaxTokens(maxTokens)
+                    .withMaxModelCalls(maxModelCalls)
+                    .withMaxToolCalls(maxToolCalls)
+                    .build())
+            .withMetrics(
+                ImmutableAgentInstanceMetricsValue.builder()
+                    .withInputTokens(inputTokens)
+                    .withOutputTokens(outputTokens)
+                    .withModelCalls(modelCalls)
+                    .withToolCalls(toolCalls)
+                    .build())
+            .withTools(List.of(toolValue))
+            .build();
+
+    final Record<AgentInstanceRecordValue> record =
+        factory.generateRecord(
+            ValueType.AGENT_INSTANCE,
+            r ->
+                r.withIntent(AgentInstanceIntent.CREATED)
+                    .withKey(recordKey)
+                    .withPartitionId(partitionId)
+                    .withValue(recordValue));
+
+    final var entity = new AgentInstanceEntity().setId(String.valueOf(recordKey));
+
+    // when
+    underTest.updateEntity(record, entity);
+
+    // then
+    final var expectedTimestamp =
+        DateUtil.toOffsetDateTime(Instant.ofEpochMilli(record.getTimestamp()));
+
+    assertThat(entity.getKey()).isEqualTo(recordKey);
+    assertThat(entity.getPartitionId()).isEqualTo(partitionId);
+    assertThat(entity.getElementId()).isEqualTo(elementId);
+    assertThat(entity.getProcessInstanceKey()).isEqualTo(processInstanceKey);
+    assertThat(entity.getRootProcessInstanceKey()).isEqualTo(-1L);
+    assertThat(entity.getBpmnProcessId()).isEqualTo(bpmnProcessId);
+    assertThat(entity.getProcessDefinitionKey()).isEqualTo(processDefinitionKey);
+    assertThat(entity.getProcessDefinitionVersion()).isEqualTo(processDefinitionVersion);
+    assertThat(entity.getVersionTag()).isEqualTo(versionTag);
+    assertThat(entity.getTenantId()).isEqualTo(tenantId);
+    assertThat(entity.getStatus()).isEqualTo(AgentInstanceStatus.INITIALIZING);
+    assertThat(entity.getModel()).isEqualTo(model);
+    assertThat(entity.getProvider()).isEqualTo(provider);
+    assertThat(entity.getSystemPrompt()).isEqualTo(systemPrompt);
+    assertThat(entity.getMaxTokens()).isEqualTo(maxTokens);
+    assertThat(entity.getMaxModelCalls()).isEqualTo(maxModelCalls);
+    assertThat(entity.getMaxToolCalls()).isEqualTo(maxToolCalls);
+    assertThat(entity.getInputTokens()).isEqualTo(inputTokens);
+    assertThat(entity.getOutputTokens()).isEqualTo(outputTokens);
+    assertThat(entity.getModelCalls()).isEqualTo(modelCalls);
+    assertThat(entity.getToolCalls()).isEqualTo(toolCalls);
+    assertThat(entity.getTools())
+        .containsExactly(new AgentInstanceToolValue("search", "Search the web", "searchElement"));
+    assertThat(entity.getElementInstanceKeys()).containsExactly(elementInstanceKey);
+    assertThat(entity.getCreationDate()).isEqualTo(expectedTimestamp);
+    assertThat(entity.getLastUpdatedDate()).isEqualTo(expectedTimestamp);
+    assertThat(entity.getCompletionDate()).isNull();
+  }
+
+  @Test
+  void shouldUpdateEntityOnUpdated() {
+    // given
+    final long recordKey = 100L;
+    final var recordValue = buildMinimalRecordValue(recordKey);
+
+    final Record<AgentInstanceRecordValue> record =
+        factory.generateRecord(
+            ValueType.AGENT_INSTANCE,
+            r ->
+                r.withIntent(AgentInstanceIntent.UPDATED)
+                    .withKey(recordKey)
+                    .withValue(recordValue));
+
+    // pre-populate creationDate as if set by a prior CREATED event
+    final var existingCreationDate = DateUtil.toOffsetDateTime(Instant.now().minusSeconds(60));
+    final var entity =
+        new AgentInstanceEntity()
+            .setId(String.valueOf(recordKey))
+            .setCreationDate(existingCreationDate);
+
+    // when
+    underTest.updateEntity(record, entity);
+
+    // then
+    final var expectedTimestamp =
+        DateUtil.toOffsetDateTime(Instant.ofEpochMilli(record.getTimestamp()));
+
+    assertThat(entity.getLastUpdatedDate()).isEqualTo(expectedTimestamp);
+    assertThat(entity.getCreationDate()).isEqualTo(existingCreationDate);
+    assertThat(entity.getCompletionDate()).isNull();
+  }
+
+  @Test
+  void shouldUpdateEntityOnCompleted() {
+    // given
+    final long recordKey = 100L;
+    final var recordValue =
+        ImmutableAgentInstanceRecordValue.builder()
+            .from(buildMinimalRecordValue(recordKey))
+            .withStatus(io.camunda.zeebe.protocol.record.value.AgentInstanceStatus.COMPLETED)
+            .build();
+
+    final Record<AgentInstanceRecordValue> record =
+        factory.generateRecord(
+            ValueType.AGENT_INSTANCE,
+            r ->
+                r.withIntent(AgentInstanceIntent.COMPLETED)
+                    .withKey(recordKey)
+                    .withValue(recordValue));
+
+    // pre-populate creationDate as if set by a prior CREATED event
+    final var existingCreationDate = DateUtil.toOffsetDateTime(Instant.now().minusSeconds(120));
+    final var entity =
+        new AgentInstanceEntity()
+            .setId(String.valueOf(recordKey))
+            .setCreationDate(existingCreationDate);
+
+    // when
+    underTest.updateEntity(record, entity);
+
+    // then
+    final var expectedTimestamp =
+        DateUtil.toOffsetDateTime(Instant.ofEpochMilli(record.getTimestamp()));
+
+    assertThat(entity.getStatus()).isEqualTo(AgentInstanceStatus.COMPLETED);
+    assertThat(entity.getCompletionDate()).isEqualTo(expectedTimestamp);
+    assertThat(entity.getLastUpdatedDate()).isEqualTo(expectedTimestamp);
+    assertThat(entity.getCreationDate()).isEqualTo(existingCreationDate);
+  }
+
+  @ParameterizedTest
+  @EnumSource(io.camunda.zeebe.protocol.record.value.AgentInstanceStatus.class)
+  void shouldMapAllProtocolStatuses(
+      final io.camunda.zeebe.protocol.record.value.AgentInstanceStatus protocolStatus) {
+    // given
+    final var recordValue =
+        ImmutableAgentInstanceRecordValue.builder()
+            .from(buildMinimalRecordValue(1L))
+            .withStatus(protocolStatus)
+            .build();
+    final Record<AgentInstanceRecordValue> record =
+        factory.generateRecord(
+            ValueType.AGENT_INSTANCE,
+            r -> r.withIntent(AgentInstanceIntent.CREATED).withValue(recordValue));
+    final var entity = new AgentInstanceEntity().setId("1");
+
+    // when
+    underTest.updateEntity(record, entity);
+
+    // then
+    assertThat(entity.getStatus()).isNotNull();
+    assertThat(entity.getStatus().name()).isEqualTo(protocolStatus.name());
+  }
+
+  @Test
+  void shouldUpsertEntityOnFlush() {
+    // given
+    final String entityId = "100";
+    final var tools = List.of(new AgentInstanceToolValue("tool", "does stuff", "toolElement"));
+    final var entity =
+        new AgentInstanceEntity()
+            .setId(entityId)
+            .setStatus(AgentInstanceStatus.THINKING)
+            .setInputTokens(10L)
+            .setOutputTokens(5L)
+            .setModelCalls(1)
+            .setToolCalls(0)
+            .setTools(tools)
+            .setElementInstanceKeys(List.of(200L))
+            .setLastUpdatedDate(DateUtil.toOffsetDateTime(Instant.now()));
+
+    final Map<String, Object> expectedUpdateFields = new LinkedHashMap<>();
+    expectedUpdateFields.put(STATUS, entity.getStatus());
+    expectedUpdateFields.put(INPUT_TOKENS, entity.getInputTokens());
+    expectedUpdateFields.put(OUTPUT_TOKENS, entity.getOutputTokens());
+    expectedUpdateFields.put(MODEL_CALLS, entity.getModelCalls());
+    expectedUpdateFields.put(TOOL_CALLS, entity.getToolCalls());
+    expectedUpdateFields.put(TOOLS, entity.getTools());
+    expectedUpdateFields.put(ELEMENT_INSTANCE_KEYS, entity.getElementInstanceKeys());
+    expectedUpdateFields.put(LAST_UPDATED_DATE, entity.getLastUpdatedDate());
+
+    final BatchRequest mockRequest = Mockito.mock(BatchRequest.class);
+
+    // when
+    underTest.flush(entity, mockRequest);
+
+    // then
+    verify(mockRequest, times(1)).upsert(indexName, entityId, entity, expectedUpdateFields);
+  }
+
+  @Test
+  void shouldIncludeCompletionDateInUpdateFieldsWhenSet() {
+    // given
+    final String entityId = "100";
+    final var completionDate = DateUtil.toOffsetDateTime(Instant.now());
+    final var entity =
+        new AgentInstanceEntity()
+            .setId(entityId)
+            .setStatus(AgentInstanceStatus.COMPLETED)
+            .setCompletionDate(completionDate)
+            .setLastUpdatedDate(completionDate);
+
+    final BatchRequest mockRequest = Mockito.mock(BatchRequest.class);
+
+    // when
+    underTest.flush(entity, mockRequest);
+
+    // then
+    verify(mockRequest, times(1))
+        .upsert(
+            Mockito.eq(indexName),
+            Mockito.eq(entityId),
+            Mockito.eq(entity),
+            Mockito.argThat(
+                (Map<String, Object> fields) ->
+                    fields.containsKey(COMPLETION_DATE)
+                        && fields.get(COMPLETION_DATE).equals(completionDate)));
+  }
+
+  private Record<AgentInstanceRecordValue> generateRecord(final AgentInstanceIntent intent) {
+    return factory.generateRecord(ValueType.AGENT_INSTANCE, r -> r.withIntent(intent));
+  }
+
+  private AgentInstanceRecordValue buildMinimalRecordValue(final long agentInstanceKey) {
+    return ImmutableAgentInstanceRecordValue.builder()
+        .withAgentInstanceKey(agentInstanceKey)
+        .withStatus(io.camunda.zeebe.protocol.record.value.AgentInstanceStatus.IDLE)
+        .withDefinition(
+            ImmutableAgentInstanceDefinitionValue.builder()
+                .withModel("gpt-4o")
+                .withProvider("openai")
+                .withSystemPrompt("You are helpful.")
+                .build())
+        .withLimits(
+            ImmutableAgentInstanceLimitsValue.builder()
+                .withMaxTokens(500L)
+                .withMaxModelCalls(5)
+                .withMaxToolCalls(3)
+                .build())
+        .withMetrics(
+            ImmutableAgentInstanceMetricsValue.builder()
+                .withInputTokens(0L)
+                .withOutputTokens(0L)
+                .withModelCalls(0)
+                .withToolCalls(0)
+                .build())
+        .build();
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentInstanceHandlerTest.java
@@ -242,7 +242,12 @@ final class AgentInstanceHandlerTest {
   }
 
   @ParameterizedTest(name = "[{index}] Should map protocol status \''{0}\' to entity status")
-  @EnumSource(io.camunda.zeebe.protocol.record.value.AgentInstanceStatus.class)
+  @EnumSource(
+      value = io.camunda.zeebe.protocol.record.value.AgentInstanceStatus.class,
+      // The broker should never emit UNSPECIFIED;
+      // all other protocol statuses must map to an exporter status.
+      names = {"UNSPECIFIED"},
+      mode = Mode.EXCLUDE)
   void shouldMapAllProtocolStatuses(
       final io.camunda.zeebe.protocol.record.value.AgentInstanceStatus protocolStatus) {
     // given
@@ -262,7 +267,37 @@ final class AgentInstanceHandlerTest {
 
     // then
     assertThat(entity.getStatus()).isNotNull();
-    assertThat(entity.getStatus().name()).isEqualTo(protocolStatus.name());
+    assertThat(entity.getStatus().name())
+        .as(
+            """
+            Protocol status '%s' has no explicit mapping in 'AgentInstanceHandler.mapStatus()' \
+            and falls back to 'UNKNOWN' — add '%s' to '%s' entity enum and handle \
+            it explicitly in the switch, or exclude it from this test if UNKNOWN is intentional.\
+            """,
+            protocolStatus, protocolStatus, AgentInstanceStatus.class.getName())
+        .isEqualTo(protocolStatus.name());
+  }
+
+  @Test
+  void shouldMapUnexpectedStatusToUnknown() {
+    // given — UNSPECIFIED is not explicitly handled in mapStatus() and acts as a proxy
+    // for any unexpected/future protocol status that hits the default branch
+    final var recordValue =
+        ImmutableAgentInstanceRecordValue.builder()
+            .from(buildMinimalRecordValue(1L))
+            .withStatus(io.camunda.zeebe.protocol.record.value.AgentInstanceStatus.UNSPECIFIED)
+            .build();
+    final Record<AgentInstanceRecordValue> record =
+        factory.generateRecord(
+            ValueType.AGENT_INSTANCE,
+            r -> r.withIntent(AgentInstanceIntent.CREATED).withValue(recordValue));
+    final var entity = new AgentInstanceEntity().setId("1");
+
+    // when
+    underTest.updateEntity(record, entity);
+
+    // then
+    assertThat(entity.getStatus()).isEqualTo(AgentInstanceStatus.UNKNOWN);
   }
 
   @Test


### PR DESCRIPTION
## Description

Part 2 of 3 for [#51512](https://github.com/camunda/camunda/issues/51512) — delivers the Camunda Exporter handler that writes `AGENT_INSTANCE` records to Elasticsearch/OpenSearch.

### Rationale

PR-1 ([#53144](https://github.com/camunda/camunda/pull/53144)) established the schema foundation: entity model, index template, and ES/OS mappings. This PR wires up the export handler that consumes `AGENT_INSTANCE` records from the Zeebe engine and writes them to the `agent-instance` index.

### What is in scope

- **`AgentInstanceHandler`** — new `ExportHandler<AgentInstanceEntity, AgentInstanceRecordValue>` implementation
  - Handles `CREATED`, `UPDATED`, and `COMPLETED` intents
  - Two-phase flush: `updateEntity()` builds the in-memory entity from the full-state protocol record; `flush()` writes via `batchRequest.upsert()` with a sparse `updateFields` map
  - Sparse update map contains only mutable fields (`status`, `metrics`, `tools`, `elementInstanceKeys`, `lastUpdatedDate`, conditionally `completionDate`) — immutable `identity`, `definition`, and `limits` fields are written once on INSERT and never overwritten on subsequent UPDATED events
  - Handler-computed date fields (`creationDate`, `lastUpdatedDate`, `completionDate`) are derived from `record.getTimestamp()` since they are not carried in `AgentInstanceRecordValue`
  - `rootProcessInstanceKey` set to `-1L` (Zeebe sentinel for "not set") until the protocol exposes it (tracked: [#53236](https://github.com/camunda/camunda/issues/53236))

- **Forward compatibility** — `AgentInstanceStatus.UNKNOWN` added to the entity enum; any protocol status without an explicit mapping (e.g. future additions, or the `UNSPECIFIED` protobuf wire default) maps to `UNKNOWN` with a warning log rather than throwing

- **Registration** — `AgentInstanceHandler` registered in `DefaultExporterResourceProvider`; `AGENT_INSTANCE` added to `CamundaExporterRecordFilter.VALUE_TYPES_2_EXPORT`

### What is out of scope (covered by follow-up PRs)

| Excluded | Covered by |
|----------|------------|
| RDBMS schema (Liquibase), mapper, writer, and RDBMS Exporter handler | PR-3 `feat/51512-agent-instance-rdbms` |
| REST API layer — `GET /agent-instances`, `POST /agent-instances/search` | [#51510](https://github.com/camunda/camunda/issues/51510) |

### Test coverage

`AgentInstanceHandlerTest` — 19 tests covering:
- Handler metadata (value type, entity type, index name)
- Intent filtering: `CREATED`, `UPDATED`, `COMPLETED` accepted; all others rejected
- ID generation from record key
- Full field mapping on `CREATED` — all 22 entity fields asserted
- Date immutability across `CREATED → UPDATED → COMPLETED` lifecycle: `creationDate` preserved through all intents, `completionDate` set only on `COMPLETED`
- Exhaustive protocol-to-entity status mapping via `@EnumSource` — auto-expands when new protocol statuses are added, failing with an actionable message if no explicit mapping is provided
- Sparse `updateFields` map driven by `updateEntity()` output, catching field-name drift between template constants and entity getters
- Conditional inclusion of `completionDate` in `updateFields`
- Fallback to `UNKNOWN` for unrecognized protocol statuses

The existing `shouldHaveAllHandlerValueTypesRegisteredInExporterFilter` test in `CamundaExporterTest` automatically verifies that `AGENT_INSTANCE` is registered in both the handler list and the record filter — no change needed there.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

Part 2 of 3 for #51512 — this PR does **not** close the issue. The issue will be closed once PR-3 (RDBMS full stack) is merged.