### PR TITLE
fix: make @ClusterVariables initialization idempotent across restarts

### DIFF
--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/annotation/processor/ClusterVariablesAnnotationProcessor.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/annotation/processor/ClusterVariablesAnnotationProcessor.java
@@ -24,6 +24,7 @@ import io.camunda.client.annotation.value.ClusterVariablesValue;
 import io.camunda.client.annotation.value.MethodClusterVariablesValue;
 import io.camunda.client.annotation.value.ResourceClusterVariablesValue;
 import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.bean.BeanInfo;
 import io.camunda.client.spring.properties.CamundaClientClusterVariablesProperties;
 import java.io.IOException;
@@ -96,7 +97,7 @@ public class ClusterVariablesAnnotationProcessor extends AbstractCamundaAnnotati
     final Map<String, Object> propertyVariables = properties.getVariables();
     if (propertyVariables != null && !propertyVariables.isEmpty()) {
       LOGGER.debug("Creating {} cluster variable(s) from properties", propertyVariables.size());
-      createClusterVariables(client, propertyVariables, null);
+      upsertClusterVariables(client, propertyVariables, null);
     }
 
     // Process variables from annotations
@@ -109,7 +110,7 @@ public class ClusterVariablesAnnotationProcessor extends AbstractCamundaAnnotati
       } else {
         continue;
       }
-      createClusterVariables(client, variables, value.getTenantId());
+      upsertClusterVariables(client, variables, value.getTenantId());
     }
   }
 
@@ -152,18 +153,55 @@ public class ClusterVariablesAnnotationProcessor extends AbstractCamundaAnnotati
     return jsonMapper.fromJsonAsMap(jsonMapper.toJson(result));
   }
 
