### PR TITLE
Downgrade failsafe to 3.5.2 on stable/8.9

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -226,7 +226,7 @@
     <plugin.version.dependency>3.10.0</plugin.version.dependency>
     <plugin.version.enforcer>3.6.3</plugin.version.enforcer>
     <plugin.version.exec>3.6.3</plugin.version.exec>
-    <plugin.version.failsafe>3.5.5</plugin.version.failsafe>
+    <plugin.version.failsafe>3.5.2</plugin.version.failsafe>
     <plugin.version.flaky-tests>2.1.1</plugin.version.flaky-tests>
     <plugin.version.jacoco>0.8.14</plugin.version.jacoco>
     <plugin.version.maven-jar>3.5.0</plugin.version.maven-jar>


### PR DESCRIPTION
## Description

Restore alignment between `maven-failsafe-plugin` and `maven-surefire-plugin` on `stable/8.9` by downgrading `plugin.version.failsafe` from `3.5.5` back to `3.5.2`, matching the surefire version already pinned on this branch.

The two plugins share a common codebase and must move in lockstep — codified in [`.github/renovate.json:567-591`](https://github.com/camunda/camunda/blob/main/.github/renovate.json#L567-L591). On `stable/8.9`, failsafe drifted to `3.5.5` in [`cd6b1441789`](https://github.com/camunda/camunda/commit/cd6b1441789) (2026-02-24), 9 days before the protective policy was introduced on `main` in [`6a115559483`](https://github.com/camunda/camunda/commit/6a115559483) (2026-03-05). The corresponding downgrade fix on `main` ([`a67d3f12b30`](https://github.com/camunda/camunda/commit/a67d3f12b30), 2026-03-31, "deps: downgrade failsafe in same version as surefire") was never backported. This PR is that backport.

`3.5.2` remains the last known-good version for the pair:
- `3.5.3` has an ArchUnit-blocking bug
- `3.5.4` introduced [apache/maven-surefire#3203](https://github.com/apache/maven-surefire/issues/3203) (inner-class test report bug), still open upstream
- `3.5.5` has not fixed it

Renovate's surefire rule on `stable/8.9` is `"enabled": false`, so Renovate cannot self-correct this; it must be done manually. This replaces the rejected Renovate PR #53078, which proposed bumping surefire to align *up* with failsafe — the wrong direction given the known bugs in 3.5.3–3.5.5.

## Checklist

- [x] Single-line pom version change; CI will exercise the suite. No backport target (this *is* the backport to stable/8.9).

## Related issues

Replaces #53078
Refs [apache/maven-surefire#3203](https://github.com/apache/maven-surefire/issues/3203)