### PR TITLE
test: remove flakiness from command rejection it

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/CommandRejectionIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/CommandRejectionIT.java
@@ -8,7 +8,7 @@
 package io.camunda.it;
 
 import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
-import static io.camunda.it.util.TestHelper.waitUntilJobExistsForProcessInstance;
+import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.client.CamundaClient;
@@ -20,6 +20,7 @@ import io.camunda.security.api.model.config.AuthenticationMethod;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.qa.util.actuator.BanningActuator;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
@@ -51,19 +52,23 @@ public class CommandRejectionIT {
     BanningActuator.of(CAMUNDA_APPLICATION).ban(processInstanceKey);
 
     // when - we attempt to modify the banned process instance
-    final var modifyFuture =
-        assertThatThrownBy(
-                () ->
-                    camundaClient
-                        .newModifyProcessInstanceCommand(processInstanceKey)
-                        .activateElement("taskB")
-                        .send()
-                        .join())
-            .isInstanceOf(ProblemException.class)
-            .hasMessageContaining("INVALID_STATE")
-            .hasMessageContaining(
-                "Expected to process command for process instance with key '%d', but the process instance is banned"
-                    .formatted(processInstanceKey));
+    Awaitility.await("should reject PI modification command")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertThatThrownBy(
+                        () ->
+                            camundaClient
+                                .newModifyProcessInstanceCommand(processInstanceKey)
+                                .activateElement("taskB")
+                                .send()
+                                .join())
+                    .isInstanceOf(ProblemException.class)
+                    .hasMessageContaining("INVALID_STATE")
+                    .hasMessageContaining(
+                        "Expected to process command for process instance with key '%d', but the process instance is banned"
+                            .formatted(processInstanceKey)));
   }
 
   @Test
@@ -75,27 +80,28 @@ public class CommandRejectionIT {
 
     final long processInstanceKey = createProcessInstance(processId);
     waitForProcessInstancesToStart(camundaClient, f -> f.processInstanceKey(processInstanceKey), 1);
-    waitUntilJobExistsForProcessInstance(camundaClient, processInstanceKey);
-    final long jobKey =
-        camundaClient
-            .newJobSearchRequest()
-            .filter(f -> f.processInstanceKey(processInstanceKey))
-            .send()
-            .join()
-            .items()
-            .getFirst()
-            .getJobKey();
 
     // and - the process instance is banned
     BanningActuator.of(CAMUNDA_APPLICATION).ban(processInstanceKey);
 
     // when - we attempt to complete the job of the banned process instance
-    assertThatThrownBy(() -> camundaClient.newCompleteCommand(jobKey).send().join())
-        .isInstanceOf(ProblemException.class)
-        .hasMessageContaining("INVALID_STATE")
-        .hasMessageContaining(
-            "Expected to process command for process instance with key '%d', but the process instance is banned"
-                .formatted(processInstanceKey));
+    Awaitility.await("should reject set variable command")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertThatThrownBy(
+                        () ->
+                            camundaClient
+                                .newSetVariablesCommand(processInstanceKey)
+                                .variable("test", "test")
+                                .send()
+                                .join())
+                    .isInstanceOf(ProblemException.class)
+                    .hasMessageContaining("INVALID_STATE")
+                    .hasMessageContaining(
+                        "Expected to process command for process instance with key '%d', but the process instance is banned"
+                            .formatted(processInstanceKey)));
   }
 
   private static BpmnModelInstance twoServiceTasksProcess(


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Remove the flakiness when the client sends commands before the banning of the process instance is applied to the state.

We introduce Awaitility as we don't have a mechanism to detect a banning in IT tests.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
