### PR TITLE
feat(rest-api): conditional security enforcement on OCA endpoints

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -8,7 +8,7 @@ paths:
         - Agent instance
       operationId: createAgentInstance
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Create agent instance
       description: |
@@ -54,7 +54,7 @@ paths:
         - Agent instance
       operationId: getAgentInstance
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Get agent instance
       description: Returns agent instance as JSON.
@@ -98,7 +98,7 @@ paths:
         - Agent instance
       operationId: updateAgentInstance
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Update agent instance
       description: |
@@ -146,7 +146,7 @@ paths:
         - Agent instance
       operationId: searchAgentInstances
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Search agent instances
       description: Search for agent instances based on given criteria.

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -7,6 +7,9 @@ paths:
       tags:
         - Agent instance
       operationId: createAgentInstance
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Create agent instance
       description: |
         Creates a new agent instance. The returned key identifies the instance and must
@@ -50,6 +53,9 @@ paths:
       tags:
         - Agent instance
       operationId: getAgentInstance
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Get agent instance
       description: Returns agent instance as JSON.
       parameters:
@@ -91,6 +97,9 @@ paths:
       tags:
         - Agent instance
       operationId: updateAgentInstance
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Update agent instance
       description: |
         Updates the mutable fields of an agent instance: status, metric counters, and
@@ -136,6 +145,9 @@ paths:
       tags:
         - Agent instance
       operationId: searchAgentInstances
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Search agent instances
       description: Search for agent instances based on given criteria.
       requestBody:

--- a/zeebe/gateway-protocol/src/main/proto/v2/audit-logs.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/audit-logs.yaml
@@ -6,6 +6,9 @@ paths:
       tags:
         - Audit Log
       operationId: searchAuditLogs
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Search audit logs
       description: Search for audit logs based on given criteria.
       requestBody:
@@ -37,6 +40,9 @@ paths:
       tags:
         - Audit Log
       operationId: getAuditLog
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Get audit log
       description: Get an audit log entry by auditLogKey.
       parameters:

--- a/zeebe/gateway-protocol/src/main/proto/v2/audit-logs.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/audit-logs.yaml
@@ -7,7 +7,7 @@ paths:
         - Audit Log
       operationId: searchAuditLogs
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Search audit logs
       description: Search for audit logs based on given criteria.
@@ -41,7 +41,7 @@ paths:
         - Audit Log
       operationId: getAuditLog
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Get audit log
       description: Get an audit log entry by auditLogKey.

--- a/zeebe/gateway-protocol/src/main/proto/v2/authentication.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/authentication.yaml
@@ -9,7 +9,7 @@ paths:
       summary: Get current user
       description: Retrieves the current authenticated user.
       security:
-        - BearerAuth: []
+        - bearerAuth: []
       responses:
         "200":
           description: The current user is successfully returned.

--- a/zeebe/gateway-protocol/src/main/proto/v2/authorizations.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/authorizations.yaml
@@ -6,6 +6,9 @@ paths:
       tags:
         - Authorization
       operationId: createAuthorization
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Create authorization
       description: Create the authorization.
       requestBody:
@@ -45,6 +48,9 @@ paths:
       tags:
         - Authorization
       operationId: updateAuthorization
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Update authorization
       description: Update the authorization with the given key.
       parameters:
@@ -82,6 +88,9 @@ paths:
       tags:
         - Authorization
       operationId: getAuthorization
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Get authorization
       description: Get authorization by the given key.
       parameters:
@@ -117,6 +126,9 @@ paths:
       tags:
         - Authorization
       operationId: deleteAuthorization
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Delete authorization
       description: Deletes the authorization with the given key.
       parameters:
@@ -151,6 +163,9 @@ paths:
       summary: Search authorizations
       description: Search for authorizations based on given criteria.
       operationId: searchAuthorizations
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       requestBody:
         content:
           application/json:

--- a/zeebe/gateway-protocol/src/main/proto/v2/authorizations.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/authorizations.yaml
@@ -7,7 +7,7 @@ paths:
         - Authorization
       operationId: createAuthorization
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Create authorization
       description: Create the authorization.
@@ -49,7 +49,7 @@ paths:
         - Authorization
       operationId: updateAuthorization
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Update authorization
       description: Update the authorization with the given key.
@@ -89,7 +89,7 @@ paths:
         - Authorization
       operationId: getAuthorization
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Get authorization
       description: Get authorization by the given key.
@@ -127,7 +127,7 @@ paths:
         - Authorization
       operationId: deleteAuthorization
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Delete authorization
       description: Deletes the authorization with the given key.
@@ -164,7 +164,7 @@ paths:
       description: Search for authorizations based on given criteria.
       operationId: searchAuthorizations
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       requestBody:
         content:

--- a/zeebe/gateway-protocol/src/main/proto/v2/batch-operations.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/batch-operations.yaml
@@ -7,6 +7,9 @@ paths:
       tags:
         - Batch operation
       operationId: getBatchOperation
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Get batch operation
       description: Get batch operation by key.
       parameters:
@@ -45,6 +48,9 @@ paths:
       tags:
         - Batch operation
       operationId: searchBatchOperations
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Search batch operations
       description: Search for batch operations based on given criteria.
       requestBody:
@@ -76,6 +82,9 @@ paths:
       tags:
         - Batch operation
       operationId: cancelBatchOperation
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Cancel Batch operation
       description: |
         Cancels a running batch operation.
@@ -115,6 +124,9 @@ paths:
       tags:
         - Batch operation
       operationId: suspendBatchOperation
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Suspend Batch operation
       description: |
         Suspends a running batch operation.
@@ -156,6 +168,9 @@ paths:
       tags:
         - Batch operation
       operationId: resumeBatchOperation
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Resume Batch operation
       description: |
         Resumes a suspended batch operation.
@@ -197,6 +212,9 @@ paths:
       tags:
         - Batch operation
       operationId: searchBatchOperationItems
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Search batch operation items
       description: Search for batch operation items based on given criteria.
       requestBody:

--- a/zeebe/gateway-protocol/src/main/proto/v2/batch-operations.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/batch-operations.yaml
@@ -8,7 +8,7 @@ paths:
         - Batch operation
       operationId: getBatchOperation
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Get batch operation
       description: Get batch operation by key.
@@ -49,7 +49,7 @@ paths:
         - Batch operation
       operationId: searchBatchOperations
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Search batch operations
       description: Search for batch operations based on given criteria.
@@ -83,7 +83,7 @@ paths:
         - Batch operation
       operationId: cancelBatchOperation
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Cancel Batch operation
       description: |
@@ -125,7 +125,7 @@ paths:
         - Batch operation
       operationId: suspendBatchOperation
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Suspend Batch operation
       description: |
@@ -169,7 +169,7 @@ paths:
         - Batch operation
       operationId: resumeBatchOperation
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Resume Batch operation
       description: |
@@ -213,7 +213,7 @@ paths:
         - Batch operation
       operationId: searchBatchOperationItems
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Search batch operation items
       description: Search for batch operation items based on given criteria.

--- a/zeebe/gateway-protocol/src/main/proto/v2/clock.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/clock.yaml
@@ -7,6 +7,9 @@ paths:
       tags:
         - Clock
       operationId: pinClock
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Pin internal clock (alpha)
       description: |
         Set a precise, static time for the Zeebe engine's internal clock.
@@ -38,6 +41,9 @@ paths:
       tags:
         - Clock
       operationId: resetClock
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Reset internal clock (alpha)
       description: |
         Resets the Zeebe engine's internal clock to the current system time, enabling it to tick in real-time.

--- a/zeebe/gateway-protocol/src/main/proto/v2/clock.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/clock.yaml
@@ -8,7 +8,7 @@ paths:
         - Clock
       operationId: pinClock
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Pin internal clock (alpha)
       description: |
@@ -42,7 +42,7 @@ paths:
         - Clock
       operationId: resetClock
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Reset internal clock (alpha)
       description: |

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
@@ -5,7 +5,7 @@ paths:
     post:
       operationId: createGlobalClusterVariable
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       x-eventually-consistent: false
       tags:
@@ -48,7 +48,7 @@ paths:
     post:
       operationId: createTenantClusterVariable
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       x-eventually-consistent: false
       tags:
@@ -111,7 +111,7 @@ paths:
         - Cluster Variable
       operationId: searchClusterVariables
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       x-eventually-consistent: true
       description: Search for cluster variables based on given criteria. By default, long variable values in the response are truncated.
@@ -148,7 +148,7 @@ paths:
     get:
       operationId: getGlobalClusterVariable
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       x-eventually-consistent: true
       tags:
@@ -191,7 +191,7 @@ paths:
     put:
       operationId: updateGlobalClusterVariable
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       x-eventually-consistent: false
       tags:
@@ -242,7 +242,7 @@ paths:
     delete:
       operationId: deleteGlobalClusterVariable
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       x-eventually-consistent: false
       tags:
@@ -282,7 +282,7 @@ paths:
     get:
       operationId: getTenantClusterVariable
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       x-eventually-consistent: true
       tags:
@@ -332,7 +332,7 @@ paths:
     put:
       operationId: updateTenantClusterVariable
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       x-eventually-consistent: false
       tags:
@@ -390,7 +390,7 @@ paths:
     delete:
       operationId: deleteTenantClusterVariable
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       x-eventually-consistent: false
       tags:

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
@@ -4,6 +4,9 @@ paths:
   /cluster-variables/global:
     post:
       operationId: createGlobalClusterVariable
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       x-eventually-consistent: false
       tags:
         - Cluster Variable
@@ -44,6 +47,9 @@ paths:
   /cluster-variables/tenants/{tenantId}:
     post:
       operationId: createTenantClusterVariable
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       x-eventually-consistent: false
       tags:
         - Cluster Variable
@@ -104,6 +110,9 @@ paths:
       tags:
         - Cluster Variable
       operationId: searchClusterVariables
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       x-eventually-consistent: true
       description: Search for cluster variables based on given criteria. By default, long variable values in the response are truncated.
       parameters:
