### PR TITLE
test: reduce partitions for reduced flakiness

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/ClusterMultiplePartitionsBatchOperationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/ClusterMultiplePartitionsBatchOperationIT.java
@@ -53,10 +53,7 @@ public class ClusterMultiplePartitionsBatchOperationIT {
           .withUnauthenticatedAccess()
           .withUnifiedConfig(
               b -> {
-                // We want to test multiple partitions and concurrency. To make the test potentially
-                // flaky we increase the partitions and exporter threads
-                b.getCluster().setPartitionCount(9);
-                b.getSystem().setIoThreadCount(9);
+                b.getCluster().setPartitionCount(3);
               });
 
   private static CamundaClient camundaClient;


### PR DESCRIPTION
## Description

Reduce the number of partitions in the `ClusterMultiplePartitionsBatchOperationIT` again to 3 for reduced flakiness.

Follow-up issue to actually solve the problem: https://github.com/camunda/camunda/issues/53703
