### PR TITLE
fix: preserve existing ILM/ISM policies when managePolicy is disabled

### DIFF
--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/os/ILMPolicyUpdateOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/os/ILMPolicyUpdateOpenSearch.java
@@ -43,8 +43,12 @@ public class ILMPolicyUpdateOpenSearch implements ILMPolicyUpdate {
   public void applyIlmPolicyToAllIndices() throws IOException {
     LOGGER.info("Applying ISM policy to index templates and existing indices");
 
-    // Ensure that the ISM policy exists before applying it to any templates or indices
-    schemaManager.createIndexLifeCyclesIfNotExist();
+    if (tasklistProperties.getArchiver().isIlmManagePolicy()) {
+      // Ensure that the ISM policy exists before applying it to any templates or indices
+      schemaManager.createIndexLifeCyclesIfNotExist();
+    } else {
+      LOGGER.info("ISM policy is not managed by tasklist, skipping creation");
+    }
 
     // Apply the ISM policy to the index templates
     applyIlmPolicyToIndexTemplate(true);

--- a/tasklist/els-schema/src/test/java/io/camunda/tasklist/os/ILMPolicyUpdateOpenSearchTest.java
+++ b/tasklist/els-schema/src/test/java/io/camunda/tasklist/os/ILMPolicyUpdateOpenSearchTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.tasklist.os;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.tasklist.property.TasklistProperties;
+import io.camunda.tasklist.schema.manager.OpenSearchSchemaManager;
+import java.io.IOException;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ILMPolicyUpdateOpenSearchTest {
+
+  @Mock private RetryOpenSearchClient retryOpenSearchClient;
+  @Mock private OpenSearchSchemaManager schemaManager;
+  @Spy private TasklistProperties tasklistProperties;
+  @InjectMocks private ILMPolicyUpdateOpenSearch instance;
+
+  @Test
+  void shouldCreatePolicyWhenManagePolicyEnabled() throws IOException {
+    // given
+    tasklistProperties.getArchiver().setIlmManagePolicy(true);
+    when(retryOpenSearchClient.getIndexTemplateSettings(anyString())).thenReturn(null);
+    when(retryOpenSearchClient.getIndexNames(anyString())).thenReturn(Set.of());
+
+    // when
+    instance.applyIlmPolicyToAllIndices();
+
+    // then
+    verify(schemaManager, times(1)).createIndexLifeCyclesIfNotExist();
+  }
+
+  @Test
+  void shouldSkipPolicyCreationWhenManagePolicyDisabled() throws IOException {
+    // given
+    tasklistProperties.getArchiver().setIlmManagePolicy(false);
+    when(retryOpenSearchClient.getIndexTemplateSettings(anyString())).thenReturn(null);
+    when(retryOpenSearchClient.getIndexNames(anyString())).thenReturn(Set.of());
+
+    // when
+    instance.applyIlmPolicyToAllIndices();
+
+    // then
+    verify(schemaManager, never()).createIndexLifeCyclesIfNotExist();
+  }
+}

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/ILMService.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/ILMService.java
@@ -28,14 +28,17 @@ public class ILMService {
 
   @PostConstruct
   public void init() throws IOException {
-    if (tasklistProperties.isArchiverEnabled()) {
-      if (tasklistProperties.getArchiver().isIlmEnabled()) {
-        applyIlmPolicyToAllIndices();
-      } else {
-        removeIlmPolicyFromAllIndices();
-      }
-    } else {
+    if (!tasklistProperties.isArchiverEnabled()) {
       LOGGER.info("Archiver is not enabled, skipping ILM policy update");
+      return;
+    }
+    if (tasklistProperties.getArchiver().isIlmEnabled()) {
+      applyIlmPolicyToAllIndices();
+    } else if (tasklistProperties.getArchiver().isIlmManagePolicy()) {
+      removeIlmPolicyFromAllIndices();
+    } else {
+      LOGGER.info(
+          "ILM is disabled and ilmManagePolicy=false; leaving existing ILM/ISM policy assignments untouched");
     }
   }
 

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/service/ILMServiceTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/service/ILMServiceTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.tasklist.webapp.service;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.tasklist.management.ILMPolicyUpdate;
+import io.camunda.tasklist.property.TasklistProperties;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ILMServiceTest {
+
+  @Mock private ILMPolicyUpdate ilmPolicyUpdate;
+  @Spy private TasklistProperties tasklistProperties;
+  @InjectMocks private ILMService instance;
+
+  @Test
+  void shouldApplyPolicyWhenIlmEnabled() throws IOException {
+    // given
+    tasklistProperties.setArchiverEnabled(true);
+    tasklistProperties.getArchiver().setIlmEnabled(true);
+    tasklistProperties.getArchiver().setIlmManagePolicy(true);
+
+    // when
+    instance.init();
+
+    // then
+    verify(ilmPolicyUpdate, times(1)).applyIlmPolicyToAllIndices();
+    verify(ilmPolicyUpdate, never()).removeIlmPolicyFromAllIndices();
+  }
+
+  @Test
+  void shouldRemovePolicyWhenIlmDisabledAndManagePolicyEnabled() throws IOException {
+    // given
+    tasklistProperties.setArchiverEnabled(true);
+    tasklistProperties.getArchiver().setIlmEnabled(false);
+    tasklistProperties.getArchiver().setIlmManagePolicy(true);
+
+    // when
+    instance.init();
+
+    // then
+    verify(ilmPolicyUpdate, never()).applyIlmPolicyToAllIndices();
+    verify(ilmPolicyUpdate, times(1)).removeIlmPolicyFromAllIndices();
+  }
+
+  @Test
+  void shouldLeaveExistingPolicyAloneWhenIlmDisabledAndManagePolicyDisabled() throws IOException {
+    // given
+    tasklistProperties.setArchiverEnabled(true);
+    tasklistProperties.getArchiver().setIlmEnabled(false);
+    tasklistProperties.getArchiver().setIlmManagePolicy(false);
+
+    // when
+    instance.init();
+
+    // then neither apply nor remove is invoked — pre-existing assignments are preserved
+    verify(ilmPolicyUpdate, never()).applyIlmPolicyToAllIndices();
+    verify(ilmPolicyUpdate, never()).removeIlmPolicyFromAllIndices();
+  }
+
+  @Test
+  void shouldSkipEntirelyWhenArchiverDisabled() throws IOException {
+    // given
+    tasklistProperties.setArchiverEnabled(false);
+
+    // when
+    instance.init();
+
+    // then
+    verify(ilmPolicyUpdate, never()).applyIlmPolicyToAllIndices();
+    verify(ilmPolicyUpdate, never()).removeIlmPolicyFromAllIndices();
+  }
+}

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/SchemaManager.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/SchemaManager.java
@@ -57,8 +57,10 @@ public class SchemaManager {
     final boolean acknowledged;
     if (configuration.retention.isEnabled()) {
       acknowledged = client.bulkPutIndexLifecycleSettings(configuration.retention.getPolicyName());
-    } else {
+    } else if (configuration.retention.isManagePolicy()) {
       acknowledged = client.bulkPutIndexLifecycleSettings(null);
+    } else {
+      return;
     }
 
     if (!acknowledged) {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/TemplateReader.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/TemplateReader.java
@@ -91,8 +91,12 @@ final class TemplateReader {
       settings.put("number_of_replicas", numberOfReplicas);
     }
 
-    // update index.lifecycle in template in case a retention policy is configured
-    if (config.retention.isEnabled()) {
+    // update index.lifecycle in template in case a retention policy is configured.
+    // When managePolicy is false the exporter must leave existing lifecycle settings
+    // intact, so we keep writing the configured policy name into the template even when
+    // retention is disabled - otherwise the template would be overwritten without the
+    // policy and future rolled indices would be created without it.
+    if (config.retention.isEnabled() || !config.retention.isManagePolicy()) {
       settings.put("index.lifecycle.name", config.retention.getPolicyName());
     }
   }

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
@@ -337,6 +337,31 @@ final class ElasticsearchExporterIT {
       assertIndexSettingsHasNoLifecyclePolicy(response1);
     }
 
+    @Test
+    void shouldPreserveExistingLifecyclePolicyWhenManagePolicyIsDisabled() {
+      // given retention is enabled and a record is exported so the policy is set
+      configureExporter(true);
+      final var record1 = generateRecord(ValueType.JOB);
+      export(record1);
+
+      final var index1 = indexRouter.indexFor(record1);
+      var response1 = testClient.getIndexSettings(index1);
+      assertIndexSettingsHasLifecyclePolicy(response1);
+
+      // when retention is disabled but the exporter is told not to manage policies
+      configureExporter(
+          config -> {
+            config.retention.setEnabled(false);
+            config.retention.setManagePolicy(false);
+          });
+      final var record2 = generateRecord(ValueType.JOB);
+      export(record2);
+
+      // then the pre-existing policy must remain on the existing index
+      response1 = testClient.getIndexSettings(index1);
+      assertIndexSettingsHasLifecyclePolicy(response1);
+    }
+
     /**
      * Default timeout for elasticsearch `PUT /<target>/_settings` is 30 seconds.
      *

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TemplateReaderTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TemplateReaderTest.java
@@ -157,4 +157,36 @@ final class TemplateReaderTest {
     // then
     assertThat(template.template().settings()).containsEntry("index.lifecycle.name", "auto-trash");
   }
+
+  @Test
+  void shouldKeepLifecyclePolicyInTemplateWhenManagePolicyIsDisabledAndRetentionDisabled() {
+    // given retention is disabled but managePolicy=false means hands-off; the template
+    // must retain the policy name so future rolled indices inherit it
+    config.retention.setEnabled(false);
+    config.retention.setManagePolicy(false);
+    config.retention.setPolicyName("auto-trash");
+    final var valueType = ValueType.VARIABLE;
+
+    // when
+    final var template = templateReader.readIndexTemplate(valueType, "searchPattern", "alias");
+
+    // then
+    assertThat(template.template().settings()).containsEntry("index.lifecycle.name", "auto-trash");
+  }
+
+  @Test
+  void shouldOmitLifecyclePolicyFromTemplateWhenRetentionDisabledAndManagePolicyEnabled() {
+    // given the destructive default behavior: retention disabled with managePolicy=true
+    // should strip the policy from the template
+    config.retention.setEnabled(false);
+    config.retention.setManagePolicy(true);
+    config.retention.setPolicyName("auto-trash");
+    final var valueType = ValueType.VARIABLE;
+
+    // when
+    final var template = templateReader.readIndexTemplate(valueType, "searchPattern", "alias");
+
+    // then
+    assertThat(template.template().settings()).doesNotContainKey("index.lifecycle.name");
+  }
 }

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
@@ -219,10 +219,12 @@ public class OpensearchExporter implements Exporter {
   }
 
   private void createIndexTemplates(final String version) {
-    if (configuration.retention.isEnabled()) {
-      createIndexStateManagementPolicy();
-    } else {
-      deleteIndexStateManagementPolicy();
+    if (configuration.retention.isManagePolicy()) {
+      if (configuration.retention.isEnabled()) {
+        createIndexStateManagementPolicy();
+      } else {
+        deleteIndexStateManagementPolicy();
+      }
     }
 
     final IndexConfiguration index = configuration.index;
@@ -393,8 +395,10 @@ public class OpensearchExporter implements Exporter {
     final boolean successful;
     if (configuration.retention.isEnabled()) {
       successful = client.bulkAddISMPolicyToAllZeebeIndices();
-    } else {
+    } else if (configuration.retention.isManagePolicy()) {
       successful = client.bulkRemoveISMPolicyToAllZeebeIndices();
+    } else {
+      return;
     }
 
     if (!successful) {

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
@@ -410,6 +410,7 @@ public class OpensearchExporterConfiguration {
     private String minimumAge = "30d";
     private String policyName = "zeebe-record-retention-policy";
     private String policyDescription = "Zeebe record retention policy";
+    private boolean managePolicy = true;
 
     public boolean isEnabled() {
       return enabled;
@@ -443,6 +444,14 @@ public class OpensearchExporterConfiguration {
       this.policyDescription = policyDescription;
     }
 
+    public boolean isManagePolicy() {
+      return managePolicy;
+    }
+
+    public void setManagePolicy(final boolean managePolicy) {
+      this.managePolicy = managePolicy;
+    }
+
     @Override
     public String toString() {
       return "RetentionConfiguration{"
@@ -455,6 +464,8 @@ public class OpensearchExporterConfiguration {
           + ", policyDescription='"
           + policyDescription
           + '\''
+          + ", managePolicy="
+          + managePolicy
           + '}';
     }
   }

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
@@ -463,6 +463,45 @@ final class OpensearchExporterIT {
     }
 
     @Test
+    void shouldPreserveExistingISMPolicyWhenManagePolicyIsDisabled() {
+      // given retention is enabled and a record exists with the policy applied
+      configureExporter(true);
+      final var record1 = generateRecord(ValueType.JOB);
+      export(record1);
+
+      final var index1 = indexRouter.indexFor(record1);
+      await()
+          .atMost(Duration.ofSeconds(30))
+          .untilAsserted(
+              () -> {
+                final var indexPolicy1 = testClient.explainIndex(index1);
+                assertHasISMPolicy(indexPolicy1);
+              });
+
+      // when retention is disabled but the exporter is told not to manage policies
+      configureExporter(
+          config -> {
+            config.retention.setEnabled(false);
+            config.retention.setManagePolicy(false);
+          });
+      final var record2 = generateRecord(ValueType.JOB);
+      export(record2);
+
+      // then the pre-existing policy must remain on existing indices
+      final var index2 = indexRouter.indexFor(record2);
+      await()
+          .during(Duration.ofSeconds(5))
+          .atMost(Duration.ofSeconds(30))
+          .untilAsserted(
+              () -> {
+                final var indexPolicy1 = testClient.explainIndex(index1);
+                assertHasISMPolicy(indexPolicy1);
+                final var indexPolicy2 = testClient.explainIndex(index2);
+                assertHasISMPolicy(indexPolicy2);
+              });
+    }
+
+    @Test
     void shouldNotTimeoutWhenUpdatingLifecyclePolicyForExistingIndices() {
       // given
       configureExporter(false);

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterTest.java
@@ -149,6 +149,51 @@ final class OpensearchExporterTest {
   }
 
   @Test
+  void shouldNotManagePolicyResourceWhenManagePolicyIsDisabledAndRetentionEnabled() {
+    // given
+    config.retention.setEnabled(true);
+    config.retention.setManagePolicy(false);
+    exporter.configure(context);
+    exporter.open(controller);
+
+    // when
+    final var recordMock = mock(Record.class);
+    when(recordMock.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
+    exporter.export(recordMock);
+
+    // then the policy resource is left untouched (no read/create/update/delete)
+    verify(client, never()).getIndexStateManagementPolicy();
+    verify(client, never()).createIndexStateManagementPolicy();
+    verify(client, never()).updateIndexStateManagementPolicy(anyInt(), anyInt());
+    verify(client, never()).deleteIndexStateManagementPolicy();
+    // but the (externally managed) policy is still attached to existing indices
+    verify(client, times(1)).bulkAddISMPolicyToAllZeebeIndices();
+    verify(client, never()).bulkRemoveISMPolicyToAllZeebeIndices();
+  }
+
+  @Test
+  void shouldNotTouchPolicyWhenManagePolicyIsDisabledAndRetentionDisabled() {
+    // given
+    config.retention.setEnabled(false);
+    config.retention.setManagePolicy(false);
+    exporter.configure(context);
+    exporter.open(controller);
+
+    // when
+    final var recordMock = mock(Record.class);
+    when(recordMock.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
+    exporter.export(recordMock);
+
+    // then nothing about the policy resource or its assignments is touched
+    verify(client, never()).getIndexStateManagementPolicy();
+    verify(client, never()).createIndexStateManagementPolicy();
+    verify(client, never()).updateIndexStateManagementPolicy(anyInt(), anyInt());
+    verify(client, never()).deleteIndexStateManagementPolicy();
+    verify(client, never()).bulkAddISMPolicyToAllZeebeIndices();
+    verify(client, never()).bulkRemoveISMPolicyToAllZeebeIndices();
+  }
+
+  @Test
   void shouldNotCreateOrUpdateIndexStateManagementPolicy() {
     // given
     config.retention.setEnabled(true);


### PR DESCRIPTION
## Summary

Closes #28571.

When retention is disabled, the Zeebe ES/OS exporters and the Tasklist importer actively removed the existing ILM/ISM policy from indices at startup. This caused production impact for customers whose application user lacked permission to modify the policy (403 errors), and silently stripped manually-managed policies on every restart.

The `managePolicy` / `ilmManagePolicy` flag already existed for the Zeebe ES exporter and Tasklist ES importer but only gated policy *creation*, not the destructive removal path. This PR closes that gap and adds the same flag to the Zeebe OS exporter, which had no escape hatch at all.

## Behavior

| `enabled` | `managePolicy` | Behavior |
|-----------|----------------|----------|
| `true`    | `true` (default) | Create the policy resource, attach it to existing indices. Existing behavior. |
| `true`    | `false`          | Skip create/update of the policy resource (assumes externally managed), still attach to indices. Existing behavior on ES exporter / Tasklist ES, new on OS exporter. |
| `false`   | `true` (default) | Remove the policy resource and detach it from existing indices. Existing destructive behavior preserved when explicitly opted into. |
| `false`   | `false`          | **Leave everything untouched.** The fix. |

Default is `true`, so users on existing configurations see no behavior change.

## Changes

- **Zeebe OS exporter** — adds `managePolicy` to `OpensearchExporterConfiguration.RetentionConfiguration`. Gates `createIndexStateManagementPolicy` / `deleteIndexStateManagementPolicy` / `bulkRemoveISMPolicyToAllZeebeIndices` on it. `bulkAddISMPolicyToAllZeebeIndices` still runs when retention is enabled regardless, mirroring the ES exporter semantic.
- **Zeebe ES exporter** — extends the existing gate in `SchemaManager.updateRetentionPolicyForExistingIndices` so `bulkPutIndexLifecycleSettings(null)` is skipped when `managePolicy=false`.
- **Tasklist** — extends `ILMService.init` so `removeIlmPolicyFromAllIndices` is skipped when `ilmManagePolicy=false`. Covers both ES and OS via the shared `ILMPolicyUpdate` interface.

## Tests

- New unit tests on `OpensearchExporterTest` covering both `enabled=true,managePolicy=false` (attach but don't touch policy resource) and `enabled=false,managePolicy=false` (leave everything alone).
- New IT in `OpensearchExporterIT` proving that a pre-existing ISM policy is preserved on indices across an exporter restart with `enabled=false, managePolicy=false`.
- New IT in `ElasticsearchExporterIT` proving the same for ILM.
- New `ILMServiceTest` covering the four `archiverEnabled` / `ilmEnabled` / `ilmManagePolicy` permutations.

## Notes for reviewers

- The issue description lists Operate importer ≤ 8.7 as affected, but on inspection neither `ElasticsearchSchemaManager.createSchema()` / `OpensearchSchemaManager.createSchema()` nor the archiver repositories contain any policy-removal code on 8.7. They only *apply* policies when `ilmEnabled=true` and skip otherwise. I have therefore not added a flag on the Operate side. If Operate confirms there is a destructive code path I missed, happy to extend.
- Forward-port to `main` / `stable/8.9` / `stable/8.8` will land as a separate PR — the ES exporter and Tasklist diffs apply almost verbatim; the OS exporter delta will need light reshaping where the file structure has drifted.

## Test plan

- [x] Module-scoped unit tests pass: `./mvnw verify -pl zeebe/exporters/opensearch-exporter -DskipITs -DskipTests=false -Dquickly` (264 tests, 0 failures)
- [x] Module-scoped unit tests pass: `./mvnw verify -pl zeebe/exporters/elasticsearch-exporter -DskipITs -DskipTests=false -Dquickly` (258 tests, 0 failures)
- [x] Module-scoped unit test passes: `./mvnw verify -pl tasklist/webapp -Dtest=ILMServiceTest -DskipITs -DskipTests=false -Dquickly` (4 tests, 0 failures)
- [x] Spotless/license format clean.
- [ ] CI integration tests pass on stable/8.7.