### PR TITLE
feat: add adhoc subprocess and usage metric events to analytics exporter

### DIFF
--- a/zeebe/exporters/analytics-exporter/README.md
+++ b/zeebe/exporters/analytics-exporter/README.md
@@ -37,29 +37,9 @@ filtering layers and the rationale behind partition-based deduplication.
 
 ## What it exports
 
-|                Event                | OTel Signal |
-|-------------------------------------|-------------|
-| `PROCESS_INSTANCE_CREATION` (event) | Log Record  |
-
 Events follow the [OTel Events semantic convention](https://opentelemetry.io/docs/specs/semconv/general/events/) —
-identified by the `event.name` attribute. Body is not set (per spec: "Events SHOULD NOT use
-body except to represent a string display message").
-
-### Log record attributes
-
-|              Attribute              |  Type  |                   Description                    |
-|-------------------------------------|--------|--------------------------------------------------|
-| `event.name`                        | string | Event type identifier (OTel semantic convention) |
-| `camunda.bpmn_process_id`           | string | BPMN process ID                                  |
-| `camunda.process_version`           | long   | Process definition version                       |
-| `camunda.process_definition_key`    | long   | Process definition key                           |
-| `camunda.process_instance_key`      | long   | Process instance key                             |
-| `camunda.root_process_instance_key` | long   | Root process instance key (for call activities)  |
-| `camunda.tenant_id`                 | string | Tenant ID                                        |
-| `camunda.log.position`              | long   | Log stream position (de-duplication key)         |
-
-Attribute names follow [OTel naming conventions](https://opentelemetry.io/docs/specs/semconv/general/naming/) —
-dot-delimited namespaces, snake_case for multi-word components.
+identified by the `event.name` attribute. See handler classes in `handler/` and
+`AnalyticsAttributes` for the specific events and their attributes.
 
 ### OTel resource attributes
 
@@ -93,25 +73,13 @@ zeebe:
 
 ## Architecture
 
-```
-Zeebe actor thread                          Background thread
-─────────────────                          ─────────────────
-export(record)
-  ├── updatePosition (always, unconditionally)
-  ├── EnumMap lookup → handler or null
-  └── handler → OtelSdkManager.logEvent(eventName, logPosition, builder)
-       └── BatchLogRecordProcessor.onEmit()   ──→  queue  ──→  OTLP/HTTP POST
-           (non-blocking, drops if full)                       to analytics endpoint
-```
+See source Javadocs for component details. Key files:
 
-Key components:
-
-- **`AnalyticsExporter`** — Zeebe exporter. Owns handler registry and record routing.
-  Handlers build OTel log records directly via the `logEvent()` lambda API.
-- **`OtelSdkManager`** — Manages the OTel SDK lifecycle (Resource, LoggerProvider, SDK).
-  Provides `logEvent(eventName, logPosition, builder)` — sets `event.name`, severity,
-  and log position automatically; the builder lambda adds event-specific attributes.
-- **`AnalyticsAttributes`** — Shared OTel attribute key constants following naming conventions.
+- **`AnalyticsExporter`** — Zeebe exporter lifecycle and handler wiring.
+- **`HandlerRegistry`** — Routes records by (ValueType, Intent) to handlers.
+- **`AnalyticsRecordFilter`** — Broker-level filtering (type, value, intent, partition).
+- **`OtelSdkManager`** — OTel SDK lifecycle (Resource, LoggerProvider, BatchProcessor).
+- **`handler/`** — Individual event handlers (one per analytics event type).
 
 ## Building
 

--- a/zeebe/exporters/analytics-exporter/pom.xml
+++ b/zeebe/exporters/analytics-exporter/pom.xml
@@ -84,11 +84,6 @@
       <scope>runtime</scope>
     </dependency>
 
-    <dependency>
-      <groupId>org.jspecify</groupId>
-      <artifactId>jspecify</artifactId>
-    </dependency>
-
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsAttributes.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsAttributes.java
@@ -50,5 +50,15 @@ public final class AnalyticsAttributes {
   public static final AttributeKey<String> ELEMENT_ID =
       AttributeKey.stringKey("camunda.element_id");
 
+  // Usage metrics
+  public static final AttributeKey<String> USAGE_METRIC_EVENT_TYPE =
+      AttributeKey.stringKey("camunda.usage_metric.event_type");
+  public static final AttributeKey<Long> USAGE_METRIC_COUNT =
+      AttributeKey.longKey("camunda.usage_metric.count");
+  public static final AttributeKey<Long> USAGE_METRIC_INTERVAL_START =
+      AttributeKey.longKey("camunda.usage_metric.interval_start");
+  public static final AttributeKey<Long> USAGE_METRIC_INTERVAL_END =
+      AttributeKey.longKey("camunda.usage_metric.interval_end");
+
   private AnalyticsAttributes() {}
 }

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsAttributes.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsAttributes.java
@@ -15,30 +15,35 @@ import io.opentelemetry.api.common.AttributeKey;
  *
  * @see <a href="https://opentelemetry.io/docs/specs/semconv/general/naming/">OTel Naming</a>
  */
-final class AnalyticsAttributes {
+public final class AnalyticsAttributes {
 
   // Resource-level
-  static final AttributeKey<String> SERVICE_NAME = AttributeKey.stringKey("service.name");
-  static final AttributeKey<String> CLUSTER_ID = AttributeKey.stringKey("camunda.cluster.id");
-  static final AttributeKey<Long> PARTITION_ID = AttributeKey.longKey("camunda.partition.id");
+  public static final AttributeKey<String> SERVICE_NAME = AttributeKey.stringKey("service.name");
+  public static final AttributeKey<String> CLUSTER_ID =
+      AttributeKey.stringKey("camunda.cluster.id");
+  public static final AttributeKey<Long> PARTITION_ID =
+      AttributeKey.longKey("camunda.partition.id");
 
   // OTel semantic convention for events (until Event API is stable)
-  static final AttributeKey<String> EVENT_NAME = AttributeKey.stringKey("event.name");
+  public static final AttributeKey<String> EVENT_NAME = AttributeKey.stringKey("event.name");
 
   // Common
-  static final AttributeKey<Long> LOG_POSITION = AttributeKey.longKey("camunda.log.position");
-  static final AttributeKey<Long> SEQUENCE_NUMBER = AttributeKey.longKey("camunda.sequence_number");
-  static final AttributeKey<String> TENANT_ID = AttributeKey.stringKey("camunda.tenant_id");
+  public static final AttributeKey<Long> LOG_POSITION =
+      AttributeKey.longKey("camunda.log.position");
+  public static final AttributeKey<Long> SEQUENCE_NUMBER =
+      AttributeKey.longKey("camunda.sequence_number");
+  public static final AttributeKey<String> TENANT_ID = AttributeKey.stringKey("camunda.tenant_id");
 
   // Process instance
-  static final AttributeKey<String> BPMN_PROCESS_ID =
+  public static final AttributeKey<String> BPMN_PROCESS_ID =
       AttributeKey.stringKey("camunda.bpmn_process_id");
-  static final AttributeKey<Long> PROCESS_VERSION = AttributeKey.longKey("camunda.process_version");
-  static final AttributeKey<Long> PROCESS_DEFINITION_KEY =
+  public static final AttributeKey<Long> PROCESS_VERSION =
+      AttributeKey.longKey("camunda.process_version");
+  public static final AttributeKey<Long> PROCESS_DEFINITION_KEY =
       AttributeKey.longKey("camunda.process_definition_key");
-  static final AttributeKey<Long> PROCESS_INSTANCE_KEY =
+  public static final AttributeKey<Long> PROCESS_INSTANCE_KEY =
       AttributeKey.longKey("camunda.process_instance_key");
-  static final AttributeKey<Long> ROOT_PROCESS_INSTANCE_KEY =
+  public static final AttributeKey<Long> ROOT_PROCESS_INSTANCE_KEY =
       AttributeKey.longKey("camunda.root_process_instance_key");
 
   private AnalyticsAttributes() {}

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsAttributes.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsAttributes.java
@@ -46,5 +46,9 @@ public final class AnalyticsAttributes {
   public static final AttributeKey<Long> ROOT_PROCESS_INSTANCE_KEY =
       AttributeKey.longKey("camunda.root_process_instance_key");
 
+  // Adhoc subprocess
+  public static final AttributeKey<String> ELEMENT_ID =
+      AttributeKey.stringKey("camunda.element_id");
+
   private AnalyticsAttributes() {}
 }

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsAttributes.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsAttributes.java
@@ -50,6 +50,11 @@ public final class AnalyticsAttributes {
   public static final AttributeKey<String> ELEMENT_ID =
       AttributeKey.stringKey("camunda.element_id");
 
+  // Event names
+  public static final String EVENT_PROCESS_INSTANCE_CREATED = "process_instance_created";
+  public static final String EVENT_ADHOC_SUBPROCESS_ACTIVATED = "adhoc_subprocess_activated";
+  public static final String EVENT_USAGE_METRIC_EXPORTED = "usage_metric_exported";
+
   // Usage metrics
   public static final AttributeKey<String> USAGE_METRIC_EVENT_TYPE =
       AttributeKey.stringKey("camunda.usage_metric.event_type");

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporter.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporter.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.analytics;
 
 import io.camunda.exporter.analytics.handler.AdHocSubProcessHandler;
 import io.camunda.exporter.analytics.handler.ProcessInstanceCreationHandler;
+import io.camunda.exporter.analytics.handler.UsageMetricHandler;
 import io.camunda.zeebe.exporter.api.Exporter;
 import io.camunda.zeebe.exporter.api.context.Context;
 import io.camunda.zeebe.exporter.api.context.Controller;
@@ -16,6 +17,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.UsageMetricIntent;
 import io.camunda.zeebe.util.logging.ThrottledLogger;
 import java.time.Duration;
 import org.slf4j.Logger;
@@ -64,6 +66,10 @@ public class AnalyticsExporter implements Exporter {
                 ValueType.PROCESS_INSTANCE,
                 ProcessInstanceIntent.ELEMENT_ACTIVATED,
                 new AdHocSubProcessHandler(otelSdkManager))
+            .register(
+                ValueType.USAGE_METRIC,
+                UsageMetricIntent.EXPORTED,
+                new UsageMetricHandler(otelSdkManager))
             .apply(context);
 
     LOG.info(

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporter.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporter.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.analytics;
 
+import io.camunda.exporter.analytics.handler.AdHocSubProcessHandler;
 import io.camunda.exporter.analytics.handler.ProcessInstanceCreationHandler;
 import io.camunda.zeebe.exporter.api.Exporter;
 import io.camunda.zeebe.exporter.api.context.Context;
@@ -14,6 +15,7 @@ import io.camunda.zeebe.exporter.api.context.Controller;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.util.logging.ThrottledLogger;
 import java.time.Duration;
 import org.slf4j.Logger;
@@ -58,6 +60,10 @@ public class AnalyticsExporter implements Exporter {
                 ValueType.PROCESS_INSTANCE_CREATION,
                 ProcessInstanceCreationIntent.CREATED,
                 new ProcessInstanceCreationHandler(otelSdkManager))
+            .register(
+                ValueType.PROCESS_INSTANCE,
+                ProcessInstanceIntent.ELEMENT_ACTIVATED,
+                new AdHocSubProcessHandler(otelSdkManager))
             .apply(context);
 
     LOG.info(

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporter.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporter.java
@@ -7,25 +7,15 @@
  */
 package io.camunda.exporter.analytics;
 
-import static io.camunda.exporter.analytics.AnalyticsAttributes.BPMN_PROCESS_ID;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.PROCESS_DEFINITION_KEY;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.PROCESS_INSTANCE_KEY;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.PROCESS_VERSION;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.TENANT_ID;
-
+import io.camunda.exporter.analytics.handler.ProcessInstanceCreationHandler;
 import io.camunda.zeebe.exporter.api.Exporter;
 import io.camunda.zeebe.exporter.api.context.Context;
 import io.camunda.zeebe.exporter.api.context.Controller;
 import io.camunda.zeebe.protocol.record.Record;
-import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.ValueType;
-import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.util.logging.ThrottledLogger;
 import java.time.Duration;
-import java.util.EnumMap;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
-import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,8 +26,6 @@ public class AnalyticsExporter implements Exporter {
   private static final String CLUSTER_ID_ENV_VAR = "ZEEBE_BROKER_CLUSTER_CLUSTERID";
   private static final Logger LOG =
       LoggerFactory.getLogger(AnalyticsExporter.class.getPackageName());
-  private static final ThrottledLogger SAMPLED_LOG =
-      new ThrottledLogger(LOG, Duration.ofMinutes(1));
   private static final ThrottledLogger SAMPLED_WARN_LOG =
       new ThrottledLogger(LOG, Duration.ofMinutes(1));
   private final OtelSdkManager otelSdkManager;
@@ -66,7 +54,10 @@ public class AnalyticsExporter implements Exporter {
 
     handlers =
         new HandlerRegistry()
-            .register(ValueType.PROCESS_INSTANCE_CREATION, this::handleProcessInstanceCreation)
+            .register(
+                ValueType.PROCESS_INSTANCE_CREATION,
+                ProcessInstanceCreationIntent.CREATED,
+                new ProcessInstanceCreationHandler(otelSdkManager))
             .apply(context);
 
     LOG.info(
@@ -97,40 +88,12 @@ public class AnalyticsExporter implements Exporter {
   @Override
   public void export(final Record<?> record) {
     try {
-      final var handler = handlers.get(record);
-      if (handler != null) {
-        handler.accept(record);
-      }
+      handlers.handle(record);
     } catch (final Exception e) {
       SAMPLED_WARN_LOG.warn("Failed to handle record at position {}", record.getPosition(), e);
     }
 
     controller.updateLastExportedRecordPosition(record.getPosition(), metadata.serialize());
-  }
-
-  private void handleProcessInstanceCreation(
-      final Record<ProcessInstanceCreationRecordValue> record) {
-    final var value = record.getValue();
-
-    otelSdkManager.logEvent(
-        "process_instance_created",
-        record.getPosition(),
-        log ->
-            log.setAttribute(BPMN_PROCESS_ID, value.getBpmnProcessId())
-                .setAttribute(PROCESS_VERSION, (long) value.getVersion())
-                .setAttribute(PROCESS_DEFINITION_KEY, value.getProcessDefinitionKey())
-                .setAttribute(PROCESS_INSTANCE_KEY, record.getKey())
-                //                Uncomment as this is not available on 8.8
-                //                .setAttribute(ROOT_PROCESS_INSTANCE_KEY,
-                // value.getRootProcessInstanceKey())
-                .setAttribute(TENANT_ID, value.getTenantId())
-                .setTimestamp(record.getTimestamp(), TimeUnit.MILLISECONDS));
-
-    SAMPLED_LOG.info(
-        "Process instance created: bpmnProcessId={}, processInstanceKey={}, position={}",
-        value.getBpmnProcessId(),
-        record.getKey(),
-        record.getPosition());
   }
 
   /**
@@ -165,27 +128,6 @@ public class AnalyticsExporter implements Exporter {
     } catch (final NoSuchMethodError e) {
       final var fromEnv = System.getenv(CLUSTER_ID_ENV_VAR);
       return fromEnv != null ? fromEnv : "";
-    }
-  }
-
-  static final class HandlerRegistry {
-
-    private final EnumMap<ValueType, Consumer<Record<?>>> handlers = new EnumMap<>(ValueType.class);
-
-    @SuppressWarnings("unchecked")
-    <T extends RecordValue> HandlerRegistry register(
-        final ValueType valueType, final Consumer<Record<T>> handler) {
-      handlers.put(valueType, record -> handler.accept((Record<T>) record));
-      return this;
-    }
-
-    HandlerRegistry apply(final Context context) {
-      context.setFilter(new AnalyticsRecordFilter(handlers.keySet(), context.getPartitionId()));
-      return this;
-    }
-
-    @Nullable Consumer<Record<?>> get(final Record<?> record) {
-      return handlers.get(record.getValueType());
     }
   }
 }

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsHandler.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordValue;
+
+/**
+ * Handler for a single analytics event type. Usable as a functional interface via method references
+ * for simple handlers, or as a class for handlers with internal filtering logic.
+ */
+@FunctionalInterface
+public interface AnalyticsHandler<T extends RecordValue> {
+
+  void handle(Record<T> record);
+}

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsRecordFilter.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsRecordFilter.java
@@ -12,22 +12,27 @@ import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
 import java.util.Set;
 
 /**
- * Record filter for the analytics exporter with three filtering layers:
+ * Record filter for the analytics exporter with four filtering layers:
  *
  * <ol>
  *   <li><b>Record type</b> — only {@link RecordType#EVENT} records pass; commands and rejections
  *       are skipped.
  *   <li><b>Value type</b> — only value types with registered handlers pass (e.g. {@link
  *       ValueType#PROCESS_INSTANCE_CREATION}).
+ *   <li><b>Intent</b> — only intents with registered handlers pass. This is an intentional
+ *       over-approximation: the set is flat across all value types, so a record may pass intent
+ *       filtering even if its (ValueType, Intent) pair has no handler. Exact routing happens in
+ *       {@link HandlerRegistry#handle}.
  *   <li><b>Partition ownership</b> — only events whose key encodes the local partition ID pass.
  * </ol>
  *
- * <p>Layers 1 and 2 are metadata-based and evaluated in phase 1 of the broker's filter pipeline
- * (before record deserialization). Layer 3 runs in phase 2 on the deserialized record, but only for
- * the small subset that passed phase 1.
+ * <p>Layers 1-3 are metadata-based and evaluated in phase 1 of the broker's filter pipeline (before
+ * record deserialization). Layer 4 runs in phase 2 on the deserialized record, but only for the
+ * small subset that passed phase 1.
  *
  * <h3>Partition filtering rationale</h3>
  *
@@ -44,11 +49,13 @@ import java.util.Set;
  * command.getKey()} directly, or via keys embedded in the distributed command's value that were
  * generated on the originating partition.
  */
-record AnalyticsRecordFilter(Set<ValueType> acceptedValueTypes, int partitionId)
+record AnalyticsRecordFilter(
+    Set<ValueType> acceptedValueTypes, Set<Intent> acceptedIntents, int partitionId)
     implements RecordFilter {
 
   AnalyticsRecordFilter {
     acceptedValueTypes = Set.copyOf(acceptedValueTypes);
+    acceptedIntents = Set.copyOf(acceptedIntents);
   }
 
   @Override
@@ -59,6 +66,11 @@ record AnalyticsRecordFilter(Set<ValueType> acceptedValueTypes, int partitionId)
   @Override
   public boolean acceptValue(final ValueType valueType) {
     return acceptedValueTypes.contains(valueType);
+  }
+
+  @Override
+  public boolean acceptIntent(final Intent intent) {
+    return acceptedIntents.contains(intent);
   }
 
   @Override

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/HandlerRegistry.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/HandlerRegistry.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics;
+
+import io.camunda.zeebe.exporter.api.context.Context;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Routes records to handlers by (ValueType, Intent) pairs. Supports multiple handlers per
+ * ValueType, each keyed by a distinct Intent. Two-level lookup: EnumMap for ValueType, then HashMap
+ * for Intent.
+ *
+ * <p>On {@link #apply}, installs an {@link AnalyticsRecordFilter} derived from the registered types
+ * and intents.
+ */
+final class HandlerRegistry {
+
+  private final EnumMap<ValueType, Map<Intent, AnalyticsHandler<?>>> handlers =
+      new EnumMap<>(ValueType.class);
+
+  <T extends RecordValue> HandlerRegistry register(
+      final ValueType valueType, final Intent intent, final AnalyticsHandler<T> handler) {
+    final var intentMap = handlers.computeIfAbsent(valueType, k -> new HashMap<>());
+    if (intentMap.containsKey(intent)) {
+      throw new IllegalStateException("Duplicate handler for (" + valueType + ", " + intent + ")");
+    }
+    intentMap.put(intent, handler);
+    return this;
+  }
+
+  HandlerRegistry apply(final Context context) {
+    final var acceptedIntents =
+        handlers.values().stream()
+            .flatMap(m -> m.keySet().stream())
+            .collect(Collectors.toUnmodifiableSet());
+    context.setFilter(
+        new AnalyticsRecordFilter(handlers.keySet(), acceptedIntents, context.getPartitionId()));
+    return this;
+  }
+
+  /** Routes the record to its handler. Does nothing if no handler is registered. */
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  void handle(final Record<?> record) {
+    final var intentMap = handlers.get(record.getValueType());
+    if (intentMap == null) {
+      return;
+    }
+    final AnalyticsHandler handler = intentMap.get(record.getIntent());
+    if (handler != null) {
+      handler.handle(record);
+    }
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/OtelSdkManager.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/OtelSdkManager.java
@@ -27,7 +27,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 /** Manages the OTel SDK lifecycle for one partition. */
-class OtelSdkManager {
+public class OtelSdkManager {
 
   private static final String INSTRUMENTATION_SCOPE = "io.camunda.analytics";
   private static final String SCHEMA_URL = "https://camunda.io/schemas/analytics/v1";
@@ -51,7 +51,7 @@ class OtelSdkManager {
     return this;
   }
 
-  void logEvent(
+  public void logEvent(
       final String eventName, final long logPosition, final Consumer<LogRecordBuilder> builder) {
     final var record =
         otelLogger

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/AdHocSubProcessHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/AdHocSubProcessHandler.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics.handler;
+
+import static io.camunda.exporter.analytics.AnalyticsAttributes.BPMN_PROCESS_ID;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.ELEMENT_ID;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.PROCESS_DEFINITION_KEY;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.PROCESS_INSTANCE_KEY;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.TENANT_ID;
+
+import io.camunda.exporter.analytics.AnalyticsHandler;
+import io.camunda.exporter.analytics.OtelSdkManager;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Emits an {@code adhoc_subprocess_activated} OTel event when an ad-hoc subprocess element is
+ * activated. Skips non-ad-hoc element types silently.
+ */
+public final class AdHocSubProcessHandler implements AnalyticsHandler<ProcessInstanceRecordValue> {
+
+  private final OtelSdkManager otelSdkManager;
+
+  public AdHocSubProcessHandler(final OtelSdkManager otelSdkManager) {
+    this.otelSdkManager = Objects.requireNonNull(otelSdkManager);
+  }
+
+  @Override
+  public void handle(final Record<ProcessInstanceRecordValue> record) {
+    final var value = record.getValue();
+    if (value.getBpmnElementType() != BpmnElementType.AD_HOC_SUB_PROCESS) {
+      return;
+    }
+
+    otelSdkManager.logEvent(
+        "adhoc_subprocess_activated",
+        record.getPosition(),
+        log ->
+            log.setAttribute(BPMN_PROCESS_ID, value.getBpmnProcessId())
+                .setAttribute(PROCESS_DEFINITION_KEY, value.getProcessDefinitionKey())
+                .setAttribute(PROCESS_INSTANCE_KEY, value.getProcessInstanceKey())
+                .setAttribute(ELEMENT_ID, value.getElementId())
+                .setAttribute(TENANT_ID, value.getTenantId())
+                .setTimestamp(record.getTimestamp(), TimeUnit.MILLISECONDS));
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/AdHocSubProcessHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/AdHocSubProcessHandler.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.analytics.handler;
 
 import static io.camunda.exporter.analytics.AnalyticsAttributes.BPMN_PROCESS_ID;
 import static io.camunda.exporter.analytics.AnalyticsAttributes.ELEMENT_ID;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.EVENT_ADHOC_SUBPROCESS_ACTIVATED;
 import static io.camunda.exporter.analytics.AnalyticsAttributes.PROCESS_DEFINITION_KEY;
 import static io.camunda.exporter.analytics.AnalyticsAttributes.PROCESS_INSTANCE_KEY;
 import static io.camunda.exporter.analytics.AnalyticsAttributes.TENANT_ID;
@@ -41,7 +42,7 @@ public final class AdHocSubProcessHandler implements AnalyticsHandler<ProcessIns
     }
 
     otelSdkManager.logEvent(
-        "adhoc_subprocess_activated",
+        EVENT_ADHOC_SUBPROCESS_ACTIVATED,
         record.getPosition(),
         log ->
             log.setAttribute(BPMN_PROCESS_ID, value.getBpmnProcessId())

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/ProcessInstanceCreationHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/ProcessInstanceCreationHandler.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics.handler;
+
+import static io.camunda.exporter.analytics.AnalyticsAttributes.BPMN_PROCESS_ID;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.PROCESS_DEFINITION_KEY;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.PROCESS_INSTANCE_KEY;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.PROCESS_VERSION;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.ROOT_PROCESS_INSTANCE_KEY;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.TENANT_ID;
+
+import io.camunda.exporter.analytics.AnalyticsHandler;
+import io.camunda.exporter.analytics.OtelSdkManager;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/** Emits a {@code process_instance_created} OTel event for each process instance creation. */
+public final class ProcessInstanceCreationHandler
+    implements AnalyticsHandler<ProcessInstanceCreationRecordValue> {
+
+  private final OtelSdkManager otelSdkManager;
+
+  public ProcessInstanceCreationHandler(final OtelSdkManager otelSdkManager) {
+    this.otelSdkManager = Objects.requireNonNull(otelSdkManager);
+  }
+
+  @Override
+  public void handle(final Record<ProcessInstanceCreationRecordValue> record) {
+    final var value = record.getValue();
+
+    otelSdkManager.logEvent(
+        "process_instance_created",
+        record.getPosition(),
+        log ->
+            log.setAttribute(BPMN_PROCESS_ID, value.getBpmnProcessId())
+                .setAttribute(PROCESS_VERSION, (long) value.getVersion())
+                .setAttribute(PROCESS_DEFINITION_KEY, value.getProcessDefinitionKey())
+                .setAttribute(PROCESS_INSTANCE_KEY, record.getKey())
+                .setAttribute(ROOT_PROCESS_INSTANCE_KEY, value.getRootProcessInstanceKey())
+                .setAttribute(TENANT_ID, value.getTenantId())
+                .setTimestamp(record.getTimestamp(), TimeUnit.MILLISECONDS));
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/ProcessInstanceCreationHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/ProcessInstanceCreationHandler.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.analytics.handler;
 
 import static io.camunda.exporter.analytics.AnalyticsAttributes.BPMN_PROCESS_ID;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.EVENT_PROCESS_INSTANCE_CREATED;
 import static io.camunda.exporter.analytics.AnalyticsAttributes.PROCESS_DEFINITION_KEY;
 import static io.camunda.exporter.analytics.AnalyticsAttributes.PROCESS_INSTANCE_KEY;
 import static io.camunda.exporter.analytics.AnalyticsAttributes.PROCESS_VERSION;
@@ -35,7 +36,7 @@ public final class ProcessInstanceCreationHandler
     final var value = record.getValue();
 
     otelSdkManager.logEvent(
-        "process_instance_created",
+        EVENT_PROCESS_INSTANCE_CREATED,
         record.getPosition(),
         log ->
             log.setAttribute(BPMN_PROCESS_ID, value.getBpmnProcessId())

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/ProcessInstanceCreationHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/ProcessInstanceCreationHandler.java
@@ -11,7 +11,6 @@ import static io.camunda.exporter.analytics.AnalyticsAttributes.BPMN_PROCESS_ID;
 import static io.camunda.exporter.analytics.AnalyticsAttributes.PROCESS_DEFINITION_KEY;
 import static io.camunda.exporter.analytics.AnalyticsAttributes.PROCESS_INSTANCE_KEY;
 import static io.camunda.exporter.analytics.AnalyticsAttributes.PROCESS_VERSION;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.ROOT_PROCESS_INSTANCE_KEY;
 import static io.camunda.exporter.analytics.AnalyticsAttributes.TENANT_ID;
 
 import io.camunda.exporter.analytics.AnalyticsHandler;
@@ -43,7 +42,9 @@ public final class ProcessInstanceCreationHandler
                 .setAttribute(PROCESS_VERSION, (long) value.getVersion())
                 .setAttribute(PROCESS_DEFINITION_KEY, value.getProcessDefinitionKey())
                 .setAttribute(PROCESS_INSTANCE_KEY, record.getKey())
-                .setAttribute(ROOT_PROCESS_INSTANCE_KEY, value.getRootProcessInstanceKey())
+                // TODO: re-enable once 8.8 brokers are no longer supported —
+                //  getRootProcessInstanceKey() does not exist on 8.8
+                // .setAttribute(ROOT_PROCESS_INSTANCE_KEY, value.getRootProcessInstanceKey())
                 .setAttribute(TENANT_ID, value.getTenantId())
                 .setTimestamp(record.getTimestamp(), TimeUnit.MILLISECONDS));
   }

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/UsageMetricHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/UsageMetricHandler.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics.handler;
+
+import static io.camunda.exporter.analytics.AnalyticsAttributes.USAGE_METRIC_COUNT;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.USAGE_METRIC_EVENT_TYPE;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.USAGE_METRIC_INTERVAL_END;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.USAGE_METRIC_INTERVAL_START;
+
+import io.camunda.exporter.analytics.AnalyticsHandler;
+import io.camunda.exporter.analytics.OtelSdkManager;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Emits a {@code usage_metric_exported} OTel event for each usage metric export (RPI, EDI, TU).
+ * Skips internal {@link UsageMetricRecordValue.EventType#NONE NONE} reset events.
+ */
+public final class UsageMetricHandler implements AnalyticsHandler<UsageMetricRecordValue> {
+
+  private final OtelSdkManager otelSdkManager;
+
+  public UsageMetricHandler(final OtelSdkManager otelSdkManager) {
+    this.otelSdkManager = Objects.requireNonNull(otelSdkManager);
+  }
+
+  @Override
+  public void handle(final Record<UsageMetricRecordValue> record) {
+    final var value = record.getValue();
+
+    if (value.getEventType() == UsageMetricRecordValue.EventType.NONE) {
+      return;
+    }
+
+    final long count =
+        switch (value.getEventType()) {
+          case TU -> value.getSetValues().values().stream().mapToLong(set -> set.size()).sum();
+          default -> value.getCounterValues().values().stream().mapToLong(Long::longValue).sum();
+        };
+
+    otelSdkManager.logEvent(
+        "usage_metric_exported",
+        record.getPosition(),
+        log ->
+            log.setAttribute(USAGE_METRIC_EVENT_TYPE, value.getEventType().name())
+                .setAttribute(USAGE_METRIC_COUNT, count)
+                .setAttribute(USAGE_METRIC_INTERVAL_START, value.getStartTime())
+                .setAttribute(USAGE_METRIC_INTERVAL_END, value.getEndTime())
+                .setTimestamp(record.getTimestamp(), TimeUnit.MILLISECONDS));
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/UsageMetricHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/UsageMetricHandler.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.analytics.handler;
 
+import static io.camunda.exporter.analytics.AnalyticsAttributes.EVENT_USAGE_METRIC_EXPORTED;
 import static io.camunda.exporter.analytics.AnalyticsAttributes.USAGE_METRIC_COUNT;
 import static io.camunda.exporter.analytics.AnalyticsAttributes.USAGE_METRIC_EVENT_TYPE;
 import static io.camunda.exporter.analytics.AnalyticsAttributes.USAGE_METRIC_INTERVAL_END;
@@ -46,7 +47,7 @@ public final class UsageMetricHandler implements AnalyticsHandler<UsageMetricRec
         };
 
     otelSdkManager.logEvent(
-        "usage_metric_exported",
+        EVENT_USAGE_METRIC_EXPORTED,
         record.getPosition(),
         log ->
             log.setAttribute(USAGE_METRIC_EVENT_TYPE, value.getEventType().name())

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterOtelIT.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterOtelIT.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.analytics;
 
+import static io.camunda.exporter.analytics.AnalyticsAttributes.EVENT_PROCESS_INSTANCE_CREATED;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.exporter.test.ExporterTestConfiguration;
@@ -66,7 +67,7 @@ class AnalyticsExporterOtelIT {
 
     // then
     awaitCollectorLogs(
-        "process_instance_created",
+        EVENT_PROCESS_INSTANCE_CREATED,
         "camunda.cluster.id",
         "test-cluster",
         "camunda.bpmn_process_id");

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterTest.java
@@ -21,8 +21,6 @@ import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import io.opentelemetry.api.logs.LogRecordBuilder;
 import io.opentelemetry.api.logs.Severity;
-import io.opentelemetry.sdk.logs.SdkLoggerProvider;
-import io.opentelemetry.sdk.logs.export.SimpleLogRecordProcessor;
 import io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter;
 import java.util.ArrayList;
 import java.util.function.Consumer;
@@ -233,18 +231,7 @@ class AnalyticsExporterTest {
 
   private static AnalyticsExporter exporterWithInMemory(
       final InMemoryLogRecordExporter memoryExporter, final ExporterTestController controller) {
-    return newExporter(
-        new OtelSdkManager() {
-          @Override
-          protected SdkLoggerProvider createLoggerProvider(
-              final AnalyticsExporterConfig cfg, final AnalyticsExporterContext context) {
-            return SdkLoggerProvider.builder()
-                .setResource(OtelSdkManager.buildResource(context))
-                .addLogRecordProcessor(SimpleLogRecordProcessor.create(memoryExporter))
-                .build();
-          }
-        },
-        controller);
+    return newExporter(TestOtelSdkManager.inMemory(memoryExporter), controller);
   }
 
   private static AnalyticsExporter exporterWithThrowingOtel(
@@ -252,7 +239,7 @@ class AnalyticsExporterTest {
     return newExporter(
         new OtelSdkManager() {
           @Override
-          void logEvent(
+          public void logEvent(
               final String eventName,
               final long logPosition,
               final Consumer<LogRecordBuilder> builder) {

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.analytics;
 
+import static io.camunda.exporter.analytics.AnalyticsAttributes.EVENT_PROCESS_INSTANCE_CREATED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -87,7 +88,7 @@ class AnalyticsExporterTest {
             logRecord -> {
               assertThat(logRecord.getSeverity()).isEqualTo(Severity.INFO);
               assertThat(logRecord.getAttributes().asMap())
-                  .containsEntry(AnalyticsAttributes.EVENT_NAME, "process_instance_created")
+                  .containsEntry(AnalyticsAttributes.EVENT_NAME, EVENT_PROCESS_INSTANCE_CREATED)
                   .containsEntry(AnalyticsAttributes.BPMN_PROCESS_ID, value.getBpmnProcessId())
                   .containsEntry(AnalyticsAttributes.PROCESS_VERSION, (long) value.getVersion())
                   .containsEntry(

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsRecordFilterTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsRecordFilterTest.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
@@ -26,8 +27,8 @@ class AnalyticsRecordFilterTest {
 
   private final AnalyticsRecordFilter filter =
       new AnalyticsRecordFilter(
-          Set.of(ValueType.PROCESS_INSTANCE_CREATION),
-          Set.of(ProcessInstanceCreationIntent.CREATED),
+          Set.of(ValueType.PROCESS_INSTANCE_CREATION, ValueType.PROCESS_INSTANCE),
+          Set.of(ProcessInstanceCreationIntent.CREATED, ProcessInstanceIntent.ELEMENT_ACTIVATED),
           TEST_PARTITION_ID);
 
   @Test
@@ -48,13 +49,14 @@ class AnalyticsRecordFilterTest {
   @Test
   void shouldAcceptAllRegisteredValueTypes() {
     assertThat(filter.acceptValue(ValueType.PROCESS_INSTANCE_CREATION)).isTrue();
+    assertThat(filter.acceptValue(ValueType.PROCESS_INSTANCE)).isTrue();
   }
 
   @ParameterizedTest
   @EnumSource(
       value = ValueType.class,
       mode = EnumSource.Mode.EXCLUDE,
-      names = {"PROCESS_INSTANCE_CREATION"})
+      names = {"PROCESS_INSTANCE_CREATION", "PROCESS_INSTANCE"})
   void shouldRejectUnregisteredValueType(final ValueType type) {
     assertThat(filter.acceptValue(type)).isFalse();
   }
@@ -62,6 +64,7 @@ class AnalyticsRecordFilterTest {
   @Test
   void shouldAcceptAllRegisteredIntents() {
     assertThat(filter.acceptIntent(ProcessInstanceCreationIntent.CREATED)).isTrue();
+    assertThat(filter.acceptIntent(ProcessInstanceIntent.ELEMENT_ACTIVATED)).isTrue();
   }
 
   @Test

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsRecordFilterTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsRecordFilterTest.java
@@ -12,14 +12,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
+import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.UsageMetricIntent;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import java.util.Set;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class AnalyticsRecordFilterTest {
 
@@ -43,14 +47,13 @@ class AnalyticsRecordFilterTest {
     assertThat(filter.acceptType(RecordType.EVENT)).isTrue();
   }
 
-  @Test
-  void shouldRejectCommandRecordType() {
-    assertThat(filter.acceptType(RecordType.COMMAND)).isFalse();
-  }
-
-  @Test
-  void shouldRejectCommandRejectionRecordType() {
-    assertThat(filter.acceptType(RecordType.COMMAND_REJECTION)).isFalse();
+  @ParameterizedTest
+  @EnumSource(
+      value = RecordType.class,
+      mode = EnumSource.Mode.EXCLUDE,
+      names = {"EVENT"})
+  void shouldRejectNonEventRecordType(final RecordType type) {
+    assertThat(filter.acceptType(type)).isFalse();
   }
 
   @Test
@@ -76,9 +79,17 @@ class AnalyticsRecordFilterTest {
     assertThat(filter.acceptIntent(UsageMetricIntent.EXPORTED)).isTrue();
   }
 
-  @Test
-  void shouldRejectUnregisteredIntent() {
-    assertThat(filter.acceptIntent(ProcessInstanceCreationIntent.CREATE)).isFalse();
+  @ParameterizedTest
+  @MethodSource("unregisteredIntents")
+  void shouldRejectUnregisteredIntent(final Intent intent) {
+    assertThat(filter.acceptIntent(intent)).isFalse();
+  }
+
+  private static Stream<Intent> unregisteredIntents() {
+    return Stream.of(
+        ProcessInstanceCreationIntent.CREATE,
+        ProcessInstanceIntent.ELEMENT_COMPLETING,
+        DeploymentIntent.CREATED);
   }
 
   @Test

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsRecordFilterTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsRecordFilterTest.java
@@ -25,7 +25,10 @@ class AnalyticsRecordFilterTest {
   private static final ProtocolFactory FACTORY = new ProtocolFactory();
 
   private final AnalyticsRecordFilter filter =
-      new AnalyticsRecordFilter(Set.of(ValueType.PROCESS_INSTANCE_CREATION), TEST_PARTITION_ID);
+      new AnalyticsRecordFilter(
+          Set.of(ValueType.PROCESS_INSTANCE_CREATION),
+          Set.of(ProcessInstanceCreationIntent.CREATED),
+          TEST_PARTITION_ID);
 
   @Test
   void shouldAcceptEventRecordType() {
@@ -42,22 +45,28 @@ class AnalyticsRecordFilterTest {
     assertThat(filter.acceptType(RecordType.COMMAND_REJECTION)).isFalse();
   }
 
-  @ParameterizedTest
-  @EnumSource(
-      value = ValueType.class,
-      mode = EnumSource.Mode.INCLUDE,
-      names = "PROCESS_INSTANCE_CREATION")
-  void shouldAcceptRegisteredValueType(final ValueType type) {
-    assertThat(filter.acceptValue(type)).isTrue();
+  @Test
+  void shouldAcceptAllRegisteredValueTypes() {
+    assertThat(filter.acceptValue(ValueType.PROCESS_INSTANCE_CREATION)).isTrue();
   }
 
   @ParameterizedTest
   @EnumSource(
       value = ValueType.class,
       mode = EnumSource.Mode.EXCLUDE,
-      names = "PROCESS_INSTANCE_CREATION")
+      names = {"PROCESS_INSTANCE_CREATION"})
   void shouldRejectUnregisteredValueType(final ValueType type) {
     assertThat(filter.acceptValue(type)).isFalse();
+  }
+
+  @Test
+  void shouldAcceptAllRegisteredIntents() {
+    assertThat(filter.acceptIntent(ProcessInstanceCreationIntent.CREATED)).isTrue();
+  }
+
+  @Test
+  void shouldRejectUnregisteredIntent() {
+    assertThat(filter.acceptIntent(ProcessInstanceCreationIntent.CREATE)).isFalse();
   }
 
   @Test

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsRecordFilterTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsRecordFilterTest.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.UsageMetricIntent;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
@@ -27,8 +28,14 @@ class AnalyticsRecordFilterTest {
 
   private final AnalyticsRecordFilter filter =
       new AnalyticsRecordFilter(
-          Set.of(ValueType.PROCESS_INSTANCE_CREATION, ValueType.PROCESS_INSTANCE),
-          Set.of(ProcessInstanceCreationIntent.CREATED, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+          Set.of(
+              ValueType.PROCESS_INSTANCE_CREATION,
+              ValueType.PROCESS_INSTANCE,
+              ValueType.USAGE_METRIC),
+          Set.of(
+              ProcessInstanceCreationIntent.CREATED,
+              ProcessInstanceIntent.ELEMENT_ACTIVATED,
+              UsageMetricIntent.EXPORTED),
           TEST_PARTITION_ID);
 
   @Test
@@ -50,13 +57,14 @@ class AnalyticsRecordFilterTest {
   void shouldAcceptAllRegisteredValueTypes() {
     assertThat(filter.acceptValue(ValueType.PROCESS_INSTANCE_CREATION)).isTrue();
     assertThat(filter.acceptValue(ValueType.PROCESS_INSTANCE)).isTrue();
+    assertThat(filter.acceptValue(ValueType.USAGE_METRIC)).isTrue();
   }
 
   @ParameterizedTest
   @EnumSource(
       value = ValueType.class,
       mode = EnumSource.Mode.EXCLUDE,
-      names = {"PROCESS_INSTANCE_CREATION", "PROCESS_INSTANCE"})
+      names = {"PROCESS_INSTANCE_CREATION", "PROCESS_INSTANCE", "USAGE_METRIC"})
   void shouldRejectUnregisteredValueType(final ValueType type) {
     assertThat(filter.acceptValue(type)).isFalse();
   }
@@ -65,6 +73,7 @@ class AnalyticsRecordFilterTest {
   void shouldAcceptAllRegisteredIntents() {
     assertThat(filter.acceptIntent(ProcessInstanceCreationIntent.CREATED)).isTrue();
     assertThat(filter.acceptIntent(ProcessInstanceIntent.ELEMENT_ACTIVATED)).isTrue();
+    assertThat(filter.acceptIntent(UsageMetricIntent.EXPORTED)).isTrue();
   }
 
   @Test

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/HandlerRegistryTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/HandlerRegistryTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.zeebe.exporter.test.ExporterTestConfiguration;
+import io.camunda.zeebe.exporter.test.ExporterTestContext;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Test;
+
+class HandlerRegistryTest {
+
+  private static final ProtocolFactory FACTORY = new ProtocolFactory();
+
+  @Test
+  void shouldRouteToHandlerByValueTypeAndIntent() {
+    // given
+    final var handled = new AtomicBoolean(false);
+    final var registry =
+        new HandlerRegistry()
+            .register(
+                ValueType.PROCESS_INSTANCE_CREATION,
+                ProcessInstanceCreationIntent.CREATED,
+                record -> handled.set(true))
+            .apply(testContext());
+
+    final var record =
+        FACTORY.generateRecord(
+            ValueType.PROCESS_INSTANCE_CREATION,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(ProcessInstanceCreationIntent.CREATED));
+
+    // when
+    registry.handle(record);
+
+    // then
+    assertThat(handled).isTrue();
+  }
+
+  @Test
+  void shouldNotRouteWhenIntentDoesNotMatch() {
+    // given
+    final var handled = new AtomicBoolean(false);
+    final var registry =
+        new HandlerRegistry()
+            .register(
+                ValueType.PROCESS_INSTANCE,
+                ProcessInstanceIntent.ELEMENT_ACTIVATED,
+                record -> handled.set(true))
+            .apply(testContext());
+
+    final var record =
+        FACTORY.generateRecord(
+            ValueType.PROCESS_INSTANCE,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(ProcessInstanceIntent.ELEMENT_COMPLETED));
+
+    // when
+    registry.handle(record);
+
+    // then
+    assertThat(handled).isFalse();
+  }
+
+  @Test
+  void shouldSupportMultipleHandlersForSameValueType() {
+    // given
+    final var activatedHandled = new AtomicBoolean(false);
+    final var completedHandled = new AtomicBoolean(false);
+    final var registry =
+        new HandlerRegistry()
+            .register(
+                ValueType.PROCESS_INSTANCE,
+                ProcessInstanceIntent.ELEMENT_ACTIVATED,
+                record -> activatedHandled.set(true))
+            .register(
+                ValueType.PROCESS_INSTANCE,
+                ProcessInstanceIntent.ELEMENT_COMPLETED,
+                record -> completedHandled.set(true))
+            .apply(testContext());
+
+    final var activatedRecord =
+        FACTORY.generateRecord(
+            ValueType.PROCESS_INSTANCE,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATED));
+    final var completedRecord =
+        FACTORY.generateRecord(
+            ValueType.PROCESS_INSTANCE,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(ProcessInstanceIntent.ELEMENT_COMPLETED));
+
+    // when
+    registry.handle(activatedRecord);
+    registry.handle(completedRecord);
+
+    // then
+    assertThat(activatedHandled).isTrue();
+    assertThat(completedHandled).isTrue();
+  }
+
+  @Test
+  void shouldRejectDuplicateRegistration() {
+    // given
+    final var registry =
+        new HandlerRegistry()
+            .register(
+                ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_ACTIVATED, record -> {});
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                registry.register(
+                    ValueType.PROCESS_INSTANCE,
+                    ProcessInstanceIntent.ELEMENT_ACTIVATED,
+                    record -> {}))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Duplicate");
+  }
+
+  @Test
+  void shouldDoNothingForUnregisteredValueType() {
+    // given
+    final var registry = new HandlerRegistry().apply(testContext());
+
+    final var record = FACTORY.generateRecord(ValueType.JOB);
+
+    // when / then — no exception
+    registry.handle(record);
+  }
+
+  private static ExporterTestContext testContext() {
+    return new ExporterTestContext()
+        .setConfiguration(new ExporterTestConfiguration<>("test", new AnalyticsExporterConfig()))
+        .setPartitionId(1);
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/TestOtelSdkManager.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/TestOtelSdkManager.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics;
+
+import io.opentelemetry.sdk.logs.SdkLoggerProvider;
+import io.opentelemetry.sdk.logs.export.SimpleLogRecordProcessor;
+import io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter;
+
+/** Test factory for {@link OtelSdkManager} with in-memory OTel transport. */
+public final class TestOtelSdkManager {
+
+  private TestOtelSdkManager() {}
+
+  /** Creates an initialized OtelSdkManager that captures events in the given exporter. */
+  public static OtelSdkManager inMemory(final InMemoryLogRecordExporter memoryExporter) {
+    final var manager =
+        new OtelSdkManager() {
+          @Override
+          protected SdkLoggerProvider createLoggerProvider(
+              final AnalyticsExporterConfig cfg, final AnalyticsExporterContext context) {
+            return SdkLoggerProvider.builder()
+                .setResource(OtelSdkManager.buildResource(context))
+                .addLogRecordProcessor(SimpleLogRecordProcessor.create(memoryExporter))
+                .build();
+          }
+        };
+    manager.initialize(
+        new AnalyticsExporterConfig(),
+        AnalyticsExporterContext.create("test-license", "test-cluster", 1),
+        new AnalyticsExporterMetadata());
+    return manager;
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/AdHocSubProcessHandlerTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/AdHocSubProcessHandlerTest.java
@@ -65,7 +65,9 @@ class AdHocSubProcessHandlerTest {
         .satisfies(
             logRecord ->
                 assertThat(logRecord.getAttributes().asMap())
-                    .containsEntry(AnalyticsAttributes.EVENT_NAME, "adhoc_subprocess_activated")
+                    .containsEntry(
+                        AnalyticsAttributes.EVENT_NAME,
+                        AnalyticsAttributes.EVENT_ADHOC_SUBPROCESS_ACTIVATED)
                     .containsEntry(AnalyticsAttributes.BPMN_PROCESS_ID, "my-process")
                     .containsEntry(AnalyticsAttributes.PROCESS_DEFINITION_KEY, 42L)
                     .containsEntry(AnalyticsAttributes.PROCESS_INSTANCE_KEY, 99L)

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/AdHocSubProcessHandlerTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/AdHocSubProcessHandlerTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.exporter.analytics.AnalyticsAttributes;
+import io.camunda.exporter.analytics.TestOtelSdkManager;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AdHocSubProcessHandlerTest {
+
+  private static final ProtocolFactory FACTORY = new ProtocolFactory();
+
+  private InMemoryLogRecordExporter memoryExporter;
+  private AdHocSubProcessHandler handler;
+
+  @BeforeEach
+  void setUp() {
+    memoryExporter = InMemoryLogRecordExporter.create();
+    handler = new AdHocSubProcessHandler(TestOtelSdkManager.inMemory(memoryExporter));
+  }
+
+  @Test
+  void shouldEmitEventForAdHocSubProcess() {
+    // given
+    final var value =
+        ImmutableProcessInstanceRecordValue.builder()
+            .withBpmnElementType(BpmnElementType.AD_HOC_SUB_PROCESS)
+            .withBpmnProcessId("my-process")
+            .withProcessDefinitionKey(42L)
+            .withProcessInstanceKey(99L)
+            .withElementId("adhoc-1")
+            .withTenantId("tenant-a")
+            .build();
+    final var record =
+        FACTORY.generateRecord(
+            ValueType.PROCESS_INSTANCE,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                    .withValue(value));
+
+    // when
+    handler.handle(typed(record));
+
+    // then
+    assertThat(memoryExporter.getFinishedLogRecordItems())
+        .singleElement()
+        .satisfies(
+            logRecord ->
+                assertThat(logRecord.getAttributes().asMap())
+                    .containsEntry(AnalyticsAttributes.EVENT_NAME, "adhoc_subprocess_activated")
+                    .containsEntry(AnalyticsAttributes.BPMN_PROCESS_ID, "my-process")
+                    .containsEntry(AnalyticsAttributes.PROCESS_DEFINITION_KEY, 42L)
+                    .containsEntry(AnalyticsAttributes.PROCESS_INSTANCE_KEY, 99L)
+                    .containsEntry(AnalyticsAttributes.ELEMENT_ID, "adhoc-1")
+                    .containsEntry(AnalyticsAttributes.TENANT_ID, "tenant-a"));
+  }
+
+  @Test
+  void shouldSkipNonAdHocSubProcessElement() {
+    // given
+    final var value =
+        ImmutableProcessInstanceRecordValue.builder()
+            .withBpmnElementType(BpmnElementType.SERVICE_TASK)
+            .build();
+    final var record =
+        FACTORY.generateRecord(
+            ValueType.PROCESS_INSTANCE,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                    .withValue(value));
+
+    // when
+    handler.handle(typed(record));
+
+    // then
+    assertThat(memoryExporter.getFinishedLogRecordItems()).isEmpty();
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T extends RecordValue> Record<T> typed(final Record<?> record) {
+    return (Record<T>) record;
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/UsageMetricHandlerTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/UsageMetricHandlerTest.java
@@ -52,7 +52,9 @@ class UsageMetricHandlerTest {
         .satisfies(
             logRecord ->
                 assertThat(logRecord.getAttributes().asMap())
-                    .containsEntry(AnalyticsAttributes.EVENT_NAME, "usage_metric_exported")
+                    .containsEntry(
+                        AnalyticsAttributes.EVENT_NAME,
+                        AnalyticsAttributes.EVENT_USAGE_METRIC_EXPORTED)
                     .containsEntry(AnalyticsAttributes.USAGE_METRIC_EVENT_TYPE, "RPI")
                     .containsEntry(AnalyticsAttributes.USAGE_METRIC_COUNT, 30L)
                     .containsEntry(AnalyticsAttributes.USAGE_METRIC_INTERVAL_START, 1000L)

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/UsageMetricHandlerTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/UsageMetricHandlerTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.exporter.analytics.AnalyticsAttributes;
+import io.camunda.exporter.analytics.TestOtelSdkManager;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.UsageMetricIntent;
+import io.camunda.zeebe.protocol.record.value.ImmutableUsageMetricRecordValue;
+import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class UsageMetricHandlerTest {
+
+  private static final ProtocolFactory FACTORY = new ProtocolFactory();
+
+  private InMemoryLogRecordExporter memoryExporter;
+  private UsageMetricHandler handler;
+
+  @BeforeEach
+  void setUp() {
+    memoryExporter = InMemoryLogRecordExporter.create();
+    handler = new UsageMetricHandler(TestOtelSdkManager.inMemory(memoryExporter));
+  }
+
+  @Test
+  void shouldEmitRpiEventWithSummedCounterValues() {
+    // given
+    final var record = usageMetricRecord(UsageMetricRecordValue.EventType.RPI, 10L, 20L);
+
+    // when
+    handler.handle(typed(record));
+
+    // then
+    assertThat(memoryExporter.getFinishedLogRecordItems())
+        .singleElement()
+        .satisfies(
+            logRecord ->
+                assertThat(logRecord.getAttributes().asMap())
+                    .containsEntry(AnalyticsAttributes.EVENT_NAME, "usage_metric_exported")
+                    .containsEntry(AnalyticsAttributes.USAGE_METRIC_EVENT_TYPE, "RPI")
+                    .containsEntry(AnalyticsAttributes.USAGE_METRIC_COUNT, 30L)
+                    .containsEntry(AnalyticsAttributes.USAGE_METRIC_INTERVAL_START, 1000L)
+                    .containsEntry(AnalyticsAttributes.USAGE_METRIC_INTERVAL_END, 2000L));
+  }
+
+  @Test
+  void shouldEmitEdiEventWithSummedCounterValues() {
+    // given
+    final var record = usageMetricRecord(UsageMetricRecordValue.EventType.EDI, 5L, 15L);
+
+    // when
+    handler.handle(typed(record));
+
+    // then
+    assertThat(memoryExporter.getFinishedLogRecordItems())
+        .singleElement()
+        .satisfies(
+            logRecord ->
+                assertThat(logRecord.getAttributes().asMap())
+                    .containsEntry(AnalyticsAttributes.USAGE_METRIC_EVENT_TYPE, "EDI")
+                    .containsEntry(AnalyticsAttributes.USAGE_METRIC_COUNT, 20L));
+  }
+
+  @Test
+  void shouldEmitTuEventWithSetSizes() {
+    // given
+    final var value =
+        ImmutableUsageMetricRecordValue.builder()
+            .withEventType(UsageMetricRecordValue.EventType.TU)
+            .withSetValues(Map.of("tenant-a", Set.of(1L, 2L), "tenant-b", Set.of(3L)))
+            .withStartTime(1000L)
+            .withEndTime(2000L)
+            .build();
+    final var record =
+        FACTORY.generateRecord(
+            ValueType.USAGE_METRIC,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(UsageMetricIntent.EXPORTED)
+                    .withValue(value));
+
+    // when
+    handler.handle(typed(record));
+
+    // then
+    assertThat(memoryExporter.getFinishedLogRecordItems())
+        .singleElement()
+        .satisfies(
+            logRecord ->
+                assertThat(logRecord.getAttributes().asMap())
+                    .containsEntry(AnalyticsAttributes.USAGE_METRIC_COUNT, 3L));
+  }
+
+  @Test
+  void shouldSkipNoneEventType() {
+    // given
+    final var value =
+        ImmutableUsageMetricRecordValue.builder()
+            .withEventType(UsageMetricRecordValue.EventType.NONE)
+            .build();
+    final var record =
+        FACTORY.generateRecord(
+            ValueType.USAGE_METRIC,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(UsageMetricIntent.EXPORTED)
+                    .withValue(value));
+
+    // when
+    handler.handle(typed(record));
+
+    // then
+    assertThat(memoryExporter.getFinishedLogRecordItems()).isEmpty();
+  }
+
+  // -- helpers --
+
+  private Record<?> usageMetricRecord(
+      final UsageMetricRecordValue.EventType eventType,
+      final long tenantACount,
+      final long tenantBCount) {
+    final var value =
+        ImmutableUsageMetricRecordValue.builder()
+            .withEventType(eventType)
+            .withCounterValues(Map.of("tenant-a", tenantACount, "tenant-b", tenantBCount))
+            .withStartTime(1000L)
+            .withEndTime(2000L)
+            .build();
+    return FACTORY.generateRecord(
+        ValueType.USAGE_METRIC,
+        r ->
+            r.withRecordType(RecordType.EVENT)
+                .withIntent(UsageMetricIntent.EXPORTED)
+                .withValue(value));
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T extends RecordValue> Record<T> typed(final Record<?> record) {
+    return (Record<T>) record;
+  }
+}


### PR DESCRIPTION
## Summary

Extends the analytics exporter with two new event types and refactors the handler infrastructure for clean extensibility.

- **HandlerRegistry** extracted to own file with two-level `EnumMap<ValueType, Map<Intent, handler>>` lookup — supports multiple handlers per ValueType keyed by Intent, O(1) dispatch
- **AnalyticsHandler** extracted as `@FunctionalInterface` — simple `void handle(Record<T>)`, usable as method reference or class
- **AnalyticsRecordFilter** gains `acceptIntent()` for phase-1 broker-level intent filtering (pre-deserialization)
- **AdHocSubProcessHandler** emits `adhoc_subprocess_activated` for `PROCESS_INSTANCE / ELEMENT_ACTIVATED` events on `AD_HOC_SUB_PROCESS` elements
- **UsageMetricHandler** emits `usage_metric_exported` for `USAGE_METRIC / EXPORTED` events, aggregating counter/set values into a single count per metric type (RPI, EDI, TU), skipping internal NONE resets
- Handlers live in a dedicated `handler/` subpackage, exporter is pure lifecycle + wiring

### Microbenchmark results (no regression)

```
Benchmark                                 Before (ns/op)       After (ns/op)
exportUnmatchedRecord (hot path, ~99%)    3.919 ± 0.033        3.943 ± 0.483
exportPiCreatedRecord (handler match)     396.507 ± 70.361     382.588 ± 4.955
```

Closes #52383

## Test plan

- [x] Behavioral tests with pinned `ImmutableProcessInstanceRecordValue` / `ImmutableUsageMetricRecordValue` builders
- [x] AdHoc: positive (AD_HOC_SUB_PROCESS emits with correct attributes) + negative (SERVICE_TASK skipped)
- [x] Usage metric: RPI counter sum, TU set size sum, NONE event skip
- [x] Filter tests for all registered value types, intents, partition ownership
- [x] Existing PI creation and resilience tests pass (32 total)
- [x] JMH microbenchmarks confirm no performance regression
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)