### PR TITLE
fix: increase orchestration memory requests and limits to 4Gi

### DIFF
--- a/load-tests/camunda-platform-values.yaml
+++ b/load-tests/camunda-platform-values.yaml
@@ -215,10 +215,10 @@ orchestration:
   resources:
     requests:
       cpu: 3000m
-      memory: 2Gi
+      memory: 4Gi
     limits:
       cpu: 3000m
-      memory: 2Gi
+      memory: 4Gi
 
   tolerations:
     - key: nodepool


### PR DESCRIPTION
## Description
This pull request increases the memory allocation for the orchestration component in the load testing configuration. The memory requests and limits have both been raised from 2Gi to 4Gi to better support resource-intensive workloads.

- Resource configuration update:
  * Increased `memory` requests and limits from 2Gi to 4Gi in the `orchestration` section of `load-tests/camunda-platform-values.yaml` to improve performance under load.


## Checklist

<!--- Please delete options that are not relevant. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [x] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes https://camunda.slack.com/archives/C0B4HJVNQMP/p1779118980921039?thread_ts=1779094417.683539&cid=C0B4HJVNQMP
