### PR TITLE
ci: fix Playwright version for workflow "Operate Update Visual Regression Snapshots"

### DIFF
--- a/.github/workflows/operate-update_visual_snapshots.yml
+++ b/.github/workflows/operate-update_visual_snapshots.yml
@@ -22,7 +22,7 @@ jobs:
       contents: write
       pull-requests: write
     container:
-      image: mcr.microsoft.com/playwright:v1.58.2
+      image: mcr.microsoft.com/playwright:v1.59.1
       options: --user 1001:1000
 
     steps:


### PR DESCRIPTION


## Description
[We missed this workflow when bumping Playwright](https://github.com/camunda/camunda/pull/50436/changes)