@@ -138,6 +147,9 @@ paths:
   /cluster-variables/global/{name}:
     get:
       operationId: getGlobalClusterVariable
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       x-eventually-consistent: true
       tags:
         - Cluster Variable
@@ -178,6 +190,9 @@ paths:
       x-added-in-version: "8.9"
     put:
       operationId: updateGlobalClusterVariable
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       x-eventually-consistent: false
       tags:
         - Cluster Variable
@@ -226,6 +241,9 @@ paths:
       x-added-in-version: "8.9"
     delete:
       operationId: deleteGlobalClusterVariable
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       x-eventually-consistent: false
       tags:
         - Cluster Variable
@@ -263,6 +281,9 @@ paths:
   /cluster-variables/tenants/{tenantId}/{name}:
     get:
       operationId: getTenantClusterVariable
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       x-eventually-consistent: true
       tags:
         - Cluster Variable
@@ -310,6 +331,9 @@ paths:
       x-added-in-version: "8.9"
     put:
       operationId: updateTenantClusterVariable
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       x-eventually-consistent: false
       tags:
         - Cluster Variable
@@ -365,6 +389,9 @@ paths:
       x-added-in-version: "8.9"
     delete:
       operationId: deleteTenantClusterVariable
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       x-eventually-consistent: false
       tags:
         - Cluster Variable

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
@@ -7,6 +7,9 @@ paths:
       tags:
         - Cluster
       operationId: getTopology
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Get cluster topology
       description: Obtains the current topology of the cluster the gateway is part of.
       responses:
@@ -28,6 +31,10 @@ paths:
       tags:
         - Cluster
       operationId: getStatus
+      # Public health-check endpoint — declared unauthenticated at runtime
+      # via SecurityPathAdapter. `security: []` overrides the conditional
+      # enforcement on the global schemes for this operation.
+      security: []
       summary: Get cluster status
       description: Checks the health status of the cluster by verifying if there's at least one partition with a healthy leader.
       responses:

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
@@ -8,7 +8,7 @@ paths:
         - Cluster
       operationId: getTopology
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Get cluster topology
       description: Obtains the current topology of the cluster the gateway is part of.

--- a/zeebe/gateway-protocol/src/main/proto/v2/conditionals.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/conditionals.yaml
@@ -7,6 +7,9 @@ paths:
       tags:
         - Conditional
       operationId: evaluateConditionals
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Evaluate root level conditional start events
       description: |
         Evaluates root-level conditional start events for process definitions.

--- a/zeebe/gateway-protocol/src/main/proto/v2/conditionals.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/conditionals.yaml
@@ -8,7 +8,7 @@ paths:
         - Conditional
       operationId: evaluateConditionals
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Evaluate root level conditional start events
       description: |

--- a/zeebe/gateway-protocol/src/main/proto/v2/decision-definitions.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/decision-definitions.yaml
@@ -7,6 +7,9 @@ paths:
       tags:
         - Decision definition
       operationId: searchDecisionDefinitions
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Search decision definitions
       description: Search for decision definitions based on given criteria.
       requestBody:
@@ -38,6 +41,9 @@ paths:
       tags:
         - Decision definition
       operationId: getDecisionDefinition
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Get decision definition
       description: Returns a decision definition by key.
       parameters:
@@ -78,6 +84,9 @@ paths:
       tags:
         - Decision definition
       operationId: getDecisionDefinitionXML
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Get decision definition XML
       description: Returns decision definition as XML.
       parameters:
@@ -118,6 +127,9 @@ paths:
       tags:
         - Decision definition
       operationId: evaluateDecision
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Evaluate decision
       description: |
         Evaluates a decision.

--- a/zeebe/gateway-protocol/src/main/proto/v2/decision-definitions.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/decision-definitions.yaml
@@ -8,7 +8,7 @@ paths:
         - Decision definition
       operationId: searchDecisionDefinitions
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Search decision definitions
       description: Search for decision definitions based on given criteria.
@@ -42,7 +42,7 @@ paths:
         - Decision definition
       operationId: getDecisionDefinition
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Get decision definition
       description: Returns a decision definition by key.
@@ -85,7 +85,7 @@ paths:
         - Decision definition
       operationId: getDecisionDefinitionXML
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Get decision definition XML
       description: Returns decision definition as XML.
@@ -128,7 +128,7 @@ paths:
         - Decision definition
       operationId: evaluateDecision
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Evaluate decision
       description: |

--- a/zeebe/gateway-protocol/src/main/proto/v2/decision-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/decision-instances.yaml
@@ -8,7 +8,7 @@ paths:
         - Decision instance
       operationId: searchDecisionInstances
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Search decision instances
       description: Search for decision instances based on given criteria.
@@ -42,7 +42,7 @@ paths:
         - Decision instance
       operationId: getDecisionInstance
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Get decision instance
       description: Returns a decision instance.
@@ -85,7 +85,7 @@ paths:
         - Decision instance
       operationId: deleteDecisionInstance
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Delete decision instance
       description: Delete all associated decision evaluations based on provided key.
@@ -128,7 +128,7 @@ paths:
         - Decision instance
       operationId: deleteDecisionInstancesBatchOperation
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Delete decision instances (batch)
       description: |

--- a/zeebe/gateway-protocol/src/main/proto/v2/decision-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/decision-instances.yaml
@@ -7,6 +7,9 @@ paths:
       tags:
         - Decision instance
       operationId: searchDecisionInstances
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Search decision instances
       description: Search for decision instances based on given criteria.
       requestBody:
@@ -38,6 +41,9 @@ paths:
       tags:
         - Decision instance
       operationId: getDecisionInstance
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Get decision instance
       description: Returns a decision instance.
       parameters:
@@ -78,6 +84,9 @@ paths:
       tags:
         - Decision instance
       operationId: deleteDecisionInstance
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Delete decision instance
       description: Delete all associated decision evaluations based on provided key.
       parameters:
@@ -118,6 +127,9 @@ paths:
       tags:
         - Decision instance
       operationId: deleteDecisionInstancesBatchOperation
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Delete decision instances (batch)
       description: |
         Delete multiple decision instances. This will delete the historic data from secondary storage.

--- a/zeebe/gateway-protocol/src/main/proto/v2/decision-requirements.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/decision-requirements.yaml
@@ -7,6 +7,9 @@ paths:
       tags:
         - Decision requirements
       operationId: searchDecisionRequirements
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Search decision requirements
       description: Search for decision requirements based on given criteria.
       requestBody:
@@ -38,6 +41,9 @@ paths:
       tags:
         - Decision requirements
       operationId: getDecisionRequirements
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Get decision requirements
       description: Returns Decision Requirements as JSON.
       parameters:
@@ -78,6 +84,9 @@ paths:
       tags:
         - Decision requirements
       operationId: getDecisionRequirementsXML
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Get decision requirements XML
       description: Returns decision requirements as XML.
       parameters:

--- a/zeebe/gateway-protocol/src/main/proto/v2/decision-requirements.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/decision-requirements.yaml
@@ -8,7 +8,7 @@ paths:
         - Decision requirements
       operationId: searchDecisionRequirements
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Search decision requirements
       description: Search for decision requirements based on given criteria.
@@ -42,7 +42,7 @@ paths:
         - Decision requirements
       operationId: getDecisionRequirements
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Get decision requirements
       description: Returns Decision Requirements as JSON.
@@ -85,7 +85,7 @@ paths:
         - Decision requirements
       operationId: getDecisionRequirementsXML
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Get decision requirements XML
       description: Returns decision requirements as XML.

--- a/zeebe/gateway-protocol/src/main/proto/v2/deployments.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/deployments.yaml
@@ -7,6 +7,9 @@ paths:
       tags:
         - Resource
       operationId: createDeployment
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Deploy resources
       description: |
         Deploys one or more resources (e.g. processes, decision models, or forms).
@@ -49,6 +52,9 @@ paths:
       tags:
         - Resource
       operationId: getResource
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Get resource
       description: |
         Returns a deployed resource.
@@ -88,6 +94,9 @@ paths:
       tags:
         - Resource
       operationId: getResourceContent
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Get RPA resource content (deprecated)
       description: |
         **Deprecated** — use `/resources/{resourceKey}/content/binary` instead, which supports all
@@ -135,6 +144,9 @@ paths:
       tags:
         - Resource
       operationId: getResourceContentBinary
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Get resource content as binary
       description: |
         Returns the content of a deployed resource in binary format (octet-stream).
@@ -174,6 +186,9 @@ paths:
       tags:
         - Resource
       operationId: searchResources
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Search resources
       description: |
         Search for deployed resources based on given criteria.
@@ -211,6 +226,9 @@ paths:
       tags:
         - Resource
       operationId: deleteResource
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Delete resource
       description: |-
         Deletes a deployed resource. This can be a process definition, decision requirements

--- a/zeebe/gateway-protocol/src/main/proto/v2/deployments.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/deployments.yaml
@@ -8,7 +8,7 @@ paths:
         - Resource
       operationId: createDeployment
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Deploy resources
       description: |
@@ -53,7 +53,7 @@ paths:
         - Resource
       operationId: getResource
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Get resource
       description: |
@@ -95,7 +95,7 @@ paths:
         - Resource
       operationId: getResourceContent
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Get RPA resource content (deprecated)
       description: |
@@ -145,7 +145,7 @@ paths:
         - Resource
       operationId: getResourceContentBinary
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Get resource content as binary
       description: |
@@ -187,7 +187,7 @@ paths:
         - Resource
       operationId: searchResources
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Search resources
       description: |
@@ -227,7 +227,7 @@ paths:
         - Resource
       operationId: deleteResource
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Delete resource
       description: |-

--- a/zeebe/gateway-protocol/src/main/proto/v2/documents.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/documents.yaml
@@ -8,7 +8,7 @@ paths:
         - Document
       operationId: createDocument
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Upload document
       description: |
