### PR TITLE
test: demo submit-build-status with runner type field

### DIFF
--- a/.github/actions/observe-build-status/action.yml
+++ b/.github/actions/observe-build-status/action.yml
@@ -95,7 +95,7 @@ runs:
         job_name_override: "${{ inputs.job_name }}"
         gcp_credentials_json: "${{ steps.secrets.outputs.gcloud_sa_key }}"
    ######################## Report build result #############################
-    - uses: camunda/infra-global-github-actions/submit-build-status@main
+    - uses: camunda/infra-global-github-actions/submit-build-status@analytics-read-runner-type-from-metadata
       if: ${{ always() && steps.secrets.outputs.gcloud_sa_key != '' }}
       with:
         job_name_override: "${{ inputs.job_name }}"


### PR DESCRIPTION
## Demo PR for camunda/infra-global-github-actions#693

Points `submit-build-status` at the `analytics-read-runner-type-from-metadata` branch to test the new `runs_on` BigQuery field that reads from `/home/runner/.camunda-arc-runner-info/runs-on`.

**This is a test PR — do not merge.**

Related: https://github.com/camunda/infra-global-github-actions/pull/693