### PR TITLE
ci: relabel Oracle 23ai to 26ai and pin to 23.26.1

### DIFF
--- a/.ci/db-versions.yml
+++ b/.ci/db-versions.yml
@@ -56,4 +56,4 @@ mssql:
 
 oracle:
   - "21-slim-faststart"
-  - "23-slim-faststart"
+  - "23.26.1-slim-faststart"

--- a/.github/actions/read-db-versions/generate-db-versions.py
+++ b/.github/actions/read-db-versions/generate-db-versions.py
@@ -136,6 +136,7 @@ set_output("ci-database-matrix", json.dumps(ci_db_matrix))
 # database-type. Oracle versions use non-numeric suffixes (21c, 26ai) that
 # cannot be derived mechanically from the version number alone.
 oracle_meta = {
+    # 23.x family is branded "Oracle 26ai" since RU 23.26 (Oct 2025).
     "23": {"name": "Oracle 26ai", "type": "oracle"},
     "21": {"name": "Oracle 21c",  "type": "oracle-21"},
 }

--- a/.github/actions/read-db-versions/generate-db-versions.py
+++ b/.github/actions/read-db-versions/generate-db-versions.py
@@ -133,10 +133,10 @@ set_output("ci-database-matrix", json.dumps(ci_db_matrix))
 
 # ── RDBMS matrix (zeebe-rdbms-integration-tests.yml) ─────────────────────────
 # Maps the first segment of an Oracle image tag to its display name and
-# database-type. Oracle versions use non-numeric suffixes (21c, 23ai) that
+# database-type. Oracle versions use non-numeric suffixes (21c, 26ai) that
 # cannot be derived mechanically from the version number alone.
 oracle_meta = {
-    "23": {"name": "Oracle 23ai", "type": "oracle"},
+    "23": {"name": "Oracle 26ai", "type": "oracle"},
     "21": {"name": "Oracle 21c",  "type": "oracle-21"},
 }
 
@@ -177,7 +177,7 @@ for v in versions["mssql"]:
     })
 
 for v in versions["oracle"]:
