### PR TITLE
deps: teach Renovate about HeroDevs NES Spring artifacts

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,8 @@
   "enabled": true,
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "github>camunda/infra-renovate-config:herodevs.json5"
   ],
   "commitMessagePrefix": "deps:",
   "baseBranchPatterns": [
@@ -39,6 +40,12 @@
       "password": "{{ secrets.INFRA_MINIMUS_REGISTRY_TOKEN }}"
     },
     {
+      "hostType": "maven",
+      "matchHost": "https://artifacts.camunda.com",
+      "username": "{{ secrets.ARTIFACTORY_USERNAME }}",
+      "password": "{{ secrets.ARTIFACTORY_PASSWORD }}"
+    },
+    {
       "timeout": 10000
     }
   ],
@@ -50,6 +57,19 @@
       ],
       "registryUrls": [
         "https://repo.maven.apache.org/maven2"
+      ]
+    },
+    {
+      "description": "HeroDevs NES Spring artifacts must also be discovered from the HeroDevs Maven repository. Overrides the Maven-Central-only rule above for Spring artifacts.",
+      "matchDatasources": [
+        "maven"
+      ],
+      "matchPackageNames": [
+        "/^org\\.springframework(\\..+)?:/"
+      ],
+      "registryUrls": [
+        "https://repo.maven.apache.org/maven2",
+        "https://artifacts.camunda.com/artifactory/herodevs-nes"
       ]
     },
     {


### PR DESCRIPTION
## Description

Related to https://github.com/camunda/team-infrastructure/issues/1036.

Configures Renovate so that HeroDevs Never-Ending Support (NES) Spring artifacts are discovered and upgraded transparently on the `stable/8.7` and `stable/8.8` branches after Spring Boot 3.5 OSS EOL on 2026-06-30.

Three changes:

- Extends the shared [`herodevs.json5`](https://github.com/camunda/infra-renovate-config/blob/main/herodevs.json5) preset, which provides the regex versioning that maps OSS and NES versions (e.g. `3.5.14-spring-boot-3.5.15`) to the same major/minor/patch space so Renovate proposes upgrades transparently. The preset covers both the built-in Maven manager (parent pom BOM import) **and** this repo's `customManagers` that track `<version.spring-boot>` / `<version.spring>` in the dual-major starter (`clients/camunda-spring-boot-{3,4}-starter`) and test (`testing/camunda-process-test-spring-boot-{3,4}`) modules — see [`camunda/infra-renovate-config#413`](https://github.com/camunda/infra-renovate-config/pull/413) for the preset's `custom.regex` coverage.
- Adds an `org.springframework**` `packageRule` that introduces the HeroDevs Maven repository as a registry URL for Spring artifacts. Without it, the catch-all Maven-Central-only rule above would prevent Renovate from ever querying HeroDevs.
- Adds an `artifacts.camunda.com` Maven `hostRule` so Renovate can authenticate against the gated HeroDevs remote.

The corresponding `<repositories>` / `<pluginRepositories>` entries in `bom/pom.xml`, and the CI Maven mirror update in `.github/actions/setup-build/action.yml`, are added separately on `stable/8.7` and `stable/8.8`, since `main` (Spring Boot 4.0.6) does not need HeroDevs NES today.

Renovate uses `main`'s `renovate.json` for all base branches via `baseBranchPatterns` with `useBaseBranchConfig: none`, so this single change covers both stable branches.

## Checklist

- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

Refs camunda/team-infrastructure#1036