### PR TITLE
Agent instance search layer

### DIFF
--- a/search/search-domain/src/main/java/io/camunda/search/entities/AgentInstanceEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/AgentInstanceEntity.java
@@ -27,6 +27,9 @@ public record AgentInstanceEntity(
     Long processInstanceKey,
     @Nullable Long rootProcessInstanceKey,
     Long processDefinitionKey,
+    String processDefinitionId,
+    Integer processDefinitionVersion,
+    @Nullable String versionTag,
     String tenantId,
     OffsetDateTime creationDate,
     OffsetDateTime lastUpdatedDate,
@@ -43,6 +46,8 @@ public record AgentInstanceEntity(
     Objects.requireNonNull(elementId, "elementId");
     Objects.requireNonNull(processInstanceKey, "processInstanceKey");
     Objects.requireNonNull(processDefinitionKey, "processDefinitionKey");
+    Objects.requireNonNull(processDefinitionId, "processDefinitionId");
+    Objects.requireNonNull(processDefinitionVersion, "processDefinitionVersion");
     Objects.requireNonNull(tenantId, "tenantId");
     Objects.requireNonNull(creationDate, "creationDate");
     Objects.requireNonNull(lastUpdatedDate, "lastUpdatedDate");

--- a/search/search-domain/src/main/java/io/camunda/search/entities/AgentInstanceEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/AgentInstanceEntity.java
@@ -17,6 +17,7 @@ import org.jspecify.annotations.Nullable;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record AgentInstanceEntity(
     Long agentInstanceKey,
+    Long elementInstanceKey,
     AgentInstanceStatus status,
     AgentInstanceDefinition definition,
     AgentInstanceMetrics metrics,
@@ -24,6 +25,7 @@ public record AgentInstanceEntity(
     List<AgentInstanceTool> tools,
     String elementId,
     Long processInstanceKey,
+    @Nullable Long rootProcessInstanceKey,
     Long processDefinitionKey,
     String tenantId,
     OffsetDateTime creationDate,
@@ -33,6 +35,7 @@ public record AgentInstanceEntity(
 
   public AgentInstanceEntity {
     Objects.requireNonNull(agentInstanceKey, "agentInstanceKey");
+    Objects.requireNonNull(elementInstanceKey, "elementInstanceKey");
     Objects.requireNonNull(status, "status");
     Objects.requireNonNull(definition, "definition");
     Objects.requireNonNull(metrics, "metrics");

--- a/search/search-domain/src/main/java/io/camunda/search/entities/AgentInstanceEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/AgentInstanceEntity.java
@@ -44,7 +44,7 @@ public record AgentInstanceEntity(
     Objects.requireNonNull(creationDate, "creationDate");
     Objects.requireNonNull(lastUpdatedDate, "lastUpdatedDate");
     // Mutable list required: MyBatis hydrates by calling .add()
-    tools = tools != null ? tools : new ArrayList<>();
+    tools = tools != null ? new ArrayList<>(tools) : new ArrayList<>();
   }
 
   @JsonIgnoreProperties(ignoreUnknown = true)

--- a/search/search-domain/src/main/java/io/camunda/search/entities/AgentInstanceEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/AgentInstanceEntity.java
@@ -17,7 +17,7 @@ import org.jspecify.annotations.Nullable;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record AgentInstanceEntity(
     Long agentInstanceKey,
-    Long elementInstanceKey,
+    List<Long> elementInstanceKeys,
     AgentInstanceStatus status,
     AgentInstanceDefinition definition,
     AgentInstanceMetrics metrics,
@@ -38,7 +38,6 @@ public record AgentInstanceEntity(
 
   public AgentInstanceEntity {
     Objects.requireNonNull(agentInstanceKey, "agentInstanceKey");
-    Objects.requireNonNull(elementInstanceKey, "elementInstanceKey");
     Objects.requireNonNull(status, "status");
     Objects.requireNonNull(definition, "definition");
     Objects.requireNonNull(metrics, "metrics");
@@ -51,7 +50,9 @@ public record AgentInstanceEntity(
     Objects.requireNonNull(tenantId, "tenantId");
     Objects.requireNonNull(creationDate, "creationDate");
     Objects.requireNonNull(lastUpdatedDate, "lastUpdatedDate");
-    // Mutable list required: MyBatis hydrates by calling .add()
+    // Mutable lists required: MyBatis hydrates by calling .add()
+    elementInstanceKeys =
+        elementInstanceKeys != null ? new ArrayList<>(elementInstanceKeys) : new ArrayList<>();
     tools = tools != null ? new ArrayList<>(tools) : new ArrayList<>();
   }
 

--- a/search/search-domain/src/main/java/io/camunda/search/entities/AgentInstanceEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/AgentInstanceEntity.java
@@ -85,6 +85,7 @@ public record AgentInstanceEntity(
     THINKING,
     TOOL_CALLING,
     IDLE,
-    COMPLETED
+    COMPLETED,
+    UNKNOWN
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/entities/AgentInstanceEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/AgentInstanceEntity.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.entities;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import org.jspecify.annotations.Nullable;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record AgentInstanceEntity(
+    Long agentInstanceKey,
+    AgentInstanceStatus status,
+    AgentInstanceDefinition definition,
+    AgentInstanceMetrics metrics,
+    AgentInstanceLimits limits,
+    List<AgentInstanceTool> tools,
+    String elementId,
+    Long processInstanceKey,
+    Long processDefinitionKey,
+    String tenantId,
+    OffsetDateTime creationDate,
+    OffsetDateTime lastUpdatedDate,
+    @Nullable OffsetDateTime completionDate)
+    implements TenantOwnedEntity {
+
+  public AgentInstanceEntity {
+    Objects.requireNonNull(agentInstanceKey, "agentInstanceKey");
+    Objects.requireNonNull(status, "status");
+    Objects.requireNonNull(definition, "definition");
+    Objects.requireNonNull(metrics, "metrics");
+    Objects.requireNonNull(limits, "limits");
+    Objects.requireNonNull(elementId, "elementId");
+    Objects.requireNonNull(processInstanceKey, "processInstanceKey");
+    Objects.requireNonNull(processDefinitionKey, "processDefinitionKey");
+    Objects.requireNonNull(tenantId, "tenantId");
+    Objects.requireNonNull(creationDate, "creationDate");
+    Objects.requireNonNull(lastUpdatedDate, "lastUpdatedDate");
+    // Mutable list required: MyBatis hydrates by calling .add()
+    tools = tools != null ? tools : new ArrayList<>();
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public record AgentInstanceDefinition(String model, String provider, String systemPrompt) {
+    public AgentInstanceDefinition {
+      Objects.requireNonNull(model, "model");
+      Objects.requireNonNull(provider, "provider");
+      Objects.requireNonNull(systemPrompt, "systemPrompt");
+    }
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public record AgentInstanceLimits(long maxTokens, int maxModelCalls, int maxToolCalls) {}
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public record AgentInstanceMetrics(
+      long inputTokens, long outputTokens, int modelCalls, int toolCalls) {}
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public record AgentInstanceTool(
+      String name, @Nullable String description, @Nullable String elementId) {
+    public AgentInstanceTool {
+      Objects.requireNonNull(name, "name");
+    }
+  }
+
+  public enum AgentInstanceStatus {
+    INITIALIZING,
+    TOOL_DISCOVERY,
+    THINKING,
+    TOOL_CALLING,
+    IDLE,
+    COMPLETED
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/filter/AgentInstanceFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/AgentInstanceFilter.java
@@ -20,10 +20,13 @@ import java.util.Objects;
 import java.util.function.Function;
 
 public record AgentInstanceFilter(
-    List<Long> agentInstanceKeys,
-    List<Long> elementInstanceKeys,
-    List<Long> processInstanceKeys,
-    List<Long> processDefinitionKeys,
+    List<Operation<Long>> agentInstanceKeyOperations,
+    List<Operation<Long>> elementInstanceKeyOperations,
+    List<Operation<Long>> processInstanceKeyOperations,
+    List<Operation<Long>> processDefinitionKeyOperations,
+    List<Operation<String>> processDefinitionIdOperations,
+    List<Operation<Integer>> processDefinitionVersionOperations,
+    List<Operation<String>> versionTagOperations,
     List<Operation<String>> elementIdOperations,
     List<Operation<String>> statusOperations,
     List<Operation<String>> tenantIdOperations,
@@ -39,10 +42,13 @@ public record AgentInstanceFilter(
 
   public static final class Builder implements ObjectBuilder<AgentInstanceFilter> {
 
-    private List<Long> agentInstanceKeys;
-    private List<Long> elementInstanceKeys;
-    private List<Long> processInstanceKeys;
-    private List<Long> processDefinitionKeys;
+    private List<Operation<Long>> agentInstanceKeyOperations;
+    private List<Operation<Long>> elementInstanceKeyOperations;
+    private List<Operation<Long>> processInstanceKeyOperations;
+    private List<Operation<Long>> processDefinitionKeyOperations;
+    private List<Operation<String>> processDefinitionIdOperations;
+    private List<Operation<Integer>> processDefinitionVersionOperations;
+    private List<Operation<String>> versionTagOperations;
     private List<Operation<String>> elementIdOperations;
     private List<Operation<String>> statusOperations;
     private List<Operation<String>> tenantIdOperations;
@@ -50,40 +56,111 @@ public record AgentInstanceFilter(
     private List<Operation<OffsetDateTime>> lastUpdatedDateOperations;
     private List<Operation<OffsetDateTime>> completionDateOperations;
 
-    public Builder agentInstanceKeys(final List<Long> values) {
-      agentInstanceKeys = addValuesToList(agentInstanceKeys, values);
+    public Builder agentInstanceKeyOperations(final List<Operation<Long>> operations) {
+      agentInstanceKeyOperations = addValuesToList(agentInstanceKeyOperations, operations);
       return this;
     }
 
-    public Builder agentInstanceKeys(final Long... values) {
-      return agentInstanceKeys(collectValuesAsList(values));
+    @SafeVarargs
+    public final Builder agentInstanceKeyOperations(
+        final Operation<Long> operation, final Operation<Long>... operations) {
+      return agentInstanceKeyOperations(collectValues(operation, operations));
     }
 
-    public Builder elementInstanceKeys(final List<Long> values) {
-      elementInstanceKeys = addValuesToList(elementInstanceKeys, values);
+    public Builder agentInstanceKeys(final Long value, final Long... values) {
+      return agentInstanceKeyOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder elementInstanceKeyOperations(final List<Operation<Long>> operations) {
+      elementInstanceKeyOperations = addValuesToList(elementInstanceKeyOperations, operations);
       return this;
     }
 
-    public Builder elementInstanceKeys(final Long... values) {
-      return elementInstanceKeys(collectValuesAsList(values));
+    @SafeVarargs
+    public final Builder elementInstanceKeyOperations(
+        final Operation<Long> operation, final Operation<Long>... operations) {
+      return elementInstanceKeyOperations(collectValues(operation, operations));
     }
 
-    public Builder processInstanceKeys(final List<Long> values) {
-      processInstanceKeys = addValuesToList(processInstanceKeys, values);
+    public Builder elementInstanceKeys(final Long value, final Long... values) {
+      return elementInstanceKeyOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder processInstanceKeyOperations(final List<Operation<Long>> operations) {
+      processInstanceKeyOperations = addValuesToList(processInstanceKeyOperations, operations);
       return this;
     }
 
-    public Builder processInstanceKeys(final Long... values) {
-      return processInstanceKeys(collectValuesAsList(values));
+    @SafeVarargs
+    public final Builder processInstanceKeyOperations(
+        final Operation<Long> operation, final Operation<Long>... operations) {
+      return processInstanceKeyOperations(collectValues(operation, operations));
     }
 
-    public Builder processDefinitionKeys(final List<Long> values) {
-      processDefinitionKeys = addValuesToList(processDefinitionKeys, values);
+    public Builder processInstanceKeys(final Long value, final Long... values) {
+      return processInstanceKeyOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder processDefinitionKeyOperations(final List<Operation<Long>> operations) {
+      processDefinitionKeyOperations = addValuesToList(processDefinitionKeyOperations, operations);
       return this;
     }
 
-    public Builder processDefinitionKeys(final Long... values) {
-      return processDefinitionKeys(collectValuesAsList(values));
+    @SafeVarargs
+    public final Builder processDefinitionKeyOperations(
+        final Operation<Long> operation, final Operation<Long>... operations) {
+      return processDefinitionKeyOperations(collectValues(operation, operations));
+    }
+
+    public Builder processDefinitionKeys(final Long value, final Long... values) {
+      return processDefinitionKeyOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder processDefinitionIdOperations(final List<Operation<String>> operations) {
+      processDefinitionIdOperations = addValuesToList(processDefinitionIdOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder processDefinitionIdOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return processDefinitionIdOperations(collectValues(operation, operations));
+    }
+
+    public Builder processDefinitionIds(final String value, final String... values) {
+      return processDefinitionIdOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder processDefinitionVersionOperations(
+        final List<Operation<Integer>> operations) {
+      processDefinitionVersionOperations =
+          addValuesToList(processDefinitionVersionOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder processDefinitionVersionOperations(
+        final Operation<Integer> operation, final Operation<Integer>... operations) {
+      return processDefinitionVersionOperations(collectValues(operation, operations));
+    }
+
+    public Builder processDefinitionVersions(final Integer value, final Integer... values) {
+      return processDefinitionVersionOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder versionTagOperations(final List<Operation<String>> operations) {
+      versionTagOperations = addValuesToList(versionTagOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder versionTagOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return versionTagOperations(collectValues(operation, operations));
+    }
+
+    public Builder versionTags(final String value, final String... values) {
+      return versionTagOperations(FilterUtil.mapDefaultToOperation(value, values));
     }
 
     public Builder elementIdOperations(final List<Operation<String>> operations) {
@@ -167,10 +244,13 @@ public record AgentInstanceFilter(
     @Override
     public AgentInstanceFilter build() {
       return new AgentInstanceFilter(
-          Objects.requireNonNullElse(agentInstanceKeys, Collections.emptyList()),
-          Objects.requireNonNullElse(elementInstanceKeys, Collections.emptyList()),
-          Objects.requireNonNullElse(processInstanceKeys, Collections.emptyList()),
-          Objects.requireNonNullElse(processDefinitionKeys, Collections.emptyList()),
+          Objects.requireNonNullElse(agentInstanceKeyOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(elementInstanceKeyOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(processInstanceKeyOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(processDefinitionKeyOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(processDefinitionIdOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(processDefinitionVersionOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(versionTagOperations, Collections.emptyList()),
           Objects.requireNonNullElse(elementIdOperations, Collections.emptyList()),
           Objects.requireNonNullElse(statusOperations, Collections.emptyList()),
           Objects.requireNonNullElse(tenantIdOperations, Collections.emptyList()),

--- a/search/search-domain/src/main/java/io/camunda/search/filter/AgentInstanceFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/AgentInstanceFilter.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.filter;
+
+import static io.camunda.util.CollectionUtil.addValuesToList;
+import static io.camunda.util.CollectionUtil.collectValues;
+import static io.camunda.util.CollectionUtil.collectValuesAsList;
+
+import io.camunda.util.FilterUtil;
+import io.camunda.util.ObjectBuilder;
+import java.time.OffsetDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+
+public record AgentInstanceFilter(
+    List<Long> agentInstanceKeys,
+    List<Long> processInstanceKeys,
+    List<Long> processDefinitionKeys,
+    List<Operation<String>> elementIdOperations,
+    List<Operation<String>> statusOperations,
+    List<Operation<String>> tenantIdOperations,
+    List<Operation<OffsetDateTime>> creationDateOperations,
+    List<Operation<OffsetDateTime>> lastUpdatedDateOperations,
+    List<Operation<OffsetDateTime>> completionDateOperations)
+    implements FilterBase {
+
+  public static AgentInstanceFilter of(
+      final Function<AgentInstanceFilter.Builder, ObjectBuilder<AgentInstanceFilter>> fn) {
+    return FilterBuilders.agentInstance(fn);
+  }
+
+  public static final class Builder implements ObjectBuilder<AgentInstanceFilter> {
+
+    private List<Long> agentInstanceKeys;
+    private List<Long> processInstanceKeys;
+    private List<Long> processDefinitionKeys;
+    private List<Operation<String>> elementIdOperations;
+    private List<Operation<String>> statusOperations;
+    private List<Operation<String>> tenantIdOperations;
+    private List<Operation<OffsetDateTime>> creationDateOperations;
+    private List<Operation<OffsetDateTime>> lastUpdatedDateOperations;
+    private List<Operation<OffsetDateTime>> completionDateOperations;
+
+    public Builder agentInstanceKeys(final List<Long> values) {
+      agentInstanceKeys = addValuesToList(agentInstanceKeys, values);
+      return this;
+    }
+
+    public Builder agentInstanceKeys(final Long... values) {
+      return agentInstanceKeys(collectValuesAsList(values));
+    }
+
+    public Builder processInstanceKeys(final List<Long> values) {
+      processInstanceKeys = addValuesToList(processInstanceKeys, values);
+      return this;
+    }
+
+    public Builder processInstanceKeys(final Long... values) {
+      return processInstanceKeys(collectValuesAsList(values));
+    }
+
+    public Builder processDefinitionKeys(final List<Long> values) {
+      processDefinitionKeys = addValuesToList(processDefinitionKeys, values);
+      return this;
+    }
+
+    public Builder processDefinitionKeys(final Long... values) {
+      return processDefinitionKeys(collectValuesAsList(values));
+    }
+
+    public Builder elementIdOperations(final List<Operation<String>> operations) {
+      elementIdOperations = addValuesToList(elementIdOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder elementIdOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return elementIdOperations(collectValues(operation, operations));
+    }
+
+    public Builder elementIds(final String value, final String... values) {
+      return elementIdOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder statusOperations(final List<Operation<String>> operations) {
+      statusOperations = addValuesToList(statusOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder statusOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return statusOperations(collectValues(operation, operations));
+    }
+
+    public Builder statuses(final String value, final String... values) {
+      return statusOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder tenantIdOperations(final List<Operation<String>> operations) {
+      tenantIdOperations = addValuesToList(tenantIdOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder tenantIdOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return tenantIdOperations(collectValues(operation, operations));
+    }
+
+    public Builder tenantIds(final String value, final String... values) {
+      return tenantIdOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder creationDateOperations(final List<Operation<OffsetDateTime>> operations) {
+      creationDateOperations = addValuesToList(creationDateOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder creationDateOperations(
+        final Operation<OffsetDateTime> operation, final Operation<OffsetDateTime>... operations) {
+      return creationDateOperations(collectValues(operation, operations));
+    }
+
+    public Builder lastUpdatedDateOperations(final List<Operation<OffsetDateTime>> operations) {
+      lastUpdatedDateOperations = addValuesToList(lastUpdatedDateOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder lastUpdatedDateOperations(
+        final Operation<OffsetDateTime> operation, final Operation<OffsetDateTime>... operations) {
+      return lastUpdatedDateOperations(collectValues(operation, operations));
+    }
+
+    public Builder completionDateOperations(final List<Operation<OffsetDateTime>> operations) {
+      completionDateOperations = addValuesToList(completionDateOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder completionDateOperations(
+        final Operation<OffsetDateTime> operation, final Operation<OffsetDateTime>... operations) {
+      return completionDateOperations(collectValues(operation, operations));
+    }
+
+    @Override
+    public AgentInstanceFilter build() {
+      return new AgentInstanceFilter(
+          Objects.requireNonNullElse(agentInstanceKeys, Collections.emptyList()),
+          Objects.requireNonNullElse(processInstanceKeys, Collections.emptyList()),
+          Objects.requireNonNullElse(processDefinitionKeys, Collections.emptyList()),
+          Objects.requireNonNullElse(elementIdOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(statusOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(tenantIdOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(creationDateOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(lastUpdatedDateOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(completionDateOperations, Collections.emptyList()));
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/filter/AgentInstanceFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/AgentInstanceFilter.java
@@ -21,6 +21,7 @@ import java.util.function.Function;
 
 public record AgentInstanceFilter(
     List<Long> agentInstanceKeys,
+    List<Long> elementInstanceKeys,
     List<Long> processInstanceKeys,
     List<Long> processDefinitionKeys,
     List<Operation<String>> elementIdOperations,
@@ -39,6 +40,7 @@ public record AgentInstanceFilter(
   public static final class Builder implements ObjectBuilder<AgentInstanceFilter> {
 
     private List<Long> agentInstanceKeys;
+    private List<Long> elementInstanceKeys;
     private List<Long> processInstanceKeys;
     private List<Long> processDefinitionKeys;
     private List<Operation<String>> elementIdOperations;
@@ -55,6 +57,15 @@ public record AgentInstanceFilter(
 
     public Builder agentInstanceKeys(final Long... values) {
       return agentInstanceKeys(collectValuesAsList(values));
+    }
+
+    public Builder elementInstanceKeys(final List<Long> values) {
+      elementInstanceKeys = addValuesToList(elementInstanceKeys, values);
+      return this;
+    }
+
+    public Builder elementInstanceKeys(final Long... values) {
+      return elementInstanceKeys(collectValuesAsList(values));
     }
 
     public Builder processInstanceKeys(final List<Long> values) {
@@ -157,6 +168,7 @@ public record AgentInstanceFilter(
     public AgentInstanceFilter build() {
       return new AgentInstanceFilter(
           Objects.requireNonNullElse(agentInstanceKeys, Collections.emptyList()),
+          Objects.requireNonNullElse(elementInstanceKeys, Collections.emptyList()),
           Objects.requireNonNullElse(processInstanceKeys, Collections.emptyList()),
           Objects.requireNonNullElse(processDefinitionKeys, Collections.emptyList()),
           Objects.requireNonNullElse(elementIdOperations, Collections.emptyList()),

--- a/search/search-domain/src/main/java/io/camunda/search/filter/AgentInstanceFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/AgentInstanceFilter.java
@@ -9,7 +9,6 @@ package io.camunda.search.filter;
 
 import static io.camunda.util.CollectionUtil.addValuesToList;
 import static io.camunda.util.CollectionUtil.collectValues;
-import static io.camunda.util.CollectionUtil.collectValuesAsList;
 
 import io.camunda.util.FilterUtil;
 import io.camunda.util.ObjectBuilder;
@@ -131,8 +130,7 @@ public record AgentInstanceFilter(
       return processDefinitionIdOperations(FilterUtil.mapDefaultToOperation(value, values));
     }
 
-    public Builder processDefinitionVersionOperations(
-        final List<Operation<Integer>> operations) {
+    public Builder processDefinitionVersionOperations(final List<Operation<Integer>> operations) {
       processDefinitionVersionOperations =
           addValuesToList(processDefinitionVersionOperations, operations);
       return this;

--- a/search/search-domain/src/main/java/io/camunda/search/filter/FilterBuilders.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/FilterBuilders.java
@@ -14,6 +14,15 @@ public final class FilterBuilders {
 
   private FilterBuilders() {}
 
+  public static AgentInstanceFilter.Builder agentInstance() {
+    return new AgentInstanceFilter.Builder();
+  }
+
+  public static AgentInstanceFilter agentInstance(
+      final Function<AgentInstanceFilter.Builder, ObjectBuilder<AgentInstanceFilter>> fn) {
+    return fn.apply(agentInstance()).build();
+  }
+
   public static UsageMetricsFilter.Builder usageMetrics() {
     return new UsageMetricsFilter.Builder();
   }

--- a/search/search-domain/src/main/java/io/camunda/search/query/AgentInstanceQuery.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/AgentInstanceQuery.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.query;
+
+import io.camunda.search.filter.AgentInstanceFilter;
+import io.camunda.search.filter.FilterBuilders;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.sort.AgentInstanceSort;
+import io.camunda.search.sort.SortOptionBuilders;
+import io.camunda.util.ObjectBuilder;
+import java.util.Objects;
+import java.util.function.Function;
+
+public final record AgentInstanceQuery(
+    AgentInstanceFilter filter, AgentInstanceSort sort, SearchQueryPage page)
+    implements TypedSearchQuery<AgentInstanceFilter, AgentInstanceSort> {
+
+  public static AgentInstanceQuery of(
+      final Function<Builder, ObjectBuilder<AgentInstanceQuery>> fn) {
+    return fn.apply(new Builder()).build();
+  }
+
+  public static final class Builder extends SearchQueryBase.AbstractQueryBuilder<Builder>
+      implements TypedSearchQueryBuilder<
+          AgentInstanceQuery, Builder, AgentInstanceFilter, AgentInstanceSort> {
+
+    private static final AgentInstanceFilter EMPTY_FILTER = FilterBuilders.agentInstance().build();
+    private static final AgentInstanceSort EMPTY_SORT = SortOptionBuilders.agentInstance().build();
+
+    private AgentInstanceFilter filter;
+    private AgentInstanceSort sort;
+
+    @Override
+    public Builder filter(final AgentInstanceFilter value) {
+      filter = value;
+      return this;
+    }
+
+    @Override
+    public Builder sort(final AgentInstanceSort value) {
+      sort = value;
+      return this;
+    }
+
+    public Builder filter(
+        final Function<AgentInstanceFilter.Builder, ObjectBuilder<AgentInstanceFilter>> fn) {
+      return filter(FilterBuilders.agentInstance(fn));
+    }
+
+    public Builder sort(
+        final Function<AgentInstanceSort.Builder, ObjectBuilder<AgentInstanceSort>> fn) {
+      return sort(SortOptionBuilders.agentInstance(fn));
+    }
+
+    @Override
+    protected Builder self() {
+      return this;
+    }
+
+    @Override
+    public AgentInstanceQuery build() {
+      filter = Objects.requireNonNullElse(filter, EMPTY_FILTER);
+      sort = Objects.requireNonNullElse(sort, EMPTY_SORT);
+      return new AgentInstanceQuery(filter, sort, page());
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/query/SearchQueryBuilders.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/SearchQueryBuilders.java
@@ -14,6 +14,15 @@ public final class SearchQueryBuilders {
 
   private SearchQueryBuilders() {}
 
+  public static AgentInstanceQuery.Builder agentInstanceSearchQuery() {
+    return new AgentInstanceQuery.Builder();
+  }
+
+  public static AgentInstanceQuery agentInstanceSearchQuery(
+      final Function<AgentInstanceQuery.Builder, ObjectBuilder<AgentInstanceQuery>> fn) {
+    return fn.apply(agentInstanceSearchQuery()).build();
+  }
+
   public static UsageMetricsQuery.Builder usageMetricsSearchQuery() {
     return new UsageMetricsQuery.Builder();
   }

--- a/search/search-domain/src/main/java/io/camunda/search/sort/AgentInstanceSort.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/AgentInstanceSort.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.sort;
+
+import io.camunda.util.ObjectBuilder;
+import java.util.List;
+import java.util.function.Function;
+
+public record AgentInstanceSort(List<FieldSorting> orderings) implements SortOption {
+
+  @Override
+  public List<FieldSorting> getFieldSortings() {
+    return orderings;
+  }
+
+  public static AgentInstanceSort of(
+      final Function<AgentInstanceSort.Builder, ObjectBuilder<AgentInstanceSort>> fn) {
+    return SortOptionBuilders.agentInstance(fn);
+  }
+
+  public static final class Builder extends AbstractBuilder<Builder>
+      implements ObjectBuilder<AgentInstanceSort> {
+
+    public Builder creationDate() {
+      currentOrdering = new FieldSorting("creationDate", null);
+      return this;
+    }
+
+    public Builder lastUpdatedDate() {
+      currentOrdering = new FieldSorting("lastUpdatedDate", null);
+      return this;
+    }
+
+    public Builder completionDate() {
+      currentOrdering = new FieldSorting("completionDate", null);
+      return this;
+    }
+
+    public Builder status() {
+      currentOrdering = new FieldSorting("status", null);
+      return this;
+    }
+
+    @Override
+    protected Builder self() {
+      return this;
+    }
+
+    @Override
+    public AgentInstanceSort build() {
+      return new AgentInstanceSort(orderings);
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/sort/SortOptionBuilders.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/SortOptionBuilders.java
@@ -14,6 +14,15 @@ public final class SortOptionBuilders {
 
   private SortOptionBuilders() {}
 
+  public static AgentInstanceSort.Builder agentInstance() {
+    return new AgentInstanceSort.Builder();
+  }
+
+  public static AgentInstanceSort agentInstance(
+      final Function<AgentInstanceSort.Builder, ObjectBuilder<AgentInstanceSort>> fn) {
+    return fn.apply(agentInstance()).build();
+  }
+
   public static UsageMetricsSort.Builder usageMetrics() {
     return new UsageMetricsSort.Builder();
   }


### PR DESCRIPTION
## Description

Adds the common search-domain entities for agent instances as required by the Query API workstream (#53684). This change is storage-backend agnostic — no ES/OS or RDBMS implementation is included.

### New files

| File | Purpose |
|---|---|
| `AgentInstanceEntity.java` | Search document record; implements `TenantOwnedEntity`; inner types for `AgentInstanceDefinition`, `AgentInstanceLimits`, `AgentInstanceMetrics`, `AgentInstanceTool`, and `AgentInstanceStatus` enum |
| `AgentInstanceFilter.java` | Filter record with key-list filters (`agentInstanceKey`, `processInstanceKey`, `processDefinitionKey`) and `Operation<T>`-based filters for `elementId`, `status`, `tenantId`, `creationDate`, `lastUpdatedDate`, `completionDate` |
| `AgentInstanceSort.java` | Sort record; sortable fields: `creationDate`, `lastUpdatedDate`, `completionDate`, `status` |
| `AgentInstanceQuery.java` | Query record composing the above |

### Modified files

| File | Change |
|---|---|
| `FilterBuilders.java` | Register `agentInstance()` factory |
| `SortOptionBuilders.java` | Register `agentInstance()` factory |
| `SearchQueryBuilders.java` | Register `agentInstanceSearchQuery()` factory |

### Design decisions

- `AgentInstanceTool.description` and `AgentInstanceTool.elementId` are `@Nullable` — tools are not required to have these populated
- Status is stored as a plain `String` in filter operations (same pattern as `stateOperations` in `FlowNodeInstanceFilter`) to decouple the filter from the entity enum
- Inner types (`AgentInstanceDefinition`, `AgentInstanceLimits`, etc.) are defined inside `AgentInstanceEntity` as records, mirroring how other entities handle nested data

## Related
closes #53684
