### PR TITLE
feat: align StructuredList cells vertically on Operate

### DIFF
--- a/operate/client/src/modules/components/StructuredList/styled.tsx
+++ b/operate/client/src/modules/components/StructuredList/styled.tsx
@@ -25,7 +25,7 @@ const StructuredListCell = styled(
 )<StructuredListCellProps>`
   ${({$size = 'md', $width, $verticalCellPadding}) => {
     return css`
-      vertical-align: top;
+      vertical-align: middle;
       ${$size === 'sm' &&
       css`
         ${styles.label01};


### PR DESCRIPTION
## Description

This PR has been extracted from https://github.com/camunda/camunda/pull/52913 because it creates a bunch of visual-regression updates, and I don't not want to bloat the scope of the related PR.

@vsgoulart Not sure we actually want this. Check [this change for inline JSON views](https://camunda.github.io/camunda/vr-preview/pr-53712/#?q=s%3Afailed&testId=133e5d3e7288349d0d42-3495b1615f23e6e224c1). Now it looks worse... Feel free to close this PR, if you agree that it is not a good change for https://github.com/camunda/camunda/pull/52913.