### PR TITLE
Feat/postgres lsn integration test

### DIFF
--- a/db/docker-compose.yml
+++ b/db/docker-compose.yml
@@ -147,6 +147,9 @@ services:
   postgres-primary:
     image: bitnamilegacy/postgresql:17
     container_name: pg-primary
+    depends_on:
+      - postgres-replica-1
+      - postgres-replica-2
     ports:
       - "5432:5432"
     volumes:
@@ -161,12 +164,16 @@ services:
       - POSTGRESQL_REPLICATION_PASSWORD=repl_pass
     networks:
       - pgnet
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U camunda -d camunda" ]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
 
   postgres-replica-1:
     image: bitnamilegacy/postgresql:17
     container_name: pg-replica1
-    depends_on:
-      - postgres-primary
     ports:
       - "5433:5432"
     environment:
@@ -178,12 +185,16 @@ services:
       - POSTGRESQL_REPLICATION_PASSWORD=repl_pass
     networks:
       - pgnet
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U camunda -d camunda" ]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
 
   postgres-replica-2:
     image: bitnamilegacy/postgresql:17
     container_name: pg-replica2
-    depends_on:
-      - postgres-primary
     ports:
       - "5434:5432"
     environment:
@@ -195,3 +206,9 @@ services:
       - POSTGRESQL_REPLICATION_PASSWORD=repl_pass
     networks:
       - pgnet
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U camunda -d camunda" ]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 10s

