### PR TITLE
docs: add architecture overview and ADR structure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,13 +80,12 @@ module.
 
 Architecture overview: `docs/architecture/overview.md`.
 
-Before making any architectural change, consult the relevant ADR indexes in order:
+Before making any architectural change, consult the relevant ADR indexes in order (see
+`docs/adr/README.md` for the full tier structure):
 
 1. `docs/adr/` — cross-cutting decisions affecting multiple modules
-2. `<module>/docs/adr/` — decisions scoped to the module you are working in (if the directory
-   exists)
-3. For sub-modules (e.g. `zeebe/engine`), also walk up each parent module to the repo root and
-   check for `docs/adr/` at each level (e.g. `zeebe/docs/adr/`)
+2. `<module>/docs/adr/` — decisions scoped to the module you are working in
+3. For sub-modules, walk up each parent module to the repo root
 
 If the decision is not covered by an existing ADR, draft a new one using the
 `create-architecture-decision` skill before proceeding.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,10 +79,17 @@ module.
 ### Architecture
 
 Architecture overview: `docs/architecture/overview.md`.
-Cross-cutting decisions: `docs/adr/`.
 
-Before making any architectural change, consult the ADR index. If the decision is not covered by
-an existing ADR, draft a new one using the `create-architecture-decision` skill before proceeding.
+Before making any architectural change, consult the relevant ADR indexes in order:
+
+1. `docs/adr/` — cross-cutting decisions affecting multiple modules
+2. `<module>/docs/adr/` — decisions scoped to the module you are working in (if the directory
+   exists)
+3. For sub-modules (e.g. `zeebe/engine`), also walk up each parent module to the repo root and
+   check for `docs/adr/` at each level (e.g. `zeebe/docs/adr/`)
+
+If the decision is not covered by an existing ADR, draft a new one using the
+`create-architecture-decision` skill before proceeding.
 
 ### Skills
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,15 @@
+# Architecture Decision Records
+
+This directory contains ADRs for decisions that affect multiple modules across the monorepo.
+
+## Tiers
+
+|                               Scope                                |                    Location                     |
+|--------------------------------------------------------------------|-------------------------------------------------|
+| Monorepo-wide (cross-cutting)                                      | `docs/adr/` — this directory                    |
+| Domain/subsystem (cross-cutting within a group of related modules) | `docs/adr/<domain>/` — e.g. `docs/adr/storage/` |
+| Module-scoped                                                      | `<module>/docs/adr/`                            |
+
+## Index
+
+<!-- ADRs will be listed here as they are created -->

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -4,11 +4,17 @@ This directory contains ADRs for decisions that affect multiple modules across t
 
 ## Tiers
 
-|                               Scope                                |                    Location                     |
-|--------------------------------------------------------------------|-------------------------------------------------|
-| Monorepo-wide (cross-cutting)                                      | `docs/adr/` — this directory                    |
-| Domain/subsystem (cross-cutting within a group of related modules) | `docs/adr/<domain>/` — e.g. `docs/adr/storage/` |
-| Module-scoped                                                      | `<module>/docs/adr/`                            |
+|                            Scope                            |                    Location                     |
+|-------------------------------------------------------------|-------------------------------------------------|
+| Monorepo-wide (affects the whole repo or its core design)   | `docs/adr/` — this directory                    |
+| Domain (spans a few related components, not the whole repo) | `docs/adr/<domain>/` — e.g. `docs/adr/storage/` |
+| Module-scoped                                               | `<module>/docs/adr/`                            |
+
+A **domain** is a logical subsystem that groups a few related components — for example, `storage`
+(covers `db/`, `search/`, `webapps-schema/`, `schema-manager/`) or `security` (covers `security/`,
+`authentication/`, `identity/`). A decision belongs at domain level when it is too broad for a
+single module but does not affect the entire monorepo. Create the domain directory when the first
+ADR for that domain is written.
 
 ## Index
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,3 +1,137 @@
 # Architecture Overview
 
