### PR TITLE
Skip nightly stable/8.9

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-definition/evaluate-decision-definitions-api.tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-definition/evaluate-decision-definitions-api.tests.spec.ts
@@ -44,7 +44,8 @@ test.describe.parallel('Evaluate Decision Definitions API Tests', () => {
     decisionDefinition2 = state['decisionDefinition2'] as DecisionDeployment;
   });
 
-  test('Evaluate Decision Definition by decisionDefinitionKey For Input 8.8', async ({
+  // Skipped due to bug #52944: https://github.com/camunda/camunda/issues/52944
+  test.skip('Evaluate Decision Definition by decisionDefinitionKey For Input 8.8', async ({
     request,
   }) => {
     const matchedRule = {
@@ -106,7 +107,8 @@ test.describe.parallel('Evaluate Decision Definitions API Tests', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Evaluate Decision Definition by decisionDefinitionKey For Input 8.7', async ({
+  // Skipped due to bug #52944: https://github.com/camunda/camunda/issues/52944
+  test.skip('Evaluate Decision Definition by decisionDefinitionKey For Input 8.7', async ({
     request,
   }) => {
     const matchedRule = {
@@ -164,7 +166,8 @@ test.describe.parallel('Evaluate Decision Definitions API Tests', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Evaluate Decision Definition by decisionDefinitionKey For Input 8.6', async ({
+  // Skipped due to bug #52944: https://github.com/camunda/camunda/issues/52944
+  test.skip('Evaluate Decision Definition by decisionDefinitionKey For Input 8.6', async ({
     request,
   }) => {
     const matchedRule = {
@@ -282,7 +285,8 @@ test.describe.parallel('Evaluate Decision Definitions API Tests', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Evaluate Decision Definition by decisionDefinitionId For Input With status VIP and Score 50', async ({
+  // Skipped due to bug #52944: https://github.com/camunda/camunda/issues/52944
+  test.skip('Evaluate Decision Definition by decisionDefinitionId For Input With status VIP and Score 50', async ({
     request,
   }) => {
     const matchedRule = {
@@ -360,7 +364,8 @@ test.describe.parallel('Evaluate Decision Definitions API Tests', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Evaluate Decision Definition by decisionDefinitionId For Input With status Regular and Score 40', async ({
+  // Skipped due to bug #52944: https://github.com/camunda/camunda/issues/52944
+  test.skip('Evaluate Decision Definition by decisionDefinitionId For Input With status Regular and Score 40', async ({
     request,
   }) => {
     const matchedRule = {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-ad-hoc-activities-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-ad-hoc-activities-api.spec.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {test} from '@playwright/test';
+import {test, expect} from '@playwright/test';
 import {
   assertBadRequest,
   assertNotFoundRequest,
@@ -21,6 +21,7 @@ import {
   deploy,
 } from '../../../../utils/zeebeClient';
 import {resolveAdHocSubProcessInstanceKey} from '@requestHelpers';
+import {defaultAssertionOptions} from 'utils/constants';
 
 const state: Record<string, unknown> = {};
 
@@ -86,22 +87,24 @@ test.describe.parallel('Element Instance Ad-hoc Activities API', () => {
       ],
     };
 
-    const res = await test.step('Call activation endpoint', async () => {
-      return await request.post(
-        buildUrl(
-          '/element-instances/ad-hoc-activities/{adHocSubProcessInstanceKey}/activation',
-          {adHocSubProcessInstanceKey: adHocKey},
-        ),
-        {
-          headers: jsonHeaders(),
-          data: body,
-        },
-      );
-    });
-
-    await test.step('Assert successful response', async () => {
+    // Retry to absorb engine read-after-write lag: the ad-hoc subprocess
+    // instance can be visible via search before the activation command can
+    // resolve it (404 → 204).
+    await expect(async () => {
+      const res = await test.step('Call activation endpoint', async () => {
+        return await request.post(
+          buildUrl(
+            '/element-instances/ad-hoc-activities/{adHocSubProcessInstanceKey}/activation',
+            {adHocSubProcessInstanceKey: adHocKey},
+          ),
+          {
+            headers: jsonHeaders(),
+            data: body,
+          },
+        );
+      });
       await assertStatusCode(res, 204);
-    });
+    }).toPass(defaultAssertionOptions);
   });
 
   test('Activate AdHoc Activities SucceedsWithVariablesAndCancel', async ({
@@ -121,8 +124,11 @@ test.describe.parallel('Element Instance Ad-hoc Activities API', () => {
       cancelRemainingInstances: true,
     };
 
-    const res = await test.step('Call activation endpoint', async () => {
-      return await request.post(
+    // Retry to absorb engine read-after-write lag: the ad-hoc subprocess
+    // instance can be visible via search before the activation command can
+    // resolve it (404 → 204).
+    await expect(async () => {
+      const res = await request.post(
         buildUrl(
           '/element-instances/ad-hoc-activities/{adHocSubProcessInstanceKey}/activation',
           {adHocSubProcessInstanceKey: adHocKey},
@@ -132,11 +138,8 @@ test.describe.parallel('Element Instance Ad-hoc Activities API', () => {
           data: body,
         },
       );
-    });
-
-    await test.step('Assert successful response', async () => {
       await assertStatusCode(res, 204);
-    });
+    }).toPass(defaultAssertionOptions);
   });
 
   test('Activate AdHoc Activities FailsWithMissingElements', async ({

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-mapping-rules-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-mapping-rules-api-tests.spec.ts
@@ -180,25 +180,28 @@ test.describe.parallel('Group Mapping Rules API Tests', () => {
     await test.step('Search Mapping Rules After Deletion', async () => {
       const p = {groupId: state['groupId3'] as string};
 
-      const res = await request.post(
+      await expect(async () => {
+        const res = await request.post(
         buildUrl('/groups/{groupId}/mapping-rules/search', p),
-        {
-          headers: jsonHeaders(),
-          data: {},
-        },
-      );
-      await assertStatusCode(res, 200);
-      await validateResponse(
-        {
-          path: '/groups/{groupId}/mapping-rules/search',
-          method: 'POST',
-          status: '200',
-        },
-        res,
-      );
-      const json = await res.json();
-      expect(json.page.totalItems).toBe(0);
-      expect(json.items.length).toBe(0);
+          {
+            headers: jsonHeaders(),
+            data: {},
+          },
+        );
+        await assertStatusCode(res, 200);
+        await validateResponse(
+          {
+            path: '/groups/{groupId}/mapping-rules/search',
+            method: 'POST',
+            status: '200',
+          },
+          res,
+        );
+        const json = await res.json();
+        expect(json.page.totalItems).toBe(0);
+        expect(json.items.length).toBe(0);
+      }).toPass(defaultAssertionOptions);
+      
     });
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-statistics-by-worker-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-statistics-by-worker-api-tests.spec.ts
@@ -87,8 +87,8 @@ test.describe.parallel('Job Statistics By Worker API Tests', () => {
       expect(item.completed.count).toBeGreaterThanOrEqual(0);
       expect(item.failed.count).toBeGreaterThanOrEqual(1);
     }).toPass({
-      intervals: [5_000, 10_000, 15_000],
-      timeout: 90_000,
+      intervals: [5_000, 10_000, 15_000, 20_000, 30_000],
+      timeout: 180_000,
     });
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message/search-correlated-message-subscriptions-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message/search-correlated-message-subscriptions-api-tests.spec.ts
@@ -43,7 +43,6 @@ test.describe.serial('Correlated Message Subscriptions API Tests', () => {
     correlationKey: '3838383',
     elementId: 'Event_17u9bac',
     messageName: 'Message_3tvi9o8',
-    partitionId: 1,
     processDefinitionId: 'messageCatchEvent3',
     tenantId: '<default>',
   };
@@ -165,11 +164,11 @@ test.describe.serial('Correlated Message Subscriptions API Tests', () => {
           'correlationKey',
           'elementId',
           'messageName',
-          'partitionId',
           'processDefinitionId',
           'tenantId',
         ],
       );
+      expect(subscription.partitionId).toBeGreaterThanOrEqual(1);
     }).toPass(defaultAssertionOptions);
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-resolve-related-incident-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-resolve-related-incident-api.spec.ts
@@ -27,7 +27,7 @@ import {validateResponse} from '../../../../json-body-assertions';
 import {createUser, grantUserResourceAuthorization} from '@requestHelpers';
 import {cleanupUsers} from 'utils/usersCleanup';
 
-test.describe.parallel('Resolve related incidents API Tests', () => {
+test.describe.serial('Resolve related incidents API Tests', () => {
   let processInstanceKeyWithIncidentToResolve: string = '';
   let userWithResourcesAuthorizationToSendRequest: {
     username: string;

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/usage-metrics/usage-metrics-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/usage-metrics/usage-metrics-api.spec.ts
@@ -221,7 +221,7 @@ test.describe('Get Usage Metrics API Tests - User with no permission', () => {
     });
   });
 
-  test('Get Usage Metrics - User with no granted authorization', async ({
+  test('Get Usage Metrics - User with no granted authorization - 200, empty', async ({
     request,
   }) => {
     // eslint-disable-next-line playwright/no-conditional-in-test
@@ -256,7 +256,17 @@ test.describe('Get Usage Metrics API Tests - User with no permission', () => {
           headers: jsonHeaders(token), // overrides default demo:demo
         },
       );
-      await assertUnauthorizedRequest(res);
+      await assertStatusCode(res, 200);
+      await validateResponse({
+        path: USAGE_METRICS_GET_ENDPOINT,
+        method: 'GET',
+        status: '200',
+      }, res);
+      const body = await res.json();
+      expect(body.activeTenants).toBe(0);
+      expect(body.processInstances).toBe(0);
+      expect(body.decisionInstances).toBe(0);
+      expect(body.assignees).toBe(0);
     }).toPass(defaultAssertionOptions);
   });
 });


### PR DESCRIPTION
## Description

- 5 DMN evaluate tests are skipped due to https://github.com/camunda/camunda/issues/52944
- 4 flaky tests stabilisation: 

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

related https://github.com/camunda/camunda/issues/52944

## On demand workflow
[Was all green](https://github.com/camunda/camunda/actions/runs/26045227518)