### PR TITLE
fix: updated orchestration memory to match 8.8+ release versions

### DIFF
--- a/load-tests/camunda-platform-values.yaml
+++ b/load-tests/camunda-platform-values.yaml
@@ -241,10 +241,10 @@ orchestration:
   resources:
     requests:
       cpu: 3000m
-      memory: 2Gi
+      memory: 4Gi
     limits:
       cpu: 3000m
-      memory: 2Gi
+      memory: 4Gi
 
   tolerations:
     - key: nodepool


### PR DESCRIPTION
## Description

This pull request makes a small change to the resource configuration for the orchestration component in `load-tests/camunda-platform-values.yaml`, increasing the memory requests and limits from 2Gi to 4Gi.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
