### PR TITLE
Build standalone analytics exporter jar

### DIFF
--- a/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/Context.java
+++ b/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/Context.java
@@ -64,10 +64,7 @@ public interface Context {
    *
    * @return the cluster ID, or an empty string if not configured.
    */
-  default String getClusterId() {
-    final var fromEnv = System.getenv("ZEEBE_BROKER_CLUSTER_CLUSTERID");
-    return fromEnv != null ? fromEnv : "";
-  }
+  String getClusterId();
 
   /**
    * Apply the given filter to limit the records which are exported.

--- a/zeebe/exporter-api/src/test/java/io/camunda/zeebe/exporter/api/ExporterTest.java
+++ b/zeebe/exporter-api/src/test/java/io/camunda/zeebe/exporter/api/ExporterTest.java
@@ -150,6 +150,11 @@ public final class ExporterTest {
       return 0;
     }
 
+    @Override
+    public String getClusterId() {
+      return "";
+    }
+
     public RecordFilter getFilter() {
       return filter;
     }

--- a/zeebe/exporters/analytics-exporter/pom.xml
+++ b/zeebe/exporters/analytics-exporter/pom.xml
@@ -141,4 +141,58 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>standalone-jar</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-shade-plugin</artifactId>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>shade</goal>
+                </goals>
+                <phase>package</phase>
+                <configuration>
+                  <!-- Produce an extra jar with classifier 'standalone'; leave the original jar intact -->
+                  <shadedArtifactAttached>true</shadedArtifactAttached>
+                  <shadedClassifierName>standalone</shadedClassifierName>
+                  <createDependencyReducedPom>false</createDependencyReducedPom>
+                  <artifactSet>
+                    <excludes>
+                      <!-- Provided by the Zeebe broker at runtime -->
+                      <exclude>io.camunda:zeebe-exporter-api</exclude>
+                      <exclude>io.camunda:zeebe-protocol</exclude>
+                      <exclude>io.camunda:zeebe-util</exclude>
+                      <exclude>org.slf4j:slf4j-api</exclude>
+                    </excludes>
+                  </artifactSet>
+                  <relocations>
+                    <!--
+                      Relocate all OTel classes to avoid version conflicts when the exporter is
+                      deployed alongside a broker that ships its own OTel dependencies.
+                    -->
+                    <relocation>
+                      <pattern>io.opentelemetry</pattern>
+                      <shadedPattern>io.camunda.shaded.otel</shadedPattern>
+                    </relocation>
+                  </relocations>
+                  <transformers>
+                    <!--
+                      Rename META-INF/services file names to match relocated package names,
+                      so ServiceLoader can find the HttpSenderProvider after relocation.
+                    -->
+                    <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                  </transformers>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporter.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporter.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
 /** Exporter that ships Camunda process analytics to the Camunda Analytics backend. */
 public class AnalyticsExporter implements Exporter {
 
-  public static final String CLUSTER_ID_ENV_VAR = "ZEEBE_BROKER_CLUSTER_CLUSTERID";
+  private static final String CLUSTER_ID_ENV_VAR = "ZEEBE_BROKER_CLUSTER_CLUSTERID";
   private static final Logger LOG =
       LoggerFactory.getLogger(AnalyticsExporter.class.getPackageName());
   private static final ThrottledLogger SAMPLED_LOG =
@@ -62,7 +62,7 @@ public class AnalyticsExporter implements Exporter {
     try {
       clusterId = context.getClusterId();
     } catch (final NoSuchMethodError ex) {
-      // Fallback for customers testing this exporter on 8.8 where getCluserId does not exist.
+      // Fallback for customers testing this exporter on 8.8 where getClusterId does not exist.
       final var fromEnv = System.getenv(CLUSTER_ID_ENV_VAR);
       clusterId = fromEnv != null ? fromEnv : "";
     }

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporter.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporter.java
@@ -11,7 +11,6 @@ import static io.camunda.exporter.analytics.AnalyticsAttributes.BPMN_PROCESS_ID;
 import static io.camunda.exporter.analytics.AnalyticsAttributes.PROCESS_DEFINITION_KEY;
 import static io.camunda.exporter.analytics.AnalyticsAttributes.PROCESS_INSTANCE_KEY;
 import static io.camunda.exporter.analytics.AnalyticsAttributes.PROCESS_VERSION;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.ROOT_PROCESS_INSTANCE_KEY;
 import static io.camunda.exporter.analytics.AnalyticsAttributes.TENANT_ID;
 
 import io.camunda.zeebe.exporter.api.Exporter;
@@ -33,14 +32,13 @@ import org.slf4j.LoggerFactory;
 /** Exporter that ships Camunda process analytics to the Camunda Analytics backend. */
 public class AnalyticsExporter implements Exporter {
 
+  public static final String CLUSTER_ID_ENV_VAR = "ZEEBE_BROKER_CLUSTER_CLUSTERID";
   private static final Logger LOG =
       LoggerFactory.getLogger(AnalyticsExporter.class.getPackageName());
-
   private static final ThrottledLogger SAMPLED_LOG =
       new ThrottledLogger(LOG, Duration.ofMinutes(1));
   private static final ThrottledLogger SAMPLED_WARN_LOG =
       new ThrottledLogger(LOG, Duration.ofMinutes(1));
-
   private final OtelSdkManager otelSdkManager;
 
   private AnalyticsExporterConfig config;
@@ -61,7 +59,13 @@ public class AnalyticsExporter implements Exporter {
   public void configure(final Context context) {
     config = context.getConfiguration().instantiate(AnalyticsExporterConfig.class).validate();
     partitionId = context.getPartitionId();
-    clusterId = context.getClusterId();
+    try {
+      clusterId = context.getClusterId();
+    } catch (final NoSuchMethodError ex) {
+      // Fallback for customers testing this exporter on 8.8 where getCluserId does not exist.
+      final var fromEnv = System.getenv(CLUSTER_ID_ENV_VAR);
+      clusterId = fromEnv != null ? fromEnv : "";
+    }
 
     handlers = new EnumMap<>(ValueType.class);
     registerHandler(ValueType.PROCESS_INSTANCE_CREATION, this::handleProcessInstanceCreation);
@@ -111,7 +115,9 @@ public class AnalyticsExporter implements Exporter {
                 .setAttribute(PROCESS_VERSION, (long) value.getVersion())
                 .setAttribute(PROCESS_DEFINITION_KEY, value.getProcessDefinitionKey())
                 .setAttribute(PROCESS_INSTANCE_KEY, record.getKey())
-                .setAttribute(ROOT_PROCESS_INSTANCE_KEY, value.getRootProcessInstanceKey())
+                //                Uncomment as this is not available on 8.8
+                //                .setAttribute(ROOT_PROCESS_INSTANCE_KEY,
+                // value.getRootProcessInstanceKey())
                 .setAttribute(TENANT_ID, value.getTenantId())
                 .setTimestamp(record.getTimestamp(), TimeUnit.MILLISECONDS));
 

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterTest.java
@@ -81,9 +81,10 @@ class AnalyticsExporterTest {
                   .containsEntry(
                       AnalyticsAttributes.PROCESS_DEFINITION_KEY, value.getProcessDefinitionKey())
                   .containsEntry(AnalyticsAttributes.PROCESS_INSTANCE_KEY, record.getKey())
-                  .containsEntry(
-                      AnalyticsAttributes.ROOT_PROCESS_INSTANCE_KEY,
-                      value.getRootProcessInstanceKey())
+                  // Temporarily commented out as root process instance key doesn't exist on 8.8.
+                  //                  .containsEntry(
+                  //                      AnalyticsAttributes.ROOT_PROCESS_INSTANCE_KEY,
+                  //                      value.getRootProcessInstanceKey())
                   .containsEntry(AnalyticsAttributes.TENANT_ID, value.getTenantId())
                   .containsEntry(AnalyticsAttributes.LOG_POSITION, record.getPosition());
             });


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Adds the mave shade plugin to the analytics exporter. When building this module with the `standalone-jar` profile a standalone jar is created. This jar excludes broker classes where necessary and can be loaded into an existing broker.

I tried running this with version 8.8. I had to change 2 things in order to get this to work:
1. I had to add a try-cath on `context.getClusterId()`. This method doesn't exist on older versions, and as the exporter api is provided by the broker, the exporter would throw `NoSuchMethodErrors`. By simply catching this error and falling back to the default behavior we fix this problem for older brokers.
2. I commented out the adding of root process instance keys to the logged events. This field is also not available on 8.8 and would also throw `NoSuchMethodErrors`. As there is no sensible default I've opted to just comment it out entirely. This should be good enough for the MVP.

-------

I've verified this locally by building the jar and running it on `main` and `stable/8.8`. I configured the broker to add the jar using these properties:

```yaml
zeebe:
  broker:
    exporters:
      analytics:
        className: io.camunda.exporter.analytics.AnalyticsExporter
        jarPath: /../analytics-exporter-8.10.0-SNAPSHOT-standalone.jar
        args:
          endpoint: "..."
```


## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #52388
