### PR TITLE
fix: update editorconfig for Makefiles

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,3 @@
-
 [*]
 indent_style = space
 charset = utf-8
@@ -21,3 +20,6 @@ indent_size = 2
 
 [*.yml,*.yaml]
 indent_size = 2
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
## Description

Makefile must be indented with tabs, not spaces, see https://www.gnu.org/software/make/manual/make.html#Rule-Introduction:

> **Please note**: you need to put a tab character at the beginning of every recipe line! This is an obscurity that catches the unwary.
> If you prefer to prefix your recipes with a character other than tab, you can set the `.RECIPEPREFIX` variable to an alternate character (see [Other Special Variables](https://www.gnu.org/software/make/manual/make.html#Special-Variables)).

The [initial "catch all" rule configures editors to use spaces instead of tabs](https://github.com/camunda/camunda/blob/cf6dadf0347b82a30617225c6a9acd07748663a6/.editorconfig#L2-L3).

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
