### PR TITLE
DO NOT MERGE: add well-formed new property with incorrect annotation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1942,6 +1942,12 @@ jobs:
     env:
       # renovate: datasource=npm depName=@stoplight/spectral-cli
       SPECTRAL_VERSION: '6.16.0'
+      # Pin the transitive @stoplight/spectral-rulesets to avoid a nimma
+      # null-deref triggered by the duplicated-entry-in-enum rule in
+      # spectral-rulesets >= 1.22.3 against null example values in the spec.
+      # Revisit once nimma releases past 0.7.2 or spectral-rulesets ships a fix.
+      # renovate: datasource=npm depName=@stoplight/spectral-rulesets
+      SPECTRAL_RULESETS_VERSION: '1.22.2'
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -1950,7 +1956,10 @@ jobs:
         with:
           node-version: 24
       - name: Install Spectral CLI
-        run: npm install -g "@stoplight/spectral-cli@${SPECTRAL_VERSION}"
+        run: |
+          npm install -g \
+            "@stoplight/spectral-cli@${SPECTRAL_VERSION}" \
+            "@stoplight/spectral-rulesets@${SPECTRAL_RULESETS_VERSION}"
         shell: bash
       - name: Run OpenAPI Linter (Structural pass)
         # Spectral provides comprehensive OpenAPI validation including:

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
@@ -967,6 +967,7 @@ components:
         - processInstanceKey
         - tags
         - businessId
+        - spuriousNewProperty
       type: object
       properties:
         processDefinitionId:
@@ -1009,10 +1010,16 @@ components:
           description: Business id as provided on creation.
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/BusinessId'
+        spuriousNewProperty:
+          type: string
+          description: |
+            Correctly annotated property should not trigger gate.
       x-properties-added-in-version:
         - propertyName: tags
           addedInVersion: "8.8"
         - propertyName: businessId
+          addedInVersion: "8.9"
+        - propertyName: spuriousNewProperty
           addedInVersion: "8.9"
 
     ProcessInstanceSearchQuerySortRequest:


### PR DESCRIPTION
## Description

Testing new CI gate. Should fail due to extended property schema with well-formed but incorrect annotation.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
