### PR TITLE
ci: exclude Renovate PRs from flaky test gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1343,12 +1343,16 @@ jobs:
     # Two conditions cover both automated (monorepo-devops-automation[bot]) and
     # manually-named (backport-* / backport/*) backports. Direct fixes on
     # stable/* branches by humans still run the gate.
+    # Skip Renovate PRs: dependency bumps never introduce flaky tests; any flake
+    # they hit is pre-existing. Renovate also automerges within minutes, leaving
+    # no time for the gate to be useful.
     if: >-
       always()
       && github.event_name == 'pull_request'
       && !github.event.pull_request.head.repo.fork
       && !startsWith(github.head_ref, 'backport')
       && github.event.pull_request.user.login != 'monorepo-devops-automation[bot]'
+      && github.event.pull_request.user.login != 'renovate[bot]'
     needs:
       - detect-changes
       - archunit-tests


### PR DESCRIPTION
## Summary

- Adds `github.event.pull_request.user.login != 'renovate[bot]'` condition to the `detect-new-flaky-tests` job
- Dependency bumps never introduce flaky tests — any flake Renovate hits is pre-existing infra noise
- Renovate automerges within minutes, leaving no time for the gate to be useful anyway

## Background

Post-fix monitoring (7 days after #53121 merged) identified 2 false positives out of 5 alerts — both were Renovate PRs:
- #53349 (`shouldInsertHistoryDeletion`) — prior errors outside 20-day window
- #53353 (`shouldFailListWhenStoreIsNotReachable`) — BQ ingestion race with sibling Renovate PR

Backport exclusion was already in place (`monorepo-devops-automation[bot]` and `backport-*` branches); this adds the equivalent for Renovate.