### PR TITLE
test: stabilize four nightly API-test flakes on stable/8.9

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-cancel-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-cancel-api-tests.spec.ts
@@ -18,6 +18,7 @@ import {
 } from '../../../../utils/http';
 import {defaultAssertionOptions} from '../../../../utils/constants';
 import {
+  batchOperationLifecycleOptions,
   createCancellationBatch,
   cancelBatchOperation,
   createCompletedBatchOperation,
@@ -50,15 +51,12 @@ test.describe.parallel('Cancel Batch Operation Tests', () => {
     await test.step('Cancel batch operation', async () => {
       // The batch operation may not be visible to the cancel endpoint
       // immediately after creation; retry on 404 until it is. The default
-      // 30s budget is too tight on a loaded shared cluster, so use the
-      // dedicated lifecycle options.
+      // 30s budget is too tight on a loaded shared cluster, so reuse the
+      // shared lifecycle options that suspend/resume already use.
       await expect(async () => {
         const res = await cancelBatchOperation(request, key);
         await assertStatusCode(res, 204);
-      }).toPass({
-        intervals: [5_000, 10_000, 10_000, 15_000, 20_000, 30_000],
-        timeout: 90_000,
-      });
+      }).toPass(batchOperationLifecycleOptions);
     });
 
     await test.step('Poll batch status', async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-cancel-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-cancel-api-tests.spec.ts
@@ -49,11 +49,16 @@ test.describe.parallel('Cancel Batch Operation Tests', () => {
 
     await test.step('Cancel batch operation', async () => {
       // The batch operation may not be visible to the cancel endpoint
-      // immediately after creation; retry on 404 until it is.
+      // immediately after creation; retry on 404 until it is. The default
+      // 30s budget is too tight on a loaded shared cluster, so use the
+      // dedicated lifecycle options.
       await expect(async () => {
         const res = await cancelBatchOperation(request, key);
         await assertStatusCode(res, 204);
-      }).toPass(defaultAssertionOptions);
+      }).toPass({
+        intervals: [5_000, 10_000, 10_000, 15_000, 20_000, 30_000],
+        timeout: 90_000,
+      });
     });
 
     await test.step('Poll batch status', async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-failure-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-failure-api-tests.spec.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {test} from '@playwright/test';
+import {expect, test} from '@playwright/test';
 import {
   assertBadRequest,
   assertNotFoundRequest,
@@ -18,6 +18,7 @@ import {
   activateJobToObtainAValidJobKey,
   setupProcessInstanceForTests,
 } from '@requestHelpers';
+import {defaultAssertionOptions} from '../../../../utils/constants';
 
 /* eslint-disable playwright/expect-expect */
 test.describe('Job Fail API Tests', () => {
@@ -90,17 +91,21 @@ test.describe('Job Fail API Tests', () => {
     });
 
     await test.step('fail the job for the first time', async () => {
-      const failRes = await request.post(
-        buildUrl(`/jobs/${localState['jobKey']}/failure`),
-        {
-          headers: jsonHeaders(),
-          data: {
-            retries: 0,
-            errorMessage: 'Simulated failure',
+      // Retry on 404: the engine may not yet recognize the freshly
+      // activated jobKey on a loaded cluster, returning "no such job".
+      await expect(async () => {
+        const failRes = await request.post(
+          buildUrl(`/jobs/${localState['jobKey']}/failure`),
+          {
+            headers: jsonHeaders(),
+            data: {
+              retries: 0,
+              errorMessage: 'Simulated failure',
+            },
           },
-        },
-      );
-      await assertStatusCode(failRes, 204);
+        );
+        await assertStatusCode(failRes, 204);
+      }).toPass(defaultAssertionOptions);
     });
 
     await test.step('fail the job for the second time', async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-create-batch-to-migrate-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-create-batch-to-migrate-api.spec.ts
@@ -22,7 +22,11 @@ import {
 import {defaultAssertionOptions} from '../../../../utils/constants';
 import {APIRequestContext} from 'playwright-core';
 import {JSONDoc} from '@camunda8/sdk/dist/zeebe/types.js';
-import {expectBatchState, findUserTask} from '@requestHelpers';
+import {
+  expectBatchState,
+  findUserTask,
+  postMigrationAssertionOptions,
+} from '@requestHelpers';
 import {validateResponse} from 'json-body-assertions';
 
 /* eslint-disable playwright/expect-expect */
@@ -193,6 +197,7 @@ test.describe.serial('Create Process Instance Batch to Migrate Tests', () => {
         localState.processInstanceKey1,
         localState.processInstanceKey2,
         'do_something_else',
+        postMigrationAssertionOptions,
       );
     });
   });
@@ -269,6 +274,7 @@ test.describe.serial('Create Process Instance Batch to Migrate Tests', () => {
         localState.processInstanceKey2,
         'CREATED',
         'do_something_else',
+        postMigrationAssertionOptions,
       );
     });
   });
@@ -343,6 +349,7 @@ test.describe.serial('Create Process Instance Batch to Migrate Tests', () => {
         localState.processInstanceKey1,
         localState.processInstanceKey2,
         'do_something_else',
+        postMigrationAssertionOptions,
       );
     });
   });
