### PR TITLE
Temporarily disable broken tests

### DIFF
--- a/load-tests/load-tester/src/test/java/io/camunda/zeebe/it/DataAvailabilityIT.java
+++ b/load-tests/load-tester/src/test/java/io/camunda/zeebe/it/DataAvailabilityIT.java
@@ -13,6 +13,7 @@ import io.camunda.process.test.impl.containers.CamundaContainer;
 import io.camunda.zeebe.LoadTesterApplication;
 import io.camunda.zeebe.metrics.StarterLatencyMetricsDoc;
 import io.micrometer.core.instrument.MeterRegistry;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -47,6 +48,8 @@ import org.testcontainers.junit.jupiter.Testcontainers;
       "load-tester.perform-read-benchmarks=false",
     })
 @ActiveProfiles({"starter", "it"})
+@Disabled(
+    "Temporariy disabled due to https://camunda.slack.com/archives/C071KP5BTHB/p1779098983781369")
 class DataAvailabilityIT {
 
   @Container

--- a/load-tests/load-tester/src/test/java/io/camunda/zeebe/it/StarterWorkerIT.java
+++ b/load-tests/load-tester/src/test/java/io/camunda/zeebe/it/StarterWorkerIT.java
@@ -15,6 +15,7 @@ import io.camunda.client.api.search.enums.ProcessInstanceState;
 import io.camunda.process.test.impl.containers.CamundaContainer;
 import io.camunda.zeebe.LoadTesterApplication;
 import java.time.Duration;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -47,6 +48,8 @@ import org.testcontainers.junit.jupiter.Testcontainers;
       "load-tester.perform-read-benchmarks=false",
     })
 @ActiveProfiles({"starter", "worker", "it"})
+@Disabled(
+    "Temporariy disabled due to https://camunda.slack.com/archives/C071KP5BTHB/p1779098983781369")
 class StarterWorkerIT {
 
   @Container


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

These test always pull the camunda SNAPSHOT image. This can break on our stable branches blocking backports. Temporarily disabling until this is fixed.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

Relates to #51020
