### PR TITLE
feat: publish BrokerInfo per partition group from broker

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -121,9 +121,10 @@ public final class PartitionManagerImpl
     // Each physical tenant needs its own BrokerInfo instance so that concurrent TopologyManagerImpl
     // actors don't overwrite each other's partition state. withPartitionGroup copies the
     // broker-level fields and sets the correct group name for this tenant.
-    final var tenantBroker = localBroker.withPartitionGroup(partitionGroup);
+    final var partitionGroupInfo = localBroker.withPartitionGroup(partitionGroup);
     // TODO: Do this as a separate step before starting the partition manager
-    topologyManager = new TopologyManagerImpl(clusterServices.getMembershipService(), tenantBroker);
+    topologyManager =
+        new TopologyManagerImpl(clusterServices.getMembershipService(), partitionGroupInfo);
 
     final List<PartitionListener> listeners = new ArrayList<>(partitionListeners);
     listeners.add(topologyManager);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -118,8 +118,12 @@ public final class PartitionManagerImpl
     final var featureFlags = brokerCfg.getExperimental().getFeatures().toFeatureFlags();
     this.clusterConfigurationService = clusterConfigurationService;
     brokerMeterRegistry = meterRegistry;
+    // Each physical tenant needs its own BrokerInfo instance so that concurrent TopologyManagerImpl
+    // actors don't overwrite each other's partition state. withPartitionGroup copies the
+    // broker-level fields and sets the correct group name for this tenant.
+    final var tenantBroker = localBroker.withPartitionGroup(partitionGroup);
     // TODO: Do this as a separate step before starting the partition manager
-    topologyManager = new TopologyManagerImpl(clusterServices.getMembershipService(), localBroker);
+    topologyManager = new TopologyManagerImpl(clusterServices.getMembershipService(), tenantBroker);
 
     final List<PartitionListener> listeners = new ArrayList<>(partitionListeners);
     listeners.add(topologyManager);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyManagerImpl.java
@@ -46,7 +46,7 @@ public final class TopologyManagerImpl extends Actor
     this.membershipService = membershipService;
     this.localBroker = localBroker;
 
-    actorName = "TopologyManager";
+    actorName = "TopologyManager-" + localBroker.getPartitionGroup();
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyManagerImpl.java
@@ -36,17 +36,17 @@ public final class TopologyManagerImpl extends Actor
 
   private final Int2ObjectHashMap<BrokerInfo> partitionLeaders = new Int2ObjectHashMap<>();
   private final ClusterMembershipService membershipService;
-  private final BrokerInfo localBroker;
+  private final BrokerInfo localPartitionGroupInfo;
 
   private final List<TopologyPartitionListener> topologyPartitionListeners = new ArrayList<>();
   private final String actorName;
 
   public TopologyManagerImpl(
-      final ClusterMembershipService membershipService, final BrokerInfo localBroker) {
+      final ClusterMembershipService membershipService, final BrokerInfo partitionGroupInfo) {
     this.membershipService = membershipService;
-    this.localBroker = localBroker;
+    localPartitionGroupInfo = partitionGroupInfo;
 
-    actorName = "TopologyManager-" + localBroker.getPartitionGroup();
+    actorName = "TopologyManager-" + partitionGroupInfo.getPartitionGroup();
   }
 
   @Override
@@ -86,18 +86,18 @@ public final class TopologyManagerImpl extends Actor
   public ActorFuture<Void> setLeader(final long term, final int partitionId) {
     return actor.call(
         () -> {
-          partitionLeaders.put(partitionId, localBroker);
-          localBroker.setLeaderForPartition(partitionId, term);
+          partitionLeaders.put(partitionId, localPartitionGroupInfo);
+          localPartitionGroupInfo.setLeaderForPartition(partitionId, term);
           publishTopologyChanges();
-          notifyPartitionLeaderUpdated(partitionId, localBroker);
+          notifyPartitionLeaderUpdated(partitionId, localPartitionGroupInfo);
         });
   }
 
   public ActorFuture<Void> setFollower(final int partitionId) {
     return actor.call(
         () -> {
-          removeIfLeader(localBroker, partitionId);
-          localBroker.setFollowerForPartition(partitionId);
+          removeIfLeader(localPartitionGroupInfo, partitionId);
+          localPartitionGroupInfo.setFollowerForPartition(partitionId);
           publishTopologyChanges();
         });
   }
