### PR TITLE
docs: add skill for assembling GHA scheduled workflow health report

### DIFF
--- a/.claude/skills/ci-scheduled-workflow-health/SKILL.md
+++ b/.claude/skills/ci-scheduled-workflow-health/SKILL.md
@@ -1,0 +1,57 @@
+---
+
+name: ci-scheduled-workflow-health
+description: Generate an HTML health report for all scheduled GitHub Actions workflows in this monorepo. Discovers workflows with `schedule:` triggers from the `main` branch via git, queries the GitHub API for recent run results, extracts `# owner:` metadata from YAML comments, and produces a categorized report (failing, flaky, ok, no runs). Use when asked about CI health, scheduled workflow health, nightly build failures, flaky CI, or workflow ownership.
+
+---
+
+# Scheduled Workflow Health Report
+
+Generates an HTML report showing the health status of all scheduled GitHub Actions workflows in the `camunda/camunda` repository.
+
+Then summarizes the concerning failing and flaky workflows by owner.
+
+## What it does
+
+1. Lists all workflow files from `git show main:.github/workflows/`
+2. Filters to those containing a `schedule:` trigger
+3. Extracts the `# owner:` comment from the first 20 lines of each YAML file
+4. Queries the GitHub API (via `gh`) for the last 5 scheduled runs on `main`
+5. Classifies each workflow:
+   - **failing** — most recent run failed AND all checked runs failed
+   - **flaky** — most recent run failed BUT some checked runs passed
+   - **ok** — most recent run passed
+   - **no_runs** / **in_progress** — no completed scheduled runs found
+6. Outputs `scheduled-workflow-report.html` with collapsible sections, owner info, and a legend
+
+## Prerequisites
+
+- `git` with access to the `main` branch (fetched)
+- `gh` CLI authenticated (`gh auth status`)
+- `python3`
+
+## How to run
+
+```bash
+python3 .claude/skills/ci-scheduled-workflow-health/scripts/scheduled-workflow-report.py
+```
+
+The script is at: `.claude/skills/ci-scheduled-workflow-health/scripts/scheduled-workflow-report.py`.
+
+Output: `scheduled-workflow-report.html` in the current directory. Open with a browser.
+
+stderr shows progress and a summary of failing/flaky workflows with their owners.
+
+## Customization
+
+- `RUNS_TO_CHECK` constant (default 5) controls how many recent runs to inspect per workflow
+- `OWNER` / `REPO` constants control the target repository
+- Owner extraction looks for `# owner: <team>` in the first 20 lines of each workflow YAML
+
+## Key design decisions
+
+- Uses `git show main:` instead of filesystem reads to always reflect the `main` branch state
+- Uses `gh api` (no pagination) since we only need ≤5 runs per workflow
+- Filters API calls to `event=schedule&branch=main` to only see scheduled runs
+- HTML report uses `<details>` for collapsible sections — failing/flaky are open by default
+

