### PR TITLE
fix: declare 409 ALREADY_EXISTS response on 6 create endpoints

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
@@ -32,6 +32,8 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Unauthorized'
         "403":
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
+        "409":
+          description: A cluster variable with this name already exists.
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.9"
@@ -84,6 +86,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+        "409":
+          description: A cluster variable with this name already exists for the given tenant.
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.9"

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
@@ -34,6 +34,10 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "409":
           description: A cluster variable with this name already exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "problem-detail.yaml#/components/schemas/ProblemDetail"
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.9"
@@ -88,6 +92,10 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "409":
           description: A cluster variable with this name already exists for the given tenant.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "problem-detail.yaml#/components/schemas/ProblemDetail"
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.9"

--- a/zeebe/gateway-protocol/src/main/proto/v2/groups.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/groups.yaml
@@ -48,6 +48,10 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "409":
           description: Group with this id already exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "problem-detail.yaml#/components/schemas/ProblemDetail"
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":

--- a/zeebe/gateway-protocol/src/main/proto/v2/groups.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/groups.yaml
@@ -46,6 +46,8 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Unauthorized'
         "403":
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
+        "409":
+          description: Group with this id already exists.
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":

--- a/zeebe/gateway-protocol/src/main/proto/v2/mapping-rules.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/mapping-rules.yaml
@@ -42,6 +42,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: "problem-detail.yaml#/components/schemas/ProblemDetail"
+        "409":
+          description: Mapping rule with this id already exists.
         "500":
           $ref: "common-responses.yaml#/components/responses/InternalServerError"
       x-added-in-version: "8.8"

--- a/zeebe/gateway-protocol/src/main/proto/v2/mapping-rules.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/mapping-rules.yaml
@@ -44,6 +44,10 @@ paths:
                 $ref: "problem-detail.yaml#/components/schemas/ProblemDetail"
         "409":
           description: Mapping rule with this id already exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "problem-detail.yaml#/components/schemas/ProblemDetail"
         "500":
           $ref: "common-responses.yaml#/components/responses/InternalServerError"
       x-added-in-version: "8.8"

--- a/zeebe/gateway-protocol/src/main/proto/v2/roles.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/roles.yaml
@@ -33,6 +33,10 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "409":
           description: Role with this id already exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "problem-detail.yaml#/components/schemas/ProblemDetail"
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":

--- a/zeebe/gateway-protocol/src/main/proto/v2/roles.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/roles.yaml
@@ -31,6 +31,8 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Unauthorized'
         "403":
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
+        "409":
+          description: Role with this id already exists.
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":

--- a/zeebe/gateway-protocol/src/main/proto/v2/setup.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/setup.yaml
@@ -26,6 +26,8 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InvalidData'
         "403":
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
+        "409":
+          description: A user with this username already exists.
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":

--- a/zeebe/gateway-protocol/src/main/proto/v2/setup.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/setup.yaml
@@ -28,6 +28,10 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "409":
           description: A user with this username already exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "problem-detail.yaml#/components/schemas/ProblemDetail"
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":

--- a/zeebe/gateway-protocol/src/main/proto/v2/tenants.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/tenants.yaml
@@ -38,6 +38,10 @@ paths:
                 $ref: "problem-detail.yaml#/components/schemas/ProblemDetail"
         "409":
           description: Tenant with this id already exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "problem-detail.yaml#/components/schemas/ProblemDetail"
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":


### PR DESCRIPTION
## Summary

Adds the `"409"` (ALREADY_EXISTS) response declaration to 6 create endpoints whose OpenAPI specs were silent on it, even though the engine returns 409 in this case today:

- `createGroup`
- `createRole`
- `createMappingRule`
- `createGlobalClusterVariable`
- `createTenantClusterVariable`
- `createAdminUser`

Aligns these endpoints with the existing `createTenant` / `createUser` declarations, which already declare 409 with an inline description.

## Why

When a caller posts a create request with an identifier that already exists, the engine returns:

```
{"type":"about:blank","title":"ALREADY_EXISTS","status":409,"detail":"..."}
```

Because 409 was not declared in the spec, SDK code generators produced no typed handler for this status — callers had to introspect the response body to detect the conflict.

## Evidence

Discovered while re-running the api-test-generator Playwright suite a second time against the same live cluster. The repeat run produced 80 downstream failures, all traced back to 6 distinct create operations returning unexpected `409`. The affected resource types — group, role, tenant, mapping rule, cluster variable (global + tenant-scoped), admin user — map 1:1 to the 6 endpoints touched here.

## Scope

Purely additive YAML edits in `zeebe/gateway-protocol/src/main/proto/v2/`. No engine behavior change; no breaking change. `./mvnw install -pl zeebe/gateway-protocol -am -Dquickly` is green.

Closes #53540
