### PR TITLE
fix: Logging exception when starting a test in Intellij

### DIFF
--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -185,6 +185,12 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-security-library-spring-boot-starter</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>


### PR DESCRIPTION
This pull request introduces a minor change to the `authentication/pom.xml` file, specifically to the dependencies configuration. The change excludes the `spring-boot-starter-logging` dependency from the `camunda-security-library-spring-boot-starter` dependency. 

- Excluded `spring-boot-starter-logging` from the `camunda-security-library-spring-boot-starter` dependency in `pom.xml` to prevent redundant or conflicting logging dependencies.

This is needed to fix an error which happens when running authenticaton tests in Intellij:

```
java.lang.ExceptionInInitializerError
	at io.camunda.authentication.config.spi.AdminUserPresenceAdapterTest.<init>(AdminUserPresenceAdapterTest.java:33)
Caused by: org.apache.logging.log4j.LoggingException: log4j-slf4j2-impl cannot be present with log4j-to-slf4j
	at org.apache.logging.slf4j.Log4jLoggerFactory.validateContext(Log4jLoggerFactory.java:67)
	at org.apache.logging.slf4j.Log4jLoggerFactory.newLogger(Log4jLoggerFactory.java:49)
	at org.apache.logging.slf4j.Log4jLoggerFactory.newLogger(Log4jLoggerFactory.java:32)
	at org.apache.logging.log4j.spi.AbstractLoggerAdapter.getLogger(AbstractLoggerAdapter.java:52)
	at org.apache.logging.slf4j.Log4jLoggerFactory.getLogger(Log4jLoggerFactory.java:32)
	at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:447)
	at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:472)
	at io.camunda.authentication.config.spi.AdminUserPresenceAdapter.<clinit>(AdminUserPresenceAdapter.java:33)
	... 1 more


java.lang.NoClassDefFoundError: Could not initialize class io.camunda.authentication.config.spi.AdminUserPresenceAdapter

	at io.camunda.authentication.config.spi.AdminUserPresenceAdapterTest.<init>(AdminUserPresenceAdapterTest.java:33)
Caused by: java.lang.ExceptionInInitializerError: Exception org.apache.logging.log4j.LoggingException: log4j-slf4j2-impl cannot be present with log4j-to-slf4j [in thread "main"]
	at org.apache.logging.slf4j.Log4jLoggerFactory.validateContext(Log4jLoggerFactory.java:67)
	at org.apache.logging.slf4j.Log4jLoggerFactory.newLogger(Log4jLoggerFactory.java:49)
	at org.apache.logging.slf4j.Log4jLoggerFactory.newLogger(Log4jLoggerFactory.java:32)
	at org.apache.logging.log4j.spi.AbstractLoggerAdapter.getLogger(AbstractLoggerAdapter.java:52)
	at org.apache.logging.slf4j.Log4jLoggerFactory.getLogger(Log4jLoggerFactory.java:32)
	at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:447)
	at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:472)
	at io.camunda.authentication.config.spi.AdminUserPresenceAdapter.<clinit>(AdminUserPresenceAdapter.java:33)
	... 1 more
```