@@ -68,7 +68,7 @@ paths:
         - Document
       operationId: createDocuments
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Upload multiple documents
       description: |
@@ -154,7 +154,7 @@ paths:
         - Document
       operationId: getDocument
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Download document
       description: |
@@ -207,7 +207,7 @@ paths:
         - Document
       operationId: deleteDocument
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Delete document
       description: |
@@ -247,7 +247,7 @@ paths:
         - Document
       operationId: createDocumentLink
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Create document link
       description: |

--- a/zeebe/gateway-protocol/src/main/proto/v2/documents.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/documents.yaml
@@ -7,6 +7,9 @@ paths:
       tags:
         - Document
       operationId: createDocument
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Upload document
       description: |
         Upload a document to the Camunda 8 cluster.
@@ -64,6 +67,9 @@ paths:
       tags:
         - Document
       operationId: createDocuments
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Upload multiple documents
       description: |
         Upload multiple documents to the Camunda 8 cluster.
@@ -147,6 +153,9 @@ paths:
       tags:
         - Document
       operationId: getDocument
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Download document
       description: |
         Download a document from the Camunda 8 cluster.
@@ -197,6 +206,9 @@ paths:
       tags:
         - Document
       operationId: deleteDocument
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Delete document
       description: |
         Delete a document from the Camunda 8 cluster.
@@ -234,6 +246,9 @@ paths:
       tags:
         - Document
       operationId: createDocumentLink
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Create document link
       description: |
         Create a link to a document in the Camunda 8 cluster.

--- a/zeebe/gateway-protocol/src/main/proto/v2/element-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/element-instances.yaml
@@ -41,6 +41,9 @@ paths:
       tags:
         - Element instance
       operationId: searchElementInstanceWaitStates
+      security:
+        - bearerAuth: []
+        - basicAuth: []
       summary: Search element instance wait states
       description: >
         Returns the wait states for element instances matching the given filter.

--- a/zeebe/gateway-protocol/src/main/proto/v2/element-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/element-instances.yaml
@@ -8,7 +8,7 @@ paths:
         - Element instance
       operationId: searchElementInstances
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Search element instances
       description: Search for element instances based on given criteria.
@@ -74,7 +74,7 @@ paths:
         - Element instance
       operationId: getElementInstance
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Get element instance
       description: Returns element instance as JSON.
@@ -117,7 +117,7 @@ paths:
         - Element instance
       operationId: createElementInstanceVariables
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Update element instance variables
       description: |
@@ -163,7 +163,7 @@ paths:
         - Element instance
       operationId: searchElementInstanceIncidents
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Search for incidents of a specific element instance
       description: |
@@ -217,7 +217,7 @@ paths:
         - Ad-hoc sub-process
       operationId: activateAdHocSubProcessActivities
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Activate activities within an ad-hoc sub-process
       description: |

--- a/zeebe/gateway-protocol/src/main/proto/v2/element-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/element-instances.yaml
@@ -7,6 +7,9 @@ paths:
       tags:
         - Element instance
       operationId: searchElementInstances
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Search element instances
       description: Search for element instances based on given criteria.
       requestBody:
@@ -70,6 +73,9 @@ paths:
       tags:
         - Element instance
       operationId: getElementInstance
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Get element instance
       description: Returns element instance as JSON.
       parameters:
@@ -110,6 +116,9 @@ paths:
       tags:
         - Element instance
       operationId: createElementInstanceVariables
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Update element instance variables
       description: |
         Updates all the variables of a particular scope (for example, process instance, element instance) with the given variable data.
@@ -153,6 +162,9 @@ paths:
       tags:
         - Element instance
       operationId: searchElementInstanceIncidents
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Search for incidents of a specific element instance
       description: |
         Search for incidents caused by the specified element instance, including incidents of any child instances created from this element instance.
@@ -204,6 +216,9 @@ paths:
       tags:
         - Ad-hoc sub-process
       operationId: activateAdHocSubProcessActivities
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Activate activities within an ad-hoc sub-process
       description: |
         Activates selected activities within an ad-hoc sub-process identified by element ID.

--- a/zeebe/gateway-protocol/src/main/proto/v2/expression.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/expression.yaml
@@ -4,6 +4,9 @@ paths:
   /expression/evaluation:
     post:
       operationId: evaluateExpression
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       x-eventually-consistent: false
       tags:
         - Expression

--- a/zeebe/gateway-protocol/src/main/proto/v2/expression.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/expression.yaml
@@ -5,7 +5,7 @@ paths:
     post:
       operationId: evaluateExpression
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       x-eventually-consistent: false
       tags:

--- a/zeebe/gateway-protocol/src/main/proto/v2/forms.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/forms.yaml
@@ -7,6 +7,9 @@ paths:
       tags:
         - Form
       operationId: getFormByKey
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Get form by key
       description: |
         Get a form by its unique form key.

--- a/zeebe/gateway-protocol/src/main/proto/v2/forms.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/forms.yaml
@@ -8,7 +8,7 @@ paths:
         - Form
       operationId: getFormByKey
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Get form by key
       description: |

--- a/zeebe/gateway-protocol/src/main/proto/v2/global-listeners.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/global-listeners.yaml
@@ -8,7 +8,7 @@ paths:
         - Global listener
       operationId: createGlobalTaskListener
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Create global user task listener
       description: Create a new global user task listener.
@@ -54,7 +54,7 @@ paths:
         - Global listener
       operationId: getGlobalTaskListener
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Get global user task listener
       description: Get a global user task listener by its id.
@@ -96,7 +96,7 @@ paths:
         - Global listener
       operationId: updateGlobalTaskListener
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Update global user task listener
       description: Updates a global user task listener.
@@ -148,7 +148,7 @@ paths:
         - Global listener
       operationId: deleteGlobalTaskListener
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Delete global user task listener
       description: Deletes a global user task listener.
@@ -191,7 +191,7 @@ paths:
         - Global listener
       operationId: searchGlobalTaskListeners
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Search global user task listeners
       description: Search for global user task listeners based on given criteria.

--- a/zeebe/gateway-protocol/src/main/proto/v2/global-listeners.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/global-listeners.yaml
@@ -7,6 +7,9 @@ paths:
       tags:
         - Global listener
       operationId: createGlobalTaskListener
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Create global user task listener
       description: Create a new global user task listener.
       x-semantic-establishes:
@@ -50,6 +53,9 @@ paths:
       tags:
         - Global listener
       operationId: getGlobalTaskListener
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Get global user task listener
       description: Get a global user task listener by its id.
       x-semantic-requires:
@@ -89,6 +95,9 @@ paths:
       tags:
         - Global listener
       operationId: updateGlobalTaskListener
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Update global user task listener
       description: Updates a global user task listener.
       x-semantic-requires:
@@ -138,6 +147,9 @@ paths:
       tags:
         - Global listener
       operationId: deleteGlobalTaskListener
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Delete global user task listener
       description: Deletes a global user task listener.
       x-semantic-requires:
@@ -178,6 +190,9 @@ paths:
       tags:
         - Global listener
       operationId: searchGlobalTaskListeners
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Search global user task listeners
       description: Search for global user task listeners based on given criteria.
       requestBody:

--- a/zeebe/gateway-protocol/src/main/proto/v2/groups.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/groups.yaml
@@ -7,7 +7,7 @@ paths:
         - Group
       operationId: createGroup
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Create group
       description: |
@@ -68,7 +68,7 @@ paths:
         - Group
       operationId: searchGroups
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Search groups
       description: Search for groups based on given criteria.
@@ -102,7 +102,7 @@ paths:
         - Group
       operationId: getGroup
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Get group
       description: Get a group by its ID.
@@ -144,7 +144,7 @@ paths:
         - Group
       operationId: updateGroup
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Update group
       description: Update a group with the given ID.
@@ -194,7 +194,7 @@ paths:
         - Group
       operationId: deleteGroup
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Delete group
       description: Deletes the group with the given ID.
@@ -233,7 +233,7 @@ paths:
         - Group
       operationId: assignUserToGroup
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Assign a user to a group
       description: |
@@ -289,7 +289,7 @@ paths:
         - Group
       operationId: unassignUserFromGroup
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Unassign a user from a group
       description: |
@@ -339,7 +339,7 @@ paths:
         - Group
       operationId: searchUsersForGroup
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Search group users
       description: Search users assigned to a group.
@@ -390,7 +390,7 @@ paths:
         - Group
       operationId: assignClientToGroup
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Assign a client to a group
       description: |
@@ -446,7 +446,7 @@ paths:
         - Group
       operationId: unassignClientFromGroup
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Unassign a client from a group
       description: |
@@ -496,7 +496,7 @@ paths:
         - Group
       operationId: searchClientsForGroup
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Search group clients
       description: Search clients assigned to a group.
@@ -547,7 +547,7 @@ paths:
         - Group
       operationId: assignMappingRuleToGroup
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Assign a mapping rule to a group
       description: Assigns a mapping rule to a group.
@@ -601,7 +601,7 @@ paths:
         - Group
       operationId: unassignMappingRuleFromGroup
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Unassign a mapping rule from a group
       description: Unassigns a mapping rule from a group.
@@ -649,7 +649,7 @@ paths:
         - Group
       operationId: searchMappingRulesForGroup
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Search group mapping rules
       description: Search mapping rules assigned to a group.
@@ -700,7 +700,7 @@ paths:
         - Group
       operationId: searchRolesForGroup
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Search group roles
       description: Search roles assigned to a group.

--- a/zeebe/gateway-protocol/src/main/proto/v2/groups.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/groups.yaml
@@ -6,6 +6,9 @@ paths:
       tags:
         - Group
       operationId: createGroup
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Create group
       description: |
         Create a new group.
@@ -64,6 +67,9 @@ paths:
       tags:
         - Group
       operationId: searchGroups
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Search groups
       description: Search for groups based on given criteria.
       requestBody:
