### PR TITLE
refactor: use ActorFuture<Void>, not @Nullable Void

### DIFF
--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/Actor.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/Actor.java
@@ -100,7 +100,7 @@ public abstract class Actor implements AutoCloseable, AsyncClosable, Concurrency
   }
 
   @Override
-  public ActorFuture<@Nullable Void> closeAsync() {
+  public ActorFuture<Void> closeAsync() {
     return actor.close();
   }
 

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorControl.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorControl.java
@@ -70,8 +70,8 @@ public class ActorControl implements ConcurrencyControl {
    * @param action
    * @return
    */
-  public ActorFuture<@Nullable Void> call(final Runnable action) {
-    final Callable<@Nullable Void> c =
+  public ActorFuture<Void> call(final Runnable action) {
+    final Callable<Void> c =
         () -> {
           action.run();
           return null;
@@ -316,7 +316,7 @@ public class ActorControl implements ConcurrencyControl {
     job.getTask().yieldThread();
   }
 
-  public ActorFuture<@Nullable Void> close() {
+  public ActorFuture<Void> close() {
     final ActorJob closeJob = new ActorJob();
 
     closeJob.onJobAddedToTask(task);

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorExecutor.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorExecutor.java
@@ -11,7 +11,6 @@ import io.camunda.zeebe.scheduler.ActorScheduler.ActorSchedulerBuilder;
 import io.camunda.zeebe.scheduler.ActorTask.ActorLifecyclePhase;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import java.util.concurrent.CompletableFuture;
-import org.jspecify.annotations.Nullable;
 
 /**
  * Used to submit {@link ActorTask ActorTasks} and Blocking Actions to the scheduler's internal
@@ -31,20 +30,19 @@ public final class ActorExecutor {
    *
    * @param task the task to submit
    */
-  public ActorFuture<@Nullable Void> submitCpuBound(final ActorTask task) {
+  public ActorFuture<Void> submitCpuBound(final ActorTask task) {
     return submitTask(task, cpuBoundThreads);
   }
 
-  public ActorFuture<@Nullable Void> submitIoBoundTask(final ActorTask task) {
+  public ActorFuture<Void> submitIoBoundTask(final ActorTask task) {
     return submitTask(task, ioBoundThreads);
   }
 
-  private ActorFuture<@Nullable Void> submitTask(
-      final ActorTask task, final ActorThreadGroup threadGroup) {
+  private ActorFuture<Void> submitTask(final ActorTask task, final ActorThreadGroup threadGroup) {
     if (task.getLifecyclePhase() != ActorLifecyclePhase.CLOSED) {
       throw new IllegalStateException("ActorTask was already submitted!");
     }
-    final ActorFuture<@Nullable Void> startingFuture = task.onTaskScheduled(threadGroup);
+    final ActorFuture<Void> startingFuture = task.onTaskScheduled(threadGroup);
 
     threadGroup.submit(task);
     return startingFuture;
@@ -55,7 +53,7 @@ public final class ActorExecutor {
     ioBoundThreads.start();
   }
 
-  public CompletableFuture<@Nullable Void> closeAsync() {
+  public CompletableFuture<Void> closeAsync() {
     return CompletableFuture.allOf(ioBoundThreads.closeAsync(), cpuBoundThreads.closeAsync());
   }
 

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorScheduler.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorScheduler.java
@@ -17,7 +17,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import org.agrona.concurrent.BackoffIdleStrategy;
 import org.agrona.concurrent.IdleStrategy;
-import org.jspecify.annotations.Nullable;
 
 public final class ActorScheduler implements AutoCloseable, ActorSchedulingService {
   private final AtomicReference<SchedulerState> state = new AtomicReference<>();
@@ -36,7 +35,7 @@ public final class ActorScheduler implements AutoCloseable, ActorSchedulingServi
    * @param actor the actor to submit
    */
   @Override
-  public ActorFuture<@Nullable Void> submitActor(final Actor actor) {
+  public ActorFuture<Void> submitActor(final Actor actor) {
     return submitActor(actor, SchedulingHints.cpuBound());
   }
 
@@ -58,8 +57,7 @@ public final class ActorScheduler implements AutoCloseable, ActorSchedulingServi
    * @param schedulingHints additional scheduling hint
    */
   @Override
-  public ActorFuture<@Nullable Void> submitActor(
-      final Actor actor, final SchedulingHints schedulingHints) {
+  public ActorFuture<Void> submitActor(final Actor actor, final SchedulingHints schedulingHints) {
     checkRunningState();
 
     final ActorTask task = actor.actor.task;
@@ -85,7 +83,7 @@ public final class ActorScheduler implements AutoCloseable, ActorSchedulingServi
     }
   }
 
-  public Future<@Nullable Void> stop() {
+  public Future<Void> stop() {
     if (state.compareAndSet(SchedulerState.RUNNING, SchedulerState.TERMINATING)) {
 
       return actorTaskExecutor.closeAsync().thenRun(() -> state.set(SchedulerState.TERMINATED));

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorSchedulingService.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorSchedulingService.java
@@ -8,14 +8,13 @@
 package io.camunda.zeebe.scheduler;
 
 import io.camunda.zeebe.scheduler.future.ActorFuture;
-import org.jspecify.annotations.Nullable;
 
 /**
  * Service interface to schedule an actor (without exposing the full interface of {@code
  * ActorScheduler}
  */
 public interface ActorSchedulingService {
-  ActorFuture<@Nullable Void> submitActor(final Actor actor);
+  ActorFuture<Void> submitActor(final Actor actor);
 
-  ActorFuture<@Nullable Void> submitActor(final Actor actor, SchedulingHints schedulingHints);
+  ActorFuture<Void> submitActor(final Actor actor, SchedulingHints schedulingHints);
 }

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorTask.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorTask.java
@@ -40,7 +40,7 @@ public class ActorTask {
 
   // Start with a completed future to allow closing unscheduled tasks. The future is reset to
   // uncompleted in `onTaskScheduled`.
-  public final CompletableActorFuture<Void> closeFuture = CompletableActorFuture.completed(null);
+  public final CompletableActorFuture<Void> closeFuture = CompletableActorFuture.completed();
   final Actor actor;
   ActorJob currentJob;
   boolean shouldYield;

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorTask.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorTask.java
@@ -23,7 +23,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import org.agrona.concurrent.ManyToOneConcurrentLinkedQueue;
 import org.jetbrains.annotations.Async;
-import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,19 +40,15 @@ public class ActorTask {
 
   // Start with a completed future to allow closing unscheduled tasks. The future is reset to
   // uncompleted in `onTaskScheduled`.
-  public final CompletableActorFuture<@Nullable Void> closeFuture =
-      CompletableActorFuture.completed(null);
+  public final CompletableActorFuture<Void> closeFuture = CompletableActorFuture.completed(null);
   final Actor actor;
   ActorJob currentJob;
   boolean shouldYield;
   final AtomicReference<TaskSchedulingState> schedulingState = new AtomicReference<>();
   final AtomicLong stateCount = new AtomicLong(0);
-  private final CompletableActorFuture<@Nullable Void> jobClosingTaskFuture =
-      new CompletableActorFuture<>();
-  private final CompletableActorFuture<@Nullable Void> startingFuture =
-      new CompletableActorFuture<>();
-  private final CompletableActorFuture<@Nullable Void> jobStartingTaskFuture =
-      new CompletableActorFuture<>();
+  private final CompletableActorFuture<Void> jobClosingTaskFuture = new CompletableActorFuture<>();
+  private final CompletableActorFuture<Void> startingFuture = new CompletableActorFuture<>();
+  private final CompletableActorFuture<Void> jobStartingTaskFuture = new CompletableActorFuture<>();
   private ActorThreadGroup actorThreadGroup;
   private Deque<ActorJob> fastLaneJobs = new ClosedQueue();
   private volatile ActorLifecyclePhase lifecyclePhase = ActorLifecyclePhase.CLOSED;
@@ -72,7 +67,7 @@ public class ActorTask {
   }
 
   /** called when the task is initially scheduled. */
-  public ActorFuture<@Nullable Void> onTaskScheduled(final ActorThreadGroup actorThreadGroup) {
+  public ActorFuture<Void> onTaskScheduled(final ActorThreadGroup actorThreadGroup) {
     this.actorThreadGroup = actorThreadGroup;
     // reset previous state to allow re-scheduling
     closeFuture.close();
@@ -486,7 +481,7 @@ public class ActorTask {
     return lifecyclePhase;
   }
 
-  public CompletableActorFuture<@Nullable Void> getStartingFuture() {
+  public CompletableActorFuture<Void> getStartingFuture() {
     return startingFuture;
   }
 

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorThread.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorThread.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.scheduler;
 
+import static io.camunda.zeebe.util.Unit.unit;
+
 import io.camunda.zeebe.scheduler.ActorScheduler.ActorSchedulerBuilder;
 import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.scheduler.clock.DefaultActorClock;
@@ -229,7 +231,7 @@ public class ActorThread extends Thread implements Consumer<Runnable> {
 
     state = ActorThreadState.TERMINATED;
 
-    terminationFuture.complete(null);
+    terminationFuture.complete(unit());
   }
 
   public CompletableFuture<Void> close() {

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorThread.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorThread.java
@@ -19,7 +19,6 @@ import java.util.concurrent.locks.LockSupport;
 import java.util.function.Consumer;
 import org.agrona.concurrent.IdleStrategy;
 import org.agrona.concurrent.ManyToManyConcurrentArrayQueue;
-import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.MDC;
 
@@ -43,7 +42,7 @@ public class ActorThread extends Thread implements Consumer<Runnable> {
   protected ActorTaskRunnerIdleStrategy idleStrategy;
   ActorTask currentTask;
   private final ActorMetrics actorMetrics;
-  private final CompletableFuture<@Nullable Void> terminationFuture = new CompletableFuture<>();
+  private final CompletableFuture<Void> terminationFuture = new CompletableFuture<>();
   private final ActorClock clock;
   private final int threadId;
   private final TaskScheduler taskScheduler;
@@ -233,7 +232,7 @@ public class ActorThread extends Thread implements Consumer<Runnable> {
     terminationFuture.complete(null);
   }
 
-  public CompletableFuture<@Nullable Void> close() {
+  public CompletableFuture<Void> close() {
     if (STATE_HANDLE.compareAndSet(this, ActorThreadState.RUNNING, ActorThreadState.TERMINATING)) {
       return terminationFuture;
     } else {

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorThreadGroup.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorThreadGroup.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.scheduler;
 
+import static io.camunda.zeebe.util.Unit.unit;
+
 import io.camunda.zeebe.scheduler.ActorScheduler.ActorSchedulerBuilder;
 import io.camunda.zeebe.util.Loggers;
 import java.util.concurrent.CompletableFuture;
@@ -91,7 +93,7 @@ public abstract class ActorThreadGroup {
             groupName,
             thread.getRunnerId(),
             e);
-        terminationFutures[i] = CompletableFuture.completedFuture(null);
+        terminationFutures[i] = CompletableFuture.completedFuture(unit());
       }
     }
 

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorThreadGroup.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorThreadGroup.java
@@ -11,7 +11,6 @@ import io.camunda.zeebe.scheduler.ActorScheduler.ActorSchedulerBuilder;
 import io.camunda.zeebe.util.Loggers;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ThreadLocalRandom;
-import org.jspecify.annotations.Nullable;
 
 /**
  * A thread group is a group of threads which process the same kind of tasks (ie. blocking I/O vs.
@@ -77,11 +76,10 @@ public abstract class ActorThreadGroup {
     return schedulerName;
   }
 
-  public CompletableFuture<@Nullable Void> closeAsync() {
+  public CompletableFuture<Void> closeAsync() {
     Loggers.ACTOR_LOGGER.debug("Closing actor thread ground '{}'", groupName);
 
-    final CompletableFuture<@Nullable Void>[] terminationFutures =
-        new CompletableFuture[numOfThreads];
+    final CompletableFuture<Void>[] terminationFutures = new CompletableFuture[numOfThreads];
 
     for (int i = 0; i < numOfThreads; i++) {
       final ActorThread thread = threads[i];

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/AsyncClosable.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/AsyncClosable.java
@@ -19,9 +19,9 @@ public interface AsyncClosable {
    *
    * @return the future, which is completed when resources are closed
    */
-  ActorFuture<@Nullable Void> closeAsync();
+  ActorFuture<Void> closeAsync();
 
-  static ActorFuture<@Nullable Void> closeHelper(final @Nullable AsyncClosable closeable) {
+  static ActorFuture<Void> closeHelper(final @Nullable AsyncClosable closeable) {
     if (closeable != null) {
       return closeable.closeAsync();
     } else {

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/ActorFuture.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/ActorFuture.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.scheduler.future;
 
+import static io.camunda.zeebe.util.Unit.unit;
+
 import io.camunda.zeebe.scheduler.ActorTask;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -245,12 +247,11 @@ public interface ActorFuture<V extends @Nullable Object>
    *     exceptionally if this future completes exceptionally. This future can be used for further
    *     chaining.
    */
-  @SuppressWarnings("NullAway")
   default ActorFuture<Void> thenAccept(final Consumer<V> next, final Executor executor) {
     return thenApply(
         value -> {
           next.accept(value);
-          return null;
+          return unit();
         },
         executor);
   }
@@ -303,12 +304,11 @@ public interface ActorFuture<V extends @Nullable Object>
    *     exceptionally if this future completes exceptionally. This future can be used for further
    *     chaining.
    */
-  @SuppressWarnings("NullAway")
   default ActorFuture<Void> thenAccept(final Consumer<V> next) {
     return thenApply(
         value -> {
           next.accept(value);
-          return null;
+          return unit();
         });
   }
 

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/ActorFuture.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/ActorFuture.java
@@ -22,6 +22,7 @@ import org.jspecify.annotations.Nullable;
 /** interface for actor futures */
 public interface ActorFuture<V extends @Nullable Object>
     extends Future<V>, BiConsumer<V, @Nullable Throwable> {
+
   void complete(V value);
 
   void completeExceptionally(@Nullable String failure, Throwable throwable);
@@ -232,6 +233,45 @@ public interface ActorFuture<V extends @Nullable Object>
   <U extends @Nullable Object> ActorFuture<U> thenApply(Function<V, U> next, Executor executor);
 
   /**
+   * Similar to {@link CompletableFuture#thenAccept(Consumer)} in that it consumes the result of
+   * this future without producing another value.
+   *
+   * <p>This is the preferred alternative to {@code thenApply(value -> { ...; return null; })} for
+   * side-effecting continuations.
+   *
+   * @param next consumer to apply to the result of this future.
+   * @param executor The executor used to handle completion callbacks.
+   * @return a new void future that completes after consuming the result of this future or
+   *     exceptionally if this future completes exceptionally. This future can be used for further
+   *     chaining.
+   */
+  @SuppressWarnings("NullAway")
+  default ActorFuture<Void> thenAccept(final Consumer<V> next, final Executor executor) {
+    return thenApply(
+        value -> {
+          next.accept(value);
+          return null;
+        },
+        executor);
+  }
+
+  /**
+   * Similar to {@link CompletableFuture#thenRun(Runnable)} in that it runs a callback when this
+   * future completes successfully without using its result.
+   *
+   * <p>This is the preferred alternative to {@code thenApply(value -> { ...; return null; })} when
+   * the continuation does not need this future's result.
+   *
+   * @param next runnable to run after this future completes successfully.
+   * @param executor The executor used to handle completion callbacks.
+   * @return a new void future that completes after running the callback or exceptionally if this
+   *     future completes exceptionally. This future can be used for further chaining.
+   */
+  default ActorFuture<Void> thenRun(final Runnable next, final Executor executor) {
+    return thenAccept(ignored -> next.run(), executor);
+  }
+
+  /**
    * Similar to {@link CompletableFuture#thenApply(Function)} in that it applies a function to the
    * result of this future, allowing you to change types on the fly.
    *
@@ -250,4 +290,40 @@ public interface ActorFuture<V extends @Nullable Object>
    * @param <U> the type of the new future
    */
   <U extends @Nullable Object> ActorFuture<U> thenApply(final Function<V, U> next);
+
+  /**
+   * Similar to {@link CompletableFuture#thenAccept(Consumer)} in that it consumes the result of
+   * this future without producing another value.
+   *
+   * <p>If the caller is not an actor, {@link ActorFuture#thenAccept(Consumer, Executor)} must be
+   * used to avoid blocking the actor execution context.
+   *
+   * @param next consumer to apply to the result of this future.
+   * @return a new void future that completes after consuming the result of this future or
+   *     exceptionally if this future completes exceptionally. This future can be used for further
+   *     chaining.
+   */
+  @SuppressWarnings("NullAway")
+  default ActorFuture<Void> thenAccept(final Consumer<V> next) {
+    return thenApply(
+        value -> {
+          next.accept(value);
+          return null;
+        });
+  }
+
+  /**
+   * Similar to {@link CompletableFuture#thenRun(Runnable)} in that it runs a callback when this
+   * future completes successfully without using its result.
+   *
+   * <p>If the caller is not an actor, {@link ActorFuture#thenRun(Runnable, Executor)} must be used
+   * to avoid blocking the actor execution context.
+   *
+   * @param next runnable to run after this future completes successfully.
+   * @return a new void future that completes after running the callback or exceptionally if this
+   *     future completes exceptionally. This future can be used for further chaining.
+   */
+  default ActorFuture<Void> thenRun(final Runnable next) {
+    return thenAccept(ignored -> next.run());
+  }
 }

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/CompletableActorFuture.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/CompletableActorFuture.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.scheduler.future;
 
 import static io.camunda.zeebe.util.Nulls.uncheckedCastToNonNull;
+import static io.camunda.zeebe.util.Unit.unit;
 import static java.util.Objects.requireNonNull;
 
 import io.camunda.zeebe.scheduler.ActorControl;
@@ -90,9 +91,8 @@ public final class CompletableActorFuture<V extends @Nullable Object> implements
     isDoneCondition = completionLock.newCondition();
   }
 
-  @SuppressWarnings("NullAway")
   public static CompletableActorFuture<Void> completed() {
-    return CompletableActorFuture.completed(null);
+    return CompletableActorFuture.completed(unit());
   }
 
   public static <V extends @Nullable Object> CompletableActorFuture<V> completed(final V result) {

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/CompletableActorFuture.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/CompletableActorFuture.java
@@ -90,7 +90,8 @@ public final class CompletableActorFuture<V extends @Nullable Object> implements
     isDoneCondition = completionLock.newCondition();
   }
 
-  public static CompletableActorFuture<@Nullable Void> completed() {
+  @SuppressWarnings("NullAway")
+  public static CompletableActorFuture<Void> completed() {
     return CompletableActorFuture.completed(null);
   }
 
@@ -113,11 +114,11 @@ public final class CompletableActorFuture<V extends @Nullable Object> implements
    *     successfully. if one future returns an error, the computation is stopped (the rest of the
    *     Future will not be started) and the error is returned
    */
-  public static <A> ActorFuture<@Nullable Void> traverseIgnoring(
+  public static <A> ActorFuture<Void> traverseIgnoring(
       final Collection<A> collection,
-      final Function<A, ActorFuture<@Nullable Void>> function,
+      final Function<A, ActorFuture<Void>> function,
       final Executor executor) {
-    ActorFuture<@Nullable Void> future = completed();
+    ActorFuture<Void> future = completed();
     for (final A a : collection) {
       future = future.andThen(unused -> function.apply(a), executor);
     }

--- a/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/future/CompletableActorFutureTest.java
+++ b/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/future/CompletableActorFutureTest.java
@@ -15,6 +15,8 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.Nested;
@@ -23,6 +25,56 @@ import org.junit.jupiter.api.Test;
 public class CompletableActorFutureTest {
 
   @AutoClose private static final ExecutorService EXECUTOR = Executors.newWorkStealingPool();
+
+  @Nested
+  class VoidContinuations {
+    @Test
+    public void shouldConsumeFutureResult() {
+      // given
+      final var consumed = new AtomicReference<String>();
+
+      // when
+      final var future =
+          CompletableActorFuture.completed("value").thenAccept(consumed::set, EXECUTOR);
+
+      // then
+      assertThat(future.join()).isNull();
+      assertThat(consumed).hasValue("value");
+    }
+
+    @Test
+    public void shouldRunAfterFutureCompletes() {
+      // given
+      final var ran = new AtomicBoolean();
+
+      // when
+      final var future =
+          CompletableActorFuture.completed("value").thenRun(() -> ran.set(true), EXECUTOR);
+
+      // then
+      assertThat(future.join()).isNull();
+      assertThat(ran).isTrue();
+    }
+
+    @Test
+    public void shouldPropagateFailureWithoutRunningContinuation() {
+      // given
+      final var ran = new AtomicBoolean();
+      final var exception = new RuntimeException("Expected");
+
+      // when
+      final var future =
+          CompletableActorFuture.completedExceptionally(exception)
+              .thenRun(() -> ran.set(true), EXECUTOR);
+
+      // then
+      assertThat(future)
+          .failsWithin(Duration.ofSeconds(5))
+          .withThrowableThat()
+          .withMessageContaining("Expected");
+      assertThat(ran).isFalse();
+    }
+  }
 
   @Nested
   class TraverseIgnoring {

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/ServerTransport.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/ServerTransport.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.transport;
 
 import io.camunda.zeebe.scheduler.future.ActorFuture;
-import org.jspecify.annotations.Nullable;
 
 public interface ServerTransport extends ServerOutput, AutoCloseable {
 
@@ -20,7 +19,7 @@ public interface ServerTransport extends ServerOutput, AutoCloseable {
    * @param requestType the type of request that should be handled
    * @param requestHandler the handler which should be called.
    */
-  ActorFuture<@Nullable Void> subscribe(
+  ActorFuture<Void> subscribe(
       int partitionId, RequestType requestType, RequestHandler requestHandler);
 
   /**
@@ -30,5 +29,5 @@ public interface ServerTransport extends ServerOutput, AutoCloseable {
    * @param partitionId the partition, from which we should unsubscribe
    * @param requestType
    */
-  ActorFuture<@Nullable Void> unsubscribe(int partitionId, RequestType requestType);
+  ActorFuture<Void> unsubscribe(int partitionId, RequestType requestType);
 }

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/impl/AtomixServerTransport.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/impl/AtomixServerTransport.java
@@ -22,7 +22,6 @@ import org.agrona.collections.Int2ObjectHashMap;
 import org.agrona.collections.Long2ObjectHashMap;
 import org.agrona.concurrent.IdGenerator;
 import org.agrona.concurrent.UnsafeBuffer;
-import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 
 public class AtomixServerTransport extends Actor implements ServerTransport {
@@ -69,7 +68,7 @@ public class AtomixServerTransport extends Actor implements ServerTransport {
   }
 
   @Override
-  public ActorFuture<@Nullable Void> subscribe(
+  public ActorFuture<Void> subscribe(
       final int partitionId, final RequestType requestType, final RequestHandler requestHandler) {
     return actor.call(
         () -> {
@@ -81,8 +80,7 @@ public class AtomixServerTransport extends Actor implements ServerTransport {
   }
 
   @Override
-  public ActorFuture<@Nullable Void> unsubscribe(
-      final int partitionId, final RequestType requestType) {
+  public ActorFuture<Void> unsubscribe(final int partitionId, final RequestType requestType) {
     return actor.call(() -> removeRequestHandlers(partitionId, requestType));
   }
 

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamConsumer.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamConsumer.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.transport.stream.api;
 
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import org.agrona.DirectBuffer;
-import org.jspecify.annotations.Nullable;
 
 /**
  * Represents a consumer of a stream which can consume data pushed from the server. The data is
@@ -25,5 +24,5 @@ public interface ClientStreamConsumer {
    *
    * @param payload the data to be consumed by the client
    */
-  ActorFuture<@Nullable Void> push(DirectBuffer payload);
+  ActorFuture<Void> push(DirectBuffer payload);
 }

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamService.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamService.java
@@ -15,7 +15,6 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.Collection;
 import java.util.Optional;
-import org.jspecify.annotations.Nullable;
 
 /**
  * Manages an instance of {@link ClientStreamer}. Intended to be the main entry point when setting
@@ -31,7 +30,7 @@ public interface ClientStreamService<M extends BufferWriter> extends AsyncClosab
    * Starts the service, optionally with the given actor scheduling service. Assumes the scheduling
    * service is already running.
    */
-  ActorFuture<@Nullable Void> start(final ActorSchedulingService schedulingService);
+  ActorFuture<Void> start(final ActorSchedulingService schedulingService);
 
   /**
    * A callback to be invoked when a new streaming server is added. Implementations should be

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamer.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamer.java
@@ -11,7 +11,6 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.util.CloseableSilently;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import org.agrona.DirectBuffer;
-import org.jspecify.annotations.Nullable;
 
 /**
  * Allows to add and remove client streams.
@@ -47,5 +46,5 @@ public interface ClientStreamer<M extends BufferWriter> extends CloseableSilentl
    * @param streamId unique id of the stream
    * @return a future which will be completed after the stream is removed
    */
-  ActorFuture<@Nullable Void> remove(final ClientStreamId streamId);
+  ActorFuture<Void> remove(final ClientStreamId streamId);
 }

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/api/RemoteStreamService.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/api/RemoteStreamService.java
@@ -13,7 +13,6 @@ import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.Collection;
-import org.jspecify.annotations.Nullable;
 
 /**
  * A remote stream service that manages streams from the Gateways.
@@ -26,7 +25,7 @@ public interface RemoteStreamService<M, P extends BufferWriter>
   ActorFuture<RemoteStreamer<M, P>> start(
       ActorSchedulingService actorSchedulingService, ConcurrencyControl concurrencyControl);
 
-  ActorFuture<@Nullable Void> closeAsync(ConcurrencyControl concurrencyControl);
+  ActorFuture<Void> closeAsync(ConcurrencyControl concurrencyControl);
 
   /** Returns all registered remote streams. */
   Collection<RemoteStreamInfo<M>> streams();

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamApiHandler.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamApiHandler.java
@@ -33,7 +33,7 @@ final class ClientStreamApiHandler {
   CompletableFuture<StreamResponse> handlePushRequest(final PushStreamRequest request) {
     final CompletableFuture<StreamResponse> responseFuture = new CompletableFuture<>();
 
-    final ActorFuture<@Nullable Void> payloadPushed = new CompletableActorFuture<>();
+    final ActorFuture<Void> payloadPushed = new CompletableActorFuture<>();
     clientStreamManager.onPayloadReceived(request, payloadPushed);
     payloadPushed.onComplete((ok, error) -> handlePayloadPushed(responseFuture, error), executor);
 

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
@@ -18,7 +18,6 @@ import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.HashSet;
 import java.util.Set;
 import org.agrona.DirectBuffer;
-import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -88,7 +87,7 @@ final class ClientStreamManager<M extends BufferWriter> {
   }
 
   public void onPayloadReceived(
-      final PushStreamRequest pushStreamRequest, final ActorFuture<@Nullable Void> responseFuture) {
+      final PushStreamRequest pushStreamRequest, final ActorFuture<Void> responseFuture) {
     final var streamId = pushStreamRequest.streamId();
     final var payload = pushStreamRequest.payload();
 

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamPusher.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamPusher.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.transport.stream.impl;
 
+import static io.camunda.zeebe.util.Unit.unit;
+
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.transport.stream.api.ClientStreamBlockedException;
@@ -23,7 +25,6 @@ import java.util.List;
 import java.util.Queue;
 import java.util.UUID;
 import org.agrona.DirectBuffer;
-import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,7 +62,7 @@ final class ClientStreamPusher {
   void push(
       final AggregatedClientStream<?> stream,
       final DirectBuffer payload,
-      final ActorFuture<@Nullable Void> future) {
+      final ActorFuture<Void> future) {
     final var streams = stream.clientStreams().values();
     if (streams.isEmpty()) {
       future.completeExceptionally(
@@ -81,7 +82,7 @@ final class ClientStreamPusher {
       final UUID streamId,
       final Queue<ClientStreamImpl<?>> targets,
       final DirectBuffer buffer,
-      final ActorFuture<@Nullable Void> future,
+      final ActorFuture<Void> future,
       final List<Throwable> errors) {
     final var clientStream = targets.poll();
     if (clientStream == null) {
@@ -94,7 +95,7 @@ final class ClientStreamPusher {
         .onComplete(
             (ok, pushFailed) -> {
               if (pushFailed == null) {
-                future.complete(null);
+                future.complete(unit());
                 return;
               }
 
@@ -105,8 +106,7 @@ final class ClientStreamPusher {
             });
   }
 
-  private ActorFuture<@Nullable Void> push(
-      final ClientStreamImpl<?> stream, final DirectBuffer payload) {
+  private ActorFuture<Void> push(final ClientStreamImpl<?> stream, final DirectBuffer payload) {
     try {
       return stream.clientStreamConsumer().push(payload);
     } catch (final Exception e) {
@@ -114,8 +114,7 @@ final class ClientStreamPusher {
     }
   }
 
-  private void failOnStreamExhausted(
-      final ActorFuture<@Nullable Void> future, final List<Throwable> errors) {
+  private void failOnStreamExhausted(final ActorFuture<Void> future, final List<Throwable> errors) {
     final StreamExhaustedException error =
         new StreamExhaustedException(
             "Failed to push data to all available clients. No more clients left to retry.");

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamServiceImpl.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamServiceImpl.java
@@ -26,7 +26,6 @@ import java.util.Collection;
 import java.util.Optional;
 import java.util.function.Function;
 import org.agrona.DirectBuffer;
-import org.jspecify.annotations.Nullable;
 
 /**
  * Implementation for both {@link ClientStreamer} and {@link ClientStreamService}.
@@ -85,12 +84,12 @@ public final class ClientStreamServiceImpl<M extends BufferWriter> extends Actor
   }
 
   @Override
-  public ActorFuture<@Nullable Void> remove(final ClientStreamId streamId) {
+  public ActorFuture<Void> remove(final ClientStreamId streamId) {
     return actor.call(() -> clientStreamManager.remove(streamId));
   }
 
   @Override
-  public ActorFuture<@Nullable Void> start(final ActorSchedulingService schedulingService) {
+  public ActorFuture<Void> start(final ActorSchedulingService schedulingService) {
     return schedulingService.submitActor(this);
   }
 

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamServiceImpl.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamServiceImpl.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.transport.stream.impl;
 
+import static io.camunda.zeebe.util.Unit.unit;
+
 import io.atomix.cluster.ClusterMembershipEvent;
 import io.atomix.cluster.ClusterMembershipEvent.Type;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
@@ -21,7 +23,6 @@ import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.stream.Stream;
-import org.jspecify.annotations.Nullable;
 
 public class RemoteStreamServiceImpl<M, P extends BufferWriter>
     implements RemoteStreamService<M, P> {
@@ -59,8 +60,8 @@ public class RemoteStreamServiceImpl<M, P extends BufferWriter>
   }
 
   @Override
-  public ActorFuture<@Nullable Void> closeAsync(final ConcurrencyControl executor) {
-    final CompletableActorFuture<@Nullable Void> closed = new CompletableActorFuture<>();
+  public ActorFuture<Void> closeAsync(final ConcurrencyControl executor) {
+    final CompletableActorFuture<Void> closed = new CompletableActorFuture<>();
     final var streamerClosed = streamer.closeAsync();
     final var serverClosed = apiServer.closeAsync();
     final var combined =
@@ -71,7 +72,7 @@ public class RemoteStreamServiceImpl<M, P extends BufferWriter>
           if (error != null) {
             closed.completeExceptionally(error);
           } else {
-            closed.complete(null);
+            closed.complete(unit());
           }
         });
     return closed;

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/Unit.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/Unit.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.util;
+
+public final class Unit {
+  private Unit() {}
+
+  /**
+   * {@link java.lang.Void} type has no value, but at runtime it's always represented by null. Per
+   * jspecify, null cannot be assigned `Void`, but it can assigned to `@Nullable Void`.
+   *
+   * <p>To avoid polluting every Future with `@Nullable Void` you can use this helper that already
+   * suppress NullAway warnings. For example:
+   *
+   * <pre><code>
+   *    var future = new CompletableFuture<Void>();
+   *    future.complete(unit());
+   * </code></pre>
+   *
+   * @return an instance of Void
+   */
+  @SuppressWarnings("NullAway")
+  public static Void unit() {
+    return null;
+  }
+}


### PR DESCRIPTION
## Description
Refactor all code to use `ActorFuture<Void>` instead of `ActorFuture<@Nullable Void>` as that requires a lot of changes and it pollutes the codebase with annotations that are not providing any extra safety.

- Additional combinators are added to ActorFuture for Runnable and Consumer.
- A `Unit` utility class has been added that returns an instance of `Void` that can be used when it's required to complete the future directly.


## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