-> This file is a placeholder. It will be populated as part of https://github.com/camunda/camunda/issues/53131.
+## What this repo is
+
+Camunda 8 is a process automation platform that executes BPMN workflows and evaluates DMN decisions
+at scale, for both self-managed and SaaS deployments. The monorepo contains the full platform: Zeebe
+(write-side execution engine), Operate (process monitoring), Tasklist (human task management),
+Identity (authentication and authorization), and Optimize (process analytics), plus shared
+libraries, gateways, and supporting infrastructure. Java 21 backend built with Maven; React/Carbon
+frontends. `dist/` wires the components into deployable Spring Boot application variants (e.g.
+`StandaloneBroker`, `StandaloneCamunda`); components can also be deployed independently.
+
+## Runtime topology
+
+### Write path
+
+Clients submit commands (deploy a process, start an instance, complete a job) through one of two
+entry points:
+
+- **gRPC gateway** (`zeebe/gateway`, `zeebe/gateway-grpc`): exposes the Zeebe gRPC API defined in
+  `zeebe/gateway-protocol`. Used by the Java client (`clients/java`), the Go client (`clients/go`),
+  and the Spring Boot starter (`clients/camunda-spring-boot-starter`).
+- **REST gateway** (`zeebe/gateway-rest`): exposes the Camunda v2 REST API. Commands flow through
+  `service/`, which translates them into calls to the internal Zeebe gateway.
+  `gateways/gateway-mapping-http` provides HTTP request/response mapping utilities used by this
+  layer.
+- **MCP gateway** (`gateways/gateway-mcp`): exposes the Camunda API as a Model Context Protocol
+  server for AI agent integrations.
+
+Both entry points authenticate via `authentication/` (OIDC token processing, Spring Security).
+Authorization is enforced by `security/` against rules managed by `identity/`.
+
+The **Zeebe broker** (`zeebe/broker`) receives commands, appends them to a partitioned append-only
+log (Raft consensus via `zeebe/atomix`), and executes them against its primary state store (RocksDB
+via `zeebe/zb-db`).
+
+### Export path
+
+After processing, the broker emits records to configured exporters:
+
+|           Exporter            |                  Module                  |           Target            |
+|-------------------------------|------------------------------------------|-----------------------------|
+| Elasticsearch exporter        | `zeebe/exporters/elasticsearch-exporter` | Elasticsearch indices       |
+| OpenSearch exporter           | `zeebe/exporters/opensearch-exporter`    | OpenSearch indices          |
+| RDBMS exporter                | `zeebe/exporters/rdbms-exporter`         | Relational DB via `db/`     |
+| Camunda exporter (all-in-one) | `zeebe/exporters/camunda-exporter`       | All of the above (combined) |
+
+ES/OS index shapes are defined in `webapps-schema/` and applied at startup by `schema-manager/`.
+
+The Camunda Exporter also runs background **archiver jobs** that move completed process data from
+active ES/OS indices into dated archive indices (e.g. `operate-list-view-8.3.0_2024-01-01`),
+keeping primary indices lean. Archiving is ES/OS-only; RDBMS deployments use TTL-based cleanup
+instead. Operate and Tasklist queries span both active and archive indices.
+
+### Read path
+
+Operate and Tasklist are read-side webapps that query secondary storage (ES/OS or RDBMS) through
+the `search/` abstraction layer. The REST API also serves read queries: `zeebe/gateway-rest` calls
+`service/`, which delegates to `search/`. Optimize reads from the same ES/OS indices through
+its own internal analytics pipeline.
+
+## Architectural decisions
+
+Cross-cutting architectural decisions are recorded as ADRs in `docs/adr/`. Before making any
+architectural change, check the index there first. If the decision is not covered by an existing
+ADR, draft a new one using the `create-architecture-decision` skill before proceeding.
+
+## Architectural boundaries
+
+Contracts that must not be bypassed:
+
+**Zeebe gRPC protocol** (`zeebe/gateway-protocol/src/main/proto/gateway.proto`)\
+The interface between external clients and the gRPC gateway. Java stubs are generated at build time
+in `zeebe/gateway-protocol-impl/`; never edit them manually. Changing the `.proto` requires
+regenerating stubs and updating all consumers in `clients/`.
+
+**Zeebe record/exporter contract** (`zeebe/exporter-api`, `zeebe/protocol`)\
+The SBE-encoded record format emitted by the broker and consumed by exporters. Access broker state
+only through this contract; never read from RocksDB directly.
+
+**ES/OS index schema** (`webapps-schema/`)\
+All templates use `"dynamic": "strict"` — new fields must be explicitly added to the template
+definitions before the exporter writes them. Changing a field type is a breaking change that
+requires a migration plan. Never query ES/OS indices directly from application code; always go
+through `search/`.
+
+**`service/` as the REST-to-engine bridge**\
+All REST commands must flow through `service/` before reaching Zeebe. REST controllers in
+`zeebe/gateway-rest` must not call the Zeebe gRPC gateway directly.
+
+**RDBMS schema migrations** (`db/rdbms-schema`)\
+Schema changes are versioned Liquibase changesets. Never alter tables outside a migration.
+
+## Cross-module blast radius
+
+Changes that propagate farthest:
+
+- **`.proto` change in `zeebe/gateway-protocol`**: regenerates stubs in `gateway-protocol-impl`,
+  breaks `clients/java`, `clients/go`, and `clients/camunda-spring-boot-starter`, and affects every
+  call in `service/` and
+  `gateways/` that maps to the changed RPC.
+- **Field type change or removal in `webapps-schema/`**: breaks exporter indexing (strict mapping
+  rejects documents with unknown or mistyped fields) and all queries in `operate/`, `tasklist/`, and
+  `search/` that reference that field. Requires a versioned template migration.
+- **`service/` interface change**: simultaneous breakage in `zeebe/gateway-rest`, `operate/`, and
+  `tasklist/`, which all depend on these interfaces.
+- **`security/` permission model change**: new or renamed permissions must be added to `security/`
+  first; enforcement in `service/`, `gateways/`, and `identity/` must be updated before the
+  permission is used.
+- **`authentication/` claim mapping change**: affects all webapps and gateways that extract tenant
+  ID, user ID, or roles from OIDC tokens.
+
+## Path rules
+
+- `zeebe/gateway-protocol-impl/target/generated-sources/` — gRPC Java stubs generated from
+  `gateway.proto`; never edit. Modify the `.proto` source in
+  `zeebe/gateway-protocol/src/main/proto/` instead.
+- `zeebe/protocol/src/main/resources/` (`protocol.xml`, `common-types.xml`,
+  `cluster-management-protocol.xml`) — SBE protocol definitions; generated Java lives in `target/`.
+- `target/` everywhere — Maven build output; never edit or commit.
+- `optimize/` — independent internal build; excluded by default with `-Dquickly`. Build explicitly
+  with `-pl optimize` when needed.
+- `webapps-schema/src/main/resources/schema/` — canonical ES/OS template JSON; changes here affect
+  exporters, `schema-manager/`, `operate/`, `tasklist/`, and `search/` simultaneously.
+- `bom-deprecated/` — legacy BOM kept for backwards compatibility; do not add new entries.
+- `dist/` — distribution assembly only; no application logic lives here.
+
+## Further detail
+
+- Data layer guide (ES/OS and RDBMS best practices): `docs/data-layer/working-with-secondary-storage.md`
+- Archiving (active vs archive indices, archiver jobs): `docs/data-layer/archiving.md`
+- Cross-cutting ADRs: `docs/adr/`
+- Module-specific ADRs: `<module>/docs/adr/`
+- Zeebe internals: `docs/zeebe/`
+- Module-specific architecture: `<module>/docs/architecture.md` (where present)
+- Module-specific behavioral rules: `<module>/AGENTS.md`
+

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -136,7 +136,9 @@ Contracts that must not be bypassed:
 **Zeebe gRPC protocol** (`zeebe/gateway-protocol/src/main/proto/gateway.proto`)\
 The interface between external clients and the gRPC gateway. Java stubs are generated at build time
 in `zeebe/gateway-protocol-impl/`; never edit them manually. Changing the `.proto` requires
