### PR TITLE
 fix: scope snapshot-update concurrency and update owner

### DIFF
--- a/.github/workflows/operate-update_visual_snapshots.yml
+++ b/.github/workflows/operate-update_visual_snapshots.yml
@@ -8,10 +8,11 @@ on:
   pull_request:
     types: [labeled]
 
-# Limit workflow to 1 concurrent run per ref (branch): new commit -> old runs are canceled to save costs
+# Limit to 1 concurrent run per (ref, label): re-adding `update-snapshots` cancels its previous
+# in-flight run, but adding other labels at the same time doesn't cancel the snapshot update.
 concurrency:
   cancel-in-progress: true
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.label.name }}
 
 jobs:
   update-snapshots:

--- a/.github/workflows/operate-vr-preview-cleanup.yml
+++ b/.github/workflows/operate-vr-preview-cleanup.yml
@@ -1,6 +1,6 @@
 # description: Weekly cleanup of orphaned Operate VR report preview deployments
 # type: maintenance
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/fe-operate
 ---
 name: Operate VR Preview Cleanup
 


### PR DESCRIPTION
## Description

Context: the Operate snapshot-update workflow's concurrency group was keyed by`(workflow, ref)`, so every `labeled` event on the same PR(regardless of which label was added) resolved to the same group. With `cancel-in-progress: true`,adding any other label while `update-snapshots` was in flight would silently cancel the snapshot job before it could commit the regenerated PNGs. 

- scope the concurrency group by `github.event.label.name`
- change the owner for `.github/workflows/operate-vr-preview-cleanup.yml`

## Related issues

closes #
