### PR TITLE
fix: handle empty bulk incident update

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java
@@ -187,6 +187,10 @@ public final class ElasticsearchIncidentUpdateRepository extends ElasticsearchRe
   @Override
   public CompletionStage<List<String>> bulkUpdate(final IncidentBulkUpdate bulk) {
     final var updates = bulk.stream().map(this::createUpdateOperation).toList();
+    if (updates.isEmpty()) {
+      return CompletableFuture.completedFuture(List.of());
+    }
+
     final var request =
         new BulkRequest.Builder()
             .operations(updates)

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/OpenSearchIncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/OpenSearchIncidentUpdateRepository.java
@@ -203,6 +203,10 @@ public final class OpenSearchIncidentUpdateRepository extends OpensearchReposito
   @Override
   public CompletionStage<List<String>> bulkUpdate(final IncidentBulkUpdate bulk) {
     final var updates = bulk.stream().map(this::createUpdateOperation).toList();
+    if (updates.isEmpty()) {
+      return CompletableFuture.completedFuture(List.of());
+    }
+
     final var request =
         new BulkRequest.Builder()
             .operations(updates)

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepositoryTest.java
@@ -10,13 +10,16 @@ package io.camunda.exporter.tasks.incident;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
+import co.elastic.clients.elasticsearch.core.BulkRequest;
 import co.elastic.clients.elasticsearch.core.ClearScrollRequest;
 import co.elastic.clients.elasticsearch.core.ClearScrollResponse;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.search.Hit;
+import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.IncidentBulkUpdate;
 import io.camunda.webapps.schema.entities.incident.IncidentEntity;
 import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
+import io.camunda.zeebe.test.util.junit.RegressionTest;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -106,6 +109,20 @@ public final class ElasticsearchIncidentUpdateRepositoryTest {
     assertThat(result).failsWithin(Duration.ofSeconds(5));
     inOrder.verify(client, Mockito.times(1)).clearScroll(Mockito.any(ClearScrollRequest.class));
     inOrder.verifyNoMoreInteractions();
+  }
+
+  @RegressionTest("https://github.com/camunda/camunda/pull/53585")
+  void shouldSkipBulkCallWhenUpdateIsEmpty() {
+    // given
+    final var repository = createRepository();
+
+    // when
+    final var result = repository.bulkUpdate(new IncidentBulkUpdate());
+
+    // then - client.bulk() must not be invoked; previously this sent an empty body and ES threw
+    // "[es/bulk] failed: [parse_exception] request body is required"
+    assertThat(result).succeedsWithin(Duration.ofSeconds(5)).isEqualTo(List.of());
+    Mockito.verify(client, Mockito.never()).bulk(Mockito.any(BulkRequest.class));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
@@ -719,38 +719,6 @@ final class IncidentUpdateTaskTest {
     }
 
     @Test
-    void shouldSucceedWhenBulkUpdateIsEmpty() {
-      // Regression: when all incidents are skipped (e.g. every process instance was deleted),
-      // bulkUpdate is called with empty maps; previously this triggered
-      // "[es/bulk] failed: [parse_exception] request body is required"
-      final var task =
-          new IncidentUpdateTask(
-              metadata,
-              repository,
-              false,
-              10,
-              EXECUTOR,
-              incidentNotifier,
-              metrics,
-              LOGGER,
-              Duration.ZERO);
-      when(repository.deletedProcessInstances(any()))
-          .thenReturn(
-              CompletableFuture.completedFuture(Set.of(incidentEntity.getProcessInstanceKey())));
-
-      // when
-      final var result = task.execute();
-
-      // then
-      assertThat(result).succeedsWithin(TIMEOUT).isEqualTo(0);
-      verify(repository).bulkUpdate(bulkUpdateCaptor.capture());
-      final var update = bulkUpdateCaptor.getValue();
-      assertThat(update.incidentRequests()).isEmpty();
-      assertThat(update.listViewRequests()).isEmpty();
-      assertThat(update.flowNodeInstanceRequests()).isEmpty();
-    }
-
-    @Test
     void shouldIgnoreDeletedProcessInstance() {
       // given
       final var task =

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
@@ -719,6 +719,38 @@ final class IncidentUpdateTaskTest {
     }
 
     @Test
+    void shouldSucceedWhenBulkUpdateIsEmpty() {
+      // Regression: when all incidents are skipped (e.g. every process instance was deleted),
+      // bulkUpdate is called with empty maps; previously this triggered
+      // "[es/bulk] failed: [parse_exception] request body is required"
+      final var task =
+          new IncidentUpdateTask(
+              metadata,
+              repository,
+              false,
+              10,
+              EXECUTOR,
+              incidentNotifier,
+              metrics,
+              LOGGER,
+              Duration.ZERO);
+      when(repository.deletedProcessInstances(any()))
+          .thenReturn(
+              CompletableFuture.completedFuture(Set.of(incidentEntity.getProcessInstanceKey())));
+
+      // when
+      final var result = task.execute();
+
+      // then
+      assertThat(result).succeedsWithin(TIMEOUT).isEqualTo(0);
+      verify(repository).bulkUpdate(bulkUpdateCaptor.capture());
+      final var update = bulkUpdateCaptor.getValue();
+      assertThat(update.incidentRequests()).isEmpty();
+      assertThat(update.listViewRequests()).isEmpty();
+      assertThat(update.flowNodeInstanceRequests()).isEmpty();
+    }
+
+    @Test
     void shouldIgnoreDeletedProcessInstance() {
       // given
       final var task =

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/OpenSearchIncidentUpdateRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/OpenSearchIncidentUpdateRepositoryTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.incident;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.IncidentBulkUpdate;
+import io.camunda.zeebe.test.util.junit.RegressionTest;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.client.opensearch.OpenSearchAsyncClient;
+import org.opensearch.client.opensearch.core.BulkRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ExtendWith(MockitoExtension.class)
+public final class OpenSearchIncidentUpdateRepositoryTest {
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(OpenSearchIncidentUpdateRepositoryTest.class);
+
+  @Mock private OpenSearchAsyncClient client;
+
+  @RegressionTest("https://github.com/camunda/camunda/pull/53585")
+  void shouldSkipBulkCallWhenUpdateIsEmpty() throws Exception {
+    // given
+    final var repository = createRepository();
+
+    // when
+    final var result = repository.bulkUpdate(new IncidentBulkUpdate());
+
+    // then - client.bulk() must not be invoked; previously this sent an empty body and OS threw
+    // "[os/bulk] failed: [parse_exception] request body is required"
+    assertThat(result).succeedsWithin(Duration.ofSeconds(5)).isEqualTo(List.of());
+    Mockito.verify(client, Mockito.never()).bulk(Mockito.any(BulkRequest.class));
+  }
+
+  private OpenSearchIncidentUpdateRepository createRepository() {
+    return new OpenSearchIncidentUpdateRepository(
+        1,
+        "pendingUpdateAlias",
+        "incidentAlias",
+        "listViewAlias",
+        "listViewFullQualifiedName",
+        "flowNodeAlias",
+        "operationAlias",
+        client,
+        Runnable::run,
+        LOGGER);
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Handle empty bulk update on incidents. Enabling the ignore missing data flag when all incidents are missing causes the updater to enter a rescheduling loop because Elasticsearch fails the query since it has no body in it.

```
Error occurred while performing a background task Incident update task; error message [es/bulk] failed: [parse_exception] request body is required; operation will be retried
```

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
