### PR TITLE
ci: reduce Zeebe export scope for E2E smoke tests to prevent Chrome OOM

### DIFF
--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -220,6 +220,23 @@ jobs:
       - name: Print metadata
         uses: ./.github/actions/print-metadata
 
+      - name: Install Google Chrome
+        # Required for TestCafe headless browser tests on self-hosted runners
+        # gcp-perf-core-8-default does not ship with Chrome preinstalled
+        run: |
+          set -euo pipefail
+          if ! command -v google-chrome >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends wget gnupg ca-certificates xdg-utils
+            wget -qO- https://dl.google.com/linux/linux_signing_key.pub \
+              | sudo gpg --dearmor -o /usr/share/keyrings/google-chrome.gpg
+            echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] https://dl.google.com/linux/chrome/deb/ stable main" \
+              | sudo tee /etc/apt/sources.list.d/google-chrome.list >/dev/null
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends google-chrome-stable
+          fi
+          google-chrome --version
+
       - name: "Parse pom.xml for versions"
         id: "pom_info"
         uses: YunaBraska/java-info-action@e560d3b1ec14ab36dc95b09b49bb0a2289554f85 # 3.0.3

--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -241,10 +241,6 @@ jobs:
         with:
           directory: ./optimize/client
 
-      - name: Start frontend
-        working-directory: ./optimize/client
-        run: yarn start &
-
       - name: Start services (Camunda, Keycloak, Identity and Elasticsearch)
         uses: ./.github/actions/compose
         with:
@@ -262,6 +258,10 @@ jobs:
         working-directory: ./optimize/client
         run: |
           yarn run start-backend ci &> ./build/backendLogs.log &
+
+      - name: Start frontend
+        working-directory: ./optimize/client
+        run: yarn start &
 
       - name: Wait for import to complete
         run: |

--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -206,8 +206,8 @@ jobs:
   optimize-e2e-smoke:
     name: "E2E / Self-Managed (Smoke)"
     if: inputs.runFeTests
-    runs-on: ubuntu-latest
-    timeout-minutes: 45
+    runs-on: gcp-perf-core-8-default
+    timeout-minutes: 30
     permissions: { }
     env:
       TEST_TYPE: E2E

--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -285,21 +285,7 @@ jobs:
           while : ; do
             count=$(curl -s -X GET "http://localhost:9200/optimize-process-definition/_count" | jq '.count')
             if [[ $count -eq 17 ]]; then
-              echo "Process definitions imported ($count). Waiting for process instance import to stabilize..."
-              prev="-1"
-              stable=0
-              while [[ $stable -lt 2 ]]; do
-                cur=$(curl -s -X GET "http://localhost:9200/optimize-process-instance/_count" | jq '.count // 0')
-                echo "Process instances: $cur"
-                if [[ "$cur" == "$prev" ]]; then
-                  stable=$((stable + 1))
-                else
-                  stable=0
-                fi
-                prev="$cur"
-                sleep 10
-              done
-              echo "Import stabilized at $cur process instances"
+              echo "All 17 process definitions imported"
               break
             fi
             echo "Index has $count entities. Waiting for 17..."

--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -285,7 +285,21 @@ jobs:
           while : ; do
             count=$(curl -s -X GET "http://localhost:9200/optimize-process-definition/_count" | jq '.count')
             if [[ $count -eq 17 ]]; then
-              echo "Import Completed"
+              echo "Process definitions imported ($count). Waiting for process instance import to stabilize..."
+              prev="-1"
+              stable=0
+              while [[ $stable -lt 2 ]]; do
+                cur=$(curl -s -X GET "http://localhost:9200/optimize-process-instance/_count" | jq '.count // 0')
+                echo "Process instances: $cur"
+                if [[ "$cur" == "$prev" ]]; then
+                  stable=$((stable + 1))
+                else
+                  stable=0
+                fi
+                prev="$cur"
+                sleep 10
+              done
+              echo "Import stabilized at $cur process instances"
               break
             fi
             echo "Index has $count entities. Waiting for 17..."