@@ -95,6 +101,9 @@ paths:
       tags:
         - Group
       operationId: getGroup
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Get group
       description: Get a group by its ID.
       x-semantic-requires:
@@ -134,6 +143,9 @@ paths:
       tags:
         - Group
       operationId: updateGroup
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Update group
       description: Update a group with the given ID.
       x-semantic-requires:
@@ -181,6 +193,9 @@ paths:
       tags:
         - Group
       operationId: deleteGroup
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Delete group
       description: Deletes the group with the given ID.
       x-semantic-requires:
@@ -217,6 +232,9 @@ paths:
       tags:
         - Group
       operationId: assignUserToGroup
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Assign a user to a group
       description: |
         Assigns a user to a group, making the user a member of the group.
@@ -270,6 +288,9 @@ paths:
       tags:
         - Group
       operationId: unassignUserFromGroup
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Unassign a user from a group
       description: |
         Unassigns a user from a group.
@@ -317,6 +338,9 @@ paths:
       tags:
         - Group
       operationId: searchUsersForGroup
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Search group users
       description: Search users assigned to a group.
       x-semantic-requires:
@@ -365,6 +389,9 @@ paths:
       tags:
         - Group
       operationId: assignClientToGroup
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Assign a client to a group
       description: |
         Assigns a client to a group, making it a member of the group.
@@ -418,6 +445,9 @@ paths:
       tags:
         - Group
       operationId: unassignClientFromGroup
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Unassign a client from a group
       description: |
         Unassigns a client from a group.
@@ -465,6 +495,9 @@ paths:
       tags:
         - Group
       operationId: searchClientsForGroup
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Search group clients
       description: Search clients assigned to a group.
       x-semantic-requires:
@@ -513,6 +546,9 @@ paths:
       tags:
         - Group
       operationId: assignMappingRuleToGroup
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Assign a mapping rule to a group
       description: Assigns a mapping rule to a group.
       x-semantic-establishes:
@@ -564,6 +600,9 @@ paths:
       tags:
         - Group
       operationId: unassignMappingRuleFromGroup
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Unassign a mapping rule from a group
       description: Unassigns a mapping rule from a group.
       x-semantic-requires:
@@ -609,6 +648,9 @@ paths:
       tags:
         - Group
       operationId: searchMappingRulesForGroup
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Search group mapping rules
       description: Search mapping rules assigned to a group.
       x-semantic-requires:
@@ -657,6 +699,9 @@ paths:
       tags:
         - Group
       operationId: searchRolesForGroup
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Search group roles
       description: Search roles assigned to a group.
       x-semantic-requires:

--- a/zeebe/gateway-protocol/src/main/proto/v2/incidents.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/incidents.yaml
@@ -7,6 +7,9 @@ paths:
       tags:
         - Incident
       operationId: searchIncidents
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Search incidents
       description: |
         Search for incidents based on given criteria.
@@ -39,6 +42,9 @@ paths:
       tags:
         - Incident
       operationId: getIncident
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Get incident
       description: |
         Returns incident as JSON.
@@ -78,6 +84,9 @@ paths:
       tags:
         - Incident
       operationId: resolveIncident
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Resolve incident
       description: |
         Marks the incident as resolved; most likely a call to Update job will be necessary
@@ -126,6 +135,9 @@ paths:
       tags:
         - Incident
       operationId: getProcessInstanceStatisticsByError
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Get process instance statistics by error
       description: |
         Returns statistics for active process instances that currently have active incidents,
@@ -161,6 +173,9 @@ paths:
       tags:
         - Incident
       operationId: getProcessInstanceStatisticsByDefinition
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Get process instance statistics by definition
       description: |
         Returns statistics for active process instances with incidents, grouped by process

--- a/zeebe/gateway-protocol/src/main/proto/v2/incidents.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/incidents.yaml
@@ -8,7 +8,7 @@ paths:
         - Incident
       operationId: searchIncidents
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Search incidents
       description: |
@@ -43,7 +43,7 @@ paths:
         - Incident
       operationId: getIncident
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Get incident
       description: |
@@ -85,7 +85,7 @@ paths:
         - Incident
       operationId: resolveIncident
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Resolve incident
       description: |
@@ -136,7 +136,7 @@ paths:
         - Incident
       operationId: getProcessInstanceStatisticsByError
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Get process instance statistics by error
       description: |
@@ -174,7 +174,7 @@ paths:
         - Incident
       operationId: getProcessInstanceStatisticsByDefinition
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Get process instance statistics by definition
       description: |

--- a/zeebe/gateway-protocol/src/main/proto/v2/job-metrics.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/job-metrics.yaml
@@ -7,6 +7,9 @@ paths:
       tags:
         - Job
       operationId: getGlobalJobStatistics
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Global job statistics
       description: |
         Returns global aggregated counts for jobs. Filter by the creation time window (required) and optionally by jobType.
@@ -59,6 +62,9 @@ paths:
       tags:
         - Job
       operationId: getJobTypeStatistics
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Get job statistics by type
       description: |
         Get statistics about jobs, grouped by job type.
@@ -91,6 +97,9 @@ paths:
       tags:
         - Job
       operationId: getJobWorkerStatistics
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Get job statistics by worker
       description: |
         Get statistics about jobs, grouped by worker, for a given job type.
@@ -123,6 +132,9 @@ paths:
       tags:
         - Job
       operationId: getJobTimeSeriesStatistics
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Get time-series metrics for a job type
       description: |
         Returns a list of time-bucketed metrics ordered ascending by time.
@@ -157,6 +169,9 @@ paths:
       tags:
         - Job
       operationId: getJobErrorStatistics
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Get error metrics for a job type
       description: |
         Returns aggregated metrics per error for the given jobType.

--- a/zeebe/gateway-protocol/src/main/proto/v2/job-metrics.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/job-metrics.yaml
@@ -8,7 +8,7 @@ paths:
         - Job
       operationId: getGlobalJobStatistics
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Global job statistics
       description: |
@@ -63,7 +63,7 @@ paths:
         - Job
       operationId: getJobTypeStatistics
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Get job statistics by type
       description: |
@@ -98,7 +98,7 @@ paths:
         - Job
       operationId: getJobWorkerStatistics
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Get job statistics by worker
       description: |
@@ -133,7 +133,7 @@ paths:
         - Job
       operationId: getJobTimeSeriesStatistics
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Get time-series metrics for a job type
       description: |
@@ -170,7 +170,7 @@ paths:
         - Job
       operationId: getJobErrorStatistics
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Get error metrics for a job type
       description: |

--- a/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
@@ -7,6 +7,9 @@ paths:
       tags:
         - Job
       operationId: activateJobs
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Activate jobs
       description: |
         Iterate through all known partitions and activate jobs up to the requested maximum.
@@ -39,6 +42,9 @@ paths:
       tags:
         - Job
       operationId: searchJobs
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Search jobs
       description: Search for jobs based on given criteria.
       requestBody:
@@ -70,6 +76,9 @@ paths:
       tags:
         - Job
       operationId: failJob
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Fail job
       description: |
         Mark the job as failed.
@@ -120,6 +129,9 @@ paths:
       tags:
         - Job
       operationId: throwJobError
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Throw error for job
       description: |
         Reports a business error (i.e. non-technical) that occurs while processing a job.
@@ -168,6 +180,9 @@ paths:
       tags:
         - Job
       operationId: completeJob
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Complete job
       description: |
         Complete a job with the given payload, which allows completing the associated service task.
@@ -215,6 +230,9 @@ paths:
       tags:
         - Job
       operationId: updateJob
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Update job
       description: Update a job with the given key.
       parameters:

--- a/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
@@ -8,7 +8,7 @@ paths:
         - Job
       operationId: activateJobs
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Activate jobs
       description: |
@@ -43,7 +43,7 @@ paths:
         - Job
       operationId: searchJobs
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Search jobs
       description: Search for jobs based on given criteria.
@@ -77,7 +77,7 @@ paths:
         - Job
       operationId: failJob
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Fail job
       description: |
@@ -130,7 +130,7 @@ paths:
         - Job
       operationId: throwJobError
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Throw error for job
       description: |
@@ -181,7 +181,7 @@ paths:
         - Job
       operationId: completeJob
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Complete job
       description: |
@@ -231,7 +231,7 @@ paths:
         - Job
       operationId: updateJob
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Update job
       description: Update a job with the given key.

--- a/zeebe/gateway-protocol/src/main/proto/v2/licenses.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/licenses.yaml
@@ -7,6 +7,10 @@ paths:
       tags:
         - License
       operationId: getLicense
+      # Public license-status endpoint — declared unauthenticated at runtime
+      # via SecurityPathAdapter. `security: []` overrides the conditional
+      # enforcement on the global schemes for this operation.
+      security: []
       summary: Get license status
       description: Obtains the status of the current Camunda license.
       responses:

--- a/zeebe/gateway-protocol/src/main/proto/v2/mapping-rules.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/mapping-rules.yaml
@@ -8,7 +8,7 @@ paths:
         - Mapping rule
       operationId: createMappingRule
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Create mapping rule
       description: |
@@ -61,7 +61,7 @@ paths:
         - Mapping rule
       operationId: updateMappingRule
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Update mapping rule
       description: |
@@ -116,7 +116,7 @@ paths:
         - Mapping rule
       operationId: deleteMappingRule
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Delete a mapping rule
       description: |
@@ -154,7 +154,7 @@ paths:
         - Mapping rule
       operationId: getMappingRule
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Get a mapping rule
       description: |
@@ -195,7 +195,7 @@ paths:
         - Mapping rule
       operationId: searchMappingRule
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Search mapping rules
       description: |

--- a/zeebe/gateway-protocol/src/main/proto/v2/mapping-rules.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/mapping-rules.yaml
@@ -7,6 +7,9 @@ paths:
       tags:
         - Mapping rule
       operationId: createMappingRule
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Create mapping rule
       description: |
         Create a new mapping rule
