### PR TITLE
ci: change optimize ci data layer to nightly

### DIFF
--- a/.github/workflows/optimize-ci-data-upgrade-nightly.yml
+++ b/.github/workflows/optimize-ci-data-upgrade-nightly.yml
@@ -1,31 +1,11 @@
-# description: Workflow for running CI tests for Optimize. Runs integration tests, database upgrade tests, and deploys a SNAPSHOT of Optimize on a push to main
-# test location: /optimize/backend/src/it/java, optimize/upgrade/src/test/java/io/camunda/optimize/upgrade
+# description: Workflow for database upgrade CI tests for Optimize nightly.
+# test location: optimize/upgrade/src/test/java/io/camunda/optimize/upgrade
 # type: CI
 # owner: @camunda/core-features
-name: "[Legacy] Optimize / Data Layer"
+name: "Optimize ES/OS Data Upgrade Tests (Nightly)"
 on:
-  pull_request:
-    paths:
-      - ".github/actions/**"
-      - ".github/workflows/optimize-*"
-      - "bom/*"
-      - "parent/*"
-      - "pom.xml"
-      - "optimize/**"
-      - "optimize.Dockerfile"
-  push:
-    branches:
-      - main
-      - stable/**
-      - release/**
-    paths:
-      - ".github/actions/**"
-      - ".github/workflows/optimize-*"
-      - "bom/*"
-      - "parent/*"
-      - "pom.xml"
-      - "optimize/**"
-      - "optimize.Dockerfile"
+  schedule:
+    - cron: "0 2 * * *"
   workflow_dispatch:
 
 # Will limit the workflow to 1 concurrent run per ref (branch / PR)

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -64,6 +64,7 @@
 /.github/workflows/ci-optimize.yml                        @camunda/core-features
 /.github/workflows/optimize-check-c4.yml                  @camunda/core-features
 /.github/workflows/optimize-e2e-tests-sm-nightly.yml      @camunda/core-features
+/.github/workflows/optimize-ci-data-upgrade-nightly.yml   @camunda/core-features
 
 # Unit Test Suites
 /operate/common/src/test/java/io/camunda/operate/OperateCoreFeaturesTestSuite.java    @camunda/core-features


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Changes the behaviour of a legacy data layer CI in Optimize that only tests for a database upgrade script to be checked nightly.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #52774