-regenerating stubs and updating all consumers in `clients/`.
+regenerating stubs in `gateway-protocol-impl/`, updating every caller in `service/` and `gateways/`,
+and bumping `clients/java` and the Spring Boot starter — a cascade that touches every layer of the
+write path.
 
 **Zeebe record/exporter contract** (`zeebe/exporter-api`, `zeebe/protocol`)\
 The SBE-encoded record format emitted by the broker and consumed by exporters. Access broker state
@@ -144,9 +146,10 @@ only through this contract; never read from RocksDB directly.
 
 **ES/OS index schema** (`webapps-schema/`)\
 All templates use `"dynamic": "strict"` — new fields must be explicitly added to the template
-definitions before the exporter writes them. Changing a field type is a breaking change that
-requires a migration plan. Never query ES/OS indices directly from application code; always go
-through `search/`.
+definitions before the exporter writes them. Fields are additive-only; never change or remove a
+field once deployed — strict mapping will reject mistyped documents from the exporter, and any
+query in `search/` referencing the field breaks, surfacing in `operate/` and `tasklist/`. Never
+query ES/OS indices directly from application code; always go through `search/`.
 
 **ES/OS exporter index templates** (`zeebe/exporters/elasticsearch-exporter/src/main/resources`,
 `zeebe/exporters/opensearch-exporter/src/main/resources`)\
