### PR TITLE
fix: initialize post importer position from legacy index

### DIFF
--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/IndexDescriptors.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/IndexDescriptors.java
@@ -16,7 +16,6 @@ import io.camunda.webapps.schema.descriptors.index.FormIndex;
 import io.camunda.webapps.schema.descriptors.index.GlobalListenerIndex;
 import io.camunda.webapps.schema.descriptors.index.GroupIndex;
 import io.camunda.webapps.schema.descriptors.index.HistoryDeletionIndex;
-import io.camunda.webapps.schema.descriptors.index.ImportPositionIndex;
 import io.camunda.webapps.schema.descriptors.index.MappingRuleIndex;
 import io.camunda.webapps.schema.descriptors.index.MetadataIndex;
 import io.camunda.webapps.schema.descriptors.index.PersistentWebSessionIndexDescriptor;
@@ -89,7 +88,6 @@ public class IndexDescriptors {
                 new UsageMetricTUTemplate(indexPrefix, isElasticsearch),
                 new AuditLogTemplate(indexPrefix, isElasticsearch),
                 new HistoryDeletionIndex(indexPrefix, isElasticsearch),
-                new ImportPositionIndex(indexPrefix, isElasticsearch),
                 new JobMetricsBatchTemplate(indexPrefix, isElasticsearch),
                 new AuditLogCleanupIndex(indexPrefix, isElasticsearch),
                 new GlobalListenerIndex(indexPrefix, isElasticsearch))

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/IndexDescriptors.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/IndexDescriptors.java
@@ -16,6 +16,7 @@ import io.camunda.webapps.schema.descriptors.index.FormIndex;
 import io.camunda.webapps.schema.descriptors.index.GlobalListenerIndex;
 import io.camunda.webapps.schema.descriptors.index.GroupIndex;
 import io.camunda.webapps.schema.descriptors.index.HistoryDeletionIndex;
+import io.camunda.webapps.schema.descriptors.index.ImportPositionIndex;
 import io.camunda.webapps.schema.descriptors.index.MappingRuleIndex;
 import io.camunda.webapps.schema.descriptors.index.MetadataIndex;
 import io.camunda.webapps.schema.descriptors.index.PersistentWebSessionIndexDescriptor;
