### PR TITLE
feat: enhance element instance details on Operate

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.test.tsx
@@ -20,6 +20,7 @@ import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fe
 import {mockSearchProcessInstances} from 'modules/mocks/api/v2/processInstances/searchProcessInstances';
 import {mockSearchDecisionInstances} from 'modules/mocks/api/v2/decisionInstances/searchDecisionInstances';
 import {mockSearchUserTasks} from 'modules/mocks/api/v2/userTasks/searchUserTasks';
+import {mockSearchMessageSubscriptions} from 'modules/mocks/api/v2/messageSubscriptions/searchMessageSubscriptions';
 import {searchResult} from 'modules/testUtils';
 import * as clientConfig from 'modules/utils/getClientConfig';
 import type {
@@ -28,6 +29,7 @@ import type {
   ProcessInstance,
   DecisionInstance,
   UserTask,
+  MessageSubscription,
 } from '@camunda/camunda-api-zod-schemas/8.10';
 
 const PROCESS_INSTANCE_ID = '111222333';
@@ -62,6 +64,22 @@ const CAMUNDA_USER_TASK_XML = `<?xml version="1.0" encoding="UTF-8"?>
         <zeebe:userTask />
       </bpmn:extensionElements>
     </bpmn:userTask>
+  </bpmn:process>
+</bpmn:definitions>`;
+
+const RECEIVE_TASK_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:receiveTask id="Task_1" name="Receive Task" />
+  </bpmn:process>
+</bpmn:definitions>`;
+
+const MESSAGE_CATCH_EVENT_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:intermediateCatchEvent id="Task_1" name="Message Catch Event">
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1" />
+    </bpmn:intermediateCatchEvent>
   </bpmn:process>
 </bpmn:definitions>`;
 
@@ -195,6 +213,38 @@ const mockUserTask = {
   priority: 50,
 } satisfies UserTask;
 
+const mockUserTaskWithDetails = {
+  ...mockUserTask,
+  assignee: 'john.doe',
+  candidateUsers: ['alice', 'bob'],
+  candidateGroups: ['managers', 'reviewers'],
+  dueDate: '2023-02-01T10:00:00.000Z',
+  followUpDate: '2023-01-20T10:00:00.000Z',
+  priority: 80,
+  formKey: 'camunda-forms:bpmn:form_1',
+} satisfies UserTask;
+
+const mockMessageSubscription = {
+  messageSubscriptionKey: '444555666777',
+  processDefinitionId: 'process-def-1',
+  processDefinitionKey: PROCESS_DEFINITION_KEY,
+  processInstanceKey: PROCESS_INSTANCE_ID,
+  elementId: 'Task_1',
+  elementInstanceKey: '123456789',
+  messageSubscriptionState: 'CREATED',
+  messageSubscriptionType: 'PROCESS_EVENT',
+  lastUpdatedDate: '2023-01-15T10:00:00.000Z',
+  messageName: 'order-placed',
+  correlationKey: 'order-123',
+  tenantId: '<default>',
+  rootProcessInstanceKey: null,
+  toolProperties: {},
+  processDefinitionName: null,
+  processDefinitionVersion: null,
+  toolName: null,
+  inboundConnectorType: null,
+} satisfies MessageSubscription;
+
 function getWrapper(initialSearchParams?: string) {
   const path = Paths.processInstanceDetails({
     processInstanceId: PROCESS_INSTANCE_ID,
@@ -238,6 +288,7 @@ describe('<DetailsTab />', () => {
     mockSearchJobs().withSuccess(searchResult([]));
     mockSearchProcessInstances().withSuccess(searchResult([]));
     mockSearchDecisionInstances().withSuccess(searchResult([]));
+    mockSearchMessageSubscriptions().withSuccess(searchResult([]));
   });
 
   it('should show multi-instance message when multiple instances exist', async () => {
@@ -604,5 +655,141 @@ describe('<DetailsTab />', () => {
         'https://tasklist.example.com/tasklist/999888777?filter=all-open',
       );
     });
+  });
+
+  it('should display job type when a job exists', async () => {
+    mockFetchElementInstance('123456789').withSuccess(mockElementInstance);
+    mockSearchJobs().withSuccess(searchResult([mockJob]));
+
+    render(<DetailsTab />, {
+      wrapper: getWrapper('elementId=Task_1&elementInstanceKey=123456789'),
+    });
+
+    expect(await screen.findByText('Job Type')).toBeInTheDocument();
+    expect(screen.getByText('httpService')).toBeInTheDocument();
+  });
+
+  it('should display worker when a job exists', async () => {
+    mockFetchElementInstance('123456789').withSuccess(mockElementInstance);
+    mockSearchJobs().withSuccess(searchResult([mockJob]));
+
+    render(<DetailsTab />, {
+      wrapper: getWrapper('elementId=Task_1&elementInstanceKey=123456789'),
+    });
+
+    expect(await screen.findByText('Worker')).toBeInTheDocument();
+    expect(screen.getByText('worker-1')).toBeInTheDocument();
+  });
+
+  it('should not display job type or worker when no job exists', async () => {
+    mockFetchElementInstance('123456789').withSuccess(mockElementInstance);
+
+    render(<DetailsTab />, {
+      wrapper: getWrapper('elementId=Task_1&elementInstanceKey=123456789'),
+    });
+
+    expect(await screen.findByText('Element Instance Key')).toBeInTheDocument();
+    expect(screen.queryByText('Job Type')).not.toBeInTheDocument();
+    expect(screen.queryByText('Worker')).not.toBeInTheDocument();
+  });
+
+  it('should display user task details for camunda user tasks', async () => {
+    mockFetchProcessDefinitionXml().withSuccess(CAMUNDA_USER_TASK_XML);
+    mockFetchElementInstance('123456789').withSuccess({
+      ...mockElementInstance,
+      type: 'USER_TASK',
+    });
+    mockSearchUserTasks().withSuccess(
+      searchResult([mockUserTaskWithDetails]),
+    );
+
+    render(<DetailsTab />, {
+      wrapper: getWrapper('elementId=Task_1&elementInstanceKey=123456789'),
+    });
+
+    expect(await screen.findByText('Assignee')).toBeInTheDocument();
+    expect(screen.getByText('john.doe')).toBeInTheDocument();
+    expect(screen.getByText('Candidate Users')).toBeInTheDocument();
+    expect(screen.getByText('alice, bob')).toBeInTheDocument();
+    expect(screen.getByText('Candidate Groups')).toBeInTheDocument();
+    expect(screen.getByText('managers, reviewers')).toBeInTheDocument();
+    expect(screen.getByText('Due Date')).toBeInTheDocument();
+    expect(screen.getByText('Follow-up Date')).toBeInTheDocument();
+    expect(screen.getByText('Priority')).toBeInTheDocument();
+    expect(screen.getByText('80')).toBeInTheDocument();
+    expect(screen.getByText('Form Key')).toBeInTheDocument();
+    expect(screen.getByText('camunda-forms:bpmn:form_1')).toBeInTheDocument();
+  });
+
+  it('should not display user task details for non-camunda user tasks', async () => {
+    mockFetchProcessDefinitionXml().withSuccess(USER_TASK_XML);
+    mockFetchElementInstance('123456789').withSuccess({
+      ...mockElementInstance,
+      type: 'USER_TASK',
+    });
+
+    render(<DetailsTab />, {
+      wrapper: getWrapper('elementId=Task_1&elementInstanceKey=123456789'),
+    });
+
+    expect(await screen.findByText('Element Instance Key')).toBeInTheDocument();
+    expect(screen.queryByText('Assignee')).not.toBeInTheDocument();
+  });
+
+  it('should display message subscription details for receive tasks', async () => {
+    mockFetchProcessDefinitionXml().withSuccess(RECEIVE_TASK_XML);
+    mockFetchElementInstance('123456789').withSuccess({
+      ...mockElementInstance,
+      type: 'RECEIVE_TASK',
+    });
+    mockSearchMessageSubscriptions().withSuccess(
+      searchResult([mockMessageSubscription]),
+    );
+
+    render(<DetailsTab />, {
+      wrapper: getWrapper('elementId=Task_1&elementInstanceKey=123456789'),
+    });
+
+    expect(await screen.findByText('Message Name')).toBeInTheDocument();
+    expect(screen.getByText('order-placed')).toBeInTheDocument();
+    expect(screen.getByText('Correlation Key')).toBeInTheDocument();
+    expect(screen.getByText('order-123')).toBeInTheDocument();
+    expect(screen.getByText('Subscription State')).toBeInTheDocument();
+    expect(screen.getByText('CREATED')).toBeInTheDocument();
+  });
+
+  it('should display message subscription details for message catch events', async () => {
+    mockFetchProcessDefinitionXml().withSuccess(MESSAGE_CATCH_EVENT_XML);
+    mockFetchElementInstance('123456789').withSuccess({
+      ...mockElementInstance,
+      type: 'INTERMEDIATE_CATCH_EVENT',
+    });
+    mockSearchMessageSubscriptions().withSuccess(
+      searchResult([mockMessageSubscription]),
+    );
+
+    render(<DetailsTab />, {
+      wrapper: getWrapper('elementId=Task_1&elementInstanceKey=123456789'),
+    });
+
+    expect(await screen.findByText('Message Name')).toBeInTheDocument();
+    expect(screen.getByText('order-placed')).toBeInTheDocument();
+    expect(screen.getByText('Correlation Key')).toBeInTheDocument();
+    expect(screen.getByText('order-123')).toBeInTheDocument();
+    expect(screen.getByText('Subscription State')).toBeInTheDocument();
+    expect(screen.getByText('CREATED')).toBeInTheDocument();
+  });
+
+  it('should not display message subscription details for non-message elements', async () => {
+    mockFetchElementInstance('123456789').withSuccess(mockElementInstance);
+
+    render(<DetailsTab />, {
+      wrapper: getWrapper('elementId=Task_1&elementInstanceKey=123456789'),
+    });
+
+    expect(await screen.findByText('Element Instance Key')).toBeInTheDocument();
+    expect(screen.queryByText('Message Name')).not.toBeInTheDocument();
+    expect(screen.queryByText('Correlation Key')).not.toBeInTheDocument();
+    expect(screen.queryByText('Subscription State')).not.toBeInTheDocument();
   });
 });

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.test.tsx
@@ -699,9 +699,7 @@ describe('<DetailsTab />', () => {
       ...mockElementInstance,
       type: 'USER_TASK',
     });
-    mockSearchUserTasks().withSuccess(
-      searchResult([mockUserTaskWithDetails]),
-    );
+    mockSearchUserTasks().withSuccess(searchResult([mockUserTaskWithDetails]));
 
     render(<DetailsTab />, {
       wrapper: getWrapper('elementId=Task_1&elementInstanceKey=123456789'),

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.tsx
@@ -229,14 +229,14 @@ const DetailsTab: React.FC = () => {
       });
     }
 
-    if (job?.type) {
+    if (job?.type !== undefined) {
       baseRows.push({
         key: 'job-type',
         columns: [{cellContent: 'Job Type'}, {cellContent: job.type}],
       });
     }
 
-    if (job?.worker) {
+    if (job?.worker !== undefined) {
       baseRows.push({
         key: 'worker',
         columns: [{cellContent: 'Worker'}, {cellContent: job.worker}],
@@ -337,7 +337,7 @@ const DetailsTab: React.FC = () => {
       });
     }
 
-    if (isCamundaTask && userTask) {
+    if (isCamundaTask && userTask !== null) {
       baseRows.push(
         {
           key: 'assignee',
@@ -401,7 +401,7 @@ const DetailsTab: React.FC = () => {
       );
     }
 
-    if (isMessageElement && messageSubscription) {
+    if (isMessageElement && messageSubscription !== null) {
       baseRows.push(
         {
           key: 'message-name',

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.tsx
@@ -19,7 +19,9 @@ import {useProcessInstancesSearch} from 'modules/queries/processInstance/useProc
 import {useJobs} from 'modules/queries/jobs/useJobs';
 import {useDecisionInstancesSearch} from 'modules/queries/decisionInstances/useDecisionInstancesSearch';
 import {isCamundaUserTask} from 'modules/bpmn-js/utils/isCamundaUserTask';
+import {isMessageEventElement} from 'modules/bpmn-js/utils/isMessageEventElement';
 import {useSearchUserTasks} from 'modules/queries/userTasks/useSearchUserTasks';
+import {useMessageSubscriptions} from 'modules/queries/messageSubscriptions/useMessageSubscriptions';
 import {IS_AI_AGENT_ENABLED} from 'modules/feature-flags';
 import {getClientConfig} from 'modules/utils/getClientConfig';
 import {mergePathname} from 'modules/request/mergePathname';
@@ -108,14 +110,25 @@ const DetailsTab: React.FC = () => {
       page: {limit: 1},
     },
     {
-      enabled:
-        !!elementInstanceKey &&
-        isCamundaTask &&
-        !isNil(clientConfig.tasklistUrl),
+      enabled: !!elementInstanceKey && isCamundaTask,
     },
   );
 
   const userTask = userTaskSearchResult?.items?.[0] ?? null;
+
+  const isMessageElement = isMessageEventElement(businessObject);
+
+  const {data: messageSubscriptionResult} = useMessageSubscriptions(
+    {
+      filter: {elementInstanceKey: {$eq: elementInstanceKey ?? ''}},
+      page: {limit: 1},
+    },
+    {
+      enabled: !!elementInstanceKey && isMessageElement,
+    },
+  );
+
+  const messageSubscription = messageSubscriptionResult?.items?.[0] ?? null;
 
   const {
     agentInstance,
@@ -216,6 +229,20 @@ const DetailsTab: React.FC = () => {
       });
     }
 
+    if (job?.type) {
+      baseRows.push({
+        key: 'job-type',
+        columns: [{cellContent: 'Job Type'}, {cellContent: job.type}],
+      });
+    }
+
+    if (job?.worker) {
+      baseRows.push({
+        key: 'worker',
+        columns: [{cellContent: 'Worker'}, {cellContent: job.worker}],
+      });
+    }
+
     if (
       businessObject?.$type === 'bpmn:CallActivity' &&
       calledProcessInstancesCount === 0
@@ -310,6 +337,96 @@ const DetailsTab: React.FC = () => {
       });
     }
 
+    if (isCamundaTask && userTask) {
+      baseRows.push(
+        {
+          key: 'assignee',
+          columns: [
+            {cellContent: 'Assignee'},
+            {cellContent: userTask.assignee ?? '-'},
+          ],
+        },
+        {
+          key: 'candidate-users',
+          columns: [
+            {cellContent: 'Candidate Users'},
+            {
+              cellContent:
+                userTask.candidateUsers.length > 0
+                  ? userTask.candidateUsers.join(', ')
+                  : '-',
+            },
+          ],
+        },
+        {
+          key: 'candidate-groups',
+          columns: [
+            {cellContent: 'Candidate Groups'},
+            {
+              cellContent:
+                userTask.candidateGroups.length > 0
+                  ? userTask.candidateGroups.join(', ')
+                  : '-',
+            },
+          ],
+        },
+        {
+          key: 'due-date',
+          columns: [
+            {cellContent: 'Due Date'},
+            {cellContent: userTask.dueDate ?? '-'},
+          ],
+        },
+        {
+          key: 'follow-up-date',
+          columns: [
+            {cellContent: 'Follow-up Date'},
+            {cellContent: userTask.followUpDate ?? '-'},
+          ],
+        },
+        {
+          key: 'priority',
+          columns: [
+            {cellContent: 'Priority'},
+            {cellContent: String(userTask.priority)},
+          ],
+        },
+        {
+          key: 'form-key',
+          columns: [
+            {cellContent: 'Form Key'},
+            {cellContent: userTask.formKey ?? '-'},
+          ],
+        },
+      );
+    }
+
+    if (isMessageElement && messageSubscription) {
+      baseRows.push(
+        {
+          key: 'message-name',
+          columns: [
+            {cellContent: 'Message Name'},
+            {cellContent: messageSubscription.messageName ?? '-'},
+          ],
+        },
+        {
+          key: 'correlation-key',
+          columns: [
+            {cellContent: 'Correlation Key'},
+            {cellContent: messageSubscription.correlationKey ?? '-'},
+          ],
+        },
+        {
+          key: 'message-subscription-state',
+          columns: [
+            {cellContent: 'Subscription State'},
+            {cellContent: messageSubscription.messageSubscriptionState ?? '-'},
+          ],
+        },
+      );
+    }
+
     return baseRows;
   }, [
     resolvedElementInstance,
@@ -323,6 +440,8 @@ const DetailsTab: React.FC = () => {
     clientConfig.tasklistUrl,
     isCamundaTask,
     userTask,
+    isMessageElement,
+    messageSubscription,
   ]);
 
   if (isFetchingElement) {

--- a/operate/client/src/modules/api/v2/messageSubscriptions/searchMessageSubscriptions.ts
+++ b/operate/client/src/modules/api/v2/messageSubscriptions/searchMessageSubscriptions.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {
+  endpoints,
+  type QueryMessageSubscriptionsRequestBody,
+  type QueryMessageSubscriptionsResponseBody,
+} from '@camunda/camunda-api-zod-schemas/8.10';
+import {requestWithThrow} from 'modules/request';
+
+const searchMessageSubscriptions = async (
+  payload: QueryMessageSubscriptionsRequestBody,
+) => {
+  return requestWithThrow<QueryMessageSubscriptionsResponseBody>({
+    url: endpoints.queryMessageSubscriptions.getUrl(),
+    method: endpoints.queryMessageSubscriptions.method,
+    body: payload,
+  });
+};
+
+export {searchMessageSubscriptions};

--- a/operate/client/src/modules/bpmn-js/utils/isMessageEventElement.test.ts
+++ b/operate/client/src/modules/bpmn-js/utils/isMessageEventElement.test.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {isMessageEventElement} from './isMessageEventElement';
+import type {BusinessObject} from 'bpmn-js/lib/NavigatedViewer';
+
+describe('isMessageEventElement', () => {
+  it('should return false for undefined', () => {
+    expect(isMessageEventElement(undefined)).toBe(false);
+  });
+
+  it('should return false for null', () => {
+    expect(isMessageEventElement(null)).toBe(false);
+  });
+
+  it('should return true for receive tasks', () => {
+    const businessObject: BusinessObject = {
+      $type: 'bpmn:ReceiveTask',
+      id: 'task1',
+      name: 'Receive Task',
+    };
+
+    expect(isMessageEventElement(businessObject)).toBe(true);
+  });
+
+  it('should return true for intermediate catch events with message event definition', () => {
+    const businessObject: BusinessObject = {
+      $type: 'bpmn:IntermediateCatchEvent',
+      id: 'event1',
+      name: 'Message Catch Event',
+      eventDefinitions: [{$type: 'bpmn:MessageEventDefinition'}],
+    };
+
+    expect(isMessageEventElement(businessObject)).toBe(true);
+  });
+
+  it('should return true for boundary events with message event definition', () => {
+    const businessObject: BusinessObject = {
+      $type: 'bpmn:BoundaryEvent',
+      id: 'event1',
+      name: 'Message Boundary Event',
+      eventDefinitions: [{$type: 'bpmn:MessageEventDefinition'}],
+    };
+
+    expect(isMessageEventElement(businessObject)).toBe(true);
+  });
+
+  it('should return false for intermediate catch events with non-message event definition', () => {
+    const businessObject: BusinessObject = {
+      $type: 'bpmn:IntermediateCatchEvent',
+      id: 'event1',
+      name: 'Timer Catch Event',
+      eventDefinitions: [{$type: 'bpmn:TimerEventDefinition'}],
+    };
+
+    expect(isMessageEventElement(businessObject)).toBe(false);
+  });
+
+  it('should return false for boundary events without event definitions', () => {
+    const businessObject: BusinessObject = {
+      $type: 'bpmn:BoundaryEvent',
+      id: 'event1',
+      name: 'Boundary Event',
+    };
+
+    expect(isMessageEventElement(businessObject)).toBe(false);
+  });
+
+  it('should return false for non-message element types', () => {
+    const businessObject: BusinessObject = {
+      $type: 'bpmn:ServiceTask',
+      id: 'task1',
+      name: 'Service Task',
+    };
+
+    expect(isMessageEventElement(businessObject)).toBe(false);
+  });
+});

--- a/operate/client/src/modules/bpmn-js/utils/isMessageEventElement.ts
+++ b/operate/client/src/modules/bpmn-js/utils/isMessageEventElement.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {type BusinessObject} from 'bpmn-js/lib/NavigatedViewer';
+import {hasType} from './hasType';
+import {hasEventType} from './hasEventType';
+
+/**
+ * Checks if an element is a message event element (receive task, message catch event,
+ * or message boundary event).
+ *
+ * @param businessObject - The BPMN business object to check
+ * @returns true if the element is a message event element
+ */
+const isMessageEventElement = (
+  businessObject?: BusinessObject | null,
+): boolean => {
+  if (!businessObject) {
+    return false;
+  }
+
+  if (hasType({businessObject, types: ['bpmn:ReceiveTask']})) {
+    return true;
+  }
+
+  return (
+    hasType({
+      businessObject,
+      types: ['bpmn:IntermediateCatchEvent', 'bpmn:BoundaryEvent'],
+    }) && hasEventType({businessObject, types: ['bpmn:MessageEventDefinition']})
+  );
+};
+
+export {isMessageEventElement};

--- a/operate/client/src/modules/bpmn-js/utils/isMessageEventElement.ts
+++ b/operate/client/src/modules/bpmn-js/utils/isMessageEventElement.ts
@@ -10,13 +10,6 @@ import {type BusinessObject} from 'bpmn-js/lib/NavigatedViewer';
 import {hasType} from './hasType';
 import {hasEventType} from './hasEventType';
 
-/**
- * Checks if an element is a message event element (receive task, message catch event,
- * or message boundary event).
- *
- * @param businessObject - The BPMN business object to check
- * @returns true if the element is a message event element
- */
 const isMessageEventElement = (
   businessObject?: BusinessObject | null,
 ): boolean => {

--- a/operate/client/src/modules/queries/messageSubscriptions/useMessageSubscriptions.ts
+++ b/operate/client/src/modules/queries/messageSubscriptions/useMessageSubscriptions.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useQuery} from '@tanstack/react-query';
+import {searchMessageSubscriptions} from 'modules/api/v2/messageSubscriptions/searchMessageSubscriptions';
+import type {QueryMessageSubscriptionsRequestBody} from '@camunda/camunda-api-zod-schemas/8.10';
+import {queryKeys} from '../queryKeys';
+
+const useMessageSubscriptions = (
+  payload: QueryMessageSubscriptionsRequestBody,
+  options: {enabled: boolean} = {enabled: true},
+) => {
+  return useQuery({
+    queryKey: queryKeys.messageSubscriptions.search(payload),
+    queryFn: async () => {
+      const {response, error} = await searchMessageSubscriptions(payload);
+      if (response !== null) {
+        return response;
+      }
+
+      throw error;
+    },
+    ...options,
+  });
+};
+
+export {useMessageSubscriptions};

--- a/operate/client/src/modules/queries/queryKeys.ts
+++ b/operate/client/src/modules/queries/queryKeys.ts
@@ -22,6 +22,7 @@ import type {
   QueryElementInstanceIncidentsRequestBody,
   QueryElementInstancesRequestBody,
   QueryJobsRequestBody,
+  QueryMessageSubscriptionsRequestBody,
   QueryProcessInstanceIncidentsRequestBody,
   QueryProcessInstancesRequestBody,
   QueryUserTasksRequestBody,
@@ -248,6 +249,12 @@ const queryKeys = {
   },
   jobs: {
     search: (payload: QueryJobsRequestBody) => ['jobsSearch', payload],
+  },
+  messageSubscriptions: {
+    search: (payload: QueryMessageSubscriptionsRequestBody) => [
+      'messageSubscriptionsSearch',
+      payload,
+    ],
   },
   processInstance: {
     get: (processInstanceKey: string) => [


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

On this PR we're adding more information on the details tab for service tasks, Camunda user tasks and message events

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #52233