@@ -155,30 +158,22 @@ the impact on existing index mappings.
 
 **`service/` as the REST-to-engine bridge**\
 All REST commands must flow through `service/` before reaching Zeebe. REST controllers in
-`zeebe/gateway-rest` must not call the Zeebe gRPC gateway directly.
+`zeebe/gateway-rest` must not call the Zeebe gRPC gateway directly. An interface change here breaks
+`zeebe/gateway-rest` at compile time; `operate/` and `tasklist/` are indirect consumers via the
+REST API and will break at runtime.
 
 **RDBMS schema** (`db/rdbms-schema`)\
 Schema changes are versioned Liquibase changesets and must be additive-only (new tables or columns).
 Never drop or alter existing columns; never modify tables outside a changeset.
 
-## Cross-module blast radius
+**`security/` permission model**\
+New or renamed permissions must land in `security/` before enforcement is wired elsewhere. A model
+change propagates to `service/`, `gateways/`, and `identity/` — all must be updated before the new
+permission is used.
 
-Changes that propagate farthest:
-
-- **`.proto` change in `zeebe/gateway-protocol`**: regenerates stubs in `gateway-protocol-impl`,
-  breaks `clients/java`, `clients/go`, and `clients/camunda-spring-boot-starter`, and affects every
-  call in `service/` and
-  `gateways/` that maps to the changed RPC.
-- **Field type change or removal in `webapps-schema/`**: breaks exporter indexing (strict mapping
-  rejects documents with unknown or mistyped fields) and all queries in `operate/`, `tasklist/`, and
-  `search/` that reference that field. Requires a versioned template migration.
-- **`service/` interface change**: simultaneous breakage in `zeebe/gateway-rest`, `operate/`, and
-  `tasklist/`, which all depend on these interfaces.
-- **`security/` permission model change**: new or renamed permissions must be added to `security/`
-  first; enforcement in `service/`, `gateways/`, and `identity/` must be updated before the
-  permission is used.
-- **`authentication/` claim mapping change**: affects all webapps and gateways that extract tenant
-  ID, user ID, or roles from OIDC tokens.
+**`authentication/` claim mapping**\
+A claim mapping change affects every webapp and gateway that extracts tenant ID, user ID, or roles
+from OIDC tokens. Update all consumers before changing the mapping.
 
 ## Path rules
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,4 +1,3 @@
 # Architecture Overview
 
 > This file is a placeholder. It will be populated as part of https://github.com/camunda/camunda/issues/53131.
-

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -6,24 +6,77 @@ Camunda 8 is a process automation platform that executes BPMN workflows and eval
 at scale, for both self-managed and SaaS deployments. The monorepo contains the full platform: Zeebe
 (process engine), Operate (process monitoring), Tasklist (human task management),
 Identity (authentication and authorization), and Optimize (process analytics), plus shared
-libraries, gateways, and supporting infrastructure. Java 21 backend built with Maven; React/Carbon
+libraries, gateways, and supporting infrastructure. Java backend built with Maven; React/Carbon
 frontends. `dist/` wires the components into deployable Spring Boot application variants (e.g.
 `StandaloneBroker`, `StandaloneCamunda`); components can also be deployed independently.
 
 ## Runtime topology
