### PR TITLE
test: extend startup timeout for *BackupCompatibilityIT old broker

### DIFF
--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/backup/BackupCompatibilityAcceptance.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/backup/BackupCompatibilityAcceptance.java
@@ -376,6 +376,9 @@ public interface BackupCompatibilityAcceptance {
                     .withPrefix(imageName.asCanonicalNameString()))
             .withEmbeddedGateway()
             .withTopologyCheck(new ZeebeTopologyWaitStrategy(1, 1, 1))
+            // Previous-version monolith needs 50–60 s to reach /ready on a contended CI
+            // runner; the default 1 min budget sits on the cliff and flakes.
+            .withStartupTimeout(Duration.ofSeconds(90))
             .withEnv("CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI", "true");
 
     // Apply backup store specific env vars


### PR DESCRIPTION
Bump the Testcontainers startup timeout for the old broker in `BackupCompatibilityAcceptance.createOldBroker()` from the default 1 min to 90 seconds.

The three `*BackupCompatibilityIT` tests (Azure / GCS / S3) under `zeebe/qa/update-tests` flake intermittently with `ContainerLaunchException: Could not create/start container` on the previous-version broker container (`camunda/camunda:8.9.0`). Two recent occurrences:

- https://github.com/camunda/camunda/actions/runs/26043130232/attempts/1 (Azure)
- https://github.com/camunda/camunda/actions/runs/26030779126/attempts/1 (GCS)

Reconstructing the boot timeline from the failed attempt's `-1-output.txt`, the 8.9 monolith reaches `/ready` on the management Tomcat (port 9600) at roughly **T+57s**. The Testcontainers wait strategy in `CamundaContainer.newDefaultWaitStrategy()` runs with a **1 min outer budget**, which leaves essentially zero slack for the HTTP poll and `ZeebeTopologyWaitStrategy` to observe ready state. Any minor CI noise (image-layer extract, JVM JIT under shared-CPU contention, disk stall) pushes the boot past 60 s and Testcontainers aborts.

Where the ~57 s go:

- ~10 s JVM cold start + entrypoint
- ~16 s Spring `WebApplicationContext` init for the main (8080) context (monolith bean wiring)
- ~13 s Zeebe broker startup: cluster/raft/migrations/snapshot
- ~8 s opaque silent gap inside the LEADER transition
- ~5 s management Tomcat + final health recovery