--- a/.claude/skills/ci-scheduled-workflow-health/scripts/scheduled-workflow-report.py
+++ b/.claude/skills/ci-scheduled-workflow-health/scripts/scheduled-workflow-report.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""
+Generate an HTML report of failing scheduled GitHub Actions workflows.
+
+Extracts scheduled workflow filenames from git main branch, queries the
+GitHub API for recent runs, and outputs an HTML report of failures.
+"""
+
+import json
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+
+OWNER = "camunda"
+REPO = "camunda"
+# How many recent runs per workflow to check
+RUNS_TO_CHECK = 5
+
+
+def git_list_workflow_files():
+    """List workflow files from the main branch via git ls-tree (plumbing)."""
+    result = subprocess.run(
+        ["git", "ls-tree", "--name-only", "main", ".github/workflows/"],
+        capture_output=True, text=True, check=True,
+    )
+    # Each line is ".github/workflows/<filename>"; extract just the filename
+    return [
+        line.rsplit("/", 1)[-1]
+        for line in result.stdout.splitlines()
+        if line.strip()
+    ]
+
+
+def git_read_workflow(filename):
+    """Read a workflow file from the main branch."""
+    result = subprocess.run(
+        ["git", "show", f"main:.github/workflows/{filename}"],
+        capture_output=True, text=True, check=True,
+    )
+    return result.stdout
+
+
+def git_file_has_schedule(content):
+    """Check if workflow content contains a schedule trigger."""
+    return "schedule:" in content
+
+
+def extract_owner(content):
+    """Extract owner from '# owner: ...' comment in the first 20 lines."""
+    for line in content.splitlines()[:20]:
+        m = re.match(r'^\s*#\s*owner:?\s*(.+)', line, re.IGNORECASE)
+        if m:
+            owner = m.group(1).strip()
+            # Some lines have "# owner @team" (without colon after owner)
+            owner = re.sub(r'^#\s*owner\s*', '', owner, flags=re.IGNORECASE).strip()
+            if owner:
+                return owner
+    return None
+
+
+def gh_api(endpoint):
+    """Call GitHub API via gh CLI."""
+    result = subprocess.run(
+        ["gh", "api", endpoint],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        print(f"  WARNING: API call failed for {endpoint}: {result.stderr.strip()}", file=sys.stderr)
+        return None
+    return json.loads(result.stdout)
+
+
+def get_recent_runs(workflow_filename):
+    """Get recent workflow runs for a given workflow file."""
+    endpoint = (
+        f"/repos/{OWNER}/{REPO}/actions/workflows/{workflow_filename}/runs"
+        f"?per_page={RUNS_TO_CHECK}&branch=main&event=schedule"
+    )
+    data = gh_api(endpoint)
+    if data is None:
+        return []
+    return data.get("workflow_runs", [])
+
+
+def classify_workflow(runs):
+    """Classify workflow status based on recent runs.
+    Returns (status, details) where status is 'failing', 'flaky', 'ok', or 'no_runs'.
+    """
+    if not runs:
+        return "no_runs", []
+
+    details = []
+    for run in runs:
+        details.append({
+            "id": run["id"],
+            "conclusion": run.get("conclusion"),
+            "status": run["status"],
+            "created_at": run["created_at"],
+            "html_url": run["html_url"],
+            "run_number": run["run_number"],
+        })
+
+    conclusions = [r["conclusion"] for r in details if r["conclusion"] is not None]
+    if not conclusions:
+        return "in_progress", details
+
+    if conclusions[0] == "failure":
+        if all(c == "failure" for c in conclusions):
+            return "failing", details
+        return "flaky", details
+
+    return "ok", details
+
+
+def generate_html(workflows):
+    """Generate an HTML report from classified workflow data."""
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+    # Separate into categories
+    failing = [(w, o, s, d) for w, o, s, d in workflows if s == "failing"]
+    flaky = [(w, o, s, d) for w, o, s, d in workflows if s == "flaky"]
+    ok = [(w, o, s, d) for w, o, s, d in workflows if s == "ok"]
+    no_runs = [(w, o, s, d) for w, o, s, d in workflows if s in ("no_runs", "in_progress")]
+
+    def status_badge(status):
+        colors = {
+            "failing": "#d73a49",
+            "flaky": "#e36209",
+            "ok": "#28a745",
+            "no_runs": "#6a737d",
+            "in_progress": "#0366d6",
+        }
+        color = colors.get(status, "#6a737d")
+        return f'<span style="background:{color};color:#fff;padding:2px 8px;border-radius:4px;font-size:0.85em;">{status}</span>'
+
+    def conclusion_icon(conclusion):
+        icons = {
+            "success": "&#x2705;",
+            "failure": "&#x274C;",
+            "cancelled": "&#x23F9;",
+            "skipped": "&#x23ED;",
+            "timed_out": "&#x23F0;",
+            None: "&#x23F3;",
+        }
+        return icons.get(conclusion, f"&#x2753; {conclusion}")
+
+    def render_section(title, items, open_by_default=False):
+        if not items:
+            return ""
+        open_attr = " open" if open_by_default else ""
+        rows = []
+        for wf_name, wf_owner, status, details in items:
+            run_cells = ""
+            for d in details[:RUNS_TO_CHECK]:
+                created = d["created_at"][:10]
+                url = d["html_url"]
+                icon = conclusion_icon(d["conclusion"])
+                run_cells += f'<a href="{url}" title="{d["conclusion"] or "in_progress"} on {created}" style="text-decoration:none;margin-right:4px;">{icon}</a>'
+            wf_url = f"https://github.com/{OWNER}/{REPO}/actions/workflows/{wf_name}?query=event%3Aschedule"
+            owner_cell = wf_owner or '<span style="color:#6a737d;">unknown</span>'
+            rows.append(
+                f"<tr>"
+                f'<td><a href="{wf_url}">{wf_name}</a></td>'
+                f"<td>{owner_cell}</td>"
+                f"<td>{status_badge(status)}</td>"
+                f"<td>{run_cells or 'N/A'}</td>"
+                f"</tr>"
+            )
+        return f"""
+        <details{open_attr}>
+          <summary><strong>{title}</strong> ({len(items)})</summary>
+          <table>
+            <thead><tr><th>Workflow</th><th>Owner</th><th>Status</th><th>Recent Runs (newest first)</th></tr></thead>
+            <tbody>{"".join(rows)}</tbody>
+          </table>
+        </details>
+        """
+
+    html = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Scheduled Workflow Report — {OWNER}/{REPO}</title>
+<style>
+  body {{ font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; margin: 2em; color: #24292e; }}
+  h1 {{ border-bottom: 1px solid #e1e4e8; padding-bottom: 0.3em; }}
+  table {{ border-collapse: collapse; width: 100%; margin: 0.5em 0 1.5em; }}
+  th, td {{ border: 1px solid #e1e4e8; padding: 6px 12px; text-align: left; }}
+  th {{ background: #f6f8fa; }}
+  tr:hover {{ background: #f6f8fa; }}
+  details {{ margin: 1em 0; }}
+  summary {{ cursor: pointer; font-size: 1.1em; padding: 0.3em 0; }}
+  a {{ color: #0366d6; text-decoration: none; }}
+  a:hover {{ text-decoration: underline; }}
+  .stats {{ display: flex; gap: 1.5em; margin: 1em 0; }}
+  .stat {{ padding: 0.8em 1.2em; border-radius: 6px; }}
+  .stat-failing {{ background: #ffeef0; border: 1px solid #d73a49; }}
+  .stat-flaky {{ background: #fff8e1; border: 1px solid #e36209; }}
+  .stat-ok {{ background: #e6ffed; border: 1px solid #28a745; }}
+  .stat-other {{ background: #f1f8ff; border: 1px solid #0366d6; }}
+  .legend {{ border-collapse: collapse; width: auto; margin: 0.3em 0; }}
+  .legend th, .legend td {{ border: 1px solid #e1e4e8; padding: 4px 12px; }}
+  .legend th {{ background: #f6f8fa; }}
+</style>
+</head>
+<body>
+<h1>Scheduled Workflow Report</h1>
+<p>Repository: <a href="https://github.com/{OWNER}/{REPO}">{OWNER}/{REPO}</a> &mdash; Generated: {now}</p>
+<p>Checked last {RUNS_TO_CHECK} scheduled runs on <code>main</code> for each workflow.</p>
+<div class="stats">
+  <div class="stat stat-failing"><strong>{len(failing)}</strong> Failing</div>
+  <div class="stat stat-flaky"><strong>{len(flaky)}</strong> Flaky</div>
+  <div class="stat stat-ok"><strong>{len(ok)}</strong> OK</div>
+  <div class="stat stat-other"><strong>{len(no_runs)}</strong> No runs (yet, could be new) / In progress</div>
+</div>
+<details>
+<summary><strong>Legend</strong></summary>
+<table class="legend">
+  <tr><th>Symbol</th><th>Meaning</th></tr>
+  <tr><td>&#x2705;</td><td>Run succeeded</td></tr>
+  <tr><td>&#x274C;</td><td>Run failed</td></tr>
+  <tr><td>&#x23F9;</td><td>Run was cancelled</td></tr>
+  <tr><td>&#x23ED;</td><td>Run was skipped</td></tr>
+  <tr><td>&#x23F0;</td><td>Run timed out</td></tr>
+  <tr><td>&#x23F3;</td><td>Run is in progress</td></tr>
+  <tr><td>&#x2753;</td><td>Unknown / other conclusion</td></tr>
+</table>
+<table class="legend" style="margin-top:0.5em;">
+  <tr><th>Badge</th><th>Meaning</th></tr>
+  <tr><td><span style="background:#d73a49;color:#fff;padding:2px 8px;border-radius:4px;font-size:0.85em;">failing</span></td><td>Most recent run failed and all checked runs failed</td></tr>
+  <tr><td><span style="background:#e36209;color:#fff;padding:2px 8px;border-radius:4px;font-size:0.85em;">flaky</span></td><td>Most recent run failed but some checked runs passed</td></tr>
+  <tr><td><span style="background:#28a745;color:#fff;padding:2px 8px;border-radius:4px;font-size:0.85em;">ok</span></td><td>Most recent run passed</td></tr>
+  <tr><td><span style="background:#6a737d;color:#fff;padding:2px 8px;border-radius:4px;font-size:0.85em;">no_runs</span></td><td>No scheduled runs found on main</td></tr>
+  <tr><td><span style="background:#0366d6;color:#fff;padding:2px 8px;border-radius:4px;font-size:0.85em;">in_progress</span></td><td>All recent runs still in progress</td></tr>
+</table>
+</details>
+
+{render_section("&#x274C; Failing (most recent run failed, all recent runs failed)", failing, open_by_default=True)}
+{render_section("&#x26A0;&#xFE0F; Flaky (most recent run failed, but some recent runs passed)", flaky, open_by_default=True)}
+{render_section("&#x2705; OK (most recent run passed)", ok, open_by_default=False)}
+{render_section("&#x2754; No Runs / In Progress", no_runs, open_by_default=False)}
+</body>
+</html>"""
+    return html
+
+
+def main():
+    print("Discovering scheduled workflows from git main branch...", file=sys.stderr)
+    all_files = git_list_workflow_files()
+
+    # Read all files and filter for scheduled ones, extracting owners
+    scheduled = []  # list of (filename, owner)
+    for f in all_files:
+        content = git_read_workflow(f)
+        if git_file_has_schedule(content):
+            owner = extract_owner(content)
+            scheduled.append((f, owner))
+    print(f"Found {len(scheduled)} scheduled workflows.", file=sys.stderr)
+
+    results = []
+    for i, (wf, owner) in enumerate(scheduled, 1):
+        print(f"  [{i}/{len(scheduled)}] Checking {wf}...", file=sys.stderr)
+        runs = get_recent_runs(wf)
+        status, details = classify_workflow(runs)
+        results.append((wf, owner, status, details))
+
+    # Sort: failing first, then flaky, then the rest
+    order = {"failing": 0, "flaky": 1, "in_progress": 2, "no_runs": 3, "ok": 4}
+    results.sort(key=lambda x: (order.get(x[2], 99), x[0]))
+
+    html = generate_html(results)
+
+    outfile = "scheduled-workflow-report.html"
+    with open(outfile, "w") as f:
+        f.write(html)
+    print(f"\nReport written to {outfile}", file=sys.stderr)
+
+    # Also print summary to stderr
+    failing = [(w, o) for w, o, s, _ in results if s == "failing"]
+    flaky = [(w, o) for w, o, s, _ in results if s == "flaky"]
+    if failing:
+        print(f"\nFAILING ({len(failing)}):", file=sys.stderr)
+        for w, o in failing:
+            print(f"  - {w}  [{o or 'unknown'}]", file=sys.stderr)
+    if flaky:
+        print(f"\nFLAKY ({len(flaky)}):", file=sys.stderr)
+        for w, o in flaky:
+            print(f"  - {w}  [{o or 'unknown'}]", file=sys.stderr)
+    if not failing and not flaky:
+        print("\nAll scheduled workflows are passing!", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/.codeowners
+++ b/.codeowners
@@ -52,6 +52,8 @@ buf.yaml                    @camunda/orchestration-cluster
 ## @camunda/monorepo-devops-team
 ################################
 
+/.claude/skills/ci-scheduled-workflow-health/ @camunda/monorepo-devops-team
+
 /.ci/                       @camunda/monorepo-devops-team
 /.github/                   @camunda/monorepo-devops-team
 /.mvn/                      @camunda/monorepo-devops-team


### PR DESCRIPTION
## Description

This pull request introduces a new (Claude, can also be used by Copilot) skill for monitoring the health of scheduled GitHub Actions workflows in the repository. It adds documentation and a Python script to generate an HTML report summarizing the status of all scheduled workflows, including ownership information and recent run results. The report helps identify failing and flaky workflows that should be prioritized fixing.

The most important changes are:

**New Skill and Documentation**
* Added `.claude/skills/ci-scheduled-workflow-health/SKILL.md` documenting the new `ci-scheduled-workflow-health` skill, including its purpose, usage, prerequisites, and design decisions.

**Scheduled Workflow Health Reporting**
* Introduced `.claude/skills/ci-scheduled-workflow-health/scripts/scheduled-workflow-report.py`, a Python script that:
  - Lists all workflow files from the `main` branch and filters those with a `schedule:` trigger.
  - Extracts workflow owner metadata from YAML comments.
  - Queries the GitHub API for recent scheduled runs and classifies workflows as failing, flaky, ok, or no runs.
  - Generates a detailed HTML report with collapsible sections, owner info, and a legend.

**Example**

* [scheduled-workflow-report.html](https://github.com/user-attachments/files/28058680/scheduled-workflow-report.html)
* this skill was used to identify several action items tracked in https://github.com/camunda/product-hub/issues/3667

<img width="1613" height="1014" alt="image" src="https://github.com/user-attachments/assets/87e98d5e-2a48-4048-94e2-7e5236a13425" />

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)) - no, only relevant on `main`
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

None
