### PR TITLE
[DO NOT MERGE] ci: reproduce #52956 to isolate CI failure cause

### DIFF
--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -5,10 +5,13 @@
 name: Docker Build and Helm Integration Test
 
 on:
+  push:
+    branches:
+      - stable/8.8
   workflow_dispatch:
     inputs:
       version:
-        description: 'Docker image version tag (defaults to pr-<sha> or Maven version)'
+        description: 'Docker image version tag (defaults to ...-mq<PR_NUMBER>-run<run_id>-a<attempt> for merge queue, ...-dispatch-run<run_id>-a<attempt> for manual dispatch, or ...-stable-8.8-run<run_id>-a<attempt> for push to stable/8.8)'
         type: string
         required: false
       helmRepositoryBranchName:
@@ -22,7 +25,7 @@ on:
       scenario:
         description: 'Test scenario'
         type: string
-        default: 'keycloak-original'
+        default: 'alwaysgreen'
       deployment-ttl:
         description: 'Deployment TTL'
         type: string
@@ -30,22 +33,15 @@ on:
       shortname:
         description: 'Short name for the deployment'
         type: string
-        default: 'kcor'
-  pull_request:
-    paths:
-      - ".github/workflows/docker-build-helm-integration.yml"
-      - "camunda.Dockerfile"
-      - "dist/**"
-      - "zeebe/**"
-      - "operate/**"
-      - "tasklist/**"
-      - "identity/**"
-      - "optimize/**"
-      - "parent/pom.xml"
+        default: 'agrn'
+  merge_group:
+    types:
+      - checks_requested
 
