### PR TITLE
feat: implement business id support for message start events (single partition)

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -207,7 +207,8 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             eventTriggerBehavior,
             stateBehavior,
             writers,
-            clock);
+            clock,
+            config.isBusinessIdUniquenessEnabled());
 
     jobActivationBehavior =
         new BpmnJobActivationBehavior(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBufferedMessageStartEventBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBufferedMessageStartEventBehavior.java
@@ -120,10 +120,15 @@ public final class BpmnBufferedMessageStartEventBehavior {
               messageName,
               correlationKey,
               storedMessage -> {
-                // correlate the first message with same correlation key that was not correlated yet
-                // additionally, skip a buffered message whose businessId is currently taken by an
-                // active PI on this partition — leaving it in the buffer so a future release can
-                // pick it up
+                // correlate the first message with same correlation key that was not correlated
+                // yet. Additionally, when the feature is enabled, skip a buffered message whose
+                // businessId is currently taken by another active PI on this partition; the
+                // visitor returns true so the scan continues to subsequent buffered entries for
+                // the same correlation key — the queue itself is not stalled, only the skipped
+                // entry is left in the buffer until its TTL or until another K-keyed completion
+                // triggers a rescan. A businessId-keyed retry (so the skipped entry can be picked
+                // up the moment the holding PI ends, regardless of correlation key) is the job of
+                // the release-driven retry path added in a later increment.
                 if (storedMessage.getMessage().getDeadline() > clock.millis()
                     && !messageState.existMessageCorrelation(
                         storedMessage.getMessageKey(), process.getBpmnProcessId())
@@ -151,6 +156,16 @@ public final class BpmnBufferedMessageStartEventBehavior {
     }
   }
 
+  /**
+   * Returns {@code true} when the feature is enabled, the buffered message carries a businessId,
+   * and an active root PI on this partition already holds that businessId for the same process
+   * definition. A {@code true} result causes the buffered-message scan to skip this entry and keep
+   * looking; the entry remains in the buffer subject to its TTL. There is no businessId-keyed
+   * retrigger here: the scan only fires on completion of a PI that holds the correlation-key lock,
+   * so an entry skipped because of a long-lived businessId holder on a different correlation key
+   * can be left untouched until TTL. The release-driven retry path added in a later increment
+   * closes that gap.
+   */
   private boolean isBufferedMessageBlockedByBusinessIdUniqueness(
       final StoredMessage storedMessage, final DeployedProcess process) {
     if (!businessIdUniquenessEnabled) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBufferedMessageStartEventBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBufferedMessageStartEventBehavior.java
@@ -132,7 +132,7 @@ public final class BpmnBufferedMessageStartEventBehavior {
                 if (storedMessage.getMessage().getDeadline() > clock.millis()
                     && !messageState.existMessageCorrelation(
                         storedMessage.getMessageKey(), process.getBpmnProcessId())
-                    && !isBufferedMessageBlockedByBusinessIdUniqueness(storedMessage, process)) {
+                    && !isBusinessIdAlreadyHeld(storedMessage, process)) {
 
                   // correlate the first published message across all message start events
                   // - using the message key to decide which message was published before
@@ -166,7 +166,7 @@ public final class BpmnBufferedMessageStartEventBehavior {
    * can be left untouched until TTL. The release-driven retry path added in a later increment
    * closes that gap.
    */
-  private boolean isBufferedMessageBlockedByBusinessIdUniqueness(
+  private boolean isBusinessIdAlreadyHeld(
       final StoredMessage storedMessage, final DeployedProcess process) {
     if (!businessIdUniquenessEnabled) {
       return false;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBufferedMessageStartEventBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBufferedMessageStartEventBehavior.java
@@ -12,12 +12,16 @@ import io.camunda.zeebe.engine.processing.common.EventHandle;
 import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
+import io.camunda.zeebe.engine.state.immutable.BannedInstanceState;
+import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.MessageStartEventSubscriptionState;
 import io.camunda.zeebe.engine.state.immutable.MessageState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.engine.state.message.StoredMessage;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartEventSubscriptionRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.time.InstantSource;
 import java.util.Optional;
 import org.agrona.DirectBuffer;
@@ -27,6 +31,9 @@ public final class BpmnBufferedMessageStartEventBehavior {
   private final MessageState messageState;
   private final ProcessState processState;
   private final MessageStartEventSubscriptionState messageStartEventSubscriptionState;
+  private final ElementInstanceState elementInstanceState;
+  private final BannedInstanceState bannedInstanceState;
+  private final boolean businessIdUniquenessEnabled;
 
   private final EventHandle eventHandle;
   private final InstantSource clock;
@@ -37,10 +44,14 @@ public final class BpmnBufferedMessageStartEventBehavior {
       final EventTriggerBehavior eventTriggerBehavior,
       final BpmnStateBehavior stateBehavior,
       final Writers writers,
-      final InstantSource clock) {
+      final InstantSource clock,
+      final boolean businessIdUniquenessEnabled) {
     messageState = processingState.getMessageState();
     processState = processingState.getProcessState();
     messageStartEventSubscriptionState = processingState.getMessageStartEventSubscriptionState();
+    elementInstanceState = processingState.getElementInstanceState();
+    bannedInstanceState = processingState.getBannedInstanceState();
+    this.businessIdUniquenessEnabled = businessIdUniquenessEnabled;
     this.clock = clock;
 
     eventHandle =
@@ -110,9 +121,13 @@ public final class BpmnBufferedMessageStartEventBehavior {
               correlationKey,
               storedMessage -> {
                 // correlate the first message with same correlation key that was not correlated yet
+                // additionally, skip a buffered message whose businessId is currently taken by an
+                // active PI on this partition — leaving it in the buffer so a future release can
+                // pick it up
                 if (storedMessage.getMessage().getDeadline() > clock.millis()
                     && !messageState.existMessageCorrelation(
-                        storedMessage.getMessageKey(), process.getBpmnProcessId())) {
+                        storedMessage.getMessageKey(), process.getBpmnProcessId())
+                    && !isBufferedMessageBlockedByBusinessIdUniqueness(storedMessage, process)) {
 
                   // correlate the first published message across all message start events
                   // - using the message key to decide which message was published before
@@ -134,6 +149,22 @@ public final class BpmnBufferedMessageStartEventBehavior {
     } else {
       return Optional.empty();
     }
+  }
+
+  private boolean isBufferedMessageBlockedByBusinessIdUniqueness(
+      final StoredMessage storedMessage, final DeployedProcess process) {
+    if (!businessIdUniquenessEnabled) {
+      return false;
+    }
+    final var businessId = storedMessage.getMessage().getBusinessIdBuffer();
+    if (businessId == null || businessId.capacity() == 0) {
+      return false;
+    }
+    return elementInstanceState.hasActiveProcessInstanceWithBusinessId(
+        BufferUtil.bufferAsString(businessId),
+        BufferUtil.bufferAsString(process.getBpmnProcessId()),
+        storedMessage.getMessage().getTenantId(),
+        bannedInstanceState::isProcessInstanceBanned);
   }
 
   private static final class Correlation {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBufferedMessageStartEventBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBufferedMessageStartEventBehavior.java
@@ -159,13 +159,10 @@ public final class BpmnBufferedMessageStartEventBehavior {
 
   /**
    * Returns {@code true} when the feature is enabled, the buffered message carries a businessId,
-   * and an active root PI on this partition already holds that businessId for the same process
-   * definition. A {@code true} result causes the buffered-message scan to skip this entry and keep
-   * looking; the entry remains in the buffer subject to its TTL. There is no businessId-keyed
-   * retrigger here: the scan only fires on completion of a PI that holds the correlation-key lock,
-   * so an entry skipped because of a long-lived businessId holder on a different correlation key
-   * can be left untouched until TTL. The release-driven retry path added in a later increment
-   * closes that gap.
+   * and an active root PI on this partition already holds that businessId for this process
+   * definition. See the class JavaDoc of {@link
+   * io.camunda.zeebe.engine.processing.message.MessageCorrelateBehavior} for the system-level
+   * retry/cross-partition narrative this predicate participates in.
    */
   private boolean isBusinessIdAlreadyHeld(
       final StoredMessage storedMessage, final String bpmnProcessId) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBufferedMessageStartEventBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBufferedMessageStartEventBehavior.java
@@ -108,6 +108,7 @@ public final class BpmnBufferedMessageStartEventBehavior {
       final DeployedProcess process, final DirectBuffer correlationKey) {
 
     final var messageCorrelation = new Correlation();
+    final var bpmnProcessId = BufferUtil.bufferAsString(process.getBpmnProcessId());
 
     messageStartEventSubscriptionState.visitSubscriptionsByProcessDefinition(
         process.getKey(),
@@ -132,7 +133,7 @@ public final class BpmnBufferedMessageStartEventBehavior {
                 if (storedMessage.getMessage().getDeadline() > clock.millis()
                     && !messageState.existMessageCorrelation(
                         storedMessage.getMessageKey(), process.getBpmnProcessId())
-                    && !isBusinessIdAlreadyHeld(storedMessage, process)) {
+                    && !isBusinessIdAlreadyHeld(storedMessage, bpmnProcessId)) {
 
                   // correlate the first published message across all message start events
                   // - using the message key to decide which message was published before
@@ -167,7 +168,7 @@ public final class BpmnBufferedMessageStartEventBehavior {
    * closes that gap.
    */
   private boolean isBusinessIdAlreadyHeld(
-      final StoredMessage storedMessage, final DeployedProcess process) {
+      final StoredMessage storedMessage, final String bpmnProcessId) {
     if (!businessIdUniquenessEnabled) {
       return false;
     }
@@ -177,7 +178,7 @@ public final class BpmnBufferedMessageStartEventBehavior {
     }
     return elementInstanceState.hasActiveProcessInstanceWithBusinessId(
         BufferUtil.bufferAsString(businessId),
-        BufferUtil.bufferAsString(process.getBpmnProcessId()),
+        bpmnProcessId,
         storedMessage.getMessage().getTenantId(),
         bannedInstanceState::isProcessInstanceBanned);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBufferedMessageStartEventBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBufferedMessageStartEventBehavior.java
@@ -88,7 +88,8 @@ public final class BpmnBufferedMessageStartEventBehavior {
                   storedMessage.getMessageKey(),
                   storedMessage.getMessage().getNameBuffer(),
                   storedMessage.getMessage().getCorrelationKeyBuffer(),
-                  storedMessage.getMessage().getVariablesBuffer());
+                  storedMessage.getMessage().getVariablesBuffer(),
+                  storedMessage.getMessage().getBusinessIdBuffer());
             });
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventHandle.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventHandle.java
@@ -264,7 +264,8 @@ public final class EventHandle {
 
     // Set the businessId from the message-start path on the new PI's creation record so that
     // subsequent uniqueness checks (and exporters) see the PI as carrying the businessId, mirroring
-    // how a PI created via PROCESS_INSTANCE_CREATION already does.
+    // how a PI created via PROCESS_INSTANCE_CREATION already does. Reset to "" when absent so a
+    // stale value from a previous invocation of this reused record cannot leak through.
     if (businessId != null && businessId.capacity() > 0) {
       recordForPICreation.setBusinessId(businessId);
     } else {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventHandle.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventHandle.java
@@ -193,7 +193,8 @@ public final class EventHandle {
       final long messageKey,
       final DirectBuffer messageName,
       final DirectBuffer correlationKey,
-      final DirectBuffer variables) {
+      final DirectBuffer variables,
+      final DirectBuffer businessId) {
 
     final var newProcessInstanceKey = keyGenerator.nextKey();
     startEventSubscriptionRecord
@@ -217,7 +218,8 @@ public final class EventHandle {
         newProcessInstanceKey,
         startEventSubscriptionRecord.getStartEventIdBuffer(),
         variables,
-        subscription.getTenantId());
+        subscription.getTenantId(),
+        businessId);
 
     return newProcessInstanceKey;
   }
@@ -228,6 +230,17 @@ public final class EventHandle {
       final DirectBuffer targetElementId,
       final DirectBuffer variablesBuffer,
       final String tenantId) {
+    activateProcessInstanceForStartEvent(
+        processDefinitionKey, processInstanceKey, targetElementId, variablesBuffer, tenantId, null);
+  }
+
+  public void activateProcessInstanceForStartEvent(
+      final long processDefinitionKey,
+      final long processInstanceKey,
+      final DirectBuffer targetElementId,
+      final DirectBuffer variablesBuffer,
+      final String tenantId,
+      final DirectBuffer businessId) {
 
     triggeringProcessEvent(
         processDefinitionKey,
@@ -248,6 +261,15 @@ public final class EventHandle {
         .setElementId(process.getProcess().getId())
         .setBpmnElementType(process.getProcess().getElementType())
         .setTenantId(tenantId);
+
+    // Set the businessId from the message-start path on the new PI's creation record so that
+    // subsequent uniqueness checks (and exporters) see the PI as carrying the businessId, mirroring
+    // how a PI created via PROCESS_INSTANCE_CREATION already does.
+    if (businessId != null && businessId.capacity() > 0) {
+      recordForPICreation.setBusinessId(businessId);
+    } else {
+      recordForPICreation.setBusinessId("");
+    }
 
     commandWriter.appendFollowUpCommand(
         processInstanceKey, ProcessInstanceIntent.ACTIVATE_ELEMENT, recordForPICreation);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventHandle.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventHandle.java
@@ -284,6 +284,16 @@ public final class EventHandle {
         .setRootProcessInstanceKey(processInstanceKey)
         .setTenantId(tenantId);
 
+    // Mirror the businessId stamping onto the PROCESS_INSTANCE_CREATION:CREATED event so that
+    // consumers reading ProcessInstanceCreationRecordValue.getBusinessId() see the same value as
+    // PIs created via the PROCESS_INSTANCE_CREATION command path. Reset to "" when absent so a
+    // stale value from a previous invocation of this reused record cannot leak through.
+    if (businessId != null && businessId.capacity() > 0) {
+      recordForPICreationEvent.setBusinessId(businessId);
+    } else {
+      recordForPICreationEvent.setBusinessId("");
+    }
+
     stateWriter.appendFollowUpEvent(
         processInstanceKey, ProcessInstanceCreationIntent.CREATED, recordForPICreationEvent);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
@@ -78,7 +78,9 @@ public final class MessageCorrelateBehavior {
           // - allow multiple instance if correlation key is empty
           // additionally, when the published message carries a businessId, also enforce that no
           // active PI exists locally with the same businessId for this process definition (the
-          // local arm of the design's uniqueness check; cross-partition handling lands later)
+          // local arm of the design's uniqueness check; cross-partition handling lands later).
+          // A message suppressed here is left in the buffer subject to its TTL only; there is no
+          // businessId-keyed retry trigger yet — release-driven retries land in a later increment.
           if ((messageData.correlationKey().capacity() == 0
                   || !messageState.existActiveProcessInstance(
                       messageData.tenantId(), bpmnProcessIdBuffer, messageData.correlationKey()))
@@ -225,12 +227,19 @@ public final class MessageCorrelateBehavior {
   /**
    * Local arm of the design's start-event uniqueness check: when the published message carries a
    * businessId and the feature is enabled, reject the start when a root PI with the same businessId
-   * is already active for this process definition on this partition. The message itself is left in
-   * the buffer (the existing TTL path), so it can correlate later when the holding instance ends.
+   * is already active for this process definition on this partition.
+   *
+   * <p>A suppressed message remains in the existing message buffer and is only freed by its TTL.
+   * There is no businessId-keyed retry trigger today: the existing buffered-message scan in {@link
+   * io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBufferedMessageStartEventBehavior} is
+   * driven by completion of a PI that holds the correlation-key lock, so a suppressed message whose
+   * correlation key does not match an active holder's lock will not be retried even after the
+   * businessId is released. Release-driven retries — both same-partition and across partitions via
+   * the pull-based ask to {@code P_B} — are introduced in a later increment by design.
    *
    * <p>Cross-partition uniqueness (i.e. when the businessId hashes to a different partition than
-   * the correlation key) is intentionally out of scope here and is delegated to {@code P_B} in a
-   * later increment via a cross-partition ask. This method only resolves what {@code P_K} can
+   * the correlation key) is also intentionally out of scope here and is delegated to {@code P_B} in
+   * a later increment via a cross-partition ask. This method only resolves what {@code P_K} can
    * answer locally.
    */
   private boolean isBlockedByBusinessIdUniqueness(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
@@ -21,6 +21,27 @@ import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.Collection;
 import org.agrona.DirectBuffer;
 
+/**
+ * Correlates published messages to message start-event subscriptions and to intermediate message
+ * catch-event subscriptions on this partition.
+ *
+ * <h3>Business-id uniqueness — local arm only</h3>
+ *
+ * When the {@code businessIdUniquenessEnabled} feature is on and a published message carries a
+ * businessId, start-event correlation additionally requires that no active root PI on this
+ * partition already holds that businessId for the same process definition. This is the local arm of
+ * the design's uniqueness check; cross-partition uniqueness (when the businessId hashes to a
+ * different partition than the message correlation key) is delegated to {@code P_B} in a later
+ * increment via a cross-partition ask.
+ *
+ * <p>A message suppressed by this check remains in the existing message buffer and is only freed by
+ * its TTL. There is no businessId-keyed retry trigger today: the buffered-message scan in {@link
+ * io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBufferedMessageStartEventBehavior} is driven
+ * by completion of a PI that holds the correlation-key lock, so a suppressed message whose
+ * correlation key does not match an active holder's lock will not be retried even after the
+ * businessId is released. Release-driven retries — both same-partition and across partitions — are
+ * introduced in a later increment by design.
+ */
 public final class MessageCorrelateBehavior {
 
   private final MessageStartEventSubscriptionState startEventSubscriptionState;
@@ -230,22 +251,9 @@ public final class MessageCorrelateBehavior {
   }
 
   /**
-   * Local arm of the design's start-event uniqueness check: when the published message carries a
-   * businessId and the feature is enabled, reject the start when a root PI with the same businessId
-   * is already active for this process definition on this partition.
-   *
-   * <p>A suppressed message remains in the existing message buffer and is only freed by its TTL.
-   * There is no businessId-keyed retry trigger today: the existing buffered-message scan in {@link
-   * io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBufferedMessageStartEventBehavior} is
-   * driven by completion of a PI that holds the correlation-key lock, so a suppressed message whose
-   * correlation key does not match an active holder's lock will not be retried even after the
-   * businessId is released. Release-driven retries — both same-partition and across partitions via
-   * the pull-based ask to {@code P_B} — are introduced in a later increment by design.
-   *
-   * <p>Cross-partition uniqueness (i.e. when the businessId hashes to a different partition than
-   * the correlation key) is also intentionally out of scope here and is delegated to {@code P_B} in
-   * a later increment via a cross-partition ask. This method only resolves what {@code P_K} can
-   * answer locally.
+   * Returns {@code true} when the feature is enabled, the message carries a businessId, and an
+   * active root PI on this partition already holds that businessId for this process definition. See
+   * the class JavaDoc for the system-level retry/cross-partition narrative.
    */
   private boolean isBusinessIdAlreadyHeld(
       final MessageData messageData, final MessageStartEventSubscriptionRecord subscriptionRecord) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
@@ -74,17 +74,7 @@ public final class MessageCorrelateBehavior {
             return;
           }
 
-          // create only one instance of a process per correlation key
-          // - allow multiple instance if correlation key is empty
-          // additionally, when the published message carries a businessId, also enforce that no
-          // active PI exists locally with the same businessId for this process definition (the
-          // local arm of the design's uniqueness check; cross-partition handling lands later).
-          // A message suppressed here is left in the buffer subject to its TTL only; there is no
-          // businessId-keyed retry trigger yet — release-driven retries land in a later increment.
-          if ((messageData.correlationKey().capacity() == 0
-                  || !messageState.existActiveProcessInstance(
-                      messageData.tenantId(), bpmnProcessIdBuffer, messageData.correlationKey()))
-              && !isBusinessIdAlreadyHeld(messageData, subscriptionRecord)) {
+          if (shouldCorrelateStartEvent(messageData, subscriptionRecord)) {
             final var processInstanceKey =
                 eventHandle.triggerMessageStartEvent(
                     subscription.getKey(),
@@ -122,10 +112,7 @@ public final class MessageCorrelateBehavior {
 
           // Mirror the same uniqueness gates as the real correlation path so authorization is only
           // checked for subscriptions that would actually correlate.
-          if ((messageData.correlationKey().capacity() == 0
-                  || !messageState.existActiveProcessInstance(
-                      messageData.tenantId(), bpmnProcessIdBuffer, messageData.correlationKey()))
-              && !isBusinessIdAlreadyHeld(messageData, subscriptionRecord)) {
+          if (shouldCorrelateStartEvent(messageData, subscriptionRecord)) {
             // Just collect, don't write state yet
             correlatingSubscriptions.add(subscriptionRecord);
           }
@@ -222,6 +209,24 @@ public final class MessageCorrelateBehavior {
       return true;
     }
     return BufferUtil.equals(messageBusinessId, subscriptionBusinessId);
+  }
+
+  /**
+   * Returns {@code true} when this start-event subscription should correlate for the given message:
+   * only one instance per (process definition, correlation key) is created — an empty correlation
+   * key allows multiple instances — and, when the businessId uniqueness feature is enabled and the
+   * message carries a businessId, no active root PI on this partition may already hold that
+   * businessId for this process definition.
+   */
+  private boolean shouldCorrelateStartEvent(
+      final MessageData messageData, final MessageStartEventSubscriptionRecord subscriptionRecord) {
+    final var correlationKeyFree =
+        messageData.correlationKey().capacity() == 0
+            || !messageState.existActiveProcessInstance(
+                messageData.tenantId(),
+                subscriptionRecord.getBpmnProcessIdBuffer(),
+                messageData.correlationKey());
+    return correlationKeyFree && !isBusinessIdAlreadyHeld(messageData, subscriptionRecord);
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
@@ -74,7 +74,8 @@ public final class MessageCorrelateBehavior {
                     messageData.messageKey(),
                     messageData.messageName(),
                     messageData.correlationKey(),
-                    messageData.variables());
+                    messageData.variables(),
+                    messageData.businessId());
 
             subscriptionRecord.setProcessInstanceKey(processInstanceKey);
             correlatingSubscriptions.add(subscriptionRecord);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
@@ -84,7 +84,7 @@ public final class MessageCorrelateBehavior {
           if ((messageData.correlationKey().capacity() == 0
                   || !messageState.existActiveProcessInstance(
                       messageData.tenantId(), bpmnProcessIdBuffer, messageData.correlationKey()))
-              && !isBlockedByBusinessIdUniqueness(messageData, subscriptionRecord)) {
+              && !isBusinessIdAlreadyHeld(messageData, subscriptionRecord)) {
             final var processInstanceKey =
                 eventHandle.triggerMessageStartEvent(
                     subscription.getKey(),
@@ -125,7 +125,7 @@ public final class MessageCorrelateBehavior {
           if ((messageData.correlationKey().capacity() == 0
                   || !messageState.existActiveProcessInstance(
                       messageData.tenantId(), bpmnProcessIdBuffer, messageData.correlationKey()))
-              && !isBlockedByBusinessIdUniqueness(messageData, subscriptionRecord)) {
+              && !isBusinessIdAlreadyHeld(messageData, subscriptionRecord)) {
             // Just collect, don't write state yet
             correlatingSubscriptions.add(subscriptionRecord);
           }
@@ -242,7 +242,7 @@ public final class MessageCorrelateBehavior {
    * a later increment via a cross-partition ask. This method only resolves what {@code P_K} can
    * answer locally.
    */
-  private boolean isBlockedByBusinessIdUniqueness(
+  private boolean isBusinessIdAlreadyHeld(
       final MessageData messageData, final MessageStartEventSubscriptionRecord subscriptionRecord) {
     if (!businessIdUniquenessEnabled) {
       return false;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
@@ -10,9 +10,12 @@ package io.camunda.zeebe.engine.processing.message;
 import io.camunda.zeebe.engine.processing.common.EventHandle;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.state.immutable.BannedInstanceState;
+import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.MessageStartEventSubscriptionState;
 import io.camunda.zeebe.engine.state.immutable.MessageState;
 import io.camunda.zeebe.engine.state.immutable.MessageSubscriptionState;
+import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartEventSubscriptionRecord;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.Collection;
@@ -23,6 +26,9 @@ public final class MessageCorrelateBehavior {
   private final MessageStartEventSubscriptionState startEventSubscriptionState;
   private final MessageSubscriptionState messageSubscriptionState;
   private final MessageState messageState;
+  private final ElementInstanceState elementInstanceState;
+  private final BannedInstanceState bannedInstanceState;
+  private final boolean businessIdUniquenessEnabled;
   private final EventHandle eventHandle;
   private final StateWriter stateWriter;
   private final SubscriptionCommandSender commandSender;
@@ -33,13 +39,19 @@ public final class MessageCorrelateBehavior {
       final EventHandle eventHandle,
       final StateWriter stateWriter,
       final MessageSubscriptionState messageSubscriptionState,
-      final SubscriptionCommandSender commandSender) {
+      final SubscriptionCommandSender commandSender,
+      final ElementInstanceState elementInstanceState,
+      final BannedInstanceState bannedInstanceState,
+      final boolean businessIdUniquenessEnabled) {
     this.startEventSubscriptionState = startEventSubscriptionState;
     this.messageSubscriptionState = messageSubscriptionState;
     this.messageState = messageState;
     this.eventHandle = eventHandle;
     this.stateWriter = stateWriter;
     this.commandSender = commandSender;
+    this.elementInstanceState = elementInstanceState;
+    this.bannedInstanceState = bannedInstanceState;
+    this.businessIdUniquenessEnabled = businessIdUniquenessEnabled;
   }
 
   public void correlateToMessageStartEvents(
@@ -64,9 +76,13 @@ public final class MessageCorrelateBehavior {
 
           // create only one instance of a process per correlation key
           // - allow multiple instance if correlation key is empty
-          if (messageData.correlationKey().capacity() == 0
-              || !messageState.existActiveProcessInstance(
-                  messageData.tenantId(), bpmnProcessIdBuffer, messageData.correlationKey())) {
+          // additionally, when the published message carries a businessId, also enforce that no
+          // active PI exists locally with the same businessId for this process definition (the
+          // local arm of the design's uniqueness check; cross-partition handling lands later)
+          if ((messageData.correlationKey().capacity() == 0
+                  || !messageState.existActiveProcessInstance(
+                      messageData.tenantId(), bpmnProcessIdBuffer, messageData.correlationKey()))
+              && !isBlockedByBusinessIdUniqueness(messageData, subscriptionRecord)) {
             final var processInstanceKey =
                 eventHandle.triggerMessageStartEvent(
                     subscription.getKey(),
@@ -102,12 +118,13 @@ public final class MessageCorrelateBehavior {
             return;
           }
 
-          // create only one instance of a process per correlation key
-          // - allow multiple instance if correlation key is empty
-          if (messageData.correlationKey().capacity() == 0
-              || !messageState.existActiveProcessInstance(
-                  messageData.tenantId(), bpmnProcessIdBuffer, messageData.correlationKey())) {
-            // Just collect, don't trigger events yet
+          // Mirror the same uniqueness gates as the real correlation path so authorization is only
+          // checked for subscriptions that would actually correlate.
+          if ((messageData.correlationKey().capacity() == 0
+                  || !messageState.existActiveProcessInstance(
+                      messageData.tenantId(), bpmnProcessIdBuffer, messageData.correlationKey()))
+              && !isBlockedByBusinessIdUniqueness(messageData, subscriptionRecord)) {
+            // Just collect, don't write state yet
             correlatingSubscriptions.add(subscriptionRecord);
           }
         });
@@ -203,6 +220,33 @@ public final class MessageCorrelateBehavior {
       return true;
     }
     return BufferUtil.equals(messageBusinessId, subscriptionBusinessId);
+  }
+
+  /**
+   * Local arm of the design's start-event uniqueness check: when the published message carries a
+   * businessId and the feature is enabled, reject the start when a root PI with the same businessId
+   * is already active for this process definition on this partition. The message itself is left in
+   * the buffer (the existing TTL path), so it can correlate later when the holding instance ends.
+   *
+   * <p>Cross-partition uniqueness (i.e. when the businessId hashes to a different partition than
+   * the correlation key) is intentionally out of scope here and is delegated to {@code P_B} in a
+   * later increment via a cross-partition ask. This method only resolves what {@code P_K} can
+   * answer locally.
+   */
+  private boolean isBlockedByBusinessIdUniqueness(
+      final MessageData messageData, final MessageStartEventSubscriptionRecord subscriptionRecord) {
+    if (!businessIdUniquenessEnabled) {
+      return false;
+    }
+    final var businessId = messageData.businessId();
+    if (businessId == null || businessId.capacity() == 0) {
+      return false;
+    }
+    return elementInstanceState.hasActiveProcessInstanceWithBusinessId(
+        BufferUtil.bufferAsString(businessId),
+        subscriptionRecord.getBpmnProcessId(),
+        messageData.tenantId(),
+        bannedInstanceState::isProcessInstanceBanned);
   }
 
   public record MessageData(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
@@ -21,6 +21,8 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.BannedInstanceState;
+import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.EventScopeInstanceState;
 import io.camunda.zeebe.engine.state.immutable.MessageStartEventSubscriptionState;
 import io.camunda.zeebe.engine.state.immutable.MessageState;
@@ -68,7 +70,10 @@ public final class MessageCorrelationCorrelateProcessor
       final MessageState messageState,
       final MessageSubscriptionState messageSubscriptionState,
       final SubscriptionCommandSender commandSender,
-      final AuthorizationCheckBehavior authCheckBehavior) {
+      final AuthorizationCheckBehavior authCheckBehavior,
+      final ElementInstanceState elementInstanceState,
+      final BannedInstanceState bannedInstanceState,
+      final boolean businessIdUniquenessEnabled) {
     stateWriter = writers.state();
     responseWriter = writers.response();
     rejectionWriter = writers.rejection();
@@ -89,7 +94,10 @@ public final class MessageCorrelationCorrelateProcessor
             eventHandle,
             stateWriter,
             messageSubscriptionState,
-            commandSender);
+            commandSender,
+            elementInstanceState,
+            bannedInstanceState,
+            businessIdUniquenessEnabled);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -60,6 +60,9 @@ public final class MessageEventProcessors {
         processingState.getEventScopeInstanceState();
     final KeyGenerator keyGenerator = processingState.getKeyGenerator();
     final var processState = processingState.getProcessState();
+    final var elementInstanceState = processingState.getElementInstanceState();
+    final var bannedInstanceState = processingState.getBannedInstanceState();
+    final var businessIdUniquenessEnabled = config.isBusinessIdUniquenessEnabled();
 
     typedRecordProcessors
         .onCommand(
@@ -78,7 +81,10 @@ public final class MessageEventProcessors {
                 bpmnBehaviors.eventTriggerBehavior(),
                 bpmnBehaviors.stateBehavior(),
                 authCheckBehavior,
-                routingInfo))
+                routingInfo,
+                elementInstanceState,
+                bannedInstanceState,
+                businessIdUniquenessEnabled))
         .onCommand(
             ValueType.MESSAGE_BATCH,
             MessageBatchIntent.EXPIRE,
@@ -145,7 +151,10 @@ public final class MessageEventProcessors {
                 messageState,
                 subscriptionState,
                 subscriptionCommandSender,
-                authCheckBehavior))
+                authCheckBehavior,
+                elementInstanceState,
+                bannedInstanceState,
+                businessIdUniquenessEnabled))
         .withListener(
             new MessageTimeToLiveCheckScheduler(
                 config.getMessagesTtlCheckerInterval(),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessagePublishProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessagePublishProcessor.java
@@ -21,6 +21,8 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.BannedInstanceState;
+import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.EventScopeInstanceState;
 import io.camunda.zeebe.engine.state.immutable.MessageStartEventSubscriptionState;
 import io.camunda.zeebe.engine.state.immutable.MessageState;
@@ -66,7 +68,10 @@ public final class MessagePublishProcessor implements TypedRecordProcessor<Messa
       final EventTriggerBehavior eventTriggerBehavior,
       final BpmnStateBehavior stateBehavior,
       final AuthorizationCheckBehavior authCheckBehavior,
-      final RoutingInfo routingInfo) {
+      final RoutingInfo routingInfo,
+      final ElementInstanceState elementInstanceState,
+      final BannedInstanceState bannedInstanceState,
+      final boolean businessIdUniquenessEnabled) {
     this.partitionId = partitionId;
     this.messageState = messageState;
     this.keyGenerator = keyGenerator;
@@ -90,7 +95,10 @@ public final class MessagePublishProcessor implements TypedRecordProcessor<Messa
             eventHandle,
             stateWriter,
             subscriptionState,
-            commandSender);
+            commandSender,
+            elementInstanceState,
+            bannedInstanceState,
+            businessIdUniquenessEnabled);
   }
 
   @Override

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartEventBusinessIdUniquenessDisabledTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartEventBusinessIdUniquenessDisabledTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.util.Map;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Regression pin: with {@code businessIdUniquenessEnabled = false} (the default), publishing two
+ * messages with the same {@code businessId} that target a message start event must still produce
+ * two process instances — the businessId is recorded but never used as a gate. This guards against
+ * silently flipping the default or coupling the filter to flag-independent code paths.
+ */
+public final class MessageStartEventBusinessIdUniquenessDisabledTest {
+
+  private static final String PROCESS_ID = "wf";
+  private static final String MESSAGE_NAME = "start-msg";
+
+  private static final BpmnModelInstance MESSAGE_START_PROCESS =
+      Bpmn.createExecutableProcess(PROCESS_ID)
+          .startEvent("start")
+          .message(MESSAGE_NAME)
+          .serviceTask("task", t -> t.zeebeJobType("test"))
+          .endEvent()
+          .done();
+
+  // Explicitly disabled to make the regression intent visible at the call site, even though it
+  // matches the EngineConfiguration default.
+  @Rule
+  public final EngineRule engine =
+      EngineRule.singlePartition()
+          .withEngineConfig(config -> config.setBusinessIdUniquenessEnabled(false));
+
+  @Test
+  public void shouldAllowDuplicateBusinessIdWhenFlagDisabled() {
+    // given
+    engine.deployment().withXmlResource(MESSAGE_START_PROCESS).deploy();
+    engine
+        .message()
+        .withName(MESSAGE_NAME)
+        .withCorrelationKey("")
+        .withBusinessId("biz-42")
+        .withVariables(Map.of("seq", 1))
+        .publish();
+    RecordingExporter.jobRecords(JobIntent.CREATED).getFirst();
+
+    // when
+    engine
+        .message()
+        .withName(MESSAGE_NAME)
+        .withCorrelationKey("")
+        .withBusinessId("biz-42")
+        .withVariables(Map.of("seq", 2))
+        .publish();
+
+    // then two PIs are created, both stamped with the businessId
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+                .withElementType(BpmnElementType.PROCESS)
+                .limit(2))
+        .extracting(r -> r.getValue().getBusinessId())
+        .containsExactly("biz-42", "biz-42");
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartEventBusinessIdUniquenessTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartEventBusinessIdUniquenessTest.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
+import java.util.Map;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Local arm of the design's start-event uniqueness rule: when {@code businessIdUniquenessEnabled}
+ * is on and a published message carries a {@code businessId}, a new instance is only created if no
+ * active process instance on this partition already holds that {@code businessId} for the same
+ * process definition.
+ *
+ * <p>This pins:
+ *
+ * <ul>
+ *   <li>Live correlation path ({@link MessageCorrelateBehavior#correlateToMessageStartEvents}):
+ *       second publish with same businessId is suppressed; later publishes with a different
+ *       businessId still start a new PI; messages without a businessId are never blocked.
+ *   <li>Buffered correlation path ({@link
+ *       io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBufferedMessageStartEventBehavior}): a
+ *       buffered second message with the same correlation key is correlated only after the holding
+ *       PI completes, demonstrating that the uniqueness filter consults observable PI state and
+ *       unblocks once the holder is gone.
+ *   <li>The businessId from the message is stamped on the new PI's creation record so future
+ *       uniqueness checks (and exporters) see it.
+ * </ul>
+ *
+ * <p>A companion test ({@link MessageStartEventBusinessIdUniquenessDisabledTest}) pins the
+ * regression behaviour with the flag off so the gate cannot silently change defaults.
+ *
+ * <p>Cross-partition uniqueness (where the businessId hashes to a different partition than the
+ * message correlation key) is intentionally out of scope for this increment and is covered in a
+ * later increment via the cross-partition ask to {@code P_B}.
+ */
+public final class MessageStartEventBusinessIdUniquenessTest {
+
+  private static final String PROCESS_ID = "wf";
+  private static final String MESSAGE_NAME = "start-msg";
+
+  // A process whose only start event is a message start event with a service-task body so we have
+  // a stable observable signal (a JOB CREATED record per started PI) without auto-completion.
+  private static final BpmnModelInstance MESSAGE_START_PROCESS =
+      Bpmn.createExecutableProcess(PROCESS_ID)
+          .startEvent("start")
+          .message(MESSAGE_NAME)
+          .serviceTask("task", t -> t.zeebeJobType("test"))
+          .endEvent()
+          .done();
+
+  @Rule
+  public final EngineRule engine =
+      EngineRule.singlePartition()
+          .withEngineConfig(config -> config.setBusinessIdUniquenessEnabled(true));
+
+  @Test
+  public void shouldBlockSecondStartWhenBusinessIdIsAlreadyHeldByActivePI() {
+    // given a started PI holds businessId "biz-42" for this process definition
+    engine.deployment().withXmlResource(MESSAGE_START_PROCESS).deploy();
+    engine
+        .message()
+        .withName(MESSAGE_NAME)
+        .withCorrelationKey("") // empty key so the existing correlation-key lock is not the gate
+        .withBusinessId("biz-42")
+        .withVariables(Map.of("seq", 1))
+        .publish();
+    final var firstJob = RecordingExporter.jobRecords(JobIntent.CREATED).getFirst();
+
+    // when a second message with the same businessId is published with TTL=0 so we get a
+    // deterministic terminal (EXPIRED) to bound the assertion stream on
+    engine
+        .message()
+        .withName(MESSAGE_NAME)
+        .withCorrelationKey("")
+        .withBusinessId("biz-42")
+        .withVariables(Map.of("seq", 2))
+        .withTimeToLive(0L)
+        .publish();
+
+    // then no second PI is created up to the EXPIRED terminal of the suppressed message
+    final long secondPiCount =
+        RecordingExporter.records()
+            .limit(r -> r.getIntent() == MessageIntent.EXPIRED)
+            .processInstanceRecords()
+            .withElementType(BpmnElementType.PROCESS)
+            .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .count();
+    assertThat(secondPiCount)
+        .as("only the original PI should exist; the duplicate-businessId publish is suppressed")
+        .isEqualTo(1L);
+    assertThat(firstJob.getValue().getProcessInstanceKey()).isPositive();
+  }
+
+  @Test
+  public void shouldAllowSecondStartWhenBusinessIdDiffers() {
+    // given
+    engine.deployment().withXmlResource(MESSAGE_START_PROCESS).deploy();
+    engine
+        .message()
+        .withName(MESSAGE_NAME)
+        .withCorrelationKey("")
+        .withBusinessId("biz-A")
+        .withVariables(Map.of("seq", 1))
+        .publish();
+    RecordingExporter.jobRecords(JobIntent.CREATED).getFirst();
+
+    // when a second message with a different businessId is published
+    engine
+        .message()
+        .withName(MESSAGE_NAME)
+        .withCorrelationKey("")
+        .withBusinessId("biz-B")
+        .withVariables(Map.of("seq", 2))
+        .publish();
+
+    // then both PIs are started — the uniqueness rule is per businessId, not per definition
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+                .withElementType(BpmnElementType.PROCESS)
+                .limit(2))
+        .extracting(r -> r.getValue().getBusinessId())
+        .containsExactly("biz-A", "biz-B");
+  }
+
+  @Test
+  public void shouldAllowMessageWithoutBusinessIdEvenWhenBusinessIdIsHeld() {
+    // given a PI already holds "biz-42"
+    engine.deployment().withXmlResource(MESSAGE_START_PROCESS).deploy();
+    engine
+        .message()
+        .withName(MESSAGE_NAME)
+        .withCorrelationKey("")
+        .withBusinessId("biz-42")
+        .withVariables(Map.of("seq", 1))
+        .publish();
+    RecordingExporter.jobRecords(JobIntent.CREATED).getFirst();
+
+    // when a message without a businessId is published
+    engine
+        .message()
+        .withName(MESSAGE_NAME)
+        .withCorrelationKey("")
+        .withVariables(Map.of("seq", 2))
+        .publish();
+
+    // then it still starts a new PI — the rule is asymmetric: only messages carrying a
+    // businessId are subject to uniqueness, mirroring the catch-event filter from increment 1b.
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+                .withElementType(BpmnElementType.PROCESS)
+                .limit(2))
+        .extracting(r -> r.getValue().getBusinessId())
+        .containsExactly("biz-42", "");
+  }
+
+  @Test
+  public void shouldStampBusinessIdFromMessageOnTheNewProcessInstanceRecord() {
+    // given
+    engine.deployment().withXmlResource(MESSAGE_START_PROCESS).deploy();
+
+    // when
+    engine
+        .message()
+        .withName(MESSAGE_NAME)
+        .withCorrelationKey("")
+        .withBusinessId("biz-stamped")
+        .publish();
+
+    // then the activating PROCESS record carries the businessId so exporters and the local
+    // uniqueness check see it
+    final var processActivating =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withElementType(BpmnElementType.PROCESS)
+            .getFirst();
+    assertThat(processActivating.getValue().getBusinessId()).isEqualTo("biz-stamped");
+  }
+
+  @Test
+  public void shouldCorrelateBufferedMessageAfterHoldingInstanceCompletes() {
+    // given a first PI holds the correlation-key lock and businessId "biz-42"
+    engine.deployment().withXmlResource(MESSAGE_START_PROCESS).deploy();
+    engine
+        .message()
+        .withName(MESSAGE_NAME)
+        .withCorrelationKey("k-1")
+        .withBusinessId("biz-42")
+        .withVariables(Map.of("seq", 1))
+        .publish();
+    final var firstJob = RecordingExporter.jobRecords(JobIntent.CREATED).getFirst();
+
+    // and a second message is buffered behind the correlation-key lock
+    engine
+        .message()
+        .withName(MESSAGE_NAME)
+        .withCorrelationKey("k-1")
+        .withBusinessId("biz-42")
+        .withTimeToLive(Duration.ofMinutes(5))
+        .withVariables(Map.of("seq", 2))
+        .publish();
+
+    // when the holding PI completes — at this point no active PI holds "biz-42" anymore so the
+    // buffered scan's uniqueness filter does NOT block correlation
+    engine.job().withKey(firstJob.getKey()).complete();
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+        .withProcessInstanceKey(firstJob.getValue().getProcessInstanceKey())
+        .filterRootScope()
+        .await();
+
+    // then the buffered second message correlates and starts a new PI also carrying "biz-42"
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+                .withElementType(BpmnElementType.PROCESS)
+                .limit(2))
+        .extracting(r -> r.getValue().getBusinessId())
+        .containsExactly("biz-42", "biz-42");
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartEventBusinessIdUniquenessTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartEventBusinessIdUniquenessTest.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
@@ -190,6 +191,16 @@ public final class MessageStartEventBusinessIdUniquenessTest {
             .withElementType(BpmnElementType.PROCESS)
             .getFirst();
     assertThat(processActivating.getValue().getBusinessId()).isEqualTo("biz-stamped");
+
+    // and the PROCESS_INSTANCE_CREATION:CREATED follow-up event carries it as well, so consumers
+    // of ProcessInstanceCreationRecordValue.getBusinessId() observe the same value as for a PI
+    // created via the PROCESS_INSTANCE_CREATION command path
+    final var creationCreated =
+        RecordingExporter.processInstanceCreationRecords()
+            .withIntent(ProcessInstanceCreationIntent.CREATED)
+            .withInstanceKey(processActivating.getValue().getProcessInstanceKey())
+            .getFirst();
+    assertThat(creationCreated.getValue().getBusinessId()).isEqualTo("biz-stamped");
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartEventBusinessIdUniquenessTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartEventBusinessIdUniquenessTest.java
@@ -281,6 +281,47 @@ public final class MessageStartEventBusinessIdUniquenessTest {
   }
 
   @Test
+  public void shouldAllowStartWhenBusinessIdIsHeldOnlyByBannedProcessInstance() {
+    // Pins the deliberate semantics that the uniqueness lookup ignores PIs which have been
+    // banned: a banned PI cannot make progress and must not indefinitely block new starts that
+    // carry the same businessId. The `hasActiveProcessInstanceWithBusinessId` callsites all pass
+    // `bannedInstanceState::isProcessInstanceBanned` for exactly this reason; this test fails if
+    // that predicate is ever dropped from the callsite.
+
+    // given a PI holds businessId "biz-banned"
+    engine.deployment().withXmlResource(MESSAGE_START_PROCESS).deploy();
+    engine
+        .message()
+        .withName(MESSAGE_NAME)
+        .withCorrelationKey("")
+        .withBusinessId("biz-banned")
+        .withVariables(Map.of("seq", 1))
+        .publish();
+    final var firstJob = RecordingExporter.jobRecords(JobIntent.CREATED).getFirst();
+
+    // and that PI is banned (e.g. due to an unrecoverable processing error) — it stays "active"
+    // structurally but its banned state must exempt it from blocking new starts
+    engine.banInstanceInNewTransaction(1, firstJob.getValue().getProcessInstanceKey());
+
+    // when a second message with the same businessId is published
+    engine
+        .message()
+        .withName(MESSAGE_NAME)
+        .withCorrelationKey("")
+        .withBusinessId("biz-banned")
+        .withVariables(Map.of("seq", 2))
+        .publish();
+
+    // then a new PI is started — the banned holder does not gate
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+                .withElementType(BpmnElementType.PROCESS)
+                .limit(2))
+        .extracting(r -> r.getValue().getBusinessId())
+        .containsExactly("biz-banned", "biz-banned");
+  }
+
+  @Test
   public void shouldCorrelateBufferedMessageAfterHoldingInstanceCompletes() {
     // given a first PI holds the correlation-key lock and businessId "biz-42"
     engine.deployment().withXmlResource(MESSAGE_START_PROCESS).deploy();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartEventBusinessIdUniquenessTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartEventBusinessIdUniquenessTest.java
@@ -211,6 +211,76 @@ public final class MessageStartEventBusinessIdUniquenessTest {
   }
 
   @Test
+  public void shouldCorrelateNextBufferedMessageWhenPreviousIsSkippedByBusinessIdUniqueness() {
+    // Pins the buffered scan's "skip the blocked entry, continue iterating" invariant: if the
+    // visitor flipped from `return true` to `return false` after a businessId-uniqueness skip,
+    // the queue for the correlation key would silently stall and the next buffered entry would
+    // not be correlated even after the correlation-key holder completes.
+
+    // given a long-lived holder PI on correlation key "k-holder" carrying "biz-held"
+    engine.deployment().withXmlResource(MESSAGE_START_PROCESS).deploy();
+    engine
+        .message()
+        .withName(MESSAGE_NAME)
+        .withCorrelationKey("k-holder")
+        .withBusinessId("biz-held")
+        .withVariables(Map.of("seq", 0))
+        .publish();
+    final var holderJob = RecordingExporter.jobRecords(JobIntent.CREATED).getFirst();
+
+    // and a second PI on correlation key "k-1" that owns the correlation-key lock for "k-1"
+    engine
+        .message()
+        .withName(MESSAGE_NAME)
+        .withCorrelationKey("k-1")
+        .withBusinessId("biz-k1")
+        .withVariables(Map.of("seq", 1))
+        .publish();
+    final var k1Job =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .filter(
+                j ->
+                    j.getValue().getProcessInstanceKey()
+                        != holderJob.getValue().getProcessInstanceKey())
+            .getFirst();
+
+    // and two buffered messages on "k-1": the first carries "biz-held" (will be skipped by the
+    // uniqueness filter as long as the holder PI is alive), the second carries "biz-free"
+    engine
+        .message()
+        .withName(MESSAGE_NAME)
+        .withCorrelationKey("k-1")
+        .withBusinessId("biz-held")
+        .withTimeToLive(Duration.ofMinutes(5))
+        .withVariables(Map.of("seq", 2))
+        .publish();
+    engine
+        .message()
+        .withName(MESSAGE_NAME)
+        .withCorrelationKey("k-1")
+        .withBusinessId("biz-free")
+        .withTimeToLive(Duration.ofMinutes(5))
+        .withVariables(Map.of("seq", 3))
+        .publish();
+
+    // when the correlation-key holder for "k-1" completes (the buffered scan runs on "k-1")
+    engine.job().withKey(k1Job.getKey()).complete();
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+        .withProcessInstanceKey(k1Job.getValue().getProcessInstanceKey())
+        .filterRootScope()
+        .await();
+
+    // then the scan skips the blocked "biz-held" entry but still correlates the "biz-free" one,
+    // proving the queue is not stalled by a single skipped entry
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+                .withElementType(BpmnElementType.PROCESS)
+                .limit(3))
+        .extracting(r -> r.getValue().getBusinessId())
+        .containsExactly("biz-held", "biz-k1", "biz-free");
+  }
+
+  @Test
   public void shouldCorrelateBufferedMessageAfterHoldingInstanceCompletes() {
     // given a first PI holds the correlation-key lock and businessId "biz-42"
     engine.deployment().withXmlResource(MESSAGE_START_PROCESS).deploy();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartEventBusinessIdUniquenessTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartEventBusinessIdUniquenessTest.java
@@ -100,7 +100,7 @@ public final class MessageStartEventBusinessIdUniquenessTest {
     // The limit predicate keys on the suppressed message's record key (not just intent) so that
     // an unrelated EXPIRED — e.g. introduced by future test-setup changes — cannot short-circuit
     // the bound and silently mask a regression.
-    final long secondPiCount =
+    final long processInstancesStarted =
         RecordingExporter.records()
             .limit(
                 r ->
@@ -110,7 +110,7 @@ public final class MessageStartEventBusinessIdUniquenessTest {
             .withElementType(BpmnElementType.PROCESS)
             .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATING)
             .count();
-    assertThat(secondPiCount)
+    assertThat(processInstancesStarted)
         .as("only the original PI should exist; the duplicate-businessId publish is suppressed")
         .isEqualTo(1L);
     assertThat(firstJob.getValue().getProcessInstanceKey()).isPositive();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartEventBusinessIdUniquenessTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartEventBusinessIdUniquenessTest.java
@@ -85,20 +85,27 @@ public final class MessageStartEventBusinessIdUniquenessTest {
     final var firstJob = RecordingExporter.jobRecords(JobIntent.CREATED).getFirst();
 
     // when a second message with the same businessId is published with TTL=0 so we get a
-    // deterministic terminal (EXPIRED) to bound the assertion stream on
-    engine
-        .message()
-        .withName(MESSAGE_NAME)
-        .withCorrelationKey("")
-        .withBusinessId("biz-42")
-        .withVariables(Map.of("seq", 2))
-        .withTimeToLive(0L)
-        .publish();
+    // deterministic terminal (EXPIRED for this specific message) to bound the assertion stream on
+    final var suppressedPublish =
+        engine
+            .message()
+            .withName(MESSAGE_NAME)
+            .withCorrelationKey("")
+            .withBusinessId("biz-42")
+            .withVariables(Map.of("seq", 2))
+            .withTimeToLive(0L)
+            .publish();
 
-    // then no second PI is created up to the EXPIRED terminal of the suppressed message
+    // then no second PI is created up to the EXPIRED terminal of the suppressed message.
+    // The limit predicate keys on the suppressed message's record key (not just intent) so that
+    // an unrelated EXPIRED — e.g. introduced by future test-setup changes — cannot short-circuit
+    // the bound and silently mask a regression.
     final long secondPiCount =
         RecordingExporter.records()
-            .limit(r -> r.getIntent() == MessageIntent.EXPIRED)
+            .limit(
+                r ->
+                    r.getIntent() == MessageIntent.EXPIRED
+                        && r.getKey() == suppressedPublish.getKey())
             .processInstanceRecords()
             .withElementType(BpmnElementType.PROCESS)
             .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATING)


### PR DESCRIPTION
## Description

This PR implements the **local (single-partition) arm** of Business ID uniqueness support for message start events. It covers the scenario where the message, correlation key, and business ID all resolve to the same partition (`P_K == P_B`), establishing the correct lock/buffer semantics before cross-partition coordination is introduced in a subsequent increment.

### What changed

**Uniqueness gate in the live correlation path (`MessageCorrelateBehavior`)**
When a published message carries a `businessId` and the `businessIdUniquenessEnabled` feature flag is on, `correlateToMessageStartEvents` now checks whether an active process instance with the same `businessId` already exists for the target process definition on this partition. If one is found, the message is left in the buffer (subject to its TTL) rather than being dropped, so it can correlate once the holding instance completes.

**Uniqueness gate in the buffered correlation path (`BpmnBufferedMessageStartEventBehavior`)**
The same local uniqueness check is applied when scanning buffered messages during a process instance completion. A buffered message whose `businessId` is currently held by an active PI on this partition is skipped and left in the buffer for a future scan.

**Business ID stamped on the new PI creation record (`EventHandle`)**
When a message start event triggers a new process instance, the `businessId` from the message is now propagated to the `PROCESS_INSTANCE_CREATION` record. This ensures downstream uniqueness checks and exporters see the PI as carrying the `businessId`, mirroring how a PI created via `PROCESS_INSTANCE_CREATION` already behaves.

**Wiring through processors and behaviors**
`MessagePublishProcessor`, `MessageCorrelationCorrelateProcessor`, `MessageEventProcessors`, and `BpmnBehaviorsImpl` are updated to thread `ElementInstanceState`, `BannedInstanceState`, and the `businessIdUniquenessEnabled` flag down into `MessageCorrelateBehavior` and `BpmnBufferedMessageStartEventBehavior`.

### Test coverage

Two new test classes are added:

- **`MessageStartEventBusinessIdUniquenessTest`** (flag enabled): covers the live correlation path (second publish suppressed, different `businessId` allowed, no `businessId` always allowed), the buffered path (buffered message correlates after the holding PI completes), and that the `businessId` is stamped on the PI creation record.
- **`MessageStartEventBusinessIdUniquenessDisabledTest`** (flag disabled): regression pin that two messages with the same `businessId` still produce two process instances when the flag is off, guarding against silently flipping the default.

### Out of scope

Cross-partition uniqueness (where the `businessId` hashes to a different partition than the correlation key) is intentionally **not** addressed here. That will be handled in a follow-up increment via a cross-partition ask to `P_B`.

## Checklist

- [ ] Enable backports when necessary (e.g. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #53393 