### PR TITLE
ci: drop PostgreSQL 14 from CI matrix

### DIFF
--- a/.ci/db-versions.yml
+++ b/.ci/db-versions.yml
@@ -35,7 +35,6 @@ opensearch:
 # See: .github/workflows/zeebe-rdbms-integration-tests.yml
 
 postgresql:
-  - "14-alpine"
   - "15-alpine"
   - "16-alpine"
   - "17-alpine"

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
@@ -369,10 +369,10 @@ jobs:
       fail-fast: false
       matrix:
         database:
-          # PostgreSQL - Supported versions: 14, 18
-          - database-name: "Postgres 14"
+          # PostgreSQL - Supported versions: 15, 18
+          - database-name: "Postgres 15"
             database-type: "postgres"
-            database-image-version: "14-alpine"
+            database-image-version: "15-alpine"
             jdbc-url: "jdbc:postgresql://localhost:5432/camunda"
             jdbc-username: "camunda"
             jdbc-password: "camunda"

--- a/.github/workflows/c8-orchestration-cluster-reusable-rdbms-api-tests.yml
+++ b/.github/workflows/c8-orchestration-cluster-reusable-rdbms-api-tests.yml
@@ -77,13 +77,7 @@ jobs:
       fail-fast: false
       matrix:
         database:
-          # PostgreSQL - Supported versions: 14, 15, 16, 17, 18
-          - database-name: "Postgres 14"
-            database-type: "postgres"
-            database-image-version: "14-alpine"
-            jdbc-url: "jdbc:postgresql://localhost:5432/camunda"
-            jdbc-username: "camunda"
-            jdbc-password: "camunda"
+          # PostgreSQL - Supported versions: 15, 16, 17, 18
           - database-name: "Postgres 15"
             database-type: "postgres"
             database-image-version: "15-alpine"


### PR DESCRIPTION
- Removes PostgreSQL 14 from `.ci/db-versions.yml` (the single source of truth for tested DB versions).
- Removes the `Postgres 14` matrix entry from `c8-orchestration-cluster-reusable-rdbms-api-tests.yml` (nightly RDBMS API tests).
- Substitutes `Postgres 14` with `Postgres 15` in `c8-orchestration-cluster-e2e-tests-release.yml` to preserve the oldest/newest coverage pattern that workflow already uses for MariaDB (10.11/11.8) and MSSQL (2019/2025).

PostgreSQL 14 is no longer a supported target for the 8.10 release.

Closes #52146.

Related: #52147 (Aurora PostgreSQL 14) requires no code changes — the Aurora workflow (`zeebe-aws-aurora-dispatch-tests.yml`) already targets the `camunda-ci-eks-aurora-postgresql-15` cluster. Can be closed separately.