@@ -57,6 +60,9 @@ paths:
       tags:
         - Mapping rule
       operationId: updateMappingRule
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Update mapping rule
       description: |
         Update a mapping rule.
@@ -109,6 +115,9 @@ paths:
       tags:
         - Mapping rule
       operationId: deleteMappingRule
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Delete a mapping rule
       description: |
         Deletes the mapping rule with the given ID.
@@ -144,6 +153,9 @@ paths:
       tags:
         - Mapping rule
       operationId: getMappingRule
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Get a mapping rule
       description: |
         Gets the mapping rule with the given ID.
@@ -182,6 +194,9 @@ paths:
       tags:
         - Mapping rule
       operationId: searchMappingRule
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Search mapping rules
       description: |
         Search for mapping rules based on given criteria.

--- a/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
@@ -8,7 +8,7 @@ paths:
         - Message
       operationId: publishMessage
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Publish message
       description: |
@@ -45,7 +45,7 @@ paths:
         - Message
       operationId: correlateMessage
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Correlate message
       description: |
@@ -89,7 +89,7 @@ paths:
         - Message subscription
       operationId: searchMessageSubscriptions
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Search message subscriptions
       description: |
@@ -136,7 +136,7 @@ paths:
         - Message subscription
       operationId: searchCorrelatedMessageSubscriptions
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Search correlated message subscriptions
       description: Search correlated message subscriptions based on given criteria.

--- a/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
@@ -7,6 +7,9 @@ paths:
       tags:
         - Message
       operationId: publishMessage
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Publish message
       description: |
         Publishes a single message.
@@ -41,6 +44,9 @@ paths:
       tags:
         - Message
       operationId: correlateMessage
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Correlate message
       description: |
         Publishes a message and correlates it to a subscription.
@@ -82,6 +88,9 @@ paths:
       tags:
         - Message subscription
       operationId: searchMessageSubscriptions
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Search message subscriptions
       description: |
         Search for message subscriptions based on given criteria.
@@ -126,6 +135,9 @@ paths:
       tags:
         - Message subscription
       operationId: searchCorrelatedMessageSubscriptions
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Search correlated message subscriptions
       description: Search correlated message subscriptions based on given criteria.
       requestBody:

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-definitions.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-definitions.yaml
@@ -7,6 +7,9 @@ paths:
       tags:
         - Process definition
       operationId: searchProcessDefinitions
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Search process definitions
       description: Search for process definitions based on given criteria.
       requestBody:
@@ -38,6 +41,9 @@ paths:
       tags:
         - Process definition
       operationId: getProcessDefinition
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Get process definition
       description: Returns process definition as JSON.
       parameters:
@@ -80,6 +86,9 @@ paths:
       tags:
         - Process definition
       operationId: getProcessDefinitionXML
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Get process definition XML
       description: Returns process definition as XML.
       parameters:
@@ -127,6 +136,9 @@ paths:
       tags:
         - Process definition
       operationId: getStartProcessForm
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Get process start form
       description: |
         Get the start form of a process.
@@ -169,6 +181,9 @@ paths:
       tags:
         - Process definition
       operationId: getProcessDefinitionStatistics
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Get process definition statistics
       description: Get statistics about elements in currently running process instances by process definition key and search filter.
       parameters:
@@ -207,6 +222,9 @@ paths:
       tags:
         - Process definition
       operationId: getProcessDefinitionMessageSubscriptionStatistics
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Get message subscription statistics
       description: |
         Get message subscription statistics, grouped by process definition.
@@ -239,6 +257,9 @@ paths:
       tags:
         - Process definition
       operationId: getProcessDefinitionInstanceStatistics
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Get process instance statistics
       description: |
         Get statistics about process instances, grouped by process definition and tenant.
@@ -271,6 +292,9 @@ paths:
       tags:
         - Process definition
       operationId: getProcessDefinitionInstanceVersionStatistics
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Get process instance statistics by version
       description: |
         Get statistics about process instances, grouped by version for a given process definition.

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-definitions.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-definitions.yaml
@@ -8,7 +8,7 @@ paths:
         - Process definition
       operationId: searchProcessDefinitions
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Search process definitions
       description: Search for process definitions based on given criteria.
@@ -42,7 +42,7 @@ paths:
         - Process definition
       operationId: getProcessDefinition
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Get process definition
       description: Returns process definition as JSON.
@@ -87,7 +87,7 @@ paths:
         - Process definition
       operationId: getProcessDefinitionXML
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Get process definition XML
       description: Returns process definition as XML.
@@ -137,7 +137,7 @@ paths:
         - Process definition
       operationId: getStartProcessForm
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Get process start form
       description: |
@@ -182,7 +182,7 @@ paths:
         - Process definition
       operationId: getProcessDefinitionStatistics
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Get process definition statistics
       description: Get statistics about elements in currently running process instances by process definition key and search filter.
@@ -223,7 +223,7 @@ paths:
         - Process definition
       operationId: getProcessDefinitionMessageSubscriptionStatistics
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Get message subscription statistics
       description: |
@@ -258,7 +258,7 @@ paths:
         - Process definition
       operationId: getProcessDefinitionInstanceStatistics
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Get process instance statistics
       description: |
@@ -293,7 +293,7 @@ paths:
         - Process definition
       operationId: getProcessDefinitionInstanceVersionStatistics
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Get process instance statistics by version
       description: |

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
@@ -7,6 +7,9 @@ paths:
       tags:
         - Process instance
       operationId: createProcessInstance
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Create process instance
       description: |
         Creates and starts an instance of the specified process.
@@ -74,6 +77,9 @@ paths:
       tags:
         - Process instance
       operationId: getProcessInstance
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Get process instance
       description: Get the process instance by the process instance key.
       parameters:
@@ -112,6 +118,9 @@ paths:
       tags:
         - Process instance
       operationId: getProcessInstanceSequenceFlows
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Get sequence flows
       description: Get sequence flows taken by the process instance.
       parameters:
@@ -144,6 +153,9 @@ paths:
       tags:
         - Process instance
       operationId: getProcessInstanceStatistics
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Get element instance statistics
       description: Get statistics about elements by the process instance key.
       parameters:
@@ -176,6 +188,9 @@ paths:
       tags:
         - Process instance
       operationId: searchProcessInstances
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Search process instances
       description: Search for process instances based on given criteria.
       requestBody:
@@ -207,6 +222,9 @@ paths:
       tags:
         - Process instance
       operationId: searchProcessInstanceIncidents
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Search related incidents
       description: |
         Search for incidents caused by the process instance or any of its called process or decision instances.
@@ -257,6 +275,9 @@ paths:
       tags:
         - Process instance
       operationId: resolveProcessInstanceIncidents
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Resolve related incidents
       description: Creates a batch operation to resolve multiple incidents of a process instance.
       parameters:
@@ -295,6 +316,9 @@ paths:
       tags:
         - Process instance
       operationId: cancelProcessInstance
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Cancel process instance
       description: >
         Cancels a running process instance. As a cancellation includes more than just the removal
@@ -340,6 +364,9 @@ paths:
       tags:
         - Process instance
       operationId: cancelProcessInstancesBatchOperation
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Cancel process instances (batch)
       description: |
         Cancels multiple running process instances.
@@ -381,6 +408,9 @@ paths:
       tags:
         - Process instance
       operationId: resolveIncidentsBatchOperation
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Resolve related incidents (batch)
       description: |
         Resolves multiple instances of process instances.
@@ -422,6 +452,9 @@ paths:
       tags:
         - Process instance
       operationId: migrateProcessInstancesBatchOperation
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Migrate process instances (batch)
       description: |
         Migrate multiple process instances.
@@ -463,6 +496,9 @@ paths:
       tags:
         - Process instance
       operationId: modifyProcessInstancesBatchOperation
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Modify process instances (batch)
       description: |
         Modify multiple process instances.
@@ -506,6 +542,9 @@ paths:
       tags:
         - Process instance
       operationId: deleteProcessInstance
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Delete process instance
       description: Deletes a process instance. Only instances that are completed or terminated can be deleted.
       parameters:
@@ -552,6 +591,9 @@ paths:
       tags:
         - Process instance
       operationId: deleteProcessInstancesBatchOperation
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Delete process instances (batch)
       description: |
         Delete multiple process instances. This will delete the historic data from secondary storage.
@@ -592,6 +634,9 @@ paths:
       tags:
         - Process instance
       operationId: migrateProcessInstance
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Migrate process instance
       description: |
         Migrates a process instance to a new process definition.
@@ -645,6 +690,9 @@ paths:
       tags:
         - Process instance
       operationId: modifyProcessInstance
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Modify process instance
       description: |
         Modifies a running process instance.
@@ -689,6 +737,9 @@ paths:
       tags:
         - Process instance
       operationId: getProcessInstanceCallHierarchy
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Get call hierarchy
       description: Returns the call hierarchy for a given process instance, showing its ancestry up to the root instance.
       parameters:

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
@@ -8,7 +8,7 @@ paths:
         - Process instance
       operationId: createProcessInstance
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Create process instance
       description: |
@@ -78,7 +78,7 @@ paths:
         - Process instance
       operationId: getProcessInstance
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Get process instance
       description: Get the process instance by the process instance key.
@@ -119,7 +119,7 @@ paths:
         - Process instance
       operationId: getProcessInstanceSequenceFlows
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Get sequence flows
       description: Get sequence flows taken by the process instance.
@@ -154,7 +154,7 @@ paths:
         - Process instance
       operationId: getProcessInstanceStatistics
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Get element instance statistics
       description: Get statistics about elements by the process instance key.
@@ -189,7 +189,7 @@ paths:
         - Process instance
       operationId: searchProcessInstances
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Search process instances
       description: Search for process instances based on given criteria.
@@ -223,7 +223,7 @@ paths:
         - Process instance
       operationId: searchProcessInstanceIncidents
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Search related incidents
       description: |
@@ -276,7 +276,7 @@ paths:
         - Process instance
       operationId: resolveProcessInstanceIncidents
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Resolve related incidents
       description: Creates a batch operation to resolve multiple incidents of a process instance.
