### PR TITLE
build: prevent build from running in parallel with typecheck and lint scripts

### DIFF
--- a/webapp/client/scripts/prepublishOnly.js
+++ b/webapp/client/scripts/prepublishOnly.js
@@ -74,8 +74,14 @@ try {
 		cwd: repoRoot,
 	});
 
-	console.log('🔧 Running lint, typecheck, and build in parallel...');
-	await runInParallel(['lint', 'typecheck', 'build'], repoRoot);
+	console.log('🔧 Running build...');
+	execSync('npm run build -w @camunda/camunda-api-zod-schemas', {
+		stdio: 'inherit',
+		cwd: repoRoot,
+	});
+
+	console.log('🔧 Running lint and typecheck in parallel...');
+	await runInParallel(['lint', 'typecheck'], repoRoot);
 
 	console.log('🎉 All done!');
 } catch (error) {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Since we added schema consumers on the NPM monorepo we need to guarantee that the build runs before the lint and typecheck scripts. Since there was a chance they would run before the build is finished we were getting some [typecheck failures](https://github.com/camunda/camunda/actions/runs/26161074983/job/76954194915?pr=53619)