### PR TITLE
build: add env-down to webapp Makefile

### DIFF
--- a/webapp/Makefile
+++ b/webapp/Makefile
@@ -26,3 +26,8 @@ env-up:
 	mvn clean install -DskipTests -DskipChecks -f ../dist/pom.xml spring-boot:run \
 		-Dspring-boot.run.mainClass="io.camunda.application.StandaloneCamunda" \
 		-Dspring-boot.run.profiles=tmp-webapp,broker,dev,dev-data,consolidated-auth
+
+.PHONY: env-down
+env-down:
+	docker compose -f docker-compose.yml down -v \
+	&& mvn clean


### PR DESCRIPTION
## Description

- add `env-down` to webapp Makefile

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
