### PR TITLE
feat: add partitionGroup field to BrokerInfo

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -38,6 +38,7 @@ import io.camunda.zeebe.dynamic.config.changes.PartitionScalingChangeExecutor;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer;
+import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
@@ -64,7 +65,7 @@ import org.slf4j.LoggerFactory;
 public final class PartitionManagerImpl
     implements PartitionManager, PartitionChangeExecutor, PartitionScalingChangeExecutor {
 
-  public static final String DEFAULT_GROUP_NAME = "default";
+  public static final String DEFAULT_GROUP_NAME = Protocol.DEFAULT_PARTITION_GROUP_NAME;
   private static final Logger LOGGER = LoggerFactory.getLogger(PartitionManagerImpl.class);
 
   private final String partitionGroup;

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/RaftPartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/RaftPartitionFactory.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.broker.raft.ZeebeEntryValidator;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.ExperimentalCfg;
 import io.camunda.zeebe.broker.system.configuration.RaftCfg.FlushConfig;
+import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.util.FileUtil;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
@@ -29,7 +30,7 @@ import java.time.Duration;
 import org.slf4j.Logger;
 
 public final class RaftPartitionFactory {
-  public static final String GROUP_NAME = "default";
+  public static final String GROUP_NAME = Protocol.DEFAULT_PARTITION_GROUP_NAME;
   private static final String LEGACY_GROUP_NAME = "raft-partition";
   private static final Logger LOG = Loggers.SYSTEM_LOGGER;
   private final String partitionGroup;

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
@@ -16,6 +16,7 @@ import static io.camunda.zeebe.protocol.record.BrokerInfoEncoder.versionHeaderLe
 import static io.camunda.zeebe.protocol.record.BrokerInfoEncoder.zoneHeaderLength;
 import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 
+import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.Loggers;
 import io.camunda.zeebe.protocol.record.BrokerInfoDecoder;
 import io.camunda.zeebe.protocol.record.BrokerInfoDecoder.AddressesDecoder;
@@ -58,7 +59,7 @@ import org.slf4j.Logger;
 @NullMarked
 public final class BrokerInfo implements BufferReader, BufferWriter {
 
-  public static final String DEFAULT_PARTITION_GROUP = "default";
+  public static final String DEFAULT_PARTITION_GROUP = Protocol.DEFAULT_PARTITION_GROUP_NAME;
 
   private static final String BROKER_INFO_PROPERTY_NAME = "brokerInfo";
   private static final DirectBuffer COMMAND_API_NAME = wrapString("commandApi");

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.protocol.impl.encoding;
 
 import static io.camunda.zeebe.protocol.record.BrokerInfoEncoder.clusterSizeNullValue;
 import static io.camunda.zeebe.protocol.record.BrokerInfoEncoder.nodeIdNullValue;
+import static io.camunda.zeebe.protocol.record.BrokerInfoEncoder.partitionGroupHeaderLength;
 import static io.camunda.zeebe.protocol.record.BrokerInfoEncoder.partitionsCountNullValue;
 import static io.camunda.zeebe.protocol.record.BrokerInfoEncoder.replicationFactorNullValue;
 import static io.camunda.zeebe.protocol.record.BrokerInfoEncoder.versionHeaderLength;
@@ -57,6 +58,8 @@ import org.slf4j.Logger;
 @NullMarked
 public final class BrokerInfo implements BufferReader, BufferWriter {
 
+  public static final String DEFAULT_PARTITION_GROUP = "default";
+
   private static final String BROKER_INFO_PROPERTY_NAME = "brokerInfo";
   private static final DirectBuffer COMMAND_API_NAME = wrapString("commandApi");
   private static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
@@ -83,6 +86,7 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
   private int replicationFactor;
   private DirectBuffer version = new UnsafeBuffer();
   private @Nullable String zone;
+  private @Nullable String partitionGroup;
 
   public BrokerInfo() {
     reset();
@@ -103,6 +107,7 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
     addresses.clear();
     version.wrap(0, 0);
     zone = null;
+    partitionGroup = null;
     clearPartitions();
 
     return this;
@@ -199,6 +204,22 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
 
   public @Nullable String getZone() {
     return zone;
+  }
+
+  public String getPartitionGroup() {
+    // can be null for older versions that are received via gossip, but in that case we want to
+    // treat is as the default partition group.
+    return partitionGroup != null ? partitionGroup : DEFAULT_PARTITION_GROUP;
+  }
+
+  public BrokerInfo setPartitionGroup(final String partitionGroup) {
+    // partitionGroup can only be null in older versions that are received via gossip.
+    Objects.requireNonNull(partitionGroup);
+    if (partitionGroup.isBlank()) {
+      throw new IllegalArgumentException("partitionGroup must not be blank");
+    }
+    this.partitionGroup = partitionGroup.isBlank() ? null : partitionGroup;
+    return this;
   }
 
   public Map<DirectBuffer, DirectBuffer> getAddresses() {
@@ -351,6 +372,13 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
       bodyDecoder.skipZone();
     }
 
+    if (bodyDecoder.partitionGroupLength() > 0) {
+      partitionGroup = bodyDecoder.partitionGroup();
+    } else {
+      partitionGroup = null;
+      bodyDecoder.skipPartitionGroup();
+    }
+
     assert bodyDecoder.limit() == frameEnd
         : "Decoder read only to position "
             + bodyDecoder.limit()
@@ -371,7 +399,9 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
             + versionHeaderLength()
             + version.capacity()
             + zoneHeaderLength()
-            + (zone != null ? zone.getBytes(StandardCharsets.UTF_8).length : 0);
+            + (zone != null ? zone.getBytes(StandardCharsets.UTF_8).length : 0)
+            + partitionGroupHeaderLength()
+            + (partitionGroup != null ? partitionGroup.getBytes(StandardCharsets.UTF_8).length : 0);
 
     for (final Entry<DirectBuffer, DirectBuffer> entry : addresses.entrySet()) {
       length +=
@@ -453,6 +483,12 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
       bodyEncoder.zone(zone);
     } else {
       bodyEncoder.putZone(EMPTY_BYTE_ARRAY, 0, 0);
+    }
+
+    if (partitionGroup != null) {
+      bodyEncoder.partitionGroup(partitionGroup);
+    } else {
+      bodyEncoder.putPartitionGroup(EMPTY_BYTE_ARRAY, 0, 0);
     }
 
     return headerEncoder.encodedLength() + bodyEncoder.encodedLength();
@@ -549,6 +585,8 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
         + BufferUtil.bufferAsString(version)
         + ", zone="
         + zone
+        + ", partitionGroup="
+        + partitionGroup
         + '}';
   }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/BrokerInfoTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/BrokerInfoTest.java
@@ -27,6 +27,90 @@ import org.junit.jupiter.api.Test;
 final class BrokerInfoTest {
 
   @Test
+  void shouldEncodeDecodePartitionGroup() {
+    // given
+    final BrokerInfo brokerInfo =
+        new BrokerInfo()
+            .setBrokerId(1, null)
+            .setPartitionsCount(3)
+            .setClusterSize(3)
+            .setReplicationFactor(1)
+            .setPartitionGroup("tenant1");
+
+    // when
+    final var decoded = encodeDecode(brokerInfo);
+
+    // then
+    assertThat(decoded.getPartitionGroup()).isEqualTo("tenant1");
+  }
+
+  @Test
+  void shouldReturnDefaultPartitionGroupWhenNotSet() {
+    // given
+    final BrokerInfo brokerInfo =
+        new BrokerInfo()
+            .setBrokerId(1, null)
+            .setPartitionsCount(1)
+            .setClusterSize(1)
+            .setReplicationFactor(1);
+
+    // when
+    final var decoded = encodeDecode(brokerInfo);
+
+    // then
+    assertThat(decoded.getPartitionGroup()).isEqualTo(BrokerInfo.DEFAULT_PARTITION_GROUP);
+  }
+
+  @Test
+  void shouldDecodeVersion8PayloadWithoutPartitionGroup() {
+    // given -- a v8 payload (has zone but not partitionGroup)
+    final int nodeId = 5;
+    final int partitionsCount = 3;
+    final int clusterSize = 3;
+    final int replicationFactor = 1;
+    final String versionStr = "8.8.0";
+    final byte[] versionBytes = versionStr.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+
+    final MutableDirectBuffer buffer = new UnsafeBuffer(new byte[1024]);
+    int offset = 0;
+
+    final MessageHeaderEncoder headerEncoder = new MessageHeaderEncoder();
+    headerEncoder.wrap(buffer, offset);
+    headerEncoder
+        .blockLength(BrokerInfoEncoder.BLOCK_LENGTH)
+        .templateId(BrokerInfoEncoder.TEMPLATE_ID)
+        .schemaId(BrokerInfoEncoder.SCHEMA_ID)
+        .version(8);
+    offset += MessageHeaderEncoder.ENCODED_LENGTH;
+
+    final BrokerInfoEncoder bodyEncoder = new BrokerInfoEncoder();
+    bodyEncoder
+        .wrap(buffer, offset)
+        .nodeId(nodeId)
+        .partitionsCount(partitionsCount)
+        .clusterSize(clusterSize)
+        .replicationFactor(replicationFactor);
+
+    bodyEncoder.addressesCount(0);
+    bodyEncoder.partitionRolesCount(0);
+    bodyEncoder.partitionLeaderTermsCount(0);
+    bodyEncoder.putVersion(versionBytes, 0, versionBytes.length);
+    bodyEncoder.partitionHealthCount(0);
+    bodyEncoder.zone("eu-west-1a");
+    // partitionGroup is NOT written (v8 payload)
+
+    final int totalLength = MessageHeaderEncoder.ENCODED_LENGTH + bodyEncoder.encodedLength();
+
+    // when
+    final BrokerInfo decoded = new BrokerInfo();
+    assertThatNoException().isThrownBy(() -> decoded.wrap(buffer, 0, totalLength));
+
+    // then -- zone decoded correctly, partitionGroup falls back to default
+    assertThat(decoded.getZone()).isEqualTo("eu-west-1a");
+    assertThat(decoded.getPartitionGroup()).isEqualTo(BrokerInfo.DEFAULT_PARTITION_GROUP);
+  }
+
+  @Test
   void shouldEncodeDecodeBrokerInfo() {
     // given
     final int nodeId = 123;

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/Protocol.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/Protocol.java
@@ -113,6 +113,9 @@ public final class Protocol {
   /** Linked resources header used in service task */
   public static final String LINKED_RESOURCES_HEADER_NAME = "linkedResources";
 
+  /** The partition group name used by the default physical tenant. */
+  public static final String DEFAULT_PARTITION_GROUP_NAME = "default";
+
   public static long encodePartitionId(final int partitionId, final long key) {
     if (key < 0) {
       throw new IllegalArgumentException(

--- a/zeebe/protocol/src/main/resources/protocol.xml
+++ b/zeebe/protocol/src/main/resources/protocol.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
   xmlns:xi="http://www.w3.org/2001/XInclude" package="io.camunda.zeebe.protocol.record"
-  id="0" version="8"
+  id="0" version="9"
   description="Zeebe Protocol" byteOrder="littleEndian">
 
   <xi:include href="common-types.xml"/>
@@ -221,6 +221,7 @@
          version
          partitionHealth
          zone
+         partitionGroup
      -->
     <group name="partitionHealth" id="15" sinceVersion="3">
       <field name="partitionId" id="16" type="int32"/>
@@ -228,5 +229,6 @@
     </group>
     <data name="version" id="14" type="varDataEncoding"/>
     <data name="zone" id="18" type="varDataEncoding" sinceVersion="8"/>
+    <data name="partitionGroup" id="19" type="varDataEncoding" sinceVersion="9"/>
   </sbe:message>
 </sbe:messageSchema>


### PR DESCRIPTION
## Description

- Adds partitionGroup (string, SBE schema version 8 → 9) to BrokerInfo so each published broker  info record identifies which physical tenant's partition group it describes
- When absent in older payloads the field defaults to "default", preserving backward compatibility during rolling upgrades
- Adds `Protocol.DEFAULT_PARTITION_GROUP_NAME = "default"` to Protocol.java as the single source  of truth; existing public constants in `BrokerInfo`, `PartitionManagerImpl`, and  `RaftPartitionFactory` delegate to it

The goal is to publish a `BrokerInfo` per (broker, partitionGroup) instead of one per broker, so that gateway can calculate and keep track of topology per partitionGroup. 

Alternative is to have a map of partitionGroup to partitions statuses with in a single `BrokerInfo`. This makes SBE schema of BrokerInfo quite complex. Also the `TopologyManagerImpl` that publishes topology  changes is run per partitionGroup. So it is simpler if the object is not shared among the partition groups.

## Related issues

closes #50543