+
+Camunda follows a **CQRS** (Command Query Responsibility Segregation) pattern: writes flow from a
+gateway through the Zeebe broker/engine and land in secondary storage via exporters; reads go
+directly from a gateway (through `service/` and `search/`) to secondary storage, bypassing the
+broker/engine entirely. This keeps reads from affecting process execution performance.
+
+```mermaid
+flowchart TD
+  subgraph gw["Gateways"]
+    REST["REST gateway\nzeebe/gateway-rest\nprimary — all new features"]
+    GRPC["gRPC gateway\nzeebe/gateway-grpc\nbackward compat · streaming"]
+    MCP["MCP gateway\ngateways/gateway-mcp\nAI agent integrations"]
+  end
+
+  AUTH(["authentication/ · security/ · identity/"])
+
+  subgraph write["Zeebe — write path"]
+    BROKER["broker\nzeebe/broker\nRaft log"]
+    ENGINE["engine\nzeebe/engine\nBPMN / DMN execution"]
+    STATE[("state store\nzeebe/zb-db · RocksDB")]
+    BROKER --> ENGINE
+    ENGINE <-.->|state| STATE
+  end
+
+  subgraph exp["Exporters"]
+    direction LR
+    CE["Camunda exporter\nnew features here"]
+    ESE["ES exporter\nSM + Optimize"]
+    OSE["OS exporter\nSM"]
+    RE["RDBMS exporter"]
+  end
+
+  subgraph storage["Secondary storage"]
+    direction LR
+    ESOS[("Elasticsearch / OpenSearch\nwebapps-schema · schema-manager")]
+    RDB[("Relational DB\ndb/rdbms-schema")]
+  end
+
+  SVC["service/"]
+  SEARCH["search/"]
+
+  gw --> AUTH
+  AUTH -->|commands| BROKER
+  ENGINE -->|records| exp
+  CE --> ESOS & RDB
+  ESE & OSE --> ESOS
+  RE --> RDB
+
+  REST -.->|read queries| SVC
+  SVC --> SEARCH
+  SEARCH --> ESOS & RDB
+```
 
 ### Write path
 
 Clients submit commands (deploy a process, start an instance, complete a job) through one of three
 entry points:
 
+- **REST gateway** (`zeebe/gateway-rest`): exposes the Camunda REST API and is the primary entry
+  point for new features. Commands flow through `service/`, which translates them into calls to the
+  internal Zeebe gateway. `gateways/gateway-mapping-http` provides HTTP request/response mapping
+  utilities used by this layer. All new core features must be exposed here first.
 - **gRPC gateway** (`zeebe/gateway`, `zeebe/gateway-grpc`): exposes the Zeebe gRPC API defined in
-  `zeebe/gateway-protocol`. Used by the Java client (`clients/java`), the Go client (`clients/go`),
-  and the Spring Boot starter (`clients/camunda-spring-boot-starter`).
-- **REST gateway** (`zeebe/gateway-rest`): exposes the Camunda v2 REST API. Commands flow through
-  `service/`, which translates them into calls to the internal Zeebe gateway.
-  `gateways/gateway-mapping-http` provides HTTP request/response mapping utilities used by this
-  layer.
+  `zeebe/gateway-protocol`. Used by the Java client (`clients/java`) and the Spring Boot starter
+  (`clients/camunda-spring-boot-starter`). Kept for backward compatibility and performance (gRPC is
+  more efficient at scale; job streaming is gRPC-only).
 - **MCP gateway** (`gateways/gateway-mcp`): exposes the Camunda API as a Model Context Protocol
   server for AI agent integrations.
 
