### PR TITLE
deps: integrate HeroDevs NES Maven repository (stable/8.8)

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -179,7 +179,7 @@ runs:
           "id": "camunda-nexus",
           "name": "Camunda Nexus",
           "url": "https://repository.nexus.camunda.cloud/content/groups/internal/",
-          "mirrorOf": "zeebe,zeebe-snapshots"
+          "mirrorOf": "zeebe,zeebe-snapshots,herodevs-nes"
         }]
       CAMUNDA_NEXUS_MAVEN_SERVER: >-
         [{

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -228,7 +228,38 @@
       <name>Camunda BPM Snapshot Repository</name>
       <url>https://artifacts.camunda.com/artifactory/camunda-bpm-snapshots/</url>
     </repository>
+
+    <!-- HeroDevs Never-Ending Support (NES) -->
+    <repository>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>herodevs-nes</id>
+      <name>HeroDevs NES Repository</name>
+      <url>https://artifacts.camunda.com/artifactory/herodevs-nes</url>
+    </repository>
   </repositories>
+
+  <pluginRepositories>
+    <!-- Resolve plugins through the HeroDevs Never-Ending Support (NES)
+         repository in addition to Maven Central — notably the Spring Boot
+         Maven plugin, which is pinned to ${version.spring-boot} and follows
+         the BOM into NES versioning. -->
+    <pluginRepository>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>herodevs-nes</id>
+      <name>HeroDevs NES Repository</name>
+      <url>https://artifacts.camunda.com/artifactory/herodevs-nes</url>
+    </pluginRepository>
+  </pluginRepositories>
 
   <build>
     <pluginManagement>


### PR DESCRIPTION
## Description

Related to https://github.com/camunda/team-infrastructure/issues/1036. Companion to camunda/camunda#53738 (Renovate config on `main`).

Adds the HeroDevs Never-Ending Support (NES) Maven repository to `bom/pom.xml`, incl. a new `<pluginRepositories>` block (since `spring-boot-maven-plugin` is used in `parent/pom.xml`, `dist/pom.xml`, `load-tests/load-tester/pom.xml`, and `optimize/backend/pom.xml`, pinned to `${version.spring-boot}` and will follow the BOM into NES versioning) — so Spring Boot 3.5.x patches can be pulled from HeroDevs via Camunda Artifactory after the OSS EOL on 2026-06-30.

`.github/actions/setup-build/action.yml`: extends the Camunda Nexus mirror's `mirrorOf` from `"zeebe,zeebe-snapshots"` to `"zeebe,zeebe-snapshots,herodevs-nes"`. This routes the new repository through Nexus's `/internal` virtual repo (which already proxies HeroDevs, see [`infra-core#12835`](https://github.com/camunda/infra-core/pull/12835)) and reuses the existing `camunda-nexus` server credentials in CI. Without this, Maven would query `artifacts.camunda.com/artifactory/herodevs-nes` directly without authentication and fail.

The matching Renovate config lives on `main` only (camunda/camunda#53738); on stable branches Renovate uses `main`'s `renovate.json` via `baseBranchPatterns` with `useBaseBranchConfig: none`, so no `renovate.json` change is needed here.

## Checklist

- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

Refs camunda/team-infrastructure#1036