-    major = v.split("-")[0]
+    major = v.split(".")[0].split("-")[0]  # "23.26.1-slim-faststart" -> "23"; "21-slim-faststart" -> "21"
     meta  = oracle_meta.get(major, {"name": f"Oracle {major}", "type": "oracle"})
     rdbms_matrix["include"].append({
         "database-name":          meta["name"],

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
@@ -415,10 +415,10 @@ jobs:
             jdbc-url: "jdbc:sqlserver://localhost:1433;Encrypt=false"
             jdbc-username: "sa"
             jdbc-password: "Camunda#8_demo"
-          # Oracle - Supported versions: 21c, 23ai
-          - database-name: "Oracle 23ai"
+          # Oracle - Supported versions: 21c, 26ai
+          - database-name: "Oracle 26ai"
             database-type: "oracle"
-            database-image-version: "23-slim-faststart"
+            database-image-version: "23.26.1-slim-faststart"
             jdbc-url: "jdbc:oracle:thin:@localhost:1521/FREEPDB1"
             jdbc-username: "camunda"
             jdbc-password: "camunda"

--- a/.github/workflows/c8-orchestration-cluster-reusable-rdbms-api-tests.yml
+++ b/.github/workflows/c8-orchestration-cluster-reusable-rdbms-api-tests.yml
@@ -153,10 +153,10 @@ jobs:
             jdbc-url: "jdbc:sqlserver://localhost:1433;Encrypt=false"
             jdbc-username: "sa"
             jdbc-password: "Camunda#8_demo"
-          # Oracle - Supported versions: 21c, 23ai
-          - database-name: "Oracle 23ai"
+          # Oracle - Supported versions: 21c, 26ai
+          - database-name: "Oracle 26ai"
             database-type: "oracle"
-            database-image-version: "23-slim-faststart"
+            database-image-version: "23.26.1-slim-faststart"
             jdbc-url: "jdbc:oracle:thin:@localhost:1521/FREEPDB1"
             jdbc-username: "camunda"
             jdbc-password: "camunda"

--- a/db/docker-compose.yml
+++ b/db/docker-compose.yml
@@ -56,7 +56,7 @@ services:
 
       # Name of the Docker Compose service
   oracle:
-    # Docker Hub image (feel free to change the tag "latest" to any other available one)
+    # Override the pinned tag via the IMAGE_VERSION env var (see Docker Hub for available tags).
     image: gvenzl/oracle-free:${IMAGE_VERSION:-23.26.1-slim-faststart}
     # Forward Oracle port to localhost
     ports:
@@ -75,7 +75,7 @@ services:
       start_period: 5s
 
   oracle-21:
-    # Docker Hub image (feel free to change the tag "latest" to any other available one)
+    # Override the pinned tag via the IMAGE_VERSION env var (see Docker Hub for available tags).
     image: gvenzl/oracle-xe:${IMAGE_VERSION:-21-slim-faststart}
     # Forward Oracle port to localhost
     ports:

--- a/db/docker-compose.yml
+++ b/db/docker-compose.yml
@@ -57,7 +57,7 @@ services:
       # Name of the Docker Compose service
   oracle:
     # Docker Hub image (feel free to change the tag "latest" to any other available one)
-    image: gvenzl/oracle-free:${IMAGE_VERSION:-23-slim-faststart}
+    image: gvenzl/oracle-free:${IMAGE_VERSION:-23.26.1-slim-faststart}
     # Forward Oracle port to localhost
     ports:
       - "1521:1521"


### PR DESCRIPTION
## Summary

- Pin the Oracle image tag from the floating `23-slim-faststart` to the explicit `23.26.1-slim-faststart`. CI was already silently running on this version (the floating tag was rebuilt to point at 23.26.1 on 2026-02-11), but the floating tag would auto-bump on any future RU rebuild.
- Rename the display label everywhere from `Oracle 23ai` to `Oracle 26ai`.

5 files: `.ci/db-versions.yml`, `.github/actions/read-db-versions/generate-db-versions.py`, the two `c8-orchestration-cluster-*` workflows, and `db/docker-compose.yml`.

Oracle 21c is untouched.

## Context

Oracle announced Oracle AI Database 26ai in October 2025; on-prem Linux GA was January 27, 2026. It is **not** a new code line — the internal version is still `23.x` (specifically `23.26.1.0.0`). The brand transition from 23ai to 26ai is achieved by applying RU 23.26, with no database upgrade or application re-certification required.

The customer-facing docs say `Oracle | 19c, 23ai` as supported versions; switching the brand to `26ai` matches what Oracle considers the current supported product. Pre-26 RUs of 23.x are no longer the supported patch level — Oracle's stated upgrade path is "apply RU 23.26".

JDBC driver: unchanged. We do not bundle the Oracle driver (declared `<scope>provided</scope>` in `dist/pom.xml` and explicitly excluded in `dist/src/main/assembly.xml`); customers supply it. Oracle states no driver re-certification is required for 26ai.

## Alternatives considered

- **Stay on floating `23-slim-faststart`.** Cheap and auto-tracks the newest RU, but silently drifts. Documented "26ai" could end up testing a future "27ai" RU without us noticing.
- **Pin AND keep floating side-by-side.** Adds an early-warning canary for RU regressions, at the cost of doubling Oracle CI time. Roman opted to skip this for now; can be added later if RU-regression catching becomes valuable.
- **Pin to `23.26.0` instead of `23.26.1`.** Both are 26ai. Going with the newer of the two as the explicit pin.

## Test plan

- [ ] `python3 .github/actions/read-db-versions/generate-db-versions.py` produces an `rdbms-matrix` entry `"Oracle 26ai"` with `database-image-version: 23.26.1-slim-faststart`, and the existing `"Oracle 21c"` entry is unchanged. (Verified locally.)
- [ ] The two `c8-orchestration-cluster-*` matrices render the new label and pinned image.
- [ ] `docker compose up oracle` (from `db/`, no env override) pulls `gvenzl/oracle-free:23.26.1-slim-faststart`.

Closes #52151.