### PR TITLE
fix: preserve existing ILM/ISM policies when managePolicy is disabled

### DIFF
--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -813,6 +813,7 @@ public class ElasticsearchExporterConfiguration implements FilterConfiguration {
     private boolean enabled = false;
     private String minimumAge = "30d";
     private String policyName = "zeebe-record-retention-policy";
+    private boolean managePolicy = true;
 
     public boolean isEnabled() {
       return enabled;
@@ -838,6 +839,14 @@ public class ElasticsearchExporterConfiguration implements FilterConfiguration {
       this.policyName = policyName;
     }
 
+    public boolean isManagePolicy() {
+      return managePolicy;
+    }
+
+    public void setManagePolicy(final boolean managePolicy) {
+      this.managePolicy = managePolicy;
+    }
+
     @Override
     public String toString() {
       return "RetentionConfiguration{"
@@ -848,6 +857,8 @@ public class ElasticsearchExporterConfiguration implements FilterConfiguration {
           + ", policyName='"
           + policyName
           + '\''
+          + ", managePolicy="
+          + managePolicy
           + '}';
     }
   }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterSchemaManager.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterSchemaManager.java
@@ -58,8 +58,10 @@ public class ElasticsearchExporterSchemaManager {
     final boolean acknowledged;
     if (configuration.retention.isEnabled()) {
       acknowledged = client.bulkPutIndexLifecycleSettings(configuration.retention.getPolicyName());
-    } else {
+    } else if (configuration.retention.isManagePolicy()) {
       acknowledged = client.bulkPutIndexLifecycleSettings(null);
+    } else {
+      return;
     }
 
     if (!acknowledged) {
@@ -68,7 +70,7 @@ public class ElasticsearchExporterSchemaManager {
   }
 
   private void createIndexTemplates(final String version) {
-    if (configuration.retention.isEnabled()) {
+    if (configuration.retention.isEnabled() && configuration.retention.isManagePolicy()) {
       createIndexLifecycleManagementPolicy();
     }
 

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/TemplateReader.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/TemplateReader.java
@@ -91,8 +91,12 @@ final class TemplateReader {
       settings.put("number_of_replicas", numberOfReplicas);
     }
 
-    // update index.lifecycle in template in case a retention policy is configured
-    if (config.retention.isEnabled()) {
+    // update index.lifecycle in template in case a retention policy is configured.
+    // When managePolicy is false the exporter must leave existing lifecycle settings
+    // intact, so we keep writing the configured policy name into the template even when
+    // retention is disabled - otherwise the template would be overwritten without the
+    // policy and future rolled indices would be created without it.
+    if (config.retention.isEnabled() || !config.retention.isManagePolicy()) {
       settings.put("index.lifecycle.name", config.retention.getPolicyName());
     }
   }

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
@@ -405,6 +405,31 @@ final class ElasticsearchExporterIT {
       assertIndexSettingsHasNoLifecyclePolicy(response1);
     }
 
+    @Test
+    void shouldPreserveExistingLifecyclePolicyWhenManagePolicyIsDisabled() {
+      // given retention is enabled and a record is exported so the policy is set
+      configureExporter(true);
+      final var record1 = generateRecord(ValueType.JOB);
+      export(record1);
+
+      final var index1 = indexRouter.indexFor(record1);
+      var response1 = testClient.getIndexSettings(index1);
+      assertIndexSettingsHasLifecyclePolicy(response1);
+
+      // when retention is disabled but the exporter is told not to manage policies
+      configureExporter(
+          config -> {
+            config.retention.setEnabled(false);
+            config.retention.setManagePolicy(false);
+          });
+      final var record2 = generateRecord(ValueType.JOB);
+      export(record2);
+
+      // then the pre-existing policy must remain on the existing index
+      response1 = testClient.getIndexSettings(index1);
+      assertIndexSettingsHasLifecyclePolicy(response1);
+    }
+
     /**
      * Default timeout for elasticsearch `PUT /<target>/_settings` is 30 seconds.
      *

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TemplateReaderTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TemplateReaderTest.java
@@ -157,4 +157,36 @@ final class TemplateReaderTest {
     // then
     assertThat(template.template().settings()).containsEntry("index.lifecycle.name", "auto-trash");
   }
+
+  @Test
+  void shouldKeepLifecyclePolicyInTemplateWhenManagePolicyIsDisabledAndRetentionDisabled() {
+    // given retention is disabled but managePolicy=false means hands-off; the template
+    // must retain the policy name so future rolled indices inherit it
+    config.retention.setEnabled(false);
+    config.retention.setManagePolicy(false);
+    config.retention.setPolicyName("auto-trash");
+    final var valueType = ValueType.VARIABLE;
+
+    // when
+    final var template = templateReader.readIndexTemplate(valueType, "searchPattern", "alias");
+
+    // then
+    assertThat(template.template().settings()).containsEntry("index.lifecycle.name", "auto-trash");
+  }
+
+  @Test
+  void shouldOmitLifecyclePolicyFromTemplateWhenRetentionDisabledAndManagePolicyEnabled() {
+    // given the destructive default behavior: retention disabled with managePolicy=true
+    // should strip the policy from the template
+    config.retention.setEnabled(false);
+    config.retention.setManagePolicy(true);
+    config.retention.setPolicyName("auto-trash");
+    final var valueType = ValueType.VARIABLE;
+
+    // when
+    final var template = templateReader.readIndexTemplate(valueType, "searchPattern", "alias");
+
+    // then
+    assertThat(template.template().settings()).doesNotContainKey("index.lifecycle.name");
+  }
 }

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
@@ -960,9 +960,9 @@ public class OpensearchExporterConfiguration implements FilterConfiguration {
           + enabled
           + ", minimumAge='"
           + minimumAge
-          + ", policyName='"
+          + "', policyName='"
           + policyName
-          + ", policyDescription='"
+          + "', policyDescription='"
           + policyDescription
           + '\''
           + ", managePolicy="

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
@@ -911,6 +911,7 @@ public class OpensearchExporterConfiguration implements FilterConfiguration {
     private String minimumAge = "30d";
     private String policyName = "zeebe-record-retention-policy";
     private String policyDescription = "Zeebe record retention policy";
+    private boolean managePolicy = true;
 
     public boolean isEnabled() {
       return enabled;
@@ -944,6 +945,14 @@ public class OpensearchExporterConfiguration implements FilterConfiguration {
       this.policyDescription = policyDescription;
     }
 
+    public boolean isManagePolicy() {
+      return managePolicy;
+    }
+
+    public void setManagePolicy(final boolean managePolicy) {
+      this.managePolicy = managePolicy;
+    }
+
     @Override
     public String toString() {
       return "RetentionConfiguration{"
@@ -956,6 +965,8 @@ public class OpensearchExporterConfiguration implements FilterConfiguration {
           + ", policyDescription='"
           + policyDescription
           + '\''
+          + ", managePolicy="
+          + managePolicy
           + '}';
     }
   }

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterSchemaManager.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterSchemaManager.java
@@ -40,10 +40,12 @@ public class OpensearchExporterSchemaManager {
   }
 
   private void createIndexTemplates(final String version) {
-    if (configuration.retention.isEnabled()) {
-      createIndexStateManagementPolicy();
-    } else {
-      deleteIndexStateManagementPolicy();
+    if (configuration.retention.isManagePolicy()) {
+      if (configuration.retention.isEnabled()) {
+        createIndexStateManagementPolicy();
+      } else {
+        deleteIndexStateManagementPolicy();
+      }
     }
 
     final IndexConfiguration index = configuration.index;
@@ -234,8 +236,10 @@ public class OpensearchExporterSchemaManager {
     final boolean successful;
     if (configuration.retention.isEnabled()) {
       successful = client.bulkAddISMPolicyToAllZeebeIndices();
-    } else {
+    } else if (configuration.retention.isManagePolicy()) {
       successful = client.bulkRemoveISMPolicyFromAllZeebeIndices();
+    } else {
+      return;
     }
 
     if (!successful) {

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
@@ -539,6 +539,45 @@ final class OpensearchExporterIT {
     }
 
     @Test
+    void shouldPreserveExistingISMPolicyWhenManagePolicyIsDisabled() {
+      // given retention is enabled and a record exists with the policy applied
+      configureExporter(true);
+      final var record1 = generateRecord(ValueType.JOB);
+      export(record1);
+
+      final var index1 = indexRouter.indexFor(record1);
+      await()
+          .atMost(Duration.ofSeconds(30))
+          .untilAsserted(
+              () -> {
+                final var indexPolicy1 = testClient.explainIndex(index1);
+                assertHasISMPolicy(indexPolicy1);
+              });
+
+      // when retention is disabled but the exporter is told not to manage policies
+      configureExporter(
+          config -> {
+            config.retention.setEnabled(false);
+            config.retention.setManagePolicy(false);
+          });
+      final var record2 = generateRecord(ValueType.JOB);
+      export(record2);
+
+      // then the pre-existing policy must remain on existing indices
+      final var index2 = indexRouter.indexFor(record2);
+      await()
+          .during(Duration.ofSeconds(5))
+          .atMost(Duration.ofSeconds(30))
+          .untilAsserted(
+              () -> {
+                final var indexPolicy1 = testClient.explainIndex(index1);
+                assertHasISMPolicy(indexPolicy1);
+                final var indexPolicy2 = testClient.explainIndex(index2);
+                assertHasISMPolicy(indexPolicy2);
+              });
+    }
+
+    @Test
     void shouldNotTimeoutWhenUpdatingLifecyclePolicyForExistingIndices() {
       // given
       configureExporter(false);

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterTest.java
@@ -169,6 +169,53 @@ final class OpensearchExporterTest {
   }
 
   @Test
+  void shouldNotManagePolicyResourceWhenManagePolicyIsDisabledAndRetentionEnabled() {
+    // given
+    config.retention.setEnabled(true);
+    config.retention.setManagePolicy(false);
+    exporter.configure(context);
+    exporter.open(controller);
+
+    // when
+    final var recordMock = mock(Record.class);
+    when(recordMock.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
+    when(recordMock.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
+    exporter.export(recordMock);
+
+    // then the policy resource is left untouched (no read/create/update/delete)
+    verify(client, never()).maybeGetIndexStateManagementPolicy();
+    verify(client, never()).createIndexStateManagementPolicy();
+    verify(client, never()).updateIndexStateManagementPolicy(anyInt(), anyInt());
+    verify(client, never()).deleteIndexStateManagementPolicy();
+    // but the (externally managed) policy is still attached to existing indices
+    verify(client, times(1)).bulkAddISMPolicyToAllZeebeIndices();
+    verify(client, never()).bulkRemoveISMPolicyFromAllZeebeIndices();
+  }
+
+  @Test
+  void shouldNotTouchPolicyWhenManagePolicyIsDisabledAndRetentionDisabled() {
+    // given
+    config.retention.setEnabled(false);
+    config.retention.setManagePolicy(false);
+    exporter.configure(context);
+    exporter.open(controller);
+
+    // when
+    final var recordMock = mock(Record.class);
+    when(recordMock.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
+    when(recordMock.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
+    exporter.export(recordMock);
+
+    // then nothing about the policy resource or its assignments is touched
+    verify(client, never()).maybeGetIndexStateManagementPolicy();
+    verify(client, never()).createIndexStateManagementPolicy();
+    verify(client, never()).updateIndexStateManagementPolicy(anyInt(), anyInt());
+    verify(client, never()).deleteIndexStateManagementPolicy();
+    verify(client, never()).bulkAddISMPolicyToAllZeebeIndices();
+    verify(client, never()).bulkRemoveISMPolicyFromAllZeebeIndices();
+  }
+
+  @Test
   void shouldNotCreateOrUpdateIndexStateManagementPolicy() {
     // given
     config.retention.setEnabled(true);


### PR DESCRIPTION
## Summary

Forward port of #53505 (stable/8.7) to main.

Closes #28571.

When retention is disabled, the Zeebe ES/OS exporters actively removed the existing ILM/ISM policy from indices at startup. This caused production impact for customers whose application user lacked permission to modify the policy (403 errors) and silently stripped manually-managed policies on every restart.

This PR adds a `managePolicy` flag (default `true`) to the retention configuration of both exporters and gates the destructive paths on it.

## Behavior

| `enabled` | `managePolicy` | Behavior |
|-----------|----------------|----------|
| `true`    | `true` (default) | Create the policy resource, attach it to existing indices, write it into the template. Existing behavior. |
| `true`    | `false`          | Skip create/update of the policy resource (assumed externally managed), still attach to indices, still write into the template. |
| `false`   | `true` (default) | Remove the policy resource and detach it from existing indices, strip from template. Existing destructive behavior preserved when explicitly opted into. |
| `false`   | `false`          | **Leave everything untouched.** The fix. |

Default is `true`, so users on existing configurations see no behavior change.

## Changes

- **Zeebe OS exporter** — adds `managePolicy` to `OpensearchExporterConfiguration.RetentionConfiguration`. Gates `createIndexStateManagementPolicy` / `deleteIndexStateManagementPolicy` / `bulkRemoveISMPolicyFromAllZeebeIndices` on it. `bulkAddISMPolicyToAllZeebeIndices` still runs when retention is enabled.
- **Zeebe ES exporter** — adds `managePolicy` to `ElasticsearchExporterConfiguration.RetentionConfiguration`. Gates `createIndexLifecycleManagementPolicy` and `bulkPutIndexLifecycleSettings(null)` on it. `TemplateReader.substituteConfiguration` now writes `index.lifecycle.name` to the rendered template when retention is enabled OR `managePolicy=false`, so future rolled indices inherit the externally-managed policy across restarts.

## Out of scope (vs the 8.7 PR)

- **Tasklist** — the standalone Tasklist importer (`ILMService`, `ILMPolicyUpdateElasticSearch`, `ILMPolicyUpdateOpenSearch`, `ArchiverProperties`) was removed before 8.8 and consolidated into the shared `schema-manager/` module. That shared module's `SchemaManager.createLifecyclePolicies()` only creates a policy when enabled and never removes — so no destructive path to gate on main.
- **Follow-up scope** — a related design observation (only ever touch the policy whose name matches `config.retention.policyName`, never blindly clear all attached policies) was raised in #53505 by @yohanfernando and is tracked separately as #TODO. That work is a behavior change for default config so is intentionally not bundled here.

## Tests

- Unit: `OpensearchExporterTest` gains two cases (`enabled=true,managePolicy=false` proves bulk-add still runs but the policy resource is left alone; `enabled=false,managePolicy=false` proves nothing is called).
- IT: `OpensearchExporterIT.shouldPreserveExistingISMPolicyWhenManagePolicyIsDisabled` proves a pre-existing ISM policy survives an exporter restart.
- IT: `ElasticsearchExporterIT.shouldPreserveExistingLifecyclePolicyWhenManagePolicyIsDisabled` proves the same for ILM.
- Unit: `TemplateReaderTest` gains two cases — preserve `index.lifecycle.name` when `managePolicy=false`, strip when `managePolicy=true` with retention disabled.

## Test plan

- [x] Module-scoped unit tests pass: `./mvnw verify -pl zeebe/exporters/opensearch-exporter -DskipITs -Dquickly` (400 tests, 0 failures)
- [x] Module-scoped unit tests pass: `./mvnw verify -pl zeebe/exporters/elasticsearch-exporter -DskipITs -Dquickly` (390 tests, 0 failures)
- [x] Spotless/license format clean
- [ ] CI integration tests pass on main
- [ ] Backport bot picks up `stable/8.9` (label-driven); `stable/8.8` requires a separate PR due to upstream refactors (OS schema manager extraction + `getIndexStateManagementPolicy` rename happened in 8.9)