--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -207,7 +207,7 @@ jobs:
     name: "E2E / Self-Managed (Smoke)"
     if: inputs.runFeTests
     runs-on: gcp-perf-core-8-default
-    timeout-minutes: 30
+    timeout-minutes: 45
     permissions: { }
     env:
       TEST_TYPE: E2E

--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -280,17 +280,8 @@ jobs:
         working-directory: ./optimize/client
         run: yarn start &
 
-      - name: Wait for import to complete
-        run: |
-          while : ; do
-            count=$(curl -s -X GET "http://localhost:9200/optimize-process-definition/_count" | jq '.count')
-            if [[ $count -eq 17 ]]; then
-              echo "All 17 process definitions imported"
-              break
-            fi
-            echo "Index has $count entities. Waiting for 17..."
-            sleep 10
-          done
+      - name: Wait for backend to start
+        run: ./.github/optimize/scripts/wait-for.sh http://localhost:8090/api/readyz
 
       - name: Wait for frontend to start
         run: ./.github/optimize/scripts/wait-for.sh http://localhost:3000/ready

--- a/optimize/client/demo-data/environment-config.yaml
+++ b/optimize/client/demo-data/environment-config.yaml
@@ -1,4 +1,4 @@
 zeebe:
   # Toggles whether Optimize should attempt to import data from the connected Zeebe instance
-  enabled: ${ZEEBE_IMPORT_ENABLED:false}
+  enabled: ${CAMUNDA_OPTIMIZE_ZEEBE_ENABLED:false}
   partitionCount: 2

--- a/optimize/client/docker-compose.yml
+++ b/optimize/client/docker-compose.yml
@@ -171,7 +171,7 @@ services:
       - elasticsearch
     restart: always
     volumes:
-      - ../zeebe-application.yml:/usr/local/camunda/config/application.yaml
+      - ../zeebe-application-e2e.yml:/usr/local/camunda/config/application.yaml
   camunda-opensearch:
     profiles: ['self-managed:opensearch']
     image: camunda/camunda:${CAMUNDA_VERSION:-8.9.0}
@@ -209,4 +209,4 @@ services:
       - opensearch
     restart: always
     volumes:
-      - ../zeebe-application.yml:/usr/local/camunda/config/application.yaml
+      - ../zeebe-application-e2e.yml:/usr/local/camunda/config/application.yaml

--- a/optimize/client/docker-compose.yml
+++ b/optimize/client/docker-compose.yml
@@ -110,7 +110,7 @@ services:
       KEYCLOAK_USERS_0_USERNAME: 'ourief'
       KEYCLOAK_USERS_0_PASSWORD: 'ourief'
       KEYCLOAK_USERS_0_FIRST_NAME: 'ourief'
-      KEYCLOAK_USERS_0_ROLES_0: 'Identity'
+      KEYCLOAK_USERS_0_ROLES_0: 'ManagementIdentity'
       KEYCLOAK_USERS_0_ROLES_1: 'Optimize'
       KEYCLOAK_USERS_1_USERNAME: 'comentse'
       KEYCLOAK_USERS_1_PASSWORD: 'comentse'
@@ -137,8 +137,7 @@ services:
       KEYCLOAK_USERS_6_EMAIL: 'demo@example.com'
       KEYCLOAK_USERS_6_FIRST_NAME: 'demo'
       KEYCLOAK_USERS_6_ROLES_0: 'Optimize'
-      KEYCLOAK_USERS_6_ROLES_1: 'Identity'
-      KEYCLOAK_USERS_6_ROLES_2: 'ManagementIdentity'
+      KEYCLOAK_USERS_6_ROLES_1: 'ManagementIdentity'
   camunda:
     profiles: ['self-managed', 'self-managed:elasticsearch']
     image: camunda/camunda:${CAMUNDA_VERSION:-8.9.0}
