### PR TITLE
feat: add functionality to cleanup legacy indexes

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/DocumentBasedSecondaryStorageDatabase.java
+++ b/configuration/src/main/java/io/camunda/configuration/DocumentBasedSecondaryStorageDatabase.java
@@ -72,6 +72,9 @@ public abstract class DocumentBasedSecondaryStorageDatabase
   /** Whether to create the schema automatically */
   private boolean createSchema = true;
 
+  /** Whether to schedule the cleanup of legacy indexes */
+  private boolean performCleanup = false;
+
   @NestedConfigurationProperty
   private IncidentNotifier incidentNotifier = new IncidentNotifier(databaseName());
 
@@ -177,6 +180,14 @@ public abstract class DocumentBasedSecondaryStorageDatabase
 
   public void setCreateSchema(final boolean createSchema) {
     this.createSchema = createSchema;
+  }
+
+  public boolean isPerformCleanup() {
+    return performCleanup;
+  }
+
+  public void setPerformCleanup(final boolean performCleanup) {
+    this.performCleanup = performCleanup;
   }
 
   public Cache getBatchOperationCache() {

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineSchemaManagerPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineSchemaManagerPropertiesOverride.java
@@ -50,6 +50,17 @@ public class SearchEngineSchemaManagerPropertiesOverride {
     override.setVersionCheckRestrictionEnabled(
         unifiedConfiguration.getCamunda().getSystem().getUpgrade().getEnableVersionCheck());
 
+    /* Clean-up properties */
+    unifiedConfiguration
+        .getCamunda()
+        .getData()
+        .getSecondaryStorage()
+        .getElasticsearchOrOpensearch()
+        .ifPresent(
+            secondaryStorage -> {
+              override.setPerformCleanup(secondaryStorage.isPerformCleanup());
+            });
+
     return override;
   }
 }