-# Cancel in-progress runs when a new commit is pushed to the same PR
+# Limit workflow to 1 concurrent run per ref (branch) and trigger event (push/schedule/etc): new commit -> old runs are canceled to save costs
+# Exception for main + stable/* branches: complete builds for every commit needed for confidence
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ format('{0}-{1}-{2}', github.workflow, github.event_name, (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/')) && github.sha || github.ref) }}
   cancel-in-progress: true
 
 env:
@@ -63,11 +59,12 @@ jobs:
     name: Check Run Conditions
     runs-on: ubuntu-latest
     timeout-minutes: 1
+    continue-on-error: ${{ github.event_name == 'merge_group' }}
     permissions: { }
     if: >
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' &&
-       !contains(github.event.pull_request.labels.*.name, 'skip-always-green'))
+      github.event_name == 'push' ||
+      github.event_name == 'merge_group'
     steps:
       - run: echo "Workflow conditions met, proceeding with build"
   # Parallel frontend builds
@@ -77,6 +74,7 @@ jobs:
     permissions: { }
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    continue-on-error: ${{ github.event_name == 'merge_group' }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -106,6 +104,7 @@ jobs:
     permissions: { }
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    continue-on-error: ${{ github.event_name == 'merge_group' }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -135,6 +134,7 @@ jobs:
     permissions: { }
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    continue-on-error: ${{ github.event_name == 'merge_group' }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -167,6 +167,7 @@ jobs:
     permissions: { }
     runs-on: gcp-perf-core-8-default
     timeout-minutes: 30
+    continue-on-error: ${{ github.event_name == 'merge_group' }}
     outputs:
       image-tag: ${{ steps.set-image-tag.outputs.tag }}
     steps:
@@ -196,13 +197,20 @@ jobs:
           if [[ -n "${{ inputs.version }}" ]]; then
             # Use explicitly provided version
             echo "tag=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
-          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            # For PRs: <maven-version>-pr<PR_NUMBER>-run<run_id>-a<run_attempt>
-            echo "tag=${MAVEN_VERSION}-pr${{ github.event.pull_request.number }}-run${{ github.run_id }}-a${{ github.run_attempt }}" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.event_name }}" == "merge_group" ]]; then
+            # For merge queue: <maven-version>-mq<PR_NUMBER>-run<run_id>-a<run_attempt>
+            PR_NUM=$(sed -nE 's|^refs/heads/gh-readonly-queue/.+/pr-([0-9]+)-.*$|\1|p' <<< "${{ github.ref }}")
+            if [[ -z "${PR_NUM}" ]]; then
+              echo "Failed to resolve a single PR number from merge_group ref: '${{ github.ref }}'" >&2
+              exit 1
+            fi
+            echo "tag=${MAVEN_VERSION}-mq${PR_NUM}-run${{ github.run_id }}-a${{ github.run_attempt }}" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            # For manual dispatch: <maven-version>-dispatch-run<run_id>-a<run_attempt> (e.g., 8.8.0-SNAPSHOT-dispatch-run12345678-a1)
+            echo "tag=${MAVEN_VERSION}-dispatch-run${{ github.run_id }}-a${{ github.run_attempt }}" >> "$GITHUB_OUTPUT"
           else
-            # For manual dispatch: <maven-version>-<short-sha> (e.g., 8.8.0-SNAPSHOT-abc1234)
-            SHA_SHORT="${GITHUB_SHA::7}"
-            echo "tag=${MAVEN_VERSION}-${SHA_SHORT}" >> "$GITHUB_OUTPUT"
+            # For push to stable/8.8: <maven-version>-stable-8.8-run<run_id>-a<run_attempt> (e.g., 8.8.0-SNAPSHOT-stable-8.8-run12345678-a1)
+            echo "tag=${MAVEN_VERSION}-stable-8.8-run${{ github.run_id }}-a${{ github.run_attempt }}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Download Operate frontend artifact
@@ -268,6 +276,7 @@ jobs:
     permissions: { }
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    continue-on-error: ${{ github.event_name == 'merge_group' }}
     outputs:
       identifier: ${{ steps.format.outputs.identifier }}
     steps:
@@ -296,8 +305,8 @@ jobs:
       test-enabled: true
       e2e-enabled: true
       deployment-ttl: ${{ inputs.deployment-ttl || '' }}
-      scenario: ${{ inputs.scenario || 'keycloak-original' }}
-      shortname: ${{ inputs.shortname || 'kcor' }}
+      scenario: ${{ inputs.scenario || 'alwaysgreen' }}
+      shortname: ${{ inputs.shortname || 'agrn' }}
       always-delete-namespace: true
       flows: install
       extra-values: |
@@ -322,6 +331,7 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 3
+    continue-on-error: ${{ github.event_name == 'merge_group' }}
     permissions: { }
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Why this PR exists — diagnostic only

This PR carries the **byte-identical diff** of #52956 (`ci: switch docker-build-helm-integration to merge_group trigger (stable/8.8)`) on a fresh branch off the current `stable/8.8` tip. Its only purpose is to A/B-test whether the failures observed on #52956 are reproducible on any new PR with the same diff, or tied to something specific to #52956's branch.

**Do not merge.** I'll close this once we have a CI result.

## Background

#52956 has been failing `General / Unit - Back End` and `Zeebe / Integration / Zeebe Engine Modules ITs` since at least 2026-05-18, with the same `Container exited with code 255` error pulling `camunda/camunda:SNAPSHOT` via Testcontainers. Sara has rebased onto `stable/8.8` multiple times without changing the outcome.

The working theory is:

- The `.github/workflows/**` paths-filter rule in `.github/actions/paths-filter/action.yml` flips `ci-relevant=true` for any non-excluded workflow-file change, which OR's into every backend test filter and triggers the full Java suite, including `testing/camunda-process-test-example` (`ProcessNestedUnitTest`) and Zeebe ITs (`DataAvailabilityIT`, `StarterWorkerIT`).
- Those tests pull `camunda/camunda:SNAPSHOT` from Docker Hub. The currently published `:SNAPSHOT` image exits 255 on startup, so every fresh CI run on a diff that triggers those tests fails identically.
- Other open stable/8.8 PRs (renovate dep bumps etc.) don't match the paths-filter rule, so they don't exercise these tests — they "look passing" without actually validating against the broken image.

## Expected outcome

- If this PR fails with the same `camunda/camunda:SNAPSHOT` exit-255 error → the failures are **diff-driven** (paths-filter + broken `:SNAPSHOT` image), and #52956 is fine. Fix lives in whoever publishes `camunda/camunda:SNAPSHOT` from `main`.
- If this PR **passes** → the failures are tied to something on #52956's branch (e.g. accumulated rebase state, a specific commit) and we should look there.

## Companion

Same investigation also applies to stable/8.9 PR #52955. Happy to mirror this branch off `stable/8.9` if useful for a second data point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)