@@ -317,7 +317,7 @@ paths:
         - Process instance
       operationId: cancelProcessInstance
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Cancel process instance
       description: >
@@ -365,7 +365,7 @@ paths:
         - Process instance
       operationId: cancelProcessInstancesBatchOperation
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Cancel process instances (batch)
       description: |
@@ -409,7 +409,7 @@ paths:
         - Process instance
       operationId: resolveIncidentsBatchOperation
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Resolve related incidents (batch)
       description: |
@@ -453,7 +453,7 @@ paths:
         - Process instance
       operationId: migrateProcessInstancesBatchOperation
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Migrate process instances (batch)
       description: |
@@ -497,7 +497,7 @@ paths:
         - Process instance
       operationId: modifyProcessInstancesBatchOperation
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Modify process instances (batch)
       description: |
@@ -543,7 +543,7 @@ paths:
         - Process instance
       operationId: deleteProcessInstance
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Delete process instance
       description: Deletes a process instance. Only instances that are completed or terminated can be deleted.
@@ -592,7 +592,7 @@ paths:
         - Process instance
       operationId: deleteProcessInstancesBatchOperation
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Delete process instances (batch)
       description: |
@@ -635,7 +635,7 @@ paths:
         - Process instance
       operationId: migrateProcessInstance
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Migrate process instance
       description: |
@@ -691,7 +691,7 @@ paths:
         - Process instance
       operationId: modifyProcessInstance
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Modify process instance
       description: |
@@ -738,7 +738,7 @@ paths:
         - Process instance
       operationId: getProcessInstanceCallHierarchy
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Get call hierarchy
       description: Returns the call hierarchy for a given process instance, showing its ancestry up to the root instance.

--- a/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
@@ -478,6 +478,16 @@ components:
       type: http
       scheme: bearer
       bearerFormat: JWT
+      # Conditional enforcement. The scheme is enforced when the
+      # Orchestration Cluster REST API server is running in `secured` mode
+      # and bypassed when in `unsecured` mode. `x-enforcement-modes` names
+      # the deployment-mode axis (`auth`) whose values trigger enforcement.
+      x-enforcement: conditional
+      x-enforcement-modes:
+        auth: [secured]
     basicAuth:
       type: http
       scheme: basic
+      x-enforcement: conditional
+      x-enforcement-modes:
+        auth: [secured]

--- a/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
@@ -474,7 +474,7 @@ paths:
 
 components:
   securitySchemes:
-    BearerAuth:
+    bearerAuth:
       type: http
       scheme: bearer
       bearerFormat: JWT

--- a/zeebe/gateway-protocol/src/main/proto/v2/roles.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/roles.yaml
@@ -8,7 +8,7 @@ paths:
         - Role
       operationId: createRole
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Create role
       description: Create a new role.
@@ -53,7 +53,7 @@ paths:
         - Role
       operationId: searchRoles
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Search roles
       description: Search for roles based on given criteria.
@@ -87,7 +87,7 @@ paths:
         - Role
       operationId: getRole
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Get role
       description: Get a role by its ID.
@@ -129,7 +129,7 @@ paths:
         - Role
       operationId: updateRole
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Update role
       description: Update a role with the given ID.
@@ -179,7 +179,7 @@ paths:
         - Role
       operationId: deleteRole
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Delete role
       description: Deletes the role with the given ID.
@@ -218,7 +218,7 @@ paths:
         - Role
       operationId: assignRoleToUser
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Assign a role to a user
       description: Assigns the specified role to the user. The user will inherit the authorizations associated with this role.
@@ -272,7 +272,7 @@ paths:
         - Role
       operationId: unassignRoleFromUser
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Unassign a role from a user
       description: Unassigns a role from a user. The user will no longer inherit the authorizations associated with this role.
@@ -320,7 +320,7 @@ paths:
         - Role
       operationId: searchUsersForRole
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Search role users
       description: Search users with assigned role.
@@ -371,7 +371,7 @@ paths:
         - Role
       operationId: assignRoleToClient
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Assign a role to a client
       description: Assigns the specified role to the client. The client will inherit the authorizations associated with this role.
@@ -425,7 +425,7 @@ paths:
         - Role
       operationId: unassignRoleFromClient
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Unassign a role from a client
       description: Unassigns the specified role from the client. The client will no longer inherit the authorizations associated with this role.
@@ -473,7 +473,7 @@ paths:
         - Role
       operationId: searchClientsForRole
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Search role clients
       description: Search clients with assigned role.
@@ -524,7 +524,7 @@ paths:
         - Role
       operationId: assignRoleToGroup
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Assign a role to a group
       description: Assigns the specified role to the group. Every member of the group (user or client) will inherit the authorizations associated with this role.
@@ -584,7 +584,7 @@ paths:
         - Role
       operationId: unassignRoleFromGroup
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Unassign a role from a group
       description: Unassigns the specified role from the group. All group members (user or client) no longer inherit the authorizations associated with this role.
@@ -632,7 +632,7 @@ paths:
         - Role
       operationId: searchGroupsForRole
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Search role groups
       description: Search groups with assigned role.
@@ -683,7 +683,7 @@ paths:
         - Role
       operationId: assignRoleToMappingRule
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Assign a role to a mapping rule
       description: Assigns a role to a mapping rule.
@@ -737,7 +737,7 @@ paths:
         - Role
       operationId: unassignRoleFromMappingRule
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Unassign a role from a mapping rule
       description: Unassigns a role from a mapping rule.
@@ -785,7 +785,7 @@ paths:
         - Role
       operationId: searchMappingRulesForRole
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Search role mapping rules
       description: Search mapping rules with assigned role.

--- a/zeebe/gateway-protocol/src/main/proto/v2/roles.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/roles.yaml
@@ -7,6 +7,9 @@ paths:
       tags:
         - Role
       operationId: createRole
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Create role
       description: Create a new role.
       x-semantic-establishes:
@@ -49,6 +52,9 @@ paths:
       tags:
         - Role
       operationId: searchRoles
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Search roles
       description: Search for roles based on given criteria.
       requestBody:
@@ -80,6 +86,9 @@ paths:
       tags:
         - Role
       operationId: getRole
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Get role
       description: Get a role by its ID.
       x-semantic-requires:
@@ -119,6 +128,9 @@ paths:
       tags:
         - Role
       operationId: updateRole
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Update role
       description: Update a role with the given ID.
       x-semantic-requires:
@@ -166,6 +178,9 @@ paths:
       tags:
         - Role
       operationId: deleteRole
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Delete role
       description: Deletes the role with the given ID.
       x-semantic-requires:
@@ -202,6 +217,9 @@ paths:
       tags:
         - Role
       operationId: assignRoleToUser
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Assign a role to a user
       description: Assigns the specified role to the user. The user will inherit the authorizations associated with this role.
       x-semantic-establishes:
@@ -253,6 +271,9 @@ paths:
       tags:
         - Role
       operationId: unassignRoleFromUser
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Unassign a role from a user
       description: Unassigns a role from a user. The user will no longer inherit the authorizations associated with this role.
       x-semantic-requires:
@@ -298,6 +319,9 @@ paths:
       tags:
         - Role
       operationId: searchUsersForRole
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Search role users
       description: Search users with assigned role.
       x-semantic-requires:
@@ -346,6 +370,9 @@ paths:
       tags:
         - Role
       operationId: assignRoleToClient
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Assign a role to a client
       description: Assigns the specified role to the client. The client will inherit the authorizations associated with this role.
       x-semantic-establishes:
@@ -397,6 +424,9 @@ paths:
       tags:
         - Role
       operationId: unassignRoleFromClient
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Unassign a role from a client
       description: Unassigns the specified role from the client. The client will no longer inherit the authorizations associated with this role.
       x-semantic-requires:
@@ -442,6 +472,9 @@ paths:
       tags:
         - Role
       operationId: searchClientsForRole
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Search role clients
       description: Search clients with assigned role.
       x-semantic-requires:
@@ -490,6 +523,9 @@ paths:
       tags:
         - Role
       operationId: assignRoleToGroup
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Assign a role to a group
       description: Assigns the specified role to the group. Every member of the group (user or client) will inherit the authorizations associated with this role.
       x-semantic-establishes:
@@ -547,6 +583,9 @@ paths:
       tags:
         - Role
       operationId: unassignRoleFromGroup
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Unassign a role from a group
       description: Unassigns the specified role from the group. All group members (user or client) no longer inherit the authorizations associated with this role.
       x-semantic-requires:
@@ -592,6 +631,9 @@ paths:
       tags:
         - Role
       operationId: searchGroupsForRole
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Search role groups
       description: Search groups with assigned role.
       x-semantic-requires:
@@ -640,6 +682,9 @@ paths:
       tags:
         - Role
       operationId: assignRoleToMappingRule
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Assign a role to a mapping rule
       description: Assigns a role to a mapping rule.
       x-semantic-establishes:
@@ -691,6 +736,9 @@ paths:
       tags:
         - Role
       operationId: unassignRoleFromMappingRule
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Unassign a role from a mapping rule
       description: Unassigns a role from a mapping rule.
       x-semantic-requires:
@@ -736,6 +784,9 @@ paths:
       tags:
         - Role
       operationId: searchMappingRulesForRole
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Search role mapping rules
       description: Search mapping rules with assigned role.
       x-semantic-requires:

--- a/zeebe/gateway-protocol/src/main/proto/v2/setup.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/setup.yaml
@@ -7,6 +7,11 @@ paths:
       tags:
         - Setup
       operationId: createAdminUser
+      # Bootstrapping endpoint — declared unauthenticated at runtime via
+      # SecurityPathAdapter (uses an anonymous authentication context to
+      # create the initial admin user). `security: []` overrides the
+      # conditional enforcement on the global schemes for this operation.
+      security: []
       summary: Create admin user
       description: Creates a new user and assigns the admin role to it. This endpoint is only usable when users are managed in the Orchestration Cluster and while no user is assigned to the admin role.
       requestBody:

