### PR TITLE
ci: enable CPU + RAM measurements for more jobs

### DIFF
--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -51,6 +51,7 @@ jobs:
             -Dquickly=true
             -DskipQaBuild=true
     steps:
+    - uses: camunda/infra-global-github-actions/start-build-monitor@main
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     # Import FOSSA_API_KEY secret from Vault

--- a/.github/workflows/ci-database-integration-tests-reusable.yml
+++ b/.github/workflows/ci-database-integration-tests-reusable.yml
@@ -78,6 +78,7 @@ jobs:
     outputs:
       flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - run: |
           if [ -z "${{ inputs.database-container }}" ]; then
             echo "DATABASE_CONTAINER=${{ inputs.database-type }}" >> "$GITHUB_ENV"

--- a/.github/workflows/ci-operate.yml
+++ b/.github/workflows/ci-operate.yml
@@ -70,6 +70,7 @@ jobs:
       TEST_OWNER: Core Features
       TEST_TYPE: Build
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Print metadata
@@ -122,6 +123,7 @@ jobs:
       run:
         working-directory: operate/client
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Print metadata
         uses: ./.github/actions/print-metadata
@@ -200,6 +202,7 @@ jobs:
       run:
         working-directory: operate/client
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Print metadata
         uses: ./.github/actions/print-metadata
@@ -236,6 +239,7 @@ jobs:
       run:
         working-directory: operate/client
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Print metadata
         uses: ./.github/actions/print-metadata
@@ -271,6 +275,7 @@ jobs:
       run:
         working-directory: operate/client
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Print metadata
         uses: ./.github/actions/print-metadata
@@ -305,6 +310,7 @@ jobs:
       run:
         working-directory: operate/client
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Print metadata
         uses: ./.github/actions/print-metadata
@@ -354,6 +360,7 @@ jobs:
       run:
         working-directory: operate/client
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - name: Check out repository code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Print metadata
@@ -406,6 +413,7 @@ jobs:
       run:
         working-directory: operate/client
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - name: Check out repository code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Print metadata
@@ -453,6 +461,7 @@ jobs:
       run:
         working-directory: operate/client
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - name: Check out repository code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Print metadata
@@ -520,6 +529,7 @@ jobs:
       run:
         working-directory: operate/client
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Print metadata
         uses: ./.github/actions/print-metadata

--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -73,6 +73,7 @@ jobs:
       TEST_OWNER: Core Features
       TEST_TYPE: Unit
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Print metadata
@@ -125,6 +126,7 @@ jobs:
       TEST_OWNER: Core Features
       TEST_TYPE: Tool
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Print metadata
@@ -185,6 +187,7 @@ jobs:
             "optimize.Dockerfile",
           ]
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Print metadata
         uses: ./.github/actions/print-metadata
@@ -214,6 +217,7 @@ jobs:
       TEST_OWNER: Core Features
 
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -316,6 +320,7 @@ jobs:
       TEST_OWNER: Core Features
       TEST_TYPE: E2E
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Print metadata

--- a/.github/workflows/ci-tasklist.yml
+++ b/.github/workflows/ci-tasklist.yml
@@ -72,6 +72,7 @@ jobs:
       run:
         working-directory: tasklist/client
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Print metadata
         uses: ./.github/actions/print-metadata
@@ -107,6 +108,7 @@ jobs:
       run:
         working-directory: tasklist/client
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Print metadata
         uses: ./.github/actions/print-metadata
@@ -141,6 +143,7 @@ jobs:
       run:
         working-directory: tasklist/client
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Print metadata
         uses: ./.github/actions/print-metadata
@@ -176,6 +179,7 @@ jobs:
       run:
         working-directory: tasklist/client
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Print metadata
         uses: ./.github/actions/print-metadata
@@ -210,6 +214,7 @@ jobs:
       run:
         working-directory: tasklist/client
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Print metadata
         uses: ./.github/actions/print-metadata
@@ -244,6 +249,7 @@ jobs:
       run:
         working-directory: tasklist/client
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Print metadata
         uses: ./.github/actions/print-metadata
@@ -292,6 +298,7 @@ jobs:
       run:
         working-directory: tasklist/client
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - name: Check out repository code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Print metadata
@@ -339,6 +346,7 @@ jobs:
       run:
         working-directory: tasklist/client
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - name: Check out repository code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Print metadata
@@ -474,6 +482,7 @@ jobs:
         ports:
           - 5000:5000
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Print metadata
         uses: ./.github/actions/print-metadata

--- a/.github/workflows/ci-webapp-client.yml
+++ b/.github/workflows/ci-webapp-client.yml
@@ -21,6 +21,7 @@ jobs:
       run:
         working-directory: webapp/client
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -48,6 +49,7 @@ jobs:
       run:
         working-directory: webapp/client
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -75,6 +77,7 @@ jobs:
       run:
         working-directory: webapp/client
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -102,6 +105,7 @@ jobs:
       run:
         working-directory: webapp/client
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/.github/workflows/ci-zeebe.yml
+++ b/.github/workflows/ci-zeebe.yml
@@ -57,6 +57,7 @@ jobs:
             runner: "aws-arm-core-4-longrunning"
             arch: arm64
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Print metadata
         uses: ./.github/actions/print-metadata
@@ -135,6 +136,7 @@ jobs:
       TEST_OWNER: Core Features
       TEST_TYPE: Unit
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Print metadata
         uses: ./.github/actions/print-metadata
@@ -194,6 +196,7 @@ jobs:
       TEST_OWNER: Core Features
       TEST_TYPE: Performance
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Print metadata
         uses: ./.github/actions/print-metadata
@@ -264,6 +267,7 @@ jobs:
       TEST_OWNER: Core Features
       TEST_TYPE: Unit
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Print metadata
         uses: ./.github/actions/print-metadata
@@ -334,6 +338,7 @@ jobs:
       TEST_OWNER: Core Features
       TEST_TYPE: Build
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Print metadata
         uses: ./.github/actions/print-metadata
@@ -440,6 +445,7 @@ jobs:
       group:  ${{ needs.utils-get-concurrency-group.outputs.concurrency_group_name }}
       cancel-in-progress: false
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-build
         with:
@@ -498,6 +504,7 @@ jobs:
       IMAGE_REPOSITORY: registry.camunda.cloud/team-zeebe
       IMAGE_TAG: ${{ needs.utils-get-snapshot-docker-tag.outputs.snapshot_tag != '' && needs.utils-get-snapshot-docker-tag.outputs.snapshot_tag || needs.utils-get-snapshot-docker-tag.outputs.version_tag }}
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-build
         with:
@@ -559,6 +566,7 @@ jobs:
       checks: read
       pull-requests: write
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - name: Generate GitHub token
         id: github-token
         uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@732a017b858dbc516d87dbe0780fafb770532ed7 # main


### PR DESCRIPTION
## Description

With https://github.com/camunda/camunda/pull/51730 we enabled it for ci.yml jobs which is working, no negative impact reported.

This PR extends coverage to all workflows called by Unified CI + FOSSA license check, checked by `SELECT * FROM ci-30-162810.prod_ci_analytics.build_status_v2 WHERE build_head_ref='refs/heads/enable-more-cpu-mem-utilization-analytics'`

## Checklist

<!--- Please delete options that are not relevant. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

https://github.com/camunda/camunda/pull/51730