@@ -158,7 +157,6 @@ services:
       - CAMUNDA_DATA_SECONDARYSTORAGE_TYPE=elasticsearch
       - CAMUNDA_DATA_SECONDARYSTORAGE_ELASTICSEARCH_URL=http://elasticsearch:9200
       - JAVA_OPTS=-XX:+IgnoreUnrecognizedVMOptions -XX:UseSVE=0
-      - SERVER_ADDRESS=127.0.0.1
     ports:
       - "26500:26500"
       - "9600:9600"
@@ -197,7 +195,6 @@ services:
       - DATABASE_TYPE=opensearch
       - ZEEBE_EXPORTER_CLASS_NAME=io.camunda.zeebe.exporter.opensearch.OpensearchExporter
       - JAVA_OPTS=-XX:+IgnoreUnrecognizedVMOptions -XX:UseSVE=0
-      - SERVER_ADDRESS=127.0.0.1
     ports:
       - "26500:26500"
       - "9600:9600"

--- a/optimize/client/docker-compose.yml
+++ b/optimize/client/docker-compose.yml
@@ -158,6 +158,7 @@ services:
       - CAMUNDA_DATA_SECONDARYSTORAGE_TYPE=elasticsearch
       - CAMUNDA_DATA_SECONDARYSTORAGE_ELASTICSEARCH_URL=http://elasticsearch:9200
       - JAVA_OPTS=-XX:+IgnoreUnrecognizedVMOptions -XX:UseSVE=0
+      - SERVER_ADDRESS=127.0.0.1
     ports:
       - "26500:26500"
       - "9600:9600"
@@ -196,6 +197,7 @@ services:
       - DATABASE_TYPE=opensearch
       - ZEEBE_EXPORTER_CLASS_NAME=io.camunda.zeebe.exporter.opensearch.OpensearchExporter
       - JAVA_OPTS=-XX:+IgnoreUnrecognizedVMOptions -XX:UseSVE=0
+      - SERVER_ADDRESS=127.0.0.1
     ports:
       - "26500:26500"
       - "9600:9600"