--- a/zeebe/gateway-protocol/src/main/proto/v2/signals.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/signals.yaml
@@ -7,6 +7,9 @@ paths:
       tags:
         - Signal
       operationId: broadcastSignal
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Broadcast signal
       description: Broadcasts a signal.
       requestBody:

--- a/zeebe/gateway-protocol/src/main/proto/v2/signals.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/signals.yaml
@@ -8,7 +8,7 @@ paths:
         - Signal
       operationId: broadcastSignal
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Broadcast signal
       description: Broadcasts a signal.

--- a/zeebe/gateway-protocol/src/main/proto/v2/system.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/system.yaml
@@ -8,7 +8,7 @@ paths:
         - System
       operationId: getUsageMetrics
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Get usage metrics
       description: Retrieve the usage metrics based on given criteria.
@@ -87,7 +87,7 @@ paths:
         - System
       operationId: getSystemConfiguration
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       x-eventually-consistent: false
       summary: System configuration (alpha)

--- a/zeebe/gateway-protocol/src/main/proto/v2/system.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/system.yaml
@@ -7,6 +7,9 @@ paths:
       tags:
         - System
       operationId: getUsageMetrics
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Get usage metrics
       description: Retrieve the usage metrics based on given criteria.
       parameters:
@@ -83,6 +86,9 @@ paths:
       tags:
         - System
       operationId: getSystemConfiguration
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       x-eventually-consistent: false
       summary: System configuration (alpha)
       description: |

--- a/zeebe/gateway-protocol/src/main/proto/v2/tenants.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/tenants.yaml
@@ -8,7 +8,7 @@ paths:
         - Tenant
       operationId: createTenant
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Create tenant
       description: Creates a new tenant.
@@ -58,7 +58,7 @@ paths:
         - Tenant
       operationId: searchTenants
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Search tenants
       description: Retrieves a filtered and sorted list of tenants.
@@ -98,7 +98,7 @@ paths:
         - Tenant
       operationId: getTenant
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Get tenant
       description: Retrieves a single tenant by tenant ID.
@@ -142,7 +142,7 @@ paths:
         - Tenant
       operationId: updateTenant
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Update tenant
       description: Updates an existing tenant.
@@ -192,7 +192,7 @@ paths:
         - Tenant
       operationId: deleteTenant
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Delete tenant
       description: Deletes an existing tenant.
@@ -233,7 +233,7 @@ paths:
         - Tenant
       operationId: assignUserToTenant
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Assign a user to a tenant
       description: Assign a single user to a specified tenant. The user can then access tenant data and perform authorized actions.
@@ -281,7 +281,7 @@ paths:
         - Tenant
       operationId: unassignUserFromTenant
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Unassign a user from a tenant
       description: |
@@ -331,7 +331,7 @@ paths:
         - Tenant
       operationId: searchUsersForTenant
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Search users for tenant
       description: Retrieves a filtered and sorted list of users for a specified tenant.
@@ -368,7 +368,7 @@ paths:
         - Tenant
       operationId: assignClientToTenant
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Assign a client to a tenant
       description: |
@@ -418,7 +418,7 @@ paths:
         - Tenant
       operationId: unassignClientFromTenant
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Unassign a client from a tenant
       description: |
@@ -468,7 +468,7 @@ paths:
         - Tenant
       operationId: searchClientsForTenant
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Search clients for tenant
       description: Retrieves a filtered and sorted list of clients for a specified tenant.
@@ -505,7 +505,7 @@ paths:
         - Tenant
       operationId: assignGroupToTenant
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Assign a group to a tenant
       description: |
@@ -561,7 +561,7 @@ paths:
         - Tenant
       operationId: unassignGroupFromTenant
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Unassign a group from a tenant
       description: |
@@ -611,7 +611,7 @@ paths:
         - Tenant
       operationId: searchGroupIdsForTenant
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Search groups for tenant
       description: Retrieves a filtered and sorted list of groups for a specified tenant.
@@ -648,7 +648,7 @@ paths:
         - Tenant
       operationId: searchRolesForTenant
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Search roles for tenant
       description: Retrieves a filtered and sorted list of roles for a specified tenant.
@@ -685,7 +685,7 @@ paths:
         - Tenant
       operationId: assignRoleToTenant
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Assign a role to a tenant
       description: |
@@ -735,7 +735,7 @@ paths:
         - Tenant
       operationId: unassignRoleFromTenant
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Unassign a role from a tenant
       description: |
@@ -786,7 +786,7 @@ paths:
         - Tenant
       operationId: assignMappingRuleToTenant
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Assign a mapping rule to a tenant
       description: Assign a single mapping rule to a specified tenant.
@@ -834,7 +834,7 @@ paths:
         - Tenant
       operationId: unassignMappingRuleFromTenant
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Unassign a mapping rule from a tenant
       description: Unassigns a single mapping rule from a specified tenant without deleting the rule.
@@ -882,7 +882,7 @@ paths:
         - Tenant
       operationId: searchMappingRulesForTenant
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Search mapping rules for tenant
       description: Retrieves a filtered and sorted list of MappingRules for a specified tenant.

--- a/zeebe/gateway-protocol/src/main/proto/v2/tenants.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/tenants.yaml
@@ -7,6 +7,9 @@ paths:
       tags:
         - Tenant
       operationId: createTenant
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Create tenant
       description: Creates a new tenant.
       x-semantic-establishes:
@@ -54,6 +57,9 @@ paths:
       tags:
         - Tenant
       operationId: searchTenants
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Search tenants
       description: Retrieves a filtered and sorted list of tenants.
       requestBody:
@@ -91,6 +97,9 @@ paths:
       tags:
         - Tenant
       operationId: getTenant
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Get tenant
       description: Retrieves a single tenant by tenant ID.
       x-semantic-requires:
@@ -132,6 +141,9 @@ paths:
       tags:
         - Tenant
       operationId: updateTenant
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Update tenant
       description: Updates an existing tenant.
       x-semantic-requires:
@@ -179,6 +191,9 @@ paths:
       tags:
         - Tenant
       operationId: deleteTenant
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Delete tenant
       description: Deletes an existing tenant.
       x-semantic-requires:
@@ -217,6 +232,9 @@ paths:
       tags:
         - Tenant
       operationId: assignUserToTenant
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Assign a user to a tenant
       description: Assign a single user to a specified tenant. The user can then access tenant data and perform authorized actions.
       x-semantic-establishes:
@@ -262,6 +280,9 @@ paths:
       tags:
         - Tenant
       operationId: unassignUserFromTenant
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Unassign a user from a tenant
       description: |
         Unassigns the user from the specified tenant.
@@ -309,6 +330,9 @@ paths:
       tags:
         - Tenant
       operationId: searchUsersForTenant
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Search users for tenant
       description: Retrieves a filtered and sorted list of users for a specified tenant.
       x-semantic-requires:
@@ -343,6 +367,9 @@ paths:
       tags:
         - Tenant
       operationId: assignClientToTenant
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Assign a client to a tenant
       description: |
         Assign the client to the specified tenant.
@@ -390,6 +417,9 @@ paths:
       tags:
         - Tenant
       operationId: unassignClientFromTenant
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Unassign a client from a tenant
       description: |
         Unassigns the client from the specified tenant.
@@ -437,6 +467,9 @@ paths:
       tags:
         - Tenant
       operationId: searchClientsForTenant
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Search clients for tenant
       description: Retrieves a filtered and sorted list of clients for a specified tenant.
       x-semantic-requires:
@@ -471,6 +504,9 @@ paths:
       tags:
         - Tenant
       operationId: assignGroupToTenant
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Assign a group to a tenant
       description: |
         Assigns a group to a specified tenant.
@@ -524,6 +560,9 @@ paths:
       tags:
         - Tenant
       operationId: unassignGroupFromTenant
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Unassign a group from a tenant
       description: |
         Unassigns a group from a specified tenant.
@@ -571,6 +610,9 @@ paths:
       tags:
         - Tenant
       operationId: searchGroupIdsForTenant
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Search groups for tenant
       description: Retrieves a filtered and sorted list of groups for a specified tenant.
       x-semantic-requires:
@@ -605,6 +647,9 @@ paths:
       tags:
         - Tenant
       operationId: searchRolesForTenant
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Search roles for tenant
       description: Retrieves a filtered and sorted list of roles for a specified tenant.
       x-semantic-requires:
@@ -639,6 +684,9 @@ paths:
       tags:
         - Tenant
       operationId: assignRoleToTenant
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Assign a role to a tenant
       description: |
         Assigns a role to a specified tenant.
@@ -686,6 +734,9 @@ paths:
       tags:
         - Tenant
       operationId: unassignRoleFromTenant
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Unassign a role from a tenant
       description: |
         Unassigns a role from a specified tenant.
@@ -734,6 +785,9 @@ paths:
       tags:
         - Tenant
       operationId: assignMappingRuleToTenant
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Assign a mapping rule to a tenant
       description: Assign a single mapping rule to a specified tenant.
       x-semantic-establishes:
@@ -779,6 +833,9 @@ paths:
       tags:
         - Tenant
       operationId: unassignMappingRuleFromTenant
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Unassign a mapping rule from a tenant
       description: Unassigns a single mapping rule from a specified tenant without deleting the rule.
       x-semantic-requires:
@@ -824,6 +881,9 @@ paths:
       tags:
         - Tenant
       operationId: searchMappingRulesForTenant
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Search mapping rules for tenant
       description: Retrieves a filtered and sorted list of MappingRules for a specified tenant.
       x-semantic-requires:

--- a/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
@@ -7,6 +7,9 @@ paths:
       tags:
         - User task
       operationId: completeUserTask
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Complete user task
       description: >
         Completes a user task with the given key. Completion waits for blocking task listeners on