-  private void createClusterVariables(
+  private void upsertClusterVariables(
       final CamundaClient client, final Map<String, Object> variables, final String tenantId) {
     for (final Map.Entry<String, Object> entry : variables.entrySet()) {
       final String name = entry.getKey();
       final Object value = entry.getValue();
-      if (tenantId != null) {
-        client.newTenantScopedClusterVariableCreateRequest(tenantId).create(name, value).execute();
-        LOGGER.debug("Created tenant-scoped cluster variable '{}' for tenant '{}'", name, tenantId);
+      if (clusterVariableExists(client, name, tenantId)) {
+        updateClusterVariable(client, name, value, tenantId);
       } else {
-        client.newGloballyScopedClusterVariableCreateRequest().create(name, value).execute();
-        LOGGER.debug("Created globally-scoped cluster variable '{}'", name);
+        createClusterVariable(client, name, value, tenantId);
       }
+    }
+  }
+
+  private boolean clusterVariableExists(
+      final CamundaClient client, final String name, final String tenantId) {
+    try {
+      if (tenantId != null) {
+        client.newTenantScopedClusterVariableGetRequest(tenantId).withName(name).execute();
+      } else {
+        client.newGloballyScopedClusterVariableGetRequest().withName(name).execute();
+      }
+      return true;
+    } catch (final ProblemException e) {
+      if (e.code() == 404) {
+        return false;
+      }
+      throw e;
+    }
+  }
+
+  private void createClusterVariable(
+      final CamundaClient client, final String name, final Object value, final String tenantId) {
+    if (tenantId != null) {
+      client.newTenantScopedClusterVariableCreateRequest(tenantId).create(name, value).execute();
+      LOGGER.debug("Created tenant-scoped cluster variable '{}' for tenant '{}'", name, tenantId);
+    } else {
+      client.newGloballyScopedClusterVariableCreateRequest().create(name, value).execute();
+      LOGGER.debug("Created globally-scoped cluster variable '{}'", name);
+    }
+  }
+
+  private void updateClusterVariable(
+      final CamundaClient client, final String name, final Object value, final String tenantId) {
+    if (tenantId != null) {
+      client.newTenantScopedClusterVariableUpdateRequest(tenantId).update(name, value).execute();
+      LOGGER.debug("Updated tenant-scoped cluster variable '{}' for tenant '{}'", name, tenantId);
+    } else {
+      client.newGloballyScopedClusterVariableUpdateRequest().update(name, value).execute();
+      LOGGER.debug("Updated globally-scoped cluster variable '{}'", name);
     }
   }
 

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/annotation/processor/ClusterVariablesAnnotationProcessor.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/annotation/processor/ClusterVariablesAnnotationProcessor.java
@@ -158,28 +158,15 @@ public class ClusterVariablesAnnotationProcessor extends AbstractCamundaAnnotati
     for (final Map.Entry<String, Object> entry : variables.entrySet()) {
       final String name = entry.getKey();
       final Object value = entry.getValue();
-      if (clusterVariableExists(client, name, tenantId)) {
-        updateClusterVariable(client, name, value, tenantId);
-      } else {
+      try {
         createClusterVariable(client, name, value, tenantId);
+      } catch (final ProblemException e) {
+        if (e.code() == 409) {
+          updateClusterVariable(client, name, value, tenantId);
+        } else {
+          throw e;
+        }
       }
-    }
-  }
-
-  private boolean clusterVariableExists(
-      final CamundaClient client, final String name, final String tenantId) {
-    try {
-      if (tenantId != null) {
-        client.newTenantScopedClusterVariableGetRequest(tenantId).withName(name).execute();
-      } else {
-        client.newGloballyScopedClusterVariableGetRequest().withName(name).execute();
-      }
-      return true;
-    } catch (final ProblemException e) {
-      if (e.code() == 404) {
-        return false;
-      }
-      throw e;
     }
   }
 

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/annotation/processor/ClusterVariablesAnnotationProcessor.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/annotation/processor/ClusterVariablesAnnotationProcessor.java
@@ -96,7 +96,7 @@ public class ClusterVariablesAnnotationProcessor extends AbstractCamundaAnnotati
     // Process variables from properties
     final Map<String, Object> propertyVariables = properties.getVariables();
     if (propertyVariables != null && !propertyVariables.isEmpty()) {
-      LOGGER.debug("Creating {} cluster variable(s) from properties", propertyVariables.size());
+      LOGGER.debug("Upserting {} cluster variable(s) from properties", propertyVariables.size());
       upsertClusterVariables(client, propertyVariables, null);
     }
 

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/processor/ClusterVariablesAnnotationProcessorTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/processor/ClusterVariablesAnnotationProcessorTest.java
@@ -318,6 +318,28 @@ public class ClusterVariablesAnnotationProcessorTest {
   }
 
   @Test
+  void shouldPropagateNonConflictExceptionOnCreate() throws IOException {
+    // given
+    final Resource resource = mockJsonResource("{\"myVar\": \"value\"}");
+    when(resourcePatternResolver.getResources("classpath:variables.json"))
+        .thenReturn(new Resource[] {resource});
+    when(client.newGloballyScopedClusterVariableCreateRequest()).thenReturn(globalCreateStep);
+    when(globalCreateStep.create(anyString(), any())).thenReturn(globalCreateStep);
+    doThrow(new ProblemException(500, "Internal Server Error", null))
+        .when(globalCreateStep)
+        .execute();
+
+    // when / then
+    assertThatExceptionOfType(ProblemException.class)
+        .isThrownBy(
+            () -> {
+              processor.configureFor(beanInfo(new WithSingleResource()));
+              processor.start(client);
+            });
+    verifyNoInteractions(globalUpdateStep);
+  }
+
+  @Test
   void shouldUpdateTenantScopedVariableWhenAlreadyExists() throws IOException {
     // given
     final Resource resource = mockJsonResource("{\"tenantVar\": \"newValue\"}");

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/processor/ClusterVariablesAnnotationProcessorTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/processor/ClusterVariablesAnnotationProcessorTest.java
@@ -313,6 +313,7 @@ public class ClusterVariablesAnnotationProcessorTest {
     processor.start(client);
 
     // then
+    verify(globalCreateStep).create("myVar", "newValue");
     verify(globalUpdateStep).update("myVar", "newValue");
   }
 
@@ -333,6 +334,7 @@ public class ClusterVariablesAnnotationProcessorTest {
     processor.start(client);
 
     // then
+    verify(tenantCreateStep).create("tenantVar", "newValue");
     verify(tenantUpdateStep).update("tenantVar", "newValue");
   }
 

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/processor/ClusterVariablesAnnotationProcessorTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/processor/ClusterVariablesAnnotationProcessorTest.java
@@ -24,7 +24,13 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.annotation.ClusterVariables;
 import io.camunda.client.api.JsonMapper;
 import io.camunda.client.api.command.GloballyScopedClusterVariableCreationCommandStep1;
+import io.camunda.client.api.command.GloballyScopedClusterVariableUpdateCommandStep1;
+import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.command.TenantScopedClusterVariableCreationCommandStep1;
+import io.camunda.client.api.command.TenantScopedClusterVariableUpdateCommandStep1;
+import io.camunda.client.api.fetch.GloballyScopedClusterVariableGetRequest;
+import io.camunda.client.api.fetch.TenantScopedClusterVariableGetRequest;
+import io.camunda.client.api.search.response.ClusterVariable;
 import io.camunda.client.impl.CamundaObjectMapper;
 import io.camunda.client.spring.annotation.processor.ClusterVariablesAnnotationProcessor;
 import io.camunda.client.spring.properties.CamundaClientClusterVariablesProperties;
@@ -47,8 +53,12 @@ public class ClusterVariablesAnnotationProcessorTest {
   @Mock private CamundaClient client;
 
   @Mock private GloballyScopedClusterVariableCreationCommandStep1 globalCreateStep;
+  @Mock private GloballyScopedClusterVariableUpdateCommandStep1 globalUpdateStep;
+  @Mock private GloballyScopedClusterVariableGetRequest globalGetStep;
 
   @Mock private TenantScopedClusterVariableCreationCommandStep1 tenantCreateStep;
+  @Mock private TenantScopedClusterVariableUpdateCommandStep1 tenantUpdateStep;
+  @Mock private TenantScopedClusterVariableGetRequest tenantGetStep;
 
   @Mock private ResourcePatternResolver resourcePatternResolver;
 
@@ -292,15 +302,88 @@ public class ClusterVariablesAnnotationProcessorTest {
     verify(globalCreateStep).create("fromResource", "resourceValue");
   }
 
+  @Test
+  void shouldUpdateGlobalVariableWhenAlreadyExists() throws IOException {
+    // given
+    final Resource resource = mockJsonResource("{\"myVar\": \"newValue\"}");
+    when(resourcePatternResolver.getResources("classpath:variables.json"))
+        .thenReturn(new Resource[] {resource});
+    mockGlobalGetFound();
+    mockGlobalUpdateCommand();
+
+    // when
+    processor.configureFor(beanInfo(new WithSingleResource()));
+    processor.start(client);
+
+    // then
+    verify(globalUpdateStep).update("myVar", "newValue");
+    verify(client, never()).newGloballyScopedClusterVariableCreateRequest();
+  }
+
+  @Test
+  void shouldUpdateTenantScopedVariableWhenAlreadyExists() throws IOException {
+    // given
+    final Resource resource = mockJsonResource("{\"tenantVar\": \"newValue\"}");
+    when(resourcePatternResolver.getResources("classpath:tenant-variables.json"))
+        .thenReturn(new Resource[] {resource});
+    mockTenantGetFound();
+    mockTenantUpdateCommand();
+
+    // when
+    processor.configureFor(beanInfo(new WithTenantScopedResource()));
+    processor.start(client);
+
+    // then
+    verify(tenantUpdateStep).update("tenantVar", "newValue");
+    verify(client, never()).newTenantScopedClusterVariableCreateRequest(anyString());
+  }
+
   private void mockGlobalCreateCommand() {
+    mockGlobalGetNotFound();
     when(client.newGloballyScopedClusterVariableCreateRequest()).thenReturn(globalCreateStep);
     when(globalCreateStep.create(anyString(), any())).thenReturn(globalCreateStep);
   }
 
+  private void mockGlobalGetNotFound() {
+    when(client.newGloballyScopedClusterVariableGetRequest()).thenReturn(globalGetStep);
+    when(globalGetStep.withName(anyString())).thenReturn(globalGetStep);
+    doThrow(new ProblemException(404, "Not Found", null)).when(globalGetStep).execute();
+  }
+
+  private void mockGlobalGetFound() {
+    when(client.newGloballyScopedClusterVariableGetRequest()).thenReturn(globalGetStep);
+    when(globalGetStep.withName(anyString())).thenReturn(globalGetStep);
+    when(globalGetStep.execute()).thenReturn(mock(ClusterVariable.class));
+  }
+
+  private void mockGlobalUpdateCommand() {
+    when(client.newGloballyScopedClusterVariableUpdateRequest()).thenReturn(globalUpdateStep);
+    when(globalUpdateStep.update(anyString(), any())).thenReturn(globalUpdateStep);
+  }
+
   private void mockTenantCreateCommand() {
+    mockTenantGetNotFound();
     when(client.newTenantScopedClusterVariableCreateRequest(anyString()))
         .thenReturn(tenantCreateStep);
     when(tenantCreateStep.create(anyString(), any())).thenReturn(tenantCreateStep);
+  }
+
+  private void mockTenantGetNotFound() {
+    when(client.newTenantScopedClusterVariableGetRequest(anyString())).thenReturn(tenantGetStep);
+    when(tenantGetStep.withName(anyString())).thenReturn(tenantGetStep);
+    doThrow(new ProblemException(404, "Not Found", null)).when(tenantGetStep).execute();
+  }
+
+  private void mockTenantGetFound() {
+    when(client.newTenantScopedClusterVariableGetRequest(anyString())).thenReturn(tenantGetStep);
+    when(tenantGetStep.withName(anyString())).thenReturn(tenantGetStep);
+    when(tenantGetStep.execute()).thenReturn(mock(ClusterVariable.class));
+  }
+
+  private void mockTenantUpdateCommand() {
+    when(client.newTenantScopedClusterVariableUpdateRequest(anyString()))
+        .thenReturn(tenantUpdateStep);
+    when(tenantUpdateStep.update(anyString(), any())).thenReturn(tenantUpdateStep);
   }
 
   private Resource mockJsonResource(final String jsonContent) throws IOException {

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/processor/ClusterVariablesAnnotationProcessorTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/processor/ClusterVariablesAnnotationProcessorTest.java
@@ -28,9 +28,6 @@ import io.camunda.client.api.command.GloballyScopedClusterVariableUpdateCommandS
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.command.TenantScopedClusterVariableCreationCommandStep1;
 import io.camunda.client.api.command.TenantScopedClusterVariableUpdateCommandStep1;
-import io.camunda.client.api.fetch.GloballyScopedClusterVariableGetRequest;
-import io.camunda.client.api.fetch.TenantScopedClusterVariableGetRequest;
-import io.camunda.client.api.search.response.ClusterVariable;
 import io.camunda.client.impl.CamundaObjectMapper;
 import io.camunda.client.spring.annotation.processor.ClusterVariablesAnnotationProcessor;
 import io.camunda.client.spring.properties.CamundaClientClusterVariablesProperties;
@@ -54,11 +51,9 @@ public class ClusterVariablesAnnotationProcessorTest {
 
   @Mock private GloballyScopedClusterVariableCreationCommandStep1 globalCreateStep;
   @Mock private GloballyScopedClusterVariableUpdateCommandStep1 globalUpdateStep;
-  @Mock private GloballyScopedClusterVariableGetRequest globalGetStep;
 
   @Mock private TenantScopedClusterVariableCreationCommandStep1 tenantCreateStep;
   @Mock private TenantScopedClusterVariableUpdateCommandStep1 tenantUpdateStep;
-  @Mock private TenantScopedClusterVariableGetRequest tenantGetStep;
 
   @Mock private ResourcePatternResolver resourcePatternResolver;
 
@@ -308,7 +303,9 @@ public class ClusterVariablesAnnotationProcessorTest {
     final Resource resource = mockJsonResource("{\"myVar\": \"newValue\"}");
     when(resourcePatternResolver.getResources("classpath:variables.json"))
         .thenReturn(new Resource[] {resource});
-    mockGlobalGetFound();
+    when(client.newGloballyScopedClusterVariableCreateRequest()).thenReturn(globalCreateStep);
+    when(globalCreateStep.create(anyString(), any())).thenReturn(globalCreateStep);
+    doThrow(new ProblemException(409, "Conflict", null)).when(globalCreateStep).execute();
     mockGlobalUpdateCommand();
 
     // when
@@ -317,7 +314,6 @@ public class ClusterVariablesAnnotationProcessorTest {
 
     // then
     verify(globalUpdateStep).update("myVar", "newValue");
-    verify(client, never()).newGloballyScopedClusterVariableCreateRequest();
   }
 
   @Test
@@ -326,7 +322,10 @@ public class ClusterVariablesAnnotationProcessorTest {
     final Resource resource = mockJsonResource("{\"tenantVar\": \"newValue\"}");
     when(resourcePatternResolver.getResources("classpath:tenant-variables.json"))
         .thenReturn(new Resource[] {resource});
-    mockTenantGetFound();
+    when(client.newTenantScopedClusterVariableCreateRequest(anyString()))
+        .thenReturn(tenantCreateStep);
+    when(tenantCreateStep.create(anyString(), any())).thenReturn(tenantCreateStep);
+    doThrow(new ProblemException(409, "Conflict", null)).when(tenantCreateStep).execute();
     mockTenantUpdateCommand();
 
     // when
@@ -335,25 +334,11 @@ public class ClusterVariablesAnnotationProcessorTest {
 
     // then
     verify(tenantUpdateStep).update("tenantVar", "newValue");
-    verify(client, never()).newTenantScopedClusterVariableCreateRequest(anyString());
   }
 
   private void mockGlobalCreateCommand() {
-    mockGlobalGetNotFound();
     when(client.newGloballyScopedClusterVariableCreateRequest()).thenReturn(globalCreateStep);
     when(globalCreateStep.create(anyString(), any())).thenReturn(globalCreateStep);
-  }
-
-  private void mockGlobalGetNotFound() {
-    when(client.newGloballyScopedClusterVariableGetRequest()).thenReturn(globalGetStep);
-    when(globalGetStep.withName(anyString())).thenReturn(globalGetStep);
-    doThrow(new ProblemException(404, "Not Found", null)).when(globalGetStep).execute();
-  }
-
-  private void mockGlobalGetFound() {
-    when(client.newGloballyScopedClusterVariableGetRequest()).thenReturn(globalGetStep);
-    when(globalGetStep.withName(anyString())).thenReturn(globalGetStep);
-    when(globalGetStep.execute()).thenReturn(mock(ClusterVariable.class));
   }
 
   private void mockGlobalUpdateCommand() {
@@ -362,22 +347,9 @@ public class ClusterVariablesAnnotationProcessorTest {
   }
 
   private void mockTenantCreateCommand() {
-    mockTenantGetNotFound();
     when(client.newTenantScopedClusterVariableCreateRequest(anyString()))
         .thenReturn(tenantCreateStep);
     when(tenantCreateStep.create(anyString(), any())).thenReturn(tenantCreateStep);
-  }
-
-  private void mockTenantGetNotFound() {
-    when(client.newTenantScopedClusterVariableGetRequest(anyString())).thenReturn(tenantGetStep);
-    when(tenantGetStep.withName(anyString())).thenReturn(tenantGetStep);
-    doThrow(new ProblemException(404, "Not Found", null)).when(tenantGetStep).execute();
-  }
-
-  private void mockTenantGetFound() {
-    when(client.newTenantScopedClusterVariableGetRequest(anyString())).thenReturn(tenantGetStep);
-    when(tenantGetStep.withName(anyString())).thenReturn(tenantGetStep);
-    when(tenantGetStep.execute()).thenReturn(mock(ClusterVariable.class));
   }
 
   private void mockTenantUpdateCommand() {


### PR DESCRIPTION
Application restarts failed after the first boot when using `@ClusterVariables`: the processor always called the create API on startup, and the engine rejects creating a variable whose name already exists in scope.

The processor now uses a create-first strategy: it attempts to create each variable and, if the engine returns HTTP 409 (conflict — variable already exists), falls back to an update instead. Both globally-scoped and tenant-scoped variables follow this path.

Closes #53570

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Sonnet_4.6_(200K)](https://img.shields.io/badge/Sonnet_4.6_(200K)-D97757?logo=claude&logoColor=white)