### PR TITLE
feat(service): pass physicalTenantId down to service and search clients

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/spi/AdminUserPresenceAdapter.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/spi/AdminUserPresenceAdapter.java
@@ -58,7 +58,7 @@ public class AdminUserPresenceAdapter implements AdminUserPresencePort {
 
     try {
       return roleServices.hasMembersOfType(
-          ADMIN_ROLE_ID, EntityType.USER, CamundaAuthentication.anonymous());
+          ADMIN_ROLE_ID, EntityType.USER, CamundaAuthentication.anonymous(), "default");
     } catch (final RuntimeException ex) {
       LOG.error(
           "Error while searching for admin role members. This might indicate that secondary storage is down.",

--- a/authentication/src/main/java/io/camunda/authentication/service/BasicCamundaUserService.java
+++ b/authentication/src/main/java/io/camunda/authentication/service/BasicCamundaUserService.java
@@ -85,7 +85,7 @@ public class BasicCamundaUserService implements CamundaUserService {
 
   protected UserEntity getUser(final CamundaAuthentication authentication) {
     final var username = authentication.authenticatedUsername();
-    return userServices.getUser(username, CamundaAuthentication.anonymous());
+    return userServices.getUser(username, CamundaAuthentication.anonymous(), "default");
   }
 
   protected List<String> getAuthorizedComponents(final CamundaAuthentication authentication) {
@@ -114,7 +114,8 @@ public class BasicCamundaUserService implements CamundaUserService {
     return tenantServices
         .search(
             TenantQuery.of(q -> q.filter(f -> f.tenantIds(tenantIds)).unlimited()),
-            CamundaAuthentication.anonymous())
+            CamundaAuthentication.anonymous(),
+            "default")
         .items();
   }
 }

--- a/authentication/src/main/java/io/camunda/authentication/service/DefaultMembershipService.java
+++ b/authentication/src/main/java/io/camunda/authentication/service/DefaultMembershipService.java
@@ -79,7 +79,8 @@ public class DefaultMembershipService implements MembershipPort {
     }
     final var ids =
         mappingRuleServices
-            .getMatchingMappingRules(query.tokenClaims(), CamundaAuthentication.anonymous())
+            .getMatchingMappingRules(
+                query.tokenClaims(), CamundaAuthentication.anonymous(), "default")
             .map(MappingRuleEntity::mappingRuleId)
             .collect(Collectors.toSet());
     if (ids.isEmpty()) {
@@ -101,7 +102,7 @@ public class DefaultMembershipService implements MembershipPort {
     final var owners = buildOwners(query);
     final var ids =
         groupServices
-            .getGroupsByMemberTypeAndMemberIds(owners, CamundaAuthentication.anonymous())
+            .getGroupsByMemberTypeAndMemberIds(owners, CamundaAuthentication.anonymous(), "default")
             .stream()
             .map(GroupEntity::groupId)
             .collect(Collectors.toSet());
@@ -116,7 +117,7 @@ public class DefaultMembershipService implements MembershipPort {
     }
     final var ids =
         roleServices
-            .getRolesByMemberTypeAndMemberIds(owners, CamundaAuthentication.anonymous())
+            .getRolesByMemberTypeAndMemberIds(owners, CamundaAuthentication.anonymous(), "default")
             .stream()
             .map(RoleEntity::roleId)
             .collect(Collectors.toSet());
@@ -133,7 +134,7 @@ public class DefaultMembershipService implements MembershipPort {
       owners.put(EntityType.ROLE, new HashSet<>(query.resolvedRoleIds()));
     }
     return tenantServices
-        .getTenantsByMemberTypeAndMemberIds(owners, CamundaAuthentication.anonymous())
+        .getTenantsByMemberTypeAndMemberIds(owners, CamundaAuthentication.anonymous(), "default")
         .stream()
         .map(TenantEntity::tenantId)
         .toList();

--- a/authentication/src/main/java/io/camunda/authentication/service/OidcCamundaUserService.java
+++ b/authentication/src/main/java/io/camunda/authentication/service/OidcCamundaUserService.java
@@ -190,7 +190,8 @@ public class OidcCamundaUserService implements CamundaUserService {
     return tenantServices
         .search(
             TenantQuery.of(q -> q.filter(f -> f.tenantIds(tenantIds)).unlimited()),
-            CamundaAuthentication.anonymous())
+            CamundaAuthentication.anonymous(),
+            "default")
         .items();
   }
 

--- a/authentication/src/test/java/io/camunda/authentication/SessionAuthenticationRefreshTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/SessionAuthenticationRefreshTest.java
@@ -60,7 +60,7 @@ public class SessionAuthenticationRefreshTest {
 
     @BeforeEach
     public void setup() {
-      when(roleServices.hasMembersOfType(any(), any(), any())).thenReturn(true);
+      when(roleServices.hasMembersOfType(any(), any(), any(), any())).thenReturn(true);
       refreshInterval =
           Duration.parse(
               securityConfiguration.getAuthentication().getAuthenticationRefreshInterval());

--- a/authentication/src/test/java/io/camunda/authentication/config/spi/AdminUserPresenceAdapterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/spi/AdminUserPresenceAdapterTest.java
@@ -52,7 +52,7 @@ class AdminUserPresenceAdapterTest {
   void shouldReturnTrueWhenLiveStoreReportsAdminMember() {
     // given
     when(roleServices.hasMembersOfType(
-            eq(ADMIN_ROLE_ID), eq(EntityType.USER), any(CamundaAuthentication.class)))
+            eq(ADMIN_ROLE_ID), eq(EntityType.USER), any(CamundaAuthentication.class), any()))
         .thenReturn(true);
 
     // when / then
@@ -63,7 +63,7 @@ class AdminUserPresenceAdapterTest {
   void shouldReturnFalseWhenNoConfiguredOrLiveAdminUser() {
     // given
     when(roleServices.hasMembersOfType(
-            eq(ADMIN_ROLE_ID), eq(EntityType.USER), any(CamundaAuthentication.class)))
+            eq(ADMIN_ROLE_ID), eq(EntityType.USER), any(CamundaAuthentication.class), any()))
         .thenReturn(false);
 
     // when / then
@@ -74,7 +74,7 @@ class AdminUserPresenceAdapterTest {
   void shouldReturnTrueWhenLiveStoreThrows() {
     // given — mirror AdminUserCheckFilter: don't block traffic on transient failures
     when(roleServices.hasMembersOfType(
-            eq(ADMIN_ROLE_ID), eq(EntityType.USER), any(CamundaAuthentication.class)))
+            eq(ADMIN_ROLE_ID), eq(EntityType.USER), any(CamundaAuthentication.class), any()))
         .thenThrow(new RuntimeException("secondary storage down"));
 
     // when / then

--- a/authentication/src/test/java/io/camunda/authentication/service/BasicCamundaUserServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/service/BasicCamundaUserServiceTest.java
@@ -56,7 +56,7 @@ public class BasicCamundaUserServiceTest {
     when(user.userKey()).thenReturn(100L);
     when(user.name()).thenReturn("Foo Bar");
     when(user.email()).thenReturn("foo@bar.com");
-    when(userServices.getUser(eq("foo@bar.com"), any())).thenReturn(user);
+    when(userServices.getUser(eq("foo@bar.com"), any(), any())).thenReturn(user);
 
     basicCamundaUserService =
         new BasicCamundaUserService(
@@ -101,7 +101,7 @@ public class BasicCamundaUserServiceTest {
   void shouldIncludeTenants() {
     // given
     when(authentication.authenticatedTenantIds()).thenReturn(List.of("tenant1", "tenant2"));
-    when(tenantServices.search(any(TenantQuery.class), any()))
+    when(tenantServices.search(any(TenantQuery.class), any(), any()))
         .thenReturn(
             SearchQueryResult.of(
                 new TenantEntity(1L, "tenant1", "name", "desc"),

--- a/authentication/src/test/java/io/camunda/authentication/service/DefaultMembershipServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/service/DefaultMembershipServiceTest.java
@@ -58,7 +58,7 @@ class DefaultMembershipServiceTest {
 
   @Test
   void mappingRuleIdsReturnsMatchingRules() {
-    when(mappingRuleServices.getMatchingMappingRules(any(), any()))
+    when(mappingRuleServices.getMatchingMappingRules(any(), any(), any()))
         .thenReturn(Stream.of(new MappingRuleEntity("mr1", 1L, "claim", "value", "rule")));
 
     assertThat(service.mappingRuleIds(baseQuery())).containsExactly("mr1");
@@ -72,7 +72,7 @@ class DefaultMembershipServiceTest {
 
   @Test
   void groupIdsLooksUpGroupsFromDb() {
-    when(groupServices.getGroupsByMemberTypeAndMemberIds(any(), any()))
+    when(groupServices.getGroupsByMemberTypeAndMemberIds(any(), any(), any()))
         .thenReturn(List.of(new GroupEntity(1L, "g1", "group", null)));
     final var query = baseQuery().withMappingRuleIds(List.of("mr1"));
 
@@ -81,7 +81,7 @@ class DefaultMembershipServiceTest {
 
   @Test
   void roleIdsIncludesGroupsInOwnerMap() {
-    when(roleServices.getRolesByMemberTypeAndMemberIds(any(), any()))
+    when(roleServices.getRolesByMemberTypeAndMemberIds(any(), any(), any()))
         .thenReturn(List.of(new RoleEntity(1L, "r1", "role", null)));
     final var query = baseQuery().withMappingRuleIds(List.of()).withGroupIds(List.of("g1"));
 
@@ -90,7 +90,7 @@ class DefaultMembershipServiceTest {
 
   @Test
   void tenantIdsIncludesGroupsAndRolesInOwnerMap() {
-    when(tenantServices.getTenantsByMemberTypeAndMemberIds(any(), any()))
+    when(tenantServices.getTenantsByMemberTypeAndMemberIds(any(), any(), any()))
         .thenReturn(List.of(new TenantEntity(1L, "t1", "tenant", null)));
     final var query =
         baseQuery()

--- a/authentication/src/test/java/io/camunda/authentication/service/OidcCamundaUserServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/service/OidcCamundaUserServiceTest.java
@@ -140,7 +140,7 @@ public class OidcCamundaUserServiceTest {
   void shouldIncludeTenants() {
     // given
     when(camundaAuthentication.authenticatedTenantIds()).thenReturn(List.of("tenant1", "tenant2"));
-    when(tenantServices.search(any(TenantQuery.class), any()))
+    when(tenantServices.search(any(TenantQuery.class), any(), any()))
         .thenReturn(
             SearchQueryResult.of(
                 new TenantEntity(1L, "tenant1", "name", "desc"),

--- a/dist/src/main/java/io/camunda/application/commons/identity/CamundaUserDetailsService.java
+++ b/dist/src/main/java/io/camunda/application/commons/identity/CamundaUserDetailsService.java
@@ -35,7 +35,7 @@ public class CamundaUserDetailsService implements UserDetailsService {
 
   private UserEntity getUser(final String username) {
     try {
-      return userServices.getUser(username, CamundaAuthentication.anonymous());
+      return userServices.getUser(username, CamundaAuthentication.anonymous(), "default");
     } catch (final Exception e) {
       throw new UsernameNotFoundException(username, e);
     }

--- a/dist/src/test/java/io/camunda/application/commons/identity/CamundaUserDetailsServiceTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/identity/CamundaUserDetailsServiceTest.java
@@ -38,7 +38,7 @@ public class CamundaUserDetailsServiceTest {
   @Test
   public void testUserDetailsIsLoaded() {
     // given
-    when(userService.getUser(any(), any()))
+    when(userService.getUser(any(), any(), any()))
         .thenReturn(new UserEntity(100L, TEST_USER_ID, "Foo Bar", "email@tested", "password1"));
 
     // when
@@ -52,7 +52,7 @@ public class CamundaUserDetailsServiceTest {
   @Test
   public void testUserDetailsNotFound() {
     // given
-    when(userService.getUser(any(), any()))
+    when(userService.getUser(any(), any(), any()))
         .thenThrow(new ServiceException("not found", Status.NOT_FOUND));
 
     // when/then

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/processes/ProcessesToolRepository.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/processes/ProcessesToolRepository.java
@@ -103,7 +103,7 @@ public class ProcessesToolRepository implements ToolRepository {
 
     // combine static and dynamic tools
     return Stream.concat(
-            messageSubscriptionServices.search(query, auth).items().stream()
+            messageSubscriptionServices.search(query, auth, "default").items().stream()
                 .map(ProcessesToolRepository::buildTool),
             staticTools.stream().map(SyncToolSpecification::tool))
         .toList();
@@ -142,7 +142,7 @@ public class ProcessesToolRepository implements ToolRepository {
 
     // find the message subscription based on the key
     final var auth = authenticationProvider.getCamundaAuthentication();
-    final var entity = messageSubscriptionServices.getByKey(subscriptionKey, auth);
+    final var entity = messageSubscriptionServices.getByKey(subscriptionKey, auth, "default");
 
     if (entity == null) {
       return Either.left("Tool not found: " + toolName);
@@ -166,7 +166,8 @@ public class ProcessesToolRepository implements ToolRepository {
                   UUID.randomUUID().toString(),
                   arguments,
                   entity.tenantId()),
-              authenticationProvider.getCamundaAuthentication()),
+              authenticationProvider.getCamundaAuthentication(),
+              "default"),
           record -> Map.of("processInstanceKey", record.getProcessInstanceKey()));
     };
   }

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/incident/IncidentTools.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/incident/IncidentTools.java
@@ -71,7 +71,9 @@ public class IncidentTools {
       return CallToolResultMapper.from(
           SearchQueryResponseMapper.toIncidentSearchQueryResponse(
               incidentServices.search(
-                  incidentSearchQuery.get(), authenticationProvider.getCamundaAuthentication())));
+                  incidentSearchQuery.get(),
+                  authenticationProvider.getCamundaAuthentication(),
+                  "default")));
     } catch (final Exception e) {
       return CallToolResultMapper.mapErrorToResult(e);
     }
@@ -91,7 +93,7 @@ public class IncidentTools {
       return CallToolResultMapper.from(
           SearchQueryResponseMapper.toIncident(
               incidentServices.getByKey(
-                  incidentKey, authenticationProvider.getCamundaAuthentication())));
+                  incidentKey, authenticationProvider.getCamundaAuthentication(), "default")));
     } catch (final Exception e) {
       return CallToolResultMapper.mapErrorToResult(e);
     }
@@ -106,7 +108,7 @@ public class IncidentTools {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
       return CallToolResultMapper.fromPrimitive(
-          incidentServices.resolveIncident(incidentKey, null, authentication),
+          incidentServices.resolveIncident(incidentKey, null, authentication, "default"),
           r -> "Incident with key %s resolved.".formatted(incidentKey),
           error ->
               isNoJobRetriesLeft(error)
@@ -127,7 +129,7 @@ public class IncidentTools {
       final Long incidentKey, final CamundaAuthentication authentication) {
     try {
       // fetch the incident to retrieve the job key
-      final var incident = incidentServices.getByKey(incidentKey, authentication);
+      final var incident = incidentServices.getByKey(incidentKey, authentication, "default");
       // incident cannot be null, service throws exception if incident not found
       final var jobKey = incident.jobKey();
       if (jobKey == null) {
@@ -137,13 +139,14 @@ public class IncidentTools {
       // update retries for the job to 1
       final Either<Throwable, JobRecord> updateResult =
           CallToolResultMapper.executeServiceMethod(
-              jobServices.updateJob(jobKey, null, new UpdateJobChangeset(1, null), authentication));
+              jobServices.updateJob(
+                  jobKey, null, new UpdateJobChangeset(1, null), authentication, "default"));
       if (updateResult.isLeft()) {
         return CallToolResultMapper.mapErrorToResult(updateResult.getLeft());
       }
       // resolve incident again
       return CallToolResultMapper.fromPrimitive(
-          incidentServices.resolveIncident(incidentKey, null, authentication),
+          incidentServices.resolveIncident(incidentKey, null, authentication, "default"),
           r -> "Incident with key %s resolved.".formatted(incidentKey));
     } catch (final Exception e) {
       return CallToolResultMapper.mapErrorToResult(e);

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/process/definition/ProcessDefinitionTools.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/process/definition/ProcessDefinitionTools.java
@@ -60,7 +60,8 @@ public class ProcessDefinitionTools {
           SearchQueryResponseMapper.toProcessDefinitionSearchQueryResponse(
               processDefinitionServices.search(
                   processDefinitionQuery.get(),
-                  authenticationProvider.getCamundaAuthentication())));
+                  authenticationProvider.getCamundaAuthentication(),
+                  "default")));
     } catch (final Exception e) {
       return CallToolResultMapper.mapErrorToResult(e);
     }
@@ -78,7 +79,9 @@ public class ProcessDefinitionTools {
       return CallToolResultMapper.from(
           SearchQueryResponseMapper.toProcessDefinition(
               processDefinitionServices.getByKey(
-                  processDefinitionKey, authenticationProvider.getCamundaAuthentication())));
+                  processDefinitionKey,
+                  authenticationProvider.getCamundaAuthentication(),
+                  "default")));
     } catch (final Exception e) {
       return CallToolResultMapper.mapErrorToResult(e);
     }
@@ -96,7 +99,9 @@ public class ProcessDefinitionTools {
       final var xml =
           processDefinitionServices
               .getProcessDefinitionXml(
-                  processDefinitionKey, authenticationProvider.getCamundaAuthentication())
+                  processDefinitionKey,
+                  authenticationProvider.getCamundaAuthentication(),
+                  "default")
               .orElseThrow(
                   () ->
                       new ServiceException(

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceTools.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceTools.java
@@ -63,7 +63,9 @@ public class ProcessInstanceTools {
       return CallToolResultMapper.from(
           SearchQueryResponseMapper.toProcessInstanceSearchQueryResponse(
               processInstanceServices.search(
-                  processInstanceQuery.get(), authenticationProvider.getCamundaAuthentication())));
+                  processInstanceQuery.get(),
+                  authenticationProvider.getCamundaAuthentication(),
+                  "default")));
     } catch (final Exception e) {
       return CallToolResultMapper.mapErrorToResult(e);
     }
@@ -84,7 +86,9 @@ public class ProcessInstanceTools {
       return CallToolResultMapper.from(
           SearchQueryResponseMapper.toProcessInstance(
               processInstanceServices.getByKey(
-                  processInstanceKey, authenticationProvider.getCamundaAuthentication())));
+                  processInstanceKey,
+                  authenticationProvider.getCamundaAuthentication(),
+                  "default")));
     } catch (final Exception e) {
       return CallToolResultMapper.mapErrorToResult(e);
     }
@@ -117,13 +121,13 @@ public class ProcessInstanceTools {
       if (Boolean.TRUE.equals(processInstanceCreateRequest.awaitCompletion())) {
         return CallToolResultMapper.from(
             processInstanceServices.createProcessInstanceWithResult(
-                processInstanceCreateRequest, camundaAuthentication),
+                processInstanceCreateRequest, camundaAuthentication, "default"),
             ResponseMapper::toCreateProcessInstanceWithResultResponse);
       }
 
       return CallToolResultMapper.from(
           processInstanceServices.createProcessInstance(
-              processInstanceCreateRequest, camundaAuthentication),
+              processInstanceCreateRequest, camundaAuthentication, "default"),
           ResponseMapper::toCreateProcessInstanceResponse);
     } catch (final Exception e) {
       return CallToolResultMapper.mapErrorToResult(e);

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/usertask/UserTaskTools.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/usertask/UserTaskTools.java
@@ -71,7 +71,9 @@ public class UserTaskTools {
       return CallToolResultMapper.from(
           SearchQueryResponseMapper.toUserTaskSearchQueryResponse(
               userTaskServices.search(
-                  userTaskSearchQuery.get(), authenticationProvider.getCamundaAuthentication())));
+                  userTaskSearchQuery.get(),
+                  authenticationProvider.getCamundaAuthentication(),
+                  "default")));
     } catch (final Exception e) {
       return CallToolResultMapper.mapErrorToResult(e);
     }
@@ -89,7 +91,7 @@ public class UserTaskTools {
       return CallToolResultMapper.from(
           SearchQueryResponseMapper.toUserTask(
               userTaskServices.getByKey(
-                  userTaskKey, authenticationProvider.getCamundaAuthentication())));
+                  userTaskKey, authenticationProvider.getCamundaAuthentication(), "default")));
     } catch (final Exception e) {
       return CallToolResultMapper.mapErrorToResult(e);
     }
@@ -144,7 +146,8 @@ public class UserTaskTools {
             assignmentRequest.assignee(),
             assignmentRequest.action(),
             assignmentRequest.allowOverride(),
-            authenticationProvider.getCamundaAuthentication()),
+            authenticationProvider.getCamundaAuthentication(),
+            "default"),
         r ->
             "User task with key %s assigned to %s."
                 .formatted(assignmentRequest.userTaskKey(), assignmentRequest.assignee()));
@@ -157,7 +160,8 @@ public class UserTaskTools {
         userTaskServices.unassignUserTask(
             unassignRequest.userTaskKey(),
             unassignRequest.action(),
-            authenticationProvider.getCamundaAuthentication()),
+            authenticationProvider.getCamundaAuthentication(),
+            "default"),
         r -> "User task with key %s unassigned.".formatted(unassignRequest.userTaskKey()));
   }
 
@@ -194,7 +198,8 @@ public class UserTaskTools {
               userTaskServices.searchUserTaskEffectiveVariables(
                   userTaskKey,
                   variableSearchQuery.get(),
-                  authenticationProvider.getCamundaAuthentication()),
+                  authenticationProvider.getCamundaAuthentication(),
+                  "default"),
               shouldTruncate));
     } catch (final Exception e) {
       return CallToolResultMapper.mapErrorToResult(e);

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/variable/VariableTools.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/variable/VariableTools.java
@@ -72,7 +72,9 @@ public class VariableTools {
       return CallToolResultMapper.from(
           SearchQueryResponseMapper.toVariableSearchQueryResponse(
               variableServices.search(
-                  variableSearchQuery.get(), authenticationProvider.getCamundaAuthentication()),
+                  variableSearchQuery.get(),
+                  authenticationProvider.getCamundaAuthentication(),
+                  "default"),
               shouldTruncate));
     } catch (final Exception e) {
       return CallToolResultMapper.mapErrorToResult(e);
@@ -92,7 +94,7 @@ public class VariableTools {
       return CallToolResultMapper.from(
           SearchQueryResponseMapper.toVariableItem(
               variableServices.getByKey(
-                  variableKey, authenticationProvider.getCamundaAuthentication())));
+                  variableKey, authenticationProvider.getCamundaAuthentication(), "default")));
     } catch (final Exception e) {
       return CallToolResultMapper.mapErrorToResult(e);
     }

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/processes/ProcessesToolRepositoryTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/processes/ProcessesToolRepositoryTest.java
@@ -100,7 +100,7 @@ class ProcessesToolRepositoryTest {
               "orderMessage",
               "<default>",
               MessageSubscriptionState.CREATED);
-      when(messageSubscriptionServices.search(any(), any()))
+      when(messageSubscriptionServices.search(any(), any(), any()))
           .thenReturn(SearchQueryResult.of(entity));
 
       // when
@@ -134,7 +134,7 @@ class ProcessesToolRepositoryTest {
               "order.start",
               "<default>",
               MessageSubscriptionState.CREATED);
-      when(messageSubscriptionServices.search(any(), any()))
+      when(messageSubscriptionServices.search(any(), any(), any()))
           .thenReturn(SearchQueryResult.of(entity));
 
       // when
@@ -167,7 +167,7 @@ class ProcessesToolRepositoryTest {
       final var entity =
           buildStartSubscriptionEntity(
               5L, "minimalTool", props, "minMsg", "<default>", MessageSubscriptionState.CREATED);
-      when(messageSubscriptionServices.search(any(), any()))
+      when(messageSubscriptionServices.search(any(), any(), any()))
           .thenReturn(SearchQueryResult.of(entity));
 
       // when
@@ -212,7 +212,7 @@ class ProcessesToolRepositoryTest {
               "orderMessage",
               "<default>",
               MessageSubscriptionState.CREATED);
-      when(messageSubscriptionServices.search(any(), any()))
+      when(messageSubscriptionServices.search(any(), any(), any()))
           .thenReturn(SearchQueryResult.of(entity));
 
       // when
@@ -231,14 +231,15 @@ class ProcessesToolRepositoryTest {
     @Test
     void shouldFilterByStartEventTypeAndNonDeletedStateAndToolNameExists() {
       // given
-      when(messageSubscriptionServices.search(any(), any())).thenReturn(SearchQueryResult.empty());
+      when(messageSubscriptionServices.search(any(), any(), any()))
+          .thenReturn(SearchQueryResult.empty());
 
       // when
       repository.getTools(transportContext);
 
       // then
       final var queryCaptor = ArgumentCaptor.forClass(MessageSubscriptionQuery.class);
-      verify(messageSubscriptionServices).search(queryCaptor.capture(), any());
+      verify(messageSubscriptionServices).search(queryCaptor.capture(), any(), any());
 
       final var filter = queryCaptor.getValue().filter();
       assertThat(filter.messageSubscriptionTypeOperations())
@@ -268,8 +269,8 @@ class ProcessesToolRepositoryTest {
               "deploy.start",
               "tenant-a",
               MessageSubscriptionState.CREATED);
-      when(messageSubscriptionServices.getByKey(eq(77L), any())).thenReturn(entity);
-      when(messageSubscriptionServices.search(any(), any()))
+      when(messageSubscriptionServices.getByKey(eq(77L), any(), any())).thenReturn(entity);
+      when(messageSubscriptionServices.search(any(), any(), any()))
           .thenReturn(SearchQueryResult.of(entity));
 
       final var toolSpec = repository.getTools(transportContext).getFirst();
@@ -294,10 +295,10 @@ class ProcessesToolRepositoryTest {
               "deploy.start",
               "tenant-a",
               MessageSubscriptionState.CREATED);
-      when(messageSubscriptionServices.getByKey(eq(77L), any())).thenReturn(entity);
+      when(messageSubscriptionServices.getByKey(eq(77L), any(), any())).thenReturn(entity);
 
       final var correlationRecord = new MessageCorrelationRecord();
-      when(messageServices.correlateMessage(any(), any()))
+      when(messageServices.correlateMessage(any(), any(), any()))
           .thenReturn(CompletableFuture.completedFuture(correlationRecord));
 
       final var result = repository.findTool(transportContext, "deploy_77");
@@ -311,7 +312,7 @@ class ProcessesToolRepositoryTest {
               CallToolRequest.builder("deploy_77").arguments(Map.of("foo", "bar")).build());
 
       final var reqCaptor = ArgumentCaptor.forClass(CorrelateMessageRequest.class);
-      verify(messageServices).correlateMessage(reqCaptor.capture(), any());
+      verify(messageServices).correlateMessage(reqCaptor.capture(), any(), any());
 
       assertThat(reqCaptor.getValue().name()).isEqualTo("deploy.start");
       assertThat(reqCaptor.getValue().tenantId()).isEqualTo("tenant-a");
@@ -324,7 +325,7 @@ class ProcessesToolRepositoryTest {
     @Test
     void shouldReturnNotFoundWhenSubscriptionDoesNotExist() {
       // given
-      when(messageSubscriptionServices.getByKey(anyLong(), any())).thenReturn(null);
+      when(messageSubscriptionServices.getByKey(anyLong(), any(), any())).thenReturn(null);
 
       // when
       final var result = repository.findTool(transportContext, "missingTool_123");
@@ -345,7 +346,7 @@ class ProcessesToolRepositoryTest {
               "old.message",
               "<default>",
               MessageSubscriptionState.DELETED);
-      when(messageSubscriptionServices.getByKey(eq(55L), any())).thenReturn(entity);
+      when(messageSubscriptionServices.getByKey(eq(55L), any(), any())).thenReturn(entity);
 
       // when
       final var result = repository.findTool(transportContext, "oldTool_55");
@@ -386,7 +387,7 @@ class ProcessesToolRepositoryTest {
               "corr.msg",
               "<default>",
               MessageSubscriptionState.CORRELATED);
-      when(messageSubscriptionServices.search(any(), any()))
+      when(messageSubscriptionServices.search(any(), any(), any()))
           .thenReturn(SearchQueryResult.of(entity));
 
       // when
@@ -408,8 +409,8 @@ class ProcessesToolRepositoryTest {
               "message",
               "<default>",
               MessageSubscriptionState.CREATED);
-      when(messageSubscriptionServices.getByKey(eq(88L), any())).thenReturn(entity);
-      when(messageServices.correlateMessage(any(), any()))
+      when(messageSubscriptionServices.getByKey(eq(88L), any(), any())).thenReturn(entity);
+      when(messageServices.correlateMessage(any(), any(), any()))
           .thenReturn(
               CompletableFuture.completedFuture(
                   new MessageCorrelationRecord().setProcessInstanceKey(12345678910L)));
@@ -435,7 +436,7 @@ class ProcessesToolRepositoryTest {
       assertThat(incident).containsExactly(entry("processInstanceKey", 12345678910L));
 
       final var captor = ArgumentCaptor.forClass(CorrelateMessageRequest.class);
-      verify(messageServices).correlateMessage(captor.capture(), any());
+      verify(messageServices).correlateMessage(captor.capture(), any(), any());
       assertThat(captor.getValue().name()).isEqualTo("message");
       assertThat(captor.getValue().tenantId()).isEqualTo("<default>");
       assertThat(captor.getValue().correlationKey()).isNotBlank();
@@ -455,8 +456,8 @@ class ProcessesToolRepositoryTest {
               "message",
               "<default>",
               MessageSubscriptionState.CREATED);
-      when(messageSubscriptionServices.getByKey(eq(88L), any())).thenReturn(entity);
-      when(messageServices.correlateMessage(any(), any()))
+      when(messageSubscriptionServices.getByKey(eq(88L), any(), any())).thenReturn(entity);
+      when(messageServices.correlateMessage(any(), any(), any()))
           .thenReturn(
               CompletableFuture.completedFuture(
                   new MessageCorrelationRecord().setProcessInstanceKey(12345678910L)));
@@ -467,7 +468,7 @@ class ProcessesToolRepositoryTest {
       callHandler.apply(
           transportContext, CallToolRequest.builder("myTool_88").arguments(Map.of()).build());
       final var firstCaptor = ArgumentCaptor.forClass(CorrelateMessageRequest.class);
-      verify(messageServices).correlateMessage(firstCaptor.capture(), any());
+      verify(messageServices).correlateMessage(firstCaptor.capture(), any(), any());
 
       // when
       callHandler.apply(
@@ -475,7 +476,7 @@ class ProcessesToolRepositoryTest {
 
       // then
       final var secondCaptor = ArgumentCaptor.forClass(CorrelateMessageRequest.class);
-      verify(messageServices, times(2)).correlateMessage(secondCaptor.capture(), any());
+      verify(messageServices, times(2)).correlateMessage(secondCaptor.capture(), any(), any());
       assertThat(firstCaptor.getValue().correlationKey()).isNotBlank();
       assertThat(secondCaptor.getValue().correlationKey()).isNotBlank();
       assertThat(secondCaptor.getValue().correlationKey())
@@ -518,7 +519,7 @@ class ProcessesToolRepositoryTest {
               "start.message",
               "<default>",
               MessageSubscriptionState.CREATED);
-      when(messageSubscriptionServices.search(any(), any()))
+      when(messageSubscriptionServices.search(any(), any(), any()))
           .thenReturn(SearchQueryResult.of(entity));
 
       // when
@@ -533,7 +534,8 @@ class ProcessesToolRepositoryTest {
     @Test
     void shouldReturnOnlyStaticToolsWhenNoDynamicToolsExist() {
       // given
-      when(messageSubscriptionServices.search(any(), any())).thenReturn(SearchQueryResult.empty());
+      when(messageSubscriptionServices.search(any(), any(), any()))
+          .thenReturn(SearchQueryResult.empty());
 
       // when
       final var tools = repository.getTools(transportContext);
@@ -556,7 +558,7 @@ class ProcessesToolRepositoryTest {
     @Test
     void shouldNotFallThroughToDynamicLookupForUnknownTools() {
       // given
-      when(messageSubscriptionServices.getByKey(anyLong(), any())).thenReturn(null);
+      when(messageSubscriptionServices.getByKey(anyLong(), any(), any())).thenReturn(null);
 
       // when
       final var result = repository.findTool(transportContext, "unknown_999");

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/incident/IncidentToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/incident/IncidentToolsTest.java
@@ -120,7 +120,7 @@ class IncidentToolsTest extends OperationalToolsTest {
     @Test
     void shouldGetIncidentByKey() {
       // given
-      when(incidentServices.getByKey(any(), any())).thenReturn(INCIDENT_ENTITY);
+      when(incidentServices.getByKey(any(), any(), any())).thenReturn(INCIDENT_ENTITY);
 
       // when
       final CallToolResult result =
@@ -135,7 +135,7 @@ class IncidentToolsTest extends OperationalToolsTest {
           objectMapper.convertValue(result.structuredContent(), IncidentResult.class);
       assertExampleIncident(incident);
 
-      verify(incidentServices).getByKey(eq(5L), any());
+      verify(incidentServices).getByKey(eq(5L), any(), any());
 
       assertTextContentFallback(result);
     }
@@ -143,7 +143,7 @@ class IncidentToolsTest extends OperationalToolsTest {
     @Test
     void shouldFailGetIncidentByKeyOnException() {
       // given
-      when(incidentServices.getByKey(any(), any()))
+      when(incidentServices.getByKey(any(), any(), any()))
           .thenThrow(new ServiceException("Expected failure", Status.NOT_FOUND));
 
       // when
@@ -231,7 +231,7 @@ class IncidentToolsTest extends OperationalToolsTest {
     @Test
     void shouldSearchIncidentsWithCreationTimeDateRangeFilter() {
       // given
-      when(incidentServices.search(any(IncidentQuery.class), any()))
+      when(incidentServices.search(any(IncidentQuery.class), any(), any()))
           .thenReturn(SEARCH_QUERY_RESULT);
 
       final var creationTimeFrom = OffsetDateTime.of(2025, 5, 23, 9, 35, 12, 0, ZoneOffset.UTC);
@@ -253,7 +253,7 @@ class IncidentToolsTest extends OperationalToolsTest {
       // then
       assertThat(result.isError()).isFalse();
 
-      verify(incidentServices).search(queryCaptor.capture(), any());
+      verify(incidentServices).search(queryCaptor.capture(), any(), any());
       final IncidentQuery capturedQuery = queryCaptor.getValue();
 
       assertThat(capturedQuery.filter().creationTimeOperations())
@@ -266,7 +266,7 @@ class IncidentToolsTest extends OperationalToolsTest {
     @Test
     void shouldSearchIncidentsWithFilterSortAndPaging() {
       // given
-      when(incidentServices.search(any(IncidentQuery.class), any()))
+      when(incidentServices.search(any(IncidentQuery.class), any(), any()))
           .thenReturn(SEARCH_QUERY_RESULT);
 
       // when
@@ -298,7 +298,7 @@ class IncidentToolsTest extends OperationalToolsTest {
           .first()
           .satisfies(IncidentToolsTest.this::assertExampleIncident);
 
-      verify(incidentServices).search(queryCaptor.capture(), any());
+      verify(incidentServices).search(queryCaptor.capture(), any(), any());
       final IncidentQuery capturedQuery = queryCaptor.getValue();
 
       final IncidentFilter filter = capturedQuery.filter();
@@ -323,7 +323,7 @@ class IncidentToolsTest extends OperationalToolsTest {
     @Test
     void shouldFailSearchIncidentsOnException() {
       // given
-      when(incidentServices.search(any(IncidentQuery.class), any()))
+      when(incidentServices.search(any(IncidentQuery.class), any(), any()))
           .thenThrow(new ServiceException("Expected failure", Status.NOT_FOUND));
 
       // when
@@ -397,7 +397,7 @@ class IncidentToolsTest extends OperationalToolsTest {
     @Test
     void shouldResolveIncidentByKey() {
       // given
-      when(incidentServices.resolveIncident(anyLong(), any(), any()))
+      when(incidentServices.resolveIncident(anyLong(), any(), any(), any()))
           .thenReturn(CompletableFuture.completedFuture(new IncidentRecord()));
 
       // when
@@ -417,7 +417,7 @@ class IncidentToolsTest extends OperationalToolsTest {
               textContent ->
                   assertThat(textContent.text()).isEqualTo("Incident with key 5 resolved."));
 
-      verify(incidentServices).resolveIncident(eq(5L), isNull(), any());
+      verify(incidentServices).resolveIncident(eq(5L), isNull(), any(), any());
     }
 
     @Test
@@ -425,14 +425,14 @@ class IncidentToolsTest extends OperationalToolsTest {
       // given
       final var incidentEntity = mock(IncidentEntity.class);
       // noinspection unchecked
-      when(incidentServices.resolveIncident(anyLong(), any(), any()))
+      when(incidentServices.resolveIncident(anyLong(), any(), any(), any()))
           .thenReturn(
               CompletableFuture.failedFuture(
                   new ServiceException("no retries left", Status.INVALID_STATE)),
               CompletableFuture.completedFuture(new IncidentRecord()));
       when(incidentEntity.jobKey()).thenReturn(4L);
-      when(incidentServices.getByKey(anyLong(), any())).thenReturn(incidentEntity);
-      when(jobServices.updateJob(anyLong(), any(), any(UpdateJobChangeset.class), any()))
+      when(incidentServices.getByKey(anyLong(), any(), any())).thenReturn(incidentEntity);
+      when(jobServices.updateJob(anyLong(), any(), any(UpdateJobChangeset.class), any(), any()))
           .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
 
       // when
@@ -452,9 +452,10 @@ class IncidentToolsTest extends OperationalToolsTest {
               textContent ->
                   assertThat(textContent.text()).isEqualTo("Incident with key 5 resolved."));
 
-      verify(incidentServices, times(2)).resolveIncident(eq(5L), isNull(), any());
-      verify(incidentServices).getByKey(eq(5L), any());
-      verify(jobServices).updateJob(eq(4L), isNull(), eq(new UpdateJobChangeset(1, null)), any());
+      verify(incidentServices, times(2)).resolveIncident(eq(5L), isNull(), any(), any());
+      verify(incidentServices).getByKey(eq(5L), any(), any());
+      verify(jobServices)
+          .updateJob(eq(4L), isNull(), eq(new UpdateJobChangeset(1, null)), any(), any());
     }
 
     @Test
@@ -462,14 +463,14 @@ class IncidentToolsTest extends OperationalToolsTest {
       // given
       final var incidentEntity = mock(IncidentEntity.class);
       // noinspection unchecked
-      when(incidentServices.resolveIncident(anyLong(), any(), any()))
+      when(incidentServices.resolveIncident(anyLong(), any(), any(), any()))
           .thenReturn(
               CompletableFuture.failedFuture(
                   new ServiceException("no retries left", Status.INVALID_STATE)),
               CompletableFuture.completedFuture(new IncidentRecord()));
       when(incidentEntity.jobKey()).thenReturn(4L);
-      when(incidentServices.getByKey(anyLong(), any())).thenReturn(incidentEntity);
-      when(jobServices.updateJob(anyLong(), any(), any(UpdateJobChangeset.class), any()))
+      when(incidentServices.getByKey(anyLong(), any(), any())).thenReturn(incidentEntity);
+      when(jobServices.updateJob(anyLong(), any(), any(UpdateJobChangeset.class), any(), any()))
           .thenReturn(
               CompletableFuture.failedFuture(
                   new ServiceException("Expected failure", Status.NOT_FOUND)));
@@ -491,9 +492,10 @@ class IncidentToolsTest extends OperationalToolsTest {
       assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
       assertThat(problemDetail.getTitle()).isEqualTo("NOT_FOUND");
 
-      verify(incidentServices).resolveIncident(eq(5L), isNull(), any());
-      verify(incidentServices).getByKey(eq(5L), any());
-      verify(jobServices).updateJob(eq(4L), isNull(), eq(new UpdateJobChangeset(1, null)), any());
+      verify(incidentServices).resolveIncident(eq(5L), isNull(), any(), any());
+      verify(incidentServices).getByKey(eq(5L), any(), any());
+      verify(jobServices)
+          .updateJob(eq(4L), isNull(), eq(new UpdateJobChangeset(1, null)), any(), any());
 
       assertTextContentFallback(result);
     }

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/process/definition/ProcessDefinitionToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/process/definition/ProcessDefinitionToolsTest.java
@@ -97,7 +97,8 @@ class ProcessDefinitionToolsTest extends OperationalToolsTest {
     @Test
     void shouldGetProcessDefinitionByKey() {
       // given
-      when(processDefinitionServices.getByKey(eq(5L), any())).thenReturn(PROCESS_DEFINITION_ENTITY);
+      when(processDefinitionServices.getByKey(eq(5L), any(), any()))
+          .thenReturn(PROCESS_DEFINITION_ENTITY);
 
       // when
       final CallToolResult result =
@@ -189,7 +190,7 @@ class ProcessDefinitionToolsTest extends OperationalToolsTest {
     @Test
     void shouldSearchProcessDefinitionsWithFilterSortAndPaging() {
       // given
-      when(processDefinitionServices.search(any(ProcessDefinitionQuery.class), any()))
+      when(processDefinitionServices.search(any(ProcessDefinitionQuery.class), any(), any()))
           .thenReturn(SEARCH_QUERY_RESULT);
 
       // when
@@ -222,7 +223,7 @@ class ProcessDefinitionToolsTest extends OperationalToolsTest {
           .first()
           .satisfies(ProcessDefinitionToolsTest.this::assertExampleProcessDefinitionResult);
 
-      verify(processDefinitionServices).search(queryCaptor.capture(), any());
+      verify(processDefinitionServices).search(queryCaptor.capture(), any(), any());
       final ProcessDefinitionQuery capturedQuery = queryCaptor.getValue();
 
       final ProcessDefinitionFilter filter = capturedQuery.filter();
@@ -243,7 +244,7 @@ class ProcessDefinitionToolsTest extends OperationalToolsTest {
     @Test
     void shouldFailSearchProcessDefinitionsOnException() {
       // given
-      when(processDefinitionServices.search(any(ProcessDefinitionQuery.class), any()))
+      when(processDefinitionServices.search(any(ProcessDefinitionQuery.class), any(), any()))
           .thenThrow(new ServiceException("Expected failure", Status.NOT_FOUND));
 
       // when
@@ -267,7 +268,7 @@ class ProcessDefinitionToolsTest extends OperationalToolsTest {
     @Test
     void shouldIgnoreTenantIdInFilter() {
       // given
-      when(processDefinitionServices.search(any(ProcessDefinitionQuery.class), any()))
+      when(processDefinitionServices.search(any(ProcessDefinitionQuery.class), any(), any()))
           .thenReturn(SEARCH_QUERY_RESULT);
 
       // when (tenantId passed in arguments should be ignored by MCP filter schema)
@@ -277,7 +278,7 @@ class ProcessDefinitionToolsTest extends OperationalToolsTest {
               .build());
 
       // then
-      verify(processDefinitionServices).search(queryCaptor.capture(), any());
+      verify(processDefinitionServices).search(queryCaptor.capture(), any(), any());
       final ProcessDefinitionQuery capturedQuery = queryCaptor.getValue();
       assertThat(capturedQuery.filter().tenantIds()).isEmpty();
     }
@@ -354,7 +355,7 @@ class ProcessDefinitionToolsTest extends OperationalToolsTest {
     @Test
     void shouldGetProcessDefinitionXmlByKey() {
       // given
-      when(processDefinitionServices.getProcessDefinitionXml(any(), any()))
+      when(processDefinitionServices.getProcessDefinitionXml(any(), any(), any()))
           .thenReturn(Optional.of("<bpmn />"));
 
       // when
@@ -378,7 +379,7 @@ class ProcessDefinitionToolsTest extends OperationalToolsTest {
     @Test
     void shouldReturnErrorWhenNoProcessDefinitionXmlAvailable() {
       // given
-      when(processDefinitionServices.getProcessDefinitionXml(any(), any()))
+      when(processDefinitionServices.getProcessDefinitionXml(any(), any(), any()))
           .thenReturn(Optional.empty());
 
       // when

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceToolsTest.java
@@ -129,7 +129,8 @@ class ProcessInstanceToolsTest extends OperationalToolsTest {
     @Test
     void shouldGetProcessInstanceByKey() {
       // given
-      when(processInstanceServices.getByKey(any(), any())).thenReturn(PROCESS_INSTANCE_ENTITY);
+      when(processInstanceServices.getByKey(any(), any(), any()))
+          .thenReturn(PROCESS_INSTANCE_ENTITY);
 
       // when
       final CallToolResult result =
@@ -146,7 +147,7 @@ class ProcessInstanceToolsTest extends OperationalToolsTest {
           objectMapper.convertValue(result.structuredContent(), ProcessInstanceResult.class);
       assertExampleProcessInstance(processInstance);
 
-      verify(processInstanceServices).getByKey(eq(123L), any());
+      verify(processInstanceServices).getByKey(eq(123L), any(), any());
 
       assertTextContentFallback(result);
     }
@@ -154,7 +155,7 @@ class ProcessInstanceToolsTest extends OperationalToolsTest {
     @Test
     void shouldFailGetProcessInstanceByKeyOnException() {
       // given
-      when(processInstanceServices.getByKey(any(), any()))
+      when(processInstanceServices.getByKey(any(), any(), any()))
           .thenThrow(new ServiceException("Expected failure", Status.NOT_FOUND));
 
       // when
@@ -249,7 +250,7 @@ class ProcessInstanceToolsTest extends OperationalToolsTest {
     @Test
     void shouldSearchProcessInstancesWithFilterSortAndPaging() {
       // given
-      when(processInstanceServices.search(any(ProcessInstanceQuery.class), any()))
+      when(processInstanceServices.search(any(ProcessInstanceQuery.class), any(), any()))
           .thenReturn(SEARCH_QUERY_RESULT);
 
       // when
@@ -294,7 +295,7 @@ class ProcessInstanceToolsTest extends OperationalToolsTest {
           .first()
           .satisfies(ProcessInstanceToolsTest.this::assertExampleProcessInstance);
 
-      verify(processInstanceServices).search(queryCaptor.capture(), any());
+      verify(processInstanceServices).search(queryCaptor.capture(), any(), any());
       final ProcessInstanceQuery capturedQuery = queryCaptor.getValue();
 
       final ProcessInstanceFilter filter = capturedQuery.filter();
@@ -338,7 +339,7 @@ class ProcessInstanceToolsTest extends OperationalToolsTest {
     @Test
     void shouldIgnoreTenantIdInFilter() {
       // given
-      when(processInstanceServices.search(any(ProcessInstanceQuery.class), any()))
+      when(processInstanceServices.search(any(ProcessInstanceQuery.class), any(), any()))
           .thenReturn(SEARCH_QUERY_RESULT);
 
       // when (tenantId passed in arguments should be ignored by MCP filter schema)
@@ -348,7 +349,7 @@ class ProcessInstanceToolsTest extends OperationalToolsTest {
               .build());
 
       // then
-      verify(processInstanceServices).search(queryCaptor.capture(), any());
+      verify(processInstanceServices).search(queryCaptor.capture(), any(), any());
       final ProcessInstanceQuery capturedQuery = queryCaptor.getValue();
       assertThat(capturedQuery.filter().tenantIdOperations()).isEmpty();
     }
@@ -356,7 +357,7 @@ class ProcessInstanceToolsTest extends OperationalToolsTest {
     @Test
     void shouldFailSearchProcessInstancesOnException() {
       // given
-      when(processInstanceServices.search(any(ProcessInstanceQuery.class), any()))
+      when(processInstanceServices.search(any(ProcessInstanceQuery.class), any(), any()))
           .thenThrow(new ServiceException("Expected failure", Status.NOT_FOUND));
 
       // when
@@ -472,7 +473,7 @@ class ProcessInstanceToolsTest extends OperationalToolsTest {
               .setTags(Set.of());
 
       when(processInstanceServices.createProcessInstance(
-              any(ProcessInstanceCreateRequest.class), any()))
+              any(ProcessInstanceCreateRequest.class), any(), any()))
           .thenReturn(CompletableFuture.completedFuture(createResponse));
 
       // when
@@ -493,7 +494,8 @@ class ProcessInstanceToolsTest extends OperationalToolsTest {
       assertThat(result.isError()).isFalse();
       assertThat(result.structuredContent()).isNotNull();
 
-      verify(processInstanceServices).createProcessInstance(createRequestCaptor.capture(), any());
+      verify(processInstanceServices)
+          .createProcessInstance(createRequestCaptor.capture(), any(), any());
       final var capturedRequest = createRequestCaptor.getValue();
       assertThat(capturedRequest.processDefinitionKey()).isEqualTo(123L);
       assertThat(capturedRequest.tenantId()).isEqualTo("<default>");
@@ -528,7 +530,7 @@ class ProcessInstanceToolsTest extends OperationalToolsTest {
               .setTags(Set.of("mcp-tool:abc"));
 
       when(processInstanceServices.createProcessInstance(
-              any(ProcessInstanceCreateRequest.class), any()))
+              any(ProcessInstanceCreateRequest.class), any(), any()))
           .thenReturn(CompletableFuture.completedFuture(createResponse));
 
       // when
@@ -550,7 +552,8 @@ class ProcessInstanceToolsTest extends OperationalToolsTest {
       // then
       assertThat(result.isError()).isFalse();
 
-      verify(processInstanceServices).createProcessInstance(createRequestCaptor.capture(), any());
+      verify(processInstanceServices)
+          .createProcessInstance(createRequestCaptor.capture(), any(), any());
       final var capturedRequest = createRequestCaptor.getValue();
       assertThat(capturedRequest.bpmnProcessId()).contains("testProcessId");
       assertThat(capturedRequest.version()).isEqualTo(7);
@@ -589,7 +592,7 @@ class ProcessInstanceToolsTest extends OperationalToolsTest {
               .setTags(Set.of("mcp-tool:abc"));
 
       when(processInstanceServices.createProcessInstanceWithResult(
-              any(ProcessInstanceCreateRequest.class), any()))
+              any(ProcessInstanceCreateRequest.class), any(), any()))
           .thenReturn(CompletableFuture.completedFuture(createResponse));
 
       // when
@@ -616,7 +619,7 @@ class ProcessInstanceToolsTest extends OperationalToolsTest {
       assertThat(result.isError()).isFalse();
 
       verify(processInstanceServices)
-          .createProcessInstanceWithResult(createRequestCaptor.capture(), any());
+          .createProcessInstanceWithResult(createRequestCaptor.capture(), any(), any());
       final var capturedRequest = createRequestCaptor.getValue();
       assertThat(capturedRequest.awaitCompletion()).isTrue();
       assertThat(capturedRequest.fetchVariables()).containsExactly("foo");
@@ -652,7 +655,7 @@ class ProcessInstanceToolsTest extends OperationalToolsTest {
               .setTags(Set.of("mcp-tool:abc"));
 
       when(processInstanceServices.createProcessInstanceWithResult(
-              any(ProcessInstanceCreateRequest.class), any()))
+              any(ProcessInstanceCreateRequest.class), any(), any()))
           .thenReturn(CompletableFuture.completedFuture(createResponse));
 
       // when
@@ -679,7 +682,7 @@ class ProcessInstanceToolsTest extends OperationalToolsTest {
       assertThat(result.isError()).isFalse();
 
       verify(processInstanceServices)
-          .createProcessInstanceWithResult(createRequestCaptor.capture(), any());
+          .createProcessInstanceWithResult(createRequestCaptor.capture(), any(), any());
       final var capturedRequest = createRequestCaptor.getValue();
       assertThat(capturedRequest.awaitCompletion()).isTrue();
       assertThat(capturedRequest.requestTimeout()).isEqualTo(60000L);
@@ -704,7 +707,7 @@ class ProcessInstanceToolsTest extends OperationalToolsTest {
       when(multiTenancyConfiguration.isChecksEnabled()).thenReturn(false);
 
       when(processInstanceServices.createProcessInstance(
-              any(ProcessInstanceCreateRequest.class), any()))
+              any(ProcessInstanceCreateRequest.class), any(), any()))
           .thenThrow(new ServiceException("Expected failure", Status.INVALID_ARGUMENT));
 
       // when
@@ -784,7 +787,7 @@ class ProcessInstanceToolsTest extends OperationalToolsTest {
               .setTags(Set.of());
 
       when(processInstanceServices.createProcessInstance(
-              any(ProcessInstanceCreateRequest.class), any()))
+              any(ProcessInstanceCreateRequest.class), any(), any()))
           .thenReturn(CompletableFuture.completedFuture(createResponse));
 
       // when
@@ -807,7 +810,8 @@ class ProcessInstanceToolsTest extends OperationalToolsTest {
       assertThat(result.isError()).isFalse();
       assertThat(result.structuredContent()).isNotNull();
 
-      verify(processInstanceServices).createProcessInstance(createRequestCaptor.capture(), any());
+      verify(processInstanceServices)
+          .createProcessInstance(createRequestCaptor.capture(), any(), any());
       final var capturedRequest = createRequestCaptor.getValue();
       assertThat(capturedRequest.processDefinitionKey()).isEqualTo(123L);
       assertThat(capturedRequest.tenantId()).isEqualTo("tenant-a");
@@ -842,7 +846,7 @@ class ProcessInstanceToolsTest extends OperationalToolsTest {
               .setTags(Set.of("mcp-tool:abc"));
 
       when(processInstanceServices.createProcessInstance(
-              any(ProcessInstanceCreateRequest.class), any()))
+              any(ProcessInstanceCreateRequest.class), any(), any()))
           .thenReturn(CompletableFuture.completedFuture(createResponse));
 
       // when
@@ -866,7 +870,8 @@ class ProcessInstanceToolsTest extends OperationalToolsTest {
       // then
       assertThat(result.isError()).isFalse();
 
-      verify(processInstanceServices).createProcessInstance(createRequestCaptor.capture(), any());
+      verify(processInstanceServices)
+          .createProcessInstance(createRequestCaptor.capture(), any(), any());
       final var capturedRequest = createRequestCaptor.getValue();
       assertThat(capturedRequest.bpmnProcessId()).contains("testProcessId");
       assertThat(capturedRequest.version()).isEqualTo(7);
@@ -959,7 +964,7 @@ class ProcessInstanceToolsTest extends OperationalToolsTest {
               .setBusinessId(businessId);
 
       when(processInstanceServices.createProcessInstance(
-              any(ProcessInstanceCreateRequest.class), any()))
+              any(ProcessInstanceCreateRequest.class), any(), any()))
           .thenReturn(CompletableFuture.completedFuture(createResponse));
 
       // when
@@ -973,7 +978,8 @@ class ProcessInstanceToolsTest extends OperationalToolsTest {
       assertThat(result.isError()).isFalse();
       assertThat(result.structuredContent()).isNotNull();
 
-      verify(processInstanceServices).createProcessInstance(createRequestCaptor.capture(), any());
+      verify(processInstanceServices)
+          .createProcessInstance(createRequestCaptor.capture(), any(), any());
       final var capturedRequest = createRequestCaptor.getValue();
       assertThat(capturedRequest.processDefinitionKey()).isEqualTo(123L);
       assertThat(capturedRequest.businessId()).isEqualTo(businessId);

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/usertask/UserTaskToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/usertask/UserTaskToolsTest.java
@@ -173,7 +173,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
     @Test
     void shouldGetUserTaskByKey() {
       // given
-      when(userTaskServices.getByKey(anyLong(), any())).thenReturn(USER_TASK_ENTITY);
+      when(userTaskServices.getByKey(anyLong(), any(), any())).thenReturn(USER_TASK_ENTITY);
 
       // when
       final CallToolResult result =
@@ -188,7 +188,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
           objectMapper.convertValue(result.structuredContent(), UserTaskResult.class);
       assertExampleUserTask(userTask);
 
-      verify(userTaskServices).getByKey(eq(5L), any());
+      verify(userTaskServices).getByKey(eq(5L), any(), any());
 
       assertTextContentFallback(result);
     }
@@ -196,7 +196,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
     @Test
     void shouldFailGetUserTaskByKeyOnException() {
       // given
-      when(userTaskServices.getByKey(anyLong(), any()))
+      when(userTaskServices.getByKey(anyLong(), any(), any()))
           .thenThrow(new ServiceException("Expected failure", Status.NOT_FOUND));
 
       // when
@@ -284,7 +284,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
     @Test
     void shouldSearchUserTasksWithFilterSortAndPaging() {
       // given
-      when(userTaskServices.search(any(UserTaskQuery.class), any()))
+      when(userTaskServices.search(any(UserTaskQuery.class), any(), any()))
           .thenReturn(USER_TASK_SEARCH_QUERY_RESULT);
 
       // when
@@ -316,7 +316,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
           .first()
           .satisfies(UserTaskToolsTest.this::assertExampleUserTask);
 
-      verify(userTaskServices).search(userTaskQueryCaptor.capture(), any());
+      verify(userTaskServices).search(userTaskQueryCaptor.capture(), any(), any());
       final UserTaskQuery capturedQuery = userTaskQueryCaptor.getValue();
 
       final UserTaskFilter filter = capturedQuery.filter();
@@ -345,7 +345,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
     @Test
     void shouldSearchUserTasksWithCreationDateRangeFilter() {
       // given
-      when(userTaskServices.search(any(UserTaskQuery.class), any()))
+      when(userTaskServices.search(any(UserTaskQuery.class), any(), any()))
           .thenReturn(USER_TASK_SEARCH_QUERY_RESULT);
 
       final var creationDateFrom = OffsetDateTime.of(2025, 5, 23, 9, 35, 12, 0, ZoneOffset.UTC);
@@ -367,7 +367,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
       // then
       assertThat(result.isError()).isFalse();
 
-      verify(userTaskServices).search(userTaskQueryCaptor.capture(), any());
+      verify(userTaskServices).search(userTaskQueryCaptor.capture(), any(), any());
       final UserTaskQuery capturedQuery = userTaskQueryCaptor.getValue();
 
       assertThat(capturedQuery.filter().creationDateOperations())
@@ -380,7 +380,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
     @Test
     void shouldSearchUserTasksWithCompletionDateRangeFilter() {
       // given
-      when(userTaskServices.search(any(UserTaskQuery.class), any()))
+      when(userTaskServices.search(any(UserTaskQuery.class), any(), any()))
           .thenReturn(USER_TASK_SEARCH_QUERY_RESULT);
 
       final var completionDateFrom = OffsetDateTime.of(2026, 1, 15, 10, 20, 30, 0, ZoneOffset.UTC);
@@ -402,7 +402,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
       // then
       assertThat(result.isError()).isFalse();
 
-      verify(userTaskServices).search(userTaskQueryCaptor.capture(), any());
+      verify(userTaskServices).search(userTaskQueryCaptor.capture(), any(), any());
       final UserTaskQuery capturedQuery = userTaskQueryCaptor.getValue();
 
       assertThat(capturedQuery.filter().completionDateOperations())
@@ -415,7 +415,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
     @Test
     void shouldSearchUserTasksWithProcessInstanceVariablesFilter() {
       // given
-      when(userTaskServices.search(any(UserTaskQuery.class), any()))
+      when(userTaskServices.search(any(UserTaskQuery.class), any(), any()))
           .thenReturn(USER_TASK_SEARCH_QUERY_RESULT);
 
       // when
@@ -435,7 +435,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
       // then
       assertThat(result.isError()).isFalse();
 
-      verify(userTaskServices).search(userTaskQueryCaptor.capture(), any());
+      verify(userTaskServices).search(userTaskQueryCaptor.capture(), any(), any());
       final UserTaskQuery capturedQuery = userTaskQueryCaptor.getValue();
 
       assertThat(capturedQuery.filter().processInstanceVariableFilter())
@@ -458,7 +458,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
     @Test
     void shouldSearchUserTasksWithLocalVariablesFilter() {
       // given
-      when(userTaskServices.search(any(UserTaskQuery.class), any()))
+      when(userTaskServices.search(any(UserTaskQuery.class), any(), any()))
           .thenReturn(USER_TASK_SEARCH_QUERY_RESULT);
 
       // when
@@ -478,7 +478,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
       // then
       assertThat(result.isError()).isFalse();
 
-      verify(userTaskServices).search(userTaskQueryCaptor.capture(), any());
+      verify(userTaskServices).search(userTaskQueryCaptor.capture(), any(), any());
       final UserTaskQuery capturedQuery = userTaskQueryCaptor.getValue();
 
       assertThat(capturedQuery.filter().localVariableFilters())
@@ -501,7 +501,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
     @Test
     void shouldIgnoreTenantIdCandidateGroupAndCandidateUserInFilter() {
       // given
-      when(userTaskServices.search(any(UserTaskQuery.class), any()))
+      when(userTaskServices.search(any(UserTaskQuery.class), any(), any()))
           .thenReturn(USER_TASK_SEARCH_QUERY_RESULT);
 
       // when (tenantId, candidateGroup, candidateUser passed in arguments should be ignored by MCP
@@ -521,7 +521,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
               .build());
 
       // then
-      verify(userTaskServices).search(userTaskQueryCaptor.capture(), any());
+      verify(userTaskServices).search(userTaskQueryCaptor.capture(), any(), any());
       final UserTaskQuery capturedQuery = userTaskQueryCaptor.getValue();
       assertThat(capturedQuery.filter().tenantIdOperations()).isEmpty();
       assertThat(capturedQuery.filter().candidateGroupOperations()).isEmpty();
@@ -531,7 +531,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
     @Test
     void shouldFailSearchUserTasksOnException() {
       // given
-      when(userTaskServices.search(any(UserTaskQuery.class), any()))
+      when(userTaskServices.search(any(UserTaskQuery.class), any(), any()))
           .thenThrow(new ServiceException("Expected failure", Status.NOT_FOUND));
 
       // when
@@ -606,7 +606,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
     void shouldAssignUserTaskByKey() {
       // given
       when(userTaskServices.assignUserTask(
-              anyLong(), anyString(), anyString(), anyBoolean(), any()))
+              anyLong(), anyString(), anyString(), anyBoolean(), any(), any()))
           .thenReturn(CompletableFuture.completedFuture(new UserTaskRecord()));
 
       // when
@@ -628,14 +628,14 @@ class UserTaskToolsTest extends OperationalToolsTest {
                       .isEqualTo("User task with key 5 assigned to jane.doe."));
 
       verify(userTaskServices)
-          .assignUserTask(eq(5L), eq("jane.doe"), eq("assign"), eq(true), any());
+          .assignUserTask(eq(5L), eq("jane.doe"), eq("assign"), eq(true), any(), any());
     }
 
     @Test
     void shouldAssignUserTaskWithOptions() {
       // given
       when(userTaskServices.assignUserTask(
-              anyLong(), anyString(), anyString(), anyBoolean(), any()))
+              anyLong(), anyString(), anyString(), anyBoolean(), any(), any()))
           .thenReturn(CompletableFuture.completedFuture(new UserTaskRecord()));
 
       // when
@@ -664,13 +664,13 @@ class UserTaskToolsTest extends OperationalToolsTest {
                       .isEqualTo("User task with key 5 assigned to jane.doe."));
 
       verify(userTaskServices)
-          .assignUserTask(eq(5L), eq("jane.doe"), eq("claim"), eq(false), any());
+          .assignUserTask(eq(5L), eq("jane.doe"), eq("claim"), eq(false), any(), any());
     }
 
     @Test
     void shouldUnassignUserTaskWhenAssigneeIsMissing() {
       // given
-      when(userTaskServices.unassignUserTask(anyLong(), anyString(), any()))
+      when(userTaskServices.unassignUserTask(anyLong(), anyString(), any(), any()))
           .thenReturn(CompletableFuture.completedFuture(new UserTaskRecord()));
 
       // when
@@ -690,7 +690,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
               textContent ->
                   assertThat(textContent.text()).isEqualTo("User task with key 5 unassigned."));
 
-      verify(userTaskServices).unassignUserTask(eq(5L), eq("unassign"), any());
+      verify(userTaskServices).unassignUserTask(eq(5L), eq("unassign"), any(), any());
     }
 
     @ParameterizedTest
@@ -698,7 +698,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
     @ValueSource(strings = {"  "})
     void shouldUnassignUserTaskWhenAssigneeIsNullOrEmpty(final String assignee) {
       // given
-      when(userTaskServices.unassignUserTask(anyLong(), anyString(), any()))
+      when(userTaskServices.unassignUserTask(anyLong(), anyString(), any(), any()))
           .thenReturn(CompletableFuture.completedFuture(new UserTaskRecord()));
 
       // when
@@ -719,14 +719,14 @@ class UserTaskToolsTest extends OperationalToolsTest {
               textContent ->
                   assertThat(textContent.text()).isEqualTo("User task with key 5 unassigned."));
 
-      verify(userTaskServices).unassignUserTask(eq(5L), eq("unassign"), any());
+      verify(userTaskServices).unassignUserTask(eq(5L), eq("unassign"), any(), any());
     }
 
     @Test
     void shouldFailAssignUserTaskOnException() {
       // given
       when(userTaskServices.assignUserTask(
-              anyLong(), anyString(), anyString(), anyBoolean(), any()))
+              anyLong(), anyString(), anyString(), anyBoolean(), any(), any()))
           .thenReturn(
               CompletableFuture.failedFuture(
                   new ServiceException("Expected failure", Status.NOT_FOUND)));
@@ -826,7 +826,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
     void shouldSearchUserTaskVariablesWithTruncation() {
       // given
       when(userTaskServices.searchUserTaskEffectiveVariables(
-              anyLong(), any(VariableQuery.class), any()))
+              anyLong(), any(VariableQuery.class), any(), any()))
           .thenReturn(VARIABLE_SEARCH_QUERY_RESULT);
 
       // when
@@ -862,7 +862,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
               });
 
       verify(userTaskServices)
-          .searchUserTaskEffectiveVariables(eq(5L), variableQueryCaptor.capture(), any());
+          .searchUserTaskEffectiveVariables(eq(5L), variableQueryCaptor.capture(), any(), any());
 
       assertTextContentFallback(result);
     }
@@ -871,7 +871,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
     void shouldSearchUserTaskVariablesWithoutTruncation() {
       // given
       when(userTaskServices.searchUserTaskEffectiveVariables(
-              anyLong(), any(VariableQuery.class), any()))
+              anyLong(), any(VariableQuery.class), any(), any()))
           .thenReturn(VARIABLE_SEARCH_QUERY_RESULT);
 
       // when
@@ -898,7 +898,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
               });
 
       verify(userTaskServices)
-          .searchUserTaskEffectiveVariables(eq(5L), variableQueryCaptor.capture(), any());
+          .searchUserTaskEffectiveVariables(eq(5L), variableQueryCaptor.capture(), any(), any());
 
       assertTextContentFallback(result);
     }
@@ -907,7 +907,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
     void shouldSearchUserTaskVariablesWithFilterSortAndPaging() {
       // given
       when(userTaskServices.searchUserTaskEffectiveVariables(
-              anyLong(), any(VariableQuery.class), any()))
+              anyLong(), any(VariableQuery.class), any(), any()))
           .thenReturn(VARIABLE_SEARCH_QUERY_RESULT);
 
       // when
@@ -930,7 +930,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
       assertThat(result.isError()).isFalse();
 
       verify(userTaskServices)
-          .searchUserTaskEffectiveVariables(eq(5L), variableQueryCaptor.capture(), any());
+          .searchUserTaskEffectiveVariables(eq(5L), variableQueryCaptor.capture(), any(), any());
       final VariableQuery capturedQuery = variableQueryCaptor.getValue();
 
       assertThat(capturedQuery.filter().nameOperations())
@@ -949,7 +949,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
     void shouldFailSearchUserTaskVariablesOnException() {
       // given
       when(userTaskServices.searchUserTaskEffectiveVariables(
-              anyLong(), any(VariableQuery.class), any()))
+              anyLong(), any(VariableQuery.class), any(), any()))
           .thenThrow(new ServiceException("Expected failure", Status.NOT_FOUND));
 
       // when

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/variable/VariableToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/variable/VariableToolsTest.java
@@ -108,7 +108,7 @@ class VariableToolsTest extends OperationalToolsTest {
     @Test
     void shouldGetVariableByKey() {
       // given
-      when(variableServices.getByKey(any(), any())).thenReturn(VARIABLE_ENTITY);
+      when(variableServices.getByKey(any(), any(), any())).thenReturn(VARIABLE_ENTITY);
 
       // when
       final CallToolResult result =
@@ -125,7 +125,7 @@ class VariableToolsTest extends OperationalToolsTest {
           objectMapper.convertValue(result.structuredContent(), VariableResult.class);
       assertExampleVariable(variable);
 
-      verify(variableServices).getByKey(eq(123L), any());
+      verify(variableServices).getByKey(eq(123L), any(), any());
 
       assertTextContentFallback(result);
     }
@@ -133,7 +133,7 @@ class VariableToolsTest extends OperationalToolsTest {
     @Test
     void shouldFailGetVariableByKeyOnException() {
       // given
-      when(variableServices.getByKey(any(), any()))
+      when(variableServices.getByKey(any(), any(), any()))
           .thenThrow(new ServiceException("Expected failure", Status.NOT_FOUND));
 
       // when
@@ -223,7 +223,7 @@ class VariableToolsTest extends OperationalToolsTest {
     @Test
     void shouldSearchVariablesWithNonTruncatedValue() {
       // given
-      when(variableServices.search(any(VariableQuery.class), any()))
+      when(variableServices.search(any(VariableQuery.class), any(), any()))
           .thenReturn(SEARCH_QUERY_RESULT);
 
       // when
@@ -269,7 +269,7 @@ class VariableToolsTest extends OperationalToolsTest {
     @Test
     void shouldSearchVariablesWithFilterSortAndPaging() {
       // given
-      when(variableServices.search(any(VariableQuery.class), any()))
+      when(variableServices.search(any(VariableQuery.class), any(), any()))
           .thenReturn(SEARCH_QUERY_RESULT);
 
       // when
@@ -307,7 +307,7 @@ class VariableToolsTest extends OperationalToolsTest {
                 assertThat(variable.getValue()).isEqualTo(TRUNCATED_VALUE);
               });
 
-      verify(variableServices).search(queryCaptor.capture(), any());
+      verify(variableServices).search(queryCaptor.capture(), any(), any());
       final VariableQuery capturedQuery = queryCaptor.getValue();
 
       final VariableFilter filter = capturedQuery.filter();
@@ -336,7 +336,7 @@ class VariableToolsTest extends OperationalToolsTest {
     @Test
     void shouldFailSearchVariablesOnException() {
       // given
-      when(variableServices.search(any(VariableQuery.class), any()))
+      when(variableServices.search(any(VariableQuery.class), any(), any()))
           .thenThrow(new ServiceException("Expected failure", Status.NOT_FOUND));
 
       // when

--- a/qa/archunit-tests/src/test/java/io/camunda/service/ServicePhysicalTenantIdArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/service/ServicePhysicalTenantIdArchTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import static com.tngtech.archunit.lang.SimpleConditionEvent.satisfied;
+import static com.tngtech.archunit.lang.SimpleConditionEvent.violated;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
+
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaMethod;
+import com.tngtech.archunit.core.domain.JavaModifier;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.ConditionEvents;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Enforces that every public method in {@code io.camunda.service.*Services} classes declares a
+ * {@code String physicalTenantId} parameter, ensuring that tenant-scoped operations can be routed
+ * to the correct physical data store.
+ *
+ * <p>Parameter names are read via Java reflection. The project is compiled with {@code -parameters}
+ * (see {@code <parameters>true</parameters>} in parent/pom.xml), so reflection returns the real
+ * parameter names rather than {@code arg0}, {@code arg1}, etc.
+ */
+@AnalyzeClasses(
+    packages = "io.camunda.service",
+    importOptions = ImportOption.DoNotIncludeTests.class)
+public class ServicePhysicalTenantIdArchTest {
+
+  @ArchTest
+  static final ArchRule SERVICES_PUBLIC_METHODS_MUST_ACCEPT_PHYSICAL_TENANT_ID =
+      methods()
+          .that()
+          .arePublic()
+          .and()
+          .areDeclaredInClassesThat()
+          .haveSimpleNameEndingWith("Services")
+          .and()
+          .areDeclaredInClassesThat()
+          .resideInAPackage("io.camunda.service")
+          .and()
+          .areDeclaredInClassesThat(areNotAbstractClasses())
+          .and()
+          .areDeclaredInClassesThat(areNotInnerClasses())
+          .and()
+          .areDeclaredInClassesThat(areNotExcludedClasses())
+          .and(areNotExcludedMethods())
+          .should(havePhysicalTenantIdParameter())
+          .because(
+              "All *Services methods must declare 'String physicalTenantId' to route"
+                  + " requests to the correct physical index or store in a multi-tenant setup");
+
+  /** Parameter name all compliant service methods must include. */
+  static final String PHYSICAL_TENANT_ID = "physicalTenantId";
+
+  /**
+   * Services excluded by design — these don't participate in tenant-scoped operations and
+   * intentionally omit {@code physicalTenantId} from their public API.
+   */
+  static final Set<String> EXCLUDED_CLASSES =
+      Set.of(
+          // License management — no authentication or tenant context needed
+          ManagementServices.class.getSimpleName(),
+          // Cluster topology and health checks — infrastructure-level, not tenant-scoped
+          TopologyServices.class.getSimpleName());
+
+  /**
+   * Individual methods excluded from specific classes.
+   *
+   * <p>Use this for one-off methods that intentionally omit {@code physicalTenantId}, or as a
+   * stepping-stone during migration when only some methods in a class still need updating.
+   *
+   * <p>Format: {@code "ClassName" -> Set.of("methodName1", "methodName2")}
+   */
+  static final Map<String, Set<String>> EXCLUDED_METHODS = Map.of();
+
+  private static DescribedPredicate<JavaClass> areNotAbstractClasses() {
+    return new DescribedPredicate<>("are not abstract") {
+      @Override
+      public boolean test(final JavaClass javaClass) {
+        return !javaClass.getModifiers().contains(JavaModifier.ABSTRACT);
+      }
+    };
+  }
+
+  private static DescribedPredicate<JavaClass> areNotInnerClasses() {
+    return new DescribedPredicate<>("are not inner or nested classes") {
+      @Override
+      public boolean test(final JavaClass javaClass) {
+        return javaClass.getEnclosingClass().isEmpty();
+      }
+    };
+  }
+
+  private static DescribedPredicate<JavaClass> areNotExcludedClasses() {
+    return new DescribedPredicate<>("are not excluded from physicalTenantId enforcement") {
+      @Override
+      public boolean test(final JavaClass javaClass) {
+        final String name = javaClass.getSimpleName();
+        return !EXCLUDED_CLASSES.contains(name);
+      }
+    };
+  }
+
+  private static DescribedPredicate<JavaMethod> areNotExcludedMethods() {
+    return new DescribedPredicate<>("are not individually excluded from physicalTenantId check") {
+      @Override
+      public boolean test(final JavaMethod method) {
+        final Set<String> excluded = EXCLUDED_METHODS.get(method.getOwner().getSimpleName());
+        return excluded == null || !excluded.contains(method.getName());
+      }
+    };
+  }
+
+  private static ArchCondition<JavaMethod> havePhysicalTenantIdParameter() {
+    return new ArchCondition<>("have a 'String physicalTenantId' parameter") {
+      @Override
+      public void check(final JavaMethod method, final ConditionEvents events) {
+        final java.lang.reflect.Method reflected;
+        try {
+          reflected = method.reflect();
+        } catch (final Exception ignored) {
+          // Compiler-generated (bridge/synthetic) methods may not be reflectable; skip them.
+          return;
+        }
+
+        // Bridge methods (covariant overrides for generics) and synthetic methods don't need
+        // physicalTenantId — skip them to avoid false violations.
+        if (reflected.isBridge() || reflected.isSynthetic()) {
+          return;
+        }
+
+        final boolean hasParam =
+            Arrays.stream(reflected.getParameters())
+                .anyMatch(
+                    p -> p.getType() == String.class && PHYSICAL_TENANT_ID.equals(p.getName()));
+
+        if (hasParam) {
+          events.add(
+              satisfied(
+                  method,
+                  String.format(
+                      "%s#%s correctly declares 'String physicalTenantId'",
+                      method.getOwner().getSimpleName(), method.getName())));
+        } else {
+          events.add(
+              violated(
+                  method,
+                  String.format(
+                      "%s#%s is missing a 'String physicalTenantId' parameter",
+                      method.getOwner().getSimpleName(), method.getName())));
+        }
+      }
+    };
+  }
+}

--- a/search/search-client/src/main/java/io/camunda/search/clients/AgentInstanceSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/AgentInstanceSearchClient.java
@@ -19,4 +19,6 @@ public interface AgentInstanceSearchClient {
   SearchQueryResult<AgentInstanceEntity> searchAgentInstances(AgentInstanceQuery query);
 
   AgentInstanceSearchClient withSecurityContext(SecurityContext securityContext);
+
+  AgentInstanceSearchClient withPhysicalTenant(String physicalTenant);
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/AuditLogSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/AuditLogSearchClient.java
@@ -19,4 +19,6 @@ public interface AuditLogSearchClient {
   SearchQueryResult<AuditLogEntity> searchAuditLogs(final AuditLogQuery query);
 
   AuditLogSearchClient withSecurityContext(SecurityContext securityContext);
+
+  AuditLogSearchClient withPhysicalTenant(String physicalTenant);
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/AuthorizationSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/AuthorizationSearchClient.java
@@ -19,4 +19,6 @@ public interface AuthorizationSearchClient {
   SearchQueryResult<AuthorizationEntity> searchAuthorizations(AuthorizationQuery filter);
 
   AuthorizationSearchClient withSecurityContext(SecurityContext securityContext);
+
+  AuthorizationSearchClient withPhysicalTenant(String physicalTenant);
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/BatchOperationSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/BatchOperationSearchClient.java
@@ -24,4 +24,6 @@ public interface BatchOperationSearchClient {
       BatchOperationItemQuery query);
 
   BatchOperationSearchClient withSecurityContext(SecurityContext securityContext);
+
+  BatchOperationSearchClient withPhysicalTenant(String physicalTenant);
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/ClusterVariableSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/ClusterVariableSearchClient.java
@@ -21,4 +21,6 @@ public interface ClusterVariableSearchClient {
   SearchQueryResult<ClusterVariableEntity> searchClusterVariables(ClusterVariableQuery query);
 
   ClusterVariableSearchClient withSecurityContext(SecurityContext securityContext);
+
+  ClusterVariableSearchClient withPhysicalTenant(String physicalTenant);
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/DecisionDefinitionSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/DecisionDefinitionSearchClient.java
@@ -20,4 +20,6 @@ public interface DecisionDefinitionSearchClient {
       DecisionDefinitionQuery filter);
 
   DecisionDefinitionSearchClient withSecurityContext(SecurityContext securityContext);
+
+  DecisionDefinitionSearchClient withPhysicalTenant(String physicalTenant);
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/DecisionInstanceSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/DecisionInstanceSearchClient.java
@@ -19,4 +19,6 @@ public interface DecisionInstanceSearchClient {
   SearchQueryResult<DecisionInstanceEntity> searchDecisionInstances(DecisionInstanceQuery filter);
 
   DecisionInstanceSearchClient withSecurityContext(SecurityContext securityContext);
+
+  DecisionInstanceSearchClient withPhysicalTenant(String physicalTenant);
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/DecisionRequirementSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/DecisionRequirementSearchClient.java
@@ -20,4 +20,6 @@ public interface DecisionRequirementSearchClient {
       DecisionRequirementsQuery filter);
 
   DecisionRequirementSearchClient withSecurityContext(SecurityContext securityContext);
+
+  DecisionRequirementSearchClient withPhysicalTenant(String physicalTenant);
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/DeployedResourceSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/DeployedResourceSearchClient.java
@@ -22,4 +22,6 @@ public interface DeployedResourceSearchClient {
   SearchQueryResult<DeployedResourceEntity> searchDeployedResources(DeployedResourceQuery query);
 
   DeployedResourceSearchClient withSecurityContext(SecurityContext securityContext);
+
+  DeployedResourceSearchClient withPhysicalTenant(String physicalTenant);
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/FlowNodeInstanceSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/FlowNodeInstanceSearchClient.java
@@ -19,4 +19,6 @@ public interface FlowNodeInstanceSearchClient {
   SearchQueryResult<FlowNodeInstanceEntity> searchFlowNodeInstances(FlowNodeInstanceQuery filter);
 
   FlowNodeInstanceSearchClient withSecurityContext(SecurityContext securityContext);
+
+  FlowNodeInstanceSearchClient withPhysicalTenant(String physicalTenant);
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/FormSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/FormSearchClient.java
@@ -19,4 +19,6 @@ public interface FormSearchClient {
   SearchQueryResult<FormEntity> searchForms(FormQuery filter);
 
   FormSearchClient withSecurityContext(SecurityContext securityContext);
+
+  FormSearchClient withPhysicalTenant(String physicalTenant);
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/GlobalListenerSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/GlobalListenerSearchClient.java
@@ -21,4 +21,6 @@ public interface GlobalListenerSearchClient {
   SearchQueryResult<GlobalListenerEntity> searchGlobalListeners(GlobalListenerQuery query);
 
   GlobalListenerSearchClient withSecurityContext(SecurityContext securityContext);
+
+  GlobalListenerSearchClient withPhysicalTenant(String physicalTenant);
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/GroupSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/GroupSearchClient.java
@@ -23,4 +23,6 @@ public interface GroupSearchClient {
   SearchQueryResult<GroupMemberEntity> searchGroupMembers(GroupMemberQuery query);
 
   GroupSearchClient withSecurityContext(SecurityContext securityContext);
+
+  GroupSearchClient withPhysicalTenant(String physicalTenant);
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/IncidentSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/IncidentSearchClient.java
@@ -27,6 +27,8 @@ public interface IncidentSearchClient {
 
   IncidentSearchClient withSecurityContext(SecurityContext securityContext);
 
+  IncidentSearchClient withPhysicalTenant(String physicalTenant);
+
   SearchQueryResult<IncidentProcessInstanceStatisticsByDefinitionEntity>
       searchIncidentProcessInstanceStatisticsByDefinition(
           final IncidentProcessInstanceStatisticsByDefinitionQuery query);

--- a/search/search-client/src/main/java/io/camunda/search/clients/JobSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/JobSearchClient.java
@@ -39,4 +39,6 @@ public interface JobSearchClient {
   SearchQueryResult<JobErrorStatisticsEntity> getJobErrorStatistics(JobErrorStatisticsQuery query);
 
   JobSearchClient withSecurityContext(SecurityContext securityContext);
+
+  JobSearchClient withPhysicalTenant(String physicalTenant);
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/MappingRuleSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/MappingRuleSearchClient.java
@@ -19,4 +19,6 @@ public interface MappingRuleSearchClient {
   SearchQueryResult<MappingRuleEntity> searchMappingRules(MappingRuleQuery mappingRuleQuery);
 
   MappingRuleSearchClient withSecurityContext(SecurityContext securityContext);
+
+  MappingRuleSearchClient withPhysicalTenant(String physicalTenant);
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/MessageSubscriptionSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/MessageSubscriptionSearchClient.java
@@ -24,4 +24,6 @@ public interface MessageSubscriptionSearchClient {
   MessageSubscriptionEntity getMessageSubscription(long key);
 
   MessageSubscriptionSearchClient withSecurityContext(SecurityContext securityContext);
+
+  MessageSubscriptionSearchClient withPhysicalTenant(String physicalTenant);
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/ProcessDefinitionSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/ProcessDefinitionSearchClient.java
@@ -33,6 +33,8 @@ public interface ProcessDefinitionSearchClient {
 
   ProcessDefinitionSearchClient withSecurityContext(SecurityContext securityContext);
 
+  ProcessDefinitionSearchClient withPhysicalTenant(String physicalTenant);
+
   SearchQueryResult<ProcessDefinitionInstanceStatisticsEntity> processDefinitionInstanceStatistics(
       final ProcessDefinitionInstanceStatisticsQuery query);
 

--- a/search/search-client/src/main/java/io/camunda/search/clients/ProcessInstanceSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/ProcessInstanceSearchClient.java
@@ -24,4 +24,6 @@ public interface ProcessInstanceSearchClient {
       final long processInstanceKey);
 
   ProcessInstanceSearchClient withSecurityContext(SecurityContext securityContext);
+
+  ProcessInstanceSearchClient withPhysicalTenant(String physicalTenant);
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/RoleSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/RoleSearchClient.java
@@ -23,4 +23,6 @@ public interface RoleSearchClient {
   SearchQueryResult<RoleMemberEntity> searchRoleMembers(RoleMemberQuery filter);
 
   RoleSearchClient withSecurityContext(SecurityContext securityContext);
+
+  RoleSearchClient withPhysicalTenant(String physicalTenant);
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/SequenceFlowSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/SequenceFlowSearchClient.java
@@ -17,4 +17,6 @@ public interface SequenceFlowSearchClient {
   SearchQueryResult<SequenceFlowEntity> searchSequenceFlows(SequenceFlowQuery filter);
 
   SequenceFlowSearchClient withSecurityContext(SecurityContext securityContext);
+
+  SequenceFlowSearchClient withPhysicalTenant(String physicalTenant);
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/TenantSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/TenantSearchClient.java
@@ -23,4 +23,6 @@ public interface TenantSearchClient {
   SearchQueryResult<TenantMemberEntity> searchTenantMembers(TenantMemberQuery filter);
 
   TenantSearchClient withSecurityContext(SecurityContext securityContext);
+
+  TenantSearchClient withPhysicalTenant(String physicalTenant);
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/UsageMetricsSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/UsageMetricsSearchClient.java
@@ -17,6 +17,8 @@ public interface UsageMetricsSearchClient {
 
   UsageMetricsSearchClient withSecurityContext(SecurityContext securityContext);
 
+  UsageMetricsSearchClient withPhysicalTenant(String physicalTenant);
+
   UsageMetricStatisticsEntity usageMetricStatistics(final UsageMetricsQuery query);
 
   UsageMetricTUStatisticsEntity usageMetricTUStatistics(final UsageMetricsTUQuery query);

--- a/search/search-client/src/main/java/io/camunda/search/clients/UserSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/UserSearchClient.java
@@ -19,4 +19,6 @@ public interface UserSearchClient {
   SearchQueryResult<UserEntity> searchUsers(UserQuery userQuery);
 
   UserSearchClient withSecurityContext(SecurityContext securityContext);
+
+  UserSearchClient withPhysicalTenant(String physicalTenant);
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/UserTaskSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/UserTaskSearchClient.java
@@ -19,4 +19,6 @@ public interface UserTaskSearchClient {
   SearchQueryResult<UserTaskEntity> searchUserTasks(UserTaskQuery filter);
 
   UserTaskSearchClient withSecurityContext(SecurityContext securityContext);
+
+  UserTaskSearchClient withPhysicalTenant(String physicalTenant);
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/VariableSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/VariableSearchClient.java
@@ -19,4 +19,6 @@ public interface VariableSearchClient {
   SearchQueryResult<VariableEntity> searchVariables(VariableQuery filter);
 
   VariableSearchClient withSecurityContext(SecurityContext securityContext);
+
+  VariableSearchClient withPhysicalTenant(String physicalTenant);
 }

--- a/service/src/main/java/io/camunda/service/AdHocSubProcessActivityServices.java
+++ b/service/src/main/java/io/camunda/service/AdHocSubProcessActivityServices.java
@@ -33,7 +33,8 @@ public class AdHocSubProcessActivityServices extends ApiServices<AdHocSubProcess
 
   public CompletableFuture<AdHocSubProcessInstructionRecord> activateActivities(
       final AdHocSubProcessActivateActivitiesRequest request,
-      final CamundaAuthentication authentication) {
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     final var brokerRequest =
         new BrokerActivateAdHocSubProcessActivityRequest()
             .setAdHocSubProcessInstanceKey(request.adHocSubProcessInstanceKey());

--- a/service/src/main/java/io/camunda/service/AgentInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/AgentInstanceServices.java
@@ -44,29 +44,38 @@ public final class AgentInstanceServices
   }
 
   public CompletableFuture<AgentInstanceRecord> createAgentInstance(
-      final AgentInstanceRecord record, final CamundaAuthentication authentication) {
+      final AgentInstanceRecord record,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return sendBrokerRequest(new BrokerCreateAgentInstanceRequest(record), authentication);
   }
 
   public CompletableFuture<AgentInstanceRecord> updateAgentInstance(
-      final AgentInstanceRecord record, final CamundaAuthentication authentication) {
+      final AgentInstanceRecord record,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return sendBrokerRequest(new BrokerUpdateAgentInstanceRequest(record), authentication);
   }
 
   @Override
   public SearchQueryResult<AgentInstanceEntity> search(
-      final AgentInstanceQuery query, final CamundaAuthentication authentication) {
+      final AgentInstanceQuery query,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             agentInstanceSearchClient
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
                         authentication, AGENT_INSTANCE_READ_AUTHORIZATION))
+                .withPhysicalTenant(physicalTenantId)
                 .searchAgentInstances(query));
   }
 
   public AgentInstanceEntity getByKey(
-      final long agentInstanceKey, final CamundaAuthentication authentication) {
+      final long agentInstanceKey,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             agentInstanceSearchClient
@@ -76,6 +85,7 @@ public final class AgentInstanceServices
                         withAuthorization(
                             AGENT_INSTANCE_READ_AUTHORIZATION,
                             AgentInstanceEntity::processDefinitionId)))
+                .withPhysicalTenant(physicalTenantId)
                 .getAgentInstance(agentInstanceKey));
   }
 }

--- a/service/src/main/java/io/camunda/service/AuditLogServices.java
+++ b/service/src/main/java/io/camunda/service/AuditLogServices.java
@@ -58,24 +58,30 @@ public class AuditLogServices
 
   @Override
   public SearchQueryResult<AuditLogEntity> search(
-      final AuditLogQuery query, final CamundaAuthentication authentication) {
+      final AuditLogQuery query,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             auditLogSearchClient
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
                         authentication, AUDIT_LOG_AUTHORIZATIONS))
+                .withPhysicalTenant(physicalTenantId)
                 .searchAuditLogs(query));
   }
 
   public AuditLogEntity getAuditLog(
-      final String auditLogKey, final CamundaAuthentication authentication) {
+      final String auditLogKey,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             auditLogSearchClient
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
                         authentication, AUDIT_LOG_AUTHORIZATIONS))
+                .withPhysicalTenant(physicalTenantId)
                 .getAuditLog(auditLogKey));
   }
 }

--- a/service/src/main/java/io/camunda/service/AuthorizationServices.java
+++ b/service/src/main/java/io/camunda/service/AuthorizationServices.java
@@ -52,18 +52,23 @@ public class AuthorizationServices
 
   @Override
   public SearchQueryResult<AuthorizationEntity> search(
-      final AuthorizationQuery query, final CamundaAuthentication authentication) {
+      final AuthorizationQuery query,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             authorizationSearchClient
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
                         authentication, AUTHORIZATION_READ_AUTHORIZATION))
+                .withPhysicalTenant(physicalTenantId)
                 .searchAuthorizations(query));
   }
 
   public CompletableFuture<AuthorizationRecord> createAuthorization(
-      final CreateAuthorizationRequest request, final CamundaAuthentication authentication) {
+      final CreateAuthorizationRequest request,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     final var brokerRequest =
         new BrokerAuthorizationRequest(AuthorizationIntent.CREATE)
             .setOwnerId(request.ownerId())
@@ -78,7 +83,9 @@ public class AuthorizationServices
   }
 
   public AuthorizationEntity getAuthorization(
-      final long authorizationKey, final CamundaAuthentication authentication) {
+      final long authorizationKey,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             authorizationSearchClient
@@ -87,17 +94,22 @@ public class AuthorizationServices
                         authentication,
                         withAuthorization(
                             AUTHORIZATION_READ_AUTHORIZATION, String.valueOf(authorizationKey))))
+                .withPhysicalTenant(physicalTenantId)
                 .getAuthorization(authorizationKey));
   }
 
   public CompletableFuture<AuthorizationRecord> deleteAuthorization(
-      final long authorizationKey, final CamundaAuthentication authentication) {
+      final long authorizationKey,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     final var brokerRequest = new BrokerAuthorizationDeleteRequest(authorizationKey);
     return sendBrokerRequest(brokerRequest, authentication);
   }
 
   public CompletableFuture<AuthorizationRecord> updateAuthorization(
-      final UpdateAuthorizationRequest request, final CamundaAuthentication authentication) {
+      final UpdateAuthorizationRequest request,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     final var brokerRequest =
         new BrokerAuthorizationRequest(AuthorizationIntent.UPDATE)
             .setAuthorizationKey(request.authorizationKey())

--- a/service/src/main/java/io/camunda/service/BatchOperationServices.java
+++ b/service/src/main/java/io/camunda/service/BatchOperationServices.java
@@ -53,29 +53,37 @@ public final class BatchOperationServices
 
   @Override
   public SearchQueryResult<BatchOperationEntity> search(
-      final BatchOperationQuery query, final CamundaAuthentication authentication) {
+      final BatchOperationQuery query,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             batchOperationSearchClient
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
                         authentication, BATCH_OPERATION_READ_AUTHORIZATION))
+                .withPhysicalTenant(physicalTenantId)
                 .searchBatchOperations(query));
   }
 
   public SearchQueryResult<BatchOperationItemEntity> searchItems(
-      final BatchOperationItemQuery query, final CamundaAuthentication authentication) {
+      final BatchOperationItemQuery query,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             batchOperationSearchClient
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
                         authentication, BATCH_OPERATION_READ_AUTHORIZATION))
+                .withPhysicalTenant(physicalTenantId)
                 .searchBatchOperationItems(query));
   }
 
   public BatchOperationEntity getById(
-      final String batchOperationKey, final CamundaAuthentication authentication) {
+      final String batchOperationKey,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             batchOperationSearchClient
@@ -83,11 +91,14 @@ public final class BatchOperationServices
                     securityContextProvider.provideSecurityContext(
                         authentication,
                         withAuthorization(BATCH_OPERATION_READ_AUTHORIZATION, batchOperationKey)))
+                .withPhysicalTenant(physicalTenantId)
                 .getBatchOperation(batchOperationKey));
   }
 
   public CompletableFuture<BatchOperationLifecycleManagementRecord> cancel(
-      final String batchOperationKey, final CamundaAuthentication authentication) {
+      final String batchOperationKey,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     LOGGER.debug("Cancelling batch operation with key '{}'", batchOperationKey);
 
     final var brokerRequest =
@@ -98,7 +109,9 @@ public final class BatchOperationServices
   }
 
   public CompletableFuture<BatchOperationLifecycleManagementRecord> suspend(
-      final String batchOperationKey, final CamundaAuthentication authentication) {
+      final String batchOperationKey,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     LOGGER.debug("Suspending batch operation with key '{}'", batchOperationKey);
 
     final var brokerRequest =
@@ -109,7 +122,9 @@ public final class BatchOperationServices
   }
 
   public CompletableFuture<BatchOperationLifecycleManagementRecord> resume(
-      final String batchOperationKey, final CamundaAuthentication authentication) {
+      final String batchOperationKey,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     LOGGER.debug("Resuming batch operation with key '{}'", batchOperationKey);
 
     final var brokerRequest =

--- a/service/src/main/java/io/camunda/service/ClockServices.java
+++ b/service/src/main/java/io/camunda/service/ClockServices.java
@@ -31,11 +31,14 @@ public final class ClockServices extends ApiServices<ClockServices> {
   }
 
   public CompletableFuture<ClockRecord> pinClock(
-      final long pinnedEpoch, final CamundaAuthentication authentication) {
+      final long pinnedEpoch,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return sendBrokerRequest(new BrokerClockPinRequest(pinnedEpoch), authentication);
   }
 
-  public CompletableFuture<ClockRecord> resetClock(final CamundaAuthentication authentication) {
+  public CompletableFuture<ClockRecord> resetClock(
+      final CamundaAuthentication authentication, final String physicalTenantId) {
     return sendBrokerRequest(new BrokerClockResetRequest(), authentication);
   }
 }

--- a/service/src/main/java/io/camunda/service/ClusterVariableServices.java
+++ b/service/src/main/java/io/camunda/service/ClusterVariableServices.java
@@ -49,7 +49,9 @@ public final class ClusterVariableServices
   }
 
   public CompletableFuture<ClusterVariableRecord> createGloballyScopedClusterVariable(
-      final ClusterVariableRequest request, final CamundaAuthentication authentication) {
+      final ClusterVariableRequest request,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return sendBrokerRequest(
         new BrokerCreateClusterVariableRequest()
             .setName(request.name())
@@ -59,7 +61,9 @@ public final class ClusterVariableServices
   }
 
   public CompletableFuture<ClusterVariableRecord> createTenantScopedClusterVariable(
-      final ClusterVariableRequest request, final CamundaAuthentication authentication) {
+      final ClusterVariableRequest request,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return sendBrokerRequest(
         new BrokerCreateClusterVariableRequest()
             .setName(request.name())
@@ -69,14 +73,18 @@ public final class ClusterVariableServices
   }
 
   public CompletableFuture<ClusterVariableRecord> deleteGloballyScopedClusterVariable(
-      final ClusterVariableRequest request, final CamundaAuthentication authentication) {
+      final ClusterVariableRequest request,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return sendBrokerRequest(
         new BrokerDeleteClusterVariableRequest().setName(request.name()).setGlobalScope(),
         authentication);
   }
 
   public CompletableFuture<ClusterVariableRecord> deleteTenantScopedClusterVariable(
-      final ClusterVariableRequest request, final CamundaAuthentication authentication) {
+      final ClusterVariableRequest request,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return sendBrokerRequest(
         new BrokerDeleteClusterVariableRequest()
             .setName(request.name())
@@ -85,7 +93,9 @@ public final class ClusterVariableServices
   }
 
   public CompletableFuture<ClusterVariableRecord> updateGloballyScopedClusterVariable(
-      final ClusterVariableRequest request, final CamundaAuthentication authentication) {
+      final ClusterVariableRequest request,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return sendBrokerRequest(
         new BrokerUpdateClusterVariableRequest()
             .setName(request.name())
@@ -95,7 +105,9 @@ public final class ClusterVariableServices
   }
 
   public CompletableFuture<ClusterVariableRecord> updateTenantScopedClusterVariable(
-      final ClusterVariableRequest request, final CamundaAuthentication authentication) {
+      final ClusterVariableRequest request,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return sendBrokerRequest(
         new BrokerUpdateClusterVariableRequest()
             .setName(request.name())
@@ -105,7 +117,9 @@ public final class ClusterVariableServices
   }
 
   public ClusterVariableEntity getGloballyScopedClusterVariable(
-      final ClusterVariableRequest request, final CamundaAuthentication authentication) {
+      final ClusterVariableRequest request,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             clusterVariableSearchClient
@@ -114,11 +128,14 @@ public final class ClusterVariableServices
                         authentication,
                         withAuthorization(
                             CLUSTER_VARIABLE_READ_AUTHORIZATION, ClusterVariableEntity::name)))
+                .withPhysicalTenant(physicalTenantId)
                 .getClusterVariable(request.name()));
   }
 
   public ClusterVariableEntity getTenantScopedClusterVariable(
-      final ClusterVariableRequest request, final CamundaAuthentication authentication) {
+      final ClusterVariableRequest request,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             clusterVariableSearchClient
@@ -127,18 +144,22 @@ public final class ClusterVariableServices
                         authentication,
                         withAuthorization(
                             CLUSTER_VARIABLE_READ_AUTHORIZATION, ClusterVariableEntity::name)))
+                .withPhysicalTenant(physicalTenantId)
                 .getClusterVariable(request.name(), request.tenantId()));
   }
 
   @Override
   public SearchQueryResult<ClusterVariableEntity> search(
-      final ClusterVariableQuery query, final CamundaAuthentication authentication) {
+      final ClusterVariableQuery query,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             clusterVariableSearchClient
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
                         authentication, CLUSTER_VARIABLE_READ_AUTHORIZATION))
+                .withPhysicalTenant(physicalTenantId)
                 .searchClusterVariables(query));
   }
 

--- a/service/src/main/java/io/camunda/service/ConditionalServices.java
+++ b/service/src/main/java/io/camunda/service/ConditionalServices.java
@@ -32,7 +32,9 @@ public class ConditionalServices extends ApiServices<ConditionalServices> {
   }
 
   public CompletableFuture<BrokerResponse<ConditionalEvaluationRecord>> evaluateConditional(
-      final EvaluateConditionalRequest request, final CamundaAuthentication authentication) {
+      final EvaluateConditionalRequest request,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     final var brokerRequest =
         new BrokerEvaluateConditionalRequest()
             .setProcessDefinitionKey(request.processDefinitionKey())

--- a/service/src/main/java/io/camunda/service/DecisionDefinitionServices.java
+++ b/service/src/main/java/io/camunda/service/DecisionDefinitionServices.java
@@ -56,30 +56,36 @@ public final class DecisionDefinitionServices
 
   @Override
   public SearchQueryResult<DecisionDefinitionEntity> search(
-      final DecisionDefinitionQuery query, final CamundaAuthentication authentication) {
+      final DecisionDefinitionQuery query,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             decisionDefinitionSearchClient
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
                         authentication, DECISION_DEFINITION_READ_AUTHORIZATION))
+                .withPhysicalTenant(physicalTenantId)
                 .searchDecisionDefinitions(query));
   }
 
   public SearchQueryResult<DecisionDefinitionEntity> search(
       final Function<DecisionDefinitionQuery.Builder, ObjectBuilder<DecisionDefinitionQuery>> fn,
-      final CamundaAuthentication authentication) {
-    return search(decisionDefinitionSearchQuery(fn), authentication);
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
+    return search(decisionDefinitionSearchQuery(fn), authentication, physicalTenantId);
   }
 
   public String getDecisionDefinitionXml(
-      final long decisionKey, final CamundaAuthentication authentication) {
-    return Optional.ofNullable(getByKey(decisionKey, authentication))
+      final long decisionKey,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
+    return Optional.ofNullable(getByKey(decisionKey, authentication, physicalTenantId))
         .map(DecisionDefinitionEntity::decisionRequirementsKey)
         .map(
             k ->
                 decisionRequirementServices.getDecisionRequirementsXml(
-                    k, CamundaAuthentication.anonymous()))
+                    k, CamundaAuthentication.anonymous(), physicalTenantId))
         .orElseThrow(
             () ->
                 new ServiceException(
@@ -88,7 +94,9 @@ public final class DecisionDefinitionServices
   }
 
   public DecisionDefinitionEntity getByKey(
-      final long decisionKey, final CamundaAuthentication authentication) {
+      final long decisionKey,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             decisionDefinitionSearchClient
@@ -98,6 +106,7 @@ public final class DecisionDefinitionServices
                         withAuthorization(
                             DECISION_DEFINITION_READ_AUTHORIZATION,
                             DecisionDefinitionEntity::decisionDefinitionId)))
+                .withPhysicalTenant(physicalTenantId)
                 .getDecisionDefinition(decisionKey));
   }
 
@@ -106,7 +115,8 @@ public final class DecisionDefinitionServices
       final Long definitionKey,
       final Map<String, Object> variables,
       final String tenantId,
-      final CamundaAuthentication authentication) {
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return sendBrokerRequestWithFullResponse(
         new BrokerEvaluateDecisionRequest()
             .setDecisionId(definitionId)

--- a/service/src/main/java/io/camunda/service/DecisionInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/DecisionInstanceServices.java
@@ -56,13 +56,16 @@ public final class DecisionInstanceServices
    */
   @Override
   public SearchQueryResult<DecisionInstanceEntity> search(
-      final DecisionInstanceQuery query, final CamundaAuthentication authentication) {
+      final DecisionInstanceQuery query,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             decisionInstanceSearchClient
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
                         authentication, DECISION_INSTANCE_READ_AUTHORIZATION))
+                .withPhysicalTenant(physicalTenantId)
                 .searchDecisionInstances(
                     decisionInstanceSearchQuery(
                         q -> q.filter(query.filter()).sort(query.sort()).page(query.page()))));
@@ -77,7 +80,9 @@ public final class DecisionInstanceServices
    *     once
    */
   public DecisionInstanceEntity getById(
-      final String decisionInstanceId, final CamundaAuthentication authentication) {
+      final String decisionInstanceId,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             decisionInstanceSearchClient
@@ -87,6 +92,7 @@ public final class DecisionInstanceServices
                         withAuthorization(
                             DECISION_INSTANCE_READ_AUTHORIZATION,
                             DecisionInstanceEntity::decisionDefinitionId)))
+                .withPhysicalTenant(physicalTenantId)
                 .getDecisionInstance(decisionInstanceId));
   }
 
@@ -101,7 +107,8 @@ public final class DecisionInstanceServices
   public CompletableFuture<HistoryDeletionRecord> deleteDecisionInstance(
       final long decisionEvaluationKey,
       final Long operationReference,
-      final CamundaAuthentication authentication) {
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
 
     // Check if the decision instance exists using anonymous authentication.
     // This bypasses authorization checks to distinguish between:
@@ -115,6 +122,7 @@ public final class DecisionInstanceServices
                     .withSecurityContext(
                         securityContextProvider.provideSecurityContext(
                             CamundaAuthentication.anonymous()))
+                    .withPhysicalTenant(physicalTenantId)
                     .searchDecisionInstances(
                         decisionInstanceSearchQuery(
                             q -> q.filter(f -> f.decisionInstanceKeys(decisionEvaluationKey)))));
@@ -143,7 +151,9 @@ public final class DecisionInstanceServices
   }
 
   public CompletableFuture<BatchOperationCreationRecord> deleteDecisionInstancesBatchOperation(
-      final DecisionInstanceFilter filter, final CamundaAuthentication authentication) {
+      final DecisionInstanceFilter filter,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     final var brokerRequest =
         new BrokerCreateBatchOperationRequest()
             .setFilter(filter)

--- a/service/src/main/java/io/camunda/service/DecisionRequirementsServices.java
+++ b/service/src/main/java/io/camunda/service/DecisionRequirementsServices.java
@@ -45,25 +45,31 @@ public final class DecisionRequirementsServices
 
   @Override
   public SearchQueryResult<DecisionRequirementsEntity> search(
-      final DecisionRequirementsQuery query, final CamundaAuthentication authentication) {
+      final DecisionRequirementsQuery query,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             decisionRequirementSearchClient
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
                         authentication, DECISION_REQUIREMENTS_READ_AUTHORIZATION))
+                .withPhysicalTenant(physicalTenantId)
                 .searchDecisionRequirements(
                     decisionRequirementsSearchQuery(
                         q -> q.filter(query.filter()).sort(query.sort()).page(query.page()))));
   }
 
   public DecisionRequirementsEntity getByKey(
-      final Long key, final CamundaAuthentication authentication) {
-    return getByKey(key, false, authentication);
+      final Long key, final CamundaAuthentication authentication, final String physicalTenantId) {
+    return getByKey(key, false, authentication, physicalTenantId);
   }
 
   public DecisionRequirementsEntity getByKey(
-      final Long key, final boolean includeXml, final CamundaAuthentication authentication) {
+      final Long key,
+      final boolean includeXml,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             decisionRequirementSearchClient
@@ -73,18 +79,22 @@ public final class DecisionRequirementsServices
                         Authorization.withAuthorization(
                             DECISION_REQUIREMENTS_READ_AUTHORIZATION,
                             DecisionRequirementsEntity::decisionRequirementsId)))
+                .withPhysicalTenant(physicalTenantId)
                 .getDecisionRequirements(key, includeXml));
   }
 
   public SearchQueryResult<DecisionRequirementsEntity> search(
       final Function<DecisionRequirementsQuery.Builder, ObjectBuilder<DecisionRequirementsQuery>>
           fn,
-      final CamundaAuthentication authentication) {
-    return search(decisionRequirementsSearchQuery(fn), authentication);
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
+    return search(decisionRequirementsSearchQuery(fn), authentication, physicalTenantId);
   }
 
   public String getDecisionRequirementsXml(
-      final Long decisionRequirementsKey, final CamundaAuthentication authentication) {
-    return getByKey(decisionRequirementsKey, true, authentication).xml();
+      final Long decisionRequirementsKey,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
+    return getByKey(decisionRequirementsKey, true, authentication, physicalTenantId).xml();
   }
 }

--- a/service/src/main/java/io/camunda/service/DocumentServices.java
+++ b/service/src/main/java/io/camunda/service/DocumentServices.java
@@ -65,7 +65,9 @@ public class DocumentServices extends ApiServices<DocumentServices> {
 
   /** Will return a failed future for any error returned by the store */
   public CompletableFuture<DocumentReferenceResponse> createDocument(
-      final DocumentCreateRequest request, final CamundaAuthentication authentication) {
+      final DocumentCreateRequest request,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
 
     if (!hasDocumentPermission(PermissionType.CREATE, authentication)) {
       return CompletableFuture.failedFuture(
@@ -95,7 +97,9 @@ public class DocumentServices extends ApiServices<DocumentServices> {
   /** Will never return a failed future; an Either type is returned instead */
   public CompletableFuture<List<Either<DocumentErrorResponse, DocumentReferenceResponse>>>
       createDocumentBatch(
-          final List<DocumentCreateRequest> requests, final CamundaAuthentication authentication) {
+          final List<DocumentCreateRequest> requests,
+          final CamundaAuthentication authentication,
+          final String physicalTenantId) {
 
     if (!hasDocumentPermission(PermissionType.CREATE, authentication)) {
       return CompletableFuture.failedFuture(
@@ -136,7 +140,8 @@ public class DocumentServices extends ApiServices<DocumentServices> {
       final String documentId,
       final String storeId,
       final String contentHash,
-      final CamundaAuthentication authentication) {
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
 
     if (!hasDocumentPermission(PermissionType.READ, authentication)) {
       return CompletableFuture.failedFuture(
@@ -163,7 +168,10 @@ public class DocumentServices extends ApiServices<DocumentServices> {
   }
 
   public CompletableFuture<Void> deleteDocument(
-      final String documentId, final String storeId, final CamundaAuthentication authentication) {
+      final String documentId,
+      final String storeId,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
 
     if (!hasDocumentPermission(PermissionType.DELETE, authentication)) {
       return CompletableFuture.failedFuture(
@@ -182,7 +190,8 @@ public class DocumentServices extends ApiServices<DocumentServices> {
       final String storeId,
       final String contentHash,
       final DocumentLinkParams params,
-      final CamundaAuthentication authentication) {
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
 
     if (!hasDocumentPermission(PermissionType.CREATE, authentication)) {
       return CompletableFuture.failedFuture(

--- a/service/src/main/java/io/camunda/service/ElementInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ElementInstanceServices.java
@@ -87,7 +87,8 @@ public final class ElementInstanceServices
                     .withPhysicalTenant(physicalTenantId)
                     .getFlowNodeInstance(key));
 
-    final var cachedItem = processCache.getCacheItem(result.processDefinitionKey());
+    final var cachedItem =
+        processCache.getCacheItem(result.processDefinitionKey(), physicalTenantId);
     return toCacheEnrichedFlowNodeInstanceEntity(result, cachedItem);
   }
 
@@ -104,7 +105,7 @@ public final class ElementInstanceServices
                     .withPhysicalTenant(physicalTenantId)
                     .searchFlowNodeInstances(query));
 
-    return toCacheEnrichedResult(result);
+    return toCacheEnrichedResult(result, physicalTenantId);
   }
 
   public CompletableFuture<VariableDocumentRecord> setVariables(
@@ -124,7 +125,7 @@ public final class ElementInstanceServices
   }
 
   private SearchQueryResult<FlowNodeInstanceEntity> toCacheEnrichedResult(
-      final SearchQueryResult<FlowNodeInstanceEntity> result) {
+      final SearchQueryResult<FlowNodeInstanceEntity> result, final String physicalTenantId) {
     final var processDefinitionKeys =
         result.items().stream()
             .filter(u -> !u.hasFlowNodeName())
@@ -135,7 +136,7 @@ public final class ElementInstanceServices
       return result;
     }
 
-    final var cacheResult = processCache.getCacheItems(processDefinitionKeys);
+    final var cacheResult = processCache.getCacheItems(processDefinitionKeys, physicalTenantId);
 
     return result.withItems(
         result.items().stream()

--- a/service/src/main/java/io/camunda/service/ElementInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ElementInstanceServices.java
@@ -62,15 +62,18 @@ public final class ElementInstanceServices
 
   @Override
   public SearchQueryResult<FlowNodeInstanceEntity> search(
-      final FlowNodeInstanceQuery query, final CamundaAuthentication authentication) {
+      final FlowNodeInstanceQuery query,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return search(
         query,
         securityContextProvider.provideSecurityContext(
-            authentication, ELEMENT_INSTANCE_READ_AUTHORIZATION));
+            authentication, ELEMENT_INSTANCE_READ_AUTHORIZATION),
+        physicalTenantId);
   }
 
   public FlowNodeInstanceEntity getByKey(
-      final Long key, final CamundaAuthentication authentication) {
+      final Long key, final CamundaAuthentication authentication, final String physicalTenantId) {
     final var result =
         executeSearchRequest(
             () ->
@@ -81,6 +84,7 @@ public final class ElementInstanceServices
                             withAuthorization(
                                 ELEMENT_INSTANCE_READ_AUTHORIZATION,
                                 FlowNodeInstanceEntity::processDefinitionId)))
+                    .withPhysicalTenant(physicalTenantId)
                     .getFlowNodeInstance(key));
 
     final var cachedItem = processCache.getCacheItem(result.processDefinitionKey());
@@ -88,13 +92,16 @@ public final class ElementInstanceServices
   }
 
   private SearchQueryResult<FlowNodeInstanceEntity> search(
-      final FlowNodeInstanceQuery query, final SecurityContext securityContext) {
+      final FlowNodeInstanceQuery query,
+      final SecurityContext securityContext,
+      final String physicalTenantId) {
 
     final var result =
         executeSearchRequest(
             () ->
                 flowNodeInstanceSearchClient
                     .withSecurityContext(securityContext)
+                    .withPhysicalTenant(physicalTenantId)
                     .searchFlowNodeInstances(query));
 
     return toCacheEnrichedResult(result);
@@ -102,7 +109,8 @@ public final class ElementInstanceServices
 
   public CompletableFuture<VariableDocumentRecord> setVariables(
       final ElementInstanceServices.SetVariablesRequest request,
-      final CamundaAuthentication authentication) {
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     final var brokerRequest =
         new BrokerSetVariablesRequest()
             .setElementInstanceKey(request.elementInstanceKey())
@@ -148,8 +156,9 @@ public final class ElementInstanceServices
   public SearchQueryResult<IncidentEntity> searchIncidents(
       final long elementInstanceKey,
       final IncidentQuery query,
-      final CamundaAuthentication authentication) {
-    final var elementInstance = getByKey(elementInstanceKey, authentication);
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
+    final var elementInstance = getByKey(elementInstanceKey, authentication, physicalTenantId);
     return incidentServices.search(
         IncidentQuery.of(
             b ->
@@ -163,7 +172,8 @@ public final class ElementInstanceServices
                             .build())
                     .sort(query.sort())
                     .page(query.page())),
-        authentication);
+        authentication,
+        physicalTenantId);
   }
 
   public SearchQueryResult<WaitStateEntity> searchWaitStates(

--- a/service/src/main/java/io/camunda/service/ExpressionServices.java
+++ b/service/src/main/java/io/camunda/service/ExpressionServices.java
@@ -31,7 +31,9 @@ public final class ExpressionServices extends ApiServices<ExpressionServices> {
   }
 
   public CompletableFuture<ExpressionRecord> evaluateExpression(
-      final ExpressionEvaluationRequest request, final CamundaAuthentication authentication) {
+      final ExpressionEvaluationRequest request,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return sendBrokerRequest(
         new BrokerExpressionEvaluationRequest()
             .setExpression(request.expression())

--- a/service/src/main/java/io/camunda/service/FormServices.java
+++ b/service/src/main/java/io/camunda/service/FormServices.java
@@ -41,15 +41,19 @@ public final class FormServices extends SearchQueryService<FormServices, FormQue
 
   @Override
   public SearchQueryResult<FormEntity> search(
-      final FormQuery query, final CamundaAuthentication authentication) {
+      final FormQuery query,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             formSearchClient
                 .withSecurityContext(securityContextProvider.provideSecurityContext(authentication))
+                .withPhysicalTenant(physicalTenantId)
                 .searchForms(query));
   }
 
-  public FormEntity getByKey(final Long key, final CamundaAuthentication authentication) {
+  public FormEntity getByKey(
+      final Long key, final CamundaAuthentication authentication, final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             formSearchClient
@@ -57,17 +61,22 @@ public final class FormServices extends SearchQueryService<FormServices, FormQue
                     securityContextProvider.provideSecurityContext(
                         authentication,
                         withAuthorization(FORM_READ_AUTHORIZATION, FormEntity::formId)))
+                .withPhysicalTenant(physicalTenantId)
                 .getForm(key));
   }
 
   public Optional<FormEntity> getLatestVersionByFormIdAndTenantId(
-      final String formId, final String tenantId, final CamundaAuthentication authentication) {
+      final String formId,
+      final String tenantId,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return search(
             SearchQueryBuilders.formSearchQuery()
                 .filter(f -> f.formIds(formId).tenantId(tenantId))
                 .sort(s -> s.version().desc())
                 .build(),
-            authentication)
+            authentication,
+            physicalTenantId)
         .items()
         .stream()
         .findFirst();

--- a/service/src/main/java/io/camunda/service/GlobalListenerServices.java
+++ b/service/src/main/java/io/camunda/service/GlobalListenerServices.java
@@ -47,12 +47,16 @@ public final class GlobalListenerServices
   }
 
   public CompletableFuture<GlobalListenerRecord> createGlobalListener(
-      final GlobalListenerRecord request, final CamundaAuthentication authentication) {
+      final GlobalListenerRecord request,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return sendBrokerRequest(new BrokerCreateGlobalListenerRequest(request), authentication);
   }
 
   public GlobalListenerEntity getGlobalTaskListener(
-      final GlobalListenerRecord request, final CamundaAuthentication authentication) {
+      final GlobalListenerRecord request,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             globalListenerSearchClient
@@ -60,29 +64,37 @@ public final class GlobalListenerServices
                     securityContextProvider.provideSecurityContext(
                         authentication,
                         withAuthorization(GLOBAL_TASK_LISTENER_READ_AUTHORIZATION, WILDCARD_CHAR)))
+                .withPhysicalTenant(physicalTenantId)
                 .getGlobalListener(
                     request.getId(), GlobalListenerType.valueOf(request.getListenerType().name())));
   }
 
   public CompletableFuture<GlobalListenerRecord> updateGlobalListener(
-      final GlobalListenerRecord request, final CamundaAuthentication authentication) {
+      final GlobalListenerRecord request,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return sendBrokerRequest(new BrokerUpdateGlobalListenerRequest(request), authentication);
   }
 
   public CompletableFuture<GlobalListenerRecord> deleteGlobalListener(
-      final GlobalListenerRecord request, final CamundaAuthentication authentication) {
+      final GlobalListenerRecord request,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return sendBrokerRequest(new BrokerDeleteGlobalListenerRequest(request), authentication);
   }
 
   @Override
   public SearchQueryResult<GlobalListenerEntity> search(
-      final GlobalListenerQuery query, final CamundaAuthentication authentication) {
+      final GlobalListenerQuery query,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             globalListenerSearchClient
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
                         authentication, GLOBAL_TASK_LISTENER_READ_AUTHORIZATION))
+                .withPhysicalTenant(physicalTenantId)
                 .searchGlobalListeners(query));
   }
 }

--- a/service/src/main/java/io/camunda/service/GroupServices.java
+++ b/service/src/main/java/io/camunda/service/GroupServices.java
@@ -53,31 +53,38 @@ public class GroupServices extends SearchQueryService<GroupServices, GroupQuery,
 
   public List<GroupEntity> getGroupsByMemberTypeAndMemberIds(
       final Map<EntityType, Set<String>> memberTypesToMemberIds,
-      final CamundaAuthentication authentication) {
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return search(
             GroupQuery.of(
                 groupQuery ->
                     groupQuery
                         .filter(groupFilter -> groupFilter.memberIdsByType(memberTypesToMemberIds))
                         .unlimited()),
-            authentication)
+            authentication,
+            physicalTenantId)
         .items();
   }
 
   @Override
   public SearchQueryResult<GroupEntity> search(
-      final GroupQuery query, final CamundaAuthentication authentication) {
+      final GroupQuery query,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             groupSearchClient
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
                         authentication, GROUP_READ_AUTHORIZATION))
+                .withPhysicalTenant(physicalTenantId)
                 .searchGroups(query));
   }
 
   public CompletableFuture<GroupRecord> createGroup(
-      final GroupDTO groupDTO, final CamundaAuthentication authentication) {
+      final GroupDTO groupDTO,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return sendBrokerRequest(
         new BrokerGroupCreateRequest()
             .setGroupId(groupDTO.groupId)
@@ -86,13 +93,17 @@ public class GroupServices extends SearchQueryService<GroupServices, GroupQuery,
         authentication);
   }
 
-  public GroupEntity getGroup(final String groupId, final CamundaAuthentication authentication) {
+  public GroupEntity getGroup(
+      final String groupId,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             groupSearchClient
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
                         authentication, withAuthorization(GROUP_READ_AUTHORIZATION, groupId)))
+                .withPhysicalTenant(physicalTenantId)
                 .getGroup(groupId));
   }
 
@@ -100,19 +111,24 @@ public class GroupServices extends SearchQueryService<GroupServices, GroupQuery,
       final String groupId,
       final String name,
       final String description,
-      final CamundaAuthentication authentication) {
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return sendBrokerRequest(
         new BrokerGroupUpdateRequest(groupId).setName(name).setDescription(description),
         authentication);
   }
 
   public CompletableFuture<GroupRecord> deleteGroup(
-      final String groupId, final CamundaAuthentication authentication) {
+      final String groupId,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return sendBrokerRequest(new BrokerGroupDeleteRequest(groupId), authentication);
   }
 
   public CompletableFuture<GroupRecord> assignMember(
-      final GroupMemberDTO groupMemberDTO, final CamundaAuthentication authentication) {
+      final GroupMemberDTO groupMemberDTO,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return sendBrokerRequest(
         BrokerGroupMemberRequest.createAddRequest(groupMemberDTO.groupId)
             .setMemberId(groupMemberDTO.memberId)
@@ -121,7 +137,9 @@ public class GroupServices extends SearchQueryService<GroupServices, GroupQuery,
   }
 
   public CompletableFuture<GroupRecord> removeMember(
-      final GroupMemberDTO groupMemberDTO, final CamundaAuthentication authentication) {
+      final GroupMemberDTO groupMemberDTO,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return sendBrokerRequest(
         BrokerGroupMemberRequest.createRemoveRequest(groupMemberDTO.groupId)
             .setMemberId(groupMemberDTO.memberId)
@@ -130,13 +148,16 @@ public class GroupServices extends SearchQueryService<GroupServices, GroupQuery,
   }
 
   public SearchQueryResult<GroupMemberEntity> searchMembers(
-      final GroupMemberQuery query, final CamundaAuthentication authentication) {
+      final GroupMemberQuery query,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             groupSearchClient
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
                         authentication, GROUP_READ_AUTHORIZATION))
+                .withPhysicalTenant(physicalTenantId)
                 .searchGroupMembers(query));
   }
 

--- a/service/src/main/java/io/camunda/service/IncidentServices.java
+++ b/service/src/main/java/io/camunda/service/IncidentServices.java
@@ -53,23 +53,28 @@ public class IncidentServices
 
   public SearchQueryResult<IncidentEntity> search(
       final Function<IncidentQuery.Builder, ObjectBuilder<IncidentQuery>> fn,
-      final CamundaAuthentication authentication) {
-    return search(incidentSearchQuery(fn), authentication);
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
+    return search(incidentSearchQuery(fn), authentication, physicalTenantId);
   }
 
   @Override
   public SearchQueryResult<IncidentEntity> search(
-      final IncidentQuery query, final CamundaAuthentication authentication) {
+      final IncidentQuery query,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             incidentSearchClient
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
                         authentication, INCIDENT_READ_AUTHORIZATION))
+                .withPhysicalTenant(physicalTenantId)
                 .searchIncidents(query));
   }
 
-  public IncidentEntity getByKey(final Long key, final CamundaAuthentication authentication) {
+  public IncidentEntity getByKey(
+      final Long key, final CamundaAuthentication authentication, final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             incidentSearchClient
@@ -78,13 +83,15 @@ public class IncidentServices
                         authentication,
                         withAuthorization(
                             INCIDENT_READ_AUTHORIZATION, IncidentEntity::processDefinitionId)))
+                .withPhysicalTenant(physicalTenantId)
                 .getIncident(key));
   }
 
   public CompletableFuture<IncidentRecord> resolveIncident(
       final long incidentKey,
       final Long operationReference,
-      final CamundaAuthentication authentication) {
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     final var brokerRequest = new BrokerResolveIncidentRequest(incidentKey);
     if (operationReference != null) {
       brokerRequest.setOperationReference(operationReference);
@@ -95,7 +102,8 @@ public class IncidentServices
   public SearchQueryResult<IncidentProcessInstanceStatisticsByErrorEntity>
       incidentProcessInstanceStatisticsByError(
           final IncidentProcessInstanceStatisticsByErrorQuery query,
-          final CamundaAuthentication authentication) {
+          final CamundaAuthentication authentication,
+          final String physicalTenantId) {
     final var sanitizedQuery =
         IncidentProcessInstanceStatisticsByErrorQuery.of(
             b ->
@@ -108,19 +116,22 @@ public class IncidentServices
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
                         authentication, INCIDENT_READ_AUTHORIZATION))
+                .withPhysicalTenant(physicalTenantId)
                 .incidentProcessInstanceStatisticsByError(sanitizedQuery));
   }
 
   public SearchQueryResult<IncidentProcessInstanceStatisticsByDefinitionEntity>
       searchIncidentProcessInstanceStatisticsByDefinition(
           final IncidentProcessInstanceStatisticsByDefinitionQuery query,
-          final CamundaAuthentication authentication) {
+          final CamundaAuthentication authentication,
+          final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             incidentSearchClient
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
                         authentication, INCIDENT_READ_AUTHORIZATION))
+                .withPhysicalTenant(physicalTenantId)
                 .searchIncidentProcessInstanceStatisticsByDefinition(query));
   }
 }

--- a/service/src/main/java/io/camunda/service/JobServices.java
+++ b/service/src/main/java/io/camunda/service/JobServices.java
@@ -90,7 +90,8 @@ public final class JobServices<T> extends SearchQueryService<JobServices<T>, Job
       final ActivateJobsRequest request,
       final ResponseObserver<T> responseObserver,
       final Consumer<Runnable> cancelationHandlerConsumer,
-      final CamundaAuthentication authentication) {
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     final var brokerRequest =
         new BrokerActivateJobsRequest(request.type())
             .setMaxJobsToActivate(request.maxJobsToActivate())
@@ -112,7 +113,8 @@ public final class JobServices<T> extends SearchQueryService<JobServices<T>, Job
       final String errorMessage,
       final Long retryBackOff,
       final Map<String, Object> variables,
-      final CamundaAuthentication authentication) {
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     final var request =
         new BrokerFailJobRequest(jobKey, retries, retryBackOff)
             .setVariables(getDocumentOrEmpty(variables))
@@ -125,7 +127,8 @@ public final class JobServices<T> extends SearchQueryService<JobServices<T>, Job
       final String errorCode,
       final String errorMessage,
       final Map<String, Object> variables,
-      final CamundaAuthentication authentication) {
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     final var request =
         new BrokerThrowErrorRequest(jobKey, errorCode)
             .setErrorMessage(errorMessage)
@@ -137,7 +140,8 @@ public final class JobServices<T> extends SearchQueryService<JobServices<T>, Job
       final long jobKey,
       final Map<String, Object> variables,
       final JobResult result,
-      final CamundaAuthentication authentication) {
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return sendBrokerRequest(
         new BrokerCompleteJobRequest(
             jobKey, getDocumentOrEmpty(variables), result, maxVariableNameLength),
@@ -148,7 +152,8 @@ public final class JobServices<T> extends SearchQueryService<JobServices<T>, Job
       final long jobKey,
       final Long operationReference,
       final UpdateJobChangeset changeset,
-      final CamundaAuthentication authentication) {
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     final var brokerRequest =
         new BrokerUpdateJobRequest(jobKey, changeset.retries(), changeset.timeout());
     if (operationReference != null) {
@@ -159,68 +164,86 @@ public final class JobServices<T> extends SearchQueryService<JobServices<T>, Job
 
   @Override
   public SearchQueryResult<JobEntity> search(
-      final JobQuery query, final CamundaAuthentication authentication) {
+      final JobQuery query,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             jobSearchClient
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
                         authentication, JOB_READ_AUTHORIZATION))
+                .withPhysicalTenant(physicalTenantId)
                 .searchJobs(query));
   }
 
   public GlobalJobStatisticsEntity getGlobalStatistics(
-      final GlobalJobStatisticsQuery query, final CamundaAuthentication authentication) {
+      final GlobalJobStatisticsQuery query,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             jobSearchClient
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
                         authentication, Authorization.of(a -> a.system().readJobMetric())))
+                .withPhysicalTenant(physicalTenantId)
                 .getGlobalJobStatistics(query));
   }
 
   public SearchQueryResult<JobTypeStatisticsEntity> getJobTypeStatistics(
-      final JobTypeStatisticsQuery query, final CamundaAuthentication authentication) {
+      final JobTypeStatisticsQuery query,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             jobSearchClient
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
                         authentication, Authorization.of(a -> a.system().readJobMetric())))
+                .withPhysicalTenant(physicalTenantId)
                 .getJobTypeStatistics(query));
   }
 
   public SearchQueryResult<JobWorkerStatisticsEntity> getJobWorkerStatistics(
-      final JobWorkerStatisticsQuery query, final CamundaAuthentication authentication) {
+      final JobWorkerStatisticsQuery query,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             jobSearchClient
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
                         authentication, Authorization.of(a -> a.system().readJobMetric())))
+                .withPhysicalTenant(physicalTenantId)
                 .getJobWorkerStatistics(query));
   }
 
   public SearchQueryResult<JobTimeSeriesStatisticsEntity> getJobTimeSeriesStatistics(
-      final JobTimeSeriesStatisticsQuery query, final CamundaAuthentication authentication) {
+      final JobTimeSeriesStatisticsQuery query,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             jobSearchClient
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
                         authentication, Authorization.of(a -> a.system().readJobMetric())))
+                .withPhysicalTenant(physicalTenantId)
                 .getJobTimeSeriesStatistics(query));
   }
 
   public SearchQueryResult<JobErrorStatisticsEntity> getJobErrorStatistics(
-      final JobErrorStatisticsQuery query, final CamundaAuthentication authentication) {
+      final JobErrorStatisticsQuery query,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             jobSearchClient
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
                         authentication, JOB_READ_AUTHORIZATION))
+                .withPhysicalTenant(physicalTenantId)
                 .getJobErrorStatistics(query));
   }
 

--- a/service/src/main/java/io/camunda/service/MappingRuleServices.java
+++ b/service/src/main/java/io/camunda/service/MappingRuleServices.java
@@ -50,18 +50,23 @@ public class MappingRuleServices
 
   @Override
   public SearchQueryResult<MappingRuleEntity> search(
-      final MappingRuleQuery query, final CamundaAuthentication authentication) {
+      final MappingRuleQuery query,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             mappingRuleSearchClient
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
                         authentication, MAPPING_RULE_READ_AUTHORIZATION))
+                .withPhysicalTenant(physicalTenantId)
                 .searchMappingRules(query));
   }
 
   public CompletableFuture<MappingRuleRecord> createMappingRule(
-      final MappingRuleDTO request, final CamundaAuthentication authentication) {
+      final MappingRuleDTO request,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return sendBrokerRequest(
         new BrokerMappingRuleCreateRequest()
             .setClaimName(request.claimName())
@@ -72,7 +77,9 @@ public class MappingRuleServices
   }
 
   public CompletableFuture<MappingRuleRecord> updateMappingRule(
-      final MappingRuleDTO request, final CamundaAuthentication authentication) {
+      final MappingRuleDTO request,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return sendBrokerRequest(
         new BrokerMappingRuleUpdateRequest()
             .setClaimName(request.claimName())
@@ -83,7 +90,9 @@ public class MappingRuleServices
   }
 
   public MappingRuleEntity getMappingRule(
-      final String mappingRuleId, final CamundaAuthentication authentication) {
+      final String mappingRuleId,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             mappingRuleSearchClient
@@ -91,19 +100,25 @@ public class MappingRuleServices
                     securityContextProvider.provideSecurityContext(
                         authentication,
                         withAuthorization(MAPPING_RULE_READ_AUTHORIZATION, mappingRuleId)))
+                .withPhysicalTenant(physicalTenantId)
                 .getMappingRule(mappingRuleId));
   }
 
   public CompletableFuture<MappingRuleRecord> deleteMappingRule(
-      final String mappingRuleId, final CamundaAuthentication authentication) {
+      final String mappingRuleId,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return sendBrokerRequest(
         new BrokerMappingRuleDeleteRequest().setMappingRuleId(mappingRuleId), authentication);
   }
 
   public Stream<MappingRuleEntity> getMatchingMappingRules(
-      final Map<String, Object> claims, final CamundaAuthentication authentication) {
+      final Map<String, Object> claims,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return MappingRuleMatcher.matchingRules(
-        search(MappingRuleQuery.of(AbstractQueryBuilder::unlimited), authentication)
+        search(
+            MappingRuleQuery.of(AbstractQueryBuilder::unlimited), authentication, physicalTenantId)
             .items()
             .stream(),
         claims);

--- a/service/src/main/java/io/camunda/service/MessageServices.java
+++ b/service/src/main/java/io/camunda/service/MessageServices.java
@@ -52,7 +52,8 @@ public final class MessageServices extends ApiServices<MessageServices> {
 
   public CompletableFuture<MessageCorrelationRecord> correlateMessage(
       final CorrelateMessageRequest correlationRequest,
-      final CamundaAuthentication authentication) {
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     final var brokerRequest =
         new BrokerCorrelateMessageRequest(
                 correlationRequest.name, correlationRequest.correlationKey, maxVariableNameLength)
@@ -62,7 +63,9 @@ public final class MessageServices extends ApiServices<MessageServices> {
   }
 
   public CompletableFuture<BrokerResponse<MessageRecord>> publishMessage(
-      final PublicationMessageRequest request, final CamundaAuthentication authentication) {
+      final PublicationMessageRequest request,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     final var brokerRequest =
         new BrokerPublishMessageRequest(request.name, request.correlationKey)
             .setTimeToLive(request.timeToLive)

--- a/service/src/main/java/io/camunda/service/MessageSubscriptionServices.java
+++ b/service/src/main/java/io/camunda/service/MessageSubscriptionServices.java
@@ -45,18 +45,21 @@ public class MessageSubscriptionServices
 
   @Override
   public SearchQueryResult<MessageSubscriptionEntity> search(
-      final MessageSubscriptionQuery query, final CamundaAuthentication authentication) {
+      final MessageSubscriptionQuery query,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             searchClient
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
                         authentication, MESSAGE_SUBSCRIPTION_READ_AUTHORIZATION))
+                .withPhysicalTenant(physicalTenantId)
                 .searchMessageSubscriptions(query));
   }
 
   public MessageSubscriptionEntity getByKey(
-      final long key, final CamundaAuthentication authentication) {
+      final long key, final CamundaAuthentication authentication, final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             searchClient
@@ -66,17 +69,21 @@ public class MessageSubscriptionServices
                         Authorization.withAuthorization(
                             MESSAGE_SUBSCRIPTION_READ_AUTHORIZATION,
                             MessageSubscriptionEntity::processDefinitionId)))
+                .withPhysicalTenant(physicalTenantId)
                 .getMessageSubscription(key));
   }
 
   public SearchQueryResult<CorrelatedMessageSubscriptionEntity> searchCorrelated(
-      final CorrelatedMessageSubscriptionQuery query, final CamundaAuthentication authentication) {
+      final CorrelatedMessageSubscriptionQuery query,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             searchClient
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
                         authentication, PROCESS_INSTANCE_READ_AUTHORIZATION))
+                .withPhysicalTenant(physicalTenantId)
                 .searchCorrelatedMessageSubscriptions(query));
   }
 }

--- a/service/src/main/java/io/camunda/service/ProcessDefinitionServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessDefinitionServices.java
@@ -58,29 +58,37 @@ public class ProcessDefinitionServices
 
   @Override
   public SearchQueryResult<ProcessDefinitionEntity> search(
-      final ProcessDefinitionQuery query, final CamundaAuthentication authentication) {
+      final ProcessDefinitionQuery query,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             processDefinitionSearchClient
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
                         authentication, PROCESS_DEFINITION_READ_AUTHORIZATION))
+                .withPhysicalTenant(physicalTenantId)
                 .searchProcessDefinitions(query));
   }
 
   public List<ProcessFlowNodeStatisticsEntity> elementStatistics(
-      final ProcessDefinitionStatisticsFilter filter, final CamundaAuthentication authentication) {
+      final ProcessDefinitionStatisticsFilter filter,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             processDefinitionSearchClient
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
                         authentication, PROCESS_INSTANCE_READ_AUTHORIZATION))
+                .withPhysicalTenant(physicalTenantId)
                 .processDefinitionFlowNodeStatistics(filter));
   }
 
   public ProcessDefinitionEntity getByKey(
-      final Long processDefinitionKey, final CamundaAuthentication authentication) {
+      final Long processDefinitionKey,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             processDefinitionSearchClient
@@ -90,48 +98,57 @@ public class ProcessDefinitionServices
                         withAuthorization(
                             PROCESS_DEFINITION_READ_AUTHORIZATION,
                             ProcessDefinitionEntity::processDefinitionId)))
+                .withPhysicalTenant(physicalTenantId)
                 .getProcessDefinition(processDefinitionKey));
   }
 
   public SearchQueryResult<ProcessDefinitionInstanceStatisticsEntity>
       getProcessDefinitionInstanceStatistics(
           final ProcessDefinitionInstanceStatisticsQuery query,
-          final CamundaAuthentication authentication) {
+          final CamundaAuthentication authentication,
+          final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             processDefinitionSearchClient
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
                         authentication, PROCESS_INSTANCE_READ_AUTHORIZATION))
+                .withPhysicalTenant(physicalTenantId)
                 .processDefinitionInstanceStatistics(query));
   }
 
   public SearchQueryResult<ProcessDefinitionInstanceVersionStatisticsEntity>
       searchProcessDefinitionInstanceVersionStatistics(
           final ProcessDefinitionInstanceVersionStatisticsQuery query,
-          final CamundaAuthentication authentication) {
+          final CamundaAuthentication authentication,
+          final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             processDefinitionSearchClient
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
                         authentication, PROCESS_INSTANCE_READ_AUTHORIZATION))
+                .withPhysicalTenant(physicalTenantId)
                 .processDefinitionInstanceVersionStatistics(query));
   }
 
   public Optional<FormEntity> getProcessDefinitionStartForm(
-      final long processDefinitionKey, final CamundaAuthentication authentication) {
-    return Optional.ofNullable(getByKey(processDefinitionKey, authentication))
+      final long processDefinitionKey,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
+    return Optional.ofNullable(getByKey(processDefinitionKey, authentication, physicalTenantId))
         .filter(p -> p.formId() != null && !p.formId().isEmpty())
         .flatMap(
             p ->
                 formServices.getLatestVersionByFormIdAndTenantId(
-                    p.formId(), p.tenantId(), CamundaAuthentication.anonymous()));
+                    p.formId(), p.tenantId(), CamundaAuthentication.anonymous(), physicalTenantId));
   }
 
   public Optional<String> getProcessDefinitionXml(
-      final Long processDefinitionKey, final CamundaAuthentication authentication) {
-    final var processDefinition = getByKey(processDefinitionKey, authentication);
+      final Long processDefinitionKey,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
+    final var processDefinition = getByKey(processDefinitionKey, authentication, physicalTenantId);
     return Optional.ofNullable(processDefinition)
         .map(ProcessDefinitionEntity::bpmnXml)
         .filter(xml -> !xml.isEmpty());
@@ -140,13 +157,15 @@ public class ProcessDefinitionServices
   public SearchQueryResult<ProcessDefinitionMessageSubscriptionStatisticsEntity>
       getProcessDefinitionMessageSubscriptionStatistics(
           final ProcessDefinitionMessageSubscriptionStatisticsQuery query,
-          final CamundaAuthentication authentication) {
+          final CamundaAuthentication authentication,
+          final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             processDefinitionSearchClient
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
                         authentication, MESSAGE_SUBSCRIPTION_READ_AUTHORIZATION))
+                .withPhysicalTenant(physicalTenantId)
                 .getProcessDefinitionMessageSubscriptionStatistics(query));
   }
 }

--- a/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
@@ -177,36 +177,45 @@ public final class ProcessInstanceServices
 
   @Override
   public SearchQueryResult<ProcessInstanceEntity> search(
-      final ProcessInstanceQuery query, final CamundaAuthentication authentication) {
+      final ProcessInstanceQuery query,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             processInstanceSearchClient
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
                         authentication, PROCESS_INSTANCE_READ_AUTHORIZATION))
+                .withPhysicalTenant(physicalTenantId)
                 .searchProcessInstances(query));
   }
 
   public SearchQueryResult<ProcessInstanceEntity> search(
       final Function<ProcessInstanceQuery.Builder, ObjectBuilder<ProcessInstanceQuery>> fn,
-      final CamundaAuthentication authentication) {
-    return search(processInstanceSearchQuery(fn), authentication);
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
+    return search(processInstanceSearchQuery(fn), authentication, physicalTenantId);
   }
 
   public List<ProcessFlowNodeStatisticsEntity> elementStatistics(
-      final long processInstanceKey, final CamundaAuthentication authentication) {
+      final long processInstanceKey,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             processInstanceSearchClient
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
                         authentication, PROCESS_INSTANCE_READ_AUTHORIZATION))
+                .withPhysicalTenant(physicalTenantId)
                 .processInstanceFlowNodeStatistics(processInstanceKey));
   }
 
   public List<ProcessInstanceEntity> callHierarchy(
-      final long processInstanceKey, final CamundaAuthentication authentication) {
-    final var rootInstance = getByKey(processInstanceKey, authentication);
+      final long processInstanceKey,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
+    final var rootInstance = getByKey(processInstanceKey, authentication, physicalTenantId);
 
     final var treePath = rootInstance.treePath();
     if (treePath == null || treePath.isBlank()) {
@@ -228,6 +237,7 @@ public final class ProcessInstanceServices
                         .withSecurityContext(
                             securityContextProvider.provideSecurityContext(
                                 CamundaAuthentication.anonymous()))
+                        .withPhysicalTenant(physicalTenantId)
                         .searchProcessInstances(
                             processInstanceSearchQuery(
                                 q ->
@@ -244,13 +254,16 @@ public final class ProcessInstanceServices
   }
 
   public List<SequenceFlowEntity> sequenceFlows(
-      final long processInstanceKey, final CamundaAuthentication authentication) {
+      final long processInstanceKey,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return executeSearchRequest(
             () ->
                 sequenceFlowSearchClient
                     .withSecurityContext(
                         securityContextProvider.provideSecurityContext(
                             authentication, PROCESS_INSTANCE_READ_AUTHORIZATION))
+                    .withPhysicalTenant(physicalTenantId)
                     .searchSequenceFlows(
                         SequenceFlowQuery.of(
                             b ->
@@ -260,26 +273,34 @@ public final class ProcessInstanceServices
   }
 
   public ProcessInstanceEntity getByKey(
-      final Long processInstanceKey, final CamundaAuthentication authentication) {
+      final Long processInstanceKey,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return getByKey(
         processInstanceKey,
         securityContextProvider.provideSecurityContext(
             authentication,
             withAuthorization(
-                PROCESS_INSTANCE_READ_AUTHORIZATION, ProcessInstanceEntity::processDefinitionId)));
+                PROCESS_INSTANCE_READ_AUTHORIZATION, ProcessInstanceEntity::processDefinitionId)),
+        physicalTenantId);
   }
 
   private ProcessInstanceEntity getByKey(
-      final Long processInstanceKey, final SecurityContext securityContext) {
+      final Long processInstanceKey,
+      final SecurityContext securityContext,
+      final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             processInstanceSearchClient
                 .withSecurityContext(securityContext)
+                .withPhysicalTenant(physicalTenantId)
                 .getProcessInstance(processInstanceKey));
   }
 
   public CompletableFuture<ProcessInstanceCreationRecord> createProcessInstance(
-      final ProcessInstanceCreateRequest request, final CamundaAuthentication authentication) {
+      final ProcessInstanceCreateRequest request,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     final var brokerRequest =
         new BrokerCreateProcessInstanceRequest(maxVariableNameLength)
             .setBpmnProcessId(request.bpmnProcessId())
@@ -309,7 +330,9 @@ public final class ProcessInstanceServices
   }
 
   public CompletableFuture<ProcessInstanceResultRecord> createProcessInstanceWithResult(
-      final ProcessInstanceCreateRequest request, final CamundaAuthentication authentication) {
+      final ProcessInstanceCreateRequest request,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     final var brokerRequest =
         new BrokerCreateProcessInstanceWithResultRequest(maxVariableNameLength)
             .setBpmnProcessId(request.bpmnProcessId())
@@ -342,7 +365,9 @@ public final class ProcessInstanceServices
   }
 
   public CompletableFuture<ProcessInstanceRecord> cancelProcessInstance(
-      final ProcessInstanceCancelRequest request, final CamundaAuthentication authentication) {
+      final ProcessInstanceCancelRequest request,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     final var brokerRequest =
         new BrokerCancelProcessInstanceRequest()
             .setProcessInstanceKey(request.processInstanceKey());
@@ -355,7 +380,9 @@ public final class ProcessInstanceServices
 
   public CompletableFuture<BatchOperationCreationRecord>
       cancelProcessInstanceBatchOperationWithResult(
-          final ProcessInstanceFilter filter, final CamundaAuthentication authentication) {
+          final ProcessInstanceFilter filter,
+          final CamundaAuthentication authentication,
+          final String physicalTenantId) {
     final var brokerRequest =
         new BrokerCreateBatchOperationRequest()
             .setFilter(filter)
@@ -366,12 +393,15 @@ public final class ProcessInstanceServices
   }
 
   public CompletableFuture<BatchOperationCreationRecord> resolveProcessInstanceIncidents(
-      final long processInstanceKey, final CamundaAuthentication authentication) {
+      final long processInstanceKey,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     // internal read, no user permissions needed
     final var processInstance =
         getByKey(
             processInstanceKey,
-            securityContextProvider.provideSecurityContext(CamundaAuthentication.anonymous()));
+            securityContextProvider.provideSecurityContext(CamundaAuthentication.anonymous()),
+            physicalTenantId);
 
     final var brokerRequest =
         new BrokerCreateBatchOperationRequest()
@@ -388,7 +418,9 @@ public final class ProcessInstanceServices
   }
 
   public CompletableFuture<BatchOperationCreationRecord> resolveIncidentsBatchOperationWithResult(
-      final ProcessInstanceFilter filter, final CamundaAuthentication authentication) {
+      final ProcessInstanceFilter filter,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     final var brokerRequest =
         new BrokerCreateBatchOperationRequest()
             .setFilter(filter)
@@ -400,7 +432,8 @@ public final class ProcessInstanceServices
 
   public CompletableFuture<BatchOperationCreationRecord> migrateProcessInstancesBatchOperation(
       final ProcessInstanceMigrateBatchOperationRequest request,
-      final CamundaAuthentication authentication) {
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     final var migrationPlan = new BatchOperationProcessInstanceMigrationPlan();
     migrationPlan.setTargetProcessDefinitionKey(request.targetProcessDefinitionKey);
     request.mappingInstructions.forEach(migrationPlan::addMappingInstruction);
@@ -416,7 +449,9 @@ public final class ProcessInstanceServices
   }
 
   public CompletableFuture<ProcessInstanceMigrationRecord> migrateProcessInstance(
-      final ProcessInstanceMigrateRequest request, final CamundaAuthentication authentication) {
+      final ProcessInstanceMigrateRequest request,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     final var brokerRequest =
         new BrokerMigrateProcessInstanceRequest()
             .setProcessInstanceKey(request.processInstanceKey())
@@ -430,7 +465,9 @@ public final class ProcessInstanceServices
   }
 
   public CompletableFuture<ProcessInstanceModificationRecord> modifyProcessInstance(
-      final ProcessInstanceModifyRequest request, final CamundaAuthentication authentication) {
+      final ProcessInstanceModifyRequest request,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     final var brokerRequest =
         new BrokerModifyProcessInstanceRequest()
             .setProcessInstanceKey(request.processInstanceKey())
@@ -446,7 +483,8 @@ public final class ProcessInstanceServices
 
   public CompletableFuture<BatchOperationCreationRecord> modifyProcessInstancesBatchOperation(
       final ProcessInstanceModifyBatchOperationRequest request,
-      final CamundaAuthentication authentication) {
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     final var rootInstanceFilter =
         request.filter.toBuilder()
             // It is only possible to modify active processes in zeebe
@@ -466,7 +504,9 @@ public final class ProcessInstanceServices
   }
 
   public CompletableFuture<BatchOperationCreationRecord> deleteProcessInstancesBatchOperation(
-      final ProcessInstanceFilter filter, final CamundaAuthentication authentication) {
+      final ProcessInstanceFilter filter,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     final var brokerRequest =
         new BrokerCreateBatchOperationRequest()
             .setFilter(filter)
@@ -478,13 +518,15 @@ public final class ProcessInstanceServices
   public CompletableFuture<HistoryDeletionRecord> deleteProcessInstance(
       final Long processInstanceKey,
       final Long operationReference,
-      final CamundaAuthentication authentication) {
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
 
     // make sure process instance exists before deletion, otherwise return not found
     final var processInstance =
         getByKey(
             processInstanceKey,
-            securityContextProvider.provideSecurityContext(CamundaAuthentication.anonymous()));
+            securityContextProvider.provideSecurityContext(CamundaAuthentication.anonymous()),
+            physicalTenantId);
 
     // We pass along the process id and tenant id as the process instance won't exist in primary
     // storage anymore. We cannot rely on just the key.
@@ -505,8 +547,9 @@ public final class ProcessInstanceServices
   public SearchQueryResult<IncidentEntity> searchIncidents(
       final long processInstanceKey,
       final IncidentQuery query,
-      final CamundaAuthentication authentication) {
-    final var processInstance = getByKey(processInstanceKey, authentication);
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
+    final var processInstance = getByKey(processInstanceKey, authentication, physicalTenantId);
     final var treePath = processInstance.treePath();
 
     return incidentServices.search(
@@ -518,7 +561,8 @@ public final class ProcessInstanceServices
                             .build())
                     .page(query.page())
                     .sort(query.sort())),
-        authentication);
+        authentication,
+        physicalTenantId);
   }
 
   private <R> CompletableFuture<R> sendWithPerProcessRoundRobin(

--- a/service/src/main/java/io/camunda/service/ResourceServices.java
+++ b/service/src/main/java/io/camunda/service/ResourceServices.java
@@ -64,7 +64,8 @@ public final class ResourceServices extends ApiServices<ResourceServices> {
 
   public CompletableFuture<DeploymentRecord> deployResources(
       final DeployResourcesRequest deployResourcesRequest,
-      final CamundaAuthentication authentication) {
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     final var brokerRequest = new BrokerDeployResourceRequest();
     deployResourcesRequest.resources().forEach(brokerRequest::addResource);
     brokerRequest.setTenantId(deployResourcesRequest.tenantId());
@@ -72,13 +73,15 @@ public final class ResourceServices extends ApiServices<ResourceServices> {
   }
 
   public CompletableFuture<ResourceDeletionRecord> deleteResource(
-      final ResourceDeletionRequest request, final CamundaAuthentication authentication) {
+      final ResourceDeletionRequest request,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     final var brokerRequest =
         new BrokerDeleteResourceRequest()
             .setResourceKey(request.resourceKey())
             .setDeleteHistory(request.deleteHistory());
 
-    enrichResourceDeletionRecordWithHistoryDeletionData(request, brokerRequest);
+    enrichResourceDeletionRecordWithHistoryDeletionData(request, brokerRequest, physicalTenantId);
 
     if (request.operationReference() != null) {
       brokerRequest.setOperationReference(request.operationReference());
@@ -94,12 +97,15 @@ public final class ResourceServices extends ApiServices<ResourceServices> {
    * then be in secondary storage, we retrieve the necessary data here and pass it along the broker.
    */
   private void enrichResourceDeletionRecordWithHistoryDeletionData(
-      final ResourceDeletionRequest request, final BrokerDeleteResourceRequest brokerRequest) {
+      final ResourceDeletionRequest request,
+      final BrokerDeleteResourceRequest brokerRequest,
+      final String physicalTenantId) {
     if (request.deleteHistory()) {
       final var processDefinition =
           processDefinitionSearchClient
               .withSecurityContext(
                   securityContextProvider.provideSecurityContext(CamundaAuthentication.anonymous()))
+              .withPhysicalTenant(physicalTenantId)
               .searchProcessDefinitions(
                   processDefinitionSearchQuery()
                       .filter(f -> f.processDefinitionKeys(request.resourceKey()))
@@ -116,6 +122,7 @@ public final class ResourceServices extends ApiServices<ResourceServices> {
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
                         CamundaAuthentication.anonymous()))
+                .withPhysicalTenant(physicalTenantId)
                 .searchDecisionRequirements(
                     decisionRequirementsSearchQuery()
                         .filter(f -> f.decisionRequirementsKeys(request.resourceKey()))
@@ -132,29 +139,37 @@ public final class ResourceServices extends ApiServices<ResourceServices> {
   }
 
   public CompletableFuture<DeployedResourceEntity> getByKey(
-      final long resourceKey, final CamundaAuthentication authentication) {
-    return fetchDeployedResource(resourceKey, authentication, false, null);
+      final long resourceKey,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
+    return fetchDeployedResource(resourceKey, authentication, false, null, physicalTenantId);
   }
 
   public CompletableFuture<DeployedResourceEntity> getContentByKey(
-      final long resourceKey, final CamundaAuthentication authentication) {
-    return fetchDeployedResource(resourceKey, authentication, true, null);
+      final long resourceKey,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
+    return fetchDeployedResource(resourceKey, authentication, true, null, physicalTenantId);
   }
 
   public CompletableFuture<DeployedResourceEntity> getContentByKeyFilteredByType(
       final long resourceKey,
       final String resourceType,
-      final CamundaAuthentication authentication) {
-    return fetchDeployedResource(resourceKey, authentication, true, resourceType);
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
+    return fetchDeployedResource(resourceKey, authentication, true, resourceType, physicalTenantId);
   }
 
   public SearchQueryResult<DeployedResourceEntity> search(
-      final DeployedResourceQuery query, final CamundaAuthentication authentication) {
+      final DeployedResourceQuery query,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     try {
       return deployedResourceSearchClient
           .withSecurityContext(
               securityContextProvider.provideSecurityContext(
                   authentication, RESOURCE_READ_AUTHORIZATION))
+          .withPhysicalTenant(physicalTenantId)
           .searchDeployedResources(query);
     } catch (final CamundaSearchException e) {
       throw ErrorMapper.mapSearchError(e);
@@ -165,10 +180,11 @@ public final class ResourceServices extends ApiServices<ResourceServices> {
       final long resourceKey,
       final CamundaAuthentication authentication,
       final boolean includeContent,
-      final String resourceTypeFilter) {
+      final String resourceTypeFilter,
+      final String physicalTenantId) {
     if (secondaryStorageEnabled) {
       return fetchFromSecondaryStorage(
-          resourceKey, authentication, includeContent, resourceTypeFilter);
+          resourceKey, authentication, includeContent, resourceTypeFilter, physicalTenantId);
     }
     return fetchFromBroker(resourceKey, authentication, includeContent, resourceTypeFilter);
   }
@@ -177,7 +193,8 @@ public final class ResourceServices extends ApiServices<ResourceServices> {
       final long resourceKey,
       final CamundaAuthentication authentication,
       final boolean includeContent,
-      final String resourceTypeFilter) {
+      final String resourceTypeFilter,
+      final String physicalTenantId) {
     final var securityContext =
         securityContextProvider.provideSecurityContext(
             authentication,
@@ -185,7 +202,10 @@ public final class ResourceServices extends ApiServices<ResourceServices> {
     return CompletableFuture.supplyAsync(
         () -> {
           try {
-            final var client = deployedResourceSearchClient.withSecurityContext(securityContext);
+            final var client =
+                deployedResourceSearchClient
+                    .withSecurityContext(securityContext)
+                    .withPhysicalTenant(physicalTenantId);
             final DeployedResourceEntity entity =
                 includeContent
                     ? client.getDeployedResource(resourceKey)

--- a/service/src/main/java/io/camunda/service/RoleServices.java
+++ b/service/src/main/java/io/camunda/service/RoleServices.java
@@ -53,53 +53,64 @@ public class RoleServices extends SearchQueryService<RoleServices, RoleQuery, Ro
 
   @Override
   public SearchQueryResult<RoleEntity> search(
-      final RoleQuery query, final CamundaAuthentication authentication) {
+      final RoleQuery query,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             roleSearchClient
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
                         authentication, ROLE_READ_AUTHORIZATION))
+                .withPhysicalTenant(physicalTenantId)
                 .searchRoles(query));
   }
 
   public SearchQueryResult<RoleMemberEntity> searchMembers(
-      final RoleMemberQuery query, final CamundaAuthentication authentication) {
+      final RoleMemberQuery query,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             roleSearchClient
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
                         authentication, ROLE_READ_AUTHORIZATION))
+                .withPhysicalTenant(physicalTenantId)
                 .searchRoleMembers(query));
   }
 
   public boolean hasMembersOfType(
       final String roleId,
       final EntityType entityType,
-      final CamundaAuthentication authentication) {
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     final var query =
         RoleMemberQuery.of(
             builder -> builder.filter(filter -> filter.roleId(roleId).memberType(entityType)));
-    final var members = searchMembers(query, authentication);
+    final var members = searchMembers(query, authentication, physicalTenantId);
     return members.total() > 0;
   }
 
   public List<RoleEntity> getRolesByMemberTypeAndMemberIds(
       final Map<EntityType, Set<String>> memberTypesToMemberIds,
-      final CamundaAuthentication authentication) {
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return search(
             RoleQuery.of(
                 roleQuery ->
                     roleQuery
                         .filter(roleFilter -> roleFilter.memberIdsByType(memberTypesToMemberIds))
                         .unlimited()),
-            authentication)
+            authentication,
+            physicalTenantId)
         .items();
   }
 
   public CompletableFuture<RoleRecord> createRole(
-      final CreateRoleRequest request, final CamundaAuthentication authentication) {
+      final CreateRoleRequest request,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return sendBrokerRequest(
         new BrokerRoleCreateRequest()
             .setRoleId(request.roleId())
@@ -109,7 +120,9 @@ public class RoleServices extends SearchQueryService<RoleServices, RoleQuery, Ro
   }
 
   public CompletableFuture<RoleRecord> updateRole(
-      final UpdateRoleRequest updateRoleRequest, final CamundaAuthentication authentication) {
+      final UpdateRoleRequest updateRoleRequest,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return sendBrokerRequest(
         new BrokerRoleUpdateRequest(updateRoleRequest.roleId())
             .setName(updateRoleRequest.name())
@@ -117,23 +130,31 @@ public class RoleServices extends SearchQueryService<RoleServices, RoleQuery, Ro
         authentication);
   }
 
-  public RoleEntity getRole(final String roleId, final CamundaAuthentication authentication) {
+  public RoleEntity getRole(
+      final String roleId,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             roleSearchClient
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
                         authentication, withAuthorization(ROLE_READ_AUTHORIZATION, roleId)))
+                .withPhysicalTenant(physicalTenantId)
                 .getRole(roleId));
   }
 
   public CompletableFuture<RoleRecord> deleteRole(
-      final String roleId, final CamundaAuthentication authentication) {
+      final String roleId,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return sendBrokerRequest(new BrokerRoleDeleteRequest(roleId), authentication);
   }
 
   public CompletableFuture<?> addMember(
-      final RoleMemberRequest request, final CamundaAuthentication authentication) {
+      final RoleMemberRequest request,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return sendBrokerRequest(
         BrokerRoleEntityRequest.createAddRequest()
             .setRoleId(request.roleId())
@@ -142,7 +163,9 @@ public class RoleServices extends SearchQueryService<RoleServices, RoleQuery, Ro
   }
 
   public CompletableFuture<?> removeMember(
-      final RoleMemberRequest request, final CamundaAuthentication authentication) {
+      final RoleMemberRequest request,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return sendBrokerRequest(
         BrokerRoleEntityRequest.createRemoveRequest()
             .setRoleId(request.roleId())

--- a/service/src/main/java/io/camunda/service/SignalServices.java
+++ b/service/src/main/java/io/camunda/service/SignalServices.java
@@ -35,7 +35,8 @@ public class SignalServices extends ApiServices<SignalServices> {
       final String signalName,
       final Map<String, Object> variables,
       final String tenantId,
-      final CamundaAuthentication authentication) {
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return sendBrokerRequestWithFullResponse(
         new BrokerBroadcastSignalRequest(signalName)
             .setVariables(getDocumentOrEmpty(variables))

--- a/service/src/main/java/io/camunda/service/TenantServices.java
+++ b/service/src/main/java/io/camunda/service/TenantServices.java
@@ -55,29 +55,37 @@ public class TenantServices extends SearchQueryService<TenantServices, TenantQue
 
   @Override
   public SearchQueryResult<TenantEntity> search(
-      final TenantQuery query, final CamundaAuthentication authentication) {
+      final TenantQuery query,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             tenantSearchClient
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
                         authentication, TENANT_READER_AUTHORIZATION))
+                .withPhysicalTenant(physicalTenantId)
                 .searchTenants(query));
   }
 
   public SearchQueryResult<TenantMemberEntity> searchMembers(
-      final TenantMemberQuery query, final CamundaAuthentication authentication) {
+      final TenantMemberQuery query,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             tenantSearchClient
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
                         authentication, TENANT_READER_AUTHORIZATION))
+                .withPhysicalTenant(physicalTenantId)
                 .searchTenantMembers(query));
   }
 
   public CompletableFuture<TenantRecord> createTenant(
-      final TenantRequest request, final CamundaAuthentication authentication) {
+      final TenantRequest request,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return sendBrokerRequest(
         new BrokerTenantCreateRequest()
             .setTenantId(request.tenantId())
@@ -87,7 +95,9 @@ public class TenantServices extends SearchQueryService<TenantServices, TenantQue
   }
 
   public CompletableFuture<TenantRecord> updateTenant(
-      final TenantRequest request, final CamundaAuthentication authentication) {
+      final TenantRequest request,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     final var rejection = rejectIfDefaultTenant(request.tenantId(), "update");
     if (rejection != null) {
       return rejection;
@@ -100,7 +110,9 @@ public class TenantServices extends SearchQueryService<TenantServices, TenantQue
   }
 
   public CompletableFuture<TenantRecord> deleteTenant(
-      final String tenantId, final CamundaAuthentication authentication) {
+      final String tenantId,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     final var rejection = rejectIfDefaultTenant(tenantId, "delete");
     if (rejection != null) {
       return rejection;
@@ -109,7 +121,9 @@ public class TenantServices extends SearchQueryService<TenantServices, TenantQue
   }
 
   public CompletableFuture<TenantRecord> addMember(
-      final TenantMemberRequest request, final CamundaAuthentication authentication) {
+      final TenantMemberRequest request,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return sendBrokerRequest(
         BrokerTenantEntityRequest.createAddRequest()
             .setTenantId(request.tenantId())
@@ -118,7 +132,9 @@ public class TenantServices extends SearchQueryService<TenantServices, TenantQue
   }
 
   public CompletableFuture<TenantRecord> removeMember(
-      final TenantMemberRequest request, final CamundaAuthentication authentication) {
+      final TenantMemberRequest request,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return sendBrokerRequest(
         BrokerTenantEntityRequest.createRemoveRequest()
             .setTenantId(request.tenantId())
@@ -140,15 +156,20 @@ public class TenantServices extends SearchQueryService<TenantServices, TenantQue
 
   public List<TenantEntity> getTenantsByMemberTypeAndMemberIds(
       final Map<EntityType, Set<String>> memberTypesToMemberIds,
-      final CamundaAuthentication authentication) {
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return search(
             TenantQuery.of(
                 q -> q.filter(f -> f.memberIdsByType(memberTypesToMemberIds)).unlimited()),
-            authentication)
+            authentication,
+            physicalTenantId)
         .items();
   }
 
-  public TenantEntity getById(final String tenantId, final CamundaAuthentication authentication) {
+  public TenantEntity getById(
+      final String tenantId,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             tenantSearchClient
@@ -156,6 +177,7 @@ public class TenantServices extends SearchQueryService<TenantServices, TenantQue
                     securityContextProvider.provideSecurityContext(
                         authentication,
                         Authorization.withAuthorization(TENANT_READER_AUTHORIZATION, tenantId)))
+                .withPhysicalTenant(physicalTenantId)
                 .getTenant(tenantId));
   }
 

--- a/service/src/main/java/io/camunda/service/UsageMetricsServices.java
+++ b/service/src/main/java/io/camunda/service/UsageMetricsServices.java
@@ -47,14 +47,19 @@ public final class UsageMetricsServices
 
   @Override
   public SearchQueryResult<Tuple<UsageMetricStatisticsEntity, UsageMetricTUStatisticsEntity>>
-      search(final UsageMetricsQuery query, final CamundaAuthentication authentication) {
+      search(
+          final UsageMetricsQuery query,
+          final CamundaAuthentication authentication,
+          final String physicalTenantId) {
     if (query == null) {
       throw new IllegalArgumentException("Query must not be null");
     }
     final UsageMetricsSearchClient authUsageMetricsSearchClient =
-        usageMetricsSearchClient.withSecurityContext(
-            securityContextProvider.provideSecurityContext(
-                authentication, Authorization.of(a -> a.system().readUsageMetric())));
+        usageMetricsSearchClient
+            .withSecurityContext(
+                securityContextProvider.provideSecurityContext(
+                    authentication, Authorization.of(a -> a.system().readUsageMetric())))
+            .withPhysicalTenant(physicalTenantId);
 
     final CompletableFuture<UsageMetricStatisticsEntity> statsFuture =
         CompletableFuture.supplyAsync(

--- a/service/src/main/java/io/camunda/service/UserServices.java
+++ b/service/src/main/java/io/camunda/service/UserServices.java
@@ -51,18 +51,23 @@ public class UserServices extends SearchQueryService<UserServices, UserQuery, Us
 
   @Override
   public SearchQueryResult<UserEntity> search(
-      final UserQuery query, final CamundaAuthentication authentication) {
+      final UserQuery query,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             userSearchClient
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
                         authentication, USER_READ_AUTHORIZATION))
+                .withPhysicalTenant(physicalTenantId)
                 .searchUsers(query));
   }
 
   public CompletableFuture<UserRecord> createUser(
-      final UserDTO request, final CamundaAuthentication authentication) {
+      final UserDTO request,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     final String encodedPassword = passwordEncoder.encode(request.password());
     return sendBrokerRequest(
         new BrokerUserCreateRequest()
@@ -74,7 +79,9 @@ public class UserServices extends SearchQueryService<UserServices, UserQuery, Us
   }
 
   public CompletableFuture<UserRecord> createInitialAdminUser(
-      final UserDTO request, final CamundaAuthentication authentication) {
+      final UserDTO request,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     final String encodedPassword = passwordEncoder.encode(request.password());
     return sendBrokerRequest(
         new BrokerUserCreateRequest(UserIntent.CREATE_INITIAL_ADMIN)
@@ -85,18 +92,24 @@ public class UserServices extends SearchQueryService<UserServices, UserQuery, Us
         authentication);
   }
 
-  public UserEntity getUser(final String username, final CamundaAuthentication authentication) {
+  public UserEntity getUser(
+      final String username,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             userSearchClient
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
                         authentication, withAuthorization(USER_READ_AUTHORIZATION, username)))
+                .withPhysicalTenant(physicalTenantId)
                 .getUser(username));
   }
 
   public CompletableFuture<UserRecord> updateUser(
-      final UserDTO request, final CamundaAuthentication authentication) {
+      final UserDTO request,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     final String encodedPassword =
         StringUtils.isEmpty(request.password) ? "" : passwordEncoder.encode(request.password());
     return sendBrokerRequest(
@@ -109,7 +122,9 @@ public class UserServices extends SearchQueryService<UserServices, UserQuery, Us
   }
 
   public CompletableFuture<UserRecord> deleteUser(
-      final String username, final CamundaAuthentication authentication) {
+      final String username,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return sendBrokerRequest(new BrokerUserDeleteRequest().setUsername(username), authentication);
   }
 

--- a/service/src/main/java/io/camunda/service/UserTaskServices.java
+++ b/service/src/main/java/io/camunda/service/UserTaskServices.java
@@ -130,17 +130,26 @@ public final class UserTaskServices
 
   @Override
   public SearchQueryResult<UserTaskEntity> search(
-      final UserTaskQuery query, final CamundaAuthentication authentication) {
+      final UserTaskQuery query,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return search(
         query,
-        securityContextProvider.provideSecurityContext(authentication, USER_TASK_AUTHORIZATIONS));
+        securityContextProvider.provideSecurityContext(authentication, USER_TASK_AUTHORIZATIONS),
+        physicalTenantId);
   }
 
   private SearchQueryResult<UserTaskEntity> search(
-      final UserTaskQuery query, final SecurityContext securityContext) {
+      final UserTaskQuery query,
+      final SecurityContext securityContext,
+      final String physicalTenantId) {
     final var result =
         executeSearchRequest(
-            () -> userTaskSearchClient.withSecurityContext(securityContext).searchUserTasks(query));
+            () ->
+                userTaskSearchClient
+                    .withSecurityContext(securityContext)
+                    .withPhysicalTenant(physicalTenantId)
+                    .searchUserTasks(query));
 
     return toCacheEnrichedResult(result);
   }
@@ -184,8 +193,9 @@ public final class UserTaskServices
 
   public SearchQueryResult<UserTaskEntity> search(
       final Function<Builder, ObjectBuilder<UserTaskQuery>> fn,
-      final CamundaAuthentication authentication) {
-    return search(userTaskSearchQuery(fn), authentication);
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
+    return search(userTaskSearchQuery(fn), authentication, physicalTenantId);
   }
 
   public CompletableFuture<UserTaskRecord> assignUserTask(
@@ -193,7 +203,8 @@ public final class UserTaskServices
       final String assignee,
       final String action,
       final boolean allowOverride,
-      final CamundaAuthentication authentication) {
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return sendBrokerRequest(
         new BrokerUserTaskAssignmentRequest(
             userTaskKey,
@@ -207,7 +218,8 @@ public final class UserTaskServices
       final long userTaskKey,
       final Map<String, Object> variables,
       final String action,
-      final CamundaAuthentication authentication) {
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return sendBrokerRequest(
         new BrokerUserTaskCompletionRequest(
             userTaskKey, getDocumentOrEmpty(variables), action, maxVariableNameLength),
@@ -215,7 +227,10 @@ public final class UserTaskServices
   }
 
   public CompletableFuture<UserTaskRecord> unassignUserTask(
-      final long userTaskKey, final String action, final CamundaAuthentication authentication) {
+      final long userTaskKey,
+      final String action,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return sendBrokerRequest(
         new BrokerUserTaskAssignmentRequest(userTaskKey, "", action, UserTaskIntent.ASSIGN),
         authentication);
@@ -225,13 +240,16 @@ public final class UserTaskServices
       final long userTaskKey,
       final UserTaskRecord changeset,
       final String action,
-      final CamundaAuthentication authentication) {
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return sendBrokerRequest(
         new BrokerUserTaskUpdateRequest(userTaskKey, changeset, action), authentication);
   }
 
   public UserTaskEntity getByKey(
-      final long userTaskKey, final CamundaAuthentication authentication) {
+      final long userTaskKey,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     final var result =
         executeSearchRequest(
             () ->
@@ -239,6 +257,7 @@ public final class UserTaskServices
                     .withSecurityContext(
                         securityContextProvider.provideSecurityContext(
                             authentication, USER_TASK_AUTHORIZATIONS))
+                    .withPhysicalTenant(physicalTenantId)
                     .getUserTask(userTaskKey));
 
     final var cachedItem = processCache.getCacheItem(result.processDefinitionKey());
@@ -246,22 +265,28 @@ public final class UserTaskServices
   }
 
   public Optional<FormEntity> getUserTaskForm(
-      final long userTaskKey, final CamundaAuthentication authentication) {
-    return Optional.ofNullable(getByKey(userTaskKey, authentication))
+      final long userTaskKey,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
+    return Optional.ofNullable(getByKey(userTaskKey, authentication, physicalTenantId))
         .map(UserTaskEntity::formKey)
-        .map(formKey -> formServices.getByKey(formKey, CamundaAuthentication.anonymous()));
+        .map(
+            formKey ->
+                formServices.getByKey(
+                    formKey, CamundaAuthentication.anonymous(), physicalTenantId));
   }
 
   public SearchQueryResult<VariableEntity> searchUserTaskVariables(
       final long userTaskKey,
       final VariableQuery variableQuery,
-      final CamundaAuthentication authentication) {
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
 
     // Fetch the user task by key
-    final var userTask = getByKey(userTaskKey, authentication);
+    final var userTask = getByKey(userTaskKey, authentication, physicalTenantId);
 
     // Retrieve the tree path for the flow node instance associated to the user task
-    final String treePath = fetchFlowNodeTreePath(userTask.elementInstanceKey());
+    final String treePath = fetchFlowNodeTreePath(userTask.elementInstanceKey(), physicalTenantId);
 
     // Convert the tree path to a list of scope keys
     final List<Long> treePathList =
@@ -281,17 +306,20 @@ public final class UserTaskServices
     return executeSearchRequest(
         () ->
             variableServices.search(
-                variableQueryWithTreePathFilter, CamundaAuthentication.anonymous()));
+                variableQueryWithTreePathFilter,
+                CamundaAuthentication.anonymous(),
+                physicalTenantId));
   }
 
   public SearchQueryResult<VariableEntity> searchUserTaskEffectiveVariables(
       final long userTaskKey,
       final VariableQuery variableQuery,
-      final CamundaAuthentication authentication) {
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
 
-    final var userTask = getByKey(userTaskKey, authentication);
+    final var userTask = getByKey(userTaskKey, authentication, physicalTenantId);
 
-    final String treePath = fetchFlowNodeTreePath(userTask.elementInstanceKey());
+    final String treePath = fetchFlowNodeTreePath(userTask.elementInstanceKey(), physicalTenantId);
 
     final List<Long> treePathList =
         treePath != null
@@ -303,7 +331,8 @@ public final class UserTaskServices
     // searchUserTaskVariables, but strip cursors since this endpoint does not support
     // cursor-based pagination (in the general case, we perform in-memory deduplication).
     if (treePathList.size() <= 1) {
-      final var result = searchUserTaskVariables(userTaskKey, variableQuery, authentication);
+      final var result =
+          searchUserTaskVariables(userTaskKey, variableQuery, authentication, physicalTenantId);
       return new SearchQueryResult<>(
           result.total(), result.hasMoreTotalItems(), result.items(), null, null);
     }
@@ -317,7 +346,9 @@ public final class UserTaskServices
 
     final var allVariables =
         executeSearchRequest(
-            () -> variableServices.search(unlimitedQuery, CamundaAuthentication.anonymous()));
+            () ->
+                variableServices.search(
+                    unlimitedQuery, CamundaAuthentication.anonymous(), physicalTenantId));
 
     // Deduplicate variables by name, keeping the one from the innermost scope.
     // Since this is a sorted result set by the user's criteria, we iterate through
@@ -385,8 +416,10 @@ public final class UserTaskServices
   public SearchQueryResult<AuditLogEntity> searchUserTaskAuditLogs(
       final long userTaskKey,
       final AuditLogQuery auditLogQuery,
-      final CamundaAuthentication authentication) {
-    getByKey(userTaskKey, authentication); // Ensure user task exists and is accessible
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
+    getByKey(
+        userTaskKey, authentication, physicalTenantId); // Ensure user task exists and is accessible
 
     // Create an audit log query with user task key filter
     final var auditLogWithUserTaskKeyFilter =
@@ -400,14 +433,17 @@ public final class UserTaskServices
     return executeSearchRequest(
         () ->
             auditLogServices.search(
-                auditLogWithUserTaskKeyFilter, CamundaAuthentication.anonymous()));
+                auditLogWithUserTaskKeyFilter,
+                CamundaAuthentication.anonymous(),
+                physicalTenantId));
   }
 
-  private String fetchFlowNodeTreePath(final long flowNodeInstanceKey) {
+  private String fetchFlowNodeTreePath(
+      final long flowNodeInstanceKey, final String physicalTenantId) {
     return executeSearchRequest(
             () ->
                 elementInstanceServices.getByKey(
-                    flowNodeInstanceKey, CamundaAuthentication.anonymous()))
+                    flowNodeInstanceKey, CamundaAuthentication.anonymous(), physicalTenantId))
         .treePath();
   }
 }

--- a/service/src/main/java/io/camunda/service/UserTaskServices.java
+++ b/service/src/main/java/io/camunda/service/UserTaskServices.java
@@ -151,11 +151,11 @@ public final class UserTaskServices
                     .withPhysicalTenant(physicalTenantId)
                     .searchUserTasks(query));
 
-    return toCacheEnrichedResult(result);
+    return toCacheEnrichedResult(result, physicalTenantId);
   }
 
   private SearchQueryResult<UserTaskEntity> toCacheEnrichedResult(
-      final SearchQueryResult<UserTaskEntity> result) {
+      final SearchQueryResult<UserTaskEntity> result, final String physicalTenantId) {
 
     final var processDefinitionKeys =
         result.items().stream()
@@ -167,7 +167,7 @@ public final class UserTaskServices
       return result;
     }
 
-    final var cacheResult = processCache.getCacheItems(processDefinitionKeys);
+    final var cacheResult = processCache.getCacheItems(processDefinitionKeys, physicalTenantId);
 
     return result.withItems(
         result.items().stream()
@@ -260,7 +260,8 @@ public final class UserTaskServices
                     .withPhysicalTenant(physicalTenantId)
                     .getUserTask(userTaskKey));
 
-    final var cachedItem = processCache.getCacheItem(result.processDefinitionKey());
+    final var cachedItem =
+        processCache.getCacheItem(result.processDefinitionKey(), physicalTenantId);
     return toCacheEnrichedUserTaskEntity(result, cachedItem);
   }
 

--- a/service/src/main/java/io/camunda/service/VariableServices.java
+++ b/service/src/main/java/io/camunda/service/VariableServices.java
@@ -41,17 +41,21 @@ public final class VariableServices
 
   @Override
   public SearchQueryResult<VariableEntity> search(
-      final VariableQuery query, final CamundaAuthentication authentication) {
+      final VariableQuery query,
+      final CamundaAuthentication authentication,
+      final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             variableSearchClient
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
                         authentication, VARIABLE_READ_AUTHORIZATION))
+                .withPhysicalTenant(physicalTenantId)
                 .searchVariables(query));
   }
 
-  public VariableEntity getByKey(final Long key, final CamundaAuthentication authentication) {
+  public VariableEntity getByKey(
+      final Long key, final CamundaAuthentication authentication, final String physicalTenantId) {
     return executeSearchRequest(
         () ->
             variableSearchClient
@@ -60,6 +64,7 @@ public final class VariableServices
                         authentication,
                         withAuthorization(
                             VARIABLE_READ_AUTHORIZATION, VariableEntity::processDefinitionId)))
+                .withPhysicalTenant(physicalTenantId)
                 .getVariable(key));
   }
 }

--- a/service/src/main/java/io/camunda/service/cache/ProcessCache.java
+++ b/service/src/main/java/io/camunda/service/cache/ProcessCache.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.util.cache.CaffeineCacheStatsCounter;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -26,49 +27,64 @@ import org.slf4j.LoggerFactory;
  * Process cache uses a Caffeine {@link LoadingCache} to store process definition key and {@link
  * ProcessCacheItem} entries.
  *
- * <p>Use the {@link ProcessCache#getCacheItem(long)} method to load one item or the {@link
- * ProcessCache#getCacheItems(Set)} method to load multiple cache items at once.
+ * <p>Use the {@link ProcessCache#getCacheItem(long, String)} method to load one item or the {@link
+ * ProcessCache#getCacheItems(Set, String)} method to load multiple cache items at once.
  */
 public class ProcessCache {
 
   public static final String NAMESPACE = "camunda.gateway.rest.cache";
   private static final Logger LOGGER = LoggerFactory.getLogger(ProcessCache.class);
-  private final LoadingCache<Long, ProcessCacheItem> cache;
+  private final ConcurrentHashMap<String, LoadingCache<Long, ProcessCacheItem>>
+      cachesByPhysicalTenant;
   private final ProcessDefinitionProvider processDefinitionProvider;
+  private final Configuration configuration;
+  private final CaffeineCacheStatsCounter statsCounter;
 
   public ProcessCache(
       final Configuration configuration,
       final ProcessDefinitionServices processDefinitionServices,
       final BrokerTopologyManager brokerTopologyManager,
       final MeterRegistry meterRegistry) {
+    this.configuration = configuration;
     processDefinitionProvider = new ProcessDefinitionProvider(processDefinitionServices);
+    cachesByPhysicalTenant = new ConcurrentHashMap<>();
+    statsCounter = new CaffeineCacheStatsCounter(NAMESPACE, "process", meterRegistry);
 
-    final var statsCounter = new CaffeineCacheStatsCounter(NAMESPACE, "process", meterRegistry);
+    brokerTopologyManager.addTopologyListener(new ProcessCacheInvalidator(this));
+  }
+
+  public ProcessCacheItem getCacheItem(
+      final long processDefinitionKey, final String physicalTenantId) {
+    return getOrCreateTenantCache(physicalTenantId).get(processDefinitionKey);
+  }
+
+  public ProcessCacheResult getCacheItems(
+      final Set<Long> processDefinitionKeys, final String physicalTenantId) {
+    return new ProcessCacheResult(
+        getOrCreateTenantCache(physicalTenantId).getAll(processDefinitionKeys));
+  }
+
+  public void invalidate() {
+    cachesByPhysicalTenant.values().forEach(LoadingCache::invalidateAll);
+  }
+
+  public LoadingCache<Long, ProcessCacheItem> getRawCache(final String physicalTenantId) {
+    return getOrCreateTenantCache(physicalTenantId);
+  }
+
+  private LoadingCache<Long, ProcessCacheItem> getOrCreateTenantCache(
+      final String physicalTenantId) {
+    return cachesByPhysicalTenant.computeIfAbsent(physicalTenantId, this::buildTenantCache);
+  }
+
+  private LoadingCache<Long, ProcessCacheItem> buildTenantCache(final String physicalTenantId) {
     final var cacheBuilder =
         Caffeine.newBuilder().maximumSize(configuration.maxSize()).recordStats(() -> statsCounter);
     final var expirationIdle = configuration.expirationIdleMillis();
     if (expirationIdle != null && expirationIdle > 0) {
       cacheBuilder.expireAfterAccess(expirationIdle, TimeUnit.MILLISECONDS);
     }
-    cache = cacheBuilder.build(new ProcessCacheLoader());
-
-    brokerTopologyManager.addTopologyListener(new ProcessCacheInvalidator(this));
-  }
-
-  public ProcessCacheItem getCacheItem(final long processDefinitionKey) {
-    return cache.get(processDefinitionKey);
-  }
-
-  public ProcessCacheResult getCacheItems(final Set<Long> processDefinitionKeys) {
-    return new ProcessCacheResult(cache.getAll(processDefinitionKeys));
-  }
-
-  public void invalidate() {
-    cache.invalidateAll();
-  }
-
-  public LoadingCache<Long, ProcessCacheItem> getRawCache() {
-    return cache;
+    return cacheBuilder.build(new ProcessCacheLoader(physicalTenantId));
   }
 
   public record Configuration(long maxSize, Long expirationIdleMillis) {
@@ -79,16 +95,24 @@ public class ProcessCache {
 
   private final class ProcessCacheLoader implements CacheLoader<Long, ProcessCacheItem> {
 
+    private final String physicalTenantId;
+
+    ProcessCacheLoader(final String physicalTenantId) {
+      this.physicalTenantId = physicalTenantId;
+    }
+
     @Override
     public ProcessCacheItem load(final Long processDefinitionKey) {
-      final var processData = processDefinitionProvider.extractProcessData(processDefinitionKey);
+      final var processData =
+          processDefinitionProvider.extractProcessData(processDefinitionKey, physicalTenantId);
       return ProcessCacheItem.from(processData);
     }
 
     @Override
     public Map<Long, ProcessCacheItem> loadAll(final Set<? extends Long> processDefinitionKeys) {
       final var processDataMap =
-          processDefinitionProvider.extractProcessData((Set<Long>) processDefinitionKeys);
+          processDefinitionProvider.extractProcessData(
+              (Set<Long>) processDefinitionKeys, physicalTenantId);
       return processDataMap.entrySet().stream()
           .collect(
               Collectors.toMap(

--- a/service/src/main/java/io/camunda/service/cache/ProcessCache.java
+++ b/service/src/main/java/io/camunda/service/cache/ProcessCache.java
@@ -14,7 +14,9 @@ import io.camunda.service.ProcessDefinitionServices;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyListener;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import io.camunda.zeebe.util.cache.CaffeineCacheStatsCounter;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -34,11 +36,12 @@ public class ProcessCache {
 
   public static final String NAMESPACE = "camunda.gateway.rest.cache";
   private static final Logger LOGGER = LoggerFactory.getLogger(ProcessCache.class);
+  private static final String PHYSICAL_TENANT_ID_TAG = "physicalTenantId";
   private final ConcurrentHashMap<String, LoadingCache<Long, ProcessCacheItem>>
       cachesByPhysicalTenant;
   private final ProcessDefinitionProvider processDefinitionProvider;
   private final Configuration configuration;
-  private final CaffeineCacheStatsCounter statsCounter;
+  private final MeterRegistry meterRegistry;
 
   public ProcessCache(
       final Configuration configuration,
@@ -48,7 +51,7 @@ public class ProcessCache {
     this.configuration = configuration;
     processDefinitionProvider = new ProcessDefinitionProvider(processDefinitionServices);
     cachesByPhysicalTenant = new ConcurrentHashMap<>();
-    statsCounter = new CaffeineCacheStatsCounter(NAMESPACE, "process", meterRegistry);
+    this.meterRegistry = meterRegistry;
 
     brokerTopologyManager.addTopologyListener(new ProcessCacheInvalidator(this));
   }
@@ -78,8 +81,14 @@ public class ProcessCache {
   }
 
   private LoadingCache<Long, ProcessCacheItem> buildTenantCache(final String physicalTenantId) {
+    final var tenantRegistry =
+        MicrometerUtil.wrap(meterRegistry, Tags.of(PHYSICAL_TENANT_ID_TAG, physicalTenantId));
+    final var tenantStatsCounter =
+        new CaffeineCacheStatsCounter(NAMESPACE, "process", tenantRegistry);
     final var cacheBuilder =
-        Caffeine.newBuilder().maximumSize(configuration.maxSize()).recordStats(() -> statsCounter);
+        Caffeine.newBuilder()
+            .maximumSize(configuration.maxSize())
+            .recordStats(() -> tenantStatsCounter);
     final var expirationIdle = configuration.expirationIdleMillis();
     if (expirationIdle != null && expirationIdle > 0) {
       cacheBuilder.expireAfterAccess(expirationIdle, TimeUnit.MILLISECONDS);

--- a/service/src/main/java/io/camunda/service/cache/ProcessDefinitionProvider.java
+++ b/service/src/main/java/io/camunda/service/cache/ProcessDefinitionProvider.java
@@ -31,11 +31,12 @@ public class ProcessDefinitionProvider {
     this.processDefinitionServices = processDefinitionServices;
   }
 
-  public ProcessCacheData extractProcessData(final Long processDefinitionKey) {
+  public ProcessCacheData extractProcessData(
+      final Long processDefinitionKey, final String physicalTenantId) {
     try {
       final var processDefinition =
           processDefinitionServices.getByKey(
-              processDefinitionKey, CamundaAuthentication.anonymous(), "default");
+              processDefinitionKey, CamundaAuthentication.anonymous(), physicalTenantId);
       return buildCacheData(processDefinition);
     } catch (final Exception e) {
       LOG.warn(
@@ -46,7 +47,8 @@ public class ProcessDefinitionProvider {
     }
   }
 
-  public Map<Long, ProcessCacheData> extractProcessData(final Set<Long> processDefinitionKeys) {
+  public Map<Long, ProcessCacheData> extractProcessData(
+      final Set<Long> processDefinitionKeys, final String physicalTenantId) {
     if (processDefinitionKeys.isEmpty()) {
       LOG.debug("No process definition keys provided. Returning empty result.");
       return Collections.emptyMap();
@@ -64,7 +66,7 @@ public class ProcessDefinitionProvider {
                           .page(p -> p.size(keysList.size()))
                           .resultConfig(c -> c.includeXml(true))),
               CamundaAuthentication.anonymous(),
-              "default");
+              physicalTenantId);
 
       if (searchResult.total() < processDefinitionKeys.size()) {
         LOG.warn(

--- a/service/src/main/java/io/camunda/service/cache/ProcessDefinitionProvider.java
+++ b/service/src/main/java/io/camunda/service/cache/ProcessDefinitionProvider.java
@@ -35,7 +35,7 @@ public class ProcessDefinitionProvider {
     try {
       final var processDefinition =
           processDefinitionServices.getByKey(
-              processDefinitionKey, CamundaAuthentication.anonymous());
+              processDefinitionKey, CamundaAuthentication.anonymous(), "default");
       return buildCacheData(processDefinition);
     } catch (final Exception e) {
       LOG.warn(
@@ -63,7 +63,8 @@ public class ProcessDefinitionProvider {
                       q.filter(f -> f.processDefinitionKeys(keysList))
                           .page(p -> p.size(keysList.size()))
                           .resultConfig(c -> c.includeXml(true))),
-              CamundaAuthentication.anonymous());
+              CamundaAuthentication.anonymous(),
+              "default");
 
       if (searchResult.total() < processDefinitionKeys.size()) {
         LOG.warn(

--- a/service/src/main/java/io/camunda/service/search/core/SearchQueryService.java
+++ b/service/src/main/java/io/camunda/service/search/core/SearchQueryService.java
@@ -35,7 +35,7 @@ public abstract class SearchQueryService<T extends ApiServices<T>, Q extends Sea
   }
 
   public abstract SearchQueryResult<D> search(
-      final Q query, final CamundaAuthentication authentication);
+      final Q query, final CamundaAuthentication authentication, final String physicalTenantId);
 
   protected <R> R executeSearchRequest(final Supplier<R> searchRequest) {
     try {

--- a/service/src/test/java/io/camunda/service/AdHocSubProcessActivityServicesTest.java
+++ b/service/src/test/java/io/camunda/service/AdHocSubProcessActivityServicesTest.java
@@ -42,6 +42,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 public class AdHocSubProcessActivityServicesTest {
 
   private static final long AD_HOC_SUB_PROCESS_INSTANCE_KEY = 123456L;
+  private static final String PHYSICAL_TENANT_ID = "foo";
   private static final String ELEMENT_ID = "activity1";
 
   private static final AdHocSubProcessActivateActivitiesRequest DEFAULT_ACTIVATION_REQUEST =
@@ -90,7 +91,7 @@ public class AdHocSubProcessActivityServicesTest {
 
     // when
     final CompletableFuture<AdHocSubProcessInstructionRecord> result =
-        services.activateActivities(DEFAULT_ACTIVATION_REQUEST, authentication, "default");
+        services.activateActivities(DEFAULT_ACTIVATION_REQUEST, authentication, PHYSICAL_TENANT_ID);
 
     // then
     assertThat(result).isNotCompleted();
@@ -119,7 +120,9 @@ public class AdHocSubProcessActivityServicesTest {
 
     // when
     final AdHocSubProcessInstructionRecord result =
-        services.activateActivities(DEFAULT_ACTIVATION_REQUEST, authentication, "default").join();
+        services
+            .activateActivities(DEFAULT_ACTIVATION_REQUEST, authentication, PHYSICAL_TENANT_ID)
+            .join();
 
     // then
     assertThat(result).isEqualTo(expectedResponse);
@@ -143,7 +146,7 @@ public class AdHocSubProcessActivityServicesTest {
         .thenReturn(CompletableFuture.completedFuture(DEFAULT_BROKER_RESPONSE));
 
     // when
-    services.activateActivities(request, authentication, "default").join();
+    services.activateActivities(request, authentication, PHYSICAL_TENANT_ID).join();
 
     // then
     final var instruction = requestCaptor.getValue().getRequestWriter();
@@ -175,7 +178,7 @@ public class AdHocSubProcessActivityServicesTest {
         .thenReturn(CompletableFuture.completedFuture(DEFAULT_BROKER_RESPONSE));
 
     // when
-    services.activateActivities(request, authentication, "default").join();
+    services.activateActivities(request, authentication, PHYSICAL_TENANT_ID).join();
 
     // then
     final var instruction = requestCaptor.getValue().getRequestWriter();

--- a/service/src/test/java/io/camunda/service/AdHocSubProcessActivityServicesTest.java
+++ b/service/src/test/java/io/camunda/service/AdHocSubProcessActivityServicesTest.java
@@ -90,7 +90,7 @@ public class AdHocSubProcessActivityServicesTest {
 
     // when
     final CompletableFuture<AdHocSubProcessInstructionRecord> result =
-        services.activateActivities(DEFAULT_ACTIVATION_REQUEST, authentication);
+        services.activateActivities(DEFAULT_ACTIVATION_REQUEST, authentication, "default");
 
     // then
     assertThat(result).isNotCompleted();
@@ -119,7 +119,7 @@ public class AdHocSubProcessActivityServicesTest {
 
     // when
     final AdHocSubProcessInstructionRecord result =
-        services.activateActivities(DEFAULT_ACTIVATION_REQUEST, authentication).join();
+        services.activateActivities(DEFAULT_ACTIVATION_REQUEST, authentication, "default").join();
 
     // then
     assertThat(result).isEqualTo(expectedResponse);
@@ -143,7 +143,7 @@ public class AdHocSubProcessActivityServicesTest {
         .thenReturn(CompletableFuture.completedFuture(DEFAULT_BROKER_RESPONSE));
 
     // when
-    services.activateActivities(request, authentication).join();
+    services.activateActivities(request, authentication, "default").join();
 
     // then
     final var instruction = requestCaptor.getValue().getRequestWriter();
@@ -175,7 +175,7 @@ public class AdHocSubProcessActivityServicesTest {
         .thenReturn(CompletableFuture.completedFuture(DEFAULT_BROKER_RESPONSE));
 
     // when
-    services.activateActivities(request, authentication).join();
+    services.activateActivities(request, authentication, "default").join();
 
     // then
     final var instruction = requestCaptor.getValue().getRequestWriter();

--- a/service/src/test/java/io/camunda/service/AuditLogServicesTest.java
+++ b/service/src/test/java/io/camunda/service/AuditLogServicesTest.java
@@ -80,6 +80,7 @@ class AuditLogServicesTest {
     MockitoAnnotations.openMocks(this);
 
     when(auditLogSearchClient.withSecurityContext(any())).thenReturn(auditLogSearchClient);
+    when(auditLogSearchClient.withPhysicalTenant(any())).thenReturn(auditLogSearchClient);
 
     auditLogServices =
         new AuditLogServices(
@@ -99,7 +100,7 @@ class AuditLogServicesTest {
     when(query.filter()).thenReturn(FilterBuilders.auditLog().build());
 
     // when
-    final var result = auditLogServices.search(query, authentication);
+    final var result = auditLogServices.search(query, authentication, "default");
 
     // then
     assertThat(result).isEqualTo(searchResult);
@@ -117,7 +118,7 @@ class AuditLogServicesTest {
     when(auditLogSearchClient.getAuditLog(key)).thenReturn(AUDIT_LOG_ENTITY);
 
     // when
-    final var result = auditLogServices.getAuditLog(key, authentication);
+    final var result = auditLogServices.getAuditLog(key, authentication, "default");
 
     // then
     assertThat(result).isEqualTo(AUDIT_LOG_ENTITY);
@@ -132,7 +133,8 @@ class AuditLogServicesTest {
     when(query.filter()).thenReturn(FilterBuilders.auditLog().build());
 
     // when
-    final ThrowingCallable executeSearch = () -> auditLogServices.search(query, authentication);
+    final ThrowingCallable executeSearch =
+        () -> auditLogServices.search(query, authentication, "default");
 
     // then
     final var exception =
@@ -153,7 +155,7 @@ class AuditLogServicesTest {
 
     // when
     final ThrowingCallable executeGetByKey =
-        () -> auditLogServices.getAuditLog(key, authentication);
+        () -> auditLogServices.getAuditLog(key, authentication, "default");
 
     // then
     final var exception =

--- a/service/src/test/java/io/camunda/service/AuditLogServicesTest.java
+++ b/service/src/test/java/io/camunda/service/AuditLogServicesTest.java
@@ -37,6 +37,7 @@ import org.mockito.MockitoAnnotations;
 
 class AuditLogServicesTest {
 
+  private static final String PHYSICAL_TENANT_ID = "foo";
   private static final AuditLogEntity AUDIT_LOG_ENTITY =
       new AuditLogEntity.Builder()
           .auditLogKey("auditLogKey")
@@ -100,7 +101,7 @@ class AuditLogServicesTest {
     when(query.filter()).thenReturn(FilterBuilders.auditLog().build());
 
     // when
-    final var result = auditLogServices.search(query, authentication, "default");
+    final var result = auditLogServices.search(query, authentication, PHYSICAL_TENANT_ID);
 
     // then
     assertThat(result).isEqualTo(searchResult);
@@ -118,7 +119,7 @@ class AuditLogServicesTest {
     when(auditLogSearchClient.getAuditLog(key)).thenReturn(AUDIT_LOG_ENTITY);
 
     // when
-    final var result = auditLogServices.getAuditLog(key, authentication, "default");
+    final var result = auditLogServices.getAuditLog(key, authentication, PHYSICAL_TENANT_ID);
 
     // then
     assertThat(result).isEqualTo(AUDIT_LOG_ENTITY);
@@ -134,7 +135,7 @@ class AuditLogServicesTest {
 
     // when
     final ThrowingCallable executeSearch =
-        () -> auditLogServices.search(query, authentication, "default");
+        () -> auditLogServices.search(query, authentication, PHYSICAL_TENANT_ID);
 
     // then
     final var exception =
@@ -155,7 +156,7 @@ class AuditLogServicesTest {
 
     // when
     final ThrowingCallable executeGetByKey =
-        () -> auditLogServices.getAuditLog(key, authentication, "default");
+        () -> auditLogServices.getAuditLog(key, authentication, PHYSICAL_TENANT_ID);
 
     // then
     final var exception =

--- a/service/src/test/java/io/camunda/service/AuthorizationServiceTest.java
+++ b/service/src/test/java/io/camunda/service/AuthorizationServiceTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 
 public class AuthorizationServiceTest {
 
+  private static final String PHYSICAL_TENANT_ID = "foo";
   private CamundaAuthentication authentication;
   private AuthorizationServices services;
   private AuthorizationSearchClient client;
@@ -54,7 +55,7 @@ public class AuthorizationServiceTest {
     final var searchQuery = SearchQueryBuilders.authorizationSearchQuery((b) -> b.filter(filter));
 
     // when
-    final var searchQueryResult = services.search(searchQuery, authentication, "default");
+    final var searchQueryResult = services.search(searchQuery, authentication, PHYSICAL_TENANT_ID);
 
     // then
     assertThat(searchQueryResult).isEqualTo(result);
@@ -68,7 +69,7 @@ public class AuthorizationServiceTest {
 
     // when
     final var searchQueryResult =
-        services.getAuthorization(entity.authorizationKey(), authentication, "default");
+        services.getAuthorization(entity.authorizationKey(), authentication, PHYSICAL_TENANT_ID);
 
     // then
     assertThat(searchQueryResult).isEqualTo(entity);

--- a/service/src/test/java/io/camunda/service/AuthorizationServiceTest.java
+++ b/service/src/test/java/io/camunda/service/AuthorizationServiceTest.java
@@ -34,6 +34,7 @@ public class AuthorizationServiceTest {
     authentication = mock(CamundaAuthentication.class);
     client = mock(AuthorizationSearchClient.class);
     when(client.withSecurityContext(any())).thenReturn(client);
+    when(client.withPhysicalTenant(any())).thenReturn(client);
     services =
         new AuthorizationServices(
             mock(BrokerClient.class),
@@ -53,7 +54,7 @@ public class AuthorizationServiceTest {
     final var searchQuery = SearchQueryBuilders.authorizationSearchQuery((b) -> b.filter(filter));
 
     // when
-    final var searchQueryResult = services.search(searchQuery, authentication);
+    final var searchQueryResult = services.search(searchQuery, authentication, "default");
 
     // then
     assertThat(searchQueryResult).isEqualTo(result);
@@ -67,7 +68,7 @@ public class AuthorizationServiceTest {
 
     // when
     final var searchQueryResult =
-        services.getAuthorization(entity.authorizationKey(), authentication);
+        services.getAuthorization(entity.authorizationKey(), authentication, "default");
 
     // then
     assertThat(searchQueryResult).isEqualTo(entity);

--- a/service/src/test/java/io/camunda/service/DecisionDefinitionServiceTest.java
+++ b/service/src/test/java/io/camunda/service/DecisionDefinitionServiceTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Test;
 
 public final class DecisionDefinitionServiceTest {
 
+  private static final String PHYSICAL_TENANT_ID = "foo";
   private CamundaAuthentication authentication;
   private DecisionDefinitionServices services;
   private DecisionDefinitionSearchClient client;
@@ -68,7 +69,7 @@ public final class DecisionDefinitionServiceTest {
 
     // when
     final SearchQueryResult<DecisionDefinitionEntity> searchQueryResult =
-        services.search(searchQuery, authentication, "default");
+        services.search(searchQuery, authentication, PHYSICAL_TENANT_ID);
 
     // then
     assertThat(searchQueryResult).isEqualTo(result);
@@ -85,7 +86,7 @@ public final class DecisionDefinitionServiceTest {
         .thenReturn("<foo>bar</foo>");
 
     // when
-    final var xml = services.getDecisionDefinitionXml(42L, authentication, "default");
+    final var xml = services.getDecisionDefinitionXml(42L, authentication, PHYSICAL_TENANT_ID);
 
     // then
     assertThat(xml).isEqualTo("<foo>bar</foo>");
@@ -103,7 +104,7 @@ public final class DecisionDefinitionServiceTest {
 
     // when
     final DecisionDefinitionEntity decisionDefinition =
-        services.getByKey(42L, authentication, "default");
+        services.getByKey(42L, authentication, PHYSICAL_TENANT_ID);
 
     // then
     assertThat(decisionDefinition.decisionDefinitionKey()).isEqualTo(42L);
@@ -122,7 +123,8 @@ public final class DecisionDefinitionServiceTest {
                 Authorizations.DECISION_DEFINITION_READ_AUTHORIZATION));
 
     // when
-    final ThrowingCallable executable = () -> services.getByKey(1L, authentication, "default");
+    final ThrowingCallable executable =
+        () -> services.getByKey(1L, authentication, PHYSICAL_TENANT_ID);
 
     // then
     final var exception =
@@ -146,7 +148,7 @@ public final class DecisionDefinitionServiceTest {
 
     // when
     final ThrowingCallable executable =
-        () -> services.getDecisionDefinitionXml(1L, authentication, "default");
+        () -> services.getDecisionDefinitionXml(1L, authentication, PHYSICAL_TENANT_ID);
 
     // then
     final var exception =

--- a/service/src/test/java/io/camunda/service/DecisionDefinitionServiceTest.java
+++ b/service/src/test/java/io/camunda/service/DecisionDefinitionServiceTest.java
@@ -46,6 +46,7 @@ public final class DecisionDefinitionServiceTest {
     client = mock(DecisionDefinitionSearchClient.class);
     decisionRequirementServices = mock(DecisionRequirementsServices.class);
     when(client.withSecurityContext(any())).thenReturn(client);
+    when(client.withPhysicalTenant(any())).thenReturn(client);
     services =
         new DecisionDefinitionServices(
             mock(BrokerClient.class),
@@ -67,7 +68,7 @@ public final class DecisionDefinitionServiceTest {
 
     // when
     final SearchQueryResult<DecisionDefinitionEntity> searchQueryResult =
-        services.search(searchQuery, authentication);
+        services.search(searchQuery, authentication, "default");
 
     // then
     assertThat(searchQueryResult).isEqualTo(result);
@@ -80,11 +81,11 @@ public final class DecisionDefinitionServiceTest {
     when(definitionEntity.decisionRequirementsKey()).thenReturn(42L);
     when(definitionEntity.decisionDefinitionId()).thenReturn("decId");
     when(client.getDecisionDefinition(eq(42L))).thenReturn(definitionEntity);
-    when(decisionRequirementServices.getDecisionRequirementsXml(any(Long.class), any()))
+    when(decisionRequirementServices.getDecisionRequirementsXml(any(Long.class), any(), any()))
         .thenReturn("<foo>bar</foo>");
 
     // when
-    final var xml = services.getDecisionDefinitionXml(42L, authentication);
+    final var xml = services.getDecisionDefinitionXml(42L, authentication, "default");
 
     // then
     assertThat(xml).isEqualTo("<foo>bar</foo>");
@@ -101,7 +102,8 @@ public final class DecisionDefinitionServiceTest {
     when(client.getDecisionDefinition(eq(42L))).thenReturn(definitionEntity);
 
     // when
-    final DecisionDefinitionEntity decisionDefinition = services.getByKey(42L, authentication);
+    final DecisionDefinitionEntity decisionDefinition =
+        services.getByKey(42L, authentication, "default");
 
     // then
     assertThat(decisionDefinition.decisionDefinitionKey()).isEqualTo(42L);
@@ -120,7 +122,7 @@ public final class DecisionDefinitionServiceTest {
                 Authorizations.DECISION_DEFINITION_READ_AUTHORIZATION));
 
     // when
-    final ThrowingCallable executable = () -> services.getByKey(1L, authentication);
+    final ThrowingCallable executable = () -> services.getByKey(1L, authentication, "default");
 
     // then
     final var exception =
@@ -143,7 +145,8 @@ public final class DecisionDefinitionServiceTest {
                 Authorizations.DECISION_DEFINITION_READ_AUTHORIZATION));
 
     // when
-    final ThrowingCallable executable = () -> services.getDecisionDefinitionXml(1L, authentication);
+    final ThrowingCallable executable =
+        () -> services.getDecisionDefinitionXml(1L, authentication, "default");
 
     // then
     final var exception =
@@ -152,6 +155,7 @@ public final class DecisionDefinitionServiceTest {
         .isEqualTo(
             "Unauthorized to perform operation 'READ_DECISION_DEFINITION' on resource 'DECISION_DEFINITION'");
     assertThat(exception.getStatus()).isEqualTo(Status.FORBIDDEN);
-    verify(decisionRequirementServices, never()).getDecisionRequirementsXml(any(Long.class), any());
+    verify(decisionRequirementServices, never())
+        .getDecisionRequirementsXml(any(Long.class), any(), any());
   }
 }

--- a/service/src/test/java/io/camunda/service/DecisionInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/DecisionInstanceServiceTest.java
@@ -52,6 +52,7 @@ import org.mockito.ArgumentCaptor;
 
 class DecisionInstanceServiceTest {
 
+  private static final String PHYSICAL_TENANT_ID = "foo";
   private static final Long DECISION_INSTANCE_KEY = 1L;
   private static final Long NON_EXISTENT_KEY = 999L;
   private static final String DECISION_INSTANCE_ID = "1-1";
@@ -93,7 +94,7 @@ class DecisionInstanceServiceTest {
     final DecisionInstanceQuery query = SearchQueryBuilders.decisionInstanceSearchQuery().build();
 
     // when
-    final var response = services.search(query, authentication, "default");
+    final var response = services.search(query, authentication, PHYSICAL_TENANT_ID);
 
     // then
     assertThat(response).isEqualTo(result);
@@ -110,7 +111,7 @@ class DecisionInstanceServiceTest {
                     .page(p -> p.size(20)));
 
     // when
-    services.search(query, authentication, "default");
+    services.search(query, authentication, PHYSICAL_TENANT_ID);
 
     // then
     verify(client)
@@ -138,7 +139,7 @@ class DecisionInstanceServiceTest {
                 decisionInstanceSearchQuery(
                     q -> q.filter(f -> f.decisionInstanceKeys(DECISION_INSTANCE_KEY))),
                 authentication,
-                "default");
+                PHYSICAL_TENANT_ID);
 
     // then
     final var exception =
@@ -164,7 +165,7 @@ class DecisionInstanceServiceTest {
     when(client.getDecisionInstance(DECISION_INSTANCE_ID)).thenReturn(entity);
 
     // when
-    final var result = services.getById(DECISION_INSTANCE_ID, authentication, "default");
+    final var result = services.getById(DECISION_INSTANCE_ID, authentication, PHYSICAL_TENANT_ID);
 
     // then
     verify(client).getDecisionInstance(DECISION_INSTANCE_ID);
@@ -200,7 +201,9 @@ class DecisionInstanceServiceTest {
         .thenReturn(CompletableFuture.completedFuture(new BrokerResponse<>(record)));
 
     // when
-    services.deleteDecisionInstance(decisionInstanceKey, null, authentication, "default").join();
+    services
+        .deleteDecisionInstance(decisionInstanceKey, null, authentication, PHYSICAL_TENANT_ID)
+        .join();
 
     // then
     final var brokerRequest = (HistoryDeletionRecord) captor.getValue().getRequestWriter();
@@ -221,7 +224,8 @@ class DecisionInstanceServiceTest {
     assertThatThrownBy(
             () ->
                 services
-                    .deleteDecisionInstance(NON_EXISTENT_KEY, null, authentication, "default")
+                    .deleteDecisionInstance(
+                        NON_EXISTENT_KEY, null, authentication, PHYSICAL_TENANT_ID)
                     .join())
         .isInstanceOf(ServiceException.class)
         .hasMessage("Decision Instance with key '" + NON_EXISTENT_KEY + "' not found")
@@ -242,7 +246,8 @@ class DecisionInstanceServiceTest {
     assertThatThrownBy(
             () ->
                 services
-                    .deleteDecisionInstance(NON_EXISTENT_KEY, null, authentication, "default")
+                    .deleteDecisionInstance(
+                        NON_EXISTENT_KEY, null, authentication, PHYSICAL_TENANT_ID)
                     .join())
         .isInstanceOf(ServiceException.class)
         .hasMessage("Decision Instance with key '" + NON_EXISTENT_KEY + "' not found");
@@ -272,7 +277,9 @@ class DecisionInstanceServiceTest {
         .thenReturn(CompletableFuture.completedFuture(new BrokerResponse<>(record)));
 
     // when
-    services.deleteDecisionInstance(decisionInstanceKey, null, authentication, "default").join();
+    services
+        .deleteDecisionInstance(decisionInstanceKey, null, authentication, PHYSICAL_TENANT_ID)
+        .join();
 
     // then - verify that anonymous authentication was used for the existence check
     final var authCaptor = ArgumentCaptor.forClass(CamundaAuthentication.class);
@@ -304,7 +311,9 @@ class DecisionInstanceServiceTest {
 
     // when
     final var result =
-        services.deleteDecisionInstancesBatchOperation(filter, authentication, "default").join();
+        services
+            .deleteDecisionInstancesBatchOperation(filter, authentication, PHYSICAL_TENANT_ID)
+            .join();
 
     // then
     assertThat(result.getBatchOperationKey()).isEqualTo(batchOperationKey);

--- a/service/src/test/java/io/camunda/service/DecisionInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/DecisionInstanceServiceTest.java
@@ -70,6 +70,7 @@ class DecisionInstanceServiceTest {
     brokerClient = mock(BrokerClient.class);
     securityContextProvider = mock(SecurityContextProvider.class);
     when(client.withSecurityContext(any())).thenReturn(client);
+    when(client.withPhysicalTenant(any())).thenReturn(client);
     when(executorProvider.getExecutor()).thenReturn(ForkJoinPool.commonPool());
     services =
         new DecisionInstanceServices(
@@ -92,7 +93,7 @@ class DecisionInstanceServiceTest {
     final DecisionInstanceQuery query = SearchQueryBuilders.decisionInstanceSearchQuery().build();
 
     // when
-    final var response = services.search(query, authentication);
+    final var response = services.search(query, authentication, "default");
 
     // then
     assertThat(response).isEqualTo(result);
@@ -109,7 +110,7 @@ class DecisionInstanceServiceTest {
                     .page(p -> p.size(20)));
 
     // when
-    services.search(query, authentication);
+    services.search(query, authentication, "default");
 
     // then
     verify(client)
@@ -136,7 +137,8 @@ class DecisionInstanceServiceTest {
             services.search(
                 decisionInstanceSearchQuery(
                     q -> q.filter(f -> f.decisionInstanceKeys(DECISION_INSTANCE_KEY))),
-                authentication);
+                authentication,
+                "default");
 
     // then
     final var exception =
@@ -162,7 +164,7 @@ class DecisionInstanceServiceTest {
     when(client.getDecisionInstance(DECISION_INSTANCE_ID)).thenReturn(entity);
 
     // when
-    final var result = services.getById(DECISION_INSTANCE_ID, authentication);
+    final var result = services.getById(DECISION_INSTANCE_ID, authentication, "default");
 
     // then
     verify(client).getDecisionInstance(DECISION_INSTANCE_ID);
@@ -198,7 +200,7 @@ class DecisionInstanceServiceTest {
         .thenReturn(CompletableFuture.completedFuture(new BrokerResponse<>(record)));
 
     // when
-    services.deleteDecisionInstance(decisionInstanceKey, null, authentication).join();
+    services.deleteDecisionInstance(decisionInstanceKey, null, authentication, "default").join();
 
     // then
     final var brokerRequest = (HistoryDeletionRecord) captor.getValue().getRequestWriter();
@@ -217,7 +219,10 @@ class DecisionInstanceServiceTest {
 
     // when/then
     assertThatThrownBy(
-            () -> services.deleteDecisionInstance(NON_EXISTENT_KEY, null, authentication).join())
+            () ->
+                services
+                    .deleteDecisionInstance(NON_EXISTENT_KEY, null, authentication, "default")
+                    .join())
         .isInstanceOf(ServiceException.class)
         .hasMessage("Decision Instance with key '" + NON_EXISTENT_KEY + "' not found")
         .extracting(e -> ((ServiceException) e).getStatus())
@@ -235,7 +240,10 @@ class DecisionInstanceServiceTest {
 
     // when/then
     assertThatThrownBy(
-            () -> services.deleteDecisionInstance(NON_EXISTENT_KEY, null, authentication).join())
+            () ->
+                services
+                    .deleteDecisionInstance(NON_EXISTENT_KEY, null, authentication, "default")
+                    .join())
         .isInstanceOf(ServiceException.class)
         .hasMessage("Decision Instance with key '" + NON_EXISTENT_KEY + "' not found");
   }
@@ -264,7 +272,7 @@ class DecisionInstanceServiceTest {
         .thenReturn(CompletableFuture.completedFuture(new BrokerResponse<>(record)));
 
     // when
-    services.deleteDecisionInstance(decisionInstanceKey, null, authentication).join();
+    services.deleteDecisionInstance(decisionInstanceKey, null, authentication, "default").join();
 
     // then - verify that anonymous authentication was used for the existence check
     final var authCaptor = ArgumentCaptor.forClass(CamundaAuthentication.class);
@@ -296,7 +304,7 @@ class DecisionInstanceServiceTest {
 
     // when
     final var result =
-        services.deleteDecisionInstancesBatchOperation(filter, authentication).join();
+        services.deleteDecisionInstancesBatchOperation(filter, authentication, "default").join();
 
     // then
     assertThat(result.getBatchOperationKey()).isEqualTo(batchOperationKey);

--- a/service/src/test/java/io/camunda/service/DecisionRequirementsServiceTest.java
+++ b/service/src/test/java/io/camunda/service/DecisionRequirementsServiceTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 
 public final class DecisionRequirementsServiceTest {
 
+  private static final String PHYSICAL_TENANT_ID = "foo";
   private CamundaAuthentication authentication;
   private DecisionRequirementsServices services;
   private DecisionRequirementSearchClient client;
@@ -60,7 +61,7 @@ public final class DecisionRequirementsServiceTest {
     final var result = mock(SearchQueryResult.class);
     when(client.searchDecisionRequirements(any())).thenReturn(result);
     final SearchQueryResult<DecisionRequirementsEntity> searchQueryResult =
-        services.search(searchQuery, authentication, "default");
+        services.search(searchQuery, authentication, PHYSICAL_TENANT_ID);
 
     // then
     assertThat(result).isEqualTo(searchQueryResult);
@@ -75,7 +76,7 @@ public final class DecisionRequirementsServiceTest {
     when(client.getDecisionRequirements(eq(124L), eq(false))).thenReturn(decisionRequirementEntity);
 
     // when
-    final var searchQueryResult = services.getByKey(124L, authentication, "default");
+    final var searchQueryResult = services.getByKey(124L, authentication, PHYSICAL_TENANT_ID);
 
     // then
     final DecisionRequirementsEntity item = searchQueryResult;
@@ -94,7 +95,7 @@ public final class DecisionRequirementsServiceTest {
     // when
     final String expectedXml = "<xml/>";
     final var searchQueryResult =
-        services.getDecisionRequirementsXml(124L, authentication, "default");
+        services.getDecisionRequirementsXml(124L, authentication, PHYSICAL_TENANT_ID);
 
     // then
     assertThat(searchQueryResult).isEqualTo(expectedXml);
@@ -114,7 +115,7 @@ public final class DecisionRequirementsServiceTest {
     // then
     final var exception =
         assertThatExceptionOfType(ServiceException.class)
-            .isThrownBy(() -> services.getByKey(124L, authentication, "default"))
+            .isThrownBy(() -> services.getByKey(124L, authentication, PHYSICAL_TENANT_ID))
             .actual();
     assertThat(exception.getMessage())
         .isEqualTo(
@@ -135,7 +136,8 @@ public final class DecisionRequirementsServiceTest {
     // then
     final var exception =
         assertThatExceptionOfType(ServiceException.class)
-            .isThrownBy(() -> services.getDecisionRequirementsXml(124L, authentication, "default"))
+            .isThrownBy(
+                () -> services.getDecisionRequirementsXml(124L, authentication, PHYSICAL_TENANT_ID))
             .actual();
     assertThat(exception.getMessage())
         .isEqualTo(

--- a/service/src/test/java/io/camunda/service/DecisionRequirementsServiceTest.java
+++ b/service/src/test/java/io/camunda/service/DecisionRequirementsServiceTest.java
@@ -40,6 +40,7 @@ public final class DecisionRequirementsServiceTest {
     authentication = mock(CamundaAuthentication.class);
     client = mock(DecisionRequirementSearchClient.class);
     when(client.withSecurityContext(any())).thenReturn(client);
+    when(client.withPhysicalTenant(any())).thenReturn(client);
     services =
         new DecisionRequirementsServices(
             mock(BrokerClient.class),
@@ -59,7 +60,7 @@ public final class DecisionRequirementsServiceTest {
     final var result = mock(SearchQueryResult.class);
     when(client.searchDecisionRequirements(any())).thenReturn(result);
     final SearchQueryResult<DecisionRequirementsEntity> searchQueryResult =
-        services.search(searchQuery, authentication);
+        services.search(searchQuery, authentication, "default");
 
     // then
     assertThat(result).isEqualTo(searchQueryResult);
@@ -74,7 +75,7 @@ public final class DecisionRequirementsServiceTest {
     when(client.getDecisionRequirements(eq(124L), eq(false))).thenReturn(decisionRequirementEntity);
 
     // when
-    final var searchQueryResult = services.getByKey(124L, authentication);
+    final var searchQueryResult = services.getByKey(124L, authentication, "default");
 
     // then
     final DecisionRequirementsEntity item = searchQueryResult;
@@ -92,7 +93,8 @@ public final class DecisionRequirementsServiceTest {
 
     // when
     final String expectedXml = "<xml/>";
-    final var searchQueryResult = services.getDecisionRequirementsXml(124L, authentication);
+    final var searchQueryResult =
+        services.getDecisionRequirementsXml(124L, authentication, "default");
 
     // then
     assertThat(searchQueryResult).isEqualTo(expectedXml);
@@ -112,7 +114,7 @@ public final class DecisionRequirementsServiceTest {
     // then
     final var exception =
         assertThatExceptionOfType(ServiceException.class)
-            .isThrownBy(() -> services.getByKey(124L, authentication))
+            .isThrownBy(() -> services.getByKey(124L, authentication, "default"))
             .actual();
     assertThat(exception.getMessage())
         .isEqualTo(
@@ -133,7 +135,7 @@ public final class DecisionRequirementsServiceTest {
     // then
     final var exception =
         assertThatExceptionOfType(ServiceException.class)
-            .isThrownBy(() -> services.getDecisionRequirementsXml(124L, authentication))
+            .isThrownBy(() -> services.getDecisionRequirementsXml(124L, authentication, "default"))
             .actual();
     assertThat(exception.getMessage())
         .isEqualTo(

--- a/service/src/test/java/io/camunda/service/DocumentServicesTest.java
+++ b/service/src/test/java/io/camunda/service/DocumentServicesTest.java
@@ -47,7 +47,7 @@ import org.junit.jupiter.api.Test;
 
 public class DocumentServicesTest {
 
-  private static final String PHYSICAL_TENANT_ID = "physical-tenant-id";
+  private static final String PHYSICAL_TENANT_ID = "foo";
   private DocumentServices services;
   private final SimpleDocumentStoreRegistry registry = mock(SimpleDocumentStoreRegistry.class);
   private final AuthorizationChecker authorizationChecker = mock(AuthorizationChecker.class);

--- a/service/src/test/java/io/camunda/service/DocumentServicesTest.java
+++ b/service/src/test/java/io/camunda/service/DocumentServicesTest.java
@@ -47,6 +47,7 @@ import org.junit.jupiter.api.Test;
 
 public class DocumentServicesTest {
 
+  private static final String PHYSICAL_TENANT_ID = "physical-tenant-id";
   private DocumentServices services;
   private final SimpleDocumentStoreRegistry registry = mock(SimpleDocumentStoreRegistry.class);
   private final AuthorizationChecker authorizationChecker = mock(AuthorizationChecker.class);
@@ -81,7 +82,7 @@ public class DocumentServicesTest {
     final var fileMock = mock(DocumentCreateRequest.class);
 
     // when
-    final var future = services.createDocument(fileMock, authentication);
+    final var future = services.createDocument(fileMock, authentication, PHYSICAL_TENANT_ID);
 
     assertThat(future.isCompletedExceptionally()).isTrue();
   }
@@ -97,7 +98,7 @@ public class DocumentServicesTest {
     final var fileMock = mock(DocumentCreateRequest.class);
 
     // when
-    final var future = services.createDocument(fileMock, authentication);
+    final var future = services.createDocument(fileMock, authentication, PHYSICAL_TENANT_ID);
 
     assertThat(future.isCompletedExceptionally()).isTrue();
   }
@@ -113,7 +114,8 @@ public class DocumentServicesTest {
 
     // when
     final var future =
-        services.deleteDocument("irrelevant-document-id", "irrelevant-store-id", authentication);
+        services.deleteDocument(
+            "irrelevant-document-id", "irrelevant-store-id", authentication, PHYSICAL_TENANT_ID);
 
     assertThat(future.isCompletedExceptionally()).isTrue();
   }
@@ -130,7 +132,11 @@ public class DocumentServicesTest {
     // when
     final var future =
         services.getDocumentContent(
-            "irrelevant-document-id", "irrelevant-store-id", "irrelevant-hash", authentication);
+            "irrelevant-document-id",
+            "irrelevant-store-id",
+            "irrelevant-hash",
+            authentication,
+            PHYSICAL_TENANT_ID);
 
     assertThat(future.isCompletedExceptionally()).isTrue();
   }
@@ -154,7 +160,7 @@ public class DocumentServicesTest {
         .thenReturn(CompletableFuture.completedFuture(Either.right(expectedResult1)));
 
     // when
-    final var response = services.createDocument(file1, authentication).join();
+    final var response = services.createDocument(file1, authentication, PHYSICAL_TENANT_ID).join();
 
     // then
     assertThat(response)
@@ -190,7 +196,8 @@ public class DocumentServicesTest {
         .thenReturn(CompletableFuture.completedFuture(Either.right(null)));
 
     // when
-    final var future = services.deleteDocument(documentId, storeId, authentication);
+    final var future =
+        services.deleteDocument(documentId, storeId, authentication, PHYSICAL_TENANT_ID);
 
     // then
     assertThat(future).isNotNull();
@@ -221,7 +228,7 @@ public class DocumentServicesTest {
         .thenReturn(CompletableFuture.completedFuture(Either.right(expectedResult1)));
 
     // when
-    final var response = services.createDocument(file1, authentication).join();
+    final var response = services.createDocument(file1, authentication, PHYSICAL_TENANT_ID).join();
 
     // then
     assertThat(response)
@@ -264,7 +271,10 @@ public class DocumentServicesTest {
         .thenReturn(CompletableFuture.completedFuture(Either.right(expectedResult2)));
 
     // when
-    final var response = services.createDocumentBatch(List.of(file1, file2), authentication).join();
+    final var response =
+        services
+            .createDocumentBatch(List.of(file1, file2), authentication, PHYSICAL_TENANT_ID)
+            .join();
 
     // then
     assertThat(response).isNotNull();
@@ -319,7 +329,10 @@ public class DocumentServicesTest {
 
     // when
     final var actualDocumentContent =
-        services.getDocumentContent(documentId, storeId, contentHash, authentication).join();
+        services
+            .getDocumentContent(
+                documentId, storeId, contentHash, authentication, PHYSICAL_TENANT_ID)
+            .join();
 
     // then
     assertThat(actualDocumentContent).isNotNull();

--- a/service/src/test/java/io/camunda/service/ElementInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ElementInstanceServiceTest.java
@@ -65,7 +65,7 @@ public final class ElementInstanceServiceTest {
 
     when(client.withSecurityContext(any())).thenReturn(client);
     when(client.withPhysicalTenant(any())).thenReturn(client);
-    when(processCache.getCacheItems(any())).thenReturn(ProcessCacheResult.EMPTY);
+    when(processCache.getCacheItems(any(), any())).thenReturn(ProcessCacheResult.EMPTY);
   }
 
   @Nested
@@ -93,7 +93,7 @@ public final class ElementInstanceServiceTest {
               .set(field(FlowNodeInstanceEntity::flowNodeName), null)
               .create();
       when(client.searchFlowNodeInstances(any())).thenReturn(SearchQueryResult.of(entity));
-      when(processCache.getCacheItems(Set.of(entity.processDefinitionKey())))
+      when(processCache.getCacheItems(Set.of(entity.processDefinitionKey()), "default"))
           .thenReturn(
               ProcessCacheResult.of(
                   entity.processDefinitionKey(),
@@ -171,7 +171,7 @@ public final class ElementInstanceServiceTest {
               .create();
 
       when(client.getFlowNodeInstance(any(Long.class))).thenReturn(entity);
-      when(processCache.getCacheItem(entity.processDefinitionKey()))
+      when(processCache.getCacheItem(entity.processDefinitionKey(), "default"))
           .thenReturn(
               new ProcessCacheItem("ProcessName", Map.of(entity.flowNodeId(), "cached name")));
 
@@ -192,7 +192,7 @@ public final class ElementInstanceServiceTest {
               .create();
 
       when(client.getFlowNodeInstance(any(Long.class))).thenReturn(entity);
-      when(processCache.getCacheItem(entity.processDefinitionKey()))
+      when(processCache.getCacheItem(entity.processDefinitionKey(), "default"))
           .thenReturn(new ProcessCacheItem("ProcessName", Map.of("unknown-id", "cached name")));
 
       // when
@@ -216,7 +216,7 @@ public final class ElementInstanceServiceTest {
                 .create();
 
         when(client.getFlowNodeInstance(any(Long.class))).thenReturn(elementInstance);
-        when(processCache.getCacheItem(elementInstance.processDefinitionKey()))
+        when(processCache.getCacheItem(elementInstance.processDefinitionKey(), "default"))
             .thenReturn(new ProcessCacheItem("ProcessName", Map.of("unknown-id", "cached name")));
         final IncidentEntity incident =
             Instancio.of(IncidentEntity.class)

--- a/service/src/test/java/io/camunda/service/ElementInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ElementInstanceServiceTest.java
@@ -42,6 +42,7 @@ import org.mockito.Mock;
 
 public final class ElementInstanceServiceTest {
 
+  private static final String PHYSICAL_TENANT_ID = "foo";
   private ElementInstanceServices services;
   private FlowNodeInstanceSearchClient client;
   private ProcessCache processCache;
@@ -80,7 +81,9 @@ public final class ElementInstanceServiceTest {
       // when
       final var searchQueryResult =
           services.search(
-              SearchQueryBuilders.flownodeInstanceSearchQuery().build(), authentication, "default");
+              SearchQueryBuilders.flownodeInstanceSearchQuery().build(),
+              authentication,
+              PHYSICAL_TENANT_ID);
 
       // then
       assertThat(searchQueryResult.items()).contains(entity);
@@ -93,7 +96,7 @@ public final class ElementInstanceServiceTest {
               .set(field(FlowNodeInstanceEntity::flowNodeName), null)
               .create();
       when(client.searchFlowNodeInstances(any())).thenReturn(SearchQueryResult.of(entity));
-      when(processCache.getCacheItems(Set.of(entity.processDefinitionKey()), "default"))
+      when(processCache.getCacheItems(Set.of(entity.processDefinitionKey()), PHYSICAL_TENANT_ID))
           .thenReturn(
               ProcessCacheResult.of(
                   entity.processDefinitionKey(),
@@ -102,7 +105,7 @@ public final class ElementInstanceServiceTest {
                   "cached name"));
 
       final var searchQueryResult =
-          services.search(FlowNodeInstanceQuery.of(q -> q), authentication, "default");
+          services.search(FlowNodeInstanceQuery.of(q -> q), authentication, PHYSICAL_TENANT_ID);
 
       assertThat(searchQueryResult.items()).contains(entity.withFlowNodeName("cached name"));
     }
@@ -117,7 +120,7 @@ public final class ElementInstanceServiceTest {
       when(client.searchFlowNodeInstances(any())).thenReturn(SearchQueryResult.of(entity));
 
       final var searchQueryResult =
-          services.search(FlowNodeInstanceQuery.of(q -> q), authentication, "default");
+          services.search(FlowNodeInstanceQuery.of(q -> q), authentication, PHYSICAL_TENANT_ID);
 
       assertThat(searchQueryResult.items()).contains(entity.withFlowNodeName(entity.flowNodeId()));
     }
@@ -134,7 +137,7 @@ public final class ElementInstanceServiceTest {
 
       // when
       final var searchQueryResult =
-          services.getByKey(entity.flowNodeInstanceKey(), authentication, "default");
+          services.getByKey(entity.flowNodeInstanceKey(), authentication, PHYSICAL_TENANT_ID);
 
       // then
       assertThat(searchQueryResult).isEqualTo(entity);
@@ -151,7 +154,7 @@ public final class ElementInstanceServiceTest {
 
       // when
       final ThrowingCallable executeGetByKey =
-          () -> services.getByKey(entity.flowNodeInstanceKey(), authentication, "default");
+          () -> services.getByKey(entity.flowNodeInstanceKey(), authentication, PHYSICAL_TENANT_ID);
       // then
       final var exception =
           (ServiceException)
@@ -171,13 +174,13 @@ public final class ElementInstanceServiceTest {
               .create();
 
       when(client.getFlowNodeInstance(any(Long.class))).thenReturn(entity);
-      when(processCache.getCacheItem(entity.processDefinitionKey(), "default"))
+      when(processCache.getCacheItem(entity.processDefinitionKey(), PHYSICAL_TENANT_ID))
           .thenReturn(
               new ProcessCacheItem("ProcessName", Map.of(entity.flowNodeId(), "cached name")));
 
       // when
       final var foundEntity =
-          services.getByKey(entity.flowNodeInstanceKey(), authentication, "default");
+          services.getByKey(entity.flowNodeInstanceKey(), authentication, PHYSICAL_TENANT_ID);
 
       // then
       assertThat(foundEntity.flowNodeName()).isEqualTo("cached name");
@@ -192,12 +195,12 @@ public final class ElementInstanceServiceTest {
               .create();
 
       when(client.getFlowNodeInstance(any(Long.class))).thenReturn(entity);
-      when(processCache.getCacheItem(entity.processDefinitionKey(), "default"))
+      when(processCache.getCacheItem(entity.processDefinitionKey(), PHYSICAL_TENANT_ID))
           .thenReturn(new ProcessCacheItem("ProcessName", Map.of("unknown-id", "cached name")));
 
       // when
       final var foundEntity =
-          services.getByKey(entity.flowNodeInstanceKey(), authentication, "default");
+          services.getByKey(entity.flowNodeInstanceKey(), authentication, PHYSICAL_TENANT_ID);
 
       // then
       assertThat(foundEntity.flowNodeName()).isEqualTo(entity.flowNodeId());
@@ -216,7 +219,7 @@ public final class ElementInstanceServiceTest {
                 .create();
 
         when(client.getFlowNodeInstance(any(Long.class))).thenReturn(elementInstance);
-        when(processCache.getCacheItem(elementInstance.processDefinitionKey(), "default"))
+        when(processCache.getCacheItem(elementInstance.processDefinitionKey(), PHYSICAL_TENANT_ID))
             .thenReturn(new ProcessCacheItem("ProcessName", Map.of("unknown-id", "cached name")));
         final IncidentEntity incident =
             Instancio.of(IncidentEntity.class)
@@ -227,7 +230,7 @@ public final class ElementInstanceServiceTest {
         when(incidentServices.search(any(IncidentQuery.class), any(), any())).thenReturn(result);
         // when
         final var searchResult =
-            services.searchIncidents(elementInstanceKey, query, authentication, "default");
+            services.searchIncidents(elementInstanceKey, query, authentication, PHYSICAL_TENANT_ID);
         // then
         assertThat(searchResult.items()).containsExactly(incident);
       }
@@ -243,7 +246,7 @@ public final class ElementInstanceServiceTest {
         when(incidentServices.search(any(IncidentQuery.class), any(), any())).thenReturn(result);
         // when
         final var searchResult =
-            services.searchIncidents(elementInstanceKey, query, authentication, "default");
+            services.searchIncidents(elementInstanceKey, query, authentication, PHYSICAL_TENANT_ID);
         // then
         assertThat(searchResult.items()).isEmpty();
       }

--- a/service/src/test/java/io/camunda/service/ElementInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ElementInstanceServiceTest.java
@@ -64,6 +64,7 @@ public final class ElementInstanceServiceTest {
             null);
 
     when(client.withSecurityContext(any())).thenReturn(client);
+    when(client.withPhysicalTenant(any())).thenReturn(client);
     when(processCache.getCacheItems(any())).thenReturn(ProcessCacheResult.EMPTY);
   }
 
@@ -79,7 +80,7 @@ public final class ElementInstanceServiceTest {
       // when
       final var searchQueryResult =
           services.search(
-              SearchQueryBuilders.flownodeInstanceSearchQuery().build(), authentication);
+              SearchQueryBuilders.flownodeInstanceSearchQuery().build(), authentication, "default");
 
       // then
       assertThat(searchQueryResult.items()).contains(entity);
@@ -101,7 +102,7 @@ public final class ElementInstanceServiceTest {
                   "cached name"));
 
       final var searchQueryResult =
-          services.search(FlowNodeInstanceQuery.of(q -> q), authentication);
+          services.search(FlowNodeInstanceQuery.of(q -> q), authentication, "default");
 
       assertThat(searchQueryResult.items()).contains(entity.withFlowNodeName("cached name"));
     }
@@ -116,7 +117,7 @@ public final class ElementInstanceServiceTest {
       when(client.searchFlowNodeInstances(any())).thenReturn(SearchQueryResult.of(entity));
 
       final var searchQueryResult =
-          services.search(FlowNodeInstanceQuery.of(q -> q), authentication);
+          services.search(FlowNodeInstanceQuery.of(q -> q), authentication, "default");
 
       assertThat(searchQueryResult.items()).contains(entity.withFlowNodeName(entity.flowNodeId()));
     }
@@ -132,7 +133,8 @@ public final class ElementInstanceServiceTest {
       when(client.getFlowNodeInstance(any(Long.class))).thenReturn(entity);
 
       // when
-      final var searchQueryResult = services.getByKey(entity.flowNodeInstanceKey(), authentication);
+      final var searchQueryResult =
+          services.getByKey(entity.flowNodeInstanceKey(), authentication, "default");
 
       // then
       assertThat(searchQueryResult).isEqualTo(entity);
@@ -149,7 +151,7 @@ public final class ElementInstanceServiceTest {
 
       // when
       final ThrowingCallable executeGetByKey =
-          () -> services.getByKey(entity.flowNodeInstanceKey(), authentication);
+          () -> services.getByKey(entity.flowNodeInstanceKey(), authentication, "default");
       // then
       final var exception =
           (ServiceException)
@@ -174,7 +176,8 @@ public final class ElementInstanceServiceTest {
               new ProcessCacheItem("ProcessName", Map.of(entity.flowNodeId(), "cached name")));
 
       // when
-      final var foundEntity = services.getByKey(entity.flowNodeInstanceKey(), authentication);
+      final var foundEntity =
+          services.getByKey(entity.flowNodeInstanceKey(), authentication, "default");
 
       // then
       assertThat(foundEntity.flowNodeName()).isEqualTo("cached name");
@@ -193,7 +196,8 @@ public final class ElementInstanceServiceTest {
           .thenReturn(new ProcessCacheItem("ProcessName", Map.of("unknown-id", "cached name")));
 
       // when
-      final var foundEntity = services.getByKey(entity.flowNodeInstanceKey(), authentication);
+      final var foundEntity =
+          services.getByKey(entity.flowNodeInstanceKey(), authentication, "default");
 
       // then
       assertThat(foundEntity.flowNodeName()).isEqualTo(entity.flowNodeId());
@@ -220,10 +224,10 @@ public final class ElementInstanceServiceTest {
                 .create();
 
         final SearchQueryResult<IncidentEntity> result = SearchQueryResult.of(incident);
-        when(incidentServices.search(any(IncidentQuery.class), any())).thenReturn(result);
+        when(incidentServices.search(any(IncidentQuery.class), any(), any())).thenReturn(result);
         // when
         final var searchResult =
-            services.searchIncidents(elementInstanceKey, query, authentication);
+            services.searchIncidents(elementInstanceKey, query, authentication, "default");
         // then
         assertThat(searchResult.items()).containsExactly(incident);
       }
@@ -236,10 +240,10 @@ public final class ElementInstanceServiceTest {
         final SearchQueryResult<IncidentEntity> result = SearchQueryResult.of();
         final var entity = Instancio.create(FlowNodeInstanceEntity.class);
         when(client.getFlowNodeInstance(any(Long.class))).thenReturn(entity);
-        when(incidentServices.search(any(IncidentQuery.class), any())).thenReturn(result);
+        when(incidentServices.search(any(IncidentQuery.class), any(), any())).thenReturn(result);
         // when
         final var searchResult =
-            services.searchIncidents(elementInstanceKey, query, authentication);
+            services.searchIncidents(elementInstanceKey, query, authentication, "default");
         // then
         assertThat(searchResult.items()).isEmpty();
       }

--- a/service/src/test/java/io/camunda/service/FormServiceTest.java
+++ b/service/src/test/java/io/camunda/service/FormServiceTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 
 public final class FormServiceTest {
 
+  private static final String PHYSICAL_TENANT_ID = "foo";
   private CamundaAuthentication authentication;
   private FormServices services;
   private FormSearchClient client;
@@ -52,7 +53,7 @@ public final class FormServiceTest {
     when(client.searchForms(any())).thenReturn(result);
 
     // when
-    final var searchQueryResult = services.search(searchQuery, authentication, "default");
+    final var searchQueryResult = services.search(searchQuery, authentication, PHYSICAL_TENANT_ID);
 
     // then
     assertThat(searchQueryResult).isEqualTo(result);
@@ -68,7 +69,7 @@ public final class FormServiceTest {
     when(client.searchForms(any())).thenReturn(result);
 
     // when
-    final var searchQueryResult = services.search(searchQuery, authentication, "default");
+    final var searchQueryResult = services.search(searchQuery, authentication, PHYSICAL_TENANT_ID);
 
     // then
     assertThat(searchQueryResult).isEqualTo(result);

--- a/service/src/test/java/io/camunda/service/FormServiceTest.java
+++ b/service/src/test/java/io/camunda/service/FormServiceTest.java
@@ -32,6 +32,7 @@ public final class FormServiceTest {
     authentication = mock(CamundaAuthentication.class);
     client = mock(FormSearchClient.class);
     when(client.withSecurityContext(any())).thenReturn(client);
+    when(client.withPhysicalTenant(any())).thenReturn(client);
     services =
         new FormServices(
             mock(BrokerClient.class),
@@ -51,7 +52,7 @@ public final class FormServiceTest {
     when(client.searchForms(any())).thenReturn(result);
 
     // when
-    final var searchQueryResult = services.search(searchQuery, authentication);
+    final var searchQueryResult = services.search(searchQuery, authentication, "default");
 
     // then
     assertThat(searchQueryResult).isEqualTo(result);
@@ -67,7 +68,7 @@ public final class FormServiceTest {
     when(client.searchForms(any())).thenReturn(result);
 
     // when
-    final var searchQueryResult = services.search(searchQuery, authentication);
+    final var searchQueryResult = services.search(searchQuery, authentication, "default");
 
     // then
     assertThat(searchQueryResult).isEqualTo(result);

--- a/service/src/test/java/io/camunda/service/GroupServiceTest.java
+++ b/service/src/test/java/io/camunda/service/GroupServiceTest.java
@@ -44,6 +44,7 @@ import org.junit.jupiter.api.Test;
 
 public class GroupServiceTest {
 
+  private static final String PHYSICAL_TENANT_ID = "foo";
   private GroupServices services;
   private GroupSearchClient client;
   private CamundaAuthentication authentication;
@@ -81,7 +82,7 @@ public class GroupServiceTest {
 
     // when
     final var createGroupRequest = new GroupDTO(groupId, groupName, description);
-    services.createGroup(createGroupRequest, authentication, "default");
+    services.createGroup(createGroupRequest, authentication, PHYSICAL_TENANT_ID);
 
     // then
     final BrokerGroupCreateRequest request = stubbedBrokerClient.getSingleBrokerRequest();
@@ -104,7 +105,7 @@ public class GroupServiceTest {
     final var searchQuery = SearchQueryBuilders.groupSearchQuery((b) -> b.filter(filter));
 
     // when
-    final var searchQueryResult = services.search(searchQuery, authentication, "default");
+    final var searchQueryResult = services.search(searchQuery, authentication, PHYSICAL_TENANT_ID);
 
     // then
     assertThat(searchQueryResult).isEqualTo(result);
@@ -126,7 +127,7 @@ public class GroupServiceTest {
     when(client.getGroup(any())).thenReturn(entity);
 
     // when
-    final var searchQueryResult = services.getGroup("groupId", authentication, "default");
+    final var searchQueryResult = services.getGroup("groupId", authentication, PHYSICAL_TENANT_ID);
 
     // then
     assertThat(searchQueryResult).isEqualTo(entity);
@@ -141,7 +142,7 @@ public class GroupServiceTest {
     final var description = "UpdatedDescription";
 
     // when
-    services.updateGroup(groupId, name, description, authentication, "default");
+    services.updateGroup(groupId, name, description, authentication, PHYSICAL_TENANT_ID);
 
     // then
     final BrokerGroupUpdateRequest request = stubbedBrokerClient.getSingleBrokerRequest();
@@ -163,7 +164,7 @@ public class GroupServiceTest {
     final var description = "";
 
     // when
-    services.updateGroup(groupId, name, description, authentication, "default");
+    services.updateGroup(groupId, name, description, authentication, PHYSICAL_TENANT_ID);
 
     // then
     final BrokerGroupUpdateRequest request = stubbedBrokerClient.getSingleBrokerRequest();
@@ -183,7 +184,7 @@ public class GroupServiceTest {
     final var groupId = String.valueOf(groupKey);
 
     // when
-    services.deleteGroup(groupId, authentication, "default");
+    services.deleteGroup(groupId, authentication, PHYSICAL_TENANT_ID);
 
     // then
     final BrokerGroupDeleteRequest request = stubbedBrokerClient.getSingleBrokerRequest();
@@ -202,7 +203,7 @@ public class GroupServiceTest {
     final var dto = new GroupMemberDTO(groupId, memberId, EntityType.USER);
 
     // when
-    services.assignMember(dto, authentication, "default");
+    services.assignMember(dto, authentication, PHYSICAL_TENANT_ID);
 
     // then
     final BrokerGroupMemberRequest request = stubbedBrokerClient.getSingleBrokerRequest();
@@ -224,7 +225,7 @@ public class GroupServiceTest {
     final var dto = new GroupMemberDTO(groupId, username, EntityType.USER);
 
     // when
-    services.removeMember(dto, authentication, "default");
+    services.removeMember(dto, authentication, PHYSICAL_TENANT_ID);
 
     // then
     final BrokerGroupMemberRequest request = stubbedBrokerClient.getSingleBrokerRequest();

--- a/service/src/test/java/io/camunda/service/GroupServiceTest.java
+++ b/service/src/test/java/io/camunda/service/GroupServiceTest.java
@@ -57,6 +57,7 @@ public class GroupServiceTest {
     stubbedBrokerClient = new StubbedBrokerClient();
     client = mock(GroupSearchClient.class);
     when(client.withSecurityContext(any())).thenReturn(client);
+    when(client.withPhysicalTenant(any())).thenReturn(client);
     executorProvider = mock(ApiServicesExecutorProvider.class);
     when(executorProvider.getExecutor()).thenReturn(ForkJoinPool.commonPool());
     brokerRequestAuthorizationConverter = mock(BrokerRequestAuthorizationConverter.class);
@@ -80,7 +81,7 @@ public class GroupServiceTest {
 
     // when
     final var createGroupRequest = new GroupDTO(groupId, groupName, description);
-    services.createGroup(createGroupRequest, authentication);
+    services.createGroup(createGroupRequest, authentication, "default");
 
     // then
     final BrokerGroupCreateRequest request = stubbedBrokerClient.getSingleBrokerRequest();
@@ -103,7 +104,7 @@ public class GroupServiceTest {
     final var searchQuery = SearchQueryBuilders.groupSearchQuery((b) -> b.filter(filter));
 
     // when
-    final var searchQueryResult = services.search(searchQuery, authentication);
+    final var searchQueryResult = services.search(searchQuery, authentication, "default");
 
     // then
     assertThat(searchQueryResult).isEqualTo(result);
@@ -125,7 +126,7 @@ public class GroupServiceTest {
     when(client.getGroup(any())).thenReturn(entity);
 
     // when
-    final var searchQueryResult = services.getGroup("groupId", authentication);
+    final var searchQueryResult = services.getGroup("groupId", authentication, "default");
 
     // then
     assertThat(searchQueryResult).isEqualTo(entity);
@@ -140,7 +141,7 @@ public class GroupServiceTest {
     final var description = "UpdatedDescription";
 
     // when
-    services.updateGroup(groupId, name, description, authentication);
+    services.updateGroup(groupId, name, description, authentication, "default");
 
     // then
     final BrokerGroupUpdateRequest request = stubbedBrokerClient.getSingleBrokerRequest();
@@ -162,7 +163,7 @@ public class GroupServiceTest {
     final var description = "";
 
     // when
-    services.updateGroup(groupId, name, description, authentication);
+    services.updateGroup(groupId, name, description, authentication, "default");
 
     // then
     final BrokerGroupUpdateRequest request = stubbedBrokerClient.getSingleBrokerRequest();
@@ -182,7 +183,7 @@ public class GroupServiceTest {
     final var groupId = String.valueOf(groupKey);
 
     // when
-    services.deleteGroup(groupId, authentication);
+    services.deleteGroup(groupId, authentication, "default");
 
     // then
     final BrokerGroupDeleteRequest request = stubbedBrokerClient.getSingleBrokerRequest();
@@ -201,7 +202,7 @@ public class GroupServiceTest {
     final var dto = new GroupMemberDTO(groupId, memberId, EntityType.USER);
 
     // when
-    services.assignMember(dto, authentication);
+    services.assignMember(dto, authentication, "default");
 
     // then
     final BrokerGroupMemberRequest request = stubbedBrokerClient.getSingleBrokerRequest();
@@ -223,7 +224,7 @@ public class GroupServiceTest {
     final var dto = new GroupMemberDTO(groupId, username, EntityType.USER);
 
     // when
-    services.removeMember(dto, authentication);
+    services.removeMember(dto, authentication, "default");
 
     // then
     final BrokerGroupMemberRequest request = stubbedBrokerClient.getSingleBrokerRequest();

--- a/service/src/test/java/io/camunda/service/IncidentServiceTest.java
+++ b/service/src/test/java/io/camunda/service/IncidentServiceTest.java
@@ -48,6 +48,7 @@ public final class IncidentServiceTest {
   public void before() {
     client = mock(IncidentSearchClient.class);
     when(client.withSecurityContext(any())).thenReturn(client);
+    when(client.withPhysicalTenant(any())).thenReturn(client);
     final SecurityContextProvider securityContextProvider = mock(SecurityContextProvider.class);
     authentication = mock(CamundaAuthentication.class);
 
@@ -69,7 +70,7 @@ public final class IncidentServiceTest {
     final var searchQuery = SearchQueryBuilders.incidentSearchQuery().build();
 
     // when
-    final var searchQueryResult = services.search(searchQuery, authentication);
+    final var searchQueryResult = services.search(searchQuery, authentication, "default");
 
     // then
     assertThat(searchQueryResult).isEqualTo(result);
@@ -81,7 +82,7 @@ public final class IncidentServiceTest {
     final var entity = Instancio.create(IncidentEntity.class);
     when(client.getIncident(any(Long.class))).thenReturn(entity);
     // when
-    final var searchQueryResult = services.getByKey(1L, authentication);
+    final var searchQueryResult = services.getByKey(1L, authentication, "default");
 
     // then
     assertThat(searchQueryResult).isEqualTo(entity);
@@ -93,7 +94,7 @@ public final class IncidentServiceTest {
     when(client.getIncident(any(Long.class)))
         .thenThrow(new ResourceAccessDeniedException(Authorizations.INCIDENT_READ_AUTHORIZATION));
     // when
-    final ThrowingCallable executeGetByKey = () -> services.getByKey(1L, authentication);
+    final ThrowingCallable executeGetByKey = () -> services.getByKey(1L, authentication, "default");
     // then
     final var exception =
         (ServiceException)
@@ -117,7 +118,8 @@ public final class IncidentServiceTest {
             SearchQueryBuilders.incidentProcessInstanceStatisticsByErrorQuery()
                 .filter(f -> f.states(IncidentState.ACTIVE.name()))
                 .build(),
-            authentication);
+            authentication,
+            "default");
 
     // then
     assertThat(searchQueryResult.items()).contains(entity);
@@ -147,7 +149,8 @@ public final class IncidentServiceTest {
             SearchQueryBuilders.incidentProcessInstanceStatisticsByDefinitionQuery()
                 .filter(f -> f.state(state).errorHashCode(errorHashCode))
                 .build(),
-            authentication);
+            authentication,
+            "default");
 
     // then
     assertThat(searchQueryResult.items()).contains(entity);
@@ -176,7 +179,7 @@ public final class IncidentServiceTest {
             .build();
 
     // when
-    services.incidentProcessInstanceStatisticsByError(initialQuery, authentication);
+    services.incidentProcessInstanceStatisticsByError(initialQuery, authentication, "default");
 
     // then
     final var queryCaptor =
@@ -198,7 +201,7 @@ public final class IncidentServiceTest {
         SearchQueryBuilders.incidentProcessInstanceStatisticsByErrorQuery().build();
 
     // when
-    services.incidentProcessInstanceStatisticsByError(initialQuery, authentication);
+    services.incidentProcessInstanceStatisticsByError(initialQuery, authentication, "default");
 
     // then
     final var queryCaptor =

--- a/service/src/test/java/io/camunda/service/IncidentServiceTest.java
+++ b/service/src/test/java/io/camunda/service/IncidentServiceTest.java
@@ -40,6 +40,7 @@ import org.mockito.ArgumentCaptor;
 
 public final class IncidentServiceTest {
 
+  private static final String PHYSICAL_TENANT_ID = "foo";
   private IncidentServices services;
   private IncidentSearchClient client;
   private CamundaAuthentication authentication;
@@ -70,7 +71,7 @@ public final class IncidentServiceTest {
     final var searchQuery = SearchQueryBuilders.incidentSearchQuery().build();
 
     // when
-    final var searchQueryResult = services.search(searchQuery, authentication, "default");
+    final var searchQueryResult = services.search(searchQuery, authentication, PHYSICAL_TENANT_ID);
 
     // then
     assertThat(searchQueryResult).isEqualTo(result);
@@ -82,7 +83,7 @@ public final class IncidentServiceTest {
     final var entity = Instancio.create(IncidentEntity.class);
     when(client.getIncident(any(Long.class))).thenReturn(entity);
     // when
-    final var searchQueryResult = services.getByKey(1L, authentication, "default");
+    final var searchQueryResult = services.getByKey(1L, authentication, PHYSICAL_TENANT_ID);
 
     // then
     assertThat(searchQueryResult).isEqualTo(entity);
@@ -94,7 +95,8 @@ public final class IncidentServiceTest {
     when(client.getIncident(any(Long.class)))
         .thenThrow(new ResourceAccessDeniedException(Authorizations.INCIDENT_READ_AUTHORIZATION));
     // when
-    final ThrowingCallable executeGetByKey = () -> services.getByKey(1L, authentication, "default");
+    final ThrowingCallable executeGetByKey =
+        () -> services.getByKey(1L, authentication, PHYSICAL_TENANT_ID);
     // then
     final var exception =
         (ServiceException)
@@ -119,7 +121,7 @@ public final class IncidentServiceTest {
                 .filter(f -> f.states(IncidentState.ACTIVE.name()))
                 .build(),
             authentication,
-            "default");
+            PHYSICAL_TENANT_ID);
 
     // then
     assertThat(searchQueryResult.items()).contains(entity);
@@ -150,7 +152,7 @@ public final class IncidentServiceTest {
                 .filter(f -> f.state(state).errorHashCode(errorHashCode))
                 .build(),
             authentication,
-            "default");
+            PHYSICAL_TENANT_ID);
 
     // then
     assertThat(searchQueryResult.items()).contains(entity);
@@ -179,7 +181,8 @@ public final class IncidentServiceTest {
             .build();
 
     // when
-    services.incidentProcessInstanceStatisticsByError(initialQuery, authentication, "default");
+    services.incidentProcessInstanceStatisticsByError(
+        initialQuery, authentication, PHYSICAL_TENANT_ID);
 
     // then
     final var queryCaptor =
@@ -201,7 +204,8 @@ public final class IncidentServiceTest {
         SearchQueryBuilders.incidentProcessInstanceStatisticsByErrorQuery().build();
 
     // when
-    services.incidentProcessInstanceStatisticsByError(initialQuery, authentication, "default");
+    services.incidentProcessInstanceStatisticsByError(
+        initialQuery, authentication, PHYSICAL_TENANT_ID);
 
     // then
     final var queryCaptor =

--- a/service/src/test/java/io/camunda/service/JobServiceTest.java
+++ b/service/src/test/java/io/camunda/service/JobServiceTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 
 public class JobServiceTest {
 
+  private static final String PHYSICAL_TENANT_ID = "foo";
   private JobServices<SearchQueryResult<JobEntity>> services;
   private JobSearchClient client;
   private CamundaAuthentication authentication;
@@ -53,7 +54,7 @@ public class JobServiceTest {
     final var searchQuery = SearchQueryBuilders.jobSearchQuery().build();
 
     // when
-    final var searchQueryResult = services.search(searchQuery, authentication, "default");
+    final var searchQueryResult = services.search(searchQuery, authentication, PHYSICAL_TENANT_ID);
 
     // then
     assertThat(searchQueryResult).isEqualTo(result);

--- a/service/src/test/java/io/camunda/service/JobServiceTest.java
+++ b/service/src/test/java/io/camunda/service/JobServiceTest.java
@@ -32,6 +32,7 @@ public class JobServiceTest {
   public void before() {
     client = mock(JobSearchClient.class);
     when(client.withSecurityContext(any())).thenReturn(client);
+    when(client.withPhysicalTenant(any())).thenReturn(client);
     authentication = mock(CamundaAuthentication.class);
     services =
         new JobServices<>(
@@ -52,7 +53,7 @@ public class JobServiceTest {
     final var searchQuery = SearchQueryBuilders.jobSearchQuery().build();
 
     // when
-    final var searchQueryResult = services.search(searchQuery, authentication);
+    final var searchQueryResult = services.search(searchQuery, authentication, "default");
 
     // then
     assertThat(searchQueryResult).isEqualTo(result);

--- a/service/src/test/java/io/camunda/service/MappingRuleServicesTest.java
+++ b/service/src/test/java/io/camunda/service/MappingRuleServicesTest.java
@@ -60,6 +60,7 @@ public class MappingRuleServicesTest {
     client = mock(MappingRuleSearchClient.class);
     result = mock(SearchQueryResult.class);
     when(client.withSecurityContext(any())).thenReturn(client);
+    when(client.withPhysicalTenant(any())).thenReturn(client);
     when(client.searchMappingRules(any())).thenReturn(result);
     mappingRuleDeleteRequestArgumentCaptor =
         ArgumentCaptor.forClass(BrokerMappingRuleDeleteRequest.class);
@@ -84,7 +85,7 @@ public class MappingRuleServicesTest {
         new MappingRuleDTO("newClaimName", "newClaimValue", "mappingRuleName", "mappingRuleId");
 
     // when
-    services.createMappingRule(mappingRuleDTO, authentication);
+    services.createMappingRule(mappingRuleDTO, authentication, "default");
 
     // then
     final BrokerMappingRuleCreateRequest request = stubbedBrokerClient.getSingleBrokerRequest();
@@ -106,7 +107,7 @@ public class MappingRuleServicesTest {
     final var searchQuery = SearchQueryBuilders.mappingRuleSearchQuery((b) -> b.filter(filter));
 
     // when
-    final var searchQueryResult = services.search(searchQuery, authentication);
+    final var searchQueryResult = services.search(searchQuery, authentication, "default");
 
     // then
     assertThat(searchQueryResult).isEqualTo(result);
@@ -127,7 +128,8 @@ public class MappingRuleServicesTest {
     when(client.getMappingRule(any(String.class))).thenReturn(entity);
 
     // when
-    final var searchQueryResult = services.getMappingRule("mappingRuleId", authentication);
+    final var searchQueryResult =
+        services.getMappingRule("mappingRuleId", authentication, "default");
 
     // then
     assertThat(searchQueryResult).isEqualTo(entity);
@@ -153,7 +155,7 @@ public class MappingRuleServicesTest {
         .thenReturn(CompletableFuture.completedFuture(new BrokerResponse<>(mappingRuleRecord)));
 
     //  when
-    testMappingRuleServices.deleteMappingRule("id", testAuthentication);
+    testMappingRuleServices.deleteMappingRule("id", testAuthentication, "default");
 
     // then
     verify(mockBrokerClient).sendRequest(mappingRuleDeleteRequestArgumentCaptor.capture());
@@ -188,7 +190,7 @@ public class MappingRuleServicesTest {
             mappingRuleRecord.getMappingRuleId());
 
     //  when
-    testMappingRuleServices.updateMappingRule(mappingRuleDTO, testAuthentication);
+    testMappingRuleServices.updateMappingRule(mappingRuleDTO, testAuthentication, "default");
 
     // then
     verify(mockBrokerClient).sendRequest(mappingRuleUpdateRequestArgumentCaptor.capture());
@@ -206,7 +208,7 @@ public class MappingRuleServicesTest {
     final Map<String, Object> claims =
         Map.of("c1", "v1", "c2", List.of("v2.1", "v2.2"), "c3", 300, "c4", true);
     // when
-    services.getMatchingMappingRules(claims, authentication);
+    services.getMatchingMappingRules(claims, authentication, "default");
     // then
     final ArgumentCaptor<MappingRuleQuery> queryCaptor =
         ArgumentCaptor.forClass(MappingRuleQuery.class);

--- a/service/src/test/java/io/camunda/service/MappingRuleServicesTest.java
+++ b/service/src/test/java/io/camunda/service/MappingRuleServicesTest.java
@@ -43,6 +43,7 @@ import org.mockito.ArgumentCaptor;
 
 public class MappingRuleServicesTest {
 
+  private static final String PHYSICAL_TENANT_ID = "foo";
   ArgumentCaptor<BrokerMappingRuleDeleteRequest> mappingRuleDeleteRequestArgumentCaptor;
   ArgumentCaptor<BrokerMappingRuleUpdateRequest> mappingRuleUpdateRequestArgumentCaptor;
   private MappingRuleServices services;
@@ -85,7 +86,7 @@ public class MappingRuleServicesTest {
         new MappingRuleDTO("newClaimName", "newClaimValue", "mappingRuleName", "mappingRuleId");
 
     // when
-    services.createMappingRule(mappingRuleDTO, authentication, "default");
+    services.createMappingRule(mappingRuleDTO, authentication, PHYSICAL_TENANT_ID);
 
     // then
     final BrokerMappingRuleCreateRequest request = stubbedBrokerClient.getSingleBrokerRequest();
@@ -107,7 +108,7 @@ public class MappingRuleServicesTest {
     final var searchQuery = SearchQueryBuilders.mappingRuleSearchQuery((b) -> b.filter(filter));
 
     // when
-    final var searchQueryResult = services.search(searchQuery, authentication, "default");
+    final var searchQueryResult = services.search(searchQuery, authentication, PHYSICAL_TENANT_ID);
 
     // then
     assertThat(searchQueryResult).isEqualTo(result);
@@ -129,7 +130,7 @@ public class MappingRuleServicesTest {
 
     // when
     final var searchQueryResult =
-        services.getMappingRule("mappingRuleId", authentication, "default");
+        services.getMappingRule("mappingRuleId", authentication, PHYSICAL_TENANT_ID);
 
     // then
     assertThat(searchQueryResult).isEqualTo(entity);
@@ -155,7 +156,7 @@ public class MappingRuleServicesTest {
         .thenReturn(CompletableFuture.completedFuture(new BrokerResponse<>(mappingRuleRecord)));
 
     //  when
-    testMappingRuleServices.deleteMappingRule("id", testAuthentication, "default");
+    testMappingRuleServices.deleteMappingRule("id", testAuthentication, PHYSICAL_TENANT_ID);
 
     // then
     verify(mockBrokerClient).sendRequest(mappingRuleDeleteRequestArgumentCaptor.capture());
@@ -190,7 +191,8 @@ public class MappingRuleServicesTest {
             mappingRuleRecord.getMappingRuleId());
 
     //  when
-    testMappingRuleServices.updateMappingRule(mappingRuleDTO, testAuthentication, "default");
+    testMappingRuleServices.updateMappingRule(
+        mappingRuleDTO, testAuthentication, PHYSICAL_TENANT_ID);
 
     // then
     verify(mockBrokerClient).sendRequest(mappingRuleUpdateRequestArgumentCaptor.capture());
@@ -208,7 +210,7 @@ public class MappingRuleServicesTest {
     final Map<String, Object> claims =
         Map.of("c1", "v1", "c2", List.of("v2.1", "v2.2"), "c3", 300, "c4", true);
     // when
-    services.getMatchingMappingRules(claims, authentication, "default");
+    services.getMatchingMappingRules(claims, authentication, PHYSICAL_TENANT_ID);
     // then
     final ArgumentCaptor<MappingRuleQuery> queryCaptor =
         ArgumentCaptor.forClass(MappingRuleQuery.class);

--- a/service/src/test/java/io/camunda/service/MessageSubscriptionServiceTest.java
+++ b/service/src/test/java/io/camunda/service/MessageSubscriptionServiceTest.java
@@ -39,6 +39,7 @@ public class MessageSubscriptionServiceTest {
   public void before() {
     client = mock(MessageSubscriptionSearchClient.class);
     when(client.withSecurityContext(any())).thenReturn(client);
+    when(client.withPhysicalTenant(any())).thenReturn(client);
     authentication = mock(CamundaAuthentication.class);
     services =
         new MessageSubscriptionServices(
@@ -58,7 +59,7 @@ public class MessageSubscriptionServiceTest {
     final var searchQuery = SearchQueryBuilders.messageSubscriptionSearchQuery().build();
 
     // when
-    final var searchQueryResult = services.search(searchQuery, authentication);
+    final var searchQueryResult = services.search(searchQuery, authentication, "default");
 
     // then
     assertThat(searchQueryResult).isEqualTo(result);
@@ -71,7 +72,7 @@ public class MessageSubscriptionServiceTest {
     when(client.getMessageSubscription(any(Long.class))).thenReturn(entity);
 
     // when
-    final var result = services.getByKey(1L, authentication);
+    final var result = services.getByKey(1L, authentication, "default");
 
     // then
     assertThat(result).isEqualTo(entity);
@@ -86,7 +87,7 @@ public class MessageSubscriptionServiceTest {
                 Authorizations.MESSAGE_SUBSCRIPTION_READ_AUTHORIZATION));
 
     // when
-    final ThrowingCallable executeGetByKey = () -> services.getByKey(1L, authentication);
+    final ThrowingCallable executeGetByKey = () -> services.getByKey(1L, authentication, "default");
 
     // then
     final var exception =

--- a/service/src/test/java/io/camunda/service/MessageSubscriptionServiceTest.java
+++ b/service/src/test/java/io/camunda/service/MessageSubscriptionServiceTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 
 public class MessageSubscriptionServiceTest {
 
+  private static final String PHYSICAL_TENANT_ID = "foo";
   private MessageSubscriptionServices services;
   private MessageSubscriptionSearchClient client;
   private CamundaAuthentication authentication;
@@ -59,7 +60,7 @@ public class MessageSubscriptionServiceTest {
     final var searchQuery = SearchQueryBuilders.messageSubscriptionSearchQuery().build();
 
     // when
-    final var searchQueryResult = services.search(searchQuery, authentication, "default");
+    final var searchQueryResult = services.search(searchQuery, authentication, PHYSICAL_TENANT_ID);
 
     // then
     assertThat(searchQueryResult).isEqualTo(result);
@@ -72,7 +73,7 @@ public class MessageSubscriptionServiceTest {
     when(client.getMessageSubscription(any(Long.class))).thenReturn(entity);
 
     // when
-    final var result = services.getByKey(1L, authentication, "default");
+    final var result = services.getByKey(1L, authentication, PHYSICAL_TENANT_ID);
 
     // then
     assertThat(result).isEqualTo(entity);
@@ -87,7 +88,8 @@ public class MessageSubscriptionServiceTest {
                 Authorizations.MESSAGE_SUBSCRIPTION_READ_AUTHORIZATION));
 
     // when
-    final ThrowingCallable executeGetByKey = () -> services.getByKey(1L, authentication, "default");
+    final ThrowingCallable executeGetByKey =
+        () -> services.getByKey(1L, authentication, PHYSICAL_TENANT_ID);
 
     // then
     final var exception =

--- a/service/src/test/java/io/camunda/service/ProcessDefinitionServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ProcessDefinitionServiceTest.java
@@ -46,6 +46,8 @@ public class ProcessDefinitionServiceTest {
     processDefinitionSearchClient = mock(ProcessDefinitionSearchClient.class);
     when(processDefinitionSearchClient.withSecurityContext(any()))
         .thenReturn(processDefinitionSearchClient);
+    when(processDefinitionSearchClient.withPhysicalTenant(any()))
+        .thenReturn(processDefinitionSearchClient);
     securityContextProvider = mock(SecurityContextProvider.class);
     authentication = CamundaAuthentication.none();
     brokerClient = mock(BrokerClient.class);
@@ -82,7 +84,8 @@ public class ProcessDefinitionServiceTest {
     final var query = new ProcessDefinitionInstanceStatisticsQuery.Builder().build();
 
     // when
-    final var result = services.getProcessDefinitionInstanceStatistics(query, authentication);
+    final var result =
+        services.getProcessDefinitionInstanceStatistics(query, authentication, "default");
 
     // then
     assertThat(result).isEqualTo(statsResult);
@@ -113,7 +116,7 @@ public class ProcessDefinitionServiceTest {
 
     // when
     final var result =
-        services.searchProcessDefinitionInstanceVersionStatistics(query, authentication);
+        services.searchProcessDefinitionInstanceVersionStatistics(query, authentication, "default");
 
     // then
     assertThat(result).isEqualTo(statsResult);
@@ -140,7 +143,7 @@ public class ProcessDefinitionServiceTest {
         .thenReturn(statistics);
 
     // when
-    final var result = services.elementStatistics(filter, authentication);
+    final var result = services.elementStatistics(filter, authentication, "default");
 
     // then
     assertThat(result).isEqualTo(statistics);

--- a/service/src/test/java/io/camunda/service/ProcessDefinitionServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ProcessDefinitionServiceTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Test;
 
 public class ProcessDefinitionServiceTest {
 
+  private static final String PHYSICAL_TENANT_ID = "foo";
   private ProcessDefinitionServices services;
   private ProcessDefinitionSearchClient processDefinitionSearchClient;
   private SecurityContextProvider securityContextProvider;
@@ -85,7 +86,7 @@ public class ProcessDefinitionServiceTest {
 
     // when
     final var result =
-        services.getProcessDefinitionInstanceStatistics(query, authentication, "default");
+        services.getProcessDefinitionInstanceStatistics(query, authentication, PHYSICAL_TENANT_ID);
 
     // then
     assertThat(result).isEqualTo(statsResult);
@@ -116,7 +117,8 @@ public class ProcessDefinitionServiceTest {
 
     // when
     final var result =
-        services.searchProcessDefinitionInstanceVersionStatistics(query, authentication, "default");
+        services.searchProcessDefinitionInstanceVersionStatistics(
+            query, authentication, PHYSICAL_TENANT_ID);
 
     // then
     assertThat(result).isEqualTo(statsResult);
@@ -143,7 +145,7 @@ public class ProcessDefinitionServiceTest {
         .thenReturn(statistics);
 
     // when
-    final var result = services.elementStatistics(filter, authentication, "default");
+    final var result = services.elementStatistics(filter, authentication, PHYSICAL_TENANT_ID);
 
     // then
     assertThat(result).isEqualTo(statistics);

--- a/service/src/test/java/io/camunda/service/ProcessInstanceRoundRobinDispatchTest.java
+++ b/service/src/test/java/io/camunda/service/ProcessInstanceRoundRobinDispatchTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Test;
 
 final class ProcessInstanceRoundRobinDispatchTest {
 
+  private static final String PHYSICAL_TENANT_ID = "foo";
   private static final int PARTITION_COUNT = 3;
 
   private BrokerClient brokerClient;
@@ -67,7 +68,9 @@ final class ProcessInstanceRoundRobinDispatchTest {
     // when — first request warms up the per-definition handler via the global handler;
     // subsequent requests use the per-definition handler and cycle through all partitions
     for (int i = 0; i < PARTITION_COUNT + 1; i++) {
-      services.createProcessInstance(createRequest(100L), authentication, "default").join();
+      services
+          .createProcessInstance(createRequest(100L), authentication, PHYSICAL_TENANT_ID)
+          .join();
     }
 
     // then — the per-definition handler (requests 2..N) hit every partition
@@ -79,19 +82,23 @@ final class ProcessInstanceRoundRobinDispatchTest {
   void shouldDistributeIndependentlyPerDefinitionKey() {
     // given — warm up per-definition handlers for both definition keys
     final var partitions = capturePartitions();
-    services.createProcessInstance(createRequest(100L), authentication, "default").join();
-    services.createProcessInstance(createRequest(200L), authentication, "default").join();
+    services.createProcessInstance(createRequest(100L), authentication, PHYSICAL_TENANT_ID).join();
+    services.createProcessInstance(createRequest(200L), authentication, PHYSICAL_TENANT_ID).join();
     partitions.clear();
 
     // when — send PARTITION_COUNT requests for each process definition
     for (int i = 0; i < PARTITION_COUNT; i++) {
-      services.createProcessInstance(createRequest(100L), authentication, "default").join();
+      services
+          .createProcessInstance(createRequest(100L), authentication, PHYSICAL_TENANT_ID)
+          .join();
     }
     final var partitionsA = List.copyOf(partitions);
     partitions.clear();
 
     for (int i = 0; i < PARTITION_COUNT; i++) {
-      services.createProcessInstance(createRequest(200L), authentication, "default").join();
+      services
+          .createProcessInstance(createRequest(200L), authentication, PHYSICAL_TENANT_ID)
+          .join();
     }
     final var partitionsB = List.copyOf(partitions);
 
@@ -116,7 +123,9 @@ final class ProcessInstanceRoundRobinDispatchTest {
             });
 
     try {
-      services.createProcessInstance(createRequest(100L), authentication, "default").join();
+      services
+          .createProcessInstance(createRequest(100L), authentication, PHYSICAL_TENANT_ID)
+          .join();
     } catch (final Exception ignored) {
       // expected
     }
@@ -134,7 +143,7 @@ final class ProcessInstanceRoundRobinDispatchTest {
             });
 
     // when — send a second request for the same definition key
-    services.createProcessInstance(createRequest(100L), authentication, "default").join();
+    services.createProcessInstance(createRequest(100L), authentication, PHYSICAL_TENANT_ID).join();
 
     // then — the second request used the global handler (not a per-definition one),
     // so its partition is the global handler's next offset, different from the first

--- a/service/src/test/java/io/camunda/service/ProcessInstanceRoundRobinDispatchTest.java
+++ b/service/src/test/java/io/camunda/service/ProcessInstanceRoundRobinDispatchTest.java
@@ -67,7 +67,7 @@ final class ProcessInstanceRoundRobinDispatchTest {
     // when — first request warms up the per-definition handler via the global handler;
     // subsequent requests use the per-definition handler and cycle through all partitions
     for (int i = 0; i < PARTITION_COUNT + 1; i++) {
-      services.createProcessInstance(createRequest(100L), authentication).join();
+      services.createProcessInstance(createRequest(100L), authentication, "default").join();
     }
 
     // then — the per-definition handler (requests 2..N) hit every partition
@@ -79,19 +79,19 @@ final class ProcessInstanceRoundRobinDispatchTest {
   void shouldDistributeIndependentlyPerDefinitionKey() {
     // given — warm up per-definition handlers for both definition keys
     final var partitions = capturePartitions();
-    services.createProcessInstance(createRequest(100L), authentication).join();
-    services.createProcessInstance(createRequest(200L), authentication).join();
+    services.createProcessInstance(createRequest(100L), authentication, "default").join();
+    services.createProcessInstance(createRequest(200L), authentication, "default").join();
     partitions.clear();
 
     // when — send PARTITION_COUNT requests for each process definition
     for (int i = 0; i < PARTITION_COUNT; i++) {
-      services.createProcessInstance(createRequest(100L), authentication).join();
+      services.createProcessInstance(createRequest(100L), authentication, "default").join();
     }
     final var partitionsA = List.copyOf(partitions);
     partitions.clear();
 
     for (int i = 0; i < PARTITION_COUNT; i++) {
-      services.createProcessInstance(createRequest(200L), authentication).join();
+      services.createProcessInstance(createRequest(200L), authentication, "default").join();
     }
     final var partitionsB = List.copyOf(partitions);
 
@@ -116,7 +116,7 @@ final class ProcessInstanceRoundRobinDispatchTest {
             });
 
     try {
-      services.createProcessInstance(createRequest(100L), authentication).join();
+      services.createProcessInstance(createRequest(100L), authentication, "default").join();
     } catch (final Exception ignored) {
       // expected
     }
@@ -134,7 +134,7 @@ final class ProcessInstanceRoundRobinDispatchTest {
             });
 
     // when — send a second request for the same definition key
-    services.createProcessInstance(createRequest(100L), authentication).join();
+    services.createProcessInstance(createRequest(100L), authentication, "default").join();
 
     // then — the second request used the global handler (not a per-definition one),
     // so its partition is the global handler's next offset, different from the first

--- a/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
@@ -106,7 +106,10 @@ public final class ProcessInstanceServiceTest {
     incidentServices = mock(IncidentServices.class);
     when(processInstanceSearchClient.withSecurityContext(any()))
         .thenReturn(processInstanceSearchClient);
+    when(processInstanceSearchClient.withPhysicalTenant(any()))
+        .thenReturn(processInstanceSearchClient);
     when(sequenceFlowSearchClient.withSecurityContext(any())).thenReturn(sequenceFlowSearchClient);
+    when(sequenceFlowSearchClient.withPhysicalTenant(any())).thenReturn(sequenceFlowSearchClient);
     securityContextProvider = mock(SecurityContextProvider.class);
     brokerClient = mock(BrokerClient.class);
     when(brokerClient.getTopologyManager()).thenReturn(new StubbedTopologyManager(3));
@@ -135,7 +138,7 @@ public final class ProcessInstanceServiceTest {
 
     // when
     final SearchQueryResult<ProcessInstanceEntity> searchQueryResult =
-        services.search(searchQuery, authentication);
+        services.search(searchQuery, authentication, "default");
 
     // then
     assertThat(searchQueryResult).isEqualTo(result);
@@ -156,7 +159,7 @@ public final class ProcessInstanceServiceTest {
     when(sequenceFlowSearchClient.searchSequenceFlows(any())).thenReturn(result);
 
     // when
-    final var actual = services.sequenceFlows(123L, authentication);
+    final var actual = services.sequenceFlows(123L, authentication, "default");
 
     // then
     verify(sequenceFlowSearchClient)
@@ -175,7 +178,7 @@ public final class ProcessInstanceServiceTest {
     when(processInstanceSearchClient.getProcessInstance(eq(123L))).thenReturn(entity);
 
     // when
-    final var searchQueryResult = services.getByKey(key, authentication);
+    final var searchQueryResult = services.getByKey(key, authentication, "default");
 
     // then
     assertThat(searchQueryResult.processInstanceKey()).isEqualTo(key);
@@ -190,7 +193,7 @@ public final class ProcessInstanceServiceTest {
         .thenThrow(
             new ResourceAccessDeniedException(Authorizations.PROCESS_INSTANCE_READ_AUTHORIZATION));
     // when
-    final ThrowingCallable executeGetByKey = () -> services.getByKey(1L, authentication);
+    final ThrowingCallable executeGetByKey = () -> services.getByKey(1L, authentication, "default");
     // then
     final var exception =
         (ServiceException)
@@ -218,7 +221,9 @@ public final class ProcessInstanceServiceTest {
 
     // when
     final var result =
-        services.cancelProcessInstanceBatchOperationWithResult(filter, authentication).join();
+        services
+            .cancelProcessInstanceBatchOperationWithResult(filter, authentication, "default")
+            .join();
 
     // then
     assertThat(result.getBatchOperationKey()).isEqualTo(batchOperationKey);
@@ -251,7 +256,8 @@ public final class ProcessInstanceServiceTest {
         .thenReturn(CompletableFuture.completedFuture(new BrokerResponse<>(record)));
 
     // when
-    final var result = services.resolveProcessInstanceIncidents(345L, authentication).join();
+    final var result =
+        services.resolveProcessInstanceIncidents(345L, authentication, "default").join();
 
     // then
     assertThat(result.getBatchOperationKey()).isEqualTo(batchOperationKey);
@@ -291,7 +297,8 @@ public final class ProcessInstanceServiceTest {
             new SearchQueryResult<>(1, false, List.of(childProcess, parentProcess), null, null));
 
     // when
-    final var result = services.callHierarchy(childProcess.processInstanceKey(), authentication);
+    final var result =
+        services.callHierarchy(childProcess.processInstanceKey(), authentication, "default");
 
     // then
     assertThat(result).hasSize(2);
@@ -311,7 +318,7 @@ public final class ProcessInstanceServiceTest {
     when(processInstanceSearchClient.getProcessInstance(eq(123L))).thenReturn(rootInstance);
 
     // when
-    final var result = services.callHierarchy(123L, authentication);
+    final var result = services.callHierarchy(123L, authentication, "default");
 
     // then
     assertThat(result).isEmpty(); // No hierarchy should return an empty list
@@ -329,7 +336,7 @@ public final class ProcessInstanceServiceTest {
     when(processInstanceSearchClient.getProcessInstance(eq(123L))).thenReturn(rootInstance);
 
     // when
-    final var result = services.callHierarchy(123L, authentication);
+    final var result = services.callHierarchy(123L, authentication, "default");
 
     // then
     assertThat(result).isEmpty(); // No hierarchy should return an empty list
@@ -352,7 +359,7 @@ public final class ProcessInstanceServiceTest {
 
     // when
     final var result =
-        services.resolveIncidentsBatchOperationWithResult(filter, authentication).join();
+        services.resolveIncidentsBatchOperationWithResult(filter, authentication, "default").join();
 
     // then
     assertThat(result.getBatchOperationKey()).isEqualTo(batchOperationKey);
@@ -393,7 +400,7 @@ public final class ProcessInstanceServiceTest {
 
     // when
     final var result =
-        services.migrateProcessInstancesBatchOperation(request, authentication).join();
+        services.migrateProcessInstancesBatchOperation(request, authentication, "default").join();
 
     // then
     assertThat(result.getBatchOperationKey()).isEqualTo(batchOperationKey);
@@ -441,7 +448,7 @@ public final class ProcessInstanceServiceTest {
 
     // when
     final var result =
-        services.modifyProcessInstancesBatchOperation(request, authentication).join();
+        services.modifyProcessInstancesBatchOperation(request, authentication, "default").join();
 
     // then
     assertThat(result.getBatchOperationKey()).isEqualTo(batchOperationKey);
@@ -484,16 +491,17 @@ public final class ProcessInstanceServiceTest {
     when(processInstanceSearchClient.getProcessInstance(eq(processInstanceKey)))
         .thenReturn(processInstance);
 
-    when(incidentServices.search(any(IncidentQuery.class), any())).thenReturn(queryResult);
+    when(incidentServices.search(any(IncidentQuery.class), any(), any())).thenReturn(queryResult);
 
     // when
-    final var result = services.searchIncidents(processInstanceKey, query, authentication);
+    final var result =
+        services.searchIncidents(processInstanceKey, query, authentication, "default");
 
     // then
     assertThat(result).isEqualTo(queryResult);
 
     final var incidentQueryCaptor = ArgumentCaptor.forClass(IncidentQuery.class);
-    verify(incidentServices).search(incidentQueryCaptor.capture(), any());
+    verify(incidentServices).search(incidentQueryCaptor.capture(), any(), any());
     final var incidentQuery = incidentQueryCaptor.getValue();
     assertThat(incidentQuery.filter().treePathOperations())
         .containsExactly(Operation.like(processInstance.treePath() + "*"));
@@ -517,7 +525,7 @@ public final class ProcessInstanceServiceTest {
 
     // when
     final ThrowingCallable executeGetByKey =
-        () -> services.searchIncidents(processInstanceKey, query, authentication);
+        () -> services.searchIncidents(processInstanceKey, query, authentication, "default");
 
     // then
     final var exception =
@@ -546,7 +554,8 @@ public final class ProcessInstanceServiceTest {
         .thenReturn(CompletableFuture.completedFuture(new BrokerResponse<>(record)));
 
     // when
-    final var result = services.deleteProcessInstancesBatchOperation(filter, authentication).join();
+    final var result =
+        services.deleteProcessInstancesBatchOperation(filter, authentication, "default").join();
 
     // then
     assertThat(result.getBatchOperationKey()).isEqualTo(batchOperationKey);
@@ -586,7 +595,7 @@ public final class ProcessInstanceServiceTest {
         .thenReturn(CompletableFuture.completedFuture(new BrokerResponse<>(record)));
 
     // when
-    services.deleteProcessInstance(processInstanceKey, null, authentication).join();
+    services.deleteProcessInstance(processInstanceKey, null, authentication, "default").join();
 
     // then
     final var brokerRequest = (HistoryDeletionRecord) captor.getValue().getRequestWriter();
@@ -609,7 +618,10 @@ public final class ProcessInstanceServiceTest {
 
     // when/then
     assertThatThrownBy(
-            () -> services.deleteProcessInstance(processInstanceKey, null, authentication).join())
+            () ->
+                services
+                    .deleteProcessInstance(processInstanceKey, null, authentication, "default")
+                    .join())
         .isInstanceOf(ServiceException.class)
         .hasMessage("Process Instance with key '123' not found");
   }
@@ -641,7 +653,7 @@ public final class ProcessInstanceServiceTest {
         .thenReturn(CompletableFuture.completedFuture(new BrokerResponse<>(mockResponse)));
 
     // when
-    services.createProcessInstanceWithResult(request, authentication).join();
+    services.createProcessInstanceWithResult(request, authentication, "default").join();
 
     // then
     verify(brokerClient)
@@ -679,7 +691,7 @@ public final class ProcessInstanceServiceTest {
         .thenReturn(CompletableFuture.completedFuture(new BrokerResponse<>(mockResponse)));
 
     // when
-    services.createProcessInstanceWithResult(request, authentication).join();
+    services.createProcessInstanceWithResult(request, authentication, "default").join();
 
     // then
     verify(brokerClient)
@@ -718,7 +730,7 @@ public final class ProcessInstanceServiceTest {
         .thenReturn(CompletableFuture.completedFuture(new BrokerResponse<>(mockResponse)));
 
     // when
-    services.createProcessInstanceWithResult(request, authentication).join();
+    services.createProcessInstanceWithResult(request, authentication, "default").join();
 
     // then
     verify(brokerClient)
@@ -767,7 +779,7 @@ public final class ProcessInstanceServiceTest {
               });
 
       // when
-      final var result = services.createProcessInstance(request, authentication).join();
+      final var result = services.createProcessInstance(request, authentication, "default").join();
 
       // then - retried on a different partition and succeeded
       assertThat(result).isNotNull();
@@ -796,7 +808,8 @@ public final class ProcessInstanceServiceTest {
               });
 
       // when
-      final var result = services.createProcessInstanceWithResult(request, authentication).join();
+      final var result =
+          services.createProcessInstanceWithResult(request, authentication, "default").join();
 
       // then
       assertThat(result).isNotNull();
@@ -821,7 +834,8 @@ public final class ProcessInstanceServiceTest {
               });
 
       // when / then - all 3 partitions tried with distinct IDs, then RESOURCE_EXHAUSTED error
-      assertThatThrownBy(() -> services.createProcessInstance(request, authentication).join())
+      assertThatThrownBy(
+              () -> services.createProcessInstance(request, authentication, "default").join())
           .isInstanceOf(CompletionException.class)
           .hasCauseInstanceOf(ServiceException.class)
           .extracting(Throwable::getCause)
@@ -852,7 +866,10 @@ public final class ProcessInstanceServiceTest {
 
       // when / then
       assertThatThrownBy(
-              () -> services.createProcessInstanceWithResult(request, authentication).join())
+              () ->
+                  services
+                      .createProcessInstanceWithResult(request, authentication, "default")
+                      .join())
           .isInstanceOf(CompletionException.class)
           .hasCauseInstanceOf(ServiceException.class)
           .extracting(Throwable::getCause)
@@ -876,7 +893,8 @@ public final class ProcessInstanceServiceTest {
                       new BrokerError(ErrorCode.PROCESS_NOT_FOUND, "process not found"))));
 
       // when / then - only tried once, no retry
-      assertThatThrownBy(() -> services.createProcessInstance(request, authentication).join())
+      assertThatThrownBy(
+              () -> services.createProcessInstance(request, authentication, "default").join())
           .isInstanceOf(CompletionException.class)
           .hasCauseInstanceOf(ServiceException.class);
       verify(brokerClient, times(1)).sendRequest(any(BrokerCreateProcessInstanceRequest.class));
@@ -892,7 +910,8 @@ public final class ProcessInstanceServiceTest {
 
       // when / then - only one attempt, error propagated directly without retrying other
       // partitions
-      assertThatThrownBy(() -> services.createProcessInstance(request, authentication).join())
+      assertThatThrownBy(
+              () -> services.createProcessInstance(request, authentication, "default").join())
           .isInstanceOf(CompletionException.class)
           .hasCauseInstanceOf(ServiceException.class);
       verify(brokerClient, times(1)).sendRequest(any(BrokerCreateProcessInstanceRequest.class));
@@ -921,7 +940,8 @@ public final class ProcessInstanceServiceTest {
               });
 
       // when
-      final var result = services.createProcessInstanceWithResult(request, authentication).join();
+      final var result =
+          services.createProcessInstanceWithResult(request, authentication, "default").join();
 
       // then
       assertThat(result).isNotNull();
@@ -942,7 +962,10 @@ public final class ProcessInstanceServiceTest {
 
       // when / then - only one attempt
       assertThatThrownBy(
-              () -> services.createProcessInstanceWithResult(request, authentication).join())
+              () ->
+                  services
+                      .createProcessInstanceWithResult(request, authentication, "default")
+                      .join())
           .isInstanceOf(CompletionException.class)
           .hasCauseInstanceOf(ServiceException.class);
       verify(brokerClient, times(1))

--- a/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
@@ -84,6 +84,7 @@ import org.mockito.ArgumentCaptor;
 
 public final class ProcessInstanceServiceTest {
 
+  private static final String PHYSICAL_TENANT_ID = "foo";
   private ProcessInstanceServices services;
   private ProcessInstanceSearchClient processInstanceSearchClient;
   private SequenceFlowSearchClient sequenceFlowSearchClient;
@@ -138,7 +139,7 @@ public final class ProcessInstanceServiceTest {
 
     // when
     final SearchQueryResult<ProcessInstanceEntity> searchQueryResult =
-        services.search(searchQuery, authentication, "default");
+        services.search(searchQuery, authentication, PHYSICAL_TENANT_ID);
 
     // then
     assertThat(searchQueryResult).isEqualTo(result);
@@ -159,7 +160,7 @@ public final class ProcessInstanceServiceTest {
     when(sequenceFlowSearchClient.searchSequenceFlows(any())).thenReturn(result);
 
     // when
-    final var actual = services.sequenceFlows(123L, authentication, "default");
+    final var actual = services.sequenceFlows(123L, authentication, PHYSICAL_TENANT_ID);
 
     // then
     verify(sequenceFlowSearchClient)
@@ -178,7 +179,7 @@ public final class ProcessInstanceServiceTest {
     when(processInstanceSearchClient.getProcessInstance(eq(123L))).thenReturn(entity);
 
     // when
-    final var searchQueryResult = services.getByKey(key, authentication, "default");
+    final var searchQueryResult = services.getByKey(key, authentication, PHYSICAL_TENANT_ID);
 
     // then
     assertThat(searchQueryResult.processInstanceKey()).isEqualTo(key);
@@ -193,7 +194,8 @@ public final class ProcessInstanceServiceTest {
         .thenThrow(
             new ResourceAccessDeniedException(Authorizations.PROCESS_INSTANCE_READ_AUTHORIZATION));
     // when
-    final ThrowingCallable executeGetByKey = () -> services.getByKey(1L, authentication, "default");
+    final ThrowingCallable executeGetByKey =
+        () -> services.getByKey(1L, authentication, PHYSICAL_TENANT_ID);
     // then
     final var exception =
         (ServiceException)
@@ -222,7 +224,8 @@ public final class ProcessInstanceServiceTest {
     // when
     final var result =
         services
-            .cancelProcessInstanceBatchOperationWithResult(filter, authentication, "default")
+            .cancelProcessInstanceBatchOperationWithResult(
+                filter, authentication, PHYSICAL_TENANT_ID)
             .join();
 
     // then
@@ -257,7 +260,7 @@ public final class ProcessInstanceServiceTest {
 
     // when
     final var result =
-        services.resolveProcessInstanceIncidents(345L, authentication, "default").join();
+        services.resolveProcessInstanceIncidents(345L, authentication, PHYSICAL_TENANT_ID).join();
 
     // then
     assertThat(result.getBatchOperationKey()).isEqualTo(batchOperationKey);
@@ -298,7 +301,8 @@ public final class ProcessInstanceServiceTest {
 
     // when
     final var result =
-        services.callHierarchy(childProcess.processInstanceKey(), authentication, "default");
+        services.callHierarchy(
+            childProcess.processInstanceKey(), authentication, PHYSICAL_TENANT_ID);
 
     // then
     assertThat(result).hasSize(2);
@@ -318,7 +322,7 @@ public final class ProcessInstanceServiceTest {
     when(processInstanceSearchClient.getProcessInstance(eq(123L))).thenReturn(rootInstance);
 
     // when
-    final var result = services.callHierarchy(123L, authentication, "default");
+    final var result = services.callHierarchy(123L, authentication, PHYSICAL_TENANT_ID);
 
     // then
     assertThat(result).isEmpty(); // No hierarchy should return an empty list
@@ -336,7 +340,7 @@ public final class ProcessInstanceServiceTest {
     when(processInstanceSearchClient.getProcessInstance(eq(123L))).thenReturn(rootInstance);
 
     // when
-    final var result = services.callHierarchy(123L, authentication, "default");
+    final var result = services.callHierarchy(123L, authentication, PHYSICAL_TENANT_ID);
 
     // then
     assertThat(result).isEmpty(); // No hierarchy should return an empty list
@@ -359,7 +363,9 @@ public final class ProcessInstanceServiceTest {
 
     // when
     final var result =
-        services.resolveIncidentsBatchOperationWithResult(filter, authentication, "default").join();
+        services
+            .resolveIncidentsBatchOperationWithResult(filter, authentication, PHYSICAL_TENANT_ID)
+            .join();
 
     // then
     assertThat(result.getBatchOperationKey()).isEqualTo(batchOperationKey);
@@ -400,7 +406,9 @@ public final class ProcessInstanceServiceTest {
 
     // when
     final var result =
-        services.migrateProcessInstancesBatchOperation(request, authentication, "default").join();
+        services
+            .migrateProcessInstancesBatchOperation(request, authentication, PHYSICAL_TENANT_ID)
+            .join();
 
     // then
     assertThat(result.getBatchOperationKey()).isEqualTo(batchOperationKey);
@@ -448,7 +456,9 @@ public final class ProcessInstanceServiceTest {
 
     // when
     final var result =
-        services.modifyProcessInstancesBatchOperation(request, authentication, "default").join();
+        services
+            .modifyProcessInstancesBatchOperation(request, authentication, PHYSICAL_TENANT_ID)
+            .join();
 
     // then
     assertThat(result.getBatchOperationKey()).isEqualTo(batchOperationKey);
@@ -495,7 +505,7 @@ public final class ProcessInstanceServiceTest {
 
     // when
     final var result =
-        services.searchIncidents(processInstanceKey, query, authentication, "default");
+        services.searchIncidents(processInstanceKey, query, authentication, PHYSICAL_TENANT_ID);
 
     // then
     assertThat(result).isEqualTo(queryResult);
@@ -525,7 +535,8 @@ public final class ProcessInstanceServiceTest {
 
     // when
     final ThrowingCallable executeGetByKey =
-        () -> services.searchIncidents(processInstanceKey, query, authentication, "default");
+        () ->
+            services.searchIncidents(processInstanceKey, query, authentication, PHYSICAL_TENANT_ID);
 
     // then
     final var exception =
@@ -555,7 +566,9 @@ public final class ProcessInstanceServiceTest {
 
     // when
     final var result =
-        services.deleteProcessInstancesBatchOperation(filter, authentication, "default").join();
+        services
+            .deleteProcessInstancesBatchOperation(filter, authentication, PHYSICAL_TENANT_ID)
+            .join();
 
     // then
     assertThat(result.getBatchOperationKey()).isEqualTo(batchOperationKey);
@@ -595,7 +608,9 @@ public final class ProcessInstanceServiceTest {
         .thenReturn(CompletableFuture.completedFuture(new BrokerResponse<>(record)));
 
     // when
-    services.deleteProcessInstance(processInstanceKey, null, authentication, "default").join();
+    services
+        .deleteProcessInstance(processInstanceKey, null, authentication, PHYSICAL_TENANT_ID)
+        .join();
 
     // then
     final var brokerRequest = (HistoryDeletionRecord) captor.getValue().getRequestWriter();
@@ -620,7 +635,8 @@ public final class ProcessInstanceServiceTest {
     assertThatThrownBy(
             () ->
                 services
-                    .deleteProcessInstance(processInstanceKey, null, authentication, "default")
+                    .deleteProcessInstance(
+                        processInstanceKey, null, authentication, PHYSICAL_TENANT_ID)
                     .join())
         .isInstanceOf(ServiceException.class)
         .hasMessage("Process Instance with key '123' not found");
@@ -653,7 +669,7 @@ public final class ProcessInstanceServiceTest {
         .thenReturn(CompletableFuture.completedFuture(new BrokerResponse<>(mockResponse)));
 
     // when
-    services.createProcessInstanceWithResult(request, authentication, "default").join();
+    services.createProcessInstanceWithResult(request, authentication, PHYSICAL_TENANT_ID).join();
 
     // then
     verify(brokerClient)
@@ -691,7 +707,7 @@ public final class ProcessInstanceServiceTest {
         .thenReturn(CompletableFuture.completedFuture(new BrokerResponse<>(mockResponse)));
 
     // when
-    services.createProcessInstanceWithResult(request, authentication, "default").join();
+    services.createProcessInstanceWithResult(request, authentication, PHYSICAL_TENANT_ID).join();
 
     // then
     verify(brokerClient)
@@ -730,7 +746,7 @@ public final class ProcessInstanceServiceTest {
         .thenReturn(CompletableFuture.completedFuture(new BrokerResponse<>(mockResponse)));
 
     // when
-    services.createProcessInstanceWithResult(request, authentication, "default").join();
+    services.createProcessInstanceWithResult(request, authentication, PHYSICAL_TENANT_ID).join();
 
     // then
     verify(brokerClient)
@@ -779,7 +795,8 @@ public final class ProcessInstanceServiceTest {
               });
 
       // when
-      final var result = services.createProcessInstance(request, authentication, "default").join();
+      final var result =
+          services.createProcessInstance(request, authentication, PHYSICAL_TENANT_ID).join();
 
       // then - retried on a different partition and succeeded
       assertThat(result).isNotNull();
@@ -809,7 +826,9 @@ public final class ProcessInstanceServiceTest {
 
       // when
       final var result =
-          services.createProcessInstanceWithResult(request, authentication, "default").join();
+          services
+              .createProcessInstanceWithResult(request, authentication, PHYSICAL_TENANT_ID)
+              .join();
 
       // then
       assertThat(result).isNotNull();
@@ -835,7 +854,10 @@ public final class ProcessInstanceServiceTest {
 
       // when / then - all 3 partitions tried with distinct IDs, then RESOURCE_EXHAUSTED error
       assertThatThrownBy(
-              () -> services.createProcessInstance(request, authentication, "default").join())
+              () ->
+                  services
+                      .createProcessInstance(request, authentication, PHYSICAL_TENANT_ID)
+                      .join())
           .isInstanceOf(CompletionException.class)
           .hasCauseInstanceOf(ServiceException.class)
           .extracting(Throwable::getCause)
@@ -868,7 +890,7 @@ public final class ProcessInstanceServiceTest {
       assertThatThrownBy(
               () ->
                   services
-                      .createProcessInstanceWithResult(request, authentication, "default")
+                      .createProcessInstanceWithResult(request, authentication, PHYSICAL_TENANT_ID)
                       .join())
           .isInstanceOf(CompletionException.class)
           .hasCauseInstanceOf(ServiceException.class)
@@ -894,7 +916,10 @@ public final class ProcessInstanceServiceTest {
 
       // when / then - only tried once, no retry
       assertThatThrownBy(
-              () -> services.createProcessInstance(request, authentication, "default").join())
+              () ->
+                  services
+                      .createProcessInstance(request, authentication, PHYSICAL_TENANT_ID)
+                      .join())
           .isInstanceOf(CompletionException.class)
           .hasCauseInstanceOf(ServiceException.class);
       verify(brokerClient, times(1)).sendRequest(any(BrokerCreateProcessInstanceRequest.class));
@@ -911,7 +936,10 @@ public final class ProcessInstanceServiceTest {
       // when / then - only one attempt, error propagated directly without retrying other
       // partitions
       assertThatThrownBy(
-              () -> services.createProcessInstance(request, authentication, "default").join())
+              () ->
+                  services
+                      .createProcessInstance(request, authentication, PHYSICAL_TENANT_ID)
+                      .join())
           .isInstanceOf(CompletionException.class)
           .hasCauseInstanceOf(ServiceException.class);
       verify(brokerClient, times(1)).sendRequest(any(BrokerCreateProcessInstanceRequest.class));
@@ -941,7 +969,9 @@ public final class ProcessInstanceServiceTest {
 
       // when
       final var result =
-          services.createProcessInstanceWithResult(request, authentication, "default").join();
+          services
+              .createProcessInstanceWithResult(request, authentication, PHYSICAL_TENANT_ID)
+              .join();
 
       // then
       assertThat(result).isNotNull();
@@ -964,7 +994,7 @@ public final class ProcessInstanceServiceTest {
       assertThatThrownBy(
               () ->
                   services
-                      .createProcessInstanceWithResult(request, authentication, "default")
+                      .createProcessInstanceWithResult(request, authentication, PHYSICAL_TENANT_ID)
                       .join())
           .isInstanceOf(CompletionException.class)
           .hasCauseInstanceOf(ServiceException.class);

--- a/service/src/test/java/io/camunda/service/RoleServicesTest.java
+++ b/service/src/test/java/io/camunda/service/RoleServicesTest.java
@@ -62,6 +62,7 @@ public class RoleServicesTest {
     stubbedBrokerClient = new StubbedBrokerClient();
     client = mock(RoleSearchClient.class);
     when(client.withSecurityContext(any())).thenReturn(client);
+    when(client.withPhysicalTenant(any())).thenReturn(client);
     executorProvider = mock(ApiServicesExecutorProvider.class);
     when(executorProvider.getExecutor()).thenReturn(ForkJoinPool.commonPool());
     brokerRequestAuthorizationConverter = mock(BrokerRequestAuthorizationConverter.class);
@@ -82,7 +83,8 @@ public class RoleServicesTest {
     final var description = "description";
 
     // when
-    services.createRole(new CreateRoleRequest(roleId, roleName, description), authentication);
+    services.createRole(
+        new CreateRoleRequest(roleId, roleName, description), authentication, "default");
 
     // then
     final BrokerRoleCreateRequest request = stubbedBrokerClient.getSingleBrokerRequest();
@@ -105,7 +107,7 @@ public class RoleServicesTest {
     final var searchQuery = SearchQueryBuilders.roleSearchQuery((b) -> b.filter(filter));
 
     // when
-    final var searchQueryResult = services.search(searchQuery, authentication);
+    final var searchQueryResult = services.search(searchQuery, authentication, "default");
 
     // then
     assertThat(searchQueryResult).isEqualTo(result);
@@ -127,7 +129,7 @@ public class RoleServicesTest {
     when(client.getRole(eq("roleId"))).thenReturn(entity);
 
     // when
-    final var searchQueryResult = services.getRole(entity.roleId(), authentication);
+    final var searchQueryResult = services.getRole(entity.roleId(), authentication, "default");
 
     // then
     assertThat(searchQueryResult).isEqualTo(entity);
@@ -141,7 +143,8 @@ public class RoleServicesTest {
     final var description = "UpdatedDescription";
 
     // when
-    services.updateRole(new UpdateRoleRequest(roleId, name, description), authentication);
+    services.updateRole(
+        new UpdateRoleRequest(roleId, name, description), authentication, "default");
 
     // then
     final BrokerRoleUpdateRequest request = stubbedBrokerClient.getSingleBrokerRequest();
@@ -161,7 +164,8 @@ public class RoleServicesTest {
     final var entityId = "entityId";
 
     // when
-    services.addMember(new RoleMemberRequest(roleId, entityId, EntityType.USER), authentication);
+    services.addMember(
+        new RoleMemberRequest(roleId, entityId, EntityType.USER), authentication, "default");
 
     // then
     final BrokerRoleEntityRequest request = stubbedBrokerClient.getSingleBrokerRequest();
@@ -181,7 +185,8 @@ public class RoleServicesTest {
     final var username = "42";
 
     // when
-    services.removeMember(new RoleMemberRequest(roleId, username, EntityType.USER), authentication);
+    services.removeMember(
+        new RoleMemberRequest(roleId, username, EntityType.USER), authentication, "default");
 
     // then
     final BrokerRoleEntityRequest request = stubbedBrokerClient.getSingleBrokerRequest();
@@ -213,7 +218,8 @@ public class RoleServicesTest {
                     q ->
                         q.filter(f -> f.memberId(memberId).childMemberType(memberType))
                             .unlimited()),
-                authentication)
+                authentication,
+                "default")
             .items();
 
     // then

--- a/service/src/test/java/io/camunda/service/RoleServicesTest.java
+++ b/service/src/test/java/io/camunda/service/RoleServicesTest.java
@@ -49,6 +49,8 @@ import org.mockito.ArgumentCaptor;
 
 public class RoleServicesTest {
 
+  private static final String PHYSICAL_TENANT_ID = "foo";
+
   private RoleServices services;
   private RoleSearchClient client;
   private CamundaAuthentication authentication;
@@ -84,7 +86,7 @@ public class RoleServicesTest {
 
     // when
     services.createRole(
-        new CreateRoleRequest(roleId, roleName, description), authentication, "default");
+        new CreateRoleRequest(roleId, roleName, description), authentication, PHYSICAL_TENANT_ID);
 
     // then
     final BrokerRoleCreateRequest request = stubbedBrokerClient.getSingleBrokerRequest();
@@ -107,7 +109,7 @@ public class RoleServicesTest {
     final var searchQuery = SearchQueryBuilders.roleSearchQuery((b) -> b.filter(filter));
 
     // when
-    final var searchQueryResult = services.search(searchQuery, authentication, "default");
+    final var searchQueryResult = services.search(searchQuery, authentication, PHYSICAL_TENANT_ID);
 
     // then
     assertThat(searchQueryResult).isEqualTo(result);
@@ -129,7 +131,8 @@ public class RoleServicesTest {
     when(client.getRole(eq("roleId"))).thenReturn(entity);
 
     // when
-    final var searchQueryResult = services.getRole(entity.roleId(), authentication, "default");
+    final var searchQueryResult =
+        services.getRole(entity.roleId(), authentication, PHYSICAL_TENANT_ID);
 
     // then
     assertThat(searchQueryResult).isEqualTo(entity);
@@ -144,7 +147,7 @@ public class RoleServicesTest {
 
     // when
     services.updateRole(
-        new UpdateRoleRequest(roleId, name, description), authentication, "default");
+        new UpdateRoleRequest(roleId, name, description), authentication, PHYSICAL_TENANT_ID);
 
     // then
     final BrokerRoleUpdateRequest request = stubbedBrokerClient.getSingleBrokerRequest();
@@ -165,7 +168,9 @@ public class RoleServicesTest {
 
     // when
     services.addMember(
-        new RoleMemberRequest(roleId, entityId, EntityType.USER), authentication, "default");
+        new RoleMemberRequest(roleId, entityId, EntityType.USER),
+        authentication,
+        PHYSICAL_TENANT_ID);
 
     // then
     final BrokerRoleEntityRequest request = stubbedBrokerClient.getSingleBrokerRequest();
@@ -186,7 +191,9 @@ public class RoleServicesTest {
 
     // when
     services.removeMember(
-        new RoleMemberRequest(roleId, username, EntityType.USER), authentication, "default");
+        new RoleMemberRequest(roleId, username, EntityType.USER),
+        authentication,
+        PHYSICAL_TENANT_ID);
 
     // then
     final BrokerRoleEntityRequest request = stubbedBrokerClient.getSingleBrokerRequest();
@@ -219,7 +226,7 @@ public class RoleServicesTest {
                         q.filter(f -> f.memberId(memberId).childMemberType(memberType))
                             .unlimited()),
                 authentication,
-                "default")
+                PHYSICAL_TENANT_ID)
             .items();
 
     // then
@@ -234,14 +241,15 @@ public class RoleServicesTest {
     final var roleServicesSpy = spy(services);
     doReturn(new SearchQueryResult<RoleMemberEntity>(1, false, List.of(), null, null))
         .when(roleServicesSpy)
-        .searchMembers(any(), eq(authentication));
+        .searchMembers(any(), eq(authentication), any());
     final var queryCaptor = ArgumentCaptor.forClass(RoleMemberQuery.class);
 
     // when
-    final var result = roleServicesSpy.hasMembersOfType(roleId, entityType, authentication);
+    final var result =
+        roleServicesSpy.hasMembersOfType(roleId, entityType, authentication, PHYSICAL_TENANT_ID);
 
     // then
-    verify(roleServicesSpy).searchMembers(queryCaptor.capture(), eq(authentication));
+    verify(roleServicesSpy).searchMembers(queryCaptor.capture(), eq(authentication), any());
     assertThat(queryCaptor.getValue().filter().roleId()).isEqualTo(roleId);
     assertThat(queryCaptor.getValue().filter().memberType()).isEqualTo(entityType);
     assertThat(result).isTrue();
@@ -255,14 +263,15 @@ public class RoleServicesTest {
     final var roleServicesSpy = spy(services);
     doReturn(new SearchQueryResult<RoleMemberEntity>(0, false, List.of(), null, null))
         .when(roleServicesSpy)
-        .searchMembers(any(), eq(authentication));
+        .searchMembers(any(), eq(authentication), any());
     final var queryCaptor = ArgumentCaptor.forClass(RoleMemberQuery.class);
 
     // when
-    final var result = roleServicesSpy.hasMembersOfType(roleId, entityType, authentication);
+    final var result =
+        roleServicesSpy.hasMembersOfType(roleId, entityType, authentication, PHYSICAL_TENANT_ID);
 
     // then
-    verify(roleServicesSpy).searchMembers(queryCaptor.capture(), eq(authentication));
+    verify(roleServicesSpy).searchMembers(queryCaptor.capture(), eq(authentication), any());
     assertThat(queryCaptor.getValue().filter().roleId()).isEqualTo(roleId);
     assertThat(queryCaptor.getValue().filter().memberType()).isEqualTo(entityType);
     assertThat(result).isFalse();

--- a/service/src/test/java/io/camunda/service/TenantServiceTest.java
+++ b/service/src/test/java/io/camunda/service/TenantServiceTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.service;
 
+import static io.camunda.zeebe.protocol.record.value.TenantOwned.DEFAULT_TENANT_IDENTIFIER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -38,7 +39,6 @@ import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.TenantIntent;
 import io.camunda.zeebe.protocol.record.mapper.AuthzModelMapper;
-import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ForkJoinPool;
 import org.junit.jupiter.api.BeforeEach;
@@ -63,6 +63,7 @@ public class TenantServiceTest {
     authentication = CamundaAuthentication.of(builder -> builder.user("foo"));
     client = mock(TenantSearchClient.class);
     when(client.withSecurityContext(any())).thenReturn(client);
+    when(client.withPhysicalTenant(any())).thenReturn(client);
     executorProvider = mock(ApiServicesExecutorProvider.class);
     when(executorProvider.getExecutor()).thenReturn(ForkJoinPool.commonPool());
     brokerRequestAuthorizationConverter = mock(BrokerRequestAuthorizationConverter.class);
@@ -85,7 +86,7 @@ public class TenantServiceTest {
     final var searchQuery = SearchQueryBuilders.tenantSearchQuery((b) -> b.filter(filter));
 
     // when
-    final var searchQueryResult = services.search(searchQuery, authentication);
+    final var searchQueryResult = services.search(searchQuery, authentication, "default");
 
     // then
     assertThat(searchQueryResult).isEqualTo(result);
@@ -97,7 +98,7 @@ public class TenantServiceTest {
     when(client.getTenant(eq("tenant-id"))).thenReturn(tenantEntity);
 
     // when
-    final var searchQueryResult = services.getById("tenant-id", authentication);
+    final var searchQueryResult = services.getById("tenant-id", authentication, "default");
 
     // then
     assertThat(searchQueryResult).isEqualTo(tenantEntity);
@@ -110,7 +111,7 @@ public class TenantServiceTest {
         new TenantRequest(100L, "NewTenantName", "NewTenantId", "NewTenantDescription");
 
     // when
-    services.createTenant(tenantDTO, authentication);
+    services.createTenant(tenantDTO, authentication, "default");
 
     // then
     final BrokerTenantCreateRequest request = stubbedBrokerClient.getSingleBrokerRequest();
@@ -129,7 +130,7 @@ public class TenantServiceTest {
         new TenantRequest(tenantEntity.key(), tenantEntity.tenantId(), "UpdatedTenantId", null);
 
     // when
-    services.updateTenant(tenantDTO, authentication);
+    services.updateTenant(tenantDTO, authentication, "default");
 
     // then
     final BrokerTenantUpdateRequest request = stubbedBrokerClient.getSingleBrokerRequest();
@@ -149,7 +150,7 @@ public class TenantServiceTest {
             tenantEntity.key(), tenantEntity.tenantId(), "TenantName", "UpdatedTenantDescription");
 
     // when
-    services.updateTenant(tenantDTO, authentication);
+    services.updateTenant(tenantDTO, authentication, "default");
 
     // then
     final BrokerTenantUpdateRequest request = stubbedBrokerClient.getSingleBrokerRequest();
@@ -163,7 +164,7 @@ public class TenantServiceTest {
   @Test
   public void shouldDeleteTenant() {
     // when
-    services.deleteTenant(tenantEntity.tenantId(), authentication);
+    services.deleteTenant(tenantEntity.tenantId(), authentication, "default");
 
     // then
     final BrokerTenantDeleteRequest request = stubbedBrokerClient.getSingleBrokerRequest();
@@ -183,7 +184,7 @@ public class TenantServiceTest {
     final var tenantMemberRequest = new TenantMemberRequest(tenantId, entityId, entityType);
 
     // when
-    services.addMember(tenantMemberRequest, authentication);
+    services.addMember(tenantMemberRequest, authentication, "default");
 
     // then
     final BrokerTenantEntityRequest request = stubbedBrokerClient.getSingleBrokerRequest();
@@ -207,7 +208,7 @@ public class TenantServiceTest {
     final var tenantMemberRequest = new TenantMemberRequest(tenantId, entityId, entityType);
 
     // when
-    services.removeMember(tenantMemberRequest, authentication);
+    services.removeMember(tenantMemberRequest, authentication, "default");
 
     // then
     final BrokerTenantEntityRequest request = stubbedBrokerClient.getSingleBrokerRequest();
@@ -224,10 +225,10 @@ public class TenantServiceTest {
   public void shouldRejectUpdateOfDefaultTenant() {
     // given
     final var tenantDTO =
-        new TenantRequest(null, TenantOwned.DEFAULT_TENANT_IDENTIFIER, "NewName", "NewDescription");
+        new TenantRequest(null, DEFAULT_TENANT_IDENTIFIER, "NewName", "NewDescription");
 
     // when
-    final var future = services.updateTenant(tenantDTO, authentication);
+    final var future = services.updateTenant(tenantDTO, authentication, "default");
 
     // then
     assertThat(future).isCompletedExceptionally();
@@ -243,7 +244,7 @@ public class TenantServiceTest {
   @Test
   public void shouldRejectDeleteOfDefaultTenant() {
     // when
-    final var future = services.deleteTenant(TenantOwned.DEFAULT_TENANT_IDENTIFIER, authentication);
+    final var future = services.deleteTenant(DEFAULT_TENANT_IDENTIFIER, authentication, "default");
 
     // then
     assertThat(future).isCompletedExceptionally();
@@ -263,7 +264,7 @@ public class TenantServiceTest {
 
     final var exception =
         (ServiceException)
-            assertThatThrownBy(() -> services.getById("tenant-id", authentication))
+            assertThatThrownBy(() -> services.getById("tenant-id", authentication, "default"))
                 .isInstanceOf(ServiceException.class)
                 .actual();
     assertThat(exception.getStatus()).isEqualTo(Status.FORBIDDEN);

--- a/service/src/test/java/io/camunda/service/TenantServiceTest.java
+++ b/service/src/test/java/io/camunda/service/TenantServiceTest.java
@@ -48,6 +48,7 @@ import org.junit.jupiter.params.provider.EnumSource;
 
 public class TenantServiceTest {
 
+  private static final String PHYSICAL_TENANT_ID = "foo";
   private TenantServices services;
   private TenantSearchClient client;
   private StubbedBrokerClient stubbedBrokerClient;
@@ -86,7 +87,7 @@ public class TenantServiceTest {
     final var searchQuery = SearchQueryBuilders.tenantSearchQuery((b) -> b.filter(filter));
 
     // when
-    final var searchQueryResult = services.search(searchQuery, authentication, "default");
+    final var searchQueryResult = services.search(searchQuery, authentication, PHYSICAL_TENANT_ID);
 
     // then
     assertThat(searchQueryResult).isEqualTo(result);
@@ -98,7 +99,7 @@ public class TenantServiceTest {
     when(client.getTenant(eq("tenant-id"))).thenReturn(tenantEntity);
 
     // when
-    final var searchQueryResult = services.getById("tenant-id", authentication, "default");
+    final var searchQueryResult = services.getById("tenant-id", authentication, PHYSICAL_TENANT_ID);
 
     // then
     assertThat(searchQueryResult).isEqualTo(tenantEntity);
@@ -111,7 +112,7 @@ public class TenantServiceTest {
         new TenantRequest(100L, "NewTenantName", "NewTenantId", "NewTenantDescription");
 
     // when
-    services.createTenant(tenantDTO, authentication, "default");
+    services.createTenant(tenantDTO, authentication, PHYSICAL_TENANT_ID);
 
     // then
     final BrokerTenantCreateRequest request = stubbedBrokerClient.getSingleBrokerRequest();
@@ -130,7 +131,7 @@ public class TenantServiceTest {
         new TenantRequest(tenantEntity.key(), tenantEntity.tenantId(), "UpdatedTenantId", null);
 
     // when
-    services.updateTenant(tenantDTO, authentication, "default");
+    services.updateTenant(tenantDTO, authentication, PHYSICAL_TENANT_ID);
 
     // then
     final BrokerTenantUpdateRequest request = stubbedBrokerClient.getSingleBrokerRequest();
@@ -150,7 +151,7 @@ public class TenantServiceTest {
             tenantEntity.key(), tenantEntity.tenantId(), "TenantName", "UpdatedTenantDescription");
 
     // when
-    services.updateTenant(tenantDTO, authentication, "default");
+    services.updateTenant(tenantDTO, authentication, PHYSICAL_TENANT_ID);
 
     // then
     final BrokerTenantUpdateRequest request = stubbedBrokerClient.getSingleBrokerRequest();
@@ -164,7 +165,7 @@ public class TenantServiceTest {
   @Test
   public void shouldDeleteTenant() {
     // when
-    services.deleteTenant(tenantEntity.tenantId(), authentication, "default");
+    services.deleteTenant(tenantEntity.tenantId(), authentication, PHYSICAL_TENANT_ID);
 
     // then
     final BrokerTenantDeleteRequest request = stubbedBrokerClient.getSingleBrokerRequest();
@@ -184,7 +185,7 @@ public class TenantServiceTest {
     final var tenantMemberRequest = new TenantMemberRequest(tenantId, entityId, entityType);
 
     // when
-    services.addMember(tenantMemberRequest, authentication, "default");
+    services.addMember(tenantMemberRequest, authentication, PHYSICAL_TENANT_ID);
 
     // then
     final BrokerTenantEntityRequest request = stubbedBrokerClient.getSingleBrokerRequest();
@@ -208,7 +209,7 @@ public class TenantServiceTest {
     final var tenantMemberRequest = new TenantMemberRequest(tenantId, entityId, entityType);
 
     // when
-    services.removeMember(tenantMemberRequest, authentication, "default");
+    services.removeMember(tenantMemberRequest, authentication, PHYSICAL_TENANT_ID);
 
     // then
     final BrokerTenantEntityRequest request = stubbedBrokerClient.getSingleBrokerRequest();
@@ -228,7 +229,7 @@ public class TenantServiceTest {
         new TenantRequest(null, DEFAULT_TENANT_IDENTIFIER, "NewName", "NewDescription");
 
     // when
-    final var future = services.updateTenant(tenantDTO, authentication, "default");
+    final var future = services.updateTenant(tenantDTO, authentication, PHYSICAL_TENANT_ID);
 
     // then
     assertThat(future).isCompletedExceptionally();
@@ -244,7 +245,8 @@ public class TenantServiceTest {
   @Test
   public void shouldRejectDeleteOfDefaultTenant() {
     // when
-    final var future = services.deleteTenant(DEFAULT_TENANT_IDENTIFIER, authentication, "default");
+    final var future =
+        services.deleteTenant(DEFAULT_TENANT_IDENTIFIER, authentication, PHYSICAL_TENANT_ID);
 
     // then
     assertThat(future).isCompletedExceptionally();
@@ -264,7 +266,8 @@ public class TenantServiceTest {
 
     final var exception =
         (ServiceException)
-            assertThatThrownBy(() -> services.getById("tenant-id", authentication, "default"))
+            assertThatThrownBy(
+                    () -> services.getById("tenant-id", authentication, PHYSICAL_TENANT_ID))
                 .isInstanceOf(ServiceException.class)
                 .actual();
     assertThat(exception.getStatus()).isEqualTo(Status.FORBIDDEN);

--- a/service/src/test/java/io/camunda/service/UsageMetricsServiceTest.java
+++ b/service/src/test/java/io/camunda/service/UsageMetricsServiceTest.java
@@ -36,6 +36,7 @@ public final class UsageMetricsServiceTest {
   public void before() {
     client = mock(UsageMetricsSearchClient.class);
     when(client.withSecurityContext(any())).thenReturn(client);
+    when(client.withPhysicalTenant(any())).thenReturn(client);
     authentication = mock(CamundaAuthentication.class);
     services =
         new UsageMetricsServices(
@@ -63,7 +64,7 @@ public final class UsageMetricsServiceTest {
             .build();
 
     // when
-    final var searchQueryResult = services.search(searchQuery, authentication);
+    final var searchQueryResult = services.search(searchQuery, authentication, "default");
 
     // then
     assertThat(searchQueryResult.items().getFirst())

--- a/service/src/test/java/io/camunda/service/UsageMetricsServiceTest.java
+++ b/service/src/test/java/io/camunda/service/UsageMetricsServiceTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 
 public final class UsageMetricsServiceTest {
 
+  private static final String PHYSICAL_TENANT_ID = "foo";
   private UsageMetricsServices services;
   private UsageMetricsSearchClient client;
   private CamundaAuthentication authentication;
@@ -64,7 +65,7 @@ public final class UsageMetricsServiceTest {
             .build();
 
     // when
-    final var searchQueryResult = services.search(searchQuery, authentication, "default");
+    final var searchQueryResult = services.search(searchQuery, authentication, PHYSICAL_TENANT_ID);
 
     // then
     assertThat(searchQueryResult.items().getFirst())

--- a/service/src/test/java/io/camunda/service/UserServiceTest.java
+++ b/service/src/test/java/io/camunda/service/UserServiceTest.java
@@ -36,6 +36,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 
 public class UserServiceTest {
 
+  private static final String PHYSICAL_TENANT_ID = "foo";
   ArgumentCaptor<BrokerUserDeleteRequest> userDeleteRequestArgumentCaptor;
   private UserServices services;
   private UserSearchClient client;
@@ -75,7 +76,7 @@ public class UserServiceTest {
     final var searchQuery = SearchQueryBuilders.userSearchQuery((b) -> b.filter(filter));
 
     // when
-    final var searchQueryResult = services.search(searchQuery, authentication, "default");
+    final var searchQueryResult = services.search(searchQuery, authentication, PHYSICAL_TENANT_ID);
 
     // then
     assertThat(searchQueryResult).isEqualTo(result);
@@ -91,7 +92,7 @@ public class UserServiceTest {
     when(brokerClient.sendRequest(any()))
         .thenReturn(CompletableFuture.completedFuture(new BrokerResponse<>(userRecord)));
 
-    services.deleteUser(username, authentication, "default");
+    services.deleteUser(username, authentication, PHYSICAL_TENANT_ID);
 
     verify(brokerClient).sendRequest(userDeleteRequestArgumentCaptor.capture());
     final var request = userDeleteRequestArgumentCaptor.getValue().getRequestWriter();
@@ -107,7 +108,8 @@ public class UserServiceTest {
     when(client.getUser(eq("test"))).thenReturn(entity);
 
     // when
-    final var searchQueryResult = services.getUser(entity.username(), authentication, "default");
+    final var searchQueryResult =
+        services.getUser(entity.username(), authentication, PHYSICAL_TENANT_ID);
 
     // then
     assertThat(searchQueryResult).isEqualTo(entity);

--- a/service/src/test/java/io/camunda/service/UserServiceTest.java
+++ b/service/src/test/java/io/camunda/service/UserServiceTest.java
@@ -47,6 +47,7 @@ public class UserServiceTest {
   public void before() {
     client = mock(UserSearchClient.class);
     when(client.withSecurityContext(any())).thenReturn(client);
+    when(client.withPhysicalTenant(any())).thenReturn(client);
     brokerClient = mock(BrokerClient.class);
     authentication = mock(CamundaAuthentication.class);
     final PasswordEncoder passwordEncoder = mock(PasswordEncoder.class);
@@ -74,7 +75,7 @@ public class UserServiceTest {
     final var searchQuery = SearchQueryBuilders.userSearchQuery((b) -> b.filter(filter));
 
     // when
-    final var searchQueryResult = services.search(searchQuery, authentication);
+    final var searchQueryResult = services.search(searchQuery, authentication, "default");
 
     // then
     assertThat(searchQueryResult).isEqualTo(result);
@@ -90,7 +91,7 @@ public class UserServiceTest {
     when(brokerClient.sendRequest(any()))
         .thenReturn(CompletableFuture.completedFuture(new BrokerResponse<>(userRecord)));
 
-    services.deleteUser(username, authentication);
+    services.deleteUser(username, authentication, "default");
 
     verify(brokerClient).sendRequest(userDeleteRequestArgumentCaptor.capture());
     final var request = userDeleteRequestArgumentCaptor.getValue().getRequestWriter();
@@ -106,7 +107,7 @@ public class UserServiceTest {
     when(client.getUser(eq("test"))).thenReturn(entity);
 
     // when
-    final var searchQueryResult = services.getUser(entity.username(), authentication);
+    final var searchQueryResult = services.getUser(entity.username(), authentication, "default");
 
     // then
     assertThat(searchQueryResult).isEqualTo(entity);

--- a/service/src/test/java/io/camunda/service/UserTaskServiceTest.java
+++ b/service/src/test/java/io/camunda/service/UserTaskServiceTest.java
@@ -53,6 +53,7 @@ import org.junit.jupiter.api.Test;
 
 public class UserTaskServiceTest {
 
+  private static final String PHYSICAL_TENANT_ID = "foo";
   private UserTaskServices services;
   private UserTaskSearchClient client;
   private FormServices formServices;
@@ -102,7 +103,7 @@ public class UserTaskServiceTest {
       final ThrowingCallable executable =
           () ->
               services.searchUserTaskVariables(
-                  1L, variableSearchQuery().build(), authentication, "default");
+                  1L, variableSearchQuery().build(), authentication, PHYSICAL_TENANT_ID);
 
       // then
       final var exception =
@@ -135,7 +136,10 @@ public class UserTaskServiceTest {
       // when
       final SearchQueryResult<VariableEntity> searchQueryResult =
           services.searchUserTaskVariables(
-              entity.userTaskKey(), variableSearchQuery().build(), authentication, "default");
+              entity.userTaskKey(),
+              variableSearchQuery().build(),
+              authentication,
+              PHYSICAL_TENANT_ID);
 
       // then
       assertThat(searchQueryResult.total()).isEqualTo(1);
@@ -170,7 +174,10 @@ public class UserTaskServiceTest {
       // when
       final SearchQueryResult<VariableEntity> result =
           services.searchUserTaskEffectiveVariables(
-              entity.userTaskKey(), variableSearchQuery().build(), authentication, "default");
+              entity.userTaskKey(),
+              variableSearchQuery().build(),
+              authentication,
+              PHYSICAL_TENANT_ID);
 
       // then — innermost scope (3) wins, only one "city" returned
       assertThat(result.total()).isEqualTo(1);
@@ -203,7 +210,10 @@ public class UserTaskServiceTest {
       // when
       final SearchQueryResult<VariableEntity> result =
           services.searchUserTaskEffectiveVariables(
-              entity.userTaskKey(), variableSearchQuery().build(), authentication, "default");
+              entity.userTaskKey(),
+              variableSearchQuery().build(),
+              authentication,
+              PHYSICAL_TENANT_ID);
 
       // then — leaf (innermost) wins
       assertThat(result.total()).isEqualTo(1);
@@ -238,7 +248,10 @@ public class UserTaskServiceTest {
       // when
       final SearchQueryResult<VariableEntity> result =
           services.searchUserTaskEffectiveVariables(
-              entity.userTaskKey(), variableSearchQuery().build(), authentication, "default");
+              entity.userTaskKey(),
+              variableSearchQuery().build(),
+              authentication,
+              PHYSICAL_TENANT_ID);
 
       // then — 3 unique names after dedup, total reflects deduplicated count
       assertThat(result.total()).isEqualTo(3);
@@ -280,7 +293,7 @@ public class UserTaskServiceTest {
           VariableQuery.of(q -> q.sort(SortOptionBuilders.variable(s -> s.name().asc())));
       final SearchQueryResult<VariableEntity> result =
           services.searchUserTaskEffectiveVariables(
-              entity.userTaskKey(), query, authentication, "default");
+              entity.userTaskKey(), query, authentication, PHYSICAL_TENANT_ID);
 
       // then — 3 unique variables after dedup, sorted by name ASC
       assertThat(result.total()).isEqualTo(3);
@@ -320,7 +333,7 @@ public class UserTaskServiceTest {
           VariableQuery.of(q -> q.sort(SortOptionBuilders.variable(s -> s.value().desc())));
       final SearchQueryResult<VariableEntity> result =
           services.searchUserTaskEffectiveVariables(
-              entity.userTaskKey(), query, authentication, "default");
+              entity.userTaskKey(), query, authentication, PHYSICAL_TENANT_ID);
 
       // then — 3 unique variables, sorted by value DESC (zebra > charlie > bravo)
       assertThat(result.total()).isEqualTo(3);
@@ -364,7 +377,7 @@ public class UserTaskServiceTest {
                       .page(p -> p.from(1).size(2)));
       final SearchQueryResult<VariableEntity> result =
           services.searchUserTaskEffectiveVariables(
-              entity.userTaskKey(), query, authentication, "default");
+              entity.userTaskKey(), query, authentication, PHYSICAL_TENANT_ID);
 
       // then — 4 unique after dedup, page returns items at index 1 and 2 (b-inner, c)
       assertThat(result.total()).isEqualTo(4);
@@ -401,7 +414,10 @@ public class UserTaskServiceTest {
       // when
       final SearchQueryResult<VariableEntity> result =
           services.searchUserTaskEffectiveVariables(
-              entity.userTaskKey(), variableSearchQuery().build(), authentication, "default");
+              entity.userTaskKey(),
+              variableSearchQuery().build(),
+              authentication,
+              PHYSICAL_TENANT_ID);
 
       // then — items are returned but cursors are stripped (null)
       assertThat(result.total()).isEqualTo(2);
@@ -436,7 +452,10 @@ public class UserTaskServiceTest {
       // when
       final SearchQueryResult<VariableEntity> result =
           services.searchUserTaskEffectiveVariables(
-              entity.userTaskKey(), variableSearchQuery().build(), authentication, "default");
+              entity.userTaskKey(),
+              variableSearchQuery().build(),
+              authentication,
+              PHYSICAL_TENANT_ID);
 
       // then — items are returned but cursors are always null
       assertThat(result.total()).isEqualTo(2);
@@ -461,7 +480,7 @@ public class UserTaskServiceTest {
       final ThrowingCallable executable =
           () ->
               services.searchUserTaskAuditLogs(
-                  1L, auditLogSearchQuery().build(), authentication, "default");
+                  1L, auditLogSearchQuery().build(), authentication, PHYSICAL_TENANT_ID);
 
       // then
       final var exception =
@@ -488,7 +507,10 @@ public class UserTaskServiceTest {
       // when
       final SearchQueryResult<AuditLogEntity> searchQueryResult =
           services.searchUserTaskAuditLogs(
-              entity.userTaskKey(), auditLogSearchQuery().build(), authentication, "default");
+              entity.userTaskKey(),
+              auditLogSearchQuery().build(),
+              authentication,
+              PHYSICAL_TENANT_ID);
 
       // then
       assertThat(searchQueryResult.items()).containsOnly(outputEntity);
@@ -508,7 +530,8 @@ public class UserTaskServiceTest {
       when(formServices.getByKey(eq(entity.formKey()), any(), any())).thenReturn(form);
 
       // when
-      final var result = services.getUserTaskForm(entity.userTaskKey(), authentication, "default");
+      final var result =
+          services.getUserTaskForm(entity.userTaskKey(), authentication, PHYSICAL_TENANT_ID);
 
       // then
       assertThat(result).isPresent();
@@ -524,7 +547,7 @@ public class UserTaskServiceTest {
       when(client.getUserTask(any(Long.class))).thenReturn(entity);
 
       // when
-      final var result = services.getUserTaskForm(1L, authentication, "default");
+      final var result = services.getUserTaskForm(1L, authentication, PHYSICAL_TENANT_ID);
 
       // then
       assertThat(result).isEmpty();
@@ -541,7 +564,7 @@ public class UserTaskServiceTest {
       when(client.getUserTask(any(Long.class))).thenReturn(entity);
 
       final var searchQueryResult =
-          services.getByKey(entity.userTaskKey(), authentication, "default");
+          services.getByKey(entity.userTaskKey(), authentication, PHYSICAL_TENANT_ID);
 
       assertThat(searchQueryResult).isEqualTo(entity);
     }
@@ -555,11 +578,12 @@ public class UserTaskServiceTest {
               .create();
 
       when(client.getUserTask(any(Long.class))).thenReturn(entity);
-      when(processCache.getCacheItem(entity.processDefinitionKey(), "default"))
+      when(processCache.getCacheItem(entity.processDefinitionKey(), PHYSICAL_TENANT_ID))
           .thenReturn(
               new ProcessCacheItem("ProcessName", Map.of(entity.elementId(), "cached name")));
 
-      final var foundEntity = services.getByKey(entity.userTaskKey(), authentication, "default");
+      final var foundEntity =
+          services.getByKey(entity.userTaskKey(), authentication, PHYSICAL_TENANT_ID);
 
       assertThat(foundEntity.name()).isEqualTo("cached name");
     }
@@ -570,11 +594,12 @@ public class UserTaskServiceTest {
           Instancio.of(UserTaskEntity.class).set(field(UserTaskEntity::processName), null).create();
 
       when(client.getUserTask(any(Long.class))).thenReturn(entity);
-      when(processCache.getCacheItem(entity.processDefinitionKey(), "default"))
+      when(processCache.getCacheItem(entity.processDefinitionKey(), PHYSICAL_TENANT_ID))
           .thenReturn(
               new ProcessCacheItem("ProcessName", Map.of(entity.elementId(), "cached name")));
 
-      final var foundEntity = services.getByKey(entity.userTaskKey(), authentication, "default");
+      final var foundEntity =
+          services.getByKey(entity.userTaskKey(), authentication, PHYSICAL_TENANT_ID);
 
       assertThat(foundEntity.processName()).isEqualTo("ProcessName");
     }
@@ -585,10 +610,11 @@ public class UserTaskServiceTest {
           Instancio.of(UserTaskEntity.class).set(field(UserTaskEntity::name), null).create();
 
       when(client.getUserTask(any(Long.class))).thenReturn(entity);
-      when(processCache.getCacheItem(entity.processDefinitionKey(), "default"))
+      when(processCache.getCacheItem(entity.processDefinitionKey(), PHYSICAL_TENANT_ID))
           .thenReturn(new ProcessCacheItem("ProcessName", Map.of("unknown-id", "cached name")));
 
-      final var foundEntity = services.getByKey(entity.userTaskKey(), authentication, "default");
+      final var foundEntity =
+          services.getByKey(entity.userTaskKey(), authentication, PHYSICAL_TENANT_ID);
 
       assertThat(foundEntity.name()).isEqualTo(entity.elementId());
       assertThat(foundEntity.processName()).isEqualTo(entity.processName());
@@ -604,7 +630,7 @@ public class UserTaskServiceTest {
                   Authorizations.PROCESS_DEFINITION_READ_USER_TASK_AUTHORIZATION));
 
       final ThrowingCallable executable =
-          () -> services.getByKey(entity.userTaskKey(), authentication, "default");
+          () -> services.getByKey(entity.userTaskKey(), authentication, PHYSICAL_TENANT_ID);
 
       final var exception =
           (ServiceException)
@@ -623,7 +649,7 @@ public class UserTaskServiceTest {
       when(client.searchUserTasks(any())).thenReturn(SearchQueryResult.of(entity));
 
       final var searchQueryResult =
-          services.search(UserTaskQuery.of(q -> q), authentication, "default");
+          services.search(UserTaskQuery.of(q -> q), authentication, PHYSICAL_TENANT_ID);
 
       assertThat(searchQueryResult.items()).contains(entity);
     }
@@ -633,13 +659,13 @@ public class UserTaskServiceTest {
       final var entity =
           Instancio.of(UserTaskEntity.class).set(field(UserTaskEntity::name), null).create();
       when(client.searchUserTasks(any())).thenReturn(SearchQueryResult.of(entity));
-      when(processCache.getCacheItems(Set.of(entity.processDefinitionKey()), "default"))
+      when(processCache.getCacheItems(Set.of(entity.processDefinitionKey()), PHYSICAL_TENANT_ID))
           .thenReturn(
               ProcessCacheResult.of(
                   entity.processDefinitionKey(), "ProcessName", entity.elementId(), "cached name"));
 
       final var searchQueryResult =
-          services.search(UserTaskQuery.of(q -> q), authentication, "default");
+          services.search(UserTaskQuery.of(q -> q), authentication, PHYSICAL_TENANT_ID);
 
       assertThat(searchQueryResult.items()).contains(entity.withName("cached name"));
     }
@@ -649,13 +675,13 @@ public class UserTaskServiceTest {
       final var entity =
           Instancio.of(UserTaskEntity.class).set(field(UserTaskEntity::processName), null).create();
       when(client.searchUserTasks(any())).thenReturn(SearchQueryResult.of(entity));
-      when(processCache.getCacheItems(Set.of(entity.processDefinitionKey()), "default"))
+      when(processCache.getCacheItems(Set.of(entity.processDefinitionKey()), PHYSICAL_TENANT_ID))
           .thenReturn(
               ProcessCacheResult.of(
                   entity.processDefinitionKey(), "ProcessName", entity.elementId(), "cached name"));
 
       final var searchQueryResult =
-          services.search(UserTaskQuery.of(q -> q), authentication, "default");
+          services.search(UserTaskQuery.of(q -> q), authentication, PHYSICAL_TENANT_ID);
 
       assertThat(searchQueryResult.items()).contains(entity.withProcessName("ProcessName"));
     }
@@ -667,7 +693,7 @@ public class UserTaskServiceTest {
       when(client.searchUserTasks(any())).thenReturn(SearchQueryResult.of(entity));
 
       final var searchQueryResult =
-          services.search(UserTaskQuery.of(q -> q), authentication, "default");
+          services.search(UserTaskQuery.of(q -> q), authentication, PHYSICAL_TENANT_ID);
 
       assertThat(searchQueryResult.items()).contains(entity.withName(entity.elementId()));
     }

--- a/service/src/test/java/io/camunda/service/UserTaskServiceTest.java
+++ b/service/src/test/java/io/camunda/service/UserTaskServiceTest.java
@@ -84,7 +84,7 @@ public class UserTaskServiceTest {
             mock(ApiServicesExecutorProvider.class),
             null);
 
-    when(processCache.getCacheItems(any())).thenReturn(ProcessCacheResult.EMPTY);
+    when(processCache.getCacheItems(any(), any())).thenReturn(ProcessCacheResult.EMPTY);
   }
 
   @Nested
@@ -555,7 +555,7 @@ public class UserTaskServiceTest {
               .create();
 
       when(client.getUserTask(any(Long.class))).thenReturn(entity);
-      when(processCache.getCacheItem(entity.processDefinitionKey()))
+      when(processCache.getCacheItem(entity.processDefinitionKey(), "default"))
           .thenReturn(
               new ProcessCacheItem("ProcessName", Map.of(entity.elementId(), "cached name")));
 
@@ -570,7 +570,7 @@ public class UserTaskServiceTest {
           Instancio.of(UserTaskEntity.class).set(field(UserTaskEntity::processName), null).create();
 
       when(client.getUserTask(any(Long.class))).thenReturn(entity);
-      when(processCache.getCacheItem(entity.processDefinitionKey()))
+      when(processCache.getCacheItem(entity.processDefinitionKey(), "default"))
           .thenReturn(
               new ProcessCacheItem("ProcessName", Map.of(entity.elementId(), "cached name")));
 
@@ -585,7 +585,7 @@ public class UserTaskServiceTest {
           Instancio.of(UserTaskEntity.class).set(field(UserTaskEntity::name), null).create();
 
       when(client.getUserTask(any(Long.class))).thenReturn(entity);
-      when(processCache.getCacheItem(entity.processDefinitionKey()))
+      when(processCache.getCacheItem(entity.processDefinitionKey(), "default"))
           .thenReturn(new ProcessCacheItem("ProcessName", Map.of("unknown-id", "cached name")));
 
       final var foundEntity = services.getByKey(entity.userTaskKey(), authentication, "default");
@@ -633,7 +633,7 @@ public class UserTaskServiceTest {
       final var entity =
           Instancio.of(UserTaskEntity.class).set(field(UserTaskEntity::name), null).create();
       when(client.searchUserTasks(any())).thenReturn(SearchQueryResult.of(entity));
-      when(processCache.getCacheItems(Set.of(entity.processDefinitionKey())))
+      when(processCache.getCacheItems(Set.of(entity.processDefinitionKey()), "default"))
           .thenReturn(
               ProcessCacheResult.of(
                   entity.processDefinitionKey(), "ProcessName", entity.elementId(), "cached name"));
@@ -649,7 +649,7 @@ public class UserTaskServiceTest {
       final var entity =
           Instancio.of(UserTaskEntity.class).set(field(UserTaskEntity::processName), null).create();
       when(client.searchUserTasks(any())).thenReturn(SearchQueryResult.of(entity));
-      when(processCache.getCacheItems(Set.of(entity.processDefinitionKey())))
+      when(processCache.getCacheItems(Set.of(entity.processDefinitionKey()), "default"))
           .thenReturn(
               ProcessCacheResult.of(
                   entity.processDefinitionKey(), "ProcessName", entity.elementId(), "cached name"));

--- a/service/src/test/java/io/camunda/service/UserTaskServiceTest.java
+++ b/service/src/test/java/io/camunda/service/UserTaskServiceTest.java
@@ -100,7 +100,9 @@ public class UserTaskServiceTest {
 
       // when
       final ThrowingCallable executable =
-          () -> services.searchUserTaskVariables(1L, variableSearchQuery().build(), authentication);
+          () ->
+              services.searchUserTaskVariables(
+                  1L, variableSearchQuery().build(), authentication, "default");
 
       // then
       final var exception =
@@ -108,8 +110,8 @@ public class UserTaskServiceTest {
               assertThatThrownBy(executable).isInstanceOf(ServiceException.class).actual();
       assertThat(exception.getStatus()).isEqualTo(Status.FORBIDDEN);
       verify(client).getUserTask(any(Long.class));
-      verify(elementInstanceServices, never()).search(any(), any());
-      verify(variableServices, never()).search(any(), any());
+      verify(elementInstanceServices, never()).search(any(), any(), any());
+      verify(variableServices, never()).search(any(), any(), any());
     }
 
     @Test
@@ -126,14 +128,14 @@ public class UserTaskServiceTest {
 
       when(client.getUserTask(any(Long.class))).thenReturn(entity);
       when(elementInstanceServices.getByKey(
-              eq(flowNodeInstanceEntity.flowNodeInstanceKey()), any()))
+              eq(flowNodeInstanceEntity.flowNodeInstanceKey()), any(), any()))
           .thenReturn(flowNodeInstanceEntity);
-      when(variableServices.search(any(), any())).thenReturn(SearchQueryResult.of(variable));
+      when(variableServices.search(any(), any(), any())).thenReturn(SearchQueryResult.of(variable));
 
       // when
       final SearchQueryResult<VariableEntity> searchQueryResult =
           services.searchUserTaskVariables(
-              entity.userTaskKey(), variableSearchQuery().build(), authentication);
+              entity.userTaskKey(), variableSearchQuery().build(), authentication, "default");
 
       // then
       assertThat(searchQueryResult.total()).isEqualTo(1);
@@ -160,15 +162,15 @@ public class UserTaskServiceTest {
 
       when(client.getUserTask(any(Long.class))).thenReturn(entity);
       when(elementInstanceServices.getByKey(
-              eq(flowNodeInstanceEntity.flowNodeInstanceKey()), any()))
+              eq(flowNodeInstanceEntity.flowNodeInstanceKey()), any(), any()))
           .thenReturn(flowNodeInstanceEntity);
-      when(variableServices.search(any(), any()))
+      when(variableServices.search(any(), any(), any()))
           .thenReturn(SearchQueryResult.of(outerVar, innerVar));
 
       // when
       final SearchQueryResult<VariableEntity> result =
           services.searchUserTaskEffectiveVariables(
-              entity.userTaskKey(), variableSearchQuery().build(), authentication);
+              entity.userTaskKey(), variableSearchQuery().build(), authentication, "default");
 
       // then — innermost scope (3) wins, only one "city" returned
       assertThat(result.total()).isEqualTo(1);
@@ -193,15 +195,15 @@ public class UserTaskServiceTest {
 
       when(client.getUserTask(any(Long.class))).thenReturn(entity);
       when(elementInstanceServices.getByKey(
-              eq(flowNodeInstanceEntity.flowNodeInstanceKey()), any()))
+              eq(flowNodeInstanceEntity.flowNodeInstanceKey()), any(), any()))
           .thenReturn(flowNodeInstanceEntity);
-      when(variableServices.search(any(), any()))
+      when(variableServices.search(any(), any(), any()))
           .thenReturn(SearchQueryResult.of(rootVar, midVar, leafVar));
 
       // when
       final SearchQueryResult<VariableEntity> result =
           services.searchUserTaskEffectiveVariables(
-              entity.userTaskKey(), variableSearchQuery().build(), authentication);
+              entity.userTaskKey(), variableSearchQuery().build(), authentication, "default");
 
       // then — leaf (innermost) wins
       assertThat(result.total()).isEqualTo(1);
@@ -228,15 +230,15 @@ public class UserTaskServiceTest {
 
       when(client.getUserTask(any(Long.class))).thenReturn(entity);
       when(elementInstanceServices.getByKey(
-              eq(flowNodeInstanceEntity.flowNodeInstanceKey()), any()))
+              eq(flowNodeInstanceEntity.flowNodeInstanceKey()), any(), any()))
           .thenReturn(flowNodeInstanceEntity);
-      when(variableServices.search(any(), any()))
+      when(variableServices.search(any(), any(), any()))
           .thenReturn(SearchQueryResult.of(b -> b.total(vars.size()).items(vars)));
 
       // when
       final SearchQueryResult<VariableEntity> result =
           services.searchUserTaskEffectiveVariables(
-              entity.userTaskKey(), variableSearchQuery().build(), authentication);
+              entity.userTaskKey(), variableSearchQuery().build(), authentication, "default");
 
       // then — 3 unique names after dedup, total reflects deduplicated count
       assertThat(result.total()).isEqualTo(3);
@@ -267,17 +269,18 @@ public class UserTaskServiceTest {
 
       when(client.getUserTask(any(Long.class))).thenReturn(entity);
       when(elementInstanceServices.getByKey(
-              eq(flowNodeInstanceEntity.flowNodeInstanceKey()), any()))
+              eq(flowNodeInstanceEntity.flowNodeInstanceKey()), any(), any()))
           .thenReturn(flowNodeInstanceEntity);
       // Mock returns variables sorted by name ASC (like data layer would)
-      when(variableServices.search(any(), any()))
+      when(variableServices.search(any(), any(), any()))
           .thenReturn(SearchQueryResult.of(b -> b.total(vars.size()).items(vars)));
 
       // when — sort by name ASC after deduplication
       final var query =
           VariableQuery.of(q -> q.sort(SortOptionBuilders.variable(s -> s.name().asc())));
       final SearchQueryResult<VariableEntity> result =
-          services.searchUserTaskEffectiveVariables(entity.userTaskKey(), query, authentication);
+          services.searchUserTaskEffectiveVariables(
+              entity.userTaskKey(), query, authentication, "default");
 
       // then — 3 unique variables after dedup, sorted by name ASC
       assertThat(result.total()).isEqualTo(3);
@@ -306,17 +309,18 @@ public class UserTaskServiceTest {
 
       when(client.getUserTask(any(Long.class))).thenReturn(entity);
       when(elementInstanceServices.getByKey(
-              eq(flowNodeInstanceEntity.flowNodeInstanceKey()), any()))
+              eq(flowNodeInstanceEntity.flowNodeInstanceKey()), any(), any()))
           .thenReturn(flowNodeInstanceEntity);
       // Mock returns variables sorted by value DESC (like data layer would)
-      when(variableServices.search(any(), any()))
+      when(variableServices.search(any(), any(), any()))
           .thenReturn(SearchQueryResult.of(b -> b.total(vars.size()).items(vars)));
 
       // when — sort by value DESC after deduplication
       final var query =
           VariableQuery.of(q -> q.sort(SortOptionBuilders.variable(s -> s.value().desc())));
       final SearchQueryResult<VariableEntity> result =
-          services.searchUserTaskEffectiveVariables(entity.userTaskKey(), query, authentication);
+          services.searchUserTaskEffectiveVariables(
+              entity.userTaskKey(), query, authentication, "default");
 
       // then — 3 unique variables, sorted by value DESC (zebra > charlie > bravo)
       assertThat(result.total()).isEqualTo(3);
@@ -346,10 +350,10 @@ public class UserTaskServiceTest {
 
       when(client.getUserTask(any(Long.class))).thenReturn(entity);
       when(elementInstanceServices.getByKey(
-              eq(flowNodeInstanceEntity.flowNodeInstanceKey()), any()))
+              eq(flowNodeInstanceEntity.flowNodeInstanceKey()), any(), any()))
           .thenReturn(flowNodeInstanceEntity);
       // Mock returns variables sorted by name ASC (like data layer would)
-      when(variableServices.search(any(), any()))
+      when(variableServices.search(any(), any(), any()))
           .thenReturn(SearchQueryResult.of(b -> b.total(vars.size()).items(vars)));
 
       // when — sort by name ASC, then paginate from=1, size=2
@@ -359,7 +363,8 @@ public class UserTaskServiceTest {
                   q.sort(SortOptionBuilders.variable(s -> s.name().asc()))
                       .page(p -> p.from(1).size(2)));
       final SearchQueryResult<VariableEntity> result =
-          services.searchUserTaskEffectiveVariables(entity.userTaskKey(), query, authentication);
+          services.searchUserTaskEffectiveVariables(
+              entity.userTaskKey(), query, authentication, "default");
 
       // then — 4 unique after dedup, page returns items at index 1 and 2 (b-inner, c)
       assertThat(result.total()).isEqualTo(4);
@@ -387,16 +392,16 @@ public class UserTaskServiceTest {
 
       when(client.getUserTask(any(Long.class))).thenReturn(entity);
       when(elementInstanceServices.getByKey(
-              eq(flowNodeInstanceEntity.flowNodeInstanceKey()), any()))
+              eq(flowNodeInstanceEntity.flowNodeInstanceKey()), any(), any()))
           .thenReturn(flowNodeInstanceEntity);
       // The search backend returns cursors, but the early-exit must strip them
-      when(variableServices.search(any(), any()))
+      when(variableServices.search(any(), any(), any()))
           .thenReturn(new SearchQueryResult<>(2, false, vars, "start-cursor", "end-cursor"));
 
       // when
       final SearchQueryResult<VariableEntity> result =
           services.searchUserTaskEffectiveVariables(
-              entity.userTaskKey(), variableSearchQuery().build(), authentication);
+              entity.userTaskKey(), variableSearchQuery().build(), authentication, "default");
 
       // then — items are returned but cursors are stripped (null)
       assertThat(result.total()).isEqualTo(2);
@@ -422,16 +427,16 @@ public class UserTaskServiceTest {
 
       when(client.getUserTask(any(Long.class))).thenReturn(entity);
       when(elementInstanceServices.getByKey(
-              eq(flowNodeInstanceEntity.flowNodeInstanceKey()), any()))
+              eq(flowNodeInstanceEntity.flowNodeInstanceKey()), any(), any()))
           .thenReturn(flowNodeInstanceEntity);
       // The search backend returns cursors, but the service should strip them
-      when(variableServices.search(any(), any()))
+      when(variableServices.search(any(), any(), any()))
           .thenReturn(new SearchQueryResult<>(2, false, vars, "start-cursor", "end-cursor"));
 
       // when
       final SearchQueryResult<VariableEntity> result =
           services.searchUserTaskEffectiveVariables(
-              entity.userTaskKey(), variableSearchQuery().build(), authentication);
+              entity.userTaskKey(), variableSearchQuery().build(), authentication, "default");
 
       // then — items are returned but cursors are always null
       assertThat(result.total()).isEqualTo(2);
@@ -454,7 +459,9 @@ public class UserTaskServiceTest {
 
       // when
       final ThrowingCallable executable =
-          () -> services.searchUserTaskAuditLogs(1L, auditLogSearchQuery().build(), authentication);
+          () ->
+              services.searchUserTaskAuditLogs(
+                  1L, auditLogSearchQuery().build(), authentication, "default");
 
       // then
       final var exception =
@@ -462,8 +469,8 @@ public class UserTaskServiceTest {
               assertThatThrownBy(executable).isInstanceOf(ServiceException.class).actual();
       assertThat(exception.getStatus()).isEqualTo(Status.FORBIDDEN);
       verify(client).getUserTask(any(Long.class));
-      verify(elementInstanceServices, never()).search(any(), any());
-      verify(auditLogServices, never()).search(any(), any());
+      verify(elementInstanceServices, never()).search(any(), any(), any());
+      verify(auditLogServices, never()).search(any(), any(), any());
     }
 
     @Test
@@ -474,13 +481,14 @@ public class UserTaskServiceTest {
       final var outputEntity = Instancio.create(AuditLogEntity.class);
       when(auditLogServices.search(
               eq(auditLogSearchQuery(q -> q.filter(f -> f.userTaskKeys(entity.userTaskKey())))),
+              any(),
               any()))
           .thenReturn(SearchQueryResult.of(outputEntity));
 
       // when
       final SearchQueryResult<AuditLogEntity> searchQueryResult =
           services.searchUserTaskAuditLogs(
-              entity.userTaskKey(), auditLogSearchQuery().build(), authentication);
+              entity.userTaskKey(), auditLogSearchQuery().build(), authentication, "default");
 
       // then
       assertThat(searchQueryResult.items()).containsOnly(outputEntity);
@@ -497,10 +505,10 @@ public class UserTaskServiceTest {
           Instancio.of(FormEntity.class).set(field(FormEntity::formKey), entity.formKey()).create();
 
       when(client.getUserTask(any(Long.class))).thenReturn(entity);
-      when(formServices.getByKey(eq(entity.formKey()), any())).thenReturn(form);
+      when(formServices.getByKey(eq(entity.formKey()), any(), any())).thenReturn(form);
 
       // when
-      final var result = services.getUserTaskForm(entity.userTaskKey(), authentication);
+      final var result = services.getUserTaskForm(entity.userTaskKey(), authentication, "default");
 
       // then
       assertThat(result).isPresent();
@@ -516,7 +524,7 @@ public class UserTaskServiceTest {
       when(client.getUserTask(any(Long.class))).thenReturn(entity);
 
       // when
-      final var result = services.getUserTaskForm(1L, authentication);
+      final var result = services.getUserTaskForm(1L, authentication, "default");
 
       // then
       assertThat(result).isEmpty();
@@ -532,7 +540,8 @@ public class UserTaskServiceTest {
 
       when(client.getUserTask(any(Long.class))).thenReturn(entity);
 
-      final var searchQueryResult = services.getByKey(entity.userTaskKey(), authentication);
+      final var searchQueryResult =
+          services.getByKey(entity.userTaskKey(), authentication, "default");
 
       assertThat(searchQueryResult).isEqualTo(entity);
     }
@@ -550,7 +559,7 @@ public class UserTaskServiceTest {
           .thenReturn(
               new ProcessCacheItem("ProcessName", Map.of(entity.elementId(), "cached name")));
 
-      final var foundEntity = services.getByKey(entity.userTaskKey(), authentication);
+      final var foundEntity = services.getByKey(entity.userTaskKey(), authentication, "default");
 
       assertThat(foundEntity.name()).isEqualTo("cached name");
     }
@@ -565,7 +574,7 @@ public class UserTaskServiceTest {
           .thenReturn(
               new ProcessCacheItem("ProcessName", Map.of(entity.elementId(), "cached name")));
 
-      final var foundEntity = services.getByKey(entity.userTaskKey(), authentication);
+      final var foundEntity = services.getByKey(entity.userTaskKey(), authentication, "default");
 
       assertThat(foundEntity.processName()).isEqualTo("ProcessName");
     }
@@ -579,7 +588,7 @@ public class UserTaskServiceTest {
       when(processCache.getCacheItem(entity.processDefinitionKey()))
           .thenReturn(new ProcessCacheItem("ProcessName", Map.of("unknown-id", "cached name")));
 
-      final var foundEntity = services.getByKey(entity.userTaskKey(), authentication);
+      final var foundEntity = services.getByKey(entity.userTaskKey(), authentication, "default");
 
       assertThat(foundEntity.name()).isEqualTo(entity.elementId());
       assertThat(foundEntity.processName()).isEqualTo(entity.processName());
@@ -595,7 +604,7 @@ public class UserTaskServiceTest {
                   Authorizations.PROCESS_DEFINITION_READ_USER_TASK_AUTHORIZATION));
 
       final ThrowingCallable executable =
-          () -> services.getByKey(entity.userTaskKey(), authentication);
+          () -> services.getByKey(entity.userTaskKey(), authentication, "default");
 
       final var exception =
           (ServiceException)
@@ -613,7 +622,8 @@ public class UserTaskServiceTest {
       final var entity = Instancio.create(UserTaskEntity.class);
       when(client.searchUserTasks(any())).thenReturn(SearchQueryResult.of(entity));
 
-      final var searchQueryResult = services.search(UserTaskQuery.of(q -> q), authentication);
+      final var searchQueryResult =
+          services.search(UserTaskQuery.of(q -> q), authentication, "default");
 
       assertThat(searchQueryResult.items()).contains(entity);
     }
@@ -628,7 +638,8 @@ public class UserTaskServiceTest {
               ProcessCacheResult.of(
                   entity.processDefinitionKey(), "ProcessName", entity.elementId(), "cached name"));
 
-      final var searchQueryResult = services.search(UserTaskQuery.of(q -> q), authentication);
+      final var searchQueryResult =
+          services.search(UserTaskQuery.of(q -> q), authentication, "default");
 
       assertThat(searchQueryResult.items()).contains(entity.withName("cached name"));
     }
@@ -643,7 +654,8 @@ public class UserTaskServiceTest {
               ProcessCacheResult.of(
                   entity.processDefinitionKey(), "ProcessName", entity.elementId(), "cached name"));
 
-      final var searchQueryResult = services.search(UserTaskQuery.of(q -> q), authentication);
+      final var searchQueryResult =
+          services.search(UserTaskQuery.of(q -> q), authentication, "default");
 
       assertThat(searchQueryResult.items()).contains(entity.withProcessName("ProcessName"));
     }
@@ -654,7 +666,8 @@ public class UserTaskServiceTest {
           Instancio.of(UserTaskEntity.class).set(field(UserTaskEntity::name), null).create();
       when(client.searchUserTasks(any())).thenReturn(SearchQueryResult.of(entity));
 
-      final var searchQueryResult = services.search(UserTaskQuery.of(q -> q), authentication);
+      final var searchQueryResult =
+          services.search(UserTaskQuery.of(q -> q), authentication, "default");
 
       assertThat(searchQueryResult.items()).contains(entity.withName(entity.elementId()));
     }

--- a/service/src/test/java/io/camunda/service/VariableServiceTest.java
+++ b/service/src/test/java/io/camunda/service/VariableServiceTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Test;
 
 public class VariableServiceTest {
 
+  private static final String PHYSICAL_TENANT_ID = "foo";
   private VariableServices services;
   private VariableSearchClient client;
   private CamundaAuthentication authentication;
@@ -62,7 +63,7 @@ public class VariableServiceTest {
     final var searchQuery = SearchQueryBuilders.variableSearchQuery((b) -> b.filter(filter));
 
     // when
-    final var searchQueryResult = services.search(searchQuery, authentication, "default");
+    final var searchQueryResult = services.search(searchQuery, authentication, PHYSICAL_TENANT_ID);
 
     // then
     assertThat(searchQueryResult).isEqualTo(result);
@@ -85,7 +86,7 @@ public class VariableServiceTest {
     when(client.getVariable(any(Long.class))).thenReturn(entity);
 
     // when
-    final var searchQueryResult = services.getByKey(1L, authentication, "default");
+    final var searchQueryResult = services.getByKey(1L, authentication, PHYSICAL_TENANT_ID);
 
     // then
     assertThat(searchQueryResult).isEqualTo(entity);
@@ -100,7 +101,8 @@ public class VariableServiceTest {
     when(client.getVariable(any(Long.class)))
         .thenThrow(new ResourceAccessDeniedException(Authorizations.VARIABLE_READ_AUTHORIZATION));
     // when
-    final ThrowingCallable executeGetByKey = () -> services.getByKey(1L, authentication, "default");
+    final ThrowingCallable executeGetByKey =
+        () -> services.getByKey(1L, authentication, PHYSICAL_TENANT_ID);
 
     // then
     final var exception =

--- a/service/src/test/java/io/camunda/service/VariableServiceTest.java
+++ b/service/src/test/java/io/camunda/service/VariableServiceTest.java
@@ -41,6 +41,7 @@ public class VariableServiceTest {
   public void before() {
     client = mock(VariableSearchClient.class);
     when(client.withSecurityContext(any())).thenReturn(client);
+    when(client.withPhysicalTenant(any())).thenReturn(client);
     authentication = mock(CamundaAuthentication.class);
     services =
         new VariableServices(
@@ -61,7 +62,7 @@ public class VariableServiceTest {
     final var searchQuery = SearchQueryBuilders.variableSearchQuery((b) -> b.filter(filter));
 
     // when
-    final var searchQueryResult = services.search(searchQuery, authentication);
+    final var searchQueryResult = services.search(searchQuery, authentication, "default");
 
     // then
     assertThat(searchQueryResult).isEqualTo(result);
@@ -84,7 +85,7 @@ public class VariableServiceTest {
     when(client.getVariable(any(Long.class))).thenReturn(entity);
 
     // when
-    final var searchQueryResult = services.getByKey(1L, authentication);
+    final var searchQueryResult = services.getByKey(1L, authentication, "default");
 
     // then
     assertThat(searchQueryResult).isEqualTo(entity);
@@ -99,7 +100,7 @@ public class VariableServiceTest {
     when(client.getVariable(any(Long.class)))
         .thenThrow(new ResourceAccessDeniedException(Authorizations.VARIABLE_READ_AUTHORIZATION));
     // when
-    final ThrowingCallable executeGetByKey = () -> services.getByKey(1L, authentication);
+    final ThrowingCallable executeGetByKey = () -> services.getByKey(1L, authentication, "default");
 
     // then
     final var exception =

--- a/service/src/test/java/io/camunda/service/cache/ProcessCacheTest.java
+++ b/service/src/test/java/io/camunda/service/cache/ProcessCacheTest.java
@@ -62,7 +62,7 @@ class ProcessCacheTest {
         new ProcessCache(
             configuration, processDefinitionServices, brokerTopologyManager, meterRegistry);
 
-    when(processDefinitionServices.getByKey(eq(entity.processDefinitionKey()), any()))
+    when(processDefinitionServices.getByKey(eq(entity.processDefinitionKey()), any(), any()))
         .thenReturn(entity);
   }
 
@@ -87,21 +87,23 @@ class ProcessCacheTest {
     final var cacheItem = processCache.getCacheItem(entity.processDefinitionKey());
 
     // then - extractElementNames not called again
-    verify(processDefinitionServices, times(1)).getByKey(eq(entity.processDefinitionKey()), any());
+    verify(processDefinitionServices, times(1))
+        .getByKey(eq(entity.processDefinitionKey()), any(), any());
     assertThat(cacheItem).isNotEqualTo(ProcessCacheItem.EMPTY);
   }
 
   @Test
   void shouldNotPopulateCacheWhenNotFound() {
     // given
-    when(processDefinitionServices.getByKey(eq(entity.processDefinitionKey()), any()))
+    when(processDefinitionServices.getByKey(eq(entity.processDefinitionKey()), any(), any()))
         .thenThrow(new NoSuchElementException());
 
     // when
     final var cacheItem = processCache.getCacheItem(entity.processDefinitionKey());
 
     // then - extractElementNames not called again
-    verify(processDefinitionServices, times(1)).getByKey(eq(entity.processDefinitionKey()), any());
+    verify(processDefinitionServices, times(1))
+        .getByKey(eq(entity.processDefinitionKey()), any(), any());
     assertThat(cacheItem).isEqualTo(ProcessCacheItem.EMPTY);
   }
 
@@ -113,7 +115,8 @@ class ProcessCacheTest {
     processCache.getCacheItem(entity.processDefinitionKey());
 
     // then - extractElementNames not called again
-    verify(processDefinitionServices, times(1)).getByKey(eq(entity.processDefinitionKey()), any());
+    verify(processDefinitionServices, times(1))
+        .getByKey(eq(entity.processDefinitionKey()), any(), any());
   }
 
   @Test
@@ -124,7 +127,7 @@ class ProcessCacheTest {
             .set(field(ProcessDefinitionEntity::processDefinitionId), "parent_process_v1")
             .create();
 
-    when(processDefinitionServices.search(any(), any()))
+    when(processDefinitionServices.search(any(), any(), any()))
         .thenReturn(SearchQueryResult.of(entity, otherEntity));
 
     // when
@@ -133,7 +136,7 @@ class ProcessCacheTest {
             Set.of(entity.processDefinitionKey(), otherEntity.processDefinitionKey()));
 
     // then
-    verify(processDefinitionServices, times(1)).search(any(), any());
+    verify(processDefinitionServices, times(1)).search(any(), any(), any());
     final var cacheMap = getCacheMap();
     assertThat(cacheMap)
         .containsOnlyKeys(entity.processDefinitionKey(), otherEntity.processDefinitionKey());
@@ -198,7 +201,7 @@ class ProcessCacheTest {
               .set(field(ProcessDefinitionEntity::processDefinitionId), "parent_process_v1")
               .create();
 
-      when(processDefinitionServices.search(any(), any()))
+      when(processDefinitionServices.search(any(), any(), any()))
           .thenReturn(SearchQueryResult.of(entity, otherEntity));
 
       // when

--- a/service/src/test/java/io/camunda/service/cache/ProcessCacheTest.java
+++ b/service/src/test/java/io/camunda/service/cache/ProcessCacheTest.java
@@ -38,6 +38,8 @@ import org.junit.jupiter.api.Test;
 
 class ProcessCacheTest {
 
+  private static final String TENANT = "default";
+
   private ProcessCache processCache;
   private ProcessCache.Configuration configuration;
   private ProcessDefinitionServices processDefinitionServices;
@@ -74,7 +76,7 @@ class ProcessCacheTest {
   }
 
   private LoadingCache<Long, ProcessCacheItem> getCache() {
-    return processCache.getRawCache();
+    return processCache.getRawCache(TENANT);
   }
 
   private ConcurrentMap<Long, ProcessCacheItem> getCacheMap() {
@@ -84,7 +86,7 @@ class ProcessCacheTest {
   @Test
   void shouldPopulateCache() {
     // when
-    final var cacheItem = processCache.getCacheItem(entity.processDefinitionKey());
+    final var cacheItem = processCache.getCacheItem(entity.processDefinitionKey(), TENANT);
 
     // then - extractElementNames not called again
     verify(processDefinitionServices, times(1))
@@ -99,7 +101,7 @@ class ProcessCacheTest {
         .thenThrow(new NoSuchElementException());
 
     // when
-    final var cacheItem = processCache.getCacheItem(entity.processDefinitionKey());
+    final var cacheItem = processCache.getCacheItem(entity.processDefinitionKey(), TENANT);
 
     // then - extractElementNames not called again
     verify(processDefinitionServices, times(1))
@@ -110,9 +112,9 @@ class ProcessCacheTest {
   @Test
   void shouldNotRepopulateWhenAlreadyCached() {
     // when
-    processCache.getCacheItem(entity.processDefinitionKey());
+    processCache.getCacheItem(entity.processDefinitionKey(), TENANT);
     getCache().cleanUp();
-    processCache.getCacheItem(entity.processDefinitionKey());
+    processCache.getCacheItem(entity.processDefinitionKey(), TENANT);
 
     // then - extractElementNames not called again
     verify(processDefinitionServices, times(1))
@@ -133,7 +135,7 @@ class ProcessCacheTest {
     // when
     final var cacheResult =
         processCache.getCacheItems(
-            Set.of(entity.processDefinitionKey(), otherEntity.processDefinitionKey()));
+            Set.of(entity.processDefinitionKey(), otherEntity.processDefinitionKey()), TENANT);
 
     // then
     verify(processDefinitionServices, times(1)).search(any(), any(), any());
@@ -149,14 +151,14 @@ class ProcessCacheTest {
     processCache =
         new ProcessCache(
             configuration, processDefinitionServices, brokerTopologyManager, meterRegistry);
-    processCache.getCacheItem(1L);
-    processCache.getCacheItem(2L);
+    processCache.getCacheItem(1L, TENANT);
+    processCache.getCacheItem(2L, TENANT);
     getCache().cleanUp();
     assertThat(getCacheMap()).hasSize(2);
 
     // when - read 1 and adding 3
-    processCache.getCacheItem(1L);
-    processCache.getCacheItem(3L);
+    processCache.getCacheItem(1L, TENANT);
+    processCache.getCacheItem(3L, TENANT);
     getCache().cleanUp();
 
     // then - 2 should be removed
@@ -177,7 +179,7 @@ class ProcessCacheTest {
     @Test
     void shouldResolveName() {
       // when
-      final var cacheItem = processCache.getCacheItem(entity.processDefinitionKey());
+      final var cacheItem = processCache.getCacheItem(entity.processDefinitionKey(), TENANT);
 
       // then - extractElementNames not called again
       assertThat(cacheItem.getElementName("StartEvent_1")).isEqualTo("Start");
@@ -187,7 +189,7 @@ class ProcessCacheTest {
     @Test
     void shouldResolveDefaultName() {
       // given
-      final var cacheItem = processCache.getCacheItem(entity.processDefinitionKey());
+      final var cacheItem = processCache.getCacheItem(entity.processDefinitionKey(), TENANT);
 
       // then - extractElementNames not called again
       assertThat(cacheItem.getElementName("non-existing")).isEqualTo("non-existing");
@@ -207,7 +209,7 @@ class ProcessCacheTest {
       // when
       final var cacheResult =
           processCache.getCacheItems(
-              Set.of(entity.processDefinitionKey(), otherEntity.processDefinitionKey()));
+              Set.of(entity.processDefinitionKey(), otherEntity.processDefinitionKey()), TENANT);
 
       // then
       assertThat(
@@ -221,6 +223,73 @@ class ProcessCacheTest {
                   .getProcessItem(otherEntity.processDefinitionKey())
                   .getElementName("call_activity"))
           .isEqualTo("Call Activity");
+    }
+  }
+
+  @Nested
+  class PerTenantCache {
+
+    @Test
+    void shouldHaveSeparateCachesPerTenant() {
+      // when - load key for tenantA only
+      processCache.getCacheItem(entity.processDefinitionKey(), "tenantA");
+
+      // then - tenantB's cache is untouched
+      assertThat(processCache.getRawCache("tenantB").asMap()).isEmpty();
+    }
+
+    @Test
+    void shouldLoadSeparatelyForEachTenant() {
+      // when - same key loaded for two different tenants
+      processCache.getCacheItem(entity.processDefinitionKey(), "tenantA");
+      processCache.getCacheItem(entity.processDefinitionKey(), "tenantB");
+
+      // then - service called once per tenant, not served from a shared cache
+      verify(processDefinitionServices, times(2))
+          .getByKey(eq(entity.processDefinitionKey()), any(), any());
+    }
+
+    @Test
+    void shouldRespectMaxSizePerTenantIndependently() {
+      // given - small cache (max 2 per tenant)
+      configuration = new Configuration(2, null);
+      processCache =
+          new ProcessCache(
+              configuration, processDefinitionServices, brokerTopologyManager, meterRegistry);
+
+      processCache.getCacheItem(1L, "tenantA");
+      processCache.getCacheItem(2L, "tenantA");
+      processCache.getCacheItem(1L, "tenantB");
+      processCache.getCacheItem(2L, "tenantB");
+      processCache.getRawCache("tenantA").cleanUp();
+      processCache.getRawCache("tenantB").cleanUp();
+      assertThat(processCache.getRawCache("tenantA").asMap()).hasSize(2);
+      assertThat(processCache.getRawCache("tenantB").asMap()).hasSize(2);
+
+      // when - add a third entry to tenantA only
+      processCache.getCacheItem(3L, "tenantA");
+      processCache.getRawCache("tenantA").cleanUp();
+      processCache.getRawCache("tenantB").cleanUp();
+
+      // then - tenantA evicted one entry, tenantB is unaffected
+      assertThat(processCache.getRawCache("tenantA").asMap()).hasSize(2);
+      assertThat(processCache.getRawCache("tenantB").asMap()).hasSize(2);
+    }
+
+    @Test
+    void shouldInvalidateAllTenantCaches() {
+      // given - both tenants have cached entries
+      processCache.getCacheItem(entity.processDefinitionKey(), "tenantA");
+      processCache.getCacheItem(entity.processDefinitionKey(), "tenantB");
+      assertThat(processCache.getRawCache("tenantA").asMap()).isNotEmpty();
+      assertThat(processCache.getRawCache("tenantB").asMap()).isNotEmpty();
+
+      // when
+      processCache.invalidate();
+
+      // then - both caches are cleared
+      assertThat(processCache.getRawCache("tenantA").asMap()).isEmpty();
+      assertThat(processCache.getRawCache("tenantB").asMap()).isEmpty();
     }
   }
 }

--- a/service/src/test/java/io/camunda/service/cache/ProcessCacheTest.java
+++ b/service/src/test/java/io/camunda/service/cache/ProcessCacheTest.java
@@ -38,7 +38,7 @@ import org.junit.jupiter.api.Test;
 
 class ProcessCacheTest {
 
-  private static final String TENANT = "default";
+  private static final String PHYSICAL_TENANT_ID = "foo";
 
   private ProcessCache processCache;
   private ProcessCache.Configuration configuration;
@@ -76,7 +76,7 @@ class ProcessCacheTest {
   }
 
   private LoadingCache<Long, ProcessCacheItem> getCache() {
-    return processCache.getRawCache(TENANT);
+    return processCache.getRawCache(PHYSICAL_TENANT_ID);
   }
 
   private ConcurrentMap<Long, ProcessCacheItem> getCacheMap() {
@@ -86,7 +86,8 @@ class ProcessCacheTest {
   @Test
   void shouldPopulateCache() {
     // when
-    final var cacheItem = processCache.getCacheItem(entity.processDefinitionKey(), TENANT);
+    final var cacheItem =
+        processCache.getCacheItem(entity.processDefinitionKey(), PHYSICAL_TENANT_ID);
 
     // then - extractElementNames not called again
     verify(processDefinitionServices, times(1))
@@ -101,7 +102,8 @@ class ProcessCacheTest {
         .thenThrow(new NoSuchElementException());
 
     // when
-    final var cacheItem = processCache.getCacheItem(entity.processDefinitionKey(), TENANT);
+    final var cacheItem =
+        processCache.getCacheItem(entity.processDefinitionKey(), PHYSICAL_TENANT_ID);
 
     // then - extractElementNames not called again
     verify(processDefinitionServices, times(1))
@@ -112,9 +114,9 @@ class ProcessCacheTest {
   @Test
   void shouldNotRepopulateWhenAlreadyCached() {
     // when
-    processCache.getCacheItem(entity.processDefinitionKey(), TENANT);
+    processCache.getCacheItem(entity.processDefinitionKey(), PHYSICAL_TENANT_ID);
     getCache().cleanUp();
-    processCache.getCacheItem(entity.processDefinitionKey(), TENANT);
+    processCache.getCacheItem(entity.processDefinitionKey(), PHYSICAL_TENANT_ID);
 
     // then - extractElementNames not called again
     verify(processDefinitionServices, times(1))
@@ -135,7 +137,8 @@ class ProcessCacheTest {
     // when
     final var cacheResult =
         processCache.getCacheItems(
-            Set.of(entity.processDefinitionKey(), otherEntity.processDefinitionKey()), TENANT);
+            Set.of(entity.processDefinitionKey(), otherEntity.processDefinitionKey()),
+            PHYSICAL_TENANT_ID);
 
     // then
     verify(processDefinitionServices, times(1)).search(any(), any(), any());
@@ -151,14 +154,14 @@ class ProcessCacheTest {
     processCache =
         new ProcessCache(
             configuration, processDefinitionServices, brokerTopologyManager, meterRegistry);
-    processCache.getCacheItem(1L, TENANT);
-    processCache.getCacheItem(2L, TENANT);
+    processCache.getCacheItem(1L, PHYSICAL_TENANT_ID);
+    processCache.getCacheItem(2L, PHYSICAL_TENANT_ID);
     getCache().cleanUp();
     assertThat(getCacheMap()).hasSize(2);
 
     // when - read 1 and adding 3
-    processCache.getCacheItem(1L, TENANT);
-    processCache.getCacheItem(3L, TENANT);
+    processCache.getCacheItem(1L, PHYSICAL_TENANT_ID);
+    processCache.getCacheItem(3L, PHYSICAL_TENANT_ID);
     getCache().cleanUp();
 
     // then - 2 should be removed
@@ -179,7 +182,8 @@ class ProcessCacheTest {
     @Test
     void shouldResolveName() {
       // when
-      final var cacheItem = processCache.getCacheItem(entity.processDefinitionKey(), TENANT);
+      final var cacheItem =
+          processCache.getCacheItem(entity.processDefinitionKey(), PHYSICAL_TENANT_ID);
 
       // then - extractElementNames not called again
       assertThat(cacheItem.getElementName("StartEvent_1")).isEqualTo("Start");
@@ -189,7 +193,8 @@ class ProcessCacheTest {
     @Test
     void shouldResolveDefaultName() {
       // given
-      final var cacheItem = processCache.getCacheItem(entity.processDefinitionKey(), TENANT);
+      final var cacheItem =
+          processCache.getCacheItem(entity.processDefinitionKey(), PHYSICAL_TENANT_ID);
 
       // then - extractElementNames not called again
       assertThat(cacheItem.getElementName("non-existing")).isEqualTo("non-existing");
@@ -209,7 +214,8 @@ class ProcessCacheTest {
       // when
       final var cacheResult =
           processCache.getCacheItems(
-              Set.of(entity.processDefinitionKey(), otherEntity.processDefinitionKey()), TENANT);
+              Set.of(entity.processDefinitionKey(), otherEntity.processDefinitionKey()),
+              PHYSICAL_TENANT_ID);
 
       // then
       assertThat(

--- a/service/src/test/java/io/camunda/service/cache/ProcessDefinitionProviderTest.java
+++ b/service/src/test/java/io/camunda/service/cache/ProcessDefinitionProviderTest.java
@@ -73,7 +73,8 @@ class ProcessDefinitionProviderTest {
     bpmn4 = loadBpmn("xmlUtil-test4.bpmn");
     when(processDefinition.processDefinitionKey()).thenReturn(PROC_DEF_KEY);
     when(processDefinition.processDefinitionId()).thenReturn(PROC_DEF_ID1);
-    when(processDefinitionServices.getByKey(eq(PROC_DEF_KEY), any())).thenReturn(processDefinition);
+    when(processDefinitionServices.getByKey(eq(PROC_DEF_KEY), any(), any()))
+        .thenReturn(processDefinition);
   }
 
   private void verifyElementsBpmn1(final ProcessCacheData processCacheData) {
@@ -198,7 +199,7 @@ class ProcessDefinitionProviderTest {
         new ProcessDefinitionEntity(2L, "Process 2", PROC_DEF_ID2, bpmn2, "", 1, "", "", "");
     final var processDefinition3 =
         new ProcessDefinitionEntity(3L, "Process 3", PROC_DEF_ID3, bpmn3, "", 1, "", "", "");
-    when(processDefinitionServices.search(any(), any()))
+    when(processDefinitionServices.search(any(), any(), any()))
         .thenReturn(
             new SearchQueryResult.Builder<ProcessDefinitionEntity>()
                 .items(List.of(processDefinition, processDefinition2, processDefinition3))
@@ -222,7 +223,7 @@ class ProcessDefinitionProviderTest {
     verifyElementsBpmn3(processData3);
 
     final var searchRequestCaptor = ArgumentCaptor.forClass(ProcessDefinitionQuery.class);
-    verify(processDefinitionServices).search(searchRequestCaptor.capture(), any());
+    verify(processDefinitionServices).search(searchRequestCaptor.capture(), any(), any());
     final var actualQuery = searchRequestCaptor.getValue();
     assertThat(actualQuery.filter().processDefinitionKeys()).hasSize(3);
     assertThat(actualQuery.filter().processDefinitionKeys()).containsOnly(PROC_DEF_KEY, 2L, 3L);

--- a/service/src/test/java/io/camunda/service/cache/ProcessDefinitionProviderTest.java
+++ b/service/src/test/java/io/camunda/service/cache/ProcessDefinitionProviderTest.java
@@ -37,6 +37,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class ProcessDefinitionProviderTest {
 
+  public static final String DEFAULT_TENANT_ID = "default";
   public static final String PROC_DEF_ID1 = "testProcess";
   public static final String PROC_DEF_ID2 = "parent_process_v1";
   public static final String PROC_DEF_ID3 = "eventSubprocessProcess";
@@ -109,7 +110,7 @@ class ProcessDefinitionProviderTest {
 
     // when
     final ProcessCacheData processCacheData =
-        processDefinitionProvider.extractProcessData(PROC_DEF_KEY);
+        processDefinitionProvider.extractProcessData(PROC_DEF_KEY, DEFAULT_TENANT_ID);
 
     // then
     assertThat(processCacheData.elementIdNameMap()).isEmpty();
@@ -122,7 +123,7 @@ class ProcessDefinitionProviderTest {
 
     // when
     final ProcessCacheData processCacheData =
-        processDefinitionProvider.extractProcessData(PROC_DEF_KEY);
+        processDefinitionProvider.extractProcessData(PROC_DEF_KEY, DEFAULT_TENANT_ID);
 
     // then
     verifyElementsBpmn1(processCacheData);
@@ -136,7 +137,7 @@ class ProcessDefinitionProviderTest {
 
     // when
     final ProcessCacheData processCacheData =
-        processDefinitionProvider.extractProcessData(PROC_DEF_KEY);
+        processDefinitionProvider.extractProcessData(PROC_DEF_KEY, DEFAULT_TENANT_ID);
 
     // then
     verifyElementsBpmn2(processCacheData);
@@ -150,7 +151,7 @@ class ProcessDefinitionProviderTest {
 
     // when
     final ProcessCacheData processCacheData =
-        processDefinitionProvider.extractProcessData(PROC_DEF_KEY);
+        processDefinitionProvider.extractProcessData(PROC_DEF_KEY, DEFAULT_TENANT_ID);
 
     // then
     verifyElementsBpmn3(processCacheData);
@@ -164,7 +165,7 @@ class ProcessDefinitionProviderTest {
 
     // when
     final ProcessCacheData processCacheData =
-        processDefinitionProvider.extractProcessData(PROC_DEF_KEY);
+        processDefinitionProvider.extractProcessData(PROC_DEF_KEY, DEFAULT_TENANT_ID);
 
     // then
     assertThat(processCacheData.elementIdNameMap())
@@ -181,7 +182,7 @@ class ProcessDefinitionProviderTest {
 
     // when
     final ProcessCacheData processCacheData =
-        processDefinitionProvider.extractProcessData(PROC_DEF_KEY);
+        processDefinitionProvider.extractProcessData(PROC_DEF_KEY, DEFAULT_TENANT_ID);
 
     // then
     assertThat(processCacheData.elementIdNameMap())
@@ -208,7 +209,8 @@ class ProcessDefinitionProviderTest {
 
     // when
     final var processDataMap =
-        processDefinitionProvider.extractProcessData(Set.of(PROC_DEF_KEY, 2L, 3L));
+        processDefinitionProvider.extractProcessData(
+            Set.of(PROC_DEF_KEY, 2L, 3L), DEFAULT_TENANT_ID);
 
     // then
     assertThat(processDataMap).hasSize(3);

--- a/service/src/test/java/io/camunda/service/cache/ProcessDefinitionProviderTest.java
+++ b/service/src/test/java/io/camunda/service/cache/ProcessDefinitionProviderTest.java
@@ -37,12 +37,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class ProcessDefinitionProviderTest {
 
-  public static final String DEFAULT_TENANT_ID = "default";
   public static final String PROC_DEF_ID1 = "testProcess";
   public static final String PROC_DEF_ID2 = "parent_process_v1";
   public static final String PROC_DEF_ID3 = "eventSubprocessProcess";
   public static final String PROC_DEF_ID41 = "Process_0diikxu";
   public static final String PROC_DEF_ID42 = "Process_18z2cdf";
+  private static final String PHYSICAL_TENANT_ID = "foo";
   private static final Long PROC_DEF_KEY = 1L;
 
   @InjectMocks ProcessDefinitionProvider processDefinitionProvider;
@@ -110,7 +110,7 @@ class ProcessDefinitionProviderTest {
 
     // when
     final ProcessCacheData processCacheData =
-        processDefinitionProvider.extractProcessData(PROC_DEF_KEY, DEFAULT_TENANT_ID);
+        processDefinitionProvider.extractProcessData(PROC_DEF_KEY, PHYSICAL_TENANT_ID);
 
     // then
     assertThat(processCacheData.elementIdNameMap()).isEmpty();
@@ -123,7 +123,7 @@ class ProcessDefinitionProviderTest {
 
     // when
     final ProcessCacheData processCacheData =
-        processDefinitionProvider.extractProcessData(PROC_DEF_KEY, DEFAULT_TENANT_ID);
+        processDefinitionProvider.extractProcessData(PROC_DEF_KEY, PHYSICAL_TENANT_ID);
 
     // then
     verifyElementsBpmn1(processCacheData);
@@ -137,7 +137,7 @@ class ProcessDefinitionProviderTest {
 
     // when
     final ProcessCacheData processCacheData =
-        processDefinitionProvider.extractProcessData(PROC_DEF_KEY, DEFAULT_TENANT_ID);
+        processDefinitionProvider.extractProcessData(PROC_DEF_KEY, PHYSICAL_TENANT_ID);
 
     // then
     verifyElementsBpmn2(processCacheData);
@@ -151,7 +151,7 @@ class ProcessDefinitionProviderTest {
 
     // when
     final ProcessCacheData processCacheData =
-        processDefinitionProvider.extractProcessData(PROC_DEF_KEY, DEFAULT_TENANT_ID);
+        processDefinitionProvider.extractProcessData(PROC_DEF_KEY, PHYSICAL_TENANT_ID);
 
     // then
     verifyElementsBpmn3(processCacheData);
@@ -165,7 +165,7 @@ class ProcessDefinitionProviderTest {
 
     // when
     final ProcessCacheData processCacheData =
-        processDefinitionProvider.extractProcessData(PROC_DEF_KEY, DEFAULT_TENANT_ID);
+        processDefinitionProvider.extractProcessData(PROC_DEF_KEY, PHYSICAL_TENANT_ID);
 
     // then
     assertThat(processCacheData.elementIdNameMap())
@@ -182,7 +182,7 @@ class ProcessDefinitionProviderTest {
 
     // when
     final ProcessCacheData processCacheData =
-        processDefinitionProvider.extractProcessData(PROC_DEF_KEY, DEFAULT_TENANT_ID);
+        processDefinitionProvider.extractProcessData(PROC_DEF_KEY, PHYSICAL_TENANT_ID);
 
     // then
     assertThat(processCacheData.elementIdNameMap())
@@ -210,7 +210,7 @@ class ProcessDefinitionProviderTest {
     // when
     final var processDataMap =
         processDefinitionProvider.extractProcessData(
-            Set.of(PROC_DEF_KEY, 2L, 3L), DEFAULT_TENANT_ID);
+            Set.of(PROC_DEF_KEY, 2L, 3L), PHYSICAL_TENANT_ID);
 
     // then
     assertThat(processDataMap).hasSize(3);

--- a/tasklist/data-generator/src/main/java/io/camunda/tasklist/data/DevDataGeneratorAbstract.java
+++ b/tasklist/data-generator/src/main/java/io/camunda/tasklist/data/DevDataGeneratorAbstract.java
@@ -274,7 +274,8 @@ public abstract class DevDataGeneratorAbstract implements DataGenerator {
             (authentication) ->
                 resourceServices.deployResources(
                     new DeployResourcesRequest(Map.of(classpathResource, bytes), tenantId),
-                    authentication));
+                    authentication,
+                    "default"));
       } else {
         throw new FileNotFoundException(classpathResource);
       }
@@ -304,7 +305,8 @@ public abstract class DevDataGeneratorAbstract implements DataGenerator {
                     null,
                     Set.of(),
                     null),
-                authentication));
+                authentication,
+                "default"));
   }
 
   private <T> T executeCamundaServiceAnonymously(

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationHandler.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationHandler.java
@@ -202,7 +202,10 @@ public sealed interface AuthenticationHandler {
       final var userQuery =
           SearchQueryBuilders.userSearchQuery(
               fn -> fn.filter(f -> f.usernames(username)).page(p -> p.size(1)));
-      return userServices.search(userQuery, CamundaAuthentication.anonymous()).items().stream()
+      return userServices
+          .search(userQuery, CamundaAuthentication.anonymous(), "default")
+          .items()
+          .stream()
           .filter(Objects::nonNull)
           .findFirst();
     }

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationInterceptorTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationInterceptorTest.java
@@ -78,7 +78,7 @@ public class AuthenticationInterceptorTest {
     // demo:demo
     metadata.put(Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER), "Basic ZGVtbzpkZW1v");
     final var userServices = mock(UserServices.class);
-    when(userServices.search(any(), any()))
+    when(userServices.search(any(), any(), any()))
         .thenReturn(new SearchQueryResult<>(1, false, List.of(createUserEntity()), null, null));
     final var passwordEncoder = mock(PasswordEncoder.class);
     when(passwordEncoder.matches(anyString(), anyString())).thenReturn(true);
@@ -104,7 +104,7 @@ public class AuthenticationInterceptorTest {
     // demo:demo
     metadata.put(Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER), "Basic ZGVtbzpkZW1v");
     final var userServices = mock(UserServices.class);
-    when(userServices.search(any(), any()))
+    when(userServices.search(any(), any(), any()))
         .thenReturn(new SearchQueryResult<>(1, false, List.of(createUserEntity()), null, null));
     new AuthenticationInterceptor(new BasicAuth(userServices, mock(PasswordEncoder.class)))
         .interceptCall(
@@ -127,7 +127,7 @@ public class AuthenticationInterceptorTest {
     // demo:demo
     metadata.put(Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER), "Basic ZGVtbzpkZW1v");
     final var userServices = mock(UserServices.class);
-    when(userServices.search(any(), any()))
+    when(userServices.search(any(), any(), any()))
         .thenReturn(new SearchQueryResult<>(0, false, List.of(), null, null));
     new AuthenticationInterceptor(new BasicAuth(userServices, mock(PasswordEncoder.class)))
         .interceptCall(closeStatusCapturingServerCall, metadata, failingNextHandler());
@@ -150,7 +150,7 @@ public class AuthenticationInterceptorTest {
     // demo:demo
     metadata.put(Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER), "Basic ZGVtbzpkZW1v");
     final var userServices = mock(UserServices.class);
-    when(userServices.search(any(), any()))
+    when(userServices.search(any(), any(), any()))
         .thenReturn(new SearchQueryResult<>(1, false, List.of(createUserEntity()), null, null));
     final var passwordEncoder = mock(PasswordEncoder.class);
     when(passwordEncoder.matches(anyString(), anyString())).thenReturn(false);
@@ -619,7 +619,7 @@ public class AuthenticationInterceptorTest {
     // demo:demo
     metadata.put(Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER), "Basic ZGVtbzpkZW1v");
     final var userServices = mock(UserServices.class);
-    when(userServices.search(any(), any()))
+    when(userServices.search(any(), any(), any()))
         .thenReturn(new SearchQueryResult<>(1, false, List.of(createUserEntity()), null, null));
     final var passwordEncoder = mock(PasswordEncoder.class);
     when(passwordEncoder.matches(anyString(), anyString())).thenReturn(true);
@@ -654,7 +654,7 @@ public class AuthenticationInterceptorTest {
     // not demo:demo
     metadata.put(Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER), "Basic ZGVtbzpkZW1b");
     final var userServices = mock(UserServices.class);
-    when(userServices.search(any(), any()))
+    when(userServices.search(any(), any(), any()))
         .thenReturn(new SearchQueryResult<>(1, false, List.of(createUserEntity()), null, null));
     final var passwordEncoder = mock(PasswordEncoder.class);
     when(passwordEncoder.matches("demo", "demo")).thenReturn(true);
@@ -688,7 +688,7 @@ public class AuthenticationInterceptorTest {
     final var capturingCall = new CloseStatusCapturingServerCall();
     final Metadata metadata = new Metadata();
     final var userServices = mock(UserServices.class);
-    when(userServices.search(any(), any()))
+    when(userServices.search(any(), any(), any()))
         .thenReturn(new SearchQueryResult<>(1, false, List.of(createUserEntity()), null, null));
     final var passwordEncoder = mock(PasswordEncoder.class);
     when(passwordEncoder.matches("demo", "demo")).thenReturn(true);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubProcessActivityController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubProcessActivityController.java
@@ -13,6 +13,7 @@ import io.camunda.security.api.context.CamundaAuthenticationProvider;
 import io.camunda.service.AdHocSubProcessActivityServices;
 import io.camunda.service.AdHocSubProcessActivityServices.AdHocSubProcessActivateActivitiesRequest;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
+import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
 import java.util.concurrent.CompletableFuture;
@@ -38,16 +39,21 @@ public class AdHocSubProcessActivityController {
   @CamundaPostMapping(path = "/{adHocSubProcessInstanceKey}/activation")
   public CompletableFuture<ResponseEntity<Object>> activateAdHocSubProcessActivities(
       @PathVariable final String adHocSubProcessInstanceKey,
-      @RequestBody final AdHocSubProcessActivateActivitiesInstruction activationRequest) {
+      @RequestBody final AdHocSubProcessActivateActivitiesInstruction activationRequest,
+      @PhysicalTenantId final String physicalTenantId) {
     return RequestMapper.toAdHocSubProcessActivateActivitiesRequest(
             adHocSubProcessInstanceKey, activationRequest)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::activateActivities);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> activateActivities(req, physicalTenantId));
   }
 
   private CompletableFuture<ResponseEntity<Object>> activateActivities(
-      final AdHocSubProcessActivateActivitiesRequest request) {
+      final AdHocSubProcessActivateActivitiesRequest request, final String physicalTenantId) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethodWithNoContentResult(
-        () -> adHocSubProcessActivityServices.activateActivities(request, authentication));
+        () ->
+            adHocSubProcessActivityServices.activateActivities(
+                request, authentication, physicalTenantId));
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceController.java
@@ -24,6 +24,7 @@ import io.camunda.service.AgentInstanceServices;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPatchMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
+import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
@@ -53,29 +54,34 @@ public class AgentInstanceController {
 
   @CamundaPostMapping
   public CompletableFuture<ResponseEntity<Object>> createAgentInstance(
-      @RequestBody final AgentInstanceCreationRequest request) {
+      @RequestBody final AgentInstanceCreationRequest request,
+      @PhysicalTenantId final String physicalTenantId) {
     return mapper
         .toCreateAgentInstanceRecord(request)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::create);
+        .fold(RestErrorMapper::mapProblemToCompletedResponse, r -> create(r, physicalTenantId));
   }
 
   @CamundaPatchMapping(path = "/{agentInstanceKey}")
   public CompletableFuture<ResponseEntity<Object>> updateAgentInstance(
       @PathVariable final String agentInstanceKey,
-      @RequestBody final AgentInstanceUpdateRequest request) {
+      @RequestBody final AgentInstanceUpdateRequest request,
+      @PhysicalTenantId final String physicalTenantId) {
     return mapper
         .toUpdateAgentInstanceRecord(agentInstanceKey, request)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::update);
+        .fold(RestErrorMapper::mapProblemToCompletedResponse, r -> update(r, physicalTenantId));
   }
 
   @RequiresSecondaryStorage
   @CamundaGetMapping(path = "/{agentInstanceKey}")
   public ResponseEntity<AgentInstanceResult> getAgentInstance(
-      @PathVariable("agentInstanceKey") final long agentInstanceKey) {
+      @PathVariable("agentInstanceKey") final long agentInstanceKey,
+      @PhysicalTenantId final String physicalTenantId) {
     try {
       final var agentInstance =
           agentInstanceServices.getByKey(
-              agentInstanceKey, authenticationProvider.getCamundaAuthentication());
+              agentInstanceKey,
+              authenticationProvider.getCamundaAuthentication(),
+              physicalTenantId);
       return ResponseEntity.ok(SearchQueryResponseMapper.toAgentInstanceResult(agentInstance));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
@@ -85,29 +91,34 @@ public class AgentInstanceController {
   @RequiresSecondaryStorage
   @CamundaPostMapping(path = "/search")
   public ResponseEntity<AgentInstanceSearchQueryResult> searchAgentInstances(
-      @RequestBody(required = false) final AgentInstanceSearchQuery request) {
+      @RequestBody(required = false) final AgentInstanceSearchQuery request,
+      @PhysicalTenantId final String physicalTenantId) {
     return SearchQueryRequestMapper.toAgentInstanceQuery(request)
-        .fold(RestErrorMapper::mapProblemToResponse, this::search);
+        .fold(RestErrorMapper::mapProblemToResponse, q -> search(q, physicalTenantId));
   }
 
-  private CompletableFuture<ResponseEntity<Object>> create(final AgentInstanceRecord record) {
+  private CompletableFuture<ResponseEntity<Object>> create(
+      final AgentInstanceRecord record, final String physicalTenantId) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethod(
-        () -> agentInstanceServices.createAgentInstance(record, authentication),
+        () -> agentInstanceServices.createAgentInstance(record, authentication, physicalTenantId),
         mapper::toAgentInstanceCreationResult,
         HttpStatus.OK);
   }
 
-  private CompletableFuture<ResponseEntity<Object>> update(final AgentInstanceRecord record) {
+  private CompletableFuture<ResponseEntity<Object>> update(
+      final AgentInstanceRecord record, final String physicalTenantId) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethodWithNoContentResult(
-        () -> agentInstanceServices.updateAgentInstance(record, authentication));
+        () -> agentInstanceServices.updateAgentInstance(record, authentication, physicalTenantId));
   }
 
-  private ResponseEntity<AgentInstanceSearchQueryResult> search(final AgentInstanceQuery query) {
+  private ResponseEntity<AgentInstanceSearchQueryResult> search(
+      final AgentInstanceQuery query, final String physicalTenantId) {
     try {
       final var result =
-          agentInstanceServices.search(query, authenticationProvider.getCamundaAuthentication());
+          agentInstanceServices.search(
+              query, authenticationProvider.getCamundaAuthentication(), physicalTenantId);
       return ResponseEntity.ok(
           SearchQueryResponseMapper.toAgentInstanceSearchQueryResponse(result));
     } catch (final Exception e) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationController.java
@@ -19,6 +19,7 @@ import io.camunda.security.api.context.CamundaAuthenticationProvider;
 import io.camunda.service.BatchOperationServices;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
+import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
@@ -55,13 +56,15 @@ public class BatchOperationController {
 
   @CamundaGetMapping(path = "/{batchOperationKey}")
   public ResponseEntity<BatchOperationResponse> getById(
-      @PathVariable("batchOperationKey") final String batchOperationKey) {
+      @PathVariable("batchOperationKey") final String batchOperationKey,
+      @PhysicalTenantId final String physicalTenantId) {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
       return ResponseEntity.ok()
           .body(
               SearchQueryResponseMapper.toBatchOperation(
-                  batchOperationServices.getById(batchOperationKey, authentication)));
+                  batchOperationServices.getById(
+                      batchOperationKey, authentication, physicalTenantId)));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }
@@ -69,18 +72,22 @@ public class BatchOperationController {
 
   @CamundaPostMapping(path = "/search")
   public ResponseEntity<BatchOperationSearchQueryResult> searchBatchOperations(
-      @RequestBody(required = false) final BatchOperationSearchQuery query) {
+      @RequestBody(required = false) final BatchOperationSearchQuery query,
+      @PhysicalTenantId final String physicalTenantId) {
     return SearchQueryRequestMapper.toBatchOperationQuery(query)
-        .fold(RestErrorMapper::mapProblemToResponse, this::search);
+        .fold(RestErrorMapper::mapProblemToResponse, q -> search(q, physicalTenantId));
   }
 
   @CamundaPostMapping(
       path = "/{batchOperationKey}/cancellation",
       consumes = {})
-  public ResponseEntity<Object> cancelBatchOperation(@PathVariable final String batchOperationKey) {
+  public ResponseEntity<Object> cancelBatchOperation(
+      @PathVariable final String batchOperationKey,
+      @PhysicalTenantId final String physicalTenantId) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethodWithNoContentResult(
-            () -> batchOperationServices.cancel(batchOperationKey, authentication))
+            () ->
+                batchOperationServices.cancel(batchOperationKey, authentication, physicalTenantId))
         .join();
   }
 
@@ -88,27 +95,33 @@ public class BatchOperationController {
       path = "/{batchOperationKey}/suspension",
       consumes = {})
   public ResponseEntity<Object> suspendBatchOperation(
-      @PathVariable final String batchOperationKey) {
+      @PathVariable final String batchOperationKey,
+      @PhysicalTenantId final String physicalTenantId) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethodWithNoContentResult(
-            () -> batchOperationServices.suspend(batchOperationKey, authentication))
+            () ->
+                batchOperationServices.suspend(batchOperationKey, authentication, physicalTenantId))
         .join();
   }
 
   @CamundaPostMapping(
       path = "/{batchOperationKey}/resumption",
       consumes = {})
-  public ResponseEntity<Object> resumeBatchOperation(@PathVariable final String batchOperationKey) {
+  public ResponseEntity<Object> resumeBatchOperation(
+      @PathVariable final String batchOperationKey,
+      @PhysicalTenantId final String physicalTenantId) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethodWithNoContentResult(
-            () -> batchOperationServices.resume(batchOperationKey, authentication))
+            () ->
+                batchOperationServices.resume(batchOperationKey, authentication, physicalTenantId))
         .join();
   }
 
-  private ResponseEntity<BatchOperationSearchQueryResult> search(final BatchOperationQuery query) {
+  private ResponseEntity<BatchOperationSearchQueryResult> search(
+      final BatchOperationQuery query, final String physicalTenantId) {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
-      final var result = batchOperationServices.search(query, authentication);
+      final var result = batchOperationServices.search(query, authentication, physicalTenantId);
       return ResponseEntity.ok(SearchQueryResponseMapper.toBatchOperationSearchQueryResult(result));
     } catch (final Exception e) {
       return mapErrorToResponse(e);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationItemsController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationItemsController.java
@@ -17,6 +17,7 @@ import io.camunda.search.query.BatchOperationItemQuery;
 import io.camunda.security.api.context.CamundaAuthenticationProvider;
 import io.camunda.service.BatchOperationServices;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
+import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
 import org.springframework.http.ResponseEntity;
@@ -40,16 +41,18 @@ public class BatchOperationItemsController {
 
   @CamundaPostMapping(path = "/search")
   public ResponseEntity<BatchOperationItemSearchQueryResult> searchBatchOperationItems(
-      @RequestBody(required = false) final BatchOperationItemSearchQuery query) {
+      @RequestBody(required = false) final BatchOperationItemSearchQuery query,
+      @PhysicalTenantId final String physicalTenantId) {
     return SearchQueryRequestMapper.toBatchOperationItemQuery(query)
-        .fold(RestErrorMapper::mapProblemToResponse, this::search);
+        .fold(RestErrorMapper::mapProblemToResponse, q -> search(q, physicalTenantId));
   }
 
   private ResponseEntity<BatchOperationItemSearchQueryResult> search(
-      final BatchOperationItemQuery query) {
+      final BatchOperationItemQuery query, final String physicalTenantId) {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
-      final var result = batchOperationServices.searchItems(query, authentication);
+      final var result =
+          batchOperationServices.searchItems(query, authentication, physicalTenantId);
       return ResponseEntity.ok(
           SearchQueryResponseMapper.toBatchOperationItemSearchQueryResult(result));
     } catch (final Exception e) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClockController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClockController.java
@@ -13,6 +13,7 @@ import io.camunda.security.api.context.CamundaAuthenticationProvider;
 import io.camunda.service.ClockServices;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPutMapping;
+import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
 import java.util.concurrent.CompletableFuture;
@@ -37,24 +38,27 @@ public class ClockController {
 
   @CamundaPutMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
   public CompletableFuture<ResponseEntity<Object>> pinClock(
-      @RequestBody final ClockPinRequest pinRequest) {
+      @RequestBody final ClockPinRequest pinRequest,
+      @PhysicalTenantId final String physicalTenantId) {
 
     return RequestMapper.getPinnedEpoch(pinRequest)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::pinClock);
+        .fold(RestErrorMapper::mapProblemToCompletedResponse, e -> pinClock(e, physicalTenantId));
   }
 
   @CamundaPostMapping(
       path = "/reset",
       consumes = {})
-  public CompletableFuture<ResponseEntity<Object>> resetClock() {
+  public CompletableFuture<ResponseEntity<Object>> resetClock(
+      @PhysicalTenantId final String physicalTenantId) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethodWithNoContentResult(
-        () -> clockServices.resetClock(authentication));
+        () -> clockServices.resetClock(authentication, physicalTenantId));
   }
 
-  private CompletableFuture<ResponseEntity<Object>> pinClock(final long pinnedEpoch) {
+  private CompletableFuture<ResponseEntity<Object>> pinClock(
+      final long pinnedEpoch, final String physicalTenantId) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethodWithNoContentResult(
-        () -> clockServices.pinClock(pinnedEpoch, authentication));
+        () -> clockServices.pinClock(pinnedEpoch, authentication, physicalTenantId));
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterVariableController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterVariableController.java
@@ -27,6 +27,7 @@ import io.camunda.zeebe.gateway.rest.annotation.CamundaDeleteMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPutMapping;
+import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
@@ -59,54 +60,72 @@ public class ClusterVariableController {
 
   @CamundaPostMapping(path = "/global")
   public CompletableFuture<ResponseEntity<Object>> createGlobalClusterVariable(
-      @RequestBody final CreateClusterVariableRequest createClusterVariableRequest) {
+      @RequestBody final CreateClusterVariableRequest createClusterVariableRequest,
+      @PhysicalTenantId final String physicalTenantId) {
     return clusterVariableMapper
         .toGlobalClusterVariableCreateRequest(createClusterVariableRequest)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::createGlobalClusterVariable);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> createGlobalClusterVariable(req, physicalTenantId));
   }
 
   @CamundaPostMapping(path = "/tenants/{tenantId}")
   public CompletableFuture<ResponseEntity<Object>> createTenantClusterVariable(
       @PathVariable("tenantId") final String tenantId,
-      @RequestBody final CreateClusterVariableRequest createClusterVariableRequest) {
+      @RequestBody final CreateClusterVariableRequest createClusterVariableRequest,
+      @PhysicalTenantId final String physicalTenantId) {
     return clusterVariableMapper
         .toTenantClusterVariableCreateRequest(createClusterVariableRequest, tenantId)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::createTenantClusterVariable);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> createTenantClusterVariable(req, physicalTenantId));
   }
 
   @CamundaDeleteMapping(path = "/global/{name}")
   public CompletableFuture<ResponseEntity<Object>> deleteGlobalClusterVariable(
-      @PathVariable("name") final String name) {
+      @PathVariable("name") final String name, @PhysicalTenantId final String physicalTenantId) {
     return clusterVariableMapper
         .toGlobalClusterVariableRequest(name)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::deleteGlobalClusterVariable);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> deleteGlobalClusterVariable(req, physicalTenantId));
   }
 
   @CamundaDeleteMapping(path = "/tenants/{tenantId}/{name}")
   public CompletableFuture<ResponseEntity<Object>> deleteTenantClusterVariable(
-      @PathVariable("tenantId") final String tenantId, @PathVariable("name") final String name) {
+      @PathVariable("tenantId") final String tenantId,
+      @PathVariable("name") final String name,
+      @PhysicalTenantId final String physicalTenantId) {
     return clusterVariableMapper
         .toTenantClusterVariableRequest(name, tenantId)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::deleteTenantClusterVariable);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> deleteTenantClusterVariable(req, physicalTenantId));
   }
 
   @CamundaPutMapping(path = "/global/{name}")
   public CompletableFuture<ResponseEntity<Object>> updateGlobalClusterVariable(
       @PathVariable("name") final String name,
-      @RequestBody final UpdateClusterVariableRequest updateClusterVariableRequest) {
+      @RequestBody final UpdateClusterVariableRequest updateClusterVariableRequest,
+      @PhysicalTenantId final String physicalTenantId) {
     return clusterVariableMapper
         .toGlobalClusterVariableUpdateRequest(name, updateClusterVariableRequest)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::updateGlobalClusterVariable);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> updateGlobalClusterVariable(req, physicalTenantId));
   }
 
   @CamundaPutMapping(path = "/tenants/{tenantId}/{name}")
   public CompletableFuture<ResponseEntity<Object>> updateTenantClusterVariable(
       @PathVariable("tenantId") final String tenantId,
       @PathVariable("name") final String name,
-      @RequestBody final UpdateClusterVariableRequest updateClusterVariableRequest) {
+      @RequestBody final UpdateClusterVariableRequest updateClusterVariableRequest,
+      @PhysicalTenantId final String physicalTenantId) {
     return clusterVariableMapper
         .toTenantClusterVariableUpdateRequest(name, updateClusterVariableRequest, tenantId)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::updateTenantClusterVariable);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> updateTenantClusterVariable(req, physicalTenantId));
   }
 
   @RequiresSecondaryStorage
@@ -114,16 +133,21 @@ public class ClusterVariableController {
   public ResponseEntity<Object> search(
       @RequestBody final ClusterVariableSearchQueryRequest query,
       @RequestParam(name = "truncateValues", required = false, defaultValue = "true")
-          final boolean truncateValues) {
+          final boolean truncateValues,
+      @PhysicalTenantId final String physicalTenantId) {
     return SearchQueryRequestMapper.toClusterVariableQuery(query)
-        .fold(RestErrorMapper::mapProblemToResponse, q -> search(q, truncateValues));
+        .fold(
+            RestErrorMapper::mapProblemToResponse,
+            q -> search(q, truncateValues, physicalTenantId));
   }
 
   private ResponseEntity<Object> search(
-      final ClusterVariableQuery query, final boolean truncateValues) {
+      final ClusterVariableQuery query,
+      final boolean truncateValues,
+      final String physicalTenantId) {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
-      final var result = clusterVariableServices.search(query, authentication);
+      final var result = clusterVariableServices.search(query, authentication, physicalTenantId);
       return ResponseEntity.ok(
           SearchQueryResponseMapper.toClusterVariableSearchQueryResponse(result, truncateValues));
     } catch (final Exception e) {
@@ -133,92 +157,114 @@ public class ClusterVariableController {
 
   @RequiresSecondaryStorage
   @CamundaGetMapping(path = "/global/{name}")
-  public ResponseEntity<Object> getGlobalClusterVariable(@PathVariable("name") final String name) {
+  public ResponseEntity<Object> getGlobalClusterVariable(
+      @PathVariable("name") final String name, @PhysicalTenantId final String physicalTenantId) {
     return clusterVariableMapper
         .toGlobalClusterVariableRequest(name)
-        .fold(RestErrorMapper::mapProblemToResponse, this::getGlobalClusterVariable);
+        .fold(
+            RestErrorMapper::mapProblemToResponse,
+            req -> getGlobalClusterVariable(req, physicalTenantId));
   }
 
   @RequiresSecondaryStorage
   @CamundaGetMapping(path = "/tenants/{tenantId}/{name}")
   public ResponseEntity<Object> getTenantClusterVariable(
-      @PathVariable("tenantId") final String tenantId, @PathVariable("name") final String name) {
+      @PathVariable("tenantId") final String tenantId,
+      @PathVariable("name") final String name,
+      @PhysicalTenantId final String physicalTenantId) {
     return clusterVariableMapper
         .toTenantClusterVariableRequest(name, tenantId)
-        .fold(RestErrorMapper::mapProblemToResponse, this::getTenantClusterVariable);
+        .fold(
+            RestErrorMapper::mapProblemToResponse,
+            req -> getTenantClusterVariable(req, physicalTenantId));
   }
 
-  private ResponseEntity<Object> getGlobalClusterVariable(final ClusterVariableRequest request) {
+  private ResponseEntity<Object> getGlobalClusterVariable(
+      final ClusterVariableRequest request, final String physicalTenantId) {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
       return ResponseEntity.ok()
           .body(
               SearchQueryResponseMapper.toClusterVariableResult(
                   clusterVariableServices.getGloballyScopedClusterVariable(
-                      request, authentication)));
+                      request, authentication, physicalTenantId)));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }
   }
 
-  private ResponseEntity<Object> getTenantClusterVariable(final ClusterVariableRequest request) {
+  private ResponseEntity<Object> getTenantClusterVariable(
+      final ClusterVariableRequest request, final String physicalTenantId) {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
       return ResponseEntity.ok()
           .body(
               SearchQueryResponseMapper.toClusterVariableResult(
-                  clusterVariableServices.getTenantScopedClusterVariable(request, authentication)));
+                  clusterVariableServices.getTenantScopedClusterVariable(
+                      request, authentication, physicalTenantId)));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }
   }
 
   private CompletableFuture<ResponseEntity<Object>> createGlobalClusterVariable(
-      final ClusterVariableRequest request) {
+      final ClusterVariableRequest request, final String physicalTenantId) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethod(
-        () -> clusterVariableServices.createGloballyScopedClusterVariable(request, authentication),
+        () ->
+            clusterVariableServices.createGloballyScopedClusterVariable(
+                request, authentication, physicalTenantId),
         ResponseMapper::toClusterVariableResponse,
         HttpStatus.OK);
   }
 
   private CompletableFuture<ResponseEntity<Object>> createTenantClusterVariable(
-      final ClusterVariableRequest request) {
+      final ClusterVariableRequest request, final String physicalTenantId) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethod(
-        () -> clusterVariableServices.createTenantScopedClusterVariable(request, authentication),
+        () ->
+            clusterVariableServices.createTenantScopedClusterVariable(
+                request, authentication, physicalTenantId),
         ResponseMapper::toClusterVariableResponse,
         HttpStatus.OK);
   }
 
   private CompletableFuture<ResponseEntity<Object>> deleteGlobalClusterVariable(
-      final ClusterVariableRequest request) {
+      final ClusterVariableRequest request, final String physicalTenantId) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethodWithNoContentResult(
-        () -> clusterVariableServices.deleteGloballyScopedClusterVariable(request, authentication));
+        () ->
+            clusterVariableServices.deleteGloballyScopedClusterVariable(
+                request, authentication, physicalTenantId));
   }
 
   private CompletableFuture<ResponseEntity<Object>> deleteTenantClusterVariable(
-      final ClusterVariableRequest request) {
+      final ClusterVariableRequest request, final String physicalTenantId) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethodWithNoContentResult(
-        () -> clusterVariableServices.deleteTenantScopedClusterVariable(request, authentication));
+        () ->
+            clusterVariableServices.deleteTenantScopedClusterVariable(
+                request, authentication, physicalTenantId));
   }
 
   private CompletableFuture<ResponseEntity<Object>> updateGlobalClusterVariable(
-      final ClusterVariableRequest request) {
+      final ClusterVariableRequest request, final String physicalTenantId) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethod(
-        () -> clusterVariableServices.updateGloballyScopedClusterVariable(request, authentication),
+        () ->
+            clusterVariableServices.updateGloballyScopedClusterVariable(
+                request, authentication, physicalTenantId),
         ResponseMapper::toClusterVariableResponse,
         HttpStatus.OK);
   }
 
   private CompletableFuture<ResponseEntity<Object>> updateTenantClusterVariable(
-      final ClusterVariableRequest request) {
+      final ClusterVariableRequest request, final String physicalTenantId) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethod(
-        () -> clusterVariableServices.updateTenantScopedClusterVariable(request, authentication),
+        () ->
+            clusterVariableServices.updateTenantScopedClusterVariable(
+                request, authentication, physicalTenantId),
         ResponseMapper::toClusterVariableResponse,
         HttpStatus.OK);
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ConditionalController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ConditionalController.java
@@ -15,6 +15,7 @@ import io.camunda.security.api.model.config.MultiTenancyConfiguration;
 import io.camunda.service.ConditionalServices;
 import io.camunda.service.ConditionalServices.EvaluateConditionalRequest;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
+import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
 import java.util.concurrent.CompletableFuture;
@@ -42,16 +43,21 @@ public class ConditionalController {
 
   @CamundaPostMapping(path = "/evaluation")
   public CompletableFuture<ResponseEntity<Object>> evaluate(
-      @RequestBody final ConditionalEvaluationInstruction request) {
+      @RequestBody final ConditionalEvaluationInstruction request,
+      @PhysicalTenantId final String physicalTenantId) {
     return RequestMapper.toEvaluateConditionalRequest(request, multiTenancyCfg.isChecksEnabled())
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::evaluateConditionalEvent);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> evaluateConditionalEvent(req, physicalTenantId));
   }
 
   private CompletableFuture<ResponseEntity<Object>> evaluateConditionalEvent(
-      final EvaluateConditionalRequest createRequest) {
+      final EvaluateConditionalRequest createRequest, final String physicalTenantId) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethod(
-        () -> conditionalServices.evaluateConditional(createRequest, authentication),
+        () ->
+            conditionalServices.evaluateConditional(
+                createRequest, authentication, physicalTenantId),
         ResponseMapper::toConditionalEvaluationResponse,
         HttpStatus.OK);
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionController.java
@@ -24,6 +24,7 @@ import io.camunda.security.api.model.config.MultiTenancyConfiguration;
 import io.camunda.service.DecisionDefinitionServices;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
+import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
@@ -55,29 +56,36 @@ public class DecisionDefinitionController {
 
   @CamundaPostMapping(path = "/evaluation")
   public CompletableFuture<ResponseEntity<Object>> evaluateDecision(
-      @RequestBody final DecisionEvaluationInstruction evaluateDecisionRequest) {
+      @RequestBody final DecisionEvaluationInstruction evaluateDecisionRequest,
+      @PhysicalTenantId final String physicalTenantId) {
     return RequestMapper.toEvaluateDecisionRequest(
             evaluateDecisionRequest, multiTenancyCfg.isChecksEnabled())
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::evaluateDecision);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> evaluateDecision(req, physicalTenantId));
   }
 
   @RequiresSecondaryStorage
   @CamundaPostMapping(path = "/search")
   public ResponseEntity<DecisionDefinitionSearchQueryResult> searchDecisionDefinitions(
-      @RequestBody(required = false) final DecisionDefinitionSearchQuery query) {
+      @RequestBody(required = false) final DecisionDefinitionSearchQuery query,
+      @PhysicalTenantId final String physicalTenantId) {
     return SearchQueryRequestMapper.toDecisionDefinitionQuery(query)
-        .fold(RestErrorMapper::mapProblemToResponse, this::search);
+        .fold(RestErrorMapper::mapProblemToResponse, q -> search(q, physicalTenantId));
   }
 
   @RequiresSecondaryStorage
   @CamundaGetMapping(path = "/{decisionDefinitionKey}")
   public ResponseEntity<DecisionDefinitionResult> getDecisionDefinitionByKey(
-      @PathVariable("decisionDefinitionKey") final long decisionDefinitionKey) {
+      @PathVariable("decisionDefinitionKey") final long decisionDefinitionKey,
+      @PhysicalTenantId final String physicalTenantId) {
     try {
       return ResponseEntity.ok(
           SearchQueryResponseMapper.toDecisionDefinition(
               decisionDefinitionServices.getByKey(
-                  decisionDefinitionKey, authenticationProvider.getCamundaAuthentication())));
+                  decisionDefinitionKey,
+                  authenticationProvider.getCamundaAuthentication(),
+                  physicalTenantId)));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }
@@ -88,24 +96,27 @@ public class DecisionDefinitionController {
       path = "/{decisionDefinitionKey}/xml",
       produces = {MediaType.TEXT_XML_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
   public ResponseEntity<String> getDecisionDefinitionXml(
-      @PathVariable("decisionDefinitionKey") final long decisionDefinitionKey) {
+      @PathVariable("decisionDefinitionKey") final long decisionDefinitionKey,
+      @PhysicalTenantId final String physicalTenantId) {
     try {
       return ResponseEntity.ok()
           .contentType(new MediaType(MediaType.TEXT_XML, StandardCharsets.UTF_8))
           .body(
               decisionDefinitionServices.getDecisionDefinitionXml(
-                  decisionDefinitionKey, authenticationProvider.getCamundaAuthentication()));
+                  decisionDefinitionKey,
+                  authenticationProvider.getCamundaAuthentication(),
+                  physicalTenantId));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }
   }
 
   private ResponseEntity<DecisionDefinitionSearchQueryResult> search(
-      final DecisionDefinitionQuery query) {
+      final DecisionDefinitionQuery query, final String physicalTenantId) {
     try {
       final var result =
           decisionDefinitionServices.search(
-              query, authenticationProvider.getCamundaAuthentication());
+              query, authenticationProvider.getCamundaAuthentication(), physicalTenantId);
       return ResponseEntity.ok(
           SearchQueryResponseMapper.toDecisionDefinitionSearchQueryResponse(result));
     } catch (final Exception e) {
@@ -114,7 +125,7 @@ public class DecisionDefinitionController {
   }
 
   private CompletableFuture<ResponseEntity<Object>> evaluateDecision(
-      final DecisionEvaluationRequest request) {
+      final DecisionEvaluationRequest request, final String physicalTenantId) {
     return RequestExecutor.executeServiceMethod(
         () ->
             decisionDefinitionServices.evaluateDecision(
@@ -122,7 +133,8 @@ public class DecisionDefinitionController {
                 request.decisionKey(),
                 request.variables(),
                 request.tenantId(),
-                authenticationProvider.getCamundaAuthentication()),
+                authenticationProvider.getCamundaAuthentication(),
+                physicalTenantId),
         ResponseMapper::toEvaluateDecisionResponse,
         HttpStatus.OK);
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceController.java
@@ -22,6 +22,7 @@ import io.camunda.security.api.context.CamundaAuthenticationProvider;
 import io.camunda.service.DecisionInstanceServices;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
+import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
@@ -50,49 +51,57 @@ public class DecisionInstanceController {
   @RequiresSecondaryStorage
   @CamundaPostMapping(path = "/search")
   public ResponseEntity<DecisionInstanceSearchQueryResult> searchDecisionInstances(
-      @RequestBody(required = false) final DecisionInstanceSearchQuery query) {
+      @RequestBody(required = false) final DecisionInstanceSearchQuery query,
+      @PhysicalTenantId final String physicalTenantId) {
     return SearchQueryRequestMapper.toDecisionInstanceQuery(query)
-        .fold(RestErrorMapper::mapProblemToResponse, this::search);
+        .fold(RestErrorMapper::mapProblemToResponse, q -> search(q, physicalTenantId));
   }
 
   @RequiresSecondaryStorage
   @CamundaGetMapping(path = "/{decisionEvaluationInstanceKey}")
   public ResponseEntity<DecisionInstanceGetQueryResult> getDecisionInstanceById(
-      @PathVariable("decisionEvaluationInstanceKey") final String decisionEvaluationInstanceKey) {
+      @PathVariable("decisionEvaluationInstanceKey") final String decisionEvaluationInstanceKey,
+      @PhysicalTenantId final String physicalTenantId) {
     return RequestValidator.validate(
             violations ->
                 RequestValidator.validateDecisionEvaluationInstanceKeyFormat(
                     decisionEvaluationInstanceKey, violations))
         .<ResponseEntity<DecisionInstanceGetQueryResult>>map(RestErrorMapper::mapProblemToResponse)
-        .orElseGet(() -> getDecisionInstance(decisionEvaluationInstanceKey));
+        .orElseGet(() -> getDecisionInstance(decisionEvaluationInstanceKey, physicalTenantId));
   }
 
   @RequiresSecondaryStorage
   @CamundaPostMapping(path = "/{decisionEvaluationKey}/deletion")
   public CompletableFuture<ResponseEntity<Object>> deleteDecisionInstance(
       @PathVariable final long decisionEvaluationKey,
-      @RequestBody(required = false) final DeleteDecisionInstanceRequest request) {
+      @RequestBody(required = false) final DeleteDecisionInstanceRequest request,
+      @PhysicalTenantId final String physicalTenantId) {
     return RequestExecutor.executeServiceMethodWithNoContentResult(
         () ->
             decisionInstanceServices.deleteDecisionInstance(
                 decisionEvaluationKey,
                 Objects.nonNull(request) ? request.getOperationReference() : null,
-                authenticationProvider.getCamundaAuthentication()));
+                authenticationProvider.getCamundaAuthentication(),
+                physicalTenantId));
   }
 
   @RequiresSecondaryStorage
   @CamundaPostMapping(path = "/deletion")
   public CompletableFuture<ResponseEntity<Object>> deleteDecisionInstancesBatchOperation(
-      @RequestBody final DecisionInstanceDeletionBatchOperationRequest request) {
+      @RequestBody final DecisionInstanceDeletionBatchOperationRequest request,
+      @PhysicalTenantId final String physicalTenantId) {
     return RequestMapper.toRequiredDecisionInstanceFilter(request.getFilter())
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::batchOperationDeletion);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            filter -> batchOperationDeletion(filter, physicalTenantId));
   }
 
   private ResponseEntity<DecisionInstanceSearchQueryResult> search(
-      final DecisionInstanceQuery query) {
+      final DecisionInstanceQuery query, final String physicalTenantId) {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
-      final var decisionInstances = decisionInstanceServices.search(query, authentication);
+      final var decisionInstances =
+          decisionInstanceServices.search(query, authentication, physicalTenantId);
       return ResponseEntity.ok(
           SearchQueryResponseMapper.toDecisionInstanceSearchQueryResponse(decisionInstances));
     } catch (final Exception e) {
@@ -101,11 +110,12 @@ public class DecisionInstanceController {
   }
 
   private ResponseEntity<DecisionInstanceGetQueryResult> getDecisionInstance(
-      final String decisionEvaluationInstanceKey) {
+      final String decisionEvaluationInstanceKey, final String physicalTenantId) {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
       final var decisionInstanceById =
-          decisionInstanceServices.getById(decisionEvaluationInstanceKey, authentication);
+          decisionInstanceServices.getById(
+              decisionEvaluationInstanceKey, authentication, physicalTenantId);
       return ResponseEntity.ok(
           SearchQueryResponseMapper.toDecisionInstanceGetQueryResponse(decisionInstanceById));
     } catch (final Exception e) {
@@ -114,11 +124,12 @@ public class DecisionInstanceController {
   }
 
   private CompletableFuture<ResponseEntity<Object>> batchOperationDeletion(
-      final io.camunda.search.filter.DecisionInstanceFilter filter) {
+      final io.camunda.search.filter.DecisionInstanceFilter filter, final String physicalTenantId) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethod(
         () ->
-            decisionInstanceServices.deleteDecisionInstancesBatchOperation(filter, authentication),
+            decisionInstanceServices.deleteDecisionInstancesBatchOperation(
+                filter, authentication, physicalTenantId),
         ResponseMapper::toBatchOperationCreatedWithResultResponse,
         HttpStatus.OK);
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DecisionRequirementsController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DecisionRequirementsController.java
@@ -18,6 +18,7 @@ import io.camunda.security.api.context.CamundaAuthenticationProvider;
 import io.camunda.service.DecisionRequirementsServices;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
+import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
 import java.nio.charset.StandardCharsets;
@@ -44,15 +45,18 @@ public class DecisionRequirementsController {
 
   @CamundaPostMapping(path = "/search")
   public ResponseEntity<Object> searchDecisionRequirements(
-      @RequestBody(required = false) final DecisionRequirementsSearchQuery query) {
+      @RequestBody(required = false) final DecisionRequirementsSearchQuery query,
+      @PhysicalTenantId final String physicalTenantId) {
     return SearchQueryRequestMapper.toDecisionRequirementsQuery(query)
-        .fold(RestErrorMapper::mapProblemToResponse, this::search);
+        .fold(RestErrorMapper::mapProblemToResponse, q -> search(q, physicalTenantId));
   }
 
-  private ResponseEntity<Object> search(final DecisionRequirementsQuery query) {
+  private ResponseEntity<Object> search(
+      final DecisionRequirementsQuery query, final String physicalTenantId) {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
-      final var result = decisionRequirementsServices.search(query, authentication);
+      final var result =
+          decisionRequirementsServices.search(query, authentication, physicalTenantId);
       return ResponseEntity.ok(
           SearchQueryResponseMapper.toDecisionRequirementsSearchQueryResponse(result));
     } catch (final Exception e) {
@@ -62,13 +66,15 @@ public class DecisionRequirementsController {
 
   @CamundaGetMapping(path = "/{decisionRequirementsKey}")
   public ResponseEntity<DecisionRequirementsResult> getByKey(
-      @PathVariable("decisionRequirementsKey") final Long decisionRequirementsKey) {
+      @PathVariable("decisionRequirementsKey") final Long decisionRequirementsKey,
+      @PhysicalTenantId final String physicalTenantId) {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
       return ResponseEntity.ok()
           .body(
               SearchQueryResponseMapper.toDecisionRequirements(
-                  decisionRequirementsServices.getByKey(decisionRequirementsKey, authentication)));
+                  decisionRequirementsServices.getByKey(
+                      decisionRequirementsKey, authentication, physicalTenantId)));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }
@@ -78,14 +84,15 @@ public class DecisionRequirementsController {
       path = "/{decisionRequirementsKey}/xml",
       produces = {MediaType.TEXT_XML_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
   public ResponseEntity<String> getDecisionRequirementsXml(
-      @PathVariable("decisionRequirementsKey") final Long decisionRequirementsKey) {
+      @PathVariable("decisionRequirementsKey") final Long decisionRequirementsKey,
+      @PhysicalTenantId final String physicalTenantId) {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
       return ResponseEntity.ok()
           .contentType(new MediaType(MediaType.TEXT_XML, StandardCharsets.UTF_8))
           .body(
               decisionRequirementsServices.getDecisionRequirementsXml(
-                  decisionRequirementsKey, authentication));
+                  decisionRequirementsKey, authentication, physicalTenantId));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DocumentController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DocumentController.java
@@ -19,6 +19,7 @@ import io.camunda.service.DocumentServices.DocumentLinkParams;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaDeleteMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
+import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
 import jakarta.servlet.http.Part;
@@ -56,10 +57,13 @@ public class DocumentController {
       @RequestParam(required = false) final String documentId,
       @RequestParam(required = false) final String storeId,
       @RequestPart(value = "file") final Part file,
-      @RequestPart(value = "metadata", required = false) final DocumentMetadata metadata) {
+      @RequestPart(value = "metadata", required = false) final DocumentMetadata metadata,
+      @PhysicalTenantId final String physicalTenantId) {
 
     return RequestMapper.toDocumentCreateRequest(documentId, storeId, file, metadata)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::createDocument);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            r -> createDocument(r, physicalTenantId));
   }
 
   @CamundaPostMapping(path = "/batch", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
@@ -67,28 +71,31 @@ public class DocumentController {
       @RequestPart(value = "files") final List<Part> files,
       @RequestPart(value = "metadataList", required = false)
           final List<DocumentMetadata> metadataList,
-      @RequestParam(required = false) final String storeId) {
+      @RequestParam(required = false) final String storeId,
+      @PhysicalTenantId final String physicalTenantId) {
     // Pass metadataList to let mapper prefer it over legacy headers when provided
     return RequestMapper.toDocumentCreateRequestBatch(files, storeId, objectMapper, metadataList)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::createDocumentBatch);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            r -> createDocumentBatch(r, physicalTenantId));
   }
 
   private CompletableFuture<ResponseEntity<Object>> createDocument(
-      final DocumentServices.DocumentCreateRequest request) {
+      final DocumentServices.DocumentCreateRequest request, final String physicalTenantId) {
 
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethod(
-        () -> documentServices.createDocument(request, authentication),
+        () -> documentServices.createDocument(request, authentication, physicalTenantId),
         ResponseMapper::toDocumentReference,
         HttpStatus.CREATED);
   }
 
   private CompletableFuture<ResponseEntity<Object>> createDocumentBatch(
-      final List<DocumentServices.DocumentCreateRequest> requests) {
+      final List<DocumentServices.DocumentCreateRequest> requests, final String physicalTenantId) {
 
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethod(
-        () -> documentServices.createDocumentBatch(requests, authentication),
+        () -> documentServices.createDocumentBatch(requests, authentication, physicalTenantId),
         ResponseMapper::toDocumentReferenceBatch,
         response ->
             response.getFailedDocuments().isEmpty() ? HttpStatus.CREATED : HttpStatus.MULTI_STATUS);
@@ -100,13 +107,14 @@ public class DocumentController {
   public ResponseEntity<StreamingResponseBody> getDocumentContent(
       @PathVariable final String documentId,
       @RequestParam(required = false) final String storeId,
-      @RequestParam(required = false) final String contentHash) {
+      @RequestParam(required = false) final String contentHash,
+      @PhysicalTenantId final String physicalTenantId) {
 
     final var authentication = authenticationProvider.getCamundaAuthentication();
     // handle the future explicitly here because a StreamingResponseBody is needed as result instead
     // of a future wrapping the stream response
     return documentServices
-        .getDocumentContent(documentId, storeId, contentHash, authentication)
+        .getDocumentContent(documentId, storeId, contentHash, authentication, physicalTenantId)
         // Any service exception that can occur is handled by the GlobalControllerExceptionHandler
         .thenApply(DocumentController::toDocumentContentResponse)
         .join();
@@ -127,11 +135,14 @@ public class DocumentController {
 
   @CamundaDeleteMapping(path = "/{documentId}")
   public CompletableFuture<ResponseEntity<Object>> deleteDocument(
-      @PathVariable final String documentId, @RequestParam(required = false) final String storeId) {
+      @PathVariable final String documentId,
+      @RequestParam(required = false) final String storeId,
+      @PhysicalTenantId final String physicalTenantId) {
 
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethodWithNoContentResult(
-        () -> documentServices.deleteDocument(documentId, storeId, authentication));
+        () ->
+            documentServices.deleteDocument(documentId, storeId, authentication, physicalTenantId));
   }
 
   @CamundaPostMapping(path = "/{documentId}/links")
@@ -139,23 +150,28 @@ public class DocumentController {
       @PathVariable final String documentId,
       @RequestParam(required = false) final String storeId,
       @RequestParam(required = false) final String contentHash,
-      @RequestBody final DocumentLinkRequest linkRequest) {
+      @RequestBody final DocumentLinkRequest linkRequest,
+      @PhysicalTenantId final String physicalTenantId) {
 
     return RequestMapper.toDocumentLinkParams(linkRequest)
         .fold(
             RestErrorMapper::mapProblemToCompletedResponse,
-            params -> createDocumentLink(documentId, storeId, contentHash, params));
+            params ->
+                createDocumentLink(documentId, storeId, contentHash, params, physicalTenantId));
   }
 
   private CompletableFuture<ResponseEntity<Object>> createDocumentLink(
       final String documentId,
       final String storeId,
       final String contentHash,
-      final DocumentLinkParams params) {
+      final DocumentLinkParams params,
+      final String physicalTenantId) {
 
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethod(
-        () -> documentServices.createLink(documentId, storeId, contentHash, params, authentication),
+        () ->
+            documentServices.createLink(
+                documentId, storeId, contentHash, params, authentication, physicalTenantId),
         ResponseMapper::toDocumentLinkResponse,
         HttpStatus.OK);
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ElementInstanceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ElementInstanceController.java
@@ -29,6 +29,7 @@ import io.camunda.service.ElementInstanceServices.SetVariablesRequest;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPutMapping;
+import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
@@ -58,17 +59,22 @@ public class ElementInstanceController {
       consumes = MediaType.APPLICATION_JSON_VALUE)
   public CompletableFuture<ResponseEntity<Object>> setVariables(
       @PathVariable final long elementInstanceKey,
-      @RequestBody final SetVariableRequest variableRequest) {
+      @RequestBody final SetVariableRequest variableRequest,
+      @PhysicalTenantId final String physicalTenantId) {
     return RequestMapper.toVariableRequest(variableRequest, elementInstanceKey)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::setVariables);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> setVariables(req, physicalTenantId));
   }
 
   private CompletableFuture<ResponseEntity<Object>> setVariables(
-      final SetVariablesRequest variablesRequest) {
+      final SetVariablesRequest variablesRequest, final String physicalTenantId) {
     return RequestExecutor.executeServiceMethodWithNoContentResult(
         () ->
             elementInstanceServices.setVariables(
-                variablesRequest, authenticationProvider.getCamundaAuthentication()));
+                variablesRequest,
+                authenticationProvider.getCamundaAuthentication(),
+                physicalTenantId));
   }
 
   @RequiresSecondaryStorage
@@ -98,19 +104,23 @@ public class ElementInstanceController {
   @RequiresSecondaryStorage
   @CamundaPostMapping(path = "/search")
   public ResponseEntity<ElementInstanceSearchQueryResult> searchElementInstances(
-      @RequestBody(required = false) final ElementInstanceSearchQuery query) {
+      @RequestBody(required = false) final ElementInstanceSearchQuery query,
+      @PhysicalTenantId final String physicalTenantId) {
     return SearchQueryRequestMapper.toElementInstanceQuery(query)
-        .fold(RestErrorMapper::mapProblemToResponse, this::search);
+        .fold(RestErrorMapper::mapProblemToResponse, q -> search(q, physicalTenantId));
   }
 
   @RequiresSecondaryStorage
   @CamundaGetMapping(path = "/{elementInstanceKey}")
   public ResponseEntity<ElementInstanceResult> getByKey(
-      @PathVariable("elementInstanceKey") final Long elementInstanceKey) {
+      @PathVariable("elementInstanceKey") final Long elementInstanceKey,
+      @PhysicalTenantId final String physicalTenantId) {
     try {
       final FlowNodeInstanceEntity element =
           elementInstanceServices.getByKey(
-              elementInstanceKey, authenticationProvider.getCamundaAuthentication());
+              elementInstanceKey,
+              authenticationProvider.getCamundaAuthentication(),
+              physicalTenantId);
 
       return ResponseEntity.ok().body(SearchQueryResponseMapper.toElementInstance(element));
     } catch (final Exception e) {
@@ -122,19 +132,21 @@ public class ElementInstanceController {
   @CamundaPostMapping(path = "/{elementInstanceKey}/incidents/search")
   public ResponseEntity<IncidentSearchQueryResult> searchIncidentsForElementInstance(
       @PathVariable("elementInstanceKey") final long elementInstanceKey,
-      @RequestBody(required = false) final IncidentSearchQuery query) {
+      @RequestBody(required = false) final IncidentSearchQuery query,
+      @PhysicalTenantId final String physicalTenantId) {
 
     return SearchQueryRequestMapper.toIncidentQuery(query)
         .fold(
             RestErrorMapper::mapProblemToResponse,
-            incidentQuery -> searchIncidents(elementInstanceKey, incidentQuery));
+            incidentQuery -> searchIncidents(elementInstanceKey, incidentQuery, physicalTenantId));
   }
 
   private ResponseEntity<ElementInstanceSearchQueryResult> search(
-      final FlowNodeInstanceQuery query) {
+      final FlowNodeInstanceQuery query, final String physicalTenantId) {
     try {
       final var result =
-          elementInstanceServices.search(query, authenticationProvider.getCamundaAuthentication());
+          elementInstanceServices.search(
+              query, authenticationProvider.getCamundaAuthentication(), physicalTenantId);
 
       return ResponseEntity.ok(
           SearchQueryResponseMapper.toElementInstanceSearchQueryResponse(result));
@@ -144,11 +156,14 @@ public class ElementInstanceController {
   }
 
   private ResponseEntity<IncidentSearchQueryResult> searchIncidents(
-      final long elementInstanceKey, final IncidentQuery query) {
+      final long elementInstanceKey, final IncidentQuery query, final String physicalTenantId) {
     try {
       final var result =
           elementInstanceServices.searchIncidents(
-              elementInstanceKey, query, authenticationProvider.getCamundaAuthentication());
+              elementInstanceKey,
+              query,
+              authenticationProvider.getCamundaAuthentication(),
+              physicalTenantId);
 
       return ResponseEntity.ok(SearchQueryResponseMapper.toIncidentSearchQueryResponse(result));
     } catch (final Exception e) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ExpressionController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ExpressionController.java
@@ -14,6 +14,7 @@ import io.camunda.security.api.context.CamundaAuthenticationProvider;
 import io.camunda.security.api.model.config.MultiTenancyConfiguration;
 import io.camunda.service.ExpressionServices;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
+import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
 import java.util.concurrent.CompletableFuture;
@@ -41,21 +42,24 @@ public class ExpressionController {
 
   @CamundaPostMapping(path = "/evaluation")
   public CompletableFuture<ResponseEntity<Object>> evaluateExpression(
-      @RequestBody final ExpressionEvaluationRequest request) {
+      @RequestBody final ExpressionEvaluationRequest request,
+      @PhysicalTenantId final String physicalTenantId) {
     return RequestMapper.toExpressionEvaluationRequest(
             request.getExpression(),
             request.getTenantId(),
             request.getScopeKey(),
             request.getVariables(),
             multiTenancyCfg.isChecksEnabled())
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::evaluateExpression);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> evaluateExpression(req, physicalTenantId));
   }
 
   private CompletableFuture<ResponseEntity<Object>> evaluateExpression(
-      final ExpressionServices.ExpressionEvaluationRequest request) {
+      final ExpressionServices.ExpressionEvaluationRequest request, final String physicalTenantId) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethod(
-        () -> expressionServices.evaluateExpression(request, authentication),
+        () -> expressionServices.evaluateExpression(request, authentication, physicalTenantId),
         ResponseMapper::toExpressionEvaluationResult,
         HttpStatus.OK);
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/FormController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/FormController.java
@@ -14,6 +14,7 @@ import io.camunda.gateway.protocol.model.FormResult;
 import io.camunda.security.api.context.CamundaAuthenticationProvider;
 import io.camunda.service.FormServices;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
+import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -34,10 +35,13 @@ public class FormController {
 
   @RequiresSecondaryStorage
   @CamundaGetMapping(path = "/{formKey}")
-  public ResponseEntity<FormResult> getFormByKey(@PathVariable("formKey") final Long formKey) {
+  public ResponseEntity<FormResult> getFormByKey(
+      @PathVariable("formKey") final Long formKey,
+      @PhysicalTenantId final String physicalTenantId) {
     try {
       final var form =
-          formServices.getByKey(formKey, authenticationProvider.getCamundaAuthentication());
+          formServices.getByKey(
+              formKey, authenticationProvider.getCamundaAuthentication(), physicalTenantId);
 
       return ResponseEntity.ok().body(SearchQueryResponseMapper.toFormItem(form));
     } catch (final Exception e) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/GlobalTaskListenerController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/GlobalTaskListenerController.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.gateway.rest.annotation.CamundaDeleteMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPutMapping;
+import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
@@ -55,42 +56,53 @@ public class GlobalTaskListenerController {
 
   @CamundaPostMapping()
   public CompletableFuture<ResponseEntity<Object>> createGlobalTaskListener(
-      @RequestBody final CreateGlobalTaskListenerRequest request) {
+      @RequestBody final CreateGlobalTaskListenerRequest request,
+      @PhysicalTenantId final String physicalTenantId) {
     return globalListenerMapper
         .toGlobalTaskListenerCreateRequest(request)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::createGlobalListener);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> createGlobalListener(req, physicalTenantId));
   }
 
   @RequiresSecondaryStorage
   @CamundaGetMapping(path = "/{id}")
-  public ResponseEntity<Object> getGlobalTaskListener(@PathVariable("id") final String id) {
+  public ResponseEntity<Object> getGlobalTaskListener(
+      @PathVariable("id") final String id, @PhysicalTenantId final String physicalTenantId) {
     return globalListenerMapper
         .toGlobalTaskListenerGetRequest(id)
-        .fold(RestErrorMapper::mapProblemToResponse, this::getGlobalListener);
+        .fold(
+            RestErrorMapper::mapProblemToResponse, req -> getGlobalListener(req, physicalTenantId));
   }
 
   @CamundaPutMapping(path = "/{id}")
   public CompletableFuture<ResponseEntity<Object>> updateGlobalTaskListener(
       @PathVariable("id") final String id,
-      @RequestBody final UpdateGlobalTaskListenerRequest request) {
+      @RequestBody final UpdateGlobalTaskListenerRequest request,
+      @PhysicalTenantId final String physicalTenantId) {
     return globalListenerMapper
         .toGlobalTaskListenerUpdateRequest(id, request)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::updateGlobalListener);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> updateGlobalListener(req, physicalTenantId));
   }
 
   @CamundaDeleteMapping(path = "/{id}")
   public CompletableFuture<ResponseEntity<Object>> deleteGlobalTaskListener(
-      @PathVariable("id") final String id) {
+      @PathVariable("id") final String id, @PhysicalTenantId final String physicalTenantId) {
     return globalListenerMapper
         .toGlobalTaskListenerDeleteRequest(id)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::deleteGlobalListener);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> deleteGlobalListener(req, physicalTenantId));
   }
 
   private CompletableFuture<ResponseEntity<Object>> createGlobalListener(
-      final GlobalListenerRecord request) {
+      final GlobalListenerRecord request, final String physicalTenantId) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethod(
-        () -> globalListenerServices.createGlobalListener(request, authentication),
+        () ->
+            globalListenerServices.createGlobalListener(request, authentication, physicalTenantId),
         globalListenerMapper::toGlobalListenerResponse,
         HttpStatus.CREATED);
   }
@@ -98,43 +110,49 @@ public class GlobalTaskListenerController {
   @RequiresSecondaryStorage
   @CamundaPostMapping(path = "/search")
   private ResponseEntity<Object> search(
-      @RequestBody(required = false) final GlobalTaskListenerSearchQueryRequest request) {
+      @RequestBody(required = false) final GlobalTaskListenerSearchQueryRequest request,
+      @PhysicalTenantId final String physicalTenantId) {
     return SearchQueryRequestMapper.toGlobalTaskListenerQuery(request)
-        .fold(RestErrorMapper::mapProblemToResponse, this::search);
+        .fold(RestErrorMapper::mapProblemToResponse, q -> search(q, physicalTenantId));
   }
 
-  private ResponseEntity<Object> getGlobalListener(final GlobalListenerRecord request) {
+  private ResponseEntity<Object> getGlobalListener(
+      final GlobalListenerRecord request, final String physicalTenantId) {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
       return ResponseEntity.ok()
           .body(
               SearchQueryResponseMapper.toGlobalTaskListenerResult(
-                  globalListenerServices.getGlobalTaskListener(request, authentication)));
+                  globalListenerServices.getGlobalTaskListener(
+                      request, authentication, physicalTenantId)));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }
   }
 
   private CompletableFuture<ResponseEntity<Object>> updateGlobalListener(
-      final GlobalListenerRecord request) {
+      final GlobalListenerRecord request, final String physicalTenantId) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethod(
-        () -> globalListenerServices.updateGlobalListener(request, authentication),
+        () ->
+            globalListenerServices.updateGlobalListener(request, authentication, physicalTenantId),
         globalListenerMapper::toGlobalListenerResponse,
         HttpStatus.OK);
   }
 
   private CompletableFuture<ResponseEntity<Object>> deleteGlobalListener(
-      final GlobalListenerRecord request) {
+      final GlobalListenerRecord request, final String physicalTenantId) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethodWithNoContentResult(
-        () -> globalListenerServices.deleteGlobalListener(request, authentication));
+        () ->
+            globalListenerServices.deleteGlobalListener(request, authentication, physicalTenantId));
   }
 
-  private ResponseEntity<Object> search(final GlobalListenerQuery query) {
+  private ResponseEntity<Object> search(
+      final GlobalListenerQuery query, final String physicalTenantId) {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
-      final var result = globalListenerServices.search(query, authentication);
+      final var result = globalListenerServices.search(query, authentication, physicalTenantId);
       return ResponseEntity.ok(
           SearchQueryResponseMapper.toGlobalTaskListenerSearchQueryResponse(result));
     } catch (final Exception e) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/IncidentController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/IncidentController.java
@@ -25,6 +25,7 @@ import io.camunda.security.api.context.CamundaAuthenticationProvider;
 import io.camunda.service.IncidentServices;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
+import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
@@ -53,7 +54,8 @@ public class IncidentController {
   @CamundaPostMapping(path = "/{incidentKey}/resolution")
   public CompletableFuture<ResponseEntity<Object>> incidentResolution(
       @PathVariable final long incidentKey,
-      @RequestBody(required = false) final IncidentResolutionRequest incidentResolutionRequest) {
+      @RequestBody(required = false) final IncidentResolutionRequest incidentResolutionRequest,
+      @PhysicalTenantId final String physicalTenantId) {
     final Long operationReference =
         incidentResolutionRequest == null
             ? null
@@ -63,27 +65,32 @@ public class IncidentController {
             incidentServices.resolveIncident(
                 incidentKey,
                 operationReference,
-                authenticationProvider.getCamundaAuthentication()));
+                authenticationProvider.getCamundaAuthentication(),
+                physicalTenantId));
   }
 
   @RequiresSecondaryStorage
   @CamundaPostMapping(path = "/search")
   public ResponseEntity<IncidentSearchQueryResult> searchIncidents(
-      @RequestBody(required = false) final IncidentSearchQuery query) {
+      @RequestBody(required = false) final IncidentSearchQuery query,
+      @PhysicalTenantId final String physicalTenantId) {
     return SearchQueryRequestMapper.toIncidentQuery(query)
-        .fold(RestErrorMapper::mapProblemToResponse, this::search);
+        .fold(RestErrorMapper::mapProblemToResponse, q -> search(q, physicalTenantId));
   }
 
   @RequiresSecondaryStorage
   @CamundaGetMapping(path = "/{incidentKey}")
   public ResponseEntity<IncidentResult> getByKey(
-      @PathVariable("incidentKey") final Long incidentKey) {
+      @PathVariable("incidentKey") final Long incidentKey,
+      @PhysicalTenantId final String physicalTenantId) {
     try {
       return ResponseEntity.ok()
           .body(
               SearchQueryResponseMapper.toIncident(
                   incidentServices.getByKey(
-                      incidentKey, authenticationProvider.getCamundaAuthentication())));
+                      incidentKey,
+                      authenticationProvider.getCamundaAuthentication(),
+                      physicalTenantId)));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }
@@ -93,29 +100,32 @@ public class IncidentController {
   @CamundaPostMapping(path = "/statistics/process-instances-by-error")
   public ResponseEntity<IncidentProcessInstanceStatisticsByErrorQueryResult>
       processInstanceStatisticsByError(
-          @RequestBody(required = false)
-              final IncidentProcessInstanceStatisticsByErrorQuery query) {
+          @RequestBody(required = false) final IncidentProcessInstanceStatisticsByErrorQuery query,
+          @PhysicalTenantId final String physicalTenantId) {
     return SearchQueryRequestMapper.toIncidentProcessInstanceStatisticsByErrorQuery(query)
         .fold(
             RestErrorMapper::mapProblemToResponse,
-            this::getIncidentProcessInstanceStatisticsByError);
+            q -> getIncidentProcessInstanceStatisticsByError(q, physicalTenantId));
   }
 
   @RequiresSecondaryStorage
   @CamundaPostMapping(path = "/statistics/process-instances-by-definition")
   public ResponseEntity<IncidentProcessInstanceStatisticsByDefinitionQueryResult>
       incidentProcessInstanceStatisticsByDefinition(
-          @RequestBody() final IncidentProcessInstanceStatisticsByDefinitionQuery query) {
+          @RequestBody() final IncidentProcessInstanceStatisticsByDefinitionQuery query,
+          @PhysicalTenantId final String physicalTenantId) {
     return SearchQueryRequestMapper.toIncidentProcessInstanceStatisticsByDefinitionQuery(query)
         .fold(
             RestErrorMapper::mapProblemToResponse,
-            this::searchIncidentProcessInstanceStatisticsByDefinition);
+            q -> searchIncidentProcessInstanceStatisticsByDefinition(q, physicalTenantId));
   }
 
-  private ResponseEntity<IncidentSearchQueryResult> search(final IncidentQuery query) {
+  private ResponseEntity<IncidentSearchQueryResult> search(
+      final IncidentQuery query, final String physicalTenantId) {
     try {
       final var result =
-          incidentServices.search(query, authenticationProvider.getCamundaAuthentication());
+          incidentServices.search(
+              query, authenticationProvider.getCamundaAuthentication(), physicalTenantId);
       return ResponseEntity.ok(SearchQueryResponseMapper.toIncidentSearchQueryResponse(result));
     } catch (final ValidationException e) {
       final var problemDetail =
@@ -131,11 +141,12 @@ public class IncidentController {
 
   private ResponseEntity<IncidentProcessInstanceStatisticsByErrorQueryResult>
       getIncidentProcessInstanceStatisticsByError(
-          final io.camunda.search.query.IncidentProcessInstanceStatisticsByErrorQuery query) {
+          final io.camunda.search.query.IncidentProcessInstanceStatisticsByErrorQuery query,
+          final String physicalTenantId) {
     try {
       final var result =
           incidentServices.incidentProcessInstanceStatisticsByError(
-              query, authenticationProvider.getCamundaAuthentication());
+              query, authenticationProvider.getCamundaAuthentication(), physicalTenantId);
       return ResponseEntity.ok(
           SearchQueryResponseMapper.toIncidentProcessInstanceStatisticsByErrorResult(result));
     } catch (final ValidationException e) {
@@ -152,11 +163,12 @@ public class IncidentController {
 
   private ResponseEntity<IncidentProcessInstanceStatisticsByDefinitionQueryResult>
       searchIncidentProcessInstanceStatisticsByDefinition(
-          final io.camunda.search.query.IncidentProcessInstanceStatisticsByDefinitionQuery query) {
+          final io.camunda.search.query.IncidentProcessInstanceStatisticsByDefinitionQuery query,
+          final String physicalTenantId) {
     try {
       final var result =
           incidentServices.searchIncidentProcessInstanceStatisticsByDefinition(
-              query, authenticationProvider.getCamundaAuthentication());
+              query, authenticationProvider.getCamundaAuthentication(), physicalTenantId);
       return ResponseEntity.ok(
           SearchQueryResponseMapper.toIncidentProcessInstanceStatisticsByDefinitionQueryResult(
               result));

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/JobController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/JobController.java
@@ -42,6 +42,7 @@ import io.camunda.service.JobServices.ActivateJobsRequest;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPatchMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
+import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
 import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
@@ -84,46 +85,60 @@ public class JobController {
 
   @CamundaPostMapping(path = "/activation")
   public CompletableFuture<ResponseEntity<Object>> activateJobs(
-      @RequestBody final JobActivationRequest activationRequest) {
+      @RequestBody final JobActivationRequest activationRequest,
+      @PhysicalTenantId final String physicalTenantId) {
     return RequestMapper.toJobsActivationRequest(
             activationRequest, multiTenancyCfg.isChecksEnabled())
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::activateJobs);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> activateJobs(req, physicalTenantId));
   }
 
   @CamundaPostMapping(path = "/{jobKey}/failure")
   public CompletableFuture<ResponseEntity<Object>> failureJob(
       @PathVariable final long jobKey,
-      @RequestBody(required = false) final JobFailRequest failureRequest) {
-    return failJob(RequestMapper.toJobFailRequest(failureRequest, jobKey));
+      @RequestBody(required = false) final JobFailRequest failureRequest,
+      @PhysicalTenantId final String physicalTenantId) {
+    return failJob(RequestMapper.toJobFailRequest(failureRequest, jobKey), physicalTenantId);
   }
 
   @CamundaPostMapping(path = "/{jobKey}/error")
   public CompletableFuture<ResponseEntity<Object>> errorJob(
-      @PathVariable final long jobKey, @RequestBody final JobErrorRequest errorRequest) {
+      @PathVariable final long jobKey,
+      @RequestBody final JobErrorRequest errorRequest,
+      @PhysicalTenantId final String physicalTenantId) {
     return RequestMapper.toJobErrorRequest(errorRequest, jobKey)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::errorJob);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse, req -> errorJob(req, physicalTenantId));
   }
 
   @CamundaPostMapping(path = "/{jobKey}/completion")
   public CompletableFuture<ResponseEntity<Object>> completeJob(
       @PathVariable final long jobKey,
-      @RequestBody(required = false) final JobCompletionRequest completionRequest) {
-    return completeJob(RequestMapper.toJobCompletionRequest(completionRequest, jobKey));
+      @RequestBody(required = false) final JobCompletionRequest completionRequest,
+      @PhysicalTenantId final String physicalTenantId) {
+    return completeJob(
+        RequestMapper.toJobCompletionRequest(completionRequest, jobKey), physicalTenantId);
   }
 
   @CamundaPatchMapping(path = "/{jobKey}")
   public CompletableFuture<ResponseEntity<Object>> updateJob(
-      @PathVariable final long jobKey, @RequestBody final JobUpdateRequest jobUpdateRequest) {
+      @PathVariable final long jobKey,
+      @RequestBody final JobUpdateRequest jobUpdateRequest,
+      @PhysicalTenantId final String physicalTenantId) {
     return RequestMapper.toJobUpdateRequest(jobUpdateRequest, jobKey)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::updateJob);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> updateJob(req, physicalTenantId));
   }
 
   @RequiresSecondaryStorage
   @CamundaPostMapping(path = "/search")
   public ResponseEntity<JobSearchQueryResult> searchJobs(
-      @RequestBody(required = false) final JobSearchQuery request) {
+      @RequestBody(required = false) final JobSearchQuery request,
+      @PhysicalTenantId final String physicalTenantId) {
     return SearchQueryRequestMapper.toJobQuery(request)
-        .fold(RestErrorMapper::mapProblemToResponse, this::search);
+        .fold(RestErrorMapper::mapProblemToResponse, q -> search(q, physicalTenantId));
   }
 
   @RequiresSecondaryStorage
@@ -132,57 +147,67 @@ public class JobController {
       @RequestParam final OffsetDateTime from,
       @RequestParam final OffsetDateTime to,
       @RequestParam(required = false) final String jobType,
-      final HttpServletRequest request) {
+      final HttpServletRequest request,
+      @PhysicalTenantId final String physicalTenantId) {
     return requireJobMetricsEnabled(request.getRequestURI())
         .flatMap(ok -> SearchQueryRequestMapper.toGlobalJobStatisticsQuery(from, to, jobType))
-        .fold(RestErrorMapper::mapProblemToResponse, this::getGlobalStatistics);
+        .fold(RestErrorMapper::mapProblemToResponse, q -> getGlobalStatistics(q, physicalTenantId));
   }
 
   @RequiresSecondaryStorage
   @CamundaPostMapping(path = "/statistics/by-types")
   public ResponseEntity<JobTypeStatisticsQueryResult> getJobTypeStatistics(
-      @RequestBody final JobTypeStatisticsQuery request, final HttpServletRequest httpRequest) {
+      @RequestBody final JobTypeStatisticsQuery request,
+      final HttpServletRequest httpRequest,
+      @PhysicalTenantId final String physicalTenantId) {
     return requireJobMetricsEnabled(httpRequest.getRequestURI())
         .flatMap(ok -> SearchQueryRequestMapper.toJobTypeStatisticsQuery(request))
-        .fold(RestErrorMapper::mapProblemToResponse, this::getTypeStatistics);
+        .fold(RestErrorMapper::mapProblemToResponse, q -> getTypeStatistics(q, physicalTenantId));
   }
 
   @RequiresSecondaryStorage
   @CamundaPostMapping(path = "/statistics/by-workers")
   public ResponseEntity<JobWorkerStatisticsQueryResult> getJobWorkerStatistics(
-      @RequestBody final JobWorkerStatisticsQuery request, final HttpServletRequest httpRequest) {
+      @RequestBody final JobWorkerStatisticsQuery request,
+      final HttpServletRequest httpRequest,
+      @PhysicalTenantId final String physicalTenantId) {
     return requireJobMetricsEnabled(httpRequest.getRequestURI())
         .flatMap(ok -> SearchQueryRequestMapper.toJobWorkerStatisticsQuery(request))
-        .fold(RestErrorMapper::mapProblemToResponse, this::getWorkerStatistics);
+        .fold(RestErrorMapper::mapProblemToResponse, q -> getWorkerStatistics(q, physicalTenantId));
   }
 
   @RequiresSecondaryStorage
   @CamundaPostMapping(path = "/statistics/time-series")
   public ResponseEntity<JobTimeSeriesStatisticsQueryResult> getJobTimeSeriesStatistics(
       @RequestBody final JobTimeSeriesStatisticsQuery request,
-      final HttpServletRequest httpRequest) {
+      final HttpServletRequest httpRequest,
+      @PhysicalTenantId final String physicalTenantId) {
     return requireJobMetricsEnabled(httpRequest.getRequestURI())
         .flatMap(ok -> SearchQueryRequestMapper.toJobTimeSeriesStatisticsQuery(request))
-        .fold(RestErrorMapper::mapProblemToResponse, this::getTimeSeriesStatistics);
+        .fold(
+            RestErrorMapper::mapProblemToResponse,
+            q -> getTimeSeriesStatistics(q, physicalTenantId));
   }
 
   @RequiresSecondaryStorage
   @CamundaPostMapping(path = "/statistics/errors")
   public ResponseEntity<JobErrorStatisticsQueryResult> getJobErrorStatistics(
-      @RequestBody final JobErrorStatisticsQuery request) {
+      @RequestBody final JobErrorStatisticsQuery request,
+      @PhysicalTenantId final String physicalTenantId) {
     return SearchQueryRequestMapper.toJobErrorStatisticsQuery(request)
-        .fold(RestErrorMapper::mapProblemToResponse, this::getErrorStatistics);
+        .fold(RestErrorMapper::mapProblemToResponse, q -> getErrorStatistics(q, physicalTenantId));
   }
 
   private CompletableFuture<ResponseEntity<Object>> activateJobs(
-      final ActivateJobsRequest activationRequest) {
+      final ActivateJobsRequest activationRequest, final String physicalTenantId) {
     final var result = new CompletableFuture<ResponseEntity<Object>>();
     final var responseObserver = responseObserverProvider.apply(result);
     jobServices.activateJobs(
         activationRequest,
         responseObserver,
         responseObserver::setCancelationHandler,
-        authenticationProvider.getCamundaAuthentication());
+        authenticationProvider.getCamundaAuthentication(),
+        physicalTenantId);
     return result.handleAsync(
         (res, ex) -> {
           responseObserver.invokeCancelationHandler();
@@ -190,7 +215,8 @@ public class JobController {
         });
   }
 
-  private CompletableFuture<ResponseEntity<Object>> failJob(final FailJobRequest failJobRequest) {
+  private CompletableFuture<ResponseEntity<Object>> failJob(
+      final FailJobRequest failJobRequest, final String physicalTenantId) {
     return RequestExecutor.executeServiceMethodWithNoContentResult(
         () ->
             jobServices.failJob(
@@ -199,11 +225,12 @@ public class JobController {
                 failJobRequest.errorMessage(),
                 failJobRequest.retryBackoff(),
                 failJobRequest.variables(),
-                authenticationProvider.getCamundaAuthentication()));
+                authenticationProvider.getCamundaAuthentication(),
+                physicalTenantId));
   }
 
   private CompletableFuture<ResponseEntity<Object>> errorJob(
-      final ErrorJobRequest errorJobRequest) {
+      final ErrorJobRequest errorJobRequest, final String physicalTenantId) {
     return RequestExecutor.executeServiceMethodWithNoContentResult(
         () ->
             jobServices.errorJob(
@@ -211,35 +238,40 @@ public class JobController {
                 errorJobRequest.errorCode(),
                 errorJobRequest.errorMessage(),
                 errorJobRequest.variables(),
-                authenticationProvider.getCamundaAuthentication()));
+                authenticationProvider.getCamundaAuthentication(),
+                physicalTenantId));
   }
 
   private CompletableFuture<ResponseEntity<Object>> completeJob(
-      final CompleteJobRequest completeJobRequest) {
+      final CompleteJobRequest completeJobRequest, final String physicalTenantId) {
     return RequestExecutor.executeServiceMethodWithNoContentResult(
         () ->
             jobServices.completeJob(
                 completeJobRequest.jobKey(),
                 completeJobRequest.variables(),
                 completeJobRequest.result(),
-                authenticationProvider.getCamundaAuthentication()));
+                authenticationProvider.getCamundaAuthentication(),
+                physicalTenantId));
   }
 
   private CompletableFuture<ResponseEntity<Object>> updateJob(
-      final UpdateJobRequest updateJobRequest) {
+      final UpdateJobRequest updateJobRequest, final String physicalTenantId) {
     return RequestExecutor.executeServiceMethodWithNoContentResult(
         () ->
             jobServices.updateJob(
                 updateJobRequest.jobKey(),
                 updateJobRequest.operationReference(),
                 updateJobRequest.changeset(),
-                authenticationProvider.getCamundaAuthentication()));
+                authenticationProvider.getCamundaAuthentication(),
+                physicalTenantId));
   }
 
-  private ResponseEntity<JobSearchQueryResult> search(final JobQuery query) {
+  private ResponseEntity<JobSearchQueryResult> search(
+      final JobQuery query, final String physicalTenantId) {
     try {
       final var result =
-          jobServices.search(query, authenticationProvider.getCamundaAuthentication());
+          jobServices.search(
+              query, authenticationProvider.getCamundaAuthentication(), physicalTenantId);
       return ResponseEntity.ok(SearchQueryResponseMapper.toJobSearchQueryResponse(result));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
@@ -247,10 +279,11 @@ public class JobController {
   }
 
   private ResponseEntity<GlobalJobStatisticsQueryResult> getGlobalStatistics(
-      final io.camunda.search.query.GlobalJobStatisticsQuery query) {
+      final io.camunda.search.query.GlobalJobStatisticsQuery query, final String physicalTenantId) {
     try {
       final var result =
-          jobServices.getGlobalStatistics(query, authenticationProvider.getCamundaAuthentication());
+          jobServices.getGlobalStatistics(
+              query, authenticationProvider.getCamundaAuthentication(), physicalTenantId);
       return ResponseEntity.ok(SearchQueryResponseMapper.toGlobalJobStatisticsQueryResult(result));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
@@ -258,11 +291,11 @@ public class JobController {
   }
 
   private ResponseEntity<JobTypeStatisticsQueryResult> getTypeStatistics(
-      final io.camunda.search.query.JobTypeStatisticsQuery query) {
+      final io.camunda.search.query.JobTypeStatisticsQuery query, final String physicalTenantId) {
     try {
       final var result =
           jobServices.getJobTypeStatistics(
-              query, authenticationProvider.getCamundaAuthentication());
+              query, authenticationProvider.getCamundaAuthentication(), physicalTenantId);
       return ResponseEntity.ok(SearchQueryResponseMapper.toJobTypeStatisticsQueryResult(result));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
@@ -270,11 +303,11 @@ public class JobController {
   }
 
   private ResponseEntity<JobWorkerStatisticsQueryResult> getWorkerStatistics(
-      final io.camunda.search.query.JobWorkerStatisticsQuery query) {
+      final io.camunda.search.query.JobWorkerStatisticsQuery query, final String physicalTenantId) {
     try {
       final var result =
           jobServices.getJobWorkerStatistics(
-              query, authenticationProvider.getCamundaAuthentication());
+              query, authenticationProvider.getCamundaAuthentication(), physicalTenantId);
       return ResponseEntity.ok(SearchQueryResponseMapper.toJobWorkerStatisticsQueryResult(result));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
@@ -282,11 +315,12 @@ public class JobController {
   }
 
   private ResponseEntity<JobTimeSeriesStatisticsQueryResult> getTimeSeriesStatistics(
-      final io.camunda.search.query.JobTimeSeriesStatisticsQuery query) {
+      final io.camunda.search.query.JobTimeSeriesStatisticsQuery query,
+      final String physicalTenantId) {
     try {
       final var result =
           jobServices.getJobTimeSeriesStatistics(
-              query, authenticationProvider.getCamundaAuthentication());
+              query, authenticationProvider.getCamundaAuthentication(), physicalTenantId);
       return ResponseEntity.ok(
           SearchQueryResponseMapper.toJobTimeSeriesStatisticsQueryResult(result));
     } catch (final Exception e) {
@@ -295,11 +329,11 @@ public class JobController {
   }
 
   private ResponseEntity<JobErrorStatisticsQueryResult> getErrorStatistics(
-      final io.camunda.search.query.JobErrorStatisticsQuery query) {
+      final io.camunda.search.query.JobErrorStatisticsQuery query, final String physicalTenantId) {
     try {
       final var result =
           jobServices.getJobErrorStatistics(
-              query, authenticationProvider.getCamundaAuthentication());
+              query, authenticationProvider.getCamundaAuthentication(), physicalTenantId);
       return ResponseEntity.ok(SearchQueryResponseMapper.toJobErrorStatisticsQueryResult(result));
     } catch (final Exception e) {
       return mapErrorToResponse(e);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/MessageController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/MessageController.java
@@ -17,6 +17,7 @@ import io.camunda.service.MessageServices;
 import io.camunda.service.MessageServices.CorrelateMessageRequest;
 import io.camunda.service.MessageServices.PublicationMessageRequest;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
+import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
 import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
@@ -48,34 +49,41 @@ public class MessageController {
 
   @CamundaPostMapping(path = "/publication")
   public CompletableFuture<ResponseEntity<Object>> publishMessage(
-      @RequestBody final MessagePublicationRequest publicationRequest) {
+      @RequestBody final MessagePublicationRequest publicationRequest,
+      @PhysicalTenantId final String physicalTenantId) {
     return RequestMapper.toMessagePublicationRequest(
             publicationRequest, multiTenancyCfg.isChecksEnabled(), maxNameFieldLength)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::publishMessage);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> publishMessage(req, physicalTenantId));
   }
 
   @CamundaPostMapping(path = "/correlation")
   public CompletableFuture<ResponseEntity<Object>> correlateMessage(
-      @RequestBody final MessageCorrelationRequest correlationRequest) {
+      @RequestBody final MessageCorrelationRequest correlationRequest,
+      @PhysicalTenantId final String physicalTenantId) {
     return RequestMapper.toMessageCorrelationRequest(
             correlationRequest, multiTenancyCfg.isChecksEnabled(), maxNameFieldLength)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::correlateMessage);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> correlateMessage(req, physicalTenantId));
   }
 
   private CompletableFuture<ResponseEntity<Object>> correlateMessage(
-      final CorrelateMessageRequest correlationRequest) {
+      final CorrelateMessageRequest correlationRequest, final String physicalTenantId) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethod(
-        () -> messageServices.correlateMessage(correlationRequest, authentication),
+        () ->
+            messageServices.correlateMessage(correlationRequest, authentication, physicalTenantId),
         ResponseMapper::toMessageCorrelationResponse,
         HttpStatus.OK);
   }
 
   private CompletableFuture<ResponseEntity<Object>> publishMessage(
-      final PublicationMessageRequest request) {
+      final PublicationMessageRequest request, final String physicalTenantId) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethod(
-        () -> messageServices.publishMessage(request, authentication),
+        () -> messageServices.publishMessage(request, authentication, physicalTenantId),
         ResponseMapper::toMessagePublicationResponse,
         HttpStatus.OK);
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/MessageSubscriptionController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/MessageSubscriptionController.java
@@ -20,6 +20,7 @@ import io.camunda.search.query.MessageSubscriptionQuery;
 import io.camunda.security.api.context.CamundaAuthenticationProvider;
 import io.camunda.service.MessageSubscriptionServices;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
+import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
 import org.springframework.http.ResponseEntity;
@@ -43,9 +44,10 @@ public class MessageSubscriptionController {
   @RequiresSecondaryStorage
   @CamundaPostMapping(path = "/message-subscriptions/search")
   public ResponseEntity<MessageSubscriptionSearchQueryResult> searchMessageSubscriptions(
-      @RequestBody(required = false) final MessageSubscriptionSearchQuery searchRequest) {
+      @RequestBody(required = false) final MessageSubscriptionSearchQuery searchRequest,
+      @PhysicalTenantId final String physicalTenantId) {
     return SearchQueryRequestMapper.toMessageSubscriptionQuery(searchRequest)
-        .fold(RestErrorMapper::mapProblemToResponse, this::search);
+        .fold(RestErrorMapper::mapProblemToResponse, q -> search(q, physicalTenantId));
   }
 
   @RequiresSecondaryStorage
@@ -53,16 +55,21 @@ public class MessageSubscriptionController {
   public ResponseEntity<CorrelatedMessageSubscriptionSearchQueryResult>
       searchCorrelatedMessageSubscriptions(
           @RequestBody(required = false)
-              final CorrelatedMessageSubscriptionSearchQuery searchRequest) {
+              final CorrelatedMessageSubscriptionSearchQuery searchRequest,
+          @PhysicalTenantId final String physicalTenantId) {
     return SearchQueryRequestMapper.toCorrelatedMessageSubscriptionQuery(searchRequest)
-        .fold(RestErrorMapper::mapProblemToResponse, this::searchCorrelatedMessageSubscriptions);
+        .fold(
+            RestErrorMapper::mapProblemToResponse,
+            q -> searchCorrelatedMessageSubscriptions(q, physicalTenantId));
   }
 
   private ResponseEntity<CorrelatedMessageSubscriptionSearchQueryResult>
-      searchCorrelatedMessageSubscriptions(final CorrelatedMessageSubscriptionQuery query) {
+      searchCorrelatedMessageSubscriptions(
+          final CorrelatedMessageSubscriptionQuery query, final String physicalTenantId) {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
-      final var result = messageSubscriptionServices.searchCorrelated(query, authentication);
+      final var result =
+          messageSubscriptionServices.searchCorrelated(query, authentication, physicalTenantId);
       return ResponseEntity.ok(
           SearchQueryResponseMapper.toCorrelatedMessageSubscriptionSearchQueryResponse(result));
     } catch (final Exception e) {
@@ -71,10 +78,11 @@ public class MessageSubscriptionController {
   }
 
   private ResponseEntity<MessageSubscriptionSearchQueryResult> search(
-      final MessageSubscriptionQuery query) {
+      final MessageSubscriptionQuery query, final String physicalTenantId) {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
-      final var result = messageSubscriptionServices.search(query, authentication);
+      final var result =
+          messageSubscriptionServices.search(query, authentication, physicalTenantId);
       return ResponseEntity.ok(
           SearchQueryResponseMapper.toMessageSubscriptionSearchQueryResponse(result));
     } catch (final Exception e) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionController.java
@@ -28,6 +28,7 @@ import io.camunda.security.api.context.CamundaAuthenticationProvider;
 import io.camunda.service.ProcessDefinitionServices;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
+import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
 import java.nio.charset.StandardCharsets;
@@ -55,17 +56,18 @@ public class ProcessDefinitionController {
   @RequiresSecondaryStorage
   @CamundaPostMapping(path = "/search")
   public ResponseEntity<ProcessDefinitionSearchQueryResult> searchProcessDefinitions(
-      @RequestBody(required = false) final ProcessDefinitionSearchQuery query) {
+      @RequestBody(required = false) final ProcessDefinitionSearchQuery query,
+      @PhysicalTenantId final String physicalTenantId) {
     return SearchQueryRequestMapper.toProcessDefinitionQuery(query)
-        .fold(RestErrorMapper::mapProblemToResponse, this::search);
+        .fold(RestErrorMapper::mapProblemToResponse, q -> search(q, physicalTenantId));
   }
 
   private ResponseEntity<ProcessDefinitionSearchQueryResult> search(
-      final ProcessDefinitionQuery query) {
+      final ProcessDefinitionQuery query, final String physicalTenantId) {
     try {
       final var result =
           processDefinitionServices.search(
-              query, authenticationProvider.getCamundaAuthentication());
+              query, authenticationProvider.getCamundaAuthentication(), physicalTenantId);
       return ResponseEntity.ok(
           SearchQueryResponseMapper.toProcessDefinitionSearchQueryResponse(result));
     } catch (final Exception e) {
@@ -76,7 +78,8 @@ public class ProcessDefinitionController {
   @RequiresSecondaryStorage
   @CamundaGetMapping(path = "/{processDefinitionKey}")
   public ResponseEntity<Object> getByKey(
-      @PathVariable("processDefinitionKey") final Long processDefinitionKey) {
+      @PathVariable("processDefinitionKey") final Long processDefinitionKey,
+      @PhysicalTenantId final String physicalTenantId) {
     try {
       // Success case: Return the left side with the ProcessDefinitionEntity wrapped in
       // ResponseEntity
@@ -84,7 +87,9 @@ public class ProcessDefinitionController {
           .body(
               SearchQueryResponseMapper.toProcessDefinition(
                   processDefinitionServices.getByKey(
-                      processDefinitionKey, authenticationProvider.getCamundaAuthentication())));
+                      processDefinitionKey,
+                      authenticationProvider.getCamundaAuthentication(),
+                      physicalTenantId)));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }
@@ -95,11 +100,14 @@ public class ProcessDefinitionController {
       path = "/{processDefinitionKey}/xml",
       produces = {MediaType.TEXT_XML_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
   public ResponseEntity<String> getProcessDefinitionXml(
-      @PathVariable("processDefinitionKey") final long processDefinitionKey) {
+      @PathVariable("processDefinitionKey") final long processDefinitionKey,
+      @PhysicalTenantId final String physicalTenantId) {
     try {
       return processDefinitionServices
           .getProcessDefinitionXml(
-              processDefinitionKey, authenticationProvider.getCamundaAuthentication())
+              processDefinitionKey,
+              authenticationProvider.getCamundaAuthentication(),
+              physicalTenantId)
           .map(
               s ->
                   ResponseEntity.ok()
@@ -114,11 +122,14 @@ public class ProcessDefinitionController {
   @RequiresSecondaryStorage
   @CamundaGetMapping(path = "/{processDefinitionKey}/form")
   public ResponseEntity<FormResult> getStartProcessForm(
-      @PathVariable("processDefinitionKey") final long processDefinitionKey) {
+      @PathVariable("processDefinitionKey") final long processDefinitionKey,
+      @PhysicalTenantId final String physicalTenantId) {
     try {
       return processDefinitionServices
           .getProcessDefinitionStartForm(
-              processDefinitionKey, authenticationProvider.getCamundaAuthentication())
+              processDefinitionKey,
+              authenticationProvider.getCamundaAuthentication(),
+              physicalTenantId)
           .map(SearchQueryResponseMapper::toFormItem)
           .map(s -> ResponseEntity.ok().body(s))
           .orElseGet(() -> ResponseEntity.noContent().build());
@@ -131,9 +142,12 @@ public class ProcessDefinitionController {
   @CamundaPostMapping(path = "/{processDefinitionKey}/statistics/element-instances")
   public ResponseEntity<ProcessDefinitionElementStatisticsQueryResult> elementStatistics(
       @PathVariable("processDefinitionKey") final long processDefinitionKey,
-      @RequestBody(required = false) final ProcessDefinitionElementStatisticsQuery query) {
+      @RequestBody(required = false) final ProcessDefinitionElementStatisticsQuery query,
+      @PhysicalTenantId final String physicalTenantId) {
     return SearchQueryRequestMapper.toProcessDefinitionStatisticsQuery(processDefinitionKey, query)
-        .fold(RestErrorMapper::mapProblemToResponse, this::elementStatistics);
+        .fold(
+            RestErrorMapper::mapProblemToResponse,
+            filter -> elementStatistics(filter, physicalTenantId));
   }
 
   @RequiresSecondaryStorage
@@ -141,37 +155,44 @@ public class ProcessDefinitionController {
   public ResponseEntity<ProcessDefinitionMessageSubscriptionStatisticsQueryResult>
       messageSubscriptionStatistics(
           @RequestBody(required = false)
-              final ProcessDefinitionMessageSubscriptionStatisticsQuery searchRequest) {
+              final ProcessDefinitionMessageSubscriptionStatisticsQuery searchRequest,
+          @PhysicalTenantId final String physicalTenantId) {
     return SearchQueryRequestMapper.toProcessDefinitionMessageSubscriptionStatisticsQuery(
             searchRequest)
-        .fold(RestErrorMapper::mapProblemToResponse, this::getMessageSubscriptionStatistics);
+        .fold(
+            RestErrorMapper::mapProblemToResponse,
+            q -> getMessageSubscriptionStatistics(q, physicalTenantId));
   }
 
   @RequiresSecondaryStorage
   @CamundaPostMapping(path = "/statistics/process-instances")
   public ResponseEntity<ProcessDefinitionInstanceStatisticsQueryResult> processInstanceStatistics(
-      @RequestBody(required = false) final ProcessDefinitionInstanceStatisticsQuery query) {
+      @RequestBody(required = false) final ProcessDefinitionInstanceStatisticsQuery query,
+      @PhysicalTenantId final String physicalTenantId) {
     return SearchQueryRequestMapper.toProcessDefinitionInstanceStatisticsQuery(query)
-        .fold(RestErrorMapper::mapProblemToResponse, this::getProcessDefinitionInstanceStatistics);
+        .fold(
+            RestErrorMapper::mapProblemToResponse,
+            q -> getProcessDefinitionInstanceStatistics(q, physicalTenantId));
   }
 
   @RequiresSecondaryStorage
   @CamundaPostMapping(path = "/statistics/process-instances-by-version")
   public ResponseEntity<ProcessDefinitionInstanceVersionStatisticsQueryResult>
       processInstanceVersionStatistics(
-          @RequestBody() final ProcessDefinitionInstanceVersionStatisticsQuery query) {
+          @RequestBody() final ProcessDefinitionInstanceVersionStatisticsQuery query,
+          @PhysicalTenantId final String physicalTenantId) {
     return SearchQueryRequestMapper.toProcessDefinitionInstanceVersionStatisticsQuery(query)
         .fold(
             RestErrorMapper::mapProblemToResponse,
-            this::searchProcessDefinitionInstanceVersionStatistics);
+            q -> searchProcessDefinitionInstanceVersionStatistics(q, physicalTenantId));
   }
 
   private ResponseEntity<ProcessDefinitionElementStatisticsQueryResult> elementStatistics(
-      final ProcessDefinitionStatisticsFilter filter) {
+      final ProcessDefinitionStatisticsFilter filter, final String physicalTenantId) {
     try {
       final var result =
           processDefinitionServices.elementStatistics(
-              filter, authenticationProvider.getCamundaAuthentication());
+              filter, authenticationProvider.getCamundaAuthentication(), physicalTenantId);
       return ResponseEntity.ok(
           SearchQueryResponseMapper.toProcessDefinitionElementStatisticsResult(result));
     } catch (final Exception e) {
@@ -181,11 +202,12 @@ public class ProcessDefinitionController {
 
   private ResponseEntity<ProcessDefinitionInstanceStatisticsQueryResult>
       getProcessDefinitionInstanceStatistics(
-          final io.camunda.search.query.ProcessDefinitionInstanceStatisticsQuery query) {
+          final io.camunda.search.query.ProcessDefinitionInstanceStatisticsQuery query,
+          final String physicalTenantId) {
     try {
       final var result =
           processDefinitionServices.getProcessDefinitionInstanceStatistics(
-              query, authenticationProvider.getCamundaAuthentication());
+              query, authenticationProvider.getCamundaAuthentication(), physicalTenantId);
       return ResponseEntity.ok(
           SearchQueryResponseMapper.toProcessInstanceStatisticsQueryResult(result));
     } catch (final Exception e) {
@@ -195,11 +217,12 @@ public class ProcessDefinitionController {
 
   private ResponseEntity<ProcessDefinitionMessageSubscriptionStatisticsQueryResult>
       getMessageSubscriptionStatistics(
-          final io.camunda.search.query.ProcessDefinitionMessageSubscriptionStatisticsQuery query) {
+          final io.camunda.search.query.ProcessDefinitionMessageSubscriptionStatisticsQuery query,
+          final String physicalTenantId) {
     try {
       final var result =
           processDefinitionServices.getProcessDefinitionMessageSubscriptionStatistics(
-              query, authenticationProvider.getCamundaAuthentication());
+              query, authenticationProvider.getCamundaAuthentication(), physicalTenantId);
       return ResponseEntity.ok(
           SearchQueryResponseMapper.toProcessDefinitionMessageSubscriptionStatisticsQueryResponse(
               result));
@@ -210,11 +233,12 @@ public class ProcessDefinitionController {
 
   private ResponseEntity<ProcessDefinitionInstanceVersionStatisticsQueryResult>
       searchProcessDefinitionInstanceVersionStatistics(
-          final io.camunda.search.query.ProcessDefinitionInstanceVersionStatisticsQuery query) {
+          final io.camunda.search.query.ProcessDefinitionInstanceVersionStatisticsQuery query,
+          final String physicalTenantId) {
     try {
       final var result =
           processDefinitionServices.searchProcessDefinitionInstanceVersionStatistics(
-              query, authenticationProvider.getCamundaAuthentication());
+              query, authenticationProvider.getCamundaAuthentication(), physicalTenantId);
       return ResponseEntity.ok(
           SearchQueryResponseMapper.toProcessInstanceVersionStatisticsQueryResult(result));
     } catch (final Exception e) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
@@ -40,6 +40,7 @@ import io.camunda.service.ProcessInstanceServices.ProcessInstanceModifyBatchOper
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceModifyRequest;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
+import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
@@ -70,43 +71,58 @@ public class ProcessInstanceController {
 
   @CamundaPostMapping
   public CompletableFuture<ResponseEntity<Object>> createProcessInstance(
-      @RequestBody final ProcessInstanceCreationInstruction request) {
+      @RequestBody final ProcessInstanceCreationInstruction request,
+      @PhysicalTenantId final String physicalTenantId) {
     return RequestMapper.toCreateProcessInstance(request, multiTenancyCfg.isChecksEnabled())
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::createProcessInstance);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> createProcessInstance(req, physicalTenantId));
   }
 
   @CamundaPostMapping(path = "/{processInstanceKey}/cancellation")
   public CompletableFuture<ResponseEntity<Object>> cancelProcessInstance(
       @PathVariable final long processInstanceKey,
-      @RequestBody(required = false) final CancelProcessInstanceRequest cancelRequest) {
+      @RequestBody(required = false) final CancelProcessInstanceRequest cancelRequest,
+      @PhysicalTenantId final String physicalTenantId) {
     return RequestMapper.toCancelProcessInstance(processInstanceKey, cancelRequest)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::cancelProcessInstance);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> cancelProcessInstance(req, physicalTenantId));
   }
 
   @CamundaPostMapping(path = "/{processInstanceKey}/migration")
   public CompletableFuture<ResponseEntity<Object>> migrateProcessInstance(
       @PathVariable final long processInstanceKey,
-      @RequestBody final ProcessInstanceMigrationInstruction migrationRequest) {
+      @RequestBody final ProcessInstanceMigrationInstruction migrationRequest,
+      @PhysicalTenantId final String physicalTenantId) {
     return RequestMapper.toMigrateProcessInstance(processInstanceKey, migrationRequest)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::migrateProcessInstance);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> migrateProcessInstance(req, physicalTenantId));
   }
 
   @CamundaPostMapping(path = "/{processInstanceKey}/modification")
   public CompletableFuture<ResponseEntity<Object>> modifyProcessInstance(
       @PathVariable final long processInstanceKey,
-      @RequestBody final ProcessInstanceModificationInstruction modifyRequest) {
+      @RequestBody final ProcessInstanceModificationInstruction modifyRequest,
+      @PhysicalTenantId final String physicalTenantId) {
     return RequestMapper.toModifyProcessInstance(processInstanceKey, modifyRequest)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::modifyProcessInstance);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> modifyProcessInstance(req, physicalTenantId));
   }
 
   @RequiresSecondaryStorage
   @CamundaPostMapping(path = "/{processInstanceKey}/incident-resolution")
   public CompletableFuture<ResponseEntity<Object>> resolveProcessInstanceIncidents(
-      @PathVariable final long processInstanceKey) {
+      @PathVariable final long processInstanceKey,
+      @PhysicalTenantId final String physicalTenantId) {
     return RequestExecutor.executeServiceMethod(
         () ->
             processInstanceServices.resolveProcessInstanceIncidents(
-                processInstanceKey, authenticationProvider.getCamundaAuthentication()),
+                processInstanceKey,
+                authenticationProvider.getCamundaAuthentication(),
+                physicalTenantId),
         ResponseMapper::toBatchOperationCreatedWithResultResponse,
         HttpStatus.OK);
   }
@@ -114,22 +130,26 @@ public class ProcessInstanceController {
   @RequiresSecondaryStorage
   @CamundaPostMapping(path = "/search")
   public ResponseEntity<ProcessInstanceSearchQueryResult> searchProcessInstances(
-      @RequestBody(required = false) final ProcessInstanceSearchQuery query) {
+      @RequestBody(required = false) final ProcessInstanceSearchQuery query,
+      @PhysicalTenantId final String physicalTenantId) {
     return SearchQueryRequestMapper.toProcessInstanceQuery(query)
-        .fold(RestErrorMapper::mapProblemToResponse, this::search);
+        .fold(RestErrorMapper::mapProblemToResponse, piq -> search(piq, physicalTenantId));
   }
 
   @RequiresSecondaryStorage
   @CamundaGetMapping(path = "/{processInstanceKey}")
   public ResponseEntity<Object> getByKey(
-      @PathVariable("processInstanceKey") final Long processInstanceKey) {
+      @PathVariable("processInstanceKey") final Long processInstanceKey,
+      @PhysicalTenantId final String physicalTenantId) {
     try {
       // Success case: Return the left side with the ProcessInstanceItem wrapped in ResponseEntity
       return ResponseEntity.ok()
           .body(
               SearchQueryResponseMapper.toProcessInstance(
                   processInstanceServices.getByKey(
-                      processInstanceKey, authenticationProvider.getCamundaAuthentication())));
+                      processInstanceKey,
+                      authenticationProvider.getCamundaAuthentication(),
+                      physicalTenantId)));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }
@@ -139,25 +159,30 @@ public class ProcessInstanceController {
   @CamundaPostMapping(path = "/{processInstanceKey}/deletion")
   public CompletableFuture<ResponseEntity<Object>> deleteProcessInstance(
       @PathVariable("processInstanceKey") final Long processInstanceKey,
-      @RequestBody(required = false) final DeleteProcessInstanceRequest request) {
+      @RequestBody(required = false) final DeleteProcessInstanceRequest request,
+      @PhysicalTenantId final String physicalTenantId) {
     return RequestExecutor.executeServiceMethodWithNoContentResult(
         () ->
             processInstanceServices.deleteProcessInstance(
                 processInstanceKey,
                 Objects.nonNull(request) ? request.getOperationReference() : null,
-                authenticationProvider.getCamundaAuthentication()));
+                authenticationProvider.getCamundaAuthentication(),
+                physicalTenantId));
   }
 
   @RequiresSecondaryStorage
   @CamundaGetMapping(path = "/{processInstanceKey}/call-hierarchy")
   public ResponseEntity<Object> getCallHierarchy(
-      @PathVariable("processInstanceKey") final Long processInstanceKey) {
+      @PathVariable("processInstanceKey") final Long processInstanceKey,
+      @PhysicalTenantId final String physicalTenantId) {
     try {
       return ResponseEntity.ok()
           .body(
               SearchQueryResponseMapper.toProcessInstanceCallHierarchyEntries(
                   processInstanceServices.callHierarchy(
-                      processInstanceKey, authenticationProvider.getCamundaAuthentication())));
+                      processInstanceKey,
+                      authenticationProvider.getCamundaAuthentication(),
+                      physicalTenantId)));
 
     } catch (final Exception e) {
       return mapErrorToResponse(e);
@@ -167,13 +192,16 @@ public class ProcessInstanceController {
   @RequiresSecondaryStorage
   @CamundaGetMapping(path = "/{processInstanceKey}/statistics/element-instances")
   public ResponseEntity<Object> elementStatistics(
-      @PathVariable("processInstanceKey") final Long processInstanceKey) {
+      @PathVariable("processInstanceKey") final Long processInstanceKey,
+      @PhysicalTenantId final String physicalTenantId) {
     try {
       return ResponseEntity.ok()
           .body(
               SearchQueryResponseMapper.toProcessInstanceElementStatisticsResult(
                   processInstanceServices.elementStatistics(
-                      processInstanceKey, authenticationProvider.getCamundaAuthentication())));
+                      processInstanceKey,
+                      authenticationProvider.getCamundaAuthentication(),
+                      physicalTenantId)));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }
@@ -182,13 +210,16 @@ public class ProcessInstanceController {
   @RequiresSecondaryStorage
   @CamundaGetMapping(path = "/{processInstanceKey}/sequence-flows")
   public ResponseEntity<Object> sequenceFlows(
-      @PathVariable("processInstanceKey") final Long processInstanceKey) {
+      @PathVariable("processInstanceKey") final Long processInstanceKey,
+      @PhysicalTenantId final String physicalTenantId) {
     try {
       return ResponseEntity.ok()
           .body(
               SearchQueryResponseMapper.toSequenceFlowsResult(
                   processInstanceServices.sequenceFlows(
-                      processInstanceKey, authenticationProvider.getCamundaAuthentication())));
+                      processInstanceKey,
+                      authenticationProvider.getCamundaAuthentication(),
+                      physicalTenantId)));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }
@@ -197,59 +228,76 @@ public class ProcessInstanceController {
   @RequiresSecondaryStorage
   @CamundaPostMapping(path = "/cancellation")
   public CompletableFuture<ResponseEntity<Object>> cancelProcessInstancesBatchOperation(
-      @RequestBody final ProcessInstanceCancellationBatchOperationRequest request) {
+      @RequestBody final ProcessInstanceCancellationBatchOperationRequest request,
+      @PhysicalTenantId final String physicalTenantId) {
     return RequestMapper.toRequiredProcessInstanceFilter(request.getFilter())
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::batchOperationCancellation);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            filter -> batchOperationCancellation(filter, physicalTenantId));
   }
 
   @RequiresSecondaryStorage
   @CamundaPostMapping(path = "/incident-resolution")
   public CompletableFuture<ResponseEntity<Object>> resolveIncidentsBatchOperation(
-      @RequestBody final ProcessInstanceIncidentResolutionBatchOperationRequest request) {
+      @RequestBody final ProcessInstanceIncidentResolutionBatchOperationRequest request,
+      @PhysicalTenantId final String physicalTenantId) {
     return RequestMapper.toRequiredProcessInstanceFilter(request.getFilter())
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::batchOperationResolveIncidents);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            filter -> batchOperationResolveIncidents(filter, physicalTenantId));
   }
 
   @RequiresSecondaryStorage
   @CamundaPostMapping(path = "/migration")
   public CompletableFuture<ResponseEntity<Object>> migrateProcessInstancesBatchOperation(
-      @RequestBody final ProcessInstanceMigrationBatchOperationRequest request) {
+      @RequestBody final ProcessInstanceMigrationBatchOperationRequest request,
+      @PhysicalTenantId final String physicalTenantId) {
     return RequestMapper.toProcessInstanceMigrationBatchOperationRequest(request)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::batchOperationMigrate);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> batchOperationMigrate(req, physicalTenantId));
   }
 
   @RequiresSecondaryStorage
   @CamundaPostMapping(path = "/modification")
   public CompletableFuture<ResponseEntity<Object>> modifyProcessInstancesBatchOperation(
-      @RequestBody final ProcessInstanceModificationBatchOperationRequest request) {
+      @RequestBody final ProcessInstanceModificationBatchOperationRequest request,
+      @PhysicalTenantId final String physicalTenantId) {
     return RequestMapper.toProcessInstanceModifyBatchOperationRequest(request)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::batchOperationModify);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> batchOperationModify(req, physicalTenantId));
   }
 
   @RequiresSecondaryStorage
   @CamundaPostMapping(path = "/deletion")
   public CompletableFuture<ResponseEntity<Object>> deleteProcessInstancesBatchOperation(
-      @RequestBody final ProcessInstanceDeletionBatchOperationRequest request) {
+      @RequestBody final ProcessInstanceDeletionBatchOperationRequest request,
+      @PhysicalTenantId final String physicalTenantId) {
     return RequestMapper.toRequiredProcessInstanceFilter(request.getFilter())
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::batchOperationDeletion);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            filter -> batchOperationDeletion(filter, physicalTenantId));
   }
 
   @RequiresSecondaryStorage
   @CamundaPostMapping(path = "/{processInstanceKey}/incidents/search")
   public ResponseEntity<IncidentSearchQueryResult> searchIncidents(
       @PathVariable("processInstanceKey") final long processInstanceKey,
-      @RequestBody(required = false) final IncidentSearchQuery query) {
+      @RequestBody(required = false) final IncidentSearchQuery query,
+      @PhysicalTenantId final String physicalTenantId) {
     return SearchQueryRequestMapper.toIncidentQuery(query)
         .fold(
             RestErrorMapper::mapProblemToResponse,
-            incidentQuery -> searchIncidents(processInstanceKey, incidentQuery));
+            incidentQuery -> searchIncidents(processInstanceKey, incidentQuery, physicalTenantId));
   }
 
   private ResponseEntity<ProcessInstanceSearchQueryResult> search(
-      final ProcessInstanceQuery query) {
+      final ProcessInstanceQuery query, final String physicalTenantId) {
     try {
       final var result =
-          processInstanceServices.search(query, authenticationProvider.getCamundaAuthentication());
+          processInstanceServices.search(
+              query, authenticationProvider.getCamundaAuthentication(), physicalTenantId);
       return ResponseEntity.ok(
           SearchQueryResponseMapper.toProcessInstanceSearchQueryResponse(result));
     } catch (final Exception e) {
@@ -258,11 +306,14 @@ public class ProcessInstanceController {
   }
 
   private ResponseEntity<IncidentSearchQueryResult> searchIncidents(
-      final long processInstanceKey, final IncidentQuery query) {
+      final long processInstanceKey, final IncidentQuery query, final String physicalTenantId) {
     try {
       final var result =
           processInstanceServices.searchIncidents(
-              processInstanceKey, query, authenticationProvider.getCamundaAuthentication());
+              processInstanceKey,
+              query,
+              authenticationProvider.getCamundaAuthentication(),
+              physicalTenantId);
       return ResponseEntity.ok(SearchQueryResponseMapper.toIncidentSearchQueryResponse(result));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
@@ -270,94 +321,94 @@ public class ProcessInstanceController {
   }
 
   private CompletableFuture<ResponseEntity<Object>> batchOperationCancellation(
-      final io.camunda.search.filter.ProcessInstanceFilter filter) {
+      final io.camunda.search.filter.ProcessInstanceFilter filter, final String physicalTenantId) {
     return RequestExecutor.executeServiceMethod(
         () ->
             processInstanceServices.cancelProcessInstanceBatchOperationWithResult(
-                filter, authenticationProvider.getCamundaAuthentication()),
+                filter, authenticationProvider.getCamundaAuthentication(), physicalTenantId),
         ResponseMapper::toBatchOperationCreatedWithResultResponse,
         HttpStatus.OK);
   }
 
   private CompletableFuture<ResponseEntity<Object>> batchOperationResolveIncidents(
-      final io.camunda.search.filter.ProcessInstanceFilter filter) {
+      final io.camunda.search.filter.ProcessInstanceFilter filter, final String physicalTenantId) {
     return RequestExecutor.executeServiceMethod(
         () ->
             processInstanceServices.resolveIncidentsBatchOperationWithResult(
-                filter, authenticationProvider.getCamundaAuthentication()),
+                filter, authenticationProvider.getCamundaAuthentication(), physicalTenantId),
         ResponseMapper::toBatchOperationCreatedWithResultResponse,
         HttpStatus.OK);
   }
 
   private CompletableFuture<ResponseEntity<Object>> batchOperationMigrate(
-      final ProcessInstanceMigrateBatchOperationRequest request) {
+      final ProcessInstanceMigrateBatchOperationRequest request, final String physicalTenantId) {
     return RequestExecutor.executeServiceMethod(
         () ->
             processInstanceServices.migrateProcessInstancesBatchOperation(
-                request, authenticationProvider.getCamundaAuthentication()),
+                request, authenticationProvider.getCamundaAuthentication(), physicalTenantId),
         ResponseMapper::toBatchOperationCreatedWithResultResponse,
         HttpStatus.OK);
   }
 
   private CompletableFuture<ResponseEntity<Object>> batchOperationModify(
-      final ProcessInstanceModifyBatchOperationRequest request) {
+      final ProcessInstanceModifyBatchOperationRequest request, final String physicalTenantId) {
     return RequestExecutor.executeServiceMethod(
         () ->
             processInstanceServices.modifyProcessInstancesBatchOperation(
-                request, authenticationProvider.getCamundaAuthentication()),
+                request, authenticationProvider.getCamundaAuthentication(), physicalTenantId),
         ResponseMapper::toBatchOperationCreatedWithResultResponse,
         HttpStatus.OK);
   }
 
   private CompletableFuture<ResponseEntity<Object>> batchOperationDeletion(
-      final io.camunda.search.filter.ProcessInstanceFilter filter) {
+      final io.camunda.search.filter.ProcessInstanceFilter filter, final String physicalTenantId) {
     return RequestExecutor.executeServiceMethod(
         () ->
             processInstanceServices.deleteProcessInstancesBatchOperation(
-                filter, authenticationProvider.getCamundaAuthentication()),
+                filter, authenticationProvider.getCamundaAuthentication(), physicalTenantId),
         ResponseMapper::toBatchOperationCreatedWithResultResponse,
         HttpStatus.OK);
   }
 
   private CompletableFuture<ResponseEntity<Object>> createProcessInstance(
-      final ProcessInstanceCreateRequest request) {
+      final ProcessInstanceCreateRequest request, final String physicalTenantId) {
     if (request.awaitCompletion()) {
       return RequestExecutor.executeServiceMethod(
           () ->
               processInstanceServices.createProcessInstanceWithResult(
-                  request, authenticationProvider.getCamundaAuthentication()),
+                  request, authenticationProvider.getCamundaAuthentication(), physicalTenantId),
           ResponseMapper::toCreateProcessInstanceWithResultResponse,
           HttpStatus.OK);
     }
     return RequestExecutor.executeServiceMethod(
         () ->
             processInstanceServices.createProcessInstance(
-                request, authenticationProvider.getCamundaAuthentication()),
+                request, authenticationProvider.getCamundaAuthentication(), physicalTenantId),
         ResponseMapper::toCreateProcessInstanceResponse,
         HttpStatus.OK);
   }
 
   private CompletableFuture<ResponseEntity<Object>> cancelProcessInstance(
-      final ProcessInstanceCancelRequest request) {
+      final ProcessInstanceCancelRequest request, final String physicalTenantId) {
     return RequestExecutor.executeServiceMethodWithNoContentResult(
         () ->
             processInstanceServices.cancelProcessInstance(
-                request, authenticationProvider.getCamundaAuthentication()));
+                request, authenticationProvider.getCamundaAuthentication(), physicalTenantId));
   }
 
   private CompletableFuture<ResponseEntity<Object>> migrateProcessInstance(
-      final ProcessInstanceMigrateRequest request) {
+      final ProcessInstanceMigrateRequest request, final String physicalTenantId) {
     return RequestExecutor.executeServiceMethodWithNoContentResult(
         () ->
             processInstanceServices.migrateProcessInstance(
-                request, authenticationProvider.getCamundaAuthentication()));
+                request, authenticationProvider.getCamundaAuthentication(), physicalTenantId));
   }
 
   private CompletableFuture<ResponseEntity<Object>> modifyProcessInstance(
-      final ProcessInstanceModifyRequest request) {
+      final ProcessInstanceModifyRequest request, final String physicalTenantId) {
     return RequestExecutor.executeServiceMethodWithNoContentResult(
         () ->
             processInstanceServices.modifyProcessInstance(
-                request, authenticationProvider.getCamundaAuthentication()));
+                request, authenticationProvider.getCamundaAuthentication(), physicalTenantId));
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ResourceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ResourceController.java
@@ -22,6 +22,7 @@ import io.camunda.service.ResourceServices.DeployResourcesRequest;
 import io.camunda.service.ResourceServices.ResourceDeletionRequest;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
+import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
@@ -56,37 +57,43 @@ public class ResourceController {
   @CamundaPostMapping(path = "/deployments", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   public CompletableFuture<ResponseEntity<Object>> deployResources(
       @RequestPart("resources") final List<MultipartFile> resources,
-      @RequestPart(value = "tenantId", required = false) final String tenantId) {
+      @RequestPart(value = "tenantId", required = false) final String tenantId,
+      @PhysicalTenantId final String physicalTenantId) {
 
     return RequestMapper.toDeployResourceRequest(
             resources, tenantId, multiTenancyCfg.isChecksEnabled())
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::deployResources);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> deployResources(req, physicalTenantId));
   }
 
   @CamundaPostMapping(path = "/resources/{resourceKey}/deletion")
   public CompletableFuture<ResponseEntity<Object>> deleteResource(
       @PathVariable final long resourceKey,
-      @RequestBody(required = false) final DeleteResourceRequest deleteRequest) {
+      @RequestBody(required = false) final DeleteResourceRequest deleteRequest,
+      @PhysicalTenantId final String physicalTenantId) {
     return RequestMapper.toResourceDeletion(resourceKey, deleteRequest)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::delete);
+        .fold(RestErrorMapper::mapProblemToCompletedResponse, req -> delete(req, physicalTenantId));
   }
 
   @CamundaGetMapping(path = "/resources/{resourceKey}")
   public CompletableFuture<ResponseEntity<Object>> getResource(
-      @PathVariable final long resourceKey) {
+      @PathVariable final long resourceKey, @PhysicalTenantId final String physicalTenantId) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethod(
-        () -> resourceServices.getByKey(resourceKey, authentication),
+        () -> resourceServices.getByKey(resourceKey, authentication, physicalTenantId),
         ResponseMapper::toGetResourceResponse,
         HttpStatus.OK);
   }
 
   @CamundaGetMapping(path = "/resources/{resourceKey}/content")
   public CompletableFuture<ResponseEntity<Object>> getResourceContent(
-      @PathVariable final long resourceKey) {
+      @PathVariable final long resourceKey, @PhysicalTenantId final String physicalTenantId) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethod(
-        () -> resourceServices.getContentByKeyFilteredByType(resourceKey, "rpa", authentication),
+        () ->
+            resourceServices.getContentByKeyFilteredByType(
+                resourceKey, "rpa", authentication, physicalTenantId),
         entity ->
             ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_JSON)
@@ -95,10 +102,10 @@ public class ResourceController {
 
   @CamundaGetMapping(path = "/resources/{resourceKey}/content/binary")
   public CompletableFuture<ResponseEntity<Object>> getResourceContentBinary(
-      @PathVariable final long resourceKey) {
+      @PathVariable final long resourceKey, @PhysicalTenantId final String physicalTenantId) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethod(
-        () -> resourceServices.getContentByKey(resourceKey, authentication),
+        () -> resourceServices.getContentByKey(resourceKey, authentication, physicalTenantId),
         entity ->
             ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_OCTET_STREAM)
@@ -108,15 +115,18 @@ public class ResourceController {
   @RequiresSecondaryStorage
   @CamundaPostMapping(path = "/resources/search")
   public ResponseEntity<ResourceSearchQueryResult> searchResources(
-      @RequestBody(required = false) final ResourceSearchQuery query) {
+      @RequestBody(required = false) final ResourceSearchQuery query,
+      @PhysicalTenantId final String physicalTenantId) {
     return SearchQueryRequestMapper.toDeployedResourceQuery(query)
-        .fold(RestErrorMapper::mapProblemToResponse, this::search);
+        .fold(RestErrorMapper::mapProblemToResponse, q -> search(q, physicalTenantId));
   }
 
-  private ResponseEntity<ResourceSearchQueryResult> search(final DeployedResourceQuery query) {
+  private ResponseEntity<ResourceSearchQueryResult> search(
+      final DeployedResourceQuery query, final String physicalTenantId) {
     try {
       final var result =
-          resourceServices.search(query, authenticationProvider.getCamundaAuthentication());
+          resourceServices.search(
+              query, authenticationProvider.getCamundaAuthentication(), physicalTenantId);
       return ResponseEntity.ok(SearchQueryResponseMapper.toResourceSearchQueryResponse(result));
     } catch (final Exception e) {
       return RestErrorMapper.mapErrorToResponse(e);
@@ -124,18 +134,19 @@ public class ResourceController {
   }
 
   private CompletableFuture<ResponseEntity<Object>> deployResources(
-      final DeployResourcesRequest request) {
+      final DeployResourcesRequest request, final String physicalTenantId) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethod(
-        () -> resourceServices.deployResources(request, authentication),
+        () -> resourceServices.deployResources(request, authentication, physicalTenantId),
         ResponseMapper::toDeployResourceResponse,
         HttpStatus.OK);
   }
 
-  private CompletableFuture<ResponseEntity<Object>> delete(final ResourceDeletionRequest request) {
+  private CompletableFuture<ResponseEntity<Object>> delete(
+      final ResourceDeletionRequest request, final String physicalTenantId) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethod(
-        () -> resourceServices.deleteResource(request, authentication),
+        () -> resourceServices.deleteResource(request, authentication, physicalTenantId),
         ResponseMapper::toDeleteResourceResponse,
         HttpStatus.OK);
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/SignalController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/SignalController.java
@@ -15,6 +15,7 @@ import io.camunda.security.api.context.CamundaAuthenticationProvider;
 import io.camunda.security.api.model.config.MultiTenancyConfiguration;
 import io.camunda.service.SignalServices;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
+import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
 import java.util.concurrent.CompletableFuture;
@@ -44,18 +45,25 @@ public class SignalController {
 
   @CamundaPostMapping(path = "/broadcast")
   public CompletableFuture<ResponseEntity<Object>> broadcastSignal(
-      @RequestBody final SignalBroadcastRequest request) {
+      @RequestBody final SignalBroadcastRequest request,
+      @PhysicalTenantId final String physicalTenantId) {
     return RequestMapper.toBroadcastSignalRequest(request, multiTenancyCfg.isChecksEnabled())
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::broadcastSignal);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> broadcastSignal(req, physicalTenantId));
   }
 
   private CompletableFuture<ResponseEntity<Object>> broadcastSignal(
-      final BroadcastSignalRequest request) {
+      final BroadcastSignalRequest request, final String physicalTenantId) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethod(
         () ->
             signalServices.broadcastSignal(
-                request.signalName(), request.variables(), request.tenantId(), authentication),
+                request.signalName(),
+                request.variables(),
+                request.tenantId(),
+                authentication,
+                physicalTenantId),
         ResponseMapper::toSignalBroadcastResponse,
         HttpStatus.OK);
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/UserTaskController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/UserTaskController.java
@@ -36,6 +36,7 @@ import io.camunda.zeebe.gateway.rest.annotation.CamundaDeleteMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPatchMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
+import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
@@ -63,52 +64,64 @@ public class UserTaskController {
   @CamundaPostMapping(path = "/{userTaskKey}/completion")
   public CompletableFuture<ResponseEntity<Object>> completeUserTask(
       @PathVariable final long userTaskKey,
-      @RequestBody(required = false) final UserTaskCompletionRequest completionRequest) {
+      @RequestBody(required = false) final UserTaskCompletionRequest completionRequest,
+      @PhysicalTenantId final String physicalTenantId) {
 
     return completeUserTask(
-        RequestMapper.toUserTaskCompletionRequest(completionRequest, userTaskKey));
+        RequestMapper.toUserTaskCompletionRequest(completionRequest, userTaskKey),
+        physicalTenantId);
   }
 
   @CamundaPostMapping(path = "/{userTaskKey}/assignment")
   public CompletableFuture<ResponseEntity<Object>> assignUserTask(
       @PathVariable final long userTaskKey,
-      @RequestBody final UserTaskAssignmentRequest assignmentRequest) {
+      @RequestBody final UserTaskAssignmentRequest assignmentRequest,
+      @PhysicalTenantId final String physicalTenantId) {
 
     return RequestMapper.toUserTaskAssignmentRequest(assignmentRequest, userTaskKey)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::assignUserTask);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> assignUserTask(req, physicalTenantId));
   }
 
   @CamundaDeleteMapping(path = "/{userTaskKey}/assignee")
   public CompletableFuture<ResponseEntity<Object>> unassignUserTask(
-      @PathVariable final long userTaskKey) {
+      @PathVariable final long userTaskKey, @PhysicalTenantId final String physicalTenantId) {
 
-    return unassignUserTask(RequestMapper.toUserTaskUnassignmentRequest(userTaskKey));
+    return unassignUserTask(
+        RequestMapper.toUserTaskUnassignmentRequest(userTaskKey), physicalTenantId);
   }
 
   @CamundaPatchMapping(path = "/{userTaskKey}")
   public CompletableFuture<ResponseEntity<Object>> updateUserTask(
       @PathVariable final long userTaskKey,
-      @RequestBody(required = false) final UserTaskUpdateRequest updateRequest) {
+      @RequestBody(required = false) final UserTaskUpdateRequest updateRequest,
+      @PhysicalTenantId final String physicalTenantId) {
 
     return RequestMapper.toUserTaskUpdateRequest(updateRequest, userTaskKey)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::updateUserTask);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> updateUserTask(req, physicalTenantId));
   }
 
   @RequiresSecondaryStorage
   @CamundaPostMapping(path = "/search")
   public ResponseEntity<UserTaskSearchQueryResult> searchUserTasks(
-      @RequestBody(required = false) final UserTaskSearchQuery query) {
+      @RequestBody(required = false) final UserTaskSearchQuery query,
+      @PhysicalTenantId final String physicalTenantId) {
     return SearchQueryRequestMapper.toUserTaskQuery(query)
-        .fold(RestErrorMapper::mapProblemToResponse, this::search);
+        .fold(RestErrorMapper::mapProblemToResponse, q -> search(q, physicalTenantId));
   }
 
   @RequiresSecondaryStorage
   @CamundaGetMapping(path = "/{userTaskKey}")
   public ResponseEntity<UserTaskResult> getByKey(
-      @PathVariable("userTaskKey") final Long userTaskKey) {
+      @PathVariable("userTaskKey") final Long userTaskKey,
+      @PhysicalTenantId final String physicalTenantId) {
     try {
       final var userTask =
-          userTaskServices.getByKey(userTaskKey, authenticationProvider.getCamundaAuthentication());
+          userTaskServices.getByKey(
+              userTaskKey, authenticationProvider.getCamundaAuthentication(), physicalTenantId);
 
       return ResponseEntity.ok().body(SearchQueryResponseMapper.toUserTask(userTask));
     } catch (final Exception e) {
@@ -119,10 +132,12 @@ public class UserTaskController {
   @RequiresSecondaryStorage
   @CamundaGetMapping(path = "/{userTaskKey}/form")
   public ResponseEntity<FormResult> getFormByUserTaskKey(
-      @PathVariable("userTaskKey") final long userTaskKey) {
+      @PathVariable("userTaskKey") final long userTaskKey,
+      @PhysicalTenantId final String physicalTenantId) {
     try {
       return userTaskServices
-          .getUserTaskForm(userTaskKey, authenticationProvider.getCamundaAuthentication())
+          .getUserTaskForm(
+              userTaskKey, authenticationProvider.getCamundaAuthentication(), physicalTenantId)
           .map(SearchQueryResponseMapper::toFormItem)
           .map(ResponseEntity::ok)
           .orElseGet(() -> ResponseEntity.noContent().build());
@@ -138,11 +153,13 @@ public class UserTaskController {
       @RequestBody(required = false)
           final UserTaskVariableSearchQueryRequest userTaskVariablesSearchQueryRequest,
       @RequestParam(name = "truncateValues", required = false, defaultValue = "true")
-          final boolean truncateValues) {
+          final boolean truncateValues,
+      @PhysicalTenantId final String physicalTenantId) {
     return SearchQueryRequestMapper.toUserTaskVariableQuery(userTaskVariablesSearchQueryRequest)
         .fold(
             RestErrorMapper::mapProblemToResponse,
-            query -> searchUserTaskVariableQuery(userTaskKey, query, truncateValues));
+            query ->
+                searchUserTaskVariableQuery(userTaskKey, query, truncateValues, physicalTenantId));
   }
 
   @RequiresSecondaryStorage
@@ -153,12 +170,15 @@ public class UserTaskController {
           final UserTaskEffectiveVariableSearchQueryRequest
               userTaskEffectiveVariablesSearchQueryRequest,
       @RequestParam(name = "truncateValues", required = false, defaultValue = "true")
-          final boolean truncateValues) {
+          final boolean truncateValues,
+      @PhysicalTenantId final String physicalTenantId) {
     return SearchQueryRequestMapper.toUserTaskEffectiveVariableQuery(
             userTaskEffectiveVariablesSearchQueryRequest)
         .fold(
             RestErrorMapper::mapProblemToResponse,
-            query -> searchUserTaskEffectiveVariableQuery(userTaskKey, query, truncateValues));
+            query ->
+                searchUserTaskEffectiveVariableQuery(
+                    userTaskKey, query, truncateValues, physicalTenantId));
   }
 
   @RequiresSecondaryStorage
@@ -166,17 +186,20 @@ public class UserTaskController {
   public ResponseEntity<AuditLogSearchQueryResult> searchAuditLogs(
       @PathVariable final long userTaskKey,
       @RequestBody(required = false)
-          final UserTaskAuditLogSearchQueryRequest auditLogSearchQueryRequest) {
+          final UserTaskAuditLogSearchQueryRequest auditLogSearchQueryRequest,
+      @PhysicalTenantId final String physicalTenantId) {
     return SearchQueryRequestMapper.toUserTaskAuditLogQuery(auditLogSearchQueryRequest)
         .fold(
             RestErrorMapper::mapProblemToResponse,
-            query -> searchUserTaskAuditLogQuery(userTaskKey, query));
+            query -> searchUserTaskAuditLogQuery(userTaskKey, query, physicalTenantId));
   }
 
-  private ResponseEntity<UserTaskSearchQueryResult> search(final UserTaskQuery query) {
+  private ResponseEntity<UserTaskSearchQueryResult> search(
+      final UserTaskQuery query, final String physicalTenantId) {
     try {
       final var result =
-          userTaskServices.search(query, authenticationProvider.getCamundaAuthentication());
+          userTaskServices.search(
+              query, authenticationProvider.getCamundaAuthentication(), physicalTenantId);
 
       return ResponseEntity.ok(SearchQueryResponseMapper.toUserTaskSearchQueryResponse(result));
     } catch (final Exception e) {
@@ -185,11 +208,17 @@ public class UserTaskController {
   }
 
   private ResponseEntity<VariableSearchQueryResult> searchUserTaskVariableQuery(
-      final long userTaskKey, final VariableQuery query, final boolean truncateValues) {
+      final long userTaskKey,
+      final VariableQuery query,
+      final boolean truncateValues,
+      final String physicalTenantId) {
     try {
       final var result =
           userTaskServices.searchUserTaskVariables(
-              userTaskKey, query, authenticationProvider.getCamundaAuthentication());
+              userTaskKey,
+              query,
+              authenticationProvider.getCamundaAuthentication(),
+              physicalTenantId);
       return ResponseEntity.ok(
           SearchQueryResponseMapper.toVariableSearchQueryResponse(result, truncateValues));
     } catch (final Exception e) {
@@ -198,11 +227,17 @@ public class UserTaskController {
   }
 
   private ResponseEntity<VariableSearchQueryResult> searchUserTaskEffectiveVariableQuery(
-      final long userTaskKey, final VariableQuery query, final boolean truncateValues) {
+      final long userTaskKey,
+      final VariableQuery query,
+      final boolean truncateValues,
+      final String physicalTenantId) {
     try {
       final var result =
           userTaskServices.searchUserTaskEffectiveVariables(
-              userTaskKey, query, authenticationProvider.getCamundaAuthentication());
+              userTaskKey,
+              query,
+              authenticationProvider.getCamundaAuthentication(),
+              physicalTenantId);
       return ResponseEntity.ok(
           SearchQueryResponseMapper.toVariableSearchQueryResponse(result, truncateValues));
     } catch (final Exception e) {
@@ -211,11 +246,14 @@ public class UserTaskController {
   }
 
   private ResponseEntity<AuditLogSearchQueryResult> searchUserTaskAuditLogQuery(
-      final long userTaskKey, final AuditLogQuery query) {
+      final long userTaskKey, final AuditLogQuery query, final String physicalTenantId) {
     try {
       final var result =
           userTaskServices.searchUserTaskAuditLogs(
-              userTaskKey, query, authenticationProvider.getCamundaAuthentication());
+              userTaskKey,
+              query,
+              authenticationProvider.getCamundaAuthentication(),
+              physicalTenantId);
       return ResponseEntity.ok(SearchQueryResponseMapper.toAuditLogSearchQueryResponse(result));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
@@ -223,7 +261,7 @@ public class UserTaskController {
   }
 
   private CompletableFuture<ResponseEntity<Object>> assignUserTask(
-      final AssignUserTaskRequest request) {
+      final AssignUserTaskRequest request, final String physicalTenantId) {
     return RequestExecutor.executeServiceMethodWithNoContentResult(
         () ->
             userTaskServices.assignUserTask(
@@ -231,38 +269,42 @@ public class UserTaskController {
                 request.assignee(),
                 request.action(),
                 request.allowOverride(),
-                authenticationProvider.getCamundaAuthentication()));
+                authenticationProvider.getCamundaAuthentication(),
+                physicalTenantId));
   }
 
   private CompletableFuture<ResponseEntity<Object>> completeUserTask(
-      final CompleteUserTaskRequest request) {
+      final CompleteUserTaskRequest request, final String physicalTenantId) {
     return RequestExecutor.executeServiceMethodWithNoContentResult(
         () ->
             userTaskServices.completeUserTask(
                 request.userTaskKey(),
                 request.variables(),
                 request.action(),
-                authenticationProvider.getCamundaAuthentication()));
+                authenticationProvider.getCamundaAuthentication(),
+                physicalTenantId));
   }
 
   private CompletableFuture<ResponseEntity<Object>> unassignUserTask(
-      final AssignUserTaskRequest request) {
+      final AssignUserTaskRequest request, final String physicalTenantId) {
     return RequestExecutor.executeServiceMethodWithNoContentResult(
         () ->
             userTaskServices.unassignUserTask(
                 request.userTaskKey(),
                 request.action(),
-                authenticationProvider.getCamundaAuthentication()));
+                authenticationProvider.getCamundaAuthentication(),
+                physicalTenantId));
   }
 
   private CompletableFuture<ResponseEntity<Object>> updateUserTask(
-      final UpdateUserTaskRequest request) {
+      final UpdateUserTaskRequest request, final String physicalTenantId) {
     return RequestExecutor.executeServiceMethodWithNoContentResult(
         () ->
             userTaskServices.updateUserTask(
                 request.userTaskKey(),
                 request.changeset(),
                 request.action(),
-                authenticationProvider.getCamundaAuthentication()));
+                authenticationProvider.getCamundaAuthentication(),
+                physicalTenantId));
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/VariableController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/VariableController.java
@@ -17,6 +17,7 @@ import io.camunda.security.api.context.CamundaAuthenticationProvider;
 import io.camunda.service.VariableServices;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
+import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
 import org.springframework.http.ResponseEntity;
@@ -44,15 +45,20 @@ public class VariableController {
   public ResponseEntity<Object> searchVariables(
       @RequestBody(required = false) final VariableSearchQuery query,
       @RequestParam(name = "truncateValues", required = false, defaultValue = "true")
-          final boolean truncateValues) {
+          final boolean truncateValues,
+      @PhysicalTenantId final String physicalTenantId) {
     return SearchQueryRequestMapper.toVariableQuery(query)
-        .fold(RestErrorMapper::mapProblemToResponse, q -> search(q, truncateValues));
+        .fold(
+            RestErrorMapper::mapProblemToResponse,
+            q -> search(q, truncateValues, physicalTenantId));
   }
 
-  private ResponseEntity<Object> search(final VariableQuery query, final boolean truncateValues) {
+  private ResponseEntity<Object> search(
+      final VariableQuery query, final boolean truncateValues, final String physicalTenantId) {
     try {
       final var result =
-          variableServices.search(query, authenticationProvider.getCamundaAuthentication());
+          variableServices.search(
+              query, authenticationProvider.getCamundaAuthentication(), physicalTenantId);
       return ResponseEntity.ok(
           SearchQueryResponseMapper.toVariableSearchQueryResponse(result, truncateValues));
     } catch (final Exception e) {
@@ -61,14 +67,17 @@ public class VariableController {
   }
 
   @CamundaGetMapping(path = "/{variableKey}")
-  public ResponseEntity<Object> getByKey(@PathVariable("variableKey") final Long variableKey) {
+  public ResponseEntity<Object> getByKey(
+      @PathVariable("variableKey") final Long variableKey,
+      @PhysicalTenantId final String physicalTenantId) {
     try {
-      // Success case: Return the left side with the VariableItem wrapped in ResponseEntity
       return ResponseEntity.ok()
           .body(
               SearchQueryResponseMapper.toVariableItem(
                   variableServices.getByKey(
-                      variableKey, authenticationProvider.getCamundaAuthentication())));
+                      variableKey,
+                      authenticationProvider.getCamundaAuthentication(),
+                      physicalTenantId)));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/auditlog/AuditLogController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/auditlog/AuditLogController.java
@@ -17,6 +17,7 @@ import io.camunda.security.api.context.CamundaAuthenticationProvider;
 import io.camunda.service.AuditLogServices;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
+import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
 import io.camunda.zeebe.gateway.rest.controller.CamundaRestController;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
@@ -42,29 +43,35 @@ public class AuditLogController {
   @RequiresSecondaryStorage
   @CamundaPostMapping(path = "/search")
   public ResponseEntity<AuditLogSearchQueryResult> searchAuditLogs(
-      @RequestBody(required = false) final AuditLogSearchQueryRequest query) {
+      @RequestBody(required = false) final AuditLogSearchQueryRequest query,
+      @PhysicalTenantId final String physicalTenantId) {
     return SearchQueryRequestMapper.toAuditLogQuery(query)
-        .fold(RestErrorMapper::mapProblemToResponse, this::search);
+        .fold(RestErrorMapper::mapProblemToResponse, q -> search(q, physicalTenantId));
   }
 
   @RequiresSecondaryStorage
   @CamundaGetMapping(path = "/{auditLogKey}")
-  public ResponseEntity<AuditLogResult> getAuditLog(@PathVariable final String auditLogKey) {
+  public ResponseEntity<AuditLogResult> getAuditLog(
+      @PathVariable final String auditLogKey, @PhysicalTenantId final String physicalTenantId) {
     try {
       return ResponseEntity.ok()
           .body(
               SearchQueryResponseMapper.toAuditLog(
                   auditLogServices.getAuditLog(
-                      auditLogKey, authenticationProvider.getCamundaAuthentication())));
+                      auditLogKey,
+                      authenticationProvider.getCamundaAuthentication(),
+                      physicalTenantId)));
     } catch (final Exception exception) {
       return RestErrorMapper.mapErrorToResponse(exception);
     }
   }
 
-  private ResponseEntity<AuditLogSearchQueryResult> search(final AuditLogQuery query) {
+  private ResponseEntity<AuditLogSearchQueryResult> search(
+      final AuditLogQuery query, final String physicalTenantId) {
     try {
       final var result =
-          auditLogServices.search(query, authenticationProvider.getCamundaAuthentication());
+          auditLogServices.search(
+              query, authenticationProvider.getCamundaAuthentication(), physicalTenantId);
       return ResponseEntity.ok(SearchQueryResponseMapper.toAuditLogSearchQueryResponse(result));
     } catch (final Exception e) {
       return RestErrorMapper.mapErrorToResponse(e);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/setup/SetupController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/setup/SetupController.java
@@ -24,6 +24,7 @@ import io.camunda.service.UserServices;
 import io.camunda.service.exception.ServiceException;
 import io.camunda.service.exception.ServiceException.Status;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
+import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
 import io.camunda.zeebe.gateway.rest.controller.CamundaRestController;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
@@ -65,7 +66,7 @@ public class SetupController {
 
   @CamundaPostMapping(path = "/user")
   public CompletableFuture<ResponseEntity<Object>> createAdminUser(
-      @RequestBody final UserRequest request) {
+      @RequestBody final UserRequest request, @PhysicalTenantId final String physicalTenantId) {
     if (securityConfiguration.getAuthentication().getMethod() != AuthenticationMethod.BASIC) {
       final var exception =
           new ServiceException(WRONG_AUTHENTICATION_METHOD_ERROR_MESSAGE, Status.FORBIDDEN);
@@ -74,7 +75,8 @@ public class SetupController {
     }
 
     final var anonymousAuth = authenticationProvider.getAnonymousCamundaAuthentication();
-    if (roleServices.hasMembersOfType(DefaultRole.ADMIN.getId(), EntityType.USER, anonymousAuth)) {
+    if (roleServices.hasMembersOfType(
+        DefaultRole.ADMIN.getId(), EntityType.USER, anonymousAuth, physicalTenantId)) {
       final var exception = new ServiceException(ADMIN_EXISTS_ERROR_MESSAGE, Status.FORBIDDEN);
       return RestErrorMapper.mapProblemToCompletedResponse(
           GatewayErrorMapper.mapErrorToProblem(exception));
@@ -86,7 +88,7 @@ public class SetupController {
             RestErrorMapper::mapProblemToCompletedResponse,
             dto ->
                 RequestExecutor.executeServiceMethod(
-                    () -> userServices.createInitialAdminUser(dto, anonymousAuth),
+                    () -> userServices.createInitialAdminUser(dto, anonymousAuth, physicalTenantId),
                     ResponseMapper::toUserCreateResponse,
                     HttpStatus.CREATED));
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/system/SystemController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/system/SystemController.java
@@ -26,6 +26,7 @@ import io.camunda.security.configuration.SaasConfigurationHelper;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.UsageMetricsServices;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
+import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
 import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration.JobMetricsConfiguration;
@@ -72,10 +73,11 @@ public class SystemController {
       @RequestParam final String startTime,
       @RequestParam final String endTime,
       @RequestParam(required = false) final String tenantId,
-      @RequestParam(required = false, defaultValue = "false") final boolean withTenants) {
+      @RequestParam(required = false, defaultValue = "false") final boolean withTenants,
+      @PhysicalTenantId final String physicalTenantId) {
 
     return SearchQueryRequestMapper.toUsageMetricsQuery(startTime, endTime, tenantId, withTenants)
-        .fold(RestErrorMapper::mapProblemToResponse, this::getMetrics);
+        .fold(RestErrorMapper::mapProblemToResponse, q -> getMetrics(q, physicalTenantId));
   }
 
   @CamundaGetMapping(path = "/configuration")
@@ -140,11 +142,13 @@ public class SystemController {
         .build();
   }
 
-  private ResponseEntity<UsageMetricsResponse> getMetrics(final UsageMetricsQuery query) {
+  private ResponseEntity<UsageMetricsResponse> getMetrics(
+      final UsageMetricsQuery query, final String physicalTenantId) {
     try {
       return ResponseEntity.ok(
           SearchQueryResponseMapper.toUsageMetricsResponse(
-              usageMetricsServices.search(query, authenticationProvider.getCamundaAuthentication()),
+              usageMetricsServices.search(
+                  query, authenticationProvider.getCamundaAuthentication(), physicalTenantId),
               query.filter().withTenants()));
     } catch (final Exception e) {
       return mapErrorToResponse(e);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
@@ -14,7 +14,6 @@ import io.camunda.gateway.mapping.http.mapper.TenantMapper;
 import io.camunda.gateway.mapping.http.search.SearchQueryRequestMapper;
 import io.camunda.gateway.mapping.http.search.SearchQueryResponseMapper;
 import io.camunda.gateway.mapping.http.validator.TenantRequestValidator;
-import io.camunda.gateway.protocol.model.GroupSearchQueryResult;
 import io.camunda.gateway.protocol.model.MappingRuleSearchQueryRequest;
 import io.camunda.gateway.protocol.model.MappingRuleSearchQueryResult;
 import io.camunda.gateway.protocol.model.RoleSearchQueryRequest;
@@ -30,7 +29,6 @@ import io.camunda.gateway.protocol.model.TenantSearchQueryResult;
 import io.camunda.gateway.protocol.model.TenantUpdateRequest;
 import io.camunda.gateway.protocol.model.TenantUserSearchQueryRequest;
 import io.camunda.gateway.protocol.model.TenantUserSearchResult;
-import io.camunda.gateway.protocol.model.UserSearchResult;
 import io.camunda.search.query.GroupQuery;
 import io.camunda.search.query.MappingRuleQuery;
 import io.camunda.search.query.RoleQuery;
@@ -52,6 +50,7 @@ import io.camunda.zeebe.gateway.rest.annotation.CamundaDeleteMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPutMapping;
+import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
 import io.camunda.zeebe.gateway.rest.controller.CamundaRestController;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
@@ -59,7 +58,9 @@ import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
 import java.util.concurrent.CompletableFuture;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 
 @CamundaRestController
 @RequestMapping("/v2/tenants")
@@ -92,20 +93,25 @@ public class TenantController {
 
   @CamundaPostMapping
   public CompletableFuture<ResponseEntity<Object>> createTenant(
-      @RequestBody final TenantCreateRequest createTenantRequest) {
+      @RequestBody final TenantCreateRequest createTenantRequest,
+      @PhysicalTenantId final String physicalTenantId) {
     return tenantMapper
         .toTenantCreateDto(createTenantRequest)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::createTenant);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> createTenant(req, physicalTenantId));
   }
 
   @RequiresSecondaryStorage
   @CamundaGetMapping(path = "/{tenantId}")
-  public ResponseEntity<TenantResult> getTenant(@PathVariable final String tenantId) {
+  public ResponseEntity<TenantResult> getTenant(
+      @PathVariable final String tenantId, @PhysicalTenantId final String physicalTenantId) {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
       return ResponseEntity.ok()
           .body(
-              SearchQueryResponseMapper.toTenant(tenantServices.getById(tenantId, authentication)));
+              SearchQueryResponseMapper.toTenant(
+                  tenantServices.getById(tenantId, authentication, physicalTenantId)));
     } catch (final Exception exception) {
       return RestErrorMapper.mapErrorToResponse(exception);
     }
@@ -114,203 +120,241 @@ public class TenantController {
   @RequiresSecondaryStorage
   @CamundaPostMapping(path = "/search")
   public ResponseEntity<TenantSearchQueryResult> searchTenants(
-      @RequestBody(required = false) final TenantSearchQueryRequest query) {
+      @RequestBody(required = false) final TenantSearchQueryRequest query,
+      @PhysicalTenantId final String physicalTenantId) {
     return SearchQueryRequestMapper.toTenantQuery(query)
-        .fold(RestErrorMapper::mapProblemToResponse, this::search);
+        .fold(RestErrorMapper::mapProblemToResponse, q -> search(q, physicalTenantId));
   }
 
   @CamundaPutMapping(path = "/{tenantId}")
   public CompletableFuture<ResponseEntity<Object>> updateTenant(
       @PathVariable final String tenantId,
-      @RequestBody final TenantUpdateRequest tenantUpdateRequest) {
+      @RequestBody final TenantUpdateRequest tenantUpdateRequest,
+      @PhysicalTenantId final String physicalTenantId) {
     return tenantMapper
         .toTenantUpdateDto(tenantId, tenantUpdateRequest)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::updateTenant);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> updateTenant(req, physicalTenantId));
   }
 
   @CamundaPutMapping(path = "/{tenantId}/users/{username}")
   public CompletableFuture<ResponseEntity<Object>> assignUserToTenant(
-      @PathVariable final String tenantId, @PathVariable final String username) {
+      @PathVariable final String tenantId,
+      @PathVariable final String username,
+      @PhysicalTenantId final String physicalTenantId) {
     return tenantMapper
         .toTenantMemberRequest(tenantId, username, EntityType.USER)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::addMemberToTenant);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> addMemberToTenant(req, physicalTenantId));
   }
 
   @RequiresSecondaryStorage
   @CamundaPostMapping(path = "/{tenantId}/users/search")
   public ResponseEntity<TenantUserSearchResult> searchUsersInTenant(
       @PathVariable final String tenantId,
-      @RequestBody(required = false) final TenantUserSearchQueryRequest query) {
+      @RequestBody(required = false) final TenantUserSearchQueryRequest query,
+      @PhysicalTenantId final String physicalTenantId) {
     return SearchQueryRequestMapper.toTenantMemberQuery(query)
         .fold(
             RestErrorMapper::mapProblemToResponse,
-            tenantQuery -> searchUsersInTenant(tenantId, tenantQuery));
+            tenantQuery -> searchUsersInTenant(tenantId, tenantQuery, physicalTenantId));
   }
 
   @CamundaPutMapping(path = "/{tenantId}/clients/{clientId}")
   public CompletableFuture<ResponseEntity<Object>> assignClientToTenant(
-      @PathVariable final String tenantId, @PathVariable final String clientId) {
+      @PathVariable final String tenantId,
+      @PathVariable final String clientId,
+      @PhysicalTenantId final String physicalTenantId) {
     return tenantMapper
         .toTenantMemberRequest(tenantId, clientId, EntityType.CLIENT)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::addMemberToTenant);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> addMemberToTenant(req, physicalTenantId));
   }
 
   @CamundaPutMapping(path = "/{tenantId}/mapping-rules/{mappingRuleId}")
   public CompletableFuture<ResponseEntity<Object>> assignMappingRuleToTenant(
-      @PathVariable final String tenantId, @PathVariable final String mappingRuleId) {
+      @PathVariable final String tenantId,
+      @PathVariable final String mappingRuleId,
+      @PhysicalTenantId final String physicalTenantId) {
     return tenantMapper
         .toTenantMemberRequest(tenantId, mappingRuleId, EntityType.MAPPING_RULE)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::addMemberToTenant);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> addMemberToTenant(req, physicalTenantId));
   }
 
   @CamundaPutMapping(path = "/{tenantId}/groups/{groupId}")
   public CompletableFuture<ResponseEntity<Object>> assignGroupToTenant(
-      @PathVariable final String tenantId, @PathVariable final String groupId) {
+      @PathVariable final String tenantId,
+      @PathVariable final String groupId,
+      @PhysicalTenantId final String physicalTenantId) {
     return tenantMapper
         .toTenantMemberRequest(tenantId, groupId, EntityType.GROUP)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::addMemberToTenant);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> addMemberToTenant(req, physicalTenantId));
   }
 
   @CamundaPutMapping(path = "/{tenantId}/roles/{roleId}")
   public CompletableFuture<ResponseEntity<Object>> assignRoleToTenant(
-      @PathVariable final String tenantId, @PathVariable final String roleId) {
+      @PathVariable final String tenantId,
+      @PathVariable final String roleId,
+      @PhysicalTenantId final String physicalTenantId) {
     return tenantMapper
         .toTenantMemberRequest(tenantId, roleId, EntityType.ROLE)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::addMemberToTenant);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> addMemberToTenant(req, physicalTenantId));
   }
 
   @CamundaDeleteMapping(path = "/{tenantId}")
   public CompletableFuture<ResponseEntity<Object>> deleteTenant(
-      @PathVariable final String tenantId) {
+      @PathVariable final String tenantId, @PhysicalTenantId final String physicalTenantId) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethodWithNoContentResult(
-        () -> tenantServices.deleteTenant(tenantId, authentication));
+        () -> tenantServices.deleteTenant(tenantId, authentication, physicalTenantId));
   }
 
   @CamundaDeleteMapping(path = "/{tenantId}/users/{username}")
   public CompletableFuture<ResponseEntity<Object>> unassignUserFromTenant(
-      @PathVariable final String tenantId, @PathVariable final String username) {
+      @PathVariable final String tenantId,
+      @PathVariable final String username,
+      @PhysicalTenantId final String physicalTenantId) {
     return tenantMapper
         .toTenantMemberRequest(tenantId, username, EntityType.USER)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::removeMemberFromTenant);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> removeMemberFromTenant(req, physicalTenantId));
   }
 
   @CamundaDeleteMapping(path = "/{tenantId}/clients/{clientId}")
   public CompletableFuture<ResponseEntity<Object>> unassignClientFromTenant(
-      @PathVariable final String tenantId, @PathVariable final String clientId) {
+      @PathVariable final String tenantId,
+      @PathVariable final String clientId,
+      @PhysicalTenantId final String physicalTenantId) {
     return tenantMapper
         .toTenantMemberRequest(tenantId, clientId, EntityType.CLIENT)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::removeMemberFromTenant);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> removeMemberFromTenant(req, physicalTenantId));
   }
 
   @RequiresSecondaryStorage
   @CamundaPostMapping(path = "/{tenantId}/mapping-rules/search")
   public ResponseEntity<MappingRuleSearchQueryResult> searchMappingRulesForTenant(
       @PathVariable final String tenantId,
-      @RequestBody(required = false) final MappingRuleSearchQueryRequest query) {
+      @RequestBody(required = false) final MappingRuleSearchQueryRequest query,
+      @PhysicalTenantId final String physicalTenantId) {
     return SearchQueryRequestMapper.toMappingRuleQuery(query)
         .fold(
             RestErrorMapper::mapProblemToResponse,
-            mappingRuleQuery -> searchMappingRulesForTenant(tenantId, mappingRuleQuery));
+            mappingRuleQuery ->
+                searchMappingRulesForTenant(tenantId, mappingRuleQuery, physicalTenantId));
   }
 
   @CamundaDeleteMapping(path = "/{tenantId}/mapping-rules/{mappingRuleId}")
   public CompletableFuture<ResponseEntity<Object>> unassignMappingRuleFromTenant(
-      @PathVariable final String tenantId, @PathVariable final String mappingRuleId) {
+      @PathVariable final String tenantId,
+      @PathVariable final String mappingRuleId,
+      @PhysicalTenantId final String physicalTenantId) {
     return tenantMapper
         .toTenantMemberRequest(tenantId, mappingRuleId, EntityType.MAPPING_RULE)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::removeMemberFromTenant);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> removeMemberFromTenant(req, physicalTenantId));
   }
 
   @CamundaDeleteMapping(path = "/{tenantId}/groups/{groupId}")
   public CompletableFuture<ResponseEntity<Object>> unassignGroupFromTenant(
-      @PathVariable final String tenantId, @PathVariable final String groupId) {
+      @PathVariable final String tenantId,
+      @PathVariable final String groupId,
+      @PhysicalTenantId final String physicalTenantId) {
     return tenantMapper
         .toTenantMemberRequest(tenantId, groupId, EntityType.GROUP)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::removeMemberFromTenant);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> removeMemberFromTenant(req, physicalTenantId));
   }
 
   @CamundaDeleteMapping(path = "/{tenantId}/roles/{roleId}")
   public CompletableFuture<ResponseEntity<Object>> unassignRoleFromTenant(
-      @PathVariable final String tenantId, @PathVariable final String roleId) {
+      @PathVariable final String tenantId,
+      @PathVariable final String roleId,
+      @PhysicalTenantId final String physicalTenantId) {
     return tenantMapper
         .toTenantMemberRequest(tenantId, roleId, EntityType.ROLE)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::removeMemberFromTenant);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> removeMemberFromTenant(req, physicalTenantId));
   }
 
   @RequiresSecondaryStorage
   @CamundaPostMapping(path = "/{tenantId}/groups/search")
   public ResponseEntity<TenantGroupSearchResult> searchGroupIdsInTenant(
       @PathVariable final String tenantId,
-      @RequestBody(required = false) final TenantGroupSearchQueryRequest query) {
+      @RequestBody(required = false) final TenantGroupSearchQueryRequest query,
+      @PhysicalTenantId final String physicalTenantId) {
     return SearchQueryRequestMapper.toTenantMemberQuery(query)
         .fold(
             RestErrorMapper::mapProblemToResponse,
-            tenantQuery -> searchGroupIdsInTenant(tenantId, tenantQuery));
-  }
-
-  private ResponseEntity<TenantGroupSearchResult> searchGroupIdsInTenant(
-      final String tenantId, final TenantMemberQuery query) {
-    try {
-      final var authentication = authenticationProvider.getCamundaAuthentication();
-      final var result =
-          tenantServices.searchMembers(
-              buildTenantMemberQuery(tenantId, EntityType.GROUP, query), authentication);
-      return ResponseEntity.ok(SearchQueryResponseMapper.toTenantGroupSearchQueryResponse(result));
-    } catch (final Exception e) {
-      return mapErrorToResponse(e);
-    }
+            tenantQuery -> searchGroupIdsInTenant(tenantId, tenantQuery, physicalTenantId));
   }
 
   @RequiresSecondaryStorage
   @CamundaPostMapping(path = "/{tenantId}/roles/search")
   public ResponseEntity<RoleSearchQueryResult> searchRolesInTenant(
       @PathVariable final String tenantId,
-      @RequestBody(required = false) final RoleSearchQueryRequest query) {
+      @RequestBody(required = false) final RoleSearchQueryRequest query,
+      @PhysicalTenantId final String physicalTenantId) {
     return SearchQueryRequestMapper.toRoleQuery(query)
         .fold(
             RestErrorMapper::mapProblemToResponse,
-            roleQuery -> searchRolesInTenant(tenantId, roleQuery));
+            roleQuery -> searchRolesInTenant(tenantId, roleQuery, physicalTenantId));
   }
 
   @RequiresSecondaryStorage
   @CamundaPostMapping(path = "/{tenantId}/clients/search")
   public ResponseEntity<TenantClientSearchResult> searchClientsInTenant(
       @PathVariable final String tenantId,
-      @RequestBody(required = false) final TenantClientSearchQueryRequest query) {
+      @RequestBody(required = false) final TenantClientSearchQueryRequest query,
+      @PhysicalTenantId final String physicalTenantId) {
     return SearchQueryRequestMapper.toTenantMemberQuery(query)
         .fold(
             RestErrorMapper::mapProblemToResponse,
-            tenantQuery -> searchClientsInTenant(tenantId, tenantQuery));
+            tenantQuery -> searchClientsInTenant(tenantId, tenantQuery, physicalTenantId));
   }
 
   private CompletableFuture<ResponseEntity<Object>> createTenant(
-      final TenantRequest tenantRequest) {
+      final TenantRequest tenantRequest, final String physicalTenantId) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethod(
-        () -> tenantServices.createTenant(tenantRequest, authentication),
+        () -> tenantServices.createTenant(tenantRequest, authentication, physicalTenantId),
         ResponseMapper::toTenantCreateResponse,
         HttpStatus.CREATED);
   }
 
   private CompletableFuture<ResponseEntity<Object>> addMemberToTenant(
-      final TenantMemberRequest request) {
+      final TenantMemberRequest request, final String physicalTenantId) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethodWithNoContentResult(
-        () -> tenantServices.addMember(request, authentication));
+        () -> tenantServices.addMember(request, authentication, physicalTenantId));
   }
 
   private CompletableFuture<ResponseEntity<Object>> removeMemberFromTenant(
-      final TenantMemberRequest request) {
+      final TenantMemberRequest request, final String physicalTenantId) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethodWithNoContentResult(
-        () -> tenantServices.removeMember(request, authentication));
+        () -> tenantServices.removeMember(request, authentication, physicalTenantId));
   }
 
-  private ResponseEntity<TenantSearchQueryResult> search(final TenantQuery query) {
+  private ResponseEntity<TenantSearchQueryResult> search(
+      final TenantQuery query, final String physicalTenantId) {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
-      final var result = tenantServices.search(query, authentication);
+      final var result = tenantServices.search(query, authentication, physicalTenantId);
       return ResponseEntity.ok(SearchQueryResponseMapper.toTenantSearchQueryResponse(result));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
@@ -318,12 +362,16 @@ public class TenantController {
   }
 
   private ResponseEntity<TenantUserSearchResult> searchUsersInTenant(
-      final String tenantId, final TenantMemberQuery tenantMemberQuery) {
+      final String tenantId,
+      final TenantMemberQuery tenantMemberQuery,
+      final String physicalTenantId) {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
       final var result =
           tenantServices.searchMembers(
-              buildTenantMemberQuery(tenantId, EntityType.USER, tenantMemberQuery), authentication);
+              buildTenantMemberQuery(tenantId, EntityType.USER, tenantMemberQuery),
+              authentication,
+              physicalTenantId);
       return ResponseEntity.ok(SearchQueryResponseMapper.toTenantUserSearchQueryResponse(result));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
@@ -331,60 +379,56 @@ public class TenantController {
   }
 
   private ResponseEntity<TenantClientSearchResult> searchClientsInTenant(
-      final String tenantId, final TenantMemberQuery query) {
+      final String tenantId, final TenantMemberQuery query, final String physicalTenantId) {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
       final var result =
           tenantServices.searchMembers(
-              buildTenantMemberQuery(tenantId, EntityType.CLIENT, query), authentication);
+              buildTenantMemberQuery(tenantId, EntityType.CLIENT, query),
+              authentication,
+              physicalTenantId);
       return ResponseEntity.ok(SearchQueryResponseMapper.toTenantClientSearchQueryResponse(result));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }
   }
 
+  private ResponseEntity<TenantGroupSearchResult> searchGroupIdsInTenant(
+      final String tenantId, final TenantMemberQuery query, final String physicalTenantId) {
+    try {
+      final var authentication = authenticationProvider.getCamundaAuthentication();
+      final var result =
+          tenantServices.searchMembers(
+              buildTenantMemberQuery(tenantId, EntityType.GROUP, query),
+              authentication,
+              physicalTenantId);
+      return ResponseEntity.ok(SearchQueryResponseMapper.toTenantGroupSearchQueryResponse(result));
+    } catch (final Exception e) {
+      return mapErrorToResponse(e);
+    }
+  }
+
   private ResponseEntity<MappingRuleSearchQueryResult> searchMappingRulesForTenant(
-      final String tenantId, final MappingRuleQuery mappingRuleQuery) {
+      final String tenantId,
+      final MappingRuleQuery mappingRuleQuery,
+      final String physicalTenantId) {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
       final var composedMappingRuleQuery = buildMappingRuleQuery(tenantId, mappingRuleQuery);
-      final var result = mappingRuleServices.search(composedMappingRuleQuery, authentication);
+      final var result =
+          mappingRuleServices.search(composedMappingRuleQuery, authentication, physicalTenantId);
       return ResponseEntity.ok(SearchQueryResponseMapper.toMappingRuleSearchQueryResponse(result));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }
   }
 
-  private ResponseEntity<UserSearchResult> searchUsersInTenant(
-      final String tenantId, final UserQuery userQuery) {
-    try {
-      final var authentication = authenticationProvider.getCamundaAuthentication();
-      final var composedUserQuery = buildUserQuery(tenantId, userQuery);
-      final var result = userServices.search(composedUserQuery, authentication);
-      return ResponseEntity.ok(SearchQueryResponseMapper.toUserSearchQueryResponse(result));
-    } catch (final Exception e) {
-      return mapErrorToResponse(e);
-    }
-  }
-
-  private ResponseEntity<GroupSearchQueryResult> searchGroupsInTenant(
-      final String tenantId, final GroupQuery groupQuery) {
-    try {
-      final var authentication = authenticationProvider.getCamundaAuthentication();
-      final var composedGroupQuery = buildGroupQuery(tenantId, groupQuery);
-      final var result = groupServices.search(composedGroupQuery, authentication);
-      return ResponseEntity.ok(SearchQueryResponseMapper.toGroupSearchQueryResponse(result));
-    } catch (final Exception e) {
-      return mapErrorToResponse(e);
-    }
-  }
-
   private ResponseEntity<RoleSearchQueryResult> searchRolesInTenant(
-      final String tenantId, final RoleQuery roleQuery) {
+      final String tenantId, final RoleQuery roleQuery, final String physicalTenantId) {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
       final var composedRoleQuery = buildRoleQuery(tenantId, roleQuery);
-      final var result = roleServices.search(composedRoleQuery, authentication);
+      final var result = roleServices.search(composedRoleQuery, authentication, physicalTenantId);
       return ResponseEntity.ok(SearchQueryResponseMapper.toRoleSearchQueryResponse(result));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
@@ -424,10 +468,10 @@ public class TenantController {
   }
 
   private CompletableFuture<ResponseEntity<Object>> updateTenant(
-      final TenantRequest tenantRequest) {
+      final TenantRequest tenantRequest, final String physicalTenantId) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethod(
-        () -> tenantServices.updateTenant(tenantRequest, authentication),
+        () -> tenantServices.updateTenant(tenantRequest, authentication, physicalTenantId),
         ResponseMapper::toTenantUpdateResponse,
         HttpStatus.OK);
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationController.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.gateway.rest.annotation.CamundaDeleteMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPutMapping;
+import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
 import io.camunda.zeebe.gateway.rest.controller.CamundaRestController;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
@@ -59,21 +60,24 @@ public class AuthorizationController {
 
   @CamundaPostMapping()
   public CompletableFuture<ResponseEntity<Object>> createAuthorization(
-      @RequestBody final AuthorizationRequest authorizationCreateRequest) {
+      @RequestBody final AuthorizationRequest authorizationCreateRequest,
+      @PhysicalTenantId final String physicalTenantId) {
     return authorizationMapper
         .toCreateAuthorizationRequest(authorizationCreateRequest)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::create);
+        .fold(RestErrorMapper::mapProblemToCompletedResponse, req -> create(req, physicalTenantId));
   }
 
   @RequiresSecondaryStorage
   @CamundaGetMapping(path = "/{authorizationKey}")
-  public ResponseEntity<Object> getAuthorization(@PathVariable final long authorizationKey) {
+  public ResponseEntity<Object> getAuthorization(
+      @PathVariable final long authorizationKey, @PhysicalTenantId final String physicalTenantId) {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
       return ResponseEntity.ok()
           .body(
               SearchQueryResponseMapper.toAuthorization(
-                  authorizationServices.getAuthorization(authorizationKey, authentication)));
+                  authorizationServices.getAuthorization(
+                      authorizationKey, authentication, physicalTenantId)));
     } catch (final Exception exception) {
       return RestErrorMapper.mapErrorToResponse(exception);
     }
@@ -81,33 +85,38 @@ public class AuthorizationController {
 
   @CamundaDeleteMapping(path = "/{authorizationKey}")
   public CompletableFuture<ResponseEntity<Object>> delete(
-      @PathVariable final long authorizationKey) {
+      @PathVariable final long authorizationKey, @PhysicalTenantId final String physicalTenantId) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethodWithNoContentResult(
-        () -> authorizationServices.deleteAuthorization(authorizationKey, authentication));
+        () ->
+            authorizationServices.deleteAuthorization(
+                authorizationKey, authentication, physicalTenantId));
   }
 
   @CamundaPutMapping(path = "/{authorizationKey}")
   public CompletableFuture<ResponseEntity<Object>> updateAuthorization(
       @PathVariable final long authorizationKey,
-      @RequestBody final AuthorizationRequest authorizationUpdateRequest) {
+      @RequestBody final AuthorizationRequest authorizationUpdateRequest,
+      @PhysicalTenantId final String physicalTenantId) {
     return authorizationMapper
         .toUpdateAuthorizationRequest(authorizationKey, authorizationUpdateRequest)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::update);
+        .fold(RestErrorMapper::mapProblemToCompletedResponse, req -> update(req, physicalTenantId));
   }
 
   @RequiresSecondaryStorage
   @CamundaPostMapping(path = "/search")
   public ResponseEntity<AuthorizationSearchResult> searchAuthorizations(
-      @RequestBody(required = false) final AuthorizationSearchQuery query) {
+      @RequestBody(required = false) final AuthorizationSearchQuery query,
+      @PhysicalTenantId final String physicalTenantId) {
     return SearchQueryRequestMapper.toAuthorizationQuery(query)
-        .fold(RestErrorMapper::mapProblemToResponse, this::search);
+        .fold(RestErrorMapper::mapProblemToResponse, q -> search(q, physicalTenantId));
   }
 
-  private ResponseEntity<AuthorizationSearchResult> search(final AuthorizationQuery query) {
+  private ResponseEntity<AuthorizationSearchResult> search(
+      final AuthorizationQuery query, final String physicalTenantId) {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
-      final var result = authorizationServices.search(query, authentication);
+      final var result = authorizationServices.search(query, authentication, physicalTenantId);
       return ResponseEntity.ok(
           SearchQueryResponseMapper.toAuthorizationSearchQueryResponse(result));
     } catch (final Exception e) {
@@ -116,18 +125,22 @@ public class AuthorizationController {
   }
 
   private CompletableFuture<ResponseEntity<Object>> create(
-      final CreateAuthorizationRequest createAuthorizationRequest) {
+      final CreateAuthorizationRequest createAuthorizationRequest, final String physicalTenantId) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethod(
-        () -> authorizationServices.createAuthorization(createAuthorizationRequest, authentication),
+        () ->
+            authorizationServices.createAuthorization(
+                createAuthorizationRequest, authentication, physicalTenantId),
         ResponseMapper::toAuthorizationCreateResponse,
         HttpStatus.CREATED);
   }
 
   private CompletableFuture<ResponseEntity<Object>> update(
-      final UpdateAuthorizationRequest authorizationRequest) {
+      final UpdateAuthorizationRequest authorizationRequest, final String physicalTenantId) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethodWithNoContentResult(
-        () -> authorizationServices.updateAuthorization(authorizationRequest, authentication));
+        () ->
+            authorizationServices.updateAuthorization(
+                authorizationRequest, authentication, physicalTenantId));
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupController.java
@@ -45,6 +45,7 @@ import io.camunda.zeebe.gateway.rest.annotation.CamundaDeleteMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPutMapping;
+import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
 import io.camunda.zeebe.gateway.rest.controller.CamundaRestController;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
@@ -83,127 +84,165 @@ public class GroupController {
 
   @CamundaPostMapping
   public CompletableFuture<ResponseEntity<Object>> createGroup(
-      @RequestBody final GroupCreateRequest createGroupRequest) {
+      @RequestBody final GroupCreateRequest createGroupRequest,
+      @PhysicalTenantId final String physicalTenantId) {
     return groupMapper
         .toGroupCreateRequest(createGroupRequest)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::createGroup);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> createGroup(req, physicalTenantId));
   }
 
   @CamundaPutMapping(path = "/{groupId}")
   public CompletableFuture<ResponseEntity<Object>> updateGroup(
       @PathVariable final String groupId,
-      @RequestBody final GroupUpdateRequest groupUpdateRequest) {
+      @RequestBody final GroupUpdateRequest groupUpdateRequest,
+      @PhysicalTenantId final String physicalTenantId) {
     return groupMapper
         .toGroupUpdateRequest(groupUpdateRequest, groupId)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::updateGroup);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> updateGroup(req, physicalTenantId));
   }
 
   @CamundaDeleteMapping(path = "/{groupId}")
-  public CompletableFuture<ResponseEntity<Object>> deleteGroup(@PathVariable final String groupId) {
+  public CompletableFuture<ResponseEntity<Object>> deleteGroup(
+      @PathVariable final String groupId, @PhysicalTenantId final String physicalTenantId) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethodWithNoContentResult(
-        () -> groupServices.deleteGroup(groupId, authentication));
+        () -> groupServices.deleteGroup(groupId, authentication, physicalTenantId));
   }
 
   @CamundaPutMapping(path = "/{groupId}/users/{username}")
   public CompletableFuture<ResponseEntity<Object>> assignUserToGroup(
-      @PathVariable final String groupId, @PathVariable final String username) {
+      @PathVariable final String groupId,
+      @PathVariable final String username,
+      @PhysicalTenantId final String physicalTenantId) {
     return groupMapper
         .toGroupMemberRequest(groupId, username, EntityType.USER)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::assignMember);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> assignMember(req, physicalTenantId));
   }
 
   @CamundaPutMapping(path = "/{groupId}/clients/{clientId}")
   public CompletableFuture<ResponseEntity<Object>> assignClientToGroup(
-      @PathVariable final String groupId, @PathVariable final String clientId) {
+      @PathVariable final String groupId,
+      @PathVariable final String clientId,
+      @PhysicalTenantId final String physicalTenantId) {
     return groupMapper
         .toGroupMemberRequest(groupId, clientId, EntityType.CLIENT)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::assignMember);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> assignMember(req, physicalTenantId));
   }
 
   @CamundaPutMapping(path = "/{groupId}/mapping-rules/{mappingRuleId}")
   public CompletableFuture<ResponseEntity<Object>> assignMappingRuleToGroup(
-      @PathVariable final String groupId, @PathVariable final String mappingRuleId) {
+      @PathVariable final String groupId,
+      @PathVariable final String mappingRuleId,
+      @PhysicalTenantId final String physicalTenantId) {
     return groupMapper
         .toGroupMemberRequest(groupId, mappingRuleId, EntityType.MAPPING_RULE)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::assignMember);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> assignMember(req, physicalTenantId));
   }
 
   @CamundaDeleteMapping(path = "/{groupId}/users/{username}")
   public CompletableFuture<ResponseEntity<Object>> unassignUserFromGroup(
-      @PathVariable final String groupId, @PathVariable final String username) {
+      @PathVariable final String groupId,
+      @PathVariable final String username,
+      @PhysicalTenantId final String physicalTenantId) {
     return groupMapper
         .toGroupMemberRequest(groupId, username, EntityType.USER)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::unassignMember);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> unassignMember(req, physicalTenantId));
   }
 
   @CamundaDeleteMapping(path = "/{groupId}/clients/{clientId}")
   public CompletableFuture<ResponseEntity<Object>> unassignClientFromGroup(
-      @PathVariable final String groupId, @PathVariable final String clientId) {
+      @PathVariable final String groupId,
+      @PathVariable final String clientId,
+      @PhysicalTenantId final String physicalTenantId) {
     return groupMapper
         .toGroupMemberRequest(groupId, clientId, EntityType.CLIENT)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::unassignMember);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> unassignMember(req, physicalTenantId));
   }
 
   @CamundaDeleteMapping(path = "/{groupId}/mapping-rules/{mappingRuleId}")
   public CompletableFuture<ResponseEntity<Object>> unassignMappingRuleFromGroup(
-      @PathVariable final String groupId, @PathVariable final String mappingRuleId) {
+      @PathVariable final String groupId,
+      @PathVariable final String mappingRuleId,
+      @PhysicalTenantId final String physicalTenantId) {
     return groupMapper
         .toGroupMemberRequest(groupId, mappingRuleId, EntityType.MAPPING_RULE)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::unassignMember);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> unassignMember(req, physicalTenantId));
   }
 
   @RequiresSecondaryStorage
   @CamundaPostMapping(path = "/{groupId}/users/search")
   public ResponseEntity<GroupUserSearchResult> usersByGroup(
       @PathVariable final String groupId,
-      @RequestBody(required = false) final GroupUserSearchQueryRequest query) {
+      @RequestBody(required = false) final GroupUserSearchQueryRequest query,
+      @PhysicalTenantId final String physicalTenantId) {
     return SearchQueryRequestMapper.toGroupMemberQuery(query)
         .fold(
             RestErrorMapper::mapProblemToResponse,
-            groupQuery -> searchUsersInGroup(groupId, groupQuery));
+            groupQuery -> searchUsersInGroup(groupId, groupQuery, physicalTenantId));
   }
 
   @RequiresSecondaryStorage
   @CamundaPostMapping(path = "/{groupId}/mapping-rules/search")
   public ResponseEntity<MappingRuleSearchQueryResult> mappingRulesByGroup(
       @PathVariable final String groupId,
-      @RequestBody(required = false) final MappingRuleSearchQueryRequest query) {
+      @RequestBody(required = false) final MappingRuleSearchQueryRequest query,
+      @PhysicalTenantId final String physicalTenantId) {
     return SearchQueryRequestMapper.toMappingRuleQuery(query)
         .fold(
             RestErrorMapper::mapProblemToResponse,
-            mappingRuleQuery -> searchMappingsInGroup(groupId, mappingRuleQuery));
+            mappingRuleQuery -> searchMappingsInGroup(groupId, mappingRuleQuery, physicalTenantId));
   }
 
   @RequiresSecondaryStorage
   @CamundaPostMapping(path = "/{groupId}/roles/search")
   public ResponseEntity<RoleSearchQueryResult> rolesByGroup(
       @PathVariable final String groupId,
-      @RequestBody(required = false) final RoleSearchQueryRequest query) {
+      @RequestBody(required = false) final RoleSearchQueryRequest query,
+      @PhysicalTenantId final String physicalTenantId) {
     return SearchQueryRequestMapper.toRoleQuery(query)
         .fold(
             RestErrorMapper::mapProblemToResponse,
-            userQuery -> searchRolesInGroup(groupId, userQuery));
+            userQuery -> searchRolesInGroup(groupId, userQuery, physicalTenantId));
   }
 
   @RequiresSecondaryStorage
   @CamundaPostMapping(path = "/{groupId}/clients/search")
   public ResponseEntity<GroupClientSearchResult> clientsByGroup(
       @PathVariable final String groupId,
-      @RequestBody(required = false) final GroupClientSearchQueryRequest query) {
+      @RequestBody(required = false) final GroupClientSearchQueryRequest query,
+      @PhysicalTenantId final String physicalTenantId) {
     return SearchQueryRequestMapper.toGroupMemberQuery(query)
         .fold(
             RestErrorMapper::mapProblemToResponse,
-            groupMemberQuery -> searchClientsInGroup(groupId, groupMemberQuery));
+            groupMemberQuery -> searchClientsInGroup(groupId, groupMemberQuery, physicalTenantId));
   }
 
   @RequiresSecondaryStorage
   @CamundaGetMapping(path = "/{groupId}")
-  public ResponseEntity<Object> getGroup(@PathVariable final String groupId) {
+  public ResponseEntity<Object> getGroup(
+      @PathVariable final String groupId, @PhysicalTenantId final String physicalTenantId) {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
       return ResponseEntity.ok()
-          .body(SearchQueryResponseMapper.toGroup(groupServices.getGroup(groupId, authentication)));
+          .body(
+              SearchQueryResponseMapper.toGroup(
+                  groupServices.getGroup(groupId, authentication, physicalTenantId)));
     } catch (final Exception exception) {
       return RestErrorMapper.mapErrorToResponse(exception);
     }
@@ -212,30 +251,34 @@ public class GroupController {
   @RequiresSecondaryStorage
   @CamundaPostMapping(path = "/search")
   public ResponseEntity<GroupSearchQueryResult> searchGroups(
-      @RequestBody(required = false) final GroupSearchQueryRequest query) {
+      @RequestBody(required = false) final GroupSearchQueryRequest query,
+      @PhysicalTenantId final String physicalTenantId) {
     return SearchQueryRequestMapper.toGroupQuery(query)
-        .fold(RestErrorMapper::mapProblemToResponse, this::search);
+        .fold(RestErrorMapper::mapProblemToResponse, q -> search(q, physicalTenantId));
   }
 
-  private ResponseEntity<GroupSearchQueryResult> search(final GroupQuery query) {
+  private ResponseEntity<GroupSearchQueryResult> search(
+      final GroupQuery query, final String physicalTenantId) {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
-      final var result = groupServices.search(query, authentication);
+      final var result = groupServices.search(query, authentication, physicalTenantId);
       return ResponseEntity.ok(SearchQueryResponseMapper.toGroupSearchQueryResponse(result));
     } catch (final Exception e) {
       return RestErrorMapper.mapErrorToResponse(e);
     }
   }
 
-  private CompletableFuture<ResponseEntity<Object>> createGroup(final GroupDTO groupDTO) {
+  private CompletableFuture<ResponseEntity<Object>> createGroup(
+      final GroupDTO groupDTO, final String physicalTenantId) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethod(
-        () -> groupServices.createGroup(groupDTO, authentication),
+        () -> groupServices.createGroup(groupDTO, authentication, physicalTenantId),
         ResponseMapper::toGroupCreateResponse,
         HttpStatus.CREATED);
   }
 
-  public CompletableFuture<ResponseEntity<Object>> updateGroup(final GroupDTO updateGroupRequest) {
+  public CompletableFuture<ResponseEntity<Object>> updateGroup(
+      final GroupDTO updateGroupRequest, final String physicalTenantId) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethod(
         () ->
@@ -243,24 +286,30 @@ public class GroupController {
                 updateGroupRequest.groupId(),
                 updateGroupRequest.name(),
                 updateGroupRequest.description(),
-                authentication),
+                authentication,
+                physicalTenantId),
         ResponseMapper::toGroupUpdateResponse,
         HttpStatus.OK);
   }
 
-  public CompletableFuture<ResponseEntity<Object>> assignMember(final GroupMemberDTO request) {
+  public CompletableFuture<ResponseEntity<Object>> assignMember(
+      final GroupMemberDTO request, final String physicalTenantId) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethodWithNoContentResult(
-        () -> groupServices.assignMember(request, authentication));
+        () -> groupServices.assignMember(request, authentication, physicalTenantId));
   }
 
   private ResponseEntity<GroupUserSearchResult> searchUsersInGroup(
-      final String groupId, final GroupMemberQuery groupMemberQuery) {
+      final String groupId,
+      final GroupMemberQuery groupMemberQuery,
+      final String physicalTenantId) {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
       final var result =
           groupServices.searchMembers(
-              buildGroupMemberQuery(groupId, EntityType.USER, groupMemberQuery), authentication);
+              buildGroupMemberQuery(groupId, EntityType.USER, groupMemberQuery),
+              authentication,
+              physicalTenantId);
       return ResponseEntity.ok(SearchQueryResponseMapper.toGroupUserSearchQueryResponse(result));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
@@ -268,12 +317,16 @@ public class GroupController {
   }
 
   private ResponseEntity<GroupClientSearchResult> searchClientsInGroup(
-      final String groupId, final GroupMemberQuery groupMemberQuery) {
+      final String groupId,
+      final GroupMemberQuery groupMemberQuery,
+      final String physicalTenantId) {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
       final var result =
           groupServices.searchMembers(
-              buildGroupMemberQuery(groupId, EntityType.CLIENT, groupMemberQuery), authentication);
+              buildGroupMemberQuery(groupId, EntityType.CLIENT, groupMemberQuery),
+              authentication,
+              physicalTenantId);
       return ResponseEntity.ok(SearchQueryResponseMapper.toGroupClientSearchQueryResponse(result));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
@@ -281,11 +334,14 @@ public class GroupController {
   }
 
   private ResponseEntity<MappingRuleSearchQueryResult> searchMappingsInGroup(
-      final String groupId, final MappingRuleQuery mappingRuleQuery) {
+      final String groupId,
+      final MappingRuleQuery mappingRuleQuery,
+      final String physicalTenantId) {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
       final var composedMappingQuery = buildMappingQuery(groupId, mappingRuleQuery);
-      final var result = mappingRuleServices.search(composedMappingQuery, authentication);
+      final var result =
+          mappingRuleServices.search(composedMappingQuery, authentication, physicalTenantId);
       return ResponseEntity.ok(SearchQueryResponseMapper.toMappingRuleSearchQueryResponse(result));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
@@ -293,11 +349,11 @@ public class GroupController {
   }
 
   private ResponseEntity<RoleSearchQueryResult> searchRolesInGroup(
-      final String groupId, final RoleQuery roleQuery) {
+      final String groupId, final RoleQuery roleQuery, final String physicalTenantId) {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
       final var composedRoleQuery = buildRoleQuery(groupId, roleQuery);
-      final var result = roleServices.search(composedRoleQuery, authentication);
+      final var result = roleServices.search(composedRoleQuery, authentication, physicalTenantId);
       return ResponseEntity.ok(SearchQueryResponseMapper.toRoleSearchQueryResponse(result));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
@@ -325,9 +381,10 @@ public class GroupController {
         .build();
   }
 
-  public CompletableFuture<ResponseEntity<Object>> unassignMember(final GroupMemberDTO request) {
+  public CompletableFuture<ResponseEntity<Object>> unassignMember(
+      final GroupMemberDTO request, final String physicalTenantId) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethodWithNoContentResult(
-        () -> groupServices.removeMember(request, authentication));
+        () -> groupServices.removeMember(request, authentication, physicalTenantId));
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingRuleController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingRuleController.java
@@ -29,6 +29,7 @@ import io.camunda.zeebe.gateway.rest.annotation.CamundaDeleteMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPutMapping;
+import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
 import io.camunda.zeebe.gateway.rest.controller.CamundaRestController;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
@@ -60,39 +61,47 @@ public class MappingRuleController {
 
   @CamundaPostMapping
   public CompletableFuture<ResponseEntity<Object>> create(
-      @RequestBody final MappingRuleCreateRequest mappingRuleRequest) {
+      @RequestBody final MappingRuleCreateRequest mappingRuleRequest,
+      @PhysicalTenantId final String physicalTenantId) {
     return mappingRuleMapper
         .toMappingRuleCreateRequest(mappingRuleRequest)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::createMappingRule);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> createMappingRule(req, physicalTenantId));
   }
 
   @CamundaPutMapping(path = "/{mappingRuleId}")
   public CompletableFuture<ResponseEntity<Object>> update(
       @PathVariable final String mappingRuleId,
-      @RequestBody final MappingRuleUpdateRequest mappingRuleRequest) {
+      @RequestBody final MappingRuleUpdateRequest mappingRuleRequest,
+      @PhysicalTenantId final String physicalTenantId) {
     return mappingRuleMapper
         .toMappingRuleUpdateRequest(mappingRuleId, mappingRuleRequest)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::updateMappingRule);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> updateMappingRule(req, physicalTenantId));
   }
 
   @CamundaDeleteMapping(path = "/{mappingRuleId}")
   public CompletableFuture<ResponseEntity<Object>> deleteMappingRule(
-      @PathVariable final String mappingRuleId) {
+      @PathVariable final String mappingRuleId, @PhysicalTenantId final String physicalTenantId) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethodWithNoContentResult(
-        () -> mappingRuleServices.deleteMappingRule(mappingRuleId, authentication));
+        () ->
+            mappingRuleServices.deleteMappingRule(mappingRuleId, authentication, physicalTenantId));
   }
 
   @RequiresSecondaryStorage
   @CamundaGetMapping(path = "/{mappingRuleId}")
   public ResponseEntity<MappingRuleResult> getMappingRule(
-      @PathVariable final String mappingRuleId) {
+      @PathVariable final String mappingRuleId, @PhysicalTenantId final String physicalTenantId) {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
       return ResponseEntity.ok()
           .body(
               SearchQueryResponseMapper.toMappingRule(
-                  mappingRuleServices.getMappingRule(mappingRuleId, authentication)));
+                  mappingRuleServices.getMappingRule(
+                      mappingRuleId, authentication, physicalTenantId)));
     } catch (final Exception exception) {
       return RestErrorMapper.mapErrorToResponse(exception);
     }
@@ -101,33 +110,35 @@ public class MappingRuleController {
   @RequiresSecondaryStorage
   @CamundaPostMapping(path = "/search")
   public ResponseEntity<MappingRuleSearchQueryResult> searchMappingRules(
-      @RequestBody(required = false) final MappingRuleSearchQueryRequest query) {
+      @RequestBody(required = false) final MappingRuleSearchQueryRequest query,
+      @PhysicalTenantId final String physicalTenantId) {
     return SearchQueryRequestMapper.toMappingRuleQuery(query)
-        .fold(RestErrorMapper::mapProblemToResponse, this::search);
+        .fold(RestErrorMapper::mapProblemToResponse, q -> search(q, physicalTenantId));
   }
 
   private CompletableFuture<ResponseEntity<Object>> createMappingRule(
-      final MappingRuleDTO request) {
+      final MappingRuleDTO request, final String physicalTenantId) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethod(
-        () -> mappingRuleServices.createMappingRule(request, authentication),
+        () -> mappingRuleServices.createMappingRule(request, authentication, physicalTenantId),
         ResponseMapper::toMappingRuleCreateResponse,
         HttpStatus.CREATED);
   }
 
   private CompletableFuture<ResponseEntity<Object>> updateMappingRule(
-      final MappingRuleDTO request) {
+      final MappingRuleDTO request, final String physicalTenantId) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethod(
-        () -> mappingRuleServices.updateMappingRule(request, authentication),
+        () -> mappingRuleServices.updateMappingRule(request, authentication, physicalTenantId),
         ResponseMapper::toMappingRuleUpdateResponse,
         HttpStatus.OK);
   }
 
-  private ResponseEntity<MappingRuleSearchQueryResult> search(final MappingRuleQuery query) {
+  private ResponseEntity<MappingRuleSearchQueryResult> search(
+      final MappingRuleQuery query, final String physicalTenantId) {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
-      final var result = mappingRuleServices.search(query, authentication);
+      final var result = mappingRuleServices.search(query, authentication, physicalTenantId);
       return ResponseEntity.ok(SearchQueryResponseMapper.toMappingRuleSearchQueryResponse(result));
     } catch (final Exception e) {
       return mapErrorToResponse(e);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
@@ -42,6 +42,7 @@ import io.camunda.zeebe.gateway.rest.annotation.CamundaDeleteMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPutMapping;
+import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
 import io.camunda.zeebe.gateway.rest.controller.CamundaRestController;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
@@ -74,52 +75,63 @@ public class RoleController {
 
   @CamundaPostMapping
   public CompletableFuture<ResponseEntity<Object>> createRole(
-      @RequestBody final RoleCreateRequest createRoleRequest) {
+      @RequestBody final RoleCreateRequest createRoleRequest,
+      @PhysicalTenantId final String physicalTenantId) {
     return roleMapper
         .toRoleCreateRequest(createRoleRequest)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::createRole);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> createRole(req, physicalTenantId));
   }
 
   private CompletableFuture<ResponseEntity<Object>> createRole(
-      final CreateRoleRequest createRoleRequest) {
+      final CreateRoleRequest createRoleRequest, final String physicalTenantId) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethod(
-        () -> roleServices.createRole(createRoleRequest, authentication),
+        () -> roleServices.createRole(createRoleRequest, authentication, physicalTenantId),
         ResponseMapper::toRoleCreateResponse,
         HttpStatus.CREATED);
   }
 
   @CamundaPutMapping(path = "/{roleId}")
   public CompletableFuture<ResponseEntity<Object>> updateRole(
-      @PathVariable final String roleId, @RequestBody final RoleUpdateRequest roleUpdateRequest) {
+      @PathVariable final String roleId,
+      @RequestBody final RoleUpdateRequest roleUpdateRequest,
+      @PhysicalTenantId final String physicalTenantId) {
     return roleMapper
         .toRoleUpdateRequest(roleUpdateRequest, roleId)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::updateRole);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> updateRole(req, physicalTenantId));
   }
 
   public CompletableFuture<ResponseEntity<Object>> updateRole(
-      final UpdateRoleRequest updateRoleRequest) {
+      final UpdateRoleRequest updateRoleRequest, final String physicalTenantId) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethod(
-        () -> roleServices.updateRole(updateRoleRequest, authentication),
+        () -> roleServices.updateRole(updateRoleRequest, authentication, physicalTenantId),
         ResponseMapper::toRoleUpdateResponse,
         HttpStatus.OK);
   }
 
   @CamundaDeleteMapping(path = "/{roleId}")
-  public CompletableFuture<ResponseEntity<Object>> deleteRole(@PathVariable final String roleId) {
+  public CompletableFuture<ResponseEntity<Object>> deleteRole(
+      @PathVariable final String roleId, @PhysicalTenantId final String physicalTenantId) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethodWithNoContentResult(
-        () -> roleServices.deleteRole(roleId, authentication));
+        () -> roleServices.deleteRole(roleId, authentication, physicalTenantId));
   }
 
   @RequiresSecondaryStorage
   @CamundaGetMapping(path = "/{roleId}")
-  public ResponseEntity<Object> getRole(@PathVariable final String roleId) {
+  public ResponseEntity<Object> getRole(
+      @PathVariable final String roleId, @PhysicalTenantId final String physicalTenantId) {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
       return ResponseEntity.ok()
-          .body(SearchQueryResponseMapper.toRole(roleServices.getRole(roleId, authentication)));
+          .body(
+              SearchQueryResponseMapper.toRole(
+                  roleServices.getRole(roleId, authentication, physicalTenantId)));
     } catch (final Exception exception) {
       return RestErrorMapper.mapErrorToResponse(exception);
     }
@@ -128,15 +140,17 @@ public class RoleController {
   @RequiresSecondaryStorage
   @CamundaPostMapping(path = "/search")
   public ResponseEntity<RoleSearchQueryResult> searchRoles(
-      @RequestBody(required = false) final RoleSearchQueryRequest query) {
+      @RequestBody(required = false) final RoleSearchQueryRequest query,
+      @PhysicalTenantId final String physicalTenantId) {
     return SearchQueryRequestMapper.toRoleQuery(query)
-        .fold(RestErrorMapper::mapProblemToResponse, this::search);
+        .fold(RestErrorMapper::mapProblemToResponse, q -> search(q, physicalTenantId));
   }
 
-  private ResponseEntity<RoleSearchQueryResult> search(final RoleQuery query) {
+  private ResponseEntity<RoleSearchQueryResult> search(
+      final RoleQuery query, final String physicalTenantId) {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
-      final var result = roleServices.search(query, authentication);
+      final var result = roleServices.search(query, authentication, physicalTenantId);
       return ResponseEntity.ok(SearchQueryResponseMapper.toRoleSearchQueryResponse(result));
     } catch (final Exception e) {
       return RestErrorMapper.mapErrorToResponse(e);
@@ -147,20 +161,23 @@ public class RoleController {
   @CamundaPostMapping(path = "/{roleId}/users/search")
   public ResponseEntity<RoleUserSearchResult> searchUsersByRole(
       @PathVariable final String roleId,
-      @RequestBody(required = false) final RoleUserSearchQueryRequest query) {
+      @RequestBody(required = false) final RoleUserSearchQueryRequest query,
+      @PhysicalTenantId final String physicalTenantId) {
     return SearchQueryRequestMapper.toRoleMemberQuery(query)
         .fold(
             RestErrorMapper::mapProblemToResponse,
-            userQuery -> searchUsersInRole(roleId, userQuery));
+            userQuery -> searchUsersInRole(roleId, userQuery, physicalTenantId));
   }
 
   private ResponseEntity<RoleUserSearchResult> searchUsersInRole(
-      final String roleId, final RoleMemberQuery query) {
+      final String roleId, final RoleMemberQuery query, final String physicalTenantId) {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
       final var result =
           roleServices.searchMembers(
-              buildRoleMemberQuery(roleId, EntityType.USER, query), authentication);
+              buildRoleMemberQuery(roleId, EntityType.USER, query),
+              authentication,
+              physicalTenantId);
       return ResponseEntity.ok(SearchQueryResponseMapper.toRoleUserSearchQueryResponse(result));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
@@ -171,20 +188,23 @@ public class RoleController {
   @CamundaPostMapping(path = "/{roleId}/clients/search")
   public ResponseEntity<RoleClientSearchResult> searchClientsByRole(
       @PathVariable final String roleId,
-      @RequestBody(required = false) final RoleClientSearchQueryRequest query) {
+      @RequestBody(required = false) final RoleClientSearchQueryRequest query,
+      @PhysicalTenantId final String physicalTenantId) {
     return SearchQueryRequestMapper.toRoleMemberQuery(query)
         .fold(
             RestErrorMapper::mapProblemToResponse,
-            roleQuery -> searchClientsInRole(roleId, roleQuery));
+            roleQuery -> searchClientsInRole(roleId, roleQuery, physicalTenantId));
   }
 
   private ResponseEntity<RoleClientSearchResult> searchClientsInRole(
-      final String tenantId, final RoleMemberQuery query) {
+      final String tenantId, final RoleMemberQuery query, final String physicalTenantId) {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
       final var result =
           roleServices.searchMembers(
-              buildRoleMemberQuery(tenantId, EntityType.CLIENT, query), authentication);
+              buildRoleMemberQuery(tenantId, EntityType.CLIENT, query),
+              authentication,
+              physicalTenantId);
       return ResponseEntity.ok(SearchQueryResponseMapper.toRoleClientSearchQueryResponse(result));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
@@ -202,19 +222,21 @@ public class RoleController {
   @CamundaPostMapping(path = "/{roleId}/mapping-rules/search")
   public ResponseEntity<MappingRuleSearchQueryResult> searchMappingRulesByRole(
       @PathVariable final String roleId,
-      @RequestBody(required = false) final MappingRuleSearchQueryRequest query) {
+      @RequestBody(required = false) final MappingRuleSearchQueryRequest query,
+      @PhysicalTenantId final String physicalTenantId) {
     return SearchQueryRequestMapper.toMappingRuleQuery(query)
         .fold(
             RestErrorMapper::mapProblemToResponse,
-            mappingQuery -> searchMappingRulesInRole(roleId, mappingQuery));
+            mappingQuery -> searchMappingRulesInRole(roleId, mappingQuery, physicalTenantId));
   }
 
   private ResponseEntity<MappingRuleSearchQueryResult> searchMappingRulesInRole(
-      final String roleId, final MappingRuleQuery mappingRuleQuery) {
+      final String roleId, final MappingRuleQuery mappingRuleQuery, final String physicalTenantId) {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
       final var composedMappingQuery = buildMappingQuery(roleId, mappingRuleQuery);
-      final var result = mappingServices.search(composedMappingQuery, authentication);
+      final var result =
+          mappingServices.search(composedMappingQuery, authentication, physicalTenantId);
       return ResponseEntity.ok(SearchQueryResponseMapper.toMappingRuleSearchQueryResponse(result));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
@@ -230,94 +252,129 @@ public class RoleController {
 
   @CamundaPutMapping(path = "/{roleId}/users/{username}")
   public CompletableFuture<ResponseEntity<Object>> assignRoleToUser(
-      @PathVariable final String roleId, @PathVariable final String username) {
+      @PathVariable final String roleId,
+      @PathVariable final String username,
+      @PhysicalTenantId final String physicalTenantId) {
     return roleMapper
         .toRoleMemberRequest(roleId, username, EntityType.USER)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::addMemberToRole);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> addMemberToRole(req, physicalTenantId));
   }
 
   @CamundaPutMapping(path = "/{roleId}/clients/{clientId}")
   public CompletableFuture<ResponseEntity<Object>> assignRoleToClient(
-      @PathVariable final String roleId, @PathVariable final String clientId) {
+      @PathVariable final String roleId,
+      @PathVariable final String clientId,
+      @PhysicalTenantId final String physicalTenantId) {
     return roleMapper
         .toRoleMemberRequest(roleId, clientId, EntityType.CLIENT)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::addMemberToRole);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> addMemberToRole(req, physicalTenantId));
   }
 
   @CamundaPutMapping(path = "/{roleId}/groups/{groupId}")
   public CompletableFuture<ResponseEntity<Object>> assignRoleToGroup(
-      @PathVariable final String roleId, @PathVariable final String groupId) {
+      @PathVariable final String roleId,
+      @PathVariable final String groupId,
+      @PhysicalTenantId final String physicalTenantId) {
     return roleMapper
         .toRoleMemberRequest(roleId, groupId, EntityType.GROUP)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::addMemberToRole);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> addMemberToRole(req, physicalTenantId));
   }
 
   private CompletableFuture<ResponseEntity<Object>> addMemberToRole(
-      final RoleMemberRequest request) {
+      final RoleMemberRequest request, final String physicalTenantId) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethodWithNoContentResult(
-        () -> roleServices.addMember(request, authentication));
+        () -> roleServices.addMember(request, authentication, physicalTenantId));
   }
 
   @CamundaPutMapping(path = "/{roleId}/mapping-rules/{mappingRuleId}")
   public CompletableFuture<ResponseEntity<Object>> assignRoleToMappingRule(
-      @PathVariable final String roleId, @PathVariable final String mappingRuleId) {
+      @PathVariable final String roleId,
+      @PathVariable final String mappingRuleId,
+      @PhysicalTenantId final String physicalTenantId) {
     return roleMapper
         .toRoleMemberRequest(roleId, mappingRuleId, EntityType.MAPPING_RULE)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::addMemberToRole);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> addMemberToRole(req, physicalTenantId));
   }
 
   @CamundaDeleteMapping(path = "/{roleId}/mapping-rules/{mappingRuleId}")
   public CompletableFuture<ResponseEntity<Object>> unassignRoleFromMappingRule(
-      @PathVariable final String roleId, @PathVariable final String mappingRuleId) {
+      @PathVariable final String roleId,
+      @PathVariable final String mappingRuleId,
+      @PhysicalTenantId final String physicalTenantId) {
     return roleMapper
         .toRoleMemberRequest(roleId, mappingRuleId, EntityType.MAPPING_RULE)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::removeMemberFromRole);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> removeMemberFromRole(req, physicalTenantId));
   }
 
   @CamundaDeleteMapping(path = "/{roleId}/users/{username}")
   public CompletableFuture<ResponseEntity<Object>> unassignRoleFromUser(
-      @PathVariable final String roleId, @PathVariable final String username) {
+      @PathVariable final String roleId,
+      @PathVariable final String username,
+      @PhysicalTenantId final String physicalTenantId) {
     return roleMapper
         .toRoleMemberRequest(roleId, username, EntityType.USER)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::removeMemberFromRole);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> removeMemberFromRole(req, physicalTenantId));
   }
 
   @CamundaDeleteMapping(path = "/{roleId}/clients/{clientId}")
   public CompletableFuture<ResponseEntity<Object>> unassignRoleFromClient(
-      @PathVariable final String roleId, @PathVariable final String clientId) {
+      @PathVariable final String roleId,
+      @PathVariable final String clientId,
+      @PhysicalTenantId final String physicalTenantId) {
     return roleMapper
         .toRoleMemberRequest(roleId, clientId, EntityType.CLIENT)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::removeMemberFromRole);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> removeMemberFromRole(req, physicalTenantId));
   }
 
   @CamundaDeleteMapping(path = "/{roleId}/groups/{groupId}")
   public CompletableFuture<ResponseEntity<Object>> unassignRoleFromGroup(
-      @PathVariable final String roleId, @PathVariable final String groupId) {
+      @PathVariable final String roleId,
+      @PathVariable final String groupId,
+      @PhysicalTenantId final String physicalTenantId) {
     return roleMapper
         .toRoleMemberRequest(roleId, groupId, EntityType.GROUP)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::removeMemberFromRole);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> removeMemberFromRole(req, physicalTenantId));
   }
 
   @RequiresSecondaryStorage
   @CamundaPostMapping(path = "/{roleId}/groups/search")
   public ResponseEntity<RoleGroupSearchResult> searchGroupsByRole(
       @PathVariable final String roleId,
-      @RequestBody(required = false) final RoleGroupSearchQueryRequest query) {
+      @RequestBody(required = false) final RoleGroupSearchQueryRequest query,
+      @PhysicalTenantId final String physicalTenantId) {
 
     return SearchQueryRequestMapper.toRoleMemberQuery(query)
         .fold(
             RestErrorMapper::mapProblemToResponse,
-            roleQuery -> searchGroupsInRole(roleId, roleQuery));
+            roleQuery -> searchGroupsInRole(roleId, roleQuery, physicalTenantId));
   }
 
   private ResponseEntity<RoleGroupSearchResult> searchGroupsInRole(
-      final String roleId, final RoleMemberQuery query) {
+      final String roleId, final RoleMemberQuery query, final String physicalTenantId) {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
       final var result =
           roleServices.searchMembers(
-              buildRoleMemberQuery(roleId, EntityType.GROUP, query), authentication);
+              buildRoleMemberQuery(roleId, EntityType.GROUP, query),
+              authentication,
+              physicalTenantId);
       return ResponseEntity.ok(SearchQueryResponseMapper.toRoleGroupSearchQueryResponse(result));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
@@ -325,9 +382,9 @@ public class RoleController {
   }
 
   private CompletableFuture<ResponseEntity<Object>> removeMemberFromRole(
-      final RoleMemberRequest request) {
+      final RoleMemberRequest request, final String physicalTenantId) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethodWithNoContentResult(
-        () -> roleServices.removeMember(request, authentication));
+        () -> roleServices.removeMember(request, authentication, physicalTenantId));
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserController.java
@@ -29,6 +29,7 @@ import io.camunda.zeebe.gateway.rest.annotation.CamundaDeleteMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPutMapping;
+import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
 import io.camunda.zeebe.gateway.rest.controller.CamundaRestController;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
@@ -59,51 +60,63 @@ public class UserController {
 
   @CamundaPostMapping
   public CompletableFuture<ResponseEntity<Object>> createUser(
-      @RequestBody final UserRequest userRequest) {
+      @RequestBody final UserRequest userRequest, @PhysicalTenantId final String physicalTenantId) {
     return userMapper
         .toUserRequest(userRequest)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::createUser);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> createUser(req, physicalTenantId));
   }
 
   @CamundaGetMapping(path = "/{username}")
   @RequiresSecondaryStorage
-  public ResponseEntity<Object> getUser(@PathVariable final String username) {
+  public ResponseEntity<Object> getUser(
+      @PathVariable final String username, @PhysicalTenantId final String physicalTenantId) {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
       return ResponseEntity.ok()
-          .body(SearchQueryResponseMapper.toUser(userServices.getUser(username, authentication)));
+          .body(
+              SearchQueryResponseMapper.toUser(
+                  userServices.getUser(username, authentication, physicalTenantId)));
     } catch (final Exception exception) {
       return RestErrorMapper.mapErrorToResponse(exception);
     }
   }
 
   @CamundaDeleteMapping(path = "/{username}")
-  public CompletableFuture<ResponseEntity<Object>> deleteUser(@PathVariable final String username) {
+  public CompletableFuture<ResponseEntity<Object>> deleteUser(
+      @PathVariable final String username, @PhysicalTenantId final String physicalTenantId) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethodWithNoContentResult(
-        () -> userServices.deleteUser(username, authentication));
+        () -> userServices.deleteUser(username, authentication, physicalTenantId));
   }
 
-  private CompletableFuture<ResponseEntity<Object>> createUser(final UserDTO request) {
+  private CompletableFuture<ResponseEntity<Object>> createUser(
+      final UserDTO request, final String physicalTenantId) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethod(
-        () -> userServices.createUser(request, authentication),
+        () -> userServices.createUser(request, authentication, physicalTenantId),
         ResponseMapper::toUserCreateResponse,
         HttpStatus.CREATED);
   }
 
   @CamundaPutMapping(path = "/{username}")
   public CompletableFuture<ResponseEntity<Object>> updateUser(
-      @PathVariable final String username, @RequestBody final UserUpdateRequest userUpdateRequest) {
+      @PathVariable final String username,
+      @RequestBody final UserUpdateRequest userUpdateRequest,
+      @PhysicalTenantId final String physicalTenantId) {
     return userMapper
         .toUserUpdateRequest(userUpdateRequest, username)
-        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::updateUser);
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            req -> updateUser(req, physicalTenantId));
   }
 
-  private CompletableFuture<ResponseEntity<Object>> updateUser(final UserDTO request) {
+  private CompletableFuture<ResponseEntity<Object>> updateUser(
+      final UserDTO request, final String physicalTenantId) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethod(
-        () -> userServices.updateUser(request, authentication),
+        () -> userServices.updateUser(request, authentication, physicalTenantId),
         ResponseMapper::toUserUpdateResponse,
         HttpStatus.OK);
   }
@@ -111,15 +124,17 @@ public class UserController {
   @CamundaPostMapping(path = "/search")
   @RequiresSecondaryStorage
   public ResponseEntity<UserSearchResult> searchUsers(
-      @RequestBody(required = false) final UserSearchQueryRequest query) {
+      @RequestBody(required = false) final UserSearchQueryRequest query,
+      @PhysicalTenantId final String physicalTenantId) {
     return SearchQueryRequestMapper.toUserQuery(query)
-        .fold(RestErrorMapper::mapProblemToResponse, this::search);
+        .fold(RestErrorMapper::mapProblemToResponse, q -> search(q, physicalTenantId));
   }
 
-  private ResponseEntity<UserSearchResult> search(final UserQuery query) {
+  private ResponseEntity<UserSearchResult> search(
+      final UserQuery query, final String physicalTenantId) {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
-      final var result = userServices.search(query, authentication);
+      final var result = userServices.search(query, authentication, physicalTenantId);
       return ResponseEntity.ok(SearchQueryResponseMapper.toUserSearchQueryResponse(result));
     } catch (final Exception e) {
       return mapErrorToResponse(e);

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiConfigurationTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiConfigurationTest.java
@@ -34,7 +34,7 @@ abstract class RestApiConfigurationTest extends RestControllerTest {
 
   @BeforeEach
   void setupServices() {
-    when(processInstanceServices.search(any(ProcessInstanceQuery.class), any()))
+    when(processInstanceServices.search(any(ProcessInstanceQuery.class), any(), any()))
         .thenReturn(new Builder<ProcessInstanceEntity>().build());
     when(topologyServices.getTopology())
         .thenReturn(

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiDefaultConfigurationTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiDefaultConfigurationTest.java
@@ -42,7 +42,7 @@ public class RestApiDefaultConfigurationTest extends RestApiConfigurationTest {
         .expectStatus()
         .isOk();
 
-    verify(processInstanceServices).search(any(ProcessInstanceQuery.class), any());
+    verify(processInstanceServices).search(any(ProcessInstanceQuery.class), any(), any());
   }
 
   @Test

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiJacksonConfigTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiJacksonConfigTest.java
@@ -72,7 +72,7 @@ public class RestApiJacksonConfigTest extends RestApiConfigurationTest {
         .expectBody()
         .json(expectedResponse, JsonCompareMode.STRICT);
 
-    verify(processInstanceServices, never()).search(any(ProcessInstanceQuery.class), any());
+    verify(processInstanceServices, never()).search(any(ProcessInstanceQuery.class), any(), any());
   }
 
   @ParameterizedTest
@@ -113,6 +113,6 @@ public class RestApiJacksonConfigTest extends RestApiConfigurationTest {
         .expectBody()
         .json(expectedResponse, JsonCompareMode.STRICT);
 
-    verify(processInstanceServices, never()).search(any(ProcessInstanceQuery.class), any());
+    verify(processInstanceServices, never()).search(any(ProcessInstanceQuery.class), any(), any());
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubProcessActivityControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubProcessActivityControllerTest.java
@@ -59,7 +59,7 @@ class AdHocSubProcessActivityControllerTest extends RestControllerTest {
     @ValueSource(booleans = {true, false})
     void shouldActivateActivities(final boolean cancelRemainingInstances) {
       when(adHocSubProcessActivityServices.activateActivities(
-              any(AdHocSubProcessActivateActivitiesRequest.class), any()))
+              any(AdHocSubProcessActivateActivitiesRequest.class), any(), any()))
           .thenReturn(CompletableFuture.completedFuture(new AdHocSubProcessInstructionRecord()));
 
       webClient
@@ -116,13 +116,14 @@ class AdHocSubProcessActivityControllerTest extends RestControllerTest {
                               assertThat(element.variables()).isEmpty();
                             });
                   }),
+              any(),
               any());
     }
 
     @Test
     void shouldActivateActivitiesWithMissingCancelRemainingActivitiesFlag() {
       when(adHocSubProcessActivityServices.activateActivities(
-              any(AdHocSubProcessActivateActivitiesRequest.class), any()))
+              any(AdHocSubProcessActivateActivitiesRequest.class), any(), any()))
           .thenReturn(CompletableFuture.completedFuture(new AdHocSubProcessInstructionRecord()));
 
       webClient
@@ -157,6 +158,7 @@ class AdHocSubProcessActivityControllerTest extends RestControllerTest {
                               assertThat(element.variables()).isEmpty();
                             });
                   }),
+              any(),
               any());
     }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
@@ -52,7 +52,7 @@ class AgentInstanceControllerTest extends RestControllerTest {
     // given
     final var responseRecord = new AgentInstanceRecord();
     responseRecord.setAgentInstanceKey(AGENT_INSTANCE_KEY);
-    when(agentInstanceServices.createAgentInstance(any(AgentInstanceRecord.class), any()))
+    when(agentInstanceServices.createAgentInstance(any(AgentInstanceRecord.class), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(responseRecord));
 
     final var requestBody =
@@ -99,6 +99,7 @@ class AgentInstanceControllerTest extends RestControllerTest {
                   assertThat(record.getLimits().getMaxModelCalls()).isEqualTo(-1);
                   assertThat(record.getLimits().getMaxToolCalls()).isEqualTo(-1);
                 }),
+            any(),
             any());
   }
 
@@ -107,7 +108,7 @@ class AgentInstanceControllerTest extends RestControllerTest {
     // given
     final var responseRecord = new AgentInstanceRecord();
     responseRecord.setAgentInstanceKey(AGENT_INSTANCE_KEY);
-    when(agentInstanceServices.createAgentInstance(any(AgentInstanceRecord.class), any()))
+    when(agentInstanceServices.createAgentInstance(any(AgentInstanceRecord.class), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(responseRecord));
 
     final var requestBody =
@@ -147,6 +148,7 @@ class AgentInstanceControllerTest extends RestControllerTest {
                   assertThat(record.getLimits().getMaxModelCalls()).isEqualTo(10);
                   assertThat(record.getLimits().getMaxToolCalls()).isEqualTo(50);
                 }),
+            any(),
             any());
   }
 
@@ -284,7 +286,7 @@ class AgentInstanceControllerTest extends RestControllerTest {
   @Test
   void shouldReturn5xxOnServiceError() {
     // given
-    when(agentInstanceServices.createAgentInstance(any(AgentInstanceRecord.class), any()))
+    when(agentInstanceServices.createAgentInstance(any(AgentInstanceRecord.class), any(), any()))
         .thenReturn(CompletableFuture.failedFuture(new RuntimeException("broker unavailable")));
 
     final var requestBody =
@@ -315,7 +317,7 @@ class AgentInstanceControllerTest extends RestControllerTest {
   @Test
   void shouldUpdateAgentInstanceWithStatus() {
     // given
-    when(agentInstanceServices.updateAgentInstance(any(AgentInstanceRecord.class), any()))
+    when(agentInstanceServices.updateAgentInstance(any(AgentInstanceRecord.class), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new AgentInstanceRecord()));
 
     final var requestBody =
@@ -347,13 +349,14 @@ class AgentInstanceControllerTest extends RestControllerTest {
                   assertThat(record.getStatus().name()).isEqualTo("THINKING");
                   assertThat(record.getChangedAttributes()).containsExactly("status");
                 }),
+            any(),
             any());
   }
 
   @Test
   void shouldUpdateAgentInstanceWithMetrics() {
     // given
-    when(agentInstanceServices.updateAgentInstance(any(AgentInstanceRecord.class), any()))
+    when(agentInstanceServices.updateAgentInstance(any(AgentInstanceRecord.class), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new AgentInstanceRecord()));
 
     final var requestBody =
@@ -391,13 +394,14 @@ class AgentInstanceControllerTest extends RestControllerTest {
                   assertThat(record.getMetrics().getToolCalls()).isEqualTo(7);
                   assertThat(record.getChangedAttributes()).containsExactly("metrics");
                 }),
+            any(),
             any());
   }
 
   @Test
   void shouldUpdateAgentInstanceWithTools() {
     // given
-    when(agentInstanceServices.updateAgentInstance(any(AgentInstanceRecord.class), any()))
+    when(agentInstanceServices.updateAgentInstance(any(AgentInstanceRecord.class), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new AgentInstanceRecord()));
 
     final var requestBody =
@@ -437,13 +441,14 @@ class AgentInstanceControllerTest extends RestControllerTest {
                   assertThat(record.getTools().get(0).getElementId()).isEqualTo("searchTask");
                   assertThat(record.getChangedAttributes()).containsExactly("tools");
                 }),
+            any(),
             any());
   }
 
   @Test
   void shouldUpdateAgentInstanceWithEmptyToolsList() {
     // given
-    when(agentInstanceServices.updateAgentInstance(any(AgentInstanceRecord.class), any()))
+    when(agentInstanceServices.updateAgentInstance(any(AgentInstanceRecord.class), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new AgentInstanceRecord()));
 
     final var requestBody =
@@ -473,13 +478,14 @@ class AgentInstanceControllerTest extends RestControllerTest {
                   assertThat(record.getTools()).isEmpty();
                   assertThat(record.getChangedAttributes()).containsExactly("tools");
                 }),
+            any(),
             any());
   }
 
   @Test
   void shouldUpdateAgentInstanceWithOnlyElementInstanceKey() {
     // given
-    when(agentInstanceServices.updateAgentInstance(any(AgentInstanceRecord.class), any()))
+    when(agentInstanceServices.updateAgentInstance(any(AgentInstanceRecord.class), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new AgentInstanceRecord()));
 
     final var requestBody =
@@ -507,6 +513,7 @@ class AgentInstanceControllerTest extends RestControllerTest {
                 record -> {
                   assertThat(record.getChangedAttributes()).isEmpty();
                 }),
+            any(),
             any());
   }
 
@@ -637,7 +644,7 @@ class AgentInstanceControllerTest extends RestControllerTest {
   @Test
   void shouldReturn5xxOnUpdateServiceError() {
     // given
-    when(agentInstanceServices.updateAgentInstance(any(AgentInstanceRecord.class), any()))
+    when(agentInstanceServices.updateAgentInstance(any(AgentInstanceRecord.class), any(), any()))
         .thenReturn(CompletableFuture.failedFuture(new RuntimeException("broker unavailable")));
 
     // when / then

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceQueryControllerTest.java
@@ -146,7 +146,7 @@ class AgentInstanceQueryControllerTest extends RestControllerTest {
   @Test
   void shouldGetAgentInstance() {
     // given
-    when(agentInstanceServices.getByKey(eq(AGENT_INSTANCE_KEY), any()))
+    when(agentInstanceServices.getByKey(eq(AGENT_INSTANCE_KEY), any(), any()))
         .thenReturn(AGENT_INSTANCE_ENTITY);
 
     // when / then
@@ -210,14 +210,14 @@ class AgentInstanceQueryControllerTest extends RestControllerTest {
                     ELEMENT_INSTANCE_KEY),
             JsonCompareMode.STRICT);
 
-    verify(agentInstanceServices).getByKey(eq(AGENT_INSTANCE_KEY), any());
+    verify(agentInstanceServices).getByKey(eq(AGENT_INSTANCE_KEY), any(), any());
   }
 
   @Test
   void shouldReturnNotFoundForUnknownAgentInstanceKey() {
     // given
     final var path = "%s/%d".formatted(AGENT_INSTANCES_URL, AGENT_INSTANCE_KEY);
-    when(agentInstanceServices.getByKey(eq(AGENT_INSTANCE_KEY), any()))
+    when(agentInstanceServices.getByKey(eq(AGENT_INSTANCE_KEY), any(), any()))
         .thenThrow(
             ErrorMapper.mapSearchError(
                 new CamundaSearchException(
@@ -248,7 +248,7 @@ class AgentInstanceQueryControllerTest extends RestControllerTest {
   @Test
   void shouldSearchAgentInstancesWithEmptyBody() {
     // given
-    when(agentInstanceServices.search(any(AgentInstanceQuery.class), any()))
+    when(agentInstanceServices.search(any(AgentInstanceQuery.class), any(), any()))
         .thenReturn(
             new SearchQueryResult.Builder<AgentInstanceEntity>()
                 .total(1)
@@ -271,13 +271,14 @@ class AgentInstanceQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
-    verify(agentInstanceServices).search(eq(new AgentInstanceQuery.Builder().build()), any());
+    verify(agentInstanceServices)
+        .search(eq(new AgentInstanceQuery.Builder().build()), any(), any());
   }
 
   @Test
   void shouldSearchAgentInstancesWithStatusFilter() {
     // given
-    when(agentInstanceServices.search(any(AgentInstanceQuery.class), any()))
+    when(agentInstanceServices.search(any(AgentInstanceQuery.class), any(), any()))
         .thenReturn(
             new SearchQueryResult.Builder<AgentInstanceEntity>()
                 .total(1)
@@ -317,6 +318,7 @@ class AgentInstanceQueryControllerTest extends RestControllerTest {
                             .statusOperations(List.of(Operation.eq("COMPLETED")))
                             .build())
                     .build()),
+            any(),
             any());
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationControllerTest.java
@@ -59,7 +59,7 @@ class BatchOperationControllerTest extends RestControllerTest {
     final var batchOperationKey = "1";
     final var batchOperationEntity = getBatchOperationEntity(batchOperationKey);
 
-    when(batchOperationServices.getById(eq(batchOperationKey), any()))
+    when(batchOperationServices.getById(eq(batchOperationKey), any(), any()))
         .thenReturn(batchOperationEntity);
 
     webClient
@@ -95,7 +95,7 @@ class BatchOperationControllerTest extends RestControllerTest {
         getFailedBatchOperationEntity(
             batchOperationKey, BatchOperationState.PARTIALLY_COMPLETED, 10, 0, 10);
 
-    when(batchOperationServices.getById(eq(batchOperationKey), any()))
+    when(batchOperationServices.getById(eq(batchOperationKey), any(), any()))
         .thenReturn(batchOperationEntity);
 
     webClient
@@ -141,7 +141,7 @@ class BatchOperationControllerTest extends RestControllerTest {
     final var batchOperationEntity =
         getFailedBatchOperationEntity(batchOperationKey, BatchOperationState.FAILED, 0, 0, 0);
 
-    when(batchOperationServices.getById(eq(batchOperationKey), any()))
+    when(batchOperationServices.getById(eq(batchOperationKey), any(), any()))
         .thenReturn(batchOperationEntity);
 
     webClient
@@ -269,7 +269,7 @@ class BatchOperationControllerTest extends RestControllerTest {
             .formatted(filterString);
 
     // when / then
-    when(batchOperationServices.search(any(BatchOperationQuery.class), any()))
+    when(batchOperationServices.search(any(BatchOperationQuery.class), any(), any()))
         .thenReturn(new SearchQueryResult<>(1, false, List.of(entity), null, null));
 
     webClient
@@ -309,13 +309,13 @@ class BatchOperationControllerTest extends RestControllerTest {
             JsonCompareMode.STRICT);
 
     verify(batchOperationServices)
-        .search(eq(new BatchOperationQuery.Builder().filter(filter).build()), any());
+        .search(eq(new BatchOperationQuery.Builder().filter(filter).build()), any(), any());
   }
 
   @Test
   void shouldCancelBatchOperation() {
     final var batchOperationKey = "1";
-    when(batchOperationServices.cancel(eq(batchOperationKey), any()))
+    when(batchOperationServices.cancel(eq(batchOperationKey), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(null));
 
     webClient
@@ -330,7 +330,7 @@ class BatchOperationControllerTest extends RestControllerTest {
   @Test
   void shouldSuspendBatchOperation() {
     final var batchOperationKey = "1";
-    when(batchOperationServices.suspend(eq(batchOperationKey), any()))
+    when(batchOperationServices.suspend(eq(batchOperationKey), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(null));
 
     webClient
@@ -345,7 +345,7 @@ class BatchOperationControllerTest extends RestControllerTest {
   @Test
   void shouldResumeBatchOperation() {
     final var batchOperationKey = "1";
-    when(batchOperationServices.resume(eq(batchOperationKey), any()))
+    when(batchOperationServices.resume(eq(batchOperationKey), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(null));
 
     webClient
@@ -416,7 +416,7 @@ class BatchOperationControllerTest extends RestControllerTest {
         { "sort": [{ "field": "%s", "order": "%s" }] }"""
             .formatted(sortedByField, order);
 
-    when(batchOperationServices.search(any(BatchOperationQuery.class), any()))
+    when(batchOperationServices.search(any(BatchOperationQuery.class), any(), any()))
         .thenReturn(
             new SearchQueryResult<>(
                 searchResultItems.size(), false, searchResultItems, null, null));
@@ -438,7 +438,7 @@ class BatchOperationControllerTest extends RestControllerTest {
 
     // then
     verify(batchOperationServices)
-        .search(eq(new BatchOperationQuery.Builder().sort(sort).build()), any());
+        .search(eq(new BatchOperationQuery.Builder().sort(sort).build()), any(), any());
   }
 
   private static BatchOperationEntity getBatchOperationEntity(final String batchOperationKey) {

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationItemControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationItemControllerTest.java
@@ -105,7 +105,7 @@ class BatchOperationItemControllerTest extends RestControllerTest {
             .formatted(filterString);
 
     // when / then
-    when(batchOperationServices.searchItems(any(BatchOperationItemQuery.class), any()))
+    when(batchOperationServices.searchItems(any(BatchOperationItemQuery.class), any(), any()))
         .thenReturn(new SearchQueryResult(1, false, List.of(entity), null, null));
 
     webClient
@@ -143,7 +143,8 @@ class BatchOperationItemControllerTest extends RestControllerTest {
             JsonCompareMode.STRICT);
 
     verify(batchOperationServices)
-        .searchItems(eq(new BatchOperationItemQuery.Builder().filter(filter).build()), any());
+        .searchItems(
+            eq(new BatchOperationItemQuery.Builder().filter(filter).build()), any(), any());
   }
 
   private static BatchOperationItemEntity getBatchOperationItemEntity(

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClockControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClockControllerTest.java
@@ -57,7 +57,7 @@ public class ClockControllerTest extends RestControllerTest {
     final var request = ClockPinRequest.Builder.create().timestamp(timestamp).build();
     final var clockRecord = new ClockRecord().pinAt(timestamp);
 
-    when(clockServices.pinClock(eq(timestamp), any()))
+    when(clockServices.pinClock(eq(timestamp), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(clockRecord));
 
     // when - then
@@ -71,7 +71,7 @@ public class ClockControllerTest extends RestControllerTest {
         .expectStatus()
         .isNoContent();
 
-    verify(clockServices).pinClock(eq(timestamp), any());
+    verify(clockServices).pinClock(eq(timestamp), any(), any());
   }
 
   static Stream<Arguments> invalidClockPinRequests() {
@@ -109,7 +109,7 @@ public class ClockControllerTest extends RestControllerTest {
   @Test
   void restClockShouldReturnNoContent() {
     // given
-    when(clockServices.resetClock(any()))
+    when(clockServices.resetClock(any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new ClockRecord()));
 
     // when - then
@@ -121,6 +121,6 @@ public class ClockControllerTest extends RestControllerTest {
         .expectStatus()
         .isNoContent();
 
-    verify(clockServices).resetClock(any());
+    verify(clockServices).resetClock(any(), any());
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterVariableControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterVariableControllerTest.java
@@ -67,7 +67,7 @@ public class ClusterVariableControllerTest extends RestControllerTest {
     when(clusterVariableEntity.scope()).thenReturn(ClusterVariableScope.GLOBAL);
 
     when(clusterVariableServices.getGloballyScopedClusterVariable(
-            any(ClusterVariableRequest.class), any()))
+            any(ClusterVariableRequest.class), any(), any()))
         .thenReturn(clusterVariableEntity);
 
     // when / then
@@ -80,7 +80,7 @@ public class ClusterVariableControllerTest extends RestControllerTest {
         .isOk();
 
     verify(clusterVariableServices)
-        .getGloballyScopedClusterVariable(createRequestCaptor.capture(), any());
+        .getGloballyScopedClusterVariable(createRequestCaptor.capture(), any(), any());
     final var capturedRequest = createRequestCaptor.getValue();
     assertThat(capturedRequest.name()).isEqualTo("foo");
     assertThat(capturedRequest.value()).isNull();
@@ -119,7 +119,7 @@ public class ClusterVariableControllerTest extends RestControllerTest {
   void shouldCreateGlobalClusterVariable() {
     // given
     when(clusterVariableServices.createGloballyScopedClusterVariable(
-            any(ClusterVariableRequest.class), any()))
+            any(ClusterVariableRequest.class), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new ClusterVariableRecord().setName("foo")));
 
     final var request =
@@ -141,7 +141,7 @@ public class ClusterVariableControllerTest extends RestControllerTest {
         .isOk();
 
     verify(clusterVariableServices)
-        .createGloballyScopedClusterVariable(createRequestCaptor.capture(), any());
+        .createGloballyScopedClusterVariable(createRequestCaptor.capture(), any(), any());
     final var capturedRequest = createRequestCaptor.getValue();
     assertThat(capturedRequest.name()).isEqualTo("foo");
     assertThat(capturedRequest.value()).isEqualTo("bar");
@@ -261,7 +261,7 @@ public class ClusterVariableControllerTest extends RestControllerTest {
   void shouldDeleteGlobalClusterVariable() {
     // given
     when(clusterVariableServices.deleteGloballyScopedClusterVariable(
-            any(ClusterVariableRequest.class), any()))
+            any(ClusterVariableRequest.class), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new ClusterVariableRecord().setName("foo")));
 
     // when / then
@@ -274,7 +274,7 @@ public class ClusterVariableControllerTest extends RestControllerTest {
         .isNoContent();
 
     verify(clusterVariableServices)
-        .deleteGloballyScopedClusterVariable(createRequestCaptor.capture(), any());
+        .deleteGloballyScopedClusterVariable(createRequestCaptor.capture(), any(), any());
     final var capturedRequest = createRequestCaptor.getValue();
     assertThat(capturedRequest.name()).isEqualTo("foo");
     assertThat(capturedRequest.value()).isNull();
@@ -285,7 +285,7 @@ public class ClusterVariableControllerTest extends RestControllerTest {
   void shouldUpdateGlobalClusterVariable() {
     // given
     when(clusterVariableServices.updateGloballyScopedClusterVariable(
-            any(ClusterVariableRequest.class), any()))
+            any(ClusterVariableRequest.class), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new ClusterVariableRecord().setName("foo")));
 
     final var request =
@@ -306,7 +306,7 @@ public class ClusterVariableControllerTest extends RestControllerTest {
         .isOk();
 
     verify(clusterVariableServices)
-        .updateGloballyScopedClusterVariable(createRequestCaptor.capture(), any());
+        .updateGloballyScopedClusterVariable(createRequestCaptor.capture(), any(), any());
     final var capturedRequest = createRequestCaptor.getValue();
     assertThat(capturedRequest.name()).isEqualTo("foo");
     assertThat(capturedRequest.value()).isEqualTo("newValue");
@@ -420,7 +420,7 @@ public class ClusterVariableControllerTest extends RestControllerTest {
     when(clusterVariableEntity.tenantId()).thenReturn("tenant1");
 
     when(clusterVariableServices.getTenantScopedClusterVariable(
-            any(ClusterVariableRequest.class), any()))
+            any(ClusterVariableRequest.class), any(), any()))
         .thenReturn(clusterVariableEntity);
 
     // when / then
@@ -433,7 +433,7 @@ public class ClusterVariableControllerTest extends RestControllerTest {
         .isOk();
 
     verify(clusterVariableServices)
-        .getTenantScopedClusterVariable(createRequestCaptor.capture(), any());
+        .getTenantScopedClusterVariable(createRequestCaptor.capture(), any(), any());
     final var capturedRequest = createRequestCaptor.getValue();
     assertThat(capturedRequest.name()).isEqualTo("foo");
     assertThat(capturedRequest.value()).isNull();
@@ -500,7 +500,7 @@ public class ClusterVariableControllerTest extends RestControllerTest {
   void shouldCreateTenantClusterVariable() {
     // given
     when(clusterVariableServices.createTenantScopedClusterVariable(
-            any(ClusterVariableRequest.class), any()))
+            any(ClusterVariableRequest.class), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new ClusterVariableRecord().setName("foo")));
 
     final var request =
@@ -522,7 +522,7 @@ public class ClusterVariableControllerTest extends RestControllerTest {
         .isOk();
 
     verify(clusterVariableServices)
-        .createTenantScopedClusterVariable(createRequestCaptor.capture(), any());
+        .createTenantScopedClusterVariable(createRequestCaptor.capture(), any(), any());
     final var capturedRequest = createRequestCaptor.getValue();
     assertThat(capturedRequest.name()).isEqualTo("foo");
     assertThat(capturedRequest.value()).isEqualTo("bar");
@@ -679,7 +679,7 @@ public class ClusterVariableControllerTest extends RestControllerTest {
   void shouldDeleteTenantClusterVariable() {
     // given
     when(clusterVariableServices.deleteTenantScopedClusterVariable(
-            any(ClusterVariableRequest.class), any()))
+            any(ClusterVariableRequest.class), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new ClusterVariableRecord().setName("foo")));
 
     // when / then
@@ -692,7 +692,7 @@ public class ClusterVariableControllerTest extends RestControllerTest {
         .isNoContent();
 
     verify(clusterVariableServices)
-        .deleteTenantScopedClusterVariable(createRequestCaptor.capture(), any());
+        .deleteTenantScopedClusterVariable(createRequestCaptor.capture(), any(), any());
     final var capturedRequest = createRequestCaptor.getValue();
     assertThat(capturedRequest.name()).isEqualTo("foo");
     assertThat(capturedRequest.value()).isNull();
@@ -703,7 +703,7 @@ public class ClusterVariableControllerTest extends RestControllerTest {
   void shouldUpdateTenantClusterVariable() {
     // given
     when(clusterVariableServices.updateTenantScopedClusterVariable(
-            any(ClusterVariableRequest.class), any()))
+            any(ClusterVariableRequest.class), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new ClusterVariableRecord().setName("foo")));
 
     final var request =
@@ -724,7 +724,7 @@ public class ClusterVariableControllerTest extends RestControllerTest {
         .isOk();
 
     verify(clusterVariableServices)
-        .updateTenantScopedClusterVariable(createRequestCaptor.capture(), any());
+        .updateTenantScopedClusterVariable(createRequestCaptor.capture(), any(), any());
     final var capturedRequest = createRequestCaptor.getValue();
     assertThat(capturedRequest.name()).isEqualTo("foo");
     assertThat(capturedRequest.value()).isEqualTo("newValue");

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ConditionalControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ConditionalControllerTest.java
@@ -65,7 +65,8 @@ public class ConditionalControllerTest extends RestControllerTest {
     // given
     when(multiTenancyCfg.isChecksEnabled()).thenReturn(false);
 
-    when(conditionalServices.evaluateConditional(any(EvaluateConditionalRequest.class), any()))
+    when(conditionalServices.evaluateConditional(
+            any(EvaluateConditionalRequest.class), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(mockResponse));
 
     final var request =
@@ -92,7 +93,7 @@ public class ConditionalControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedApiResponse, JsonCompareMode.STRICT);
 
-    verify(conditionalServices).evaluateConditional(requestCaptor.capture(), any());
+    verify(conditionalServices).evaluateConditional(requestCaptor.capture(), any(), any());
     final var capturedRequest = requestCaptor.getValue();
     assertThat(capturedRequest.variables()).containsEntry("x", 100).containsEntry("y", 50);
     assertThat(capturedRequest.processDefinitionKey()).isEqualTo(-1);
@@ -181,7 +182,8 @@ public class ConditionalControllerTest extends RestControllerTest {
 
     final var expectedError = "This is an expected error";
 
-    when(conditionalServices.evaluateConditional(any(EvaluateConditionalRequest.class), any()))
+    when(conditionalServices.evaluateConditional(
+            any(EvaluateConditionalRequest.class), any(), any()))
         .thenReturn(
             CompletableFuture.failedFuture(
                 new ServiceException(expectedError, ServiceException.Status.INVALID_ARGUMENT)));
@@ -264,7 +266,8 @@ public class ConditionalControllerTest extends RestControllerTest {
     // given
     when(multiTenancyCfg.isChecksEnabled()).thenReturn(false);
 
-    when(conditionalServices.evaluateConditional(any(EvaluateConditionalRequest.class), any()))
+    when(conditionalServices.evaluateConditional(
+            any(EvaluateConditionalRequest.class), any(), any()))
         .thenThrow(
             ErrorMapper.createForbiddenException(
                 Authorization.of(a -> a.processDefinition().createProcessInstance())));

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionControllerTest.java
@@ -86,7 +86,8 @@ public class DecisionDefinitionControllerTest extends RestControllerTest {
     when(multiTenancyCfg.isChecksEnabled()).thenReturn(true);
     when(authenticationProvider.getCamundaAuthentication())
         .thenReturn(AUTHENTICATION_WITH_NON_DEFAULT_TENANT);
-    when(decisionServices.evaluateDecision(anyString(), anyLong(), anyMap(), anyString(), any()))
+    when(decisionServices.evaluateDecision(
+            anyString(), anyLong(), anyMap(), anyString(), any(), any()))
         .thenReturn((buildResponse("tenantId")));
 
     final var request =
@@ -114,14 +115,20 @@ public class DecisionDefinitionControllerTest extends RestControllerTest {
     response.expectBody().json(EXPECTED_EVALUATION_RESPONSE, JsonCompareMode.STRICT);
     Mockito.verify(decisionServices)
         .evaluateDecision(
-            eq(""), eq(123456L), eq(Map.<String, Object>of("key", "value")), eq("tenantId"), any());
+            eq(""),
+            eq(123456L),
+            eq(Map.<String, Object>of("key", "value")),
+            eq("tenantId"),
+            any(),
+            any());
   }
 
   @Test
   void shouldEvaluateDecisionWithMultitenancyDisabled() {
     // given
     when(multiTenancyCfg.isChecksEnabled()).thenReturn(false);
-    when(decisionServices.evaluateDecision(anyString(), anyLong(), anyMap(), anyString(), any()))
+    when(decisionServices.evaluateDecision(
+            anyString(), anyLong(), anyMap(), anyString(), any(), any()))
         .thenReturn((buildResponse(TenantOwned.DEFAULT_TENANT_IDENTIFIER)));
 
     final var request =
@@ -150,6 +157,7 @@ public class DecisionDefinitionControllerTest extends RestControllerTest {
             eq(123456L),
             eq(Map.<String, Object>of("key", "value")),
             eq(TenantOwned.DEFAULT_TENANT_IDENTIFIER),
+            any(),
             any());
   }
 
@@ -159,7 +167,8 @@ public class DecisionDefinitionControllerTest extends RestControllerTest {
     when(multiTenancyCfg.isChecksEnabled()).thenReturn(true);
     when(authenticationProvider.getCamundaAuthentication())
         .thenReturn(AUTHENTICATION_WITH_NON_DEFAULT_TENANT);
-    when(decisionServices.evaluateDecision(anyString(), anyLong(), anyMap(), anyString(), any()))
+    when(decisionServices.evaluateDecision(
+            anyString(), anyLong(), anyMap(), anyString(), any(), any()))
         .thenReturn((buildResponse("tenantId")));
 
     final var request =
@@ -191,6 +200,7 @@ public class DecisionDefinitionControllerTest extends RestControllerTest {
             eq(-1L),
             eq(Map.<String, Object>of("key", "value")),
             eq("tenantId"),
+            any(),
             any());
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionQueryControllerTest.java
@@ -94,7 +94,7 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
   @Test
   void shouldSearchDecisionDefinitionsWithEmptyBody() {
     // given
-    when(decisionDefinitionServices.search(any(DecisionDefinitionQuery.class), any()))
+    when(decisionDefinitionServices.search(any(DecisionDefinitionQuery.class), any(), any()))
         .thenReturn(SEARCH_QUERY_RESULT);
     // when / then
     webClient
@@ -109,13 +109,13 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
         .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(decisionDefinitionServices)
-        .search(eq(new DecisionDefinitionQuery.Builder().build()), any());
+        .search(eq(new DecisionDefinitionQuery.Builder().build()), any(), any());
   }
 
   @Test
   void shouldSearchDecisionDefinitionsWithEmptyQuery() {
     // given
-    when(decisionDefinitionServices.search(any(DecisionDefinitionQuery.class), any()))
+    when(decisionDefinitionServices.search(any(DecisionDefinitionQuery.class), any(), any()))
         .thenReturn(SEARCH_QUERY_RESULT);
     final String request = "{}";
     // when / then
@@ -134,13 +134,13 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
         .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(decisionDefinitionServices)
-        .search(eq(new DecisionDefinitionQuery.Builder().build()), any());
+        .search(eq(new DecisionDefinitionQuery.Builder().build()), any(), any());
   }
 
   @Test
   void shouldSearchDecisionDefinitionsWithAllFilters() {
     // given
-    when(decisionDefinitionServices.search(any(DecisionDefinitionQuery.class), any()))
+    when(decisionDefinitionServices.search(any(DecisionDefinitionQuery.class), any(), any()))
         .thenReturn(SEARCH_QUERY_RESULT);
     final var request =
         """
@@ -190,13 +190,14 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
                             .decisionRequirementsVersions(2)
                             .build())
                     .build()),
+            any(),
             any());
   }
 
   @Test
   void shouldSearchDecisionDefinitionsWithFullSorting() {
     // given
-    when(decisionDefinitionServices.search(any(DecisionDefinitionQuery.class), any()))
+    when(decisionDefinitionServices.search(any(DecisionDefinitionQuery.class), any(), any()))
         .thenReturn(SEARCH_QUERY_RESULT);
     final var request =
         """
@@ -275,6 +276,7 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
                             .asc()
                             .build())
                     .build()),
+            any(),
             any());
   }
 
@@ -316,7 +318,8 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedResponse, JsonCompareMode.STRICT);
 
-    verify(decisionDefinitionServices, never()).search(any(DecisionDefinitionQuery.class), any());
+    verify(decisionDefinitionServices, never())
+        .search(any(DecisionDefinitionQuery.class), any(), any());
   }
 
   @Test
@@ -324,7 +327,8 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
     // given
     final Long decisionDefinitionKey = 1L;
     final String xml = "<xml/>";
-    when(decisionDefinitionServices.getDecisionDefinitionXml(eq(decisionDefinitionKey), any()))
+    when(decisionDefinitionServices.getDecisionDefinitionXml(
+            eq(decisionDefinitionKey), any(), any()))
         .thenReturn(xml);
 
     // when/then
@@ -344,7 +348,8 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
   public void shouldReturn404ForNotFoundDecisionDefinition() {
     // given
     final Long decisionDefinitionKey = 1L;
-    when(decisionDefinitionServices.getDecisionDefinitionXml(eq(decisionDefinitionKey), any()))
+    when(decisionDefinitionServices.getDecisionDefinitionXml(
+            eq(decisionDefinitionKey), any(), any()))
         .thenThrow(
             ErrorMapper.mapSearchError(
                 new CamundaSearchException(
@@ -378,7 +383,8 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
   public void shouldReturn500ForInternalError() {
     // given
     final Long decisionDefinitionKey = 1L;
-    when(decisionDefinitionServices.getDecisionDefinitionXml(eq(decisionDefinitionKey), any()))
+    when(decisionDefinitionServices.getDecisionDefinitionXml(
+            eq(decisionDefinitionKey), any(), any()))
         .thenThrow(new RuntimeException("Failed to get decision definition xml."));
 
     // when/then
@@ -438,7 +444,7 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
     final Long decisionDefinitionKey = 1L;
     final DecisionDefinitionEntity decisionDefinitionEntity =
         new DecisionDefinitionEntity(0L, "dId", "name", 1, "drId", 2L, "drN", 2, "t");
-    when(decisionDefinitionServices.getByKey(eq(decisionDefinitionKey), any()))
+    when(decisionDefinitionServices.getByKey(eq(decisionDefinitionKey), any(), any()))
         .thenReturn(decisionDefinitionEntity);
     final var expectedResponse =
         """
@@ -470,7 +476,7 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
   public void shouldReturn404ForNotFoundDecisionDefinitionByKey() {
     // given
     final Long decisionDefinitionKey = 1L;
-    when(decisionDefinitionServices.getByKey(eq(decisionDefinitionKey), any()))
+    when(decisionDefinitionServices.getByKey(eq(decisionDefinitionKey), any(), any()))
         .thenThrow(
             ErrorMapper.mapSearchError(
                 new CamundaSearchException(
@@ -503,7 +509,7 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
   public void shouldReturn500ForInternalErrorGetDecisionDefinitionByKey() {
     // given
     final Long decisionDefinitionKey = 1L;
-    when(decisionDefinitionServices.getByKey(eq(decisionDefinitionKey), any()))
+    when(decisionDefinitionServices.getByKey(eq(decisionDefinitionKey), any(), any()))
         .thenThrow(new RuntimeException("Failed to get decision definition."));
 
     // when/then
@@ -569,9 +575,11 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
   private static Stream<Pair<String, BiFunction<DecisionDefinitionServices, Long, ?>>>
       getDecisionDecisionTestCasesParameters() {
     return Stream.of(
-        Pair.of(DECISION_DEFINITIONS_GET_URL, (service, key) -> service.getByKey(eq(key), any())),
+        Pair.of(
+            DECISION_DEFINITIONS_GET_URL,
+            (service, key) -> service.getByKey(eq(key), any(), any())),
         Pair.of(
             DECISION_DEFINITIONS_GET_XML_URL,
-            (service, key) -> service.getDecisionDefinitionXml(eq(key), any())));
+            (service, key) -> service.getDecisionDefinitionXml(eq(key), any(), any())));
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceControllerTest.java
@@ -51,7 +51,7 @@ public class DecisionInstanceControllerTest extends RestControllerTest {
     record.setResourceKey(123L);
     record.setResourceType(HistoryDeletionType.DECISION_INSTANCE);
 
-    when(decisionInstanceServices.deleteDecisionInstance(eq(1L), eq(123L), any()))
+    when(decisionInstanceServices.deleteDecisionInstance(eq(1L), eq(123L), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(record));
 
     final var request =
@@ -71,7 +71,7 @@ public class DecisionInstanceControllerTest extends RestControllerTest {
         .expectStatus()
         .isNoContent();
 
-    verify(decisionInstanceServices).deleteDecisionInstance(eq(1L), eq(123L), any());
+    verify(decisionInstanceServices).deleteDecisionInstance(eq(1L), eq(123L), any(), any());
   }
 
   @Test
@@ -81,7 +81,7 @@ public class DecisionInstanceControllerTest extends RestControllerTest {
     record.setResourceKey(123L);
     record.setResourceType(HistoryDeletionType.DECISION_INSTANCE);
 
-    when(decisionInstanceServices.deleteDecisionInstance(eq(2L), isNull(), any()))
+    when(decisionInstanceServices.deleteDecisionInstance(eq(2L), isNull(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(record));
 
     // when / then
@@ -93,7 +93,7 @@ public class DecisionInstanceControllerTest extends RestControllerTest {
         .expectStatus()
         .isNoContent();
 
-    verify(decisionInstanceServices).deleteDecisionInstance(eq(2L), isNull(), any());
+    verify(decisionInstanceServices).deleteDecisionInstance(eq(2L), isNull(), any(), any());
   }
 
   @Test
@@ -103,7 +103,7 @@ public class DecisionInstanceControllerTest extends RestControllerTest {
     record.setResourceKey(123L);
     record.setResourceType(HistoryDeletionType.DECISION_INSTANCE);
 
-    when(decisionInstanceServices.deleteDecisionInstance(eq(3L), isNull(), any()))
+    when(decisionInstanceServices.deleteDecisionInstance(eq(3L), isNull(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(record));
 
     final var request =
@@ -121,13 +121,13 @@ public class DecisionInstanceControllerTest extends RestControllerTest {
         .expectStatus()
         .isNoContent();
 
-    verify(decisionInstanceServices).deleteDecisionInstance(eq(3L), isNull(), any());
+    verify(decisionInstanceServices).deleteDecisionInstance(eq(3L), isNull(), any(), any());
   }
 
   @Test
   void shouldRejectDeleteDecisionInstanceOnDecisionInstanceNotFound() {
     // given
-    when(decisionInstanceServices.deleteDecisionInstance(eq(999L), isNull(), any()))
+    when(decisionInstanceServices.deleteDecisionInstance(eq(999L), isNull(), any(), any()))
         .thenReturn(
             CompletableFuture.failedFuture(
                 new io.camunda.service.exception.ServiceException(
@@ -158,13 +158,13 @@ public class DecisionInstanceControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedBody, JsonCompareMode.STRICT);
 
-    verify(decisionInstanceServices).deleteDecisionInstance(eq(999L), isNull(), any());
+    verify(decisionInstanceServices).deleteDecisionInstance(eq(999L), isNull(), any(), any());
   }
 
   @Test
   void shouldRejectDeleteDecisionInstanceOnForbidden() {
     // given
-    when(decisionInstanceServices.deleteDecisionInstance(eq(4L), isNull(), any()))
+    when(decisionInstanceServices.deleteDecisionInstance(eq(4L), isNull(), any(), any()))
         .thenReturn(
             CompletableFuture.failedFuture(
                 new io.camunda.service.exception.ServiceException(
@@ -195,7 +195,7 @@ public class DecisionInstanceControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedBody, JsonCompareMode.STRICT);
 
-    verify(decisionInstanceServices).deleteDecisionInstance(eq(4L), isNull(), any());
+    verify(decisionInstanceServices).deleteDecisionInstance(eq(4L), isNull(), any(), any());
   }
 
   @Test
@@ -206,7 +206,7 @@ public class DecisionInstanceControllerTest extends RestControllerTest {
     record.setBatchOperationType(BatchOperationType.DELETE_DECISION_INSTANCE);
 
     when(decisionInstanceServices.deleteDecisionInstancesBatchOperation(
-            any(DecisionInstanceFilter.class), any()))
+            any(DecisionInstanceFilter.class), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(record));
 
     final var request =
@@ -238,7 +238,7 @@ public class DecisionInstanceControllerTest extends RestControllerTest {
             JsonCompareMode.STRICT);
 
     verify(decisionInstanceServices)
-        .deleteDecisionInstancesBatchOperation(any(DecisionInstanceFilter.class), any());
+        .deleteDecisionInstancesBatchOperation(any(DecisionInstanceFilter.class), any(), any());
   }
 
   @Test

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceQueryControllerTest.java
@@ -207,7 +207,7 @@ public class DecisionInstanceQueryControllerTest extends RestControllerTest {
           expectedQuery) {
     // given
     when(decisionInstanceServices.search(
-            eq(SearchQueryBuilders.decisionInstanceSearchQuery(expectedQuery)), any()))
+            eq(SearchQueryBuilders.decisionInstanceSearchQuery(expectedQuery)), any(), any()))
         .thenReturn(SEARCH_QUERY_RESULT);
     // when
     webClient
@@ -226,7 +226,7 @@ public class DecisionInstanceQueryControllerTest extends RestControllerTest {
   void shouldReturnDecisionInstancesForNullBody() {
     // given
     when(decisionInstanceServices.search(
-            eq(SearchQueryBuilders.decisionInstanceSearchQuery(q -> q)), any()))
+            eq(SearchQueryBuilders.decisionInstanceSearchQuery(q -> q)), any(), any()))
         .thenReturn(SEARCH_QUERY_RESULT);
     // when
     webClient
@@ -269,7 +269,7 @@ public class DecisionInstanceQueryControllerTest extends RestControllerTest {
                 new DecisionInstanceOutputEntity("1", "name1", "value1", "ruleId1", 1),
                 new DecisionInstanceOutputEntity("2", "name2", "value2", "ruleId1", 1),
                 new DecisionInstanceOutputEntity("3", "name3", "value3", "ruleId2", 2)));
-    when(decisionInstanceServices.getById(eq(decisionInstanceId), any()))
+    when(decisionInstanceServices.getById(eq(decisionInstanceId), any(), any()))
         .thenReturn(decisionInstanceInDB);
     // when
     webClient
@@ -349,7 +349,7 @@ public class DecisionInstanceQueryControllerTest extends RestControllerTest {
   void shouldReturn404WhenDecisionInstanceNotFound() {
     // given
     final var decisionInstanceId = "123-1";
-    when(decisionInstanceServices.getById(eq(decisionInstanceId), any()))
+    when(decisionInstanceServices.getById(eq(decisionInstanceId), any(), any()))
         .thenThrow(
             ErrorMapper.mapSearchError(
                 new CamundaSearchException(
@@ -381,7 +381,7 @@ public class DecisionInstanceQueryControllerTest extends RestControllerTest {
   void shouldReturn500ForInternalErrorGetDecisionDefinitionByKey() {
     // given
     final var decisionInstanceId = "123-1";
-    when(decisionInstanceServices.getById(eq(decisionInstanceId), any()))
+    when(decisionInstanceServices.getById(eq(decisionInstanceId), any(), any()))
         .thenThrow(new RuntimeException("Something bad happened."));
     // when
     webClient
@@ -409,7 +409,7 @@ public class DecisionInstanceQueryControllerTest extends RestControllerTest {
   void shouldReturn403ForUnauthorizedGetDecisionDefinitionByKey() {
     // given
     final var decisionInstanceId = "123-1";
-    when(decisionInstanceServices.getById(eq(decisionInstanceId), any()))
+    when(decisionInstanceServices.getById(eq(decisionInstanceId), any(), any()))
         .thenThrow(
             ErrorMapper.createForbiddenException(
                 Authorization.of(a -> a.decisionDefinition().readDecisionInstance())));
@@ -463,7 +463,7 @@ public class DecisionInstanceQueryControllerTest extends RestControllerTest {
         .contentType(MediaType.APPLICATION_PROBLEM_JSON);
 
     // then - the service must not be invoked when validation fails
-    verify(decisionInstanceServices, never()).getById(eq(invalidKey), any());
+    verify(decisionInstanceServices, never()).getById(eq(invalidKey), any(), any());
   }
 
   private static Stream<Arguments> provideAdvancedSearchParameters() {
@@ -528,7 +528,7 @@ public class DecisionInstanceQueryControllerTest extends RestControllerTest {
             }"""
             .formatted(filterString);
     System.out.println("request = " + request);
-    when(decisionInstanceServices.search(any(DecisionInstanceQuery.class), any()))
+    when(decisionInstanceServices.search(any(DecisionInstanceQuery.class), any(), any()))
         .thenReturn(SEARCH_QUERY_RESULT);
     final var decisionInstanceKey = 123L;
 
@@ -548,7 +548,7 @@ public class DecisionInstanceQueryControllerTest extends RestControllerTest {
         .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(decisionInstanceServices)
-        .search(eq(new DecisionInstanceQuery.Builder().filter(filter).build()), any());
+        .search(eq(new DecisionInstanceQuery.Builder().filter(filter).build()), any(), any());
   }
 
   @Test
@@ -580,7 +580,8 @@ public class DecisionInstanceQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedResponse, JsonCompareMode.STRICT);
 
-    verify(decisionInstanceServices, never()).search(any(DecisionInstanceQuery.class), any());
+    verify(decisionInstanceServices, never())
+        .search(any(DecisionInstanceQuery.class), any(), any());
   }
 
   @Test
@@ -612,7 +613,8 @@ public class DecisionInstanceQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedResponse, JsonCompareMode.STRICT);
 
-    verify(decisionInstanceServices, never()).search(any(DecisionInstanceQuery.class), any());
+    verify(decisionInstanceServices, never())
+        .search(any(DecisionInstanceQuery.class), any(), any());
   }
 
   private record TestArguments(

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionRequirementsQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionRequirementsQueryControllerTest.java
@@ -97,10 +97,10 @@ public class DecisionRequirementsQueryControllerTest extends RestControllerTest 
     when(authenticationProvider.getCamundaAuthentication())
         .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
 
-    when(decisionRequirementsServices.getByKey(eq(VALID_DECISION_REQUIREMENTS_KEY), any()))
+    when(decisionRequirementsServices.getByKey(eq(VALID_DECISION_REQUIREMENTS_KEY), any(), any()))
         .thenReturn(new DecisionRequirementsEntity(1L, "id", "name", 1, "rN", null, "t"));
 
-    when(decisionRequirementsServices.getByKey(eq(INVALID_DECISION_REQUIREMENTS_KEY), any()))
+    when(decisionRequirementsServices.getByKey(eq(INVALID_DECISION_REQUIREMENTS_KEY), any(), any()))
         .thenThrow(
             ErrorMapper.mapSearchError(
                 new CamundaSearchException(
@@ -113,7 +113,7 @@ public class DecisionRequirementsQueryControllerTest extends RestControllerTest 
   @Test
   void shouldSearchDecisionRequirementsWithEmptyBody() {
     // given
-    when(decisionRequirementsServices.search(any(DecisionRequirementsQuery.class), any()))
+    when(decisionRequirementsServices.search(any(DecisionRequirementsQuery.class), any(), any()))
         .thenReturn(SEARCH_QUERY_RESULT);
     // when / then
     webClient
@@ -128,13 +128,13 @@ public class DecisionRequirementsQueryControllerTest extends RestControllerTest 
         .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(decisionRequirementsServices)
-        .search(eq(new DecisionRequirementsQuery.Builder().build()), any());
+        .search(eq(new DecisionRequirementsQuery.Builder().build()), any(), any());
   }
 
   @Test
   void shouldSearchDecisionRequirementsWithEmptyQuery() {
     // given
-    when(decisionRequirementsServices.search(any(DecisionRequirementsQuery.class), any()))
+    when(decisionRequirementsServices.search(any(DecisionRequirementsQuery.class), any(), any()))
         .thenReturn(SEARCH_QUERY_RESULT);
     final String request = "{}";
     // when / then
@@ -153,13 +153,13 @@ public class DecisionRequirementsQueryControllerTest extends RestControllerTest 
         .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(decisionRequirementsServices)
-        .search(eq(new DecisionRequirementsQuery.Builder().build()), any());
+        .search(eq(new DecisionRequirementsQuery.Builder().build()), any(), any());
   }
 
   @Test
   void shouldSearchDecisionRequirementsWithAllFilters() {
     // given
-    when(decisionRequirementsServices.search(any(DecisionRequirementsQuery.class), any()))
+    when(decisionRequirementsServices.search(any(DecisionRequirementsQuery.class), any(), any()))
         .thenReturn(SEARCH_QUERY_RESULT);
     final var request =
         """
@@ -203,13 +203,14 @@ public class DecisionRequirementsQueryControllerTest extends RestControllerTest 
                             .resourceNames("rN")
                             .build())
                     .build()),
+            any(),
             any());
   }
 
   @Test
   void shouldSearchDecisionRequirementsWithSorting() {
     // given
-    when(decisionRequirementsServices.search(any(DecisionRequirementsQuery.class), any()))
+    when(decisionRequirementsServices.search(any(DecisionRequirementsQuery.class), any(), any()))
         .thenReturn(SEARCH_QUERY_RESULT);
     final var request =
         """
@@ -270,6 +271,7 @@ public class DecisionRequirementsQueryControllerTest extends RestControllerTest 
                             .asc()
                             .build())
                     .build()),
+            any(),
             any());
   }
 
@@ -313,7 +315,7 @@ public class DecisionRequirementsQueryControllerTest extends RestControllerTest 
         .json(expectedResponse, JsonCompareMode.STRICT);
 
     verify(decisionRequirementsServices, never())
-        .search(any(DecisionRequirementsQuery.class), any());
+        .search(any(DecisionRequirementsQuery.class), any(), any());
   }
 
   @Test
@@ -329,7 +331,7 @@ public class DecisionRequirementsQueryControllerTest extends RestControllerTest 
         .json(DECISION_REQUIREMENTS_ITEM_JSON, JsonCompareMode.STRICT);
 
     verify(decisionRequirementsServices, times(1))
-        .getByKey(eq(VALID_DECISION_REQUIREMENTS_KEY), any());
+        .getByKey(eq(VALID_DECISION_REQUIREMENTS_KEY), any(), any());
   }
 
   @Test
@@ -357,7 +359,7 @@ public class DecisionRequirementsQueryControllerTest extends RestControllerTest 
             JsonCompareMode.STRICT);
 
     verify(decisionRequirementsServices, times(1))
-        .getByKey(eq(INVALID_DECISION_REQUIREMENTS_KEY), any());
+        .getByKey(eq(INVALID_DECISION_REQUIREMENTS_KEY), any(), any());
   }
 
   @ParameterizedTest
@@ -401,15 +403,17 @@ public class DecisionRequirementsQueryControllerTest extends RestControllerTest 
   private static Stream<Pair<String, BiFunction<DecisionRequirementsServices, Long, ?>>>
       getDecisionRequirementsTestCasesParameters() {
     return Stream.of(
-        Pair.of(DECISION_REQUIREMENTS_GET_URL, (service, key) -> service.getByKey(eq(key), any())),
+        Pair.of(
+            DECISION_REQUIREMENTS_GET_URL,
+            (service, key) -> service.getByKey(eq(key), any(), any())),
         Pair.of(
             DECISION_REQUIREMENTS_GET_XML_URL,
-            (service, key) -> service.getDecisionRequirementsXml(eq(key), any())));
+            (service, key) -> service.getDecisionRequirementsXml(eq(key), any(), any())));
   }
 
   @Test
   public void shouldReturn500OnUnexpectedException() throws Exception {
-    when(decisionRequirementsServices.getByKey(eq(VALID_DECISION_REQUIREMENTS_KEY), any()))
+    when(decisionRequirementsServices.getByKey(eq(VALID_DECISION_REQUIREMENTS_KEY), any(), any()))
         .thenThrow(new RuntimeException("Unexpected error"));
 
     webClient
@@ -433,7 +437,7 @@ public class DecisionRequirementsQueryControllerTest extends RestControllerTest 
             JsonCompareMode.STRICT);
 
     verify(decisionRequirementsServices, times(1))
-        .getByKey(eq(VALID_DECISION_REQUIREMENTS_KEY), any());
+        .getByKey(eq(VALID_DECISION_REQUIREMENTS_KEY), any(), any());
   }
 
   @Test
@@ -442,7 +446,7 @@ public class DecisionRequirementsQueryControllerTest extends RestControllerTest 
     final Long decisionRequirementsKey = 1L;
     final String xml = "<xml/>";
     when(decisionRequirementsServices.getDecisionRequirementsXml(
-            eq(decisionRequirementsKey), any()))
+            eq(decisionRequirementsKey), any(), any()))
         .thenReturn(xml);
 
     // when/then
@@ -463,7 +467,7 @@ public class DecisionRequirementsQueryControllerTest extends RestControllerTest 
     // given
     final Long decisionRequirementsKey = 1L;
     when(decisionRequirementsServices.getDecisionRequirementsXml(
-            eq(decisionRequirementsKey), any()))
+            eq(decisionRequirementsKey), any(), any()))
         .thenThrow(
             ErrorMapper.mapSearchError(
                 new CamundaSearchException(
@@ -498,7 +502,7 @@ public class DecisionRequirementsQueryControllerTest extends RestControllerTest 
     // given
     final Long decisionRequirementsKey = 1L;
     when(decisionRequirementsServices.getDecisionRequirementsXml(
-            eq(decisionRequirementsKey), any()))
+            eq(decisionRequirementsKey), any(), any()))
         .thenThrow(new RuntimeException("Failed to get decision requirements xml."));
 
     // when/then

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DocumentControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DocumentControllerTest.java
@@ -68,7 +68,7 @@ public class DocumentControllerTest extends RestControllerTest {
 
     final ArgumentCaptor<DocumentCreateRequest> requestCaptor =
         ArgumentCaptor.forClass(DocumentCreateRequest.class);
-    when(documentServices.createDocument(any(), any()))
+    when(documentServices.createDocument(any(), any(), any()))
         .thenReturn(
             CompletableFuture.completedFuture(
                 new DocumentReferenceResponse(
@@ -114,7 +114,7 @@ public class DocumentControllerTest extends RestControllerTest {
                 timestamp),
             JsonCompareMode.STRICT);
 
-    verify(documentServices).createDocument(requestCaptor.capture(), any());
+    verify(documentServices).createDocument(requestCaptor.capture(), any(), any());
 
     final DocumentCreateRequest request = requestCaptor.getValue();
     assertThat(request.documentId()).isNull();
@@ -144,7 +144,7 @@ public class DocumentControllerTest extends RestControllerTest {
 
     final ArgumentCaptor<DocumentCreateRequest> requestCaptor =
         ArgumentCaptor.forClass(DocumentCreateRequest.class);
-    when(documentServices.createDocument(any(), any()))
+    when(documentServices.createDocument(any(), any(), any()))
         .thenReturn(
             CompletableFuture.completedFuture(
                 new DocumentReferenceResponse(
@@ -198,7 +198,7 @@ public class DocumentControllerTest extends RestControllerTest {
                 timestamp),
             JsonCompareMode.STRICT);
 
-    verify(documentServices).createDocument(requestCaptor.capture(), any());
+    verify(documentServices).createDocument(requestCaptor.capture(), any(), any());
 
     final DocumentCreateRequest request = requestCaptor.getValue();
     assertThat(request.documentId()).isNull();
@@ -237,7 +237,7 @@ public class DocumentControllerTest extends RestControllerTest {
             "dummy_hash",
             new DocumentMetadataModel(
                 contentType.toString(), filename1, timestamp, 0L, null, 123L, Map.of()));
-    when(documentServices.createDocumentBatch(any(), any()))
+    when(documentServices.createDocumentBatch(any(), any(), any()))
         .thenReturn(
             CompletableFuture.completedFuture(List.of(Either.right(ref1), Either.right(ref1))));
 
@@ -318,7 +318,7 @@ public class DocumentControllerTest extends RestControllerTest {
                 .formatted(timestamp, timestamp),
             JsonCompareMode.STRICT);
 
-    verify(documentServices).createDocumentBatch(requestCaptor.capture(), any());
+    verify(documentServices).createDocumentBatch(requestCaptor.capture(), any(), any());
 
     final var values = requestCaptor.getValue();
     assertThat(values).extracting(DocumentCreateRequest::documentId).containsOnlyNulls();
@@ -348,7 +348,7 @@ public class DocumentControllerTest extends RestControllerTest {
     // given
     final var content = new byte[] {1, 2, 3};
 
-    when(documentServices.getDocumentContent(eq("documentId"), isNull(), isNull(), any()))
+    when(documentServices.getDocumentContent(eq("documentId"), isNull(), isNull(), any(), any()))
         .thenReturn(
             CompletableFuture.completedFuture(
                 new DocumentContentResponse(new ByteArrayInputStream(content), "application/pdf")));
@@ -368,7 +368,7 @@ public class DocumentControllerTest extends RestControllerTest {
   @Test
   void testDeleteDocument() {
     // given
-    when(documentServices.deleteDocument(eq("documentId"), isNull(), any()))
+    when(documentServices.deleteDocument(eq("documentId"), isNull(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(null));
 
     // when/then
@@ -385,7 +385,7 @@ public class DocumentControllerTest extends RestControllerTest {
     // given
     final var content = new byte[] {1, 2, 3};
 
-    when(documentServices.getDocumentContent(eq("documentId"), isNull(), isNull(), any()))
+    when(documentServices.getDocumentContent(eq("documentId"), isNull(), isNull(), any(), any()))
         .thenReturn(
             CompletableFuture.completedFuture(
                 new DocumentContentResponse(new ByteArrayInputStream(content), null)));
@@ -405,7 +405,7 @@ public class DocumentControllerTest extends RestControllerTest {
   @Test
   void shouldYieldBadRequestWhenNoHashDocumentForGetDocument() {
     // given
-    when(documentServices.getDocumentContent(any(), any(), any(), any()))
+    when(documentServices.getDocumentContent(any(), any(), any(), any(), any()))
         .thenReturn(
             CompletableFuture.failedFuture(
                 ErrorMapper.mapDocumentError(new DocumentHashMismatch("foo", null))));
@@ -436,7 +436,7 @@ public class DocumentControllerTest extends RestControllerTest {
   @Test
   void shouldYieldBadRequestWhenWrongHashForGetDocument() {
     // given
-    when(documentServices.getDocumentContent(any(), any(), any(), any()))
+    when(documentServices.getDocumentContent(any(), any(), any(), any(), any()))
         .thenReturn(
             CompletableFuture.failedFuture(
                 ErrorMapper.mapDocumentError(new DocumentHashMismatch("foo", "barbaz"))));
@@ -497,7 +497,7 @@ public class DocumentControllerTest extends RestControllerTest {
             "The provided processDefinitionId contains illegal characters. "
                 + "It must match the pattern '^[\\p{L}_][\\p{L}\\p{N}_\\-.]*$'.");
 
-    verify(documentServices, never()).createDocument(any(), any());
+    verify(documentServices, never()).createDocument(any(), any(), any());
   }
 
   @Test
@@ -539,7 +539,7 @@ public class DocumentControllerTest extends RestControllerTest {
         .isEqualTo("metadataList length (1) does not match files length (2)");
 
     // ensure service layer was not invoked
-    verify(documentServices, never()).createDocumentBatch(any(), any());
+    verify(documentServices, never()).createDocumentBatch(any(), any(), any());
   }
 
   @Test
@@ -561,7 +561,7 @@ public class DocumentControllerTest extends RestControllerTest {
             "dummy_hash",
             new DocumentMetadataModel(
                 contentType.toString(), filename1, timestamp, 0L, null, 123L, Map.of()));
-    when(documentServices.createDocumentBatch(any(), any()))
+    when(documentServices.createDocumentBatch(any(), any(), any()))
         .thenReturn(
             CompletableFuture.completedFuture(List.of(Either.right(ref), Either.right(ref))));
 
@@ -599,7 +599,7 @@ public class DocumentControllerTest extends RestControllerTest {
         .expectStatus()
         .isCreated();
 
-    verify(documentServices).createDocumentBatch(requestCaptor.capture(), any());
+    verify(documentServices).createDocumentBatch(requestCaptor.capture(), any(), any());
     final var values = requestCaptor.getValue();
     assertThat(values).hasSize(2);
     assertThat(values)
@@ -691,7 +691,7 @@ public class DocumentControllerTest extends RestControllerTest {
         .jsonPath("$.detail")
         .isEqualTo("Specify either metadataList part or X-Document-Metadata headers, but not both");
 
-    verify(documentServices, never()).createDocumentBatch(any(), any());
+    verify(documentServices, never()).createDocumentBatch(any(), any(), any());
   }
 
   @Test
@@ -728,7 +728,7 @@ public class DocumentControllerTest extends RestControllerTest {
                     Map.of())),
             ErrorMapper.mapDocumentError(new DocumentHashMismatch("doc2", "expected")));
 
-    when(documentServices.createDocumentBatch(any(), any()))
+    when(documentServices.createDocumentBatch(any(), any(), any()))
         .thenReturn(
             CompletableFuture.completedFuture(
                 List.of(Either.right(successfulRef), Either.left(failedError))));
@@ -793,6 +793,6 @@ public class DocumentControllerTest extends RestControllerTest {
             "The provided processDefinitionId contains illegal characters. "
                 + "It must match the pattern '^[\\p{L}_][\\p{L}\\p{N}_\\-.]*$'.");
 
-    verify(documentServices, never()).createDocumentBatch(any(), any());
+    verify(documentServices, never()).createDocumentBatch(any(), any(), any());
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ElementInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ElementInstanceControllerTest.java
@@ -149,7 +149,7 @@ public class ElementInstanceControllerTest extends RestControllerTest {
   @Test
   void shouldSetSetVariables() {
     // given
-    when(elementInstanceServices.setVariables(any(SetVariablesRequest.class), any()))
+    when(elementInstanceServices.setVariables(any(SetVariablesRequest.class), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new VariableDocumentRecord()));
 
     final var request =
@@ -173,7 +173,7 @@ public class ElementInstanceControllerTest extends RestControllerTest {
         .expectStatus()
         .isNoContent();
 
-    Mockito.verify(elementInstanceServices).setVariables(requestCaptor.capture(), any());
+    Mockito.verify(elementInstanceServices).setVariables(requestCaptor.capture(), any(), any());
     final var capturedRequest = requestCaptor.getValue();
     assertThat(capturedRequest.elementInstanceKey()).isEqualTo(123L);
     assertThat(capturedRequest.variables()).isEqualTo(Map.of("key", "value"));
@@ -292,7 +292,7 @@ public class ElementInstanceControllerTest extends RestControllerTest {
   @Test
   void shouldReturnGatewayTimeoutWhenSetVariablesTimesOut() {
     // given
-    when(elementInstanceServices.setVariables(any(SetVariablesRequest.class), any()))
+    when(elementInstanceServices.setVariables(any(SetVariablesRequest.class), any(), any()))
         .thenReturn(
             CompletableFuture.failedFuture(
                 ErrorMapper.mapError(new TimeoutException("Task listener blocked set variables"))));

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ElementInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ElementInstanceQueryControllerTest.java
@@ -280,7 +280,7 @@ public class ElementInstanceQueryControllerTest extends RestControllerTest {
   @Test
   void shouldSearchElementInstancesWithEmptyBody() {
     // given
-    when(elementInstanceServices.search(any(FlowNodeInstanceQuery.class), any()))
+    when(elementInstanceServices.search(any(FlowNodeInstanceQuery.class), any(), any()))
         .thenReturn(SEARCH_QUERY_RESULT);
     // when / then
     webClient
@@ -294,13 +294,14 @@ public class ElementInstanceQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
-    verify(elementInstanceServices).search(eq(new FlowNodeInstanceQuery.Builder().build()), any());
+    verify(elementInstanceServices)
+        .search(eq(new FlowNodeInstanceQuery.Builder().build()), any(), any());
   }
 
   @Test
   void shouldSearchElementInstancesWithEmptyQuery() {
     // given
-    when(elementInstanceServices.search(any(FlowNodeInstanceQuery.class), any()))
+    when(elementInstanceServices.search(any(FlowNodeInstanceQuery.class), any(), any()))
         .thenReturn(SEARCH_QUERY_RESULT);
     // when / then
     final var request = "{}";
@@ -318,13 +319,14 @@ public class ElementInstanceQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
-    verify(elementInstanceServices).search(eq(new FlowNodeInstanceQuery.Builder().build()), any());
+    verify(elementInstanceServices)
+        .search(eq(new FlowNodeInstanceQuery.Builder().build()), any(), any());
   }
 
   @Test
   void shouldSearchElementInstancesWithAllFilters() {
     // given
-    when(elementInstanceServices.search(any(FlowNodeInstanceQuery.class), any()))
+    when(elementInstanceServices.search(any(FlowNodeInstanceQuery.class), any(), any()))
         .thenReturn(SEARCH_QUERY_RESULT);
     // when / then
     final var request =
@@ -386,13 +388,14 @@ public class ElementInstanceQueryControllerTest extends RestControllerTest {
                             .elementInstanceScopeKeys(2251799813685979L)
                             .build())
                     .build()),
+            any(),
             any());
   }
 
   @Test
   void shouldSearchElementInstancesWithOrFilter() {
     // given
-    when(elementInstanceServices.search(any(FlowNodeInstanceQuery.class), any()))
+    when(elementInstanceServices.search(any(FlowNodeInstanceQuery.class), any(), any()))
         .thenReturn(SEARCH_QUERY_RESULT);
     // when / then
     final var request =
@@ -438,13 +441,14 @@ public class ElementInstanceQueryControllerTest extends RestControllerTest {
                                     .build())
                             .build())
                     .build()),
+            any(),
             any());
   }
 
   @Test
   public void shouldSearchElementInstancesWithFullSorting() {
     // given
-    when(elementInstanceServices.search(any(FlowNodeInstanceQuery.class), any()))
+    when(elementInstanceServices.search(any(FlowNodeInstanceQuery.class), any(), any()))
         .thenReturn(SEARCH_QUERY_RESULT);
     final var request =
         """
@@ -508,12 +512,14 @@ public class ElementInstanceQueryControllerTest extends RestControllerTest {
                             .asc()
                             .build())
                     .build()),
+            any(),
             any());
   }
 
   @Test
   void shouldGetElementInstanceByKey() {
-    when(elementInstanceServices.getByKey(any(Long.class), any())).thenReturn(GET_QUERY_RESULT);
+    when(elementInstanceServices.getByKey(any(Long.class), any(), any()))
+        .thenReturn(GET_QUERY_RESULT);
     // when / then
     webClient
         .get()
@@ -524,12 +530,12 @@ public class ElementInstanceQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(EXPECTED_GET_RESPONSE, JsonCompareMode.STRICT);
 
-    verify(elementInstanceServices).getByKey(eq(23L), any());
+    verify(elementInstanceServices).getByKey(eq(23L), any(), any());
   }
 
   @Test
   void shouldThrowNotFoundIfKeyNotExistsForGetElementInstanceByKey() {
-    when(elementInstanceServices.getByKey(any(Long.class), any()))
+    when(elementInstanceServices.getByKey(any(Long.class), any(), any()))
         .thenThrow(
             ErrorMapper.mapSearchError(
                 new CamundaSearchException("", CamundaSearchException.Reason.NOT_FOUND)));
@@ -554,7 +560,7 @@ public class ElementInstanceQueryControllerTest extends RestControllerTest {
                 """,
             JsonCompareMode.STRICT);
 
-    verify(elementInstanceServices).getByKey(eq(5L), any());
+    verify(elementInstanceServices).getByKey(eq(5L), any(), any());
   }
 
   private static Stream<Arguments> provideAdvancedSearchParameters() {
@@ -604,7 +610,7 @@ public class ElementInstanceQueryControllerTest extends RestControllerTest {
             }"""
             .formatted(filterString);
     System.out.println("request = " + request);
-    when(elementInstanceServices.search(queryCaptor.capture(), any()))
+    when(elementInstanceServices.search(queryCaptor.capture(), any(), any()))
         .thenReturn(SEARCH_QUERY_RESULT);
 
     // when / then
@@ -623,13 +629,14 @@ public class ElementInstanceQueryControllerTest extends RestControllerTest {
         .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(elementInstanceServices)
-        .search(eq(new FlowNodeInstanceQuery.Builder().filter(filter).build()), any());
+        .search(eq(new FlowNodeInstanceQuery.Builder().filter(filter).build()), any(), any());
   }
 
   @Test
   void shouldSearchIncidentsForElementInstance() {
     // given
-    when(elementInstanceServices.searchIncidents(any(Long.class), any(IncidentQuery.class), any()))
+    when(elementInstanceServices.searchIncidents(
+            any(Long.class), any(IncidentQuery.class), any(), any()))
         .thenReturn(INCIDENT_SEARCH_RESULT);
     // when / then
     webClient
@@ -645,13 +652,14 @@ public class ElementInstanceQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(EXPECTED_INCIDENT_SEARCH_RESPONSE, JsonCompareMode.STRICT);
     verify(elementInstanceServices)
-        .searchIncidents(any(Long.class), any(IncidentQuery.class), any());
+        .searchIncidents(any(Long.class), any(IncidentQuery.class), any(), any());
   }
 
   @Test
   void shouldSearchIncidentsForElementInstanceWithNullBody() {
     // given
-    when(elementInstanceServices.searchIncidents(any(Long.class), any(IncidentQuery.class), any()))
+    when(elementInstanceServices.searchIncidents(
+            any(Long.class), any(IncidentQuery.class), any(), any()))
         .thenReturn(INCIDENT_SEARCH_RESULT);
     // when / then
     webClient
@@ -666,7 +674,7 @@ public class ElementInstanceQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(EXPECTED_INCIDENT_SEARCH_RESPONSE, JsonCompareMode.STRICT);
     verify(elementInstanceServices)
-        .searchIncidents(any(Long.class), any(IncidentQuery.class), any());
+        .searchIncidents(any(Long.class), any(IncidentQuery.class), any(), any());
   }
 
   private static Stream<Arguments> provideAdvancedIncidentSearchParameters() {
@@ -767,7 +775,8 @@ public class ElementInstanceQueryControllerTest extends RestControllerTest {
                 "filter": %s
             }"""
             .formatted(filterString);
-    when(elementInstanceServices.searchIncidents(eq(123L), incidentQueryCaptor.capture(), any()))
+    when(elementInstanceServices.searchIncidents(
+            eq(123L), incidentQueryCaptor.capture(), any(), any()))
         .thenReturn(SEARCH_INCIDENT_QUERY_RESULT);
 
     // when / then
@@ -786,6 +795,7 @@ public class ElementInstanceQueryControllerTest extends RestControllerTest {
         .consumeWith(result -> assertJsonNonExtensible(result.getResponseBody()));
 
     verify(elementInstanceServices)
-        .searchIncidents(eq(123L), eq(new IncidentQuery.Builder().filter(filter).build()), any());
+        .searchIncidents(
+            eq(123L), eq(new IncidentQuery.Builder().filter(filter).build()), any(), any());
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ErrorMapperTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ErrorMapperTest.java
@@ -77,7 +77,7 @@ public class ErrorMapperTest extends RestControllerTest {
   @Test
   void shouldYieldNotFoundWhenBrokerErrorNotFound() {
     // given
-    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any()))
+    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any(), any()))
         .thenReturn(
             CompletableFuture.failedFuture(
                 ErrorMapper.mapBrokerError(
@@ -106,7 +106,7 @@ public class ErrorMapperTest extends RestControllerTest {
   @Test
   void shouldYieldServiceUnavailableWhenBrokerErrorExhausted() {
     // given
-    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any()))
+    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any(), any()))
         .thenReturn(
             CompletableFuture.failedFuture(
                 ErrorMapper.mapBrokerError(
@@ -135,7 +135,7 @@ public class ErrorMapperTest extends RestControllerTest {
   @Test
   void shouldYieldUnavailableWhenBrokerErrorLeaderMismatch() {
     // given
-    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any()))
+    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any(), any()))
         .thenReturn(
             CompletableFuture.failedFuture(
                 ErrorMapper.mapBrokerError(
@@ -175,7 +175,7 @@ public class ErrorMapperTest extends RestControllerTest {
       })
   public void shouldYieldInternalErrorWhenBrokerError(final ErrorCode errorCode) {
     // given
-    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any()))
+    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any(), any()))
         .thenReturn(
             CompletableFuture.failedFuture(
                 ErrorMapper.mapBrokerError(new BrokerError(errorCode, "Just an error"))));
@@ -210,7 +210,7 @@ public class ErrorMapperTest extends RestControllerTest {
       names = {"PROCESSING_ERROR", "EXCEEDED_BATCH_RECORD_SIZE"})
   public void shouldYieldInternalErrorWhenRejectionInternal(final RejectionType rejectionType) {
     // given
-    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any()))
+    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any(), any()))
         .thenReturn(
             CompletableFuture.failedFuture(
                 ErrorMapper.mapBrokerRejection(
@@ -242,7 +242,7 @@ public class ErrorMapperTest extends RestControllerTest {
         .expectBody()
         .json(expectedBody, JsonCompareMode.STRICT);
 
-    Mockito.verify(userTaskServices).completeUserTask(eq(1L), eq(Map.of()), eq(""), any());
+    Mockito.verify(userTaskServices).completeUserTask(eq(1L), eq(Map.of()), eq(""), any(), any());
   }
 
   @ParameterizedTest
@@ -251,7 +251,7 @@ public class ErrorMapperTest extends RestControllerTest {
       names = {"SBE_UNKNOWN", "NULL_VAL"})
   public void shouldYieldInternalErrorWhenRejectionUnknown(final RejectionType rejectionType) {
     // given
-    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any()))
+    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any(), any()))
         .thenReturn(
             CompletableFuture.failedFuture(
                 ErrorMapper.mapBrokerRejection(
@@ -283,13 +283,13 @@ public class ErrorMapperTest extends RestControllerTest {
         .expectBody()
         .json(expectedBody, JsonCompareMode.STRICT);
 
-    Mockito.verify(userTaskServices).completeUserTask(eq(1L), eq(Map.of()), eq(""), any());
+    Mockito.verify(userTaskServices).completeUserTask(eq(1L), eq(Map.of()), eq(""), any(), any());
   }
 
   @Test
   public void shouldYieldInternalErrorWhenException() {
     // given
-    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any()))
+    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any(), any()))
         .thenReturn(
             CompletableFuture.failedFuture(
                 ErrorMapper.mapSearchError(
@@ -346,7 +346,7 @@ public class ErrorMapperTest extends RestControllerTest {
   @Test
   public void shouldReturnGatewayTimeoutOnTimeoutException() {
     // given
-    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any()))
+    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any(), any()))
         .thenReturn(
             CompletableFuture.failedFuture(
                 ErrorMapper.mapError(new TimeoutException("Oh noes, timeouts!"))));
@@ -379,7 +379,7 @@ public class ErrorMapperTest extends RestControllerTest {
   public void shouldReturnBadGatewayOnConnectionClosed() {
     // given
     final var errorMsg = "Oh noes, connection closed!";
-    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any()))
+    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any(), any()))
         .thenReturn(
             CompletableFuture.failedFuture(ErrorMapper.mapError(new ConnectionClosed(errorMsg))));
 
@@ -411,7 +411,7 @@ public class ErrorMapperTest extends RestControllerTest {
   @Test
   public void shouldReturnServiceUnavailableOnConnectTimeoutException() {
     // given
-    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any()))
+    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any(), any()))
         .thenReturn(
             CompletableFuture.failedFuture(
                 ErrorMapper.mapError(
@@ -444,7 +444,7 @@ public class ErrorMapperTest extends RestControllerTest {
   @Test
   public void shouldReturnServiceUnavailableOnConnectException() {
     // given
-    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any()))
+    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any(), any()))
         .thenReturn(
             CompletableFuture.failedFuture(
                 ErrorMapper.mapError(new ConnectException("Oh noes, connection timeouts!"))));
@@ -476,7 +476,7 @@ public class ErrorMapperTest extends RestControllerTest {
   @Test
   public void shouldReturnServiceUnavailableOnPartitionNotFoundException() {
     // given
-    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any()))
+    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any(), any()))
         .thenReturn(
             CompletableFuture.failedFuture(
                 ErrorMapper.mapError(new PartitionNotFoundException(1))));
@@ -508,7 +508,7 @@ public class ErrorMapperTest extends RestControllerTest {
   @Test
   public void shouldReturnBadRequestOnMsgpackException() {
     // given;
-    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any()))
+    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any(), any()))
         .thenReturn(
             CompletableFuture.failedFuture(
                 ErrorMapper.mapError(new MsgpackException("Oh noes, msg parsing!"))));
@@ -540,7 +540,7 @@ public class ErrorMapperTest extends RestControllerTest {
   @Test
   public void shouldReturnBadRequestOnJsonParseException() {
     // given
-    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any()))
+    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any(), any()))
         .thenReturn(
             CompletableFuture.failedFuture(
                 ErrorMapper.mapError(new JsonParseException("Oh noes, json parsing!"))));
@@ -571,7 +571,7 @@ public class ErrorMapperTest extends RestControllerTest {
   @Test
   public void shouldReturnBadRequestOnIllegalArgumentException() {
     // given
-    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any()))
+    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any(), any()))
         .thenReturn(
             CompletableFuture.failedFuture(
                 ErrorMapper.mapError(new IllegalArgumentException("Oh noes, illegal arguments!"))));
@@ -602,7 +602,7 @@ public class ErrorMapperTest extends RestControllerTest {
   @Test
   public void shouldReturnServiceUnavailableOnRequestRetriesExhaustedException() {
     // given
-    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any()))
+    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any(), any()))
         .thenReturn(
             CompletableFuture.failedFuture(
                 ErrorMapper.mapError(new RequestRetriesExhaustedException())));
@@ -634,7 +634,7 @@ public class ErrorMapperTest extends RestControllerTest {
   @Test
   void shouldYieldUnavailableWhenPartitionPausesProcessing() {
     // given
-    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any()))
+    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any(), any()))
         .thenReturn(
             CompletableFuture.failedFuture(
                 ErrorMapper.mapBrokerError(
@@ -663,7 +663,7 @@ public class ErrorMapperTest extends RestControllerTest {
   @Test
   public void shouldYieldMaxMessageSizeExceededWhenRequestIsTooLarge() {
     // given
-    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any()))
+    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any(), any()))
         .thenReturn(
             CompletableFuture.failedFuture(
                 ErrorMapper.mapBrokerError(

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ExpressionControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ExpressionControllerTest.java
@@ -60,7 +60,8 @@ public class ExpressionControllerTest extends RestControllerTest {
     when(expressionRecord.getResultValue()).thenReturn("10");
     when(expressionRecord.getWarnings()).thenReturn(List.of());
 
-    when(expressionServices.evaluateExpression(any(ExpressionEvaluationRequest.class), any()))
+    when(expressionServices.evaluateExpression(
+            any(ExpressionEvaluationRequest.class), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(expressionRecord));
 
     final var request =
@@ -90,7 +91,7 @@ public class ExpressionControllerTest extends RestControllerTest {
             }""",
             JsonCompareMode.STRICT);
 
-    verify(expressionServices).evaluateExpression(requestCaptor.capture(), any());
+    verify(expressionServices).evaluateExpression(requestCaptor.capture(), any(), any());
     final var capturedRequest = requestCaptor.getValue();
     assertThat(capturedRequest.expression()).isEqualTo("=x + y");
     assertThat(capturedRequest.tenantId()).isEqualTo("tenant1");
@@ -105,7 +106,8 @@ public class ExpressionControllerTest extends RestControllerTest {
     when(expressionRecord.getResultValue()).thenReturn("10");
     when(expressionRecord.getWarnings()).thenReturn(List.of());
 
-    when(expressionServices.evaluateExpression(any(ExpressionEvaluationRequest.class), any()))
+    when(expressionServices.evaluateExpression(
+            any(ExpressionEvaluationRequest.class), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(expressionRecord));
 
     final var request =
@@ -139,7 +141,7 @@ public class ExpressionControllerTest extends RestControllerTest {
             }""",
             JsonCompareMode.STRICT);
 
-    verify(expressionServices).evaluateExpression(requestCaptor.capture(), any());
+    verify(expressionServices).evaluateExpression(requestCaptor.capture(), any(), any());
     final var capturedRequest = requestCaptor.getValue();
     assertThat(capturedRequest.expression()).isEqualTo("=x + y");
     assertThat(capturedRequest.tenantId()).isEqualTo("tenant1");
@@ -155,7 +157,8 @@ public class ExpressionControllerTest extends RestControllerTest {
     when(expressionRecord.getWarnings())
         .thenReturn(List.of("No function found with name 'invalid_function' and 0 parameters"));
 
-    when(expressionServices.evaluateExpression(any(ExpressionEvaluationRequest.class), any()))
+    when(expressionServices.evaluateExpression(
+            any(ExpressionEvaluationRequest.class), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(expressionRecord));
 
     final var request =
@@ -301,7 +304,7 @@ public class ExpressionControllerTest extends RestControllerTest {
         .json(expectedBody, JsonCompareMode.STRICT);
 
     verify(expressionServices, never())
-        .evaluateExpression(any(ExpressionEvaluationRequest.class), any());
+        .evaluateExpression(any(ExpressionEvaluationRequest.class), any(), any());
   }
 
   @Test
@@ -312,7 +315,8 @@ public class ExpressionControllerTest extends RestControllerTest {
     when(expressionRecord.getResultValue()).thenReturn("1");
     when(expressionRecord.getWarnings()).thenReturn(List.of());
 
-    when(expressionServices.evaluateExpression(any(ExpressionEvaluationRequest.class), any()))
+    when(expressionServices.evaluateExpression(
+            any(ExpressionEvaluationRequest.class), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(expressionRecord));
 
     final var request =
@@ -334,7 +338,7 @@ public class ExpressionControllerTest extends RestControllerTest {
         .expectStatus()
         .isOk();
 
-    verify(expressionServices).evaluateExpression(requestCaptor.capture(), any());
+    verify(expressionServices).evaluateExpression(requestCaptor.capture(), any(), any());
     final var captured = requestCaptor.getValue();
     assertThat(captured.scopeKey()).isEqualTo(2251799813685249L);
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/GlobalTaskListenerControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/GlobalTaskListenerControllerTest.java
@@ -72,7 +72,8 @@ public class GlobalTaskListenerControllerTest extends RestControllerTest {
             GlobalListenerSource.API,
             GlobalListenerType.USER_TASK);
 
-    when(globalListenerServices.getGlobalTaskListener(any(GlobalListenerRecord.class), any()))
+    when(globalListenerServices.getGlobalTaskListener(
+            any(GlobalListenerRecord.class), any(), any()))
         .thenReturn(entity);
 
     // when / then
@@ -84,7 +85,8 @@ public class GlobalTaskListenerControllerTest extends RestControllerTest {
         .expectStatus()
         .isOk();
 
-    verify(globalListenerServices).getGlobalTaskListener(listenerRecordCaptor.capture(), any());
+    verify(globalListenerServices)
+        .getGlobalTaskListener(listenerRecordCaptor.capture(), any(), any());
     final var capturedRequest = listenerRecordCaptor.getValue();
     assertThat(capturedRequest.getId()).isEqualTo("my-listener");
     assertThat(capturedRequest.getListenerType())
@@ -152,7 +154,7 @@ public class GlobalTaskListenerControllerTest extends RestControllerTest {
             .items(List.of(entity1, entity2))
             .build();
 
-    when(globalListenerServices.search(any(GlobalListenerQuery.class), any()))
+    when(globalListenerServices.search(any(GlobalListenerQuery.class), any(), any()))
         .thenReturn(searchResult);
 
     final var requestBody =
@@ -172,14 +174,15 @@ public class GlobalTaskListenerControllerTest extends RestControllerTest {
         .expectStatus()
         .isOk();
 
-    verify(globalListenerServices).search(searchQueryCaptor.capture(), any());
+    verify(globalListenerServices).search(searchQueryCaptor.capture(), any(), any());
     assertThat(searchQueryCaptor.getValue()).isNotNull();
   }
 
   @Test
   void shouldHandleErrorInGetGlobalTaskListener() {
     // given
-    when(globalListenerServices.getGlobalTaskListener(any(GlobalListenerRecord.class), any()))
+    when(globalListenerServices.getGlobalTaskListener(
+            any(GlobalListenerRecord.class), any(), any()))
         .thenThrow(new RuntimeException("Test error"));
 
     // when / then
@@ -195,7 +198,7 @@ public class GlobalTaskListenerControllerTest extends RestControllerTest {
   @Test
   void shouldHandleErrorInSearch() {
     // given
-    when(globalListenerServices.search(any(GlobalListenerQuery.class), any()))
+    when(globalListenerServices.search(any(GlobalListenerQuery.class), any(), any()))
         .thenThrow(new RuntimeException("Test error"));
 
     final var requestBody =

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/IncidentControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/IncidentControllerTest.java
@@ -49,7 +49,7 @@ public class IncidentControllerTest extends RestControllerTest {
   @Test
   void shouldResolveIncident() {
     // given
-    when(incidentServices.resolveIncident(anyLong(), any(), any()))
+    when(incidentServices.resolveIncident(anyLong(), any(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new IncidentRecord()));
 
     final String request =
@@ -69,13 +69,13 @@ public class IncidentControllerTest extends RestControllerTest {
         .expectStatus()
         .isNoContent();
 
-    verify(incidentServices).resolveIncident(eq(1L), eq(12345678L), any());
+    verify(incidentServices).resolveIncident(eq(1L), eq(12345678L), any(), any());
   }
 
   @Test
   void shouldReturnNotFoundIfIncidentNotFound() {
     // given
-    Mockito.when(incidentServices.resolveIncident(anyLong(), any(), any()))
+    Mockito.when(incidentServices.resolveIncident(anyLong(), any(), any(), any()))
         .thenReturn(
             CompletableFuture.failedFuture(
                 ErrorMapper.mapBrokerRejection(
@@ -110,6 +110,6 @@ public class IncidentControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedBody, JsonCompareMode.STRICT);
 
-    verify(incidentServices).resolveIncident(eq(1L), isNull(), any());
+    verify(incidentServices).resolveIncident(eq(1L), isNull(), any(), any());
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/IncidentQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/IncidentQueryControllerTest.java
@@ -217,7 +217,8 @@ public class IncidentQueryControllerTest extends RestControllerTest {
   @Test
   void shouldSearchIncidentWithEmptyBody() {
     // given
-    when(incidentServices.search(any(IncidentQuery.class), any())).thenReturn(SEARCH_QUERY_RESULT);
+    when(incidentServices.search(any(IncidentQuery.class), any(), any()))
+        .thenReturn(SEARCH_QUERY_RESULT);
     // when / then
     webClient
         .post()
@@ -230,13 +231,14 @@ public class IncidentQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
-    verify(incidentServices).search(eq(new IncidentQuery.Builder().build()), any());
+    verify(incidentServices).search(eq(new IncidentQuery.Builder().build()), any(), any());
   }
 
   @Test
   void shouldSearchIncidentWithEmptyQuery() {
     // given
-    when(incidentServices.search(any(IncidentQuery.class), any())).thenReturn(SEARCH_QUERY_RESULT);
+    when(incidentServices.search(any(IncidentQuery.class), any(), any()))
+        .thenReturn(SEARCH_QUERY_RESULT);
     final var request = "{}";
     // when / then
     webClient
@@ -253,12 +255,13 @@ public class IncidentQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
-    verify(incidentServices).search(eq(new IncidentQuery.Builder().build()), any());
+    verify(incidentServices).search(eq(new IncidentQuery.Builder().build()), any(), any());
   }
 
   @Test
   void shouldSearchIncidentWithAllFilters() {
-    when(incidentServices.search(any(IncidentQuery.class), any())).thenReturn(SEARCH_QUERY_RESULT);
+    when(incidentServices.search(any(IncidentQuery.class), any(), any()))
+        .thenReturn(SEARCH_QUERY_RESULT);
     final var request =
         """
             {
@@ -316,12 +319,14 @@ public class IncidentQueryControllerTest extends RestControllerTest {
                             .tenantIds("tenantId")
                             .build())
                     .build()),
+            any(),
             any());
   }
 
   @Test
   void shouldSearchIncidentWithFullSorting() {
-    when(incidentServices.search(any(IncidentQuery.class), any())).thenReturn(SEARCH_QUERY_RESULT);
+    when(incidentServices.search(any(IncidentQuery.class), any(), any()))
+        .thenReturn(SEARCH_QUERY_RESULT);
     final var request =
         """
             {
@@ -354,12 +359,13 @@ public class IncidentQueryControllerTest extends RestControllerTest {
                 new IncidentQuery.Builder()
                     .sort(new IncidentSort.Builder().incidentKey().asc().build())
                     .build()),
+            any(),
             any());
   }
 
   @Test
   void shouldGetIncidentByKey() {
-    when(incidentServices.getByKey(any(Long.class), any())).thenReturn(GET_QUERY_RESULT);
+    when(incidentServices.getByKey(any(Long.class), any(), any())).thenReturn(GET_QUERY_RESULT);
     // when / then
     webClient
         .get()
@@ -372,12 +378,12 @@ public class IncidentQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(EXPECTED_GET_RESPONSE, JsonCompareMode.STRICT);
 
-    verify(incidentServices).getByKey(eq(23L), any());
+    verify(incidentServices).getByKey(eq(23L), any(), any());
   }
 
   @Test
   void shouldThrowNotFoundIfKeyNotExistsForGetIncidentByKey() {
-    when(incidentServices.getByKey(any(Long.class), any()))
+    when(incidentServices.getByKey(any(Long.class), any(), any()))
         .thenThrow(
             ErrorMapper.mapSearchError(
                 new CamundaSearchException("", CamundaSearchException.Reason.NOT_FOUND)));
@@ -402,13 +408,13 @@ public class IncidentQueryControllerTest extends RestControllerTest {
                 """,
             JsonCompareMode.STRICT);
 
-    verify(incidentServices).getByKey(eq(5L), any());
+    verify(incidentServices).getByKey(eq(5L), any(), any());
   }
 
   @Test
   void shouldReturnIncidentProcessInstanceStatisticsByError() {
     when(incidentServices.incidentProcessInstanceStatisticsByError(
-            any(IncidentProcessInstanceStatisticsByErrorQuery.class), any()))
+            any(IncidentProcessInstanceStatisticsByErrorQuery.class), any(), any()))
         .thenReturn(INCIDENT_PROCESS_INSTANCE_STATISTICS_BY_ERROR_QUERY_RESULT);
 
     webClient
@@ -427,14 +433,14 @@ public class IncidentQueryControllerTest extends RestControllerTest {
 
     verify(incidentServices)
         .incidentProcessInstanceStatisticsByError(
-            eq(new IncidentProcessInstanceStatisticsByErrorQuery.Builder().build()), any());
+            eq(new IncidentProcessInstanceStatisticsByErrorQuery.Builder().build()), any(), any());
   }
 
   @Test
   void shouldSortIncidentProcessInstanceStatisticsByError() {
     // given
     when(incidentServices.incidentProcessInstanceStatisticsByError(
-            any(IncidentProcessInstanceStatisticsByErrorQuery.class), any()))
+            any(IncidentProcessInstanceStatisticsByErrorQuery.class), any(), any()))
         .thenReturn(INCIDENT_PROCESS_INSTANCE_STATISTICS_BY_ERROR_QUERY_RESULT);
 
     final var request =
@@ -476,6 +482,7 @@ public class IncidentQueryControllerTest extends RestControllerTest {
                 new IncidentProcessInstanceStatisticsByErrorQuery.Builder()
                     .sort(s -> s.errorMessage().asc().activeInstancesWithErrorCount().desc())
                     .build()),
+            any(),
             any());
   }
 
@@ -483,7 +490,7 @@ public class IncidentQueryControllerTest extends RestControllerTest {
   void shouldPaginateIncidentProcessInstanceStatisticsByError() {
     // given
     when(incidentServices.incidentProcessInstanceStatisticsByError(
-            any(IncidentProcessInstanceStatisticsByErrorQuery.class), any()))
+            any(IncidentProcessInstanceStatisticsByErrorQuery.class), any(), any()))
         .thenReturn(INCIDENT_PROCESS_INSTANCE_STATISTICS_BY_ERROR_QUERY_RESULT);
 
     final var request =
@@ -516,6 +523,7 @@ public class IncidentQueryControllerTest extends RestControllerTest {
                 new IncidentProcessInstanceStatisticsByErrorQuery.Builder()
                     .page(p -> p.from(0).size(5))
                     .build()),
+            any(),
             any());
   }
 
@@ -523,7 +531,7 @@ public class IncidentQueryControllerTest extends RestControllerTest {
   void shouldReturnIncidentProcessInstanceStatisticsByDefinition() {
     // given
     when(incidentServices.searchIncidentProcessInstanceStatisticsByDefinition(
-            any(IncidentProcessInstanceStatisticsByDefinitionQuery.class), any()))
+            any(IncidentProcessInstanceStatisticsByDefinitionQuery.class), any(), any()))
         .thenReturn(INCIDENT_PROCESS_INSTANCE_STATISTICS_BY_DEFINITION_QUERY_RESULT);
 
     final var request =
@@ -554,7 +562,8 @@ public class IncidentQueryControllerTest extends RestControllerTest {
         new IncidentProcessInstanceStatisticsByDefinitionQuery.Builder()
             .filter(f -> f.errorHashCode(ERROR_HASH_CODE).state(IncidentState.ACTIVE.name()))
             .build();
-    verify(incidentServices).searchIncidentProcessInstanceStatisticsByDefinition(eq(result), any());
+    verify(incidentServices)
+        .searchIncidentProcessInstanceStatisticsByDefinition(eq(result), any(), any());
   }
 
   @Test
@@ -664,7 +673,7 @@ public class IncidentQueryControllerTest extends RestControllerTest {
   void shouldSortIncidentProcessInstanceStatisticsByDefinition() {
     // given
     when(incidentServices.searchIncidentProcessInstanceStatisticsByDefinition(
-            any(IncidentProcessInstanceStatisticsByDefinitionQuery.class), any()))
+            any(IncidentProcessInstanceStatisticsByDefinitionQuery.class), any(), any()))
         .thenReturn(INCIDENT_PROCESS_INSTANCE_STATISTICS_BY_DEFINITION_QUERY_RESULT);
 
     final var request =
@@ -722,6 +731,7 @@ public class IncidentQueryControllerTest extends RestControllerTest {
                                 .activeInstancesWithErrorCount()
                                 .asc())
                     .build()),
+            any(),
             any());
   }
 
@@ -729,7 +739,7 @@ public class IncidentQueryControllerTest extends RestControllerTest {
   void shouldPaginateIncidentProcessInstanceStatisticsByDefinition() {
     // given
     when(incidentServices.searchIncidentProcessInstanceStatisticsByDefinition(
-            any(IncidentProcessInstanceStatisticsByDefinitionQuery.class), any()))
+            any(IncidentProcessInstanceStatisticsByDefinitionQuery.class), any(), any()))
         .thenReturn(INCIDENT_PROCESS_INSTANCE_STATISTICS_BY_DEFINITION_QUERY_RESULT);
 
     final var request =
@@ -765,6 +775,7 @@ public class IncidentQueryControllerTest extends RestControllerTest {
                         f -> f.errorHashCode(ERROR_HASH_CODE).state(IncidentState.ACTIVE.name()))
                     .page(p -> p.from(0).size(5))
                     .build()),
+            any(),
             any());
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
@@ -78,7 +78,7 @@ public class JobControllerTest extends RestControllerTest {
   @Test
   void shouldFailJob() {
     // given
-    when(jobServices.failJob(anyLong(), anyInt(), anyString(), anyLong(), any(), any()))
+    when(jobServices.failJob(anyLong(), anyInt(), anyString(), anyLong(), any(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
 
     final var request =
@@ -103,13 +103,13 @@ public class JobControllerTest extends RestControllerTest {
         .isNoContent();
 
     Mockito.verify(jobServices)
-        .failJob(eq(1L), eq(1), eq("error"), eq(1L), eq(Map.of("foo", "bar")), any());
+        .failJob(eq(1L), eq(1), eq("error"), eq(1L), eq(Map.of("foo", "bar")), any(), any());
   }
 
   @Test
   void shouldFailJobWithoutBody() {
     // given
-    when(jobServices.failJob(anyLong(), anyInt(), anyString(), anyLong(), any(), any()))
+    when(jobServices.failJob(anyLong(), anyInt(), anyString(), anyLong(), any(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
 
     // when/then
@@ -121,13 +121,13 @@ public class JobControllerTest extends RestControllerTest {
         .exchange()
         .expectStatus()
         .isNoContent();
-    Mockito.verify(jobServices).failJob(eq(1L), eq(0), eq(""), eq(0L), eq(Map.of()), any());
+    Mockito.verify(jobServices).failJob(eq(1L), eq(0), eq(""), eq(0L), eq(Map.of()), any(), any());
   }
 
   @Test
   void shouldFailJobWithEmptyBody() {
     // given
-    when(jobServices.failJob(anyLong(), anyInt(), anyString(), anyLong(), any(), any()))
+    when(jobServices.failJob(anyLong(), anyInt(), anyString(), anyLong(), any(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
 
     final var request =
@@ -146,13 +146,13 @@ public class JobControllerTest extends RestControllerTest {
         .expectStatus()
         .isNoContent();
 
-    Mockito.verify(jobServices).failJob(eq(1L), eq(0), eq(""), eq(0L), eq(Map.of()), any());
+    Mockito.verify(jobServices).failJob(eq(1L), eq(0), eq(""), eq(0L), eq(Map.of()), any(), any());
   }
 
   @Test
   void shouldThrowErrorJob() {
     // given
-    when(jobServices.errorJob(anyLong(), anyString(), anyString(), any(), any()))
+    when(jobServices.errorJob(anyLong(), anyString(), anyString(), any(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
 
     final var request =
@@ -176,7 +176,7 @@ public class JobControllerTest extends RestControllerTest {
         .isNoContent();
 
     Mockito.verify(jobServices)
-        .errorJob(eq(1L), eq("400"), eq("error"), eq(Map.of("foo", "bar")), any());
+        .errorJob(eq(1L), eq("400"), eq("error"), eq(Map.of("foo", "bar")), any(), any());
   }
 
   @Test
@@ -330,7 +330,7 @@ public class JobControllerTest extends RestControllerTest {
   @Test
   void shouldCompleteJob() {
     // given
-    when(jobServices.completeJob(anyLong(), any(), any(), any()))
+    when(jobServices.completeJob(anyLong(), any(), any(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
     // when/then
     webClient
@@ -342,13 +342,14 @@ public class JobControllerTest extends RestControllerTest {
         .expectStatus()
         .isNoContent();
 
-    Mockito.verify(jobServices).completeJob(eq(1L), eq(Map.of()), any(JobResult.class), any());
+    Mockito.verify(jobServices)
+        .completeJob(eq(1L), eq(Map.of()), any(JobResult.class), any(), any());
   }
 
   @Test
   void shouldCompleteJobWithResultDeniedTrue() {
     // given
-    when(jobServices.completeJob(anyLong(), any(), any(), any()))
+    when(jobServices.completeJob(anyLong(), any(), any(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
 
     final var request =
@@ -376,14 +377,14 @@ public class JobControllerTest extends RestControllerTest {
     final ArgumentCaptor<JobResult> jobResultArgumentCaptor =
         ArgumentCaptor.forClass(JobResult.class);
     Mockito.verify(jobServices)
-        .completeJob(eq(1L), eq(Map.of()), jobResultArgumentCaptor.capture(), any());
+        .completeJob(eq(1L), eq(Map.of()), jobResultArgumentCaptor.capture(), any(), any());
     assertThat(jobResultArgumentCaptor.getValue().isDenied()).isTrue();
   }
 
   @Test
   void shouldCompleteJobWithResultDeniedTrueAndDeniedReason() {
     // given
-    when(jobServices.completeJob(anyLong(), any(), any(), any()))
+    when(jobServices.completeJob(anyLong(), any(), any(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
 
     final var request =
@@ -412,7 +413,7 @@ public class JobControllerTest extends RestControllerTest {
     final ArgumentCaptor<JobResult> jobResultArgumentCaptor =
         ArgumentCaptor.forClass(JobResult.class);
     Mockito.verify(jobServices)
-        .completeJob(eq(1L), eq(Map.of()), jobResultArgumentCaptor.capture(), any());
+        .completeJob(eq(1L), eq(Map.of()), jobResultArgumentCaptor.capture(), any(), any());
     assertThat(jobResultArgumentCaptor.getValue().isDenied()).isTrue();
     assertThat(jobResultArgumentCaptor.getValue().getDeniedReason())
         .isEqualTo("Reason to deny lifecycle transition");
@@ -421,7 +422,7 @@ public class JobControllerTest extends RestControllerTest {
   @Test
   void shouldCompleteJobWithResultWithCorrections() {
     // given
-    when(jobServices.completeJob(anyLong(), any(), any(), any()))
+    when(jobServices.completeJob(anyLong(), any(), any(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
 
     final var request =
@@ -456,7 +457,7 @@ public class JobControllerTest extends RestControllerTest {
     final ArgumentCaptor<JobResult> jobResultArgumentCaptor =
         ArgumentCaptor.forClass(JobResult.class);
     Mockito.verify(jobServices)
-        .completeJob(eq(1L), eq(Map.of()), jobResultArgumentCaptor.capture(), any());
+        .completeJob(eq(1L), eq(Map.of()), jobResultArgumentCaptor.capture(), any(), any());
 
     assertThat(jobResultArgumentCaptor.getValue().getCorrections())
         .isEqualTo(
@@ -481,7 +482,7 @@ public class JobControllerTest extends RestControllerTest {
   @Test
   void shouldCompleteJobWithResultWithCorrectionsPartiallySet() {
     // given
-    when(jobServices.completeJob(anyLong(), any(), any(), any()))
+    when(jobServices.completeJob(anyLong(), any(), any(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
 
     final var request =
@@ -514,7 +515,7 @@ public class JobControllerTest extends RestControllerTest {
     final ArgumentCaptor<JobResult> jobResultArgumentCaptor =
         ArgumentCaptor.forClass(JobResult.class);
     Mockito.verify(jobServices)
-        .completeJob(eq(1L), eq(Map.of()), jobResultArgumentCaptor.capture(), any());
+        .completeJob(eq(1L), eq(Map.of()), jobResultArgumentCaptor.capture(), any(), any());
 
     assertThat(jobResultArgumentCaptor.getValue().getCorrections())
         .isEqualTo(
@@ -535,7 +536,7 @@ public class JobControllerTest extends RestControllerTest {
   @Test
   void shouldCompleteJobWithResultWithCorrectionsPartiallySetAndDefault() {
     // given
-    when(jobServices.completeJob(anyLong(), any(), any(), any()))
+    when(jobServices.completeJob(anyLong(), any(), any(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
 
     final var request =
@@ -567,7 +568,7 @@ public class JobControllerTest extends RestControllerTest {
 
     final var jobResultArgumentCaptor = ArgumentCaptor.forClass(JobResult.class);
     Mockito.verify(jobServices)
-        .completeJob(eq(1L), eq(Map.of()), jobResultArgumentCaptor.capture(), any());
+        .completeJob(eq(1L), eq(Map.of()), jobResultArgumentCaptor.capture(), any(), any());
 
     assertThat(jobResultArgumentCaptor.getValue().getCorrections())
         .isEqualTo(
@@ -588,7 +589,7 @@ public class JobControllerTest extends RestControllerTest {
   @Test
   void shouldCompleteJobWithResultDeniedFalse() {
     // given
-    when(jobServices.completeJob(anyLong(), any(), any(), any()))
+    when(jobServices.completeJob(anyLong(), any(), any(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
 
     final var request =
@@ -616,7 +617,7 @@ public class JobControllerTest extends RestControllerTest {
     final ArgumentCaptor<JobResult> jobResultArgumentCaptor =
         ArgumentCaptor.forClass(JobResult.class);
     Mockito.verify(jobServices)
-        .completeJob(eq(1L), eq(Map.of()), jobResultArgumentCaptor.capture(), any());
+        .completeJob(eq(1L), eq(Map.of()), jobResultArgumentCaptor.capture(), any(), any());
     assertThat(jobResultArgumentCaptor.getValue().isDenied()).isFalse();
     assertThat(jobResultArgumentCaptor.getValue().getDeniedReason()).isEqualTo("");
   }
@@ -624,7 +625,7 @@ public class JobControllerTest extends RestControllerTest {
   @Test
   void shouldCompleteJobWithVariables() {
     // given
-    when(jobServices.completeJob(anyLong(), any(), any(), any()))
+    when(jobServices.completeJob(anyLong(), any(), any(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
 
     final var request =
@@ -648,13 +649,13 @@ public class JobControllerTest extends RestControllerTest {
         .isNoContent();
 
     Mockito.verify(jobServices)
-        .completeJob(eq(1L), eq(Map.of("foo", "bar")), any(JobResult.class), any());
+        .completeJob(eq(1L), eq(Map.of("foo", "bar")), any(JobResult.class), any(), any());
   }
 
   @Test
   void shouldUpdateJob() {
     // given
-    when(jobServices.updateJob(anyLong(), any(), any(), any()))
+    when(jobServices.updateJob(anyLong(), any(), any(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
 
     final var request =
@@ -678,13 +679,13 @@ public class JobControllerTest extends RestControllerTest {
         .isNoContent();
 
     Mockito.verify(jobServices)
-        .updateJob(eq(1L), isNull(), eq(new UpdateJobChangeset(5, 1000L)), any());
+        .updateJob(eq(1L), isNull(), eq(new UpdateJobChangeset(5, 1000L)), any(), any());
   }
 
   @Test
   void shouldUpdateJobWithOnlyRetries() {
     // given
-    when(jobServices.updateJob(anyLong(), any(), any(), any()))
+    when(jobServices.updateJob(anyLong(), any(), any(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
 
     final var request =
@@ -707,13 +708,13 @@ public class JobControllerTest extends RestControllerTest {
         .isNoContent();
 
     Mockito.verify(jobServices)
-        .updateJob(eq(1L), isNull(), eq(new UpdateJobChangeset(5, null)), any());
+        .updateJob(eq(1L), isNull(), eq(new UpdateJobChangeset(5, null)), any(), any());
   }
 
   @Test
   void shouldUpdateJobWithOnlyTimeout() {
     // given
-    when(jobServices.updateJob(anyLong(), any(), any(), any()))
+    when(jobServices.updateJob(anyLong(), any(), any(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
 
     final var request =
@@ -735,13 +736,13 @@ public class JobControllerTest extends RestControllerTest {
         .isNoContent();
 
     Mockito.verify(jobServices)
-        .updateJob(eq(1L), isNull(), eq(new UpdateJobChangeset(null, 1000L)), any());
+        .updateJob(eq(1L), isNull(), eq(new UpdateJobChangeset(null, 1000L)), any(), any());
   }
 
   @Test
   void shouldUpdateJobWithOperationReference() {
     // given
-    when(jobServices.updateJob(anyLong(), any(), any(), any()))
+    when(jobServices.updateJob(anyLong(), any(), any(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
 
     final var request =
@@ -764,7 +765,7 @@ public class JobControllerTest extends RestControllerTest {
         .isNoContent();
 
     Mockito.verify(jobServices)
-        .updateJob(eq(1L), eq(12345678L), eq(new UpdateJobChangeset(null, 1000L)), any());
+        .updateJob(eq(1L), eq(12345678L), eq(new UpdateJobChangeset(null, 1000L)), any(), any());
   }
 
   @Test
@@ -939,7 +940,7 @@ public class JobControllerTest extends RestControllerTest {
             new StatusMetric(5, lastUpdatedAt),
             false);
 
-    when(jobServices.getGlobalStatistics(any(), any())).thenReturn(statisticsEntity);
+    when(jobServices.getGlobalStatistics(any(), any(), any())).thenReturn(statisticsEntity);
 
     final var expectedResponse =
         """
@@ -1029,7 +1030,7 @@ public class JobControllerTest extends RestControllerTest {
             .endCursor("endCursor")
             .build();
 
-    when(jobServices.getJobTypeStatistics(any(), any())).thenReturn(searchResult);
+    when(jobServices.getJobTypeStatistics(any(), any(), any())).thenReturn(searchResult);
 
     final var request =
         """
@@ -1120,7 +1121,7 @@ public class JobControllerTest extends RestControllerTest {
             .items(List.of(statisticsEntity))
             .build();
 
-    when(jobServices.getJobTypeStatistics(any(), any())).thenReturn(searchResult);
+    when(jobServices.getJobTypeStatistics(any(), any(), any())).thenReturn(searchResult);
 
     final var request =
         """
@@ -1198,7 +1199,7 @@ public class JobControllerTest extends RestControllerTest {
             .items(List.of(statisticsEntity))
             .build();
 
-    when(jobServices.getJobTypeStatistics(any(), any())).thenReturn(searchResult);
+    when(jobServices.getJobTypeStatistics(any(), any(), any())).thenReturn(searchResult);
 
     final var request =
         """
@@ -1407,7 +1408,7 @@ public class JobControllerTest extends RestControllerTest {
 
     Mockito.doNothing()
         .when(jobServices)
-        .activateJobs(requestCaptor.capture(), any(), any(), any());
+        .activateJobs(requestCaptor.capture(), any(), any(), any(), any());
 
     final var request =
         """
@@ -1457,7 +1458,7 @@ public class JobControllerTest extends RestControllerTest {
 
     Mockito.doNothing()
         .when(jobServices)
-        .activateJobs(requestCaptor.capture(), any(), any(), any());
+        .activateJobs(requestCaptor.capture(), any(), any(), any(), any());
 
     final var request =
         """
@@ -1509,7 +1510,7 @@ public class JobControllerTest extends RestControllerTest {
 
     Mockito.doNothing()
         .when(jobServices)
-        .activateJobs(requestCaptor.capture(), any(), any(), any());
+        .activateJobs(requestCaptor.capture(), any(), any(), any(), any());
 
     final var request =
         """
@@ -1565,7 +1566,7 @@ public class JobControllerTest extends RestControllerTest {
             .items(List.of(workerEntity1, workerEntity2))
             .build();
 
-    when(jobServices.getJobWorkerStatistics(any(), any())).thenReturn(searchResult);
+    when(jobServices.getJobWorkerStatistics(any(), any(), any())).thenReturn(searchResult);
 
     final var request =
         """
@@ -1654,7 +1655,7 @@ public class JobControllerTest extends RestControllerTest {
             .items(List.of(workerEntity))
             .build();
 
-    when(jobServices.getJobWorkerStatistics(any(), any())).thenReturn(searchResult);
+    when(jobServices.getJobWorkerStatistics(any(), any(), any())).thenReturn(searchResult);
 
     final var request =
         """
@@ -1901,7 +1902,7 @@ public class JobControllerTest extends RestControllerTest {
             .endCursor("endCursor")
             .build();
 
-    when(jobServices.getJobTimeSeriesStatistics(any(), any())).thenReturn(searchResult);
+    when(jobServices.getJobTimeSeriesStatistics(any(), any(), any())).thenReturn(searchResult);
 
     final var request =
         """
@@ -1971,7 +1972,7 @@ public class JobControllerTest extends RestControllerTest {
             .items(List.of(entity))
             .build();
 
-    when(jobServices.getJobTimeSeriesStatistics(any(), any())).thenReturn(searchResult);
+    when(jobServices.getJobTimeSeriesStatistics(any(), any(), any())).thenReturn(searchResult);
 
     final var request =
         """
@@ -2199,7 +2200,7 @@ public class JobControllerTest extends RestControllerTest {
             .endCursor("endCursor")
             .build();
 
-    when(jobServices.getJobErrorStatistics(any(), any())).thenReturn(searchResult);
+    when(jobServices.getJobErrorStatistics(any(), any(), any())).thenReturn(searchResult);
 
     final var request =
         """
@@ -2262,7 +2263,7 @@ public class JobControllerTest extends RestControllerTest {
             .items(List.of(entity))
             .build();
 
-    when(jobServices.getJobErrorStatistics(any(), any())).thenReturn(searchResult);
+    when(jobServices.getJobErrorStatistics(any(), any(), any())).thenReturn(searchResult);
 
     final var request =
         """

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobQueryControllerTest.java
@@ -132,7 +132,7 @@ public class JobQueryControllerTest extends RestControllerTest {
   @Test
   void shouldSearchJobWithEmptyBody() {
     // given
-    when(jobServices.search(any(JobQuery.class), any())).thenReturn(SEARCH_QUERY_RESULT);
+    when(jobServices.search(any(JobQuery.class), any(), any())).thenReturn(SEARCH_QUERY_RESULT);
 
     // when / then
     webClient
@@ -146,13 +146,13 @@ public class JobQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
-    verify(jobServices).search(eq(new JobQuery.Builder().build()), any());
+    verify(jobServices).search(eq(new JobQuery.Builder().build()), any(), any());
   }
 
   @Test
   void shouldSearchJobWithAllFilters() {
     // given
-    when(jobServices.search(any(JobQuery.class), any())).thenReturn(SEARCH_QUERY_RESULT);
+    when(jobServices.search(any(JobQuery.class), any(), any())).thenReturn(SEARCH_QUERY_RESULT);
 
     final var request =
         """
@@ -231,6 +231,7 @@ public class JobQueryControllerTest extends RestControllerTest {
                             .lastUpdateTimes(OffsetDateTime.parse("2025-06-05T10:04:00.000Z"))
                             .build())
                     .build()),
+            any(),
             any());
   }
 
@@ -266,7 +267,7 @@ public class JobQueryControllerTest extends RestControllerTest {
             .startCursor("abc")
             .endCursor("def")
             .build();
-    when(jobServices.search(any(JobQuery.class), any())).thenReturn(cancelElResult);
+    when(jobServices.search(any(JobQuery.class), any(), any())).thenReturn(cancelElResult);
 
     final var request =
         """
@@ -338,13 +339,14 @@ public class JobQueryControllerTest extends RestControllerTest {
                             .listenerEventTypes(ListenerEventType.CANCEL.name())
                             .build())
                     .build()),
+            any(),
             any());
   }
 
   @Test
   void shouldSearchJobWithFullSorting() {
     // given
-    when(jobServices.search(any(JobQuery.class), any())).thenReturn(SEARCH_QUERY_RESULT);
+    when(jobServices.search(any(JobQuery.class), any(), any())).thenReturn(SEARCH_QUERY_RESULT);
 
     final var request =
         """
@@ -439,6 +441,7 @@ public class JobQueryControllerTest extends RestControllerTest {
                                 .tenantId()
                                 .desc())
                     .build()),
+            any(),
             any());
   }
 
@@ -464,7 +467,7 @@ public class JobQueryControllerTest extends RestControllerTest {
             .creationTime(OffsetDateTime.parse("2025-06-05T09:00:00.000Z"))
             .lastUpdateTime(OffsetDateTime.parse("2025-06-05T10:04:00.000Z"))
             .build();
-    when(jobServices.search(any(JobQuery.class), any()))
+    when(jobServices.search(any(JobQuery.class), any(), any()))
         .thenReturn(
             new SearchQueryResult.Builder<JobEntity>()
                 .total(1L)

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/MessageControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/MessageControllerTest.java
@@ -71,7 +71,7 @@ public class MessageControllerTest extends RestControllerTest {
   void shouldCorrelateMessageWithMultiTenancyDisabled() {
     // given
     when(multiTenancyCfg.isChecksEnabled()).thenReturn(false);
-    when(messageServices.correlateMessage(any(), any()))
+    when(messageServices.correlateMessage(any(), any(), any()))
         .thenReturn(
             CompletableFuture.completedFuture(
                 new MessageCorrelationRecord()
@@ -102,7 +102,8 @@ public class MessageControllerTest extends RestControllerTest {
             .expectStatus()
             .isOk();
 
-    Mockito.verify(messageServices).correlateMessage(correlationRequestCaptor.capture(), any());
+    Mockito.verify(messageServices)
+        .correlateMessage(correlationRequestCaptor.capture(), any(), any());
     final var capturedRequest = correlationRequestCaptor.getValue();
     assertThat(capturedRequest.name()).isEqualTo("messageName");
     assertThat(capturedRequest.correlationKey()).isEqualTo("correlationKey");
@@ -127,7 +128,7 @@ public class MessageControllerTest extends RestControllerTest {
     when(authenticationProvider.getCamundaAuthentication())
         .thenReturn(AUTHENTICATION_WITH_NON_DEFAULT_TENANT);
     when(multiTenancyCfg.isChecksEnabled()).thenReturn(true);
-    when(messageServices.correlateMessage(any(), any()))
+    when(messageServices.correlateMessage(any(), any(), any()))
         .thenReturn(
             CompletableFuture.completedFuture(
                 new MessageCorrelationRecord()
@@ -158,7 +159,8 @@ public class MessageControllerTest extends RestControllerTest {
             .expectStatus()
             .isOk();
 
-    Mockito.verify(messageServices).correlateMessage(correlationRequestCaptor.capture(), any());
+    Mockito.verify(messageServices)
+        .correlateMessage(correlationRequestCaptor.capture(), any(), any());
     final var capturedRequest = correlationRequestCaptor.getValue();
     assertThat(capturedRequest.name()).isEqualTo("messageName");
     assertThat(capturedRequest.correlationKey()).isEqualTo("correlationKey");
@@ -402,7 +404,7 @@ public class MessageControllerTest extends RestControllerTest {
   @Test
   void shouldPublishMessage() {
     // given
-    when(messageServices.publishMessage(any(), any())).thenReturn(buildPublishResponse());
+    when(messageServices.publishMessage(any(), any(), any())).thenReturn(buildPublishResponse());
 
     final var request =
         """
@@ -430,7 +432,8 @@ public class MessageControllerTest extends RestControllerTest {
         .expectBody()
         .json(EXPECTED_PUBLICATION_RESPONSE, JsonCompareMode.STRICT);
 
-    Mockito.verify(messageServices).publishMessage(publicationRequestCaptor.capture(), any());
+    Mockito.verify(messageServices)
+        .publishMessage(publicationRequestCaptor.capture(), any(), any());
     final var capturedRequest = publicationRequestCaptor.getValue();
     assertThat(capturedRequest.name()).isEqualTo("messageName");
     assertThat(capturedRequest.correlationKey()).isEqualTo("correlationKey");
@@ -443,7 +446,7 @@ public class MessageControllerTest extends RestControllerTest {
   @Test
   void shouldPublishMessageWithoutCorrelationKey() {
     // given
-    when(messageServices.publishMessage(any(), any())).thenReturn(buildPublishResponse());
+    when(messageServices.publishMessage(any(), any(), any())).thenReturn(buildPublishResponse());
 
     final var request =
         """
@@ -470,7 +473,8 @@ public class MessageControllerTest extends RestControllerTest {
         .expectBody()
         .json(EXPECTED_PUBLICATION_RESPONSE, JsonCompareMode.STRICT);
 
-    Mockito.verify(messageServices).publishMessage(publicationRequestCaptor.capture(), any());
+    Mockito.verify(messageServices)
+        .publishMessage(publicationRequestCaptor.capture(), any(), any());
     final var capturedRequest = publicationRequestCaptor.getValue();
     assertThat(capturedRequest.name()).isEqualTo("messageName");
     assertThat(capturedRequest.correlationKey()).isEqualTo("");
@@ -483,7 +487,7 @@ public class MessageControllerTest extends RestControllerTest {
   @Test
   void shouldPublishMessageWithoutTimeToLive() {
     // given
-    when(messageServices.publishMessage(any(), any())).thenReturn(buildPublishResponse());
+    when(messageServices.publishMessage(any(), any(), any())).thenReturn(buildPublishResponse());
 
     final var request =
         """
@@ -509,7 +513,8 @@ public class MessageControllerTest extends RestControllerTest {
         .expectBody()
         .json(EXPECTED_PUBLICATION_RESPONSE, JsonCompareMode.STRICT);
 
-    Mockito.verify(messageServices).publishMessage(publicationRequestCaptor.capture(), any());
+    Mockito.verify(messageServices)
+        .publishMessage(publicationRequestCaptor.capture(), any(), any());
     final var capturedRequest = publicationRequestCaptor.getValue();
     assertThat(capturedRequest.name()).isEqualTo("messageName");
     assertThat(capturedRequest.correlationKey()).isEqualTo("");
@@ -522,7 +527,7 @@ public class MessageControllerTest extends RestControllerTest {
   @Test
   void shouldRejectPublishMessageWithoutName() {
     // given
-    when(messageServices.publishMessage(any(), any())).thenReturn(buildPublishResponse());
+    when(messageServices.publishMessage(any(), any(), any())).thenReturn(buildPublishResponse());
 
     final var request =
         """

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/MessageSubscriptionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/MessageSubscriptionQueryControllerTest.java
@@ -156,7 +156,7 @@ public class MessageSubscriptionQueryControllerTest extends RestControllerTest {
   @Test
   public void shouldSearchMessageSubscriptionsWithEmptyBody() {
     // given
-    when(services.search(any(), any())).thenReturn(SEARCH_QUERY_RESULT);
+    when(services.search(any(), any(), any())).thenReturn(SEARCH_QUERY_RESULT);
 
     // when / then
     webClient
@@ -170,13 +170,13 @@ public class MessageSubscriptionQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
-    verify(services).search(eq(new MessageSubscriptionQuery.Builder().build()), any());
+    verify(services).search(eq(new MessageSubscriptionQuery.Builder().build()), any(), any());
   }
 
   @Test
   public void shouldSearchMessageSubscriptionsWithEmptyQuery() {
     // given
-    when(services.search(any(), any())).thenReturn(SEARCH_QUERY_RESULT);
+    when(services.search(any(), any(), any())).thenReturn(SEARCH_QUERY_RESULT);
 
     // when / then
     webClient
@@ -192,13 +192,13 @@ public class MessageSubscriptionQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
-    verify(services).search(eq(new MessageSubscriptionQuery.Builder().build()), any());
+    verify(services).search(eq(new MessageSubscriptionQuery.Builder().build()), any(), any());
   }
 
   @Test
   public void shouldSearchMessageSubscriptionsWithFilters() {
     // given
-    when(services.search(any(), any())).thenReturn(SEARCH_QUERY_RESULT);
+    when(services.search(any(), any(), any())).thenReturn(SEARCH_QUERY_RESULT);
 
     // when / then
     webClient
@@ -263,13 +263,14 @@ public class MessageSubscriptionQueryControllerTest extends RestControllerTest {
                                 .toolNames("myTool")
                                 .inboundConnectorTypes("io.camunda:http-webhook:1"))
                     .build()),
+            any(),
             any());
   }
 
   @Test
   public void shouldSearchMessageSubscriptionsWithSorting() {
     // given
-    when(services.search(any(), any())).thenReturn(SEARCH_QUERY_RESULT);
+    when(services.search(any(), any(), any())).thenReturn(SEARCH_QUERY_RESULT);
 
     // when / then
     webClient
@@ -388,13 +389,14 @@ public class MessageSubscriptionQueryControllerTest extends RestControllerTest {
                                 .inboundConnectorType()
                                 .desc())
                     .build()),
+            any(),
             any());
   }
 
   @Test
   public void shouldSearchCorrelatedWithEmptyBody() {
     // given
-    when(services.searchCorrelated(any(), any())).thenReturn(SEARCH_CORRELATED_QUERY_RESULT);
+    when(services.searchCorrelated(any(), any(), any())).thenReturn(SEARCH_CORRELATED_QUERY_RESULT);
 
     // when / then
     webClient
@@ -409,13 +411,14 @@ public class MessageSubscriptionQueryControllerTest extends RestControllerTest {
         .json(EXPECTED_CORRELATED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(services)
-        .searchCorrelated(eq(new CorrelatedMessageSubscriptionQuery.Builder().build()), any());
+        .searchCorrelated(
+            eq(new CorrelatedMessageSubscriptionQuery.Builder().build()), any(), any());
   }
 
   @Test
   public void shouldSearchCorrelatedWithEmptyQuery() {
     // given
-    when(services.searchCorrelated(any(), any())).thenReturn(SEARCH_CORRELATED_QUERY_RESULT);
+    when(services.searchCorrelated(any(), any(), any())).thenReturn(SEARCH_CORRELATED_QUERY_RESULT);
 
     // when / then
     webClient
@@ -432,13 +435,14 @@ public class MessageSubscriptionQueryControllerTest extends RestControllerTest {
         .json(EXPECTED_CORRELATED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(services)
-        .searchCorrelated(eq(new CorrelatedMessageSubscriptionQuery.Builder().build()), any());
+        .searchCorrelated(
+            eq(new CorrelatedMessageSubscriptionQuery.Builder().build()), any(), any());
   }
 
   @Test
   public void shouldSearchCorrelatedWithFilters() {
     // given
-    when(services.searchCorrelated(any(), any())).thenReturn(SEARCH_CORRELATED_QUERY_RESULT);
+    when(services.searchCorrelated(any(), any(), any())).thenReturn(SEARCH_CORRELATED_QUERY_RESULT);
 
     // when / then
     webClient
@@ -491,13 +495,14 @@ public class MessageSubscriptionQueryControllerTest extends RestControllerTest {
                                 .subscriptionKeys(2251799813685860L)
                                 .tenantIds("test-tenant"))
                     .build()),
+            any(),
             any());
   }
 
   @Test
   public void shouldSearchCorrelatedWithSorting() {
     // given
-    when(services.searchCorrelated(any(), any())).thenReturn(SEARCH_CORRELATED_QUERY_RESULT);
+    when(services.searchCorrelated(any(), any(), any())).thenReturn(SEARCH_CORRELATED_QUERY_RESULT);
 
     // when / then
     webClient
@@ -598,6 +603,7 @@ public class MessageSubscriptionQueryControllerTest extends RestControllerTest {
                                 .tenantId()
                                 .asc())
                     .build()),
+            any(),
             any());
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionQueryControllerTest.java
@@ -157,7 +157,7 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
   @Test
   void shouldSearchProcessDefinitionWithEmptyBody() {
     // given
-    when(processDefinitionServices.search(any(ProcessDefinitionQuery.class), any()))
+    when(processDefinitionServices.search(any(ProcessDefinitionQuery.class), any(), any()))
         .thenReturn(SEARCH_QUERY_RESULT);
     // when / then
     webClient
@@ -172,13 +172,13 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
         .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(processDefinitionServices)
-        .search(eq(new ProcessDefinitionQuery.Builder().build()), any());
+        .search(eq(new ProcessDefinitionQuery.Builder().build()), any(), any());
   }
 
   @Test
   public void shouldReturn404ForInvalidProcessDefinitionKey() {
     // given
-    when(processDefinitionServices.getByKey(eq(17L), any()))
+    when(processDefinitionServices.getByKey(eq(17L), any(), any()))
         .thenThrow(
             ErrorMapper.mapSearchError(
                 new CamundaSearchException(
@@ -206,13 +206,14 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
             JsonCompareMode.STRICT);
 
     // Verify that the service was called with the invalid key
-    verify(processDefinitionServices).getByKey(eq(17L), any());
+    verify(processDefinitionServices).getByKey(eq(17L), any(), any());
   }
 
   @Test
   public void shouldReturnProcessDefinitionForValidKey() {
     // given
-    when(processDefinitionServices.getByKey(eq(23L), any())).thenReturn(PROCESS_DEFINITION_ENTITY);
+    when(processDefinitionServices.getByKey(eq(23L), any(), any()))
+        .thenReturn(PROCESS_DEFINITION_ENTITY);
 
     // when / then
     webClient
@@ -226,7 +227,7 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
         .json(PROCESS_DEFINITION_ENTITY_JSON, JsonCompareMode.STRICT);
 
     // Verify that the service was called with the valid key
-    verify(processDefinitionServices).getByKey(eq(23L), any());
+    verify(processDefinitionServices).getByKey(eq(23L), any(), any());
   }
 
   @ParameterizedTest
@@ -270,13 +271,15 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
   private static Stream<Pair<String, BiFunction<ProcessDefinitionServices, Long, ?>>>
       getProcessDefinitionTestCasesParameters() {
     return Stream.of(
-        Pair.of(PROCESS_DEFINITION_URL + "%d", (service, key) -> service.getByKey(eq(key), any())),
+        Pair.of(
+            PROCESS_DEFINITION_URL + "%d",
+            (service, key) -> service.getByKey(eq(key), any(), any())),
         Pair.of(
             PROCESS_DEFINITION_URL + "%d/xml",
-            (service, key) -> service.getProcessDefinitionXml(eq(key), any())),
+            (service, key) -> service.getProcessDefinitionXml(eq(key), any(), any())),
         Pair.of(
             PROCESS_DEFINITION_URL + "%d/form",
-            (service, key) -> service.getProcessDefinitionStartForm(eq(key), any())));
+            (service, key) -> service.getProcessDefinitionStartForm(eq(key), any(), any())));
   }
 
   @Test
@@ -284,7 +287,7 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
     // given
     final long processDefinitionKey = 1L;
     final var stats = List.of(new ProcessFlowNodeStatisticsEntity("node1", 1L, 1L, 1L, 1L));
-    when(processDefinitionServices.elementStatistics(any(), any())).thenReturn(stats);
+    when(processDefinitionServices.elementStatistics(any(), any(), any())).thenReturn(stats);
     final var request =
         """
             {
@@ -325,6 +328,7 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
                 new ProcessDefinitionStatisticsFilter.Builder(processDefinitionKey)
                     .hasIncident(true)
                     .build()),
+            any(),
             any());
   }
 
@@ -333,7 +337,7 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
     // given
     final long processDefinitionKey = 1L;
     final var stats = List.of(new ProcessFlowNodeStatisticsEntity("node1", 1L, 1L, 1L, 1L));
-    when(processDefinitionServices.elementStatistics(any(), any())).thenReturn(stats);
+    when(processDefinitionServices.elementStatistics(any(), any(), any())).thenReturn(stats);
     final var request =
         """
             {
@@ -387,6 +391,7 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
                             .hasFlowNodeInstanceIncident(true)
                             .build())
                     .build()),
+            any(),
             any());
   }
 
@@ -428,13 +433,13 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedResponse, JsonCompareMode.STRICT);
 
-    verify(processDefinitionServices, never()).elementStatistics(any(), any());
+    verify(processDefinitionServices, never()).elementStatistics(any(), any(), any());
   }
 
   @Test
   public void shouldGetProcessDefinitionXml() {
     // given
-    when(processDefinitionServices.getProcessDefinitionXml(eq(23L), any()))
+    when(processDefinitionServices.getProcessDefinitionXml(eq(23L), any(), any()))
         .thenReturn(Optional.of("<xml/>"));
     // when / then
     webClient
@@ -447,13 +452,13 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
         .expectBody()
         .xml("<xml/>");
     // Verify that the service was called with the valid key
-    verify(processDefinitionServices).getProcessDefinitionXml(eq(23L), any());
+    verify(processDefinitionServices).getProcessDefinitionXml(eq(23L), any(), any());
   }
 
   @Test
   public void shouldGetProcessDefinitionXmlHasNoXml() {
     // given
-    when(processDefinitionServices.getProcessDefinitionXml(eq(23L), any()))
+    when(processDefinitionServices.getProcessDefinitionXml(eq(23L), any(), any()))
         .thenReturn(Optional.empty());
     // when / then
     webClient
@@ -464,12 +469,12 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
         .expectStatus()
         .isNoContent();
     // Verify that the service was called with the valid key
-    verify(processDefinitionServices).getProcessDefinitionXml(eq(23L), any());
+    verify(processDefinitionServices).getProcessDefinitionXml(eq(23L), any(), any());
   }
 
   @Test
   public void shouldReturnFormItemForValidFormKey() {
-    when(processDefinitionServices.getProcessDefinitionStartForm(eq(1L), any()))
+    when(processDefinitionServices.getProcessDefinitionStartForm(eq(1L), any(), any()))
         .thenReturn(Optional.of(new FormEntity(0L, "tenant-1", "formId", "schema", 1L)));
 
     webClient
@@ -482,12 +487,12 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(FORM_ITEM_JSON, JsonCompareMode.STRICT);
 
-    verify(processDefinitionServices, times(1)).getProcessDefinitionStartForm(eq(1L), any());
+    verify(processDefinitionServices, times(1)).getProcessDefinitionStartForm(eq(1L), any(), any());
   }
 
   @Test
   public void shouldReturn404ForFormInvaliProcessKey() {
-    when(processDefinitionServices.getProcessDefinitionStartForm(eq(999L), any()))
+    when(processDefinitionServices.getProcessDefinitionStartForm(eq(999L), any(), any()))
         .thenThrow(
             ErrorMapper.mapSearchError(
                 new CamundaSearchException(
@@ -516,7 +521,7 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
 
   @Test
   public void shouldReturn500OnUnexpectedException() {
-    when(processDefinitionServices.getProcessDefinitionStartForm(eq(1L), any()))
+    when(processDefinitionServices.getProcessDefinitionStartForm(eq(1L), any(), any()))
         .thenThrow(new RuntimeException("Unexpected error"));
 
     webClient
@@ -567,7 +572,7 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
                 "filter": %s
             }"""
             .formatted(filterString);
-    when(processDefinitionServices.search(any(ProcessDefinitionQuery.class), any()))
+    when(processDefinitionServices.search(any(ProcessDefinitionQuery.class), any(), any()))
         .thenReturn(SEARCH_QUERY_RESULT);
 
     // when / then
@@ -586,7 +591,7 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
         .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(processDefinitionServices)
-        .search(eq(new ProcessDefinitionQuery.Builder().filter(filter).build()), any());
+        .search(eq(new ProcessDefinitionQuery.Builder().filter(filter).build()), any(), any());
   }
 
   @Test
@@ -600,7 +605,7 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
             .startCursor(null)
             .endCursor(null)
             .build();
-    when(processDefinitionServices.getProcessDefinitionInstanceStatistics(any(), any()))
+    when(processDefinitionServices.getProcessDefinitionInstanceStatistics(any(), any(), any()))
         .thenReturn(statsResult);
 
     final var request = "{ \"filter\": {} }";
@@ -639,7 +644,7 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
             .startCursor(null)
             .endCursor(null)
             .build();
-    when(processDefinitionServices.getProcessDefinitionInstanceStatistics(any(), any()))
+    when(processDefinitionServices.getProcessDefinitionInstanceStatistics(any(), any(), any()))
         .thenReturn(statsResult);
 
     final var request = "{}";
@@ -672,7 +677,7 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
         .json(response, JsonCompareMode.STRICT);
 
     verify(processDefinitionServices)
-        .getProcessDefinitionInstanceStatistics(instanceStatsQueryCaptor.capture(), any());
+        .getProcessDefinitionInstanceStatistics(instanceStatsQueryCaptor.capture(), any(), any());
     final var capturedQuery = instanceStatsQueryCaptor.getValue();
     assertThat(capturedQuery).isNotNull();
     final var filter = capturedQuery.filter();
@@ -691,7 +696,7 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
             .startCursor(null)
             .endCursor(null)
             .build();
-    when(processDefinitionServices.getProcessDefinitionInstanceStatistics(any(), any()))
+    when(processDefinitionServices.getProcessDefinitionInstanceStatistics(any(), any(), any()))
         .thenReturn(statsResult);
 
     final var response =
@@ -721,7 +726,7 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
         .json(response, JsonCompareMode.STRICT);
 
     verify(processDefinitionServices)
-        .getProcessDefinitionInstanceStatistics(instanceStatsQueryCaptor.capture(), any());
+        .getProcessDefinitionInstanceStatistics(instanceStatsQueryCaptor.capture(), any(), any());
     final var capturedQuery = instanceStatsQueryCaptor.getValue();
     assertThat(capturedQuery).isNotNull();
     final var filter = capturedQuery.filter();
@@ -745,7 +750,7 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
             .endCursor(null)
             .build();
     when(processDefinitionServices.searchProcessDefinitionInstanceVersionStatistics(
-            any(ProcessDefinitionInstanceVersionStatisticsQuery.class), any()))
+            any(ProcessDefinitionInstanceVersionStatisticsQuery.class), any(), any()))
         .thenReturn(statsResult);
     final var request =
         """
@@ -798,7 +803,7 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
 
     verify(processDefinitionServices)
         .searchProcessDefinitionInstanceVersionStatistics(
-            instanceVersionStatsQueryCaptor.capture(), any());
+            instanceVersionStatsQueryCaptor.capture(), any(), any());
     final var capturedQuery = instanceVersionStatsQueryCaptor.getValue();
     assertThat(capturedQuery).isNotNull();
     assertThat(capturedQuery.filter().processDefinitionId()).isEqualTo(processDefinitionId);
@@ -947,7 +952,8 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedResponse, JsonCompareMode.STRICT);
 
-    verify(processDefinitionServices, never()).search(any(ProcessDefinitionQuery.class), any());
+    verify(processDefinitionServices, never())
+        .search(any(ProcessDefinitionQuery.class), any(), any());
   }
 
   @Test
@@ -989,7 +995,8 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedResponse, JsonCompareMode.STRICT);
 
-    verify(processDefinitionServices, never()).search(any(ProcessDefinitionQuery.class), any());
+    verify(processDefinitionServices, never())
+        .search(any(ProcessDefinitionQuery.class), any(), any());
   }
 
   @Test
@@ -1031,7 +1038,8 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedResponse, JsonCompareMode.STRICT);
 
-    verify(processDefinitionServices, never()).search(any(ProcessDefinitionQuery.class), any());
+    verify(processDefinitionServices, never())
+        .search(any(ProcessDefinitionQuery.class), any(), any());
   }
 
   @ParameterizedTest
@@ -1083,7 +1091,8 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedResponse, JsonCompareMode.STRICT);
 
-    verify(processDefinitionServices, never()).search(any(ProcessDefinitionQuery.class), any());
+    verify(processDefinitionServices, never())
+        .search(any(ProcessDefinitionQuery.class), any(), any());
   }
 
   @Test
@@ -1100,7 +1109,7 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
                     "limit": 10
                 }
             }""";
-    when(processDefinitionServices.search(any(ProcessDefinitionQuery.class), any()))
+    when(processDefinitionServices.search(any(ProcessDefinitionQuery.class), any(), any()))
         .thenReturn(SEARCH_QUERY_RESULT);
     // when / then
     webClient
@@ -1117,7 +1126,7 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
-    verify(processDefinitionServices).search(any(ProcessDefinitionQuery.class), any());
+    verify(processDefinitionServices).search(any(ProcessDefinitionQuery.class), any(), any());
   }
 
   @ParameterizedTest
@@ -1142,7 +1151,7 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
                 ]
             }""",
             supportedField.getValue());
-    when(processDefinitionServices.search(any(ProcessDefinitionQuery.class), any()))
+    when(processDefinitionServices.search(any(ProcessDefinitionQuery.class), any(), any()))
         .thenReturn(SEARCH_QUERY_RESULT);
     // when / then
     webClient
@@ -1159,6 +1168,6 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
-    verify(processDefinitionServices).search(any(ProcessDefinitionQuery.class), any());
+    verify(processDefinitionServices).search(any(ProcessDefinitionQuery.class), any(), any());
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
@@ -119,7 +119,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
     when(authenticationProvider.getCamundaAuthentication())
         .thenReturn(AUTHENTICATION_WITH_NON_DEFAULT_TENANT);
     when(processInstanceServices.createProcessInstance(
-            any(ProcessInstanceCreateRequest.class), any()))
+            any(ProcessInstanceCreateRequest.class), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(mockResponse));
 
     final var request =
@@ -147,7 +147,8 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .expectBody()
         .json(EXPECTED_START_RESPONSE, JsonCompareMode.STRICT);
 
-    verify(processInstanceServices).createProcessInstance(createRequestCaptor.capture(), any());
+    verify(processInstanceServices)
+        .createProcessInstance(createRequestCaptor.capture(), any(), any());
     final var capturedRequest = createRequestCaptor.getValue();
     assertThat(capturedRequest.processDefinitionKey()).isEqualTo(123L);
     assertThat(capturedRequest.tenantId()).isEqualTo("tenantId");
@@ -164,7 +165,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
             .setTenantId("<default>");
 
     when(processInstanceServices.createProcessInstance(
-            any(ProcessInstanceCreateRequest.class), any()))
+            any(ProcessInstanceCreateRequest.class), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(mockResponse));
 
     final var request =
@@ -200,7 +201,8 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedResponse, JsonCompareMode.STRICT);
 
-    verify(processInstanceServices).createProcessInstance(createRequestCaptor.capture(), any());
+    verify(processInstanceServices)
+        .createProcessInstance(createRequestCaptor.capture(), any(), any());
     final var capturedRequest = createRequestCaptor.getValue();
     assertThat(capturedRequest.processDefinitionKey()).isEqualTo(123L);
     assertThat(capturedRequest.tenantId()).isEqualTo("<default>");
@@ -220,7 +222,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
     when(authenticationProvider.getCamundaAuthentication())
         .thenReturn(AUTHENTICATION_WITH_NON_DEFAULT_TENANT);
     when(processInstanceServices.createProcessInstance(
-            any(ProcessInstanceCreateRequest.class), any()))
+            any(ProcessInstanceCreateRequest.class), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(mockResponse));
 
     final var request =
@@ -249,7 +251,8 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .expectBody()
         .json(EXPECTED_START_RESPONSE, JsonCompareMode.STRICT);
 
-    verify(processInstanceServices).createProcessInstance(createRequestCaptor.capture(), any());
+    verify(processInstanceServices)
+        .createProcessInstance(createRequestCaptor.capture(), any(), any());
     final var capturedRequest = createRequestCaptor.getValue();
     assertThat(capturedRequest.bpmnProcessId()).isEqualTo("bpmnProcessId");
     assertThat(capturedRequest.version()).isEqualTo(1);
@@ -269,7 +272,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
     when(authenticationProvider.getCamundaAuthentication())
         .thenReturn(AUTHENTICATION_WITH_NON_DEFAULT_TENANT);
     when(processInstanceServices.createProcessInstance(
-            any(ProcessInstanceCreateRequest.class), any()))
+            any(ProcessInstanceCreateRequest.class), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(mockResponse));
 
     final var request =
@@ -297,7 +300,8 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .expectBody()
         .json(EXPECTED_START_RESPONSE, JsonCompareMode.STRICT);
 
-    verify(processInstanceServices).createProcessInstance(createRequestCaptor.capture(), any());
+    verify(processInstanceServices)
+        .createProcessInstance(createRequestCaptor.capture(), any(), any());
     final var capturedRequest = createRequestCaptor.getValue();
     assertThat(capturedRequest.bpmnProcessId()).isEqualTo("bpmnProcessId");
     assertThat(capturedRequest.version()).isEqualTo(-1);
@@ -316,7 +320,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
             .setBusinessId(businessId);
 
     when(processInstanceServices.createProcessInstance(
-            any(ProcessInstanceCreateRequest.class), any()))
+            any(ProcessInstanceCreateRequest.class), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(mockResponse));
 
     final var request =
@@ -354,7 +358,8 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedResponse, JsonCompareMode.STRICT);
 
-    verify(processInstanceServices).createProcessInstance(createRequestCaptor.capture(), any());
+    verify(processInstanceServices)
+        .createProcessInstance(createRequestCaptor.capture(), any(), any());
     final var capturedRequest = createRequestCaptor.getValue();
     assertThat(capturedRequest.processDefinitionKey()).isEqualTo(123L);
     assertThat(capturedRequest.businessId()).isEqualTo(businessId);
@@ -369,7 +374,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         "Expected to create instance of process with business id '%s', but an instance with this business id already exists for process definition '%s'"
             .formatted(businessId, processDefinitionId);
     when(processInstanceServices.createProcessInstance(
-            any(ProcessInstanceCreateRequest.class), any()))
+            any(ProcessInstanceCreateRequest.class), any(), any()))
         .thenReturn(
             CompletableFuture.failedFuture(
                 new ServiceException(rejectionReason, ServiceException.Status.ALREADY_EXISTS)));
@@ -417,7 +422,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
             .setTenantId("<default>");
 
     when(processInstanceServices.createProcessInstance(
-            any(ProcessInstanceCreateRequest.class), any()))
+            any(ProcessInstanceCreateRequest.class), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(mockResponse));
 
     final var request =
@@ -443,7 +448,8 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .expectStatus()
         .isOk();
 
-    verify(processInstanceServices).createProcessInstance(createRequestCaptor.capture(), any());
+    verify(processInstanceServices)
+        .createProcessInstance(createRequestCaptor.capture(), any(), any());
     final var capturedRequest = createRequestCaptor.getValue();
     assertThat(capturedRequest.bpmnProcessId()).isEqualTo("bpmnProcessId");
     assertThat(capturedRequest.startInstructions()).hasSize(1);
@@ -467,7 +473,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
             .setTenantId("<default>");
 
     when(processInstanceServices.createProcessInstance(
-            any(ProcessInstanceCreateRequest.class), any()))
+            any(ProcessInstanceCreateRequest.class), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(mockResponse));
 
     final var request =
@@ -493,7 +499,8 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .expectStatus()
         .isOk();
 
-    verify(processInstanceServices).createProcessInstance(createRequestCaptor.capture(), any());
+    verify(processInstanceServices)
+        .createProcessInstance(createRequestCaptor.capture(), any(), any());
     final var capturedRequest = createRequestCaptor.getValue();
     assertThat(capturedRequest.processDefinitionKey()).isEqualTo(123L);
     assertThat(capturedRequest.startInstructions()).hasSize(1);
@@ -517,7 +524,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
             .setTenantId("<default>");
 
     when(processInstanceServices.createProcessInstance(
-            any(ProcessInstanceCreateRequest.class), any()))
+            any(ProcessInstanceCreateRequest.class), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(mockResponse));
 
     final var request =
@@ -541,7 +548,8 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .expectStatus()
         .isOk();
 
-    verify(processInstanceServices).createProcessInstance(createRequestCaptor.capture(), any());
+    verify(processInstanceServices)
+        .createProcessInstance(createRequestCaptor.capture(), any(), any());
     final var capturedRequest = createRequestCaptor.getValue();
     assertThat(capturedRequest.runtimeInstructions()).hasSize(2);
     assertThat(capturedRequest.runtimeInstructions().get(0).getType())
@@ -568,7 +576,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
     when(authenticationProvider.getCamundaAuthentication())
         .thenReturn(AUTHENTICATION_WITH_NON_DEFAULT_TENANT);
     when(processInstanceServices.createProcessInstanceWithResult(
-            any(ProcessInstanceCreateRequest.class), any()))
+            any(ProcessInstanceCreateRequest.class), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(mockResponse));
 
     final var request =
@@ -598,7 +606,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .json(EXPECTED_START_RESPONSE, JsonCompareMode.STRICT);
 
     verify(processInstanceServices)
-        .createProcessInstanceWithResult(createRequestCaptor.capture(), any());
+        .createProcessInstanceWithResult(createRequestCaptor.capture(), any(), any());
     final var capturedRequest = createRequestCaptor.getValue();
     assertThat(capturedRequest.processDefinitionKey()).isEqualTo(123L);
     assertThat(capturedRequest.awaitCompletion()).isTrue();
@@ -618,7 +626,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
     when(authenticationProvider.getCamundaAuthentication())
         .thenReturn(AUTHENTICATION_WITH_NON_DEFAULT_TENANT);
     when(processInstanceServices.createProcessInstanceWithResult(
-            any(ProcessInstanceCreateRequest.class), any()))
+            any(ProcessInstanceCreateRequest.class), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(mockResponse));
 
     final var request =
@@ -649,7 +657,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .json(EXPECTED_START_RESPONSE, JsonCompareMode.STRICT);
 
     verify(processInstanceServices)
-        .createProcessInstanceWithResult(createRequestCaptor.capture(), any());
+        .createProcessInstanceWithResult(createRequestCaptor.capture(), any(), any());
     final var capturedRequest = createRequestCaptor.getValue();
     assertThat(capturedRequest.bpmnProcessId()).isEqualTo("bpmnProcessId");
     assertThat(capturedRequest.version()).isEqualTo(1);
@@ -669,7 +677,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
     when(authenticationProvider.getCamundaAuthentication())
         .thenReturn(AUTHENTICATION_WITH_NON_DEFAULT_TENANT);
     when(processInstanceServices.createProcessInstanceWithResult(
-            any(ProcessInstanceCreateRequest.class), any()))
+            any(ProcessInstanceCreateRequest.class), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(mockResponse));
 
     final var request =
@@ -699,7 +707,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .json(EXPECTED_START_RESPONSE, JsonCompareMode.STRICT);
 
     verify(processInstanceServices)
-        .createProcessInstanceWithResult(createRequestCaptor.capture(), any());
+        .createProcessInstanceWithResult(createRequestCaptor.capture(), any(), any());
     final var capturedRequest = createRequestCaptor.getValue();
     assertThat(capturedRequest.bpmnProcessId()).isEqualTo("bpmnProcessId");
     assertThat(capturedRequest.version()).isEqualTo(-1);
@@ -719,7 +727,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
     when(authenticationProvider.getCamundaAuthentication())
         .thenReturn(AUTHENTICATION_WITH_NON_DEFAULT_TENANT);
     when(processInstanceServices.createProcessInstanceWithResult(
-            any(ProcessInstanceCreateRequest.class), any()))
+            any(ProcessInstanceCreateRequest.class), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(mockResponse));
 
     final var request =
@@ -750,7 +758,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .json(EXPECTED_START_RESPONSE, JsonCompareMode.STRICT);
 
     verify(processInstanceServices)
-        .createProcessInstanceWithResult(createRequestCaptor.capture(), any());
+        .createProcessInstanceWithResult(createRequestCaptor.capture(), any(), any());
     final var capturedRequest = createRequestCaptor.getValue();
     assertThat(capturedRequest.processDefinitionKey()).isEqualTo(123L);
     assertThat(capturedRequest.awaitCompletion()).isTrue();
@@ -770,7 +778,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
             .setBusinessId(businessId);
 
     when(processInstanceServices.createProcessInstanceWithResult(
-            any(ProcessInstanceCreateRequest.class), any()))
+            any(ProcessInstanceCreateRequest.class), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(mockResponse));
 
     // when / then
@@ -807,7 +815,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
             JsonCompareMode.STRICT);
 
     verify(processInstanceServices)
-        .createProcessInstanceWithResult(createRequestCaptor.capture(), any());
+        .createProcessInstanceWithResult(createRequestCaptor.capture(), any(), any());
     final var capturedRequest = createRequestCaptor.getValue();
     assertThat(capturedRequest.processDefinitionKey()).isEqualTo(123L);
     assertThat(capturedRequest.awaitCompletion()).isTrue();
@@ -823,7 +831,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         "Expected to create instance of process with business id '%s', but an instance with this business id already exists for process definition '%s'"
             .formatted(businessId, processDefinitionId);
     when(processInstanceServices.createProcessInstanceWithResult(
-            any(ProcessInstanceCreateRequest.class), any()))
+            any(ProcessInstanceCreateRequest.class), any(), any()))
         .thenReturn(
             CompletableFuture.failedFuture(
                 new ServiceException(rejectionReason, ServiceException.Status.ALREADY_EXISTS)));
@@ -974,7 +982,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
   void shouldCancelProcessInstance() {
     // given
     when(processInstanceServices.cancelProcessInstance(
-            any(ProcessInstanceCancelRequest.class), any()))
+            any(ProcessInstanceCancelRequest.class), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new ProcessInstanceRecord()));
 
     final var request =
@@ -995,7 +1003,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .isNoContent();
 
     Mockito.verify(processInstanceServices)
-        .cancelProcessInstance(cancelRequestCaptor.capture(), any());
+        .cancelProcessInstance(cancelRequestCaptor.capture(), any(), any());
     final var capturedRequest = cancelRequestCaptor.getValue();
     assertThat(capturedRequest.processInstanceKey()).isEqualTo(1);
     assertThat(capturedRequest.operationReference()).isEqualTo(123L);
@@ -1005,7 +1013,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
   void shouldCancelProcessInstanceWithNoBody() {
     // given
     when(processInstanceServices.cancelProcessInstance(
-            any(ProcessInstanceCancelRequest.class), any()))
+            any(ProcessInstanceCancelRequest.class), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new ProcessInstanceRecord()));
 
     // when/then
@@ -1019,7 +1027,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .isNoContent();
 
     Mockito.verify(processInstanceServices)
-        .cancelProcessInstance(cancelRequestCaptor.capture(), any());
+        .cancelProcessInstance(cancelRequestCaptor.capture(), any(), any());
     final var capturedRequest = cancelRequestCaptor.getValue();
     assertThat(capturedRequest.processInstanceKey()).isEqualTo(1);
     assertThat(capturedRequest.operationReference()).isNull();
@@ -1029,7 +1037,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
   void shouldDeleteResourceWithEmptyBody() {
     // given
     when(processInstanceServices.cancelProcessInstance(
-            any(ProcessInstanceCancelRequest.class), any()))
+            any(ProcessInstanceCancelRequest.class), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new ProcessInstanceRecord()));
 
     final var request =
@@ -1048,7 +1056,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .isNoContent();
 
     Mockito.verify(processInstanceServices)
-        .cancelProcessInstance(cancelRequestCaptor.capture(), any());
+        .cancelProcessInstance(cancelRequestCaptor.capture(), any(), any());
     final var capturedRequest = cancelRequestCaptor.getValue();
     assertThat(capturedRequest.processInstanceKey()).isEqualTo(1);
     assertThat(capturedRequest.operationReference()).isNull();
@@ -1093,7 +1101,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
   void shouldReturnGatewayTimeoutWhenCancelProcessInstanceTimesOut() {
     // given
     when(processInstanceServices.cancelProcessInstance(
-            any(ProcessInstanceCancelRequest.class), any()))
+            any(ProcessInstanceCancelRequest.class), any(), any()))
         .thenReturn(
             CompletableFuture.failedFuture(
                 ErrorMapper.mapError(new TimeoutException("Task listener blocked cancellation"))));
@@ -1121,7 +1129,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
   void shouldMigrateProcessInstance() {
     // given
     when(processInstanceServices.migrateProcessInstance(
-            any(ProcessInstanceMigrateRequest.class), any()))
+            any(ProcessInstanceMigrateRequest.class), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new ProcessInstanceMigrationRecord()));
 
     final var request =
@@ -1153,7 +1161,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .isNoContent();
 
     Mockito.verify(processInstanceServices)
-        .migrateProcessInstance(migrateRequestCaptor.capture(), any());
+        .migrateProcessInstance(migrateRequestCaptor.capture(), any(), any());
     final var capturedRequest = migrateRequestCaptor.getValue();
     assertThat(capturedRequest.processInstanceKey()).isEqualTo(1);
     assertThat(capturedRequest.targetProcessDefinitionKey()).isEqualTo(123456);
@@ -1375,7 +1383,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
   void shouldModifyProcessInstance() {
     // given
     when(processInstanceServices.modifyProcessInstance(
-            any(ProcessInstanceModifyRequest.class), any()))
+            any(ProcessInstanceModifyRequest.class), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new ProcessInstanceModificationRecord()));
 
     final var variables = new UnsafeBuffer(MsgPackConverter.convertToMsgPack(Map.of("foo", "bar")));
@@ -1627,7 +1635,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .isNoContent();
 
     Mockito.verify(processInstanceServices)
-        .modifyProcessInstance(modifyRequestCaptor.capture(), any());
+        .modifyProcessInstance(modifyRequestCaptor.capture(), any(), any());
     assertThat(modifyRequestCaptor.getValue()).isEqualTo(expectedMappedRequest);
   }
 
@@ -1635,7 +1643,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
   void shouldModifyProcessInstanceWithOnlyTerminateInstructions() {
     // given
     when(processInstanceServices.modifyProcessInstance(
-            any(ProcessInstanceModifyRequest.class), any()))
+            any(ProcessInstanceModifyRequest.class), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new ProcessInstanceModificationRecord()));
 
     final var request =
@@ -1664,7 +1672,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .isNoContent();
 
     Mockito.verify(processInstanceServices)
-        .modifyProcessInstance(modifyRequestCaptor.capture(), any());
+        .modifyProcessInstance(modifyRequestCaptor.capture(), any(), any());
     final var capturedRequest = modifyRequestCaptor.getValue();
     assertThat(capturedRequest.processInstanceKey()).isEqualTo(1);
     assertThat(capturedRequest.activateInstructions()).isEmpty();
@@ -1677,7 +1685,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
   void shouldModifyProcessInstanceWithOnlyActivateInstructions() {
     // given
     when(processInstanceServices.modifyProcessInstance(
-            any(ProcessInstanceModifyRequest.class), any()))
+            any(ProcessInstanceModifyRequest.class), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new ProcessInstanceModificationRecord()));
 
     final var request =
@@ -1708,7 +1716,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .isNoContent();
 
     Mockito.verify(processInstanceServices)
-        .modifyProcessInstance(modifyRequestCaptor.capture(), any());
+        .modifyProcessInstance(modifyRequestCaptor.capture(), any(), any());
     final var capturedRequest = modifyRequestCaptor.getValue();
     assertThat(capturedRequest.processInstanceKey()).isEqualTo(1);
     assertThat(capturedRequest.activateInstructions()).hasSize(2);
@@ -1721,7 +1729,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
   void shouldModifyProcessInstanceWithOnlyMoveInstructions() {
     // given
     when(processInstanceServices.modifyProcessInstance(
-            any(ProcessInstanceModifyRequest.class), any()))
+            any(ProcessInstanceModifyRequest.class), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new ProcessInstanceModificationRecord()));
 
     final var request =
@@ -1751,7 +1759,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .isNoContent();
 
     Mockito.verify(processInstanceServices)
-        .modifyProcessInstance(modifyRequestCaptor.capture(), any());
+        .modifyProcessInstance(modifyRequestCaptor.capture(), any(), any());
     final var capturedRequest = modifyRequestCaptor.getValue();
     assertThat(capturedRequest.processInstanceKey()).isEqualTo(1);
     assertThat(capturedRequest.activateInstructions()).isEmpty();
@@ -2172,7 +2180,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
     record.setBatchOperationType(BatchOperationType.CANCEL_PROCESS_INSTANCE);
 
     when(processInstanceServices.cancelProcessInstanceBatchOperationWithResult(
-            any(ProcessInstanceFilter.class), any()))
+            any(ProcessInstanceFilter.class), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(record));
 
     final var request =
@@ -2204,7 +2212,8 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
             JsonCompareMode.STRICT);
 
     verify(processInstanceServices)
-        .cancelProcessInstanceBatchOperationWithResult(any(ProcessInstanceFilter.class), any());
+        .cancelProcessInstanceBatchOperationWithResult(
+            any(ProcessInstanceFilter.class), any(), any());
   }
 
   @Test
@@ -2215,7 +2224,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
     record.setBatchOperationType(BatchOperationType.MODIFY_PROCESS_INSTANCE);
 
     when(processInstanceServices.modifyProcessInstancesBatchOperation(
-            any(ProcessInstanceModifyBatchOperationRequest.class), any()))
+            any(ProcessInstanceModifyBatchOperationRequest.class), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(record));
 
     final var request =
@@ -2254,7 +2263,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
 
     verify(processInstanceServices)
         .modifyProcessInstancesBatchOperation(
-            any(ProcessInstanceModifyBatchOperationRequest.class), any());
+            any(ProcessInstanceModifyBatchOperationRequest.class), any(), any());
   }
 
   @Test
@@ -2262,7 +2271,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
     // given
     final long processInstanceKey = 1L;
     final var stats = List.of(new ProcessFlowNodeStatisticsEntity("node1", 1L, 1L, 1L, 1L));
-    when(processInstanceServices.elementStatistics(eq(processInstanceKey), any()))
+    when(processInstanceServices.elementStatistics(eq(processInstanceKey), any(), any()))
         .thenReturn(stats);
     final var response =
         """
@@ -2291,7 +2300,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .expectBody()
         .json(response, JsonCompareMode.STRICT);
 
-    verify(processInstanceServices).elementStatistics(eq(processInstanceKey), any());
+    verify(processInstanceServices).elementStatistics(eq(processInstanceKey), any(), any());
   }
 
   @Test
@@ -2302,7 +2311,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
     record.setBatchOperationType(BatchOperationType.RESOLVE_INCIDENT);
 
     when(processInstanceServices.resolveIncidentsBatchOperationWithResult(
-            any(ProcessInstanceFilter.class), any()))
+            any(ProcessInstanceFilter.class), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(record));
 
     final var request =
@@ -2334,7 +2343,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
             JsonCompareMode.STRICT);
 
     verify(processInstanceServices)
-        .resolveIncidentsBatchOperationWithResult(any(ProcessInstanceFilter.class), any());
+        .resolveIncidentsBatchOperationWithResult(any(ProcessInstanceFilter.class), any(), any());
   }
 
   @Test
@@ -2345,7 +2354,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
     record.setBatchOperationType(BatchOperationType.MIGRATE_PROCESS_INSTANCE);
 
     when(processInstanceServices.migrateProcessInstancesBatchOperation(
-            any(ProcessInstanceMigrateBatchOperationRequest.class), any()))
+            any(ProcessInstanceMigrateBatchOperationRequest.class), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(record));
 
     final var request =
@@ -2386,7 +2395,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
 
     verify(processInstanceServices)
         .migrateProcessInstancesBatchOperation(
-            any(ProcessInstanceMigrateBatchOperationRequest.class), any());
+            any(ProcessInstanceMigrateBatchOperationRequest.class), any(), any());
   }
 
   @Test
@@ -2396,7 +2405,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
     final var sequenceFlows =
         List.of(
             new SequenceFlowEntity("pi1_sequenceFlow1", "node1", 1L, 37L, 1L, "pd1", "<default>"));
-    when(processInstanceServices.sequenceFlows(eq(processInstanceKey), any()))
+    when(processInstanceServices.sequenceFlows(eq(processInstanceKey), any(), any()))
         .thenReturn(sequenceFlows);
     final var response =
         """
@@ -2425,7 +2434,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .expectBody()
         .json(response, JsonCompareMode.STRICT);
 
-    verify(processInstanceServices).sequenceFlows(eq(processInstanceKey), any());
+    verify(processInstanceServices).sequenceFlows(eq(processInstanceKey), any(), any());
   }
 
   @Test
@@ -2455,7 +2464,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
             .endCursor("<cursor after>")
             .build();
     final var query = new IncidentQuery.Builder().build();
-    when(processInstanceServices.searchIncidents(eq(processInstanceKey), eq(query), any()))
+    when(processInstanceServices.searchIncidents(eq(processInstanceKey), eq(query), any(), any()))
         .thenReturn(queryResult);
     final var expectedResponse =
         """
@@ -2498,7 +2507,8 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedResponse, JsonCompareMode.STRICT);
 
-    verify(processInstanceServices).searchIncidents(eq(processInstanceKey), eq(query), any());
+    verify(processInstanceServices)
+        .searchIncidents(eq(processInstanceKey), eq(query), any(), any());
   }
 
   @Test
@@ -2784,7 +2794,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
     record.setBatchOperationType(BatchOperationType.MIGRATE_PROCESS_INSTANCE);
 
     when(processInstanceServices.migrateProcessInstancesBatchOperation(
-            any(ProcessInstanceMigrateBatchOperationRequest.class), any()))
+            any(ProcessInstanceMigrateBatchOperationRequest.class), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(record));
 
     final var request =
@@ -2829,7 +2839,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
     record.setBatchOperationType(BatchOperationType.MIGRATE_PROCESS_INSTANCE);
 
     when(processInstanceServices.migrateProcessInstancesBatchOperation(
-            any(ProcessInstanceMigrateBatchOperationRequest.class), any()))
+            any(ProcessInstanceMigrateBatchOperationRequest.class), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(record));
 
     final var request =
@@ -3031,7 +3041,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
     record.setBatchOperationType(BatchOperationType.DELETE_PROCESS_INSTANCE);
 
     when(processInstanceServices.deleteProcessInstancesBatchOperation(
-            any(ProcessInstanceFilter.class), any()))
+            any(ProcessInstanceFilter.class), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(record));
 
     final var request =
@@ -3063,7 +3073,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
             JsonCompareMode.STRICT);
 
     verify(processInstanceServices)
-        .deleteProcessInstancesBatchOperation(any(ProcessInstanceFilter.class), any());
+        .deleteProcessInstancesBatchOperation(any(ProcessInstanceFilter.class), any(), any());
   }
 
   @Test
@@ -3167,7 +3177,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
     record.setResourceKey(123L);
     record.setResourceType(HistoryDeletionType.PROCESS_INSTANCE);
 
-    when(processInstanceServices.deleteProcessInstance(eq(1L), eq(123L), any()))
+    when(processInstanceServices.deleteProcessInstance(eq(1L), eq(123L), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(record));
 
     final var request =
@@ -3195,7 +3205,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
     record.setResourceKey(123L);
     record.setResourceType(HistoryDeletionType.PROCESS_INSTANCE);
 
-    when(processInstanceServices.deleteProcessInstance(eq(1L), isNull(), any()))
+    when(processInstanceServices.deleteProcessInstance(eq(1L), isNull(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(record));
 
     // when / then
@@ -3215,7 +3225,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
     record.setResourceKey(123L);
     record.setResourceType(HistoryDeletionType.PROCESS_INSTANCE);
 
-    when(processInstanceServices.deleteProcessInstance(eq(1L), isNull(), any()))
+    when(processInstanceServices.deleteProcessInstance(eq(1L), isNull(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(record));
 
     final var request =
@@ -3237,7 +3247,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
   @Test
   void shouldRejectDeleteProcessInstanceOnProcessInstanceNotFound() {
     // given
-    when(processInstanceServices.deleteProcessInstance(eq(1L), isNull(), any()))
+    when(processInstanceServices.deleteProcessInstance(eq(1L), isNull(), any(), any()))
         .thenReturn(
             CompletableFuture.failedFuture(
                 new io.camunda.service.exception.ServiceException(

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
@@ -250,7 +250,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
   @Test
   void shouldSearchProcessInstancesWithEmptyBody() {
     // given
-    when(processInstanceServices.search(any(ProcessInstanceQuery.class), any()))
+    when(processInstanceServices.search(any(ProcessInstanceQuery.class), any(), any()))
         .thenReturn(SEARCH_QUERY_RESULT);
     // when / then
     webClient
@@ -265,13 +265,14 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
         .consumeWith(
             result -> assertJsonNonExtensible(EXPECTED_SEARCH_RESPONSE, result.getResponseBody()));
 
-    verify(processInstanceServices).search(eq(new ProcessInstanceQuery.Builder().build()), any());
+    verify(processInstanceServices)
+        .search(eq(new ProcessInstanceQuery.Builder().build()), any(), any());
   }
 
   @Test
   void shouldSearchProcessInstancesWithEmptyQuery() {
     // given
-    when(processInstanceServices.search(any(ProcessInstanceQuery.class), any()))
+    when(processInstanceServices.search(any(ProcessInstanceQuery.class), any(), any()))
         .thenReturn(SEARCH_QUERY_RESULT);
     final String request = "{}";
     // when / then
@@ -290,7 +291,8 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
         .consumeWith(
             result -> assertJsonNonExtensible(EXPECTED_SEARCH_RESPONSE, result.getResponseBody()));
 
-    verify(processInstanceServices).search(eq(new ProcessInstanceQuery.Builder().build()), any());
+    verify(processInstanceServices)
+        .search(eq(new ProcessInstanceQuery.Builder().build()), any(), any());
   }
 
   @Test
@@ -334,7 +336,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedResponse, JsonCompareMode.STRICT);
 
-    verify(processInstanceServices, never()).search(any(ProcessInstanceQuery.class), any());
+    verify(processInstanceServices, never()).search(any(ProcessInstanceQuery.class), any(), any());
   }
 
   @Test
@@ -377,7 +379,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedResponse, JsonCompareMode.STRICT);
 
-    verify(processInstanceServices, never()).search(any(ProcessInstanceQuery.class), any());
+    verify(processInstanceServices, never()).search(any(ProcessInstanceQuery.class), any(), any());
   }
 
   @Test
@@ -417,7 +419,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedResponse, JsonCompareMode.STRICT);
 
-    verify(processInstanceServices, never()).search(any(ProcessInstanceQuery.class), any());
+    verify(processInstanceServices, never()).search(any(ProcessInstanceQuery.class), any(), any());
   }
 
   @Test
@@ -436,7 +438,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
             .batchOperationIdOperations(Operation.eq("op-id-1"))
             .build();
 
-    when(processInstanceServices.search(queryCaptor.capture(), any()))
+    when(processInstanceServices.search(queryCaptor.capture(), any(), any()))
         .thenReturn(SEARCH_QUERY_RESULT);
 
     // when / then
@@ -456,13 +458,14 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
             result -> assertJsonNonExtensible(EXPECTED_SEARCH_RESPONSE, result.getResponseBody()));
 
     verify(processInstanceServices)
-        .search(eq(new ProcessInstanceQuery.Builder().filter(expectedFilter).build()), any());
+        .search(
+            eq(new ProcessInstanceQuery.Builder().filter(expectedFilter).build()), any(), any());
   }
 
   @Test
   void shouldSearchProcessInstancessWithSorting() {
     // given
-    when(processInstanceServices.search(any(ProcessInstanceQuery.class), any()))
+    when(processInstanceServices.search(any(ProcessInstanceQuery.class), any(), any()))
         .thenReturn(SEARCH_QUERY_RESULT);
     final var request =
         """
@@ -506,6 +509,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
                             .asc()
                             .build())
                     .build()),
+            any(),
             any());
   }
 
@@ -548,7 +552,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedResponse, JsonCompareMode.STRICT);
 
-    verify(processInstanceServices, never()).search(any(ProcessInstanceQuery.class), any());
+    verify(processInstanceServices, never()).search(any(ProcessInstanceQuery.class), any(), any());
   }
 
   @Test
@@ -590,7 +594,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedResponse, JsonCompareMode.STRICT);
 
-    verify(processInstanceServices, never()).search(any(ProcessInstanceQuery.class), any());
+    verify(processInstanceServices, never()).search(any(ProcessInstanceQuery.class), any(), any());
   }
 
   @Test
@@ -631,7 +635,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedResponse, JsonCompareMode.STRICT);
 
-    verify(processInstanceServices, never()).search(any(ProcessInstanceQuery.class), any());
+    verify(processInstanceServices, never()).search(any(ProcessInstanceQuery.class), any(), any());
   }
 
   @Test
@@ -671,7 +675,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedResponse, JsonCompareMode.STRICT);
 
-    verify(processInstanceServices, never()).search(any(ProcessInstanceQuery.class), any());
+    verify(processInstanceServices, never()).search(any(ProcessInstanceQuery.class), any(), any());
   }
 
   @Test
@@ -712,7 +716,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedResponse, JsonCompareMode.STRICT);
 
-    verify(processInstanceServices, never()).search(any(ProcessInstanceQuery.class), any());
+    verify(processInstanceServices, never()).search(any(ProcessInstanceQuery.class), any(), any());
   }
 
   @Test
@@ -720,7 +724,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
     // given
     final var validProcesInstanceKey = 123L;
     when(processInstanceServices.getByKey(
-            eq(validProcesInstanceKey), any(CamundaAuthentication.class)))
+            eq(validProcesInstanceKey), any(CamundaAuthentication.class), any()))
         .thenReturn(PROCESS_INSTANCE_ENTITY);
 
     // when / then
@@ -738,7 +742,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
 
     // Verify that the service was called with the valid key
     verify(processInstanceServices)
-        .getByKey(eq(validProcesInstanceKey), any(CamundaAuthentication.class));
+        .getByKey(eq(validProcesInstanceKey), any(CamundaAuthentication.class), any());
   }
 
   @Test
@@ -764,7 +768,8 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
             "PI_456",
             null,
             null);
-    when(processInstanceServices.getByKey(eq(processInstanceKey), any(CamundaAuthentication.class)))
+    when(processInstanceServices.getByKey(
+            eq(processInstanceKey), any(CamundaAuthentication.class), any()))
         .thenReturn(entityWithNullBusinessId);
 
     final var expectedJson =
@@ -801,7 +806,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
         .consumeWith(result -> assertJsonNonExtensible(expectedJson, result.getResponseBody()));
 
     verify(processInstanceServices)
-        .getByKey(eq(processInstanceKey), any(CamundaAuthentication.class));
+        .getByKey(eq(processInstanceKey), any(CamundaAuthentication.class), any());
   }
 
   @Test
@@ -809,7 +814,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
     // given
     final var invalidProcesInstanceKey = 100L;
     when(processInstanceServices.getByKey(
-            eq(invalidProcesInstanceKey), any(CamundaAuthentication.class)))
+            eq(invalidProcesInstanceKey), any(CamundaAuthentication.class), any()))
         .thenThrow(
             ErrorMapper.mapSearchError(
                 new CamundaSearchException(
@@ -840,7 +845,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
 
     // Verify that the service was called with the invalid key
     verify(processInstanceServices)
-        .getByKey(eq(invalidProcesInstanceKey), any(CamundaAuthentication.class));
+        .getByKey(eq(invalidProcesInstanceKey), any(CamundaAuthentication.class), any());
   }
 
   private static Stream<Arguments> provideAdvancedSearchParameters() {
@@ -928,7 +933,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
             }"""
             .formatted(filterString);
     System.out.println("request = " + request);
-    when(processInstanceServices.search(queryCaptor.capture(), any()))
+    when(processInstanceServices.search(queryCaptor.capture(), any(), any()))
         .thenReturn(SEARCH_QUERY_RESULT);
 
     // when / then
@@ -948,7 +953,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
             result -> assertJsonNonExtensible(EXPECTED_SEARCH_RESPONSE, result.getResponseBody()));
 
     verify(processInstanceServices)
-        .search(eq(new ProcessInstanceQuery.Builder().filter(filter).build()), any());
+        .search(eq(new ProcessInstanceQuery.Builder().filter(filter).build()), any(), any());
   }
 
   @ParameterizedTest
@@ -968,7 +973,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
             .build();
 
     // when
-    when(processInstanceServices.search(queryCaptor.capture(), any()))
+    when(processInstanceServices.search(queryCaptor.capture(), any(), any()))
         .thenReturn(SEARCH_QUERY_RESULT);
     webClient
         .post()
@@ -987,7 +992,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
 
     // then
     verify(processInstanceServices)
-        .search(eq(new ProcessInstanceQuery.Builder().filter(filter).build()), any());
+        .search(eq(new ProcessInstanceQuery.Builder().filter(filter).build()), any(), any());
   }
 
   @Test
@@ -1020,7 +1025,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
             .tenantIdOperations(Operation.eq("tenant"));
     orFilters.forEach(expectedFilter::addOrOperation);
 
-    when(processInstanceServices.search(queryCaptor.capture(), any()))
+    when(processInstanceServices.search(queryCaptor.capture(), any(), any()))
         .thenReturn(SEARCH_QUERY_RESULT);
 
     // when / then
@@ -1041,7 +1046,9 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
 
     verify(processInstanceServices)
         .search(
-            eq(new ProcessInstanceQuery.Builder().filter(expectedFilter.build()).build()), any());
+            eq(new ProcessInstanceQuery.Builder().filter(expectedFilter.build()).build()),
+            any(),
+            any());
   }
 
   @Test
@@ -1084,7 +1091,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedResponse, JsonCompareMode.STRICT);
 
-    verify(processInstanceServices, never()).search(any(ProcessInstanceQuery.class), any());
+    verify(processInstanceServices, never()).search(any(ProcessInstanceQuery.class), any(), any());
   }
 
   @Test
@@ -1092,7 +1099,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
     // given
     final var processInstanceKey = 123L;
 
-    when(processInstanceServices.callHierarchy(eq(processInstanceKey), any()))
+    when(processInstanceServices.callHierarchy(eq(processInstanceKey), any(), any()))
         .thenReturn(List.of(PROCESS_INSTANCE_ENTITY));
 
     // when / then
@@ -1107,7 +1114,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
         .json(EXPECTED_CALL_HIERARCHY, JsonCompareMode.STRICT);
 
     // Verify that the service was called with the valid key
-    verify(processInstanceServices).callHierarchy(eq(processInstanceKey), any());
+    verify(processInstanceServices).callHierarchy(eq(processInstanceKey), any(), any());
   }
 
   @Test
@@ -1238,7 +1245,8 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
                 "filter": %s
             }"""
             .formatted(filterString);
-    when(processInstanceServices.searchIncidents(anyLong(), incidentQueryCaptor.capture(), any()))
+    when(processInstanceServices.searchIncidents(
+            anyLong(), incidentQueryCaptor.capture(), any(), any()))
         .thenReturn(SEARCH_INCIDENT_QUERY_RESULT);
 
     // when / then
@@ -1260,7 +1268,8 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
                     EXPECTED_PROCESS_INSTANCE_INCIDENTS_SEARCH_RESPONSE, result.getResponseBody()));
 
     verify(processInstanceServices)
-        .searchIncidents(eq(123L), eq(new IncidentQuery.Builder().filter(filter).build()), any());
+        .searchIncidents(
+            eq(123L), eq(new IncidentQuery.Builder().filter(filter).build()), any(), any());
   }
 
   @Test
@@ -1299,7 +1308,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedResponse, JsonCompareMode.STRICT);
 
-    verify(processInstanceServices, never()).search(any(ProcessInstanceQuery.class), any());
+    verify(processInstanceServices, never()).search(any(ProcessInstanceQuery.class), any(), any());
   }
 
   @Test
@@ -1339,6 +1348,6 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedResponse, JsonCompareMode.STRICT);
 
-    verify(processInstanceServices, never()).search(any(ProcessInstanceQuery.class), any());
+    verify(processInstanceServices, never()).search(any(ProcessInstanceQuery.class), any(), any());
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ResourceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ResourceControllerTest.java
@@ -89,7 +89,7 @@ public class ResourceControllerTest extends RestControllerTest {
         .setVersion(1)
         .setKey(123456L)
         .setChecksum(BufferUtil.wrapString("checksum"));
-    when(resourceServices.deployResources(any(), any()))
+    when(resourceServices.deployResources(any(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(mockedResponse));
 
     final var multipartBodyBuilder = new MultipartBodyBuilder();
@@ -107,7 +107,7 @@ public class ResourceControllerTest extends RestControllerTest {
             .expectStatus()
             .isOk();
 
-    verify(resourceServices).deployResources(deployRequestCaptor.capture(), any());
+    verify(resourceServices).deployResources(deployRequestCaptor.capture(), any(), any());
     final var capturedRequest = deployRequestCaptor.getValue();
     assertThat(capturedRequest.resources()).isNotEmpty();
     assertThat(capturedRequest.resources()).size().isEqualTo(1);
@@ -157,7 +157,7 @@ public class ResourceControllerTest extends RestControllerTest {
         .setVersion(1)
         .setKey(123456L)
         .setChecksum(BufferUtil.wrapString("checksum"));
-    when(resourceServices.deployResources(any(), any()))
+    when(resourceServices.deployResources(any(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(mockedResponse));
 
     final var multipartBodyBuilder = new MultipartBodyBuilder();
@@ -175,7 +175,7 @@ public class ResourceControllerTest extends RestControllerTest {
             .expectStatus()
             .isOk();
 
-    verify(resourceServices).deployResources(deployRequestCaptor.capture(), any());
+    verify(resourceServices).deployResources(deployRequestCaptor.capture(), any(), any());
     final var capturedRequest = deployRequestCaptor.getValue();
     assertThat(capturedRequest.resources()).isNotEmpty();
     assertThat(capturedRequest.resources()).size().isEqualTo(1);
@@ -228,7 +228,7 @@ public class ResourceControllerTest extends RestControllerTest {
         .setKey(123456L)
         .setTenantId("tenantId")
         .setChecksum(BufferUtil.wrapString("checksum"));
-    when(resourceServices.deployResources(any(), any()))
+    when(resourceServices.deployResources(any(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(mockedResponse));
 
     final var multipartBodyBuilder = new MultipartBodyBuilder();
@@ -247,7 +247,7 @@ public class ResourceControllerTest extends RestControllerTest {
             .expectStatus()
             .isOk();
 
-    verify(resourceServices).deployResources(deployRequestCaptor.capture(), any());
+    verify(resourceServices).deployResources(deployRequestCaptor.capture(), any(), any());
     final var capturedRequest = deployRequestCaptor.getValue();
     assertThat(capturedRequest.resources()).isNotEmpty();
     assertThat(capturedRequest.resources()).size().isEqualTo(1);
@@ -318,7 +318,7 @@ public class ResourceControllerTest extends RestControllerTest {
         .setFormId("formId")
         .setFormKey(123456L)
         .setChecksum(BufferUtil.wrapString("checksum"));
-    when(resourceServices.deployResources(any(), any()))
+    when(resourceServices.deployResources(any(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(mockedResponse));
 
     final var multipartBodyBuilder = new MultipartBodyBuilder();
@@ -344,7 +344,7 @@ public class ResourceControllerTest extends RestControllerTest {
             .expectStatus()
             .isOk();
 
-    verify(resourceServices).deployResources(deployRequestCaptor.capture(), any());
+    verify(resourceServices).deployResources(deployRequestCaptor.capture(), any(), any());
     final var capturedRequest = deployRequestCaptor.getValue();
     assertThat(capturedRequest.resources()).isNotEmpty();
     assertThat(capturedRequest.resources()).size().isEqualTo(3);
@@ -422,7 +422,7 @@ public class ResourceControllerTest extends RestControllerTest {
   @Test
   void shouldGetResource() {
     // given
-    when(resourceServices.getByKey(eq(1L), any()))
+    when(resourceServices.getByKey(eq(1L), any(), any()))
         .thenReturn(
             CompletableFuture.completedFuture(
                 new DeployedResourceEntity.Builder()
@@ -460,7 +460,7 @@ public class ResourceControllerTest extends RestControllerTest {
   @Test
   void getResourceShouldYieldNotFoundWhenResourceNotFound() {
     // given
-    when(resourceServices.getByKey(eq(1L), any()))
+    when(resourceServices.getByKey(eq(1L), any(), any()))
         .thenReturn(
             CompletableFuture.failedFuture(
                 ErrorMapper.mapBrokerRejection(
@@ -495,7 +495,7 @@ public class ResourceControllerTest extends RestControllerTest {
   @Test
   void getResourceShouldYieldInternalServerErrorForProcessingErrorRejection() {
     // given
-    when(resourceServices.getByKey(eq(1L), any()))
+    when(resourceServices.getByKey(eq(1L), any(), any()))
         .thenReturn(
             CompletableFuture.failedFuture(
                 ErrorMapper.mapBrokerRejection(
@@ -533,7 +533,7 @@ public class ResourceControllerTest extends RestControllerTest {
   @Test
   void getResourceShouldYieldInternalServerErrorForBrokerError() {
     // given
-    when(resourceServices.getByKey(eq(1L), any()))
+    when(resourceServices.getByKey(eq(1L), any(), any()))
         .thenReturn(
             CompletableFuture.failedFuture(
                 ErrorMapper.mapBrokerError(
@@ -575,7 +575,7 @@ public class ResourceControllerTest extends RestControllerTest {
           "script": "foo"
         }
         """;
-    when(resourceServices.getContentByKeyFilteredByType(eq(1L), eq("rpa"), any()))
+    when(resourceServices.getContentByKeyFilteredByType(eq(1L), eq("rpa"), any(), any()))
         .thenReturn(
             CompletableFuture.completedFuture(
                 new DeployedResourceEntity(
@@ -603,7 +603,7 @@ public class ResourceControllerTest extends RestControllerTest {
           "script": "foo"
         }
         """;
-    when(resourceServices.getContentByKey(eq(1L), any()))
+    when(resourceServices.getContentByKey(eq(1L), any(), any()))
         .thenReturn(
             CompletableFuture.completedFuture(
                 new DeployedResourceEntity(
@@ -628,7 +628,7 @@ public class ResourceControllerTest extends RestControllerTest {
   @Test
   void getResourceContentShouldYieldNotFoundWhenResourceNotFound() {
     // given
-    when(resourceServices.getContentByKeyFilteredByType(eq(1L), eq("rpa"), any()))
+    when(resourceServices.getContentByKeyFilteredByType(eq(1L), eq("rpa"), any(), any()))
         .thenReturn(
             CompletableFuture.failedFuture(
                 ErrorMapper.mapBrokerRejection(
@@ -663,7 +663,7 @@ public class ResourceControllerTest extends RestControllerTest {
   @Test
   void getResourceContentBinaryShouldYieldNotFoundWhenResourceNotFound() {
     // given
-    when(resourceServices.getContentByKey(eq(1L), any()))
+    when(resourceServices.getContentByKey(eq(1L), any(), any()))
         .thenReturn(
             CompletableFuture.failedFuture(
                 ErrorMapper.mapBrokerRejection(
@@ -698,7 +698,7 @@ public class ResourceControllerTest extends RestControllerTest {
   @Test
   void getResourceContentShouldYieldNotAcceptableWhenResourceIsNotRpa() {
     // given
-    when(resourceServices.getContentByKeyFilteredByType(eq(1L), eq("rpa"), any()))
+    when(resourceServices.getContentByKeyFilteredByType(eq(1L), eq("rpa"), any(), any()))
         .thenReturn(
             CompletableFuture.failedFuture(
                 new ServiceException(
@@ -733,7 +733,7 @@ public class ResourceControllerTest extends RestControllerTest {
   @Test
   void getResourceContentShouldYieldInternalServerErrorForProcessingErrorRejection() {
     // given
-    when(resourceServices.getContentByKeyFilteredByType(eq(1L), eq("rpa"), any()))
+    when(resourceServices.getContentByKeyFilteredByType(eq(1L), eq("rpa"), any(), any()))
         .thenReturn(
             CompletableFuture.failedFuture(
                 ErrorMapper.mapBrokerRejection(
@@ -771,7 +771,7 @@ public class ResourceControllerTest extends RestControllerTest {
   @Test
   void getResourceContentBinaryShouldYieldInternalServerErrorForProcessingErrorRejection() {
     // given
-    when(resourceServices.getContentByKey(eq(1L), any()))
+    when(resourceServices.getContentByKey(eq(1L), any(), any()))
         .thenReturn(
             CompletableFuture.failedFuture(
                 ErrorMapper.mapBrokerRejection(
@@ -809,7 +809,7 @@ public class ResourceControllerTest extends RestControllerTest {
   @Test
   void getResourceContentShouldYieldInternalServerErrorForBrokerError() {
     // given
-    when(resourceServices.getContentByKeyFilteredByType(eq(1L), eq("rpa"), any()))
+    when(resourceServices.getContentByKeyFilteredByType(eq(1L), eq("rpa"), any(), any()))
         .thenReturn(
             CompletableFuture.failedFuture(
                 ErrorMapper.mapBrokerError(
@@ -843,7 +843,7 @@ public class ResourceControllerTest extends RestControllerTest {
   @Test
   void getResourceContentBinaryShouldYieldInternalServerErrorForBrokerError() {
     // given
-    when(resourceServices.getContentByKey(eq(1L), any()))
+    when(resourceServices.getContentByKey(eq(1L), any(), any()))
         .thenReturn(
             CompletableFuture.failedFuture(
                 ErrorMapper.mapBrokerError(
@@ -881,7 +881,7 @@ public class ResourceControllerTest extends RestControllerTest {
     void shouldDeleteResource() {
       // given
       final var resourceKey = 1L;
-      when(resourceServices.deleteResource(any(ResourceDeletionRequest.class), any()))
+      when(resourceServices.deleteResource(any(ResourceDeletionRequest.class), any(), any()))
           .thenReturn(
               CompletableFuture.completedFuture(
                   new ResourceDeletionRecord().setResourceKey(resourceKey)));
@@ -912,7 +912,7 @@ public class ResourceControllerTest extends RestControllerTest {
               """,
               JsonCompareMode.STRICT);
 
-      Mockito.verify(resourceServices).deleteResource(deleteRequestCaptor.capture(), any());
+      Mockito.verify(resourceServices).deleteResource(deleteRequestCaptor.capture(), any(), any());
       final var capturedRequest = deleteRequestCaptor.getValue();
       assertThat(capturedRequest.resourceKey()).isEqualTo(resourceKey);
       assertThat(capturedRequest.operationReference()).isEqualTo(123L);
@@ -923,7 +923,7 @@ public class ResourceControllerTest extends RestControllerTest {
     void shouldDeleteResourceWithNoBody() {
       // given
       final var resourceKey = 1L;
-      when(resourceServices.deleteResource(any(ResourceDeletionRequest.class), any()))
+      when(resourceServices.deleteResource(any(ResourceDeletionRequest.class), any(), any()))
           .thenReturn(
               CompletableFuture.completedFuture(
                   new ResourceDeletionRecord().setResourceKey(resourceKey)));
@@ -947,7 +947,7 @@ public class ResourceControllerTest extends RestControllerTest {
               """,
               JsonCompareMode.STRICT);
 
-      Mockito.verify(resourceServices).deleteResource(deleteRequestCaptor.capture(), any());
+      Mockito.verify(resourceServices).deleteResource(deleteRequestCaptor.capture(), any(), any());
       final var capturedRequest = deleteRequestCaptor.getValue();
       assertThat(capturedRequest.resourceKey()).isEqualTo(resourceKey);
       assertThat(capturedRequest.operationReference()).isNull();
@@ -958,7 +958,7 @@ public class ResourceControllerTest extends RestControllerTest {
     void shouldDeleteResourceWithEmptyRequestBody() {
       // given
       final var resourceKey = 1L;
-      when(resourceServices.deleteResource(any(ResourceDeletionRequest.class), any()))
+      when(resourceServices.deleteResource(any(ResourceDeletionRequest.class), any(), any()))
           .thenReturn(
               CompletableFuture.completedFuture(
                   new ResourceDeletionRecord().setResourceKey(resourceKey)));
@@ -987,7 +987,7 @@ public class ResourceControllerTest extends RestControllerTest {
               """,
               JsonCompareMode.STRICT);
 
-      Mockito.verify(resourceServices).deleteResource(deleteRequestCaptor.capture(), any());
+      Mockito.verify(resourceServices).deleteResource(deleteRequestCaptor.capture(), any(), any());
       final var capturedRequest = deleteRequestCaptor.getValue();
       assertThat(capturedRequest.resourceKey()).isEqualTo(resourceKey);
       assertThat(capturedRequest.operationReference()).isNull();
@@ -1005,7 +1005,7 @@ public class ResourceControllerTest extends RestControllerTest {
               .setBatchOperationKey(999L)
               .setBatchOperationType(BatchOperationType.DELETE_PROCESS_INSTANCE);
 
-      when(resourceServices.deleteResource(any(ResourceDeletionRequest.class), any()))
+      when(resourceServices.deleteResource(any(ResourceDeletionRequest.class), any(), any()))
           .thenReturn(CompletableFuture.completedFuture(deletionRecord));
 
       final var request =
@@ -1037,7 +1037,7 @@ public class ResourceControllerTest extends RestControllerTest {
               """,
               JsonCompareMode.STRICT);
 
-      Mockito.verify(resourceServices).deleteResource(deleteRequestCaptor.capture(), any());
+      Mockito.verify(resourceServices).deleteResource(deleteRequestCaptor.capture(), any(), any());
       final var capturedRequest = deleteRequestCaptor.getValue();
       assertThat(capturedRequest.resourceKey()).isEqualTo(resourceKey);
       assertThat(capturedRequest.deleteHistory()).isTrue();
@@ -1054,7 +1054,7 @@ public class ResourceControllerTest extends RestControllerTest {
               .setBatchOperationKey(555L)
               .setBatchOperationType(BatchOperationType.DELETE_PROCESS_INSTANCE);
 
-      when(resourceServices.deleteResource(any(ResourceDeletionRequest.class), any()))
+      when(resourceServices.deleteResource(any(ResourceDeletionRequest.class), any(), any()))
           .thenReturn(CompletableFuture.completedFuture(deletionRecord));
 
       final var request =
@@ -1087,7 +1087,7 @@ public class ResourceControllerTest extends RestControllerTest {
               """,
               JsonCompareMode.STRICT);
 
-      Mockito.verify(resourceServices).deleteResource(deleteRequestCaptor.capture(), any());
+      Mockito.verify(resourceServices).deleteResource(deleteRequestCaptor.capture(), any(), any());
       final var capturedRequest = deleteRequestCaptor.getValue();
       assertThat(capturedRequest.resourceKey()).isEqualTo(resourceKey);
       assertThat(capturedRequest.operationReference()).isEqualTo(123L);

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/SignalControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/SignalControllerTest.java
@@ -59,7 +59,7 @@ public class SignalControllerTest extends RestControllerTest {
     when(authenticationProvider.getCamundaAuthentication())
         .thenReturn(AUTHENTICATION_WITH_NON_DEFAULT_TENANT);
     when(multiTenancyCfg.isChecksEnabled()).thenReturn(true);
-    when(signalServices.broadcastSignal(anyString(), anyMap(), anyString(), any()))
+    when(signalServices.broadcastSignal(anyString(), anyMap(), anyString(), any(), any()))
         .thenReturn(buildSignalResponse("tenantId"));
 
     final var request =
@@ -86,14 +86,15 @@ public class SignalControllerTest extends RestControllerTest {
 
     response.expectBody().json(EXPECTED_PUBLICATION_RESPONSE, JsonCompareMode.STRICT);
     Mockito.verify(signalServices)
-        .broadcastSignal(eq("signalName"), eq(Map.of("key", "value")), eq("tenantId"), any());
+        .broadcastSignal(
+            eq("signalName"), eq(Map.of("key", "value")), eq("tenantId"), any(), any());
   }
 
   @Test
   void shouldBroadcastSignalWithMultitenancyDisabled() {
     // given
     when(multiTenancyCfg.isChecksEnabled()).thenReturn(false);
-    when(signalServices.broadcastSignal(anyString(), anyMap(), anyString(), any()))
+    when(signalServices.broadcastSignal(anyString(), anyMap(), anyString(), any(), any()))
         .thenReturn(buildSignalResponse(TenantOwned.DEFAULT_TENANT_IDENTIFIER));
 
     final var request =
@@ -122,6 +123,7 @@ public class SignalControllerTest extends RestControllerTest {
             eq("signalName"),
             eq(Map.of("key", "value")),
             eq(TenantOwned.DEFAULT_TENANT_IDENTIFIER),
+            any(),
             any());
   }
 
@@ -131,7 +133,7 @@ public class SignalControllerTest extends RestControllerTest {
     when(authenticationProvider.getCamundaAuthentication())
         .thenReturn(AUTHENTICATION_WITH_NON_DEFAULT_TENANT);
     when(multiTenancyCfg.isChecksEnabled()).thenReturn(true);
-    when(signalServices.broadcastSignal(anyString(), anyMap(), anyString(), any()))
+    when(signalServices.broadcastSignal(anyString(), anyMap(), anyString(), any(), any()))
         .thenReturn(buildSignalResponse("tenantId"));
 
     final var request =
@@ -158,7 +160,7 @@ public class SignalControllerTest extends RestControllerTest {
 
     response.expectBody().json(EXPECTED_PUBLICATION_RESPONSE, JsonCompareMode.STRICT);
     Mockito.verify(signalServices)
-        .broadcastSignal(eq(""), eq(Map.of("key", "value")), eq("tenantId"), any());
+        .broadcastSignal(eq(""), eq(Map.of("key", "value")), eq("tenantId"), any(), any());
   }
 
   @Test

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskControllerTest.java
@@ -93,7 +93,7 @@ public class UserTaskControllerTest extends RestControllerTest {
   @MethodSource("urls")
   void shouldCompleteTaskWithoutActionAndVariables(final String baseUrl) {
     // given
-    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any()))
+    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any(), any()))
         .thenReturn(BROKER_RESPONSE);
     // when / then
     webClient
@@ -107,14 +107,14 @@ public class UserTaskControllerTest extends RestControllerTest {
         .isEmpty();
 
     Mockito.verify(userTaskServices)
-        .completeUserTask(eq(2251799813685732L), eq(Map.of()), eq(""), any());
+        .completeUserTask(eq(2251799813685732L), eq(Map.of()), eq(""), any(), any());
   }
 
   @ParameterizedTest
   @MethodSource("urls")
   void shouldCompleteTaskWithAction(final String baseUrl) {
     // given
-    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any()))
+    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any(), any()))
         .thenReturn(BROKER_RESPONSE);
     final var request =
         """
@@ -136,14 +136,14 @@ public class UserTaskControllerTest extends RestControllerTest {
         .isEmpty();
 
     Mockito.verify(userTaskServices)
-        .completeUserTask(eq(1L), eq(Map.of()), eq("customAction"), any());
+        .completeUserTask(eq(1L), eq(Map.of()), eq("customAction"), any(), any());
   }
 
   @ParameterizedTest
   @MethodSource("urls")
   void shouldCompleteTaskWithVariables(final String baseUrl) {
     // given
-    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any()))
+    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any(), any()))
         .thenReturn(BROKER_RESPONSE);
     final var request =
         """
@@ -168,14 +168,14 @@ public class UserTaskControllerTest extends RestControllerTest {
         .isEmpty();
 
     Mockito.verify(userTaskServices)
-        .completeUserTask(eq(1L), eq(Map.of("foo", "bar", "baz", 1234)), eq(""), any());
+        .completeUserTask(eq(1L), eq(Map.of("foo", "bar", "baz", 1234)), eq(""), any(), any());
   }
 
   @ParameterizedTest
   @MethodSource("urls")
   void shouldCompleteTaskWithActionAndVariables(final String baseUrl) {
     // given
-    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any()))
+    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any(), any()))
         .thenReturn(BROKER_RESPONSE);
     final var request =
         """
@@ -201,14 +201,15 @@ public class UserTaskControllerTest extends RestControllerTest {
         .isEmpty();
 
     Mockito.verify(userTaskServices)
-        .completeUserTask(eq(1L), eq(Map.of("foo", "bar", "baz", 1234)), eq("customAction"), any());
+        .completeUserTask(
+            eq(1L), eq(Map.of("foo", "bar", "baz", 1234)), eq("customAction"), any(), any());
   }
 
   @ParameterizedTest
   @MethodSource("urls")
   void shouldUpdateTaskWithAction(final String baseUrl) {
     // given
-    Mockito.when(userTaskServices.updateUserTask(anyLong(), any(), anyString(), any()))
+    Mockito.when(userTaskServices.updateUserTask(anyLong(), any(), anyString(), any(), any()))
         .thenReturn(BROKER_RESPONSE);
     final var request =
         """
@@ -231,7 +232,7 @@ public class UserTaskControllerTest extends RestControllerTest {
 
     final var argumentCaptor = ArgumentCaptor.forClass(UserTaskRecord.class);
     Mockito.verify(userTaskServices)
-        .updateUserTask(eq(1L), argumentCaptor.capture(), eq("customAction"), any());
+        .updateUserTask(eq(1L), argumentCaptor.capture(), eq("customAction"), any(), any());
     Assertions.assertThat(argumentCaptor.getValue())
         .hasNoChangedAttributes()
         .hasDueDate("")
@@ -244,7 +245,7 @@ public class UserTaskControllerTest extends RestControllerTest {
   @MethodSource("urls")
   void shouldUpdateTaskWithChanges(final String baseUrl) {
     // given
-    Mockito.when(userTaskServices.updateUserTask(anyLong(), any(), anyString(), any()))
+    Mockito.when(userTaskServices.updateUserTask(anyLong(), any(), anyString(), any(), any()))
         .thenReturn(BROKER_RESPONSE);
     final var request =
         """
@@ -274,7 +275,7 @@ public class UserTaskControllerTest extends RestControllerTest {
 
     final var argumentCaptor = ArgumentCaptor.forClass(UserTaskRecord.class);
     Mockito.verify(userTaskServices)
-        .updateUserTask(eq(1L), argumentCaptor.capture(), eq(""), any());
+        .updateUserTask(eq(1L), argumentCaptor.capture(), eq(""), any(), any());
     Assertions.assertThat(argumentCaptor.getValue())
         .hasChangedAttributes(
             UserTaskRecord.CANDIDATE_USERS,
@@ -293,7 +294,7 @@ public class UserTaskControllerTest extends RestControllerTest {
   @MethodSource("urls")
   void shouldUpdateTaskWithPartialChanges(final String baseUrl) {
     // given
-    Mockito.when(userTaskServices.updateUserTask(anyLong(), any(), anyString(), any()))
+    Mockito.when(userTaskServices.updateUserTask(anyLong(), any(), anyString(), any(), any()))
         .thenReturn(BROKER_RESPONSE);
     final var request =
         """
@@ -320,7 +321,7 @@ public class UserTaskControllerTest extends RestControllerTest {
 
     final var argumentCaptor = ArgumentCaptor.forClass(UserTaskRecord.class);
     Mockito.verify(userTaskServices)
-        .updateUserTask(eq(1L), argumentCaptor.capture(), eq(""), any());
+        .updateUserTask(eq(1L), argumentCaptor.capture(), eq(""), any(), any());
     Assertions.assertThat(argumentCaptor.getValue())
         .hasChangedAttributes(UserTaskRecord.CANDIDATE_GROUPS, UserTaskRecord.FOLLOW_UP_DATE)
         .hasDueDate("")
@@ -333,7 +334,7 @@ public class UserTaskControllerTest extends RestControllerTest {
   @MethodSource("urls")
   void shouldUpdateTaskWithPartialEmptyValueChanges(final String baseUrl) {
     // given
-    Mockito.when(userTaskServices.updateUserTask(anyLong(), any(), anyString(), any()))
+    Mockito.when(userTaskServices.updateUserTask(anyLong(), any(), anyString(), any(), any()))
         .thenReturn(BROKER_RESPONSE);
     final var request =
         """
@@ -359,7 +360,7 @@ public class UserTaskControllerTest extends RestControllerTest {
 
     final var argumentCaptor = ArgumentCaptor.forClass(UserTaskRecord.class);
     Mockito.verify(userTaskServices)
-        .updateUserTask(eq(1L), argumentCaptor.capture(), eq(""), any());
+        .updateUserTask(eq(1L), argumentCaptor.capture(), eq(""), any(), any());
     Assertions.assertThat(argumentCaptor.getValue())
         .hasChangedAttributes(UserTaskRecord.CANDIDATE_GROUPS, UserTaskRecord.FOLLOW_UP_DATE)
         .hasDueDate("")
@@ -372,7 +373,7 @@ public class UserTaskControllerTest extends RestControllerTest {
   @MethodSource("urls")
   void shouldUpdateTaskWithActionAndChanges(final String baseUrl) {
     // given
-    Mockito.when(userTaskServices.updateUserTask(anyLong(), any(), anyString(), any()))
+    Mockito.when(userTaskServices.updateUserTask(anyLong(), any(), anyString(), any(), any()))
         .thenReturn(BROKER_RESPONSE);
     final var request =
         """
@@ -403,7 +404,7 @@ public class UserTaskControllerTest extends RestControllerTest {
 
     final var argumentCaptor = ArgumentCaptor.forClass(UserTaskRecord.class);
     Mockito.verify(userTaskServices)
-        .updateUserTask(eq(1L), argumentCaptor.capture(), eq("customAction"), any());
+        .updateUserTask(eq(1L), argumentCaptor.capture(), eq("customAction"), any(), any());
     Assertions.assertThat(argumentCaptor.getValue())
         .hasChangedAttributes(
             UserTaskRecord.CANDIDATE_USERS,
@@ -422,7 +423,7 @@ public class UserTaskControllerTest extends RestControllerTest {
   @MethodSource("validDateInputsAndUrls")
   void shouldUpdateTaskWithDateChanges(final Pair<String, String> dateAndUrl) {
     // given
-    Mockito.when(userTaskServices.updateUserTask(anyLong(), any(), anyString(), any()))
+    Mockito.when(userTaskServices.updateUserTask(anyLong(), any(), anyString(), any(), any()))
         .thenReturn(BROKER_RESPONSE);
     final var request =
         """
@@ -449,7 +450,7 @@ public class UserTaskControllerTest extends RestControllerTest {
 
     final var argumentCaptor = ArgumentCaptor.forClass(UserTaskRecord.class);
     Mockito.verify(userTaskServices)
-        .updateUserTask(eq(1L), argumentCaptor.capture(), eq(""), any());
+        .updateUserTask(eq(1L), argumentCaptor.capture(), eq(""), any(), any());
     Assertions.assertThat(argumentCaptor.getValue())
         .hasChangedAttributes(UserTaskRecord.DUE_DATE, UserTaskRecord.FOLLOW_UP_DATE)
         .hasDueDate(dateAndUrl.getLeft())
@@ -793,7 +794,7 @@ public class UserTaskControllerTest extends RestControllerTest {
   @MethodSource("urls")
   void shouldYieldNotFoundWhenTaskNotFound(final String baseUrl) {
     // given
-    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any()))
+    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any(), any()))
         .thenReturn(
             CompletableFuture.failedFuture(
                 ErrorMapper.mapBrokerRejection(
@@ -825,14 +826,14 @@ public class UserTaskControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedBody, JsonCompareMode.STRICT);
 
-    Mockito.verify(userTaskServices).completeUserTask(eq(1L), eq(Map.of()), eq(""), any());
+    Mockito.verify(userTaskServices).completeUserTask(eq(1L), eq(Map.of()), eq(""), any(), any());
   }
 
   @ParameterizedTest
   @MethodSource("urls")
   void shouldReturnGatewayTimeoutWhenCompleteTaskTimesOut(final String baseUrl) {
     // given
-    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any()))
+    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any(), any()))
         .thenReturn(
             CompletableFuture.failedFuture(
                 ErrorMapper.mapError(new TimeoutException("Task listener blocked completion"))));
@@ -860,7 +861,7 @@ public class UserTaskControllerTest extends RestControllerTest {
   @MethodSource("urls")
   void shouldYieldConflictWhenInvalidState(final String baseUrl) {
     // given
-    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any()))
+    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any(), any()))
         .thenReturn(
             CompletableFuture.failedFuture(
                 ErrorMapper.mapBrokerRejection(
@@ -895,7 +896,7 @@ public class UserTaskControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedBody, JsonCompareMode.STRICT);
 
-    Mockito.verify(userTaskServices).completeUserTask(eq(1L), eq(Map.of()), eq(""), any());
+    Mockito.verify(userTaskServices).completeUserTask(eq(1L), eq(Map.of()), eq(""), any(), any());
   }
 
   @ParameterizedTest
@@ -903,7 +904,7 @@ public class UserTaskControllerTest extends RestControllerTest {
   public void shouldYieldBadRequestWhenRejectionOfInput(
       final Pair<RejectionType, String> parameters) {
     // given
-    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any()))
+    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any(), any()))
         .thenReturn(
             CompletableFuture.failedFuture(
                 ErrorMapper.mapBrokerRejection(
@@ -938,7 +939,7 @@ public class UserTaskControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedBody, JsonCompareMode.STRICT);
 
-    Mockito.verify(userTaskServices).completeUserTask(eq(1L), eq(Map.of()), eq(""), any());
+    Mockito.verify(userTaskServices).completeUserTask(eq(1L), eq(Map.of()), eq(""), any(), any());
   }
 
   @ParameterizedTest
@@ -946,7 +947,7 @@ public class UserTaskControllerTest extends RestControllerTest {
   public void shouldYieldConflictWhenRejectionOfInput(
       final Pair<RejectionType, String> parameters) {
     // given
-    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any()))
+    Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString(), any(), any()))
         .thenReturn(
             CompletableFuture.failedFuture(
                 ErrorMapper.mapBrokerRejection(
@@ -981,7 +982,7 @@ public class UserTaskControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedBody, JsonCompareMode.STRICT);
 
-    Mockito.verify(userTaskServices).completeUserTask(eq(1L), eq(Map.of()), eq(""), any());
+    Mockito.verify(userTaskServices).completeUserTask(eq(1L), eq(Map.of()), eq(""), any(), any());
   }
 
   @ParameterizedTest
@@ -990,7 +991,7 @@ public class UserTaskControllerTest extends RestControllerTest {
     // given
     Mockito.when(
             userTaskServices.assignUserTask(
-                anyLong(), anyString(), anyString(), anyBoolean(), any()))
+                anyLong(), anyString(), anyString(), anyBoolean(), any(), any()))
         .thenReturn(BROKER_RESPONSE);
     final var request =
         """
@@ -1012,7 +1013,8 @@ public class UserTaskControllerTest extends RestControllerTest {
         .isEmpty();
 
     Mockito.verify(userTaskServices)
-        .assignUserTask(eq(2251799813685732L), eq("Test Assignee"), eq("assign"), eq(true), any());
+        .assignUserTask(
+            eq(2251799813685732L), eq("Test Assignee"), eq("assign"), eq(true), any(), any());
   }
 
   @ParameterizedTest
@@ -1021,7 +1023,7 @@ public class UserTaskControllerTest extends RestControllerTest {
     // given
     Mockito.when(
             userTaskServices.assignUserTask(
-                anyLong(), anyString(), anyString(), anyBoolean(), any()))
+                anyLong(), anyString(), anyString(), anyBoolean(), any(), any()))
         .thenReturn(BROKER_RESPONSE);
     final var request =
         """
@@ -1045,7 +1047,12 @@ public class UserTaskControllerTest extends RestControllerTest {
 
     Mockito.verify(userTaskServices)
         .assignUserTask(
-            eq(2251799813685732L), eq("Test Assignee"), eq("custom action"), eq(true), any());
+            eq(2251799813685732L),
+            eq("Test Assignee"),
+            eq("custom action"),
+            eq(true),
+            any(),
+            any());
   }
 
   @ParameterizedTest
@@ -1054,7 +1061,7 @@ public class UserTaskControllerTest extends RestControllerTest {
     // given
     Mockito.when(
             userTaskServices.assignUserTask(
-                anyLong(), anyString(), anyString(), anyBoolean(), any()))
+                anyLong(), anyString(), anyString(), anyBoolean(), any(), any()))
         .thenReturn(BROKER_RESPONSE);
     final var request =
         """
@@ -1079,7 +1086,12 @@ public class UserTaskControllerTest extends RestControllerTest {
 
     Mockito.verify(userTaskServices)
         .assignUserTask(
-            eq(2251799813685732L), eq("Test Assignee"), eq("custom action"), eq(true), any());
+            eq(2251799813685732L),
+            eq("Test Assignee"),
+            eq("custom action"),
+            eq(true),
+            any(),
+            any());
   }
 
   @ParameterizedTest
@@ -1088,7 +1100,7 @@ public class UserTaskControllerTest extends RestControllerTest {
     // gíven
     Mockito.when(
             userTaskServices.assignUserTask(
-                anyLong(), anyString(), anyString(), anyBoolean(), any()))
+                anyLong(), anyString(), anyString(), anyBoolean(), any(), any()))
         .thenReturn(BROKER_RESPONSE);
     final var request =
         """
@@ -1113,7 +1125,12 @@ public class UserTaskControllerTest extends RestControllerTest {
 
     Mockito.verify(userTaskServices)
         .assignUserTask(
-            eq(2251799813685732L), eq("Test Assignee"), eq("custom action"), eq(false), any());
+            eq(2251799813685732L),
+            eq("Test Assignee"),
+            eq("custom action"),
+            eq(false),
+            any(),
+            any());
   }
 
   @ParameterizedTest
@@ -1122,7 +1139,7 @@ public class UserTaskControllerTest extends RestControllerTest {
     // given
     Mockito.when(
             userTaskServices.assignUserTask(
-                anyLong(), anyString(), anyString(), anyBoolean(), any()))
+                anyLong(), anyString(), anyString(), anyBoolean(), any(), any()))
         .thenReturn(BROKER_RESPONSE);
     final var request =
         """
@@ -1145,7 +1162,8 @@ public class UserTaskControllerTest extends RestControllerTest {
         .isEmpty();
 
     Mockito.verify(userTaskServices)
-        .assignUserTask(eq(2251799813685732L), eq("Test Assignee"), eq("assign"), eq(true), any());
+        .assignUserTask(
+            eq(2251799813685732L), eq("Test Assignee"), eq("assign"), eq(true), any(), any());
   }
 
   @ParameterizedTest
@@ -1154,7 +1172,7 @@ public class UserTaskControllerTest extends RestControllerTest {
     // given
     Mockito.when(
             userTaskServices.assignUserTask(
-                anyLong(), anyString(), anyString(), anyBoolean(), any()))
+                anyLong(), anyString(), anyString(), anyBoolean(), any(), any()))
         .thenReturn(BROKER_RESPONSE);
     final var request =
         """
@@ -1177,7 +1195,8 @@ public class UserTaskControllerTest extends RestControllerTest {
         .isEmpty();
 
     Mockito.verify(userTaskServices)
-        .assignUserTask(eq(2251799813685732L), eq("Test Assignee"), eq("assign"), eq(false), any());
+        .assignUserTask(
+            eq(2251799813685732L), eq("Test Assignee"), eq("assign"), eq(false), any(), any());
   }
 
   @ParameterizedTest
@@ -1221,7 +1240,7 @@ public class UserTaskControllerTest extends RestControllerTest {
     // given
     Mockito.when(
             userTaskServices.assignUserTask(
-                anyLong(), anyString(), anyString(), anyBoolean(), any()))
+                anyLong(), anyString(), anyString(), anyBoolean(), any(), any()))
         .thenReturn(
             CompletableFuture.failedFuture(
                 ErrorMapper.mapError(new TimeoutException("Task listener blocked assignment"))));
@@ -1257,7 +1276,7 @@ public class UserTaskControllerTest extends RestControllerTest {
   @MethodSource("urls")
   void shouldReturnGatewayTimeoutWhenUpdateTaskTimesOut(final String baseUrl) {
     // given
-    Mockito.when(userTaskServices.updateUserTask(anyLong(), any(), anyString(), any()))
+    Mockito.when(userTaskServices.updateUserTask(anyLong(), any(), anyString(), any(), any()))
         .thenReturn(
             CompletableFuture.failedFuture(
                 ErrorMapper.mapError(new TimeoutException("Task listener blocked update"))));
@@ -1295,7 +1314,7 @@ public class UserTaskControllerTest extends RestControllerTest {
   @MethodSource("urls")
   void shouldUnassignTask(final String baseUrl) {
     // given
-    Mockito.when(userTaskServices.unassignUserTask(anyLong(), anyString(), any()))
+    Mockito.when(userTaskServices.unassignUserTask(anyLong(), anyString(), any(), any()))
         .thenReturn(BROKER_RESPONSE);
     // when / then
     webClient
@@ -1307,14 +1326,15 @@ public class UserTaskControllerTest extends RestControllerTest {
         .expectBody()
         .isEmpty();
 
-    Mockito.verify(userTaskServices).unassignUserTask(eq(2251799813685732L), eq("unassign"), any());
+    Mockito.verify(userTaskServices)
+        .unassignUserTask(eq(2251799813685732L), eq("unassign"), any(), any());
   }
 
   @ParameterizedTest
   @MethodSource("urls")
   void shouldReturnGatewayTimeoutWhenUnassignTaskTimesOut(final String baseUrl) {
     // given
-    Mockito.when(userTaskServices.unassignUserTask(anyLong(), anyString(), any()))
+    Mockito.when(userTaskServices.unassignUserTask(anyLong(), anyString(), any(), any()))
         .thenReturn(
             CompletableFuture.failedFuture(
                 ErrorMapper.mapError(new TimeoutException("Task listener blocked unassignment"))));

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryControllerTest.java
@@ -418,7 +418,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
         .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
 
     // Mock the behavior of userTaskServices for a valid key
-    when(userTaskServices.getByKey(eq(VALID_USER_TASK_KEY), any()))
+    when(userTaskServices.getByKey(eq(VALID_USER_TASK_KEY), any(), any()))
         .thenReturn(
             new UserTaskEntity(
                 0L,
@@ -446,7 +446,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
                 50,
                 Set.of()));
     // Mock the behavior for an invalid userTaskKey to throw NotFoundException
-    when(userTaskServices.getByKey(eq(INVALID_USER_TASK_KEY), any()))
+    when(userTaskServices.getByKey(eq(INVALID_USER_TASK_KEY), any(), any()))
         .thenThrow(
             ErrorMapper.mapSearchError(
                 new CamundaSearchException(
@@ -457,7 +457,8 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
   @Test
   void shouldSearchUserTasksWithEmptyBody() {
     // given
-    when(userTaskServices.search(any(UserTaskQuery.class), any())).thenReturn(SEARCH_QUERY_RESULT);
+    when(userTaskServices.search(any(UserTaskQuery.class), any(), any()))
+        .thenReturn(SEARCH_QUERY_RESULT);
     // when / then
     webClient
         .post()
@@ -470,13 +471,14 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
-    verify(userTaskServices).search(eq(new UserTaskQuery.Builder().build()), any());
+    verify(userTaskServices).search(eq(new UserTaskQuery.Builder().build()), any(), any());
   }
 
   @Test
   void shouldSearchUserTasksWithEmptyQuery() {
     // given
-    when(userTaskServices.search(any(UserTaskQuery.class), any())).thenReturn(SEARCH_QUERY_RESULT);
+    when(userTaskServices.search(any(UserTaskQuery.class), any(), any()))
+        .thenReturn(SEARCH_QUERY_RESULT);
     final String request = "{}";
     // when / then
     webClient
@@ -493,13 +495,14 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
-    verify(userTaskServices).search(eq(new UserTaskQuery.Builder().build()), any());
+    verify(userTaskServices).search(eq(new UserTaskQuery.Builder().build()), any(), any());
   }
 
   @Test
   void shouldSearchUserTasksWithSorting() {
     // given
-    when(userTaskServices.search(any(UserTaskQuery.class), any())).thenReturn(SEARCH_QUERY_RESULT);
+    when(userTaskServices.search(any(UserTaskQuery.class), any(), any()))
+        .thenReturn(SEARCH_QUERY_RESULT);
     final var request =
         """
                 {
@@ -541,6 +544,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
                             .asc()
                             .build())
                     .build()),
+            any(),
             any());
   }
 
@@ -585,7 +589,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedResponse, JsonCompareMode.STRICT);
 
-    verify(userTaskServices, never()).search(any(UserTaskQuery.class), any());
+    verify(userTaskServices, never()).search(any(UserTaskQuery.class), any(), any());
   }
 
   @Test
@@ -628,7 +632,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedResponse, JsonCompareMode.STRICT);
 
-    verify(userTaskServices, never()).search(any(UserTaskQuery.class), any());
+    verify(userTaskServices, never()).search(any(UserTaskQuery.class), any(), any());
   }
 
   @Test
@@ -672,7 +676,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedResponse, JsonCompareMode.STRICT);
 
-    verify(userTaskServices, never()).search(any(UserTaskQuery.class), any());
+    verify(userTaskServices, never()).search(any(UserTaskQuery.class), any(), any());
   }
 
   @Test
@@ -715,7 +719,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedResponse, JsonCompareMode.STRICT);
 
-    verify(userTaskServices, never()).search(any(UserTaskQuery.class), any());
+    verify(userTaskServices, never()).search(any(UserTaskQuery.class), any(), any());
   }
 
   @Test
@@ -757,7 +761,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedResponse, JsonCompareMode.STRICT);
 
-    verify(userTaskServices, never()).search(any(UserTaskQuery.class), any());
+    verify(userTaskServices, never()).search(any(UserTaskQuery.class), any(), any());
   }
 
   @Test
@@ -799,7 +803,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedResponse, JsonCompareMode.STRICT);
 
-    verify(userTaskServices, never()).search(any(UserTaskQuery.class), any());
+    verify(userTaskServices, never()).search(any(UserTaskQuery.class), any(), any());
   }
 
   @Test
@@ -840,7 +844,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedResponse, JsonCompareMode.STRICT);
 
-    verify(userTaskServices, never()).search(any(UserTaskQuery.class), any());
+    verify(userTaskServices, never()).search(any(UserTaskQuery.class), any(), any());
   }
 
   @Test
@@ -880,7 +884,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedResponse, JsonCompareMode.STRICT);
 
-    verify(userTaskServices, never()).search(any(UserTaskQuery.class), any());
+    verify(userTaskServices, never()).search(any(UserTaskQuery.class), any(), any());
   }
 
   @Test
@@ -897,7 +901,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
         .json(USER_TASK_ITEM_JSON, JsonCompareMode.STRICT);
 
     // Verify that the service was called with the invalid userTaskKey
-    verify(userTaskServices).getByKey(eq(VALID_USER_TASK_KEY), any());
+    verify(userTaskServices).getByKey(eq(VALID_USER_TASK_KEY), any(), any());
   }
 
   @Test
@@ -926,12 +930,12 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
             JsonCompareMode.STRICT);
 
     // Verify that the service was called with the invalid userTaskKey
-    verify(userTaskServices).getByKey(eq(INVALID_USER_TASK_KEY), any());
+    verify(userTaskServices).getByKey(eq(INVALID_USER_TASK_KEY), any(), any());
   }
 
   @Test
   public void shouldReturnFormItemForValidFormKey() {
-    when(userTaskServices.getUserTaskForm(eq(VALID_FORM_KEY), any()))
+    when(userTaskServices.getUserTaskForm(eq(VALID_FORM_KEY), any(), any()))
         .thenReturn(Optional.of(new FormEntity(0L, "tenant-1", "bpmn-1", "schema", 1L)));
 
     webClient
@@ -944,13 +948,13 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(FORM_ITEM_JSON, JsonCompareMode.STRICT);
 
-    verify(userTaskServices).getUserTaskForm(eq(VALID_FORM_KEY), any());
+    verify(userTaskServices).getUserTaskForm(eq(VALID_FORM_KEY), any(), any());
   }
 
   @Test
   public void shouldReturn404ForFormInvalidUserTaskKey() {
     // given
-    when(userTaskServices.getUserTaskForm(eq(INVALID_USER_TASK_KEY), any()))
+    when(userTaskServices.getUserTaskForm(eq(INVALID_USER_TASK_KEY), any(), any()))
         .thenThrow(
             ErrorMapper.mapSearchError(
                 new CamundaSearchException(
@@ -981,7 +985,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
 
   @Test
   public void shouldReturn500OnUnexpectedException() throws Exception {
-    when(userTaskServices.getUserTaskForm(eq(VALID_FORM_KEY), any()))
+    when(userTaskServices.getUserTaskForm(eq(VALID_FORM_KEY), any(), any()))
         .thenThrow(new RuntimeException("Unexpected error"));
 
     webClient
@@ -1023,6 +1027,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
                 variableSearchQuery()
                     .filter(f -> f.nameOperations(Operation.eq("varName")))
                     .build()),
+            any(),
             any()))
         .thenReturn(SEARCH_VAR_QUERY_RESULT);
     // when and then
@@ -1045,6 +1050,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
                 variableSearchQuery()
                     .filter(f -> f.nameOperations(Operation.eq("varName")))
                     .build()),
+            any(),
             any());
   }
 
@@ -1066,6 +1072,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
                 variableSearchQuery()
                     .filter(f -> f.nameOperations(Operation.eq("varName")))
                     .build()),
+            any(),
             any()))
         .thenReturn(SEARCH_VAR_QUERY_RESULT);
     // when and then
@@ -1088,6 +1095,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
                 variableSearchQuery()
                     .filter(f -> f.nameOperations(Operation.eq("varName")))
                     .build()),
+            any(),
             any());
   }
 
@@ -1109,6 +1117,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
                 variableSearchQuery()
                     .filter(f -> f.nameOperations(Operation.eq("varName")))
                     .build()),
+            any(),
             any()))
         .thenReturn(SEARCH_EFFECTIVE_VAR_QUERY_RESULT);
     // when and then
@@ -1131,6 +1140,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
                 variableSearchQuery()
                     .filter(f -> f.nameOperations(Operation.eq("varName")))
                     .build()),
+            any(),
             any());
   }
 
@@ -1174,7 +1184,8 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
                 }"""
             .formatted(filterString);
     System.out.println("request = " + request);
-    when(userTaskServices.search(any(UserTaskQuery.class), any())).thenReturn(SEARCH_QUERY_RESULT);
+    when(userTaskServices.search(any(UserTaskQuery.class), any(), any()))
+        .thenReturn(SEARCH_QUERY_RESULT);
 
     // when / then
     webClient
@@ -1191,7 +1202,8 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
-    verify(userTaskServices).search(eq(new UserTaskQuery.Builder().filter(filter).build()), any());
+    verify(userTaskServices)
+        .search(eq(new UserTaskQuery.Builder().filter(filter).build()), any(), any());
   }
 
   @Test
@@ -1209,6 +1221,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
     when(userTaskServices.searchUserTaskAuditLogs(
             eq(VALID_USER_TASK_KEY),
             eq(auditLogSearchQuery().filter(f -> f.actorIds("1")).build()),
+            any(),
             any()))
         .thenReturn(SEARCH_AUDIT_LOG_QUERY_RESULT);
     // when and then
@@ -1228,6 +1241,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
         .searchUserTaskAuditLogs(
             eq(VALID_USER_TASK_KEY),
             eq(auditLogSearchQuery().filter(f -> f.actorIds("1")).build()),
+            any(),
             any());
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/VariablesQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/VariablesQueryControllerTest.java
@@ -157,19 +157,20 @@ public class VariablesQueryControllerTest extends RestControllerTest {
     when(authenticationProvider.getCamundaAuthentication())
         .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
 
-    when(variableServices.getByKey(eq(VALID_VARIABLE_KEY), any()))
+    when(variableServices.getByKey(eq(VALID_VARIABLE_KEY), any(), any()))
         .thenReturn(new VariableEntity(0L, "n", "v", null, false, 2L, 3L, 4L, "bpid", "<default>"));
-    when(variableServices.getByKey(eq(VALID_TRUNCATED_VARIABLE_KEY), any()))
+    when(variableServices.getByKey(eq(VALID_TRUNCATED_VARIABLE_KEY), any(), any()))
         .thenReturn(new VariableEntity(1L, "ne", "v", "ve", true, 2L, 3L, 4L, "bpid", "<default>"));
 
-    when(variableServices.getByKey(eq(INVALID_VARIABLE_KEY), any()))
+    when(variableServices.getByKey(eq(INVALID_VARIABLE_KEY), any(), any()))
         .thenThrow(
             ErrorMapper.mapSearchError(
                 new CamundaSearchException(
                     String.format("Variable with key %d not found", INVALID_VARIABLE_KEY),
                     CamundaSearchException.Reason.NOT_FOUND)));
 
-    when(variableServices.search(any(VariableQuery.class), any())).thenReturn(SEARCH_QUERY_RESULT);
+    when(variableServices.search(any(VariableQuery.class), any(), any()))
+        .thenReturn(SEARCH_QUERY_RESULT);
   }
 
   @Test
@@ -186,7 +187,7 @@ public class VariablesQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
-    verify(variableServices).search(eq(new VariableQuery.Builder().build()), any());
+    verify(variableServices).search(eq(new VariableQuery.Builder().build()), any(), any());
   }
 
   @Test
@@ -203,7 +204,7 @@ public class VariablesQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(EXPECTED_UNTRUNCATED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
-    verify(variableServices).search(eq(new VariableQuery.Builder().build()), any());
+    verify(variableServices).search(eq(new VariableQuery.Builder().build()), any(), any());
   }
 
   @Test
@@ -223,13 +224,14 @@ public class VariablesQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
-    verify(variableServices).search(eq(new VariableQuery.Builder().build()), any());
+    verify(variableServices).search(eq(new VariableQuery.Builder().build()), any(), any());
   }
 
   @Test
   void shouldSearchVariableWithSorting() {
     // given
-    when(variableServices.search(any(VariableQuery.class), any())).thenReturn(SEARCH_QUERY_RESULT);
+    when(variableServices.search(any(VariableQuery.class), any(), any()))
+        .thenReturn(SEARCH_QUERY_RESULT);
     final var request =
         """
             {
@@ -265,6 +267,7 @@ public class VariablesQueryControllerTest extends RestControllerTest {
                 new VariableQuery.Builder()
                     .sort(new VariableSort.Builder().name().desc().value().asc().build())
                     .build()),
+            any(),
             any());
   }
 
@@ -307,7 +310,7 @@ public class VariablesQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedResponse, JsonCompareMode.STRICT);
 
-    verify(variableServices, never()).search(any(VariableQuery.class), any());
+    verify(variableServices, never()).search(any(VariableQuery.class), any(), any());
   }
 
   @Test
@@ -348,7 +351,7 @@ public class VariablesQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedResponse, JsonCompareMode.STRICT);
 
-    verify(variableServices, never()).search(any(VariableQuery.class), any());
+    verify(variableServices, never()).search(any(VariableQuery.class), any(), any());
   }
 
   @Test
@@ -388,7 +391,7 @@ public class VariablesQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedResponse, JsonCompareMode.STRICT);
 
-    verify(variableServices, never()).search(any(VariableQuery.class), any());
+    verify(variableServices, never()).search(any(VariableQuery.class), any(), any());
   }
 
   @Test
@@ -428,7 +431,7 @@ public class VariablesQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedResponse, JsonCompareMode.STRICT);
 
-    verify(variableServices, never()).search(any(VariableQuery.class), any());
+    verify(variableServices, never()).search(any(VariableQuery.class), any(), any());
   }
 
   @Test
@@ -445,7 +448,7 @@ public class VariablesQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(EXPECT_SINGLE_VARIABLE_RESPONSE, JsonCompareMode.STRICT);
 
-    verify(variableServices).getByKey(eq(VALID_VARIABLE_KEY), any());
+    verify(variableServices).getByKey(eq(VALID_VARIABLE_KEY), any(), any());
   }
 
   @Test
@@ -462,7 +465,7 @@ public class VariablesQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(EXPECT_SINGLE_TRUNCATED_VARIABLE_RESPONSE, JsonCompareMode.STRICT);
 
-    verify(variableServices).getByKey(eq(VALID_TRUNCATED_VARIABLE_KEY), any());
+    verify(variableServices).getByKey(eq(VALID_TRUNCATED_VARIABLE_KEY), any(), any());
   }
 
   @Test
@@ -488,7 +491,7 @@ public class VariablesQueryControllerTest extends RestControllerTest {
                 }""",
             JsonCompareMode.STRICT);
 
-    verify(variableServices).getByKey(eq(INVALID_VARIABLE_KEY), any());
+    verify(variableServices).getByKey(eq(INVALID_VARIABLE_KEY), any(), any());
   }
 
   private static Stream<Arguments> provideAdvancedSearchParameters() {
@@ -522,7 +525,7 @@ public class VariablesQueryControllerTest extends RestControllerTest {
             }"""
             .formatted(filterString);
     System.out.println("request = " + request);
-    when(variableServices.search(variableQueryCaptor.capture(), any()))
+    when(variableServices.search(variableQueryCaptor.capture(), any(), any()))
         .thenReturn(SEARCH_QUERY_RESULT);
 
     // when / then
@@ -540,6 +543,7 @@ public class VariablesQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
-    verify(variableServices).search(eq(new VariableQuery.Builder().filter(filter).build()), any());
+    verify(variableServices)
+        .search(eq(new VariableQuery.Builder().filter(filter).build()), any(), any());
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/auditlog/AuditLogControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/auditlog/AuditLogControllerTest.java
@@ -172,7 +172,7 @@ public class AuditLogControllerTest extends RestControllerTest {
   void shouldSearchAuditLogsWithEmptyBody() {
     // given
     final var searchResult = SearchQueryResult.of(AUDIT_LOG_ENTITY);
-    when(auditLogServices.search(any(AuditLogQuery.class), any())).thenReturn(searchResult);
+    when(auditLogServices.search(any(AuditLogQuery.class), any(), any())).thenReturn(searchResult);
 
     // when/then
     webClient
@@ -186,7 +186,7 @@ public class AuditLogControllerTest extends RestControllerTest {
         .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     final var captor = ArgumentCaptor.forClass(AuditLogQuery.class);
-    verify(auditLogServices).search(captor.capture(), any());
+    verify(auditLogServices).search(captor.capture(), any(), any());
     assertThat(captor.getValue()).isNotNull();
   }
 
@@ -194,7 +194,7 @@ public class AuditLogControllerTest extends RestControllerTest {
   void shouldGetAuditLogByKey() {
     // given
     final var auditLogKey = "123";
-    when(auditLogServices.getAuditLog(eq(auditLogKey), any())).thenReturn(AUDIT_LOG_ENTITY);
+    when(auditLogServices.getAuditLog(eq(auditLogKey), any(), any())).thenReturn(AUDIT_LOG_ENTITY);
 
     // when/then
     webClient
@@ -207,7 +207,7 @@ public class AuditLogControllerTest extends RestControllerTest {
         .expectBody()
         .json(EXPECTED_GET_BY_KEY_RESPONSE, JsonCompareMode.STRICT);
 
-    verify(auditLogServices).getAuditLog(eq(auditLogKey), any());
+    verify(auditLogServices).getAuditLog(eq(auditLogKey), any(), any());
   }
 
   @Test
@@ -227,7 +227,7 @@ public class AuditLogControllerTest extends RestControllerTest {
         }
         """;
     final var searchResult = SearchQueryResult.of(AUDIT_LOG_ENTITY);
-    when(auditLogServices.search(any(AuditLogQuery.class), any())).thenReturn(searchResult);
+    when(auditLogServices.search(any(AuditLogQuery.class), any(), any())).thenReturn(searchResult);
 
     // when/then
     webClient
@@ -256,7 +256,8 @@ public class AuditLogControllerTest extends RestControllerTest {
                     AuditLogCategoryEnum.DEPLOYED_RESOURCES))
             .results(AuditLogResultConverter.toInternalResultAsString(AuditLogResultEnum.SUCCESS))
             .build();
-    verify(auditLogServices).search(eq(new AuditLogQuery.Builder().filter(filter).build()), any());
+    verify(auditLogServices)
+        .search(eq(new AuditLogQuery.Builder().filter(filter).build()), any(), any());
   }
 
   @Test
@@ -296,7 +297,7 @@ public class AuditLogControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedResponse, JsonCompareMode.STRICT);
 
-    verify(auditLogServices, never()).search(any(AuditLogQuery.class), any());
+    verify(auditLogServices, never()).search(any(AuditLogQuery.class), any(), any());
   }
 
   @Test
@@ -318,7 +319,7 @@ public class AuditLogControllerTest extends RestControllerTest {
         }
         """;
     final var searchResult = SearchQueryResult.of(AUDIT_LOG_ENTITY);
-    when(auditLogServices.search(any(AuditLogQuery.class), any())).thenReturn(searchResult);
+    when(auditLogServices.search(any(AuditLogQuery.class), any(), any())).thenReturn(searchResult);
 
     // when/then
     webClient
@@ -344,6 +345,7 @@ public class AuditLogControllerTest extends RestControllerTest {
                             .asc()
                             .build())
                     .build()),
+            any(),
             any());
   }
 
@@ -387,6 +389,6 @@ public class AuditLogControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedResponse, JsonCompareMode.STRICT);
 
-    verify(auditLogServices, never()).search(any(AuditLogQuery.class), any());
+    verify(auditLogServices, never()).search(any(AuditLogQuery.class), any(), any());
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/setup/SetupControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/setup/SetupControllerTest.java
@@ -88,7 +88,7 @@ class SetupControllerTest extends RestControllerTest {
             .setEmail(dto.email())
             .setPassword(dto.password());
     whenNoAdminUserExists();
-    when(userServices.createInitialAdminUser(eq(dto), any()))
+    when(userServices.createInitialAdminUser(eq(dto), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(userRecord));
 
     // when
@@ -114,7 +114,7 @@ class SetupControllerTest extends RestControllerTest {
             JsonCompareMode.STRICT);
 
     // then
-    verify(userServices, times(1)).createInitialAdminUser(eq(dto), any());
+    verify(userServices, times(1)).createInitialAdminUser(eq(dto), any(), any());
   }
 
   @Test
@@ -254,7 +254,7 @@ class SetupControllerTest extends RestControllerTest {
     final var dto = new UserDTO("foo", null, null, "zabraboof");
     final var userRecord = new UserRecord().setUsername(dto.username()).setPassword(dto.password());
     whenNoAdminUserExists();
-    when(userServices.createInitialAdminUser(eq(dto), any()))
+    when(userServices.createInitialAdminUser(eq(dto), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(userRecord));
 
     // when
@@ -280,7 +280,7 @@ class SetupControllerTest extends RestControllerTest {
             JsonCompareMode.STRICT);
 
     // then
-    verify(userServices, times(1)).createInitialAdminUser(eq(dto), any());
+    verify(userServices, times(1)).createInitialAdminUser(eq(dto), any(), any());
   }
 
   @Test
@@ -352,12 +352,14 @@ class SetupControllerTest extends RestControllerTest {
   }
 
   private void whenNoAdminUserExists() {
-    when(roleServices.hasMembersOfType(eq(DefaultRole.ADMIN.getId()), eq(EntityType.USER), any()))
+    when(roleServices.hasMembersOfType(
+            eq(DefaultRole.ADMIN.getId()), eq(EntityType.USER), any(), any()))
         .thenReturn(false);
   }
 
   private void whenAdminUserExists() {
-    when(roleServices.hasMembersOfType(eq(DefaultRole.ADMIN.getId()), eq(EntityType.USER), any()))
+    when(roleServices.hasMembersOfType(
+            eq(DefaultRole.ADMIN.getId()), eq(EntityType.USER), any(), any()))
         .thenReturn(true);
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/system/SystemControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/system/SystemControllerTest.java
@@ -104,7 +104,7 @@ public class SystemControllerTest extends RestControllerTest {
   @Test
   void shouldSearchWithStartTimeAndEndTime() {
     // given
-    when(usageMetricsServices.search(any(), any()))
+    when(usageMetricsServices.search(any(), any(), any()))
         .thenReturn(
             SearchQueryResult.of(
                 Tuple.of(
@@ -131,6 +131,7 @@ public class SystemControllerTest extends RestControllerTest {
     verify(usageMetricsServices)
         .search(
             eq(UsageMetricsQuery.of(q -> q.filter(f -> f.startTime(startTime).endTime(endTime)))),
+            any(),
             any());
   }
 
@@ -149,7 +150,7 @@ public class SystemControllerTest extends RestControllerTest {
             new UsageMetricTUStatisticsEntityTenant(1L),
             "tenant2",
             new UsageMetricTUStatisticsEntityTenant(3L));
-    when(usageMetricsServices.search(any(), any()))
+    when(usageMetricsServices.search(any(), any(), any()))
         .thenReturn(
             SearchQueryResult.of(
                 Tuple.of(
@@ -178,6 +179,7 @@ public class SystemControllerTest extends RestControllerTest {
             eq(
                 UsageMetricsQuery.of(
                     q -> q.filter(f -> f.startTime(startTime).endTime(endTime).withTenants(true)))),
+            any(),
             any());
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
@@ -92,7 +92,7 @@ public class TenantControllerTest {
       final var tenantName = "Test Tenant";
       final var tenantDescription = "Test description";
       when(tenantServices.createTenant(
-              eq(new TenantRequest(null, id, tenantName, tenantDescription)), any()))
+              eq(new TenantRequest(null, id, tenantName, tenantDescription)), any(), any()))
           .thenReturn(
               CompletableFuture.completedFuture(
                   new TenantRecord()
@@ -118,7 +118,8 @@ public class TenantControllerTest {
 
       // then
       verify(tenantServices, times(1))
-          .createTenant(eq(new TenantRequest(null, id, tenantName, tenantDescription)), any());
+          .createTenant(
+              eq(new TenantRequest(null, id, tenantName, tenantDescription)), any(), any());
     }
 
     @Test
@@ -128,7 +129,7 @@ public class TenantControllerTest {
       final var tenantId = "tenantId";
       final var tenantDescription = "Test description";
       when(tenantServices.createTenant(
-              eq(new TenantRequest(null, tenantId, tenantName, tenantDescription)), any()))
+              eq(new TenantRequest(null, tenantId, tenantName, tenantDescription)), any(), any()))
           .thenReturn(
               CompletableFuture.completedFuture(
                   new TenantRecord()
@@ -166,7 +167,7 @@ public class TenantControllerTest {
       // then
       verify(tenantServices, times(1))
           .createTenant(
-              eq(new TenantRequest(null, tenantId, tenantName, tenantDescription)), any());
+              eq(new TenantRequest(null, tenantId, tenantName, tenantDescription)), any(), any());
     }
 
     @Test
@@ -282,7 +283,7 @@ public class TenantControllerTest {
       final var tenantId = "tenant-test-id";
       final var tenantDescription = "Updated description";
       when(tenantServices.updateTenant(
-              eq(new TenantRequest(null, tenantId, tenantName, tenantDescription)), any()))
+              eq(new TenantRequest(null, tenantId, tenantName, tenantDescription)), any(), any()))
           .thenReturn(
               CompletableFuture.completedFuture(
                   new TenantRecord()
@@ -319,7 +320,7 @@ public class TenantControllerTest {
       // then
       verify(tenantServices, times(1))
           .updateTenant(
-              eq(new TenantRequest(null, tenantId, tenantName, tenantDescription)), any());
+              eq(new TenantRequest(null, tenantId, tenantName, tenantDescription)), any(), any());
     }
 
     @Test
@@ -363,7 +364,7 @@ public class TenantControllerTest {
       final var tenantDescription = "My tenant description";
       final var path = "%s/%s".formatted(TENANT_BASE_URL, tenantId);
       when(tenantServices.updateTenant(
-              eq(new TenantRequest(null, tenantId, tenantName, tenantDescription)), any()))
+              eq(new TenantRequest(null, tenantId, tenantName, tenantDescription)), any(), any()))
           .thenReturn(
               CompletableFuture.failedFuture(
                   ErrorMapper.mapBrokerRejection(
@@ -387,7 +388,7 @@ public class TenantControllerTest {
 
       verify(tenantServices, times(1))
           .updateTenant(
-              eq(new TenantRequest(null, tenantId, tenantName, tenantDescription)), any());
+              eq(new TenantRequest(null, tenantId, tenantName, tenantDescription)), any(), any());
     }
 
     @Test
@@ -397,7 +398,7 @@ public class TenantControllerTest {
 
       final var tenantRecord = new TenantRecord().setTenantId(tenantId);
 
-      when(tenantServices.deleteTenant(eq(tenantId), any()))
+      when(tenantServices.deleteTenant(eq(tenantId), any(), any()))
           .thenReturn(CompletableFuture.completedFuture(tenantRecord));
 
       // when
@@ -410,7 +411,7 @@ public class TenantControllerTest {
           .isNoContent();
 
       // then
-      verify(tenantServices, times(1)).deleteTenant(eq(tenantId), any());
+      verify(tenantServices, times(1)).deleteTenant(eq(tenantId), any(), any());
     }
 
     @ParameterizedTest
@@ -421,7 +422,7 @@ public class TenantControllerTest {
       final var entityId = "some-entity-id";
       final var request = new TenantMemberRequest(tenantId, entityId, entityType);
 
-      when(tenantServices.addMember(eq(request), any()))
+      when(tenantServices.addMember(eq(request), any(), any()))
           .thenReturn(CompletableFuture.completedFuture(null));
 
       // when
@@ -434,7 +435,7 @@ public class TenantControllerTest {
           .isNoContent();
 
       // then
-      verify(tenantServices, times(1)).addMember(eq(request), any());
+      verify(tenantServices, times(1)).addMember(eq(request), any(), any());
     }
 
     @ParameterizedTest
@@ -446,7 +447,7 @@ public class TenantControllerTest {
       final var entityId = "some-entity-id";
       final var request = new TenantMemberRequest(tenantId, entityId, entityType);
 
-      when(tenantServices.addMember(eq(request), any()))
+      when(tenantServices.addMember(eq(request), any(), any()))
           .thenReturn(CompletableFuture.completedFuture(null));
 
       // when
@@ -484,7 +485,7 @@ public class TenantControllerTest {
       final var entityId = "invalidEntityId!";
       final var request = new TenantMemberRequest(tenantId, entityId, entityType);
 
-      when(tenantServices.addMember(eq(request), any()))
+      when(tenantServices.addMember(eq(request), any(), any()))
           .thenReturn(CompletableFuture.completedFuture(null));
 
       // when
@@ -521,7 +522,7 @@ public class TenantControllerTest {
       final var entityId = "entity-id";
       final var tenantMemberRequest = new TenantMemberRequest(tenantId, entityId, entityType);
 
-      when(tenantServices.removeMember(eq(tenantMemberRequest), any()))
+      when(tenantServices.removeMember(eq(tenantMemberRequest), any(), any()))
           .thenReturn(CompletableFuture.completedFuture(null));
 
       // when
@@ -534,7 +535,7 @@ public class TenantControllerTest {
           .isNoContent();
 
       // then
-      verify(tenantServices, times(1)).removeMember(eq(tenantMemberRequest), any());
+      verify(tenantServices, times(1)).removeMember(eq(tenantMemberRequest), any(), any());
     }
 
     @ParameterizedTest
@@ -546,7 +547,7 @@ public class TenantControllerTest {
       final var entityId = "some-entity-id";
       final var request = new TenantMemberRequest(tenantId, entityId, entityType);
 
-      when(tenantServices.removeMember(eq(request), any()))
+      when(tenantServices.removeMember(eq(request), any(), any()))
           .thenReturn(CompletableFuture.completedFuture(null));
 
       // when
@@ -584,7 +585,7 @@ public class TenantControllerTest {
       final var entityId = "invalidEntityId!";
       final var request = new TenantMemberRequest(tenantId, entityId, entityType);
 
-      when(tenantServices.removeMember(eq(request), any()))
+      when(tenantServices.removeMember(eq(request), any(), any()))
           .thenReturn(CompletableFuture.completedFuture(null));
 
       // when
@@ -659,7 +660,7 @@ public class TenantControllerTest {
       final var groupId = "group id";
       final var request = new TenantMemberRequest(tenantId, groupId, EntityType.GROUP);
 
-      when(tenantServices.addMember(eq(request), any()))
+      when(tenantServices.addMember(eq(request), any(), any()))
           .thenReturn(CompletableFuture.completedFuture(null));
 
       // when
@@ -672,7 +673,7 @@ public class TenantControllerTest {
           .isNoContent();
 
       // then
-      verify(tenantServices, times(1)).addMember(eq(request), any());
+      verify(tenantServices, times(1)).addMember(eq(request), any(), any());
     }
 
     /**
@@ -686,7 +687,7 @@ public class TenantControllerTest {
       final var groupId = "group id";
       final var request = new TenantMemberRequest(tenantId, groupId, EntityType.GROUP);
 
-      when(tenantServices.removeMember(eq(request), any()))
+      when(tenantServices.removeMember(eq(request), any(), any()))
           .thenReturn(CompletableFuture.completedFuture(null));
 
       // when
@@ -699,7 +700,7 @@ public class TenantControllerTest {
           .isNoContent();
 
       // then
-      verify(tenantServices, times(1)).removeMember(eq(request), any());
+      verify(tenantServices, times(1)).removeMember(eq(request), any(), any());
     }
 
     @TestConfiguration

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
@@ -241,7 +241,7 @@ public class TenantQueryControllerTest extends RestControllerTest {
     final var tenantId = "tenant-id";
     final var tenantDescription = "Tenant Description";
     final var tenant = new TenantEntity(100L, tenantId, tenantName, tenantDescription);
-    when(tenantServices.getById(eq(tenant.tenantId()), any())).thenReturn(tenant);
+    when(tenantServices.getById(eq(tenant.tenantId()), any(), any())).thenReturn(tenant);
 
     // when
     webClient
@@ -264,7 +264,7 @@ public class TenantQueryControllerTest extends RestControllerTest {
             JsonCompareMode.STRICT);
 
     // then
-    verify(tenantServices, times(1)).getById(eq(tenant.tenantId()), any());
+    verify(tenantServices, times(1)).getById(eq(tenant.tenantId()), any(), any());
   }
 
   @Test
@@ -272,7 +272,7 @@ public class TenantQueryControllerTest extends RestControllerTest {
     // given
     final var tenantId = "non-existing-tenant";
     final var path = "%s/%s".formatted(TENANT_BASE_URL, tenantId);
-    when(tenantServices.getById(eq(tenantId), any()))
+    when(tenantServices.getById(eq(tenantId), any(), any()))
         .thenThrow(
             ErrorMapper.mapSearchError(
                 new CamundaSearchException(
@@ -300,13 +300,13 @@ public class TenantQueryControllerTest extends RestControllerTest {
             JsonCompareMode.STRICT);
 
     // then
-    verify(tenantServices, times(1)).getById(eq(tenantId), any());
+    verify(tenantServices, times(1)).getById(eq(tenantId), any(), any());
   }
 
   @Test
   void shouldSearchTenantsWithEmptyQuery() {
     // given
-    when(tenantServices.search(any(TenantQuery.class), any()))
+    when(tenantServices.search(any(TenantQuery.class), any(), any()))
         .thenReturn(
             new SearchQueryResult.Builder<TenantEntity>()
                 .total(3)
@@ -330,13 +330,13 @@ public class TenantQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(EXPECTED_RESPONSE, JsonCompareMode.STRICT);
 
-    verify(tenantServices).search(eq(new TenantQuery.Builder().build()), any());
+    verify(tenantServices).search(eq(new TenantQuery.Builder().build()), any(), any());
   }
 
   @Test
   void shouldSearchTenantsWithSorting() {
     // given
-    when(tenantServices.search(any(TenantQuery.class), any()))
+    when(tenantServices.search(any(TenantQuery.class), any(), any()))
         .thenReturn(
             new SearchQueryResult.Builder<TenantEntity>()
                 .total(TENANT_ENTITIES.size())
@@ -371,13 +371,14 @@ public class TenantQueryControllerTest extends RestControllerTest {
                 new TenantQuery.Builder()
                     .sort(TenantSort.of(builder -> builder.tenantId().asc()))
                     .build()),
+            any(),
             any());
   }
 
   @Test
   void shouldSearchTenantMappingsWithSorting() {
     // given
-    when(mappingRuleServices.search(any(MappingRuleQuery.class), any()))
+    when(mappingRuleServices.search(any(MappingRuleQuery.class), any(), any()))
         .thenReturn(
             new SearchQueryResult.Builder<MappingRuleEntity>()
                 .total(MAPPING_ENTITIES.size())
@@ -410,7 +411,7 @@ public class TenantQueryControllerTest extends RestControllerTest {
   @Test
   void shouldSearchTenantMappingsWithEmptyQuery() {
     // given
-    when(mappingRuleServices.search(any(MappingRuleQuery.class), any()))
+    when(mappingRuleServices.search(any(MappingRuleQuery.class), any(), any()))
         .thenReturn(
             new SearchQueryResult.Builder<MappingRuleEntity>()
                 .total(MAPPING_ENTITIES.size())
@@ -442,7 +443,7 @@ public class TenantQueryControllerTest extends RestControllerTest {
   @Test
   void shouldSearchTenantRolesWithSorting() {
     // given
-    when(roleServices.search(any(RoleQuery.class), any()))
+    when(roleServices.search(any(RoleQuery.class), any(), any()))
         .thenReturn(
             new SearchQueryResult.Builder<RoleEntity>()
                 .total(ROLE_ENTITIES.size())
@@ -475,7 +476,7 @@ public class TenantQueryControllerTest extends RestControllerTest {
   @Test
   void shouldSearchTenantRolesWithEmptyQuery() {
     // given
-    when(roleServices.search(any(RoleQuery.class), any()))
+    when(roleServices.search(any(RoleQuery.class), any(), any()))
         .thenReturn(
             new SearchQueryResult.Builder<RoleEntity>()
                 .total(ROLE_ENTITIES.size())
@@ -523,13 +524,13 @@ public class TenantQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedResponse, JsonCompareMode.STRICT);
 
-    verify(tenantServices, never()).search(any(TenantQuery.class), any());
+    verify(tenantServices, never()).search(any(TenantQuery.class), any(), any());
   }
 
   @Test
   void shouldListMembersOfTypeClient() {
     // given
-    when(tenantServices.searchMembers(any(TenantMemberQuery.class), any()))
+    when(tenantServices.searchMembers(any(TenantMemberQuery.class), any(), any()))
         .thenReturn(
             new SearchQueryResult.Builder<TenantMemberEntity>()
                 .total(3)
@@ -575,7 +576,7 @@ public class TenantQueryControllerTest extends RestControllerTest {
   @Test
   void shouldListMembersOfTypeUser() {
     // given
-    when(tenantServices.searchMembers(any(TenantMemberQuery.class), any()))
+    when(tenantServices.searchMembers(any(TenantMemberQuery.class), any(), any()))
         .thenReturn(
             new SearchQueryResult.Builder<TenantMemberEntity>()
                 .total(3)
@@ -621,7 +622,7 @@ public class TenantQueryControllerTest extends RestControllerTest {
   @Test
   void shouldListMembersOfTypeGroup() {
     // given
-    when(tenantServices.searchMembers(any(TenantMemberQuery.class), any()))
+    when(tenantServices.searchMembers(any(TenantMemberQuery.class), any(), any()))
         .thenReturn(
             new SearchQueryResult.Builder<TenantMemberEntity>()
                 .total(3)

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationControllerTest.java
@@ -72,7 +72,8 @@ public class AuthorizationControllerTest extends RestControllerTest {
       final CreateAuthorizationRequest expectedCreateRequest) {
     final var authorizationKey = 1L;
 
-    when(authorizationServices.createAuthorization(any(CreateAuthorizationRequest.class), any()))
+    when(authorizationServices.createAuthorization(
+            any(CreateAuthorizationRequest.class), any(), any()))
         .thenReturn(
             CompletableFuture.completedFuture(
                 new AuthorizationRecord().setAuthorizationKey(authorizationKey)));
@@ -93,7 +94,7 @@ public class AuthorizationControllerTest extends RestControllerTest {
                 .build());
 
     final var captor = ArgumentCaptor.forClass(CreateAuthorizationRequest.class);
-    verify(authorizationServices).createAuthorization(captor.capture(), any());
+    verify(authorizationServices).createAuthorization(captor.capture(), any(), any());
     final var capturedCreateRequest = captor.getValue();
     assertThat(capturedCreateRequest).isEqualTo(expectedCreateRequest);
   }
@@ -189,7 +190,7 @@ public class AuthorizationControllerTest extends RestControllerTest {
 
     final var record = new AuthorizationRecord().setAuthorizationKey(authorizationKey);
 
-    when(authorizationServices.deleteAuthorization(eq(authorizationKey), any()))
+    when(authorizationServices.deleteAuthorization(eq(authorizationKey), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(record));
 
     // when
@@ -202,7 +203,7 @@ public class AuthorizationControllerTest extends RestControllerTest {
         .isNoContent();
 
     // then
-    verify(authorizationServices).deleteAuthorization(eq(authorizationKey), any());
+    verify(authorizationServices).deleteAuthorization(eq(authorizationKey), any(), any());
   }
 
   @ParameterizedTest
@@ -213,7 +214,7 @@ public class AuthorizationControllerTest extends RestControllerTest {
     // given
     final long authorizationKey = expectedUpdateRequest.authorizationKey();
 
-    when(authorizationServices.updateAuthorization(any(), any()))
+    when(authorizationServices.updateAuthorization(any(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new AuthorizationRecord()));
 
     // when
@@ -229,7 +230,7 @@ public class AuthorizationControllerTest extends RestControllerTest {
 
     // then
     final var captor = ArgumentCaptor.forClass(UpdateAuthorizationRequest.class);
-    verify(authorizationServices).updateAuthorization(captor.capture(), any());
+    verify(authorizationServices).updateAuthorization(captor.capture(), any(), any());
     final var capturedUpdateRequest = captor.getValue();
     assertThat(capturedUpdateRequest).isEqualTo(expectedUpdateRequest);
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationQueryControllerTest.java
@@ -151,7 +151,7 @@ public class AuthorizationQueryControllerTest extends RestControllerTest {
             Set.of(PermissionType.CREATE));
 
     final Long authorizationKey = authorizationEntity.authorizationKey();
-    when(authorizationServices.getAuthorization(eq(authorizationKey), any()))
+    when(authorizationServices.getAuthorization(eq(authorizationKey), any(), any()))
         .thenReturn(authorizationEntity);
 
     // when
@@ -177,7 +177,7 @@ public class AuthorizationQueryControllerTest extends RestControllerTest {
             JsonCompareMode.STRICT);
 
     // then
-    verify(authorizationServices, times(1)).getAuthorization(eq(authorizationKey), any());
+    verify(authorizationServices, times(1)).getAuthorization(eq(authorizationKey), any(), any());
   }
 
   @Test
@@ -185,7 +185,7 @@ public class AuthorizationQueryControllerTest extends RestControllerTest {
     // given
     final var authorizationKey = 100L;
     final var path = "%s/%s".formatted("/v2/authorizations", authorizationKey);
-    when(authorizationServices.getAuthorization(eq(authorizationKey), any()))
+    when(authorizationServices.getAuthorization(eq(authorizationKey), any(), any()))
         .thenThrow(
             ErrorMapper.mapSearchError(
                 new CamundaSearchException(
@@ -213,13 +213,13 @@ public class AuthorizationQueryControllerTest extends RestControllerTest {
             JsonCompareMode.STRICT);
 
     // then
-    verify(authorizationServices, times(1)).getAuthorization(eq(authorizationKey), any());
+    verify(authorizationServices, times(1)).getAuthorization(eq(authorizationKey), any(), any());
   }
 
   @Test
   void shouldSearchAuthorizationsWithEmptyBody() {
     // given
-    when(authorizationServices.search(any(AuthorizationQuery.class), any()))
+    when(authorizationServices.search(any(AuthorizationQuery.class), any(), any()))
         .thenReturn(SEARCH_QUERY_RESULT);
     // when / then
 
@@ -234,13 +234,14 @@ public class AuthorizationQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
-    verify(authorizationServices).search(eq(new AuthorizationQuery.Builder().build()), any());
+    verify(authorizationServices)
+        .search(eq(new AuthorizationQuery.Builder().build()), any(), any());
   }
 
   @Test
   void shouldSearchAuthorizationsWithEmptyQuery() {
     // given
-    when(authorizationServices.search(any(AuthorizationQuery.class), any()))
+    when(authorizationServices.search(any(AuthorizationQuery.class), any(), any()))
         .thenReturn(SEARCH_QUERY_RESULT);
     final String request = "{}";
     // when / then
@@ -258,7 +259,8 @@ public class AuthorizationQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
-    verify(authorizationServices).search(eq(new AuthorizationQuery.Builder().build()), any());
+    verify(authorizationServices)
+        .search(eq(new AuthorizationQuery.Builder().build()), any(), any());
   }
 
   @ParameterizedTest
@@ -266,7 +268,7 @@ public class AuthorizationQueryControllerTest extends RestControllerTest {
   void shouldSearchAuthorizationsWithValidQueries(
       final String request, final AuthorizationQuery query) {
     // given
-    when(authorizationServices.search(any(AuthorizationQuery.class), any()))
+    when(authorizationServices.search(any(AuthorizationQuery.class), any(), any()))
         .thenReturn(SEARCH_QUERY_RESULT);
 
     // when / then
@@ -284,7 +286,7 @@ public class AuthorizationQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
-    verify(authorizationServices).search(eq(query), any());
+    verify(authorizationServices).search(eq(query), any(), any());
   }
 
   @ParameterizedTest
@@ -306,7 +308,7 @@ public class AuthorizationQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedResponse, JsonCompareMode.STRICT);
 
-    verify(authorizationServices, never()).search(any(AuthorizationQuery.class), any());
+    verify(authorizationServices, never()).search(any(AuthorizationQuery.class), any(), any());
   }
 
   public static Stream<Arguments> validAuthorizationSearchQueries() {

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupControllerTest.java
@@ -238,7 +238,7 @@ public class GroupControllerTest {
       final var groupName = "testGroup";
       final var description = "description";
       final var createGroupRequest = new GroupDTO(groupId, groupName, description);
-      when(groupServices.createGroup(eq(createGroupRequest), any()))
+      when(groupServices.createGroup(eq(createGroupRequest), any(), any()))
           .thenReturn(
               CompletableFuture.completedFuture(
                   new GroupRecord()
@@ -263,7 +263,7 @@ public class GroupControllerTest {
           .isCreated();
 
       // then
-      verify(groupServices, times(1)).createGroup(eq(createGroupRequest), any());
+      verify(groupServices, times(1)).createGroup(eq(createGroupRequest), any(), any());
     }
 
     @Test
@@ -425,7 +425,7 @@ public class GroupControllerTest {
       final var groupId = "111";
       final var groupName = "updatedName";
       final var description = "updatedDescription";
-      when(groupServices.updateGroup(eq(groupId), eq(groupName), eq(description), any()))
+      when(groupServices.updateGroup(eq(groupId), eq(groupName), eq(description), any(), any()))
           .thenReturn(
               CompletableFuture.completedFuture(
                   new GroupRecord()
@@ -459,7 +459,7 @@ public class GroupControllerTest {
 
       // then
       verify(groupServices, times(1))
-          .updateGroup(eq(groupId), eq(groupName), eq(description), any());
+          .updateGroup(eq(groupId), eq(groupName), eq(description), any(), any());
     }
 
     @Test
@@ -469,7 +469,7 @@ public class GroupControllerTest {
       final var groupId = "111";
       final var groupName = "updatedName";
       final var description = "";
-      when(groupServices.updateGroup(eq(groupId), eq(groupName), eq(description), any()))
+      when(groupServices.updateGroup(eq(groupId), eq(groupName), eq(description), any(), any()))
           .thenReturn(
               CompletableFuture.completedFuture(
                   new GroupRecord()
@@ -503,7 +503,7 @@ public class GroupControllerTest {
 
       // then
       verify(groupServices, times(1))
-          .updateGroup(eq(groupId), eq(groupName), eq(description), any());
+          .updateGroup(eq(groupId), eq(groupName), eq(description), any(), any());
     }
 
     @Test
@@ -550,7 +550,7 @@ public class GroupControllerTest {
       final var name = "name";
       final var uri = "%s/%s".formatted(GROUP_BASE_URL, groupId);
       final String description = null;
-      when(groupServices.updateGroup(eq(groupId), eq(name), isNull(), any()))
+      when(groupServices.updateGroup(eq(groupId), eq(name), isNull(), any(), any()))
           .thenReturn(
               CompletableFuture.completedFuture(
                   new GroupRecord().setGroupId(groupId).setName(name).setDescription(description)));
@@ -578,7 +578,8 @@ public class GroupControllerTest {
                   .formatted(groupId, name, ""),
               JsonCompareMode.STRICT);
 
-      verify(groupServices, times(1)).updateGroup(eq(groupId), eq(name), eq(description), any());
+      verify(groupServices, times(1))
+          .updateGroup(eq(groupId), eq(name), eq(description), any(), any());
     }
 
     @Test
@@ -588,7 +589,7 @@ public class GroupControllerTest {
       final var groupName = "newName";
       final var path = "%s/%s".formatted(GROUP_BASE_URL, groupId);
       final var description = "updatedDescription";
-      when(groupServices.updateGroup(eq(groupId), eq(groupName), eq(description), any()))
+      when(groupServices.updateGroup(eq(groupId), eq(groupName), eq(description), any(), any()))
           .thenReturn(
               CompletableFuture.failedFuture(
                   ErrorMapper.mapBrokerRejection(
@@ -608,7 +609,7 @@ public class GroupControllerTest {
           .isNotFound();
 
       verify(groupServices, times(1))
-          .updateGroup(eq(groupId), eq(groupName), eq(description), any());
+          .updateGroup(eq(groupId), eq(groupName), eq(description), any(), any());
     }
 
     @ParameterizedTest
@@ -652,7 +653,7 @@ public class GroupControllerTest {
 
       final var groupRecord = new GroupRecord().setGroupId(groupId);
 
-      when(groupServices.deleteGroup(eq(groupId), any()))
+      when(groupServices.deleteGroup(eq(groupId), any(), any()))
           .thenReturn(CompletableFuture.completedFuture(groupRecord));
 
       // when
@@ -665,7 +666,7 @@ public class GroupControllerTest {
           .isNoContent();
 
       // then
-      verify(groupServices, times(1)).deleteGroup(eq(groupId), any());
+      verify(groupServices, times(1)).deleteGroup(eq(groupId), any(), any());
     }
 
     @Test
@@ -674,7 +675,7 @@ public class GroupControllerTest {
       final String groupId = "111";
       final String username = "222";
       final var request = new GroupMemberDTO(groupId, username, EntityType.USER);
-      when(groupServices.assignMember(eq(request), any()))
+      when(groupServices.assignMember(eq(request), any(), any()))
           .thenReturn(CompletableFuture.completedFuture(null));
 
       // when
@@ -687,7 +688,7 @@ public class GroupControllerTest {
           .isNoContent();
 
       // then
-      verify(groupServices, times(1)).assignMember(eq(request), any());
+      verify(groupServices, times(1)).assignMember(eq(request), any(), any());
     }
 
     @Test
@@ -697,7 +698,7 @@ public class GroupControllerTest {
       final String username = "222";
       final var path = "%s/%s/users/%s".formatted(GROUP_BASE_URL, groupId, username);
       final var request = new GroupMemberDTO(groupId, username, EntityType.USER);
-      when(groupServices.assignMember(eq(request), any()))
+      when(groupServices.assignMember(eq(request), any(), any()))
           .thenReturn(
               CompletableFuture.failedFuture(
                   ErrorMapper.mapBrokerRejection(
@@ -717,7 +718,7 @@ public class GroupControllerTest {
           .isNotFound();
 
       // then
-      verify(groupServices, times(1)).assignMember(eq(request), any());
+      verify(groupServices, times(1)).assignMember(eq(request), any(), any());
     }
 
     @Test
@@ -727,7 +728,7 @@ public class GroupControllerTest {
       final String username = "222";
       final var path = "%s/%s/users/%s".formatted(GROUP_BASE_URL, groupId, username);
       final var request = new GroupMemberDTO(groupId, username, EntityType.USER);
-      when(groupServices.assignMember(eq(request), any()))
+      when(groupServices.assignMember(eq(request), any(), any()))
           .thenReturn(
               CompletableFuture.failedFuture(
                   ErrorMapper.mapBrokerRejection(
@@ -747,7 +748,7 @@ public class GroupControllerTest {
           .isNotFound();
 
       // then
-      verify(groupServices, times(1)).assignMember(eq(request), any());
+      verify(groupServices, times(1)).assignMember(eq(request), any(), any());
     }
 
     @Test
@@ -756,7 +757,7 @@ public class GroupControllerTest {
       final var groupId = Strings.newRandomValidIdentityId();
       final var mappingRuleId = Strings.newRandomValidIdentityId();
       final var request = new GroupMemberDTO(groupId, mappingRuleId, EntityType.MAPPING_RULE);
-      when(groupServices.assignMember(eq(request), any()))
+      when(groupServices.assignMember(eq(request), any(), any()))
           .thenReturn(CompletableFuture.completedFuture(null));
 
       // when
@@ -769,7 +770,7 @@ public class GroupControllerTest {
           .isNoContent();
 
       // then
-      verify(groupServices, times(1)).assignMember(eq(request), any());
+      verify(groupServices, times(1)).assignMember(eq(request), any(), any());
     }
 
     @Test
@@ -778,7 +779,7 @@ public class GroupControllerTest {
       final var groupId = Strings.newRandomValidIdentityId();
       final var mappingRuleId = Strings.newRandomValidIdentityId();
       final var request = new GroupMemberDTO(groupId, mappingRuleId, EntityType.MAPPING_RULE);
-      when(groupServices.assignMember(eq(request), any()))
+      when(groupServices.assignMember(eq(request), any(), any()))
           .thenReturn(
               CompletableFuture.failedFuture(
                   ErrorMapper.mapBrokerRejection(
@@ -798,7 +799,7 @@ public class GroupControllerTest {
           .isNotFound();
 
       // then
-      verify(groupServices, times(1)).assignMember(eq(request), any());
+      verify(groupServices, times(1)).assignMember(eq(request), any(), any());
     }
 
     @Test
@@ -807,7 +808,7 @@ public class GroupControllerTest {
       final var groupId = Strings.newRandomValidIdentityId();
       final var mappingRuleId = Strings.newRandomValidIdentityId();
       final var request = new GroupMemberDTO(groupId, mappingRuleId, EntityType.MAPPING_RULE);
-      when(groupServices.assignMember(eq(request), any()))
+      when(groupServices.assignMember(eq(request), any(), any()))
           .thenReturn(
               CompletableFuture.failedFuture(
                   ErrorMapper.mapBrokerRejection(
@@ -827,7 +828,7 @@ public class GroupControllerTest {
           .isNotFound();
 
       // then
-      verify(groupServices, times(1)).assignMember(eq(request), any());
+      verify(groupServices, times(1)).assignMember(eq(request), any(), any());
     }
 
     @Test
@@ -898,7 +899,7 @@ public class GroupControllerTest {
       final String groupId = "111";
       final String username = "222";
       final var request = new GroupMemberDTO(groupId, username, EntityType.USER);
-      when(groupServices.removeMember(eq(request), any()))
+      when(groupServices.removeMember(eq(request), any(), any()))
           .thenReturn(CompletableFuture.completedFuture(null));
 
       // when
@@ -911,7 +912,7 @@ public class GroupControllerTest {
           .isNoContent();
 
       // then
-      verify(groupServices, times(1)).removeMember(eq(request), any());
+      verify(groupServices, times(1)).removeMember(eq(request), any(), any());
     }
 
     @Test
@@ -921,7 +922,7 @@ public class GroupControllerTest {
       final String username = "222";
       final var path = "%s/%s/users/%s".formatted(GROUP_BASE_URL, groupId, username);
       final var request = new GroupMemberDTO(groupId, username, EntityType.USER);
-      when(groupServices.removeMember(eq(request), any()))
+      when(groupServices.removeMember(eq(request), any(), any()))
           .thenReturn(
               CompletableFuture.failedFuture(
                   ErrorMapper.mapBrokerRejection(
@@ -941,7 +942,7 @@ public class GroupControllerTest {
           .isNotFound();
 
       // then
-      verify(groupServices, times(1)).removeMember(eq(request), any());
+      verify(groupServices, times(1)).removeMember(eq(request), any(), any());
     }
 
     @Test
@@ -951,7 +952,7 @@ public class GroupControllerTest {
       final String username = "222";
       final var path = "%s/%s/users/%s".formatted(GROUP_BASE_URL, groupId, username);
       final var request = new GroupMemberDTO(groupId, username, EntityType.USER);
-      when(groupServices.removeMember(eq(request), any()))
+      when(groupServices.removeMember(eq(request), any(), any()))
           .thenReturn(
               CompletableFuture.failedFuture(
                   ErrorMapper.mapBrokerRejection(
@@ -971,7 +972,7 @@ public class GroupControllerTest {
           .isNotFound();
 
       // then
-      verify(groupServices, times(1)).removeMember(eq(request), any());
+      verify(groupServices, times(1)).removeMember(eq(request), any(), any());
     }
 
     @Test
@@ -980,7 +981,7 @@ public class GroupControllerTest {
       final var groupId = Strings.newRandomValidIdentityId();
       final var mappingRuleId = Strings.newRandomValidIdentityId();
       final var request = new GroupMemberDTO(groupId, mappingRuleId, EntityType.MAPPING_RULE);
-      when(groupServices.removeMember(eq(request), any()))
+      when(groupServices.removeMember(eq(request), any(), any()))
           .thenReturn(CompletableFuture.completedFuture(null));
 
       // when
@@ -993,7 +994,7 @@ public class GroupControllerTest {
           .isNoContent();
 
       // then
-      verify(groupServices, times(1)).removeMember(eq(request), any());
+      verify(groupServices, times(1)).removeMember(eq(request), any(), any());
     }
 
     @Test
@@ -1002,7 +1003,7 @@ public class GroupControllerTest {
       final var groupId = Strings.newRandomValidIdentityId();
       final var mappingRuleId = Strings.newRandomValidIdentityId();
       final var request = new GroupMemberDTO(groupId, mappingRuleId, EntityType.MAPPING_RULE);
-      when(groupServices.removeMember(eq(request), any()))
+      when(groupServices.removeMember(eq(request), any(), any()))
           .thenReturn(
               CompletableFuture.failedFuture(
                   ErrorMapper.mapBrokerRejection(
@@ -1022,7 +1023,7 @@ public class GroupControllerTest {
           .isNotFound();
 
       // then
-      verify(groupServices, times(1)).removeMember(eq(request), any());
+      verify(groupServices, times(1)).removeMember(eq(request), any(), any());
     }
 
     @Test
@@ -1031,7 +1032,7 @@ public class GroupControllerTest {
       final var groupId = Strings.newRandomValidIdentityId();
       final var mappingRuleId = Strings.newRandomValidIdentityId();
       final var request = new GroupMemberDTO(groupId, mappingRuleId, EntityType.MAPPING_RULE);
-      when(groupServices.removeMember(eq(request), any()))
+      when(groupServices.removeMember(eq(request), any(), any()))
           .thenReturn(
               CompletableFuture.failedFuture(
                   ErrorMapper.mapBrokerRejection(
@@ -1051,7 +1052,7 @@ public class GroupControllerTest {
           .isNotFound();
 
       // then
-      verify(groupServices, times(1)).removeMember(eq(request), any());
+      verify(groupServices, times(1)).removeMember(eq(request), any(), any());
     }
 
     @Test

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupQueryControllerTest.java
@@ -253,7 +253,7 @@ public class GroupQueryControllerTest extends RestControllerTest {
     final var groupName = "groupName";
     final var groupDescription = "groupDescription";
     final var group = new GroupEntity(groupKey, groupId, groupName, groupDescription);
-    when(groupServices.getGroup(eq(group.groupId()), any())).thenReturn(group);
+    when(groupServices.getGroup(eq(group.groupId()), any(), any())).thenReturn(group);
 
     // when
     webClient
@@ -275,7 +275,7 @@ public class GroupQueryControllerTest extends RestControllerTest {
             JsonCompareMode.STRICT);
 
     // then
-    verify(groupServices, times(1)).getGroup(eq(group.groupId()), any());
+    verify(groupServices, times(1)).getGroup(eq(group.groupId()), any(), any());
   }
 
   @Test
@@ -283,7 +283,7 @@ public class GroupQueryControllerTest extends RestControllerTest {
     // given
     final var groupId = Strings.newRandomValidIdentityId();
     final var path = "%s/%s".formatted(GROUP_BASE_URL, groupId);
-    when(groupServices.getGroup(eq(groupId), any()))
+    when(groupServices.getGroup(eq(groupId), any(), any()))
         .thenThrow(
             ErrorMapper.mapSearchError(
                 new CamundaSearchException(
@@ -311,7 +311,7 @@ public class GroupQueryControllerTest extends RestControllerTest {
             JsonCompareMode.STRICT);
 
     // then
-    verify(groupServices, times(1)).getGroup(eq(groupId), any());
+    verify(groupServices, times(1)).getGroup(eq(groupId), any(), any());
   }
 
   @Test
@@ -329,7 +329,7 @@ public class GroupQueryControllerTest extends RestControllerTest {
     final var description1 = "Description 1";
     final var description2 = "Description 2";
     final var description3 = "Description 3";
-    when(groupServices.search(any(GroupQuery.class), any()))
+    when(groupServices.search(any(GroupQuery.class), any(), any()))
         .thenReturn(
             new SearchQueryResult.Builder<GroupEntity>()
                 .total(3)
@@ -394,7 +394,7 @@ public class GroupQueryControllerTest extends RestControllerTest {
                     description3),
             JsonCompareMode.STRICT);
 
-    verify(groupServices).search(eq(new GroupQuery.Builder().build()), any());
+    verify(groupServices).search(eq(new GroupQuery.Builder().build()), any(), any());
   }
 
   @Test
@@ -412,7 +412,7 @@ public class GroupQueryControllerTest extends RestControllerTest {
     final var description1 = "Description 1";
     final var description2 = "Description 2";
     final var description3 = "Description 3";
-    when(groupServices.search(any(GroupQuery.class), any()))
+    when(groupServices.search(any(GroupQuery.class), any(), any()))
         .thenReturn(
             new SearchQueryResult.Builder<GroupEntity>()
                 .total(3)
@@ -485,6 +485,7 @@ public class GroupQueryControllerTest extends RestControllerTest {
     verify(groupServices)
         .search(
             eq(new GroupQuery.Builder().filter(fn -> fn.groupIds(groupId1, groupId2)).build()),
+            any(),
             any());
   }
 
@@ -503,7 +504,7 @@ public class GroupQueryControllerTest extends RestControllerTest {
     final var description1 = "Description 1";
     final var description2 = "Description 2";
     final var description3 = "Description 3";
-    when(groupServices.search(any(GroupQuery.class), any()))
+    when(groupServices.search(any(GroupQuery.class), any(), any()))
         .thenReturn(
             new SearchQueryResult.Builder<GroupEntity>()
                 .total(3)
@@ -544,6 +545,7 @@ public class GroupQueryControllerTest extends RestControllerTest {
                     .sort(GroupSort.of(builder -> builder.name().asc()))
                     .page(SearchQueryPage.of(builder -> builder.from(20).size(2)))
                     .build()),
+            any(),
             any());
   }
 
@@ -562,7 +564,7 @@ public class GroupQueryControllerTest extends RestControllerTest {
     final var description1 = "Description 1";
     final var description2 = "Description 2";
     final var description3 = "Description 3";
-    when(groupServices.search(any(GroupQuery.class), any()))
+    when(groupServices.search(any(GroupQuery.class), any(), any()))
         .thenReturn(
             new SearchQueryResult.Builder<GroupEntity>()
                 .total(3)
@@ -603,13 +605,14 @@ public class GroupQueryControllerTest extends RestControllerTest {
                     .sort(GroupSort.of(builder -> builder.name().asc()))
                     .page(SearchQueryPage.of(builder -> builder.size(20)))
                     .build()),
+            any(),
             any());
   }
 
   @Test
   void shouldSearchGroupUsersWithSorting() {
     // given
-    when(groupServices.searchMembers(any(GroupMemberQuery.class), any()))
+    when(groupServices.searchMembers(any(GroupMemberQuery.class), any(), any()))
         .thenReturn(
             new SearchQueryResult.Builder<GroupMemberEntity>()
                 .total(GROUP_USER_ENTITIES.size())
@@ -642,7 +645,7 @@ public class GroupQueryControllerTest extends RestControllerTest {
   @Test
   void shouldSearchGroupUsersWithEmptyQuery() {
     // given
-    when(groupServices.searchMembers(any(GroupMemberQuery.class), any()))
+    when(groupServices.searchMembers(any(GroupMemberQuery.class), any(), any()))
         .thenReturn(
             new SearchQueryResult.Builder<GroupMemberEntity>()
                 .total(GROUP_USER_ENTITIES.size())
@@ -674,7 +677,7 @@ public class GroupQueryControllerTest extends RestControllerTest {
   @Test
   void shouldSearchGroupMappingsWithSorting() {
     // given
-    when(mappingServices.search(any(MappingRuleQuery.class), any()))
+    when(mappingServices.search(any(MappingRuleQuery.class), any(), any()))
         .thenReturn(
             new SearchQueryResult.Builder<MappingRuleEntity>()
                 .total(MAPPNING_ENTITIES.size())
@@ -707,7 +710,7 @@ public class GroupQueryControllerTest extends RestControllerTest {
   @Test
   void shouldSearchGroupMappingsWithEmptyQuery() {
     // given
-    when(mappingServices.search(any(MappingRuleQuery.class), any()))
+    when(mappingServices.search(any(MappingRuleQuery.class), any(), any()))
         .thenReturn(
             new SearchQueryResult.Builder<MappingRuleEntity>()
                 .total(MAPPNING_ENTITIES.size())
@@ -739,7 +742,7 @@ public class GroupQueryControllerTest extends RestControllerTest {
   @Test
   void shouldSearchGroupRolesWithSorting() {
     // given
-    when(roleServices.search(any(RoleQuery.class), any()))
+    when(roleServices.search(any(RoleQuery.class), any(), any()))
         .thenReturn(
             new SearchQueryResult.Builder<RoleEntity>()
                 .total(ROLE_ENTITIES.size())
@@ -772,7 +775,7 @@ public class GroupQueryControllerTest extends RestControllerTest {
   @Test
   void shouldSearchGroupRolesWithEmptyQuery() {
     // given
-    when(roleServices.search(any(RoleQuery.class), any()))
+    when(roleServices.search(any(RoleQuery.class), any(), any()))
         .thenReturn(
             new SearchQueryResult.Builder<RoleEntity>()
                 .total(ROLE_ENTITIES.size())
@@ -804,7 +807,7 @@ public class GroupQueryControllerTest extends RestControllerTest {
   @Test
   void shouldSearchGroupClientsWithSorting() {
     // given
-    when(groupServices.searchMembers(any(GroupMemberQuery.class), any()))
+    when(groupServices.searchMembers(any(GroupMemberQuery.class), any(), any()))
         .thenReturn(
             new SearchQueryResult.Builder<GroupMemberEntity>()
                 .total(GROUP_CLIENT_ENTITIES.size())
@@ -837,7 +840,7 @@ public class GroupQueryControllerTest extends RestControllerTest {
   @Test
   void shouldSearchGroupClientsWithEmptyQuery() {
     // given
-    when(groupServices.searchMembers(any(GroupMemberQuery.class), any()))
+    when(groupServices.searchMembers(any(GroupMemberQuery.class), any(), any()))
         .thenReturn(
             new SearchQueryResult.Builder<GroupMemberEntity>()
                 .total(GROUP_CLIENT_ENTITIES.size())
@@ -885,7 +888,7 @@ public class GroupQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedResponse, JsonCompareMode.STRICT);
 
-    verify(groupServices, never()).search(any(GroupQuery.class), any());
+    verify(groupServices, never()).search(any(GroupQuery.class), any(), any());
   }
 
   public static Stream<Arguments> invalidGroupSearchQueries() {

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingRuleControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingRuleControllerTest.java
@@ -66,7 +66,7 @@ public class MappingRuleControllerTest extends RestControllerTest {
             .setMappingRuleId(id)
             .setName(dto.name());
 
-    when(mappingRuleServices.createMappingRule(eq(dto), any()))
+    when(mappingRuleServices.createMappingRule(eq(dto), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(mappingRecord));
 
     // when
@@ -81,7 +81,7 @@ public class MappingRuleControllerTest extends RestControllerTest {
         .isCreated();
 
     // then
-    verify(mappingRuleServices, times(1)).createMappingRule(eq(dto), any());
+    verify(mappingRuleServices, times(1)).createMappingRule(eq(dto), any(), any());
   }
 
   @Test
@@ -279,7 +279,7 @@ public class MappingRuleControllerTest extends RestControllerTest {
 
     final var mappingRecord = new MappingRuleRecord().setMappingRuleId(mappingId);
 
-    when(mappingRuleServices.deleteMappingRule(eq(mappingId), any()))
+    when(mappingRuleServices.deleteMappingRule(eq(mappingId), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(mappingRecord));
 
     // when
@@ -292,7 +292,7 @@ public class MappingRuleControllerTest extends RestControllerTest {
         .isNoContent();
 
     // then
-    verify(mappingRuleServices, times(1)).deleteMappingRule(eq(mappingId), any());
+    verify(mappingRuleServices, times(1)).deleteMappingRule(eq(mappingId), any(), any());
   }
 
   @ParameterizedTest
@@ -315,7 +315,7 @@ public class MappingRuleControllerTest extends RestControllerTest {
             .setMappingRuleId(id)
             .setName(dto.name());
 
-    when(mappingRuleServices.updateMappingRule(eq(dto), any()))
+    when(mappingRuleServices.updateMappingRule(eq(dto), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(mappingRecord));
 
     // when
@@ -330,7 +330,7 @@ public class MappingRuleControllerTest extends RestControllerTest {
         .isOk();
 
     // then
-    verify(mappingRuleServices, times(1)).updateMappingRule(eq(dto), any());
+    verify(mappingRuleServices, times(1)).updateMappingRule(eq(dto), any(), any());
   }
 
   @Test

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingRuleQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingRuleQueryControllerTest.java
@@ -54,7 +54,7 @@ public class MappingRuleQueryControllerTest extends RestControllerTest {
     // given
     final var mappingRule =
         new MappingRuleEntity("id", 100L, "Claim Name", "Claim Value", "Map Name");
-    when(mappingRuleServices.getMappingRule(eq(mappingRule.mappingRuleId()), any()))
+    when(mappingRuleServices.getMappingRule(eq(mappingRule.mappingRuleId()), any(), any()))
         .thenReturn(mappingRule);
 
     // when
@@ -77,7 +77,8 @@ public class MappingRuleQueryControllerTest extends RestControllerTest {
             JsonCompareMode.STRICT);
 
     // then
-    verify(mappingRuleServices, times(1)).getMappingRule(eq(mappingRule.mappingRuleId()), any());
+    verify(mappingRuleServices, times(1))
+        .getMappingRule(eq(mappingRule.mappingRuleId()), any(), any());
   }
 
   @Test
@@ -85,7 +86,7 @@ public class MappingRuleQueryControllerTest extends RestControllerTest {
     // given
     final var mappingRuleId = "id";
     final var path = "%s/%s".formatted(MAPPING_RULE_BASE_URL, mappingRuleId);
-    when(mappingRuleServices.getMappingRule(eq(mappingRuleId), any()))
+    when(mappingRuleServices.getMappingRule(eq(mappingRuleId), any(), any()))
         .thenThrow(
             ErrorMapper.mapSearchError(
                 new CamundaSearchException(
@@ -113,13 +114,13 @@ public class MappingRuleQueryControllerTest extends RestControllerTest {
             JsonCompareMode.STRICT);
 
     // then
-    verify(mappingRuleServices, times(1)).getMappingRule(eq(mappingRuleId), any());
+    verify(mappingRuleServices, times(1)).getMappingRule(eq(mappingRuleId), any(), any());
   }
 
   @Test
   void shouldSearchMappingRulesWithEmptyQuery() {
     // given
-    when(mappingRuleServices.search(any(MappingRuleQuery.class), any()))
+    when(mappingRuleServices.search(any(MappingRuleQuery.class), any(), any()))
         .thenReturn(
             new SearchQueryResult.Builder<MappingRuleEntity>()
                 .total(3)
@@ -180,13 +181,13 @@ public class MappingRuleQueryControllerTest extends RestControllerTest {
            }""",
             JsonCompareMode.STRICT);
 
-    verify(mappingRuleServices).search(eq(new MappingRuleQuery.Builder().build()), any());
+    verify(mappingRuleServices).search(eq(new MappingRuleQuery.Builder().build()), any(), any());
   }
 
   @Test
   void shouldSortAndPaginateSearchResult() {
     // given
-    when(mappingRuleServices.search(any(MappingRuleQuery.class), any()))
+    when(mappingRuleServices.search(any(MappingRuleQuery.class), any(), any()))
         .thenReturn(
             new SearchQueryResult.Builder<MappingRuleEntity>()
                 .total(3)
@@ -224,13 +225,14 @@ public class MappingRuleQueryControllerTest extends RestControllerTest {
                     .sort(MappingRuleSort.of(builder -> builder.claimName().asc()))
                     .page(SearchQueryPage.of(builder -> builder.from(20).size(10)))
                     .build()),
+            any(),
             any());
   }
 
   @Test
   void shouldSortAndPaginateByLimitOnlySearchResult() {
     // given
-    when(mappingRuleServices.search(any(MappingRuleQuery.class), any()))
+    when(mappingRuleServices.search(any(MappingRuleQuery.class), any(), any()))
         .thenReturn(
             new SearchQueryResult.Builder<MappingRuleEntity>()
                 .total(3)
@@ -268,13 +270,14 @@ public class MappingRuleQueryControllerTest extends RestControllerTest {
                     .sort(MappingRuleSort.of(builder -> builder.claimName().asc()))
                     .page(SearchQueryPage.of(builder -> builder.size(10)))
                     .build()),
+            any(),
             any());
   }
 
   @Test
   void shouldSortAndPaginateSearchResultByName() {
     // given
-    when(mappingRuleServices.search(any(MappingRuleQuery.class), any()))
+    when(mappingRuleServices.search(any(MappingRuleQuery.class), any(), any()))
         .thenReturn(
             new SearchQueryResult.Builder<MappingRuleEntity>()
                 .total(3)
@@ -312,6 +315,7 @@ public class MappingRuleQueryControllerTest extends RestControllerTest {
                     .sort(MappingRuleSort.of(builder -> builder.name().asc()))
                     .page(SearchQueryPage.of(builder -> builder.from(20).size(10)))
                     .build()),
+            any(),
             any());
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleControllerTest.java
@@ -78,7 +78,7 @@ public class RoleControllerTest {
       final var roleName = "Test Role";
       final var description = "A role used for testing";
       final var request = new CreateRoleRequest(roleId, roleName, description);
-      when(roleServices.createRole(eq(request), any()))
+      when(roleServices.createRole(eq(request), any(), any()))
           .thenReturn(
               CompletableFuture.completedFuture(
                   new RoleRecord()
@@ -103,7 +103,7 @@ public class RoleControllerTest {
           .isCreated();
 
       // then
-      verify(roleServices, times(1)).createRole(eq(request), any());
+      verify(roleServices, times(1)).createRole(eq(request), any(), any());
     }
 
     @Test
@@ -278,7 +278,7 @@ public class RoleControllerTest {
       final var roleName = "Updated Role Name";
       final var description = "Updated Role Description";
       final var request = new UpdateRoleRequest(roleId, roleName, description);
-      when(roleServices.updateRole(eq(request), any()))
+      when(roleServices.updateRole(eq(request), any(), any()))
           .thenReturn(
               CompletableFuture.completedFuture(
                   new RoleRecord()
@@ -311,7 +311,7 @@ public class RoleControllerTest {
               JsonCompareMode.STRICT);
 
       // then
-      verify(roleServices, times(1)).updateRole(eq(request), any());
+      verify(roleServices, times(1)).updateRole(eq(request), any(), any());
     }
 
     @Test
@@ -357,7 +357,7 @@ public class RoleControllerTest {
       final var description = "Updated Role Description";
       final var request = new UpdateRoleRequest(roleId, roleName, description);
       final var path = "%s/%s".formatted(ROLE_BASE_URL, roleId);
-      when(roleServices.updateRole(eq(request), any()))
+      when(roleServices.updateRole(eq(request), any(), any()))
           .thenReturn(
               CompletableFuture.failedFuture(
                   ErrorMapper.mapBrokerRejection(
@@ -376,7 +376,7 @@ public class RoleControllerTest {
           .expectStatus()
           .isNotFound();
 
-      verify(roleServices, times(1)).updateRole(eq(request), any());
+      verify(roleServices, times(1)).updateRole(eq(request), any(), any());
     }
 
     @Test
@@ -387,7 +387,7 @@ public class RoleControllerTest {
       final String description = null;
       final var uri = "%s/%s".formatted(ROLE_BASE_URL, roleId);
       final var request = new UpdateRoleRequest(roleId, roleName, description);
-      when(roleServices.updateRole(eq(request), any()))
+      when(roleServices.updateRole(eq(request), any(), any()))
           .thenReturn(
               CompletableFuture.completedFuture(
                   new RoleRecord()
@@ -418,7 +418,7 @@ public class RoleControllerTest {
                   .formatted(roleName, "", roleId),
               JsonCompareMode.STRICT);
 
-      verify(roleServices, times(1)).updateRole(eq(request), any());
+      verify(roleServices, times(1)).updateRole(eq(request), any(), any());
     }
 
     @Test
@@ -428,7 +428,7 @@ public class RoleControllerTest {
 
       final var roleRecord = new RoleRecord().setRoleId(roleId);
 
-      when(roleServices.deleteRole(eq(roleId), any()))
+      when(roleServices.deleteRole(eq(roleId), any(), any()))
           .thenReturn(CompletableFuture.completedFuture(roleRecord));
 
       // when
@@ -441,7 +441,7 @@ public class RoleControllerTest {
           .isNoContent();
 
       // then
-      verify(roleServices, times(1)).deleteRole(eq(roleId), any());
+      verify(roleServices, times(1)).deleteRole(eq(roleId), any(), any());
     }
 
     @Test
@@ -451,7 +451,7 @@ public class RoleControllerTest {
       final var username = "username";
 
       final var request = new RoleMemberRequest(roleId, username, EntityType.USER);
-      when(roleServices.addMember(eq(request), any()))
+      when(roleServices.addMember(eq(request), any(), any()))
           .thenReturn(CompletableFuture.completedFuture(null));
 
       // when
@@ -464,7 +464,7 @@ public class RoleControllerTest {
           .isNoContent();
 
       // then
-      verify(roleServices, times(1)).addMember(eq(request), any());
+      verify(roleServices, times(1)).addMember(eq(request), any(), any());
     }
 
     @Test
@@ -473,7 +473,7 @@ public class RoleControllerTest {
       final var roleId = Strings.newRandomValidIdentityId();
       final var mappingRuleId = Strings.newRandomValidIdentityId();
       final var request = new RoleMemberRequest(roleId, mappingRuleId, EntityType.MAPPING_RULE);
-      when(roleServices.addMember(eq(request), any()))
+      when(roleServices.addMember(eq(request), any(), any()))
           .thenReturn(CompletableFuture.completedFuture(null));
 
       // when
@@ -486,7 +486,7 @@ public class RoleControllerTest {
           .isNoContent();
 
       // then
-      verify(roleServices, times(1)).addMember(eq(request), any());
+      verify(roleServices, times(1)).addMember(eq(request), any(), any());
     }
 
     @Test
@@ -496,7 +496,7 @@ public class RoleControllerTest {
       final var mappingRuleId = Strings.newRandomValidIdentityId();
       final var path = "%s/%s/mapping-rules/%s".formatted(ROLE_BASE_URL, roleId, mappingRuleId);
       final var request = new RoleMemberRequest(roleId, mappingRuleId, EntityType.MAPPING_RULE);
-      when(roleServices.addMember(eq(request), any()))
+      when(roleServices.addMember(eq(request), any(), any()))
           .thenReturn(
               CompletableFuture.failedFuture(
                   ErrorMapper.mapBrokerRejection(
@@ -516,7 +516,7 @@ public class RoleControllerTest {
           .isNotFound();
 
       // then
-      verify(roleServices, times(1)).addMember(eq(request), any());
+      verify(roleServices, times(1)).addMember(eq(request), any(), any());
     }
 
     @Test
@@ -526,7 +526,7 @@ public class RoleControllerTest {
       final var mappingRuleId = Strings.newRandomValidIdentityId();
       final var path = "%s/%s/mapping-rules/%s".formatted(ROLE_BASE_URL, roleId, mappingRuleId);
       final var request = new RoleMemberRequest(roleId, mappingRuleId, EntityType.MAPPING_RULE);
-      when(roleServices.addMember(eq(request), any()))
+      when(roleServices.addMember(eq(request), any(), any()))
           .thenReturn(
               CompletableFuture.failedFuture(
                   ErrorMapper.mapBrokerRejection(
@@ -546,7 +546,7 @@ public class RoleControllerTest {
           .isNotFound();
 
       // then
-      verify(roleServices, times(1)).addMember(eq(request), any());
+      verify(roleServices, times(1)).addMember(eq(request), any(), any());
     }
 
     @Test
@@ -618,7 +618,7 @@ public class RoleControllerTest {
       final var mappingRuleId = Strings.newRandomValidIdentityId();
 
       final var request = new RoleMemberRequest(roleId, mappingRuleId, EntityType.MAPPING_RULE);
-      when(roleServices.removeMember(eq(request), any()))
+      when(roleServices.removeMember(eq(request), any(), any()))
           .thenReturn(CompletableFuture.completedFuture(null));
 
       // when
@@ -631,7 +631,7 @@ public class RoleControllerTest {
           .isNoContent();
 
       // then
-      verify(roleServices, times(1)).removeMember(eq(request), any());
+      verify(roleServices, times(1)).removeMember(eq(request), any(), any());
     }
 
     @Test
@@ -641,7 +641,7 @@ public class RoleControllerTest {
       final var mappingRuleId = Strings.newRandomValidIdentityId();
       final var path = "%s/%s/mapping-rules/%s".formatted(ROLE_BASE_URL, roleId, mappingRuleId);
       final var request = new RoleMemberRequest(roleId, mappingRuleId, EntityType.MAPPING_RULE);
-      when(roleServices.removeMember(eq(request), any()))
+      when(roleServices.removeMember(eq(request), any(), any()))
           .thenReturn(
               CompletableFuture.failedFuture(
                   ErrorMapper.mapBrokerRejection(
@@ -661,7 +661,7 @@ public class RoleControllerTest {
           .isNotFound();
 
       // then
-      verify(roleServices, times(1)).removeMember(eq(request), any());
+      verify(roleServices, times(1)).removeMember(eq(request), any(), any());
     }
 
     @Test
@@ -671,7 +671,7 @@ public class RoleControllerTest {
       final var mappingRuleId = Strings.newRandomValidIdentityId();
       final var path = "%s/%s/mapping-rules/%s".formatted(ROLE_BASE_URL, roleId, mappingRuleId);
       final var request = new RoleMemberRequest(roleId, mappingRuleId, EntityType.MAPPING_RULE);
-      when(roleServices.removeMember(eq(request), any()))
+      when(roleServices.removeMember(eq(request), any(), any()))
           .thenReturn(
               CompletableFuture.failedFuture(
                   ErrorMapper.mapBrokerRejection(
@@ -691,7 +691,7 @@ public class RoleControllerTest {
           .isNotFound();
 
       // then
-      verify(roleServices, times(1)).removeMember(eq(request), any());
+      verify(roleServices, times(1)).removeMember(eq(request), any(), any());
     }
 
     @Test
@@ -701,7 +701,7 @@ public class RoleControllerTest {
       final var username = "username";
       final var path = "%s/%s/users/%s".formatted(ROLE_BASE_URL, roleId, username);
       final var request = new RoleMemberRequest(roleId, username, EntityType.USER);
-      when(roleServices.addMember(eq(request), any()))
+      when(roleServices.addMember(eq(request), any(), any()))
           .thenReturn(
               CompletableFuture.failedFuture(
                   ErrorMapper.mapBrokerRejection(
@@ -721,7 +721,7 @@ public class RoleControllerTest {
           .isNotFound();
 
       // then
-      verify(roleServices, times(1)).addMember(eq(request), any());
+      verify(roleServices, times(1)).addMember(eq(request), any(), any());
     }
 
     @Test
@@ -731,7 +731,7 @@ public class RoleControllerTest {
       final String username = "username";
       final var path = "%s/%s/users/%s".formatted(ROLE_BASE_URL, roleId, username);
       final var request = new RoleMemberRequest(roleId, username, EntityType.USER);
-      when(roleServices.addMember(eq(request), any()))
+      when(roleServices.addMember(eq(request), any(), any()))
           .thenReturn(
               CompletableFuture.failedFuture(
                   ErrorMapper.mapBrokerRejection(
@@ -751,7 +751,7 @@ public class RoleControllerTest {
           .isNotFound();
 
       // then
-      verify(roleServices, times(1)).addMember(eq(request), any());
+      verify(roleServices, times(1)).addMember(eq(request), any(), any());
     }
 
     @Test
@@ -823,7 +823,7 @@ public class RoleControllerTest {
       final var username = "username";
 
       final var request = new RoleMemberRequest(roleId, username, EntityType.USER);
-      when(roleServices.removeMember(eq(request), any()))
+      when(roleServices.removeMember(eq(request), any(), any()))
           .thenReturn(CompletableFuture.completedFuture(null));
 
       // when
@@ -836,7 +836,7 @@ public class RoleControllerTest {
           .isNoContent();
 
       // then
-      verify(roleServices, times(1)).removeMember(eq(request), any());
+      verify(roleServices, times(1)).removeMember(eq(request), any(), any());
     }
 
     @Test
@@ -846,7 +846,7 @@ public class RoleControllerTest {
       final var username = "username";
       final var path = "%s/%s/users/%s".formatted(ROLE_BASE_URL, roleId, username);
       final var request = new RoleMemberRequest(roleId, username, EntityType.USER);
-      when(roleServices.removeMember(eq(request), any()))
+      when(roleServices.removeMember(eq(request), any(), any()))
           .thenReturn(
               CompletableFuture.failedFuture(
                   ErrorMapper.mapBrokerRejection(
@@ -866,7 +866,7 @@ public class RoleControllerTest {
           .isNotFound();
 
       // then
-      verify(roleServices, times(1)).removeMember(eq(request), any());
+      verify(roleServices, times(1)).removeMember(eq(request), any(), any());
     }
 
     @Test
@@ -876,7 +876,7 @@ public class RoleControllerTest {
       final String username = "username";
       final var path = "%s/%s/users/%s".formatted(ROLE_BASE_URL, roleId, username);
       final var request = new RoleMemberRequest(roleId, username, EntityType.USER);
-      when(roleServices.removeMember(eq(request), any()))
+      when(roleServices.removeMember(eq(request), any(), any()))
           .thenReturn(
               CompletableFuture.failedFuture(
                   ErrorMapper.mapBrokerRejection(
@@ -896,7 +896,7 @@ public class RoleControllerTest {
           .isNotFound();
 
       // then
-      verify(roleServices, times(1)).removeMember(eq(request), any());
+      verify(roleServices, times(1)).removeMember(eq(request), any(), any());
     }
 
     @Test
@@ -966,7 +966,7 @@ public class RoleControllerTest {
       final var groupId = "groupId";
 
       final var request = new RoleMemberRequest(roleId, groupId, EntityType.GROUP);
-      when(roleServices.addMember(eq(request), any()))
+      when(roleServices.addMember(eq(request), any(), any()))
           .thenReturn(CompletableFuture.completedFuture(null));
 
       // when
@@ -979,7 +979,7 @@ public class RoleControllerTest {
           .isNoContent();
 
       // then
-      verify(roleServices, times(1)).addMember(eq(request), any());
+      verify(roleServices, times(1)).addMember(eq(request), any(), any());
     }
 
     @Test
@@ -989,7 +989,7 @@ public class RoleControllerTest {
       final var groupId = "groupId";
       final var path = "%s/%s/groups/%s".formatted(ROLE_BASE_URL, roleId, groupId);
       final var request = new RoleMemberRequest(roleId, groupId, EntityType.GROUP);
-      when(roleServices.addMember(eq(request), any()))
+      when(roleServices.addMember(eq(request), any(), any()))
           .thenReturn(
               CompletableFuture.failedFuture(
                   ErrorMapper.mapBrokerRejection(
@@ -1009,7 +1009,7 @@ public class RoleControllerTest {
           .isNotFound();
 
       // then
-      verify(roleServices, times(1)).addMember(eq(request), any());
+      verify(roleServices, times(1)).addMember(eq(request), any(), any());
     }
 
     @Test
@@ -1019,7 +1019,7 @@ public class RoleControllerTest {
       final String groupId = "groupId";
       final var path = "%s/%s/groups/%s".formatted(ROLE_BASE_URL, roleId, groupId);
       final var request = new RoleMemberRequest(roleId, groupId, EntityType.GROUP);
-      when(roleServices.addMember(eq(request), any()))
+      when(roleServices.addMember(eq(request), any(), any()))
           .thenReturn(
               CompletableFuture.failedFuture(
                   ErrorMapper.mapBrokerRejection(
@@ -1039,7 +1039,7 @@ public class RoleControllerTest {
           .isNotFound();
 
       // then
-      verify(roleServices, times(1)).addMember(eq(request), any());
+      verify(roleServices, times(1)).addMember(eq(request), any(), any());
     }
 
     @Test
@@ -1111,7 +1111,7 @@ public class RoleControllerTest {
       final var groupId = "groupId";
 
       final var request = new RoleMemberRequest(roleId, groupId, EntityType.GROUP);
-      when(roleServices.removeMember(eq(request), any()))
+      when(roleServices.removeMember(eq(request), any(), any()))
           .thenReturn(CompletableFuture.completedFuture(null));
 
       // when
@@ -1124,7 +1124,7 @@ public class RoleControllerTest {
           .isNoContent();
 
       // then
-      verify(roleServices, times(1)).removeMember(eq(request), any());
+      verify(roleServices, times(1)).removeMember(eq(request), any(), any());
     }
 
     @Test
@@ -1134,7 +1134,7 @@ public class RoleControllerTest {
       final var groupId = "groupId";
       final var path = "%s/%s/groups/%s".formatted(ROLE_BASE_URL, roleId, groupId);
       final var request = new RoleMemberRequest(roleId, groupId, EntityType.GROUP);
-      when(roleServices.removeMember(eq(request), any()))
+      when(roleServices.removeMember(eq(request), any(), any()))
           .thenReturn(
               CompletableFuture.failedFuture(
                   ErrorMapper.mapBrokerRejection(
@@ -1154,7 +1154,7 @@ public class RoleControllerTest {
           .isNotFound();
 
       // then
-      verify(roleServices, times(1)).removeMember(eq(request), any());
+      verify(roleServices, times(1)).removeMember(eq(request), any(), any());
     }
 
     @Test
@@ -1164,7 +1164,7 @@ public class RoleControllerTest {
       final String groupId = "groupId";
       final var path = "%s/%s/groups/%s".formatted(ROLE_BASE_URL, roleId, groupId);
       final var request = new RoleMemberRequest(roleId, groupId, EntityType.GROUP);
-      when(roleServices.removeMember(eq(request), any()))
+      when(roleServices.removeMember(eq(request), any(), any()))
           .thenReturn(
               CompletableFuture.failedFuture(
                   ErrorMapper.mapBrokerRejection(
@@ -1184,7 +1184,7 @@ public class RoleControllerTest {
           .isNotFound();
 
       // then
-      verify(roleServices, times(1)).removeMember(eq(request), any());
+      verify(roleServices, times(1)).removeMember(eq(request), any(), any());
     }
 
     @Test
@@ -1275,7 +1275,7 @@ public class RoleControllerTest {
       final var groupId = "group Id";
       final var request = new RoleMemberRequest(roleId, groupId, EntityType.GROUP);
 
-      when(roleServices.addMember(eq(request), any()))
+      when(roleServices.addMember(eq(request), any(), any()))
           .thenReturn(CompletableFuture.completedFuture(null));
 
       // when
@@ -1288,7 +1288,7 @@ public class RoleControllerTest {
           .isNoContent();
 
       // then
-      verify(roleServices, times(1)).addMember(eq(request), any());
+      verify(roleServices, times(1)).addMember(eq(request), any(), any());
     }
 
     /**
@@ -1302,7 +1302,7 @@ public class RoleControllerTest {
       final var groupId = "group Id";
       final var request = new RoleMemberRequest(roleId, groupId, EntityType.GROUP);
 
-      when(roleServices.removeMember(eq(request), any()))
+      when(roleServices.removeMember(eq(request), any(), any()))
           .thenReturn(CompletableFuture.completedFuture(null));
 
       // when
@@ -1315,7 +1315,7 @@ public class RoleControllerTest {
           .isNoContent();
 
       // then
-      verify(roleServices, times(1)).removeMember(eq(request), any());
+      verify(roleServices, times(1)).removeMember(eq(request), any(), any());
     }
 
     @TestConfiguration

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleQueryControllerTest.java
@@ -65,7 +65,7 @@ public class RoleQueryControllerTest extends RestControllerTest {
   void getRoleShouldReturnOk() {
     // given
     final var role = new RoleEntity(100L, "roleId", "Role Name", "description");
-    when(roleServices.getRole(eq(role.roleId()), any())).thenReturn(role);
+    when(roleServices.getRole(eq(role.roleId()), any(), any())).thenReturn(role);
 
     // when
     webClient
@@ -86,7 +86,7 @@ public class RoleQueryControllerTest extends RestControllerTest {
             JsonCompareMode.STRICT);
 
     // then
-    verify(roleServices, times(1)).getRole(eq(role.roleId()), any());
+    verify(roleServices, times(1)).getRole(eq(role.roleId()), any(), any());
   }
 
   @Test
@@ -94,7 +94,7 @@ public class RoleQueryControllerTest extends RestControllerTest {
     // given
     final var roleId = Strings.newRandomValidIdentityId();
     final var path = "%s/%s".formatted(ROLE_BASE_URL, roleId);
-    when(roleServices.getRole(eq(roleId), any()))
+    when(roleServices.getRole(eq(roleId), any(), any()))
         .thenThrow(
             ErrorMapper.mapSearchError(
                 new CamundaSearchException(
@@ -122,13 +122,13 @@ public class RoleQueryControllerTest extends RestControllerTest {
             JsonCompareMode.STRICT);
 
     // then
-    verify(roleServices, times(1)).getRole(eq(roleId), any());
+    verify(roleServices, times(1)).getRole(eq(roleId), any(), any());
   }
 
   @Test
   void shouldSearchRolesWithEmptyQuery() {
     // given
-    when(roleServices.search(any(RoleQuery.class), any()))
+    when(roleServices.search(any(RoleQuery.class), any(), any()))
         .thenReturn(
             new SearchQueryResult.Builder<RoleEntity>()
                 .total(3)
@@ -183,13 +183,13 @@ public class RoleQueryControllerTest extends RestControllerTest {
            }""",
             JsonCompareMode.STRICT);
 
-    verify(roleServices).search(eq(new RoleQuery.Builder().build()), any());
+    verify(roleServices).search(eq(new RoleQuery.Builder().build()), any(), any());
   }
 
   @Test
   void shouldSortAndPaginateSearchResult() {
     // given
-    when(roleServices.search(any(RoleQuery.class), any()))
+    when(roleServices.search(any(RoleQuery.class), any(), any()))
         .thenReturn(
             new SearchQueryResult.Builder<RoleEntity>()
                 .total(3)
@@ -224,13 +224,14 @@ public class RoleQueryControllerTest extends RestControllerTest {
                     .sort(RoleSort.of(builder -> builder.name().asc()))
                     .page(SearchQueryPage.of(builder -> builder.from(20).size(10)))
                     .build()),
+            any(),
             any());
   }
 
   @Test
   void shouldSortAndPaginateByLimitOnlySearchResult() {
     // given
-    when(roleServices.search(any(RoleQuery.class), any()))
+    when(roleServices.search(any(RoleQuery.class), any(), any()))
         .thenReturn(
             new SearchQueryResult.Builder<RoleEntity>()
                 .total(3)
@@ -265,6 +266,7 @@ public class RoleQueryControllerTest extends RestControllerTest {
                     .sort(RoleSort.of(builder -> builder.name().asc()))
                     .page(SearchQueryPage.of(builder -> builder.size(10)))
                     .build()),
+            any(),
             any());
   }
 
@@ -272,7 +274,7 @@ public class RoleQueryControllerTest extends RestControllerTest {
   void shouldSearchUsersByRole() {
     // given
     final var roleId = "roleId";
-    when(roleServices.searchMembers(any(RoleMemberQuery.class), any()))
+    when(roleServices.searchMembers(any(RoleMemberQuery.class), any(), any()))
         .thenReturn(
             new SearchQueryResult.Builder<RoleMemberEntity>()
                 .total(3)
@@ -325,6 +327,7 @@ public class RoleQueryControllerTest extends RestControllerTest {
                 new RoleMemberQuery.Builder()
                     .filter(f -> f.memberType(EntityType.USER).roleId(roleId))
                     .build()),
+            any(),
             any());
   }
 
@@ -332,7 +335,7 @@ public class RoleQueryControllerTest extends RestControllerTest {
   void shouldSearchMappingsByRole() {
     // given
     final var roleId = "roleId";
-    when(mappingRuleServices.search(any(MappingRuleQuery.class), any()))
+    when(mappingRuleServices.search(any(MappingRuleQuery.class), any(), any()))
         .thenReturn(
             new SearchQueryResult.Builder<MappingRuleEntity>()
                 .total(3)
@@ -394,6 +397,7 @@ public class RoleQueryControllerTest extends RestControllerTest {
                 new MappingRuleQuery.Builder()
                     .filter(f -> f.roleId(roleId).claimNames(List.of()))
                     .build()),
+            any(),
             any());
   }
 
@@ -401,7 +405,7 @@ public class RoleQueryControllerTest extends RestControllerTest {
   public void shouldSearchClientsByRole() {
     // given
     final var roleId = "roleId";
-    when(roleServices.searchMembers(any(RoleMemberQuery.class), any()))
+    when(roleServices.searchMembers(any(RoleMemberQuery.class), any(), any()))
         .thenReturn(
             new SearchQueryResult.Builder<RoleMemberEntity>()
                 .total(3)
@@ -454,6 +458,7 @@ public class RoleQueryControllerTest extends RestControllerTest {
                 new RoleMemberQuery.Builder()
                     .filter(f -> f.roleId(roleId).memberType(EntityType.CLIENT))
                     .build()),
+            any(),
             any());
   }
 
@@ -461,7 +466,7 @@ public class RoleQueryControllerTest extends RestControllerTest {
   void shouldSearchGroupsByRole() {
     // given
     final var roleId = "roleId";
-    when(roleServices.searchMembers(any(RoleMemberQuery.class), any()))
+    when(roleServices.searchMembers(any(RoleMemberQuery.class), any(), any()))
         .thenReturn(
             new SearchQueryResult.Builder<RoleMemberEntity>()
                 .total(2)
@@ -509,6 +514,7 @@ public class RoleQueryControllerTest extends RestControllerTest {
                 new RoleMemberQuery.Builder()
                     .filter(f -> f.roleId(roleId).memberType(EntityType.GROUP))
                     .build()),
+            any(),
             any());
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserControllerTest.java
@@ -91,7 +91,7 @@ public class UserControllerTest {
               .setEmail(dto.email())
               .setPassword(dto.password());
 
-      when(userServices.createUser(eq(dto), any()))
+      when(userServices.createUser(eq(dto), any(), any()))
           .thenReturn(CompletableFuture.completedFuture(userRecord));
 
       // when
@@ -117,7 +117,7 @@ public class UserControllerTest {
               JsonCompareMode.STRICT);
 
       // then
-      verify(userServices, times(1)).createUser(eq(dto), any());
+      verify(userServices, times(1)).createUser(eq(dto), any(), any());
     }
 
     @Test
@@ -127,7 +127,7 @@ public class UserControllerTest {
 
       final var dto = validCreateUserRequest("foo");
 
-      when(userServices.createUser(eq(dto), any()))
+      when(userServices.createUser(eq(dto), any(), any()))
           .thenThrow(
               ErrorMapper.mapBrokerRejection(
                   new BrokerRejection(
@@ -240,7 +240,7 @@ public class UserControllerTest {
       final var dto = new UserDTO("foo", null, null, "zabraboof");
       final var userRecord =
           new UserRecord().setUsername(dto.username()).setPassword(dto.password());
-      when(userServices.createUser(eq(dto), any()))
+      when(userServices.createUser(eq(dto), any(), any()))
           .thenReturn(CompletableFuture.completedFuture(userRecord));
 
       // when
@@ -266,7 +266,7 @@ public class UserControllerTest {
               JsonCompareMode.STRICT);
 
       // then
-      verify(userServices, times(1)).createUser(eq(dto), any());
+      verify(userServices, times(1)).createUser(eq(dto), any(), any());
     }
 
     @Test
@@ -344,7 +344,7 @@ public class UserControllerTest {
 
       final var userRecord = new UserRecord().setUsername(username);
 
-      when(userServices.deleteUser(eq(username), any()))
+      when(userServices.deleteUser(eq(username), any(), any()))
           .thenReturn(CompletableFuture.completedFuture(userRecord));
 
       // when
@@ -357,7 +357,7 @@ public class UserControllerTest {
           .isNoContent();
 
       // then
-      verify(userServices, times(1)).deleteUser(eq(username), any());
+      verify(userServices, times(1)).deleteUser(eq(username), any(), any());
     }
 
     @Test
@@ -365,7 +365,7 @@ public class UserControllerTest {
       // given
       final String username = "alice-test";
       final UserDTO user = new UserDTO(username, "Alice", "test+alice@camunda.com", null);
-      when(userServices.updateUser(any(), any()))
+      when(userServices.updateUser(any(), any(), any()))
           .thenReturn(
               CompletableFuture.completedFuture(
                   new UserRecord()
@@ -389,7 +389,7 @@ public class UserControllerTest {
           .expectStatus()
           .isOk();
 
-      verify(userServices, times(1)).updateUser(eq(user), any());
+      verify(userServices, times(1)).updateUser(eq(user), any(), any());
     }
 
     private UserDTO validCreateUserRequest(final String username) {

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserQueryControllerTest.java
@@ -88,7 +88,7 @@ public class UserQueryControllerTest extends RestControllerTest {
   void getUserShouldReturnOk() {
     // given
     final var user = new UserEntity(100L, "username", "User Name", "email@email.com", "password");
-    when(userServices.getUser(eq(user.username()), any())).thenReturn(user);
+    when(userServices.getUser(eq(user.username()), any(), any())).thenReturn(user);
 
     // when
     webClient
@@ -109,7 +109,7 @@ public class UserQueryControllerTest extends RestControllerTest {
             JsonCompareMode.STRICT);
 
     // then
-    verify(userServices, times(1)).getUser(eq(user.username()), any());
+    verify(userServices, times(1)).getUser(eq(user.username()), any(), any());
   }
 
   @Test
@@ -117,7 +117,7 @@ public class UserQueryControllerTest extends RestControllerTest {
     // given
     final var username = Strings.newRandomValidIdentityId();
     final var path = "%s/%s".formatted("/v2/users", username);
-    when(userServices.getUser(eq(username), any()))
+    when(userServices.getUser(eq(username), any(), any()))
         .thenThrow(
             ErrorMapper.mapSearchError(
                 new CamundaSearchException(
@@ -145,13 +145,13 @@ public class UserQueryControllerTest extends RestControllerTest {
             JsonCompareMode.STRICT);
 
     // then
-    verify(userServices, times(1)).getUser(eq(username), any());
+    verify(userServices, times(1)).getUser(eq(username), any(), any());
   }
 
   @Test
   void shouldSearchUsersWithEmptyBody() {
     // given
-    when(userServices.search(any(UserQuery.class), any())).thenReturn(SEARCH_QUERY_RESULT);
+    when(userServices.search(any(UserQuery.class), any(), any())).thenReturn(SEARCH_QUERY_RESULT);
     // when / then
     webClient
         .post()
@@ -164,13 +164,13 @@ public class UserQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
-    verify(userServices).search(eq(new UserQuery.Builder().build()), any());
+    verify(userServices).search(eq(new UserQuery.Builder().build()), any(), any());
   }
 
   @Test
   void shouldSearchUsersWithEmptyQuery() {
     // given
-    when(userServices.search(any(UserQuery.class), any())).thenReturn(SEARCH_QUERY_RESULT);
+    when(userServices.search(any(UserQuery.class), any(), any())).thenReturn(SEARCH_QUERY_RESULT);
     final String request = "{}";
     // when / then
     webClient
@@ -187,13 +187,13 @@ public class UserQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
-    verify(userServices).search(eq(new UserQuery.Builder().build()), any());
+    verify(userServices).search(eq(new UserQuery.Builder().build()), any(), any());
   }
 
   @Test
   void shouldSearchUsersWithSorting() {
     // given
-    when(userServices.search(any(UserQuery.class), any())).thenReturn(SEARCH_QUERY_RESULT);
+    when(userServices.search(any(UserQuery.class), any(), any())).thenReturn(SEARCH_QUERY_RESULT);
     final var request =
         """
             {
@@ -222,6 +222,7 @@ public class UserQueryControllerTest extends RestControllerTest {
     verify(userServices)
         .search(
             eq(new UserQuery.Builder().sort(new UserSort.Builder().name().desc().build()).build()),
+            any(),
             any());
   }
 
@@ -244,7 +245,7 @@ public class UserQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedResponse, JsonCompareMode.STRICT);
 
-    verify(userServices, never()).search(any(UserQuery.class), any());
+    verify(userServices, never()).search(any(UserQuery.class), any(), any());
   }
 
   public static Stream<Arguments> invalidUserSearchQueries() {


### PR DESCRIPTION
## Description

Enhance services with `physicalTenantId`

### TODO - Follow ups needed
- MCP resolve `physicalTenantId` and pass it to service part of https://github.com/camunda/camunda/issues/52573
- GRCP resolve `physicalTenantId` and pass it to service part of https://github.com/camunda/camunda/issues/50536
   - [AuthenticationHandler](https://github.com/camunda/camunda/pull/53607/changes#diff-23044650e97ab056645555ddcc7dbb72f0661e7ea86139b92ec4a7840bd33287)
- Identity team should follow up, resolve `physicalTenantId` and pass it to service part of 
  - [authentication](https://github.com/camunda/camunda/pull/53607/changes#diff-8563feceeaddf8eb05f3c6c43700cd3873a926414288e91f0e349d46cc443eec) 
- Any other follow-up needed after #50536 is merged

## Related issues

closes #52575
