### PR TITLE
ci: submit resolved Maven dependency tree to GitHub Dependency Submission API

### DIFF
--- a/.github/workflows/maven-dependency-snapshot.yml
+++ b/.github/workflows/maven-dependency-snapshot.yml
@@ -16,6 +16,7 @@ on:
       - '**/pom.xml'
       - 'bom/**'
       - 'parent/**'
+      - '.github/workflows/maven-dependency-snapshot.yml'  # temporary: remove before merge
   pull_request:
     paths:
       - '**/pom.xml'

--- a/.github/workflows/maven-dependency-snapshot.yml
+++ b/.github/workflows/maven-dependency-snapshot.yml
@@ -20,6 +20,7 @@ on:
       - '**/pom.xml'
       - 'bom/**'
       - 'parent/**'
+  workflow_dispatch:
 
 defaults:
   run:

--- a/.github/workflows/maven-dependency-snapshot.yml
+++ b/.github/workflows/maven-dependency-snapshot.yml
@@ -1,0 +1,58 @@
+# description: Submits the resolved Maven dependency tree to the GitHub Dependency Submission API.
+# Runs on push to main/stable (base snapshot) and on PRs that change dependency manifests (head snapshot).
+# Both snapshots are required for the Dependency Review API to diff transitive dependencies — catching
+# BOM-driven regressions that are invisible to GitHub's pom.xml auto-parse.
+# type: Security
+# owner: @camunda/monorepo-devops-team
+name: Maven Dependency Snapshot
+
+on:
+  push:
+    branches:
+      - main
+      - stable/**
+    paths:
+      - '**/pom.xml'
+      - 'bom/**'
+      - 'parent/**'
+  pull_request:
+    paths:
+      - '**/pom.xml'
+      - 'bom/**'
+      - 'parent/**'
+      - '**/package-lock.json'
+      - '**/yarn.lock'
+      - 'clients/go/go.sum'
+      - 'clients/go/go.mod'
+      - 'Dockerfile'
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  submit-maven-snapshot:
+    name: "Security / Submit Maven Dependency Snapshot"
+    # Fork PRs have no Vault access and cannot resolve internal Maven artifacts.
+    if: ${{ !github.event.pull_request.head.repo.fork }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write  # required by the Dependency Submission API
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: temurin
+          java-version: '21'
+      # Scope to shipped modules only (mirrors JAVA_PROJECTS in zeebe-snyk.yml).
+      # -am resolves the full transitive tree including BOM-pinned versions.
+      - name: Submit Maven dependency snapshot
+        uses: advanced-security/maven-dependency-submission-action@b275d12641ac2d2108b2cbb7598b154ad2f2cee8 # v5.0.0
+        with:
+          token: ${{ github.token }}
+          maven-args: >-
+            -pl bom,clients/java,clients/camunda-spring-boot-starter,zeebe/bpmn-model,zeebe/exporter-api,zeebe/gateway-protocol-impl,zeebe/protocol
+            -am
+            -Dquickly
+          correlator: ${{ github.job }}-maven

--- a/.github/workflows/maven-dependency-snapshot.yml
+++ b/.github/workflows/maven-dependency-snapshot.yml
@@ -1,7 +1,7 @@
 # description: Submits the resolved Maven dependency tree to the GitHub Dependency Submission API.
-# Runs on push to main/stable (base snapshot) and on PRs that change dependency manifests (head snapshot).
-# Both snapshots are required for the Dependency Review API to diff transitive dependencies — catching
-# BOM-driven regressions that are invisible to GitHub's pom.xml auto-parse.
+# Runs on push to main/stable to keep the base snapshot current.
+# PR-side (head) snapshot submission is handled by the pr-maven-snapshot job in ci.yml,
+# which pr-vuln-check depends on — ensuring the snapshot is ready before the gate runs.
 # type: Security
 # owner: @camunda/monorepo-devops-team
 name: Maven Dependency Snapshot
@@ -11,13 +11,6 @@ on:
     branches:
       - main
       - stable/**
-      - ci/maven-dependency-snapshot  # temporary: remove before merge
-    paths:
-      - '**/pom.xml'
-      - 'bom/**'
-      - 'parent/**'
-      - '.github/workflows/maven-dependency-snapshot.yml'  # temporary: remove before merge
-  pull_request:
     paths:
       - '**/pom.xml'
       - 'bom/**'

--- a/.github/workflows/maven-dependency-snapshot.yml
+++ b/.github/workflows/maven-dependency-snapshot.yml
@@ -11,6 +11,7 @@ on:
     branches:
       - main
       - stable/**
+      - ci/maven-dependency-snapshot  # temporary: remove before merge
     paths:
       - '**/pom.xml'
       - 'bom/**'

--- a/.github/workflows/maven-dependency-snapshot.yml
+++ b/.github/workflows/maven-dependency-snapshot.yml
@@ -20,11 +20,6 @@ on:
       - '**/pom.xml'
       - 'bom/**'
       - 'parent/**'
-      - '**/package-lock.json'
-      - '**/yarn.lock'
-      - 'clients/go/go.sum'
-      - 'clients/go/go.mod'
-      - 'Dockerfile'
 
 defaults:
   run:
@@ -33,8 +28,6 @@ defaults:
 jobs:
   submit-maven-snapshot:
     name: "Security / Submit Maven Dependency Snapshot"
-    # Fork PRs have no Vault access and cannot resolve internal Maven artifacts.
-    if: ${{ !github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -37,6 +37,7 @@
 /.github/workflows/docs*                                 @camunda/monorepo-devops-team
 /.github/workflows/generate-concurrency-group.yml        @camunda/monorepo-devops-team
 /.github/workflows/generate-snapshot-docker-tag.yml      @camunda/monorepo-devops-team
+/.github/workflows/maven-dependency-snapshot.yml         @camunda/monorepo-devops-team
 /.github/workflows/issue-add-support-label.yml           @camunda/monorepo-devops-team
 /.github/workflows/labeler.yml                           @camunda/monorepo-devops-team
 /.github/workflows/preview-env*                          @camunda/monorepo-devops-team


### PR DESCRIPTION
## Summary

- Adds a new workflow that submits the fully resolved Maven dependency tree to the GitHub Dependency Submission API on push to `main`/`stable/**` and on PRs changing dependency manifests
- Scoped to shipped modules only (mirrors `JAVA_PROJECTS` in `zeebe-snyk.yml`): `bom`, `clients/java`, `clients/camunda-spring-boot-starter`, `zeebe/bpmn-model`, `zeebe/exporter-api`, `zeebe/gateway-protocol-impl`, `zeebe/protocol`

## Why

GitHub's built-in `pom.xml` auto-parse only covers explicitly declared dependencies. BOM-driven transitive dependencies (e.g. `protobuf` pinned via `google-cloud-libraries-bom`) are invisible to the Dependency Review API without a submitted snapshot — meaning the PR vulnerability gate ([#53506](https://github.com/camunda/camunda/pull/53506)) would not have caught the exact regression from [#29728](https://github.com/camunda/camunda/pull/29728).

Both base (push to main) and head (PR) snapshots must exist for the diff to include transitive deps. This PR establishes the base snapshot. The gate PR depends on this being merged first.