### PR TITLE
feat: per-physical-tenant SqlSessionFactory, mapper bundles, and RDBMS writer factory

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsMapperBundle.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsMapperBundle.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write;
+
+import io.camunda.db.rdbms.config.VendorDatabaseProperties;
+import io.camunda.db.rdbms.sql.AgentInstanceMapper;
+import io.camunda.db.rdbms.sql.AuditLogMapper;
+import io.camunda.db.rdbms.sql.BatchOperationMapper;
+import io.camunda.db.rdbms.sql.ClusterVariableMapper;
+import io.camunda.db.rdbms.sql.CorrelatedMessageSubscriptionMapper;
+import io.camunda.db.rdbms.sql.DecisionDefinitionMapper;
+import io.camunda.db.rdbms.sql.DecisionInstanceMapper;
+import io.camunda.db.rdbms.sql.DecisionRequirementsMapper;
+import io.camunda.db.rdbms.sql.ExporterPositionMapper;
+import io.camunda.db.rdbms.sql.FlowNodeInstanceMapper;
+import io.camunda.db.rdbms.sql.HistoryDeletionMapper;
+import io.camunda.db.rdbms.sql.IncidentMapper;
+import io.camunda.db.rdbms.sql.JobMapper;
+import io.camunda.db.rdbms.sql.JobMetricsBatchMapper;
+import io.camunda.db.rdbms.sql.MessageSubscriptionMapper;
+import io.camunda.db.rdbms.sql.ProcessDefinitionMapper;
+import io.camunda.db.rdbms.sql.ProcessInstanceMapper;
+import io.camunda.db.rdbms.sql.PurgeMapper;
+import io.camunda.db.rdbms.sql.SequenceFlowMapper;
+import io.camunda.db.rdbms.sql.UsageMetricMapper;
+import io.camunda.db.rdbms.sql.UsageMetricTUMapper;
+import io.camunda.db.rdbms.sql.UserTaskMapper;
+import io.camunda.db.rdbms.sql.VariableMapper;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+
+public record RdbmsMapperBundle(
+    SqlSessionFactory sqlSessionFactory,
+    VendorDatabaseProperties vendorDatabaseProperties,
+    ExporterPositionMapper exporterPositionMapper,
+    AuditLogMapper auditLogMapper,
+    DecisionInstanceMapper decisionInstanceMapper,
+    DecisionDefinitionMapper decisionDefinitionMapper,
+    DecisionRequirementsMapper decisionRequirementsMapper,
+    FlowNodeInstanceMapper flowNodeInstanceMapper,
+    IncidentMapper incidentMapper,
+    ProcessInstanceMapper processInstanceMapper,
+    ProcessDefinitionMapper processDefinitionMapper,
+    PurgeMapper purgeMapper,
+    UserTaskMapper userTaskMapper,
+    VariableMapper variableMapper,
+    JobMapper jobMapper,
+    JobMetricsBatchMapper jobMetricsBatchMapper,
+    SequenceFlowMapper sequenceFlowMapper,
+    UsageMetricMapper usageMetricMapper,
+    UsageMetricTUMapper usageMetricTUMapper,
+    BatchOperationMapper batchOperationMapper,
+    MessageSubscriptionMapper messageSubscriptionMapper,
+    CorrelatedMessageSubscriptionMapper correlatedMessageSubscriptionMapper,
+    ClusterVariableMapper clusterVariableMapper,
+    HistoryDeletionMapper historyDeletionMapper,
+    AgentInstanceMapper agentInstanceMapper) {
+
+  public static RdbmsMapperBundle from(
+      final SqlSessionFactory sqlSessionFactory,
+      final SqlSession sqlSession,
+      final VendorDatabaseProperties vendorDatabaseProperties) {
+    return new RdbmsMapperBundle(
+        sqlSessionFactory,
+        vendorDatabaseProperties,
+        sqlSession.getMapper(ExporterPositionMapper.class),
+        sqlSession.getMapper(AuditLogMapper.class),
+        sqlSession.getMapper(DecisionInstanceMapper.class),
+        sqlSession.getMapper(DecisionDefinitionMapper.class),
+        sqlSession.getMapper(DecisionRequirementsMapper.class),
+        sqlSession.getMapper(FlowNodeInstanceMapper.class),
+        sqlSession.getMapper(IncidentMapper.class),
+        sqlSession.getMapper(ProcessInstanceMapper.class),
+        sqlSession.getMapper(ProcessDefinitionMapper.class),
+        sqlSession.getMapper(PurgeMapper.class),
+        sqlSession.getMapper(UserTaskMapper.class),
+        sqlSession.getMapper(VariableMapper.class),
+        sqlSession.getMapper(JobMapper.class),
+        sqlSession.getMapper(JobMetricsBatchMapper.class),
+        sqlSession.getMapper(SequenceFlowMapper.class),
+        sqlSession.getMapper(UsageMetricMapper.class),
+        sqlSession.getMapper(UsageMetricTUMapper.class),
+        sqlSession.getMapper(BatchOperationMapper.class),
+        sqlSession.getMapper(MessageSubscriptionMapper.class),
+        sqlSession.getMapper(CorrelatedMessageSubscriptionMapper.class),
+        sqlSession.getMapper(ClusterVariableMapper.class),
+        sqlSession.getMapper(HistoryDeletionMapper.class),
+        sqlSession.getMapper(AgentInstanceMapper.class));
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterConfig.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterConfig.java
@@ -13,6 +13,7 @@ import java.time.InstantSource;
 
 public record RdbmsWriterConfig(
     int partitionId,
+    String physicalTenantId,
     int queueSize,
     /*
      * Maximum memory (in MB) that the execution queue can consume before flushing.
@@ -40,6 +41,15 @@ public record RdbmsWriterConfig(
   public static final int DEFAULT_BATCH_OPERATION_ITEM_INSERT_BLOCK_SIZE = 10000;
   public static final boolean DEFAULT_EXPORT_BATCH_OPERATION_ITEMS_ON_CREATION = true;
 
+  public static final String DEFAULT_PHYSICAL_TENANT_ID = "default";
+
+  public RdbmsWriterConfig {
+    if (physicalTenantId == null || physicalTenantId.isBlank()) {
+      throw new IllegalArgumentException(
+          "physicalTenantId must not be null or blank, got: '" + physicalTenantId + "'");
+    }
+  }
+
   public static Builder builder() {
     return new Builder();
   }
@@ -47,6 +57,7 @@ public record RdbmsWriterConfig(
   public static class Builder implements ObjectBuilder<RdbmsWriterConfig> {
 
     private int partitionId;
+    private String physicalTenantId = DEFAULT_PHYSICAL_TENANT_ID;
     private int queueSize = DEFAULT_QUEUE_SIZE;
     private int queueMemoryLimit = DEFAULT_QUEUE_MEMORY_LIMIT;
     private int batchOperationItemInsertBlockSize = DEFAULT_BATCH_OPERATION_ITEM_INSERT_BLOCK_SIZE;
@@ -58,6 +69,11 @@ public record RdbmsWriterConfig(
 
     public Builder partitionId(final int partitionId) {
       this.partitionId = partitionId;
+      return this;
+    }
+
+    public Builder physicalTenantId(final String physicalTenantId) {
+      this.physicalTenantId = physicalTenantId;
       return this;
     }
 
@@ -101,6 +117,7 @@ public record RdbmsWriterConfig(
     public RdbmsWriterConfig build() {
       return new RdbmsWriterConfig(
           partitionId,
+          physicalTenantId,
           queueSize,
           queueMemoryLimit,
           batchOperationItemInsertBlockSize,

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterFactory.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterFactory.java
@@ -7,128 +7,40 @@
  */
 package io.camunda.db.rdbms.write;
 
-import io.camunda.db.rdbms.config.VendorDatabaseProperties;
-import io.camunda.db.rdbms.sql.AgentInstanceMapper;
-import io.camunda.db.rdbms.sql.AuditLogMapper;
-import io.camunda.db.rdbms.sql.BatchOperationMapper;
-import io.camunda.db.rdbms.sql.ClusterVariableMapper;
-import io.camunda.db.rdbms.sql.CorrelatedMessageSubscriptionMapper;
-import io.camunda.db.rdbms.sql.DecisionDefinitionMapper;
-import io.camunda.db.rdbms.sql.DecisionInstanceMapper;
-import io.camunda.db.rdbms.sql.DecisionRequirementsMapper;
-import io.camunda.db.rdbms.sql.ExporterPositionMapper;
-import io.camunda.db.rdbms.sql.FlowNodeInstanceMapper;
-import io.camunda.db.rdbms.sql.HistoryDeletionMapper;
-import io.camunda.db.rdbms.sql.IncidentMapper;
-import io.camunda.db.rdbms.sql.JobMapper;
-import io.camunda.db.rdbms.sql.JobMetricsBatchMapper;
-import io.camunda.db.rdbms.sql.MessageSubscriptionMapper;
-import io.camunda.db.rdbms.sql.ProcessDefinitionMapper;
-import io.camunda.db.rdbms.sql.ProcessInstanceMapper;
-import io.camunda.db.rdbms.sql.PurgeMapper;
-import io.camunda.db.rdbms.sql.SequenceFlowMapper;
-import io.camunda.db.rdbms.sql.UsageMetricMapper;
-import io.camunda.db.rdbms.sql.UsageMetricTUMapper;
-import io.camunda.db.rdbms.sql.UserTaskMapper;
-import io.camunda.db.rdbms.sql.VariableMapper;
 import io.camunda.db.rdbms.write.queue.DefaultExecutionQueue;
 import io.camunda.db.rdbms.write.queue.TransactionRunner;
 import io.camunda.db.rdbms.write.service.ExporterPositionService;
 import io.micrometer.core.instrument.MeterRegistry;
-import org.apache.ibatis.session.SqlSessionFactory;
+import java.util.Map;
 
 public class RdbmsWriterFactory {
 
-  private final SqlSessionFactory sqlSessionFactory;
-  private final ExporterPositionMapper exporterPositionMapper;
-  private final VendorDatabaseProperties vendorDatabaseProperties;
-  private final AuditLogMapper auditLogMapper;
-  private final DecisionInstanceMapper decisionInstanceMapper;
-  private final DecisionDefinitionMapper decisionDefinitionMapper;
-  private final DecisionRequirementsMapper decisionRequirementsMapper;
-  private final FlowNodeInstanceMapper flowNodeInstanceMapper;
-  private final IncidentMapper incidentMapper;
-  private final ProcessInstanceMapper processInstanceMapper;
-  private final ProcessDefinitionMapper processDefinitionMapper;
-  private final PurgeMapper purgeMapper;
-  private final UserTaskMapper userTaskMapper;
-  private final VariableMapper variableMapper;
+  private final Map<String, RdbmsMapperBundle> mapperBundles;
   private final MeterRegistry meterRegistry;
-  private final JobMapper jobMapper;
-  private final JobMetricsBatchMapper jobMetricsBatchMapper;
-  private final SequenceFlowMapper sequenceFlowMapper;
-  private final UsageMetricMapper usageMetricMapper;
-  private final UsageMetricTUMapper usageMetricTUMapper;
-  private final BatchOperationMapper batchOperationMapper;
-  private final MessageSubscriptionMapper messageSubscriptionMapper;
-  private final CorrelatedMessageSubscriptionMapper correlatedMessageSubscriptionMapper;
-  private final ClusterVariableMapper clusterVariableMapper;
-  private final HistoryDeletionMapper historyDeletionMapper;
-  private final AgentInstanceMapper agentInstanceMapper;
   private final TransactionRunner transactionRunner;
 
   public RdbmsWriterFactory(
-      final SqlSessionFactory sqlSessionFactory,
-      final ExporterPositionMapper exporterPositionMapper,
-      final VendorDatabaseProperties vendorDatabaseProperties,
-      final AuditLogMapper auditLogMapper,
-      final DecisionInstanceMapper decisionInstanceMapper,
-      final DecisionDefinitionMapper decisionDefinitionMapper,
-      final DecisionRequirementsMapper decisionRequirementsMapper,
-      final FlowNodeInstanceMapper flowNodeInstanceMapper,
-      final IncidentMapper incidentMapper,
-      final ProcessInstanceMapper processInstanceMapper,
-      final ProcessDefinitionMapper processDefinitionMapper,
-      final PurgeMapper purgeMapper,
-      final UserTaskMapper userTaskMapper,
-      final VariableMapper variableMapper,
+      final Map<String, RdbmsMapperBundle> mapperBundles,
       final MeterRegistry meterRegistry,
-      final JobMapper jobMapper,
-      final JobMetricsBatchMapper jobMetricsBatchMapper,
-      final SequenceFlowMapper sequenceFlowMapper,
-      final UsageMetricMapper usageMetricMapper,
-      final UsageMetricTUMapper usageMetricTUMapper,
-      final BatchOperationMapper batchOperationMapper,
-      final MessageSubscriptionMapper messageSubscriptionMapper,
-      final CorrelatedMessageSubscriptionMapper correlatedMessageSubscriptionMapper,
-      final ClusterVariableMapper clusterVariableMapper,
-      final HistoryDeletionMapper historyDeletionMapper,
-      final AgentInstanceMapper agentInstanceMapper,
       final TransactionRunner transactionRunner) {
-    this.sqlSessionFactory = sqlSessionFactory;
-    this.exporterPositionMapper = exporterPositionMapper;
-    this.vendorDatabaseProperties = vendorDatabaseProperties;
-    this.auditLogMapper = auditLogMapper;
-    this.decisionInstanceMapper = decisionInstanceMapper;
-    this.decisionDefinitionMapper = decisionDefinitionMapper;
-    this.decisionRequirementsMapper = decisionRequirementsMapper;
-    this.flowNodeInstanceMapper = flowNodeInstanceMapper;
-    this.incidentMapper = incidentMapper;
-    this.processInstanceMapper = processInstanceMapper;
-    this.processDefinitionMapper = processDefinitionMapper;
-    this.purgeMapper = purgeMapper;
-    this.userTaskMapper = userTaskMapper;
-    this.variableMapper = variableMapper;
-    this.jobMapper = jobMapper;
-    this.jobMetricsBatchMapper = jobMetricsBatchMapper;
+    this.mapperBundles = mapperBundles;
     this.meterRegistry = meterRegistry;
-    this.sequenceFlowMapper = sequenceFlowMapper;
-    this.usageMetricMapper = usageMetricMapper;
-    this.usageMetricTUMapper = usageMetricTUMapper;
-    this.batchOperationMapper = batchOperationMapper;
-    this.messageSubscriptionMapper = messageSubscriptionMapper;
-    this.correlatedMessageSubscriptionMapper = correlatedMessageSubscriptionMapper;
-    this.clusterVariableMapper = clusterVariableMapper;
-    this.historyDeletionMapper = historyDeletionMapper;
-    this.agentInstanceMapper = agentInstanceMapper;
     this.transactionRunner = transactionRunner;
   }
 
   public RdbmsWriters createWriter(final RdbmsWriterConfig config) {
+    final var bundle = mapperBundles.get(config.physicalTenantId());
+    if (bundle == null) {
+      throw new IllegalArgumentException(
+          "No RdbmsMapperBundle registered for physical tenant '"
+              + config.physicalTenantId()
+              + "'. Known tenants: "
+              + mapperBundles.keySet());
+    }
     final var metrics = new RdbmsWriterMetrics(meterRegistry, config.partitionId());
     final var executionQueue =
         new DefaultExecutionQueue(
-            sqlSessionFactory,
+            bundle.sqlSessionFactory(),
             config.partitionId(),
             config.queueSize(),
             config.queueMemoryLimit(),
@@ -137,30 +49,30 @@ public class RdbmsWriterFactory {
     return new RdbmsWriters(
         config,
         executionQueue,
-        new ExporterPositionService(executionQueue, exporterPositionMapper),
+        new ExporterPositionService(executionQueue, bundle.exporterPositionMapper()),
         metrics,
-        auditLogMapper,
-        decisionInstanceMapper,
-        decisionDefinitionMapper,
-        decisionRequirementsMapper,
-        flowNodeInstanceMapper,
-        incidentMapper,
-        processInstanceMapper,
-        processDefinitionMapper,
-        purgeMapper,
-        userTaskMapper,
-        variableMapper,
-        vendorDatabaseProperties,
-        jobMapper,
-        jobMetricsBatchMapper,
-        sequenceFlowMapper,
-        usageMetricMapper,
-        usageMetricTUMapper,
-        batchOperationMapper,
-        messageSubscriptionMapper,
-        correlatedMessageSubscriptionMapper,
-        clusterVariableMapper,
-        historyDeletionMapper,
-        agentInstanceMapper);
+        bundle.auditLogMapper(),
+        bundle.decisionInstanceMapper(),
+        bundle.decisionDefinitionMapper(),
+        bundle.decisionRequirementsMapper(),
+        bundle.flowNodeInstanceMapper(),
+        bundle.incidentMapper(),
+        bundle.processInstanceMapper(),
+        bundle.processDefinitionMapper(),
+        bundle.purgeMapper(),
+        bundle.userTaskMapper(),
+        bundle.variableMapper(),
+        bundle.vendorDatabaseProperties(),
+        bundle.jobMapper(),
+        bundle.jobMetricsBatchMapper(),
+        bundle.sequenceFlowMapper(),
+        bundle.usageMetricMapper(),
+        bundle.usageMetricTUMapper(),
+        bundle.batchOperationMapper(),
+        bundle.messageSubscriptionMapper(),
+        bundle.correlatedMessageSubscriptionMapper(),
+        bundle.clusterVariableMapper(),
+        bundle.historyDeletionMapper(),
+        bundle.agentInstanceMapper());
   }
 }

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/RdbmsWriterConfigTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/RdbmsWriterConfigTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class RdbmsWriterConfigTest {
+
+  @Test
+  void shouldDefaultPhysicalTenantToDefault() {
+    final var config = new RdbmsWriterConfig.Builder().partitionId(1).build();
+
+    assertThat(config.physicalTenantId())
+        .isEqualTo(RdbmsWriterConfig.DEFAULT_PHYSICAL_TENANT_ID)
+        .isEqualTo("default");
+  }
+
+  @Test
+  void shouldUseExplicitPhysicalTenantId() {
+    final var config =
+        new RdbmsWriterConfig.Builder().partitionId(1).physicalTenantId("tenantA").build();
+
+    assertThat(config.physicalTenantId()).isEqualTo("tenantA");
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"", "   ", "\t"})
+  void shouldRejectBlankPhysicalTenantId(final String blank) {
+    final var builder = new RdbmsWriterConfig.Builder().partitionId(1).physicalTenantId(blank);
+
+    assertThatThrownBy(builder::build)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("physicalTenantId must not be null or blank");
+  }
+
+  @Test
+  void shouldRejectNullPhysicalTenantId() {
+    final var builder = new RdbmsWriterConfig.Builder().partitionId(1).physicalTenantId(null);
+
+    assertThatThrownBy(builder::build)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("physicalTenantId must not be null or blank");
+  }
+}

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/RdbmsWriterFactoryTenantRoutingTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/RdbmsWriterFactoryTenantRoutingTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+import io.camunda.db.rdbms.config.VendorDatabaseProperties;
+import io.camunda.db.rdbms.sql.AgentInstanceMapper;
+import io.camunda.db.rdbms.sql.AuditLogMapper;
+import io.camunda.db.rdbms.sql.BatchOperationMapper;
+import io.camunda.db.rdbms.sql.ClusterVariableMapper;
+import io.camunda.db.rdbms.sql.CorrelatedMessageSubscriptionMapper;
+import io.camunda.db.rdbms.sql.DecisionDefinitionMapper;
+import io.camunda.db.rdbms.sql.DecisionInstanceMapper;
+import io.camunda.db.rdbms.sql.DecisionRequirementsMapper;
+import io.camunda.db.rdbms.sql.ExporterPositionMapper;
+import io.camunda.db.rdbms.sql.FlowNodeInstanceMapper;
+import io.camunda.db.rdbms.sql.HistoryDeletionMapper;
+import io.camunda.db.rdbms.sql.IncidentMapper;
+import io.camunda.db.rdbms.sql.JobMapper;
+import io.camunda.db.rdbms.sql.JobMetricsBatchMapper;
+import io.camunda.db.rdbms.sql.MessageSubscriptionMapper;
+import io.camunda.db.rdbms.sql.ProcessDefinitionMapper;
+import io.camunda.db.rdbms.sql.ProcessInstanceMapper;
+import io.camunda.db.rdbms.sql.PurgeMapper;
+import io.camunda.db.rdbms.sql.SequenceFlowMapper;
+import io.camunda.db.rdbms.sql.UsageMetricMapper;
+import io.camunda.db.rdbms.sql.UsageMetricTUMapper;
+import io.camunda.db.rdbms.sql.UserTaskMapper;
+import io.camunda.db.rdbms.sql.VariableMapper;
+import io.camunda.db.rdbms.write.queue.TransactionRunner;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.Map;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.junit.jupiter.api.Test;
+
+class RdbmsWriterFactoryTenantRoutingTest {
+
+  @Test
+  void shouldRouteToBundleForRequestedTenant() {
+    // given
+    final var defaultBundle = newBundle();
+    final var tenantABundle = newBundle();
+    final var factory =
+        new RdbmsWriterFactory(
+            Map.of("default", defaultBundle, "tenantA", tenantABundle),
+            new SimpleMeterRegistry(),
+            TransactionRunner.noop());
+
+    // when
+    final var defaultWriters =
+        factory.createWriter(new RdbmsWriterConfig.Builder().partitionId(0).build());
+    final var tenantAWriters =
+        factory.createWriter(
+            new RdbmsWriterConfig.Builder().partitionId(0).physicalTenantId("tenantA").build());
+
+    // then
+    assertThat(defaultWriters).isNotNull();
+    assertThat(tenantAWriters).isNotNull();
+    assertThat(defaultWriters).isNotSameAs(tenantAWriters);
+    assertThat(defaultWriters.getExecutionQueue()).isNotSameAs(tenantAWriters.getExecutionQueue());
+  }
+
+  @Test
+  void shouldRejectUnknownTenant() {
+    // given
+    final var factory =
+        new RdbmsWriterFactory(
+            Map.of("default", newBundle()), new SimpleMeterRegistry(), TransactionRunner.noop());
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                factory.createWriter(
+                    new RdbmsWriterConfig.Builder()
+                        .partitionId(0)
+                        .physicalTenantId("unknown")
+                        .build()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("unknown")
+        .hasMessageContaining("default");
+  }
+
+  private static RdbmsMapperBundle newBundle() {
+    return new RdbmsMapperBundle(
+        mock(SqlSessionFactory.class),
+        mock(VendorDatabaseProperties.class),
+        mock(ExporterPositionMapper.class),
+        mock(AuditLogMapper.class),
+        mock(DecisionInstanceMapper.class),
+        mock(DecisionDefinitionMapper.class),
+        mock(DecisionRequirementsMapper.class),
+        mock(FlowNodeInstanceMapper.class),
+        mock(IncidentMapper.class),
+        mock(ProcessInstanceMapper.class),
+        mock(ProcessDefinitionMapper.class),
+        mock(PurgeMapper.class),
+        mock(UserTaskMapper.class),
+        mock(VariableMapper.class),
+        mock(JobMapper.class),
+        mock(JobMetricsBatchMapper.class),
+        mock(SequenceFlowMapper.class),
+        mock(UsageMetricMapper.class),
+        mock(UsageMetricTUMapper.class),
+        mock(BatchOperationMapper.class),
+        mock(MessageSubscriptionMapper.class),
+        mock(CorrelatedMessageSubscriptionMapper.class),
+        mock(ClusterVariableMapper.class),
+        mock(HistoryDeletionMapper.class),
+        mock(AgentInstanceMapper.class));
+  }
+}

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/MyBatisConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/MyBatisConfiguration.java
@@ -49,9 +49,11 @@ import io.camunda.db.rdbms.sql.UsageMetricTUMapper;
 import io.camunda.db.rdbms.sql.UserMapper;
 import io.camunda.db.rdbms.sql.UserTaskMapper;
 import io.camunda.db.rdbms.sql.VariableMapper;
+import io.camunda.db.rdbms.write.RdbmsMapperBundle;
 import io.camunda.zeebe.util.VersionUtil;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Properties;
 import javax.sql.DataSource;
@@ -61,6 +63,7 @@ import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.type.JdbcType;
 import org.apache.ibatis.type.OffsetDateTimeTypeHandler;
 import org.mybatis.spring.SqlSessionFactoryBean;
+import org.mybatis.spring.SqlSessionTemplate;
 import org.mybatis.spring.mapper.MapperFactoryBean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -158,12 +161,60 @@ public class MyBatisConfiguration {
 
   @Bean
   public SqlSessionFactory sqlSessionFactory(
+      final Map<String, SqlSessionFactory> sqlSessionFactories) {
+    return sqlSessionFactories.get(DEFAULT_PHYSICAL_TENANT_ID);
+  }
+
+  @Bean
+  public Map<String, SqlSessionFactory> sqlSessionFactories(
+      final RdbmsDataSources rdbmsDataSources,
+      final PhysicalTenantResolver physicalTenantResolver,
+      final DatabaseIdProvider databaseIdProvider)
+      throws Exception {
+    final var factories = new LinkedHashMap<String, SqlSessionFactory>();
+    for (final var tenantId : rdbmsDataSources.physicalTenantIds()) {
+      final var prefix =
+          physicalTenantResolver
+              .forPhysicalTenant(tenantId)
+              .getData()
+              .getSecondaryStorage()
+              .getRdbms()
+              .getPrefix();
+      factories.put(
+          tenantId,
+          buildSqlSessionFactory(
+              rdbmsDataSources.dataSourceFor(tenantId),
+              databaseIdProvider,
+              rdbmsDataSources.vendorPropertiesFor(tenantId),
+              prefix));
+    }
+    return Map.copyOf(factories);
+  }
+
+  @Bean
+  public Map<String, RdbmsMapperBundle> rdbmsMapperBundles(
+      final Map<String, SqlSessionFactory> sqlSessionFactories,
+      final RdbmsDataSources rdbmsDataSources) {
+    final var bundles = new LinkedHashMap<String, RdbmsMapperBundle>();
+    for (final var entry : sqlSessionFactories.entrySet()) {
+      final var physicalTenantId = entry.getKey();
+      final var factory = entry.getValue();
+      bundles.put(
+          physicalTenantId,
+          RdbmsMapperBundle.from(
+              factory,
+              new SqlSessionTemplate(factory),
+              rdbmsDataSources.vendorPropertiesFor(physicalTenantId)));
+    }
+    return Map.copyOf(bundles);
+  }
+
+  private SqlSessionFactory buildSqlSessionFactory(
       final DataSource dataSource,
       final DatabaseIdProvider databaseIdProvider,
       final VendorDatabaseProperties databaseProperties,
-      @Value("${camunda.data.secondary-storage.rdbms.prefix:}") final String prefix)
+      final String prefix)
       throws Exception {
-
     final var configuration = new org.apache.ibatis.session.Configuration();
     configuration.setJdbcTypeForNull(JdbcType.NULL);
     configuration.getTypeHandlerRegistry().register(OffsetDateTimeTypeHandler.class);

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
@@ -57,6 +57,7 @@ import io.camunda.db.rdbms.read.service.UsageMetricsDbReader;
 import io.camunda.db.rdbms.read.service.UserDbReader;
 import io.camunda.db.rdbms.read.service.UserTaskDbReader;
 import io.camunda.db.rdbms.read.service.VariableDbReader;
+import io.camunda.db.rdbms.sql.AgentInstanceMapper;
 import io.camunda.db.rdbms.sql.AuditLogMapper;
 import io.camunda.db.rdbms.sql.AuthorizationMapper;
 import io.camunda.db.rdbms.sql.BatchOperationMapper;

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
@@ -57,7 +57,6 @@ import io.camunda.db.rdbms.read.service.UsageMetricsDbReader;
 import io.camunda.db.rdbms.read.service.UserDbReader;
 import io.camunda.db.rdbms.read.service.UserTaskDbReader;
 import io.camunda.db.rdbms.read.service.VariableDbReader;
-import io.camunda.db.rdbms.sql.AgentInstanceMapper;
 import io.camunda.db.rdbms.sql.AuditLogMapper;
 import io.camunda.db.rdbms.sql.AuthorizationMapper;
 import io.camunda.db.rdbms.sql.BatchOperationMapper;
@@ -67,7 +66,6 @@ import io.camunda.db.rdbms.sql.DecisionDefinitionMapper;
 import io.camunda.db.rdbms.sql.DecisionInstanceMapper;
 import io.camunda.db.rdbms.sql.DecisionRequirementsMapper;
 import io.camunda.db.rdbms.sql.DeployedResourceMapper;
-import io.camunda.db.rdbms.sql.ExporterPositionMapper;
 import io.camunda.db.rdbms.sql.FlowNodeInstanceMapper;
 import io.camunda.db.rdbms.sql.FormMapper;
 import io.camunda.db.rdbms.sql.GlobalListenerMapper;
@@ -81,7 +79,6 @@ import io.camunda.db.rdbms.sql.MessageSubscriptionMapper;
 import io.camunda.db.rdbms.sql.PersistentWebSessionMapper;
 import io.camunda.db.rdbms.sql.ProcessDefinitionMapper;
 import io.camunda.db.rdbms.sql.ProcessInstanceMapper;
-import io.camunda.db.rdbms.sql.PurgeMapper;
 import io.camunda.db.rdbms.sql.ReplicationStatusMapper;
 import io.camunda.db.rdbms.sql.RoleMapper;
 import io.camunda.db.rdbms.sql.SequenceFlowMapper;
@@ -92,6 +89,7 @@ import io.camunda.db.rdbms.sql.UsageMetricTUMapper;
 import io.camunda.db.rdbms.sql.UserMapper;
 import io.camunda.db.rdbms.sql.UserTaskMapper;
 import io.camunda.db.rdbms.sql.VariableMapper;
+import io.camunda.db.rdbms.write.RdbmsMapperBundle;
 import io.camunda.db.rdbms.write.RdbmsWriterFactory;
 import io.camunda.db.rdbms.write.queue.TransactionRunner;
 import io.camunda.db.rdbms.write.service.PersistentWebSessionWriter;
@@ -99,8 +97,8 @@ import io.camunda.search.clients.reader.ProcessDefinitionMessageSubscriptionStat
 import io.micrometer.core.instrument.MeterRegistry;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
+import java.util.Map;
 import javax.sql.DataSource;
-import org.apache.ibatis.session.SqlSessionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
@@ -432,61 +430,10 @@ public class RdbmsConfiguration {
 
   @Bean
   public RdbmsWriterFactory rdbmsWriterFactory(
-      final SqlSessionFactory sqlSessionFactory,
-      final ExporterPositionMapper exporterPositionMapper,
-      final VendorDatabaseProperties vendorDatabaseProperties,
-      final AuditLogMapper auditLogMapper,
-      final DecisionInstanceMapper decisionInstanceMapper,
-      final DecisionDefinitionMapper decisionDefinitionMapper,
-      final DecisionRequirementsMapper decisionRequirementsMapper,
-      final FlowNodeInstanceMapper flowNodeInstanceMapper,
-      final IncidentMapper incidentMapper,
-      final ProcessInstanceMapper processInstanceMapper,
-      final ProcessDefinitionMapper processDefinitionMapper,
-      final PurgeMapper purgeMapper,
-      final UserTaskMapper userTaskMapper,
-      final VariableMapper variableMapper,
+      final Map<String, RdbmsMapperBundle> rdbmsMapperBundles,
       final MeterRegistry meterRegistry,
-      final JobMapper jobMapper,
-      final JobMetricsBatchMapper jobMetricsBatchMapper,
-      final SequenceFlowMapper sequenceFlowMapper,
-      final UsageMetricMapper usageMetricMapper,
-      final UsageMetricTUMapper usageMetricTUMapper,
-      final BatchOperationMapper batchOperationMapper,
-      final MessageSubscriptionMapper messageSubscriptionMapper,
-      final CorrelatedMessageSubscriptionMapper correlatedMessageSubscriptionMapper,
-      final ClusterVariableMapper clusterVariableMapper,
-      final HistoryDeletionMapper historyDeletionMapper,
-      final AgentInstanceMapper agentInstanceMapper,
       final TransactionRunner transactionRunner) {
-    return new RdbmsWriterFactory(
-        sqlSessionFactory,
-        exporterPositionMapper,
-        vendorDatabaseProperties,
-        auditLogMapper,
-        decisionInstanceMapper,
-        decisionDefinitionMapper,
-        decisionRequirementsMapper,
-        flowNodeInstanceMapper,
-        incidentMapper,
-        processInstanceMapper,
-        processDefinitionMapper,
-        purgeMapper,
-        userTaskMapper,
-        variableMapper,
-        meterRegistry,
-        jobMapper,
-        jobMetricsBatchMapper,
-        sequenceFlowMapper,
-        usageMetricMapper,
-        usageMetricTUMapper,
-        batchOperationMapper,
-        messageSubscriptionMapper,
-        correlatedMessageSubscriptionMapper,
-        clusterVariableMapper,
-        historyDeletionMapper,
-        agentInstanceMapper,
-        transactionRunner);
+    return new RdbmsWriterFactory(rdbmsMapperBundles, meterRegistry, transactionRunner);
   }
 
   @Bean

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsDataSources.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsDataSources.java
@@ -14,6 +14,7 @@ import io.camunda.db.rdbms.config.VendorDatabasePropertiesLoader;
 import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -74,6 +75,10 @@ public final class RdbmsDataSources implements AutoCloseable {
       }
     }
     return new RdbmsDataSources(dataSources, vendorProperties);
+  }
+
+  public Set<String> physicalTenantIds() {
+    return dataSources.keySet();
   }
 
   public DataSource dataSourceFor(final String physicalTenantId) {

--- a/dist/src/test/java/io/camunda/application/commons/rdbms/MyBatisConfigurationPerTenantIT.java
+++ b/dist/src/test/java/io/camunda/application/commons/rdbms/MyBatisConfigurationPerTenantIT.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.rdbms;
+
+import static io.camunda.configuration.physicaltenants.PhysicalTenantResolver.DEFAULT_PHYSICAL_TENANT_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.UnifiedConfigurationHelper;
+import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
+import io.camunda.db.rdbms.write.RdbmsWriterConfig;
+import io.camunda.db.rdbms.write.RdbmsWriterFactory;
+import io.camunda.db.rdbms.write.queue.TransactionRunner;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.LinkedHashMap;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.mock.env.MockEnvironment;
+
+class MyBatisConfigurationPerTenantIT {
+
+  private static final MyBatisConfiguration MY_BATIS = new MyBatisConfiguration();
+  private static final RdbmsDatabaseIdProvider DATABASE_ID_PROVIDER =
+      new RdbmsDatabaseIdProvider(null);
+
+  @BeforeAll
+  @AfterAll
+  static void clearStaticEnvironment() {
+    UnifiedConfigurationHelper.setCustomEnvironment(null);
+  }
+
+  @Test
+  void shouldBuildIsolatedFactoryAndBundlePerTenantAndExposeDefaultAsSingleton() throws Exception {
+    try (final var fixture = wireTenants(DEFAULT_PHYSICAL_TENANT_ID, "tenantb")) {
+      assertThat(fixture.factories).containsOnlyKeys(DEFAULT_PHYSICAL_TENANT_ID, "tenantb");
+      assertThat(fixture.bundles).containsOnlyKeys(DEFAULT_PHYSICAL_TENANT_ID, "tenantb");
+      assertThat(fixture.factories.get(DEFAULT_PHYSICAL_TENANT_ID))
+          .isNotSameAs(fixture.factories.get("tenantb"));
+      assertThat(MY_BATIS.sqlSessionFactory(fixture.factories))
+          .isSameAs(fixture.factories.get(DEFAULT_PHYSICAL_TENANT_ID));
+    }
+  }
+
+  @Test
+  void shouldRouteWriterFactoryByPhysicalTenantId() throws Exception {
+    try (final var fixture = wireTenants(DEFAULT_PHYSICAL_TENANT_ID, "tenantb")) {
+      final var writerFactory = fixture.writerFactory();
+
+      final var defaultWriters =
+          writerFactory.createWriter(new RdbmsWriterConfig.Builder().partitionId(1).build());
+      final var tenantBWriters =
+          writerFactory.createWriter(
+              new RdbmsWriterConfig.Builder().partitionId(1).physicalTenantId("tenantb").build());
+
+      assertThat(defaultWriters.getExecutionQueue())
+          .isNotSameAs(tenantBWriters.getExecutionQueue());
+    }
+  }
+
+  @Test
+  void shouldRejectUnknownPhysicalTenantId() throws Exception {
+    try (final var fixture = wireTenants(DEFAULT_PHYSICAL_TENANT_ID)) {
+      final var writerFactory = fixture.writerFactory();
+
+      assertThatThrownBy(
+              () ->
+                  writerFactory.createWriter(
+                      new RdbmsWriterConfig.Builder()
+                          .partitionId(1)
+                          .physicalTenantId("unknown")
+                          .build()))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("unknown")
+          .hasMessageContaining(DEFAULT_PHYSICAL_TENANT_ID);
+    }
+  }
+
+  private static TenantFixture wireTenants(final String... tenantIds) throws Exception {
+    final var props = new LinkedHashMap<String, Object>();
+    for (final var tenantId : tenantIds) {
+      final var base = "camunda.physical-tenants." + tenantId + ".data.secondary-storage.";
+      props.put(base + "type", "rdbms");
+      props.put(
+          base + "rdbms.url",
+          "jdbc:h2:mem:rdbms-test-" + UUID.randomUUID() + ";DB_CLOSE_DELAY=-1;MODE=PostgreSQL");
+      props.put(base + "rdbms.username", "sa");
+      props.put(base + "rdbms.password", "");
+    }
+    final var env = new MockEnvironment();
+    env.getPropertySources().addFirst(new MapPropertySource("test", props));
+    final var resolver = PhysicalTenantResolver.of(env, new Camunda());
+    final var dataSources =
+        RdbmsDataSources.of(
+            resolver.mapValues(c -> c.getData().getSecondaryStorage().getRdbms()),
+            DATABASE_ID_PROVIDER);
+    final var factories = MY_BATIS.sqlSessionFactories(dataSources, resolver, DATABASE_ID_PROVIDER);
+    final var bundles = MY_BATIS.rdbmsMapperBundles(factories, dataSources);
+    return new TenantFixture(dataSources, factories, bundles);
+  }
+
+  private record TenantFixture(
+      RdbmsDataSources dataSources,
+      java.util.Map<String, org.apache.ibatis.session.SqlSessionFactory> factories,
+      java.util.Map<String, io.camunda.db.rdbms.write.RdbmsMapperBundle> bundles)
+      implements AutoCloseable {
+
+    RdbmsWriterFactory writerFactory() {
+      return new RdbmsWriterFactory(bundles, new SimpleMeterRegistry(), TransactionRunner.noop());
+    }
+
+    @Override
+    public void close() {
+      dataSources.close();
+    }
+  }
+}

--- a/qa/acceptance-tests/pom.xml
+++ b/qa/acceptance-tests/pom.xml
@@ -215,6 +215,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-jdbc-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
       <scope>test</scope>

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/HistoryCleanupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/HistoryCleanupIT.java
@@ -10,7 +10,6 @@ package io.camunda.it.rdbms.db;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
 
-import io.camunda.application.commons.rdbms.RdbmsConfiguration;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.write.RdbmsWriterConfig;
 import io.camunda.db.rdbms.write.RdbmsWriters;
@@ -21,26 +20,19 @@ import io.camunda.it.rdbms.db.fixtures.AuditLogFixtures;
 import io.camunda.it.rdbms.db.fixtures.BatchOperationFixtures;
 import io.camunda.it.rdbms.db.fixtures.DecisionInstanceFixtures;
 import io.camunda.it.rdbms.db.fixtures.ProcessInstanceFixtures;
-import io.camunda.it.rdbms.db.util.RdbmsTestConfiguration;
+import io.camunda.it.rdbms.db.util.RdbmsDataJdbcTest;
 import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
 import io.camunda.search.entities.BatchOperationType;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.function.Function;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
-import org.springframework.boot.data.jdbc.test.autoconfigure.DataJdbcTest;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
-@Tag("rdbms")
-@DataJdbcTest
-@ContextConfiguration(classes = {RdbmsTestConfiguration.class, RdbmsConfiguration.class})
-@AutoConfigurationPackage
+@RdbmsDataJdbcTest
 @TestPropertySource(
     properties = {"spring.liquibase.enabled=false", "camunda.data.secondary-storage.type=rdbms"})
 public class HistoryCleanupIT {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/PurgerCompletenessIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/PurgerCompletenessIT.java
@@ -11,27 +11,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
-import io.camunda.application.commons.rdbms.RdbmsConfiguration;
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.db.rdbms.sql.PurgeMapper;
 import io.camunda.db.rdbms.write.service.RdbmsPurger;
-import io.camunda.it.rdbms.db.util.RdbmsTestConfiguration;
+import io.camunda.it.rdbms.db.util.RdbmsDataJdbcTest;
 import java.util.List;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
-import org.springframework.boot.data.jdbc.test.autoconfigure.DataJdbcTest;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
-@Tag("rdbms")
-@DataJdbcTest
-@ContextConfiguration(classes = {RdbmsTestConfiguration.class, RdbmsConfiguration.class})
-@AutoConfigurationPackage
+@RdbmsDataJdbcTest
 @TestPropertySource(
     properties = {"spring.liquibase.enabled=false", "camunda.data.secondary-storage.type=rdbms"})
 public class PurgerCompletenessIT {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/TablePrefixIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/TablePrefixIT.java
@@ -9,21 +9,13 @@ package io.camunda.it.rdbms.db;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.application.commons.rdbms.RdbmsConfiguration;
-import io.camunda.it.rdbms.db.util.RdbmsTestConfiguration;
-import org.junit.jupiter.api.Tag;
+import io.camunda.it.rdbms.db.util.RdbmsDataJdbcTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
-import org.springframework.boot.data.jdbc.test.autoconfigure.DataJdbcTest;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
-@Tag("rdbms")
-@DataJdbcTest
-@ContextConfiguration(classes = {RdbmsTestConfiguration.class, RdbmsConfiguration.class})
-@AutoConfigurationPackage
+@RdbmsDataJdbcTest
 @TestPropertySource(
     properties = {
       "spring.liquibase.enabled=false",

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/authorization/AuthorizationSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/authorization/AuthorizationSpecificFilterIT.java
@@ -11,13 +11,12 @@ import static io.camunda.it.rdbms.db.fixtures.AuthorizationFixtures.createAndSav
 import static io.camunda.it.rdbms.db.fixtures.AuthorizationFixtures.createAndSaveRandomAuthorizations;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.application.commons.rdbms.RdbmsConfiguration;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.read.service.AuthorizationDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.db.rdbms.write.domain.AuthorizationDbModel;
 import io.camunda.it.rdbms.db.fixtures.AuthorizationFixtures;
-import io.camunda.it.rdbms.db.util.RdbmsTestConfiguration;
+import io.camunda.it.rdbms.db.util.RdbmsDataJdbcTest;
 import io.camunda.search.filter.AuthorizationFilter;
 import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.AuthorizationQuery;
@@ -28,21 +27,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
-import org.springframework.boot.data.jdbc.test.autoconfigure.DataJdbcTest;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
-@Tag("rdbms")
-@DataJdbcTest
-@ContextConfiguration(classes = {RdbmsTestConfiguration.class, RdbmsConfiguration.class})
-@AutoConfigurationPackage
+@RdbmsDataJdbcTest
 @TestPropertySource(
     properties = {"spring.liquibase.enabled=false", "camunda.data.secondary-storage.type=rdbms"})
 public class AuthorizationSpecificFilterIT {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisiondefinition/DecisionDefinitionSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisiondefinition/DecisionDefinitionSpecificFilterIT.java
@@ -11,32 +11,24 @@ import static io.camunda.it.rdbms.db.fixtures.DecisionDefinitionFixtures.createA
 import static io.camunda.it.rdbms.db.fixtures.DecisionDefinitionFixtures.createAndSaveRandomDecisionDefinitions;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.application.commons.rdbms.RdbmsConfiguration;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.read.service.DecisionDefinitionDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.it.rdbms.db.fixtures.DecisionDefinitionFixtures;
-import io.camunda.it.rdbms.db.util.RdbmsTestConfiguration;
+import io.camunda.it.rdbms.db.util.RdbmsDataJdbcTest;
 import io.camunda.search.filter.DecisionDefinitionFilter;
 import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.DecisionDefinitionQuery;
 import io.camunda.search.sort.DecisionDefinitionSort;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
-import org.springframework.boot.data.jdbc.test.autoconfigure.DataJdbcTest;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
-@Tag("rdbms")
-@DataJdbcTest
-@ContextConfiguration(classes = {RdbmsTestConfiguration.class, RdbmsConfiguration.class})
-@AutoConfigurationPackage
+@RdbmsDataJdbcTest
 @TestPropertySource(
     properties = {"spring.liquibase.enabled=false", "camunda.data.secondary-storage.type=rdbms"})
 public class DecisionDefinitionSpecificFilterIT {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisioninstance/DecisionInstanceSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisioninstance/DecisionInstanceSpecificFilterIT.java
@@ -12,13 +12,12 @@ import static io.camunda.it.rdbms.db.fixtures.DecisionInstanceFixtures.createAnd
 import static io.camunda.it.rdbms.db.fixtures.DecisionInstanceFixtures.createAndSaveRandomDecisionInstances;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.application.commons.rdbms.RdbmsConfiguration;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.read.service.DecisionInstanceDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.it.rdbms.db.fixtures.DecisionDefinitionFixtures;
 import io.camunda.it.rdbms.db.fixtures.DecisionInstanceFixtures;
-import io.camunda.it.rdbms.db.util.RdbmsTestConfiguration;
+import io.camunda.it.rdbms.db.util.RdbmsDataJdbcTest;
 import io.camunda.search.entities.DecisionInstanceEntity.DecisionDefinitionType;
 import io.camunda.search.entities.DecisionInstanceEntity.DecisionInstanceState;
 import io.camunda.search.filter.DecisionInstanceFilter;
@@ -29,19 +28,12 @@ import io.camunda.search.sort.DecisionInstanceSort;
 import java.time.OffsetDateTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
-import org.springframework.boot.data.jdbc.test.autoconfigure.DataJdbcTest;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
-@Tag("rdbms")
-@DataJdbcTest
-@ContextConfiguration(classes = {RdbmsTestConfiguration.class, RdbmsConfiguration.class})
-@AutoConfigurationPackage
+@RdbmsDataJdbcTest
 @TestPropertySource(
     properties = {"spring.liquibase.enabled=false", "camunda.data.secondary-storage.type=rdbms"})
 public class DecisionInstanceSpecificFilterIT {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisionrequirements/DecisionRequirementsSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/decisionrequirements/DecisionRequirementsSpecificFilterIT.java
@@ -11,31 +11,23 @@ import static io.camunda.it.rdbms.db.fixtures.DecisionRequirementsFixtures.creat
 import static io.camunda.it.rdbms.db.fixtures.DecisionRequirementsFixtures.createAndSaveRandomDecisionRequirements;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.application.commons.rdbms.RdbmsConfiguration;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.read.service.DecisionRequirementsDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.it.rdbms.db.fixtures.DecisionRequirementsFixtures;
-import io.camunda.it.rdbms.db.util.RdbmsTestConfiguration;
+import io.camunda.it.rdbms.db.util.RdbmsDataJdbcTest;
 import io.camunda.search.filter.DecisionRequirementsFilter;
 import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.DecisionRequirementsQuery;
 import io.camunda.search.sort.DecisionRequirementsSort;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
-import org.springframework.boot.data.jdbc.test.autoconfigure.DataJdbcTest;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
-@Tag("rdbms")
-@DataJdbcTest
-@ContextConfiguration(classes = {RdbmsTestConfiguration.class, RdbmsConfiguration.class})
-@AutoConfigurationPackage
+@RdbmsDataJdbcTest
 @TestPropertySource(
     properties = {"spring.liquibase.enabled=false", "camunda.data.secondary-storage.type=rdbms"})
 public class DecisionRequirementsSpecificFilterIT {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/flownodeinstance/FlowNodeInstanceSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/flownodeinstance/FlowNodeInstanceSpecificFilterIT.java
@@ -11,12 +11,11 @@ import static io.camunda.it.rdbms.db.fixtures.FlowNodeInstanceFixtures.createAnd
 import static io.camunda.it.rdbms.db.fixtures.FlowNodeInstanceFixtures.createAndSaveRandomFlowNodeInstances;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.application.commons.rdbms.RdbmsConfiguration;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.read.service.FlowNodeInstanceDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.it.rdbms.db.fixtures.FlowNodeInstanceFixtures;
-import io.camunda.it.rdbms.db.util.RdbmsTestConfiguration;
+import io.camunda.it.rdbms.db.util.RdbmsDataJdbcTest;
 import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeState;
 import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeType;
 import io.camunda.search.filter.FlowNodeInstanceFilter;
@@ -26,19 +25,12 @@ import io.camunda.search.sort.FlowNodeInstanceSort;
 import java.time.OffsetDateTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
-import org.springframework.boot.data.jdbc.test.autoconfigure.DataJdbcTest;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
-@Tag("rdbms")
-@DataJdbcTest
-@ContextConfiguration(classes = {RdbmsTestConfiguration.class, RdbmsConfiguration.class})
-@AutoConfigurationPackage
+@RdbmsDataJdbcTest
 @TestPropertySource(
     properties = {"spring.liquibase.enabled=false", "camunda.data.secondary-storage.type=rdbms"})
 public class FlowNodeInstanceSpecificFilterIT {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/group/GroupSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/group/GroupSpecificFilterIT.java
@@ -13,7 +13,6 @@ import static io.camunda.it.rdbms.db.fixtures.GroupFixtures.createRandomized;
 import static io.camunda.it.rdbms.db.fixtures.TenantFixtures.createAndSaveTenant;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.application.commons.rdbms.RdbmsConfiguration;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.read.service.GroupDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriters;
@@ -21,7 +20,7 @@ import io.camunda.db.rdbms.write.domain.TenantMemberDbModel;
 import io.camunda.it.rdbms.db.fixtures.GroupFixtures;
 import io.camunda.it.rdbms.db.fixtures.GroupMemberFixtures;
 import io.camunda.it.rdbms.db.fixtures.TenantFixtures;
-import io.camunda.it.rdbms.db.util.RdbmsTestConfiguration;
+import io.camunda.it.rdbms.db.util.RdbmsDataJdbcTest;
 import io.camunda.search.filter.GroupFilter;
 import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.GroupQuery;
@@ -31,21 +30,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
-import org.springframework.boot.data.jdbc.test.autoconfigure.DataJdbcTest;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
-@Tag("rdbms")
-@DataJdbcTest
-@ContextConfiguration(classes = {RdbmsTestConfiguration.class, RdbmsConfiguration.class})
-@AutoConfigurationPackage
+@RdbmsDataJdbcTest
 @TestPropertySource(
     properties = {"spring.liquibase.enabled=false", "camunda.data.secondary-storage.type=rdbms"})
 public class GroupSpecificFilterIT {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/incident/IncidentSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/incident/IncidentSpecificFilterIT.java
@@ -12,13 +12,12 @@ import static io.camunda.it.rdbms.db.fixtures.IncidentFixtures.createAndSaveInci
 import static io.camunda.it.rdbms.db.fixtures.IncidentFixtures.createAndSaveRandomIncidents;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.application.commons.rdbms.RdbmsConfiguration;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.read.service.IncidentDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.it.rdbms.db.fixtures.CommonFixtures;
 import io.camunda.it.rdbms.db.fixtures.IncidentFixtures;
-import io.camunda.it.rdbms.db.util.RdbmsTestConfiguration;
+import io.camunda.it.rdbms.db.util.RdbmsDataJdbcTest;
 import io.camunda.search.entities.IncidentEntity.ErrorType;
 import io.camunda.search.entities.IncidentEntity.IncidentState;
 import io.camunda.search.filter.IncidentFilter;
@@ -29,19 +28,12 @@ import io.camunda.search.sort.IncidentSort;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
-import org.springframework.boot.data.jdbc.test.autoconfigure.DataJdbcTest;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
-@Tag("rdbms")
-@DataJdbcTest
-@ContextConfiguration(classes = {RdbmsTestConfiguration.class, RdbmsConfiguration.class})
-@AutoConfigurationPackage
+@RdbmsDataJdbcTest
 @TestPropertySource(
     properties = {"spring.liquibase.enabled=false", "camunda.data.secondary-storage.type=rdbms"})
 public class IncidentSpecificFilterIT {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/mappingrules/MappingRuleSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/mappingrules/MappingRuleSpecificFilterIT.java
@@ -14,7 +14,6 @@ import static io.camunda.it.rdbms.db.fixtures.RoleFixtures.createAndSaveRole;
 import static io.camunda.security.api.model.authz.EntityType.MAPPING_RULE;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.application.commons.rdbms.RdbmsConfiguration;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.read.service.MappingRuleDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriters;
@@ -25,7 +24,7 @@ import io.camunda.it.rdbms.db.fixtures.GroupFixtures;
 import io.camunda.it.rdbms.db.fixtures.MappingRuleFixtures;
 import io.camunda.it.rdbms.db.fixtures.RoleFixtures;
 import io.camunda.it.rdbms.db.fixtures.TenantFixtures;
-import io.camunda.it.rdbms.db.util.RdbmsTestConfiguration;
+import io.camunda.it.rdbms.db.util.RdbmsDataJdbcTest;
 import io.camunda.search.entities.MappingRuleEntity;
 import io.camunda.search.filter.MappingRuleFilter;
 import io.camunda.search.page.SearchQueryPage;
@@ -33,18 +32,11 @@ import io.camunda.search.query.MappingRuleQuery;
 import io.camunda.search.sort.MappingRuleSort;
 import java.util.Arrays;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
-import org.springframework.boot.data.jdbc.test.autoconfigure.DataJdbcTest;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
-@Tag("rdbms")
-@DataJdbcTest
-@ContextConfiguration(classes = {RdbmsTestConfiguration.class, RdbmsConfiguration.class})
-@AutoConfigurationPackage
+@RdbmsDataJdbcTest
 @TestPropertySource(
     properties = {"spring.liquibase.enabled=false", "camunda.data.secondary-storage.type=rdbms"})
 public class MappingRuleSpecificFilterIT {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/messagesubscription/MessageSubscriptionSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/messagesubscription/MessageSubscriptionSpecificFilterIT.java
@@ -9,13 +9,12 @@ package io.camunda.it.rdbms.db.messagesubscription;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.application.commons.rdbms.RdbmsConfiguration;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.read.service.MessageSubscriptionDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.it.rdbms.db.fixtures.CommonFixtures;
 import io.camunda.it.rdbms.db.fixtures.MessageSubscriptionFixtures;
-import io.camunda.it.rdbms.db.util.RdbmsTestConfiguration;
+import io.camunda.it.rdbms.db.util.RdbmsDataJdbcTest;
 import io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionState;
 import io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionType;
 import io.camunda.search.filter.MessageSubscriptionFilter;
@@ -26,19 +25,12 @@ import io.camunda.search.sort.MessageSubscriptionSort;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
-import org.springframework.boot.data.jdbc.test.autoconfigure.DataJdbcTest;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
-@Tag("rdbms")
-@DataJdbcTest
-@ContextConfiguration(classes = {RdbmsTestConfiguration.class, RdbmsConfiguration.class})
-@AutoConfigurationPackage
+@RdbmsDataJdbcTest
 @TestPropertySource(
     properties = {
       "spring.liquibase.enabled=false",

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processdefinition/ProcessDefinitionSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processdefinition/ProcessDefinitionSpecificFilterIT.java
@@ -11,30 +11,22 @@ import static io.camunda.it.rdbms.db.fixtures.ProcessDefinitionFixtures.createAn
 import static io.camunda.it.rdbms.db.fixtures.ProcessDefinitionFixtures.createAndSaveRandomProcessDefinitions;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.application.commons.rdbms.RdbmsConfiguration;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.read.service.ProcessDefinitionDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.it.rdbms.db.fixtures.ProcessDefinitionFixtures;
-import io.camunda.it.rdbms.db.util.RdbmsTestConfiguration;
+import io.camunda.it.rdbms.db.util.RdbmsDataJdbcTest;
 import io.camunda.search.filter.ProcessDefinitionFilter;
 import io.camunda.search.query.ProcessDefinitionQuery;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
-import org.springframework.boot.data.jdbc.test.autoconfigure.DataJdbcTest;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
-@Tag("rdbms")
-@DataJdbcTest
-@ContextConfiguration(classes = {RdbmsTestConfiguration.class, RdbmsConfiguration.class})
-@AutoConfigurationPackage
+@RdbmsDataJdbcTest
 @TestPropertySource(
     properties = {"spring.liquibase.enabled=false", "camunda.data.secondary-storage.type=rdbms"})
 public class ProcessDefinitionSpecificFilterIT {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceSpecificFilterIT.java
@@ -12,13 +12,12 @@ import static io.camunda.it.rdbms.db.fixtures.ProcessInstanceFixtures.createAndS
 import static io.camunda.it.rdbms.db.fixtures.ProcessInstanceFixtures.createAndSaveRandomProcessInstances;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.application.commons.rdbms.RdbmsConfiguration;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.read.service.ProcessInstanceDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.it.rdbms.db.fixtures.ProcessDefinitionFixtures;
 import io.camunda.it.rdbms.db.fixtures.ProcessInstanceFixtures;
-import io.camunda.it.rdbms.db.util.RdbmsTestConfiguration;
+import io.camunda.it.rdbms.db.util.RdbmsDataJdbcTest;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.entities.ProcessInstanceEntity.ProcessInstanceState;
 import io.camunda.search.filter.ProcessInstanceFilter;
@@ -28,20 +27,13 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
-import org.springframework.boot.data.jdbc.test.autoconfigure.DataJdbcTest;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
-@Tag("rdbms")
-@DataJdbcTest
-@ContextConfiguration(classes = {RdbmsTestConfiguration.class, RdbmsConfiguration.class})
-@AutoConfigurationPackage
+@RdbmsDataJdbcTest
 @TestPropertySource(
     properties = {
       "spring.liquibase.enabled=false",

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleSpecificFilterIT.java
@@ -16,7 +16,6 @@ import static io.camunda.it.rdbms.db.fixtures.UserFixtures.createAndSaveUser;
 import static io.camunda.security.api.model.authz.EntityType.ROLE;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.application.commons.rdbms.RdbmsConfiguration;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.read.service.RoleDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriters;
@@ -27,7 +26,7 @@ import io.camunda.it.rdbms.db.fixtures.RoleFixtures;
 import io.camunda.it.rdbms.db.fixtures.RoleMemberFixtures;
 import io.camunda.it.rdbms.db.fixtures.TenantFixtures;
 import io.camunda.it.rdbms.db.fixtures.UserFixtures;
-import io.camunda.it.rdbms.db.util.RdbmsTestConfiguration;
+import io.camunda.it.rdbms.db.util.RdbmsDataJdbcTest;
 import io.camunda.search.entities.RoleEntity;
 import io.camunda.search.filter.RoleFilter;
 import io.camunda.search.page.SearchQueryPage;
@@ -40,21 +39,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
-import org.springframework.boot.data.jdbc.test.autoconfigure.DataJdbcTest;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
-@Tag("rdbms")
-@DataJdbcTest
-@ContextConfiguration(classes = {RdbmsTestConfiguration.class, RdbmsConfiguration.class})
-@AutoConfigurationPackage
+@RdbmsDataJdbcTest
 @TestPropertySource(
     properties = {
       "spring.liquibase.enabled=false",

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/tenant/TenantSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/tenant/TenantSpecificFilterIT.java
@@ -11,13 +11,12 @@ import static io.camunda.it.rdbms.db.fixtures.TenantFixtures.createAndSaveRandom
 import static io.camunda.it.rdbms.db.fixtures.TenantFixtures.createAndSaveTenant;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.application.commons.rdbms.RdbmsConfiguration;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.read.service.TenantDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.db.rdbms.write.domain.TenantMemberDbModel;
 import io.camunda.it.rdbms.db.fixtures.TenantFixtures;
-import io.camunda.it.rdbms.db.util.RdbmsTestConfiguration;
+import io.camunda.it.rdbms.db.util.RdbmsDataJdbcTest;
 import io.camunda.search.filter.TenantFilter;
 import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.TenantQuery;
@@ -28,20 +27,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
-import org.springframework.boot.data.jdbc.test.autoconfigure.DataJdbcTest;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
-@Tag("rdbms")
-@DataJdbcTest
-@ContextConfiguration(classes = {RdbmsTestConfiguration.class, RdbmsConfiguration.class})
-@AutoConfigurationPackage
+@RdbmsDataJdbcTest
 @TestPropertySource(
     properties = {"spring.liquibase.enabled=false", "camunda.data.secondary-storage.type=rdbms"})
 public class TenantSpecificFilterIT {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/user/UserSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/user/UserSpecificFilterIT.java
@@ -14,7 +14,6 @@ import static io.camunda.it.rdbms.db.fixtures.UserFixtures.createAndSaveRandomUs
 import static io.camunda.it.rdbms.db.fixtures.UserFixtures.createAndSaveUser;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.application.commons.rdbms.RdbmsConfiguration;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.read.service.UserDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriters;
@@ -25,7 +24,7 @@ import io.camunda.it.rdbms.db.fixtures.GroupFixtures;
 import io.camunda.it.rdbms.db.fixtures.RoleFixtures;
 import io.camunda.it.rdbms.db.fixtures.TenantFixtures;
 import io.camunda.it.rdbms.db.fixtures.UserFixtures;
-import io.camunda.it.rdbms.db.util.RdbmsTestConfiguration;
+import io.camunda.it.rdbms.db.util.RdbmsDataJdbcTest;
 import io.camunda.search.filter.UserFilter;
 import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.UserQuery;
@@ -33,20 +32,13 @@ import io.camunda.search.sort.UserSort;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
-import org.springframework.boot.data.jdbc.test.autoconfigure.DataJdbcTest;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
-@Tag("rdbms")
-@DataJdbcTest
-@ContextConfiguration(classes = {RdbmsTestConfiguration.class, RdbmsConfiguration.class})
-@AutoConfigurationPackage
+@RdbmsDataJdbcTest
 @TestPropertySource(
     properties = {"spring.liquibase.enabled=false", "camunda.data.secondary-storage.type=rdbms"})
 public class UserSpecificFilterIT {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/RdbmsDataJdbcTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/RdbmsDataJdbcTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.util;
+
+import io.camunda.application.commons.rdbms.RdbmsConfiguration;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.Tag;
+import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
+import org.springframework.boot.data.jdbc.test.autoconfigure.DataJdbcTest;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase.Replace;
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * Composed test annotation for RDBMS integration tests that use Spring's {@link DataJdbcTest}
+ * slice.
+ *
+ * <p>It bundles the common setup shared by tests under {@code io.camunda.it.rdbms.db}:
+ *
+ * <ul>
+ *   <li>{@link DataJdbcTest} for the JDBC test slice.
+ *   <li>{@link AutoConfigureTestDatabase} with {@link Replace#NONE} to prevent Spring Boot from
+ *       replacing the production {@code DataSource} with an embedded one. The RDBMS layer manages
+ *       its own datasource via {@code RdbmsDataSources}, and replacing it would cause the
+ *       schema-creating {@code LiquibaseSchemaManager} and the MyBatis {@code SqlSessionFactory} to
+ *       operate on different databases.
+ *   <li>{@link ContextConfiguration} loading {@link RdbmsTestConfiguration} and {@link
+ *       RdbmsConfiguration}.
+ *   <li>{@link AutoConfigurationPackage} so component scanning picks up the production
+ *       configuration.
+ *   <li>{@link Tag} {@code "rdbms"} so tests are selected by the {@code rdbms} Maven profile.
+ * </ul>
+ *
+ * <p>Tests that need additional properties can still declare their own {@code @TestPropertySource}.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Inherited
+@Tag("rdbms")
+@DataJdbcTest
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+@ContextConfiguration(classes = {RdbmsTestConfiguration.class, RdbmsConfiguration.class})
+@AutoConfigurationPackage
+public @interface RdbmsDataJdbcTest {}

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ExporterConfiguration.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ExporterConfiguration.java
@@ -216,6 +216,7 @@ public class ExporterConfiguration {
 
   public RdbmsWriterConfig createRdbmsWriterConfig(
       final int partitionId,
+      final String physicalTenantId,
       final VendorDatabaseProperties vendorDatabaseProperties,
       final InstantSource clock) {
     final var historyConfig =
@@ -244,6 +245,7 @@ public class ExporterConfiguration {
 
     return new RdbmsWriterConfig.Builder()
         .partitionId(partitionId)
+        .physicalTenantId(physicalTenantId)
         .queueSize(queueSize)
         .queueMemoryLimit(queueMemoryLimit)
         .batchOperationItemInsertBlockSize(batchOperationItemInsertBlockSize)

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporter.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporter.java
@@ -41,6 +41,7 @@ public final class RdbmsExporter {
   private Controller controller;
 
   private final int partitionId;
+  private final String physicalTenantId;
   private final RdbmsWriters rdbmsWriters;
   private final RdbmsSchemaManager rdbmsSchemaManager;
 
@@ -68,6 +69,7 @@ public final class RdbmsExporter {
 
   private RdbmsExporter(
       final int partitionId,
+      final String physicalTenantId,
       final Duration flushInterval,
       final int queueSize,
       final RdbmsWriters rdbmsWriters,
@@ -81,6 +83,7 @@ public final class RdbmsExporter {
     registeredHandlers = handlers;
 
     this.partitionId = partitionId;
+    this.physicalTenantId = physicalTenantId;
     this.flushInterval = flushInterval;
     this.queueSize = queueSize;
     this.rdbmsSchemaManager = rdbmsSchemaManager;
@@ -408,6 +411,7 @@ public final class RdbmsExporter {
   public static final class Builder {
 
     private int partitionId;
+    private String physicalTenantId;
     private Duration flushInterval;
     private int queueSize;
     private RdbmsWriters rdbmsWriters;
@@ -419,6 +423,11 @@ public final class RdbmsExporter {
 
     public Builder partitionId(final int value) {
       partitionId = value;
+      return this;
+    }
+
+    public Builder physicalTenantId(final String value) {
+      physicalTenantId = value;
       return this;
     }
 
@@ -475,6 +484,7 @@ public final class RdbmsExporter {
     public RdbmsExporter build() {
       return new RdbmsExporter(
           partitionId,
+          physicalTenantId,
           flushInterval,
           queueSize,
           rdbmsWriters,

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
@@ -11,6 +11,7 @@ import io.camunda.db.rdbms.RdbmsSchemaManager;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.db.rdbms.read.replication.ReplicationLogStatusProvider;
+import io.camunda.db.rdbms.write.RdbmsWriterConfig;
 import io.camunda.db.rdbms.write.RdbmsWriterConfig.HistoryDeletionConfig;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.db.rdbms.write.service.HistoryCleanupService;
@@ -100,13 +101,16 @@ public class RdbmsExporterWrapper implements Exporter {
     config.validate(); // throws exception if configuration is invalid
 
     final int partitionId = context.getPartitionId();
+    final var physicalTenantId = RdbmsWriterConfig.DEFAULT_PHYSICAL_TENANT_ID;
     final var rdbmsWriterConfig =
-        config.createRdbmsWriterConfig(partitionId, vendorDatabaseProperties, context.clock());
+        config.createRdbmsWriterConfig(
+            partitionId, physicalTenantId, vendorDatabaseProperties, context.clock());
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(rdbmsWriterConfig);
 
     final var builder =
         new RdbmsExporter.Builder()
             .partitionId(partitionId)
+            .physicalTenantId(physicalTenantId)
             .flushInterval(config.getFlushInterval())
             .queueSize(config.getQueueSize())
             .rdbmsWriter(rdbmsWriters);

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/ExporterConfigurationTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/ExporterConfigurationTest.java
@@ -436,7 +436,7 @@ class ExporterConfigurationTest {
 
     // when
     final var writerConfig =
-        configuration.createRdbmsWriterConfig(1, vendorProps, InstantSource.system());
+        configuration.createRdbmsWriterConfig(1, "default", vendorProps, InstantSource.system());
 
     // then
     assertThat(writerConfig.insertBatchingConfig().variableInsertBatchSize()).isEqualTo(1);
@@ -459,7 +459,7 @@ class ExporterConfigurationTest {
 
     // when
     final var writerConfig =
-        configuration.createRdbmsWriterConfig(1, vendorProps, InstantSource.system());
+        configuration.createRdbmsWriterConfig(1, "default", vendorProps, InstantSource.system());
 
     // then
     assertThat(writerConfig.insertBatchingConfig().variableInsertBatchSize()).isEqualTo(25);

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/RdbmsExporterTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/RdbmsExporterTest.java
@@ -686,6 +686,7 @@ class RdbmsExporterTest {
         new RdbmsExporter.Builder()
             .rdbmsWriter(rdbmsWriters)
             .partitionId(0)
+            .physicalTenantId("default")
             .flushInterval(Duration.ofMillis(500))
             .queueSize(100)
             .rdbmsSchemaManager(schemaManager)


### PR DESCRIPTION
## Summary

Routes the RDBMS write path by physical tenant id, in preparation for true per-tenant secondary-storage isolation.

- `RdbmsWriterConfig` gains a `physicalTenantId` field (defaulting to `"default"`); `RdbmsWriterFactory` now holds a `Map<String, RdbmsMapperBundle>` and resolves the bundle for the requested tenant — rejecting unknown ids with a clear error.
- New `RdbmsMapperBundle` record consolidates the 25 mapper dependencies + `SqlSessionFactory` + `VendorDatabaseProperties` per tenant, collapsing the previous 28-arg `RdbmsWriterFactory` constructor.
- `MyBatisConfiguration` produces one `SqlSessionFactory` and one `RdbmsMapperBundle` per physical tenant discovered by `PhysicalTenantResolver`; the existing singleton `SqlSessionFactory` bean is preserved as a view onto the `"default"` entry so the 34 `MapperFactoryBean` reader beans keep working unchanged.
- `RdbmsSchemaManager` gains an `isInitialized(String physicalTenantId)` overload (default-method delegating to the no-arg form) so future per-tenant readiness checks have a stable hook.
- The RDBMS exporter wires the writer through `RdbmsWriterConfig.DEFAULT_PHYSICAL_TENANT_ID` end-to-end (`RdbmsExporterWrapper` → `RdbmsExporter` → `ExporterConfiguration.createRdbmsWriterConfig`); this is the single line that flips once the partition→tenant mapping prerequisite (#51921) lands.

## Why

The cluster currently has a single physical-tenant `default`. Routing writes through `physicalTenantId` now — even when there is only one tenant — lets later PRs introduce additional tenants by configuration alone, without further changes to the writer-factory wiring or to the exporter.

Layering preserved: `db/rdbms` stays free of `configuration/`, and `zeebe/exporters/rdbms-exporter` stays free of `dist/`.

## Related

Closes #52043