--- a/configuration/src/test/java/io/camunda/configuration/SchemaManagerPropertiesTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SchemaManagerPropertiesTest.java
@@ -33,6 +33,8 @@ public class SchemaManagerPropertiesTest {
   @TestPropertySource(
       properties = {
         "camunda.system.upgrade.enable-version-check=false",
+        /* clean-up config */
+        "camunda.data.secondary-storage.elasticsearch.perform-cleanup=true"
       })
   class WithUnifiedConfigSet {
     final BrokerBasedProperties brokerBasedProperties;
@@ -54,6 +56,11 @@ public class SchemaManagerPropertiesTest {
     void shouldSetBrokerVersionCheckRestrictionEnabled() {
       assertThat(brokerBasedProperties.getExperimental().isVersionCheckRestrictionEnabled())
           .isFalse();
+    }
+
+    @Test
+    void shouldSetCleanupProperties() {
+      assertThat(searchEngineSchemaManagerProperties.isPerformCleanup()).isTrue();
     }
   }
 

--- a/schema-manager/src/main/java/io/camunda/search/schema/SchemaCleanup.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/SchemaCleanup.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.schema;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Helper class for cleaning up legacy Elasticsearch/OpenSearch indices that are no longer used.
+ *
+ * <p>These indices were created by Operate and Tasklist prior to the 8.8 architectural changes that
+ * introduced the unified Camunda Exporter and harmonized index schema. They are no longer written
+ * to or read from, but may still exist in clusters that have been upgraded.
+ *
+ * <p>Cleanup is performed asynchronously by the search engine, avoiding any blocking or performance
+ * impact at startup.
+ *
+ * <p>When {@code performCleanup} is {@code false}, the helper runs in dry-run mode: it detects
+ * legacy indices and logs them, but does not delete any data. Set {@code performCleanup=true} to
+ * enable actual cleanup.
+ */
+public class SchemaCleanup {
+
+  protected static final Set<String> CLEANUP_INDEXES =
+      Set.of(
+          "tasklist-process-8.4.0_",
+          "operate-user-1.2.0_",
+          "tasklist-variable-8.3.0_",
+          "tasklist-import-position-8.2.0_",
+          "tasklist-flownode-instance-8.3.0_",
+          "operate-web-session-1.1.0_",
+          "tasklist-metric-8.3.0_",
+          "operate-import-position-8.3.0_",
+          "operate-migration-steps-repository-1.1.0_",
+          "tasklist-web-session-1.1.0_",
+          "tasklist-user-1.4.0_",
+          "operate-user-task-8.5.0_",
+          "tasklist-process-instance-8.3.0_",
+          "operate-metric-8.3.0_",
+          "tasklist-migration-steps-repository-1.1.0_",
+          "tasklist-list-view-8.6.0_");
+
+  private static final String INSTRUCTIONS_1 =
+      "The following indices are legacy and could be cleaned up:\n";
+  private static final String INSTRUCTIONS_2 =
+      "Delete these indices or set camunda.data.secondary-storage.%s.perform-cleanup=true"
+          + " to perform the cleanup.\n";
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SchemaCleanup.class);
+
+  private final boolean performCleanup;
+  private final SearchEngineClient searchEngineClient;
+
+  public SchemaCleanup(final boolean performCleanup, final SearchEngineClient searchEngineClient) {
+    this.performCleanup = performCleanup;
+    this.searchEngineClient = searchEngineClient;
+  }
+
+  public Set<String> performCleanup() {
+    /* Find the potential legacy indexes */
+
+    final Set<String> legacyIndexes =
+        searchEngineClient.getIndexNames(String.join(",", CLEANUP_INDEXES));
+
+    if (legacyIndexes.isEmpty()) {
+      LOGGER.debug("No legacy indexes found.");
+      return legacyIndexes;
+    }
+
+    final StringBuilder logMessageBuilder = new StringBuilder();
+    if (!performCleanup) {
+      /* Sort the list, so that they are grouped by index prefix */
+      final List<String> sortedLegacyIndexes = legacyIndexes.stream().sorted().toList();
+      logMessageBuilder.append(INSTRUCTIONS_1);
+
+      for (final String legacyIndex : sortedLegacyIndexes) {
+        logMessageBuilder.append(legacyIndex);
+        logMessageBuilder.append("\n");
+      }
+
+      logMessageBuilder.append(
+          String.format(INSTRUCTIONS_2, searchEngineClient.getEngineName().toLowerCase()));
+      LOGGER.warn(logMessageBuilder.toString());
+      return legacyIndexes;
+    }
+
+    /* Do the cleanups */
+
+    final Set<String> deletedIndexes = new HashSet<>();
+    for (final String legacyIndex : legacyIndexes) {
+      if (searchEngineClient.deleteIndexIfExists(legacyIndex)) {
+        deletedIndexes.add(legacyIndex);
+        LOGGER.info("Legacy index '{}' cleaned up.", legacyIndex);
+      }
+    }
+
+    return deletedIndexes;
+  }
+}

--- a/schema-manager/src/main/java/io/camunda/search/schema/SchemaManager.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/SchemaManager.java
@@ -129,6 +129,9 @@ public class SchemaManager implements CloseableSilently {
           "Will not make any changes to indices and index templates as [createSchema] is false");
       return;
     }
+
+    startSchemaCleanup();
+
     final var timer =
         ofNullable(schemaManagerMetrics)
             .map(SchemaManagerMetrics::startSchemaInitTimer)
@@ -250,6 +253,13 @@ public class SchemaManager implements CloseableSilently {
       searchEngineClient.putIndexLifeCyclePolicy(
           retention.getUsageMetricsPolicyName(), retention.getUsageMetricsMinimumAge());
     }
