### PR TITLE
feat: add record filter to analytics exporter

### DIFF
--- a/zeebe/exporters/analytics-exporter/README.md
+++ b/zeebe/exporters/analytics-exporter/README.md
@@ -29,11 +29,11 @@ The OTel SDK's `BatchLogRecordProcessor` runs on a background thread with a boun
 When the queue fills, new records are silently dropped — the `export()` method on the Zeebe
 actor thread never blocks, never waits, never retries synchronously.
 
-### No record filter
+### Record filter
 
-The exporter does **not** set a `RecordFilter`. It accepts all records from the broker to
-track the full log position for compaction. Only event records with registered handlers
-produce OTel log records; everything else is a fast no-op (EnumMap lookup returning null).
+The exporter sets a `RecordFilter` that accepts only event records for registered handler
+types, originating from the local partition. See `AnalyticsRecordFilter` Javadoc for the
+filtering layers and the rationale behind partition-based deduplication.
 
 ## What it exports
 

--- a/zeebe/exporters/analytics-exporter/pom.xml
+++ b/zeebe/exporters/analytics-exporter/pom.xml
@@ -71,10 +71,20 @@
       <scope>runtime</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+    </dependency>
+
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporter.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporter.java
@@ -17,7 +17,6 @@ import io.camunda.zeebe.exporter.api.Exporter;
 import io.camunda.zeebe.exporter.api.context.Context;
 import io.camunda.zeebe.exporter.api.context.Controller;
 import io.camunda.zeebe.protocol.record.Record;
