### PR TITLE
Reject unknown afterElementId in runtime instructions

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
@@ -63,6 +63,7 @@ public class ProcessInstanceCreationHelper {
           BpmnElementType.UNSPECIFIED);
   private static final Either<Rejection, Object> VALID = Either.right(null);
   private static final int MAX_BUSINESS_ID_LENGTH = 256;
+  private static final int MAX_REPORTED_INVALID_ELEMENT_IDS = 5;
   private final AuthorizationCheckBehavior authCheckBehavior;
   private final ProcessState processState;
   private final VariableBehavior variableBehavior;
@@ -386,18 +387,35 @@ public class ProcessInstanceCreationHelper {
       final ExecutableProcess process,
       final ArrayProperty<ProcessInstanceCreationRuntimeInstruction> runtimeInstructions) {
 
-    return runtimeInstructions.stream()
-        .map(ProcessInstanceCreationRuntimeInstruction::getAfterElementId)
-        .filter(elementId -> !isElementOfProcess(process, elementId))
-        .findAny()
-        .map(
-            elementId ->
-                Either.left(
-                    new Rejection(
-                        RejectionType.INVALID_ARGUMENT,
-                        "Expected to create instance of process with runtime instructions but no element found with id '%s' in process definition '%s'."
-                            .formatted(elementId, bufferAsString(process.getId())))))
-        .orElse(VALID);
+    final var unknownIds =
+        runtimeInstructions.stream()
+            .map(ProcessInstanceCreationRuntimeInstruction::getAfterElementId)
+            .filter(elementId -> !isElementOfProcess(process, elementId))
+            .distinct()
+            .toList();
+
+    if (unknownIds.isEmpty()) {
+      return VALID;
+    }
+
+    final var processId = bufferAsString(process.getId());
+    if (unknownIds.size() <= MAX_REPORTED_INVALID_ELEMENT_IDS) {
+      final var joined = unknownIds.stream().collect(Collectors.joining("', '", "'", "'"));
+      return Either.left(
+          new Rejection(
+              RejectionType.INVALID_ARGUMENT,
+              "Expected to create instance of process with runtime instructions but no element found with id %s in process definition '%s'."
+                  .formatted(joined, processId)));
+    }
+
+    final var head = unknownIds.subList(0, MAX_REPORTED_INVALID_ELEMENT_IDS);
+    final var remaining = unknownIds.size() - MAX_REPORTED_INVALID_ELEMENT_IDS;
+    final var joined = head.stream().collect(Collectors.joining("', '", "'", "'"));
+    return Either.left(
+        new Rejection(
+            RejectionType.INVALID_ARGUMENT,
+            "Expected to create instance of process with runtime instructions but no element found with id %s and %d more in process definition '%s'."
+                .formatted(joined, remaining, processId)));
   }
 
   private Either<Rejection, ?> validateTags(final Set<String> tags) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