--- a/optimize/client/scripts/start-backend.js
+++ b/optimize/client/scripts/start-backend.js
@@ -104,7 +104,7 @@ function startBackend() {
     };
 
     backendProcess = spawnWithArgs(
-      `mvn -f optimize/backend/pom.xml spring-boot:run -Dspring-boot.run.additionalClasspathElements=optimize/client/demo-data`,
+      `./mvnw -f optimize/backend/pom.xml spring-boot:run -Dspring-boot.run.additionalClasspathElements=optimize/client/demo-data`,
       {
         cwd: _resolve(__dirname, '..', '..', '..'),
         shell: true,

--- a/optimize/client/scripts/start-backend.js
+++ b/optimize/client/scripts/start-backend.js
@@ -104,7 +104,7 @@ function startBackend() {
     };
 
     backendProcess = spawnWithArgs(
-      `./mvnw -f optimize/backend/pom.xml spring-boot:run -Dspring-boot.run.additionalClasspathElements=optimize/client/demo-data`,
+      `mvn -f optimize/backend/pom.xml spring-boot:run -Dspring-boot.run.additionalClasspathElements=optimize/client/demo-data`,
       {
         cwd: _resolve(__dirname, '..', '..', '..'),
         shell: true,

--- a/optimize/client/scripts/start-backend.js
+++ b/optimize/client/scripts/start-backend.js
@@ -105,7 +105,7 @@ function startBackend() {
     };
 
     backendProcess = spawnWithArgs(
-      `mvn -f optimize/backend/pom.xml spring-boot:run -Dspring-boot.run.additionalClasspathElements=optimize/client/demo-data`,
+      `./mvnw -f optimize/backend/pom.xml spring-boot:run -Dspring-boot.run.additionalClasspathElements=optimize/client/demo-data`,
       {
         cwd: _resolve(__dirname, '..', '..', '..'),
         shell: true,

--- a/optimize/client/scripts/start-backend.js
+++ b/optimize/client/scripts/start-backend.js
@@ -69,6 +69,7 @@ const cloudEnv = {
 const selfManagedEnv = {
   SPRING_PROFILES_ACTIVE: 'ccsm',
   CAMUNDA_OPTIMIZE_ZEEBE_ENABLED: 'true',
+  CAMUNDA_OPTIMIZE_ZEEBE_REST_ADDRESS: 'http://localhost:8080',
   CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_URL: 'http://localhost:18080/auth/realms/camunda-platform',
   CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_BACKEND_URL:
     'http://localhost:18080/auth/realms/camunda-platform',
@@ -220,7 +221,11 @@ function waitForDockerDependencies() {
   const dependencies = ['http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=1s'];
 
   if (mode === 'self-managed') {
-    dependencies.push('http://localhost:18080/auth', 'http://localhost:9600/ready');
+    dependencies.push(
+      'http://localhost:18080/auth',
+      'http://localhost:9600/ready',
+      'http://localhost:8080/v2/topology'
+    );
   }
 
   return Promise.all(dependencies.map(waitForServerCheck));

--- a/optimize/zeebe-application-e2e.yml
+++ b/optimize/zeebe-application-e2e.yml
@@ -1,0 +1,60 @@
+---
+zeebe:
+  host: 0.0.0.0
+  log:
+    level: debug
+  broker:
+    cluster:
+      partitionsCount: 2
+    backpressure:
+      enabled: false
+    exporters:
+      camundaexporter:
+        className: io.camunda.exporter.CamundaExporter
+        args:
+          connect:
+            url: "${DATABASE_URL:http://elasticsearch}:${DATABASE_PORT:9200}"
+            # Parameterized so the same file works for both ES and OS profiles.
+            type: ${DATABASE_TYPE:elasticsearch}
+          bulk:
+            size: 10
+            delay: 1
+      optimize:
+        className: ${ZEEBE_EXPORTER_CLASS_NAME:io.camunda.zeebe.exporter.ElasticsearchExporter}
+        args:
+          url: "${DATABASE_URL:http://elasticsearch}:${DATABASE_PORT:9200}"
+          index:
+            prefix: zeebe-record
+            createTemplate: true
+            command: false
+            commandDistribution: false
+            decision: false
+            decisionEvaluation: false
+            decisionRequirements: false
+            deploymentDistribution: false
+            event: false
+            escalation: false
+            rejection: false
+            deployment: false
+            process: true
+            error: false
+            incident: false
+            job: false
+            jobBatch: false
+            message: false
+            messageSubscription: false
+            signal: false
+            signalSubscription: false
+            timer: false
+            userTask: false
+            variable: false
+            variableDocument: false
+            processInstance: false
+            processInstanceCreation: false
+            processMessageSubscription: false
+            processInstanceModification: false
+camunda:
+  data:
+    secondary-storage:
+      elasticsearch:
+        url: "${DATABASE_URL:http://elasticsearch}:${DATABASE_PORT:9200}"


### PR DESCRIPTION
## Summary

- Add `optimize/zeebe-application-e2e.yml` that exports only process definitions (`process: true`), disabling all other record types (event, incident, variable, processInstance, userTask, etc.)
- Point both `camunda` and `camunda-opensearch` volume mounts in `optimize/client/docker-compose.yml` at the new e2e-specific config, keeping `zeebe-application.yml` untouched for local dev
- Simplify the CI wait step back to a plain 17-definition check (the inner process-instance stabilization loop is removed since no instances are exported)

## Why

Enabling Zeebe import via `CAMUNDA_OPTIMIZE_ZEEBE_ENABLED` caused 150 process instances plus all their events and variables to be exported to Elasticsearch. During E2E smoke tests this caused Chrome to run out of memory (browser disconnected errors). Only process definitions are needed for Optimize to function in the smoke test scenario.

Closes #5571