### PR TITLE
style: lint:fix

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/fixtures.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/fixtures.ts
@@ -84,18 +84,21 @@ type PlaywrightFixtures = {
 };
 
 const test = base.extend<PlaywrightFixtures>({
-  suppressHelperModals: [async ({page}, use) => {
-    await page.addInitScript(() => {
-      const current = JSON.parse(
-        window.localStorage.getItem('sharedState') || '{}',
-      );
-      window.localStorage.setItem(
-        'sharedState',
-        JSON.stringify({...current, hideProcessInstanceHelperModal: true}),
-      );
-    });
-    await use();
-  }, {auto: true}],
+  suppressHelperModals: [
+    async ({page}, use) => {
+      await page.addInitScript(() => {
+        const current = JSON.parse(
+          window.localStorage.getItem('sharedState') || '{}',
+        );
+        window.localStorage.setItem(
+          'sharedState',
+          JSON.stringify({...current, hideProcessInstanceHelperModal: true}),
+        );
+      });
+      await use();
+    },
+    {auto: true},
+  ],
   makeAxeBuilder: async ({page}, use) => {
     const makeAxeBuilder = () =>
       new AxeBuilder({page}).withTags([

--- a/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/index.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/index.ts
@@ -105,11 +105,10 @@ export function validateResponseShape<
   }
 
   // Call without throwing so we can filter forward-compat errors first.
-  const result = _generatedValidateResponseShape(
-    spec,
-    body,
-    {...options, throw: false},
-  ) as ValidationResult;
+  const result = _generatedValidateResponseShape(spec, body, {
+    ...options,
+    throw: false,
+  }) as ValidationResult;
 
   const filtered = _filterForwardCompatErrors(result);
   if (!filtered.ok) {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/v1/UtilitiesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/v1/UtilitiesPage.ts
@@ -25,9 +25,7 @@ export async function navigateToApp(
       process.env.CORE_APPLICATION_URL + '/' + appName.toLowerCase() + '/login',
     );
   } else if (appName == 'admin') {
-    await page.goto(
-      process.env.CORE_APPLICATION_URL + '/admin/login',
-    );
+    await page.goto(process.env.CORE_APPLICATION_URL + '/admin/login');
   }
 }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/audit-log/audit-log-search-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/audit-log/audit-log-search-api-tests.spec.ts
@@ -230,35 +230,35 @@ for (const {description, filter} of filterTestCases) {
 
 test.describe.parallel('Search Audit Logs API Tests', () => {
   let userWithResourcesAuthorizationToSendRequest: {
-      username: string;
-      name: string;
-      email: string;
-      password: string;
-    } = {} as {
-      username: string;
-      name: string;
-      email: string;
-      password: string;
-    };
+    username: string;
+    name: string;
+    email: string;
+    password: string;
+  } = {} as {
+    username: string;
+    name: string;
+    email: string;
+    password: string;
+  };
 
-    test.beforeAll(async ({request}) => {
-      await test.step('Setup - Create test user with Resource Authorization', async () => {
-        userWithResourcesAuthorizationToSendRequest = await createUser(request);
-        await grantUserResourceAuthorization(
-          request,
-          userWithResourcesAuthorizationToSendRequest,
-        );
-      });
+  test.beforeAll(async ({request}) => {
+    await test.step('Setup - Create test user with Resource Authorization', async () => {
+      userWithResourcesAuthorizationToSendRequest = await createUser(request);
+      await grantUserResourceAuthorization(
+        request,
+        userWithResourcesAuthorizationToSendRequest,
+      );
     });
-      
-    test.afterAll(async ({request}) => {
-      await test.step('Cleanup', async () => {
-        await cleanupUsers(request, [
-          userWithResourcesAuthorizationToSendRequest.username,
-        ]);
-      });
+  });
+
+  test.afterAll(async ({request}) => {
+    await test.step('Cleanup', async () => {
+      await cleanupUsers(request, [
+        userWithResourcesAuthorizationToSendRequest.username,
+      ]);
     });
-    
+  });
+
   test('Search Audit Logs Success', async ({request}) => {
     await expect(async () => {
       const res = await request.post(buildUrl(AUDIT_LOG_SEARCH_ENDPOINT), {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-client-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-client-api.spec.ts
@@ -29,9 +29,7 @@ import {
   grantUserResourceAuthorization,
 } from '@requestHelpers';
 import {validateResponse} from '../../../../json-body-assertions';
-import {
-  CREATE_CUSTOM_AUTHORIZATION_BODY,
-} from '../../../../utils/beans/requestBeans';
+import {CREATE_CUSTOM_AUTHORIZATION_BODY} from '../../../../utils/beans/requestBeans';
 
 const CREATE_AUTHORIZATION_ENDPOINT = '/authorizations';
 
@@ -281,6 +279,7 @@ test.describe('Create Authorization for Client - Forbidden', () => {
       ]);
     },
   );
+
   test('Create Authorization for client - 403 Forbidden', async ({request}) => {
     await test.step('Test - Create Authorization with user credentials', async () => {
       const token = encode(

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-group-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-group-api.spec.ts
@@ -28,9 +28,7 @@ import {
   createGroup,
 } from '@requestHelpers';
 import {validateResponse} from '../../../../json-body-assertions';
-import {
-  CREATE_CUSTOM_AUTHORIZATION_BODY,
-} from '../../../../utils/beans/requestBeans';
+import {CREATE_CUSTOM_AUTHORIZATION_BODY} from '../../../../utils/beans/requestBeans';
 
 const CREATE_AUTHORIZATION_ENDPOINT = '/authorizations';
 
@@ -41,6 +39,7 @@ test.describe
     name: string;
     description: string;
   };
+
   test.beforeAll(async ({request}) => {
     await test.step('Setup - Create group for Authorization tests', async () => {
       successGroup = await createGroup(request);
@@ -153,6 +152,7 @@ test.describe
     name: string;
     description: string;
   };
+
   test.beforeAll(async ({request}) => {
     await test.step('Setup - Create group for Authorization tests', async () => {
       failGroup = await createGroup(request);
@@ -336,6 +336,7 @@ test.describe('Create Authorization for Group - Forbidden', () => {
       ]);
     },
   );
+
   test('Create Authorization for group - 403 Forbidden', async ({request}) => {
     await test.step('Test - Create Authorization with user credentials', async () => {
       const token = encode(

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-mapping-rule-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-mapping-rule-api.spec.ts
@@ -43,6 +43,7 @@ test.describe
     claimValue: string;
     name: string;
   };
+
   test.beforeAll(async ({request}) => {
     await test.step('Setup - Create Mapping Rule for Authorization tests', async () => {
       successMappingRule = await createMappingRule(request);
@@ -161,6 +162,7 @@ test.describe
     claimValue: string;
     name: string;
   };
+
   test.beforeAll(async ({request}) => {
     await test.step('Setup - Create Mapping Rule for Authorization tests', async () => {
       unhappyPathMappingRule = await createMappingRule(request);
@@ -346,6 +348,7 @@ test.describe('Create Authorization for Mapping Rule - Forbidden', () => {
       ]);
     },
   );
+
   test('Create Authorization for Mapping Rule - 403 Forbidden', async ({
     request,
   }) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-role-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-role-api.spec.ts
@@ -31,9 +31,7 @@ import {
   createRole,
 } from '@requestHelpers';
 import {validateResponse} from '../../../../json-body-assertions';
-import {
-  CREATE_CUSTOM_AUTHORIZATION_BODY,
-} from '../../../../utils/beans/requestBeans';
+import {CREATE_CUSTOM_AUTHORIZATION_BODY} from '../../../../utils/beans/requestBeans';
 
 const CREATE_AUTHORIZATION_ENDPOINT = '/authorizations';
 
@@ -45,6 +43,7 @@ test.describe
     name: `authorization Role`,
     description: 'Create Authorization Success API test role',
   };
+
   test.beforeAll(async ({request}) => {
     await test.step('Setup - Create role for Authorization tests', async () => {
       successRole = await createRole(request);
@@ -158,6 +157,7 @@ test.describe
     name: `authorization fail role`,
     description: 'Create Authorization Fail API test role',
   };
+
   test.beforeAll(async ({request}) => {
     await test.step('Setup - Create role for Authorization tests', async () => {
       failRole = await createRole(request);
@@ -342,6 +342,7 @@ test.describe('Create Authorization for role - Forbidden', () => {
       ]);
     },
   );
+
   test('Create Authorization for role - 403 Forbidden', async ({request}) => {
     const token = encode(
       `${userWithResourcesAuthorizationToSendRequest.username}:${userWithResourcesAuthorizationToSendRequest.password}`,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-user-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/create-authorization-for-user-api.spec.ts
@@ -23,9 +23,7 @@ import {defaultAssertionOptions} from '../../../../utils/constants';
 import {cleanupUsers} from '../../../../utils/usersCleanup';
 import {createUser, grantUserResourceAuthorization} from '@requestHelpers';
 import {validateResponse} from '../../../../json-body-assertions';
-import {
-  CREATE_CUSTOM_AUTHORIZATION_BODY,
-} from '../../../../utils/beans/requestBeans';
+import {CREATE_CUSTOM_AUTHORIZATION_BODY} from '../../../../utils/beans/requestBeans';
 
 const CREATE_AUTHORIZATION_ENDPOINT = '/authorizations';
 
@@ -36,6 +34,7 @@ test.describe.serial('Create Authorization API - Success and Conflict', () => {
     email: string;
     password: string;
   };
+
   test.beforeAll(async ({request}) => {
     await test.step('Setup - Create user for Authorization tests', async () => {
       successUser = await createUser(request);
@@ -143,6 +142,7 @@ test.describe.serial('Create Authorization API - Success and Conflict', () => {
 
 test.describe.parallel('Create Authorization API - Unhappy paths', () => {
   let user: {username: string; name: string; email: string; password: string};
+
   test.beforeAll(async ({request}) => {
     await test.step('Setup - Create user for Authorization tests', async () => {
       user = await createUser(request);
@@ -330,6 +330,7 @@ test.describe('Create Authorization for User - Forbidden', () => {
       ]);
     },
   );
+
   test('Create Authorization for user - 403 Forbidden', async ({request}) => {
     await test.step('Test - Create Authorization with user credentials', async () => {
       const token = encode(

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/delete-authorization-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/delete-authorization-api.spec.ts
@@ -50,6 +50,7 @@ test.describe.parallel('Delete Authorization API', () => {
       password: string;
     };
     let userAuthorizationKey: string;
+
     await test.step('Setup - Create user for authorization tests', async () => {
       user = await createUser(request);
       cleanups.push(async (request) => {
@@ -234,6 +235,7 @@ test.describe.parallel('Delete Authorization API', () => {
       password: string;
     };
     let userAuthorizationKey: string;
+
     await test.step('Setup - Create user for authorization tests', async () => {
       user = await createUser(request);
       cleanups.push(async (request) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/get-authorization-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/get-authorization-api.spec.ts
@@ -46,6 +46,7 @@ test.describe.parallel('Get Authorization API', () => {
     };
     let userAuthorizationKey: string = '';
     let originalUserAuthorization: Authorization = {} as Authorization;
+
     await test.step('Setup - Create user for authorization tests', async () => {
       user = await createUser(request);
       cleanups.push(async (request) => {
@@ -98,6 +99,7 @@ test.describe.parallel('Get Authorization API', () => {
 
   test('Get existing Authorization - not found', async ({request}) => {
     const nonExistentAuthorizationKey = '9999999999999999';
+
     await test.step('Get Authorization and assert results', async () => {
       await expect(async () => {
         const res = await request.get(
@@ -122,6 +124,7 @@ test.describe.parallel('Get Authorization API', () => {
       password: string;
     };
     let userAuthorizationKey: string = '';
+
     await test.step('Setup - Create user for authorization tests', async () => {
       user = await createUser(request);
       cleanups.push(async (request) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/update-authorization-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/authorization/update-authorization-api.spec.ts
@@ -36,7 +36,7 @@ import {cleanupRoles} from 'utils/rolesCleanup';
 import {cleanupGroups} from 'utils/groupsCleanup';
 import {cleanupMappingRules} from 'utils/mappingRuleCleanup';
 import {sleep} from 'utils/sleep';
-import { validateResponse } from 'json-body-assertions';
+import {validateResponse} from 'json-body-assertions';
 
 test.describe.parallel('Update Authorization API', () => {
   const cleanups: ((request: APIRequestContext) => Promise<void>)[] = [];
@@ -58,6 +58,7 @@ test.describe.parallel('Update Authorization API', () => {
     };
     let userAuthorizationKey: string;
     let originalUserAuthorization: Authorization = {} as Authorization;
+
     await test.step('Setup - Create user for authorization tests', async () => {
       user = await createUser(request);
       cleanups.push(async (request) => {
@@ -318,13 +319,13 @@ test.describe.parallel('Update Authorization API', () => {
           );
           expect(getAuthRes.status()).toBe(200);
           await validateResponse(
-          {
-            path: '/authorizations/{authorizationKey}',
-            method: 'GET',
-            status: '200',
-          },
-          getAuthRes,
-        );
+            {
+              path: '/authorizations/{authorizationKey}',
+              method: 'GET',
+              status: '200',
+            },
+            getAuthRes,
+          );
 
           const authBody = await getAuthRes.json();
           verifyAuthorizationFields(authBody, expectedGroupAuthorization);
@@ -411,6 +412,7 @@ test.describe.parallel('Update Authorization API', () => {
       resourceId: `${originalGroup.groupId}`,
       permissionTypes: ['UPDATE', 'READ'],
     };
+
     await test.step('Update mapping rule authorization with new ownerId, resourceId and permissionTypes', async () => {
       const authRes = await request.put(
         buildUrl(`/authorizations/${mappingRuleAuthorizationKey}`),
@@ -566,12 +568,14 @@ test.describe.parallel('Update Authorization API', () => {
       password: string;
     };
     let originalUserAuthorization: Authorization = {} as Authorization;
+
     await test.step('Setup - Create user for authorization tests', async () => {
       user = await createUser(request);
       cleanups.push(async (request) => {
         await cleanupUsers(request, [user.username]);
       });
     });
+
     let userAuthorizationKey: string;
 
     await test.step('Setup - Grant user necessary authorizations', async () => {
@@ -649,6 +653,7 @@ test.describe.parallel('Update Authorization API', () => {
     };
     let userAuthorizationKey: string;
     let originalUserAuthorization: Authorization = {} as Authorization;
+
     await test.step('Setup - Create user for authorization tests', async () => {
       user = await createUser(request);
       cleanups.push(async (request) => {
@@ -710,6 +715,7 @@ test.describe.parallel('Update Authorization API', () => {
     };
     let notExistingUserAuthorizationKey = '9999999999999999';
     let originalUserAuthorization: Authorization = {} as Authorization;
+
     await test.step('Setup - Create user for authorization tests', async () => {
       user = await createUser(request);
       cleanups.push(async (request) => {
@@ -857,6 +863,7 @@ test.describe.parallel('Update Authorization API', () => {
     };
     let userAuthorizationKey: string;
     let originalUserAuthorization: Authorization = {} as Authorization;
+
     await test.step('Setup - Create user for authorization tests', async () => {
       user = await createUser(request);
       cleanups.push(async (request) => {
@@ -912,6 +919,7 @@ test.describe.parallel('Update Authorization API', () => {
     };
     let userAuthorizationKey: string;
     let originalUserAuthorization: Authorization = {} as Authorization;
+
     await test.step('Setup - Create user for authorization tests', async () => {
       user = await createUser(request);
       cleanups.push(async (request) => {
@@ -973,6 +981,7 @@ test.describe.parallel('Update Authorization API', () => {
     };
     let userAuthorizationKey: string;
     let originalUserAuthorization: Authorization = {} as Authorization;
+
     await test.step('Setup - Create user for authorization tests', async () => {
       user = await createUser(request);
       cleanups.push(async (request) => {
@@ -1018,6 +1027,7 @@ test.describe.parallel('Update Authorization API', () => {
     const token = encode(
       `${userWithResourcesAuthorizationToSendRequest.username}:${userWithResourcesAuthorizationToSendRequest.password}`,
     );
+
     await test.step('Update user authorization to add UPDATE permission', async () => {
       await expect(async () => {
         const authRes = await request.put(

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operation-items-search-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operation-items-search-api.spec.ts
@@ -162,6 +162,7 @@ test.describe.parallel('Batch Operation Items Search API Tests', () => {
   }) => {
     let processInstanceKeyToCancel: string;
     let batchOperationKey: string;
+
     await test.step('Create process instance to cancel', async () => {
       processInstanceKeyToCancel = (
         await createSingleInstance('processWithAnError', 1)
@@ -262,6 +263,7 @@ test.describe.parallel('Batch Operation Items Search API Tests', () => {
     let processInstanceKey1: string;
     let processInstanceKey2: string;
     let batchOperationKey: string;
+
     await test.step('Create multiple process instances to cancel', async () => {
       const processInstances = await createInstances(
         'process_with_task_listener',
@@ -635,7 +637,11 @@ test.describe.parallel('Batch Operation Items Search API Tests', () => {
         },
       );
 
-      await assertInvalidArgument(res, 400, `The provided itemKey \'${invalidFilterValue}\' is not a valid key. Expected a numeric value. Did you pass an entity id instead of an entity key?.`);
+      await assertInvalidArgument(
+        res,
+        400,
+        `The provided itemKey \'${invalidFilterValue}\' is not a valid key. Expected a numeric value. Did you pass an entity id instead of an entity key?.`,
+      );
     }).toPass(defaultAssertionOptions);
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-cancel-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-cancel-api-tests.spec.ts
@@ -118,6 +118,7 @@ test.describe.parallel('Cancel Batch Operation Tests', () => {
     request,
   }) => {
     const unknownKey = '2251799813999999';
+
     await test.step('Cancel unknown batch operation', async () => {
       const res = await cancelBatchOperation(request, unknownKey);
       await assertNotFoundRequest(

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts
@@ -89,6 +89,7 @@ test.describe('Suspend & Resume Batch Operation Tests', () => {
       await test.step('Create completed batch operation', async () => {
         return createCompletedBatchOperation(request);
       });
+
     const res = await suspendBatchOperation(request, key, 404);
     await assertNotFoundRequest(res, notFoundDetail(key));
   });
@@ -123,6 +124,7 @@ test.describe('Suspend & Resume Batch Operation Tests', () => {
       await test.step('Create batch operation for auth test', async () => {
         return createCancellationBatch(request, 3, 'batch_suspension_process');
       });
+
     const res = await request.post(
       buildUrl(`/batch-operations/${key}/suspension`),
       {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/clock/clock-reset-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/clock/clock-reset-api.spec.ts
@@ -15,6 +15,7 @@ import {createProcessInstanceAndRetrieveTimeStamp} from '@requestHelpers';
 test.describe.skip('Reset Clock API Tests', () => {
   const timestamp = Date.parse('2025-01-01T00:00:00Z');
   let processDefinitionId: string;
+
   test.beforeAll(async ({request}) => {
     const deployment = await deploy([
       './resources/clock_api_test_process.bpmn',

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/cluster-variables/cluster-variable-global-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/cluster-variables/cluster-variable-global-api-tests.spec.ts
@@ -15,9 +15,7 @@ import {
   assertBadRequest,
   assertStatusCode,
 } from '../../../../utils/http';
-import {
-  CREATE_CLUSTER_VARIABLE,
-} from '../../../../utils/beans/requestBeans';
+import {CREATE_CLUSTER_VARIABLE} from '../../../../utils/beans/requestBeans';
 import {defaultAssertionOptions} from '../../../../utils/constants';
 import {
   createGlobalClusterVariable,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/cluster-variables/cluster-variable-search-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/cluster-variables/cluster-variable-search-api.spec.ts
@@ -496,7 +496,7 @@ test.describe.parallel('Search Cluster Variables API Tests', () => {
           status: '200',
         },
         responseBody,
-      );      
+      );
       await assertPaginatedRequest(res, {
         itemsLengthEqualTo: 0,
         totalItemsEqualTo: 0,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/cluster-variables/cluster-variable-tenant-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/cluster-variables/cluster-variable-tenant-api-tests.spec.ts
@@ -15,9 +15,7 @@ import {
   assertBadRequest,
   assertStatusCode,
 } from '../../../../utils/http';
-import {
-  CREATE_CLUSTER_VARIABLE,
-} from '../../../../utils/beans/requestBeans';
+import {CREATE_CLUSTER_VARIABLE} from '../../../../utils/beans/requestBeans';
 import {defaultAssertionOptions} from '../../../../utils/constants';
 import {
   createTenantClusterVariable,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/cluster-variables/cluster-variable-update-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/cluster-variables/cluster-variable-update-api-tests.spec.ts
@@ -33,25 +33,265 @@ import {
 } from '../../../../utils/clusterVariablesCleanup';
 
 /* eslint-disable playwright/expect-expect */
-test.describe.parallel(
-  'Cluster Variable API Tests - Global Scope UPDATE',
-  () => {
-    const state: Record<string, unknown> = {};
-    const createdVariableNames: string[] = [];
+test.describe
+  .parallel('Cluster Variable API Tests - Global Scope UPDATE', () => {
+  const state: Record<string, unknown> = {};
+  const createdVariableNames: string[] = [];
 
-    test.afterAll(async ({request}) => {
-      await cleanupGlobalClusterVariables(request, createdVariableNames);
+  test.afterAll(async ({request}) => {
+    await cleanupGlobalClusterVariables(request, createdVariableNames);
+  });
+
+  test('Update Global Cluster Variable With Object Value', async ({
+    request,
+  }) => {
+    await createGlobalClusterVariable(request, state, 'updateObjVar');
+    const variableName = state['updateObjVarName'] as string;
+    createdVariableNames.push(variableName);
+
+    const newValue = {updatedKey: 'updatedValue', nested: {value: 123}};
+
+    await assertClusterVariableUpdate(
+      request,
+      buildUrl('/cluster-variables/global/{name}', {name: variableName}),
+      newValue,
+      variableName,
+      'GLOBAL',
+    );
+  });
+
+  test('Update Global Cluster Variable With String Value', async ({
+    request,
+  }) => {
+    await createGlobalClusterVariable(request, state, 'updateStringVar');
+    const variableName = state['updateStringVarName'] as string;
+    createdVariableNames.push(variableName);
+
+    const newValue = 'production';
+
+    await assertClusterVariableUpdate(
+      request,
+      buildUrl('/cluster-variables/global/{name}', {name: variableName}),
+      newValue,
+      variableName,
+      'GLOBAL',
+    );
+  });
+
+  test('Update Global Cluster Variable With Number Value', async ({
+    request,
+  }) => {
+    await createGlobalClusterVariable(request, state, 'updateNumberVar');
+    const variableName = state['updateNumberVarName'] as string;
+    createdVariableNames.push(variableName);
+
+    const newValue = 42;
+
+    await assertClusterVariableUpdate(
+      request,
+      buildUrl('/cluster-variables/global/{name}', {name: variableName}),
+      newValue,
+      variableName,
+      'GLOBAL',
+    );
+  });
+
+  test('Update Global Cluster Variable With Boolean True Value', async ({
+    request,
+  }) => {
+    await createGlobalClusterVariable(request, state, 'updateBoolTrueVar');
+    const variableName = state['updateBoolTrueVarName'] as string;
+    createdVariableNames.push(variableName);
+
+    const newValue = true;
+
+    await assertClusterVariableUpdate(
+      request,
+      buildUrl('/cluster-variables/global/{name}', {name: variableName}),
+      newValue,
+      variableName,
+      'GLOBAL',
+    );
+  });
+
+  test('Update Global Cluster Variable With Boolean False Value', async ({
+    request,
+  }) => {
+    await createGlobalClusterVariable(request, state, 'updateBoolFalseVar');
+    const variableName = state['updateBoolFalseVarName'] as string;
+    createdVariableNames.push(variableName);
+
+    const newValue = false;
+
+    await assertClusterVariableUpdate(
+      request,
+      buildUrl('/cluster-variables/global/{name}', {name: variableName}),
+      newValue,
+      variableName,
+      'GLOBAL',
+    );
+  });
+
+  test('Update Global Cluster Variable With Array Value', async ({request}) => {
+    await createGlobalClusterVariable(request, state, 'updateArrayVar');
+    const variableName = state['updateArrayVarName'] as string;
+    createdVariableNames.push(variableName);
+
+    const newValue = [1, 2, 3, 'four'];
+
+    await assertClusterVariableUpdate(
+      request,
+      buildUrl('/cluster-variables/global/{name}', {name: variableName}),
+      newValue,
+      variableName,
+      'GLOBAL',
+    );
+  });
+
+  test('Update Global Cluster Variable With Nested Object', async ({
+    request,
+  }) => {
+    await createGlobalClusterVariable(request, state, 'updateNestedVar');
+    const variableName = state['updateNestedVarName'] as string;
+    createdVariableNames.push(variableName);
+
+    const newValue = {
+      feature_flags: {
+        new_ui: true,
+        beta_features: false,
+      },
+      config: {
+        timeout: 5000,
+      },
+    };
+
+    await assertClusterVariableUpdate(
+      request,
+      buildUrl('/cluster-variables/global/{name}', {name: variableName}),
+      newValue,
+      variableName,
+      'GLOBAL',
+    );
+  });
+
+  test('Update Global Cluster Variable With Empty Object', async ({
+    request,
+  }) => {
+    await createGlobalClusterVariable(request, state, 'updateEmptyObjVar');
+    const variableName = state['updateEmptyObjVarName'] as string;
+    createdVariableNames.push(variableName);
+
+    const newValue = {};
+
+    await assertClusterVariableUpdate(
+      request,
+      buildUrl('/cluster-variables/global/{name}', {name: variableName}),
+      newValue,
+      variableName,
+      'GLOBAL',
+    );
+  });
+
+  test('Update Global Cluster Variable With Empty Array', async ({request}) => {
+    await createGlobalClusterVariable(request, state, 'updateEmptyArrVar');
+    const variableName = state['updateEmptyArrVarName'] as string;
+    createdVariableNames.push(variableName);
+
+    const newValue: unknown[] = [];
+
+    await assertClusterVariableUpdate(
+      request,
+      buildUrl('/cluster-variables/global/{name}', {name: variableName}),
+      newValue,
+      variableName,
+      'GLOBAL',
+    );
+  });
+
+  test('Update Global Cluster Variable Multiple Times', async ({request}) => {
+    await createGlobalClusterVariable(request, state, 'updateMultipleVar');
+    const variableName = state['updateMultipleVarName'] as string;
+    createdVariableNames.push(variableName);
+
+    const firstValue = {version: 1};
+    const secondValue = {version: 2};
+
+    await test.step('First update', async () => {
+      await assertClusterVariableUpdate(
+        request,
+        buildUrl('/cluster-variables/global/{name}', {name: variableName}),
+        firstValue,
+        variableName,
+        'GLOBAL',
+      );
     });
 
-    test('Update Global Cluster Variable With Object Value', async ({
-      request,
-    }) => {
-      await createGlobalClusterVariable(request, state, 'updateObjVar');
-      const variableName = state['updateObjVarName'] as string;
-      createdVariableNames.push(variableName);
+    await test.step('Second update', async () => {
+      await assertClusterVariableUpdate(
+        request,
+        buildUrl('/cluster-variables/global/{name}', {name: variableName}),
+        secondValue,
+        variableName,
+        'GLOBAL',
+      );
+    });
+  });
 
-      const newValue = {updatedKey: 'updatedValue', nested: {value: 123}};
+  test('Update Global Cluster Variable Unauthorized', async ({request}) => {
+    await createGlobalClusterVariable(request, state, 'updateUnauthorized');
+    const variableName = state['updateUnauthorizedName'] as string;
+    createdVariableNames.push(variableName);
 
+    const res = await request.put(
+      buildUrl('/cluster-variables/global/{name}', {name: variableName}),
+      {
+        headers: {},
+        data: UPDATE_CLUSTER_VARIABLE_VALUE({updated: true}),
+      },
+    );
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Update Global Cluster Variable Not Found', async ({request}) => {
+    const res = await request.put(
+      buildUrl('/cluster-variables/global/{name}', {
+        name: 'does-not-exist',
+      }),
+      {
+        headers: jsonHeaders(),
+        data: UPDATE_CLUSTER_VARIABLE_VALUE('test'),
+      },
+    );
+    await assertNotFoundRequest(res, 'does-not-exist');
+  });
+
+  test('Update Global Cluster Variable Missing Value Field Invalid Body 400', async ({
+    request,
+  }) => {
+    await createGlobalClusterVariable(request, state, 'updateMissingValue');
+    const variableName = state['updateMissingValueName'] as string;
+    createdVariableNames.push(variableName);
+
+    const res = await request.put(
+      buildUrl('/cluster-variables/global/{name}', {name: variableName}),
+      {
+        headers: jsonHeaders(),
+        data: {},
+      },
+    );
+    await assertBadRequest(res, /value/i, 'INVALID_ARGUMENT');
+  });
+
+  test('Update Global Cluster Variable Verify Response Structure', async ({
+    request,
+  }) => {
+    await createGlobalClusterVariable(request, state, 'updateVerifyResp');
+    const variableName = state['updateVerifyRespName'] as string;
+    createdVariableNames.push(variableName);
+
+    const newValue = {verified: true, timestamp: Date.now()};
+
+    await test.step('Update using helper function with retry logic', async () => {
       await assertClusterVariableUpdate(
         request,
         buildUrl('/cluster-variables/global/{name}', {name: variableName}),
@@ -61,503 +301,459 @@ test.describe.parallel(
       );
     });
 
-    test('Update Global Cluster Variable With String Value', async ({
-      request,
-    }) => {
-      await createGlobalClusterVariable(request, state, 'updateStringVar');
-      const variableName = state['updateStringVarName'] as string;
-      createdVariableNames.push(variableName);
-
-      const newValue = 'production';
-
-      await assertClusterVariableUpdate(
-        request,
-        buildUrl('/cluster-variables/global/{name}', {name: variableName}),
-        newValue,
-        variableName,
-        'GLOBAL',
-      );
-    });
-
-    test('Update Global Cluster Variable With Number Value', async ({
-      request,
-    }) => {
-      await createGlobalClusterVariable(request, state, 'updateNumberVar');
-      const variableName = state['updateNumberVarName'] as string;
-      createdVariableNames.push(variableName);
-
-      const newValue = 42;
-
-      await assertClusterVariableUpdate(
-        request,
-        buildUrl('/cluster-variables/global/{name}', {name: variableName}),
-        newValue,
-        variableName,
-        'GLOBAL',
-      );
-    });
-
-    test('Update Global Cluster Variable With Boolean True Value', async ({
-      request,
-    }) => {
-      await createGlobalClusterVariable(request, state, 'updateBoolTrueVar');
-      const variableName = state['updateBoolTrueVarName'] as string;
-      createdVariableNames.push(variableName);
-
-      const newValue = true;
-
-      await assertClusterVariableUpdate(
-        request,
-        buildUrl('/cluster-variables/global/{name}', {name: variableName}),
-        newValue,
-        variableName,
-        'GLOBAL',
-      );
-    });
-
-    test('Update Global Cluster Variable With Boolean False Value', async ({
-      request,
-    }) => {
-      await createGlobalClusterVariable(request, state, 'updateBoolFalseVar');
-      const variableName = state['updateBoolFalseVarName'] as string;
-      createdVariableNames.push(variableName);
-
-      const newValue = false;
-
-      await assertClusterVariableUpdate(
-        request,
-        buildUrl('/cluster-variables/global/{name}', {name: variableName}),
-        newValue,
-        variableName,
-        'GLOBAL',
-      );
-    });
-
-    test('Update Global Cluster Variable With Array Value', async ({
-      request,
-    }) => {
-      await createGlobalClusterVariable(request, state, 'updateArrayVar');
-      const variableName = state['updateArrayVarName'] as string;
-      createdVariableNames.push(variableName);
-
-      const newValue = [1, 2, 3, 'four'];
-
-      await assertClusterVariableUpdate(
-        request,
-        buildUrl('/cluster-variables/global/{name}', {name: variableName}),
-        newValue,
-        variableName,
-        'GLOBAL',
-      );
-    });
-
-    test('Update Global Cluster Variable With Nested Object', async ({
-      request,
-    }) => {
-      await createGlobalClusterVariable(request, state, 'updateNestedVar');
-      const variableName = state['updateNestedVarName'] as string;
-      createdVariableNames.push(variableName);
-
-      const newValue = {
-        feature_flags: {
-          new_ui: true,
-          beta_features: false,
-        },
-        config: {
-          timeout: 5000,
-        },
-      };
-
-      await assertClusterVariableUpdate(
-        request,
-        buildUrl('/cluster-variables/global/{name}', {name: variableName}),
-        newValue,
-        variableName,
-        'GLOBAL',
-      );
-    });
-
-    test('Update Global Cluster Variable With Empty Object', async ({
-      request,
-    }) => {
-      await createGlobalClusterVariable(request, state, 'updateEmptyObjVar');
-      const variableName = state['updateEmptyObjVarName'] as string;
-      createdVariableNames.push(variableName);
-
-      const newValue = {};
-
-      await assertClusterVariableUpdate(
-        request,
-        buildUrl('/cluster-variables/global/{name}', {name: variableName}),
-        newValue,
-        variableName,
-        'GLOBAL',
-      );
-    });
-
-    test('Update Global Cluster Variable With Empty Array', async ({
-      request,
-    }) => {
-      await createGlobalClusterVariable(request, state, 'updateEmptyArrVar');
-      const variableName = state['updateEmptyArrVarName'] as string;
-      createdVariableNames.push(variableName);
-
-      const newValue: unknown[] = [];
-
-      await assertClusterVariableUpdate(
-        request,
-        buildUrl('/cluster-variables/global/{name}', {name: variableName}),
-        newValue,
-        variableName,
-        'GLOBAL',
-      );
-    });
-
-    test('Update Global Cluster Variable Multiple Times', async ({
-      request,
-    }) => {
-      await createGlobalClusterVariable(request, state, 'updateMultipleVar');
-      const variableName = state['updateMultipleVarName'] as string;
-      createdVariableNames.push(variableName);
-
-      const firstValue = {version: 1};
-      const secondValue = {version: 2};
-
-      await test.step('First update', async () => {
-        await assertClusterVariableUpdate(
-          request,
+    await test.step('Verify variable structure with retry', async () => {
+      await expect(async () => {
+        const res = await request.get(
           buildUrl('/cluster-variables/global/{name}', {name: variableName}),
-          firstValue,
-          variableName,
-          'GLOBAL',
-        );
-      });
-
-      await test.step('Second update', async () => {
-        await assertClusterVariableUpdate(
-          request,
-          buildUrl('/cluster-variables/global/{name}', {name: variableName}),
-          secondValue,
-          variableName,
-          'GLOBAL',
-        );
-      });
-    });
-
-    test('Update Global Cluster Variable Unauthorized', async ({request}) => {
-      await createGlobalClusterVariable(request, state, 'updateUnauthorized');
-      const variableName = state['updateUnauthorizedName'] as string;
-      createdVariableNames.push(variableName);
-
-      const res = await request.put(
-        buildUrl('/cluster-variables/global/{name}', {name: variableName}),
-        {
-          headers: {},
-          data: UPDATE_CLUSTER_VARIABLE_VALUE({updated: true}),
-        },
-      );
-      await assertUnauthorizedRequest(res);
-    });
-
-    test('Update Global Cluster Variable Not Found', async ({request}) => {
-      const res = await request.put(
-        buildUrl('/cluster-variables/global/{name}', {
-          name: 'does-not-exist',
-        }),
-        {
-          headers: jsonHeaders(),
-          data: UPDATE_CLUSTER_VARIABLE_VALUE('test'),
-        },
-      );
-      await assertNotFoundRequest(res, 'does-not-exist');
-    });
-
-    test('Update Global Cluster Variable Missing Value Field Invalid Body 400', async ({
-      request,
-    }) => {
-      await createGlobalClusterVariable(request, state, 'updateMissingValue');
-      const variableName = state['updateMissingValueName'] as string;
-      createdVariableNames.push(variableName);
-
-      const res = await request.put(
-        buildUrl('/cluster-variables/global/{name}', {name: variableName}),
-        {
-          headers: jsonHeaders(),
-          data: {},
-        },
-      );
-      await assertBadRequest(res, /value/i, 'INVALID_ARGUMENT');
-    });
-
-    test('Update Global Cluster Variable Verify Response Structure', async ({
-      request,
-    }) => {
-      await createGlobalClusterVariable(request, state, 'updateVerifyResp');
-      const variableName = state['updateVerifyRespName'] as string;
-      createdVariableNames.push(variableName);
-
-      const newValue = {verified: true, timestamp: Date.now()};
-
-      await test.step('Update using helper function with retry logic', async () => {
-        await assertClusterVariableUpdate(
-          request,
-          buildUrl('/cluster-variables/global/{name}', {name: variableName}),
-          newValue,
-          variableName,
-          'GLOBAL',
-        );
-      });
-
-      await test.step('Verify variable structure with retry', async () => {
-        await expect(async () => {
-          const res = await request.get(
-            buildUrl('/cluster-variables/global/{name}', {name: variableName}),
-            {
-              headers: jsonHeaders(),
-            },
-          );
-
-          await assertStatusCode(res, 200);
-          await validateResponse(
-            {
-              path: '/cluster-variables/global/{name}',
-              method: 'GET',
-              status: '200',
-            },
-            res,
-          );
-          const json = await res.json();
-
-          expect(json.name).toBe(variableName);
-          expect(json.scope).toBe('GLOBAL');
-          expect(typeof json.value).toBe('string');
-          expect(JSON.parse(json.value)).toEqual(newValue);
-        }).toPass(defaultAssertionOptions);
-      });
-    });
-
-    test('Update Global Cluster Variable Immediately Retrievable', async ({
-      request,
-    }) => {
-      await createGlobalClusterVariable(
-        request,
-        state,
-        'updateImmediateRetrieval',
-      );
-      const variableName = state['updateImmediateRetrievalName'] as string;
-      createdVariableNames.push(variableName);
-
-      const newValue = {consistency: 'strong'};
-
-      await test.step('Update the variable with retry', async () => {
-        await assertClusterVariableUpdate(
-          request,
-          buildUrl('/cluster-variables/global/{name}', {name: variableName}),
-          newValue,
-          variableName,
-          'GLOBAL',
-        );
-      });
-
-      await test.step('Verify variable is immediately retrievable', async () => {
-        await expect(async () => {
-          const getRes = await request.get(
-            buildUrl('/cluster-variables/global/{name}', {name: variableName}),
-            {
-              headers: jsonHeaders(),
-            },
-          );
-          await assertStatusCode(getRes, 200);
-          const json = await getRes.json();
-          expect(JSON.parse(json.value)).toEqual(newValue);
-        }).toPass(defaultAssertionOptions);
-      });
-    });
-  },
-);
-
-test.describe.parallel(
-  'Cluster Variable API Tests - Tenant Scope UPDATE',
-  () => {
-    const state: Record<string, unknown> = {};
-    const createdVariables: {tenantId: string; name: string}[] = [];
-
-    test.beforeAll(async ({request}) => {
-      // Create tenants for testing
-      await createTenantAndStoreResponseFields(request, 2, state);
-    });
-
-    test.afterAll(async ({request}) => {
-      await cleanupTenantClusterVariables(request, createdVariables);
-    });
-
-    test('Update Tenant Cluster Variable With Object Value', async ({
-      request,
-    }) => {
-      const tenantId = state['tenantId1'] as string;
-      await createTenantClusterVariable(
-        request,
-        state,
-        'updateTenantObjVar',
-        tenantId,
-      );
-      const variableName = state['updateTenantObjVarName'] as string;
-      createdVariables.push({tenantId, name: variableName});
-
-      const newValue = {updatedKey: 'tenantValue', nested: {value: 456}};
-
-      await assertClusterVariableUpdate(
-        request,
-        buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
-          tenantId,
-          name: variableName,
-        }),
-        newValue,
-        variableName,
-        'TENANT',
-        tenantId,
-      );
-    });
-
-    test('Update Tenant Cluster Variable With String Value', async ({
-      request,
-    }) => {
-      const tenantId = state['tenantId1'] as string;
-      await createTenantClusterVariable(
-        request,
-        state,
-        'updateTenantStringVar',
-        tenantId,
-      );
-      const variableName = state['updateTenantStringVarName'] as string;
-      createdVariables.push({tenantId, name: variableName});
-
-      const newValue = 'tenant-production';
-
-      await assertClusterVariableUpdate(
-        request,
-        buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
-          tenantId,
-          name: variableName,
-        }),
-        newValue,
-        variableName,
-        'TENANT',
-        tenantId,
-      );
-    });
-
-    test('Update Tenant Cluster Variable With Number Value', async ({
-      request,
-    }) => {
-      const tenantId = state['tenantId1'] as string;
-      await createTenantClusterVariable(
-        request,
-        state,
-        'updateTenantNumberVar',
-        tenantId,
-      );
-      const variableName = state['updateTenantNumberVarName'] as string;
-      createdVariables.push({tenantId, name: variableName});
-
-      const newValue = 1000;
-
-      await assertClusterVariableUpdate(
-        request,
-        buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
-          tenantId,
-          name: variableName,
-        }),
-        newValue,
-        variableName,
-        'TENANT',
-        tenantId,
-      );
-    });
-
-    test('Update Tenant Cluster Variable With Boolean Value', async ({
-      request,
-    }) => {
-      const tenantId = state['tenantId1'] as string;
-      await createTenantClusterVariable(
-        request,
-        state,
-        'updateTenantBoolVar',
-        tenantId,
-      );
-      const variableName = state['updateTenantBoolVarName'] as string;
-      createdVariables.push({tenantId, name: variableName});
-
-      const newValue = true;
-
-      await assertClusterVariableUpdate(
-        request,
-        buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
-          tenantId,
-          name: variableName,
-        }),
-        newValue,
-        variableName,
-        'TENANT',
-        tenantId,
-      );
-    });
-
-    test('Update Tenant Cluster Variable With Array Value', async ({
-      request,
-    }) => {
-      const tenantId = state['tenantId1'] as string;
-      await createTenantClusterVariable(
-        request,
-        state,
-        'updateTenantArrayVar',
-        tenantId,
-      );
-      const variableName = state['updateTenantArrayVarName'] as string;
-      createdVariables.push({tenantId, name: variableName});
-
-      const newValue = [10, 20, 30, 'tenant-array'];
-
-      await assertClusterVariableUpdate(
-        request,
-        buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
-          tenantId,
-          name: variableName,
-        }),
-        newValue,
-        variableName,
-        'TENANT',
-        tenantId,
-      );
-    });
-
-    test('Update Tenant Cluster Variable With Complex Nested Object', async ({
-      request,
-    }) => {
-      const tenantId = state['tenantId1'] as string;
-      await createTenantClusterVariable(
-        request,
-        state,
-        'updateTenantComplexVar',
-        tenantId,
-      );
-      const variableName = state['updateTenantComplexVarName'] as string;
-      createdVariables.push({tenantId, name: variableName});
-
-      const newValue = {
-        feature_flags: {
-          new_ui: true,
-          beta_features: false,
-        },
-        settings: {
-          theme: 'dark',
-          notifications: {
-            email: true,
-            push: false,
+          {
+            headers: jsonHeaders(),
           },
-        },
-      };
+        );
 
+        await assertStatusCode(res, 200);
+        await validateResponse(
+          {
+            path: '/cluster-variables/global/{name}',
+            method: 'GET',
+            status: '200',
+          },
+          res,
+        );
+        const json = await res.json();
+
+        expect(json.name).toBe(variableName);
+        expect(json.scope).toBe('GLOBAL');
+        expect(typeof json.value).toBe('string');
+        expect(JSON.parse(json.value)).toEqual(newValue);
+      }).toPass(defaultAssertionOptions);
+    });
+  });
+
+  test('Update Global Cluster Variable Immediately Retrievable', async ({
+    request,
+  }) => {
+    await createGlobalClusterVariable(
+      request,
+      state,
+      'updateImmediateRetrieval',
+    );
+    const variableName = state['updateImmediateRetrievalName'] as string;
+    createdVariableNames.push(variableName);
+
+    const newValue = {consistency: 'strong'};
+
+    await test.step('Update the variable with retry', async () => {
+      await assertClusterVariableUpdate(
+        request,
+        buildUrl('/cluster-variables/global/{name}', {name: variableName}),
+        newValue,
+        variableName,
+        'GLOBAL',
+      );
+    });
+
+    await test.step('Verify variable is immediately retrievable', async () => {
+      await expect(async () => {
+        const getRes = await request.get(
+          buildUrl('/cluster-variables/global/{name}', {name: variableName}),
+          {
+            headers: jsonHeaders(),
+          },
+        );
+        await assertStatusCode(getRes, 200);
+        const json = await getRes.json();
+        expect(JSON.parse(json.value)).toEqual(newValue);
+      }).toPass(defaultAssertionOptions);
+    });
+  });
+});
+
+test.describe
+  .parallel('Cluster Variable API Tests - Tenant Scope UPDATE', () => {
+  const state: Record<string, unknown> = {};
+  const createdVariables: {tenantId: string; name: string}[] = [];
+
+  test.beforeAll(async ({request}) => {
+    // Create tenants for testing
+    await createTenantAndStoreResponseFields(request, 2, state);
+  });
+
+  test.afterAll(async ({request}) => {
+    await cleanupTenantClusterVariables(request, createdVariables);
+  });
+
+  test('Update Tenant Cluster Variable With Object Value', async ({
+    request,
+  }) => {
+    const tenantId = state['tenantId1'] as string;
+    await createTenantClusterVariable(
+      request,
+      state,
+      'updateTenantObjVar',
+      tenantId,
+    );
+    const variableName = state['updateTenantObjVarName'] as string;
+    createdVariables.push({tenantId, name: variableName});
+
+    const newValue = {updatedKey: 'tenantValue', nested: {value: 456}};
+
+    await assertClusterVariableUpdate(
+      request,
+      buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
+        tenantId,
+        name: variableName,
+      }),
+      newValue,
+      variableName,
+      'TENANT',
+      tenantId,
+    );
+  });
+
+  test('Update Tenant Cluster Variable With String Value', async ({
+    request,
+  }) => {
+    const tenantId = state['tenantId1'] as string;
+    await createTenantClusterVariable(
+      request,
+      state,
+      'updateTenantStringVar',
+      tenantId,
+    );
+    const variableName = state['updateTenantStringVarName'] as string;
+    createdVariables.push({tenantId, name: variableName});
+
+    const newValue = 'tenant-production';
+
+    await assertClusterVariableUpdate(
+      request,
+      buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
+        tenantId,
+        name: variableName,
+      }),
+      newValue,
+      variableName,
+      'TENANT',
+      tenantId,
+    );
+  });
+
+  test('Update Tenant Cluster Variable With Number Value', async ({
+    request,
+  }) => {
+    const tenantId = state['tenantId1'] as string;
+    await createTenantClusterVariable(
+      request,
+      state,
+      'updateTenantNumberVar',
+      tenantId,
+    );
+    const variableName = state['updateTenantNumberVarName'] as string;
+    createdVariables.push({tenantId, name: variableName});
+
+    const newValue = 1000;
+
+    await assertClusterVariableUpdate(
+      request,
+      buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
+        tenantId,
+        name: variableName,
+      }),
+      newValue,
+      variableName,
+      'TENANT',
+      tenantId,
+    );
+  });
+
+  test('Update Tenant Cluster Variable With Boolean Value', async ({
+    request,
+  }) => {
+    const tenantId = state['tenantId1'] as string;
+    await createTenantClusterVariable(
+      request,
+      state,
+      'updateTenantBoolVar',
+      tenantId,
+    );
+    const variableName = state['updateTenantBoolVarName'] as string;
+    createdVariables.push({tenantId, name: variableName});
+
+    const newValue = true;
+
+    await assertClusterVariableUpdate(
+      request,
+      buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
+        tenantId,
+        name: variableName,
+      }),
+      newValue,
+      variableName,
+      'TENANT',
+      tenantId,
+    );
+  });
+
+  test('Update Tenant Cluster Variable With Array Value', async ({request}) => {
+    const tenantId = state['tenantId1'] as string;
+    await createTenantClusterVariable(
+      request,
+      state,
+      'updateTenantArrayVar',
+      tenantId,
+    );
+    const variableName = state['updateTenantArrayVarName'] as string;
+    createdVariables.push({tenantId, name: variableName});
+
+    const newValue = [10, 20, 30, 'tenant-array'];
+
+    await assertClusterVariableUpdate(
+      request,
+      buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
+        tenantId,
+        name: variableName,
+      }),
+      newValue,
+      variableName,
+      'TENANT',
+      tenantId,
+    );
+  });
+
+  test('Update Tenant Cluster Variable With Complex Nested Object', async ({
+    request,
+  }) => {
+    const tenantId = state['tenantId1'] as string;
+    await createTenantClusterVariable(
+      request,
+      state,
+      'updateTenantComplexVar',
+      tenantId,
+    );
+    const variableName = state['updateTenantComplexVarName'] as string;
+    createdVariables.push({tenantId, name: variableName});
+
+    const newValue = {
+      feature_flags: {
+        new_ui: true,
+        beta_features: false,
+      },
+      settings: {
+        theme: 'dark',
+        notifications: {
+          email: true,
+          push: false,
+        },
+      },
+    };
+
+    await assertClusterVariableUpdate(
+      request,
+      buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
+        tenantId,
+        name: variableName,
+      }),
+      newValue,
+      variableName,
+      'TENANT',
+      tenantId,
+    );
+  });
+
+  test('Update Tenant Cluster Variable With Empty Object', async ({
+    request,
+  }) => {
+    const tenantId = state['tenantId1'] as string;
+    await createTenantClusterVariable(
+      request,
+      state,
+      'updateTenantEmptyObjVar',
+      tenantId,
+    );
+    const variableName = state['updateTenantEmptyObjVarName'] as string;
+    createdVariables.push({tenantId, name: variableName});
+
+    const newValue = {};
+
+    await assertClusterVariableUpdate(
+      request,
+      buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
+        tenantId,
+        name: variableName,
+      }),
+      newValue,
+      variableName,
+      'TENANT',
+      tenantId,
+    );
+  });
+
+  test('Update Tenant Cluster Variable With Empty Array', async ({request}) => {
+    const tenantId = state['tenantId1'] as string;
+    await createTenantClusterVariable(
+      request,
+      state,
+      'updateTenantEmptyArrVar',
+      tenantId,
+    );
+    const variableName = state['updateTenantEmptyArrVarName'] as string;
+    createdVariables.push({tenantId, name: variableName});
+
+    const newValue: unknown[] = [];
+
+    await assertClusterVariableUpdate(
+      request,
+      buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
+        tenantId,
+        name: variableName,
+      }),
+      newValue,
+      variableName,
+      'TENANT',
+      tenantId,
+    );
+  });
+
+  test('Update Tenant Cluster Variable Multiple Times', async ({request}) => {
+    const tenantId = state['tenantId2'] as string;
+    await createTenantClusterVariable(
+      request,
+      state,
+      'updateTenantMultipleVar',
+      tenantId,
+    );
+    const variableName = state['updateTenantMultipleVarName'] as string;
+    createdVariables.push({tenantId, name: variableName});
+
+    const firstValue = {version: 1};
+    const secondValue = {version: 2};
+
+    await test.step('First update', async () => {
+      await assertClusterVariableUpdate(
+        request,
+        buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
+          tenantId,
+          name: variableName,
+        }),
+        firstValue,
+        variableName,
+        'TENANT',
+        tenantId,
+      );
+    });
+
+    await test.step('Second update', async () => {
+      await assertClusterVariableUpdate(
+        request,
+        buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
+          tenantId,
+          name: variableName,
+        }),
+        secondValue,
+        variableName,
+        'TENANT',
+        tenantId,
+      );
+    });
+  });
+
+  test('Update Tenant Cluster Variable Unauthorized', async ({request}) => {
+    const tenantId = state['tenantId1'] as string;
+    await createTenantClusterVariable(
+      request,
+      state,
+      'updateTenantUnauth',
+      tenantId,
+    );
+    const variableName = state['updateTenantUnauthName'] as string;
+    createdVariables.push({tenantId, name: variableName});
+
+    const res = await request.put(
+      buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
+        tenantId,
+        name: variableName,
+      }),
+      {
+        headers: {},
+        data: UPDATE_CLUSTER_VARIABLE_VALUE({updated: true}),
+      },
+    );
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Update Tenant Cluster Variable Not Found', async ({request}) => {
+    const tenantId = state['tenantId1'] as string;
+    const res = await request.put(
+      buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
+        tenantId,
+        name: 'does-not-exist',
+      }),
+      {
+        headers: jsonHeaders(),
+        data: UPDATE_CLUSTER_VARIABLE_VALUE('test'),
+      },
+    );
+    await assertNotFoundRequest(res, 'does-not-exist');
+  });
+
+  test('Update Tenant Cluster Variable Missing Value Field Invalid Body 400', async ({
+    request,
+  }) => {
+    const tenantId = state['tenantId1'] as string;
+    await createTenantClusterVariable(
+      request,
+      state,
+      'updateTenantMissingVal',
+      tenantId,
+    );
+    const variableName = state['updateTenantMissingValName'] as string;
+    createdVariables.push({tenantId, name: variableName});
+
+    const res = await request.put(
+      buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
+        tenantId,
+        name: variableName,
+      }),
+      {
+        headers: jsonHeaders(),
+        data: {},
+      },
+    );
+    await assertBadRequest(res, /value/i, 'INVALID_ARGUMENT');
+  });
+
+  test('Update Tenant Cluster Variable Invalid Tenant Not Found', async ({
+    request,
+  }) => {
+    const res = await request.put(
+      buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
+        tenantId: 'invalid-tenant-id',
+        name: 'some-variable',
+      }),
+      {
+        headers: jsonHeaders(),
+        data: UPDATE_CLUSTER_VARIABLE_VALUE('test'),
+      },
+    );
+    await assertNotFoundRequest(res, 'invalid-tenant-id');
+  });
+
+  test('Update Tenant Cluster Variable Verify Response Structure', async ({
+    request,
+  }) => {
+    const tenantId = state['tenantId2'] as string;
+    await createTenantClusterVariable(
+      request,
+      state,
+      'updateTenantVerifyResp',
+      tenantId,
+    );
+    const variableName = state['updateTenantVerifyRespName'] as string;
+    createdVariables.push({tenantId, name: variableName});
+
+    const newValue = {verified: true, timestamp: Date.now()};
+
+    await test.step('Update using helper function with retry logic', async () => {
       await assertClusterVariableUpdate(
         request,
         buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
@@ -571,21 +767,54 @@ test.describe.parallel(
       );
     });
 
-    test('Update Tenant Cluster Variable With Empty Object', async ({
+    await test.step('Verify variable structure with retry', async () => {
+      await expect(async () => {
+        const res = await request.get(
+          buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
+            tenantId,
+            name: variableName,
+          }),
+          {
+            headers: jsonHeaders(),
+          },
+        );
+
+        await assertStatusCode(res, 200);
+        await validateResponse(
+          {
+            path: '/cluster-variables/tenants/{tenantId}/{name}',
+            method: 'GET',
+            status: '200',
+          },
+          res,
+        );
+        const json = await res.json();
+
+        expect(json.name).toBe(variableName);
+        expect(json.scope).toBe('TENANT');
+        expect(json.tenantId).toBe(tenantId);
+        expect(typeof json.value).toBe('string');
+        expect(JSON.parse(json.value)).toEqual(newValue);
+      }).toPass(defaultAssertionOptions);
+    });
+  });
+
+  test('Update Tenant Cluster Variable Immediately Retrievable', async ({
+    request,
+  }) => {
+    const tenantId = state['tenantId2'] as string;
+    await createTenantClusterVariable(
       request,
-    }) => {
-      const tenantId = state['tenantId1'] as string;
-      await createTenantClusterVariable(
-        request,
-        state,
-        'updateTenantEmptyObjVar',
-        tenantId,
-      );
-      const variableName = state['updateTenantEmptyObjVarName'] as string;
-      createdVariables.push({tenantId, name: variableName});
+      state,
+      'updateTenantImmediate',
+      tenantId,
+    );
+    const variableName = state['updateTenantImmediateName'] as string;
+    createdVariables.push({tenantId, name: variableName});
 
-      const newValue = {};
+    const newValue = {consistency: 'strong'};
 
+    await test.step('Update the variable with retry', async () => {
       await assertClusterVariableUpdate(
         request,
         buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
@@ -599,266 +828,21 @@ test.describe.parallel(
       );
     });
 
-    test('Update Tenant Cluster Variable With Empty Array', async ({
-      request,
-    }) => {
-      const tenantId = state['tenantId1'] as string;
-      await createTenantClusterVariable(
-        request,
-        state,
-        'updateTenantEmptyArrVar',
-        tenantId,
-      );
-      const variableName = state['updateTenantEmptyArrVarName'] as string;
-      createdVariables.push({tenantId, name: variableName});
-
-      const newValue: unknown[] = [];
-
-      await assertClusterVariableUpdate(
-        request,
-        buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
-          tenantId,
-          name: variableName,
-        }),
-        newValue,
-        variableName,
-        'TENANT',
-        tenantId,
-      );
-    });
-
-    test('Update Tenant Cluster Variable Multiple Times', async ({
-      request,
-    }) => {
-      const tenantId = state['tenantId2'] as string;
-      await createTenantClusterVariable(
-        request,
-        state,
-        'updateTenantMultipleVar',
-        tenantId,
-      );
-      const variableName = state['updateTenantMultipleVarName'] as string;
-      createdVariables.push({tenantId, name: variableName});
-
-      const firstValue = {version: 1};
-      const secondValue = {version: 2};
-
-      await test.step('First update', async () => {
-        await assertClusterVariableUpdate(
-          request,
+    await test.step('Verify variable is immediately retrievable', async () => {
+      await expect(async () => {
+        const getRes = await request.get(
           buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
             tenantId,
             name: variableName,
           }),
-          firstValue,
-          variableName,
-          'TENANT',
-          tenantId,
+          {
+            headers: jsonHeaders(),
+          },
         );
-      });
-
-      await test.step('Second update', async () => {
-        await assertClusterVariableUpdate(
-          request,
-          buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
-            tenantId,
-            name: variableName,
-          }),
-          secondValue,
-          variableName,
-          'TENANT',
-          tenantId,
-        );
-      });
+        await assertStatusCode(getRes, 200);
+        const json = await getRes.json();
+        expect(JSON.parse(json.value)).toEqual(newValue);
+      }).toPass(defaultAssertionOptions);
     });
-
-    test('Update Tenant Cluster Variable Unauthorized', async ({request}) => {
-      const tenantId = state['tenantId1'] as string;
-      await createTenantClusterVariable(
-        request,
-        state,
-        'updateTenantUnauth',
-        tenantId,
-      );
-      const variableName = state['updateTenantUnauthName'] as string;
-      createdVariables.push({tenantId, name: variableName});
-
-      const res = await request.put(
-        buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
-          tenantId,
-          name: variableName,
-        }),
-        {
-          headers: {},
-          data: UPDATE_CLUSTER_VARIABLE_VALUE({updated: true}),
-        },
-      );
-      await assertUnauthorizedRequest(res);
-    });
-
-    test('Update Tenant Cluster Variable Not Found', async ({request}) => {
-      const tenantId = state['tenantId1'] as string;
-      const res = await request.put(
-        buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
-          tenantId,
-          name: 'does-not-exist',
-        }),
-        {
-          headers: jsonHeaders(),
-          data: UPDATE_CLUSTER_VARIABLE_VALUE('test'),
-        },
-      );
-      await assertNotFoundRequest(res, 'does-not-exist');
-    });
-
-    test('Update Tenant Cluster Variable Missing Value Field Invalid Body 400', async ({
-      request,
-    }) => {
-      const tenantId = state['tenantId1'] as string;
-      await createTenantClusterVariable(
-        request,
-        state,
-        'updateTenantMissingVal',
-        tenantId,
-      );
-      const variableName = state['updateTenantMissingValName'] as string;
-      createdVariables.push({tenantId, name: variableName});
-
-      const res = await request.put(
-        buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
-          tenantId,
-          name: variableName,
-        }),
-        {
-          headers: jsonHeaders(),
-          data: {},
-        },
-      );
-      await assertBadRequest(res, /value/i, 'INVALID_ARGUMENT');
-    });
-
-    test('Update Tenant Cluster Variable Invalid Tenant Not Found', async ({
-      request,
-    }) => {
-      const res = await request.put(
-        buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
-          tenantId: 'invalid-tenant-id',
-          name: 'some-variable',
-        }),
-        {
-          headers: jsonHeaders(),
-          data: UPDATE_CLUSTER_VARIABLE_VALUE('test'),
-        },
-      );
-      await assertNotFoundRequest(res, 'invalid-tenant-id');
-    });
-
-    test('Update Tenant Cluster Variable Verify Response Structure', async ({
-      request,
-    }) => {
-      const tenantId = state['tenantId2'] as string;
-      await createTenantClusterVariable(
-        request,
-        state,
-        'updateTenantVerifyResp',
-        tenantId,
-      );
-      const variableName = state['updateTenantVerifyRespName'] as string;
-      createdVariables.push({tenantId, name: variableName});
-
-      const newValue = {verified: true, timestamp: Date.now()};
-
-      await test.step('Update using helper function with retry logic', async () => {
-        await assertClusterVariableUpdate(
-          request,
-          buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
-            tenantId,
-            name: variableName,
-          }),
-          newValue,
-          variableName,
-          'TENANT',
-          tenantId,
-        );
-      });
-
-      await test.step('Verify variable structure with retry', async () => {
-        await expect(async () => {
-          const res = await request.get(
-            buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
-              tenantId,
-              name: variableName,
-            }),
-            {
-              headers: jsonHeaders(),
-            },
-          );
-
-          await assertStatusCode(res, 200);
-          await validateResponse(
-            {
-              path: '/cluster-variables/tenants/{tenantId}/{name}',
-              method: 'GET',
-              status: '200',
-            },
-            res,
-          );
-          const json = await res.json();
-
-          expect(json.name).toBe(variableName);
-          expect(json.scope).toBe('TENANT');
-          expect(json.tenantId).toBe(tenantId);
-          expect(typeof json.value).toBe('string');
-          expect(JSON.parse(json.value)).toEqual(newValue);
-        }).toPass(defaultAssertionOptions);
-      });
-    });
-
-    test('Update Tenant Cluster Variable Immediately Retrievable', async ({
-      request,
-    }) => {
-      const tenantId = state['tenantId2'] as string;
-      await createTenantClusterVariable(
-        request,
-        state,
-        'updateTenantImmediate',
-        tenantId,
-      );
-      const variableName = state['updateTenantImmediateName'] as string;
-      createdVariables.push({tenantId, name: variableName});
-
-      const newValue = {consistency: 'strong'};
-
-      await test.step('Update the variable with retry', async () => {
-        await assertClusterVariableUpdate(
-          request,
-          buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
-            tenantId,
-            name: variableName,
-          }),
-          newValue,
-          variableName,
-          'TENANT',
-          tenantId,
-        );
-      });
-
-      await test.step('Verify variable is immediately retrievable', async () => {
-        await expect(async () => {
-          const getRes = await request.get(
-            buildUrl('/cluster-variables/tenants/{tenantId}/{name}', {
-              tenantId,
-              name: variableName,
-            }),
-            {
-              headers: jsonHeaders(),
-            },
-          );
-          await assertStatusCode(getRes, 200);
-          const json = await getRes.json();
-          expect(JSON.parse(json.value)).toEqual(newValue);
-        }).toPass(defaultAssertionOptions);
-      });
-    });
-  },
-);
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-definition/evaluate-decision-definitions-api.tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-definition/evaluate-decision-definitions-api.tests.spec.ts
@@ -22,7 +22,7 @@ import {
 } from '../../../../utils/beans/requestBeans';
 import {deployDecisionAndStoreResponse} from '@requestHelpers';
 import {DecisionDeployment} from '@camunda8/sdk/dist/c8/lib/C8Dto';
-import { validateResponse } from 'json-body-assertions';
+import {validateResponse} from 'json-body-assertions';
 
 test.describe.parallel('Evaluate Decision Definitions API Tests', () => {
   const state: Record<string, unknown> = {};

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-definition/get-decision-definitions-api.tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-definition/get-decision-definitions-api.tests.spec.ts
@@ -25,7 +25,7 @@ import {
 } from '@requestHelpers';
 import {DecisionDeployment} from '@camunda8/sdk/dist/c8/lib/C8Dto';
 import fs from 'fs';
-import { validateResponse } from 'json-body-assertions';
+import {validateResponse} from 'json-body-assertions';
 
 /* eslint-disable playwright/expect-expect */
 test.describe.parallel('Get Decision Definitions API Tests', () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-definition/search-decision-definitions-api.tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-definition/search-decision-definitions-api.tests.spec.ts
@@ -21,7 +21,7 @@ import {
   deployDecisionAndStoreResponse,
 } from '@requestHelpers';
 import {DecisionDeployment} from '@camunda8/sdk/dist/c8/lib/C8Dto';
-import { validateResponse } from 'json-body-assertions';
+import {validateResponse} from 'json-body-assertions';
 
 /* eslint-disable playwright/expect-expect */
 test.describe.parallel('Search Decision Definitions API Tests', () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-instance/decision-instances-get-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-instance/decision-instances-get-api.spec.ts
@@ -22,9 +22,7 @@ import {
   DecisionInstance,
 } from '@requestHelpers';
 import {validateResponse} from '../../../../json-body-assertions';
-import {
-  decisionInstanceRequiredFields,
-} from 'utils/beans/requestBeans';
+import {decisionInstanceRequiredFields} from 'utils/beans/requestBeans';
 
 test.describe.parallel('Get Decision Instances API Tests', () => {
   let decisionInstances: DecisionInstance[] = [];

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-get-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-get-api.spec.ts
@@ -23,6 +23,7 @@ import {EXPECTED_ELEMENT_INSTANCE_GET_SUCCESS} from '../../../../utils/beans/ele
 
 test.describe.parallel('Get Element Instance API', () => {
   const state: Record<string, string> = {};
+
   test.beforeAll(async () => {
     await deploy(['./resources/element_instance_get_update_tests.bpmn']);
     await createInstances('element_instance_get_update_tests', 1, 1).then(

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-search-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-search-api.spec.ts
@@ -212,7 +212,7 @@ test.describe('Element Instance Search API', () => {
           status: '200',
         },
         res,
-      );  
+      );
       const body = await res.json();
       expect(body.page.totalItems).toBeGreaterThanOrEqual(expectedTotal);
       expect(body.items.length).toBeGreaterThanOrEqual(expectedTotal);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-search-incident-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-search-incident-api.spec.ts
@@ -41,9 +41,7 @@ test.describe('Element Instance Incident Search API', () => {
 
   test.beforeAll(async ({request}) => {
     await test.step('Deploy processes and create instance', async () => {
-      const deployment1 = await deploy([
-        './resources/calledErrorProcess.bpmn',
-      ]);
+      const deployment1 = await deploy(['./resources/calledErrorProcess.bpmn']);
       state['processDefinitionKeyCalled'] =
         deployment1.processes[0].processDefinitionKey;
       await deploy(['./resources/callErrorProcess.bpmn']);
@@ -314,7 +312,11 @@ test.describe('Element Instance Incident Search API', () => {
           },
         },
       );
-      await assertInvalidArgument(res, 400, `The provided processInstanceKey 'notANumber' is not a valid key. Expected a numeric value. Did you pass an entity id instead of an entity key?.`);
+      await assertInvalidArgument(
+        res,
+        400,
+        `The provided processInstanceKey 'notANumber' is not a valid key. Expected a numeric value. Did you pass an entity id instead of an entity key?.`,
+      );
     }).toPass(defaultAssertionOptions);
   });
 
@@ -394,6 +396,7 @@ test.describe('Element Instance Incident Search API', () => {
       email: string;
       password: string;
     };
+
     await test.step('Setup - Create user for authorization tests', async () => {
       userWithResourcesAuthorizationToSendRequest = await createUser(request);
       await grantUserResourceAuthorization(

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-users-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/group/group-users-api-tests.spec.ts
@@ -24,9 +24,7 @@ import {
   createUser,
   userFromState,
 } from '@requestHelpers';
-import {
-  defaultAssertionOptions,
-} from '../../../../utils/constants';
+import {defaultAssertionOptions} from '../../../../utils/constants';
 import {cleanupGroups} from '../../../../utils/groupsCleanup';
 import {cleanupUsers} from '../../../../utils/usersCleanup';
 
@@ -237,7 +235,7 @@ test.describe.parallel('Group Users API Tests', () => {
       username: userFromState('groupId2', state) as string,
     };
     const res = await request.delete(
-      buildUrl(`/groups/${p.groupId}/users/${p.username}`,),
+      buildUrl(`/groups/${p.groupId}/users/${p.username}`),
       {
         headers: jsonHeaders(),
       },

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/incident/get-process-instance-statistics-by-definition-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/incident/get-process-instance-statistics-by-definition-api-tests.spec.ts
@@ -7,10 +7,7 @@
  */
 
 import {expect, test} from '@playwright/test';
-import {
-  cancelProcessInstance,
-  deploy,
-} from '../../../../utils/zeebeClient';
+import {cancelProcessInstance, deploy} from '../../../../utils/zeebeClient';
 import {
   assertBadRequest,
   assertStatusCode,
@@ -29,7 +26,8 @@ import {
 } from '@requestHelpers';
 import {cleanupUsers} from 'utils/usersCleanup';
 
-test.describe.parallel('Get Process Instance Statistics By Definition API Tests', () => {
+test.describe
+  .parallel('Get Process Instance Statistics By Definition API Tests', () => {
   let userWithResourcesAuthorizationToSendRequest: {
     username: string;
     name: string;
@@ -87,11 +85,18 @@ test.describe.parallel('Get Process Instance Statistics By Definition API Tests'
       await test.step('Start a process instance that will have an incident', async () => {
         const firstLocalState: Record<string, unknown> = {};
         await createTwoDifferentIncidentsInOneProcess(firstLocalState, request);
-        processInstanceKeys.push(firstLocalState['processInstanceKey'] as string);
+        processInstanceKeys.push(
+          firstLocalState['processInstanceKey'] as string,
+        );
 
         const secondLocalState: Record<string, unknown> = {};
-        await createTwoDifferentIncidentsInOneProcess(secondLocalState, request);
-        processInstanceKeys.push(secondLocalState['processInstanceKey'] as string);
+        await createTwoDifferentIncidentsInOneProcess(
+          secondLocalState,
+          request,
+        );
+        processInstanceKeys.push(
+          secondLocalState['processInstanceKey'] as string,
+        );
       });
 
       const processInstanceKeyToSearch =

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/incident/get-process-instance-statistics-by-error-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/incident/get-process-instance-statistics-by-error-api-tests.spec.ts
@@ -31,7 +31,8 @@ import {
 } from '@requestHelpers';
 import {cleanupUsers} from 'utils/usersCleanup';
 
-test.describe.parallel('Get Process Instance Statistics By Error API Tests', () => {
+test.describe
+  .parallel('Get Process Instance Statistics By Error API Tests', () => {
   let userWithResourcesAuthorizationToSendRequest: {
     username: string;
     name: string;
@@ -127,9 +128,9 @@ test.describe.parallel('Get Process Instance Statistics By Error API Tests', () 
           (item: {errorMessage: string}) => item.errorMessage === errorMessage,
         );
         expect(matchingItem).toBeDefined();
-        expect(matchingItem.activeInstancesWithErrorCount).toBeGreaterThanOrEqual(
-          1,
-        );
+        expect(
+          matchingItem.activeInstancesWithErrorCount,
+        ).toBeGreaterThanOrEqual(1);
       }).toPass(defaultAssertionOptions);
     });
   });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-api-tests.spec.ts
@@ -22,11 +22,12 @@ import {
   jsonHeaders,
   paginatedResponseFields,
 } from '../../../../utils/http';
-import {validateResponse, validateResponseShape} from '../../../../json-body-assertions';
-import {defaultAssertionOptions} from '../../../../utils/constants';
 import {
-  jobResponseFields,
-} from '../../../../utils/beans/requestBeans';
+  validateResponse,
+  validateResponseShape,
+} from '../../../../json-body-assertions';
+import {defaultAssertionOptions} from '../../../../utils/constants';
+import {jobResponseFields} from '../../../../utils/beans/requestBeans';
 
 test.describe.parallel('Job API Tests', () => {
   const state: Record<string, unknown> = {};

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-completion-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-completion-api-tests.spec.ts
@@ -96,6 +96,7 @@ test.describe('Job Completion API Tests', () => {
 
   test('Complete Job - conflict 409', async ({request}) => {
     const localState: Record<string, unknown> = {};
+
     await test.step('Activate a job to obtain a valid job key', async () => {
       localState['jobKey'] = await activateJobToObtainAValidJobKey(
         request,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-error-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-error-api-tests.spec.ts
@@ -25,8 +25,11 @@ test.describe('Job Error API Tests', () => {
     'job_api_process',
     'jobApiProcess',
   );
+
   test.beforeAll(beforeAll);
+
   test.beforeEach(beforeEach);
+
   test.afterEach(afterEach);
 
   test('Throw Error for Job - success', async ({request}) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-failure-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-failure-api-tests.spec.ts
@@ -25,8 +25,11 @@ test.describe('Job Fail API Tests', () => {
     'job_api_process',
     'jobApiProcess',
   );
+
   test.beforeAll(beforeAll);
+
   test.beforeEach(beforeEach);
+
   test.afterEach(afterEach);
 
   test('Fail Job - success', async ({request}) => {
@@ -78,6 +81,7 @@ test.describe('Job Fail API Tests', () => {
 
   test('Fail Job - 409', async ({request}) => {
     const localState: Record<string, unknown> = {};
+
     await test.step('First activate a job', async () => {
       localState['jobKey'] = await activateJobToObtainAValidJobKey(
         request,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-statistics-by-type-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-statistics-by-type-api-tests.spec.ts
@@ -23,7 +23,7 @@ import {
   StatisticsJobItem,
 } from '@requestHelpers';
 import {cleanupUsers} from 'utils/usersCleanup';
-import { defaultAssertionOptions } from 'utils/constants';
+import {defaultAssertionOptions} from 'utils/constants';
 
 test.describe.parallel('Job Statistics By Type API Tests', () => {
   let userWithResourcesAuthorizationToSendRequest: {
@@ -124,10 +124,14 @@ test.describe.parallel('Job Statistics By Type API Tests', () => {
       const extendedResponseBody = await extendedSearchRes.json();
       const extendedItem = extendedResponseBody.items[0];
       if (!extendedItem || !extendedItem.jobType) {
-        test.info().annotations.push({ type: 'blocked', description: 'No job statistics data available to verify the response with jobType filter' });
+        test.info().annotations.push({
+          type: 'blocked',
+          description:
+            'No job statistics data available to verify the response with jobType filter',
+        });
         return;
       }
-      
+
       expect(extendedItem).toBeDefined();
       expect(extendedItem.jobType).toBe(jobType);
       expect(extendedItem.created.count).toBe(item.created.count);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-statistics-error-metrics-job-type-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-statistics-error-metrics-job-type-api-tests.spec.ts
@@ -91,7 +91,11 @@ test.describe.parallel('Get error metrics for a job type API Tests', () => {
       }
 
       if (failedItems.length === 0) {
-        test.info().annotations.push({ type: 'blocked', description: 'No failed jobs in the last 24 hours to verify the response with jobType filter' });
+        test.info().annotations.push({
+          type: 'blocked',
+          description:
+            'No failed jobs in the last 24 hours to verify the response with jobType filter',
+        });
         return;
       }
     });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-statistics-time-series-job-type-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-statistics-time-series-job-type-api-tests.spec.ts
@@ -97,7 +97,11 @@ test.describe
       }
 
       if (jobType === 'uninitialized') {
-        test.info().annotations.push({ type: 'blocked', description: 'No job statistics data available to verify the response with jobType filter' });
+        test.info().annotations.push({
+          type: 'blocked',
+          description:
+            'No job statistics data available to verify the response with jobType filter',
+        });
         return;
       }
     });
@@ -231,9 +235,13 @@ test.describe
           break;
         }
       }
-      
+
       if (jobType === 'uninitialized') {
-        test.info().annotations.push({ type: 'blocked', description: 'No job statistics data available to verify the response with jobType filter' });
+        test.info().annotations.push({
+          type: 'blocked',
+          description:
+            'No job statistics data available to verify the response with jobType filter',
+        });
         return;
       }
     });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-update-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-update-api-tests.spec.ts
@@ -26,8 +26,11 @@ test.describe('Job Update API Tests', () => {
     'job_api_process',
     'jobApiProcess',
   );
+
   test.beforeAll(beforeAll);
+
   test.beforeEach(beforeEach);
+
   test.afterEach(afterEach);
 
   test('Update Job - success', async ({request}) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/mapping-rule-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/mapping-rule-api-tests.spec.ts
@@ -469,7 +469,7 @@ test.describe.parallel('Mapping Rules API Tests', () => {
           data: updateBody,
         },
       );
-      
+
       await assertStatusCode(res, 200);
       await validateResponse(
         {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message/search-correlated-message-subscriptions-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message/search-correlated-message-subscriptions-api-tests.spec.ts
@@ -247,6 +247,7 @@ test.describe.serial('Correlated Message Subscriptions API Tests', () => {
     request,
   }) => {
     const processInstanceKeyToSearch = state.processInstance4;
+
     await test.step('Search by process instance key and tenant id', async () => {
       await expect(async () => {
         const res = await request.post(
@@ -355,8 +356,12 @@ test.describe.serial('Correlated Message Subscriptions API Tests', () => {
         },
       },
     );
-    await assertInvalidArgument(res, 400, `The provided processInstanceKey \'${invalidFieldValue}\' is not a valid key. Expected a numeric value. Did you pass an entity id instead of an entity key?.`)
-      });
+    await assertInvalidArgument(
+      res,
+      400,
+      `The provided processInstanceKey \'${invalidFieldValue}\' is not a valid key. Expected a numeric value. Did you pass an entity id instead of an entity key?.`,
+    );
+  });
 
   test('Search Message Subscriptions - 401 Unauthorized', async ({request}) => {
     const res = await request.post(
@@ -387,6 +392,7 @@ test.describe.serial('Correlated Message Subscriptions API Tests', () => {
       email: string;
       password: string;
     };
+
     await test.step('Setup - Create user for authorization tests', async () => {
       userWithResourcesAuthorizationToSendRequest = await createUser(request);
       await grantUserResourceAuthorization(
@@ -419,13 +425,13 @@ test.describe.serial('Correlated Message Subscriptions API Tests', () => {
         );
         await assertStatusCode(res, 200);
         await validateResponse(
-        {
-          path: CORRELATED_MESSAGE_SUBSCRIPTION_SEARCH_ENDPOINT,
-          method: 'POST',
-          status: '200',
-        },
-        res,
-      );
+          {
+            path: CORRELATED_MESSAGE_SUBSCRIPTION_SEARCH_ENDPOINT,
+            method: 'POST',
+            status: '200',
+          },
+          res,
+        );
         const json = await res.json();
         expect(json.page.totalItems).toBe(0);
       }).toPass(defaultAssertionOptions);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-get-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-get-api.spec.ts
@@ -22,6 +22,7 @@ import {defaultAssertionOptions} from '../../../../utils/constants';
 /* eslint-disable playwright/expect-expect */
 test.describe.parallel('Process Definition Get API', () => {
   const state: Record<string, unknown> = {};
+
   test.beforeAll(async () => {
     await deploy(['./resources/process_definition_api_tests.bpmn']);
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-get-start-form-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-get-start-form-api.spec.ts
@@ -16,13 +16,17 @@ import {
   buildUrl,
   jsonHeaders,
 } from '../../../../utils/http';
-import {validateResponseShape, validateResponse} from '../../../../json-body-assertions';
+import {
+  validateResponseShape,
+  validateResponse,
+} from '../../../../json-body-assertions';
 import {defaultAssertionOptions} from '../../../../utils/constants';
 import {readFileSync} from 'node:fs';
 
 /* eslint-disable playwright/expect-expect */
 test.describe.parallel('Process Definition Get Start Form API', () => {
   const state: Record<string, unknown> = {};
+
   test.beforeAll(async () => {
     const formPath = './resources/sign_up_form.form';
     const deployment = await deploy([

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-get-statistics-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-get-statistics-api-tests.spec.ts
@@ -20,6 +20,7 @@ import {defaultAssertionOptions} from '../../../../utils/constants';
 
 test.describe.parallel('Process Definition Get Statistics API', () => {
   const state: Record<string, string> = {};
+
   test.beforeAll(async () => {
     await deploy(['./resources/process_definition_api_tests.bpmn']);
     await createInstances('process_definition_api_tests', 1, 1).then(
@@ -182,13 +183,13 @@ test.describe.parallel('Process Definition Get Statistics API', () => {
       await assertStatusCode(res, 200);
       const body = await res.json();
       validateResponseShape(
-      {
-        path: '/process-definitions/{processDefinitionKey}/statistics/element-instances',
-        method: 'POST',
-        status: '200',
-      },
-      body,
-    );
+        {
+          path: '/process-definitions/{processDefinitionKey}/statistics/element-instances',
+          method: 'POST',
+          status: '200',
+        },
+        body,
+      );
       expect(body.items.length).toBe(2);
       const elementIds = body.items.map(
         (item: Record<string, number>) => item.elementId,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-get-xml-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-get-xml-api.spec.ts
@@ -23,6 +23,7 @@ import {defaultAssertionOptions} from '../../../../utils/constants';
 /* eslint-disable playwright/expect-expect */
 test.describe.parallel('Process Definition Get XML API', () => {
   const state: Record<string, unknown> = {};
+
   test.beforeAll(async () => {
     const deployment = await deploy([
       './resources/process_definition_api_tests.bpmn',

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-search-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/process-definition-search-api-tests.spec.ts
@@ -21,6 +21,7 @@ import {defaultAssertionOptions} from '../../../../utils/constants';
 /* eslint-disable playwright/expect-expect */
 test.describe.parallel('Process Definition Search API', () => {
   const state: Record<string, unknown> = {};
+
   test.beforeAll(async () => {
     await deploy([
       './resources/process_definition_tests_1.bpmn',

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-api.spec.ts
@@ -13,6 +13,7 @@ import {validateResponseShape} from '../../../../json-body-assertions';
 import {getProcessDefinitionKey} from '@requestHelpers';
 
 const PROCESS_INSTANCE_ENDPOINT = '/process-instances';
+
 test.describe.parallel('Process instance Tests', () => {
   test.beforeAll(async () => {
     await deploy(['./resources/process_with_task_listener.bpmn']);
@@ -98,6 +99,7 @@ test.describe.parallel('Process instance Tests', () => {
     request,
   }) => {
     const localState: Record<string, unknown> = {};
+
     await test.step('Create Process Instance by Process Definition Id to get the Key', async () => {
       const res = await request.post(buildUrl(PROCESS_INSTANCE_ENDPOINT), {
         headers: jsonHeaders(),
@@ -155,6 +157,7 @@ test.describe.parallel('Process instance Tests', () => {
   }) => {
     await deploy(['./resources/process_instance_api_test.bpmn']);
     const localState: Record<string, unknown> = {};
+
     await test.step('Create Process Instance by Process Definition Id to get the Key', async () => {
       const res = await request.post(buildUrl('/process-instances'), {
         headers: jsonHeaders(),
@@ -203,6 +206,7 @@ test.describe.parallel('Process instance Tests', () => {
     request,
   }) => {
     const localState: Record<string, unknown> = {};
+
     await test.step('Create Process Instance by Process Definition Id to get the Key', async () => {
       localState['processDefinitionKey'] = await getProcessDefinitionKey(
         request,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-cancel-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-cancel-api.spec.ts
@@ -21,6 +21,7 @@ import {validateResponse} from '../../../../json-body-assertions';
 test.describe.parallel('Cancel Process instance Tests', () => {
   test('Cancel Process Instance - Success', async ({request}) => {
     const localState: Record<string, unknown> = {};
+
     await test.step('First, create a process instance', async () => {
       const res = await request.post(buildUrl('/process-instances'), {
         headers: jsonHeaders(),
@@ -103,6 +104,7 @@ test.describe.parallel('Cancel Process instance Tests', () => {
 
   test('Double Cancel Process Instance - Not Found', async ({request}) => {
     const localState: Record<string, unknown> = {};
+
     await test.step('First create a process instance', async () => {
       const res = await request.post(buildUrl('/process-instances'), {
         headers: jsonHeaders(),

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-create-batch-to-cancel-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-create-batch-to-cancel-api.spec.ts
@@ -15,7 +15,10 @@ import {
   jsonHeaders,
 } from '../../../../utils/http';
 import {createInstances, deploy} from '../../../../utils/zeebeClient';
-import {validateResponse, validateResponseShape} from '../../../../json-body-assertions';
+import {
+  validateResponse,
+  validateResponseShape,
+} from '../../../../json-body-assertions';
 import {defaultAssertionOptions} from '../../../../utils/constants';
 
 /* eslint-disable playwright/expect-expect */
@@ -42,6 +45,7 @@ test.describe.parallel('Create Process Instance Batch to Cancel Tests', () => {
     request,
   }) => {
     const localState: Record<string, string[]> = {processInstanceKeys: []};
+
     await test.step('Create multiple process instances to cancel', async () => {
       const processInstances = await createInstances(
         'process_with_task_listener',

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-create-batch-to-delete-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-create-batch-to-delete-api.spec.ts
@@ -249,6 +249,7 @@ test.describe.parallel('Delete Batch Process Instance API Tests', () => {
   }) => {
     const processInstanceKeyToDelete = activeProcessInstanceKeysToDelete[0];
     let batchOperationKey = '';
+
     await test.step('Verify Process Instance Key to Delete has state ACTIVE', async () => {
       await expect(async () => {
         const response = await request.get(
@@ -329,11 +330,14 @@ test.describe.parallel('Delete Batch Process Instance API Tests', () => {
           },
         );
         await assertStatusCode(response, 200);
-        await validateResponse({
-          path: '/process-instances/{processInstanceKey}',
-          method: 'GET',
-          status: '200',
-        }, response);
+        await validateResponse(
+          {
+            path: '/process-instances/{processInstanceKey}',
+            method: 'GET',
+            status: '200',
+          },
+          response,
+        );
         const responseBody = await response.json();
         expect(responseBody.state).toBe('ACTIVE');
       }).toPass(defaultAssertionOptions);
@@ -345,6 +349,7 @@ test.describe.parallel('Delete Batch Process Instance API Tests', () => {
   }) => {
     const processInstancesToDelete = activeProcessInstanceKeysToDelete.slice(1);
     let batchOperationKey = '';
+
     await test.step('Verify Process Instance Key to Delete has state ACTIVE', async () => {
       for (const processInstanceKey of processInstancesToDelete) {
         await expect(async () => {
@@ -428,14 +433,17 @@ test.describe.parallel('Delete Batch Process Instance API Tests', () => {
             },
           );
           await assertStatusCode(response, 200);
-          await validateResponse({
-            path: '/process-instances/{processInstanceKey}',
-            method: 'GET',
-            status: '200',
-          }, response);
+          await validateResponse(
+            {
+              path: '/process-instances/{processInstanceKey}',
+              method: 'GET',
+              status: '200',
+            },
+            response,
+          );
           const responseBody = await response.json();
           expect(responseBody.state).toBe('ACTIVE');
-      }).toPass(defaultAssertionOptions);
+        }).toPass(defaultAssertionOptions);
       }
     });
   });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-create-batch-to-migrate-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-create-batch-to-migrate-api.spec.ts
@@ -23,11 +23,12 @@ import {defaultAssertionOptions} from '../../../../utils/constants';
 import {APIRequestContext} from 'playwright-core';
 import {JSONDoc} from '@camunda8/sdk/dist/zeebe/types.js';
 import {expectBatchState, findUserTask} from '@requestHelpers';
-import { validateResponse } from 'json-body-assertions';
+import {validateResponse} from 'json-body-assertions';
 
 /* eslint-disable playwright/expect-expect */
 test.describe.serial('Create Process Instance Batch to Migrate Tests', () => {
   const instanceKeys: string[] = [];
+
   test.beforeAll(async () => {
     await deploy([
       './resources/test_migration_process_v1.bpmn',
@@ -367,6 +368,7 @@ test.describe.serial('Create Process Instance Batch to Migrate Tests', () => {
       processInstanceKey2: '',
       targetProcessDefinitionKey: '',
     };
+
     await test.step('Create two process instances of version 1', async () => {
       const instances1 = await createInstances(
         'test_migration_process',
@@ -406,6 +408,7 @@ test.describe.serial('Create Process Instance Batch to Migrate Tests', () => {
       localState.targetProcessDefinitionKey = instances[0].processDefinitionKey;
       instanceKeys.push(instances[0].processInstanceKey);
     });
+
     return localState;
   };
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-create-batch-to-modify-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-create-batch-to-modify-api.spec.ts
@@ -21,7 +21,7 @@ import {
 } from '../../../../utils/http';
 import {defaultAssertionOptions} from '../../../../utils/constants';
 import {findUserTask} from '@requestHelpers';
-import { validateResponse } from 'json-body-assertions';
+import {validateResponse} from 'json-body-assertions';
 
 /* eslint-disable playwright/expect-expect */
 test.describe.parallel('Create Process Instance Batch to Modify Tests', () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-create-batch-to-resolve-incidents-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-create-batch-to-resolve-incidents-api.spec.ts
@@ -235,6 +235,7 @@ test.describe
         expect(json.batchOperationType).toBe('RESOLVE_INCIDENT');
       }).toPass(defaultAssertionOptions);
     });
+
     await test.step('Verify that the process instances have no incidents', async () => {
       await verifyIncidentsForProcessInstance(
         request,
@@ -333,6 +334,7 @@ test.describe
         expect(json.batchOperationType).toBe('RESOLVE_INCIDENT');
       }).toPass(defaultAssertionOptions);
     });
+
     await test.step('Verify that the process instances have no incidents', async () => {
       await verifyIncidentsForProcessInstance(
         request,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-delete-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-delete-api.spec.ts
@@ -24,7 +24,11 @@ import {
 } from '../../../../utils/http';
 import {defaultAssertionOptions} from '../../../../utils/constants';
 import {validateResponse} from '../../../../json-body-assertions';
-import {createUser, expectProcessInstanceCanBeFound, grantUserResourceAuthorization} from '@requestHelpers';
+import {
+  createUser,
+  expectProcessInstanceCanBeFound,
+  grantUserResourceAuthorization,
+} from '@requestHelpers';
 import {cleanupUsers} from 'utils/usersCleanup';
 
 test.describe.parallel('Delete Single Process Instance API Tests', () => {
@@ -58,7 +62,10 @@ test.describe.parallel('Delete Single Process Instance API Tests', () => {
       activeProcessInstanceKeyToDelete =
         createdIncidentInstance.processInstanceKey;
 
-      await expectProcessInstanceCanBeFound(request, processInstanceKeyToDelete);
+      await expectProcessInstanceCanBeFound(
+        request,
+        processInstanceKeyToDelete,
+      );
       await expectProcessInstanceCanBeFound(
         request,
         activeProcessInstanceKeyToDelete,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-get-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-get-api.spec.ts
@@ -27,6 +27,7 @@ test.describe.parallel('Get Process instance Tests', () => {
 
   test('Get Process Instance - Success', async ({request}) => {
     const localState: Record<string, unknown> = {};
+
     await test.step('First, create a process instance', async () => {
       const res = await request.post(buildUrl('/process-instances'), {
         headers: jsonHeaders(),
@@ -110,6 +111,7 @@ test.describe.parallel('Get Process instance Tests', () => {
 
   test('Get Process Instance - Unauthorized', async ({request}) => {
     const localState: Record<string, unknown> = {};
+
     await test.step('Create Process Instance', async () => {
       const res = await request.post(buildUrl('/process-instances'), {
         headers: jsonHeaders(),

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-get-call-hierachy-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-get-call-hierachy-api.spec.ts
@@ -27,6 +27,7 @@ test.describe.parallel('Get Process Instance Call Hierarchy Tests', () => {
 
   test('Get Process Instance Call Hierarchy - Success', async ({request}) => {
     const localState: Record<string, unknown> = {};
+
     await test.step('First, create a process instance', async () => {
       const res = await request.post(buildUrl('/process-instances'), {
         headers: jsonHeaders(),

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-get-sequenceflows-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-get-sequenceflows-api.spec.ts
@@ -26,6 +26,7 @@ test.describe.parallel('Get Process instance Sequence Flows Tests', () => {
 
   test('Get Process Instance Sequence Flows - Success', async ({request}) => {
     const localState: Record<string, unknown> = {};
+
     await test.step('First, create a process instance for the sequence flow', async () => {
       const res = await request.post(buildUrl('/process-instances'), {
         headers: jsonHeaders(),

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-get-statistics-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-get-statistics-api.spec.ts
@@ -26,6 +26,7 @@ test.describe.parallel('Get Process Instance Statistics Tests', () => {
 
   test('Get Process Instance Statistics - Success', async ({request}) => {
     const localState: Record<string, unknown> = {};
+
     await test.step('First, create a process instance to get the statistics for', async () => {
       const res = await request.post(buildUrl('/process-instances'), {
         headers: jsonHeaders(),
@@ -72,10 +73,10 @@ test.describe.parallel('Get Process Instance Statistics Tests', () => {
         expect(json.items).toHaveLength(2);
 
         const userTask = json.items.find(
-            (item: any) => item.elementId === 'Activity_1xci2nh',
+          (item: any) => item.elementId === 'Activity_1xci2nh',
         );
         const startEvent = json.items.find(
-            (item: any) => item.elementId === 'StartEvent_1',
+          (item: any) => item.elementId === 'StartEvent_1',
         );
 
         expect(userTask).toBeDefined();

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-migrate-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-migrate-api.spec.ts
@@ -48,6 +48,7 @@ test.describe.serial('Test process instance migrate API', () => {
       processInstanceKey: '',
       processDefinitionKey: '',
     };
+
     await test.step('Create process instance of version 1', async () => {
       await createInstances('test_migration_process', 1, 1).then((instance) => {
         localState.processInstanceKey = instance[0].processInstanceKey;
@@ -118,6 +119,7 @@ test.describe.serial('Test process instance migrate API', () => {
       processInstanceKey: '',
       processDefinitionKey: '',
     };
+
     await test.step('Create process-instance of version 1', async () => {
       await createInstances('test_migration_process', 1, 1).then((instance) => {
         localState.processInstanceKey = instance[0].processInstanceKey;

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-modify-process-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-modify-process-api.spec.ts
@@ -30,6 +30,7 @@ test.describe.parallel('Process Instance Modify Process API', () => {
 
   test('Modify process instance - success', async ({request}) => {
     const localStorage: Record<string, unknown> = {};
+
     await test.step('Create process instance', async () => {
       const res = await request.post(buildUrl('/process-instances'), {
         headers: jsonHeaders(),
@@ -101,6 +102,7 @@ test.describe.parallel('Process Instance Modify Process API', () => {
       );
       await assertStatusCode(res, 204);
     });
+
     await test.step('Verify second task is active and first task canceled', async () => {
       await expect(async () => {
         const res = await request.post(buildUrl('/user-tasks/search'), {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-search-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-search-api.spec.ts
@@ -29,6 +29,7 @@ test.describe.parallel('Get Process instance Tests', () => {
 
   test('Search Process Instances - Success', async ({request}) => {
     const localState: Record<string, unknown> = {};
+
     await test.step('Create a process instance to search for', async () => {
       const res = await request.post(buildUrl('/process-instances'), {
         headers: jsonHeaders(),
@@ -49,6 +50,7 @@ test.describe.parallel('Get Process instance Tests', () => {
       const json = await res.json();
       localState.processInstanceKey = json.processInstanceKey;
     });
+
     await test.step('Search Process Instances', async () => {
       await expect(async () => {
         const res = await request.post(buildUrl('/process-instances/search'), {
@@ -68,11 +70,13 @@ test.describe.parallel('Get Process instance Tests', () => {
         expect(json.page.totalItems).toBeGreaterThan(1);
       }).toPass(defaultAssertionOptions);
     });
+
     await cancelProcessInstance(localState.processInstanceKey as string);
   });
 
   test('Search Process Instance With Filter - Success', async ({request}) => {
     const localState: Record<string, unknown> = {};
+
     await test.step('Create a process instance to filter for', async () => {
       const res = await request.post(buildUrl('/process-instances'), {
         headers: jsonHeaders(),
@@ -124,6 +128,7 @@ test.describe.parallel('Get Process instance Tests', () => {
         );
       }).toPass(defaultAssertionOptions);
     });
+
     await cancelProcessInstance(localState.processInstanceKey as string);
   });
 
@@ -131,6 +136,7 @@ test.describe.parallel('Get Process instance Tests', () => {
     request,
   }) => {
     const localState: Record<string, unknown> = {};
+
     await test.step('Create two process instances to filter for', async () => {
       const res = await request.post(buildUrl('/process-instances'), {
         headers: jsonHeaders(),
@@ -199,13 +205,13 @@ test.describe.parallel('Get Process instance Tests', () => {
         });
         await assertStatusCode(res, 200);
         await validateResponse(
-        {
-          path: '/process-instances/search',
-          method: 'POST',
-          status: '200',
-        },
-        res,
-      );
+          {
+            path: '/process-instances/search',
+            method: 'POST',
+            status: '200',
+          },
+          res,
+        );
         const json = await res.json();
         expect(json.page.totalItems).toBe(2);
         expect(json.items.length).toBe(2);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-search-incidents-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-search-incidents-api.spec.ts
@@ -36,6 +36,7 @@ test.describe.parallel('Process Instance Search Incidents Tests', () => {
     request,
   }) => {
     const localState: Record<string, unknown> = {};
+
     await test.step('Create process instances that will generate incidents', async () => {
       const processInstances = await createInstances(
         'processWithThreeParallelTasks',
@@ -88,6 +89,7 @@ test.describe.parallel('Process Instance Search Incidents Tests', () => {
         })
         .toPass(defaultAssertionOptions);
     });
+
     await cancelProcessInstance(localState['processInstanceKey'] as string);
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-get-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-get-api.spec.ts
@@ -15,7 +15,10 @@ import {
   assertNotFoundRequest,
 } from '../../../../utils/http';
 import {JSONDoc} from '@camunda8/sdk/dist/zeebe/types.js';
-import {validateResponse, validateResponseShape} from '../../../../json-body-assertions';
+import {
+  validateResponse,
+  validateResponseShape,
+} from '../../../../json-body-assertions';
 import {deployResourceAndGetMetadata, ResourceMetadata} from '@requestHelpers';
 
 function validateResourceResponse(

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/role/role-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/role/role-api-tests.spec.ts
@@ -268,6 +268,7 @@ test.describe.parallel('Roles API Tests', () => {
 
   test('Delete Role', async ({request}) => {
     const p = {roleId: state['roleId3'] as string};
+
     await test.step('Delete Role 204', async () => {
       await expect(async () => {
         const res = await request.delete(buildUrl('/roles/{roleId}', p), {
@@ -335,7 +336,7 @@ test.describe.parallel('Roles API Tests', () => {
         },
         res,
       );
-      
+
       await assertPaginatedRequest(res, {
         itemLengthGreaterThan: 2,
         totalItemGreaterThan: 2,
@@ -482,13 +483,13 @@ test.describe.parallel('Roles API Tests', () => {
     });
 
     await validateResponse(
-        {
-          path: '/roles/search',
-          method: 'POST',
-          status: '200',
-        },
-        res,
-      );
+      {
+        path: '/roles/search',
+        method: 'POST',
+        status: '200',
+      },
+      res,
+    );
 
     await assertPaginatedRequest(res, {
       itemsLengthEqualTo: 0,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/role/role-groups-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/role/role-groups-api-tests.spec.ts
@@ -160,6 +160,7 @@ test.describe.parallel('Role Groups API Tests', () => {
       groupId: groupIdFromState('roleId2', state) as string,
       roleId: state['roleId2'] as string,
     };
+
     await test.step('Unassign Role From Group', async () => {
       await expect(async () => {
         const res = await request.delete(

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/role/role-mapping-rules-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/role/role-mapping-rules-api-tests.spec.ts
@@ -151,6 +151,7 @@ test.describe.parallel('Role Mapping Rules API Tests', () => {
       roleId: state['roleId3'] as string,
       mappingRuleId: mappingRuleIdFromState('roleId3', state) as string,
     };
+
     await test.step('Unassign Role From Mapping Rule', async () => {
       await expect(async () => {
         const res = await request.delete(
@@ -256,7 +257,7 @@ test.describe.parallel('Role Mapping Rules API Tests', () => {
         totalItemsEqualTo: 2,
       });
       const json = await res.json();
-      
+
       const matchingItem1 = json.items.find(
         (it: {mappingRuleId: string}) => it.mappingRuleId === mappingRule1,
       );

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/tenant/tenant-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/tenant/tenant-api-tests.spec.ts
@@ -261,6 +261,7 @@ test.describe.parallel('Tenants API Tests', () => {
 
   test('Delete tenant', async ({request}) => {
     const p = {tenantId: state['tenantId3'] as string};
+
     await test.step('Delete tenant 204', async () => {
       await expect(async () => {
         const res = await request.delete(buildUrl('/tenants/{tenantId}', p), {
@@ -467,13 +468,13 @@ test.describe.parallel('Tenants API Tests', () => {
     });
 
     await validateResponse(
-        {
-          path: '/tenants/search',
-          method: 'POST',
-          status: '200',
-        },
-        res,
-      );
+      {
+        path: '/tenants/search',
+        method: 'POST',
+        status: '200',
+      },
+      res,
+    );
 
     await assertPaginatedRequest(res, {
       itemsLengthEqualTo: 0,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/tenant/tenant-groups-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/tenant/tenant-groups-api-tests.spec.ts
@@ -139,6 +139,7 @@ test.describe.parallel('Tenant Groups API Tests', () => {
       groupId: groupIdFromState('tenantId2', state) as string,
       tenantId: state['tenantId2'] as string,
     };
+
     await test.step('Unassign Group From Tenant', async () => {
       await expect(async () => {
         const res = await request.delete(
@@ -302,7 +303,7 @@ test.describe.parallel('Tenant Groups API Tests', () => {
       buildUrl('/tenants/{tenantId}/groups/search', p),
       {headers: jsonHeaders(), data: {}},
     );
-    
+
     await assertStatusCode(res, 200);
     await validateResponse(
       {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-api-tests.spec.ts
@@ -516,6 +516,7 @@ test.describe.parallel('Users API Tests', () => {
 
   test('Delete User', async ({request}) => {
     const p = {username: state['username3'] as string};
+
     await test.step('Delete User 204', async () => {
       await expect(async () => {
         const res = await request.delete(buildUrl('/users/{username}', p), {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-assign-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-assign-api-tests.spec.ts
@@ -24,7 +24,9 @@ test.describe.parallel('Assign User Task Tests', () => {
     setupProcessInstanceForTests('user_task_api_test_process');
 
   test.beforeAll(beforeAll);
+
   test.beforeEach(beforeEach);
+
   test.afterEach(afterEach);
 
   test('Assign user task - success', async ({request}) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-complete-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-complete-api-tests.spec.ts
@@ -25,7 +25,9 @@ test.describe.parallel('Complete User Task Tests', () => {
     setupProcessInstanceForTests('user_task_api_test_process');
 
   test.beforeAll(beforeAll);
+
   test.beforeEach(beforeEach);
+
   test.afterEach(afterEach);
 
   test('Search, complete and verify completion', async ({request}) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-get-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-get-api-tests.spec.ts
@@ -21,8 +21,11 @@ import {findUserTask} from '@requestHelpers';
 test.describe.parallel('Get User Task Tests', () => {
   const {state, beforeAll, beforeEach, afterEach} =
     setupProcessInstanceForTests('user_task_api_test_process');
+
   test.beforeAll(beforeAll);
+
   test.beforeEach(beforeEach);
+
   test.afterEach(afterEach);
 
   test('Get user task - success', async ({request}) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-search-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-search-api-tests.spec.ts
@@ -23,7 +23,9 @@ test.describe.parallel('Search User Task Tests', () => {
     setupProcessInstanceForTests('process_with_multiple_user_tasks');
 
   test.beforeAll(beforeAll);
+
   test.beforeEach(beforeEach);
+
   test.afterEach(afterEach);
 
   test('Search user tasks - success', async ({request}) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-search-variables-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-search-variables-api-tests.spec.ts
@@ -28,7 +28,9 @@ test.describe.parallel('Search User Task Variables Tests', () => {
     );
 
   test.beforeAll(beforeAll);
+
   test.beforeEach(beforeEach);
+
   test.afterEach(afterEach);
 
   test('Search user task variables - success', async ({request}) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-unassign-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-unassign-api-tests.spec.ts
@@ -24,7 +24,9 @@ test.describe.parallel('Unassign User Task Tests', () => {
     setupProcessInstanceForTests('user_task_api_test_process');
 
   test.beforeAll(beforeAll);
+
   test.beforeEach(beforeEach);
+
   test.afterEach(afterEach);
 
   test('Unassign user task - success', async ({request}) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-update-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-update-api-tests.spec.ts
@@ -26,18 +26,36 @@ import {defaultAssertionOptions} from '../../../../utils/constants';
 const generateFutureDates = () => {
   const now = new Date();
   return {
-    dueDate: new Date(now.getFullYear() + 1, 11, 31, 23, 59, 59, 0).toISOString(),
-    followUpDate: new Date(now.getFullYear() + 1, 5, 15, 10, 0, 0, 0).toISOString(),
+    dueDate: new Date(
+      now.getFullYear() + 1,
+      11,
+      31,
+      23,
+      59,
+      59,
+      0,
+    ).toISOString(),
+    followUpDate: new Date(
+      now.getFullYear() + 1,
+      5,
+      15,
+      10,
+      0,
+      0,
+      0,
+    ).toISOString(),
   };
 };
-  
+
 /* eslint-disable playwright/expect-expect */
 test.describe.parallel('Update User Task Tests', () => {
   const {state, beforeAll, beforeEach, afterEach} =
     setupProcessInstanceForTests('user_task_update_api_process');
 
   test.beforeAll(beforeAll);
+
   test.beforeEach(beforeEach);
+
   test.afterEach(afterEach);
 
   test('Update user task - success - update all fields', async ({request}) => {
@@ -197,7 +215,9 @@ test.describe.parallel('Update User Task Tests', () => {
     await assertStatusCode(res, 204);
   });
 
-  test('Update user task - bad request - empty changeset', async ({request}) => {
+  test('Update user task - bad request - empty changeset', async ({
+    request,
+  }) => {
     const userTaskKey = await findUserTask(
       request,
       state['processInstanceKey'] as string,
@@ -212,9 +232,7 @@ test.describe.parallel('Update User Task Tests', () => {
     await assertInvalidArgument(res, 400, 'changeset');
   });
 
-  test('Update user task - success - with custom action', async ({
-    request,
-  }) => {
+  test('Update user task - success - with custom action', async ({request}) => {
     const userTaskKey = await findUserTask(
       request,
       state['processInstanceKey'] as string,
@@ -367,25 +385,22 @@ test.describe.parallel('Update User Task Tests', () => {
       await completeUserTask(request, userTaskKey);
     });
 
-    await test.step(
-      'Attempt to update the completed user task',
-      async () => {
-        await expect(async () => {
-          const updateRes = await request.patch(
-            buildUrl(`/user-tasks/${userTaskKey}`),
-            {
-              headers: jsonHeaders(),
-              data: {
-                changeset: {
-                  priority: 50,
-                },
+    await test.step('Attempt to update the completed user task', async () => {
+      await expect(async () => {
+        const updateRes = await request.patch(
+          buildUrl(`/user-tasks/${userTaskKey}`),
+          {
+            headers: jsonHeaders(),
+            data: {
+              changeset: {
+                priority: 50,
               },
             },
-          );
-          await assertInvalidState(updateRes);
-        }).toPass(defaultAssertionOptions);
-      },
-    );
+          },
+        );
+        await assertInvalidState(updateRes);
+      }).toPass(defaultAssertionOptions);
+    });
 
     state['processCompleted'] = true;
   });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/variable/variable-get-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/variable/variable-get-api.spec.ts
@@ -91,6 +91,7 @@ test.describe.parallel('Get Variable API Tests', () => {
     const localState: Record<string, unknown> = {};
 
     await setupVariableTest(localState, request);
+
     await test.step('Get Variable without auth', async () => {
       const res = await request.get(
         buildUrl(`/variables/${localState['variableKey']}`),

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceHistory.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceHistory.spec.ts
@@ -250,6 +250,7 @@ test.describe('Process Instance History', () => {
 
     const mainProcessName = 'EmbeddedSubprocess';
     let expandingElementsInMainProcess;
+
     await test.step('Verify Main process has no nested element', async () => {
       expandingElementsInMainProcess =
         await operateProcessInstancePage.checkIfPresentExpandeingElementsInMainProcess(

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
@@ -134,6 +134,7 @@ test.describe('Process Instances Filters', () => {
         'Always fails',
       );
     });
+
     await test.step('Select same flow node again and see filter is removed', async () => {
       await operateProcessesPage.diagram.clickFlowNode('alwaysFails');
 
@@ -629,7 +630,8 @@ test.describe('Process Instances Filters', () => {
       await expect(operateOperationsDetailsPage.state).toBeVisible();
       await waitForAssertion({
         assertion: async () => {
-          const batchOperationStatus = await operateOperationsDetailsPage.getBatchOperationStatus();
+          const batchOperationStatus =
+            await operateOperationsDetailsPage.getBatchOperationStatus();
           expect(batchOperationStatus).toBe('Completed');
         },
         onFailure: async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processes.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processes.spec.ts
@@ -77,6 +77,7 @@ test.describe('Processes', () => {
     await captureScreenshot(page, testInfo);
     await captureFailureVideo(page, testInfo);
   });
+
   const baseUrl = process.env.CORE_APPLICATION_URL || 'http://localhost:8080';
 
   test('Processes Page Initial Load', async ({

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/globalTaskListenerCleanup.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/globalTaskListenerCleanup.ts
@@ -55,8 +55,6 @@ export async function cleanupGlobalTaskListeners(
   );
 
   if (failed.length > 0) {
-    console.warn(
-      `Failed to clean up ${failed.length} global task listeners`,
-    );
+    console.warn(`Failed to clean up ${failed.length} global task listeners`);
   }
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/authorization-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/authorization-requestHelpers.ts
@@ -76,10 +76,10 @@ export async function grantUserResourceAuthorization(
     {
       path: '/authorizations',
       method: 'POST',
-      status: '201',  
+      status: '201',
     },
     authRes,
-   );
+  );
   const authBody = await authRes.json();
 
   await expect(async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/cluster-variable-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/cluster-variable-requestHelpers.ts
@@ -183,17 +183,15 @@ export async function assertClusterVariableUpdate(
     });
 
     await assertStatusCode(res, 200);
-    
+
     // Determine the correct path for validation based on scope
-    const path = expectedScope === 'GLOBAL' 
-      ? '/cluster-variables/global/{name}' as const
-      : '/cluster-variables/tenants/{tenantId}/{name}' as const;
-    
-    await validateResponse(
-      {path, method: 'PUT', status: '200'},
-      res,
-    );
-    
+    const path =
+      expectedScope === 'GLOBAL'
+        ? ('/cluster-variables/global/{name}' as const)
+        : ('/cluster-variables/tenants/{tenantId}/{name}' as const);
+
+    await validateResponse({path, method: 'PUT', status: '200'}, res);
+
     const json = await res.json();
     expect(json.name).toBe(expectedName);
     expect(json.scope).toBe(expectedScope);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/element-instance-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/element-instance-requestHelpers.ts
@@ -11,7 +11,7 @@ import {APIRequestContext} from 'playwright-core';
 import {assertStatusCode, buildUrl, jsonHeaders} from '../http';
 import {expect} from '@playwright/test';
 import {SearchElementInstancesResponse} from '@camunda8/sdk/dist/c8/lib/C8Dto';
-import { validateResponse } from 'json-body-assertions';
+import {validateResponse} from 'json-body-assertions';
 
 export async function resolveAdHocSubProcessInstanceKey(
   request: APIRequestContext,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/expression-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/expression-requestHelpers.ts
@@ -7,10 +7,7 @@
  */
 
 import {APIRequestContext} from '@playwright/test';
-import {
-  buildUrl,
-  jsonHeaders,
-} from '../http';
+import {buildUrl, jsonHeaders} from '../http';
 
 export const EXPRESSION_URL = '/expression/evaluation';
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/group-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/group-requestHelpers.ts
@@ -19,11 +19,7 @@ import {expect} from '@playwright/test';
 import {CREATE_NEW_GROUP, groupRequiredFields} from '../beans/requestBeans';
 import {Serializable} from 'playwright-core/types/structs';
 import {validateResponse} from 'json-body-assertions';
-import{
-  createMappingRule,
-  createRole,
-  createUser,
-} from '@requestHelpers';
+import {createMappingRule, createRole, createUser} from '@requestHelpers';
 
 export async function assignUsersToGroup(
   request: APIRequestContext,
@@ -141,8 +137,8 @@ export async function createGroupAndStoreResponseFields(
         path: '/groups',
         method: 'POST',
         status: '201',
-       },
-       res,
+      },
+      res,
     );
     const json = await res.json();
     assertRequiredFields(json, groupRequiredFields);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts
@@ -58,7 +58,7 @@ export {
   setupProcessInstanceForTests,
   activateJobToObtainAValidJobKey,
   getLast24HoursRange,
-  type StatisticsJobItem
+  type StatisticsJobItem,
 } from './job-requestHelpers';
 export {
   createGlobalClusterVariable,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/job-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/job-requestHelpers.ts
@@ -12,7 +12,7 @@ import {expect} from '@playwright/test';
 import {JSONDoc} from '@camunda8/sdk/dist/zeebe/types';
 import {cancelProcessInstance, createInstances, deploy} from '../zeebeClient';
 import {defaultAssertionOptions} from '../constants';
-import { validateResponse } from 'json-body-assertions';
+import {validateResponse} from 'json-body-assertions';
 
 export async function activateJobToObtainAValidJobKey(
   request: APIRequestContext,
@@ -121,19 +121,19 @@ export function getLast24HoursRange() {
   };
 }
 
-export interface StatisticsJobItem {      
-    jobType: string,
-    created: {
-        count: number,
-        lastUpdatedAt: string
-    },
-    completed: {
-        count: number,
-        lastUpdatedAt: string
-    },
-    failed: {
-        count: number,
-        lastUpdatedAt: string
-    },
-    workers: number,
-};
+export interface StatisticsJobItem {
+  jobType: string;
+  created: {
+    count: number;
+    lastUpdatedAt: string;
+  };
+  completed: {
+    count: number;
+    lastUpdatedAt: string;
+  };
+  failed: {
+    count: number;
+    lastUpdatedAt: string;
+  };
+  workers: number;
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/message-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/message-requestHelpers.ts
@@ -9,7 +9,7 @@
 import type {APIRequestContext} from 'playwright-core';
 import {expect} from '@playwright/test';
 import {assertStatusCode, buildUrl, jsonHeaders} from '../http';
-import { validateResponse } from 'json-body-assertions';
+import {validateResponse} from 'json-body-assertions';
 
 export interface CorrelatedMessageSubscription {
   correlationKey: string;

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/process-instance-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/process-instance-requestHelpers.ts
@@ -12,7 +12,7 @@ import {assertStatusCode, buildUrl, jsonHeaders} from '../http';
 import {defaultAssertionOptions} from '../constants';
 import {cancelProcessInstance} from '../zeebeClient';
 import {sleep} from '../sleep';
-import { validateResponse } from 'json-body-assertions';
+import {validateResponse} from 'json-body-assertions';
 
 export async function getProcessDefinitionKey(
   request: APIRequestContext,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/resource-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/resource-requestHelpers.ts
@@ -16,7 +16,6 @@ export function validateProcessDefinitionDeployment(
   expectedResourceName: string,
   expectedProcessDefinitionId: string,
 ): void {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const processDeployment = deployments.find(
     (d) => (d as any).processDefinition != null,
   ) as any;
@@ -38,7 +37,6 @@ export function validateFormDeployment(
   expectedResourceName: string,
   expectedFormId: string,
 ): void {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const formDeployment = deployments.find(
     (d) => (d as any).form != null,
   ) as any;
@@ -58,7 +56,6 @@ export function validateDecisionDefinitionDeployment(
   expectedDecisionDefinitionId: string,
   expectedName: string,
 ): void {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const decisionDeployment = deployments.find(
     (d) => (d as any).decisionDefinition != null,
   ) as any;
@@ -89,7 +86,6 @@ export function validateDecisionRequirementsDeployment(
   expectedDecisionRequirementsId: string,
   expectedDecisionRequirementsName: string,
 ): void {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const decisionRequirementsDeployment = deployments.find(
     (d) => (d as any).decisionRequirements != null,
   ) as any;
@@ -124,7 +120,6 @@ export function validateRpaDeployment(
   expectedResourceName: string,
   expectedRpaId: string,
 ): void {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const rpaDeployment = deployments.find(
     (d) => (d as any).resource != null,
   ) as any;

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/tenant-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/tenant-requestHelpers.ts
@@ -34,7 +34,7 @@ import {
   createRole,
   createGroupAndStoreResponseFields,
   createMappingRule,
-} from '@requestHelpers'
+} from '@requestHelpers';
 
 export async function assignUsersToTenant(
   request: APIRequestContext,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/user-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/user-requestHelpers.ts
@@ -17,7 +17,7 @@ import {
 import {expect} from '@playwright/test';
 import {Serializable} from 'playwright-core/types/structs';
 import {CREATE_NEW_USER, userRequiredFields} from '../beans/requestBeans';
-import { validateResponse } from 'json-body-assertions';
+import {validateResponse} from 'json-body-assertions';
 
 export async function createUsersAndStoreResponseFields(
   request: APIRequestContext,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/eslint.config.mjs
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/eslint.config.mjs
@@ -1,3 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
 import js from '@eslint/js';
 import tseslint from 'typescript-eslint';
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/scripts/analyze-spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/scripts/analyze-spec.ts
@@ -1,4 +1,13 @@
 #!/usr/bin/env tsx
+
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
 import path from 'path';
 import fs from 'fs';
 import SwaggerParser from '@apidevtools/swagger-parser';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/scripts/debug-enums.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/scripts/debug-enums.ts
@@ -1,4 +1,13 @@
 #!/usr/bin/env ts-node
+
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
 import {loadSpec} from '../src/spec/loader.js';
 import path from 'path';
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/scripts/fetch-spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/scripts/fetch-spec.ts
@@ -1,4 +1,13 @@
 #!/usr/bin/env tsx
+
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
 import fs from 'fs';
 import path from 'path';
 import https from 'https';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/scripts/generate.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/scripts/generate.ts
@@ -1,4 +1,13 @@
 #!/usr/bin/env tsx
+
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
 import fs from 'fs';
 import path from 'path';
 import {loadSpec} from '../src/spec/loader.js';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/scripts/sync-tests.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/scripts/sync-tests.ts
@@ -1,4 +1,13 @@
 #!/usr/bin/env tsx
+
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
 import fs from 'fs';
 import path from 'path';
 import {fileURLToPath} from 'url';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/scripts/walker-enum-debug.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/scripts/walker-enum-debug.ts
@@ -1,4 +1,13 @@
 #!/usr/bin/env ts-node
+
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
 import {loadSpec} from '../src/spec/loader.js';
 import {buildWalk} from '../src/schema/walker.js';
 import path from 'path';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/analysis/additionalPropUniversal.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/analysis/additionalPropUniversal.ts
@@ -1,3 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
 import {OperationModel, ValidationScenario} from '../model/types.js';
 import {buildBaselineBody} from '../schema/baseline.js';
 import {makeId} from './common.js';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/analysis/additionalProps.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/analysis/additionalProps.ts
@@ -1,3 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
 import {OperationModel, ValidationScenario} from '../model/types.js';
 import {buildWalk} from '../schema/walker.js';
 import {buildBaselineBody} from '../schema/baseline.js';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/analysis/advancedSchema.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/analysis/advancedSchema.ts
@@ -1,3 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
 import {OperationModel, ValidationScenario} from '../model/types.js';
 import {buildWalk} from '../schema/walker.js';
 import {buildBaselineBody} from '../schema/baseline.js';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/analysis/allOf.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/analysis/allOf.ts
@@ -1,3 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
 import {OperationModel, ValidationScenario} from '../model/types.js';
 import {buildBaselineBody} from '../schema/baseline.js';
 import {makeId} from './common.js';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/analysis/bodyTopLevel.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/analysis/bodyTopLevel.ts
@@ -1,3 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
 import {OperationModel, ValidationScenario} from '../model/types.js';
 import {makeId} from './common.js';
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/analysis/bodyTypeMismatch.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/analysis/bodyTypeMismatch.ts
@@ -1,3 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
 import {OperationModel, ValidationScenario} from '../model/types.js';
 import {buildWalk, WalkNode} from '../schema/walker.js';
 import {buildBaselineBody} from '../schema/baseline.js';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/analysis/common.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/analysis/common.ts
@@ -1,3 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
 import {OperationModel} from '../model/types.js';
 
 export function firstResourceSegment(path: string): string {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/analysis/constraintViolations.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/analysis/constraintViolations.ts
@@ -1,3 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
 import {OperationModel, ValidationScenario} from '../model/types.js';
 import {buildWalk} from '../schema/walker.js';
 import {buildBaselineBody} from '../schema/baseline.js';
@@ -53,7 +61,6 @@ export function generateConstraintViolations(
   return out;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function planConstraintMutations(
   cons: Record<string, any>,
   type: string,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/analysis/deepMissingRequired.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/analysis/deepMissingRequired.ts
@@ -1,3 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
 import {OperationModel, ValidationScenario} from '../model/types.js';
 import {buildWalk} from '../schema/walker.js';
 import {buildBaselineBody} from '../schema/baseline.js';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/analysis/discriminatorMismatch.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/analysis/discriminatorMismatch.ts
@@ -1,3 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
 import {OperationModel, ValidationScenario} from '../model/types.js';
 import {makeId} from './common.js';
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/analysis/enumViolations.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/analysis/enumViolations.ts
@@ -1,3 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
 import {OperationModel, ValidationScenario} from '../model/types.js';
 import {buildWalk} from '../schema/walker.js';
 import {buildBaselineBody} from '../schema/baseline.js';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/analysis/missingRequired.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/analysis/missingRequired.ts
@@ -1,3 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
 import {OperationModel, ValidationScenario} from '../model/types.js';
 import {makeId, genPlaceholder} from './common.js';
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/analysis/missingRequiredCombos.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/analysis/missingRequiredCombos.ts
@@ -1,3 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
 import {OperationModel, ValidationScenario} from '../model/types.js';
 import {genPlaceholder, makeId} from './common.js';
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/analysis/multipartMissingRequired.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/analysis/multipartMissingRequired.ts
@@ -1,3 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
 import {OperationModel, ValidationScenario} from '../model/types.js';
 import {makeId} from './common.js';
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/analysis/oneOfAdvanced.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/analysis/oneOfAdvanced.ts
@@ -1,3 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
 import {OperationModel, ValidationScenario} from '../model/types.js';
 import {makeId} from './common.js';
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/analysis/oneOfAmbiguous.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/analysis/oneOfAmbiguous.ts
@@ -1,3 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
 import {OperationModel, ValidationScenario} from '../model/types.js';
 import {makeId} from './common.js';
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/analysis/oneOfNoneMatch.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/analysis/oneOfNoneMatch.ts
@@ -1,3 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
 import {OperationModel, ValidationScenario} from '../model/types.js';
 import {makeId} from './common.js';
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/analysis/paramConstraintViolations.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/analysis/paramConstraintViolations.ts
@@ -1,3 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
 import {
   OperationModel,
   ValidationScenario,
@@ -28,7 +36,6 @@ function resolveParamSchema(
   if (!schema) return undefined;
   const out: ResolvedParamSchema = {schema};
   function merge(s: any) {
-    // eslint-disable-line @typescript-eslint/no-explicit-any
     if (!s || typeof s !== 'object') return;
     if (typeof s.pattern === 'string' && out.pattern === undefined)
       out.pattern = s.pattern;

--- a/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/analysis/parameters.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/analysis/parameters.ts
@@ -1,3 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
 import {
   OperationModel,
   ValidationScenario,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/analysis/typeMismatch.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/analysis/typeMismatch.ts
@@ -1,3 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
 import {OperationModel, ValidationScenario} from '../model/types.js';
 import {makeId} from './common.js';
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/analysis/unionViolations.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/analysis/unionViolations.ts
@@ -1,3 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
 import {OperationModel, ValidationScenario} from '../model/types.js';
 import {makeId} from './common.js';
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/emit/licenseHeader.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/emit/licenseHeader.ts
@@ -1,1 +1,9 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
 export const LICENSE_HEADER = `/*\n * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under\n * one or more contributor license agreements. See the NOTICE file distributed\n * with this work for additional information regarding copyright ownership.\n * Licensed under the Camunda License 1.0. You may not use this file\n * except in compliance with the Camunda License 1.0.\n */\n`;

--- a/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/emit/qaEmitter.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/emit/qaEmitter.ts
@@ -1,3 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
 import fs from 'fs';
 import path from 'path';
 import prettier from 'prettier';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/model/types.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/model/types.ts
@@ -1,3 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
 // NOTE: Many schema shapes are dynamic OpenAPI fragments; using `any` with selective lint disable for pragmatism.
 export interface OperationModel {
   operationId: string;

--- a/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/schema/baseline.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/schema/baseline.ts
@@ -1,3 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
 import {WalkNode, buildWalk} from './walker.js';
 import {OperationModel} from '../model/types.js';
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/schema/walker.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/schema/walker.ts
@@ -1,3 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
 import {OperationModel} from '../model/types.js';
 
 export interface WalkNode {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/spec/loader.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/spec/loader.ts
@@ -1,3 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
 import SwaggerParser from '@apidevtools/swagger-parser';
 import {OperationModel, ParameterModel, SpecModel} from '../model/types.js';
 
@@ -13,7 +21,7 @@ export async function loadSpec(file: string): Promise<SpecModel> {
       const method = m.toUpperCase();
       if (!op || !op.operationId) continue;
       const params: ParameterModel[] = [];
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
       const allParams = [
         ...(op.parameters || []),
         ...((methods as any).parameters || []),

--- a/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/util/patternMismatch.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/util/patternMismatch.ts
@@ -1,3 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
 // Shared utility to derive a guaranteed non-matching string for a given regex pattern.
 // Returns undefined if we cannot confidently craft a mismatch (pattern appears overly permissive).
 


### PR DESCRIPTION
## Description

This PR fixes lint on stable/8.9
Tests are failing in [on demand run](https://github.com/camunda/camunda/actions/runs/26043230016/job/76560664265) as they are not fixed in this PR. failing tests will be handled in the [following PR](https://github.com/camunda/camunda/pull/53403)

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