@@ -26,6 +26,7 @@ import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRuntimeInstruction;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationStartInstruction;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -203,6 +204,7 @@ public class ProcessInstanceCreationHelper {
       final ProcessInstanceCreationRecord command, final DeployedProcess deployedProcess) {
     final var process = deployedProcess.getProcess();
     final var startInstructions = command.startInstructions();
+    final var runtimeInstructions = command.runtimeInstructions();
     final var tags = command.getTags();
     final var businessId = command.getBusinessId();
 
@@ -212,6 +214,8 @@ public class ProcessInstanceCreationHelper {
         .flatMap(valid -> validateTargetsSupportedElementType(process, startInstructions))
         .flatMap(
             valid -> validateElementNotBelongingToEventBasedGateway(process, startInstructions))
+        .flatMap(
+            valid -> validateRuntimeInstructionAfterElementsExist(process, runtimeInstructions))
         .flatMap(valid -> validateTags(tags))
         .flatMap(valid -> validateBusinessIdFormat(businessId))
         .flatMap(
@@ -375,6 +379,24 @@ public class ProcessInstanceCreationHelper {
                         RejectionType.INVALID_ARGUMENT,
                         "Expected to create instance of process with start instructions but the element with id '%s' belongs to an event-based gateway. The creation of elements belonging to an event-based gateway is not supported."
                             .formatted(elementId))))
+        .orElse(VALID);
+  }
+
+  private Either<Rejection, ?> validateRuntimeInstructionAfterElementsExist(
+      final ExecutableProcess process,
+      final ArrayProperty<ProcessInstanceCreationRuntimeInstruction> runtimeInstructions) {
+
+    return runtimeInstructions.stream()
+        .map(ProcessInstanceCreationRuntimeInstruction::getAfterElementId)
+        .filter(elementId -> !isElementOfProcess(process, elementId))
+        .findAny()
+        .map(
+            elementId ->
+                Either.left(
+                    new Rejection(
+                        RejectionType.INVALID_ARGUMENT,
+                        "Expected to create instance of process with runtime instructions but no element found with id '%s' in process definition '%s'."
+                            .formatted(elementId, bufferAsString(process.getId())))))
         .orElse(VALID);
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceRejectionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceRejectionTest.java
@@ -70,6 +70,76 @@ public class CreateProcessInstanceRejectionTest {
   }
 
   @Test
+  public void shouldRejectCommandIfAfterElementIdIsUnknown() {
+    // given
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .manualTask("task-A")
+                .endEvent()
+                .done())
+        .deploy();
+
+    // when
+    engine
+        .processInstance()
+        .ofBpmnProcessId(PROCESS_ID)
+        .withRuntimeTerminateInstruction("does-not-exist")
+        .expectRejection()
+        .create();
+
+    // then
+    final var rejectionRecord =
+        RecordingExporter.processInstanceCreationRecords().onlyCommandRejections().getFirst();
+
+    assertThat(rejectionRecord)
+        .hasIntent(ProcessInstanceCreationIntent.CREATE)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            "Expected to create instance of process with runtime instructions but no element found with id 'does-not-exist' in process definition '"
+                + PROCESS_ID
+                + "'.");
+  }
+
+  @Test
+  public void shouldRejectCommandIfAnyAfterElementIdIsUnknown() {
+    // given
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .manualTask("task-A")
+                .manualTask("task-B")
+                .endEvent()
+                .done())
+        .deploy();
+
+    // when
+    engine
+        .processInstance()
+        .ofBpmnProcessId(PROCESS_ID)
+        .withRuntimeTerminateInstruction("task-A")
+        .withRuntimeTerminateInstruction("does-not-exist")
+        .expectRejection()
+        .create();
+
+    // then
+    final var rejectionRecord =
+        RecordingExporter.processInstanceCreationRecords().onlyCommandRejections().getFirst();
+
+    assertThat(rejectionRecord)
+        .hasIntent(ProcessInstanceCreationIntent.CREATE)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            "Expected to create instance of process with runtime instructions but no element found with id 'does-not-exist' in process definition '"
+                + PROCESS_ID
+                + "'.");
+  }
+
+  @Test
   public void shouldRejectCommandIfElementIsInsideMultiInstance() {
     // given
     engine

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceRejectionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceRejectionTest.java
@@ -140,6 +140,82 @@ public class CreateProcessInstanceRejectionTest {
   }
 
   @Test
+  public void shouldRejectCommandWithMultipleUnknownAfterElementIds() {
+    // given
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .manualTask("task-A")
+                .endEvent()
+                .done())
+        .deploy();
+
+    // when
+    engine
+        .processInstance()
+        .ofBpmnProcessId(PROCESS_ID)
+        .withRuntimeTerminateInstruction("X")
+        .withRuntimeTerminateInstruction("Y")
+        .withRuntimeTerminateInstruction("Z")
+        .expectRejection()
+        .create();
+
+    // then
+    final var rejectionRecord =
+        RecordingExporter.processInstanceCreationRecords().onlyCommandRejections().getFirst();
+
+    assertThat(rejectionRecord)
+        .hasIntent(ProcessInstanceCreationIntent.CREATE)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            "Expected to create instance of process with runtime instructions but no element found with id 'X', 'Y', 'Z' in process definition '"
+                + PROCESS_ID
+                + "'.");
+  }
+
+  @Test
+  public void shouldTruncateRejectionWhenManyUnknownAfterElementIds() {
+    // given
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .manualTask("task-A")
+                .endEvent()
+                .done())
+        .deploy();
+
+    // when
+    engine
+        .processInstance()
+        .ofBpmnProcessId(PROCESS_ID)
+        .withRuntimeTerminateInstruction("X1")
+        .withRuntimeTerminateInstruction("X2")
+        .withRuntimeTerminateInstruction("X3")
+        .withRuntimeTerminateInstruction("X4")
+        .withRuntimeTerminateInstruction("X5")
+        .withRuntimeTerminateInstruction("X6")
+        .withRuntimeTerminateInstruction("X7")
+        .expectRejection()
+        .create();
+
+    // then
+    final var rejectionRecord =
+        RecordingExporter.processInstanceCreationRecords().onlyCommandRejections().getFirst();
+
+    assertThat(rejectionRecord)
+        .hasIntent(ProcessInstanceCreationIntent.CREATE)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            "Expected to create instance of process with runtime instructions but no element found with id 'X1', 'X2', 'X3', 'X4', 'X5' and 2 more in process definition '"
+                + PROCESS_ID
+                + "'.");
+  }
+
+  @Test
   public void shouldRejectCommandIfElementIsInsideMultiInstance() {
     // given
     engine

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceCreationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceCreationRecord.java
@@ -237,6 +237,10 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
     return startInstructionsProperty;
   }
 
+  public ArrayProperty<ProcessInstanceCreationRuntimeInstruction> runtimeInstructions() {
+    return runtimeInstructionsProperty;
+  }
+
   public ProcessInstanceCreationRecord addStartInstructions(
       final List<ProcessInstanceCreationStartInstruction> startInstructions) {
     startInstructions.forEach(this::addStartInstruction);


### PR DESCRIPTION
## Description

The Create Process Instance API silently accepted `runtimeInstructions[].afterElementId` values that did not match any element in the targeted process definition. The process instance was created and the instruction was stored, but it could never fire — and the caller got no signal that their id was wrong.

This PR adds validation in `ProcessInstanceCreationHelper`: each `afterElementId` is looked up against the process's element catalog, and the command is rejected at validation time with `INVALID_ARGUMENT` and a descriptive reason naming the unknown id and the process definition id. Phrasing follows the sibling start-instruction validator.

Scope is the Create Process Instance endpoint only. Process Instance Migration can still orphan a runtime instruction by migrating to a definition without the referenced element — that is by design (power tool, separate docs concern).

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #53526
