### PR TITLE
feat(clients/java): add batch() method to DeployResourceCommandStep1

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/command/DeployResourceCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/DeployResourceCommandStep1.java
@@ -96,6 +96,14 @@ public interface DeployResourceCommandStep1
   DeployResourceCommandStep2 addProcessModel(
       BpmnModelInstance processDefinition, String resourceName);
 
+    /**
+     * Returns a step2 command that allows adding resources without requiring
+     * at least one resource to be added first.
+     *
+     * @return the builder for this command allowing batch addition of resources.
+     */
+    DeployResourceCommandStep2 batch();
+
   interface DeployResourceCommandStep2
       extends DeployResourceCommandStep1,
           CommandWithTenantStep<DeployResourceCommandStep2>,

--- a/clients/java/src/main/java/io/camunda/client/api/command/DeployResourceCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/DeployResourceCommandStep1.java
@@ -96,13 +96,13 @@ public interface DeployResourceCommandStep1
   DeployResourceCommandStep2 addProcessModel(
       BpmnModelInstance processDefinition, String resourceName);
 
-    /**
-     * Returns a step2 command that allows adding resources without requiring
-     * at least one resource to be added first.
-     *
-     * @return the builder for this command allowing batch addition of resources.
-     */
-    DeployResourceCommandStep2 batch();
+  /**
+   * Returns a step2 command that allows adding resources without requiring at least one resource to
+   * be added first.
+   *
+   * @return the builder for this command allowing batch addition of resources.
+   */
+  DeployResourceCommandStep2 batch();
 
   interface DeployResourceCommandStep2
       extends DeployResourceCommandStep1,

--- a/clients/java/src/main/java/io/camunda/client/api/command/DeployResourceCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/DeployResourceCommandStep1.java
@@ -98,7 +98,8 @@ public interface DeployResourceCommandStep1
 
   /**
    * Returns a step2 command that allows adding resources without requiring at least one resource to
-   * be added first.
+   * be added first. At least one resource must still be added before calling {@link #send()}, which
+   * throws {@link IllegalStateException} if no resources were added.
    *
    * @return the builder for this command allowing batch addition of resources.
    */

--- a/clients/java/src/main/java/io/camunda/client/impl/command/DeployResourceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/DeployResourceCommandImpl.java
@@ -177,6 +177,11 @@ public final class DeployResourceCommandImpl
     return addResourceBytes(outStream.toByteArray(), resourceName);
   }
 
