### PR TITLE
fix: derive Camunda Docker tag from project version, not git branch

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/util/VersionedPropertiesUtil.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/util/VersionedPropertiesUtil.java
@@ -16,64 +16,64 @@
 package io.camunda.process.test.impl.runtime.util;
 
 import io.camunda.process.test.impl.runtime.GitPropertiesUtil;
-import java.util.Optional;
 import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * Convenience methods for parsing version strings in the shape of MAJOR.MINOR.PATCH-LABEL from a
- * Properties file.
+ * Resolves the Docker image tag for tests using {@code camunda-process-test-java}.
+ *
+ * <p>The tag is derived from the property value itself (which is filtered from {@code
+ * ${project.version}} at build time), so the resolution does not depend on Git branch detection.
+ *
+ * <ul>
+ *   <li>{@code 8.8.10-SNAPSHOT} → {@code 8.8-SNAPSHOT}
+ *   <li>{@code 8.10.0-SNAPSHOT} → {@code 8.10-SNAPSHOT}
+ *   <li>{@code 8.8.5} (released) → {@code 8.8.5} (used verbatim)
+ *   <li>{@code custom-version} → returned verbatim
+ * </ul>
+ *
+ * <p>Unresolved property templates such as {@code
+ * ${io.camunda.process.test.camundaDockerImageVersion}} — which appear when the test resources have
+ * not been Maven-filtered (e.g. running from IDE without a build) — fall back to {@code
+ * defaultValue}.
  */
 public class VersionedPropertiesUtil {
   public static final String SNAPSHOT_VERSION = "SNAPSHOT";
 
-  private static final Pattern STABLE_BRANCH_VERSION_PATTERN =
-      Pattern.compile("(backport-\\d+-to-)?stable/(\\d+)\\.(\\d+)");
   private static final Pattern SEMANTIC_VERSION_PATTERN =
       Pattern.compile("(\\d+)\\.(\\d+)\\.(\\d+)(-.*)?");
 
   /** Format string for snapshot versions (e.g., 8.8-SNAPSHOT). */
   private static final String SNAPSHOT_VERSION_FORMAT = "%d.%d-%s";
 
-  private final GitPropertiesUtil gitProperties;
+  private static final String UNRESOLVED_PLACEHOLDER_PREFIX = "${";
 
+  /**
+   * Kept for binary compatibility with existing callers. The git branch is no longer used to
+   * resolve the snapshot tag.
+   */
   public VersionedPropertiesUtil(final GitPropertiesUtil gitProperties) {
-    this.gitProperties = gitProperties;
+    // gitProperties is no longer consulted; the tag is derived from propertyValue / defaultValue.
   }
 
   public String getVersion(
       final Properties properties, final String propertyName, final String defaultValue) {
-    final String branchBasedSnapshotVersion = getBranchBasedSnapshotVersion(defaultValue);
+    final String rawValue = properties.getProperty(propertyName);
+    final String effectiveValue =
+        (rawValue == null || rawValue.startsWith(UNRESOLVED_PLACEHOLDER_PREFIX))
+            ? defaultValue
+            : rawValue;
 
-    return PropertiesUtil.getPropertyOrDefault(
-        properties,
-        propertyName,
-        propertyValue ->
-            Optional.of(propertyValue)
-                .map(SEMANTIC_VERSION_PATTERN::matcher)
-                .filter(Matcher::find)
-                .flatMap(matcher -> Optional.ofNullable(matcher.group(4)))
-                .filter(label -> label.contains(SNAPSHOT_VERSION))
-                .map(snapshotLabel -> branchBasedSnapshotVersion)
-                .orElse(propertyValue),
-        branchBasedSnapshotVersion);
-  }
-
-  private String getBranchBasedSnapshotVersion(final String defaultVersion) {
-    final Matcher stableBranchMatcher =
-        STABLE_BRANCH_VERSION_PATTERN.matcher(gitProperties.getBranch());
-
-    if (stableBranchMatcher.find()) {
-      final int stableBranchMajorVersion = Integer.parseInt(stableBranchMatcher.group(2));
-      final int stableBranchMinorVersion = Integer.parseInt(stableBranchMatcher.group(3));
-      return String.format(
-          SNAPSHOT_VERSION_FORMAT,
-          stableBranchMajorVersion,
-          stableBranchMinorVersion,
-          SNAPSHOT_VERSION);
-    } else {
-      return defaultVersion;
+    final Matcher matcher = SEMANTIC_VERSION_PATTERN.matcher(effectiveValue);
+    if (matcher.find()) {
+      final String suffix = matcher.group(4);
+      if (suffix != null && suffix.contains(SNAPSHOT_VERSION)) {
+        final int major = Integer.parseInt(matcher.group(1));
+        final int minor = Integer.parseInt(matcher.group(2));
+        return String.format(SNAPSHOT_VERSION_FORMAT, major, minor, SNAPSHOT_VERSION);
+      }
     }
+    return effectiveValue;
   }
 }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtilTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtilTest.java
@@ -101,15 +101,17 @@ public class ContainerRuntimePropertiesUtilTest {
 
   @ParameterizedTest
   @CsvSource({
+    // git branch is no longer consulted - the tag is derived from the property value (the Maven
+    // ${project.version}). With no property set, the hardcoded default "SNAPSHOT" is used.
     "main, SNAPSHOT",
-    "stable/8.8, 8.8-SNAPSHOT",
-    "backport-123-to-stable/8.8, 8.8-SNAPSHOT",
+    "stable/8.8, SNAPSHOT",
+    "backport-123-to-stable/8.8, SNAPSHOT",
     " , SNAPSHOT",
     "feature-123, SNAPSHOT"
   })
-  void shouldReturnDefaultVersionsBasedOnGitBranch(
+  void shouldFallBackToDefaultSnapshotWhenPropertyValueIsUnset(
       final String branchName, final String expectedVersion) {
-    // given
+    // given - no camundaDockerImageVersion property is set
     final Properties properties = new Properties();
 
     final Properties gitProperties = new Properties();
@@ -171,30 +173,35 @@ public class ContainerRuntimePropertiesUtilTest {
 
   @ParameterizedTest
   @CsvSource({
-    // minor releases
+    // The git branch column is retained to show that the resolved tag is now branch-independent:
+    // identical property values produce identical tags regardless of the branch the test runs on.
+    // minor releases (returned as-is)
     "8.8.0, main, 8.8.0",
     "8.8.0, stable/8.8, 8.8.0",
     "8.8.0, backport-123-to-stable/8.8, 8.8.0",
     "8.8.0, , 8.8.0",
-    // patch releases
+    "8.8.0, feature-123-targeting-stable-8.8, 8.8.0",
+    // patch releases (returned as-is)
     "8.8.1, main, 8.8.1",
     "8.8.1, stable/8.8, 8.8.1",
     "8.8.1, backport-123-to-stable/8.8, 8.8.1",
     "8.8.1, , 8.8.1",
-    // SNAPSHOT versions
-    "8.9.0-SNAPSHOT, main, SNAPSHOT",
-    "8.9.0-SNAPSHOT, stable/8.8, 8.8-SNAPSHOT",
-    "8.9.0-SNAPSHOT, backport-123-to-stable/8.8, 8.8-SNAPSHOT",
-    "8.9.0-SNAPSHOT, , SNAPSHOT",
-    "8.8.1-SNAPSHOT, main, SNAPSHOT",
+    // SNAPSHOT versions: tag is MAJOR.MINOR-SNAPSHOT of the property value, branch-independent
+    "8.9.0-SNAPSHOT, main, 8.9-SNAPSHOT",
+    "8.9.0-SNAPSHOT, stable/8.8, 8.9-SNAPSHOT",
+    "8.9.0-SNAPSHOT, backport-123-to-stable/8.8, 8.9-SNAPSHOT",
+    "8.9.0-SNAPSHOT, , 8.9-SNAPSHOT",
+    "8.9.0-SNAPSHOT, feature-123-targeting-stable-8.8, 8.9-SNAPSHOT",
+    "8.8.1-SNAPSHOT, main, 8.8-SNAPSHOT",
     "8.8.1-SNAPSHOT, stable/8.8, 8.8-SNAPSHOT",
     "8.8.1-SNAPSHOT, backport-123-to-stable/8.8, 8.8-SNAPSHOT",
-    "8.8.1-SNAPSHOT, , SNAPSHOT",
-    "8.8.2-SNAPSHOT, main, SNAPSHOT",
+    "8.8.1-SNAPSHOT, , 8.8-SNAPSHOT",
+    "8.8.1-SNAPSHOT, feature-123-targeting-stable-8.8, 8.8-SNAPSHOT",
+    "8.8.2-SNAPSHOT, main, 8.8-SNAPSHOT",
     "8.8.2-SNAPSHOT, stable/8.8, 8.8-SNAPSHOT",
     "8.8.2-SNAPSHOT, backport-123-to-stable/8.8, 8.8-SNAPSHOT",
-    "8.8.2-SNAPSHOT, , SNAPSHOT",
-    // rc/alpha versions
+    "8.8.2-SNAPSHOT, , 8.8-SNAPSHOT",
+    // rc/alpha versions (returned as-is)
     "8.8.0-rc1, main, 8.8.0-rc1",
     "8.8.0-rc1, stable/8.8, 8.8.0-rc1",
     "8.8.0-rc1, backport-123-to-stable/8.8, 8.8.0-rc1",
@@ -211,7 +218,7 @@ public class ContainerRuntimePropertiesUtilTest {
     "8.8.0-alpha1-rc1, stable/8.8, 8.8.0-alpha1-rc1",
     "8.8.0-alpha1-rc1, backport-123-to-stable/8.8, 8.8.0-alpha1-rc1",
     "8.8.0-alpha1-rc1, , 8.8.0-alpha1-rc1",
-    // custom versions
+    // custom versions (returned as-is)
     "8.8.0-optimize, main, 8.8.0-optimize",
     "8.8.0-optimize, stable/8.8, 8.8.0-optimize",
     "8.8.0-optimize, backport-123-to-stable/8.8, 8.8.0-optimize",
@@ -266,30 +273,35 @@ public class ContainerRuntimePropertiesUtilTest {
 
   @ParameterizedTest
   @CsvSource({
-    // minor releases
+    // The git branch column is retained to show that the resolved tag is now branch-independent:
+    // identical property values produce identical tags regardless of the branch the test runs on.
+    // minor releases (returned as-is)
     "8.8.0, main, 8.8.0",
     "8.8.0, stable/8.8, 8.8.0",
     "8.8.0, backport-123-to-stable/8.8, 8.8.0",
     "8.8.0, , 8.8.0",
-    // patch releases
+    "8.8.0, feature-123-targeting-stable-8.8, 8.8.0",
+    // patch releases (returned as-is)
     "8.8.1, main, 8.8.1",
     "8.8.1, stable/8.8, 8.8.1",
     "8.8.1, backport-123-to-stable/8.8, 8.8.1",
     "8.8.1, , 8.8.1",
-    // SNAPSHOT versions
-    "8.9.0-SNAPSHOT, main, SNAPSHOT",
-    "8.9.0-SNAPSHOT, stable/8.8, 8.8-SNAPSHOT",
-    "8.9.0-SNAPSHOT, backport-123-to-stable/8.8, 8.8-SNAPSHOT",
-    "8.9.0-SNAPSHOT, , SNAPSHOT",
-    "8.8.1-SNAPSHOT, main, SNAPSHOT",
+    // SNAPSHOT versions: tag is MAJOR.MINOR-SNAPSHOT of the property value, branch-independent
+    "8.9.0-SNAPSHOT, main, 8.9-SNAPSHOT",
+    "8.9.0-SNAPSHOT, stable/8.8, 8.9-SNAPSHOT",
+    "8.9.0-SNAPSHOT, backport-123-to-stable/8.8, 8.9-SNAPSHOT",
+    "8.9.0-SNAPSHOT, , 8.9-SNAPSHOT",
+    "8.9.0-SNAPSHOT, feature-123-targeting-stable-8.8, 8.9-SNAPSHOT",
+    "8.8.1-SNAPSHOT, main, 8.8-SNAPSHOT",
     "8.8.1-SNAPSHOT, stable/8.8, 8.8-SNAPSHOT",
     "8.8.1-SNAPSHOT, backport-123-to-stable/8.8, 8.8-SNAPSHOT",
-    "8.8.1-SNAPSHOT, , SNAPSHOT",
-    "8.8.2-SNAPSHOT, main, SNAPSHOT",
+    "8.8.1-SNAPSHOT, , 8.8-SNAPSHOT",
+    "8.8.1-SNAPSHOT, feature-123-targeting-stable-8.8, 8.8-SNAPSHOT",
+    "8.8.2-SNAPSHOT, main, 8.8-SNAPSHOT",
     "8.8.2-SNAPSHOT, stable/8.8, 8.8-SNAPSHOT",
     "8.8.2-SNAPSHOT, backport-123-to-stable/8.8, 8.8-SNAPSHOT",
-    "8.8.2-SNAPSHOT, , SNAPSHOT",
-    // rc/alpha versions
+    "8.8.2-SNAPSHOT, , 8.8-SNAPSHOT",
+    // rc/alpha versions (returned as-is)
     "8.8.0-rc1, main, 8.8.0-rc1",
     "8.8.0-rc1, stable/8.8, 8.8.0-rc1",
     "8.8.0-rc1, backport-123-to-stable/8.8, 8.8.0-rc1",
@@ -306,7 +318,7 @@ public class ContainerRuntimePropertiesUtilTest {
     "8.8.0-alpha1-rc1, stable/8.8, 8.8.0-alpha1-rc1",
     "8.8.0-alpha1-rc1, backport-123-to-stable/8.8, 8.8.0-alpha1-rc1",
     "8.8.0-alpha1-rc1, , 8.8.0-alpha1-rc1",
-    // custom versions
+    // custom versions (returned as-is)
     "8.8.0-optimize, main, 8.8.0-optimize",
     "8.8.0-optimize, stable/8.8, 8.8.0-optimize",
     "8.8.0-optimize, backport-123-to-stable/8.8, 8.8.0-optimize",


### PR DESCRIPTION
## Summary

Fixes a CI failure pattern where PRs targeting `stable/X.Y` test their changes against the wrong Camunda Docker image (`camunda/camunda:SNAPSHOT`, built from `main`) instead of the version-matching image (`camunda/camunda:X.Y-SNAPSHOT`).

## Background

`VersionedPropertiesUtil` (in `camunda-process-test-java`) resolves the Docker image tag used by tests like `ProcessNestedUnitTest`. The previous logic matched the git branch against:

```regex
(backport-\d+-to-)?stable/(\d+)\.(\d+)
```

That matches:
- ✅ `stable/8.8`
- ✅ `backport-12345-to-stable/8.8`

But it does **not** match:
- ❌ Any custom-named PR branch targeting a stable base (e.g. `28571-handle-ilm-policies-stable-8.8`)
- ❌ Local dev branches or detached HEADs

When the regex didn't match, the resolver fell back to the hardcoded `"SNAPSHOT"` default — which is `main`'s image. So a stable/8.8 PR with a non-canonical branch name would:

1. Build `camunda-process-test-java` from stable/8.8 sources (old env vars: `CAMUNDA_DATABASE_URL`)
2. Resolve image tag as `SNAPSHOT` (wrong — should be `8.8-SNAPSHOT`)
3. Pull `camunda/camunda:SNAPSHOT` (built from `main` — expects new env vars: `CAMUNDA_DATA_SECONDARYSTORAGE_RDBMS_URL`)
4. Container starts with wrong env vars → `Rdbms.url` defaults to the ES `http://localhost:9200` → `DatabaseDriver.fromJdbcUrl` throws `'url' must start with "jdbc"`
5. Tests fail

This was the root cause behind the recurring failures tracked in [#53500](https://github.com/camunda/camunda/pull/53500) (diagnostic) and worked around in [#53598](https://github.com/camunda/camunda/pull/53598) (disabled the tests).

## Fix

Derive the tag from the `camundaDockerImageVersion` property (which is filtered from `${project.version}` at build time), not from the git branch:

| `${project.version}` | Resolved tag |
|---|---|
| `8.8.10-SNAPSHOT` | `8.8-SNAPSHOT` |
| `8.10.0-SNAPSHOT` | `8.10-SNAPSHOT` |
| `8.8.5` (released) | `8.8.5` (verbatim) |
| `${...}` placeholder (unresolved, e.g. IDE without Maven filter) | `SNAPSHOT` (fall back to defaultValue) |

This makes resolution deterministic — identical project version produces identical tag regardless of branch name. Stable-branch PRs always pull the matching `X.Y-SNAPSHOT` image. Main builds will now resolve to `:8.10-SNAPSHOT` instead of `:SNAPSHOT`; both tags are pushed by the docker-build workflow (see `.github/workflows/generate-snapshot-docker-tag.yml`), so this doesn't break anything.

The `VersionedPropertiesUtil(GitPropertiesUtil)` constructor signature is retained for binary compatibility with external callers; the arg is no longer consulted internally.

## Other places that hardcode `:SNAPSHOT`

For follow-up tracking, these locations also reference `camunda/camunda:SNAPSHOT` and are likely affected by the same class of issue when consumed on stable branches:

- `dist/.../AbstractCamundaDockerIT.java:45` — `System.getProperty("camunda.docker.test.image", "camunda/camunda:SNAPSHOT")`
- `qa/orchestration-cluster-smoke-tests/config/docker-compose.yml`, `qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml` — `${CAMUNDA_DOCKER_IMAGE:-camunda/camunda:SNAPSHOT}`
- `.github/workflows/c8-orchestration-cluster-reusable-api-tests.yml` — hardcoded `CAMUNDA_DOCKER_IMAGE=camunda/camunda:SNAPSHOT`
- `zeebe/qa/.../GatewayAuthenticationNoneIT.java:214` — bespoke `dockerImageTag.contains("SNAPSHOT") ? SNAPSHOT_TAG : dockerImageTag`

Not in scope for this PR — different ownership and a single resolver would benefit each independently. Worth tracking as a follow-up to unify image-tag resolution across the codebase.

## Test plan

- [x] Module-scoped unit tests pass: `./mvnw verify -pl testing/camunda-process-test-java -Dtest=ContainerRuntimePropertiesUtilTest -DskipITs -Dquickly` (124 tests, 0 failures)
- [x] Spotless/license format clean
- [ ] CI passes on main
- [ ] Backport to `stable/8.8` (and `stable/8.9` if applicable) — required so PR branches targeting those stable branches use the new resolver. The fix is most useful where it's missing.

## Related

- #53500 — diagnostic PR that confirmed the SNAPSHOT-image mismatch
- #53598 — temporary workaround (disabled the affected tests)
- #53592 — currently-broken stable/8.8 PR that surfaced this