### PR TITLE
test: initialize the database with script instead of liquibase in Mul…

### DIFF
--- a/.github/workflows/ci-database-integration-tests-reusable.yml
+++ b/.github/workflows/ci-database-integration-tests-reusable.yml
@@ -119,6 +119,7 @@ jobs:
           -D failsafe.rerunFailingTestsCount=${{ env.FLAKY_TEST_RERUN_COUNT }}
           -D flaky.test.reportDir=failsafe-reports
           -D test.integration.camunda.database.type=${{inputs.it-database-type}}
+          -D test.integration.camunda.database.fast-init=true
           -P parallel-tests,extract-flaky-tests,skipFrontendBuild,${{inputs.maven-profiles}}
           -pl 'qa/acceptance-tests'
           verify

--- a/db/rdbms-schema/src/main/java/io/camunda/db/rdbms/LiquibaseScriptGenerator.java
+++ b/db/rdbms-schema/src/main/java/io/camunda/db/rdbms/LiquibaseScriptGenerator.java
@@ -23,6 +23,7 @@ import liquibase.change.Change;
 import liquibase.changelog.ChangeSet;
 import liquibase.database.Database;
 import liquibase.database.DatabaseFactory;
+import liquibase.database.OfflineConnection;
 import liquibase.exception.LiquibaseException;
 import liquibase.resource.ClassLoaderResourceAccessor;
 import liquibase.sqlgenerator.SqlGeneratorFactory;
@@ -38,9 +39,18 @@ public class LiquibaseScriptGenerator {
   public static final String POSTGRESQL = "postgresql";
   public static final String ORACLE = "oracle";
 
-  public static final String[] DATABASES = {H2, MARIADB, MYSQL, MSSQL, POSTGRESQL, ORACLE};
   public static final String CHANGELOG_PATH = "db/changelog/rdbms-exporter/";
   public static final String CHANGESET_PATH = CHANGELOG_PATH + "changesets/";
+
+  public static final DatabaseVersion[] DATABASE_VERSIONS = {
+    new DatabaseVersion(H2),
+    new DatabaseVersion(MARIADB),
+    new DatabaseVersion(MYSQL),
+    new DatabaseVersion(MSSQL),
+    new DatabaseVersion(POSTGRESQL),
+    // Oracle 19 target: generates NUMBER(1,0) for boolean columns (compatible with 19, 21, 23+)
+    new DatabaseVersion(ORACLE, 19L),
+  };
 
   /**
    * Generates Liquibase SQL scripts for a given database type.
@@ -65,14 +75,14 @@ public class LiquibaseScriptGenerator {
     // Validate rolling-upgrade compatibility once, before generating any scripts.
     validateRollingUpgradeCompatibility(upgradeChangesets.stream().toList());
 
-    for (final var database : DATABASES) {
+    for (final var databaseVersion : DATABASE_VERSIONS) {
       // We generate create scripts for the latest version from the changelog-master.xml
       generateLiquibaseScript(
-          database,
+          databaseVersion,
           CHANGELOG_PATH + "changelog-master.xml",
           prefix,
           targetDir + "/create",
-          database + "_master.sql");
+          databaseVersion.vendor() + "_master.sql");
 
       // We generate upgrade scripts for each version (except 8.9.0) from the changesets, so that
       // customers, who created their schema with an older version can upgrade to the latest
@@ -85,13 +95,13 @@ public class LiquibaseScriptGenerator {
         final String fileName = Paths.get(changesetFile).getFileName().toString();
         final String sqlOutputDir = targetDir + "/upgrade";
         generateLiquibaseScript(
-            database,
+            databaseVersion,
             changesetFile,
             prefix,
             sqlOutputDir,
             String.format(
                 "%s_upgrade_%s_to_%s.sql",
-                database, previousVersion, fileName.replace(".xml", "")));
+                databaseVersion.vendor(), previousVersion, fileName.replace(".xml", "")));
 
         previousVersion = fileName.replace(".xml", "");
       }
@@ -99,24 +109,24 @@ public class LiquibaseScriptGenerator {
   }
 
   public static void generateLiquibaseScript(
-      final String databaseType,
+      final DatabaseVersion databaseVersion,
       final String changesetFile,
       final String prefix,
       final String targetBaseDir,
       final String outputFileName)
       throws Exception {
-    final var properties = VendorDatabasePropertiesLoader.load(databaseType);
+    final var properties = VendorDatabasePropertiesLoader.load(databaseVersion.vendor());
 
     final var sqlScript =
         generateSqlScript(
-            databaseType,
+            databaseVersion,
             changesetFile,
             prefix,
             properties.userCharColumnSize(),
             properties.errorMessageSize(),
             properties.treePathSize());
 
-    final String basedir = targetBaseDir + "/" + databaseType;
+    final String basedir = targetBaseDir + "/" + databaseVersion.vendor();
     Files.createDirectories(Paths.get(basedir));
     Files.write(
         Paths.get(basedir + "/" + outputFileName),
@@ -126,7 +136,7 @@ public class LiquibaseScriptGenerator {
   }
 
   public static String generateSqlScript(
-      final String databaseType,
+      final DatabaseVersion databaseVersion,
       final String changesetFile,
       final String prefix,
       final int userCharColumnSize,
@@ -134,7 +144,17 @@ public class LiquibaseScriptGenerator {
       final int treePathSize)
       throws LiquibaseException {
 
-    final var database = DatabaseFactory.getInstance().getDatabase(databaseType);
+    final Database database;
+    if (databaseVersion.targetVersion() != null) {
+      final var resourceAccessor = new ClassLoaderResourceAccessor();
+      final var conn =
+          new OfflineConnection(
+              "offline:" + databaseVersion.vendor() + "?version=" + databaseVersion.targetVersion(),
+              resourceAccessor);
+      database = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(conn);
+    } else {
+      database = DatabaseFactory.getInstance().getDatabase(databaseVersion.vendor());
+    }
 
     final Liquibase liquibase =
         new Liquibase(changesetFile, new ClassLoaderResourceAccessor(), database);
@@ -233,6 +253,26 @@ public class LiquibaseScriptGenerator {
           "Rolling-upgrade compatibility violations found in RDBMS schema changesets:\n"
               + String.join("\n", allViolations);
       throw new IllegalStateException(message);
+    }
+  }
+
+  public static DatabaseVersion getDatabaseVersion(final String databaseId) {
+    return Arrays.stream(LiquibaseScriptGenerator.DATABASE_VERSIONS)
+        .filter(dv -> dv.vendor().equals(databaseId))
+        .findFirst()
+        .orElse(new DatabaseVersion(databaseId));
+  }
+
+  /**
+   * Pairs a database vendor name with an optional target version for SQL generation.
+   *
+   * <p>When {@code targetVersion} is non-null, an {@link OfflineConnection} is used so that
+   * Liquibase applies type mappings for that specific version rather than defaulting to the latest
+   * (e.g. Oracle 19 emits {@code NUMBER(1,0)} for boolean columns instead of {@code BOOLEAN}).
+   */
+  public record DatabaseVersion(String vendor, Long targetVersion) {
+    public DatabaseVersion(final String vendor) {
+      this(vendor, null);
     }
   }
 }