+    @Override
+    public DeployResourceCommandStep2 batch() {
+        return this;
+    }
+
   @Override
   public FinalCommandStep<DeploymentEvent> requestTimeout(final Duration requestTimeout) {
     this.requestTimeout = requestTimeout;

--- a/clients/java/src/main/java/io/camunda/client/impl/command/DeployResourceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/DeployResourceCommandImpl.java
@@ -70,6 +70,7 @@ public final class DeployResourceCommandImpl
   private boolean useRest;
   private final JsonMapper jsonMapper;
   private String tenantId;
+  private boolean hasResourceAdded = false;
 
   public DeployResourceCommandImpl(
       final GatewayStub asyncStub,
@@ -92,7 +93,7 @@ public final class DeployResourceCommandImpl
   @Override
   public DeployResourceCommandStep2 addResourceBytes(
       final byte[] resource, final String resourceName) {
-
+      hasResourceAdded = true;
     if (useRest) {
       multipartEntityBuilder.addBinaryBody(
           RESOURCES_FIELD_NAME, resource, ContentType.APPLICATION_OCTET_STREAM, resourceName);
@@ -191,6 +192,10 @@ public final class DeployResourceCommandImpl
 
   @Override
   public CamundaFuture<DeploymentEvent> send() {
+      if (!hasResourceAdded) {
+          throw new IllegalStateException(
+                  "At least one resource must be added before sending the command");
+      }
     if (useRest) {
       // adding here the tenantId because in the multipart request fields are only appended
       multipartEntityBuilder.addTextBody(TENANT_FIELD_NAME, tenantId);

--- a/clients/java/src/main/java/io/camunda/client/impl/command/DeployResourceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/DeployResourceCommandImpl.java
@@ -39,6 +39,7 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.Resource;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.grpc.stub.StreamObserver;
+
 import java.io.ByteArrayOutputStream;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -49,211 +50,212 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
+
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
 import org.apache.hc.core5.http.ContentType;
 
 public final class DeployResourceCommandImpl
-    implements DeployResourceCommandStep1, DeployResourceCommandStep2 {
+        implements DeployResourceCommandStep1, DeployResourceCommandStep2 {
 
-  private static final String RESOURCES_FIELD_NAME = "resources";
-  private static final String TENANT_FIELD_NAME = "tenantId";
+    private static final String RESOURCES_FIELD_NAME = "resources";
+    private static final String TENANT_FIELD_NAME = "tenantId";
 
-  private final MultipartEntityBuilder multipartEntityBuilder =
-      MultipartEntityBuilder.create().setContentType(ContentType.MULTIPART_FORM_DATA);
-  private final DeployResourceRequest.Builder requestBuilder = DeployResourceRequest.newBuilder();
-  private final GatewayStub asyncStub;
-  private final Predicate<StatusCode> retryPredicate;
-  private Duration requestTimeout;
-  private final HttpClient httpClient;
-  private final RequestConfig.Builder httpRequestConfig;
-  private boolean useRest;
-  private final JsonMapper jsonMapper;
-  private String tenantId;
-  private boolean hasResourceAdded = false;
+    private final MultipartEntityBuilder multipartEntityBuilder =
+            MultipartEntityBuilder.create().setContentType(ContentType.MULTIPART_FORM_DATA);
+    private final DeployResourceRequest.Builder requestBuilder = DeployResourceRequest.newBuilder();
+    private final GatewayStub asyncStub;
+    private final Predicate<StatusCode> retryPredicate;
+    private Duration requestTimeout;
+    private final HttpClient httpClient;
+    private final RequestConfig.Builder httpRequestConfig;
+    private boolean useRest;
+    private final JsonMapper jsonMapper;
+    private String tenantId;
+    private boolean hasResourceAdded = false;
 
-  public DeployResourceCommandImpl(
-      final GatewayStub asyncStub,
-      final CamundaClientConfiguration config,
-      final Predicate<StatusCode> retryPredicate,
-      final HttpClient httpClient,
-      final boolean preferRestOverGrpc,
-      final JsonMapper jsonMapper) {
-    this.asyncStub = asyncStub;
-    requestTimeout = config.getDefaultRequestTimeout();
-    this.retryPredicate = retryPredicate;
-    tenantId(config.getDefaultTenantId());
-    this.httpClient = httpClient;
-    httpRequestConfig = httpClient.newRequestConfig();
-    useRest = preferRestOverGrpc;
-    this.jsonMapper = jsonMapper;
-    requestTimeout(requestTimeout);
-  }
-
-  @Override
-  public DeployResourceCommandStep2 addResourceBytes(
-      final byte[] resource, final String resourceName) {
-      hasResourceAdded = true;
-    if (useRest) {
-      multipartEntityBuilder.addBinaryBody(
-          RESOURCES_FIELD_NAME, resource, ContentType.APPLICATION_OCTET_STREAM, resourceName);
-      return this;
+    public DeployResourceCommandImpl(
+            final GatewayStub asyncStub,
+            final CamundaClientConfiguration config,
+            final Predicate<StatusCode> retryPredicate,
+            final HttpClient httpClient,
+            final boolean preferRestOverGrpc,
+            final JsonMapper jsonMapper) {
+        this.asyncStub = asyncStub;
+        requestTimeout = config.getDefaultRequestTimeout();
+        this.retryPredicate = retryPredicate;
+        tenantId(config.getDefaultTenantId());
+        this.httpClient = httpClient;
+        httpRequestConfig = httpClient.newRequestConfig();
+        useRest = preferRestOverGrpc;
+        this.jsonMapper = jsonMapper;
+        requestTimeout(requestTimeout);
     }
 
-    requestBuilder.addResources(
-        Resource.newBuilder()
-            .setName(resourceName)
-            .setContent(ByteString.copyFrom(resource))
-            .build());
-    return this;
-  }
+    @Override
+    public DeployResourceCommandStep2 addResourceBytes(
+            final byte[] resource, final String resourceName) {
+        hasResourceAdded = true;
+        if (useRest) {
+            multipartEntityBuilder.addBinaryBody(
+                    RESOURCES_FIELD_NAME, resource, ContentType.APPLICATION_OCTET_STREAM, resourceName);
+            return this;
+        }
 
-  @Override
-  public DeployResourceCommandStep2 addResourceString(
-      final String resource, final Charset charset, final String resourceName) {
-    return addResourceBytes(resource.getBytes(charset), resourceName);
-  }
-
-  @Override
-  public DeployResourceCommandStep2 addResourceStringUtf8(
-      final String resourceString, final String resourceName) {
-    return addResourceString(resourceString, StandardCharsets.UTF_8, resourceName);
-  }
-
-  @Override
-  public DeployResourceCommandStep2 addResourceStream(
-      final InputStream resourceStream, final String resourceName) {
-    ensureNotNull("resource stream", resourceStream);
-
-    try {
-      final byte[] bytes = StreamUtil.readInputStream(resourceStream);
-
-      return addResourceBytes(bytes, resourceName);
-    } catch (final IOException e) {
-      final String exceptionMsg =
-          String.format("Cannot deploy bpmn resource from stream. %s", e.getMessage());
-      throw new ClientException(exceptionMsg, e);
+        requestBuilder.addResources(
+                Resource.newBuilder()
+                        .setName(resourceName)
+                        .setContent(ByteString.copyFrom(resource))
+                        .build());
+        return this;
     }
-  }
 
-  @Override
-  public DeployResourceCommandStep2 addResourceFromClasspath(final String classpathResource) {
-    ensureNotNull("classpath resource", classpathResource);
-
-    try (final InputStream resourceStream =
-        getClass().getClassLoader().getResourceAsStream(classpathResource)) {
-      if (resourceStream != null) {
-        return addResourceStream(resourceStream, classpathResource);
-      } else {
-        throw new FileNotFoundException(classpathResource);
-      }
-
-    } catch (final IOException e) {
-      final String exceptionMsg =
-          String.format("Cannot deploy resource from classpath. %s", e.getMessage());
-      throw new RuntimeException(exceptionMsg, e);
+    @Override
+    public DeployResourceCommandStep2 addResourceString(
+            final String resource, final Charset charset, final String resourceName) {
+        return addResourceBytes(resource.getBytes(charset), resourceName);
     }
-  }
 
-  @Override
-  public DeployResourceCommandStep2 addResourceFile(final String filename) {
-    ensureNotNull("filename", filename);
-
-    try (final InputStream resourceStream = new FileInputStream(filename)) {
-      return addResourceStream(resourceStream, filename);
-    } catch (final IOException e) {
-      final String exceptionMsg =
-          String.format("Cannot deploy resource from file. %s", e.getMessage());
-      throw new RuntimeException(exceptionMsg, e);
+    @Override
+    public DeployResourceCommandStep2 addResourceStringUtf8(
+            final String resourceString, final String resourceName) {
+        return addResourceString(resourceString, StandardCharsets.UTF_8, resourceName);
     }
-  }
 
-  @Override
-  public DeployResourceCommandStep2 addProcessModel(
-      final BpmnModelInstance processDefinition, final String resourceName) {
-    ensureNotNull("process model", processDefinition);
+    @Override
+    public DeployResourceCommandStep2 addResourceStream(
+            final InputStream resourceStream, final String resourceName) {
+        ensureNotNull("resource stream", resourceStream);
 
-    final ByteArrayOutputStream outStream = new ByteArrayOutputStream();
-    Bpmn.writeModelToStream(outStream, processDefinition);
-    return addResourceBytes(outStream.toByteArray(), resourceName);
-  }
+        try {
+            final byte[] bytes = StreamUtil.readInputStream(resourceStream);
+
+            return addResourceBytes(bytes, resourceName);
+        } catch (final IOException e) {
+            final String exceptionMsg =
+                    String.format("Cannot deploy bpmn resource from stream. %s", e.getMessage());
+            throw new ClientException(exceptionMsg, e);
+        }
+    }
+
+    @Override
+    public DeployResourceCommandStep2 addResourceFromClasspath(final String classpathResource) {
+        ensureNotNull("classpath resource", classpathResource);
+
+        try (final InputStream resourceStream =
+                     getClass().getClassLoader().getResourceAsStream(classpathResource)) {
+            if (resourceStream != null) {
+                return addResourceStream(resourceStream, classpathResource);
+            } else {
+                throw new FileNotFoundException(classpathResource);
+            }
+
+        } catch (final IOException e) {
+            final String exceptionMsg =
+                    String.format("Cannot deploy resource from classpath. %s", e.getMessage());
+            throw new RuntimeException(exceptionMsg, e);
+        }
+    }
+
+    @Override
+    public DeployResourceCommandStep2 addResourceFile(final String filename) {
+        ensureNotNull("filename", filename);
+
+        try (final InputStream resourceStream = new FileInputStream(filename)) {
+            return addResourceStream(resourceStream, filename);
+        } catch (final IOException e) {
+            final String exceptionMsg =
+                    String.format("Cannot deploy resource from file. %s", e.getMessage());
+            throw new RuntimeException(exceptionMsg, e);
+        }
+    }
+
+    @Override
+    public DeployResourceCommandStep2 addProcessModel(
+            final BpmnModelInstance processDefinition, final String resourceName) {
+        ensureNotNull("process model", processDefinition);
+
+        final ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+        Bpmn.writeModelToStream(outStream, processDefinition);
+        return addResourceBytes(outStream.toByteArray(), resourceName);
+    }
 
     @Override
     public DeployResourceCommandStep2 batch() {
         return this;
     }
 
-  @Override
-  public FinalCommandStep<DeploymentEvent> requestTimeout(final Duration requestTimeout) {
-    this.requestTimeout = requestTimeout;
-    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
-    return this;
-  }
-
-  @Override
-  public CamundaFuture<DeploymentEvent> send() {
-      if (!hasResourceAdded) {
-          throw new IllegalStateException(
-                  "At least one resource must be added before sending the command");
-      }
-    if (useRest) {
-      // adding here the tenantId because in the multipart request fields are only appended
-      multipartEntityBuilder.addTextBody(TENANT_FIELD_NAME, tenantId);
-      return sendRestRequest();
-    } else {
-      return sendGrpcRequest();
+    @Override
+    public FinalCommandStep<DeploymentEvent> requestTimeout(final Duration requestTimeout) {
+        this.requestTimeout = requestTimeout;
+        httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+        return this;
     }
-  }
 
-  @Override
-  public DeployResourceCommandStep2 tenantId(final String tenantId) {
-    this.tenantId = tenantId;
-    requestBuilder.setTenantId(tenantId);
-    return this;
-  }
+    @Override
+    public CamundaFuture<DeploymentEvent> send() {
+        if (!hasResourceAdded) {
+            throw new IllegalStateException(
+                    "At least one resource must be added before sending the command");
+        }
+        if (useRest) {
+            // adding here the tenantId because in the multipart request fields are only appended
+            multipartEntityBuilder.addTextBody(TENANT_FIELD_NAME, tenantId);
+            return sendRestRequest();
+        } else {
+            return sendGrpcRequest();
+        }
+    }
 
-  @Override
-  public DeployResourceCommandStep2 useRest() {
-    useRest = true;
-    return this;
-  }
+    @Override
+    public DeployResourceCommandStep2 tenantId(final String tenantId) {
+        this.tenantId = tenantId;
+        requestBuilder.setTenantId(tenantId);
+        return this;
+    }
 
-  @Override
-  public DeployResourceCommandStep2 useGrpc() {
-    useRest = false;
-    return this;
-  }
+    @Override
+    public DeployResourceCommandStep2 useRest() {
+        useRest = true;
+        return this;
+    }
 
-  private CamundaFuture<DeploymentEvent> sendRestRequest() {
-    final HttpCamundaFuture<DeploymentEvent> result = new HttpCamundaFuture<>();
-    httpClient.postMultipart(
-        "/deployments",
-        multipartEntityBuilder,
-        httpRequestConfig.build(),
-        DeploymentResult.class,
-        DeploymentEventImpl::new,
-        result);
-    return result;
-  }
+    @Override
+    public DeployResourceCommandStep2 useGrpc() {
+        useRest = false;
+        return this;
+    }
 
-  private CamundaFuture<DeploymentEvent> sendGrpcRequest() {
-    final DeployResourceRequest request = requestBuilder.build();
+    private CamundaFuture<DeploymentEvent> sendRestRequest() {
+        final HttpCamundaFuture<DeploymentEvent> result = new HttpCamundaFuture<>();
+        httpClient.postMultipart(
+                "/deployments",
+                multipartEntityBuilder,
+                httpRequestConfig.build(),
+                DeploymentResult.class,
+                DeploymentEventImpl::new,
+                result);
+        return result;
+    }
 
-    final RetriableClientFutureImpl<DeploymentEvent, DeployResourceResponse> future =
-        new RetriableClientFutureImpl<>(
-            DeploymentEventImpl::new,
-            retryPredicate,
-            streamObserver -> sendGrpcRequest(request, streamObserver));
+    private CamundaFuture<DeploymentEvent> sendGrpcRequest() {
+        final DeployResourceRequest request = requestBuilder.build();
 
-    sendGrpcRequest(request, future);
+        final RetriableClientFutureImpl<DeploymentEvent, DeployResourceResponse> future =
+                new RetriableClientFutureImpl<>(
+                        DeploymentEventImpl::new,
+                        retryPredicate,
+                        streamObserver -> sendGrpcRequest(request, streamObserver));
 
-    return future;
-  }
+        sendGrpcRequest(request, future);
 
-  private void sendGrpcRequest(
-      final DeployResourceRequest request, final StreamObserver streamObserver) {
-    asyncStub
-        .withDeadlineAfter(requestTimeout.toMillis(), TimeUnit.MILLISECONDS)
-        .deployResource(request, streamObserver);
-  }
+        return future;
+    }
+
+    private void sendGrpcRequest(
+            final DeployResourceRequest request, final StreamObserver streamObserver) {
+        asyncStub
+                .withDeadlineAfter(requestTimeout.toMillis(), TimeUnit.MILLISECONDS)
+                .deployResource(request, streamObserver);
+    }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/DeployResourceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/DeployResourceCommandImpl.java
@@ -59,8 +59,6 @@ public final class DeployResourceCommandImpl
   private static final String RESOURCES_FIELD_NAME = "resources";
   private static final String TENANT_FIELD_NAME = "tenantId";
 
-  private final MultipartEntityBuilder multipartEntityBuilder =
-      MultipartEntityBuilder.create().setContentType(ContentType.MULTIPART_FORM_DATA);
   private final DeployResourceRequest.Builder requestBuilder = DeployResourceRequest.newBuilder();
   private final GatewayStub asyncStub;
   private final Predicate<StatusCode> retryPredicate;
@@ -92,8 +90,6 @@ public final class DeployResourceCommandImpl
   @Override
   public DeployResourceCommandStep2 addResourceBytes(
       final byte[] resource, final String resourceName) {
-    multipartEntityBuilder.addBinaryBody(
-        RESOURCES_FIELD_NAME, resource, ContentType.APPLICATION_OCTET_STREAM, resourceName);
     requestBuilder.addResources(
         Resource.newBuilder()
             .setName(resourceName)
@@ -191,8 +187,6 @@ public final class DeployResourceCommandImpl
           "At least one resource must be added before sending the command");
     }
     if (useRest) {
-      // adding here the tenantId because in the multipart request fields are only appended
-      multipartEntityBuilder.addTextBody(TENANT_FIELD_NAME, tenantId);
       return sendRestRequest();
     } else {
       return sendGrpcRequest();
@@ -219,6 +213,17 @@ public final class DeployResourceCommandImpl
   }
 
   private CamundaFuture<DeploymentEvent> sendRestRequest() {
+    final MultipartEntityBuilder multipartEntityBuilder =
+        MultipartEntityBuilder.create().setContentType(ContentType.MULTIPART_FORM_DATA);
+    for (final Resource resource : requestBuilder.getResourcesList()) {
+      multipartEntityBuilder.addBinaryBody(
+          RESOURCES_FIELD_NAME,
+          resource.getContent().toByteArray(),
+          ContentType.APPLICATION_OCTET_STREAM,
+          resource.getName());
+    }
+    multipartEntityBuilder.addTextBody(TENANT_FIELD_NAME, tenantId);
+
     final HttpCamundaFuture<DeploymentEvent> result = new HttpCamundaFuture<>();
     httpClient.postMultipart(
         "/deployments",

--- a/clients/java/src/main/java/io/camunda/client/impl/command/DeployResourceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/DeployResourceCommandImpl.java
@@ -39,7 +39,6 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.Resource;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.grpc.stub.StreamObserver;
-
 import java.io.ByteArrayOutputStream;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -50,212 +49,211 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
-
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
 import org.apache.hc.core5.http.ContentType;
 
 public final class DeployResourceCommandImpl
-        implements DeployResourceCommandStep1, DeployResourceCommandStep2 {
+    implements DeployResourceCommandStep1, DeployResourceCommandStep2 {
 
-    private static final String RESOURCES_FIELD_NAME = "resources";
-    private static final String TENANT_FIELD_NAME = "tenantId";
+  private static final String RESOURCES_FIELD_NAME = "resources";
+  private static final String TENANT_FIELD_NAME = "tenantId";
 
-    private final MultipartEntityBuilder multipartEntityBuilder =
-            MultipartEntityBuilder.create().setContentType(ContentType.MULTIPART_FORM_DATA);
-    private final DeployResourceRequest.Builder requestBuilder = DeployResourceRequest.newBuilder();
-    private final GatewayStub asyncStub;
-    private final Predicate<StatusCode> retryPredicate;
-    private Duration requestTimeout;
-    private final HttpClient httpClient;
-    private final RequestConfig.Builder httpRequestConfig;
-    private boolean useRest;
-    private final JsonMapper jsonMapper;
-    private String tenantId;
-    private boolean hasResourceAdded = false;
+  private final MultipartEntityBuilder multipartEntityBuilder =
+      MultipartEntityBuilder.create().setContentType(ContentType.MULTIPART_FORM_DATA);
+  private final DeployResourceRequest.Builder requestBuilder = DeployResourceRequest.newBuilder();
+  private final GatewayStub asyncStub;
+  private final Predicate<StatusCode> retryPredicate;
+  private Duration requestTimeout;
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+  private boolean useRest;
+  private final JsonMapper jsonMapper;
+  private String tenantId;
+  private boolean hasResourceAdded = false;
 
-    public DeployResourceCommandImpl(
-            final GatewayStub asyncStub,
-            final CamundaClientConfiguration config,
-            final Predicate<StatusCode> retryPredicate,
-            final HttpClient httpClient,
-            final boolean preferRestOverGrpc,
-            final JsonMapper jsonMapper) {
-        this.asyncStub = asyncStub;
-        requestTimeout = config.getDefaultRequestTimeout();
-        this.retryPredicate = retryPredicate;
-        tenantId(config.getDefaultTenantId());
-        this.httpClient = httpClient;
-        httpRequestConfig = httpClient.newRequestConfig();
-        useRest = preferRestOverGrpc;
-        this.jsonMapper = jsonMapper;
-        requestTimeout(requestTimeout);
+  public DeployResourceCommandImpl(
+      final GatewayStub asyncStub,
+      final CamundaClientConfiguration config,
+      final Predicate<StatusCode> retryPredicate,
+      final HttpClient httpClient,
+      final boolean preferRestOverGrpc,
+      final JsonMapper jsonMapper) {
+    this.asyncStub = asyncStub;
+    requestTimeout = config.getDefaultRequestTimeout();
+    this.retryPredicate = retryPredicate;
+    tenantId(config.getDefaultTenantId());
+    this.httpClient = httpClient;
+    httpRequestConfig = httpClient.newRequestConfig();
+    useRest = preferRestOverGrpc;
+    this.jsonMapper = jsonMapper;
+    requestTimeout(requestTimeout);
+  }
+
+  @Override
+  public DeployResourceCommandStep2 addResourceBytes(
+      final byte[] resource, final String resourceName) {
+    hasResourceAdded = true;
+    if (useRest) {
+      multipartEntityBuilder.addBinaryBody(
+          RESOURCES_FIELD_NAME, resource, ContentType.APPLICATION_OCTET_STREAM, resourceName);
+      return this;
     }
 
-    @Override
-    public DeployResourceCommandStep2 addResourceBytes(
-            final byte[] resource, final String resourceName) {
-        hasResourceAdded = true;
-        if (useRest) {
-            multipartEntityBuilder.addBinaryBody(
-                    RESOURCES_FIELD_NAME, resource, ContentType.APPLICATION_OCTET_STREAM, resourceName);
-            return this;
-        }
+    requestBuilder.addResources(
+        Resource.newBuilder()
+            .setName(resourceName)
+            .setContent(ByteString.copyFrom(resource))
+            .build());
+    return this;
+  }
 
-        requestBuilder.addResources(
-                Resource.newBuilder()
-                        .setName(resourceName)
-                        .setContent(ByteString.copyFrom(resource))
-                        .build());
-        return this;
+  @Override
+  public DeployResourceCommandStep2 addResourceString(
+      final String resource, final Charset charset, final String resourceName) {
+    return addResourceBytes(resource.getBytes(charset), resourceName);
+  }
+
+  @Override
+  public DeployResourceCommandStep2 addResourceStringUtf8(
+      final String resourceString, final String resourceName) {
+    return addResourceString(resourceString, StandardCharsets.UTF_8, resourceName);
+  }
+
+  @Override
+  public DeployResourceCommandStep2 addResourceStream(
+      final InputStream resourceStream, final String resourceName) {
+    ensureNotNull("resource stream", resourceStream);
+
+    try {
+      final byte[] bytes = StreamUtil.readInputStream(resourceStream);
+
+      return addResourceBytes(bytes, resourceName);
+    } catch (final IOException e) {
+      final String exceptionMsg =
+          String.format("Cannot deploy bpmn resource from stream. %s", e.getMessage());
+      throw new ClientException(exceptionMsg, e);
     }
+  }
 
-    @Override
-    public DeployResourceCommandStep2 addResourceString(
-            final String resource, final Charset charset, final String resourceName) {
-        return addResourceBytes(resource.getBytes(charset), resourceName);
+  @Override
+  public DeployResourceCommandStep2 addResourceFromClasspath(final String classpathResource) {
+    ensureNotNull("classpath resource", classpathResource);
+
+    try (final InputStream resourceStream =
+        getClass().getClassLoader().getResourceAsStream(classpathResource)) {
+      if (resourceStream != null) {
+        return addResourceStream(resourceStream, classpathResource);
+      } else {
+        throw new FileNotFoundException(classpathResource);
+      }
+
+    } catch (final IOException e) {
+      final String exceptionMsg =
+          String.format("Cannot deploy resource from classpath. %s", e.getMessage());
+      throw new RuntimeException(exceptionMsg, e);
     }
+  }
 
-    @Override
-    public DeployResourceCommandStep2 addResourceStringUtf8(
-            final String resourceString, final String resourceName) {
-        return addResourceString(resourceString, StandardCharsets.UTF_8, resourceName);
+  @Override
+  public DeployResourceCommandStep2 addResourceFile(final String filename) {
+    ensureNotNull("filename", filename);
+
+    try (final InputStream resourceStream = new FileInputStream(filename)) {
+      return addResourceStream(resourceStream, filename);
+    } catch (final IOException e) {
+      final String exceptionMsg =
+          String.format("Cannot deploy resource from file. %s", e.getMessage());
+      throw new RuntimeException(exceptionMsg, e);
     }
+  }
 
-    @Override
-    public DeployResourceCommandStep2 addResourceStream(
-            final InputStream resourceStream, final String resourceName) {
-        ensureNotNull("resource stream", resourceStream);
+  @Override
+  public DeployResourceCommandStep2 addProcessModel(
+      final BpmnModelInstance processDefinition, final String resourceName) {
+    ensureNotNull("process model", processDefinition);
 
-        try {
-            final byte[] bytes = StreamUtil.readInputStream(resourceStream);
+    final ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+    Bpmn.writeModelToStream(outStream, processDefinition);
+    return addResourceBytes(outStream.toByteArray(), resourceName);
+  }
 
-            return addResourceBytes(bytes, resourceName);
-        } catch (final IOException e) {
-            final String exceptionMsg =
-                    String.format("Cannot deploy bpmn resource from stream. %s", e.getMessage());
-            throw new ClientException(exceptionMsg, e);
-        }
+  @Override
+  public DeployResourceCommandStep2 batch() {
+    return this;
+  }
+
+  @Override
+  public FinalCommandStep<DeploymentEvent> requestTimeout(final Duration requestTimeout) {
+    this.requestTimeout = requestTimeout;
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<DeploymentEvent> send() {
+    if (!hasResourceAdded) {
+      throw new IllegalStateException(
+          "At least one resource must be added before sending the command");
     }
-
-    @Override
-    public DeployResourceCommandStep2 addResourceFromClasspath(final String classpathResource) {
-        ensureNotNull("classpath resource", classpathResource);
-
-        try (final InputStream resourceStream =
-                     getClass().getClassLoader().getResourceAsStream(classpathResource)) {
-            if (resourceStream != null) {
-                return addResourceStream(resourceStream, classpathResource);
-            } else {
-                throw new FileNotFoundException(classpathResource);
-            }
-
-        } catch (final IOException e) {
-            final String exceptionMsg =
-                    String.format("Cannot deploy resource from classpath. %s", e.getMessage());
-            throw new RuntimeException(exceptionMsg, e);
-        }
+    if (useRest) {
+      // adding here the tenantId because in the multipart request fields are only appended
+      multipartEntityBuilder.addTextBody(TENANT_FIELD_NAME, tenantId);
+      return sendRestRequest();
+    } else {
+      return sendGrpcRequest();
     }
+  }
 
-    @Override
-    public DeployResourceCommandStep2 addResourceFile(final String filename) {
-        ensureNotNull("filename", filename);
+  @Override
+  public DeployResourceCommandStep2 tenantId(final String tenantId) {
+    this.tenantId = tenantId;
+    requestBuilder.setTenantId(tenantId);
+    return this;
+  }
 
-        try (final InputStream resourceStream = new FileInputStream(filename)) {
-            return addResourceStream(resourceStream, filename);
-        } catch (final IOException e) {
-            final String exceptionMsg =
-                    String.format("Cannot deploy resource from file. %s", e.getMessage());
-            throw new RuntimeException(exceptionMsg, e);
-        }
-    }
+  @Override
+  public DeployResourceCommandStep2 useRest() {
+    useRest = true;
+    return this;
+  }
 
-    @Override
-    public DeployResourceCommandStep2 addProcessModel(
-            final BpmnModelInstance processDefinition, final String resourceName) {
-        ensureNotNull("process model", processDefinition);
+  @Override
+  public DeployResourceCommandStep2 useGrpc() {
+    useRest = false;
+    return this;
+  }
 
-        final ByteArrayOutputStream outStream = new ByteArrayOutputStream();
-        Bpmn.writeModelToStream(outStream, processDefinition);
-        return addResourceBytes(outStream.toByteArray(), resourceName);
-    }
+  private CamundaFuture<DeploymentEvent> sendRestRequest() {
+    final HttpCamundaFuture<DeploymentEvent> result = new HttpCamundaFuture<>();
+    httpClient.postMultipart(
+        "/deployments",
+        multipartEntityBuilder,
+        httpRequestConfig.build(),
+        DeploymentResult.class,
+        DeploymentEventImpl::new,
+        result);
+    return result;
+  }
 
-    @Override
-    public DeployResourceCommandStep2 batch() {
-        return this;
-    }
+  private CamundaFuture<DeploymentEvent> sendGrpcRequest() {
+    final DeployResourceRequest request = requestBuilder.build();
 
-    @Override
-    public FinalCommandStep<DeploymentEvent> requestTimeout(final Duration requestTimeout) {
-        this.requestTimeout = requestTimeout;
-        httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
-        return this;
-    }
+    final RetriableClientFutureImpl<DeploymentEvent, DeployResourceResponse> future =
+        new RetriableClientFutureImpl<>(
+            DeploymentEventImpl::new,
+            retryPredicate,
+            streamObserver -> sendGrpcRequest(request, streamObserver));
 
-    @Override
-    public CamundaFuture<DeploymentEvent> send() {
-        if (!hasResourceAdded) {
-            throw new IllegalStateException(
-                    "At least one resource must be added before sending the command");
-        }
-        if (useRest) {
-            // adding here the tenantId because in the multipart request fields are only appended
-            multipartEntityBuilder.addTextBody(TENANT_FIELD_NAME, tenantId);
-            return sendRestRequest();
-        } else {
-            return sendGrpcRequest();
-        }
-    }
+    sendGrpcRequest(request, future);
 
-    @Override
-    public DeployResourceCommandStep2 tenantId(final String tenantId) {
-        this.tenantId = tenantId;
-        requestBuilder.setTenantId(tenantId);
-        return this;
-    }
+    return future;
+  }
 
-    @Override
-    public DeployResourceCommandStep2 useRest() {
-        useRest = true;
-        return this;
-    }
-
-    @Override
-    public DeployResourceCommandStep2 useGrpc() {
-        useRest = false;
-        return this;
-    }
-
-    private CamundaFuture<DeploymentEvent> sendRestRequest() {
-        final HttpCamundaFuture<DeploymentEvent> result = new HttpCamundaFuture<>();
-        httpClient.postMultipart(
-                "/deployments",
-                multipartEntityBuilder,
-                httpRequestConfig.build(),
-                DeploymentResult.class,
-                DeploymentEventImpl::new,
-                result);
-        return result;
-    }
-
-    private CamundaFuture<DeploymentEvent> sendGrpcRequest() {
-        final DeployResourceRequest request = requestBuilder.build();
-
-        final RetriableClientFutureImpl<DeploymentEvent, DeployResourceResponse> future =
-                new RetriableClientFutureImpl<>(
-                        DeploymentEventImpl::new,
-                        retryPredicate,
-                        streamObserver -> sendGrpcRequest(request, streamObserver));
-
-        sendGrpcRequest(request, future);
-
-        return future;
-    }
-
-    private void sendGrpcRequest(
-            final DeployResourceRequest request, final StreamObserver streamObserver) {
-        asyncStub
-                .withDeadlineAfter(requestTimeout.toMillis(), TimeUnit.MILLISECONDS)
-                .deployResource(request, streamObserver);
-    }
+  private void sendGrpcRequest(
+      final DeployResourceRequest request, final StreamObserver streamObserver) {
+    asyncStub
+        .withDeadlineAfter(requestTimeout.toMillis(), TimeUnit.MILLISECONDS)
+        .deployResource(request, streamObserver);
+  }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/DeployResourceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/DeployResourceCommandImpl.java
@@ -70,7 +70,6 @@ public final class DeployResourceCommandImpl
   private boolean useRest;
   private final JsonMapper jsonMapper;
   private String tenantId;
-  private boolean hasResourceAdded = false;
 
   public DeployResourceCommandImpl(
       final GatewayStub asyncStub,
@@ -93,7 +92,6 @@ public final class DeployResourceCommandImpl
   @Override
   public DeployResourceCommandStep2 addResourceBytes(
       final byte[] resource, final String resourceName) {
-    hasResourceAdded = true;
     multipartEntityBuilder.addBinaryBody(
         RESOURCES_FIELD_NAME, resource, ContentType.APPLICATION_OCTET_STREAM, resourceName);
     requestBuilder.addResources(
@@ -188,7 +186,7 @@ public final class DeployResourceCommandImpl
 
   @Override
   public CamundaFuture<DeploymentEvent> send() {
-    if (!hasResourceAdded) {
+    if (requestBuilder.getResourcesCount() == 0) {
       throw new IllegalStateException(
           "At least one resource must be added before sending the command");
     }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/DeployResourceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/DeployResourceCommandImpl.java
@@ -94,12 +94,8 @@ public final class DeployResourceCommandImpl
   public DeployResourceCommandStep2 addResourceBytes(
       final byte[] resource, final String resourceName) {
     hasResourceAdded = true;
-    if (useRest) {
-      multipartEntityBuilder.addBinaryBody(
-          RESOURCES_FIELD_NAME, resource, ContentType.APPLICATION_OCTET_STREAM, resourceName);
-      return this;
-    }
-
+    multipartEntityBuilder.addBinaryBody(
+        RESOURCES_FIELD_NAME, resource, ContentType.APPLICATION_OCTET_STREAM, resourceName);
     requestBuilder.addResources(
         Resource.newBuilder()
             .setName(resourceName)

--- a/clients/java/src/test/java/io/camunda/client/resource/DeployResourceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/resource/DeployResourceTest.java
@@ -471,4 +471,16 @@ public final class DeployResourceTest extends ClientTest {
         assertThat(resource2.getContent().toByteArray()).isEqualTo(getBytes(BPMN_2_FILENAME));
     }
 
+    @Test
+    public void shouldFailWhenBatchSendWithoutResources() {
+        // when/then
+        assertThatThrownBy(() ->
+                client.newDeployResourceCommand()
+                        .batch()
+                        .send()
+                        .join()
+        ).isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("At least one resource must be added");
+    }
+
 }

--- a/clients/java/src/test/java/io/camunda/client/resource/DeployResourceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/resource/DeployResourceTest.java
@@ -443,4 +443,32 @@ public final class DeployResourceTest extends ClientTest {
             new FormImpl(formId1, 1, 1, filename1, DEFAULT_TENANT),
             new FormImpl(formId2, 1, 2, filename2, DEFAULT_TENANT));
   }
+    @Test
+    public void shouldDeployResourcesUsingBatch() {
+        // given
+        final String filename1 = BPMN_1_FILENAME.substring(1);
+        final String filename2 = BPMN_2_FILENAME.substring(1);
+
+        // when
+        client
+                .newDeployResourceCommand()
+                .batch()
+                .addResourceFromClasspath(filename1)
+                .addResourceFromClasspath(filename2)
+                .send()
+                .join();
+
+        // then
+        final DeployResourceRequest request = gatewayService.getLastRequest();
+        assertThat(request.getResourcesList()).hasSize(2);
+
+        final Resource resource1 = request.getResources(0);
+        assertThat(resource1.getName()).isEqualTo(filename1);
+        assertThat(resource1.getContent().toByteArray()).isEqualTo(getBytes(BPMN_1_FILENAME));
+
+        final Resource resource2 = request.getResources(1);
+        assertThat(resource2.getName()).isEqualTo(filename2);
+        assertThat(resource2.getContent().toByteArray()).isEqualTo(getBytes(BPMN_2_FILENAME));
+    }
+
 }

--- a/clients/java/src/test/java/io/camunda/client/resource/DeployResourceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/resource/DeployResourceTest.java
@@ -443,44 +443,40 @@ public final class DeployResourceTest extends ClientTest {
             new FormImpl(formId1, 1, 1, filename1, DEFAULT_TENANT),
             new FormImpl(formId2, 1, 2, filename2, DEFAULT_TENANT));
   }
-    @Test
-    public void shouldDeployResourcesUsingBatch() {
-        // given
-        final String filename1 = BPMN_1_FILENAME.substring(1);
-        final String filename2 = BPMN_2_FILENAME.substring(1);
 
-        // when
-        client
-                .newDeployResourceCommand()
-                .batch()
-                .addResourceFromClasspath(filename1)
-                .addResourceFromClasspath(filename2)
-                .send()
-                .join();
+  @Test
+  public void shouldDeployResourcesUsingBatch() {
+    // given
+    final String filename1 = BPMN_1_FILENAME.substring(1);
+    final String filename2 = BPMN_2_FILENAME.substring(1);
 
-        // then
-        final DeployResourceRequest request = gatewayService.getLastRequest();
-        assertThat(request.getResourcesList()).hasSize(2);
+    // when
+    client
+        .newDeployResourceCommand()
+        .batch()
+        .addResourceFromClasspath(filename1)
+        .addResourceFromClasspath(filename2)
+        .send()
+        .join();
 
-        final Resource resource1 = request.getResources(0);
-        assertThat(resource1.getName()).isEqualTo(filename1);
-        assertThat(resource1.getContent().toByteArray()).isEqualTo(getBytes(BPMN_1_FILENAME));
+    // then
+    final DeployResourceRequest request = gatewayService.getLastRequest();
+    assertThat(request.getResourcesList()).hasSize(2);
 
-        final Resource resource2 = request.getResources(1);
-        assertThat(resource2.getName()).isEqualTo(filename2);
-        assertThat(resource2.getContent().toByteArray()).isEqualTo(getBytes(BPMN_2_FILENAME));
-    }
+    final Resource resource1 = request.getResources(0);
+    assertThat(resource1.getName()).isEqualTo(filename1);
+    assertThat(resource1.getContent().toByteArray()).isEqualTo(getBytes(BPMN_1_FILENAME));
 
-    @Test
-    public void shouldFailWhenBatchSendWithoutResources() {
-        // when/then
-        assertThatThrownBy(() ->
-                client.newDeployResourceCommand()
-                        .batch()
-                        .send()
-                        .join()
-        ).isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("At least one resource must be added");
-    }
+    final Resource resource2 = request.getResources(1);
+    assertThat(resource2.getName()).isEqualTo(filename2);
+    assertThat(resource2.getContent().toByteArray()).isEqualTo(getBytes(BPMN_2_FILENAME));
+  }
 
+  @Test
+  public void shouldFailWhenBatchSendWithoutResources() {
+    // when/then
+    assertThatThrownBy(() -> client.newDeployResourceCommand().batch().send().join())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("At least one resource must be added");
+  }
 }

--- a/clients/java/src/test/java/io/camunda/client/resource/DeployResourceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/resource/DeployResourceTest.java
@@ -25,6 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.client.api.command.ClientException;
+import io.camunda.client.api.command.DeployResourceCommandStep1.DeployResourceCommandStep2;
 import io.camunda.client.api.response.DeploymentEvent;
 import io.camunda.client.impl.response.DecisionImpl;
 import io.camunda.client.impl.response.DecisionRequirementsImpl;
@@ -478,5 +479,25 @@ public final class DeployResourceTest extends ClientTest {
     assertThatThrownBy(() -> client.newDeployResourceCommand().batch().send().join())
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("At least one resource must be added");
+  }
+
+  @Test
+  public void shouldDeployResourceWhenTransportSwitchedFromRestToGrpcAfterAddingResource() {
+    // given
+    final String filename = BPMN_1_FILENAME.substring(1);
+
+    // when - resource is added while REST transport is active, then switched to gRPC before send
+    final DeployResourceCommandStep2 cmd = client.newDeployResourceCommand().batch();
+    cmd.useRest();
+    cmd.addResourceFromClasspath(filename);
+    cmd.useGrpc();
+    cmd.send().join();
+
+    // then
+    final DeployResourceRequest request = gatewayService.getLastRequest();
+    assertThat(request.getResourcesList()).hasSize(1);
+    assertThat(request.getResources(0).getName()).isEqualTo(filename);
+    assertThat(request.getResources(0).getContent().toByteArray())
+        .isEqualTo(getBytes(BPMN_1_FILENAME));
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/resource/rest/DeployResourceRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/resource/rest/DeployResourceRestTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import io.camunda.client.api.command.DeployResourceCommandStep1.DeployResourceCommandStep2;
 import io.camunda.client.api.response.DeploymentEvent;
 import io.camunda.client.impl.command.StreamUtil;
@@ -489,9 +490,11 @@ public class DeployResourceRestTest extends ClientRestTest {
     cmd.send().join();
 
     // then
-    LoggedRequestAssert.assertThat(RestGatewayService.getLastRequest())
+    final LoggedRequest lastRequest = RestGatewayService.getLastRequest();
+    LoggedRequestAssert.assertThat(lastRequest)
         .hasMethod(RequestMethod.POST)
         .hasUrl(RestGatewayPaths.getDeploymentsUrl());
+    assertThat(lastRequest.getBodyAsString()).contains(filename);
   }
 
   private byte[] getBytes(final String filename) {

--- a/clients/java/src/test/java/io/camunda/client/resource/rest/DeployResourceRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/resource/rest/DeployResourceRestTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.github.tomakehurst.wiremock.http.RequestMethod;
+import io.camunda.client.api.command.DeployResourceCommandStep1.DeployResourceCommandStep2;
 import io.camunda.client.api.response.DeploymentEvent;
 import io.camunda.client.impl.command.StreamUtil;
 import io.camunda.client.impl.response.DecisionImpl;
@@ -472,6 +473,25 @@ public class DeployResourceRestTest extends ClientRestTest {
         .containsExactly(
             new FormImpl(formId1, 1, 1, filename1, DEFAULT_TENANT),
             new FormImpl(formId2, 1, 2, filename2, DEFAULT_TENANT));
+  }
+
+  @Test
+  public void shouldDeployResourceWhenTransportSwitchedFromGrpcToRestAfterAddingResource() {
+    // given
+    final String filename = BPMN_1_FILENAME.substring(1);
+    gatewayService.onDeploymentsRequest(DUMMY_RESPONSE);
+
+    // when - resource is added while gRPC transport is active, then switched to REST before send
+    final DeployResourceCommandStep2 cmd = client.newDeployResourceCommand().batch();
+    cmd.useGrpc();
+    cmd.addResourceFromClasspath(filename);
+    cmd.useRest();
+    cmd.send().join();
+
+    // then
+    LoggedRequestAssert.assertThat(RestGatewayService.getLastRequest())
+        .hasMethod(RequestMethod.POST)
+        .hasUrl(RestGatewayPaths.getDeploymentsUrl());
   }
 
   private byte[] getBytes(final String filename) {


### PR DESCRIPTION
## Description

Closes #39685

Successor of #49936 

Thanks to @dahyvuun

Adds a `batch()` method to `DeployResourceCommandStep1` that returns a `DeployResourceCommandStep2` instance, allowing users to add an arbitrary list of resources without requiring at least one resource to be added upfront.

**Before:**
```java
DeployResourceCommandStep2 deployCommand =
    client.newDeployResourceCommand().addResourceFromClasspath(resources[0]);
for (int i = 1; i < resources.length; i++) {
    deployCommand = deployCommand.addResourceFromClasspath(resources[i]);
}
deployCommand.send().join();
```

**After:**
```java
final DeployResourceCommandStep2 deploymentCommand = 
    client.newDeployResourceCommand().batch();
Arrays.stream(resources).forEach(deploymentCommand::addResourceFromClasspath);
deploymentCommand.send().join();
```

## Checklist
- [x] I have added tests for my changes
- [x] Backward compatibility is maintained