### PR TITLE
test: add docker logs dump on workflow failure

### DIFF
--- a/.github/workflows/camunda-process-test-compatibility.yml
+++ b/.github/workflows/camunda-process-test-compatibility.yml
@@ -561,14 +561,24 @@ jobs:
         timeout-minutes: 5
         shell: bash
         run: |
+          mkdir -p cpt-docker-logs
+
           echo "=== Fetching status of all containers (including stopped/failed ones) ==="
-          docker ps -a
+          docker ps -a | tee cpt-docker-logs/containers.txt
 
           echo "=== Fetching logs for all available containers ==="
-          for container_id in $(docker ps -a -q); do
-            echo "--- Logs for Container: $(docker inspect --format '{{.Name}}' $container_id) ($container_id) ---"
-            docker logs $container_id || true
-          done
+          while read -r container_id container_name; do
+            echo "--- Logs for Container: ${container_name} (${container_id}) ---"
+            docker logs "${container_id}" > "cpt-docker-logs/${container_name}-${container_id}.log" 2>&1 || true
+          done < <(docker ps -a --format '{{.ID}} {{.Names}}')
+
+      - name: Upload Docker container logs
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: cpt-docker-logs-${{ matrix.client }}-${{ matrix.server }}
+          path: cpt-docker-logs
+          retention-days: 30
 
       - name: Record tested combination
         if: success() && !contains(matrix.client, 'SNAPSHOT') && !contains(matrix.server, 'SNAPSHOT')

--- a/.github/workflows/camunda-process-test-compatibility.yml
+++ b/.github/workflows/camunda-process-test-compatibility.yml
@@ -558,6 +558,7 @@ jobs:
 
       - name: Dump All Docker Container Logs on Failure
         if: failure()
+        timeout-minutes: 5
         shell: bash
         run: |
           echo "=== Fetching status of all containers (including stopped/failed ones) ==="

--- a/.github/workflows/camunda-process-test-compatibility.yml
+++ b/.github/workflows/camunda-process-test-compatibility.yml
@@ -558,6 +558,7 @@ jobs:
 
       - name: Dump All Docker Container Logs on Failure
         if: failure()
+        shell: bash
         run: |
           echo "=== Fetching status of all containers (including stopped/failed ones) ==="
           docker ps -a

--- a/.github/workflows/camunda-process-test-compatibility.yml
+++ b/.github/workflows/camunda-process-test-compatibility.yml
@@ -556,6 +556,18 @@ jobs:
             -DfailIfNoTests=false
             ${{ steps.api-version.outputs.extra-props }}
 
+      - name: Dump All Docker Container Logs on Failure
+        if: failure()
+        run: |
+          echo "=== Fetching status of all containers (including stopped/failed ones) ==="
+          docker ps -a
+
+          echo "=== Fetching logs for all available containers ==="
+          for container_id in $(docker ps -a -q); do
+            echo "--- Logs for Container: $(docker inspect --format '{{.Name}}' $container_id) ($container_id) ---"
+            docker logs $container_id || true
+          done
+
       - name: Record tested combination
         if: success() && !contains(matrix.client, 'SNAPSHOT') && !contains(matrix.server, 'SNAPSHOT')
         run: |
@@ -716,16 +728,6 @@ jobs:
                 }
               ]
             }
-      - name: Dump All Docker Container Logs on Failure
-        run: |
-          echo "=== Fetching status of all containers (including stopped/failed ones) ==="
-          docker ps -a
-          
-          echo "=== Fetching logs for all available containers ==="
-          for container_id in $(docker ps -a -q); do
-            echo "--- Logs for Container: $(docker inspect --format '{{.Name}}' $container_id) ($container_id) ---"
-            docker logs $container_id || true
-          done
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/.github/workflows/camunda-process-test-compatibility.yml
+++ b/.github/workflows/camunda-process-test-compatibility.yml
@@ -716,7 +716,16 @@ jobs:
                 }
               ]
             }
-
+      - name: Dump All Docker Container Logs on Failure
+        run: |
+          echo "=== Fetching status of all containers (including stopped/failed ones) ==="
+          docker ps -a
+          
+          echo "=== Fetching logs for all available containers ==="
+          for container_id in $(docker ps -a -q); do
+            echo "--- Logs for Container: $(docker inspect --format '{{.Name}}' $container_id) ($container_id) ---"
+            docker logs $container_id || true
+          done
       - name: Observe build status
         if: always()
         continue-on-error: true


### PR DESCRIPTION
## Description

Allow root causing why compatibility tests run into a Docker container startup timeout of 1 minute, when most tests run under 1 minute.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

related to https://github.com/camunda/camunda/issues/52884
