### PR TITLE
deps: set local NPM min-release-age to 1

### DIFF
--- a/c8run/e2e_tests/.npmrc
+++ b/c8run/e2e_tests/.npmrc
@@ -1,2 +1,2 @@
-min-release-age=3
+min-release-age=1
 ignore-scripts=true

--- a/identity/client/.npmrc
+++ b/identity/client/.npmrc
@@ -1,2 +1,2 @@
-min-release-age=3
+min-release-age=1
 ignore-scripts=true

--- a/monorepo-docs-site/.npmrc
+++ b/monorepo-docs-site/.npmrc
@@ -1,1 +1,1 @@
-min-release-age=3
+min-release-age=1

--- a/operate/client/.npmrc
+++ b/operate/client/.npmrc
@@ -1,3 +1,3 @@
 install-links=true
-min-release-age=3
+min-release-age=1
 ignore-scripts=true

--- a/qa/c8-orchestration-cluster-e2e-test-suite/.npmrc
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/.npmrc
@@ -1,2 +1,2 @@
-min-release-age=3
+min-release-age=1
 ignore-scripts=true

--- a/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/.npmrc
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/.npmrc
@@ -1,2 +1,2 @@
-min-release-age=3
+min-release-age=1
 ignore-scripts=true

--- a/qa/orchestration-cluster-smoke-tests/.npmrc
+++ b/qa/orchestration-cluster-smoke-tests/.npmrc
@@ -1,2 +1,2 @@
-min-release-age=3
+min-release-age=1
 ignore-scripts=true

--- a/scripts/codeowners-utils/.npmrc
+++ b/scripts/codeowners-utils/.npmrc
@@ -1,2 +1,2 @@
-min-release-age=3
+min-release-age=1
 ignore-scripts=true

--- a/tasklist/client/.npmrc
+++ b/tasklist/client/.npmrc
@@ -1,3 +1,3 @@
 install-links=true
-min-release-age=3
+min-release-age=1
 ignore-scripts=true

--- a/testing/camunda-process-test-coverage-frontend/.npmrc
+++ b/testing/camunda-process-test-coverage-frontend/.npmrc
@@ -1,2 +1,2 @@
-min-release-age=3
+min-release-age=1
 ignore-scripts=true

--- a/webapp/client/.npmrc
+++ b/webapp/client/.npmrc
@@ -1,1 +1,1 @@
-min-release-age=3
+min-release-age=1


### PR DESCRIPTION
## Description

As discussed on [this thread](https://camunda.slack.com/archives/C01H4NG9XDY/p1779281998639319) we agreed to reduce the NPM config `min-release-age` to 1 day since it adds a lot of friction when pushing CVE fixes in some cases