@@ -352,10 +359,23 @@ test.describe.serial('Create Process Instance Batch to Migrate Tests', () => {
     processInstanceKey1: string,
     processInstanceKey2: string,
     elementId: string,
+    assertionOptions = defaultAssertionOptions,
   ) => {
-    await findUserTask(request, processInstanceKey1, 'CREATED', elementId);
+    await findUserTask(
+      request,
+      processInstanceKey1,
+      'CREATED',
+      elementId,
+      assertionOptions,
+    );
 
-    await findUserTask(request, processInstanceKey2, 'CREATED', elementId);
+    await findUserTask(
+      request,
+      processInstanceKey2,
+      'CREATED',
+      elementId,
+      assertionOptions,
+    );
   };
 
   const prepareTestCases = async (

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/batch-operation-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/batch-operation-requestHelpers.ts
@@ -9,14 +9,13 @@
 import {APIRequestContext, APIResponse, expect} from '@playwright/test';
 import {assertStatusCode, buildUrl, jsonHeaders} from 'utils/http';
 import {createCancellationBatch} from '@requestHelpers';
-import {defaultAssertionOptions} from 'utils/constants';
 import {validateResponse} from 'json-body-assertions';
 
 // A freshly created batch operation can take longer than the default 30s
 // to be visible to the cancel/suspend/resume commands on a loaded shared
 // cluster (404 → 204). Use a more generous budget for batch operation
 // lifecycle actions while the engine catches up.
-const batchOperationLifecycleOptions = {
+export const batchOperationLifecycleOptions = {
   intervals: [5_000, 10_000, 10_000, 15_000, 20_000, 30_000],
   timeout: 90_000,
 };

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/batch-operation-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/batch-operation-requestHelpers.ts
@@ -12,6 +12,15 @@ import {createCancellationBatch} from '@requestHelpers';
 import {defaultAssertionOptions} from 'utils/constants';
 import {validateResponse} from 'json-body-assertions';
 
+// A freshly created batch operation can take longer than the default 30s
+// to be visible to the cancel/suspend/resume commands on a loaded shared
+// cluster (404 → 204). Use a more generous budget for batch operation
+// lifecycle actions while the engine catches up.
+const batchOperationLifecycleOptions = {
+  intervals: [5_000, 10_000, 10_000, 15_000, 20_000, 30_000],
+  timeout: 90_000,
+};
+
 export async function cancelBatchOperation(
   request: APIRequestContext,
   batchOperationKey: string,
@@ -39,7 +48,7 @@ export async function suspendBatchOperation(
     );
     result.response = res;
     await assertStatusCode(res, expectedStatusCode);
-  }).toPass(defaultAssertionOptions);
+  }).toPass(batchOperationLifecycleOptions);
   return result.response as APIResponse;
 }
 
