### PR TITLE
fix: Updated x-properties-added-in-version annotation for scopeKey 

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/expression.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/expression.yaml
@@ -68,6 +68,9 @@ components:
             y: 20
           additionalProperties: true
           nullable: true
+      x-properties-added-in-version:
+        - propertyName: scopeKey
+          addedInVersion: "8.10"
     ExpressionEvaluationResult:
       type: object
       required:


### PR DESCRIPTION
Updated `x-properties-added-in-version` annotation for `scopeKey` in `expression.yaml`. Only location in the current main with a missing annotation.

## Description
This specific case would help in confirming if the docs are parsing 'x-properties-added-in-version' correctly in the latest build. It should to be merged before this [PR](https://github.com/camunda/camunda/pull/53571).
<!-- Describe the goal and purpose of this PR. -->