@@ -31,21 +84,29 @@ All entry points authenticate via `authentication/` (OIDC token processing, Spri
 Authorization is enforced by `security/` against rules managed by `identity/`.
 
 The **Zeebe broker** (`zeebe/broker`) receives commands, appends them to a partitioned append-only
-log (Raft consensus via `zeebe/atomix`), and executes them against its primary state store (RocksDB
-via `zeebe/zb-db`).
+log (Raft consensus via `zeebe/atomix`). The **Zeebe engine** (`zeebe/engine`) executes them
+against its primary state store (RocksDB via `zeebe/zb-db`).
 
 ### Export path
 
 After processing, the broker emits records to configured exporters:
 
-|           Exporter            |                  Module                  |           Target            |
-|-------------------------------|------------------------------------------|-----------------------------|
-| Elasticsearch exporter        | `zeebe/exporters/elasticsearch-exporter` | Elasticsearch indices       |
-| OpenSearch exporter           | `zeebe/exporters/opensearch-exporter`    | OpenSearch indices          |
-| RDBMS exporter                | `zeebe/exporters/rdbms-exporter`         | Relational DB via `db/`     |
-| Camunda exporter              | `zeebe/exporters/camunda-exporter`       | All of the above            |
+|        Exporter        |                  Module                  |         Target          |
+|------------------------|------------------------------------------|-------------------------|
+| Elasticsearch exporter | `zeebe/exporters/elasticsearch-exporter` | Elasticsearch indices   |
+| OpenSearch exporter    | `zeebe/exporters/opensearch-exporter`    | OpenSearch indices      |
+| RDBMS exporter         | `zeebe/exporters/rdbms-exporter`         | Relational DB via `db/` |
+| Camunda exporter       | `zeebe/exporters/camunda-exporter`       | All of the above        |
 
-ES/OS index shapes are defined in `webapps-schema/` and applied at startup by `schema-manager/`, which are then written to by the Camunda Exporter. For RDBMS, the schema is defined in `db/rdbms-schema`, which is written to by the RDBMS exporter.
+New feature work targets the Camunda Exporter. The dedicated Elasticsearch and OpenSearch exporters
+remain supported for self-managed deployments but are no longer extended with new features (Optimize
+still requires the Elasticsearch exporter).
+
+For the Camunda Exporter, ES/OS index shapes are defined in `webapps-schema/` and applied at
+startup by `schema-manager/`. The dedicated Elasticsearch and OpenSearch exporters manage their own
+index templates independently (see `zeebe/exporters/elasticsearch-exporter/src/main/resources` and
+`zeebe/exporters/opensearch-exporter/src/main/resources`). For RDBMS, the schema is defined in
+`db/rdbms-schema`, which is written to by the RDBMS exporter.
 
 The Camunda Exporter also runs background **archiver jobs** that move completed process data from
 active ES/OS indices into dated archive indices (e.g. `operate-list-view-8.3.0_2024-01-01`),
@@ -96,8 +157,9 @@ the impact on existing index mappings.
 All REST commands must flow through `service/` before reaching Zeebe. REST controllers in
 `zeebe/gateway-rest` must not call the Zeebe gRPC gateway directly.
 
-**RDBMS schema migrations** (`db/rdbms-schema`)\
-Schema changes are versioned Liquibase changesets. Never alter tables outside a migration.
+**RDBMS schema** (`db/rdbms-schema`)\
+Schema changes are versioned Liquibase changesets and must be additive-only (new tables or columns).
+Never drop or alter existing columns; never modify tables outside a changeset.
 
 ## Cross-module blast radius
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -4,7 +4,7 @@
 
 Camunda 8 is a process automation platform that executes BPMN workflows and evaluates DMN decisions
 at scale, for both self-managed and SaaS deployments. The monorepo contains the full platform: Zeebe
-(write-side execution engine), Operate (process monitoring), Tasklist (human task management),
+(process engine), Operate (process monitoring), Tasklist (human task management),
 Identity (authentication and authorization), and Optimize (process analytics), plus shared
 libraries, gateways, and supporting infrastructure. Java 21 backend built with Maven; React/Carbon
 frontends. `dist/` wires the components into deployable Spring Boot application variants (e.g.
@@ -14,7 +14,7 @@ frontends. `dist/` wires the components into deployable Spring Boot application 
 
 ### Write path
 
-Clients submit commands (deploy a process, start an instance, complete a job) through one of two
+Clients submit commands (deploy a process, start an instance, complete a job) through one of three
 entry points:
 
 - **gRPC gateway** (`zeebe/gateway`, `zeebe/gateway-grpc`): exposes the Zeebe gRPC API defined in
@@ -27,7 +27,7 @@ entry points:
 - **MCP gateway** (`gateways/gateway-mcp`): exposes the Camunda API as a Model Context Protocol
   server for AI agent integrations.
 
-Both entry points authenticate via `authentication/` (OIDC token processing, Spring Security).
+All entry points authenticate via `authentication/` (OIDC token processing, Spring Security).
 Authorization is enforced by `security/` against rules managed by `identity/`.
 
 The **Zeebe broker** (`zeebe/broker`) receives commands, appends them to a partitioned append-only
@@ -43,21 +43,24 @@ After processing, the broker emits records to configured exporters:
 | Elasticsearch exporter        | `zeebe/exporters/elasticsearch-exporter` | Elasticsearch indices       |
 | OpenSearch exporter           | `zeebe/exporters/opensearch-exporter`    | OpenSearch indices          |
 | RDBMS exporter                | `zeebe/exporters/rdbms-exporter`         | Relational DB via `db/`     |
-| Camunda exporter (all-in-one) | `zeebe/exporters/camunda-exporter`       | All of the above (combined) |
+| Camunda exporter              | `zeebe/exporters/camunda-exporter`       | All of the above            |
 
-ES/OS index shapes are defined in `webapps-schema/` and applied at startup by `schema-manager/`.
+ES/OS index shapes are defined in `webapps-schema/` and applied at startup by `schema-manager/`, which are then written to by the Camunda Exporter. For RDBMS, the schema is defined in `db/rdbms-schema`, which is written to by the RDBMS exporter.
 
 The Camunda Exporter also runs background **archiver jobs** that move completed process data from
 active ES/OS indices into dated archive indices (e.g. `operate-list-view-8.3.0_2024-01-01`),
 keeping primary indices lean. Archiving is ES/OS-only; RDBMS deployments use TTL-based cleanup
-instead. Operate and Tasklist queries span both active and archive indices.
+instead. Search queries span both active and archive indices, using aliases.
 
 ### Read path
 
-Operate and Tasklist are read-side webapps that query secondary storage (ES/OS or RDBMS) through
-the `search/` abstraction layer. The REST API also serves read queries: `zeebe/gateway-rest` calls
-`service/`, which delegates to `search/`. Optimize reads from the same ES/OS indices through
-its own internal analytics pipeline.
+Operate and Tasklist query secondary storage (ES/OS or RDBMS) through the `search/` abstraction
+layer. The REST API also serves read queries: `zeebe/gateway-rest` calls `service/`, which
+delegates to `search/`.
+
+Optimize manages its own ES/OS schema. It reads data emitted by the ES/OS exporters, transforming
+it into data structures more suited for data analysis. Optimize entities (reports/collections) are
+also stored in Optimize-managed indices. There is no RDBMS support for Optimize.
 
 ## Architectural decisions
 
@@ -83,6 +86,11 @@ All templates use `"dynamic": "strict"` — new fields must be explicitly added 
 definitions before the exporter writes them. Changing a field type is a breaking change that
 requires a migration plan. Never query ES/OS indices directly from application code; always go
 through `search/`.
+
+**ES/OS exporter index templates** (`zeebe/exporters/elasticsearch-exporter/src/main/resources`,
+`zeebe/exporters/opensearch-exporter/src/main/resources`)\
+Index templates owned by the dedicated ES/OS exporters. Do not modify them without understanding
+the impact on existing index mappings.
 
 **`service/` as the REST-to-engine bridge**\
 All REST commands must flow through `service/` before reaching Zeebe. REST controllers in
@@ -121,7 +129,7 @@ Changes that propagate farthest:
 - `optimize/` — independent internal build; excluded by default with `-Dquickly`. Build explicitly
   with `-pl optimize` when needed.
 - `webapps-schema/src/main/resources/schema/` — canonical ES/OS template JSON; changes here affect
-  exporters, `schema-manager/`, `operate/`, `tasklist/`, and `search/` simultaneously.
+  exporters, `schema-manager/`, and `search/` directly.
 - `bom-deprecated/` — legacy BOM kept for backwards compatibility; do not add new entries.
 - `dist/` — distribution assembly only; no application logic lives here.
 


### PR DESCRIPTION
## Summary

- Populates `docs/architecture/overview.md` with runtime topology, architectural boundaries, cross-module blast radius, path rules, and further reading — giving agents and engineers a map of how the system works without duplicating the module list in `AGENTS.md`
- Creates `docs/adr/` as the canonical home for cross-cutting ADRs, with a README describing the three-tier structure (monorepo-wide, domain, module)
- Updates `AGENTS.md` to instruct agents to consult ADR indexes at every level (root, module, and parent modules up the chain) before making architectural changes

## Test plan

- [ ] Verify `docs/architecture/overview.md` renders correctly on GitHub
- [ ] Verify `docs/adr/README.md` renders correctly on GitHub
- [ ] Verify `AGENTS.md` changes correctly instruct agents to walk parent modules for ADRs

Closes #53131

🤖 Generated with [Claude Code](https://claude.com/claude-code)