@@ -59,6 +62,9 @@ paths:
       tags:
         - User task
       operationId: assignUserTask
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Assign user task
       description: >
         Assigns a user task with the given key to the given assignee. Assignment waits for
@@ -112,6 +118,9 @@ paths:
       tags:
         - User task
       operationId: getUserTask
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Get user task
       description: Get the user task by the user task key.
       parameters:
@@ -149,6 +158,9 @@ paths:
       tags:
         - User task
       operationId: updateUserTask
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Update user task
       description: >
         Update a user task with the given key. Updates wait for blocking task listeners on this
@@ -201,6 +213,9 @@ paths:
       tags:
         - User task
       operationId: getUserTaskForm
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Get user task form
       description: |
         Get the form of a user task.
@@ -243,6 +258,9 @@ paths:
       tags:
         - User task
       operationId: unassignUserTask
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Unassign user task
       description: >
         Removes the assignee of a task with the given key. Unassignment waits for blocking task
@@ -290,6 +308,9 @@ paths:
       tags:
         - User task
       operationId: searchUserTasks
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Search user tasks
       description: Search for user tasks based on given criteria.
       requestBody:
@@ -321,6 +342,9 @@ paths:
       tags:
         - User task
       operationId: searchUserTaskVariables
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Search user task variables
       description: |
         Search for user task variables based on given criteria. This endpoint returns all variable
@@ -368,6 +392,9 @@ paths:
       tags:
         - User task
       operationId: searchUserTaskEffectiveVariables
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Search user task effective variables
       description: |
         Search for the effective variables of a user task. This endpoint returns deduplicated
@@ -414,6 +441,9 @@ paths:
       tags:
         - User task
       operationId: searchUserTaskAuditLogs
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Search user task audit logs
       description: Search for user task audit logs based on given criteria.
       parameters:

--- a/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
@@ -8,7 +8,7 @@ paths:
         - User task
       operationId: completeUserTask
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Complete user task
       description: >
@@ -63,7 +63,7 @@ paths:
         - User task
       operationId: assignUserTask
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Assign user task
       description: >
@@ -119,7 +119,7 @@ paths:
         - User task
       operationId: getUserTask
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Get user task
       description: Get the user task by the user task key.
@@ -159,7 +159,7 @@ paths:
         - User task
       operationId: updateUserTask
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Update user task
       description: >
@@ -214,7 +214,7 @@ paths:
         - User task
       operationId: getUserTaskForm
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Get user task form
       description: |
@@ -259,7 +259,7 @@ paths:
         - User task
       operationId: unassignUserTask
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Unassign user task
       description: >
@@ -309,7 +309,7 @@ paths:
         - User task
       operationId: searchUserTasks
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Search user tasks
       description: Search for user tasks based on given criteria.
@@ -343,7 +343,7 @@ paths:
         - User task
       operationId: searchUserTaskVariables
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Search user task variables
       description: |
@@ -393,7 +393,7 @@ paths:
         - User task
       operationId: searchUserTaskEffectiveVariables
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Search user task effective variables
       description: |
@@ -442,7 +442,7 @@ paths:
         - User task
       operationId: searchUserTaskAuditLogs
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Search user task audit logs
       description: Search for user task audit logs based on given criteria.

--- a/zeebe/gateway-protocol/src/main/proto/v2/users.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/users.yaml
@@ -7,6 +7,9 @@ paths:
       tags:
         - User
       operationId: createUser
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Create user
       description: Create a new user.
       x-semantic-establishes:
@@ -50,6 +53,9 @@ paths:
       tags:
         - User
       operationId: searchUsers
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Search users
       description: Search for users based on given criteria.
       requestBody:
@@ -80,6 +86,9 @@ paths:
       tags:
         - User
       operationId: getUser
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Get user
       description: Get a user by its username.
       x-semantic-requires:
@@ -119,6 +128,9 @@ paths:
       tags:
         - User
       operationId: updateUser
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Update user
       description: Updates a user.
       x-semantic-requires:
@@ -166,6 +178,9 @@ paths:
       tags:
         - User
       operationId: deleteUser
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Delete user
       description: Deletes a user.
       x-semantic-requires:

--- a/zeebe/gateway-protocol/src/main/proto/v2/users.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/users.yaml
@@ -8,7 +8,7 @@ paths:
         - User
       operationId: createUser
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Create user
       description: Create a new user.
@@ -54,7 +54,7 @@ paths:
         - User
       operationId: searchUsers
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Search users
       description: Search for users based on given criteria.
@@ -87,7 +87,7 @@ paths:
         - User
       operationId: getUser
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Get user
       description: Get a user by its username.
@@ -129,7 +129,7 @@ paths:
         - User
       operationId: updateUser
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Update user
       description: Updates a user.
@@ -179,7 +179,7 @@ paths:
         - User
       operationId: deleteUser
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Delete user
       description: Deletes a user.

--- a/zeebe/gateway-protocol/src/main/proto/v2/variables.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/variables.yaml
@@ -7,6 +7,9 @@ paths:
       tags:
         - Variable
       operationId: searchVariables
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Search variables
       description: |-
         Search for variables based on given criteria.
@@ -54,6 +57,9 @@ paths:
       tags:
         - Variable
       operationId: getVariable
+      security:
+        - BearerAuth: []
+        - basicAuth: []
       summary: Get variable
       description: |-
         Get a variable by its key.

--- a/zeebe/gateway-protocol/src/main/proto/v2/variables.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/variables.yaml
@@ -8,7 +8,7 @@ paths:
         - Variable
       operationId: searchVariables
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Search variables
       description: |-
@@ -58,7 +58,7 @@ paths:
         - Variable
       operationId: getVariable
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       summary: Get variable
       description: |-


### PR DESCRIPTION
## Description

The OCA spec under `zeebe/gateway-protocol/src/main/proto/v2/` declared `securitySchemes` (BearerAuth, basicAuth) under `components` but applied them to only **one** operation (`getAuthentication`). The other 189 operations didn't declare `security:` in the spec, even though the runtime enforces auth on all of them when started in secured mode.

This PR closes that gap and adds the metadata needed by the test planner (camunda/api-test-generator) to reason about per-deployment-mode enforcement.

## What changed

1. **`rest-api.yaml` — both security schemes gain conditional-enforcement metadata:**

   ```yaml
   components:
     securitySchemes:
       BearerAuth:
         type: http
         scheme: bearer
         bearerFormat: JWT
         x-enforcement: conditional
         x-enforcement-modes:
           auth: [secured]
       basicAuth:
         type: http
         scheme: basic
         x-enforcement: conditional
         x-enforcement-modes:
           auth: [secured]
   ```

   `x-enforcement: conditional` says: the scheme is enforced under some deployment-mode profiles and bypassed under others (not unconditionally required, not unconditionally absent). `x-enforcement-modes` names which profiles enforce it — here the `auth` axis with the `secured` value. The `auth` axis is the conditional-enforcement counterpart to the deployment-mode availability axis proposed in [#52511](https://github.com/camunda/camunda/issues/52511); until that registry lands, the axis is treated as an inline enum.

2. **Per-operation `security:` blocks added to 189 operations across 34 YAML files** (every op in `v2/` except `getAuthentication`, which already declared its own block):

   - **186 operations** get the conditionally-enforced schemes:

     ```yaml
     security:
       - BearerAuth: []
       - basicAuth: []
     ```

     The block alternates the two schemes (OR semantics: either is accepted).

   - **3 operations** are documented as publicly unauthenticated at runtime (per `SecurityPathAdapter`) and get `security: []` to override the global enforcement: `GET /status`, `POST /setup/user`, `GET /license`.

   Operations that already declared a `security:` block were left untouched.

## Why

The mismatch between declared and enforced security was causing the api-test-generator's planner (camunda/api-test-generator) to report 189 endpoints as "spec under-declares auth" — a known quantitative gap. After this PR:

- The spec accurately reflects deployment behaviour.
- Downstream consumers (test planner, doc generator) can reason about which endpoints to expect 401 responses from, in which deployment modes.
- The 189-op `needs-abox: spec-gap` bucket in [camunda/api-test-generator#300](https://github.com/camunda/api-test-generator/pull/300)'s analyzer moves to `computable`.

## Verification

- 189 operations gained `security:` blocks. Count matches the gap inventory in [camunda/api-test-generator#301](https://github.com/camunda/api-test-generator/issues/301) (Josh's comment).
- All 34 edited YAML files parse with `yaml.safe_load`.
- No operation that already declared `security:` was modified — `getAuthentication`'s existing single-scheme block is preserved.

## Open items / coordination

- **Shared mode registry with #52511.** The `auth` axis name is the conditional-enforcement counterpart to the availability-axis vocabulary proposed in #52511. Once #52511 lands its `deployment-modes.json` registry, `x-enforcement-modes` should reference modes by name from that registry rather than the inline enum used here. Trivial follow-up.
- **camunda-schema-bundler pass-through.** The bundler already passes ~10 other `x-*` vendor extensions through to the bundle (`x-eventually-consistent`, `x-semantic-establishes`, etc.). No bundler change should be needed for these new annotations, but worth a quick verification once #52511's registry lands.
- **Runtime confirmation.** As Josh flagged in [camunda/api-test-generator#301](https://github.com/camunda/api-test-generator/issues/301): whether each of these 189 endpoints is "actually secured at runtime when the server is started with security enabled" still needs implementation-side confirmation. This PR encodes the *intent* derived from the existing runtime auth filter; runtime checks may prune the list.

## Tests / CI

- No test changes in this PR — this is a spec annotation change. The spec lint rules under `zeebe/gateway-protocol/spectral-tests/` will exercise the YAML.
- Downstream consumers (test planner) pick up the new annotations once they bump their `spec-pin.json` to a SHA on this branch.

## Related

- camunda/api-test-generator#301 (the design + work-list issue for this PR)
- camunda/api-test-generator#300 (the analyzer that surfaced the 189-op gap)
- #52511 (sibling deployment-mode availability axis)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