+  }
+
+  private void startSchemaCleanup() {
+    LOG.debug("Starting legacy indexes cleanup...");
+    final boolean performCleanup = config.schemaManager().isPerformCleanup();
+    final SchemaCleanup schemaCleanup = new SchemaCleanup(performCleanup, searchEngineClient);
+    CompletableFuture.runAsync(schemaCleanup::performCleanup, virtualThreadExecutor);
   }
 
   private void updateSchemaSettings() {

--- a/schema-manager/src/main/java/io/camunda/search/schema/SearchEngineClient.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/SearchEngineClient.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.util.CloseableSilently;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public interface SearchEngineClient extends CloseableSilently {
   void createIndex(final IndexDescriptor indexDescriptor, final IndexConfiguration settings);
@@ -51,6 +52,16 @@ public interface SearchEngineClient extends CloseableSilently {
 
   void deleteIndex(final String indexName);
 
+  /**
+   * Deletes the index with the given name if it exists, using a single request rather than a
+   * separate existence check followed by deletion. This avoids any potential race condition between
+   * checking and deleting.
+   *
+   * @param indexName the name of the index to delete
+   * @return {@code true} if the index was deleted, {@code false} if it did not exist
+   */
+  boolean deleteIndexIfExists(final String indexName);
+
   void truncateIndex(final String indexName);
 
   boolean isHealthy();
@@ -81,4 +92,17 @@ public interface SearchEngineClient extends CloseableSilently {
    */
   void upsertDocument(
       final String indexName, final String documentId, final Map<String, Object> document);
+
+  /**
+   * Retrieve all index names matching a given pattern
+   *
+   * @param pattern the pattern to match index names against (supports wildcards, e.g. *foo*)
+   * @return a set of matching index names
+   */
+  Set<String> getIndexNames(final String pattern);
+
+  /**
+   * @return the name of the engine.
+   */
+  String getEngineName();
 }

--- a/schema-manager/src/main/java/io/camunda/search/schema/config/SchemaManagerConfiguration.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/config/SchemaManagerConfiguration.java
@@ -15,6 +15,7 @@ public class SchemaManagerConfiguration {
   private boolean isCreateSchema = true;
   private SchemaManagerRetryConfiguration retry = new SchemaManagerRetryConfiguration();
   private boolean versionCheckRestrictionEnabled = true;
+  private boolean performCleanup = false;
 
   public boolean isCreateSchema() {
     return isCreateSchema;
@@ -38,6 +39,14 @@ public class SchemaManagerConfiguration {
 
   public void setVersionCheckRestrictionEnabled(final boolean versionCheckRestrictionEnabled) {
     this.versionCheckRestrictionEnabled = versionCheckRestrictionEnabled;
+  }
+
+  public boolean isPerformCleanup() {
+    return performCleanup;
+  }
+
+  public void setPerformCleanup(final boolean performCleanup) {
+    this.performCleanup = performCleanup;
   }
 
   public static class SchemaManagerRetryConfiguration extends RetryConfiguration {

--- a/schema-manager/src/main/java/io/camunda/search/schema/elasticsearch/ElasticsearchEngineClient.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/elasticsearch/ElasticsearchEngineClient.java
@@ -38,6 +38,7 @@ import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.JsonpSerializable;
 import co.elastic.clients.json.jackson.JacksonJsonpGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.search.connect.configuration.DatabaseConfig;
 import io.camunda.search.schema.IndexMapping;
 import io.camunda.search.schema.IndexMappingProperty;
 import io.camunda.search.schema.MappingSource;
@@ -55,6 +56,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -279,6 +281,20 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
   }
 
   @Override
+  public boolean deleteIndexIfExists(final String indexName) {
+    try {
+      deleteIndex(indexName);
+      return true;
+    } catch (final ElasticsearchException e) {
+      if (e.status() == 404) {
+        return false;
+      }
+
+      throw e;
+    }
+  }
+
+  @Override
   public void truncateIndex(final String indexName) {
     final DeleteByQueryRequest deleteByQueryRequest =
         new DeleteByQueryRequest.Builder()
@@ -387,6 +403,27 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
                                 del.minAge(m -> m.time(deletionMinAge))
                                     .actions(a -> a.delete(DeleteAction.of(d -> d))))))
         .build();
+  }
+
+  @Override
+  public Set<String> getIndexNames(final String pattern) {
+    try {
+      return new HashSet<>(
+          client
+              .indices()
+              .get(req -> req.index(pattern).ignoreUnavailable(true))
+              .result()
+              .keySet());
+    } catch (final IOException | ElasticsearchException e) {
+      final var errMsg = String.format("Failed to retrieve index names for pattern '%s'", pattern);
+      LOG.error(errMsg, e);
+      throw new SearchEngineException(errMsg, e);
+    }
+  }
+
+  @Override
+  public String getEngineName() {
+    return DatabaseConfig.ELASTICSEARCH;
   }
 
   private Map<String, TypeMapping> getCurrentMappings(

--- a/schema-manager/src/main/java/io/camunda/search/schema/opensearch/OpensearchEngineClient.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/opensearch/OpensearchEngineClient.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.camunda.search.connect.configuration.DatabaseConfig;
 import io.camunda.search.schema.IndexMapping;
 import io.camunda.search.schema.IndexMappingProperty;
 import io.camunda.search.schema.MappingSource;
@@ -32,6 +33,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -304,6 +306,20 @@ public class OpensearchEngineClient implements SearchEngineClient {
     } catch (final IOException ioe) {
       final var errMsg = String.format("Index [%s] was not deleted", indexName);
       throw new SearchEngineException(errMsg, ioe);
+    }
+  }
+
+  @Override
+  public boolean deleteIndexIfExists(final String indexName) {
+    try {
+      deleteIndex(indexName);
+      return true;
+    } catch (final OpenSearchException e) {
+      if (e.status() == 404) {
+        return false;
+      }
+
+      throw e;
     }
   }
 
@@ -732,6 +748,27 @@ public class OpensearchEngineClient implements SearchEngineClient {
         throw new RuntimeException(e);
       }
     }
+  }
+
+  @Override
+  public Set<String> getIndexNames(final String pattern) {
+    try {
+      return new HashSet<>(
+          client
+              .indices()
+              .get(req -> req.index(pattern).ignoreUnavailable(true))
+              .result()
+              .keySet());
+    } catch (final IOException | OpenSearchException e) {
+      final var errMsg = String.format("Failed to retrieve index names for pattern [%s]", pattern);
+      LOG.error(errMsg, e);
+      throw new SearchEngineException(errMsg, e);
+    }
+  }
+
+  @Override
+  public String getEngineName() {
+    return DatabaseConfig.OPENSEARCH;
   }
 
   record ISMPolicyState(boolean exists, int seqNo, int primaryTerm) {

--- a/schema-manager/src/test/java/io/camunda/search/schema/ElasticsearchSchemaCleanupIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/ElasticsearchSchemaCleanupIT.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.schema;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.indices.CreateIndexRequest;
+import co.elastic.clients.elasticsearch.indices.GetIndexRequest;
+import co.elastic.clients.elasticsearch.indices.GetIndexResponse;
+import io.camunda.search.connect.configuration.ConnectConfiguration;
+import io.camunda.search.connect.es.ElasticsearchConnector;
+import io.camunda.search.schema.elasticsearch.ElasticsearchEngineClient;
+import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Set;
+import org.agrona.CloseHelper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+public class ElasticsearchSchemaCleanupIT {
+
+  private static final Set<String> LEGACY_INDEXES =
+      Set.of("tasklist-process-8.4.0_", "operate-user-1.2.0_");
+  private static final Set<String> UNAFFECTED_INDEXES =
+      Set.of("operate-list-view-8.3.0_", "operate-variable-8.3.0_");
+
+  @Container
+  private static final ElasticsearchContainer ES_CONTAINER =
+      TestSearchContainers.createDefaultElasticsearchContainer();
+
+  private ConnectConfiguration connectConfig;
+  private ElasticsearchClient esClient;
+  private SearchEngineClient esEngineClient;
+
+  @BeforeEach
+  void setup() throws IOException {
+    connectConfig = new ConnectConfiguration();
+    connectConfig.setUrl(ES_CONTAINER.getHttpHostAddress());
+    final var esConnector = new ElasticsearchConnector(connectConfig);
+    esClient = esConnector.createClient();
+    esEngineClient = new ElasticsearchEngineClient(esClient, esConnector.objectMapper());
+
+    clearDatabase();
+  }
+
+  @AfterEach
+  public void teardown() {
+    CloseHelper.quietCloseAll(esClient, esEngineClient);
+  }
+
+  @Test
+  void shouldCleanupLegacyIndexes() throws IOException {
+    /* Creation of some legacy indexes and some unaffected indexes */
+
+    for (final String legacyIndex : LEGACY_INDEXES) {
+      createIndex(legacyIndex);
+    }
+    for (final String unaffectedIndex : UNAFFECTED_INDEXES) {
+      createIndex(unaffectedIndex);
+    }
+
+    /* Trigger the cleanup */
+
+    final SchemaCleanup schemaCleanup = new SchemaCleanup(true, esEngineClient);
+    schemaCleanup.performCleanup();
+
+    /* Wait and verify that the legacy indexes are gone */
+
+    await()
+        .atMost(Duration.ofMinutes(1))
+        .pollInterval(Duration.ofSeconds(1))
+        .untilAsserted(
+            () -> {
+              final Set<String> indexes = fetchAllIndexes();
+              assertThat(indexes).containsAll(UNAFFECTED_INDEXES);
+              assertThat(indexes).doesNotContainAnyElementsOf(LEGACY_INDEXES);
+            });
+  }
+
+  private void createIndex(final String indexName) throws IOException {
+    final CreateIndexRequest request = new CreateIndexRequest.Builder().index(indexName).build();
+    esClient.indices().create(request);
+  }
+
+  private Set<String> fetchAllIndexes() throws IOException {
+    final GetIndexRequest request = new GetIndexRequest.Builder().index("*").build();
+    final GetIndexResponse response = esClient.indices().get(request);
+    return response.result().keySet();
+  }
+
+  private void clearDatabase() throws IOException {
+    esClient.indices().delete(req -> req.index("*"));
+    esClient.indices().deleteIndexTemplate(req -> req.name("*"));
+  }
+}

--- a/schema-manager/src/test/java/io/camunda/search/schema/OpenSearchSchemaCleanupIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/OpenSearchSchemaCleanupIT.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.schema;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.camunda.search.connect.configuration.ConnectConfiguration;
+import io.camunda.search.connect.os.OpensearchConnector;
+import io.camunda.search.schema.opensearch.OpensearchEngineClient;
+import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Set;
+import org.agrona.CloseHelper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch.indices.CreateIndexRequest;
+import org.opensearch.client.opensearch.indices.GetIndexRequest;
+import org.opensearch.client.opensearch.indices.GetIndexResponse;
+import org.opensearch.testcontainers.OpenSearchContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+public class OpenSearchSchemaCleanupIT {
+
+  private static final Set<String> LEGACY_INDEXES =
+      Set.of("tasklist-process-8.4.0_", "operate-user-1.2.0_");
+  private static final Set<String> UNAFFECTED_INDEXES =
+      Set.of("operate-list-view-8.3.0_", "operate-variable-8.3.0_");
+
+  @Container
+  private static final OpenSearchContainer OS_CONTAINER =
+      TestSearchContainers.createDefaultOpensearchContainer();
+
+  private ConnectConfiguration connectConfig;
+  private OpenSearchClient osClient;
+  private SearchEngineClient osEngineClient;
+
+  @BeforeEach
+  void setup() throws IOException {
+    connectConfig = new ConnectConfiguration();
+    connectConfig.setUrl(OS_CONTAINER.getHttpHostAddress());
+    final var osConnector = new OpensearchConnector(connectConfig);
+    osClient = osConnector.createClient();
+    osEngineClient = new OpensearchEngineClient(osClient, osConnector.objectMapper());
+
+    clearDatabase();
+  }
+
+  @AfterEach
+  public void teardown() {
+    CloseHelper.quietCloseAll(osEngineClient);
+  }
+
+  @Test
+  void shouldCleanupLegacyIndexes() throws IOException {
+    /* Creation of some legacy indexes and some unaffected indexes */
+
+    for (final String legacyIndex : LEGACY_INDEXES) {
+      createIndex(legacyIndex);
+    }
+    for (final String unaffectedIndex : UNAFFECTED_INDEXES) {
+      createIndex(unaffectedIndex);
+    }
+
+    /* Trigger the cleanup */
+
+    final SchemaCleanup schemaCleanup = new SchemaCleanup(true, osEngineClient);
+    schemaCleanup.performCleanup();
+
+    /* Wait and verify that the legacy indexes are gone */
+
+    await()
+        .atMost(Duration.ofMinutes(1))
+        .pollInterval(Duration.ofSeconds(1))
+        .untilAsserted(
+            () -> {
+              final Set<String> indexes = fetchAllIndexes();
+              assertThat(indexes).containsAll(UNAFFECTED_INDEXES);
+              assertThat(indexes).doesNotContainAnyElementsOf(LEGACY_INDEXES);
+            });
+  }
+
+  private void createIndex(final String indexName) throws IOException {
+    final CreateIndexRequest request = new CreateIndexRequest.Builder().index(indexName).build();
+    osClient.indices().create(request);
+  }
+
+  private Set<String> fetchAllIndexes() throws IOException {
+    final GetIndexRequest request = new GetIndexRequest.Builder().index("*").build();
+    final GetIndexResponse response = osClient.indices().get(request);
+    return response.result().keySet();
+  }
+
+  private void clearDatabase() throws IOException {
+    osClient.indices().delete(req -> req.index("*"));
+    osClient.indices().deleteIndexTemplate(req -> req.name("*"));
+  }
+}

--- a/schema-manager/src/test/java/io/camunda/search/schema/SchemaCleanupTest.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/SchemaCleanupTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.schema;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class SchemaCleanupTest {
+  private SearchEngineClient mockSearchEngineClient;
+
+  @BeforeEach
+  void setup() {
+    mockSearchEngineClient = mock(SearchEngineClient.class);
+    when(mockSearchEngineClient.getEngineName()).thenReturn("elasticsearch");
+  }
+
+  @Test
+  void shouldNotMakeChangesWhenPerformCleanupIsFalse() {
+    final SchemaCleanup schemaCleanup = new SchemaCleanup(false, mockSearchEngineClient);
+
+    /* stub getIndexNames(String) for test purposes */
+    when(mockSearchEngineClient.getIndexNames(anyString()))
+        .thenAnswer(
+            invocation -> {
+              final String pattern = invocation.getArgument(0);
+              return Set.of(pattern.split(","));
+            });
+
+    schemaCleanup.performCleanup();
+
+    /* the path to delete the indexes is not followed */
+    verify(mockSearchEngineClient, never()).deleteIndexIfExists(any());
+  }
+
+  @Test
+  void shouldMakeChangesWhenPerformCleanupIsTrue() {
+    final SchemaCleanup schemaCleanup = new SchemaCleanup(true, mockSearchEngineClient);
+
+    /* stub getIndexNames(String) for test purposes */
+    when(mockSearchEngineClient.getIndexNames(anyString()))
+        .thenAnswer(
+            invocation -> {
+              final String pattern = invocation.getArgument(0);
+              return Set.of(pattern.split(","));
+            });
+
+    schemaCleanup.performCleanup();
+
+    /* the path to delete the indexes is followed */
+    for (final String indexToDelete : SchemaCleanup.CLEANUP_INDEXES) {
+      verify(mockSearchEngineClient).deleteIndexIfExists(indexToDelete);
+    }
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Adds a functionality that schedules the cleanup of legacy indexes, if configured.

Context:
https://github.com/camunda/camunda/issues/46371

The use case of this functionality is expected to be as follows:
* the application starts, and without explicit configuration, the clean-up of the legacy indexes is setup in dry-run mode, therefore no changes will be done to the schema
* if legacy indexes are found, they are output in the log as warnings, saying that the indexes could be cleaned up, if the configuration is set. The configuration is also logged, so that the customer has easy access to it
* if the configuration is set, at the next restart, the application will delete the indexes asynchronously
* the possibility to specify an index prefix is also viable

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes https://github.com/camunda/camunda/issues/46371