@@ -58,7 +67,7 @@ export async function resumeBatchOperation(
     );
     result.response = res;
     await assertStatusCode(res, expectedStatusCode);
-  }).toPass(defaultAssertionOptions);
+  }).toPass(batchOperationLifecycleOptions);
   return result.response as APIResponse;
 }
 
@@ -118,6 +127,14 @@ export async function expectBatchState(
     timeout: 120_000,
   });
 }
+
+// Post-migration user-task search has to wait for the secondary-storage
+// indexer to reflect the migrated elementId. The default 30s budget is
+// too tight on a loaded shared cluster; give it more room.
+export const postMigrationAssertionOptions = {
+  intervals: [5_000, 10_000, 15_000, 25_000, 35_000],
+  timeout: 90_000,
+};
 
 export const notFoundDetail = (key: string) =>
   `Command 'SUSPEND' rejected with code 'NOT_FOUND': Expected to suspend a batch operation with key '${key}', but no such batch operation was found`;

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/user-task-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/user-task-requestHelpers.ts
@@ -24,6 +24,7 @@ export async function findUserTask(
   procKey: string,
   state: string,
   elementId?: string,
+  assertionOptions = defaultAssertionOptions,
 ) {
   const localState: Record<string, unknown> = {};
   await expect(async () => {
@@ -54,7 +55,7 @@ export async function findUserTask(
       expect(searchJson.items[0].elementId).toBe(elementId);
     }
     localState['userTaskKey'] = searchJson.items[0].userTaskKey;
-  }).toPass(defaultAssertionOptions);
+  }).toPass(assertionOptions);
   return localState['userTaskKey'] as string;
 }
 export async function completeUserTask(


### PR DESCRIPTION
## Summary

Stabilizes four flaky/failing API tests from the latest stable/8.9 nightly runs ([26135970462 ES](https://github.com/camunda/camunda/actions/runs/26135970462), [26136062433 RDBMS](https://github.com/camunda/camunda/actions/runs/26136062433)). All four root-causes are engine read-after-write lag or secondary-storage indexing lag on a loaded shared cluster — not product defects. Same patterns already addressed on main in #53582.

| Test | Symptom | Fix |
|---|---|---|
| `batch-operations-cancel-api-tests :42` (Cancel active batch op — ES HARD FAIL) | 404 for full 30s, both attempts | Widen inline `expect.toPass` budget 30s → 90s |
| `batch-operations-suspend-api-tests :36` (Suspend, RDBMS flaky) | 404 \"no such batch operation\" | `suspendBatchOperation` helper now uses `batchOperationLifecycleOptions` (30s → 90s); same for `resumeBatchOperation` |
| `process-instance-create-batch-to-migrate-api :134` (Migrate Success, ES flaky) | Post-migration user-task search timeout 30s, elementId still old | Add `postMigrationAssertionOptions` (90s); add optional `assertionOptions` arg to `findUserTask`; pass at all 3 post-migration verification sites |
| `job-failure-api-tests :82` (Fail Job - 409, RDBMS flaky) | 404 \"no such job\" after activation | Wrap first failure call in `expect.toPass(defaultAssertionOptions)` to absorb activation → fail race |

Changes are minimal, consistent with the pattern already proven on main, and confined to retry/wait logic — no production code changes.

## Test plan
https://github.com/camunda/camunda/actions/runs/26155407840 API tests 🟢 
- [x] Local Playwright run against 8.10-SNAPSHOT: all four originally-failing tests pass on first attempt (79 passed / 2 unrelated failed / 4 skipped, 8 min wall-clock; the two failures were unrelated `audit-log-search-api-tests` and `job-statistics-by-worker-api-tests` flakes in the teardown subset)
- [ ] Nightly C8 Orchestration Cluster ES API tests (stable/8.9) stay green
- [ ] Nightly C8 Orchestration Cluster RDBMS API tests (stable/8.9) stay green

🤖 Generated with [Claude Code](https://claude.com/claude-code)