### PR TITLE
Implement "update" Agent Instance API

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -95,6 +95,7 @@ import io.camunda.client.api.command.UnassignRoleFromUserCommandStep1;
 import io.camunda.client.api.command.UnassignUserFromGroupCommandStep1;
 import io.camunda.client.api.command.UnassignUserFromTenantCommandStep1;
 import io.camunda.client.api.command.UnassignUserTaskCommandStep1;
+import io.camunda.client.api.command.UpdateAgentInstanceCommandStep1;
 import io.camunda.client.api.command.UpdateAuthorizationCommandStep1;
 import io.camunda.client.api.command.UpdateGlobalTaskListenerCommandStep1;
 import io.camunda.client.api.command.UpdateGroupCommandStep1;
@@ -3450,6 +3451,23 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder for creating an agent instance
    */
   CreateAgentInstanceCommandStep1 newCreateAgentInstanceCommand();
+
+  /**
+   * Creates a command to update an existing agent instance.
+   *
+   * <pre>
+   *   camundaClient
+   *       .newUpdateAgentInstanceCommand(agentInstanceKey)
+   *       .elementInstanceKey(elementInstanceKey)
+   *       .status(AgentInstanceStatus.COMPLETED)
+   *       .send()
+   *       .join();
+   * </pre>
+   *
+   * @param agentInstanceKey the key of the agent instance to update
+   * @return a builder for updating the agent instance
+   */
+  UpdateAgentInstanceCommandStep1 newUpdateAgentInstanceCommand(long agentInstanceKey);
 
   /**
    * Creates a request to create a new global task listener.

--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -3459,7 +3459,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    *   camundaClient
    *       .newUpdateAgentInstanceCommand(agentInstanceKey)
    *       .elementInstanceKey(elementInstanceKey)
-   *       .status(AgentInstanceStatus.COMPLETED)
+   *       .status(AgentInstanceUpdateStatus.THINKING)
    *       .send()
    *       .join();
    * </pre>

--- a/clients/java/src/main/java/io/camunda/client/api/command/AgentInstanceUpdateStatus.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/AgentInstanceUpdateStatus.java
@@ -13,14 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.client.api.search.enums;
+package io.camunda.client.api.command;
 
-public enum AgentInstanceStatus {
-  INITIALIZING,
+/**
+ * Status values that can be set on an agent instance via an update request. COMPLETED is excluded
+ * because it is a terminal state reached through process completion, not through direct update.
+ * INITIALIZING is excluded because it is set by the creation command and it is not possible to
+ * transition back to it.
+ */
+public enum AgentInstanceUpdateStatus {
   TOOL_DISCOVERY,
   IDLE,
   THINKING,
-  TOOL_CALLING,
-  COMPLETED,
-  UNKNOWN_ENUM_VALUE
+  TOOL_CALLING
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/UpdateAgentInstanceCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/UpdateAgentInstanceCommandStep1.java
@@ -27,7 +27,7 @@ import java.util.List;
  *   camundaClient
  *       .newUpdateAgentInstanceCommand(agentInstanceKey)
  *       .elementInstanceKey(elementInstanceKey)
- *       .status(AgentInstanceStatus.COMPLETED)
+ *       .status(AgentInstanceUpdateStatus.THINKING)
  *       .send()
  *       .join();
  * </pre>
@@ -35,9 +35,8 @@ import java.util.List;
 public interface UpdateAgentInstanceCommandStep1 {
 
   /**
-   * Sets the element instance key of the AHSP or AI Agent Task element instance owning this agent
-   * instance. The engine uses this to validate that the agent instance belongs to the expected
-   * process instance.
+   * Sets the element instance key associated with this agent instance. Used to validate that the
+   * update targets the correct process instance.
    *
    * @param elementInstanceKey the key of the element instance. Must be greater than 0.
    * @return the next step of the builder

--- a/clients/java/src/main/java/io/camunda/client/api/command/UpdateAgentInstanceCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/UpdateAgentInstanceCommandStep1.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.command;
+
+import io.camunda.client.api.response.UpdateAgentInstanceResponse;
+import io.camunda.client.api.search.enums.AgentInstanceStatus;
+import java.util.List;
+
+/**
+ * Represents a request to update an existing agent instance.
+ *
+ * <p>Usage example:
+ *
+ * <pre>
+ *   camundaClient
+ *       .newUpdateAgentInstanceCommand(agentInstanceKey)
+ *       .elementInstanceKey(elementInstanceKey)
+ *       .status(AgentInstanceStatus.COMPLETED)
+ *       .send()
+ *       .join();
+ * </pre>
+ */
+public interface UpdateAgentInstanceCommandStep1 {
+
+  /**
+   * Sets the element instance key of the AHSP or AI Agent Task element instance owning this agent
+   * instance. The engine uses this to validate that the agent instance belongs to the expected
+   * process instance.
+   *
+   * @param elementInstanceKey the key of the element instance. Must be greater than 0.
+   * @return the next step of the builder
+   */
+  UpdateAgentInstanceCommandStep2 elementInstanceKey(long elementInstanceKey);
+
+  interface UpdateAgentInstanceCommandStep2 extends FinalCommandStep<UpdateAgentInstanceResponse> {
+
+    /**
+     * Sets the new status of the agent instance.
+     *
+     * @param status the new status
+     * @return this builder for method chaining
+     */
+    UpdateAgentInstanceCommandStep2 status(AgentInstanceStatus status);
+
+    /**
+     * Increments the input token counter by the given delta.
+     *
+     * @param inputTokens the number of input tokens to add. Must be >= 0.
+     * @return this builder for method chaining
+     */
+    UpdateAgentInstanceCommandStep2 inputTokens(long inputTokens);
+
+    /**
+     * Increments the output token counter by the given delta.
+     *
+     * @param outputTokens the number of output tokens to add. Must be >= 0.
+     * @return this builder for method chaining
+     */
+    UpdateAgentInstanceCommandStep2 outputTokens(long outputTokens);
+
+    /**
+     * Increments the model call counter by the given delta.
+     *
+     * @param modelCalls the number of model calls to add. Must be >= 0.
+     * @return this builder for method chaining
+     */
+    UpdateAgentInstanceCommandStep2 modelCalls(int modelCalls);
+
+    /**
+     * Increments the tool call counter by the given delta.
+     *
+     * @param toolCalls the number of tool calls to add. Must be >= 0.
+     * @return this builder for method chaining
+     */
+    UpdateAgentInstanceCommandStep2 toolCalls(int toolCalls);
+
+    /**
+     * Sets the list of tools available to the agent instance.
+     *
+     * @param tools the tools to set
+     * @return this builder for method chaining
+     */
+    UpdateAgentInstanceCommandStep2 tools(List<AgentTool> tools);
+  }
+
+  /** Represents a tool available to the agent instance. */
+  interface AgentTool {
+    String getName();
+
+    String getDescription();
+
+    String getElementId();
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/api/command/UpdateAgentInstanceCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/UpdateAgentInstanceCommandStep1.java
@@ -16,7 +16,6 @@
 package io.camunda.client.api.command;
 
 import io.camunda.client.api.response.UpdateAgentInstanceResponse;
-import io.camunda.client.api.search.enums.AgentInstanceStatus;
 import java.util.List;
 
 /**
@@ -50,10 +49,10 @@ public interface UpdateAgentInstanceCommandStep1 {
     /**
      * Sets the new status of the agent instance.
      *
-     * @param status the new status
+     * @param status the new status; see {@link AgentInstanceUpdateStatus} for available values
      * @return this builder for method chaining
      */
-    UpdateAgentInstanceCommandStep2 status(AgentInstanceStatus status);
+    UpdateAgentInstanceCommandStep2 status(AgentInstanceUpdateStatus status);
 
     /**
      * Increments the input token counter by the given delta.
@@ -88,9 +87,20 @@ public interface UpdateAgentInstanceCommandStep1 {
     UpdateAgentInstanceCommandStep2 toolCalls(int toolCalls);
 
     /**
-     * Sets the list of tools available to the agent instance.
+     * Replaces the full list of tools available to the agent instance. An empty list clears all
+     * tools. Use {@link AgentTool#of(String)} or {@link AgentTool#of(String, String, String)} to
+     * construct tool entries.
      *
-     * @param tools the tools to set
+     * <p>Example:
+     *
+     * <pre>
+     *   .tools(List.of(
+     *       AgentTool.of("search", "Search the web", "searchTask"),
+     *       AgentTool.of("summarize")
+     *   ))
+     * </pre>
+     *
+     * @param tools the tools to set; pass an empty list to clear all tools
      * @return this builder for method chaining
      */
     UpdateAgentInstanceCommandStep2 tools(List<AgentTool> tools);
@@ -103,5 +113,42 @@ public interface UpdateAgentInstanceCommandStep1 {
     String getDescription();
 
     String getElementId();
+
+    /**
+     * Creates a tool with the given name and no description or element ID.
+     *
+     * @param name the tool name. Must not be blank.
+     * @return a new {@link AgentTool}
+     */
+    static AgentTool of(final String name) {
+      return of(name, null, null);
+    }
+
+    /**
+     * Creates a tool with the given name, description, and element ID.
+     *
+     * @param name the tool name. Must not be blank.
+     * @param description optional description of the tool
+     * @param elementId optional ID of the BPMN element providing this tool
+     * @return a new {@link AgentTool}
+     */
+    static AgentTool of(final String name, final String description, final String elementId) {
+      return new AgentTool() {
+        @Override
+        public String getName() {
+          return name;
+        }
+
+        @Override
+        public String getDescription() {
+          return description;
+        }
+
+        @Override
+        public String getElementId() {
+          return elementId;
+        }
+      };
+    }
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/api/response/UpdateAgentInstanceResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/UpdateAgentInstanceResponse.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.response;
+
+public interface UpdateAgentInstanceResponse {}

--- a/clients/java/src/main/java/io/camunda/client/api/search/enums/AgentInstanceStatus.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/enums/AgentInstanceStatus.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.enums;
+
+public enum AgentInstanceStatus {
+  COMPLETED,
+  IDLE,
+  INITIALIZING,
+  THINKING,
+  TOOL_CALLING,
+  TOOL_DISCOVERY,
+  UNKNOWN_ENUM_VALUE
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -106,6 +106,7 @@ import io.camunda.client.api.command.UnassignRoleFromUserCommandStep1;
 import io.camunda.client.api.command.UnassignUserFromGroupCommandStep1;
 import io.camunda.client.api.command.UnassignUserFromTenantCommandStep1;
 import io.camunda.client.api.command.UnassignUserTaskCommandStep1;
+import io.camunda.client.api.command.UpdateAgentInstanceCommandStep1;
 import io.camunda.client.api.command.UpdateAuthorizationCommandStep1;
 import io.camunda.client.api.command.UpdateGlobalTaskListenerCommandStep1;
 import io.camunda.client.api.command.UpdateGroupCommandStep1;
@@ -289,6 +290,7 @@ import io.camunda.client.impl.command.UnassignRoleFromUserCommandImpl;
 import io.camunda.client.impl.command.UnassignUserFromGroupCommandImpl;
 import io.camunda.client.impl.command.UnassignUserFromTenantCommandImpl;
 import io.camunda.client.impl.command.UnassignUserTaskCommandImpl;
+import io.camunda.client.impl.command.UpdateAgentInstanceCommandImpl;
 import io.camunda.client.impl.command.UpdateAuthorizationCommandImpl;
 import io.camunda.client.impl.command.UpdateGlobalTaskListenerCommandImpl;
 import io.camunda.client.impl.command.UpdateGroupCommandImpl;
@@ -1715,6 +1717,12 @@ public final class CamundaClientImpl implements CamundaClient {
   @Override
   public CreateAgentInstanceCommandStep1 newCreateAgentInstanceCommand() {
     return new CreateAgentInstanceCommandImpl(httpClient, jsonMapper);
+  }
+
+  @Override
+  public UpdateAgentInstanceCommandStep1 newUpdateAgentInstanceCommand(
+      final long agentInstanceKey) {
+    return new UpdateAgentInstanceCommandImpl(agentInstanceKey, httpClient, jsonMapper);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UpdateAgentInstanceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UpdateAgentInstanceCommandImpl.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.command;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.command.UpdateAgentInstanceCommandStep1;
+import io.camunda.client.api.command.UpdateAgentInstanceCommandStep1.UpdateAgentInstanceCommandStep2;
+import io.camunda.client.api.response.UpdateAgentInstanceResponse;
+import io.camunda.client.api.search.enums.AgentInstanceStatus;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.UpdateAgentInstanceResponseImpl;
+import io.camunda.client.impl.util.EnumUtil;
+import io.camunda.client.protocol.rest.AgentInstanceMetricsDelta;
+import io.camunda.client.protocol.rest.AgentInstanceStatusEnum;
+import io.camunda.client.protocol.rest.AgentInstanceUpdateRequest;
+import io.camunda.client.protocol.rest.AgentTool;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class UpdateAgentInstanceCommandImpl
+    implements UpdateAgentInstanceCommandStep1, UpdateAgentInstanceCommandStep2 {
+
+  private final AgentInstanceUpdateRequest request;
+  private final JsonMapper jsonMapper;
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+  private final long agentInstanceKey;
+
+  public UpdateAgentInstanceCommandImpl(
+      final long agentInstanceKey, final HttpClient httpClient, final JsonMapper jsonMapper) {
+    ArgumentUtil.ensureGreaterThan("agentInstanceKey", agentInstanceKey, 0);
+    this.agentInstanceKey = agentInstanceKey;
+    this.jsonMapper = jsonMapper;
+    this.httpClient = httpClient;
+    httpRequestConfig = httpClient.newRequestConfig();
+    request = new AgentInstanceUpdateRequest();
+  }
+
+  @Override
+  public UpdateAgentInstanceCommandStep2 elementInstanceKey(final long elementInstanceKey) {
+    ArgumentUtil.ensureGreaterThan("elementInstanceKey", elementInstanceKey, 0);
+    request.elementInstanceKey(String.valueOf(elementInstanceKey));
+    return this;
+  }
+
+  @Override
+  public UpdateAgentInstanceCommandStep2 status(final AgentInstanceStatus status) {
+    request.status(EnumUtil.convert(status, AgentInstanceStatusEnum.class));
+    return this;
+  }
+
+  @Override
+  public UpdateAgentInstanceCommandStep2 inputTokens(final long inputTokens) {
+    ensureMetrics().inputTokens(inputTokens);
+    return this;
+  }
+
+  @Override
+  public UpdateAgentInstanceCommandStep2 outputTokens(final long outputTokens) {
+    ensureMetrics().outputTokens(outputTokens);
+    return this;
+  }
+
+  @Override
+  public UpdateAgentInstanceCommandStep2 modelCalls(final int modelCalls) {
+    ensureMetrics().modelCalls(modelCalls);
+    return this;
+  }
+
+  @Override
+  public UpdateAgentInstanceCommandStep2 toolCalls(final int toolCalls) {
+    ensureMetrics().toolCalls(toolCalls);
+    return this;
+  }
+
+  @Override
+  public UpdateAgentInstanceCommandStep2 tools(final List<AgentTool> tools) {
+    final List<io.camunda.client.protocol.rest.AgentTool> protocolTools =
+        tools.stream()
+            .map(
+                tool -> {
+                  final io.camunda.client.protocol.rest.AgentTool protocolTool =
+                      new io.camunda.client.protocol.rest.AgentTool();
+                  protocolTool.name(tool.getName());
+                  if (tool.getDescription() != null) {
+                    protocolTool.description(tool.getDescription());
+                  }
+                  if (tool.getElementId() != null) {
+                    protocolTool.elementId(tool.getElementId());
+                  }
+                  return protocolTool;
+                })
+            .collect(Collectors.toList());
+    request.tools(protocolTools);
+    return this;
+  }
+
+  @Override
+  public UpdateAgentInstanceCommandStep2 requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<UpdateAgentInstanceResponse> send() {
+    final HttpCamundaFuture<UpdateAgentInstanceResponse> result = new HttpCamundaFuture<>();
+    httpClient.patch(
+        "/agent-instances/" + agentInstanceKey,
+        jsonMapper.toJson(request),
+        httpRequestConfig.build(),
+        UpdateAgentInstanceResponseImpl::new,
+        result);
+    return result;
+  }
+
+  private AgentInstanceMetricsDelta ensureMetrics() {
+    if (request.getMetrics() == null) {
+      request.metrics(new AgentInstanceMetricsDelta());
+    }
+    return request.getMetrics();
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UpdateAgentInstanceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UpdateAgentInstanceCommandImpl.java
@@ -17,18 +17,18 @@ package io.camunda.client.impl.command;
 
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.command.AgentInstanceUpdateStatus;
 import io.camunda.client.api.command.UpdateAgentInstanceCommandStep1;
+import io.camunda.client.api.command.UpdateAgentInstanceCommandStep1.AgentTool;
 import io.camunda.client.api.command.UpdateAgentInstanceCommandStep1.UpdateAgentInstanceCommandStep2;
 import io.camunda.client.api.response.UpdateAgentInstanceResponse;
-import io.camunda.client.api.search.enums.AgentInstanceStatus;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.response.UpdateAgentInstanceResponseImpl;
 import io.camunda.client.impl.util.EnumUtil;
 import io.camunda.client.protocol.rest.AgentInstanceMetricsDelta;
-import io.camunda.client.protocol.rest.AgentInstanceStatusEnum;
 import io.camunda.client.protocol.rest.AgentInstanceUpdateRequest;
-import io.camunda.client.protocol.rest.AgentTool;
+import io.camunda.client.protocol.rest.AgentInstanceUpdateStatusEnum;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -62,8 +62,8 @@ public class UpdateAgentInstanceCommandImpl
   }
 
   @Override
-  public UpdateAgentInstanceCommandStep2 status(final AgentInstanceStatus status) {
-    request.status(EnumUtil.convert(status, AgentInstanceStatusEnum.class));
+  public UpdateAgentInstanceCommandStep2 status(final AgentInstanceUpdateStatus status) {
+    request.status(EnumUtil.convert(status, AgentInstanceUpdateStatusEnum.class));
     return this;
   }
 
@@ -96,15 +96,15 @@ public class UpdateAgentInstanceCommandImpl
     final List<io.camunda.client.protocol.rest.AgentTool> protocolTools =
         tools.stream()
             .map(
-                tool -> {
+                apiTool -> {
                   final io.camunda.client.protocol.rest.AgentTool protocolTool =
                       new io.camunda.client.protocol.rest.AgentTool();
-                  protocolTool.name(tool.getName());
-                  if (tool.getDescription() != null) {
-                    protocolTool.description(tool.getDescription());
+                  protocolTool.name(apiTool.getName());
+                  if (apiTool.getDescription() != null) {
+                    protocolTool.description(apiTool.getDescription());
                   }
-                  if (tool.getElementId() != null) {
-                    protocolTool.elementId(tool.getElementId());
+                  if (apiTool.getElementId() != null) {
+                    protocolTool.elementId(apiTool.getElementId());
                   }
                   return protocolTool;
                 })

--- a/clients/java/src/main/java/io/camunda/client/impl/response/UpdateAgentInstanceResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/UpdateAgentInstanceResponseImpl.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.response;
+
+import io.camunda.client.api.response.UpdateAgentInstanceResponse;
+
+public class UpdateAgentInstanceResponseImpl implements UpdateAgentInstanceResponse {
+
+  public UpdateAgentInstanceResponseImpl(final Void nothing) {}
+}

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapper.java
@@ -13,8 +13,15 @@ import io.camunda.gateway.mapping.http.validator.AgentInstanceRequestValidator;
 import io.camunda.gateway.protocol.model.AgentInstanceCreationRequest;
 import io.camunda.gateway.protocol.model.AgentInstanceCreationResult;
 import io.camunda.gateway.protocol.model.AgentInstanceLimits;
+import io.camunda.gateway.protocol.model.AgentInstanceStatusEnum;
+import io.camunda.gateway.protocol.model.AgentInstanceUpdateRequest;
+import io.camunda.gateway.protocol.model.AgentTool;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
+import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceTool;
+import io.camunda.zeebe.protocol.record.value.AgentInstanceStatus;
 import io.camunda.zeebe.util.Either;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.jspecify.annotations.NullMarked;
 import org.springframework.http.ProblemDetail;
 
@@ -51,6 +58,45 @@ public class AgentInstanceMapper {
         });
   }
 
+  public Either<ProblemDetail, AgentInstanceRecord> toUpdateAgentInstanceRecord(
+      final String agentInstanceKey, final AgentInstanceUpdateRequest request) {
+    return RequestMapper.getResult(
+        requestValidator.validateUpdateRequest(agentInstanceKey, request),
+        () -> {
+          final var record = new AgentInstanceRecord();
+          record.setAgentInstanceKey(Long.parseLong(agentInstanceKey));
+          record.setElementInstanceKey(Long.parseLong(request.getElementInstanceKey()));
+
+          if (request.getStatus() != null) {
+            record.setStatus(mapStatus(request.getStatus()));
+          }
+
+          if (request.getMetrics() != null) {
+            final var delta = request.getMetrics();
+            if (delta.getInputTokens() != null) {
+              record.getMetrics().setInputTokens(delta.getInputTokens());
+            }
+            if (delta.getOutputTokens() != null) {
+              record.getMetrics().setOutputTokens(delta.getOutputTokens());
+            }
+            if (delta.getModelCalls() != null) {
+              record.getMetrics().setModelCalls(delta.getModelCalls());
+            }
+            if (delta.getToolCalls() != null) {
+              record.getMetrics().setToolCalls(delta.getToolCalls());
+            }
+          }
+
+          if (request.getTools() != null && !request.getTools().isEmpty()) {
+            final List<AgentInstanceTool> tools =
+                request.getTools().stream().map(this::mapTool).collect(Collectors.toList());
+            record.setTools(tools);
+          }
+
+          return record;
+        });
+  }
+
   public AgentInstanceCreationResult toAgentInstanceCreationResult(
       final AgentInstanceRecord record) {
     return AgentInstanceCreationResult.Builder.create()
@@ -74,5 +120,30 @@ public class AgentInstanceMapper {
     if (requestLimits.getMaxToolCalls() != null) {
       recordLimits.setMaxToolCalls(requestLimits.getMaxToolCalls());
     }
+  }
+
+  private AgentInstanceStatus mapStatus(final AgentInstanceStatusEnum status) {
+    return switch (status) {
+      case COMPLETED -> AgentInstanceStatus.COMPLETED;
+      case IDLE -> AgentInstanceStatus.IDLE;
+      case INITIALIZING -> AgentInstanceStatus.INITIALIZING;
+      case THINKING -> AgentInstanceStatus.THINKING;
+      case TOOL_CALLING -> AgentInstanceStatus.TOOL_CALLING;
+      case TOOL_DISCOVERY -> AgentInstanceStatus.TOOL_DISCOVERY;
+        // No need for default: if a new possible value is added to the API spec
+        // then this statement will fail to compile
+    };
+  }
+
+  private AgentInstanceTool mapTool(final AgentTool tool) {
+    final var recordTool = new AgentInstanceTool();
+    recordTool.setName(tool.getName());
+    if (tool.getDescription() != null) {
+      recordTool.setDescription(tool.getDescription());
+    }
+    if (tool.getElementId() != null) {
+      recordTool.setElementId(tool.getElementId());
+    }
+    return recordTool;
   }
 }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapper.java
@@ -13,8 +13,8 @@ import io.camunda.gateway.mapping.http.validator.AgentInstanceRequestValidator;
 import io.camunda.gateway.protocol.model.AgentInstanceCreationRequest;
 import io.camunda.gateway.protocol.model.AgentInstanceCreationResult;
 import io.camunda.gateway.protocol.model.AgentInstanceLimits;
-import io.camunda.gateway.protocol.model.AgentInstanceStatusEnum;
 import io.camunda.gateway.protocol.model.AgentInstanceUpdateRequest;
+import io.camunda.gateway.protocol.model.AgentInstanceUpdateStatusEnum;
 import io.camunda.gateway.protocol.model.AgentTool;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceTool;
@@ -125,16 +125,12 @@ public class AgentInstanceMapper {
     }
   }
 
-  private AgentInstanceStatus mapStatus(final AgentInstanceStatusEnum status) {
+  private AgentInstanceStatus mapStatus(final AgentInstanceUpdateStatusEnum status) {
     return switch (status) {
-      case COMPLETED -> AgentInstanceStatus.COMPLETED;
       case IDLE -> AgentInstanceStatus.IDLE;
-      case INITIALIZING -> AgentInstanceStatus.INITIALIZING;
       case THINKING -> AgentInstanceStatus.THINKING;
       case TOOL_CALLING -> AgentInstanceStatus.TOOL_CALLING;
       case TOOL_DISCOVERY -> AgentInstanceStatus.TOOL_DISCOVERY;
-        // No need for default: if a new possible value is added to the API spec
-        // then this statement will fail to compile
     };
   }
 

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapper.java
@@ -89,7 +89,7 @@ public class AgentInstanceMapper {
             record.addChangedAttribute("metrics");
           }
 
-          if (request.getTools() != null && !request.getTools().isEmpty()) {
+          if (request.getTools() != null) {
             final List<AgentInstanceTool> tools =
                 request.getTools().stream().map(this::mapTool).collect(Collectors.toList());
             record.setTools(tools);

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapper.java
@@ -69,6 +69,7 @@ public class AgentInstanceMapper {
 
           if (request.getStatus() != null) {
             record.setStatus(mapStatus(request.getStatus()));
+            record.addChangedAttribute("status");
           }
 
           if (request.getMetrics() != null) {
@@ -85,12 +86,14 @@ public class AgentInstanceMapper {
             if (delta.getToolCalls() != null) {
               record.getMetrics().setToolCalls(delta.getToolCalls());
             }
+            record.addChangedAttribute("metrics");
           }
 
           if (request.getTools() != null && !request.getTools().isEmpty()) {
             final List<AgentInstanceTool> tools =
                 request.getTools().stream().map(this::mapTool).collect(Collectors.toList());
             record.setTools(tools);
+            record.addChangedAttribute("tools");
           }
 
           return record;

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidator.java
@@ -7,17 +7,20 @@
  */
 package io.camunda.gateway.mapping.http.validator;
 
+import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_AT_LEAST_ONE_FIELD;
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_EMPTY_ATTRIBUTE;
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_INVALID_ATTRIBUTE_VALUE;
 import static io.camunda.gateway.mapping.http.validator.RequestValidator.validate;
 import static io.camunda.gateway.mapping.http.validator.RequestValidator.validateKeyFormat;
 
 import io.camunda.gateway.protocol.model.AgentInstanceCreationRequest;
+import io.camunda.gateway.protocol.model.AgentInstanceUpdateRequest;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.springframework.http.ProblemDetail;
 
 @NullMarked
@@ -63,10 +66,69 @@ public class AgentInstanceRequestValidator {
         });
   }
 
+  // Note: even if some properties are marked @NotNull in AgentInstanceUpdateRequest,
+  // no validation is performed during deserialization, so it is still necessary to validate it here
+  @SuppressWarnings("ConstantValue")
+  public Optional<ProblemDetail> validateUpdateRequest(
+      final String agentInstanceKey, final AgentInstanceUpdateRequest request) {
+    return validate(
+        () -> {
+          final List<String> violations = new ArrayList<>();
+
+          validateKeyFormat(agentInstanceKey, "agentInstanceKey", violations);
+
+          if (request.getElementInstanceKey() == null) {
+            violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("elementInstanceKey"));
+          } else {
+            validateKeyFormat(request.getElementInstanceKey(), "elementInstanceKey", violations);
+          }
+
+          if (request.getStatus() == null
+              && !hasMetricsDelta(request)
+              && (request.getTools() == null || request.getTools().isEmpty())) {
+            violations.add(ERROR_MESSAGE_AT_LEAST_ONE_FIELD.formatted("status, metrics, tools"));
+          }
+
+          if (request.getMetrics() != null) {
+            final var metrics = request.getMetrics();
+            violations.addAll(validateDelta("metrics.inputTokens", metrics.getInputTokens()));
+            violations.addAll(validateDelta("metrics.outputTokens", metrics.getOutputTokens()));
+            violations.addAll(validateDelta("metrics.modelCalls", metrics.getModelCalls()));
+            violations.addAll(validateDelta("metrics.toolCalls", metrics.getToolCalls()));
+          }
+
+          if (request.getTools() != null) {
+            for (int i = 0; i < request.getTools().size(); i++) {
+              final var tool = request.getTools().get(i);
+              if (tool.getName() == null || tool.getName().isBlank()) {
+                violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("tools[" + i + "].name"));
+              }
+            }
+          }
+
+          return violations;
+        });
+  }
+
   private List<String> validateLimit(final String limitName, final Number limit) {
     if (limit != null && limit.longValue() < -1) {
       return List.of(ERROR_MESSAGE_INVALID_ATTRIBUTE_VALUE.formatted(limitName, limit, ">= -1"));
     }
     return Collections.emptyList();
+  }
+
+  private List<String> validateDelta(final String fieldName, final @Nullable Number value) {
+    if (value != null && value.longValue() < 0) {
+      return List.of(ERROR_MESSAGE_INVALID_ATTRIBUTE_VALUE.formatted(fieldName, value, ">= 0"));
+    }
+    return Collections.emptyList();
+  }
+
+  private boolean hasMetricsDelta(final AgentInstanceUpdateRequest request) {
+    return request.getMetrics() != null
+        && (request.getMetrics().getInputTokens() != null
+            || request.getMetrics().getOutputTokens() != null
+            || request.getMetrics().getModelCalls() != null
+            || request.getMetrics().getToolCalls() != null);
   }
 }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidator.java
@@ -85,7 +85,7 @@ public class AgentInstanceRequestValidator {
 
           if (request.getStatus() == null
               && !hasMetricsDelta(request)
-              && (request.getTools() == null || request.getTools().isEmpty())) {
+              && request.getTools() == null) {
             violations.add(ERROR_MESSAGE_AT_LEAST_ONE_FIELD.formatted("status, metrics, tools"));
           }
 

--- a/service/src/main/java/io/camunda/service/AgentInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/AgentInstanceServices.java
@@ -12,6 +12,7 @@ import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerCreateAgentInstanceRequest;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerUpdateAgentInstanceRequest;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
 import java.util.concurrent.CompletableFuture;
 
@@ -32,5 +33,10 @@ public final class AgentInstanceServices extends ApiServices<AgentInstanceServic
   public CompletableFuture<AgentInstanceRecord> createAgentInstance(
       final AgentInstanceRecord record, final CamundaAuthentication authentication) {
     return sendBrokerRequest(new BrokerCreateAgentInstanceRequest(record), authentication);
+  }
+
+  public CompletableFuture<AgentInstanceRecord> updateAgentInstance(
+      final AgentInstanceRecord record, final CamundaAuthentication authentication) {
+    return sendBrokerRequest(new BrokerUpdateAgentInstanceRequest(record), authentication);
   }
 }

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -531,6 +531,7 @@ components:
             The complete list of tools available to the agent, replacing any previously
             stored tools. When provided, the engine replaces the existing tool list with
             this value.
+          nullable: true
           type: array
           items:
             $ref: '#/components/schemas/AgentTool'

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -435,6 +435,16 @@ components:
         - TOOL_CALLING
         - TOOL_DISCOVERY
 
+    AgentInstanceUpdateStatusEnum:
+      description: |
+        The status values that can be set on an agent instance via an update request.
+      type: string
+      enum:
+        - IDLE
+        - THINKING
+        - TOOL_CALLING
+        - TOOL_DISCOVERY
+
     AgentInstanceCreationRequest:
       description: Request to create a new agent instance.
       type: object
@@ -521,7 +531,7 @@ components:
         status:
           description: The new status of the agent instance.
           allOf:
-            - $ref: '#/components/schemas/AgentInstanceStatusEnum'
+            - $ref: '#/components/schemas/AgentInstanceUpdateStatusEnum'
         metrics:
           description: Metric increments to apply to the aggregate counters.
           allOf:

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -506,7 +506,18 @@ components:
         Request to update the mutable state of an agent instance. At least one of
         status, metrics, or tools must be provided.
       type: object
+      required:
+        - elementInstanceKey
       properties:
+        elementInstanceKey:
+          nullable: false
+          description: |
+            The key of the AHSP or AI Agent Task element instance.
+            The engine uses this key to infer processInstanceKey, elementId,
+            processDefinitionKey, and tenantId.
+            This is used to validate that the agent instance being updated belongs to the expected process instance and to link the agent instance to the element instance.
+          allOf:
+            - $ref: 'keys.yaml#/components/schemas/ElementInstanceKey'
         status:
           description: The new status of the agent instance.
           allOf:

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -522,10 +522,8 @@ components:
         elementInstanceKey:
           nullable: false
           description: |
-            The key of the AHSP or AI Agent Task element instance.
-            The engine uses this key to infer processInstanceKey, elementId,
-            processDefinitionKey, and tenantId.
-            This is used to validate that the agent instance being updated belongs to the expected process instance and to link the agent instance to the element instance.
+            The key of the element instance associated with this agent instance.
+            Used to validate that the update targets the correct process instance.
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ElementInstanceKey'
         status:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceController.java
@@ -10,8 +10,10 @@ package io.camunda.zeebe.gateway.rest.controller;
 import io.camunda.gateway.mapping.http.mapper.AgentInstanceMapper;
 import io.camunda.gateway.mapping.http.validator.AgentInstanceRequestValidator;
 import io.camunda.gateway.protocol.model.AgentInstanceCreationRequest;
+import io.camunda.gateway.protocol.model.AgentInstanceUpdateRequest;
 import io.camunda.security.api.context.CamundaAuthenticationProvider;
 import io.camunda.service.AgentInstanceServices;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPatchMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
@@ -19,6 +21,7 @@ import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRe
 import java.util.concurrent.CompletableFuture;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -52,5 +55,20 @@ public class AgentInstanceController {
         () -> agentInstanceServices.createAgentInstance(record, authentication),
         mapper::toAgentInstanceCreationResult,
         HttpStatus.OK);
+  }
+
+  @CamundaPatchMapping(path = "/{agentInstanceKey}")
+  public CompletableFuture<ResponseEntity<Object>> updateAgentInstance(
+      @PathVariable final String agentInstanceKey,
+      @RequestBody final AgentInstanceUpdateRequest request) {
+    return mapper
+        .toUpdateAgentInstanceRecord(agentInstanceKey, request)
+        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::update);
+  }
+
+  private CompletableFuture<ResponseEntity<Object>> update(final AgentInstanceRecord record) {
+    final var authentication = authenticationProvider.getCamundaAuthentication();
+    return RequestExecutor.executeServiceMethodWithNoContentResult(
+        () -> agentInstanceServices.updateAgentInstance(record, authentication));
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
@@ -322,7 +322,7 @@ class AgentInstanceControllerTest extends RestControllerTest {
         """
         {
           "elementInstanceKey": "%d",
-          "status": "COMPLETED"
+          "status": "THINKING"
         }
         """
             .formatted(ELEMENT_INSTANCE_KEY);
@@ -344,7 +344,7 @@ class AgentInstanceControllerTest extends RestControllerTest {
                 record -> {
                   assertThat(record.getAgentInstanceKey()).isEqualTo(AGENT_INSTANCE_KEY);
                   assertThat(record.getElementInstanceKey()).isEqualTo(ELEMENT_INSTANCE_KEY);
-                  assertThat(record.getStatus().name()).isEqualTo("COMPLETED");
+                  assertThat(record.getStatus().name()).isEqualTo("THINKING");
                   assertThat(record.getChangedAttributes()).containsExactly("status");
                 }),
             any());
@@ -514,21 +514,21 @@ class AgentInstanceControllerTest extends RestControllerTest {
             named(
                 "missing elementInstanceKey",
                 """
-                { "status": "COMPLETED" }
+                { "status": "THINKING" }
                 """),
             "No elementInstanceKey provided."),
         Arguments.of(
             named(
                 "null elementInstanceKey",
                 """
-                { "elementInstanceKey": null, "status": "COMPLETED" }
+                { "elementInstanceKey": null, "status": "THINKING" }
                 """),
             "No elementInstanceKey provided."),
         Arguments.of(
             named(
                 "non-numeric elementInstanceKey",
                 """
-                { "elementInstanceKey": "not-a-number", "status": "COMPLETED" }
+                { "elementInstanceKey": "not-a-number", "status": "THINKING" }
                 """),
             "The provided elementInstanceKey 'not-a-number' is not a valid key."
                 + " Expected a numeric value."

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
@@ -345,6 +345,7 @@ class AgentInstanceControllerTest extends RestControllerTest {
                   assertThat(record.getAgentInstanceKey()).isEqualTo(AGENT_INSTANCE_KEY);
                   assertThat(record.getElementInstanceKey()).isEqualTo(ELEMENT_INSTANCE_KEY);
                   assertThat(record.getStatus().name()).isEqualTo("COMPLETED");
+                  assertThat(record.getChangedAttributes()).containsExactly("status");
                 }),
             any());
   }
@@ -388,6 +389,7 @@ class AgentInstanceControllerTest extends RestControllerTest {
                   assertThat(record.getMetrics().getOutputTokens()).isEqualTo(500L);
                   assertThat(record.getMetrics().getModelCalls()).isEqualTo(3);
                   assertThat(record.getMetrics().getToolCalls()).isEqualTo(7);
+                  assertThat(record.getChangedAttributes()).containsExactly("metrics");
                 }),
             any());
   }
@@ -433,6 +435,7 @@ class AgentInstanceControllerTest extends RestControllerTest {
                   assertThat(record.getTools().get(0).getDescription())
                       .isEqualTo("Searches the database");
                   assertThat(record.getTools().get(0).getElementId()).isEqualTo("searchTask");
+                  assertThat(record.getChangedAttributes()).containsExactly("tools");
                 }),
             any());
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
@@ -311,4 +311,291 @@ class AgentInstanceControllerTest extends RestControllerTest {
         .expectStatus()
         .is5xxServerError();
   }
+
+  @Test
+  void shouldUpdateAgentInstanceWithStatus() {
+    // given
+    when(agentInstanceServices.updateAgentInstance(any(AgentInstanceRecord.class), any()))
+        .thenReturn(CompletableFuture.completedFuture(new AgentInstanceRecord()));
+
+    final var requestBody =
+        """
+        {
+          "elementInstanceKey": "%d",
+          "status": "COMPLETED"
+        }
+        """
+            .formatted(ELEMENT_INSTANCE_KEY);
+
+    // when / then
+    webClient
+        .patch()
+        .uri(AGENT_INSTANCES_URL + "/%d".formatted(AGENT_INSTANCE_KEY))
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(requestBody)
+        .exchange()
+        .expectStatus()
+        .isNoContent();
+
+    verify(agentInstanceServices)
+        .updateAgentInstance(
+            assertArg(
+                record -> {
+                  assertThat(record.getAgentInstanceKey()).isEqualTo(AGENT_INSTANCE_KEY);
+                  assertThat(record.getElementInstanceKey()).isEqualTo(ELEMENT_INSTANCE_KEY);
+                  assertThat(record.getStatus().name()).isEqualTo("COMPLETED");
+                }),
+            any());
+  }
+
+  @Test
+  void shouldUpdateAgentInstanceWithMetrics() {
+    // given
+    when(agentInstanceServices.updateAgentInstance(any(AgentInstanceRecord.class), any()))
+        .thenReturn(CompletableFuture.completedFuture(new AgentInstanceRecord()));
+
+    final var requestBody =
+        """
+        {
+          "elementInstanceKey": "%d",
+          "metrics": {
+            "inputTokens": 1000,
+            "outputTokens": 500,
+            "modelCalls": 3,
+            "toolCalls": 7
+          }
+        }
+        """
+            .formatted(ELEMENT_INSTANCE_KEY);
+
+    // when / then
+    webClient
+        .patch()
+        .uri(AGENT_INSTANCES_URL + "/%d".formatted(AGENT_INSTANCE_KEY))
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(requestBody)
+        .exchange()
+        .expectStatus()
+        .isNoContent();
+
+    verify(agentInstanceServices)
+        .updateAgentInstance(
+            assertArg(
+                record -> {
+                  assertThat(record.getMetrics().getInputTokens()).isEqualTo(1000L);
+                  assertThat(record.getMetrics().getOutputTokens()).isEqualTo(500L);
+                  assertThat(record.getMetrics().getModelCalls()).isEqualTo(3);
+                  assertThat(record.getMetrics().getToolCalls()).isEqualTo(7);
+                }),
+            any());
+  }
+
+  @Test
+  void shouldUpdateAgentInstanceWithTools() {
+    // given
+    when(agentInstanceServices.updateAgentInstance(any(AgentInstanceRecord.class), any()))
+        .thenReturn(CompletableFuture.completedFuture(new AgentInstanceRecord()));
+
+    final var requestBody =
+        """
+        {
+          "elementInstanceKey": "%d",
+          "tools": [
+            {
+              "name": "searchDatabase",
+              "description": "Searches the database",
+              "elementId": "searchTask"
+            }
+          ]
+        }
+        """
+            .formatted(ELEMENT_INSTANCE_KEY);
+
+    // when / then
+    webClient
+        .patch()
+        .uri(AGENT_INSTANCES_URL + "/%d".formatted(AGENT_INSTANCE_KEY))
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(requestBody)
+        .exchange()
+        .expectStatus()
+        .isNoContent();
+
+    verify(agentInstanceServices)
+        .updateAgentInstance(
+            assertArg(
+                record -> {
+                  assertThat(record.getTools()).hasSize(1);
+                  assertThat(record.getTools().get(0).getName()).isEqualTo("searchDatabase");
+                  assertThat(record.getTools().get(0).getDescription())
+                      .isEqualTo("Searches the database");
+                  assertThat(record.getTools().get(0).getElementId()).isEqualTo("searchTask");
+                }),
+            any());
+  }
+
+  @ParameterizedTest(name = "[{index}] {0}")
+  @MethodSource("invalidUpdateRequests")
+  void shouldRejectInvalidUpdateRequest(final String requestBody, final String expectedDetail) {
+    // when / then
+    webClient
+        .patch()
+        .uri(AGENT_INSTANCES_URL + "/%d".formatted(AGENT_INSTANCE_KEY))
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(requestBody)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(
+            """
+            {
+              "type": "about:blank",
+              "title": "INVALID_ARGUMENT",
+              "status": 400,
+              "detail": "%s",
+              "instance": "/v2/agent-instances/%d"
+            }
+            """
+                .formatted(expectedDetail, AGENT_INSTANCE_KEY),
+            JsonCompareMode.STRICT);
+
+    verifyNoInteractions(agentInstanceServices);
+  }
+
+  static Stream<Arguments> invalidUpdateRequests() {
+    return Stream.of(
+        Arguments.of(
+            named(
+                "missing elementInstanceKey",
+                """
+                { "status": "COMPLETED" }
+                """),
+            "No elementInstanceKey provided."),
+        Arguments.of(
+            named(
+                "null elementInstanceKey",
+                """
+                { "elementInstanceKey": null, "status": "COMPLETED" }
+                """),
+            "No elementInstanceKey provided."),
+        Arguments.of(
+            named(
+                "non-numeric elementInstanceKey",
+                """
+                { "elementInstanceKey": "not-a-number", "status": "COMPLETED" }
+                """),
+            "The provided elementInstanceKey 'not-a-number' is not a valid key."
+                + " Expected a numeric value."
+                + " Did you pass an entity id instead of an entity key?."),
+        Arguments.of(
+            named(
+                "no mutable fields provided",
+                """
+                { "elementInstanceKey": "%d" }
+                """
+                    .formatted(ELEMENT_INSTANCE_KEY)),
+            "At least one of status, metrics, tools is required."),
+        Arguments.of(
+            named(
+                "negative inputTokens delta",
+                """
+                { "elementInstanceKey": "%d", "metrics": { "inputTokens": -1 } }
+                """
+                    .formatted(ELEMENT_INSTANCE_KEY)),
+            "The value for metrics.inputTokens is '-1' but must be >= 0."),
+        Arguments.of(
+            named(
+                "negative outputTokens delta",
+                """
+                { "elementInstanceKey": "%d", "metrics": { "outputTokens": -5 } }
+                """
+                    .formatted(ELEMENT_INSTANCE_KEY)),
+            "The value for metrics.outputTokens is '-5' but must be >= 0."),
+        Arguments.of(
+            named(
+                "negative modelCalls delta",
+                """
+                { "elementInstanceKey": "%d", "metrics": { "modelCalls": -1 } }
+                """
+                    .formatted(ELEMENT_INSTANCE_KEY)),
+            "The value for metrics.modelCalls is '-1' but must be >= 0."),
+        Arguments.of(
+            named(
+                "negative toolCalls delta",
+                """
+                { "elementInstanceKey": "%d", "metrics": { "toolCalls": -2 } }
+                """
+                    .formatted(ELEMENT_INSTANCE_KEY)),
+            "The value for metrics.toolCalls is '-2' but must be >= 0."),
+        Arguments.of(
+            named(
+                "only empty metrics object",
+                """
+                { "elementInstanceKey": "%d", "metrics": {} }
+                """
+                    .formatted(ELEMENT_INSTANCE_KEY)),
+            "At least one of status, metrics, tools is required."),
+        Arguments.of(
+            named(
+                "tool without name",
+                """
+                {
+                  "elementInstanceKey": "%d",
+                  "tools": [{ "description": "Search database" }]
+                }
+                """
+                    .formatted(ELEMENT_INSTANCE_KEY)),
+            "No tools[0].name provided."),
+        Arguments.of(
+            named(
+                "tool with blank name",
+                """
+                {
+                  "elementInstanceKey": "%d",
+                  "tools": [{ "name": "" }]
+                }
+                """
+                    .formatted(ELEMENT_INSTANCE_KEY)),
+            "No tools[0].name provided."),
+        Arguments.of(
+            named(
+                "tool with null name",
+                """
+                {
+                  "elementInstanceKey": "%d",
+                  "tools": [{ "name": null }]
+                }
+                """
+                    .formatted(ELEMENT_INSTANCE_KEY)),
+            "No tools[0].name provided."));
+  }
+
+  @Test
+  void shouldReturn5xxOnUpdateServiceError() {
+    // given
+    when(agentInstanceServices.updateAgentInstance(any(AgentInstanceRecord.class), any()))
+        .thenReturn(CompletableFuture.failedFuture(new RuntimeException("broker unavailable")));
+
+    // when / then
+    webClient
+        .patch()
+        .uri(AGENT_INSTANCES_URL + "/%d".formatted(AGENT_INSTANCE_KEY))
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(
+            """
+            { "elementInstanceKey": "%d", "status": "IDLE" }
+            """
+                .formatted(ELEMENT_INSTANCE_KEY))
+        .exchange()
+        .expectStatus()
+        .is5xxServerError();
+  }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
@@ -440,6 +440,42 @@ class AgentInstanceControllerTest extends RestControllerTest {
             any());
   }
 
+  @Test
+  void shouldUpdateAgentInstanceWithEmptyToolsList() {
+    // given
+    when(agentInstanceServices.updateAgentInstance(any(AgentInstanceRecord.class), any()))
+        .thenReturn(CompletableFuture.completedFuture(new AgentInstanceRecord()));
+
+    final var requestBody =
+        """
+        {
+          "elementInstanceKey": "%d",
+          "tools": []
+        }
+        """
+            .formatted(ELEMENT_INSTANCE_KEY);
+
+    // when / then
+    webClient
+        .patch()
+        .uri(AGENT_INSTANCES_URL + "/%d".formatted(AGENT_INSTANCE_KEY))
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(requestBody)
+        .exchange()
+        .expectStatus()
+        .isNoContent();
+
+    verify(agentInstanceServices)
+        .updateAgentInstance(
+            assertArg(
+                record -> {
+                  assertThat(record.getTools()).isEmpty();
+                  assertThat(record.getChangedAttributes()).containsExactly("tools");
+                }),
+            any());
+  }
+
   @ParameterizedTest(name = "[{index}] {0}")
   @MethodSource("invalidUpdateRequests")
   void shouldRejectInvalidUpdateRequest(final String requestBody, final String expectedDetail) {

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerUpdateAgentInstanceRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerUpdateAgentInstanceRequest.java
@@ -21,6 +21,7 @@ public class BrokerUpdateAgentInstanceRequest extends BrokerExecuteCommand<Agent
   public BrokerUpdateAgentInstanceRequest(final AgentInstanceRecord record) {
     super(ValueType.AGENT_INSTANCE, AgentInstanceIntent.UPDATE);
     requestDto = record;
+    request.setKey(record.getAgentInstanceKey());
     // Route to the partition that owns the agent instance, decoded from the key.
     // All keys in Zeebe encode the owning partition in their high bits.
     request.setPartitionId(Protocol.decodePartitionId(record.getAgentInstanceKey()));

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerUpdateAgentInstanceRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerUpdateAgentInstanceRequest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl.broker.request;
+
+import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
+import org.agrona.DirectBuffer;
+
+public class BrokerUpdateAgentInstanceRequest extends BrokerExecuteCommand<AgentInstanceRecord> {
+
+  private final AgentInstanceRecord requestDto;
+
+  public BrokerUpdateAgentInstanceRequest(final AgentInstanceRecord record) {
+    super(ValueType.AGENT_INSTANCE, AgentInstanceIntent.UPDATE);
+    requestDto = record;
+    // Route to the partition that owns the agent instance, decoded from the key.
+    // All keys in Zeebe encode the owning partition in their high bits.
+    request.setPartitionId(Protocol.decodePartitionId(record.getAgentInstanceKey()));
+  }
+
+  @Override
+  public AgentInstanceRecord getRequestWriter() {
+    return requestDto;
+  }
+
+  @Override
+  protected AgentInstanceRecord toResponseDto(final DirectBuffer buffer) {
+    final AgentInstanceRecord responseDto = new AgentInstanceRecord();
+    responseDto.wrap(buffer);
+    return responseDto;
+  }
+}


### PR DESCRIPTION
## Description

This pull request introduces a new feature to the Java client and gateway mapping for updating agent instances, along with supporting types, mapping, and validation logic. The main focus is to allow clients to update the status, metrics, and tools of existing agent instances via a new command interface, with corresponding request/response types and backend mapping.

**Key changes include:**

### Java Client API and Implementation

* Added the `UpdateAgentInstanceCommandStep1` interface and related builder pattern, enabling users to update an agent instance’s status, metrics (input/output tokens, model/tool calls), and available tools. The command is exposed via the new `newUpdateAgentInstanceCommand(long agentInstanceKey)` method in `CamundaClient`. (`UpdateAgentInstanceCommandStep1.java`, `CamundaClient.java`, `CamundaClientImpl.java`, `UpdateAgentInstanceCommandImpl.java`)

* Introduced the `UpdateAgentInstanceResponse` interface and its implementation for handling responses to update commands. (`UpdateAgentInstanceResponse.java`, `UpdateAgentInstanceResponseImpl.java`) 

* Added the `AgentInstanceStatus` enum to represent possible agent instance states. (`AgentInstanceStatus.java`)

### Gateway Mapping and Validation

* Implemented the mapping logic in `AgentInstanceMapper` to convert update requests into internal records, including status, metrics, and tools mapping. (`AgentInstanceMapper.java`) 

* Updated the request validator infrastructure to support validation for agent instance update requests. (`AgentInstanceRequestValidator.java`)

These changes collectively enable clients to update agent instance properties in a structured, validated, and extensible way via the Java client and HTTP gateway.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #51515