-import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
@@ -26,6 +25,7 @@ import java.time.Duration;
 import java.util.EnumMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,7 +43,7 @@ public class AnalyticsExporter implements Exporter {
 
   private AnalyticsExporterConfig config;
   private Controller controller;
-  private EnumMap<ValueType, Consumer<Record<?>>> handlers;
+  private HandlerRegistry handlers;
   private int partitionId;
   private String clusterId;
 
@@ -67,8 +67,10 @@ public class AnalyticsExporter implements Exporter {
       clusterId = fromEnv != null ? fromEnv : "";
     }
 
-    handlers = new EnumMap<>(ValueType.class);
-    registerHandler(ValueType.PROCESS_INSTANCE_CREATION, this::handleProcessInstanceCreation);
+    handlers =
+        new HandlerRegistry()
+            .register(ValueType.PROCESS_INSTANCE_CREATION, this::handleProcessInstanceCreation)
+            .apply(context);
 
     LOG.info(
         "Analytics exporter configured: endpoint={}, clusterId={}",
@@ -94,7 +96,7 @@ public class AnalyticsExporter implements Exporter {
     controller.updateLastExportedRecordPosition(record.getPosition());
 
     try {
-      final var handler = handlers.get(record.getValueType());
+      final var handler = handlers.get(record);
       if (handler != null) {
         handler.accept(record);
       }
@@ -128,15 +130,24 @@ public class AnalyticsExporter implements Exporter {
         record.getPosition());
   }
 
-  @SuppressWarnings("unchecked")
-  private <T extends RecordValue> void registerHandler(
-      final ValueType valueType, final Consumer<Record<T>> handler) {
-    handlers.put(
-        valueType,
-        record -> {
-          if (record.getRecordType() == RecordType.EVENT) {
-            handler.accept((Record<T>) record);
-          }
-        });
+  static final class HandlerRegistry {
+
+    private final EnumMap<ValueType, Consumer<Record<?>>> handlers = new EnumMap<>(ValueType.class);
+
+    @SuppressWarnings("unchecked")
+    <T extends RecordValue> HandlerRegistry register(
+        final ValueType valueType, final Consumer<Record<T>> handler) {
+      handlers.put(valueType, record -> handler.accept((Record<T>) record));
+      return this;
+    }
+
+    HandlerRegistry apply(final Context context) {
+      context.setFilter(new AnalyticsRecordFilter(handlers.keySet(), context.getPartitionId()));
+      return this;
+    }
+
+    @Nullable Consumer<Record<?>> get(final Record<?> record) {
+      return handlers.get(record.getValueType());
+    }
   }
 }

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsRecordFilter.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsRecordFilter.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics;
+
+import io.camunda.zeebe.exporter.api.context.Context.RecordFilter;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import java.util.Set;
+
+/**
+ * Record filter for the analytics exporter with three filtering layers:
+ *
+ * <ol>
+ *   <li><b>Record type</b> — only {@link RecordType#EVENT} records pass; commands and rejections
+ *       are skipped.
+ *   <li><b>Value type</b> — only value types with registered handlers pass (e.g. {@link
+ *       ValueType#PROCESS_INSTANCE_CREATION}).
+ *   <li><b>Partition ownership</b> — only events whose key encodes the local partition ID pass.
+ * </ol>
+ *
+ * <p>Layers 1 and 2 are metadata-based and evaluated in phase 1 of the broker's filter pipeline
+ * (before record deserialization). Layer 3 runs in phase 2 on the deserialized record, but only for
+ * the small subset that passed phase 1.
+ *
+ * <h3>Partition filtering rationale</h3>
+ *
+ * <p>Zeebe distributes certain commands (deployments, identity, tenants, etc.) to all partitions.
+ * Each partition writes follow-up events for the distributed command, but the event keys preserve
+ * the originating partition's ID — encoded in the upper 13 bits of the 64-bit key via {@link
+ * Protocol#encodePartitionId(int, long)}.
+ *
+ * <p>Without this filter, the analytics exporter on every partition would emit the same logical
+ * event, leading to N× duplication in a cluster with N partitions.
+ *
+ * <p>The key-based check works because all {@code DistributedTypedRecordProcessor} implementations
+ * in the engine preserve the originating partition ID in follow-up event keys — either via {@code
+ * command.getKey()} directly, or via keys embedded in the distributed command's value that were
+ * generated on the originating partition.
+ */
+record AnalyticsRecordFilter(Set<ValueType> acceptedValueTypes, int partitionId)
+    implements RecordFilter {
+
+  AnalyticsRecordFilter {
+    acceptedValueTypes = Set.copyOf(acceptedValueTypes);
+  }
+
+  @Override
+  public boolean acceptType(final RecordType recordType) {
+    return recordType == RecordType.EVENT;
+  }
+
+  @Override
+  public boolean acceptValue(final ValueType valueType) {
+    return acceptedValueTypes.contains(valueType);
+  }
+
+  @Override
+  public boolean acceptRecord(final Record<?> record) {
+    return Protocol.decodePartitionId(record.getKey()) == partitionId;
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterTest.java
@@ -145,6 +145,23 @@ class AnalyticsExporterTest {
     assertThat(memoryExporter.getFinishedLogRecordItems()).isEmpty();
   }
 
+  @Test
+  void shouldInstallRecordFilterOnConfigure() {
+    // given
+    final var context =
+        new ExporterTestContext()
+            .setConfiguration(
+                new ExporterTestConfiguration<>("analytics", new AnalyticsExporterConfig()))
+            .setClusterId("test-cluster")
+            .setPartitionId(1);
+
+    // when
+    new AnalyticsExporter().configure(context);
+
+    // then
+    assertThat(context.getRecordFilter()).isNotNull().isInstanceOf(AnalyticsRecordFilter.class);
+  }
+
   // -- helpers --
 
   private static io.camunda.zeebe.protocol.record.Record<?> piCreatedEvent() {

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsRecordFilterTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsRecordFilterTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+class AnalyticsRecordFilterTest {
+
+  private static final int TEST_PARTITION_ID = 1;
+  private static final ProtocolFactory FACTORY = new ProtocolFactory();
+
+  private final AnalyticsRecordFilter filter =
+      new AnalyticsRecordFilter(Set.of(ValueType.PROCESS_INSTANCE_CREATION), TEST_PARTITION_ID);
+
+  @Test
+  void shouldAcceptEventRecordType() {
+    assertThat(filter.acceptType(RecordType.EVENT)).isTrue();
+  }
+
+  @Test
+  void shouldRejectCommandRecordType() {
+    assertThat(filter.acceptType(RecordType.COMMAND)).isFalse();
+  }
+
+  @Test
+  void shouldRejectCommandRejectionRecordType() {
+    assertThat(filter.acceptType(RecordType.COMMAND_REJECTION)).isFalse();
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = ValueType.class,
+      mode = EnumSource.Mode.INCLUDE,
+      names = "PROCESS_INSTANCE_CREATION")
+  void shouldAcceptRegisteredValueType(final ValueType type) {
+    assertThat(filter.acceptValue(type)).isTrue();
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = ValueType.class,
+      mode = EnumSource.Mode.EXCLUDE,
+      names = "PROCESS_INSTANCE_CREATION")
+  void shouldRejectUnregisteredValueType(final ValueType type) {
+    assertThat(filter.acceptValue(type)).isFalse();
+  }
+
+  @Test
+  void shouldAcceptRecordFromLocalPartition() {
+    // given
+    final var record =
+        FACTORY.generateRecord(
+            ValueType.PROCESS_INSTANCE_CREATION,
+            r ->
+                r.withKey(Protocol.encodePartitionId(TEST_PARTITION_ID, 1))
+                    .withRecordType(RecordType.EVENT)
+                    .withIntent(ProcessInstanceCreationIntent.CREATED));
+
+    // when / then
+    assertThat(filter.acceptRecord(record)).isTrue();
+  }
+
+  @Test
+  void shouldRejectRecordFromRemotePartition() {
+    // given — key encodes partition 2, but exporter runs on partition 1
+    final int remotePartition = 2;
+    final var record =
+        FACTORY.generateRecord(
+            ValueType.PROCESS_INSTANCE_CREATION,
+            r ->
+                r.withKey(Protocol.encodePartitionId(remotePartition, 1))
+                    .withRecordType(RecordType.EVENT)
+                    .withIntent(ProcessInstanceCreationIntent.CREATED));
+
+    // when / then
+    assertThat(filter.acceptRecord(record)).isFalse();
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a `RecordFilter` to the analytics exporter that accepts only `EVENT` records for registered handler types, originating from the local partition
- Filters out duplicate events from distributed commands (deployments, identity, tenants, etc.) using key-based partition ownership check via `Protocol.decodePartitionId`
- Extracts handler registration into a `HandlerRegistry` with a fluent builder API that derives the filter from registered handlers

Closes #52384

## Test plan

- [x] Unit tests for `AnalyticsRecordFilter` (type, value, partition accept/reject)
- [x] Smoke test in `AnalyticsExporterTest` verifying filter is wired up
- [x] Existing exporter tests still pass (attribute mapping, position tracking, error resilience)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)