@@ -88,6 +89,7 @@ public class IndexDescriptors {
                 new UsageMetricTUTemplate(indexPrefix, isElasticsearch),
                 new AuditLogTemplate(indexPrefix, isElasticsearch),
                 new HistoryDeletionIndex(indexPrefix, isElasticsearch),
+                new ImportPositionIndex(indexPrefix, isElasticsearch),
                 new JobMetricsBatchTemplate(indexPrefix, isElasticsearch),
                 new AuditLogCleanupIndex(indexPrefix, isElasticsearch),
                 new GlobalListenerIndex(indexPrefix, isElasticsearch))

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/ImportPositionIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/ImportPositionIndex.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.schema.descriptors.index;
+
+import static io.camunda.webapps.schema.descriptors.ComponentNames.OPERATE;
+
+import io.camunda.webapps.schema.descriptors.AbstractIndexDescriptor;
+
+public final class ImportPositionIndex extends AbstractIndexDescriptor {
+
+  public static final String INDEX_NAME = "import-position";
+
+  public static final String ALIAS_NAME = "aliasName";
+
+  public static final String ID = "id";
+
+  public static final String PARTITION_ID = "partitionId";
+
+  public static final String POSITION = "position";
+
+  public static final String SEQUENCE = "sequence";
+
+  public static final String POST_IMPORTER_POSITION = "postImporterPosition";
+
+  public static final String FIELD_INDEX_NAME = "indexName";
+
+  public static final String COMPLETED = "completed";
+
+  public ImportPositionIndex(final String indexPrefix, final boolean isElasticsearch) {
+    super(indexPrefix, isElasticsearch);
+  }
+
+  @Override
+  public String getIndexName() {
+    return INDEX_NAME;
+  }
+
+  @Override
+  public String getVersion() {
+    return "8.3.0";
+  }
+
+  @Override
+  public String getComponentName() {
+    return OPERATE.toString();
+  }
+}

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/ImportPositionEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/ImportPositionEntity.java
@@ -10,14 +10,14 @@ package io.camunda.webapps.schema.entities;
 public class ImportPositionEntity
     implements ExporterEntity<ImportPositionEntity>, PartitionedEntity<ImportPositionEntity> {
 
-  private String id;
-  private String aliasName;
-  private int partitionId;
-  private long position;
-  private long sequence;
-  private long postImporterPosition;
-  private String indexName;
-  private boolean completed;
+  @BeforeVersion880 private String id;
+  @BeforeVersion880 private String aliasName;
+  @BeforeVersion880 private int partitionId;
+  @BeforeVersion880 private long position;
+  @BeforeVersion880 private long sequence;
+  @BeforeVersion880 private long postImporterPosition;
+  @BeforeVersion880 private String indexName;
+  @BeforeVersion880 private boolean completed;
 
   @Override
   public String getId() {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/ImportPositionEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/ImportPositionEntity.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.schema.entities;
+
+public class ImportPositionEntity
+    implements ExporterEntity<ImportPositionEntity>, PartitionedEntity<ImportPositionEntity> {
+
+  private String id;
+  private String aliasName;
+  private int partitionId;
+  private long position;
+  private long sequence;
+  private long postImporterPosition;
+  private String indexName;
+  private boolean completed;
+
+  @Override
+  public String getId() {
+    return id;
+  }
+
+  @Override
+  public ImportPositionEntity setId(final String id) {
+    this.id = id;
+    return this;
+  }
+
+  public String getAliasName() {
+    return aliasName;
+  }
+
+  public ImportPositionEntity setAliasName(final String aliasName) {
+    this.aliasName = aliasName;
+    return this;
+  }
+
+  @Override
+  public int getPartitionId() {
+    return partitionId;
+  }
+
+  @Override
+  public ImportPositionEntity setPartitionId(final int partitionId) {
+    this.partitionId = partitionId;
+    return this;
+  }
+
+  public long getPosition() {
+    return position;
+  }
+
+  public ImportPositionEntity setPosition(final long position) {
+    this.position = position;
+    return this;
+  }
+
+  public long getSequence() {
+    return sequence;
+  }
+
+  public ImportPositionEntity setSequence(final long sequence) {
+    this.sequence = sequence;
+    return this;
+  }
+
+  public long getPostImporterPosition() {
+    return postImporterPosition;
+  }
+
+  public ImportPositionEntity setPostImporterPosition(final long postImporterPosition) {
+    this.postImporterPosition = postImporterPosition;
+    return this;
+  }
+
+  public String getIndexName() {
+    return indexName;
+  }
+
+  public ImportPositionEntity setIndexName(final String indexName) {
+    this.indexName = indexName;
+    return this;
+  }
+
+  public boolean isCompleted() {
+    return completed;
+  }
+
+  public ImportPositionEntity setCompleted(final boolean completed) {
+    this.completed = completed;
+    return this;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
@@ -13,6 +13,7 @@ import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.exporter.ExporterMetadata;
 import io.camunda.exporter.ExporterResourceProvider;
+import io.camunda.exporter.config.ConnectionTypes;
 import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.notifier.IncidentNotifier;
@@ -184,7 +185,10 @@ public final class BackgroundTaskManagerFactory {
         resourceProvider.getIndexTemplateDescriptor(PostImporterQueueTemplate.class);
     final var operationTemplate =
         resourceProvider.getIndexTemplateDescriptor(OperationTemplate.class);
-    final var importPositionIndex = resourceProvider.getIndexDescriptor(ImportPositionIndex.class);
+    final var importPositionIndex =
+        new ImportPositionIndex(
+            config.getConnect().getIndexPrefix(),
+            ConnectionTypes.isElasticSearch(config.getConnect().getType()));
     return new OpenSearchIncidentUpdateRepository(
         partitionId,
         postImporterTemplate.getAlias(),
@@ -238,7 +242,10 @@ public final class BackgroundTaskManagerFactory {
         resourceProvider.getIndexTemplateDescriptor(PostImporterQueueTemplate.class);
     final var operationTemplate =
         resourceProvider.getIndexTemplateDescriptor(OperationTemplate.class);
-    final var importPositionIndex = resourceProvider.getIndexDescriptor(ImportPositionIndex.class);
+    final var importPositionIndex =
+        new ImportPositionIndex(
+            config.getConnect().getIndexPrefix(),
+            ConnectionTypes.isElasticSearch(config.getConnect().getType()));
     return new ElasticsearchIncidentUpdateRepository(
         partitionId,
         postImporterTemplate.getAlias(),

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
@@ -50,6 +50,7 @@ import io.camunda.webapps.schema.descriptors.BatchOperationDependant;
 import io.camunda.webapps.schema.descriptors.DecisionInstanceDependant;
 import io.camunda.webapps.schema.descriptors.ProcessInstanceDependant;
 import io.camunda.webapps.schema.descriptors.index.AuditLogCleanupIndex;
+import io.camunda.webapps.schema.descriptors.index.ImportPositionIndex;
 import io.camunda.webapps.schema.descriptors.template.AuditLogTemplate;
 import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
 import io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate;
@@ -183,6 +184,7 @@ public final class BackgroundTaskManagerFactory {
         resourceProvider.getIndexTemplateDescriptor(PostImporterQueueTemplate.class);
     final var operationTemplate =
         resourceProvider.getIndexTemplateDescriptor(OperationTemplate.class);
+    final var importPositionIndex = resourceProvider.getIndexDescriptor(ImportPositionIndex.class);
     return new OpenSearchIncidentUpdateRepository(
         partitionId,
         postImporterTemplate.getAlias(),
@@ -191,6 +193,7 @@ public final class BackgroundTaskManagerFactory {
         listViewTemplate.getFullQualifiedName(),
         flowNodeTemplate.getAlias(),
         operationTemplate.getAlias(),
+        importPositionIndex.getFullQualifiedName(),
         asyncClient,
         executor,
         logger);
@@ -235,6 +238,7 @@ public final class BackgroundTaskManagerFactory {
         resourceProvider.getIndexTemplateDescriptor(PostImporterQueueTemplate.class);
     final var operationTemplate =
         resourceProvider.getIndexTemplateDescriptor(OperationTemplate.class);
+    final var importPositionIndex = resourceProvider.getIndexDescriptor(ImportPositionIndex.class);
     return new ElasticsearchIncidentUpdateRepository(
         partitionId,
         postImporterTemplate.getAlias(),
@@ -243,6 +247,7 @@ public final class BackgroundTaskManagerFactory {
         listViewTemplate.getFullQualifiedName(),
         flowNodeTemplate.getAlias(),
         operationTemplate.getAlias(),
+        importPositionIndex.getFullQualifiedName(),
         asyncClient,
         executor,
         logger);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java
@@ -19,14 +19,17 @@ import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
 import co.elastic.clients.elasticsearch.core.bulk.BulkResponseItem;
 import co.elastic.clients.elasticsearch.core.bulk.UpdateOperation;
+import co.elastic.clients.elasticsearch.core.search.Hit;
 import co.elastic.clients.elasticsearch.core.search.SourceFilter;
 import co.elastic.clients.elasticsearch.indices.AnalyzeRequest;
 import co.elastic.clients.elasticsearch.indices.analyze.AnalyzeToken;
 import io.camunda.exporter.tasks.util.ElasticsearchRepository;
+import io.camunda.webapps.schema.descriptors.index.ImportPositionIndex;
 import io.camunda.webapps.schema.descriptors.template.IncidentTemplate;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.descriptors.template.OperationTemplate;
 import io.camunda.webapps.schema.descriptors.template.PostImporterQueueTemplate;
+import io.camunda.webapps.schema.entities.ImportPositionEntity;
 import io.camunda.webapps.schema.entities.incident.IncidentEntity;
 import io.camunda.webapps.schema.entities.incident.IncidentState;
 import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
@@ -53,6 +56,7 @@ public final class ElasticsearchIncidentUpdateRepository extends ElasticsearchRe
       List.of(
           FieldValue.of(OperationState.SENT.name()),
           FieldValue.of(OperationState.COMPLETED.name()));
+  private static final String INCIDENT_IMPORT_POSITION_ALIAS_NAME = "incident";
 
   private final int partitionId;
   private final String pendingUpdateAlias;
@@ -61,6 +65,7 @@ public final class ElasticsearchIncidentUpdateRepository extends ElasticsearchRe
   private final String listViewFullQualifiedName;
   private final String flowNodeAlias;
   private final String operationAlias;
+  private final String importPositionFullQualifiedName;
 
   public ElasticsearchIncidentUpdateRepository(
       final int partitionId,
@@ -70,6 +75,7 @@ public final class ElasticsearchIncidentUpdateRepository extends ElasticsearchRe
       final String listViewFullQualifiedName,
       final String flowNodeAlias,
       final String operationAlias,
+      final String importPositionFullQualifiedName,
       @WillCloseWhenClosed final ElasticsearchAsyncClient client,
       final Executor executor,
       final Logger logger) {
@@ -81,6 +87,7 @@ public final class ElasticsearchIncidentUpdateRepository extends ElasticsearchRe
     this.listViewFullQualifiedName = listViewFullQualifiedName;
     this.flowNodeAlias = flowNodeAlias;
     this.operationAlias = operationAlias;
+    this.importPositionFullQualifiedName = importPositionFullQualifiedName;
   }
 
   @Override
@@ -244,6 +251,36 @@ public final class ElasticsearchIncidentUpdateRepository extends ElasticsearchRe
 
     return fetchUnboundedDocumentCollection(
         request, IncidentEntity.class, h -> new ActiveIncident(h.id(), h.source().getTreePath()));
+  }
+
+  @Override
+  public CompletionStage<Long> getLegacyIncidentPostImporterPosition() {
+    final var aliasNameQ =
+        QueryBuilders.term(
+            t ->
+                t.field(ImportPositionIndex.ALIAS_NAME).value(INCIDENT_IMPORT_POSITION_ALIAS_NAME));
+    final var partitionQ =
+        QueryBuilders.term(t -> t.field(ImportPositionIndex.PARTITION_ID).value(partitionId));
+    final var request =
+        new SearchRequest.Builder()
+            .index(importPositionFullQualifiedName)
+            .query(q -> q.bool(b -> b.must(aliasNameQ, partitionQ)))
+            .allowNoIndices(true)
+            .ignoreUnavailable(true)
+            .source(s -> s.filter(f -> f.includes(ImportPositionIndex.POST_IMPORTER_POSITION)))
+            .size(1)
+            .build();
+
+    return client
+        .search(request, ImportPositionEntity.class)
+        .thenApplyAsync(
+            response ->
+                response.hits().hits().stream()
+                    .findFirst()
+                    .map(Hit::source)
+                    .map(ImportPositionEntity::getPostImporterPosition)
+                    .orElse(-1L),
+            executor);
   }
 
   private Query createProcessInstanceDeletedQuery(final Set<Long> processInstanceKeys) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepository.java
@@ -118,6 +118,16 @@ public interface IncidentUpdateRepository extends AutoCloseable {
       final Collection<String> treePathTerms);
 
   /**
+   * Returns the post-importer position for incidents from the legacy Operate import-position index.
+   * This is used as a fallback when the exporter's own position metadata is unset (e.g., after
+   * migrating from 8.8 to 8.9), to avoid re-processing the entire post-importer queue from the
+   * beginning.
+   *
+   * @return the post-importer position for incidents from the legacy index, or -1 if not found
+   */
+  CompletionStage<Long> getLegacyIncidentPostImporterPosition();
+
+  /**
    * Represents an incident document: the source identity and its ID and index.
    *
    * <p>Keeping the index is useful as we typically query by alias, so we don't know beforehand
@@ -223,6 +233,11 @@ public interface IncidentUpdateRepository extends AutoCloseable {
     public CompletionStage<Collection<ActiveIncident>> getActiveIncidentsByTreePaths(
         final Collection<String> treePathTerms) {
       return CompletableFuture.completedFuture(List.of());
+    }
+
+    @Override
+    public CompletionStage<Long> getLegacyIncidentPostImporterPosition() {
+      return CompletableFuture.completedFuture(-1L);
     }
 
     @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
@@ -41,6 +41,7 @@ import org.agrona.LangUtil;
 import org.slf4j.Logger;
 
 public final class IncidentUpdateTask implements BackgroundTask {
+  private static final long UNSET_POSITION = -1;
   private final ExporterMetadata metadata;
   private final IncidentUpdateRepository repository;
   private final boolean ignoreMissingData;
@@ -50,6 +51,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
   private final Duration waitForRefreshInterval;
   private final IncidentNotifier incidentNotifier;
   private final CamundaExporterMetrics metrics;
+  private volatile boolean legacyPositionChecked = false;
 
   public IncidentUpdateTask(
       final ExporterMetadata metadata,
@@ -639,7 +641,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
       final AdditionalData data) {
     final IncidentUpdateRepository.PendingIncidentUpdateBatch pendingIncidentsBatch =
         repository
-            .getPendingIncidentsBatch(metadata.getLastIncidentUpdatePosition(), batchSize)
+            .getPendingIncidentsBatch(getOrInitLastIncidentUpdatePosition(), batchSize)
             .toCompletableFuture()
             .join();
 
@@ -677,6 +679,30 @@ public final class IncidentUpdateTask implements BackgroundTask {
     }
 
     return pendingIncidentsBatch;
+  }
+
+  private long getOrInitLastIncidentUpdatePosition() {
+    final long position = metadata.getLastIncidentUpdatePosition();
+    if (position != UNSET_POSITION || legacyPositionChecked) {
+      return position;
+    }
+
+    final long legacyPosition =
+        repository.getLegacyIncidentPostImporterPosition().toCompletableFuture().join();
+    legacyPositionChecked = true;
+    if (legacyPosition > UNSET_POSITION) {
+      logger.info(
+          "Exporter incident update position is unset; initializing from legacy "
+              + "Operate import-position index with position {}",
+          legacyPosition);
+      metadata.setLastIncidentUpdatePosition(legacyPosition);
+      return legacyPosition;
+    }
+
+    logger.debug(
+        "No legacy post-importer position found in import-position index; "
+            + "starting from the beginning of the post-importer queue");
+    return position;
   }
 
   private void uncheckedThreadSleep() {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/OpenSearchIncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/OpenSearchIncidentUpdateRepository.java
@@ -8,10 +8,12 @@
 package io.camunda.exporter.tasks.incident;
 
 import io.camunda.exporter.tasks.util.OpensearchRepository;
+import io.camunda.webapps.schema.descriptors.index.ImportPositionIndex;
 import io.camunda.webapps.schema.descriptors.template.IncidentTemplate;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.descriptors.template.OperationTemplate;
 import io.camunda.webapps.schema.descriptors.template.PostImporterQueueTemplate;
+import io.camunda.webapps.schema.entities.ImportPositionEntity;
 import io.camunda.webapps.schema.entities.incident.IncidentEntity;
 import io.camunda.webapps.schema.entities.incident.IncidentState;
 import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
@@ -43,6 +45,7 @@ import org.opensearch.client.opensearch.core.SearchResponse;
 import org.opensearch.client.opensearch.core.bulk.BulkOperation;
 import org.opensearch.client.opensearch.core.bulk.BulkResponseItem;
 import org.opensearch.client.opensearch.core.bulk.UpdateOperation;
+import org.opensearch.client.opensearch.core.search.Hit;
 import org.opensearch.client.opensearch.core.search.SourceFilter;
 import org.opensearch.client.opensearch.indices.AnalyzeRequest;
 import org.opensearch.client.opensearch.indices.analyze.AnalyzeToken;
@@ -55,6 +58,7 @@ public final class OpenSearchIncidentUpdateRepository extends OpensearchReposito
       List.of(
           FieldValue.of(OperationState.SENT.name()),
           FieldValue.of(OperationState.COMPLETED.name()));
+  private static final String INCIDENT_IMPORT_POSITION_ALIAS_NAME = "incident";
 
   private final int partitionId;
   private final String pendingUpdateAlias;
@@ -63,6 +67,7 @@ public final class OpenSearchIncidentUpdateRepository extends OpensearchReposito
   private final String listViewFullQualifiedName;
   private final String flowNodeAlias;
   private final String operationAlias;
+  private final String importPositionFullQualifiedName;
 
   public OpenSearchIncidentUpdateRepository(
       final int partitionId,
@@ -72,6 +77,7 @@ public final class OpenSearchIncidentUpdateRepository extends OpensearchReposito
       final String listViewFullQualifiedName,
       final String flowNodeAlias,
       final String operationAlias,
+      final String importPositionFullQualifiedName,
       @WillCloseWhenClosed final OpenSearchAsyncClient client,
       final Executor executor,
       final Logger logger) {
@@ -83,6 +89,7 @@ public final class OpenSearchIncidentUpdateRepository extends OpensearchReposito
     this.listViewFullQualifiedName = listViewFullQualifiedName;
     this.flowNodeAlias = flowNodeAlias;
     this.operationAlias = operationAlias;
+    this.importPositionFullQualifiedName = importPositionFullQualifiedName;
   }
 
   @Override
@@ -413,6 +420,46 @@ public final class OpenSearchIncidentUpdateRepository extends OpensearchReposito
     }
 
     return new PendingIncidentUpdateBatch(highestPosition, incidents);
+  }
+
+  @Override
+  public CompletionStage<Long> getLegacyIncidentPostImporterPosition() {
+    final var aliasNameQ =
+        QueryBuilders.term()
+            .field(ImportPositionIndex.ALIAS_NAME)
+            .value(v -> v.stringValue(INCIDENT_IMPORT_POSITION_ALIAS_NAME))
+            .build()
+            .toQuery();
+    final var partitionQ =
+        QueryBuilders.term()
+            .field(ImportPositionIndex.PARTITION_ID)
+            .value(v -> v.longValue(partitionId))
+            .build()
+            .toQuery();
+    final var request =
+        new SearchRequest.Builder()
+            .index(importPositionFullQualifiedName)
+            .query(q -> q.bool(b -> b.must(aliasNameQ, partitionQ)))
+            .allowNoIndices(true)
+            .ignoreUnavailable(true)
+            .source(s -> s.filter(f -> f.includes(ImportPositionIndex.POST_IMPORTER_POSITION)))
+            .size(1)
+            .build();
+
+    try {
+      return client
+          .search(request, ImportPositionEntity.class)
+          .thenApplyAsync(
+              response ->
+                  response.hits().hits().stream()
+                      .findFirst()
+                      .map(Hit::source)
+                      .map(ImportPositionEntity::getPostImporterPosition)
+                      .orElse(-1L),
+              executor);
+    } catch (final Exception e) {
+      return CompletableFuture.failedFuture(e);
+    }
   }
 
   private record PendingIncidentUpdate(long key, long position, String intent) {}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepositoryIT.java
@@ -57,6 +57,7 @@ final class ElasticsearchIncidentUpdateRepositoryIT extends IncidentUpdateReposi
         listViewTemplate.getFullQualifiedName(),
         flowNodeInstanceTemplate.getAlias(),
         operationTemplate.getAlias(),
+        importPositionIndex.getFullQualifiedName(),
         client,
         Runnable::run,
         LOGGER);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepositoryTest.java
@@ -163,6 +163,7 @@ public final class ElasticsearchIncidentUpdateRepositoryTest {
         "listViewFullQualifiedName",
         "flowNodeAlias",
         "operationAlias",
+        "importPositionFullQualifiedName",
         client,
         Runnable::run,
         LOGGER);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
@@ -32,11 +32,13 @@ import io.camunda.search.schema.config.IndexConfiguration;
 import io.camunda.search.test.utils.SearchDBExtension;
 import io.camunda.webapps.operate.TreePath;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import io.camunda.webapps.schema.descriptors.index.ImportPositionIndex;
 import io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.template.IncidentTemplate;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.descriptors.template.OperationTemplate;
 import io.camunda.webapps.schema.descriptors.template.PostImporterQueueTemplate;
+import io.camunda.webapps.schema.entities.ImportPositionEntity;
 import io.camunda.webapps.schema.entities.flownode.FlowNodeInstanceEntity;
 import io.camunda.webapps.schema.entities.incident.IncidentEntity;
 import io.camunda.webapps.schema.entities.incident.IncidentState;
@@ -98,6 +100,7 @@ abstract class IncidentUpdateRepositoryIT {
   protected final ListViewTemplate listViewTemplate;
   protected final FlowNodeInstanceTemplate flowNodeInstanceTemplate;
   protected final OperationTemplate operationTemplate;
+  protected final ImportPositionIndex importPositionIndex;
   @AutoClose private final ClientAdapter clientAdapter;
   private final SearchEngineClient engineClient;
 
@@ -116,6 +119,7 @@ abstract class IncidentUpdateRepositoryIT {
     listViewTemplate = new ListViewTemplate(indexPrefix, isElastic);
     flowNodeInstanceTemplate = new FlowNodeInstanceTemplate(indexPrefix, isElastic);
     operationTemplate = new OperationTemplate(indexPrefix, isElastic);
+    importPositionIndex = new ImportPositionIndex(indexPrefix, isElastic);
   }
 
   @BeforeEach
@@ -1151,6 +1155,98 @@ abstract class IncidentUpdateRepositoryIT {
           .asInstanceOf(InstanceOfAssertFactories.collection(ProcessInstanceDocument.class))
           .containsExactly(
               new ProcessInstanceDocument("1", listViewTemplate.getFullQualifiedName(), 1, "PI_1"));
+    }
+  }
+
+  @DisabledIfSystemProperty(
+      named = SearchDBExtension.TEST_INTEGRATION_OPENSEARCH_AWS_URL,
+      matches = "^(?=\\s*\\S).*$",
+      disabledReason = "Excluding from AWS OS IT CI")
+  @Nested
+  final class GetLegacyIncidentPostImporterPositionIT {
+
+    @Test
+    void shouldReturnLegacyPositionWhenDocumentExists() throws PersistenceException {
+      // given
+      final var repository = createRepository();
+      engineClient.createIndex(importPositionIndex, new IndexConfiguration());
+
+      final var entity =
+          new ImportPositionEntity()
+              .setId("incident-" + PARTITION_ID)
+              .setAliasName("incident")
+              .setPartitionId(PARTITION_ID)
+              .setPosition(100L)
+              .setPostImporterPosition(42L);
+      final var batchRequest = clientAdapter.createBatchRequest();
+      batchRequest.addWithId(importPositionIndex.getFullQualifiedName(), entity.getId(), entity);
+      batchRequest.executeWithRefresh();
+
+      // when
+      final var result = repository.getLegacyIncidentPostImporterPosition();
+
+      // then
+      assertThat(result).succeedsWithin(REQUEST_TIMEOUT).isEqualTo(42L);
+    }
+
+    @Test
+    void shouldReturnMinusOneWhenPartitionIdDiffers() throws PersistenceException {
+      // given - index has an incident entry but for a different partition
+      final var repository = createRepository();
+      engineClient.createIndex(importPositionIndex, new IndexConfiguration());
+
+      final var entity =
+          new ImportPositionEntity()
+              .setId("incident-" + (PARTITION_ID + 1))
+              .setAliasName("incident")
+              .setPartitionId(PARTITION_ID + 1)
+              .setPosition(100L)
+              .setPostImporterPosition(42L);
+      final var batchRequest = clientAdapter.createBatchRequest();
+      batchRequest.addWithId(importPositionIndex.getFullQualifiedName(), entity.getId(), entity);
+      batchRequest.executeWithRefresh();
+
+      // when
+      final var result = repository.getLegacyIncidentPostImporterPosition();
+
+      // then
+      assertThat(result).succeedsWithin(REQUEST_TIMEOUT).isEqualTo(-1L);
+    }
+
+    @Test
+    void shouldReturnMinusOneWhenDifferentAliasName() throws PersistenceException {
+      // given - index exists but the document has a different alias name
+      final var repository = createRepository();
+      engineClient.createIndex(importPositionIndex, new IndexConfiguration());
+
+      final var entity =
+          new ImportPositionEntity()
+              .setId("process-instance-" + PARTITION_ID)
+              .setAliasName("process-instance")
+              .setPartitionId(PARTITION_ID)
+              .setPosition(100L)
+              .setPostImporterPosition(42L);
+      final var batchRequest = clientAdapter.createBatchRequest();
+      batchRequest.addWithId(importPositionIndex.getFullQualifiedName(), entity.getId(), entity);
+      batchRequest.executeWithRefresh();
+
+      // when
+      final var result = repository.getLegacyIncidentPostImporterPosition();
+
+      // then
+      assertThat(result).succeedsWithin(REQUEST_TIMEOUT).isEqualTo(-1L);
+    }
+
+    @Test
+    void shouldReturnMinusOneWhenIndexDoesNotExist() {
+      // given - no import-position index exists at all
+      final var repository = createRepository();
+
+      // when
+      final var result = repository.getLegacyIncidentPostImporterPosition();
+
+      // then
+      assertThat(result).succeedsWithin(REQUEST_TIMEOUT).isEqualTo(-1L);
     }
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
@@ -77,6 +77,8 @@ final class IncidentUpdateTaskTest {
         .thenReturn(
             CompletableFuture.completedFuture(
                 new PendingIncidentUpdateBatch(-1, Collections.emptyMap())));
+    when(repository.getLegacyIncidentPostImporterPosition())
+        .thenReturn(CompletableFuture.completedFuture(-1L));
   }
 
   @Test
@@ -121,6 +123,109 @@ final class IncidentUpdateTaskTest {
 
     // then
     Mockito.verify(repository).getPendingIncidentsBatch(anyLong(), Mockito.eq(10));
+  }
+
+  @Test
+  void shouldInitializeFromLegacyPositionWhenMetadataIsUnset() {
+    // given - metadata position is -1 (default) and legacy position is 42
+    final var task =
+        new IncidentUpdateTask(
+            metadata, repository, false, 10, EXECUTOR, incidentNotifier, metrics, LOGGER);
+    when(repository.getLegacyIncidentPostImporterPosition())
+        .thenReturn(CompletableFuture.completedFuture(42L));
+
+    // when
+    task.execute().toCompletableFuture().join();
+
+    // then - should have initialized from legacy and used it for the batch query
+    verify(repository).getLegacyIncidentPostImporterPosition();
+    verify(repository).getPendingIncidentsBatch(Mockito.eq(42L), anyInt());
+  }
+
+  @Test
+  void shouldNotCheckLegacyPositionWhenMetadataIsAlreadySet() {
+    // given - metadata position is already set
+    final var task =
+        new IncidentUpdateTask(
+            metadata, repository, false, 10, EXECUTOR, incidentNotifier, metrics, LOGGER);
+    metadata.setLastIncidentUpdatePosition(100);
+
+    // when
+    task.execute().toCompletableFuture().join();
+
+    // then
+    verify(repository, never()).getLegacyIncidentPostImporterPosition();
+    verify(repository).getPendingIncidentsBatch(Mockito.eq(100L), anyInt());
+  }
+
+  @Test
+  void shouldNotCheckLegacyPositionOnSecondExecution() {
+    // given - first execution checks legacy, second should not
+    final var task =
+        new IncidentUpdateTask(
+            metadata, repository, false, 10, EXECUTOR, incidentNotifier, metrics, LOGGER);
+    when(repository.getLegacyIncidentPostImporterPosition())
+        .thenReturn(CompletableFuture.completedFuture(-1L));
+
+    // when - execute twice
+    task.execute().toCompletableFuture().join();
+    task.execute().toCompletableFuture().join();
+
+    // then - legacy position should only be checked once
+    verify(repository, times(1)).getLegacyIncidentPostImporterPosition();
+  }
+
+  @Test
+  void shouldFailWhenLegacyPositionLookupFails() {
+    // given - legacy lookup fails due to ES connectivity issue
+    final var task =
+        new IncidentUpdateTask(
+            metadata, repository, false, 10, EXECUTOR, incidentNotifier, metrics, LOGGER);
+    when(repository.getLegacyIncidentPostImporterPosition())
+        .thenReturn(CompletableFuture.failedFuture(new RuntimeException("ES unavailable")));
+
+    // when
+    final var result = task.execute();
+
+    // then - should return a failed future so the task gets rescheduled
+    assertThat(result).failsWithin(TIMEOUT);
+    assertThat(metadata.getLastIncidentUpdatePosition()).isEqualTo(-1L);
+  }
+
+  @Test
+  void shouldRetryLegacyPositionLookupOnNextExecutionAfterFailure() {
+    // given - legacy lookup fails on first call, succeeds on second
+    final var task =
+        new IncidentUpdateTask(
+            metadata, repository, false, 10, EXECUTOR, incidentNotifier, metrics, LOGGER);
+    when(repository.getLegacyIncidentPostImporterPosition())
+        .thenReturn(CompletableFuture.failedFuture(new RuntimeException("ES unavailable")))
+        .thenReturn(CompletableFuture.completedFuture(42L));
+
+    // when - first execution fails, second succeeds
+    assertThat(task.execute()).failsWithin(TIMEOUT);
+    task.execute().toCompletableFuture().join();
+
+    // then - should have retried and initialized from legacy on second attempt
+    verify(repository, times(2)).getLegacyIncidentPostImporterPosition();
+    verify(repository).getPendingIncidentsBatch(Mockito.eq(42L), anyInt());
+  }
+
+  @Test
+  void shouldKeepUnsetPositionWhenLegacyReturnsMinusOne() {
+    // given - legacy returns -1 (no data found)
+    final var task =
+        new IncidentUpdateTask(
+            metadata, repository, false, 10, EXECUTOR, incidentNotifier, metrics, LOGGER);
+    when(repository.getLegacyIncidentPostImporterPosition())
+        .thenReturn(CompletableFuture.completedFuture(-1L));
+
+    // when
+    task.execute().toCompletableFuture().join();
+
+    // then - metadata should remain at -1 (not set by legacy fallback)
+    verify(repository).getPendingIncidentsBatch(Mockito.eq(-1L), anyInt());
+    assertThat(metadata.getLastIncidentUpdatePosition()).isEqualTo(-1L);
   }
 
   private IncidentNotifier createIncidentNotifier() {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/OpensearchIncidentUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/OpensearchIncidentUpdateRepositoryIT.java
@@ -49,6 +49,7 @@ final class OpensearchIncidentUpdateRepositoryIT extends IncidentUpdateRepositor
         listViewTemplate.getFullQualifiedName(),
         flowNodeInstanceTemplate.getAlias(),
         operationTemplate.getAlias(),
+        importPositionIndex.getFullQualifiedName(),
         client,
         Runnable::run,
         LOGGER);


### PR DESCRIPTION
## Description
Port of #50395 to stable/8.9. The fix was introduced in 8.8.22 however we still can have customers updating to 8.9 from version <8.8.22, so the postImporterPosition metadata is never properly updated.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
