### PR TITLE
test: stabilize four nightly API-test flakes

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-ad-hoc-activities-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-ad-hoc-activities-api.spec.ts
@@ -122,8 +122,11 @@ test.describe.parallel('Element Instance Ad-hoc Activities API', () => {
       cancelRemainingInstances: true,
     };
 
-    const res = await test.step('Call activation endpoint', async () => {
-      return await request.post(
+    // Retry to absorb engine read-after-write lag: the ad-hoc subprocess
+    // instance can be visible via search before the activation command can
+    // resolve it (404 → 204). Same pattern as SucceedsWithValidElements.
+    await expect(async () => {
+      const res = await request.post(
         buildUrl(
           '/element-instances/ad-hoc-activities/{adHocSubProcessInstanceKey}/activation',
           {adHocSubProcessInstanceKey: adHocKey},
@@ -133,11 +136,8 @@ test.describe.parallel('Element Instance Ad-hoc Activities API', () => {
           data: body,
         },
       );
-    });
-
-    await test.step('Assert successful response', async () => {
       await assertStatusCode(res, 204);
-    });
+    }).toPass(defaultAssertionOptions);
   });
 
   test('Activate AdHoc Activities FailsWithMissingElements', async ({

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-create-batch-to-modify-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-create-batch-to-modify-api.spec.ts
@@ -23,7 +23,7 @@ import {
   defaultAssertionOptions,
   extendedAssertionOptions,
 } from '../../../../utils/constants';
-import {findUserTask} from '@requestHelpers';
+import {expectBatchState, findUserTask} from '@requestHelpers';
 import {validateResponse} from 'json-body-assertions';
 
 /* eslint-disable playwright/expect-expect */
@@ -201,8 +201,17 @@ test.describe.parallel('Create Process Instance Batch to Modify Tests', () => {
           res,
         );
         const json = await res.json();
+        localState.batchOperationKey = json.batchOperationKey;
         expect(json.batchOperationType).toBe('MODIFY_PROCESS_INSTANCE');
       }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step('Wait for modification to complete', async () => {
+      await expectBatchState(
+        request,
+        localState.batchOperationKey,
+        'COMPLETED',
+      );
     });
 
     await test.step('Verify only second instance modified', async () => {
@@ -328,8 +337,17 @@ test.describe.parallel('Create Process Instance Batch to Modify Tests', () => {
           res,
         );
         const json = await res.json();
+        localState.batchOperationKey = json.batchOperationKey;
         expect(json.batchOperationType).toBe('MODIFY_PROCESS_INSTANCE');
       }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step('Wait for modification to complete', async () => {
+      await expectBatchState(
+        request,
+        localState.batchOperationKey,
+        'COMPLETED',
+      );
     });
 
     await test.step('Verify both instances modified', async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-create-batch-to-modify-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-create-batch-to-modify-api.spec.ts
@@ -129,6 +129,7 @@ test.describe.parallel('Create Process Instance Batch to Modify Tests', () => {
     const localState: Record<string, string> = {
       processInstanceKey1: '',
       processInstanceKey2: '',
+      batchOperationKey: '',
     };
 
     await test.step('Create two process instances', async () => {
@@ -204,6 +205,7 @@ test.describe.parallel('Create Process Instance Batch to Modify Tests', () => {
         localState.batchOperationKey = json.batchOperationKey;
         expect(json.batchOperationType).toBe('MODIFY_PROCESS_INSTANCE');
       }).toPass(defaultAssertionOptions);
+      expect(localState.batchOperationKey).toBeTruthy();
     });
 
     await test.step('Wait for modification to complete', async () => {
@@ -264,6 +266,7 @@ test.describe.parallel('Create Process Instance Batch to Modify Tests', () => {
     const localState: Record<string, string> = {
       processInstanceKey1: '',
       processInstanceKey2: '',
+      batchOperationKey: '',
     };
 
     await test.step('Create two process instances with a different set of variables', async () => {
@@ -340,6 +343,7 @@ test.describe.parallel('Create Process Instance Batch to Modify Tests', () => {
         localState.batchOperationKey = json.batchOperationKey;
         expect(json.batchOperationType).toBe('MODIFY_PROCESS_INSTANCE');
       }).toPass(defaultAssertionOptions);
+      expect(localState.batchOperationKey).toBeTruthy();
     });
 
     await test.step('Wait for modification to complete', async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/batch-operation-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/batch-operation-requestHelpers.ts
@@ -34,10 +34,12 @@ export async function cancelBatchOperation(
 // A freshly created batch operation can take longer than the default 30s
 // to be visible to the suspend/resume commands on a loaded shared cluster
 // (404 → 204). Use a more generous budget here for batch operation lifecycle
-// actions while the engine catches up.
+// actions while the engine catches up. The 180s budget proved tight when
+// multiple cancellation batches (30 instances each) accumulate within a
+// single spec file, so allow up to 240s with a longer tail interval.
 const batchOperationLifecycleOptions = {
-  intervals: [5_000, 10_000, 10_000, 15_000, 20_000, 30_000],
-  timeout: 180_000,
+  intervals: [5_000, 10_000, 10_000, 15_000, 20_000, 30_000, 45_000],
+  timeout: 240_000,
 };
 
 export async function suspendBatchOperation(
@@ -135,9 +137,13 @@ export async function expectBatchState(
   });
 }
 
+// Post-migration user-task search has to wait for the secondary-storage
+// indexer to reflect the migrated elementId. On a loaded shared cluster the
+// 180s budget proved tight (seen as flake on nightly runs), so allow up to
+// 240s with a longer tail interval.
 export const postMigrationAssertionOptions = {
-  intervals: [5_000, 10_000, 15_000, 25_000, 35_000, 45_000],
-  timeout: 180_000,
+  intervals: [5_000, 10_000, 15_000, 25_000, 35_000, 45_000, 60_000],
+  timeout: 240_000,
 };
 
 export const notFoundDetail = (key: string) =>


### PR DESCRIPTION
## Summary

Stabilizes four flaky/failing API tests from the latest nightly runs ([26137139874](https://github.com/camunda/camunda/actions/runs/26137139874), [26148253337](https://github.com/camunda/camunda/actions/runs/26148253337)). All four root-causes are engine read-after-write lag or secondary-storage indexing lag on a loaded shared cluster — not product defects.

| Test | Symptom | Fix |
|---|---|---|
| `element-instance-ad-hoc-activities-api :108` (SucceedsWithVariablesAndCancel) | Activation POST returned 404 for both initial attempt and retry — engine hadn't resolved the ad-hoc subprocess key | Wrap the POST in `expect.toPass(defaultAssertionOptions)`, mirroring the sibling `SucceedsWithValidElements` test at :77 which already handles this race |
| `process-instance-create-batch-to-modify-api` (Multiple Filters & Or Filters) | User-task search returned old/stale items because modification batch hadn't reached `COMPLETED` | Capture `batchOperationKey` and add `expectBatchState(..., 'COMPLETED')` step before verification (matches migrate-test pattern) |
| `process-instance-create-batch-to-migrate-api` (Success) | Post-migration user-task search hit 180s ceiling waiting for indexer to reflect new `elementId` | Bump `postMigrationAssertionOptions` 180s → 240s with an extra 60s tail interval |
| `batch-operations-suspend-api-tests :136` (Suspend without resume) | `suspendBatchOperation` returned 404 for full 180s — engine hadn't surfaced the batch yet | Bump `batchOperationLifecycleOptions` 180s → 240s with an extra 45s tail interval |

Closes the symptom of repeated nightly failures while a more structural fix (e.g. engine acknowledging batch-op availability before returning the key) is out of scope here.

## Test plan
https://github.com/camunda/camunda/actions/runs/26151269114
- [x] Local Playwright run against 8.10.0-SNAPSHOT: all four originally-failing tests pass on first attempt (82 passed / 4 skipped, 12 min wall-clock; the single remaining failure was an unrelated job-statistics-by-worker flake in the teardown subset)
- [ ] Nightly C8 Orchestration Cluster ES API tests stay green
- [x] On-demand C8 Orchestration Cluster API tests stay green

🤖 Generated with [Claude Code](https://claude.com/claude-code)