### PR TITLE
feat: Move Fake Ordinal Key Generator to Engine

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/process/ZeebeProcessInstanceDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/process/ZeebeProcessInstanceDataDto.java
@@ -53,11 +53,6 @@ public class ZeebeProcessInstanceDataDto implements ProcessInstanceRecordValue {
   }
 
   @Override
-  public String getBpmnProcessId() {
-    return bpmnProcessId;
-  }
-
-  @Override
   public int getVersion() {
     return version;
   }
@@ -128,8 +123,17 @@ public class ZeebeProcessInstanceDataDto implements ProcessInstanceRecordValue {
   }
 
   @Override
+  public String getBpmnProcessId() {
+    return bpmnProcessId;
+  }
+
+  @Override
   public String getBusinessId() {
     return ""; // not used in Optimize
+  }
+
+  public void setBpmnProcessId(final String bpmnProcessId) {
+    this.bpmnProcessId = bpmnProcessId;
   }
 
   public void setParentElementInstanceKey(final long parentElementInstanceKey) {
@@ -164,8 +168,9 @@ public class ZeebeProcessInstanceDataDto implements ProcessInstanceRecordValue {
     this.version = version;
   }
 
-  public void setBpmnProcessId(final String bpmnProcessId) {
-    this.bpmnProcessId = bpmnProcessId;
+  @Override
+  public int getOrdinalKey() {
+    return -1; // not used in Optimize
   }
 
   protected boolean canEqual(final Object other) {

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/usertask/ZeebeUserTaskDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/usertask/ZeebeUserTaskDataDto.java
@@ -132,6 +132,11 @@ public class ZeebeUserTaskDataDto implements UserTaskRecordValue {
   }
 
   @Override
+  public long getRootProcessInstanceKey() {
+    return -1L; // not used in Optimize
+  }
+
+  @Override
   public String getBpmnProcessId() {
     return bpmnProcessId;
   }
@@ -154,11 +159,6 @@ public class ZeebeUserTaskDataDto implements UserTaskRecordValue {
   @Override
   public Set<String> getTags() {
     return tags;
-  }
-
-  @Override
-  public long getRootProcessInstanceKey() {
-    return -1L; // not used in Optimize
   }
 
   public void setTags(final Set<String> tags) {
@@ -234,6 +234,11 @@ public class ZeebeUserTaskDataDto implements UserTaskRecordValue {
   }
 
   @Override
+  public int getOrdinalKey() {
+    return -1; // not used in Optimize
+  }
+
+  @Override
   public long getProcessInstanceKey() {
     return processInstanceKey;
   }
@@ -265,6 +270,32 @@ public class ZeebeUserTaskDataDto implements UserTaskRecordValue {
   }
 
   @Override
+  public int hashCode() {
+    return Objects.hash(
+        userTaskKey,
+        assignee,
+        candidateGroupsList,
+        candidateUsersList,
+        dueDate,
+        elementId,
+        elementInstanceKey,
+        bpmnProcessId,
+        processDefinitionVersion,
+        processDefinitionKey,
+        processInstanceKey,
+        tenantId,
+        changedAttributes,
+        variables,
+        followUpDate,
+        formKey,
+        action,
+        externalFormReference,
+        customHeaders,
+        creationTimestamp,
+        tags);
+  }
+
+  @Override
   public boolean equals(final Object o) {
     if (o == null || getClass() != o.getClass()) {
       return false;
@@ -291,32 +322,6 @@ public class ZeebeUserTaskDataDto implements UserTaskRecordValue {
         && Objects.equals(externalFormReference, that.externalFormReference)
         && Objects.equals(customHeaders, that.customHeaders)
         && Objects.equals(tags, that.tags);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(
-        userTaskKey,
-        assignee,
-        candidateGroupsList,
-        candidateUsersList,
-        dueDate,
-        elementId,
-        elementInstanceKey,
-        bpmnProcessId,
-        processDefinitionVersion,
-        processDefinitionKey,
-        processInstanceKey,
-        tenantId,
-        changedAttributes,
-        variables,
-        followUpDate,
-        formKey,
-        action,
-        externalFormReference,
-        customHeaders,
-        creationTimestamp,
-        tags);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/variable/ZeebeVariableDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/variable/ZeebeVariableDataDto.java
@@ -109,6 +109,11 @@ public class ZeebeVariableDataDto implements VariableRecordValue {
     this.name = name;
   }
 
+  @Override
+  public int getOrdinalKey() {
+    return -1; // not used in Optimize
+  }
+
   protected boolean canEqual(final Object other) {
     return other instanceof ZeebeVariableDataDto;
   }

--- a/qa/archunit-tests/src/test/java/io/camunda/zeebe/protocol/ImmutableProtocolArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/zeebe/protocol/ImmutableProtocolArchTest.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.value.AuditLogProcessInstanceRelated;
 import io.camunda.zeebe.protocol.record.value.BatchOperationRelated;
+import io.camunda.zeebe.protocol.record.value.OrdinalKeyBased;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRelated;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.lang.reflect.Method;
@@ -86,7 +87,8 @@ final class ImmutableProtocolArchTest {
     return Predicates.equivalentTo(ProcessInstanceRelated.class)
         .or(Predicates.equivalentTo(BatchOperationRelated.class))
         .or(Predicates.equivalentTo(TenantOwned.class))
-        .or(Predicates.equivalentTo(AuditLogProcessInstanceRelated.class));
+        .or(Predicates.equivalentTo(AuditLogProcessInstanceRelated.class))
+        .or(Predicates.equivalentTo(OrdinalKeyBased.class));
   }
 
   private static final class BuilderCondition extends ArchCondition<JavaClass> {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.engine.processing.message.ProcessMessageSubscriptionCorr
 import io.camunda.zeebe.engine.processing.message.ProcessMessageSubscriptionCreateProcessor;
 import io.camunda.zeebe.engine.processing.message.ProcessMessageSubscriptionDeleteProcessor;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
+import io.camunda.zeebe.engine.processing.ordinals.OrdinalKeyProvider;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceBatchActivateProcessor;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceBatchTerminateProcessor;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceCancelProcessor;
@@ -76,6 +77,7 @@ public final class BpmnProcessors {
       final RoutingInfo routingInfo,
       final InstantSource clock,
       final EngineConfiguration config,
+      final OrdinalKeyProvider ordinalKeyProvider,
       final AsyncRequestBehavior asyncRequestBehavior,
       final AuthorizationCheckBehavior authCheckBehavior,
       final TransientPendingSubscriptionState transientProcessMessageSubscriptionState,
@@ -119,6 +121,7 @@ public final class BpmnProcessors {
         processingState,
         writers,
         bpmnBehaviors,
+        ordinalKeyProvider,
         processEngineMetrics,
         config,
         authCheckBehavior);
@@ -263,6 +266,7 @@ public final class BpmnProcessors {
       final MutableProcessingState processingState,
       final Writers writers,
       final BpmnBehaviors bpmnBehaviors,
+      final OrdinalKeyProvider ordinalKeyProvider,
       final ProcessEngineMetrics metrics,
       final EngineConfiguration config,
       final AuthorizationCheckBehavior authCheckBehavior) {
@@ -277,6 +281,7 @@ public final class BpmnProcessors {
             processingState.getBannedInstanceState(),
             authCheckBehavior,
             bpmnBehaviors,
+            ordinalKeyProvider,
             config.isBusinessIdUniquenessEnabled());
     final ProcessInstanceCreationCreateProcessor createProcessor =
         new ProcessInstanceCreationCreateProcessor(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -54,6 +54,8 @@ import io.camunda.zeebe.engine.processing.message.MessageEventProcessors;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.metrics.job.JobMetricsProcessors;
 import io.camunda.zeebe.engine.processing.metrics.usage.UsageMetricsProcessors;
+import io.camunda.zeebe.engine.processing.ordinals.FakeOrdinalKeyProvider;
+import io.camunda.zeebe.engine.processing.ordinals.OrdinalKeyProvider;
 import io.camunda.zeebe.engine.processing.resource.ResourceDeletionDeleteProcessor;
 import io.camunda.zeebe.engine.processing.resource.ResourceFetchProcessor;
 import io.camunda.zeebe.engine.processing.resource.ResourceReexportReexportProcessor;
@@ -110,6 +112,8 @@ public final class EngineProcessors {
 
     final var processingState = typedRecordProcessorContext.getProcessingState();
     final var keyGenerator = processingState.getKeyGenerator();
+    final var ordinalKeyProvider = new FakeOrdinalKeyProvider(partitionsCount);
+
     final var routingInfo =
         RoutingInfo.dynamic(
             processingState.getRoutingState(), RoutingInfo.forStaticPartitions(partitionsCount));
@@ -228,6 +232,7 @@ public final class EngineProcessors {
             routingInfo,
             clock,
             config,
+            ordinalKeyProvider,
             asyncRequestBehavior,
             authCheckBehavior,
             transientProcessMessageSubscriptionState,
@@ -481,6 +486,7 @@ public final class EngineProcessors {
       final RoutingInfo routingInfo,
       final InstantSource clock,
       final EngineConfiguration config,
+      final OrdinalKeyProvider ordinalKeyProvider,
       final AsyncRequestBehavior asyncRequestBehavior,
       final AuthorizationCheckBehavior authCheckBehavior,
       final TransientPendingSubscriptionState transientProcessMessageSubscriptionState,
@@ -498,6 +504,7 @@ public final class EngineProcessors {
         routingInfo,
         clock,
         config,
+        ordinalKeyProvider,
         asyncRequestBehavior,
         authCheckBehavior,
         transientProcessMessageSubscriptionState,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementContext.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementContext.java
@@ -38,6 +38,15 @@ public interface BpmnElementContext {
    */
   long getRootProcessInstanceKey();
 
+  /**
+   * Returns the ordinal key of the root process instance in the hierarchy, either ordinal key
+   * determined by the rollover policy or the default value.
+   *
+   * <p>TODO (yohanfernando): Look at usage of above getRootProcessInstanceKey() and add ordinal to
+   * all same places
+   */
+  int getOrdinalKey();
+
   int getProcessVersion();
 
   DirectBuffer getBpmnProcessId();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementContextImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementContextImpl.java
@@ -58,6 +58,11 @@ public final class BpmnElementContextImpl implements BpmnElementContext {
   }
 
   @Override
+  public int getOrdinalKey() {
+    return recordValue.getOrdinalKey();
+  }
+
+  @Override
   public int getProcessVersion() {
     return recordValue.getVersion();
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
@@ -379,6 +379,7 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
                     context.getProcessDefinitionKey(),
                     context.getProcessInstanceKey(),
                     context.getRootProcessInstanceKey(),
+                    context.getOrdinalKey(),
                     context.getBpmnProcessId(),
                     context.getTenantId(),
                     eventTrigger.getVariables());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnAdHocSubProcessBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnAdHocSubProcessBehavior.java
@@ -74,6 +74,7 @@ public final class BpmnAdHocSubProcessBehavior {
           context.getProcessDefinitionKey(),
           context.getProcessInstanceKey(),
           context.getRootProcessInstanceKey(),
+          context.getOrdinalKey(),
           context.getBpmnProcessId(),
           context.getTenantId(),
           variablesBuffer);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -542,7 +542,8 @@ public final class BpmnJobBehavior {
         .setElementInstanceKey(context.getElementInstanceKey())
         .setTenantId(context.getTenantId())
         .setTags(getTagsFromProcessInstance(context))
-        .setRootProcessInstanceKey(context.getRootProcessInstanceKey());
+        .setRootProcessInstanceKey(context.getRootProcessInstanceKey())
+        .setOrdinalKey(context.getOrdinalKey());
 
     final var jobKey = keyGenerator.nextKey();
     stateWriter.appendFollowUpEvent(jobKey, JobIntent.CREATED, jobRecord);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateBehavior.java
@@ -242,6 +242,7 @@ public final class BpmnStateBehavior {
         context.getProcessDefinitionKey(),
         context.getProcessInstanceKey(),
         context.getRootProcessInstanceKey(),
+        context.getOrdinalKey(),
         context.getBpmnProcessId(),
         context.getTenantId(),
         variablesAsDocument);
@@ -251,20 +252,30 @@ public final class BpmnStateBehavior {
       final long sourceScopeKey,
       final long targetProcessInstanceKey,
       final long targetRootProcessInstanceKey,
+      final int targetOrdinalKey,
       final DeployedProcess targetProcess) {
     final var variables = variablesState.getVariablesAsDocument(sourceScopeKey);
     copyVariablesToProcessInstance(
-        targetProcessInstanceKey, targetRootProcessInstanceKey, targetProcess, variables);
+        targetProcessInstanceKey,
+        targetRootProcessInstanceKey,
+        targetOrdinalKey,
+        targetProcess,
+        variables);
   }
 
   public void copyLocalVariablesToProcessInstance(
       final long sourceScopeKey,
       final long targetProcessInstanceKey,
       final long targetRootProcessInstanceKey,
+      final int targetOrdinalKey,
       final DeployedProcess targetProcess) {
     final var variables = variablesState.getVariablesLocalAsDocument(sourceScopeKey);
     copyVariablesToProcessInstance(
-        targetProcessInstanceKey, targetRootProcessInstanceKey, targetProcess, variables);
+        targetProcessInstanceKey,
+        targetRootProcessInstanceKey,
+        targetOrdinalKey,
+        targetProcess,
+        variables);
   }
 
   /**
@@ -282,6 +293,7 @@ public final class BpmnStateBehavior {
   private void copyVariablesToProcessInstance(
       final long targetProcessInstanceKey,
       final long targetRootProcessInstanceKey,
+      final int targetOrdinalKey,
       final DeployedProcess targetProcess,
       final DirectBuffer variables) {
     variableBehavior.mergeDocument(
@@ -289,6 +301,7 @@ public final class BpmnStateBehavior {
         targetProcess.getKey(),
         targetProcessInstanceKey,
         targetRootProcessInstanceKey,
+        targetOrdinalKey,
         targetProcess.getBpmnProcessId(),
         targetProcess.getTenantId(),
         variables);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
@@ -65,6 +65,7 @@ public final class BpmnVariableMappingBehavior {
     final DirectBuffer bpmnProcessId = context.getBpmnProcessId();
     final Optional<Expression> inputMappingExpression = element.getInputMappings();
     final long rootProcessInstanceKey = context.getRootProcessInstanceKey();
+    final int ordinalKey = context.getOrdinalKey();
 
     if (inputMappingExpression.isPresent()) {
       return expressionProcessor
@@ -76,6 +77,7 @@ public final class BpmnVariableMappingBehavior {
                     processDefinitionKey,
                     processInstanceKey,
                     rootProcessInstanceKey,
+                    ordinalKey,
                     bpmnProcessId,
                     context.getTenantId(),
                     result);
@@ -99,6 +101,7 @@ public final class BpmnVariableMappingBehavior {
     final long processDefinitionKey = record.getProcessDefinitionKey();
     final long processInstanceKey = record.getProcessInstanceKey();
     final long rootProcessInstanceKey = context.getRootProcessInstanceKey();
+    final int ordinalKey = context.getOrdinalKey();
     final DirectBuffer bpmnProcessId = context.getBpmnProcessId();
     final long scopeKey = getVariableScopeKey(context);
     final String tenantId = context.getTenantId();
@@ -129,6 +132,7 @@ public final class BpmnVariableMappingBehavior {
             processDefinitionKey,
             processInstanceKey,
             rootProcessInstanceKey,
+            ordinalKey,
             bpmnProcessId,
             context.getTenantId(),
             variables);
@@ -157,6 +161,7 @@ public final class BpmnVariableMappingBehavior {
                     processDefinitionKey,
                     processInstanceKey,
                     rootProcessInstanceKey,
+                    ordinalKey,
                     bpmnProcessId,
                     context.getTenantId(),
                     resultDoc);
@@ -170,6 +175,7 @@ public final class BpmnVariableMappingBehavior {
           processDefinitionKey,
           processInstanceKey,
           rootProcessInstanceKey,
+          ordinalKey,
           bpmnProcessId,
           context.getTenantId(),
           variables);
@@ -183,6 +189,7 @@ public final class BpmnVariableMappingBehavior {
           processDefinitionKey,
           processInstanceKey,
           rootProcessInstanceKey,
+          ordinalKey,
           bpmnProcessId,
           context.getTenantId(),
           localVariables);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
@@ -105,12 +105,14 @@ public final class CallActivityProcessor
               final var inputMappings = element.getInputMappings();
               final var callActivityInstanceKey = activated.getElementInstanceKey();
               final var rootProcessInstanceKey = context.getRootProcessInstanceKey();
+              final var ordinalKey = context.getOrdinalKey();
 
               if (propagateAllParentVariablesEnabled) {
                 stateBehavior.copyAllVariablesToProcessInstance(
                     callActivityInstanceKey,
                     childProcessInstanceKey,
                     rootProcessInstanceKey,
+                    ordinalKey,
                     process);
               } else if (inputMappings.isPresent()) {
                 // when activating the call activity, the input mappings will be applied.
@@ -121,6 +123,7 @@ public final class CallActivityProcessor
                     callActivityInstanceKey,
                     childProcessInstanceKey,
                     rootProcessInstanceKey,
+                    ordinalKey,
                     process);
               }
             });

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventTriggerBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventTriggerBehavior.java
@@ -263,6 +263,7 @@ public class EventTriggerBehavior {
           elementRecord.getProcessDefinitionKey(),
           elementRecord.getProcessInstanceKey(),
           elementRecord.getRootProcessInstanceKey(),
+          elementRecord.getOrdinalKey(),
           elementRecord.getBpmnProcessIdBuffer(),
           elementRecord.getTenantId(),
           variables);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -334,6 +334,7 @@ public final class JobCompleteProcessor implements TypedRecordProcessor<JobRecor
         targetAdHocSubProcessInstanceValue.getProcessDefinitionKey(),
         targetAdHocSubProcessInstanceValue.getProcessInstanceKey(),
         targetAdHocSubProcessInstanceValue.getRootProcessInstanceKey(),
+        targetAdHocSubProcessInstanceValue.getOrdinalKey(),
         targetAdHocSubProcessInstanceValue.getBpmnProcessIdBuffer(),
         targetAdHocSubProcessInstanceValue.getTenantId(),
         completingJobRecord.getVariablesBuffer());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
@@ -157,6 +157,7 @@ public final class JobFailProcessor implements TypedRecordProcessor<JobRecord> {
           value.getProcessDefinitionKey(),
           value.getProcessInstanceKey(),
           value.getRootProcessInstanceKey(),
+          value.getOrdinalKey(),
           value.getBpmnProcessIdBuffer(),
           value.getTenantId(),
           variables);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/ordinals/FakeOrdinalKeyProvider.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/ordinals/FakeOrdinalKeyProvider.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.ordinals;
+
+import io.camunda.zeebe.protocol.Protocol;
+
+public class FakeOrdinalKeyProvider implements OrdinalKeyProvider {
+  private static final long APPROX_IDS_BETWEEN_ROOT_PROCESS_INSTANCES = 20;
+
+  // aim for roughly 1 hours worth at 300 PI/s (across 3 partitions)
+  private final long idsPerOrdinal;
+
+  public FakeOrdinalKeyProvider(final int partitionCount) {
+    idsPerOrdinal = (300 * 60 * 60 * APPROX_IDS_BETWEEN_ROOT_PROCESS_INSTANCES) / partitionCount;
+  }
+
+  @Override
+  public int getOrdinal(final long rootProcessInstanceKey) {
+    final long key = Protocol.decodeKeyInPartition(rootProcessInstanceKey);
+    return (int) (key / idsPerOrdinal) + 1;
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/ordinals/OrdinalKeyProvider.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/ordinals/OrdinalKeyProvider.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.ordinals;
+
+public interface OrdinalKeyProvider {
+
+  int getOrdinal(long rootProcessInstanceKey);
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutablePro
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableSequenceFlow;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
+import io.camunda.zeebe.engine.processing.ordinals.OrdinalKeyProvider;
 import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
 import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
 import io.camunda.zeebe.engine.state.immutable.BannedInstanceState;
@@ -69,6 +70,7 @@ public class ProcessInstanceCreationHelper {
   private final boolean businessIdUniquenessEnabled;
   private final ElementInstanceState elementInstanceState;
   private final BannedInstanceState bannedInstanceState;
+  private final OrdinalKeyProvider ordinalKeyProvider;
 
   public ProcessInstanceCreationHelper(
       final ProcessState processState,
@@ -76,6 +78,7 @@ public class ProcessInstanceCreationHelper {
       final BannedInstanceState bannedInstanceState,
       final AuthorizationCheckBehavior authCheckBehavior,
       final BpmnBehaviors bpmnBehaviors,
+      final OrdinalKeyProvider ordinalKeyProvider,
       final boolean businessIdUniquenessEnabled) {
     this.processState = processState;
     this.elementInstanceState = elementInstanceState;
@@ -83,6 +86,7 @@ public class ProcessInstanceCreationHelper {
     this.authCheckBehavior = authCheckBehavior;
     variableBehavior = bpmnBehaviors.variableBehavior();
     elementActivationBehavior = bpmnBehaviors.elementActivationBehavior();
+    this.ordinalKeyProvider = ordinalKeyProvider;
     this.businessIdUniquenessEnabled = businessIdUniquenessEnabled;
   }
 
@@ -115,6 +119,7 @@ public class ProcessInstanceCreationHelper {
         .setProcessDefinitionKey(process.getKey())
         .setProcessInstanceKey(processInstanceKey)
         .setRootProcessInstanceKey(processInstanceKey)
+        .setOrdinalKey(ordinalKeyProvider.getOrdinal(processInstanceKey))
         .setBpmnElementType(BpmnElementType.PROCESS)
         .setElementId(process.getProcess().getId())
         .setFlowScopeKey(-1)
@@ -228,6 +233,7 @@ public class ProcessInstanceCreationHelper {
     record
         .setProcessInstanceKey(processInstance.getProcessInstanceKey())
         .setRootProcessInstanceKey(processInstance.getRootProcessInstanceKey())
+        .setOrdinalKey(processInstance.getOrdinalKey())
         .setBpmnProcessId(processInstance.getBpmnProcessId())
         .setVersion(processInstance.getVersion())
         .setProcessDefinitionKey(processInstance.getProcessDefinitionKey());
@@ -241,6 +247,7 @@ public class ProcessInstanceCreationHelper {
         processInstance.getProcessDefinitionKey(),
         processInstance.getProcessInstanceKey(),
         processInstance.getRootProcessInstanceKey(),
+        processInstance.getOrdinalKey(),
         processInstance.getBpmnProcessIdBuffer(),
         processInstance.getTenantId(),
         variablesBuffer);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
@@ -337,6 +337,7 @@ public final class ProcessInstanceModificationModifyProcessor
         .setProcessInstanceKey(value.getProcessInstanceKey())
         .setProcessDefinitionKey(processInstanceRecord.getProcessDefinitionKey())
         .setRootProcessInstanceKey(processInstanceRecord.getRootProcessInstanceKey())
+        .setOrdinalKey(processInstanceRecord.getOrdinalKey())
         .setTenantId(processInstanceRecord.getTenantId())
         .setBpmnProcessId(processInstanceRecord.getBpmnProcessId());
 
@@ -1362,6 +1363,7 @@ public final class ProcessInstanceModificationModifyProcessor
                     process.getKey(),
                     processInstance.getKey(),
                     processInstance.getValue().getRootProcessInstanceKey(),
+                    processInstance.getValue().getOrdinalKey(),
                     process.getBpmnProcessId(),
                     process.getTenantId(),
                     variableDocument));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskUpdateProcessor.java
@@ -196,6 +196,7 @@ public final class UserTaskUpdateProcessor implements UserTaskCommandProcessor {
               userTaskRecord.getProcessDefinitionKey(),
               userTaskRecord.getProcessInstanceKey(),
               userTaskRecord.getRootProcessInstanceKey(),
+              userTaskRecord.getOrdinalKey(),
               userTaskRecord.getBpmnProcessIdBuffer(),
               userTaskRecord.getTenantId(),
               variableRecord.getVariablesBuffer());
@@ -205,6 +206,7 @@ public final class UserTaskUpdateProcessor implements UserTaskCommandProcessor {
               userTaskRecord.getProcessDefinitionKey(),
               userTaskRecord.getProcessInstanceKey(),
               userTaskRecord.getRootProcessInstanceKey(),
+              userTaskRecord.getOrdinalKey(),
               userTaskRecord.getBpmnProcessIdBuffer(),
               userTaskRecord.getTenantId(),
               variableRecord.getVariablesBuffer());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableBehavior.java
@@ -91,6 +91,7 @@ public final class VariableBehavior {
       final long processDefinitionKey,
       final long processInstanceKey,
       final long rootProcessInstanceKey,
+      final int ordinalKey,
       final DirectBuffer bpmnProcessId,
       final String tenantId,
       final DirectBuffer document) {
@@ -104,6 +105,7 @@ public final class VariableBehavior {
         .setProcessDefinitionKey(processDefinitionKey)
         .setProcessInstanceKey(processInstanceKey)
         .setRootProcessInstanceKey(rootProcessInstanceKey)
+        .setOrdinalKey(ordinalKey)
         .setBpmnProcessId(bpmnProcessId)
         .setTenantId(tenantId)
         .setSource(variableSourceRecord);
@@ -144,6 +146,7 @@ public final class VariableBehavior {
       final long processDefinitionKey,
       final long processInstanceKey,
       final long rootProcessInstanceKey,
+      final int ordinalKey,
       final DirectBuffer bpmnProcessId,
       final String tenantId,
       final DirectBuffer document) {
@@ -160,6 +163,7 @@ public final class VariableBehavior {
         .setProcessDefinitionKey(processDefinitionKey)
         .setProcessInstanceKey(processInstanceKey)
         .setRootProcessInstanceKey(rootProcessInstanceKey)
+        .setOrdinalKey(ordinalKey)
         .setBpmnProcessId(bpmnProcessId)
         .setTenantId(tenantId)
         .setSource(variableSourceRecord);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateProcessor.java
@@ -167,6 +167,7 @@ public final class VariableDocumentUpdateProcessor
                 userTaskRecord.getProcessDefinitionKey(),
                 userTaskRecord.getProcessInstanceKey(),
                 userTaskRecord.getRootProcessInstanceKey(),
+                userTaskRecord.getOrdinalKey(),
                 userTaskRecord.getBpmnProcessIdBuffer(),
                 userTaskRecord.getTenantId(),
                 value.getVariablesBuffer());
@@ -176,6 +177,7 @@ public final class VariableDocumentUpdateProcessor
                 userTaskRecord.getProcessDefinitionKey(),
                 userTaskRecord.getProcessInstanceKey(),
                 userTaskRecord.getRootProcessInstanceKey(),
+                userTaskRecord.getOrdinalKey(),
                 userTaskRecord.getBpmnProcessIdBuffer(),
                 userTaskRecord.getTenantId(),
                 value.getVariablesBuffer());
@@ -202,6 +204,7 @@ public final class VariableDocumentUpdateProcessor
     final long processDefinitionKey = scope.getValue().getProcessDefinitionKey();
     final long processInstanceKey = scope.getValue().getProcessInstanceKey();
     final long rootProcessInstanceKey = scope.getValue().getRootProcessInstanceKey();
+    final int ordinalKey = scope.getValue().getOrdinalKey();
     final DirectBuffer bpmnProcessId = scope.getValue().getBpmnProcessIdBuffer();
 
     try {
@@ -211,6 +214,7 @@ public final class VariableDocumentUpdateProcessor
             processDefinitionKey,
             processInstanceKey,
             rootProcessInstanceKey,
+            ordinalKey,
             bpmnProcessId,
             tenantId,
             value.getVariablesBuffer());
@@ -220,6 +224,7 @@ public final class VariableDocumentUpdateProcessor
             processDefinitionKey,
             processInstanceKey,
             rootProcessInstanceKey,
+            ordinalKey,
             bpmnProcessId,
             tenantId,
             value.getVariablesBuffer());

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/VariableBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/VariableBehaviorTest.java
@@ -88,6 +88,7 @@ final class VariableBehaviorTest {
     final long childScopeKey = 2;
     final long childFooKey = 3;
     final long rootKey = 4;
+    final int ordinalKey = 5;
     final DirectBuffer bpmnProcessId = BufferUtil.wrapString("process");
     final String tenantId = TenantOwned.DEFAULT_TENANT_IDENTIFIER;
     final Map<String, Object> document = Map.of("foo", "bar", "baz", "buz");
@@ -101,6 +102,7 @@ final class VariableBehaviorTest {
         processDefinitionKey,
         parentScopeKey,
         rootKey,
+        ordinalKey,
         bpmnProcessId,
         tenantId,
         MsgPackUtil.asMsgPack(document));
@@ -119,7 +121,8 @@ final class VariableBehaviorTest {
                   .hasProcessInstanceKey(parentScopeKey)
                   .hasBpmnProcessId("process")
                   .hasTenantId(tenantId)
-                  .hasRootProcessInstanceKey(rootKey);
+                  .hasRootProcessInstanceKey(rootKey)
+                  .hasOrdinalKey(ordinalKey);
             },
             event -> {
               assertThat(event.intent).isEqualTo(VariableIntent.UPDATED);
@@ -132,7 +135,8 @@ final class VariableBehaviorTest {
                   .hasProcessInstanceKey(parentScopeKey)
                   .hasBpmnProcessId("process")
                   .hasTenantId(tenantId)
-                  .hasRootProcessInstanceKey(rootKey);
+                  .hasRootProcessInstanceKey(rootKey)
+                  .hasOrdinalKey(ordinalKey);
             });
   }
 
@@ -142,6 +146,7 @@ final class VariableBehaviorTest {
     final long processDefinitionKey = 1;
     final long scopeKey = 1;
     final long rootKey = 2;
+    final int ordinalKey = 3;
     final DirectBuffer bpmnProcessId = BufferUtil.wrapString("process");
     final String tenantId = TenantOwned.DEFAULT_TENANT_IDENTIFIER;
     final Map<String, Object> document = Map.of();
@@ -153,6 +158,7 @@ final class VariableBehaviorTest {
         processDefinitionKey,
         scopeKey,
         rootKey,
+        ordinalKey,
         bpmnProcessId,
         tenantId,
         MsgPackUtil.asMsgPack(document));
@@ -169,6 +175,7 @@ final class VariableBehaviorTest {
     final long parentScopeKey = 2;
     final long childScopeKey = 3;
     final long parentFooKey = 4;
+    final int ordinalKey = 6;
     final DirectBuffer bpmnProcessId = BufferUtil.wrapString("process");
     final String tenantId = TenantOwned.DEFAULT_TENANT_IDENTIFIER;
     final Map<String, Object> document = Map.of("foo", "bar");
@@ -184,6 +191,7 @@ final class VariableBehaviorTest {
         processDefinitionKey,
         rootScopeKey,
         rootScopeKey,
+        ordinalKey,
         bpmnProcessId,
         tenantId,
         MsgPackUtil.asMsgPack(document));
@@ -213,6 +221,7 @@ final class VariableBehaviorTest {
     final long rootScopeKey = 1;
     final long parentScopeKey = 2;
     final long childScopeKey = 3;
+    final int ordinalKey = 4;
     final DirectBuffer bpmnProcessId = BufferUtil.wrapString("process");
     final String tenantId = TenantOwned.DEFAULT_TENANT_IDENTIFIER;
     final Map<String, Object> document = Map.of("foo", "bar", "buz", "baz");
@@ -226,6 +235,7 @@ final class VariableBehaviorTest {
         rootScopeKey,
         processDefinitionKey,
         rootScopeKey,
+        ordinalKey,
         bpmnProcessId,
         tenantId,
         MsgPackUtil.asMsgPack(document));
@@ -265,6 +275,7 @@ final class VariableBehaviorTest {
     final long rootScopeKey = 1;
     final long parentScopeKey = 2;
     final long childScopeKey = 3;
+    final int ordinalKey = 4;
     final String tenantId = TenantOwned.DEFAULT_TENANT_IDENTIFIER;
     final DirectBuffer bpmnProcessId = BufferUtil.wrapString("process");
     final Map<String, Object> document = Map.of("foo", "bar", "buz", "baz");
@@ -279,6 +290,7 @@ final class VariableBehaviorTest {
         processDefinitionKey,
         rootScopeKey,
         rootScopeKey,
+        ordinalKey,
         bpmnProcessId,
         tenantId,
         MsgPackUtil.asMsgPack(document));
@@ -308,6 +320,7 @@ final class VariableBehaviorTest {
     final long childScopeKey = 2;
     final long childFooKey = 3;
     final long rootKey = 5;
+    final int ordinalKey = 6;
     final String tenantId = TenantOwned.DEFAULT_TENANT_IDENTIFIER;
     final DirectBuffer bpmnProcessId = BufferUtil.wrapString("process");
     final Map<String, Object> document = Map.of("foo", "bar");
@@ -322,6 +335,7 @@ final class VariableBehaviorTest {
         processDefinitionKey,
         parentScopeKey,
         rootKey,
+        ordinalKey,
         bpmnProcessId,
         tenantId,
         MsgPackUtil.asMsgPack(document));
@@ -351,6 +365,7 @@ final class VariableBehaviorTest {
     final int parentScopeKey = 1;
     final int childScopeKey = 2;
     final long rootKey = 5;
+    final int ordinalKey = 6;
     final DirectBuffer bpmnProcessId = BufferUtil.wrapString("process");
     final String tenantId = TenantOwned.DEFAULT_TENANT_IDENTIFIER;
     final Map<String, Object> document = Map.of();
@@ -365,6 +380,7 @@ final class VariableBehaviorTest {
         processDefinitionKey,
         parentScopeKey,
         rootKey,
+        ordinalKey,
         bpmnProcessId,
         tenantId,
         MsgPackUtil.asMsgPack(document));
@@ -611,6 +627,7 @@ final class VariableBehaviorTest {
     final long childScopeKey = 2;
     final long childFooKey = 3;
     final long rootKey = 4;
+    final int ordinalKey = 5;
 
     final DirectBuffer bpmnProcessId = BufferUtil.wrapString("process");
     final Map<String, Object> document = Map.of("foo", "bar", "baz", "buz");
@@ -626,6 +643,7 @@ final class VariableBehaviorTest {
         processDefinitionKey,
         parentScopeKey,
         rootKey,
+        ordinalKey,
         bpmnProcessId,
         tenantId,
         MsgPackUtil.asMsgPack(document));
@@ -668,6 +686,7 @@ final class VariableBehaviorTest {
     final long rootScopeKey = 1;
     final long parentScopeKey = 2;
     final long childScopeKey = 3;
+    final int ordinalKey = 4;
 
     final DirectBuffer bpmnProcessId = BufferUtil.wrapString("process");
     final Map<String, Object> document = Map.of("foo", "bar", "buz", "baz");
@@ -684,6 +703,7 @@ final class VariableBehaviorTest {
         processDefinitionKey,
         rootScopeKey,
         rootScopeKey,
+        ordinalKey,
         bpmnProcessId,
         tenantId,
         MsgPackUtil.asMsgPack(document));
@@ -725,6 +745,7 @@ final class VariableBehaviorTest {
     final long parentScopeKey = 2;
     final long childScopeKey = 3;
     final long elementInstanceKey = 42;
+    final int ordinalKey = 5;
     final DirectBuffer bpmnProcessId = BufferUtil.wrapString("process");
     final String tenantId = TenantOwned.DEFAULT_TENANT_IDENTIFIER;
     final Map<String, Object> document = Map.of("foo", "bar");
@@ -741,6 +762,7 @@ final class VariableBehaviorTest {
         processDefinitionKey,
         rootScopeKey,
         rootScopeKey,
+        ordinalKey,
         bpmnProcessId,
         tenantId,
         MsgPackUtil.asMsgPack(document));
@@ -757,7 +779,9 @@ final class VariableBehaviorTest {
         .hasProcessDefinitionKey(processDefinitionKey)
         .hasProcessInstanceKey(rootScopeKey)
         .hasBpmnProcessId("process")
-        .hasSource(variableSource);
+        .hasSource(variableSource)
+        .hasRootProcessInstanceKey(rootScopeKey)
+        .hasOrdinalKey(ordinalKey);
   }
 
   @ParameterizedTest
@@ -768,6 +792,7 @@ final class VariableBehaviorTest {
     final long parentScopeKey = 1;
     final long childScopeKey = 2;
     final long rootKey = 3;
+    final int ordinalKey = 4;
     final DirectBuffer bpmnProcessId = BufferUtil.wrapString("process");
     final String tenantId = TenantOwned.DEFAULT_TENANT_IDENTIFIER;
     final Map<String, Object> document = Map.of("foo", "bar");
@@ -783,6 +808,7 @@ final class VariableBehaviorTest {
         processDefinitionKey,
         parentScopeKey,
         rootKey,
+        ordinalKey,
         bpmnProcessId,
         tenantId,
         MsgPackUtil.asMsgPack(document));
@@ -800,7 +826,9 @@ final class VariableBehaviorTest {
         .hasProcessInstanceKey(parentScopeKey)
         .hasBpmnProcessId("process")
         .hasTenantId(tenantId)
-        .hasSource(variableSource);
+        .hasSource(variableSource)
+        .hasRootProcessInstanceKey(rootKey)
+        .hasOrdinalKey(ordinalKey);
   }
 
   @SuppressWarnings("unchecked")

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/FakeOrdinalIndexLocatorProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/FakeOrdinalIndexLocatorProvider.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.value.AuditLogProcessInstanceRelated;
 import io.camunda.zeebe.protocol.record.value.BatchOperationChunkRecordValue;
+import io.camunda.zeebe.protocol.record.value.OrdinalKeyBased;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -42,7 +43,20 @@ public class FakeOrdinalIndexLocatorProvider implements IndexLocatorProvider {
 
   @Override
   public IndexLocator createIndexLocator(final Record<?> record) {
-    // TODO stop using instanceof
+    if (record.getValue() instanceof final OrdinalKeyBased ordinalKeyBased) {
+      final var suffix = getOrCreateOrdinalSuffix(ordinalKeyBased.getOrdinalKey());
+      return new SingleSuffixOrdinalIndexLocator(suffix);
+    } else {
+      LOGGER.warn(
+          "Processing a record that is not an instance of OrdinalKeyBased. Record key: {}, "
+              + "position: {}, type: {}, value type: {}. This may lead to suboptimal index usage.",
+          record.getKey(),
+          record.getPosition(),
+          record.getRecordType(),
+          record.getValueType());
+    }
+
+    // TODO(yohanfernando): Remove this and revert to only use the above ^^^
     if (record.getValue() instanceof final AuditLogProcessInstanceRelated processInstanceRelated) {
       final long rootProcessInstanceKey = processInstanceRelated.getRootProcessInstanceKey();
       if (rootProcessInstanceKey > 0) {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
@@ -87,6 +87,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
       new StringValue("isUserTaskMigration");
   private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
       new StringValue("rootProcessInstanceKey");
+  private static final StringValue ORDINAL_KEY_KEY = new StringValue("ordinalKey");
   private final StringProperty typeProp = new StringProperty(TYPE_KEY, EMPTY_STRING);
   private final StringProperty workerProp = new StringProperty(WORKER_KEY, EMPTY_STRING);
   private final LongProperty deadlineProp = new LongProperty(DEADLINE_KEY, -1);
@@ -129,9 +130,10 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
       new BooleanProperty(IS_JOB_TO_USERTASK_MIGRATION_KEY, false);
   private final LongProperty rootProcessInstanceKeyProp =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1L);
+  private final IntegerProperty ordinalKeyProp = new IntegerProperty(ORDINAL_KEY_KEY, 0);
 
   public JobRecord() {
-    super(24);
+    super(25);
     declareProperty(deadlineProp)
         .declareProperty(timeoutProp)
         .declareProperty(workerProp)
@@ -156,7 +158,8 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
         .declareProperty(resultProp)
         .declareProperty(tagsProp)
         .declareProperty(isJobToUserTaskMigrationProp)
-        .declareProperty(rootProcessInstanceKeyProp);
+        .declareProperty(rootProcessInstanceKeyProp)
+        .declareProperty(ordinalKeyProp);
   }
 
   public void wrapWithoutVariables(final JobRecord record) {
@@ -186,6 +189,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
 
     setTags(record.getTags());
     rootProcessInstanceKeyProp.setValue(record.getRootProcessInstanceKey());
+    ordinalKeyProp.setValue(record.getOrdinalKey());
   }
 
   public void wrap(final JobRecord record) {
@@ -274,6 +278,11 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   }
 
   @Override
+  public long getRootProcessInstanceKey() {
+    return rootProcessInstanceKeyProp.getValue();
+  }
+
+  @Override
   public String getBpmnProcessId() {
     return bufferAsString(bpmnProcessIdProp.getValue());
   }
@@ -356,16 +365,6 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
     return isJobToUserTaskMigrationProp.getValue();
   }
 
-  @Override
-  public long getRootProcessInstanceKey() {
-    return rootProcessInstanceKeyProp.getValue();
-  }
-
-  public JobRecord setRootProcessInstanceKey(final long rootProcessInstanceKey) {
-    rootProcessInstanceKeyProp.setValue(rootProcessInstanceKey);
-    return this;
-  }
-
   public JobRecord setProcessDefinitionVersion(final int version) {
     processDefinitionVersionProp.setValue(version);
     return this;
@@ -378,6 +377,11 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
 
   public JobRecord setBpmnProcessId(final DirectBuffer bpmnProcessId) {
     bpmnProcessIdProp.setValue(bpmnProcessId);
+    return this;
+  }
+
+  public JobRecord setRootProcessInstanceKey(final long rootProcessInstanceKey) {
+    rootProcessInstanceKeyProp.setValue(rootProcessInstanceKey);
     return this;
   }
 
@@ -455,6 +459,16 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
 
   public JobRecord setType(final DirectBuffer buf) {
     return setType(buf, 0, buf.capacity());
+  }
+
+  @Override
+  public int getOrdinalKey() {
+    return ordinalKeyProp.getValue();
+  }
+
+  public JobRecord setOrdinalKey(final int ordinal) {
+    ordinalKeyProp.setValue(ordinal);
+    return this;
   }
 
   public JobRecord setListenerEventType(final JobListenerEventType jobListenerEventType) {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageSubscriptionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageSubscriptionRecord.java
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.BooleanProperty;
 import io.camunda.zeebe.msgpack.property.DocumentProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
@@ -37,6 +38,7 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
   private static final StringValue INTERRUPTING_KEY = new StringValue("interrupting");
   private static final StringValue VARIABLES_KEY = new StringValue("variables");
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
+  private static final StringValue ORDINAL_KEY_KEY = new StringValue("ordinalKey");
 
   private final LongProperty processInstanceKeyProp = new LongProperty(PROCESS_INSTANCE_KEY_KEY);
   private final LongProperty elementInstanceKeyProp = new LongProperty(ELEMENT_INSTANCE_KEY_KEY);
@@ -51,9 +53,10 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
   private final DocumentProperty variablesProp = new DocumentProperty(VARIABLES_KEY);
   private final StringProperty tenantIdProp =
       new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  private final IntegerProperty ordinalKeyProperty = new IntegerProperty(ORDINAL_KEY_KEY, 0);
 
   public MessageSubscriptionRecord() {
-    super(10);
+    super(11);
     declareProperty(processInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
         .declareProperty(processDefinitionKeyProp)
@@ -63,7 +66,8 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
         .declareProperty(interruptingProp)
         .declareProperty(bpmnProcessIdProp)
         .declareProperty(variablesProp)
-        .declareProperty(tenantIdProp);
+        .declareProperty(tenantIdProp)
+        .declareProperty(ordinalKeyProperty);
   }
 
   public void wrap(final MessageSubscriptionRecord record) {
@@ -77,6 +81,7 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
     setBpmnProcessId(record.getBpmnProcessIdBuffer());
     setVariables(record.getVariablesBuffer());
     setTenantId(record.getTenantId());
+    setOrdinalKey(record.getOrdinalKey());
   }
 
   @JsonIgnore
@@ -95,13 +100,13 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
   }
 
   @Override
-  public long getElementInstanceKey() {
-    return elementInstanceKeyProp.getValue();
+  public long getProcessDefinitionKey() {
+    return processDefinitionKeyProp.getValue();
   }
 
   @Override
-  public long getProcessDefinitionKey() {
-    return processDefinitionKeyProp.getValue();
+  public long getElementInstanceKey() {
+    return elementInstanceKeyProp.getValue();
   }
 
   @Override
@@ -154,13 +159,13 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
     return this;
   }
 
-  public MessageSubscriptionRecord setProcessDefinitionKey(final long key) {
-    processDefinitionKeyProp.setValue(key);
+  public MessageSubscriptionRecord setElementInstanceKey(final long key) {
+    elementInstanceKeyProp.setValue(key);
     return this;
   }
 
-  public MessageSubscriptionRecord setElementInstanceKey(final long key) {
-    elementInstanceKeyProp.setValue(key);
+  public MessageSubscriptionRecord setProcessDefinitionKey(final long key) {
+    processDefinitionKeyProp.setValue(key);
     return this;
   }
 
@@ -196,6 +201,16 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
 
   public MessageSubscriptionRecord setTenantId(final String tenantId) {
     tenantIdProp.setValue(tenantId);
+    return this;
+  }
+
+  @Override
+  public int getOrdinalKey() {
+    return ordinalKeyProperty.getValue();
+  }
+
+  public MessageSubscriptionRecord setOrdinalKey(final int ordinal) {
+    ordinalKeyProperty.setValue(ordinal);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/ProcessMessageSubscriptionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/ProcessMessageSubscriptionRecord.java
@@ -42,6 +42,7 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
   private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
       new StringValue("rootProcessInstanceKey");
+  private static final StringValue ORDINAL_KEY_KEY = new StringValue("ordinalKey");
 
   private final IntegerProperty subscriptionPartitionIdProp =
       new IntegerProperty(SUBSCRIPTION_PARTITION_ID_KEY);
@@ -60,9 +61,10 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
       new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   private final LongProperty rootProcessInstanceKeyProp =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1L);
+  private final IntegerProperty ordinalKeyProperty = new IntegerProperty(ORDINAL_KEY_KEY, 0);
 
   public ProcessMessageSubscriptionRecord() {
-    super(13);
+    super(14);
     declareProperty(subscriptionPartitionIdProp)
         .declareProperty(processInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
@@ -75,7 +77,8 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
         .declareProperty(correlationKeyProp)
         .declareProperty(elementIdProp)
         .declareProperty(tenantIdProp)
-        .declareProperty(rootProcessInstanceKeyProp);
+        .declareProperty(rootProcessInstanceKeyProp)
+        .declareProperty(ordinalKeyProperty);
   }
 
   public void wrap(final ProcessMessageSubscriptionRecord record) {
@@ -92,6 +95,7 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
     setElementId(record.getElementIdBuffer());
     setTenantId(record.getTenantId());
     setRootProcessInstanceKey(record.getRootProcessInstanceKey());
+    setOrdinalKey(record.getOrdinalKey());
   }
 
   @JsonIgnore
@@ -135,22 +139,17 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
   }
 
   @Override
+  public long getProcessDefinitionKey() {
+    return processDefinitionKeyProp.getValue();
+  }
+
+  @Override
   public long getElementInstanceKey() {
     return elementInstanceKeyProp.getValue();
   }
 
   public ProcessMessageSubscriptionRecord setElementInstanceKey(final long key) {
     elementInstanceKeyProp.setValue(key);
-    return this;
-  }
-
-  @Override
-  public long getProcessDefinitionKey() {
-    return processDefinitionKeyProp.getValue();
-  }
-
-  public ProcessMessageSubscriptionRecord setProcessDefinitionKey(final long key) {
-    processDefinitionKeyProp.setValue(key);
     return this;
   }
 
@@ -224,6 +223,11 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
     return this;
   }
 
+  public ProcessMessageSubscriptionRecord setProcessDefinitionKey(final long key) {
+    processDefinitionKeyProp.setValue(key);
+    return this;
+  }
+
   public ProcessMessageSubscriptionRecord setProcessInstanceKey(final long key) {
     processInstanceKeyProp.setValue(key);
     return this;
@@ -246,6 +250,16 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
 
   public ProcessMessageSubscriptionRecord setTenantId(final String tenantId) {
     tenantIdProp.setValue(tenantId);
+    return this;
+  }
+
+  @Override
+  public int getOrdinalKey() {
+    return ordinalKeyProperty.getValue();
+  }
+
+  public ProcessMessageSubscriptionRecord setOrdinalKey(final int ordinal) {
+    ordinalKeyProperty.setValue(ordinal);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceCreationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceCreationRecord.java
@@ -48,6 +48,7 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
   private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
       new StringValue("rootProcessInstanceKey");
   private static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
+  private static final StringValue ORDINAL_KEY_KEY = new StringValue("ordinalKey");
 
   private final StringProperty bpmnProcessIdProperty = new StringProperty(BPMN_PROCESS_ID_KEY, "");
   private final LongProperty processDefinitionKeyProperty =
@@ -72,9 +73,10 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
   private final LongProperty rootProcessInstanceKeyProperty =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1);
   private final StringProperty businessIdProperty = new StringProperty(BUSINESS_ID_KEY, "");
+  private final IntegerProperty ordinalKeyProperty = new IntegerProperty(ORDINAL_KEY_KEY, 0);
 
   public ProcessInstanceCreationRecord() {
-    super(12);
+    super(13);
     declareProperty(bpmnProcessIdProperty)
         .declareProperty(processDefinitionKeyProperty)
         .declareProperty(processInstanceKeyProperty)
@@ -86,12 +88,8 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
         .declareProperty(tenantIdProperty)
         .declareProperty(tagsProperty)
         .declareProperty(rootProcessInstanceKeyProperty)
-        .declareProperty(businessIdProperty);
-  }
-
-  @Override
-  public String getBpmnProcessId() {
-    return BufferUtil.bufferAsString(bpmnProcessIdProperty.getValue());
+        .declareProperty(businessIdProperty)
+        .declareProperty(ordinalKeyProperty);
   }
 
   @Override
@@ -159,10 +157,9 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
     return rootProcessInstanceKeyProperty.getValue();
   }
 
-  public ProcessInstanceCreationRecord setRootProcessInstanceKey(
-      final long rootProcessInstanceKey) {
-    rootProcessInstanceKeyProperty.setValue(rootProcessInstanceKey);
-    return this;
+  @Override
+  public String getBpmnProcessId() {
+    return BufferUtil.bufferAsString(bpmnProcessIdProperty.getValue());
   }
 
   @Override
@@ -180,11 +177,6 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
     return this;
   }
 
-  public ProcessInstanceCreationRecord setVersion(final int version) {
-    versionProperty.setValue(version);
-    return this;
-  }
-
   public ProcessInstanceCreationRecord setBpmnProcessId(final String bpmnProcessId) {
     bpmnProcessIdProperty.setValue(bpmnProcessId);
     return this;
@@ -192,6 +184,27 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
 
   public ProcessInstanceCreationRecord setBpmnProcessId(final DirectBuffer bpmnProcessId) {
     bpmnProcessIdProperty.setValue(bpmnProcessId);
+    return this;
+  }
+
+  public ProcessInstanceCreationRecord setRootProcessInstanceKey(
+      final long rootProcessInstanceKey) {
+    rootProcessInstanceKeyProperty.setValue(rootProcessInstanceKey);
+    return this;
+  }
+
+  public ProcessInstanceCreationRecord setVersion(final int version) {
+    versionProperty.setValue(version);
+    return this;
+  }
+
+  @Override
+  public int getOrdinalKey() {
+    return ordinalKeyProperty.getValue();
+  }
+
+  public ProcessInstanceCreationRecord setOrdinalKey(final int ordinal) {
+    ordinalKeyProperty.setValue(ordinal);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceMigrationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceMigrationRecord.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
@@ -34,6 +35,7 @@ public final class ProcessInstanceMigrationRecord extends UnifiedRecordValue
   private static final StringValue PROCESS_DEFINITION_KEY_KEY =
       new StringValue("processDefinitionKey");
   private static final StringValue BPMN_PROCESS_ID_KEY = new StringValue("bpmnProcessId");
+  private static final StringValue ORDINAL_KEY_KEY = new StringValue("ordinalKey");
   private final LongProperty processInstanceKeyProperty =
       new LongProperty(PROCESS_INSTANCE_KEY_KEY);
   private final LongProperty targetProcessDefinitionKeyProperty =
@@ -50,16 +52,18 @@ public final class ProcessInstanceMigrationRecord extends UnifiedRecordValue
   private final LongProperty processDefinitionKeyProperty =
       new LongProperty(PROCESS_DEFINITION_KEY_KEY, -1L);
   private final StringProperty bpmnProcessIdProperty = new StringProperty(BPMN_PROCESS_ID_KEY, "");
+  private final IntegerProperty ordinalKeyProperty = new IntegerProperty(ORDINAL_KEY_KEY, 0);
 
   public ProcessInstanceMigrationRecord() {
-    super(7);
+    super(8);
     declareProperty(processInstanceKeyProperty)
         .declareProperty(targetProcessDefinitionKeyProperty)
         .declareProperty(mappingInstructionsProperty)
         .declareProperty(tenantIdProperty)
         .declareProperty(rootProcessInstanceKeyProperty)
         .declareProperty(processDefinitionKeyProperty)
-        .declareProperty(bpmnProcessIdProperty);
+        .declareProperty(bpmnProcessIdProperty)
+        .declareProperty(ordinalKeyProperty);
   }
 
   @Override
@@ -153,6 +157,16 @@ public final class ProcessInstanceMigrationRecord extends UnifiedRecordValue
 
   public ProcessInstanceMigrationRecord setTenantId(final String tenantId) {
     tenantIdProperty.setValue(tenantId);
+    return this;
+  }
+
+  @Override
+  public int getOrdinalKey() {
+    return ordinalKeyProperty.getValue();
+  }
+
+  public ProcessInstanceMigrationRecord setOrdinalKey(final int ordinal) {
+    ordinalKeyProperty.setValue(ordinal);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationRecord.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.protocol.impl.record.value.processinstance;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.LongValue;
@@ -40,6 +41,7 @@ public final class ProcessInstanceModificationRecord extends UnifiedRecordValue
   private static final StringValue PROCESS_DEFINITION_KEY_KEY =
       new StringValue("processDefinitionKey");
   private static final StringValue BPMN_PROCESS_ID_KEY = new StringValue("bpmnProcessId");
+  private static final StringValue ORDINAL_KEY_KEY = new StringValue("ordinalKey");
 
   private final LongProperty processInstanceKeyProperty =
       new LongProperty(PROCESS_INSTANCE_KEY_KEY);
@@ -64,9 +66,10 @@ public final class ProcessInstanceModificationRecord extends UnifiedRecordValue
       new ArrayProperty<>(ACTIVATED_ELEMENT_INSTANCE_KEYS_KEY, LongValue::new);
   private final LongProperty rootProcessInstanceKeyProperty =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1);
+  private final IntegerProperty ordinalKeyProperty = new IntegerProperty(ORDINAL_KEY_KEY, 0);
 
   public ProcessInstanceModificationRecord() {
-    super(9);
+    super(10);
     declareProperty(processInstanceKeyProperty)
         .declareProperty(terminateInstructionsProperty)
         .declareProperty(activateInstructionsProperty)
@@ -75,7 +78,8 @@ public final class ProcessInstanceModificationRecord extends UnifiedRecordValue
         .declareProperty(tenantIdProp)
         .declareProperty(rootProcessInstanceKeyProperty)
         .declareProperty(processDefinitionKeyProperty)
-        .declareProperty(bpmnProcessIdProperty);
+        .declareProperty(bpmnProcessIdProperty)
+        .declareProperty(ordinalKeyProperty);
   }
 
   /**
@@ -251,6 +255,16 @@ public final class ProcessInstanceModificationRecord extends UnifiedRecordValue
 
   public ProcessInstanceModificationRecord setTenantId(final String tenantId) {
     tenantIdProp.setValue(tenantId);
+    return this;
+  }
+
+  @Override
+  public int getOrdinalKey() {
+    return ordinalKeyProperty.getValue();
+  }
+
+  public ProcessInstanceModificationRecord setOrdinalKey(final int ordinal) {
+    ordinalKeyProperty.setValue(ordinal);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceRecord.java
@@ -59,6 +59,7 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
   public static final StringValue ROOT_PROCESS_INSTANCE_KEY =
       new StringValue("rootProcessInstanceKey");
   public static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
+  public static final StringValue ORDINAL_KEY_KEY = new StringValue("ordinalKey");
 
   private final StringProperty bpmnProcessIdProp = new StringProperty(BPMN_PROCESS_ID_KEY, "");
   private final IntegerProperty versionProp = new IntegerProperty(VERSION_KEY, -1);
@@ -99,8 +100,10 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
 
   private final StringProperty businessIdProp = new StringProperty(BUSINESS_ID_KEY, "");
 
+  private final IntegerProperty ordinalKeyProp = new IntegerProperty(ORDINAL_KEY_KEY, 0);
+
   public ProcessInstanceRecord() {
-    super(17);
+    super(18);
     declareProperty(bpmnElementTypeProp)
         .declareProperty(elementIdProp)
         .declareProperty(bpmnProcessIdProp)
@@ -117,7 +120,8 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
         .declareProperty(callingElementPathProp)
         .declareProperty(tagsProp)
         .declareProperty(rootProcessInstanceKeyProp)
-        .declareProperty(businessIdProp);
+        .declareProperty(businessIdProp)
+        .declareProperty(ordinalKeyProp);
   }
 
   public void wrap(final ProcessInstanceRecord record) {
@@ -134,6 +138,7 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
     tenantIdProp.setValue(record.getTenantId());
     rootProcessInstanceKeyProp.setValue(record.getRootProcessInstanceKey());
     businessIdProp.setValue(record.getBusinessId());
+    ordinalKeyProp.setValue(record.getOrdinalKey());
   }
 
   @JsonIgnore
@@ -150,11 +155,6 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
       final DirectBuffer directBuffer, final int offset, final int length) {
     bpmnProcessIdProp.setValue(directBuffer, offset, length);
     return this;
-  }
-
-  @Override
-  public String getBpmnProcessId() {
-    return bufferAsString(bpmnProcessIdProp.getValue());
   }
 
   @Override
@@ -282,9 +282,9 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
     return rootProcessInstanceKeyProp.getValue();
   }
 
-  public ProcessInstanceRecord setRootProcessInstanceKey(final long rootProcessInstanceKey) {
-    rootProcessInstanceKeyProp.setValue(rootProcessInstanceKey);
-    return this;
+  @Override
+  public String getBpmnProcessId() {
+    return bufferAsString(bpmnProcessIdProp.getValue());
   }
 
   @Override
@@ -299,6 +299,21 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
 
   public ProcessInstanceRecord setBusinessId(final DirectBuffer businessId) {
     businessIdProp.setValue(businessId);
+    return this;
+  }
+
+  public ProcessInstanceRecord setBpmnProcessId(final String bpmnProcessId) {
+    bpmnProcessIdProp.setValue(bpmnProcessId);
+    return this;
+  }
+
+  public ProcessInstanceRecord setBpmnProcessId(final DirectBuffer directBuffer) {
+    bpmnProcessIdProp.setValue(directBuffer);
+    return this;
+  }
+
+  public ProcessInstanceRecord setRootProcessInstanceKey(final long rootProcessInstanceKey) {
+    rootProcessInstanceKeyProp.setValue(rootProcessInstanceKey);
     return this;
   }
 
@@ -341,13 +356,13 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
     return this;
   }
 
-  public ProcessInstanceRecord setBpmnProcessId(final String bpmnProcessId) {
-    bpmnProcessIdProp.setValue(bpmnProcessId);
-    return this;
+  @Override
+  public int getOrdinalKey() {
+    return ordinalKeyProp.getValue();
   }
 
-  public ProcessInstanceRecord setBpmnProcessId(final DirectBuffer directBuffer) {
-    bpmnProcessIdProp.setValue(directBuffer);
+  public ProcessInstanceRecord setOrdinalKey(final int ordinal) {
+    ordinalKeyProp.setValue(ordinal);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
@@ -58,6 +58,7 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
   private static final StringValue VARIABLES_VALUE = new StringValue(VARIABLES);
   private static final StringValue ROOT_PROCESS_INSTANCE_KEY_VALUE =
       new StringValue("rootProcessInstanceKey");
+  private static final StringValue ORDINAL_KEY_KEY = new StringValue("ordinalKey");
 
   /**
    * Defines the mapping between names of attributes that may be modified (updated or corrected) and
@@ -111,6 +112,7 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   private final LongProperty rootProcessInstanceKeyProp =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_VALUE, -1L);
+  private final IntegerProperty ordinalKeyProp = new IntegerProperty(ORDINAL_KEY_KEY, 0);
 
   /**
    * Tracks the names of user task attributes that are intended to be modified (e.g. on `UPDATE`),
@@ -155,7 +157,7 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
   private final LongProperty listenersConfigKeyProp = new LongProperty("listenersConfigKey", -1L);
 
   public UserTaskRecord() {
-    super(25);
+    super(26);
     declareProperty(userTaskKeyProp)
         .declareProperty(assigneeProp)
         .declareProperty(candidateGroupsListProp)
@@ -180,7 +182,8 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
         .declareProperty(deniedReasonProp)
         .declareProperty(tagsProp)
         .declareProperty(listenersConfigKeyProp)
-        .declareProperty(rootProcessInstanceKeyProp);
+        .declareProperty(rootProcessInstanceKeyProp)
+        .declareProperty(ordinalKeyProp);
   }
 
   /** Like {@link #wrap(UserTaskRecord)} but does not set the variables. */
@@ -210,6 +213,7 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
     setTags(record.getTags());
     listenersConfigKeyProp.setValue(record.getListenersConfigKey());
     rootProcessInstanceKeyProp.setValue(record.getRootProcessInstanceKey());
+    ordinalKeyProp.setValue(record.getOrdinalKey());
   }
 
   /**
@@ -408,6 +412,11 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
   }
 
   @Override
+  public long getRootProcessInstanceKey() {
+    return rootProcessInstanceKeyProp.getValue();
+  }
+
+  @Override
   public String getBpmnProcessId() {
     return bufferAsString(bpmnProcessIdProp.getValue());
   }
@@ -453,16 +462,6 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
     return this;
   }
 
-  @Override
-  public long getRootProcessInstanceKey() {
-    return rootProcessInstanceKeyProp.getValue();
-  }
-
-  public UserTaskRecord setRootProcessInstanceKey(final long rootProcessInstanceKey) {
-    rootProcessInstanceKeyProp.setValue(rootProcessInstanceKey);
-    return this;
-  }
-
   public UserTaskRecord setProcessDefinitionVersion(final int version) {
     processDefinitionVersionProp.setValue(version);
     return this;
@@ -475,6 +474,11 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
 
   public UserTaskRecord setBpmnProcessId(final DirectBuffer bpmnProcessId) {
     bpmnProcessIdProp.setValue(bpmnProcessId);
+    return this;
+  }
+
+  public UserTaskRecord setRootProcessInstanceKey(final long rootProcessInstanceKey) {
+    rootProcessInstanceKeyProp.setValue(rootProcessInstanceKey);
     return this;
   }
 
@@ -580,6 +584,16 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
 
   public UserTaskRecord setUserTaskKey(final long userTaskKey) {
     userTaskKeyProp.setValue(userTaskKey);
+    return this;
+  }
+
+  @Override
+  public int getOrdinalKey() {
+    return ordinalKeyProp.getValue();
+  }
+
+  public UserTaskRecord setOrdinalKey(final int ordinal) {
+    ordinalKeyProp.setValue(ordinal);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/variable/VariableRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/variable/VariableRecord.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.BinaryProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.ObjectProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
@@ -36,6 +37,7 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
   private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
       new StringValue("rootProcessInstanceKey");
   private static final StringValue SOURCE_KEY = new StringValue("source");
+  private static final StringValue ORDINAL_KEY_KEY = new StringValue("ordinalKey");
 
   private final StringProperty nameProp = new StringProperty(NAME_KEY);
   private final BinaryProperty valueProp = new BinaryProperty(VALUE_KEY);
@@ -50,6 +52,7 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1L);
   private final ObjectProperty<VariableSourceRecord> sourceProp =
       new ObjectProperty<>(SOURCE_KEY, new VariableSourceRecord());
+  private final IntegerProperty ordinalKeyProp = new IntegerProperty(ORDINAL_KEY_KEY, 0);
 
   /**
    * Cached JSON representation of the value. Lazily computed on first call to {@link #getValue()}
@@ -58,7 +61,7 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
   private String cachedJsonValue;
 
   public VariableRecord() {
-    super(9);
+    super(10);
     declareProperty(nameProp)
         .declareProperty(valueProp)
         .declareProperty(scopeKeyProp)
@@ -67,7 +70,8 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
         .declareProperty(bpmnProcessIdProp)
         .declareProperty(tenantIdProp)
         .declareProperty(rootProcessInstanceKeyProp)
-        .declareProperty(sourceProp);
+        .declareProperty(sourceProp)
+        .declareProperty(ordinalKeyProp);
   }
 
   @Override
@@ -188,6 +192,16 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
 
   public VariableRecord setTenantId(final String tenantId) {
     tenantIdProp.setValue(tenantId);
+    return this;
+  }
+
+  @Override
+  public int getOrdinalKey() {
+    return ordinalKeyProp.getValue();
+  }
+
+  public VariableRecord setOrdinalKey(final int ordinal) {
+    ordinalKeyProp.setValue(ordinal);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -878,6 +878,7 @@ final class JsonSerializableToJsonTest {
                       "timeout": -1,
                       "tenantId": "<default>",
                       "rootProcessInstanceKey": 4321,
+                      "ordinalKey": 0,
                       "changedAttributes": ["bar", "foo"],
                       "tags": ["tag1", "tag2"],
                       "jobToUserTaskMigration": true,
@@ -1032,6 +1033,7 @@ final class JsonSerializableToJsonTest {
                       .setResult(result)
                       .setTags(Set.of("tag1", "tag2"))
                       .setRootProcessInstanceKey(rootProcessInstanceKey)
+                      .setOrdinalKey(5001)
                       .setIsJobToUserTaskMigration(true);
 
               record.setCustomHeaders(wrapArray(MsgPackConverter.convertToMsgPack(customHeaders)));
@@ -1064,6 +1066,7 @@ final class JsonSerializableToJsonTest {
                   "timeout": 14,
                   "tenantId": "<default>",
                   "rootProcessInstanceKey": 4321,
+                  "ordinalKey": 5001,
                   "tags": ["tag1", "tag2"],
                   "jobToUserTaskMigration": true,
                   "changedAttributes": ["bar", "foo"],
@@ -1139,6 +1142,7 @@ final class JsonSerializableToJsonTest {
                   "timeout": -1,
                   "tenantId": "<default>",
                   "rootProcessInstanceKey": -1,
+                  "ordinalKey": 0,
                   "tags": [],
                   "jobToUserTaskMigration": false,
                   "changedAttributes": [],
@@ -1199,6 +1203,7 @@ final class JsonSerializableToJsonTest {
                   "customHeaders": {},
                   "tenantId": "<default>",
                   "rootProcessInstanceKey": -1,
+                  "ordinalKey": 0,
                   "tags": [],
                   "jobToUserTaskMigration": false,
                   "changedAttributes": [],
@@ -1411,7 +1416,8 @@ final class JsonSerializableToJsonTest {
                     "foo": "bar"
                   },
                   "interrupting": true,
-                  "tenantId": "<default>"
+                  "tenantId": "<default>",
+                  "ordinalKey": 0
                 }
                 """
       },
@@ -1441,7 +1447,8 @@ final class JsonSerializableToJsonTest {
                   "messageKey": -1,
                   "variables": {},
                   "interrupting": true,
-                  "tenantId": "<default>"
+                  "tenantId": "<default>",
+                  "ordinalKey": 0
                 }
                 """
       },
@@ -1493,7 +1500,8 @@ final class JsonSerializableToJsonTest {
                   "elementId": "A",
                   "interrupting": true,
                   "tenantId": "<default>",
-                  "rootProcessInstanceKey": 5678
+                  "rootProcessInstanceKey": 5678,
+                  "ordinalKey": 0
                 }
                 """
       },
@@ -1527,7 +1535,8 @@ final class JsonSerializableToJsonTest {
                   "elementId": "",
                   "interrupting": true,
                   "tenantId": "<default>",
-                  "rootProcessInstanceKey": -1
+                  "rootProcessInstanceKey": -1,
+                  "ordinalKey": 0
                 }
                 """
       },
@@ -1608,6 +1617,7 @@ final class JsonSerializableToJsonTest {
                   "tenantId": "<default>",
                   "rootProcessInstanceKey": 5,
                   "elementInstanceKey": 3,
+                  "ordinalKey": 0,
                   "source": {
                     "type":"API"
                   }
@@ -1651,6 +1661,7 @@ final class JsonSerializableToJsonTest {
                   "tenantId": "tenant-test",
                   "rootProcessInstanceKey": 5,
                   "elementInstanceKey": 3,
+                  "ordinalKey": 0,
                   "source": {
                     "type":"API"
                   }
@@ -1761,7 +1772,8 @@ final class JsonSerializableToJsonTest {
                   "tags": ["tag1", "tag2"],
                   "rootProcessInstanceKey": 3,
                   "businessId": "business-id-456",
-                  "elementInstanceKey": -1
+                  "elementInstanceKey": -1,
+                  "ordinalKey": 0
                 }
                 """
       },
@@ -1787,7 +1799,8 @@ final class JsonSerializableToJsonTest {
                   "tags": [],
                   "rootProcessInstanceKey": -1,
                   "businessId": "",
-                  "elementInstanceKey": -1
+                  "elementInstanceKey": -1,
+                  "ordinalKey": 0
                 }
                 """
       },
@@ -1877,7 +1890,8 @@ final class JsonSerializableToJsonTest {
                   "rootProcessInstanceKey": 4,
                   "processDefinitionKey": 5,
                   "bpmnProcessId": "bpmnProcessId",
-                  "elementInstanceKey": -1
+                  "elementInstanceKey": -1,
+                  "ordinalKey": 0
                 }
                 """
       },
@@ -1902,7 +1916,8 @@ final class JsonSerializableToJsonTest {
                   "rootProcessInstanceKey": -1,
                   "processDefinitionKey": -1,
                   "bpmnProcessId": "",
-                  "elementInstanceKey": -1
+                  "elementInstanceKey": -1,
+                  "ordinalKey": 0
                 }
                 """
       },
@@ -1966,7 +1981,8 @@ final class JsonSerializableToJsonTest {
                   "tags": ["tag1", "tag2"],
                   "rootProcessInstanceKey": 9999,
                   "businessId": "business-id-123",
-                  "elementInstanceKey": -1
+                  "elementInstanceKey": -1,
+                  "ordinalKey": 0
                 }
                 """
       },
@@ -1998,7 +2014,8 @@ final class JsonSerializableToJsonTest {
                   "tags": [],
                   "rootProcessInstanceKey": -1,
                   "businessId": "",
-                  "elementInstanceKey": -1
+                  "elementInstanceKey": -1,
+                  "ordinalKey": 0
                 }
                 """
       },
@@ -2865,7 +2882,8 @@ final class JsonSerializableToJsonTest {
                   "tags": [],
                   "deniedReason": "Reason to deny lifecycle transition",
                   "listenersConfigKey": 42,
-                  "rootProcessInstanceKey": 4321
+                  "rootProcessInstanceKey": 4321,
+                  "ordinalKey": 0
                 }
                 """
       },
@@ -2904,7 +2922,8 @@ final class JsonSerializableToJsonTest {
                   "tags": [],
                   "deniedReason": "",
                   "listenersConfigKey": -1,
-                  "rootProcessInstanceKey": -1
+                  "rootProcessInstanceKey": -1,
+                  "ordinalKey": 0
                 }
                 """
       },
@@ -2948,7 +2967,8 @@ final class JsonSerializableToJsonTest {
                   "tags": [],
                   "deniedReason": "",
                   "listenersConfigKey": -1,
-                  "rootProcessInstanceKey": -1
+                  "rootProcessInstanceKey": -1,
+                  "ordinalKey": 0
                 }
                 """
       },
@@ -2997,7 +3017,8 @@ final class JsonSerializableToJsonTest {
                   "rootProcessInstanceKey": 321,
                   "processDefinitionKey": 234,
                   "bpmnProcessId": "bpmnProcessId",
-                  "elementInstanceKey": -1
+                  "elementInstanceKey": -1,
+                  "ordinalKey": 0
                 }
                 """
       },
@@ -3023,7 +3044,8 @@ final class JsonSerializableToJsonTest {
                   "rootProcessInstanceKey": -1,
                   "processDefinitionKey": -1,
                   "bpmnProcessId": "",
-                  "elementInstanceKey": -1
+                  "elementInstanceKey": -1,
+                  "ordinalKey": 0
                 }
                 """
       },

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/JobRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/JobRecord.golden
@@ -39,6 +39,17 @@ import org.agrona.concurrent.UnsafeBuffer;
 
 public final class JobRecord extends UnifiedRecordValue implements JobRecordValue {
 
+  /**
+   * The worker type prefix for Camunda Agentic AI jobs that are set in Camunda Connectors.
+   *
+   * <p>For 8.9 this is accepted as limitation that all agentic jobs must have this prefix in order
+   * to be categorized as agentic jobs.
+   *
+   * <p>In the future, we might want to introduce a more robust way of identifying agentic jobs
+   */
+  public static final String IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX =
+      "io.camunda.agenticai:aiagent";
+
   public static final DirectBuffer NO_HEADERS = new UnsafeBuffer(MsgPackHelper.EMTPY_OBJECT);
   public static final String RETRIES = "retries";
   public static final String TIMEOUT = "timeout";
@@ -47,7 +58,6 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   private static final String CUSTOM_HEADERS = "customHeaders";
   private static final String VARIABLES = "variables";
   private static final String ERROR_MESSAGE = "errorMessage";
-
   // Static StringValue keys to avoid memory waste
   private static final StringValue TYPE_KEY = new StringValue(TYPE);
   private static final StringValue WORKER_KEY = new StringValue("worker");
@@ -77,6 +87,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
       new StringValue("isUserTaskMigration");
   private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
       new StringValue("rootProcessInstanceKey");
+  private static final StringValue ORDINAL_KEY_KEY = new StringValue("ordinalKey");
   private final StringProperty typeProp = new StringProperty(TYPE_KEY, EMPTY_STRING);
   private final StringProperty workerProp = new StringProperty(WORKER_KEY, EMPTY_STRING);
   private final LongProperty deadlineProp = new LongProperty(DEADLINE_KEY, -1);
@@ -119,9 +130,10 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
       new BooleanProperty(IS_JOB_TO_USERTASK_MIGRATION_KEY, false);
   private final LongProperty rootProcessInstanceKeyProp =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1L);
+  private final IntegerProperty ordinalKeyProp = new IntegerProperty(ORDINAL_KEY_KEY, 0);
 
   public JobRecord() {
-    super(24);
+    super(25);
     declareProperty(deadlineProp)
         .declareProperty(timeoutProp)
         .declareProperty(workerProp)
@@ -146,7 +158,8 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
         .declareProperty(resultProp)
         .declareProperty(tagsProp)
         .declareProperty(isJobToUserTaskMigrationProp)
-        .declareProperty(rootProcessInstanceKeyProp);
+        .declareProperty(rootProcessInstanceKeyProp)
+        .declareProperty(ordinalKeyProp);
   }
 
   public void wrapWithoutVariables(final JobRecord record) {
@@ -176,6 +189,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
 
     setTags(record.getTags());
     rootProcessInstanceKeyProp.setValue(record.getRootProcessInstanceKey());
+    ordinalKeyProp.setValue(record.getOrdinalKey());
   }
 
   public void wrap(final JobRecord record) {
@@ -264,6 +278,11 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   }
 
   @Override
+  public long getRootProcessInstanceKey() {
+    return rootProcessInstanceKeyProp.getValue();
+  }
+
+  @Override
   public String getBpmnProcessId() {
     return bufferAsString(bpmnProcessIdProp.getValue());
   }
@@ -346,16 +365,6 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
     return isJobToUserTaskMigrationProp.getValue();
   }
 
-  @Override
-  public long getRootProcessInstanceKey() {
-    return rootProcessInstanceKeyProp.getValue();
-  }
-
-  public JobRecord setRootProcessInstanceKey(final long rootProcessInstanceKey) {
-    rootProcessInstanceKeyProp.setValue(rootProcessInstanceKey);
-    return this;
-  }
-
   public JobRecord setProcessDefinitionVersion(final int version) {
     processDefinitionVersionProp.setValue(version);
     return this;
@@ -368,6 +377,11 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
 
   public JobRecord setBpmnProcessId(final DirectBuffer bpmnProcessId) {
     bpmnProcessIdProp.setValue(bpmnProcessId);
+    return this;
+  }
+
+  public JobRecord setRootProcessInstanceKey(final long rootProcessInstanceKey) {
+    rootProcessInstanceKeyProp.setValue(rootProcessInstanceKey);
     return this;
   }
 
@@ -445,6 +459,16 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
 
   public JobRecord setType(final DirectBuffer buf) {
     return setType(buf, 0, buf.capacity());
+  }
+
+  @Override
+  public int getOrdinalKey() {
+    return ordinalKeyProp.getValue();
+  }
+
+  public JobRecord setOrdinalKey(final int ordinal) {
+    ordinalKeyProp.setValue(ordinal);
+    return this;
   }
 
   public JobRecord setListenerEventType(final JobListenerEventType jobListenerEventType) {
@@ -535,5 +559,10 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   public JobRecord setTenantId(final String tenantId) {
     tenantIdProp.setValue(tenantId);
     return this;
+  }
+
+  @JsonIgnore
+  public boolean isAgentic() {
+    return getType().startsWith(IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX);
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/MessageSubscriptionRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/MessageSubscriptionRecord.golden
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.BooleanProperty;
 import io.camunda.zeebe.msgpack.property.DocumentProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
@@ -37,6 +38,7 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
   private static final StringValue INTERRUPTING_KEY = new StringValue("interrupting");
   private static final StringValue VARIABLES_KEY = new StringValue("variables");
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
+  private static final StringValue ORDINAL_KEY_KEY = new StringValue("ordinalKey");
 
   private final LongProperty processInstanceKeyProp = new LongProperty(PROCESS_INSTANCE_KEY_KEY);
   private final LongProperty elementInstanceKeyProp = new LongProperty(ELEMENT_INSTANCE_KEY_KEY);
@@ -51,9 +53,10 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
   private final DocumentProperty variablesProp = new DocumentProperty(VARIABLES_KEY);
   private final StringProperty tenantIdProp =
       new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  private final IntegerProperty ordinalKeyProperty = new IntegerProperty(ORDINAL_KEY_KEY, 0);
 
   public MessageSubscriptionRecord() {
-    super(10);
+    super(11);
     declareProperty(processInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
         .declareProperty(processDefinitionKeyProp)
@@ -63,7 +66,8 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
         .declareProperty(interruptingProp)
         .declareProperty(bpmnProcessIdProp)
         .declareProperty(variablesProp)
-        .declareProperty(tenantIdProp);
+        .declareProperty(tenantIdProp)
+        .declareProperty(ordinalKeyProperty);
   }
 
   public void wrap(final MessageSubscriptionRecord record) {
@@ -77,6 +81,7 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
     setBpmnProcessId(record.getBpmnProcessIdBuffer());
     setVariables(record.getVariablesBuffer());
     setTenantId(record.getTenantId());
+    setOrdinalKey(record.getOrdinalKey());
   }
 
   @JsonIgnore
@@ -196,6 +201,16 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
 
   public MessageSubscriptionRecord setTenantId(final String tenantId) {
     tenantIdProp.setValue(tenantId);
+    return this;
+  }
+
+  @Override
+  public int getOrdinalKey() {
+    return ordinalKeyProperty.getValue();
+  }
+
+  public MessageSubscriptionRecord setOrdinalKey(final int ordinal) {
+    ordinalKeyProperty.setValue(ordinal);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceCreationRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceCreationRecord.golden
@@ -48,6 +48,7 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
   private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
       new StringValue("rootProcessInstanceKey");
   private static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
+  private static final StringValue ORDINAL_KEY_KEY = new StringValue("ordinalKey");
 
   private final StringProperty bpmnProcessIdProperty = new StringProperty(BPMN_PROCESS_ID_KEY, "");
   private final LongProperty processDefinitionKeyProperty =
@@ -72,9 +73,10 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
   private final LongProperty rootProcessInstanceKeyProperty =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1);
   private final StringProperty businessIdProperty = new StringProperty(BUSINESS_ID_KEY, "");
+  private final IntegerProperty ordinalKeyProperty = new IntegerProperty(ORDINAL_KEY_KEY, 0);
 
   public ProcessInstanceCreationRecord() {
-    super(12);
+    super(13);
     declareProperty(bpmnProcessIdProperty)
         .declareProperty(processDefinitionKeyProperty)
         .declareProperty(processInstanceKeyProperty)
@@ -86,12 +88,8 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
         .declareProperty(tenantIdProperty)
         .declareProperty(tagsProperty)
         .declareProperty(rootProcessInstanceKeyProperty)
-        .declareProperty(businessIdProperty);
-  }
-
-  @Override
-  public String getBpmnProcessId() {
-    return BufferUtil.bufferAsString(bpmnProcessIdProperty.getValue());
+        .declareProperty(businessIdProperty)
+        .declareProperty(ordinalKeyProperty);
   }
 
   @Override
@@ -159,10 +157,9 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
     return rootProcessInstanceKeyProperty.getValue();
   }
 
-  public ProcessInstanceCreationRecord setRootProcessInstanceKey(
-      final long rootProcessInstanceKey) {
-    rootProcessInstanceKeyProperty.setValue(rootProcessInstanceKey);
-    return this;
+  @Override
+  public String getBpmnProcessId() {
+    return BufferUtil.bufferAsString(bpmnProcessIdProperty.getValue());
   }
 
   @Override
@@ -180,11 +177,6 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
     return this;
   }
 
-  public ProcessInstanceCreationRecord setVersion(final int version) {
-    versionProperty.setValue(version);
-    return this;
-  }
-
   public ProcessInstanceCreationRecord setBpmnProcessId(final String bpmnProcessId) {
     bpmnProcessIdProperty.setValue(bpmnProcessId);
     return this;
@@ -193,6 +185,31 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
   public ProcessInstanceCreationRecord setBpmnProcessId(final DirectBuffer bpmnProcessId) {
     bpmnProcessIdProperty.setValue(bpmnProcessId);
     return this;
+  }
+
+  public ProcessInstanceCreationRecord setRootProcessInstanceKey(
+      final long rootProcessInstanceKey) {
+    rootProcessInstanceKeyProperty.setValue(rootProcessInstanceKey);
+    return this;
+  }
+
+  public ProcessInstanceCreationRecord setVersion(final int version) {
+    versionProperty.setValue(version);
+    return this;
+  }
+
+  @Override
+  public int getOrdinalKey() {
+    return ordinalKeyProperty.getValue();
+  }
+
+  public ProcessInstanceCreationRecord setOrdinalKey(final int ordinal) {
+    ordinalKeyProperty.setValue(ordinal);
+    return this;
+  }
+
+  public boolean hasBusinessId() {
+    return businessIdProperty.getValue().capacity() > 0;
   }
 
   @JsonIgnore

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceMigrationRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceMigrationRecord.golden
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
@@ -34,6 +35,7 @@ public final class ProcessInstanceMigrationRecord extends UnifiedRecordValue
   private static final StringValue PROCESS_DEFINITION_KEY_KEY =
       new StringValue("processDefinitionKey");
   private static final StringValue BPMN_PROCESS_ID_KEY = new StringValue("bpmnProcessId");
+  private static final StringValue ORDINAL_KEY_KEY = new StringValue("ordinalKey");
   private final LongProperty processInstanceKeyProperty =
       new LongProperty(PROCESS_INSTANCE_KEY_KEY);
   private final LongProperty targetProcessDefinitionKeyProperty =
@@ -50,16 +52,18 @@ public final class ProcessInstanceMigrationRecord extends UnifiedRecordValue
   private final LongProperty processDefinitionKeyProperty =
       new LongProperty(PROCESS_DEFINITION_KEY_KEY, -1L);
   private final StringProperty bpmnProcessIdProperty = new StringProperty(BPMN_PROCESS_ID_KEY, "");
+  private final IntegerProperty ordinalKeyProperty = new IntegerProperty(ORDINAL_KEY_KEY, 0);
 
   public ProcessInstanceMigrationRecord() {
-    super(7);
+    super(8);
     declareProperty(processInstanceKeyProperty)
         .declareProperty(targetProcessDefinitionKeyProperty)
         .declareProperty(mappingInstructionsProperty)
         .declareProperty(tenantIdProperty)
         .declareProperty(rootProcessInstanceKeyProperty)
         .declareProperty(processDefinitionKeyProperty)
-        .declareProperty(bpmnProcessIdProperty);
+        .declareProperty(bpmnProcessIdProperty)
+        .declareProperty(ordinalKeyProperty);
   }
 
   @Override
@@ -124,6 +128,16 @@ public final class ProcessInstanceMigrationRecord extends UnifiedRecordValue
     return this;
   }
 
+  @Override
+  public String getBpmnProcessId() {
+    return bufferAsString(bpmnProcessIdProperty.getValue());
+  }
+
+  public ProcessInstanceMigrationRecord setBpmnProcessId(final String bpmnProcessId) {
+    bpmnProcessIdProperty.setValue(bpmnProcessId);
+    return this;
+  }
+
   /** Returns true if this record has mapping instructions, otherwise false. */
   @JsonIgnore
   public boolean hasMappingInstructions() {
@@ -147,12 +161,12 @@ public final class ProcessInstanceMigrationRecord extends UnifiedRecordValue
   }
 
   @Override
-  public String getBpmnProcessId() {
-    return bufferAsString(bpmnProcessIdProperty.getValue());
+  public int getOrdinalKey() {
+    return ordinalKeyProperty.getValue();
   }
 
-  public ProcessInstanceMigrationRecord setBpmnProcessId(final String bpmnProcessId) {
-    bpmnProcessIdProperty.setValue(bpmnProcessId);
+  public ProcessInstanceMigrationRecord setOrdinalKey(final int ordinal) {
+    ordinalKeyProperty.setValue(ordinal);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceModificationRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceModificationRecord.golden
@@ -9,6 +9,7 @@ package io.camunda.zeebe.protocol.impl.record.value.processinstance;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.LongValue;
@@ -40,6 +41,7 @@ public final class ProcessInstanceModificationRecord extends UnifiedRecordValue
   private static final StringValue PROCESS_DEFINITION_KEY_KEY =
       new StringValue("processDefinitionKey");
   private static final StringValue BPMN_PROCESS_ID_KEY = new StringValue("bpmnProcessId");
+  private static final StringValue ORDINAL_KEY_KEY = new StringValue("ordinalKey");
 
   private final LongProperty processInstanceKeyProperty =
       new LongProperty(PROCESS_INSTANCE_KEY_KEY);
@@ -64,9 +66,10 @@ public final class ProcessInstanceModificationRecord extends UnifiedRecordValue
       new ArrayProperty<>(ACTIVATED_ELEMENT_INSTANCE_KEYS_KEY, LongValue::new);
   private final LongProperty rootProcessInstanceKeyProperty =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1);
+  private final IntegerProperty ordinalKeyProperty = new IntegerProperty(ORDINAL_KEY_KEY, 0);
 
   public ProcessInstanceModificationRecord() {
-    super(9);
+    super(10);
     declareProperty(processInstanceKeyProperty)
         .declareProperty(terminateInstructionsProperty)
         .declareProperty(activateInstructionsProperty)
@@ -75,7 +78,8 @@ public final class ProcessInstanceModificationRecord extends UnifiedRecordValue
         .declareProperty(tenantIdProp)
         .declareProperty(rootProcessInstanceKeyProperty)
         .declareProperty(processDefinitionKeyProperty)
-        .declareProperty(bpmnProcessIdProperty);
+        .declareProperty(bpmnProcessIdProperty)
+        .declareProperty(ordinalKeyProperty);
   }
 
   /**
@@ -251,6 +255,16 @@ public final class ProcessInstanceModificationRecord extends UnifiedRecordValue
 
   public ProcessInstanceModificationRecord setTenantId(final String tenantId) {
     tenantIdProp.setValue(tenantId);
+    return this;
+  }
+
+  @Override
+  public int getOrdinalKey() {
+    return ordinalKeyProperty.getValue();
+  }
+
+  public ProcessInstanceModificationRecord setOrdinalKey(final int ordinal) {
+    ordinalKeyProperty.setValue(ordinal);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceRecord.golden
@@ -59,6 +59,7 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
   public static final StringValue ROOT_PROCESS_INSTANCE_KEY =
       new StringValue("rootProcessInstanceKey");
   public static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
+  public static final StringValue ORDINAL_KEY_KEY = new StringValue("ordinalKey");
 
   private final StringProperty bpmnProcessIdProp = new StringProperty(BPMN_PROCESS_ID_KEY, "");
   private final IntegerProperty versionProp = new IntegerProperty(VERSION_KEY, -1);
@@ -99,8 +100,10 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
 
   private final StringProperty businessIdProp = new StringProperty(BUSINESS_ID_KEY, "");
 
+  private final IntegerProperty ordinalKeyProp = new IntegerProperty(ORDINAL_KEY_KEY, 0);
+
   public ProcessInstanceRecord() {
-    super(17);
+    super(18);
     declareProperty(bpmnElementTypeProp)
         .declareProperty(elementIdProp)
         .declareProperty(bpmnProcessIdProp)
@@ -117,7 +120,8 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
         .declareProperty(callingElementPathProp)
         .declareProperty(tagsProp)
         .declareProperty(rootProcessInstanceKeyProp)
-        .declareProperty(businessIdProp);
+        .declareProperty(businessIdProp)
+        .declareProperty(ordinalKeyProp);
   }
 
   public void wrap(final ProcessInstanceRecord record) {
@@ -134,6 +138,7 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
     tenantIdProp.setValue(record.getTenantId());
     rootProcessInstanceKeyProp.setValue(record.getRootProcessInstanceKey());
     businessIdProp.setValue(record.getBusinessId());
+    ordinalKeyProp.setValue(record.getOrdinalKey());
   }
 
   @JsonIgnore
@@ -163,18 +168,13 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
   }
 
   @Override
-  public long getProcessDefinitionKey() {
-    return processDefinitionKeyProp.getValue();
-  }
-
-  @Override
   public long getProcessInstanceKey() {
     return processInstanceKeyProp.getValue();
   }
 
-  public ProcessInstanceRecord setProcessInstanceKey(final long processInstanceKey) {
-    processInstanceKeyProp.setValue(processInstanceKey);
-    return this;
+  @Override
+  public long getProcessDefinitionKey() {
+    return processDefinitionKeyProp.getValue();
   }
 
   @Override
@@ -219,13 +219,14 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
 
   @Override
   public List<List<Long>> getElementInstancePath() {
-    final var elementInstancePath = new ArrayList<List<Long>>();
-    elementInstancePathProp.forEach(
-        pe -> {
-          final var pathEntry = new ArrayList<Long>();
-          pe.forEach(e -> pathEntry.add(e.getValue()));
-          elementInstancePath.add(pathEntry);
-        });
+    final var elementInstancePath = new ArrayList<List<Long>>(elementInstancePathProp.size());
+    for (final var pe : elementInstancePathProp) {
+      final var pathEntry = new ArrayList<Long>(pe.size());
+      for (final var e : pe) {
+        pathEntry.add(e.getValue());
+      }
+      elementInstancePath.add(pathEntry);
+    }
     return elementInstancePath;
   }
 
@@ -291,6 +292,21 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
     return this;
   }
 
+  @Override
+  public String getBusinessId() {
+    return bufferAsString(businessIdProp.getValue());
+  }
+
+  public ProcessInstanceRecord setBusinessId(final String businessId) {
+    businessIdProp.setValue(businessId);
+    return this;
+  }
+
+  public ProcessInstanceRecord setBusinessId(final DirectBuffer businessId) {
+    businessIdProp.setValue(businessId);
+    return this;
+  }
+
   public ProcessInstanceRecord setParentProcessInstanceKey(final long parentProcessInstanceKey) {
     parentProcessInstanceKeyProp.setValue(parentProcessInstanceKey);
     return this;
@@ -320,6 +336,11 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
     return this;
   }
 
+  public ProcessInstanceRecord setProcessInstanceKey(final long processInstanceKey) {
+    processInstanceKeyProp.setValue(processInstanceKey);
+    return this;
+  }
+
   public ProcessInstanceRecord setVersion(final int version) {
     versionProp.setValue(version);
     return this;
@@ -332,6 +353,16 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
 
   public ProcessInstanceRecord setBpmnProcessId(final DirectBuffer directBuffer) {
     bpmnProcessIdProp.setValue(directBuffer);
+    return this;
+  }
+
+  @Override
+  public int getOrdinalKey() {
+    return ordinalKeyProp.getValue();
+  }
+
+  public ProcessInstanceRecord setOrdinalKey(final int ordinal) {
+    ordinalKeyProp.setValue(ordinal);
     return this;
   }
 
@@ -350,7 +381,7 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
     return this;
   }
 
-  public boolean hasParentProcess() {
+  public boolean hasParentProcessInstance() {
     return getParentProcessInstanceKey() != -1L;
   }
 
@@ -367,21 +398,6 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
 
   public ProcessInstanceRecord setTenantId(final String tenantId) {
     tenantIdProp.setValue(tenantId);
-    return this;
-  }
-
-  @Override
-  public String getBusinessId() {
-    return bufferAsString(businessIdProp.getValue());
-  }
-
-  public ProcessInstanceRecord setBusinessId(final String businessId) {
-    businessIdProp.setValue(businessId);
-    return this;
-  }
-
-  public ProcessInstanceRecord setBusinessId(final DirectBuffer businessId) {
-    businessIdProp.setValue(businessId);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessMessageSubscriptionRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessMessageSubscriptionRecord.golden
@@ -42,6 +42,7 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
   private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
       new StringValue("rootProcessInstanceKey");
+  private static final StringValue ORDINAL_KEY_KEY = new StringValue("ordinalKey");
 
   private final IntegerProperty subscriptionPartitionIdProp =
       new IntegerProperty(SUBSCRIPTION_PARTITION_ID_KEY);
@@ -60,9 +61,10 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
       new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   private final LongProperty rootProcessInstanceKeyProp =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1L);
+  private final IntegerProperty ordinalKeyProperty = new IntegerProperty(ORDINAL_KEY_KEY, 0);
 
   public ProcessMessageSubscriptionRecord() {
-    super(13);
+    super(14);
     declareProperty(subscriptionPartitionIdProp)
         .declareProperty(processInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
@@ -75,7 +77,8 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
         .declareProperty(correlationKeyProp)
         .declareProperty(elementIdProp)
         .declareProperty(tenantIdProp)
-        .declareProperty(rootProcessInstanceKeyProp);
+        .declareProperty(rootProcessInstanceKeyProp)
+        .declareProperty(ordinalKeyProperty);
   }
 
   public void wrap(final ProcessMessageSubscriptionRecord record) {
@@ -92,6 +95,7 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
     setElementId(record.getElementIdBuffer());
     setTenantId(record.getTenantId());
     setRootProcessInstanceKey(record.getRootProcessInstanceKey());
+    setOrdinalKey(record.getOrdinalKey());
   }
 
   @JsonIgnore
@@ -246,6 +250,16 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
 
   public ProcessMessageSubscriptionRecord setTenantId(final String tenantId) {
     tenantIdProp.setValue(tenantId);
+    return this;
+  }
+
+  @Override
+  public int getOrdinalKey() {
+    return ordinalKeyProperty.getValue();
+  }
+
+  public ProcessMessageSubscriptionRecord setOrdinalKey(final int ordinal) {
+    ordinalKeyProperty.setValue(ordinal);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/UserTaskRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/UserTaskRecord.golden
@@ -58,6 +58,7 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
   private static final StringValue VARIABLES_VALUE = new StringValue(VARIABLES);
   private static final StringValue ROOT_PROCESS_INSTANCE_KEY_VALUE =
       new StringValue("rootProcessInstanceKey");
+  private static final StringValue ORDINAL_KEY_KEY = new StringValue("ordinalKey");
 
   /**
    * Defines the mapping between names of attributes that may be modified (updated or corrected) and
@@ -111,6 +112,7 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   private final LongProperty rootProcessInstanceKeyProp =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_VALUE, -1L);
+  private final IntegerProperty ordinalKeyProp = new IntegerProperty(ORDINAL_KEY_KEY, 0);
 
   /**
    * Tracks the names of user task attributes that are intended to be modified (e.g. on `UPDATE`),
@@ -155,7 +157,7 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
   private final LongProperty listenersConfigKeyProp = new LongProperty("listenersConfigKey", -1L);
 
   public UserTaskRecord() {
-    super(25);
+    super(26);
     declareProperty(userTaskKeyProp)
         .declareProperty(assigneeProp)
         .declareProperty(candidateGroupsListProp)
@@ -180,7 +182,8 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
         .declareProperty(deniedReasonProp)
         .declareProperty(tagsProp)
         .declareProperty(listenersConfigKeyProp)
-        .declareProperty(rootProcessInstanceKeyProp);
+        .declareProperty(rootProcessInstanceKeyProp)
+        .declareProperty(ordinalKeyProp);
   }
 
   /** Like {@link #wrap(UserTaskRecord)} but does not set the variables. */
@@ -210,6 +213,7 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
     setTags(record.getTags());
     listenersConfigKeyProp.setValue(record.getListenersConfigKey());
     rootProcessInstanceKeyProp.setValue(record.getRootProcessInstanceKey());
+    ordinalKeyProp.setValue(record.getOrdinalKey());
   }
 
   /**
@@ -408,6 +412,11 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
   }
 
   @Override
+  public long getRootProcessInstanceKey() {
+    return rootProcessInstanceKeyProp.getValue();
+  }
+
+  @Override
   public String getBpmnProcessId() {
     return bufferAsString(bpmnProcessIdProp.getValue());
   }
@@ -453,16 +462,6 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
     return this;
   }
 
-  @Override
-  public long getRootProcessInstanceKey() {
-    return rootProcessInstanceKeyProp.getValue();
-  }
-
-  public UserTaskRecord setRootProcessInstanceKey(final long rootProcessInstanceKey) {
-    rootProcessInstanceKeyProp.setValue(rootProcessInstanceKey);
-    return this;
-  }
-
   public UserTaskRecord setProcessDefinitionVersion(final int version) {
     processDefinitionVersionProp.setValue(version);
     return this;
@@ -475,6 +474,11 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
 
   public UserTaskRecord setBpmnProcessId(final DirectBuffer bpmnProcessId) {
     bpmnProcessIdProp.setValue(bpmnProcessId);
+    return this;
+  }
+
+  public UserTaskRecord setRootProcessInstanceKey(final long rootProcessInstanceKey) {
+    rootProcessInstanceKeyProp.setValue(rootProcessInstanceKey);
     return this;
   }
 
@@ -580,6 +584,16 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
 
   public UserTaskRecord setUserTaskKey(final long userTaskKey) {
     userTaskKeyProp.setValue(userTaskKey);
+    return this;
+  }
+
+  @Override
+  public int getOrdinalKey() {
+    return ordinalKeyProp.getValue();
+  }
+
+  public UserTaskRecord setOrdinalKey(final int ordinal) {
+    ordinalKeyProp.setValue(ordinal);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/VariableRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/VariableRecord.golden
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.BinaryProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.ObjectProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
@@ -36,6 +37,7 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
   private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
       new StringValue("rootProcessInstanceKey");
   private static final StringValue SOURCE_KEY = new StringValue("source");
+  private static final StringValue ORDINAL_KEY_KEY = new StringValue("ordinalKey");
 
   private final StringProperty nameProp = new StringProperty(NAME_KEY);
   private final BinaryProperty valueProp = new BinaryProperty(VALUE_KEY);
@@ -50,9 +52,16 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1L);
   private final ObjectProperty<VariableSourceRecord> sourceProp =
       new ObjectProperty<>(SOURCE_KEY, new VariableSourceRecord());
+  private final IntegerProperty ordinalKeyProp = new IntegerProperty(ORDINAL_KEY_KEY, 0);
+
+  /**
+   * Cached JSON representation of the value. Lazily computed on first call to {@link #getValue()}
+   * and invalidated when the underlying value changes via {@link #setValue} or {@link #wrap}.
+   */
+  private String cachedJsonValue;
 
   public VariableRecord() {
-    super(9);
+    super(10);
     declareProperty(nameProp)
         .declareProperty(valueProp)
         .declareProperty(scopeKeyProp)
@@ -61,7 +70,14 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
         .declareProperty(bpmnProcessIdProp)
         .declareProperty(tenantIdProp)
         .declareProperty(rootProcessInstanceKeyProp)
-        .declareProperty(sourceProp);
+        .declareProperty(sourceProp)
+        .declareProperty(ordinalKeyProp);
+  }
+
+  @Override
+  public void reset() {
+    super.reset();
+    cachedJsonValue = null;
   }
 
   @Override
@@ -71,7 +87,10 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
 
   @Override
   public String getValue() {
-    return MsgPackConverter.convertToJson(valueProp.getValue());
+    if (cachedJsonValue == null) {
+      cachedJsonValue = MsgPackConverter.convertToJson(valueProp.getValue());
+    }
+    return cachedJsonValue;
   }
 
   @Override
@@ -136,6 +155,7 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
 
   public VariableRecord setValue(final DirectBuffer value) {
     valueProp.setValue(value);
+    cachedJsonValue = null;
     return this;
   }
 
@@ -146,6 +166,7 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
 
   public VariableRecord setValue(final DirectBuffer value, final int offset, final int length) {
     valueProp.setValue(value, offset, length);
+    cachedJsonValue = null;
     return this;
   }
 
@@ -171,6 +192,16 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
 
   public VariableRecord setTenantId(final String tenantId) {
     tenantIdProp.setValue(tenantId);
+    return this;
+  }
+
+  @Override
+  public int getOrdinalKey() {
+    return ordinalKeyProp.getValue();
+  }
+
+  public VariableRecord setOrdinalKey(final int ordinal) {
+    ordinalKeyProp.setValue(ordinal);
     return this;
   }
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobRecordValue.java
@@ -34,6 +34,7 @@ public interface JobRecordValue
     extends RecordValueWithVariables,
         ProcessInstanceRelated,
         AuditLogProcessInstanceRelated,
+        OrdinalKeyBased,
         TenantOwned {
 
   /**
@@ -106,6 +107,18 @@ public interface JobRecordValue
   long getElementInstanceKey();
 
   /**
+   * Returns the key of the root process instance in the hierarchy. For jobs in top-level process
+   * instances, this is equal to {@link #getProcessInstanceKey()}. For jobs in child process
+   * instances (created via call activities), this is the key of the topmost parent process
+   * instance.
+   *
+   * @return the key of the root process instance, or {@code -1L} if not set for versions prior to
+   *     8.9
+   */
+  @Override
+  long getRootProcessInstanceKey();
+
+  /**
    * @return the bpmn process id of the corresponding process definition
    */
   @Override
@@ -146,17 +159,6 @@ public interface JobRecordValue
    * @return true if the job is part of a user task migration
    */
   boolean isJobToUserTaskMigration();
-
-  /**
-   * Returns the key of the root process instance in the hierarchy. For jobs in top-level process
-   * instances, this is equal to {@link #getProcessInstanceKey()}. For jobs in child process
-   * instances (created via call activities), this is the key of the topmost parent process
-   * instance.
-   *
-   * @return the key of the root process instance, or {@code -1L} if not set for versions prior to
-   *     8.9
-   */
-  long getRootProcessInstanceKey();
 
   @Value.Immutable
   @ImmutableProtocol(builder = ImmutableJobResultValue.Builder.class)

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/MessageSubscriptionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/MessageSubscriptionRecordValue.java
@@ -28,7 +28,7 @@ import org.immutables.value.Value;
 @Value.Immutable
 @ImmutableProtocol(builder = ImmutableMessageSubscriptionRecordValue.Builder.class)
 public interface MessageSubscriptionRecordValue
-    extends RecordValueWithVariables, ProcessInstanceRelated, TenantOwned {
+    extends RecordValueWithVariables, ProcessInstanceRelated, OrdinalKeyBased, TenantOwned {
 
   /**
    * @return the process instance key tied to the subscription
@@ -37,14 +37,15 @@ public interface MessageSubscriptionRecordValue
   long getProcessInstanceKey();
 
   /**
+   * @return the process definition key tied to the subscription
+   */
+  @Override
+  long getProcessDefinitionKey();
+
+  /**
    * @return the element instance key tied to the subscription
    */
   long getElementInstanceKey();
-
-  /**
-   * @return the process definition key tied to the subscription
-   */
-  long getProcessDefinitionKey();
 
   /**
    * @return the BPMN process id tied to the subscription

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/OrdinalKeyBased.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/OrdinalKeyBased.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+/**
+ * Marks a {@link io.camunda.zeebe.protocol.record.RecordValue} as belonging to a logical ordinal
+ * grouping used by the exporter to route records into ordinal-scoped indices instead of the legacy
+ * main index.
+ *
+ * <p>An ordinal is a monotonic counter assigned to a root process instance at creation time and
+ * propagated to every record that participates in that instance's hierarchy.
+ *
+ * <p>The value {@code 0} is reserved to indicate that a record must be stored in the legacy (older
+ * style) main index. This applies to records that pre-date the archiverless exporter rollout, and
+ * can also be used to explicitly force a record into the main index.
+ *
+ * <p>The value {@code -1} means the record is not ordinal-controlled and does not participate in
+ * ordinal-based routing at all. TODO(yohanfernando): verify this behaviour.
+ *
+ * <p>Engine-assigned ordinals start at {@code 1}.
+ */
+public interface OrdinalKeyBased {
+
+  /**
+   * @return the ordinal this record belongs to; {@code 0} means the record must be stored in the
+   *     main index (either a legacy record or explicitly forced); {@code -1} means the record is
+   *     not ordinal-controlled
+   */
+  int getOrdinalKey();
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceCreationRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceCreationRecordValue.java
@@ -27,13 +27,8 @@ public interface ProcessInstanceCreationRecordValue
     extends RecordValueWithVariables,
         ProcessInstanceRelated,
         AuditLogProcessInstanceRelated,
+        OrdinalKeyBased,
         TenantOwned {
-  /**
-   * @return the BPMN process id to create a process from
-   */
-  @Override
-  String getBpmnProcessId();
-
   /**
    * @return the version of the BPMN process to create a process from
    */
@@ -65,7 +60,14 @@ public interface ProcessInstanceCreationRecordValue
    *
    * @return the key of the root process instance, or {@code -1} if not set
    */
+  @Override
   long getRootProcessInstanceKey();
+
+  /**
+   * @return the BPMN process id to create a process from
+   */
+  @Override
+  String getBpmnProcessId();
 
   /**
    * Returns the business id for the process instance to be created. The business id is an

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceMigrationRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceMigrationRecordValue.java
@@ -23,7 +23,11 @@ import org.immutables.value.Value;
 @Value.Immutable
 @ImmutableProtocol(builder = ImmutableProcessInstanceMigrationRecordValue.Builder.class)
 public interface ProcessInstanceMigrationRecordValue
-    extends RecordValue, ProcessInstanceRelated, AuditLogProcessInstanceRelated, TenantOwned {
+    extends RecordValue,
+        ProcessInstanceRelated,
+        AuditLogProcessInstanceRelated,
+        OrdinalKeyBased,
+        TenantOwned {
 
   /**
    * @return the key of the process definition to migrate to
@@ -46,6 +50,7 @@ public interface ProcessInstanceMigrationRecordValue
    *
    * @return the key of the root process instance, or {@code -1} if not set
    */
+  @Override
   long getRootProcessInstanceKey();
 
   /**

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceModificationRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceModificationRecordValue.java
@@ -25,7 +25,11 @@ import org.immutables.value.Value;
 @Value.Immutable
 @ImmutableProtocol(builder = ImmutableProcessInstanceModificationRecordValue.Builder.class)
 public interface ProcessInstanceModificationRecordValue
-    extends RecordValue, ProcessInstanceRelated, AuditLogProcessInstanceRelated, TenantOwned {
+    extends RecordValue,
+        ProcessInstanceRelated,
+        AuditLogProcessInstanceRelated,
+        OrdinalKeyBased,
+        TenantOwned {
 
   /** Returns a list of terminate instructions (if available), or an empty list. */
   List<ProcessInstanceModificationTerminateInstructionValue> getTerminateInstructions();
@@ -57,6 +61,7 @@ public interface ProcessInstanceModificationRecordValue
    *
    * @return the key of the root process instance, or {@code -1} if not set
    */
+  @Override
   long getRootProcessInstanceKey();
 
   @Value.Immutable

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceRecordValue.java
@@ -30,12 +30,11 @@ import org.immutables.value.Value;
 @Value.Immutable
 @ImmutableProtocol(builder = ImmutableProcessInstanceRecordValue.Builder.class)
 public interface ProcessInstanceRecordValue
-    extends RecordValue, ProcessInstanceRelated, AuditLogProcessInstanceRelated, TenantOwned {
-  /**
-   * @return the BPMN process id this process instance belongs to.
-   */
-  @Override
-  String getBpmnProcessId();
+    extends RecordValue,
+        ProcessInstanceRelated,
+        AuditLogProcessInstanceRelated,
+        OrdinalKeyBased,
+        TenantOwned {
 
   /**
    * @return the version of the deployed process this instance belongs to.
@@ -193,7 +192,14 @@ public interface ProcessInstanceRecordValue
    *
    * @return the key of the root process instance, or {@code -1} if not set
    */
+  @Override
   long getRootProcessInstanceKey();
+
+  /**
+   * @return the BPMN process id this process instance belongs to.
+   */
+  @Override
+  String getBpmnProcessId();
 
   /**
    * Returns the business id associated with this process instance. The business id is an immutable,

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessMessageSubscriptionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessMessageSubscriptionRecordValue.java
@@ -28,7 +28,7 @@ import org.immutables.value.Value;
 @Value.Immutable
 @ImmutableProtocol(builder = ImmutableProcessMessageSubscriptionRecordValue.Builder.class)
 public interface ProcessMessageSubscriptionRecordValue
-    extends RecordValueWithVariables, ProcessInstanceRelated, TenantOwned {
+    extends RecordValueWithVariables, ProcessInstanceRelated, OrdinalKeyBased, TenantOwned {
   /**
    * @return the process instance key
    */
@@ -36,14 +36,15 @@ public interface ProcessMessageSubscriptionRecordValue
   long getProcessInstanceKey();
 
   /**
+   * @return the process definition key
+   */
+  @Override
+  long getProcessDefinitionKey();
+
+  /**
    * @return the element instance key
    */
   long getElementInstanceKey();
-
-  /**
-   * @return the process definition key
-   */
-  long getProcessDefinitionKey();
 
   /**
    * @return the BPMN process id

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/UserTaskRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/UserTaskRecordValue.java
@@ -34,6 +34,7 @@ public interface UserTaskRecordValue
     extends RecordValueWithVariables,
         ProcessInstanceRelated,
         AuditLogProcessInstanceRelated,
+        OrdinalKeyBased,
         TenantOwned {
 
   long getUserTaskKey();
@@ -72,6 +73,18 @@ public interface UserTaskRecordValue
   long getElementInstanceKey();
 
   /**
+   * Returns the key of the root process instance in the hierarchy. For user tasks in top-level
+   * process instances, this is equal to {@link #getProcessInstanceKey()}. For user tasks in child
+   * process instances (created via call activities), this is the key of the topmost parent process
+   * instance.
+   *
+   * @return the key of the root process instance, or {@code -1L} if not set for versions prior to
+   *     8.9
+   */
+  @Override
+  long getRootProcessInstanceKey();
+
+  /**
    * @return the bpmn process id of the corresponding process definition
    */
   @Override
@@ -94,15 +107,4 @@ public interface UserTaskRecordValue
    * @return the tags that were set for this user task.
    */
   Set<String> getTags();
-
-  /**
-   * Returns the key of the root process instance in the hierarchy. For user tasks in top-level
-   * process instances, this is equal to {@link #getProcessInstanceKey()}. For user tasks in child
-   * process instances (created via call activities), this is the key of the topmost parent process
-   * instance.
-   *
-   * @return the key of the root process instance, or {@code -1L} if not set for versions prior to
-   *     8.9
-   */
-  long getRootProcessInstanceKey();
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/VariableRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/VariableRecordValue.java
@@ -28,7 +28,11 @@ import org.immutables.value.Value;
 @Value.Immutable
 @ImmutableProtocol(builder = ImmutableVariableRecordValue.Builder.class)
 public interface VariableRecordValue
-    extends RecordValue, ProcessInstanceRelated, AuditLogProcessInstanceRelated, TenantOwned {
+    extends RecordValue,
+        ProcessInstanceRelated,
+        AuditLogProcessInstanceRelated,
+        OrdinalKeyBased,
+        TenantOwned {
 
   /**
    * @return the name of the variable.

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/RecordBatchTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/RecordBatchTest.java
@@ -159,7 +159,7 @@ class RecordBatchTest {
     assertThat(either.isLeft()).isTrue();
     assertThat(either.getLeft())
         .hasMessageContaining("Can't append entry")
-        .hasMessageContaining("[ currentBatchEntryCount: 1, currentBatchSize: 464]");
+        .hasMessageContaining("[ currentBatchEntryCount: 1, currentBatchSize: 476]");
   }
 
   @Test
@@ -189,7 +189,7 @@ class RecordBatchTest {
   @Test
   void shouldOnlyReturnTrueUntilMaxBatchSizeIsReached() {
     // given
-    final var recordBatch = new RecordBatch((count, size) -> size < 465);
+    final var recordBatch = new RecordBatch((count, size) -> size < 477);
     final var processInstanceRecord = Records.processInstance(1);
 
     recordBatch.appendRecord(1, RECORD_METADATA, -1, processInstanceRecord);


### PR DESCRIPTION

## Description

Add an OrdinalKeyBased interface that all process instance-related records implement, which we use to assign the ordinal from the engine. That is then used in the exporter to determine the destination index.

This assigns the ordinal at process instance creation time, and the value is propagated from that.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
