### PR TITLE
test: fix and re-enable load-tester ITs

### DIFF
--- a/load-tests/load-tester/src/test/java/io/camunda/zeebe/it/CamundaContainerProvider.java
+++ b/load-tests/load-tester/src/test/java/io/camunda/zeebe/it/CamundaContainerProvider.java
@@ -16,15 +16,30 @@ import org.testcontainers.utility.DockerImageName;
 
 /**
  * Shared utilities for creating and configuring a {@link CamundaContainer} in integration tests.
+ *
+ * <p>Image resolution honors the standard {@value #IMAGE_NAME_PROPERTY} / {@value
+ * #IMAGE_VERSION_PROPERTY} system properties at runtime, falling back to the values baked into
+ * {@code camunda-process-test-java}'s filtered {@code git.properties}. Pass the sysprops to point
+ * the IT at a specific image (e.g. a locally built {@code localhost:5000/camunda/camunda} tag from
+ * an in-job registry); otherwise the bundled defaults are used.
  */
 final class CamundaContainerProvider {
+
+  private static final String IMAGE_NAME_PROPERTY =
+      "io.camunda.process.test.camundaDockerImageName";
+  private static final String IMAGE_VERSION_PROPERTY =
+      "io.camunda.process.test.camundaDockerImageVersion";
 
   private CamundaContainerProvider() {}
 
   static CamundaContainer createCamundaContainer() {
-    return new CamundaContainer(
-            DockerImageName.parse(CamundaProcessTestRuntimeDefaults.CAMUNDA_DOCKER_IMAGE_NAME)
-                .withTag(CamundaProcessTestRuntimeDefaults.CAMUNDA_DOCKER_IMAGE_VERSION))
+    final String imageName =
+        System.getProperty(
+            IMAGE_NAME_PROPERTY, CamundaProcessTestRuntimeDefaults.CAMUNDA_DOCKER_IMAGE_NAME);
+    final String imageVersion =
+        System.getProperty(
+            IMAGE_VERSION_PROPERTY, CamundaProcessTestRuntimeDefaults.CAMUNDA_DOCKER_IMAGE_VERSION);
+    return new CamundaContainer(DockerImageName.parse(imageName).withTag(imageVersion))
         .withImagePullPolicy(PullPolicy.ageBased(Duration.ofHours(12)));
   }
 

--- a/load-tests/load-tester/src/test/java/io/camunda/zeebe/it/DataAvailabilityIT.java
+++ b/load-tests/load-tester/src/test/java/io/camunda/zeebe/it/DataAvailabilityIT.java
@@ -13,7 +13,6 @@ import io.camunda.process.test.impl.containers.CamundaContainer;
 import io.camunda.zeebe.LoadTesterApplication;
 import io.camunda.zeebe.metrics.StarterLatencyMetricsDoc;
 import io.micrometer.core.instrument.MeterRegistry;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -48,8 +47,6 @@ import org.testcontainers.junit.jupiter.Testcontainers;
       "load-tester.perform-read-benchmarks=false",
     })
 @ActiveProfiles({"starter", "it"})
-@Disabled(
-    "Temporariy disabled due to https://camunda.slack.com/archives/C071KP5BTHB/p1779098983781369")
 class DataAvailabilityIT {
 
   @Container

--- a/load-tests/load-tester/src/test/java/io/camunda/zeebe/it/StarterWorkerIT.java
+++ b/load-tests/load-tester/src/test/java/io/camunda/zeebe/it/StarterWorkerIT.java
@@ -17,7 +17,6 @@ import io.camunda.zeebe.LoadTesterApplication;
 import io.camunda.zeebe.metrics.StarterMetricsDoc;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -50,8 +49,6 @@ import org.testcontainers.junit.jupiter.Testcontainers;
       "load-tester.perform-read-benchmarks=false",
     })
 @ActiveProfiles({"starter", "worker", "it"})
-@Disabled(
-    "Temporariy disabled due to https://camunda.slack.com/archives/C071KP5BTHB/p1779098983781369")
 class StarterWorkerIT {
 
   @Container


### PR DESCRIPTION
## Description

Fixes load-tester ITs (`CamundaClientConfigIT`, `DataAvailabilityIT`, `StarterWorkerIT`) that failed on feature branches with `Container startup failed for image camunda/camunda:SNAPSHOT`.

### Root cause

`CamundaContainerProvider` delegated the image tag to `CamundaProcessTestRuntimeDefaults.CAMUNDA_DOCKER_IMAGE_VERSION`, which resolves via `VersionedPropertiesUtil`. That regex only produces an `X.Y-SNAPSHOT` tag when `git.properties` points at a `stable/X.Y` branch. On a feature branch it falls back to the bare `SNAPSHOT` literal, so the IT tried to pull `camunda/camunda:SNAPSHOT`.

### Fix

1. `CamundaContainerProvider` now resolves the image name and tag from the standard `io.camunda.process.test.camundaDockerImageName` / `io.camunda.process.test.camundaDockerImageVersion` system properties, falling back to `CamundaProcessTestRuntimeDefaults` (the values baked into `camunda-process-test-java`'s filtered `git.properties`). Passing the sysprops points the IT at a specific image without code changes; local runs keep the bundled defaults. The `ageBased(12h)` pull policy is preserved so moving tags refresh locally.

2. Re-enables `DataAvailabilityIT` and `StarterWorkerIT` by dropping the `@Disabled` annotations (and the now-unused `Disabled` imports). They were disabled while the image resolution issue tracked in [this Slack thread](https://camunda.slack.com/archives/C071KP5BTHB/p1779098983781369) was unresolved; with the override in place, the underlying failure no longer applies.

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [x] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #[Slack Thread](https://camunda.slack.com/archives/C071KP5BTHB/p1779098983781369)