--- a/qa/acceptance-tests/pom.xml
+++ b/qa/acceptance-tests/pom.xml
@@ -662,6 +662,11 @@
       <artifactId>jackson-databind</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <repositories>

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/asyncreplication/AbstractAsyncReplicationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/asyncreplication/AbstractAsyncReplicationIT.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.asyncreplication;
+
+import static io.camunda.it.util.TestHelper.deployResource;
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
+import static io.camunda.zeebe.test.StableValuePredicate.hasStableValue;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.Iterables;
+import io.camunda.client.CamundaClient;
+import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
+import io.camunda.it.rdbms.db.util.PostgresReplicationClusterContainer;
+import io.camunda.qa.util.cluster.TestCamundaApplication;
+import io.camunda.zeebe.broker.exporter.stream.ExporterMetricsDoc;
+import io.micrometer.core.instrument.Measurement;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Objects;
+import org.agrona.CloseHelper;
+import org.assertj.core.data.Offset;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+
+@Tag("rdbms")
+@TestInstance(Lifecycle.PER_CLASS)
+abstract class AbstractAsyncReplicationIT {
+
+  protected static final Duration MAX_LAG = Duration.ofSeconds(3);
+
+  protected final PostgresReplicationClusterContainer postgresCluster =
+      new PostgresReplicationClusterContainer();
+
+  protected TestCamundaApplication testInstance;
+  protected CamundaClient camundaClient;
+  protected MeterRegistry meterRegistry;
+
+  @BeforeAll
+  void beforeAll() {
+    postgresCluster.start();
+
+    testInstance =
+        new TestCamundaApplication()
+            .withSecondaryStorageType(SecondaryStorageType.rdbms)
+            .withProperty("camunda.data.secondary-storage.rdbms.url", postgresCluster.getJdbcUrl())
+            .withProperty(
+                "camunda.data.secondary-storage.rdbms.username", postgresCluster.getUsername())
+            .withProperty(
+                "camunda.data.secondary-storage.rdbms.password", postgresCluster.getPassword())
+            .withExporter(
+                "rdbms",
+                cfg -> {
+                  cfg.setClassName("io.camunda.db.rdbms.exporter.RdbmsExporter");
+                  cfg.setArgs(
+                      Map.of(
+                          "flushInterval",
+                          "PT0S",
+                          "asyncReplication",
+                          Map.of(
+                              "enabled",
+                              true,
+                              "pollingInterval",
+                              "PT1S",
+                              "maxLag",
+                              MAX_LAG.toString(),
+                              "pauseOnMaxLagExceeded",
+                              true)));
+                })
+            .withBasicAuth();
+
+    testInstance.start();
+    camundaClient = testInstance.newClientBuilder().build();
+    meterRegistry = testInstance.bean(MeterRegistry.class);
+
+    Objects.requireNonNull(meterRegistry);
+    Objects.requireNonNull(camundaClient);
+
+    deployResource(camundaClient, "process/service_tasks_v1.bpmn");
+    waitForProcessesToBeDeployed(camundaClient, 1);
+
+    exporterAcknowledgedAll();
+  }
+
+  @AfterAll
+  void afterAll() {
+    CloseHelper.quietClose(camundaClient);
+    CloseHelper.quietClose(testInstance);
+    CloseHelper.quietClose(postgresCluster);
+  }
+
+  protected void startProcessInstances(final int count) {
+    for (int i = 0; i < count; i++) {
+      startProcessInstance(camundaClient, "service_tasks_v1", "{\"xyz\":\"foo\"}");
+    }
+  }
+
+  protected void awaitExporterPositionAdvances(final long baseline) {
+    Awaitility.await()
+        .atMost(Duration.ofMinutes(2))
+        .untilAsserted(() -> assertThat(getCurrentExporterPosition()).isGreaterThan(baseline));
+  }
+
+  protected void awaitAcknowledgedPositionAdvances(final long baseline) {
+    Awaitility.await()
+        .atMost(Duration.ofMinutes(2))
+        .untilAsserted(
+            () -> assertThat(getCurrentAcknowledgedExporterPosition()).isGreaterThan(baseline));
+  }
+
+  protected void awaitExporterPositionStable(final Duration stability, final Duration atMost) {
+    Awaitility.await()
+        .atMost(atMost)
+        .during(stability)
+        .until(this::getCurrentExporterPosition, hasStableValue());
+  }
+
+  protected void assertAcknowledgedPositionNotAdvancedBeyond(final long position) {
+    // allow a small tolerance for in-flight confirmations at the moment of replica removal
+    assertThat(getCurrentAcknowledgedExporterPosition()).isLessThanOrEqualTo(position + 5L);
+  }
+
+  protected void exporterAcknowledgedAll() {
+    Awaitility.await()
+        .ignoreExceptions()
+        .atMost(Duration.ofMinutes(1))
+        .untilAsserted(
+            () ->
+                assertThat(getCurrentExporterPosition())
+                    // not all records are processed by the exporter, so we need a closeTo here
+                    .isCloseTo(getCurrentAcknowledgedExporterPosition(), Offset.offset(5L)));
+  }
+
+  protected long getCurrentExporterPosition() {
+    return getMeterLong(ExporterMetricsDoc.LAST_EXPORTED_POSITION.getName());
+  }
+
+  protected long getCurrentAcknowledgedExporterPosition() {
+    return getMeterLong(ExporterMetricsDoc.LAST_UPDATED_EXPORTED_POSITION.getName());
+  }
+
+  private long getMeterLong(final String name) {
+    final var meters =
+        meterRegistry.get(name).tag("exporter", "rdbms").tag("partition", "1").meter().measure();
+
+    final Measurement first = Iterables.getFirst(meters, null);
+
+    if (first == null) {
+      return 0;
+    }
+
+    return (long) first.getValue();
+  }
+
+  protected void wait(final Duration duration) {
+    try {
+      Thread.sleep(duration);
+    } catch (final InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/asyncreplication/AbstractAsyncReplicationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/asyncreplication/AbstractAsyncReplicationIT.java
@@ -166,6 +166,7 @@ abstract class AbstractAsyncReplicationIT {
     try {
       Thread.sleep(duration);
     } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
       throw new RuntimeException(e);
     }
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/asyncreplication/AsyncReplicationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/asyncreplication/AsyncReplicationIT.java
@@ -7,33 +7,76 @@
  */
 package io.camunda.it.rdbms.db.asyncreplication;
 
+import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.db.rdbms.RdbmsService;
-import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
-import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
-import org.junit.jupiter.api.extension.RegisterExtension;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
-@Tag("rdbms")
-public class AsyncReplicationIT {
+// Tests in this class form a lifecycle sequence and must run in order:
+// (1) replica removed → exporter pauses; (2) replica restored → exporter resumes.
+@TestMethodOrder(OrderAnnotation.class)
+public class AsyncReplicationIT extends AbstractAsyncReplicationIT {
 
-  @RegisterExtension
-  static final CamundaRdbmsInvocationContextProviderExtension TEST_APPLICATION =
-      new CamundaRdbmsInvocationContextProviderExtension(
-          "camundaWithPostgresSQL" // currently we only support PostgreSQL
-          );
+  @Test
+  void shouldAcknowledgeExportedRecordsWhenReplicated() {
+    final var exporterPosition = getCurrentExporterPosition();
 
-  @TestTemplate
-  public void shouldQueryReplicationStatus(final CamundaRdbmsTestApplication testApplication) {
-    final RdbmsService rdbmsService = testApplication.getRdbmsService();
-    final var replicationStatusProvider = rdbmsService.getReplicationLogStatusProvider();
+    // when - start some process instances to generate traffic
+    final int numProcessInstances = 10;
+    startProcessInstances(numProcessInstances);
+    waitForProcessInstancesToStart(camundaClient, numProcessInstances);
 
-    final var currentLsn = replicationStatusProvider.getCurrent();
-    final var replicationStatuses = replicationStatusProvider.getReplicationStatuses();
+    // then - exporter advances and fully catches up
+    awaitExporterPositionAdvances(exporterPosition);
+    awaitExporterPositionStable(Duration.ofSeconds(2), Duration.ofSeconds(10));
+    exporterAcknowledgedAll();
+  }
 
-    assertThat(currentLsn).isGreaterThan(0);
-    assertThat(replicationStatuses).isNotNull();
+  @Test
+  @Order(1)
+  void shouldNeverAcknowledgeAndStopExportingWhenReplicaIsRemoved() {
+    // given - a stable, fully acknowledged state
+    final long acknowledgedPositionBeforeRemoval = getCurrentAcknowledgedExporterPosition();
+
+    // when - the required read replica is removed
+    postgresCluster.stopReplica();
+    startProcessInstances(10);
+
+    // then - the exporter still exports records but never acknowledges them
+    // TODO optimize this to not wait X seconds but on a RdbmsExporter metric when implemented
+    wait(MAX_LAG.plus(3, ChronoUnit.SECONDS)); // wait for the max-lag interval + X
+    awaitExporterPositionAdvances(acknowledgedPositionBeforeRemoval);
+    assertAcknowledgedPositionNotAdvancedBeyond(acknowledgedPositionBeforeRemoval);
+
+    // when - more traffic is generated
+    final long exportedPositionAfterMaxLag = getCurrentExporterPosition();
+    startProcessInstances(10);
+
+    // then - the exporter should not export anything
+    awaitExporterPositionStable(Duration.ofSeconds(5), Duration.ofMinutes(1));
+
+    assertThat(getCurrentExporterPosition()).isEqualTo(exportedPositionAfterMaxLag);
+    assertAcknowledgedPositionNotAdvancedBeyond(acknowledgedPositionBeforeRemoval);
+  }
+
+  @Test
+  @Order(2)
+  void shouldResumeExportingAndAcknowledgeWhenReplicaRecovers() {
+    // given - exporter is paused after replica was removed (state left by test @Order(1))
+    final long exportedPositionBeforeRecovery = getCurrentExporterPosition();
+    final long acknowledgedPositionBeforeRecovery = getCurrentAcknowledgedExporterPosition();
+
+    // when - the replica is brought back, re-establishing the replication quorum
+    postgresCluster.startReplica();
+
+    // then - the exporter resumes and fully catches up
+    awaitExporterPositionAdvances(exportedPositionBeforeRecovery);
+    awaitAcknowledgedPositionAdvances(acknowledgedPositionBeforeRecovery);
+    exporterAcknowledgedAll();
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/asyncreplication/ReplicationStatusLogIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/asyncreplication/ReplicationStatusLogIT.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.asyncreplication;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import java.time.Duration;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+@Tag("rdbms")
+public class ReplicationStatusLogIT {
+
+  @RegisterExtension
+  static final CamundaRdbmsInvocationContextProviderExtension TEST_APPLICATION =
+      new CamundaRdbmsInvocationContextProviderExtension(
+          "camundaWithPostgresReplicationCluster" // currently we only support PostgreSQL
+          );
+
+  @TestTemplate
+  public void shouldQueryReplicationStatus(final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final var replicationStatusProvider = rdbmsService.getReplicationLogStatusProvider();
+
+    Awaitility.await()
+        .timeout(Duration.ofMinutes(10))
+        .untilAsserted(
+            () -> {
+              final var currentLsn = replicationStatusProvider.getCurrent();
+              final var replicationStatuses = replicationStatusProvider.getReplicationStatuses();
+
+              assertThat(currentLsn).isGreaterThan(0);
+              assertThat(replicationStatuses).isNotEmpty();
+            });
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/CamundaRdbmsInvocationContextProviderExtension.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/CamundaRdbmsInvocationContextProviderExtension.java
@@ -41,6 +41,17 @@ public class CamundaRdbmsInvocationContextProviderExtension
             .withRdbms()
             .withDatabaseContainer(createDefaultPostgresContainer()));
     applications.put(
+        "camundaWithPostgresReplicationCluster",
+        new CamundaRdbmsTestApplication(RdbmsTestConfiguration.class)
+            .withRdbms()
+            .withUnifiedConfig(
+                c -> {
+                  final var rdbms = c.getData().getSecondaryStorage().getRdbms();
+                  rdbms.getAsyncReplication().setEnabled(true);
+                  rdbms.getAsyncReplication().setMinSyncReplicas(1);
+                })
+            .withDatabaseContainer(new PostgresReplicationClusterContainer()));
+    applications.put(
         "camundaWithManualPostgresSQL",
         new CamundaRdbmsTestApplication(RdbmsTestConfiguration.class)
             .withRdbms()

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/CamundaRdbmsTestApplication.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/CamundaRdbmsTestApplication.java
@@ -76,7 +76,30 @@ public final class CamundaRdbmsTestApplication
                 "camunda.data.secondary-storage.rdbms.username", rdbms.getUsername(),
                 "camunda.data.secondary-storage.rdbms.password", rdbms.getPassword(),
                 "camunda.data.secondary-storage.rdbms.auto-ddl", rdbms.getAutoDdl()));
+      } else if (databaseContainer
+          instanceof
+          final PostgresReplicationClusterContainer postgresReplicationClusterContainer) {
+        final var rdbms = unifiedConfig.getData().getSecondaryStorage().getRdbms();
+        rdbms.setUrl(postgresReplicationClusterContainer.getJdbcUrl());
+        rdbms.setUsername(postgresReplicationClusterContainer.getUsername());
+        rdbms.setPassword(postgresReplicationClusterContainer.getPassword());
+        withAdditionalProperties(
+            Map.of(
+                "camunda.data.secondary-storage.rdbms.url", rdbms.getUrl(),
+                "camunda.data.secondary-storage.rdbms.username", rdbms.getUsername(),
+                "camunda.data.secondary-storage.rdbms.password", rdbms.getPassword(),
+                "camunda.data.secondary-storage.rdbms.auto-ddl", rdbms.getAutoDdl()));
       }
+      /*
+      // In order to ensure that a test runs against the intended database, we also need to set
+      // Spring's datasource properties. Otherwise, Spring might default to an embedded database
+      // (H2). See also property substitution in dist/application.properties for further details.
+      final var rdbms = unifiedConfig.getData().getSecondaryStorage().getRdbms();
+      withAdditionalProperties(
+          Map.of(
+              "spring.datasource.url", rdbms.getUrl(),
+              "spring.datasource.username", rdbms.getUsername(),
+              "spring.datasource.password", rdbms.getPassword()));*/
     }
 
     LOGGER.info("Start spring application ...");

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/CamundaRdbmsTestApplication.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/CamundaRdbmsTestApplication.java
@@ -90,16 +90,6 @@ public final class CamundaRdbmsTestApplication
                 "camunda.data.secondary-storage.rdbms.password", rdbms.getPassword(),
                 "camunda.data.secondary-storage.rdbms.auto-ddl", rdbms.getAutoDdl()));
       }
-      /*
-      // In order to ensure that a test runs against the intended database, we also need to set
-      // Spring's datasource properties. Otherwise, Spring might default to an embedded database
-      // (H2). See also property substitution in dist/application.properties for further details.
-      final var rdbms = unifiedConfig.getData().getSecondaryStorage().getRdbms();
-      withAdditionalProperties(
-          Map.of(
-              "spring.datasource.url", rdbms.getUrl(),
-              "spring.datasource.username", rdbms.getUsername(),
-              "spring.datasource.password", rdbms.getPassword()));*/
     }
 
     LOGGER.info("Start spring application ...");

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/PostgresReplicationClusterContainer.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/PostgresReplicationClusterContainer.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.util;
+
+import static org.awaitility.Awaitility.await;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Container which not only starts a PostgreSQL database but also a read replica.
+ *
+ * <p>This postgresql container uses the <i>postgres</i> DBA user to not rely on pg_monitor
+ * privileges to be set up.
+ */
+@SuppressWarnings("resource")
+public final class PostgresReplicationClusterContainer
+    extends GenericContainer<PostgresReplicationClusterContainer> {
+
+  private static final DockerImageName POSTGRES_IMAGE =
+      DockerImageName.parse("bitnamilegacy/postgresql").withTag("15");
+  private static final String DATABASE_NAME = "camunda";
+  private static final String USERNAME = "postgres";
+  private static final String PASSWORD = "secret";
+  private static final String REPLICATION_USER = "repl_user";
+  private static final String REPLICATION_PASSWORD = "repl_pass";
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(PostgresReplicationClusterContainer.class);
+
+  private final Network network = Network.newNetwork();
+  private final GenericContainer<?> replica;
+  private volatile boolean replicaStopped = false;
+
+  public PostgresReplicationClusterContainer() {
+    super(POSTGRES_IMAGE);
+
+    withNetwork(network)
+        .withNetworkAliases("primary")
+        .withEnv("POSTGRESQL_REPLICATION_MODE", "master")
+        .withEnv("POSTGRESQL_REPLICATION_USER", REPLICATION_USER)
+        .withEnv("POSTGRESQL_REPLICATION_PASSWORD", REPLICATION_PASSWORD)
+        .withEnv("POSTGRESQL_PASSWORD", PASSWORD)
+        .withEnv("POSTGRESQL_DATABASE", DATABASE_NAME)
+        .withExposedPorts(5432)
+        .withStartupTimeout(Duration.ofMinutes(1));
+
+    replica =
+        new GenericContainer<>(POSTGRES_IMAGE)
+            .withNetwork(network)
+            .withEnv("POSTGRESQL_REPLICATION_MODE", "slave")
+            .withEnv("POSTGRESQL_MASTER_HOST", "primary")
+            .withEnv("POSTGRESQL_REPLICATION_USER", REPLICATION_USER)
+            .withEnv("POSTGRESQL_REPLICATION_PASSWORD", REPLICATION_PASSWORD)
+            .withEnv("POSTGRESQL_PASSWORD", PASSWORD)
+            .withStartupTimeout(Duration.ofMinutes(1));
+  }
+
+  @Override
+  public void start() {
+    LOG.info("Starting PostgreSQL replication cluster (primary + replica)");
+    super.start();
+    replica.start();
+    waitForReplication();
+  }
+
+  @Override
+  public void stop() {
+    LOG.info("Stopping PostgreSQL replication cluster");
+    try {
+      stopReplica();
+    } finally {
+      try {
+        super.stop();
+      } finally {
+        network.close();
+      }
+    }
+  }
+
+  public void stopReplica() {
+    if (!replicaStopped) {
+      LOG.info("Stopping PostgreSQL replica");
+      replicaStopped = true;
+      replica.stop();
+      LOG.info("PostgreSQL replica stopped");
+    }
+  }
+
+  public void startReplica() {
+    LOG.info("Starting PostgreSQL replica");
+    replicaStopped = false;
+    replica.start();
+    waitForReplication();
+  }
+
+  public String getJdbcUrl() {
+    return "jdbc:postgresql://%s:%d/%s".formatted(getHost(), getMappedPort(5432), DATABASE_NAME);
+  }
+
+  public String getUsername() {
+    return USERNAME;
+  }
+
+  public String getPassword() {
+    return PASSWORD;
+  }
+
+  private void waitForReplication() {
+    LOG.info("Waiting for replica to connect");
+    await()
+        .atMost(Duration.ofSeconds(60))
+        .pollInterval(Duration.ofMillis(500))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              try (final Connection conn = primaryConnection();
+                  final Statement stmt = conn.createStatement();
+                  final ResultSet rs =
+                      stmt.executeQuery(
+                          """
+                        SELECT count(*) FROM pg_stat_replication
+                                        WHERE pid IS NOT NULL
+                                          AND COALESCE(pg_wal_lsn_diff(replay_lsn, '0/0'), 0)::bigint > 0
+                        """)) {
+
+                rs.next();
+                final int count = rs.getInt(1);
+                if (count < 1) {
+                  throw new AssertionError("Expected 1 replica, but found " + count);
+                }
+              }
+            });
+    LOG.info("Replica is in sync with primary");
+  }
+
+  private Connection primaryConnection() throws Exception {
+    return DriverManager.getConnection(getJdbcUrl(), USERNAME, PASSWORD);
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/PostgresReplicationClusterContainer.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/PostgresReplicationClusterContainer.java
@@ -56,7 +56,7 @@ public final class PostgresReplicationClusterContainer
         .withEnv("POSTGRESQL_PASSWORD", PASSWORD)
         .withEnv("POSTGRESQL_DATABASE", DATABASE_NAME)
         .withExposedPorts(5432)
-        .withStartupTimeout(Duration.ofMinutes(1));
+        .withStartupTimeout(Duration.ofMinutes(5));
 
     replica =
         new GenericContainer<>(POSTGRES_IMAGE)
@@ -66,7 +66,7 @@ public final class PostgresReplicationClusterContainer
             .withEnv("POSTGRESQL_REPLICATION_USER", REPLICATION_USER)
             .withEnv("POSTGRESQL_REPLICATION_PASSWORD", REPLICATION_PASSWORD)
             .withEnv("POSTGRESQL_PASSWORD", PASSWORD)
-            .withStartupTimeout(Duration.ofMinutes(1));
+            .withStartupTimeout(Duration.ofMinutes(5));
   }
 
   @Override


### PR DESCRIPTION
## Description

Adds two tests:
- a RDBMS level integration test for the `ReplicationStatusLogProvider`
- a set of acceptance tests with the full Camunda broker and a PostgreSQL cluster verifying the behavior 

For now these tests run in the regular RDBMS IT job, but when more tests are added we may need an additional CI job (currently take 1 minute to execute).

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #51488 
