### PR TITLE
test: stabilize five nightly E2E flakes on stable/8.9

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskDetailsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskDetailsPage.ts
@@ -433,10 +433,12 @@ class TaskDetailsPage {
     // Assign to the logged-in user and verify assignment
     await this.clickAssignToMeButton();
 
-    // Complete the task, wait for the banner to appear, then disappear
+    // Complete the task, wait for the banner to appear, then disappear.
+    // The completion round-trip can take longer than the default 10s on
+    // loaded shared clusters; allow 30s for the banner to surface.
     await expect(this.completeTaskButton).toBeEnabled({timeout: 15000});
     await this.clickCompleteTaskButton();
-    await expect(this.taskCompletedBanner).toBeVisible();
+    await expect(this.taskCompletedBanner).toBeVisible({timeout: 30000});
     await expect(this.taskCompletedBanner).toBeHidden({timeout: 15000});
   }
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/v1/TasklistProcessesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/v1/TasklistProcessesPage.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import type {Page, Locator} from '@playwright/test';
+import {expect, type Page, type Locator} from '@playwright/test';
 
 class TasklistProcessesPageV1 {
   private page: Page;
@@ -59,6 +59,12 @@ class TasklistProcessesPageV1 {
 
   async clickStartProcessSubButton(): Promise<void> {
     await this.startProcessSubButton.click();
+    // The start-process modal closes asynchronously after submit. If we
+    // return while its Carbon overlay (.cds--layer-one) is still mounted,
+    // the next click in the test (e.g. on the Tasks nav tab) gets
+    // intercepted by the modal header and times out. Wait for the dialog
+    // to be gone before letting the test proceed.
+    await expect(this.page.getByRole('dialog')).toBeHidden({timeout: 30000});
   }
 }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/v1/identity-users-flows.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/v1/identity-users-flows.spec.ts
@@ -21,8 +21,16 @@ import {cleanupUsers} from 'utils/usersCleanup';
 test.describe('Identity User Flows', () => {
   test.beforeAll(async () => {
     await deploy(['./resources/simpleProcessForIdentity.bpmn']);
-    await sleep(500);
-    await createInstances('identityProcess', 1, 1);
+    // The 500ms sleep after deploy is not always enough — createInstances
+    // can race the broker's process-definition propagation and fail with
+    // 404 "process definition with process ID 'identityProcess' and
+    // version '1' not found". Retry until the definition is visible.
+    await expect(async () => {
+      await createInstances('identityProcess', 1, 1);
+    }).toPass({
+      intervals: [1_000, 2_000, 5_000, 5_000],
+      timeout: 30_000,
+    });
   });
 
   const createdUsernames: string[] = [];
@@ -195,6 +203,15 @@ test.describe('Identity User Flows', () => {
       await page.goto(`${process.env.CORE_APPLICATION_URL}/tasklist`);
       await expect(page).toHaveURL(new RegExp(`tasklist`));
       await verifyAccess(page, true, 'tasklist');
+      // Tasklist's header is still mounting after verifyAccess returns —
+      // clicking the settings button immediately hits a DOM node that
+      // React detaches mid-rerender ("element was detached from the DOM,
+      // retrying"). Wait for the Tasks nav link (Tasklist-only) before
+      // touching the header. `exact: true` avoids matching the "Camunda
+      // logo Tasklist" link, whose accessible name contains "Tasks".
+      await expect(
+        page.getByRole('link', {name: 'Tasks', exact: true}),
+      ).toBeVisible({timeout: 30000});
       await identityHeader.logout();
     });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
@@ -170,6 +170,9 @@ test.describe('Operations', () => {
         ),
       ).toBeVisible({timeout: 60000});
 
+      // Canceled icons can take longer than 5s to surface after a batch
+      // cancel on a loaded shared cluster; give each instance a longer
+      // budget so the test isn't dominated by reload churn.
       await waitForAssertion({
         assertion: async () => {
           await Promise.all(
@@ -178,7 +181,7 @@ test.describe('Operations', () => {
                 operateProcessesPage.getCanceledIcon(
                   instance.processInstanceKey,
                 ),
-              ).toBeVisible({timeout: 5000}),
+              ).toBeVisible({timeout: 30000}),
             ),
           );
         },

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceListeners.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceListeners.spec.ts
@@ -178,14 +178,27 @@ test.describe('Process Instance Listeners', () => {
     });
 
     await test.step('Select specific flow node instance and verify single listener', async () => {
-      await operateProcessInstancePage
-        .getInstanceHistoryElement('Service Task B')
-        .first()
-        .click();
-      await operateProcessInstancePage.openListenersTab();
-      await expect(
-        operateProcessInstancePage.getListenerRows('execution'),
-      ).toHaveCount(1);
+      // Re-select on reload + retry: between this step and the previous
+      // one, one of the two "Service Task B" instances can finish and drop
+      // from the active history before the click lands, leaving .first()
+      // pointing at the just-added instance whose listeners haven't been
+      // recorded yet. Reload restores both instances in history, and
+      // re-clicking + re-opening the listeners tab is cheap.
+      await waitForAssertion({
+        assertion: async () => {
+          await operateProcessInstancePage
+            .getInstanceHistoryElement('Service Task B')
+            .first()
+            .click();
+          await operateProcessInstancePage.openListenersTab();
+          await expect(
+            operateProcessInstancePage.getListenerRows('execution'),
+          ).toHaveCount(1, {timeout: 5000});
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
     });
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
@@ -979,8 +979,12 @@ test.describe('Parallel job-based user task migration', () => {
           // Clicking the task card while the prior `Task completed` banner is
           // still showing on the right panel sometimes leaves the panel stuck
           // on the completed task — no Unassign button ever appears for the
-          // newly clicked task. Retry the click until the right panel
-          // actually advances to the new task (Unassign becomes visible).
+          // newly clicked task. Wait for the banner to disappear first, then
+          // retry the click until the right panel actually advances to the
+          // new task (Unassign becomes visible).
+          await expect(taskDetailsPage.taskCompletedBanner).toBeHidden({
+            timeout: 30000,
+          });
           await waitForAssertion({
             assertion: async () => {
               // Always click .nth(0) — the completed task disappears so the
@@ -993,8 +997,10 @@ test.describe('Parallel job-based user task migration', () => {
                 timeout: 10000,
               });
             },
-            onFailure: async () => {},
-            maxRetries: 3,
+            onFailure: async () => {
+              await page.reload();
+            },
+            maxRetries: 5,
           });
 
           await taskDetailsPage.unassignReassignToMeAndComplete();

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
@@ -973,18 +973,27 @@ test.describe('Parallel job-based user task migration', () => {
 
     await test.step('Open each task, unassign, assign to self, and complete', async () => {
       const taskNames = targetTaskCards.map((task) => task.name);
+      let firstIteration = true;
 
       for (const taskName of taskNames) {
         for (let i = 0; i < totalV2InstanceCount; i++) {
-          // Clicking the task card while the prior `Task completed` banner is
-          // still showing on the right panel sometimes leaves the panel stuck
-          // on the completed task — no Unassign button ever appears for the
-          // newly clicked task. Wait for the banner to disappear first, then
-          // retry the click until the right panel actually advances to the
-          // new task (Unassign becomes visible).
-          await expect(taskDetailsPage.taskCompletedBanner).toBeHidden({
-            timeout: 30000,
-          });
+          // After completing a task, the right panel can stay stuck on the
+          // just-completed task's content (URL still /tasklist/{completedId})
+          // even after the "Task completed" banner dismisses. A subsequent
+          // side-panel click then doesn't reliably update the URL/panel, so
+          // Unassign never surfaces. Force a clean panel state between
+          // iterations by navigating back to the task list root.
+          if (firstIteration) {
+            firstIteration = false;
+          } else {
+            await page.goto(
+              `${process.env.CORE_APPLICATION_URL}/tasklist?filter=all-open`,
+            );
+            await expect(taskDetailsPage.pickATaskHeader).toBeVisible({
+              timeout: 30000,
+            });
+          }
+
           await waitForAssertion({
             assertion: async () => {
               // Always click .nth(0) — the completed task disappears so the
@@ -998,7 +1007,9 @@ test.describe('Parallel job-based user task migration', () => {
               });
             },
             onFailure: async () => {
-              await page.reload();
+              await page.goto(
+                `${process.env.CORE_APPLICATION_URL}/tasklist?filter=all-open`,
+              );
             },
             maxRetries: 5,
           });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesTable.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesTable.spec.ts
@@ -105,9 +105,12 @@ test.describe('Process Instances Table', () => {
     });
 
     await test.step('Check default sorting of processes', async () => {
+      // All three rows need the longer defaultAssertionOptions budget — the
+      // nth(0) row was using Playwright's 5s default and flaked first.
       await expect
-        .poll(() =>
-          operateProcessesPage.processInstancesTable.nth(0).innerText(),
+        .poll(
+          () => operateProcessesPage.processInstancesTable.nth(0).innerText(),
+          defaultAssertionOptions,
         )
         .toContain(instanceIds[2].toString());
       await expect
@@ -275,15 +278,19 @@ test.describe('Process Instances Table', () => {
         'Process For Infinite Scroll',
       );
       await operateFiltersPanelPage.selectVersion('1');
+      // 350 instances can take longer than 10s to be indexed on a loaded
+      // shared cluster, and waitForAssertion's default 3 reloads aren't
+      // enough budget. Give each poll a longer timeout and more retries.
       await waitForAssertion({
         assertion: async () => {
           await expect(
             page.getByText(`${amountOfInstancesForInfiniteScroll} results`),
-          ).toBeVisible();
+          ).toBeVisible({timeout: 30000});
         },
         onFailure: async () => {
           await page.reload();
         },
+        maxRetries: 6,
       });
       await operateProcessesPage.clickProcessInstanceKeySortButton();
       await expect(instanceRows).toHaveCount(50);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/processes-page.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/processes-page.spec.ts
@@ -130,7 +130,11 @@ test.describe('process page', () => {
 
     await taskDetailsPage.clickAssignToMeButton();
     await taskDetailsPage.clickCompleteTaskButton();
-    await expect(page.getByText('Task completed')).toBeVisible();
+    // Completion round-trip can take longer than the default 10s on a
+    // loaded shared cluster.
+    await expect(page.getByText('Task completed')).toBeVisible({
+      timeout: 30000,
+    });
   });
 
   test('complete process with start node having deployed form', async ({

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
@@ -294,6 +294,7 @@ test.describe('task details page', () => {
   });
 
   test('task completion with form from assigned to me filter', async ({
+    page,
     taskPanelPage,
     taskDetailsPage,
   }) => {
@@ -316,11 +317,25 @@ test.describe('task details page', () => {
 
     await taskPanelPage.filterBy('Completed');
     await taskPanelPage.assertCompletedHeadingVisible();
-    await taskPanelPage.openTask('User registration');
 
-    await taskDetailsPage.assertFieldValue('Name*', 'Gaius Julius Caesar');
-    await taskDetailsPage.assertFieldValue('Address*', 'Rome');
-    await taskDetailsPage.assertFieldValue('Age', '55');
+    // Multiple "User registration" tasks may be completed across tests in
+    // this file. openTask clicks .nth(0), which can land on an earlier
+    // completion (e.g. Jon/Earth from "task completion with form") before
+    // the indexer surfaces the just-completed task at the top. Re-open and
+    // re-assert on reload so we eventually inspect the right task.
+    await waitForAssertion({
+      assertion: async () => {
+        await taskPanelPage.openTask('User registration');
+        await taskDetailsPage.assertFieldValue('Name*', 'Gaius Julius Caesar');
+        await taskDetailsPage.assertFieldValue('Address*', 'Rome');
+        await taskDetailsPage.assertFieldValue('Age', '55');
+      },
+      onFailure: async () => {
+        await page.reload();
+        await taskPanelPage.filterBy('Completed');
+        await taskPanelPage.assertCompletedHeadingVisible();
+      },
+    });
   });
 
   test('task completion with prefilled form', async ({

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-history.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-history.spec.ts
@@ -40,16 +40,22 @@ test.describe('Task History Audit Log', () => {
       await taskPanelPage.goToTaskDetails(taskKey);
 
       await taskDetailsPage.clickAssignToMeButton();
-      await expect(taskDetailsPage.unassignButton).toBeVisible();
+      // Unassign button replaces Assign-to-me asynchronously after the
+      // assign POST resolves; the default 10s races tasklist refresh on a
+      // loaded shared cluster (matches the 90s afterEach budget below).
+      await expect(taskDetailsPage.unassignButton).toBeVisible({
+        timeout: 30000,
+      });
     },
   );
 
   test.afterEach(async ({page, taskDetailsPage}, testInfo) => {
     await taskDetailsPage.clickUnassignButton();
     // The Assign-to-me toggle replaces Unassign asynchronously after the
-    // unassign POST resolves; allow up to 60s to ride out tasklist refresh.
+    // unassign POST resolves; 60s was hit by the May 19 nightly, so allow
+    // 90s to ride out tasklist refresh on a loaded shared cluster.
     await expect(taskDetailsPage.assignToMeButton).toBeVisible({
-      timeout: 60000,
+      timeout: 90000,
     });
 
     await captureScreenshot(page, testInfo);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/task-details.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/task-details.spec.ts
@@ -212,6 +212,9 @@ test.describe('task details page', () => {
     await taskPanelPageV1.filterBy('Completed');
     await taskPanelPageV1.assertCompletedHeadingVisible();
     await taskPanelPageV1.openTask('Zeebe_user_task');
+    // The variable-importer can take longer than the default 3-retry budget
+    // (3 × 60s with reload) to surface `zeebeVar` on a loaded cluster — the
+    // May 19 v1 nightly hit that ceiling. Give it more retries.
     await waitForAssertion({
       assertion: async () => {
         await expect(page.getByRole('cell', {name: 'zeebeVar'})).toBeVisible({
@@ -221,6 +224,7 @@ test.describe('task details page', () => {
       onFailure: async () => {
         await page.reload();
       },
+      maxRetries: 6,
     });
     await expect(taskDetailsPageV1.assignToMeButton).toBeHidden();
     await expect(taskDetailsPageV1.unassignButton).toBeHidden();


### PR DESCRIPTION
## Summary

Stabilization PR for the C8 Orchestration Cluster E2E nightly on `stable/8.9`. Rolls up all test issues surfaced across the May 19 nightly + two on-demand re-runs against this branch.

## Validation runs

- Initial nightly that surfaced the first batch: https://github.com/camunda/camunda/actions/runs/26071517584/job/76653731694
- On-demand re-run #1 (v1 job): https://github.com/camunda/camunda/actions/runs/26081967361/job/76685777078
- On-demand re-run #1 (v2 job): https://github.com/camunda/camunda/actions/runs/26081967361/job/76685777093
- On-demand re-run #2 (post-fixes): https://github.com/camunda/camunda/actions/runs/26088985103 all 🟢 

## Original v2 nightly (May 19)

Hard fails (2):
- `processInstancesTable.spec.ts:262` "Scrolling of process instances" — the indexer needed longer than the existing 10s × 3-retry budget to surface 350 instances. Per-poll timeout 30s, `maxRetries` 6.
- `processInstanceMigration.spec.ts:797` "Migrate parallel job-based user tasks" — the right panel can stick on the previous task's "Task completed" banner. Wait for the banner to clear before clicking the next task; give the click + Unassign-visible loop a `page.reload()` recovery and bump `maxRetries` to 5.

Flakes (3):
- `operations.spec.ts:123` "Retry and cancel multiple instances" — `getCanceledIcon` 5s → 30s.
- `processInstancesTable.spec.ts:78` "Sorting of process instances" — `nth(0)` row poll was using Playwright's 5s default while `nth(1)`/`nth(2)` used `defaultAssertionOptions` (30s). Pass options to `nth(0)` too.
- `task-details.spec.ts:296` "task completion with form from assigned to me filter" — port of #53285 (stable/8.8). Wrap open + assert in `waitForAssertion` that reloads and reapplies the Completed filter on failure.

## On-demand re-run v1 job

- `Admin user can delete user` — flaky, fails initial 0ms with 404 "process definition with process ID 'identityProcess' and version '1' not found". Retry `createInstances('identityProcess', 1, 1)` with `expect().toPass()` so it survives the deploy-propagation lag (500ms sleep wasn't enough).
- `Admin user can grant and revoke component authorization for user` — hard fail both attempts, settings button "element was detached from the DOM, retrying". Wait for Tasklist's "Tasks" nav link (`exact: true`, to avoid matching "Camunda logo Tasklist") to be visible after `verifyAccess` returns, before calling `identityHeader.logout()`.

## On-demand re-run v2 job (after first batch was already applied)

Hard fails (2):
- `processInstanceMigration.spec.ts:797` again — previous fix waited for the prior "Task completed" banner to be hidden; now the failure is the *next* task's banner not appearing within the default 10s after `clickCompleteTaskButton`. Bump the `taskCompletedBanner.toBeVisible` budget inside `TaskDetailsPage.unassignReassignToMeAndComplete` 10s → 30s.
- `processInstanceListeners.spec.ts:120` "Listeners list filtered by flow node instance" — between "verify count == 2" and "select specific instance", one of the two Service Task B instances can finish and drop from active history, leaving `.first()` pointing at the just-added instance whose listeners haven't been recorded yet (page snapshot at failure shows the empty state with only one Service Task B treeitem). Wrap the click + listener-count assertion in `waitForAssertion` with reload recovery.

Flakes (2):
- `tasklist/processes-page.spec.ts:101` "complete task started by process instance" — `Task completed` 10s → 30s.
- `tasklist/task-history.spec.ts:63` "Audit log entries" afterEach: `assignToMeButton` 60s → 90s after unassign; also bump beforeEach `unassignButton` default 10s → 30s (slow-cluster symmetry; locally the beforeEach was the first to time out).



## Test plan
- [x] `npx tsc --noEmit` — no new errors
- [x] `npx eslint` on changed files — 0 errors
- [x] Local validation against the running env: `operations.spec.ts:123`, `task-details.spec.ts:296`, `processes-page.spec.ts:101` pass; `task-history` flake passes after the additional beforeEach fix; `processInstancesTable.spec.ts:262` failed locally only due to pre-existing 1050 stale instances on the local cluster (CI runs from clean state, so the 30s × 6 retry is sufficient there); migration spec skipped locally (10+ min)
- [ ] Re-run nightly E2E on `stable/8.9` after merge — confirm all targeted tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)