@@ -105,8 +105,8 @@ public final class TopologyManagerImpl extends Actor
   public ActorFuture<Void> setInactive(final int partitionId) {
     return actor.call(
         () -> {
-          removeIfLeader(localBroker, partitionId);
-          localBroker.setInactiveForPartition(partitionId);
+          removeIfLeader(localPartitionGroupInfo, partitionId);
+          localPartitionGroupInfo.setInactiveForPartition(partitionId);
           publishTopologyChanges();
         });
   }
@@ -117,7 +117,7 @@ public final class TopologyManagerImpl extends Actor
 
     final BrokerInfo brokerInfo = BrokerInfo.fromProperties(eventSource.properties());
 
-    if (brokerInfo != null && !memberIdOf(brokerInfo).equals(memberIdOf(localBroker))) {
+    if (brokerInfo != null && !memberIdOf(brokerInfo).equals(memberIdOf(localPartitionGroupInfo))) {
       actor.run(
           () -> {
             switch (clusterMembershipEvent.type()) {
@@ -211,7 +211,7 @@ public final class TopologyManagerImpl extends Actor
   // Propagate local partition info to other nodes through Atomix member properties
   private void publishTopologyChanges() {
     final Properties memberProperties = membershipService.getLocalMember().properties();
-    localBroker.writeIntoProperties(memberProperties);
+    localPartitionGroupInfo.writeIntoProperties(memberProperties);
   }
 
   @Override
@@ -239,11 +239,11 @@ public final class TopologyManagerImpl extends Actor
     actor.run(
         () -> {
           if (status == HealthStatus.HEALTHY) {
-            localBroker.setPartitionHealthy(partitionId);
+            localPartitionGroupInfo.setPartitionHealthy(partitionId);
           } else if (status == HealthStatus.UNHEALTHY) {
-            localBroker.setPartitionUnhealthy(partitionId);
+            localPartitionGroupInfo.setPartitionUnhealthy(partitionId);
           } else if (status == HealthStatus.DEAD) {
-            localBroker.setPartitionDead(partitionId);
+            localPartitionGroupInfo.setPartitionDead(partitionId);
           }
           publishTopologyChanges();
         });
@@ -253,8 +253,8 @@ public final class TopologyManagerImpl extends Actor
   public void removePartition(final int partitionId) {
     actor.run(
         () -> {
-          removeIfLeader(localBroker, partitionId);
-          localBroker.removePartition(partitionId);
+          removeIfLeader(localPartitionGroupInfo, partitionId);
+          localPartitionGroupInfo.removePartition(partitionId);
         });
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
@@ -76,7 +76,7 @@ class PartitionManagerStepTest {
       startupFuture = CONCURRENCY_CONTROL.createFuture();
 
       testBrokerStartupContext = new MockBrokerStartupContext();
-      testBrokerStartupContext.setBrokerInfo(mock(BrokerInfo.class));
+      testBrokerStartupContext.setBrokerInfo(new BrokerInfo());
       testBrokerStartupContext.setBrokerConfiguration(TEST_BROKER_CONFIG);
       testBrokerStartupContext.setActorSchedulingService(actorScheduler);
       testBrokerStartupContext.setShutdownTimeout(TEST_SHUTDOWN_TIMEOUT);

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
@@ -534,12 +534,15 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
    */
   public BrokerInfo withPartitionGroup(final String partitionGroup) {
     final BrokerInfo copy = new BrokerInfo();
-    copy.setBrokerId(nodeId, zone);
-    copy.setPartitionsCount(partitionsCount);
-    copy.setClusterSize(clusterSize);
-    copy.setReplicationFactor(replicationFactor);
+    // Direct field assignment avoids validation checks so that null-sentinel values
+    // (e.g. partitionsCount before it has been set) are preserved faithfully.
+    copy.nodeId = nodeId;
+    copy.zone = zone;
+    copy.partitionsCount = partitionsCount;
+    copy.clusterSize = clusterSize;
+    copy.replicationFactor = replicationFactor;
     copy.version = BufferUtil.cloneBuffer(version);
-    copy.setPartitionGroup(partitionGroup);
+    copy.partitionGroup = partitionGroup;
     addresses.forEach(copy::addAddress);
     return copy;
   }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
@@ -513,8 +513,43 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
     return brokerInfo;
   }
 
+  /**
+   * Returns the member-property key under which a broker publishes its {@link BrokerInfo} for the
+   * given partition group. The default group uses the legacy {@value #BROKER_INFO_PROPERTY_NAME}
+   * key so that older readers continue to work during rolling upgrades. Non-default groups use a
+   * namespaced key of the form {@code "brokerInfo:<partitionGroup>"}.
+   */
+  public static String brokerInfoPropertyName(final String partitionGroup) {
+    if (Protocol.DEFAULT_PARTITION_GROUP_NAME.equals(partitionGroup)) {
+      return BROKER_INFO_PROPERTY_NAME;
+    }
+    return BROKER_INFO_PROPERTY_NAME + ":" + partitionGroup;
+  }
+
+  /**
+   * Creates a copy of this {@link BrokerInfo} carrying only the broker-level fields (node ID, zone,
+   * cluster config, version, addresses) with the given {@code partitionGroup} set. The returned
+   * instance has empty partition-role, leader-term, and health maps so it can be used as the
+   * starting point for a per-tenant {@code TopologyManagerImpl}.
+   */
+  public BrokerInfo withPartitionGroup(final String partitionGroup) {
+    final BrokerInfo copy = new BrokerInfo();
+    copy.setBrokerId(nodeId, zone);
+    copy.setPartitionsCount(partitionsCount);
+    copy.setClusterSize(clusterSize);
+    copy.setReplicationFactor(replicationFactor);
+    copy.version = BufferUtil.cloneBuffer(version);
+    copy.setPartitionGroup(partitionGroup);
+    addresses.forEach(copy::addAddress);
+    return copy;
+  }
+
   public void writeIntoProperties(final Properties memberProperties) {
-    memberProperties.setProperty(BROKER_INFO_PROPERTY_NAME, writeToString());
+    writeIntoProperties(memberProperties, brokerInfoPropertyName(getPartitionGroup()));
+  }
+
+  public void writeIntoProperties(final Properties memberProperties, final String propertyKey) {
+    memberProperties.setProperty(propertyKey, writeToString());
   }
 
   private String writeToString() {

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/BrokerInfoTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/BrokerInfoTest.java
@@ -19,12 +19,98 @@ import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
 import io.camunda.zeebe.protocol.record.PartitionRole;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.Test;
 
 final class BrokerInfoTest {
+
+  @Test
+  void shouldReturnDefaultPropertyNameForDefaultPartitionGroup() {
+    assertThat(BrokerInfo.brokerInfoPropertyName(BrokerInfo.DEFAULT_PARTITION_GROUP))
+        .isEqualTo("brokerInfo");
+  }
+
+  @Test
+  void shouldReturnNamespacedPropertyNameForNonDefaultPartitionGroup() {
+    assertThat(BrokerInfo.brokerInfoPropertyName("tenant1")).isEqualTo("brokerInfo:tenant1");
+  }
+
+  @Test
+  void shouldCopyBrokerLevelFieldsWithNewPartitionGroup() {
+    // given
+    final BrokerInfo original =
+        new BrokerInfo()
+            .setBrokerId(3, "us-east-1a")
+            .setPartitionsCount(3)
+            .setClusterSize(3)
+            .setReplicationFactor(1)
+            .setPartitionGroup("default");
+    original.setVersion("8.10.0");
+    original.setCommandApiAddress("10.0.0.1:26501");
+    original.setLeaderForPartition(1, 5L);
+
+    // when
+    final var copy = original.withPartitionGroup("tenant1");
+
+    // then -- broker-level fields are copied
+    assertThat(copy.getNodeId()).isEqualTo(3);
+    assertThat(copy.getZone()).isEqualTo("us-east-1a");
+    assertThat(copy.getPartitionsCount()).isEqualTo(3);
+    assertThat(copy.getClusterSize()).isEqualTo(3);
+    assertThat(copy.getReplicationFactor()).isEqualTo(1);
+    assertThat(copy.getVersion()).isEqualTo("8.10.0");
+    assertThat(copy.getCommandApiAddress()).isEqualTo("10.0.0.1:26501");
+    assertThat(copy.getPartitionGroup()).isEqualTo("tenant1");
+    // partition state is NOT copied
+    assertThat(copy.getPartitionRoles()).isEmpty();
+    assertThat(copy.getPartitionLeaderTerms()).isEmpty();
+    // original is unchanged
+    assertThat(original.getPartitionGroup()).isEqualTo("default");
+    assertThat(original.getPartitionRoles()).hasSize(1);
+  }
+
+  @Test
+  void shouldWriteToNamespacedPropertyKeyForNonDefaultGroup() {
+    // given
+    final BrokerInfo brokerInfo =
+        new BrokerInfo()
+            .setBrokerId(1, null)
+            .setPartitionsCount(1)
+            .setClusterSize(1)
+            .setReplicationFactor(1)
+            .setPartitionGroup("tenant1");
+
+    // when
+    final Properties props = new Properties();
+    brokerInfo.writeIntoProperties(props);
+
+    // then -- written under the namespaced key, not the legacy key
+    assertThat(props.getProperty("brokerInfo:tenant1")).isNotNull();
+    assertThat(props.getProperty("brokerInfo")).isNull();
+  }
+
+  @Test
+  void shouldWriteToLegacyKeyForDefaultGroup() {
+    // given
+    final BrokerInfo brokerInfo =
+        new BrokerInfo()
+            .setBrokerId(1, null)
+            .setPartitionsCount(1)
+            .setClusterSize(1)
+            .setReplicationFactor(1);
+    // partitionGroup not set → defaults to "default"
+
+    // when
+    final Properties props = new Properties();
+    brokerInfo.writeIntoProperties(props);
+
+    // then -- written under the legacy key for backward compatibility
+    assertThat(props.getProperty("brokerInfo")).isNotNull();
+    assertThat(props.getProperty("brokerInfo:default")).isNull();
+  }
 
   @Test
   void shouldEncodeDecodePartitionGroup() {


### PR DESCRIPTION
## Description

Each physical tenant's `TopologyManagerImpl` now publishes its `BrokerInfo` under a partition-group-scoped member property key: the default group continues to use the legacy "brokerInfo" key for rolling-upgrade compatibility, while non-default groups use "brokerInfo:groupName".

To prevent concurrent `TopologyManagerImpl` actors from overwriting each other's partition state on a shared `BrokerInfo` instance, `PartitionManagerImpl` creates a per-group copy via `BrokerInfo.withPartitionGroup()` before passing it to `TopologyManagerImpl`.

This PR only publishes the topology per `partitionGroup`. Topology managers in the gateway (`BrokerTopologyManager`) and the broker (`TopologyManagerImpl`) continue to read only from the default tenant. This will be handled in a different PR. 

## Related issues

closes #53503 
