### PR TITLE
feat: SearchEngineSchemaInitializer now tenant aware

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineConfigurationOverrides.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineConfigurationOverrides.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.beanoverrides;
+
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.beans.SearchEngineConnectProperties;
+import io.camunda.configuration.beans.SearchEngineIndexProperties;
+import io.camunda.configuration.beans.SearchEngineRetentionProperties;
+import io.camunda.configuration.beans.SearchEngineSchemaManagerProperties;
+import io.camunda.search.connect.configuration.DatabaseConfig;
+import io.camunda.search.schema.config.SearchEngineConfiguration;
+
+public final class SearchEngineConfigurationOverrides {
+
+  private SearchEngineConfigurationOverrides() {}
+
+  public static SearchEngineConfiguration forTenant(final Camunda tenantCamunda) {
+    final SearchEngineConnectProperties connect =
+        new SearchEngineConnectPropertiesOverride.Converter(tenantCamunda).convert();
+    final SearchEngineIndexProperties index =
+        new SearchEngineIndexPropertiesOverride.Converter(tenantCamunda).convert();
+    final SearchEngineRetentionProperties retention =
+        new SearchEngineRetentionPropertiesOverride.Converter(tenantCamunda).convert();
+    final SearchEngineSchemaManagerProperties schemaManager =
+        new SearchEngineSchemaManagerPropertiesOverride.Converter(tenantCamunda).convert();
+
+    if (DatabaseConfig.NONE.equalsIgnoreCase(connect.getTypeEnum().name())) {
+      schemaManager.setCreateSchema(false);
+    }
+
+    return SearchEngineConfiguration.of(
+        b -> b.connect(connect).index(index).retention(retention).schemaManager(schemaManager));
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineIndexPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineIndexPropertiesOverride.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.configuration.beanoverrides;
 
+import io.camunda.configuration.Camunda;
 import io.camunda.configuration.DocumentBasedSecondaryStorageDatabase;
 import io.camunda.configuration.SecondaryStorage;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
@@ -46,31 +47,47 @@ public class SearchEngineIndexPropertiesOverride {
   public SearchEngineIndexProperties searchEngineIndexProperties() {
     final SearchEngineIndexProperties override = new SearchEngineIndexProperties();
     BeanUtils.copyProperties(legacySearchEngineIndexProperties, override);
-
-    final SecondaryStorage secondaryStorage =
-        unifiedConfiguration.getCamunda().getData().getSecondaryStorage();
-
-    final DocumentBasedSecondaryStorageDatabase database =
-        (secondaryStorage.getType() == SecondaryStorageType.elasticsearch)
-            ? secondaryStorage.getElasticsearch()
-            : secondaryStorage.getOpensearch();
-
-    override.setNumberOfShards(database.getNumberOfShards());
-    override.setNumberOfReplicas(database.getNumberOfReplicas());
-    override.setVariableSizeThreshold(database.getVariableSizeThreshold());
-    override.setRefreshInterval(database.getRefreshInterval());
-
-    override.setTemplatePriority(database.getTemplatePriority());
-    if (!database.getNumberOfReplicasPerIndex().isEmpty()) {
-      override.setReplicasByIndexName(database.getNumberOfReplicasPerIndex());
-    }
-    if (!database.getNumberOfShardsPerIndex().isEmpty()) {
-      override.setShardsByIndexName(database.getNumberOfShardsPerIndex());
-    }
-    if (!database.getRefreshIntervalByIndexName().isEmpty()) {
-      override.setRefreshIntervalByIndexName(database.getRefreshIntervalByIndexName());
-    }
-
+    new Converter(unifiedConfiguration.getCamunda()).applyTo(override);
     return override;
+  }
+
+  public static final class Converter {
+
+    private final Camunda camunda;
+
+    public Converter(final Camunda camunda) {
+      this.camunda = camunda;
+    }
+
+    public SearchEngineIndexProperties convert() {
+      final SearchEngineIndexProperties override = new SearchEngineIndexProperties();
+      applyTo(override);
+      return override;
+    }
+
+    public void applyTo(final SearchEngineIndexProperties override) {
+      final SecondaryStorage secondaryStorage = camunda.getData().getSecondaryStorage();
+
+      final DocumentBasedSecondaryStorageDatabase database =
+          (secondaryStorage.getType() == SecondaryStorageType.elasticsearch)
+              ? secondaryStorage.getElasticsearch()
+              : secondaryStorage.getOpensearch();
+
+      override.setNumberOfShards(database.getNumberOfShards());
+      override.setNumberOfReplicas(database.getNumberOfReplicas());
+      override.setVariableSizeThreshold(database.getVariableSizeThreshold());
+      override.setRefreshInterval(database.getRefreshInterval());
+
+      override.setTemplatePriority(database.getTemplatePriority());
+      if (!database.getNumberOfReplicasPerIndex().isEmpty()) {
+        override.setReplicasByIndexName(database.getNumberOfReplicasPerIndex());
+      }
+      if (!database.getNumberOfShardsPerIndex().isEmpty()) {
+        override.setShardsByIndexName(database.getNumberOfShardsPerIndex());
+      }
+      if (!database.getRefreshIntervalByIndexName().isEmpty()) {
+        override.setRefreshIntervalByIndexName(database.getRefreshIntervalByIndexName());
+      }
+    }
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineRetentionPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineRetentionPropertiesOverride.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.configuration.beanoverrides;
 
+import io.camunda.configuration.Camunda;
 import io.camunda.configuration.DocumentBasedSecondaryStorageDatabase;
 import io.camunda.configuration.Retention;
 import io.camunda.configuration.SecondaryStorage;
@@ -48,35 +49,50 @@ public class SearchEngineRetentionPropertiesOverride {
   public SearchEngineRetentionProperties searchEngineRetentionProperties() {
     final SearchEngineRetentionProperties override = new SearchEngineRetentionProperties();
     BeanUtils.copyProperties(legacySearchEngineRetentionProperties, override);
-
-    populateFromRetention(override);
-    populateFromSecondaryStorage(override);
-
+    new Converter(unifiedConfiguration.getCamunda()).applyTo(override);
     return override;
   }
 
-  private void populateFromRetention(final SearchEngineRetentionProperties override) {
-    final Retention retention =
-        unifiedConfiguration.getCamunda().getData().getSecondaryStorage().getRetention();
-    override.setEnabled(retention.isEnabled());
-    override.setMinimumAge(retention.getMinimumAge());
-  }
+  public static final class Converter {
 
-  private void populateFromSecondaryStorage(final SearchEngineRetentionProperties override) {
-    final SecondaryStorage secondaryStorage =
-        unifiedConfiguration.getCamunda().getData().getSecondaryStorage();
+    private final Camunda camunda;
 
-    final DocumentBasedSecondaryStorageDatabase database =
-        switch (secondaryStorage.getType()) {
-          case elasticsearch -> secondaryStorage.getElasticsearch();
-          case opensearch -> secondaryStorage.getOpensearch();
-          default -> null;
-        };
-
-    if (database == null) {
-      return;
+    public Converter(final Camunda camunda) {
+      this.camunda = camunda;
     }
 
-    override.setPolicyName(database.getHistory().getPolicyName());
+    public SearchEngineRetentionProperties convert() {
+      final SearchEngineRetentionProperties override = new SearchEngineRetentionProperties();
+      applyTo(override);
+      return override;
+    }
+
+    public void applyTo(final SearchEngineRetentionProperties override) {
+      populateFromRetention(override);
+      populateFromSecondaryStorage(override);
+    }
+
+    private void populateFromRetention(final SearchEngineRetentionProperties override) {
+      final Retention retention = camunda.getData().getSecondaryStorage().getRetention();
+      override.setEnabled(retention.isEnabled());
+      override.setMinimumAge(retention.getMinimumAge());
+    }
+
+    private void populateFromSecondaryStorage(final SearchEngineRetentionProperties override) {
+      final SecondaryStorage secondaryStorage = camunda.getData().getSecondaryStorage();
+
+      final DocumentBasedSecondaryStorageDatabase database =
+          switch (secondaryStorage.getType()) {
+            case elasticsearch -> secondaryStorage.getElasticsearch();
+            case opensearch -> secondaryStorage.getOpensearch();
+            default -> null;
+          };
+
+      if (database == null) {
+        return;
+      }
+
+      override.setPolicyName(database.getHistory().getPolicyName());
+    }
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineSchemaManagerPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineSchemaManagerPropertiesOverride.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.configuration.beanoverrides;
 
+import io.camunda.configuration.Camunda;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.beans.LegacySearchEngineSchemaManagerProperties;
@@ -46,10 +47,28 @@ public class SearchEngineSchemaManagerPropertiesOverride {
   public SearchEngineSchemaManagerProperties searchEngineSchemaManagerProperties() {
     final SearchEngineSchemaManagerProperties override = new SearchEngineSchemaManagerProperties();
     BeanUtils.copyProperties(legacySearchEngineSchemaManagerProperties, override);
-
-    override.setVersionCheckRestrictionEnabled(
-        unifiedConfiguration.getCamunda().getSystem().getUpgrade().getEnableVersionCheck());
-
+    new Converter(unifiedConfiguration.getCamunda()).applyTo(override);
     return override;
+  }
+
+  public static final class Converter {
+
+    private final Camunda camunda;
+
+    public Converter(final Camunda camunda) {
+      this.camunda = camunda;
+    }
+
+    public SearchEngineSchemaManagerProperties convert() {
+      final SearchEngineSchemaManagerProperties override =
+          new SearchEngineSchemaManagerProperties();
+      applyTo(override);
+      return override;
+    }
+
+    public void applyTo(final SearchEngineSchemaManagerProperties override) {
+      override.setVersionCheckRestrictionEnabled(
+          camunda.getSystem().getUpgrade().getEnableVersionCheck());
+    }
   }
 }

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchEngineDatabaseConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchEngineDatabaseConfiguration.java
@@ -13,6 +13,7 @@ import io.camunda.configuration.beans.SearchEngineIndexProperties;
 import io.camunda.configuration.beans.SearchEngineRetentionProperties;
 import io.camunda.configuration.beans.SearchEngineSchemaManagerProperties;
 import io.camunda.configuration.conditions.ConditionalOnSecondaryStorageType;
+import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
 import io.camunda.search.connect.configuration.DatabaseConfig;
 import io.camunda.search.connect.configuration.DatabaseType;
 import io.camunda.search.schema.config.SearchEngineConfiguration;
@@ -32,14 +33,14 @@ public class SearchEngineDatabaseConfiguration {
 
   @Bean
   public SearchEngineSchemaInitializer searchEngineSchemaInitializer(
-      final SearchEngineConfiguration searchEngineConfiguration,
+      final PhysicalTenantResolver physicalTenantResolver,
       final MeterRegistry meterRegistry,
       @Autowired(required = false)
           final Broker broker, // if present, then it will ensure that the broker is started first
       @Autowired(required = false) final BrokerCfg brokerCfg) {
     final boolean isGatewayEnabled = brokerCfg == null || brokerCfg.getGateway().isEnable();
     return new SearchEngineSchemaInitializer(
-        searchEngineConfiguration, meterRegistry, isGatewayEnabled);
+        physicalTenantResolver, meterRegistry, isGatewayEnabled);
   }
 
   @Bean

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchEngineSchemaInitializer.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchEngineSchemaInitializer.java
@@ -7,6 +7,10 @@
  */
 package io.camunda.application.commons.search;
 
+import static java.util.stream.Collectors.toUnmodifiableMap;
+
+import io.camunda.configuration.beanoverrides.SearchEngineConfigurationOverrides;
+import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
 import io.camunda.exporter.adapters.ClientAdapter;
 import io.camunda.search.schema.SchemaManager;
 import io.camunda.search.schema.SchemaManagerContainer;
@@ -16,6 +20,7 @@ import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import io.camunda.zeebe.util.VisibleForTesting;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -25,35 +30,70 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
 
 public class SearchEngineSchemaInitializer implements InitializingBean, SchemaManagerContainer {
+  private static final int MAX_PARALLEL_SCHEMA_INITS = 4;
   private static final Logger LOGGER = LoggerFactory.getLogger(SearchEngineSchemaInitializer.class);
-  private final SearchEngineConfiguration searchEngineConfiguration;
   private final SchemaManagerMetrics schemaManagerMetrics;
   private final boolean awaitSchemaInitialization;
   private final AtomicBoolean isShutdown = new AtomicBoolean(false);
-  private final AtomicBoolean initialized = new AtomicBoolean(false);
+  private final Map<String, SearchEngineConfiguration> configs;
+  private final Map<String, IndexDescriptors> descriptors;
+  private final Map<String, AtomicBoolean> initialized;
 
   public SearchEngineSchemaInitializer(
-      final SearchEngineConfiguration searchEngineConfiguration,
+      final PhysicalTenantResolver physicalTenantResolver,
       final MeterRegistry meterRegistry,
       final boolean awaitSchemaInitialization) {
-    this.searchEngineConfiguration = searchEngineConfiguration;
     schemaManagerMetrics = new SchemaManagerMetrics(meterRegistry);
     this.awaitSchemaInitialization = awaitSchemaInitialization;
+
+    configs = physicalTenantResolver.mapValues(SearchEngineConfigurationOverrides::forTenant);
+    descriptors =
+        configs.entrySet().stream()
+            .collect(
+                toUnmodifiableMap(
+                    Map.Entry::getKey,
+                    e ->
+                        new IndexDescriptors(
+                            e.getValue().connect().getIndexPrefix(),
+                            e.getValue().connect().getTypeEnum().isElasticSearch())));
+    initialized =
+        configs.keySet().stream()
+            .collect(toUnmodifiableMap(id -> id, id -> new AtomicBoolean(false)));
   }
 
   @Override
   public void afterPropertiesSet() throws Exception {
-    LOGGER.info("Initializing search engine schema...");
-    final var executor = Executors.newSingleThreadExecutor();
+    LOGGER.info(
+        "Initializing search engine schema for {} physical tenant(s): {}",
+        configs.size(),
+        configs.keySet());
+
+    final int parallelism = Math.min(configs.size(), MAX_PARALLEL_SCHEMA_INITS);
+    final ExecutorService executor =
+        Executors.newFixedThreadPool(
+            parallelism,
+            runnable -> {
+              final Thread t = new Thread(runnable, "schema-init");
+              t.setDaemon(true);
+              return t;
+            });
+
     if (!addShutdownHook(executor)) {
       // skipping schema initialization as JVM is shutting down
       return;
     }
-    final var future = CompletableFuture.runAsync(this::startupSchemaManager, executor);
+
+    final CompletableFuture<?>[] futures =
+        configs.keySet().stream()
+            .map(
+                id -> CompletableFuture.runAsync(() -> startupSchemaManagerForTenant(id), executor))
+            .toArray(CompletableFuture[]::new);
+    final CompletableFuture<Void> all = CompletableFuture.allOf(futures);
+
     if (awaitSchemaInitialization) {
-      synchronousSchemaInitialization(future, executor);
+      synchronousSchemaInitialization(all, executor);
     } else {
-      asyncSchemaInitialization(future, executor);
+      asyncSchemaInitialization(all, executor);
     }
   }
 
@@ -99,24 +139,31 @@ public class SearchEngineSchemaInitializer implements InitializingBean, SchemaMa
         });
   }
 
-  private void startupSchemaManager() {
-    final var indexDescriptors =
-        new IndexDescriptors(
-            searchEngineConfiguration.connect().getIndexPrefix(),
-            searchEngineConfiguration.connect().getTypeEnum().isElasticSearch());
-    try (final ClientAdapter clientAdapter = ClientAdapter.of(searchEngineConfiguration.connect());
+  private void startupSchemaManagerForTenant(final String physicalTenantId) {
+    if (isShutdown.get()) {
+      return;
+    }
+
+    final SearchEngineConfiguration cfg = configs.get(physicalTenantId);
+    final IndexDescriptors descSet = descriptors.get(physicalTenantId);
+
+    try (final ClientAdapter clientAdapter = ClientAdapter.of(cfg.connect());
         final SchemaManager schemaManager =
             new SchemaManager(
                     clientAdapter.getSearchEngineClient(),
-                    indexDescriptors.indices(),
-                    indexDescriptors.templates(),
-                    searchEngineConfiguration,
+                    descSet.indices(),
+                    descSet.templates(),
+                    cfg,
                     clientAdapter.objectMapper())
                 .withMetrics(schemaManagerMetrics)) {
       schemaManager.startup();
-      initialized.set(true);
+      initialized.get(physicalTenantId).set(true);
+      LOGGER.info("Schema initialised for physical tenant '{}'", physicalTenantId);
     } catch (final IOException e) {
-      LOGGER.debug("Failed to close the search client", e);
+      LOGGER.debug("Failed to close the search client for tenant '{}'", physicalTenantId, e);
+    } catch (final Exception e) {
+      LOGGER.error("Schema initialisation failed for physical tenant '{}'", physicalTenantId, e);
+      throw e;
     }
   }
 
@@ -146,14 +193,29 @@ public class SearchEngineSchemaInitializer implements InitializingBean, SchemaMa
     }
   }
 
+  public IndexDescriptors forTenant(final String physicalTenantId) {
+    final IndexDescriptors d = descriptors.get(physicalTenantId);
+    if (d == null) {
+      throw new IllegalArgumentException("Unknown physical tenant: " + physicalTenantId);
+    }
+    return d;
+  }
+
+  @Override
+  public boolean isInitialized(final String physicalTenantId) {
+    final AtomicBoolean flag = initialized.get(physicalTenantId);
+    return flag != null && flag.get();
+  }
+
   /**
-   * Returns true if the schema initialization completed successfully. This can be used by dependent
-   * components to check if they should proceed with their initialization.
+   * Returns true if the schema initialization completed successfully for <em>all</em> physical
+   * tenants. This can be used by dependent components to check if they should proceed with their
+   * initialization.
    *
-   * @return true if schema initialization completed successfully, false otherwise
+   * @return true if schema initialization completed successfully for all tenants, false otherwise
    */
   @Override
   public boolean isInitialized() {
-    return initialized.get();
+    return !initialized.isEmpty() && initialized.values().stream().allMatch(AtomicBoolean::get);
   }
 }

--- a/schema-manager/src/main/java/io/camunda/search/schema/SchemaManagerContainer.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/SchemaManagerContainer.java
@@ -8,5 +8,7 @@
 package io.camunda.search.schema;
 
 public interface SchemaManagerContainer {
+  boolean isInitialized(final String physicalTenantId);
+
   boolean isInitialized();
 }


### PR DESCRIPTION
## Summary
- Diagnostic PR: contains only the `feat:` commit from #52963 (commit `67a1cd59b9d`), omitting the `test:` commit `7abc044d414`.
- Goal: determine whether the CI failures observed on #52963 originate from the feature commit alone or from the test commit on top of it.

Do not merge — close once CI results are collected.