--- a/db/rdbms-schema/src/test/java/io/camunda/db/rdbms/LiquibaseScriptGeneratorTest.java
+++ b/db/rdbms-schema/src/test/java/io/camunda/db/rdbms/LiquibaseScriptGeneratorTest.java
@@ -9,6 +9,7 @@ package io.camunda.db.rdbms;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.db.rdbms.LiquibaseScriptGenerator.DatabaseVersion;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import org.junit.jupiter.api.Test;
@@ -21,7 +22,8 @@ class LiquibaseScriptGeneratorTest {
 
     // when
     final String sqlScript =
-        LiquibaseScriptGenerator.generateSqlScript("h2", "test.xml", "", 4000, 4000, 4000);
+        LiquibaseScriptGenerator.generateSqlScript(
+            new DatabaseVersion("h2"), "test.xml", "", 4000, 4000, 4000);
 
     // then
     final var expected = Files.readString(Paths.get("src/test/resources/test.h2.sql"));
@@ -34,7 +36,8 @@ class LiquibaseScriptGeneratorTest {
 
     // when
     final String sqlScript =
-        LiquibaseScriptGenerator.generateSqlScript("mariadb", "test.xml", "", 4000, 4000, 4000);
+        LiquibaseScriptGenerator.generateSqlScript(
+            new DatabaseVersion("mariadb"), "test.xml", "", 4000, 4000, 4000);
 
     // then
     final var expected = Files.readString(Paths.get("src/test/resources/test.mariadb.sql"));
@@ -47,7 +50,8 @@ class LiquibaseScriptGeneratorTest {
 
     // when
     final String sqlScript =
-        LiquibaseScriptGenerator.generateSqlScript("mssql", "test.xml", "", 4000, 4000, 4000);
+        LiquibaseScriptGenerator.generateSqlScript(
+            new DatabaseVersion("mssql"), "test.xml", "", 4000, 4000, 4000);
 
     // then
     final var expected = Files.readString(Paths.get("src/test/resources/test.mssql.sql"));
@@ -60,7 +64,8 @@ class LiquibaseScriptGeneratorTest {
 
     // when
     final String sqlScript =
-        LiquibaseScriptGenerator.generateSqlScript("h2", "test.xml", "C8_", 4000, 4000, 4000);
+        LiquibaseScriptGenerator.generateSqlScript(
+            new DatabaseVersion("h2"), "test.xml", "C8_", 4000, 4000, 4000);
 
     // then
     final var expected = Files.readString(Paths.get("src/test/resources/test_prefix.h2.sql"));

--- a/qa/util/pom.xml
+++ b/qa/util/pom.xml
@@ -119,6 +119,14 @@
     </dependency>
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>camunda-db-rdbms</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-db-rdbms-schema</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>camunda-security-core</artifactId>
     </dependency>
     <dependency>

--- a/qa/util/pom.xml
+++ b/qa/util/pom.xml
@@ -198,6 +198,15 @@
     </dependency>
 
     <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-beans</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.liquibase</groupId>
+      <artifactId>liquibase-core</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.github.dasniko</groupId>
       <artifactId>testcontainers-keycloak</artifactId>
     </dependency>

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
@@ -210,6 +210,8 @@ public class CamundaMultiDBExtension
       "test.integration.aurora.aws.username";
   public static final String TEST_INTEGRATION_AURORA_AWS_PASSWORD =
       "test.integration.aurora.aws.password";
+  public static final String TEST_INTEGRATION_RDBMS_FAST_INIT =
+      "test.integration.camunda.database.fast-init";
   public static final Duration TIMEOUT_DATA_AVAILABILITY =
       Optional.ofNullable(System.getProperty(PROP_TEST_INTEGRATION_OPENSEARCH_AWS_TIMEOUT))
           .map(val -> Duration.ofSeconds(Long.parseLong(val)))

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
@@ -8,15 +8,19 @@
 package io.camunda.qa.util.multidb;
 
 import static io.camunda.configuration.beans.LegacySearchEngineSchemaManagerProperties.CREATE_SCHEMA_PROPERTY;
+import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TEST_INTEGRATION_RDBMS_FAST_INIT;
 
 import io.camunda.configuration.DocumentBasedSecondaryStorageDatabase;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.exporter.CamundaExporter;
 import io.camunda.zeebe.exporter.ElasticsearchExporter;
 import io.camunda.zeebe.exporter.opensearch.OpensearchExporter;
+import io.camunda.zeebe.qa.util.cluster.TestSpringApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneApplication;
 import java.util.HashMap;
 import java.util.Map;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.GenericBeanDefinition;
 
 /**
  * Helper class to configure any {@link TestStandaloneApplication}, with specific secondary storage.
@@ -251,6 +255,20 @@ public class MultiDbConfigurator {
       final String username,
       final String password) {
     final String tablePrefix = generateTablePrefix();
+
+    if ("true".equalsIgnoreCase(System.getProperty(TEST_INTEGRATION_RDBMS_FAST_INIT))) {
+      testApplication.withProperty("camunda.data.secondary-storage.rdbms.auto-ddl", "false");
+      if (testApplication instanceof final TestSpringApplication<?> springApp) {
+        springApp.withAdditionalInitializer(
+            ctx -> {
+              final var bd = new GenericBeanDefinition();
+              bd.setBeanClass(ScriptBasedSchemaManager.class);
+              bd.setPrimary(true);
+              ((BeanDefinitionRegistry) ctx.getBeanFactory())
+                  .registerBeanDefinition("rdbmsSchemaManager", bd);
+            });
+      }
+    }
 
     testApplication
         .withSecondaryStorageType(SecondaryStorageType.rdbms)

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/ScriptBasedSchemaManager.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/ScriptBasedSchemaManager.java
@@ -8,6 +8,7 @@
 package io.camunda.qa.util.multidb;
 
 import io.camunda.db.rdbms.LiquibaseScriptGenerator;
+import io.camunda.db.rdbms.LiquibaseScriptGenerator.DatabaseVersion;
 import io.camunda.db.rdbms.RdbmsSchemaManager;
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import java.util.concurrent.ConcurrentHashMap;
@@ -51,9 +52,11 @@ public class ScriptBasedSchemaManager implements RdbmsSchemaManager, Initializin
         SCRIPT_CACHE.computeIfAbsent(
             databaseId,
             id -> {
+              final DatabaseVersion dbVersion =
+                  LiquibaseScriptGenerator.getDatabaseVersion(databaseId);
               try {
                 return LiquibaseScriptGenerator.generateSqlScript(
-                    id,
+                    dbVersion,
                     CHANGELOG,
                     PREFIX_PLACEHOLDER,
                     vendorDatabaseProperties.userCharColumnSize(),

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/ScriptBasedSchemaManager.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/ScriptBasedSchemaManager.java
@@ -34,7 +34,7 @@ public class ScriptBasedSchemaManager implements RdbmsSchemaManager, Initializin
   private final VendorDatabaseProperties vendorDatabaseProperties;
   private final String prefix;
 
-  private boolean initialized = false;
+  private volatile boolean initialized = false;
 
   public ScriptBasedSchemaManager(
       final DataSource dataSource,

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/ScriptBasedSchemaManager.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/ScriptBasedSchemaManager.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.qa.util.multidb;
+
+import io.camunda.db.rdbms.LiquibaseScriptGenerator;
+import io.camunda.db.rdbms.RdbmsSchemaManager;
+import io.camunda.db.rdbms.config.VendorDatabaseProperties;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.sql.DataSource;
+import liquibase.exception.LiquibaseException;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Value;
+
+/**
+ * Bypasses Liquibase by pre-generating DDL SQL once per JVM (cached by databaseId) and executing it
+ * directly. Significantly faster than Liquibase for databases with expensive precondition checks
+ * (e.g. Oracle).
+ */
+public class ScriptBasedSchemaManager implements RdbmsSchemaManager, InitializingBean {
+
+  private static final ConcurrentHashMap<String, String> SCRIPT_CACHE = new ConcurrentHashMap<>();
+
+  private static final String CHANGELOG = "db/changelog/rdbms-exporter/changelog-master.xml";
+  private static final String PREFIX_PLACEHOLDER = "__PREFIX__";
+
+  private final DataSource dataSource;
+  private final VendorDatabaseProperties vendorDatabaseProperties;
+  private final String prefix;
+
+  private boolean initialized = false;
+
+  public ScriptBasedSchemaManager(
+      final DataSource dataSource,
+      final VendorDatabaseProperties vendorDatabaseProperties,
+      @Value("${camunda.data.secondary-storage.rdbms.prefix:}") final String prefix) {
+    this.dataSource = dataSource;
+    this.vendorDatabaseProperties = vendorDatabaseProperties;
+    this.prefix = prefix;
+  }
+
+  @Override
+  public void afterPropertiesSet() throws Exception {
+    final String databaseId = vendorDatabaseProperties.databaseId();
+    final String template =
+        SCRIPT_CACHE.computeIfAbsent(
+            databaseId,
+            id -> {
+              try {
+                return LiquibaseScriptGenerator.generateSqlScript(
+                    id,
+                    CHANGELOG,
+                    PREFIX_PLACEHOLDER,
+                    vendorDatabaseProperties.userCharColumnSize(),
+                    vendorDatabaseProperties.errorMessageSize(),
+                    vendorDatabaseProperties.treePathSize());
+              } catch (final LiquibaseException e) {
+                throw new IllegalStateException(
+                    "Failed to generate SQL script for database '" + id + "'", e);
+              }
+            });
+
+    final String sql =
+        template
+            .replace(PREFIX_PLACEHOLDER, StringUtils.trimToEmpty(prefix))
+            .replaceAll("--[^\n]*(\n|$)", ""); // strip single-line comments before splitting
+
+    try (final var conn = dataSource.getConnection()) {
+      for (final String stmt : sql.split(";")) {
+        final String trimmed = stmt.strip();
+        if (!trimmed.isEmpty()) {
+          conn.createStatement().execute(trimmed);
+        }
+      }
+    }
+
+    initialized = true;
+  }
+
+  @Override
+  public boolean isInitialized() {
+    return initialized;
+  }
+}


### PR DESCRIPTION
This pull request introduces a significant performance optimization for database integration tests by adding an option to bypass Liquibase and directly execute pre-generated DDL SQL scripts for RDBMS schema initialization. This is particularly beneficial for databases like Oracle, where Liquibase's precondition checks are slow. The changes include a new `ScriptBasedSchemaManager`, updates to the schema generation logic, and wiring to enable this fast initialization mode via a system property.

Key changes:

**Fast RDBMS Schema Initialization for Integration Tests**
- Added a new `ScriptBasedSchemaManager` that generates and caches DDL SQL scripts per database type, then executes them directly to initialize the schema, bypassing Liquibase for much faster test setup. This is enabled when the `test.integration.camunda.database.fast-init` property is set. [[1]](diffhunk://#diff-fb958101fbd2da50f1cd121626e541b4f36614f595f8b7eafe43c8d049822b67R1-R92) [[2]](diffhunk://#diff-b7742c288cee2646279f9664097d7efde2eb107de4ad5e76679723fbedbbe115R259-R272) [[3]](diffhunk://#diff-1f5906c8b8cc9d73481456f2d5faf50dce91820db0e69a28db7c66082e0614acR213-R214) [[4]](diffhunk://#diff-5e1410acb7b7aef766a6a464c40a3edfc946a73bac6ad4959534279bdfcfea68R122)

**Liquibase Script Generation Enhancements**
- Refactored `LiquibaseScriptGenerator` to support generating SQL scripts for specific database versions, using a new `DatabaseVersion` record to pair vendor and version. This allows for more precise control (e.g., Oracle 19 type mappings). [[1]](diffhunk://#diff-663360d0f1a9b737b67a3cb4b5c5458485610f58fbb8dcdd0ef3339f8daf6219L41-R54) [[2]](diffhunk://#diff-663360d0f1a9b737b67a3cb4b5c5458485610f58fbb8dcdd0ef3339f8daf6219L68-R85) [[3]](diffhunk://#diff-663360d0f1a9b737b67a3cb4b5c5458485610f58fbb8dcdd0ef3339f8daf6219L88-R129) [[4]](diffhunk://#diff-663360d0f1a9b737b67a3cb4b5c5458485610f58fbb8dcdd0ef3339f8daf6219L129-R157) [[5]](diffhunk://#diff-663360d0f1a9b737b67a3cb4b5c5458485610f58fbb8dcdd0ef3339f8daf6219R258-R277)
- Updated usages and tests to use the new `DatabaseVersion` abstraction, ensuring all script generation flows are consistent. [[1]](diffhunk://#diff-2ab3d6f69e2e6af66fa53b7e5c00037f4d801abac78ae5f7b0e1e9ee1656ad58R12) [[2]](diffhunk://#diff-2ab3d6f69e2e6af66fa53b7e5c00037f4d801abac78ae5f7b0e1e9ee1656ad58L24-R26) [[3]](diffhunk://#diff-2ab3d6f69e2e6af66fa53b7e5c00037f4d801abac78ae5f7b0e1e9ee1656ad58L37-R40) [[4]](diffhunk://#diff-2ab3d6f69e2e6af66fa53b7e5c00037f4d801abac78ae5f7b0e1e9ee1656ad58L50-R54) [[5]](diffhunk://#diff-2ab3d6f69e2e6af66fa53b7e5c00037f4d801abac78ae5f7b0e1e9ee1656ad58L63-R68)

**Test and Build Configuration**
- Added dependencies on `camunda-db-rdbms` and `camunda-db-rdbms-schema` in the test utility module to support the new schema manager and script generation.
- Updated the CI workflow to allow enabling fast schema initialization for integration tests via a Maven property.

**Internal Wiring and Configuration**
- Modified the multi-DB test configurator to conditionally register the new schema manager and disable Liquibase auto-DDL when fast-init is enabled, supporting both Spring and non-Spring applications. [[1]](diffhunk://#diff-b7742c288cee2646279f9664097d7efde2eb107de4ad5e76679723fbedbbe115R11-R23) [[2]](diffhunk://#diff-b7742c288cee2646279f9664097d7efde2eb107de4ad5e76679723fbedbbe115R259-R272)

These changes together provide a much faster and more flexible way to initialize RDBMS schemas in integration tests, especially for slow databases like Oracle.
