### PR TITLE
feat: Add Engine DMN Ordinal Support

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -150,7 +150,10 @@ public final class EngineProcessors {
 
     final var decisionBehavior =
         new DecisionBehavior(
-            DecisionEngineFactory.createDecisionEngine(), processingState, processEngineMetrics);
+            DecisionEngineFactory.createDecisionEngine(),
+            processingState,
+            ordinalKeyProvider,
+            processEngineMetrics);
     final var authCheckBehavior =
         new AuthorizationCheckBehavior(processingState, securityConfig, config);
     final var asyncRequestBehavior =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnDecisionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnDecisionBehavior.java
@@ -179,7 +179,8 @@ public final class BpmnDecisionBehavior {
         .setProcessInstanceKey(context.getProcessInstanceKey())
         .setElementInstanceKey(context.getElementInstanceKey())
         .setElementId(context.getElementId())
-        .setRootProcessInstanceKey(context.getRootProcessInstanceKey());
+        .setRootProcessInstanceKey(context.getRootProcessInstanceKey())
+        .setOrdinalKey(context.getOrdinalKey());
 
     stateWriter.appendFollowUpEvent(
         newDecisionEvaluationKey,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
@@ -191,7 +191,8 @@ public final class BpmnUserTaskBehavior {
             .setPriority(userTaskProperties.getPriority())
             .setCreationTimestamp(clock.millis())
             .setTags(getTagsFromProcessInstance(context))
-            .setRootProcessInstanceKey(context.getRootProcessInstanceKey());
+            .setRootProcessInstanceKey(context.getRootProcessInstanceKey())
+            .setOrdinalKey(context.getOrdinalKey());
 
     stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.CREATING, userTaskRecord);
     return userTaskRecord;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/DecisionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/DecisionBehavior.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.dmn.MatchedRule;
 import io.camunda.zeebe.dmn.ParsedDecisionRequirementsGraph;
 import io.camunda.zeebe.dmn.impl.VariablesContext;
 import io.camunda.zeebe.engine.metrics.ProcessEngineMetrics;
+import io.camunda.zeebe.engine.processing.ordinals.OrdinalKeyProvider;
 import io.camunda.zeebe.engine.state.deployment.DeployedDrg;
 import io.camunda.zeebe.engine.state.deployment.PersistedDecision;
 import io.camunda.zeebe.engine.state.immutable.DecisionState;
@@ -44,15 +45,18 @@ public class DecisionBehavior {
   private static final String SYNTHESIZED_RULE_ID_TEMPLATE = "%s_%s_v%s_r%s";
   private final DecisionEngine decisionEngine;
   private final DecisionState decisionState;
+  private final OrdinalKeyProvider ordinalKeyProvider;
   private final ProcessEngineMetrics metrics;
 
   public DecisionBehavior(
       final DecisionEngine decisionEngine,
       final ProcessingState processingState,
+      final OrdinalKeyProvider ordinalKeyProvider,
       final ProcessEngineMetrics metrics) {
 
     decisionState = processingState.getDecisionState();
     this.decisionEngine = decisionEngine;
+    this.ordinalKeyProvider = ordinalKeyProvider;
     this.metrics = metrics;
   }
 
@@ -147,7 +151,8 @@ public class DecisionBehavior {
             .setDecisionVersion(decision.getVersion())
             .setDecisionRequirementsKey(decision.getDecisionRequirementsKey())
             .setDecisionRequirementsId(decision.getDecisionRequirementsId())
-            .setTenantId(decision.getTenantId());
+            .setTenantId(decision.getTenantId())
+            .setOrdinalKey(ordinalKeyProvider.getOrdinal(decisionEvaluationKey));
 
     final var decisionKeysByDecisionId =
         decisionState

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/FakeOrdinalIndexLocatorProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/FakeOrdinalIndexLocatorProvider.java
@@ -44,7 +44,7 @@ public class FakeOrdinalIndexLocatorProvider implements IndexLocatorProvider {
   @Override
   public IndexLocator createIndexLocator(final Record<?> record) {
     if (record.getValue() instanceof final OrdinalKeyBased ordinalKeyBased) {
-      final var suffix = getOrCreateOrdinalSuffix(ordinalKeyBased.getOrdinalKey());
+      final var suffix = getOrCreateOrdinalSuffix("ord", ordinalKeyBased.getOrdinalKey());
       return new SingleSuffixOrdinalIndexLocator(suffix);
     } else {
       LOGGER.warn(
@@ -61,7 +61,7 @@ public class FakeOrdinalIndexLocatorProvider implements IndexLocatorProvider {
       final long rootProcessInstanceKey = processInstanceRelated.getRootProcessInstanceKey();
       if (rootProcessInstanceKey > 0) {
         final int ordinal = getOrdinal(rootProcessInstanceKey);
-        final var suffix = getOrCreateOrdinalSuffix(ordinal);
+        final var suffix = getOrCreateOrdinalSuffix("exp", ordinal);
         return new SingleSuffixOrdinalIndexLocator(suffix);
       }
     } else {
@@ -71,7 +71,8 @@ public class FakeOrdinalIndexLocatorProvider implements IndexLocatorProvider {
             rootProcessInstanceIdsByKey.entrySet().stream()
                 .collect(
                     Collectors.toMap(
-                        Entry::getKey, entry -> getOrdinalSuffixForRootPI(entry.getValue())));
+                        Entry::getKey,
+                        entry -> getOrdinalSuffixForRootPI("exp", entry.getValue())));
         return new MultiSuffixOrdinalIndexLocator(suffixesByKey);
       }
     }
@@ -95,9 +96,9 @@ public class FakeOrdinalIndexLocatorProvider implements IndexLocatorProvider {
     return Map.of();
   }
 
-  private String getOrdinalSuffixForRootPI(final long rootProcessInstanceKey) {
+  private String getOrdinalSuffixForRootPI(final String prefix, final long rootProcessInstanceKey) {
     final int ordinal = getOrdinal(rootProcessInstanceKey);
-    return getOrCreateOrdinalSuffix(ordinal);
+    return getOrCreateOrdinalSuffix(prefix, ordinal);
   }
 
   private static int getOrdinal(final long rootProcessInstanceKey) {
@@ -105,10 +106,10 @@ public class FakeOrdinalIndexLocatorProvider implements IndexLocatorProvider {
     return (int) (key / IDS_PER_ORDINAL);
   }
 
-  private String getOrCreateOrdinalSuffix(final int ordinal) {
+  private String getOrCreateOrdinalSuffix(final String prefix, final int ordinal) {
     var suffix = ordinalSuffixes.get(ordinal);
     if (suffix == null) {
-      final var newSuffix = createOrdinalSuffix(ordinal);
+      final var newSuffix = createOrdinalSuffix(prefix, ordinal);
       suffix = ordinalSuffixes.putIfAbsent(ordinal, newSuffix);
       if (suffix == null) {
         LOGGER.info("New ordinal started: {} ({} ordinals total)", ordinal, ordinalSuffixes.size());
@@ -118,8 +119,8 @@ public class FakeOrdinalIndexLocatorProvider implements IndexLocatorProvider {
     return suffix;
   }
 
-  private String createOrdinalSuffix(final int ordinal) {
-    return "ord" + Strings.padStart(String.valueOf(ordinal), 5, '0');
+  private String createOrdinalSuffix(final String prefix, final int ordinal) {
+    return prefix + Strings.padStart(String.valueOf(ordinal), 5, '0');
   }
 
   static class NoopIndexLocator implements IndexLocator {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/DecisionEvaluationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/DecisionEvaluationRecord.java
@@ -62,9 +62,10 @@ public final class DecisionEvaluationRecord extends UnifiedRecordValue
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   private final LongProperty rootProcessInstanceKeyProp =
       new LongProperty("rootProcessInstanceKey", -1L);
+  private final IntegerProperty ordinalKeyProp = new IntegerProperty("ordinalKey", 0);
 
   public DecisionEvaluationRecord() {
-    super(18);
+    super(19);
     declareProperty(decisionKeyProp)
         .declareProperty(decisionIdProp)
         .declareProperty(decisionNameProp)
@@ -82,7 +83,8 @@ public final class DecisionEvaluationRecord extends UnifiedRecordValue
         .declareProperty(evaluationFailureMessageProp)
         .declareProperty(failedDecisionIdProp)
         .declareProperty(tenantIdProp)
-        .declareProperty(rootProcessInstanceKeyProp);
+        .declareProperty(rootProcessInstanceKeyProp)
+        .declareProperty(ordinalKeyProp);
   }
 
   @Override
@@ -267,6 +269,16 @@ public final class DecisionEvaluationRecord extends UnifiedRecordValue
 
   public DecisionEvaluationRecord setRootProcessInstanceKey(final long rootProcessInstanceKey) {
     rootProcessInstanceKeyProp.setValue(rootProcessInstanceKey);
+    return this;
+  }
+
+  @Override
+  public int getOrdinalKey() {
+    return ordinalKeyProp.getValue();
+  }
+
+  public DecisionEvaluationRecord setOrdinalKey(final int ordinalKey) {
+    ordinalKeyProp.setValue(ordinalKey);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2225,7 +2225,8 @@ final class JsonSerializableToJsonTest {
                   "evaluationFailureMessage":"evaluation-failure-message",
                   "failedDecisionId":"failed-decision-id",
                   "tenantId": "<default>",
-                  "rootProcessInstanceKey": 6
+                  "rootProcessInstanceKey": 6,
+                  "ordinalKey": 0
                 }
                 """
       },
@@ -2337,7 +2338,8 @@ final class JsonSerializableToJsonTest {
                   "evaluationFailureMessage":"evaluation-failure-message",
                   "failedDecisionId":"failed-decision-id",
                   "tenantId": "tenant-test",
-                  "rootProcessInstanceKey": 6
+                  "rootProcessInstanceKey": 6,
+                  "ordinalKey": 0
                 }
                 """
       },
@@ -2369,7 +2371,8 @@ final class JsonSerializableToJsonTest {
                   "evaluationFailureMessage":"",
                   "failedDecisionId":"",
                   "tenantId": "<default>",
-                  "rootProcessInstanceKey": -1
+                  "rootProcessInstanceKey": -1,
+                  "ordinalKey": 0
                 }
                 """
       },

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/DecisionEvaluationRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/DecisionEvaluationRecord.golden
@@ -62,9 +62,10 @@ public final class DecisionEvaluationRecord extends UnifiedRecordValue
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   private final LongProperty rootProcessInstanceKeyProp =
       new LongProperty("rootProcessInstanceKey", -1L);
+  private final IntegerProperty ordinalKeyProp = new IntegerProperty("ordinalKey", 0);
 
   public DecisionEvaluationRecord() {
-    super(18);
+    super(19);
     declareProperty(decisionKeyProp)
         .declareProperty(decisionIdProp)
         .declareProperty(decisionNameProp)
@@ -82,7 +83,8 @@ public final class DecisionEvaluationRecord extends UnifiedRecordValue
         .declareProperty(evaluationFailureMessageProp)
         .declareProperty(failedDecisionIdProp)
         .declareProperty(tenantIdProp)
-        .declareProperty(rootProcessInstanceKeyProp);
+        .declareProperty(rootProcessInstanceKeyProp)
+        .declareProperty(ordinalKeyProp);
   }
 
   @Override
@@ -260,6 +262,26 @@ public final class DecisionEvaluationRecord extends UnifiedRecordValue
     return this;
   }
 
+  @Override
+  public long getRootProcessInstanceKey() {
+    return rootProcessInstanceKeyProp.getValue();
+  }
+
+  public DecisionEvaluationRecord setRootProcessInstanceKey(final long rootProcessInstanceKey) {
+    rootProcessInstanceKeyProp.setValue(rootProcessInstanceKey);
+    return this;
+  }
+
+  @Override
+  public int getOrdinalKey() {
+    return ordinalKeyProp.getValue();
+  }
+
+  public DecisionEvaluationRecord setOrdinalKey(final int ordinalKey) {
+    ordinalKeyProp.setValue(ordinalKey);
+    return this;
+  }
+
   public DecisionEvaluationRecord setEvaluationFailureMessage(
       final String evaluationFailureMessage) {
     evaluationFailureMessageProp.setValue(evaluationFailureMessage);
@@ -333,16 +355,6 @@ public final class DecisionEvaluationRecord extends UnifiedRecordValue
 
   public DecisionEvaluationRecord setTenantId(final String tenantId) {
     tenantIdProp.setValue(tenantId);
-    return this;
-  }
-
-  @Override
-  public long getRootProcessInstanceKey() {
-    return rootProcessInstanceKeyProp.getValue();
-  }
-
-  public DecisionEvaluationRecord setRootProcessInstanceKey(final long rootProcessInstanceKey) {
-    rootProcessInstanceKeyProp.setValue(rootProcessInstanceKey);
     return this;
   }
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/DecisionEvaluationRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/DecisionEvaluationRecordValue.java
@@ -25,7 +25,7 @@ import org.immutables.value.Value;
 @Value.Immutable
 @ImmutableProtocol(builder = ImmutableDecisionEvaluationRecordValue.Builder.class)
 public interface DecisionEvaluationRecordValue
-    extends RecordValue, RecordValueWithVariables, TenantOwned {
+    extends RecordValue, RecordValueWithVariables, OrdinalKeyBased, TenantOwned {
 
   /**
    * @return the key of the evaluated decision


### PR DESCRIPTION

## Description

Adding support for process instance related dmn and standalone and saving ordinal for user task

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
