### PR TITLE
fix: preserve existing ILM/ISM policies when managePolicy is disabled

### DIFF
--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -411,6 +411,7 @@ public class ElasticsearchExporterConfiguration {
     private boolean enabled = false;
     private String minimumAge = "30d";
     private String policyName = "zeebe-record-retention-policy";
+    private boolean managePolicy = true;
 
     public boolean isEnabled() {
       return enabled;
@@ -436,6 +437,14 @@ public class ElasticsearchExporterConfiguration {
       this.policyName = policyName;
     }
 
+    public boolean isManagePolicy() {
+      return managePolicy;
+    }
+
+    public void setManagePolicy(final boolean managePolicy) {
+      this.managePolicy = managePolicy;
+    }
+
     @Override
     public String toString() {
       return "RetentionConfiguration{"
@@ -446,6 +455,8 @@ public class ElasticsearchExporterConfiguration {
           + ", policyName='"
           + policyName
           + '\''
+          + ", managePolicy="
+          + managePolicy
           + '}';
     }
   }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterSchemaManager.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterSchemaManager.java
@@ -57,8 +57,10 @@ public class ElasticsearchExporterSchemaManager {
     final boolean acknowledged;
     if (configuration.retention.isEnabled()) {
       acknowledged = client.bulkPutIndexLifecycleSettings(configuration.retention.getPolicyName());
-    } else {
+    } else if (configuration.retention.isManagePolicy()) {
       acknowledged = client.bulkPutIndexLifecycleSettings(null);
+    } else {
+      return;
     }
 
     if (!acknowledged) {
@@ -67,7 +69,7 @@ public class ElasticsearchExporterSchemaManager {
   }
 
   private void createIndexTemplates(final String version) {
-    if (configuration.retention.isEnabled()) {
+    if (configuration.retention.isEnabled() && configuration.retention.isManagePolicy()) {
       createIndexLifecycleManagementPolicy();
     }
 

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/TemplateReader.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/TemplateReader.java
@@ -91,8 +91,12 @@ final class TemplateReader {
       settings.put("number_of_replicas", numberOfReplicas);
     }
 
-    // update index.lifecycle in template in case a retention policy is configured
-    if (config.retention.isEnabled()) {
+    // update index.lifecycle in template in case a retention policy is configured.
+    // When managePolicy is false the exporter must leave existing lifecycle settings
+    // intact, so we keep writing the configured policy name into the template even when
+    // retention is disabled - otherwise the template would be overwritten without the
+    // policy and future rolled indices would be created without it.
+    if (config.retention.isEnabled() || !config.retention.isManagePolicy()) {
       settings.put("index.lifecycle.name", config.retention.getPolicyName());
     }
   }

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
@@ -506,6 +506,31 @@ final class ElasticsearchExporterIT {
       assertIndexSettingsHasNoLifecyclePolicy(response1);
     }
 
+    @Test
+    void shouldPreserveExistingLifecyclePolicyWhenManagePolicyIsDisabled() {
+      // given retention is enabled and a record is exported so the policy is set
+      configureExporter(true);
+      final var record1 = generateRecord(ValueType.JOB);
+      export(record1);
+
+      final var index1 = indexRouter.indexFor(record1);
+      var response1 = testClient.getIndexSettings(index1);
+      assertIndexSettingsHasLifecyclePolicy(response1);
+
+      // when retention is disabled but the exporter is told not to manage policies
+      configureExporter(
+          config -> {
+            config.retention.setEnabled(false);
+            config.retention.setManagePolicy(false);
+          });
+      final var record2 = generateRecord(ValueType.JOB);
+      export(record2);
+
+      // then the pre-existing policy must remain on the existing index
+      response1 = testClient.getIndexSettings(index1);
+      assertIndexSettingsHasLifecyclePolicy(response1);
+    }
+
     /**
      * Default timeout for elasticsearch `PUT /<target>/_settings` is 30 seconds.
      *

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TemplateReaderTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TemplateReaderTest.java
@@ -157,4 +157,36 @@ final class TemplateReaderTest {
     // then
     assertThat(template.template().settings()).containsEntry("index.lifecycle.name", "auto-trash");
   }
+
+  @Test
+  void shouldKeepLifecyclePolicyInTemplateWhenManagePolicyIsDisabledAndRetentionDisabled() {
+    // given retention is disabled but managePolicy=false means hands-off; the template
+    // must retain the policy name so future rolled indices inherit it
+    config.retention.setEnabled(false);
+    config.retention.setManagePolicy(false);
+    config.retention.setPolicyName("auto-trash");
+    final var valueType = ValueType.VARIABLE;
+
+    // when
+    final var template = templateReader.readIndexTemplate(valueType, "searchPattern", "alias");
+
+    // then
+    assertThat(template.template().settings()).containsEntry("index.lifecycle.name", "auto-trash");
+  }
+
+  @Test
+  void shouldOmitLifecyclePolicyFromTemplateWhenRetentionDisabledAndManagePolicyEnabled() {
+    // given the destructive default behavior: retention disabled with managePolicy=true
+    // should strip the policy from the template
+    config.retention.setEnabled(false);
+    config.retention.setManagePolicy(true);
+    config.retention.setPolicyName("auto-trash");
+    final var valueType = ValueType.VARIABLE;
+
+    // when
+    final var template = templateReader.readIndexTemplate(valueType, "searchPattern", "alias");
+
+    // then
+    assertThat(template.template().settings()).doesNotContainKey("index.lifecycle.name");
+  }
 }

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
@@ -257,10 +257,12 @@ public class OpensearchExporter implements Exporter {
   }
 
   private void createIndexTemplates(final String version) {
-    if (configuration.retention.isEnabled()) {
-      createIndexStateManagementPolicy();
-    } else {
-      deleteIndexStateManagementPolicy();
+    if (configuration.retention.isManagePolicy()) {
+      if (configuration.retention.isEnabled()) {
+        createIndexStateManagementPolicy();
+      } else {
+        deleteIndexStateManagementPolicy();
+      }
     }
 
     final IndexConfiguration index = configuration.index;
@@ -436,8 +438,10 @@ public class OpensearchExporter implements Exporter {
     final boolean successful;
     if (configuration.retention.isEnabled()) {
       successful = client.bulkAddISMPolicyToAllZeebeIndices();
-    } else {
+    } else if (configuration.retention.isManagePolicy()) {
       successful = client.bulkRemoveISMPolicyFromAllZeebeIndices();
+    } else {
+      return;
     }
 
     if (!successful) {

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
@@ -471,9 +471,9 @@ public class OpensearchExporterConfiguration {
           + enabled
           + ", minimumAge='"
           + minimumAge
-          + ", policyName='"
+          + "', policyName='"
           + policyName
-          + ", policyDescription='"
+          + "', policyDescription='"
           + policyDescription
           + '\''
           + ", managePolicy="

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
@@ -422,6 +422,7 @@ public class OpensearchExporterConfiguration {
     private String minimumAge = "30d";
     private String policyName = "zeebe-record-retention-policy";
     private String policyDescription = "Zeebe record retention policy";
+    private boolean managePolicy = true;
 
     public boolean isEnabled() {
       return enabled;
@@ -455,6 +456,14 @@ public class OpensearchExporterConfiguration {
       this.policyDescription = policyDescription;
     }
 
+    public boolean isManagePolicy() {
+      return managePolicy;
+    }
+
+    public void setManagePolicy(final boolean managePolicy) {
+      this.managePolicy = managePolicy;
+    }
+
     @Override
     public String toString() {
       return "RetentionConfiguration{"
@@ -467,6 +476,8 @@ public class OpensearchExporterConfiguration {
           + ", policyDescription='"
           + policyDescription
           + '\''
+          + ", managePolicy="
+          + managePolicy
           + '}';
     }
   }

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
@@ -623,6 +623,45 @@ final class OpensearchExporterIT {
     }
 
     @Test
+    void shouldPreserveExistingISMPolicyWhenManagePolicyIsDisabled() {
+      // given retention is enabled and a record exists with the policy applied
+      configureExporter(true);
+      final var record1 = generateRecord(ValueType.JOB);
+      export(record1);
+
+      final var index1 = indexRouter.indexFor(record1);
+      await()
+          .atMost(Duration.ofSeconds(30))
+          .untilAsserted(
+              () -> {
+                final var indexPolicy1 = testClient.explainIndex(index1);
+                assertHasISMPolicy(indexPolicy1);
+              });
+
+      // when retention is disabled but the exporter is told not to manage policies
+      configureExporter(
+          config -> {
+            config.retention.setEnabled(false);
+            config.retention.setManagePolicy(false);
+          });
+      final var record2 = generateRecord(ValueType.JOB);
+      export(record2);
+
+      // then the pre-existing policy must remain on existing indices
+      final var index2 = indexRouter.indexFor(record2);
+      await()
+          .during(Duration.ofSeconds(5))
+          .atMost(Duration.ofSeconds(30))
+          .untilAsserted(
+              () -> {
+                final var indexPolicy1 = testClient.explainIndex(index1);
+                assertHasISMPolicy(indexPolicy1);
+                final var indexPolicy2 = testClient.explainIndex(index2);
+                assertHasISMPolicy(indexPolicy2);
+              });
+    }
+
+    @Test
     void shouldNotTimeoutWhenUpdatingLifecyclePolicyForExistingIndices() {
       // given
       configureExporter(false);

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterTest.java
@@ -169,6 +169,53 @@ final class OpensearchExporterTest {
   }
 
   @Test
+  void shouldNotManagePolicyResourceWhenManagePolicyIsDisabledAndRetentionEnabled() {
+    // given
+    config.retention.setEnabled(true);
+    config.retention.setManagePolicy(false);
+    exporter.configure(context);
+    exporter.open(controller);
+
+    // when
+    final var recordMock = mock(Record.class);
+    when(recordMock.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
+    when(recordMock.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
+    exporter.export(recordMock);
+
+    // then the policy resource is left untouched (no read/create/update/delete)
+    verify(client, never()).getIndexStateManagementPolicy();
+    verify(client, never()).createIndexStateManagementPolicy();
+    verify(client, never()).updateIndexStateManagementPolicy(anyInt(), anyInt());
+    verify(client, never()).deleteIndexStateManagementPolicy();
+    // but the (externally managed) policy is still attached to existing indices
+    verify(client, times(1)).bulkAddISMPolicyToAllZeebeIndices();
+    verify(client, never()).bulkRemoveISMPolicyFromAllZeebeIndices();
+  }
+
+  @Test
+  void shouldNotTouchPolicyWhenManagePolicyIsDisabledAndRetentionDisabled() {
+    // given
+    config.retention.setEnabled(false);
+    config.retention.setManagePolicy(false);
+    exporter.configure(context);
+    exporter.open(controller);
+
+    // when
+    final var recordMock = mock(Record.class);
+    when(recordMock.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
+    when(recordMock.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
+    exporter.export(recordMock);
+
+    // then nothing about the policy resource or its assignments is touched
+    verify(client, never()).getIndexStateManagementPolicy();
+    verify(client, never()).createIndexStateManagementPolicy();
+    verify(client, never()).updateIndexStateManagementPolicy(anyInt(), anyInt());
+    verify(client, never()).deleteIndexStateManagementPolicy();
+    verify(client, never()).bulkAddISMPolicyToAllZeebeIndices();
+    verify(client, never()).bulkRemoveISMPolicyFromAllZeebeIndices();
+  }
+
+  @Test
   void shouldNotCreateOrUpdateIndexStateManagementPolicy() {
     // given
     config.retention.setEnabled(true);


### PR DESCRIPTION
## Summary

Dedicated backport of #53590 (main) / #53505 (stable/8.7) to stable/8.8. The automated backport bot can't cherry-pick from main onto 8.8 cleanly because the OS exporter retention logic moved between branches.

Closes #28571.

When retention is disabled, the Zeebe ES/OS exporters actively removed the existing ILM/ISM policy from indices at startup. This caused production impact for customers whose application user lacked permission to modify the policy (403 errors) and silently stripped manually-managed policies on every restart.

This PR adds a `managePolicy` flag (default `true`) to the retention configuration of both exporters and gates the destructive paths on it.

## Why a dedicated PR (vs auto-backport)

Compared to the main/8.9 diff, this PR differs in exactly two places, both forced by upstream refactors that landed in 8.9:

1. OS retention logic lives in `OpensearchExporter.java` on 8.8 (extracted into `OpensearchExporterSchemaManager.java` in 8.9). Same gate, different file.
2. The OS client method is `getIndexStateManagementPolicy()` on 8.8 (renamed to `maybeGetIndexStateManagementPolicy()` in 8.9). Same `verify(...)` assertion, different method name.

Every other file (`ElasticsearchExporterConfiguration`, `ElasticsearchExporterSchemaManager`, `TemplateReader`, `OpensearchExporterConfiguration`, all four test files) takes the identical change as on main.

## Behavior

| `enabled` | `managePolicy` | Behavior |
|-----------|----------------|----------|
| `true`    | `true` (default) | Create the policy resource, attach it to existing indices, write it into the template. Existing behavior. |
| `true`    | `false`          | Skip create/update of the policy resource (assumed externally managed), still attach to indices, still write into the template. |
| `false`   | `true` (default) | Remove the policy resource and detach it from existing indices, strip from template. Existing destructive behavior preserved when explicitly opted into. |
| `false`   | `false`          | **Leave everything untouched.** The fix. |

Default is `true`, so users on existing configurations see no behavior change.

## Out of scope

- Tasklist standalone importer (`ILMService`, `ILMPolicyUpdateElasticSearch`, `ILMPolicyUpdateOpenSearch`) was removed before 8.8 and consolidated into the shared `schema-manager/` module. That shared module's `SchemaManager.createLifecyclePolicies()` only creates and never removes - no destructive path to gate.
- Scoping policy removal to only the configured `policyName` (raised by @yohanfernando in #53505) is tracked separately.

## Test plan

- [x] Module-scoped unit tests pass: `./mvnw verify -pl zeebe/exporters/opensearch-exporter -DskipITs -Dquickly` (225 tests, 0 failures)
- [x] Module-scoped unit tests pass: `./mvnw verify -pl zeebe/exporters/elasticsearch-exporter -DskipITs -Dquickly` (332 tests, 0 failures)
- [x] Spotless/license format clean
- [ ] CI integration tests pass on stable/8.8