### PR TITLE
test: skip flaky Operate FE tests

### DIFF
--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/adHocSubProcess.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/adHocSubProcess.test.tsx
@@ -25,7 +25,8 @@ import {mockQueryBatchOperationItems} from 'modules/mocks/api/v2/batchOperations
 
 const adHocProcessXml = open('AdHocProcess.bpmn');
 
-describe('ElementInstancesTree - Ad Hoc Sub Process', () => {
+// TODO: https://github.com/camunda/camunda/issues/20862
+describe.todo('ElementInstancesTree - Ad Hoc Sub Process', () => {
   beforeEach(async () => {
     mockFetchProcessInstance().withSuccess(mockAdHocSubProcessesInstance);
     mockFetchProcessDefinitionXml().withSuccess(open('AdHocProcess.bpmn'));

--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/adHocSubProcessInnerInstance.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/adHocSubProcessInnerInstance.test.tsx
@@ -29,7 +29,8 @@ import {
   queryElementInstancesRequestBodySchema,
 } from '@camunda/camunda-api-zod-schemas/8.10';
 
-describe('ElementInstancesTree - Ad Hoc Sub Process Inner Instance', () => {
+// TODO: https://github.com/camunda/camunda/issues/20862
+describe.todo('ElementInstancesTree - Ad Hoc Sub Process Inner Instance', () => {
   beforeEach(async () => {
     mockFetchProcessInstance().withSuccess(
       mockAdHocSubProcessInnerInstanceProcessInstance,

--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/adHocSubProcessInnerInstance.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/adHocSubProcessInnerInstance.test.tsx
@@ -30,216 +30,220 @@ import {
 } from '@camunda/camunda-api-zod-schemas/8.10';
 
 // TODO: https://github.com/camunda/camunda/issues/20862
-describe.todo('ElementInstancesTree - Ad Hoc Sub Process Inner Instance', () => {
-  beforeEach(async () => {
-    mockFetchProcessInstance().withSuccess(
-      mockAdHocSubProcessInnerInstanceProcessInstance,
-    );
-    mockFetchProcessDefinitionXml().withSuccess(adHocSubProcessInnerInstance);
-    mockFetchElementInstancesStatistics().withSuccess({items: []});
-    mockQueryBatchOperationItems().withSuccess(searchResult([]));
-    mockSearchElementInstances().withSuccess(
-      adHocSubProcessInnerInstanceElementInstances.level1,
-    );
-    mockFetchElementInstance('inner-1').withSuccess(
-      adHocSubProcessInnerInstanceElementInstances.level1.items[1]!,
-    );
-  });
-
-  afterEach(() => {
-    notificationsStore.reset();
-  });
-
-  it('should select inner instance with first child as anchor when node is expanded and has children', async () => {
-    const {businessObjects} = await parseBusinessObjects(
-      adHocSubProcessInnerInstance,
-    );
-    const {user} = render(
-      <ElementInstancesTree
-        processInstance={mockAdHocSubProcessInnerInstanceProcessInstance}
-        businessObjects={businessObjects}
-      />,
-      {
-        wrapper: getWrapper(),
-      },
-    );
-
-    expect(
-      await screen.findByText('Ad Hoc Inner Subprocess Test'),
-    ).toBeInTheDocument();
-
-    mockSearchElementInstances().withSuccess(
-      adHocSubProcessInnerInstanceElementInstances.level2,
-    );
-    mockSearchElementInstances().withSuccess(
-      adHocSubProcessInnerInstanceElementInstances.level2,
-    );
-
-    await user.type(
-      await screen.findByLabelText('Ad Hoc Sub Process Inner Instance', {
-        selector: "[aria-expanded='false']",
-      }),
-      '{arrowright}',
-    );
-    // The right arrow press triggers a node selection on JSDOM so we need to reset the selection. This doesn't happeng in the browser
-    await user.click(screen.getByText('Ad Hoc Inner Subprocess Test'));
-
-    await user.click(
-      await screen.findByLabelText('Ad Hoc Sub Process Inner Instance', {
-        selector: "[aria-expanded='true']",
-      }),
-    );
-
-    await waitFor(() => {
-      expect(screen.getByTestId('search')).toHaveTextContent(
-        '?elementId=ad_hoc_subprocess&elementInstanceKey=inner-1&anchorElementId=user_task_in_ad_hoc_subprocess',
+describe.todo(
+  'ElementInstancesTree - Ad Hoc Sub Process Inner Instance',
+  () => {
+    beforeEach(async () => {
+      mockFetchProcessInstance().withSuccess(
+        mockAdHocSubProcessInnerInstanceProcessInstance,
+      );
+      mockFetchProcessDefinitionXml().withSuccess(adHocSubProcessInnerInstance);
+      mockFetchElementInstancesStatistics().withSuccess({items: []});
+      mockQueryBatchOperationItems().withSuccess(searchResult([]));
+      mockSearchElementInstances().withSuccess(
+        adHocSubProcessInnerInstanceElementInstances.level1,
+      );
+      mockFetchElementInstance('inner-1').withSuccess(
+        adHocSubProcessInnerInstanceElementInstances.level1.items[1]!,
       );
     });
-  });
 
-  it('should fetch first child and select with anchor when clicking collapsed inner instance', async () => {
-    const {businessObjects} = await parseBusinessObjects(
-      adHocSubProcessInnerInstance,
-    );
-    const {user} = render(
-      <ElementInstancesTree
-        processInstance={mockAdHocSubProcessInnerInstanceProcessInstance}
-        businessObjects={businessObjects}
-      />,
-      {
-        wrapper: getWrapper(),
-      },
-    );
+    afterEach(() => {
+      notificationsStore.reset();
+    });
 
-    expect(
-      await screen.findByText('Ad Hoc Inner Subprocess Test'),
-    ).toBeInTheDocument();
-
-    mockServer.use(
-      http.post(
-        endpoints.queryElementInstances.getUrl(),
-        async ({request}) => {
-          const body = await request.json();
-          const result = queryElementInstancesRequestBodySchema.safeParse(body);
-
-          if (
-            !result.success ||
-            result.data?.filter?.elementInstanceScopeKey !== 'inner-1'
-          ) {
-            return HttpResponse.json(
-              {
-                error:
-                  'Invalid payload: elementInstanceScopeKey must be in filter',
-              },
-              {status: 400},
-            );
-          }
-
-          return HttpResponse.json(
-            adHocSubProcessInnerInstanceElementInstances.level2,
-          );
+    it('should select inner instance with first child as anchor when node is expanded and has children', async () => {
+      const {businessObjects} = await parseBusinessObjects(
+        adHocSubProcessInnerInstance,
+      );
+      const {user} = render(
+        <ElementInstancesTree
+          processInstance={mockAdHocSubProcessInnerInstanceProcessInstance}
+          businessObjects={businessObjects}
+        />,
+        {
+          wrapper: getWrapper(),
         },
-        {once: true},
-      ),
-    );
-    await user.click(screen.getByText('Ad Hoc Inner Subprocess Test'));
-
-    await user.click(
-      await screen.findByLabelText('Ad Hoc Sub Process Inner Instance', {
-        selector: "[aria-expanded='false']",
-      }),
-    );
-
-    await waitFor(() => {
-      expect(screen.getByTestId('search')).toHaveTextContent(
-        '?elementId=ad_hoc_subprocess&elementInstanceKey=inner-1&anchorElementId=user_task_in_ad_hoc_subprocess',
       );
+
+      expect(
+        await screen.findByText('Ad Hoc Inner Subprocess Test'),
+      ).toBeInTheDocument();
+
+      mockSearchElementInstances().withSuccess(
+        adHocSubProcessInnerInstanceElementInstances.level2,
+      );
+      mockSearchElementInstances().withSuccess(
+        adHocSubProcessInnerInstanceElementInstances.level2,
+      );
+
+      await user.type(
+        await screen.findByLabelText('Ad Hoc Sub Process Inner Instance', {
+          selector: "[aria-expanded='false']",
+        }),
+        '{arrowright}',
+      );
+      // The right arrow press triggers a node selection on JSDOM so we need to reset the selection. This doesn't happeng in the browser
+      await user.click(screen.getByText('Ad Hoc Inner Subprocess Test'));
+
+      await user.click(
+        await screen.findByLabelText('Ad Hoc Sub Process Inner Instance', {
+          selector: "[aria-expanded='true']",
+        }),
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('search')).toHaveTextContent(
+          '?elementId=ad_hoc_subprocess&elementInstanceKey=inner-1&anchorElementId=user_task_in_ad_hoc_subprocess',
+        );
+      });
     });
 
-    expect(notificationsStore.notifications).toEqual([]);
-  });
-
-  it('should display warning notification when inner instance has no children', async () => {
-    const {businessObjects} = await parseBusinessObjects(
-      adHocSubProcessInnerInstance,
-    );
-    const {user} = render(
-      <ElementInstancesTree
-        processInstance={mockAdHocSubProcessInnerInstanceProcessInstance}
-        businessObjects={businessObjects}
-      />,
-      {
-        wrapper: getWrapper(),
-      },
-    );
-    const originalSearch = screen.getByTestId('search').textContent;
-
-    expect(
-      await screen.findByText('Ad Hoc Inner Subprocess Test'),
-    ).toBeInTheDocument();
-
-    mockSearchElementInstances().withSuccess(searchResult([]));
-
-    await user.click(
-      await screen.findByLabelText('Ad Hoc Sub Process Inner Instance', {
-        selector: "[aria-expanded='false']",
-      }),
-    );
-
-    await waitFor(() => {
-      expect(notificationsStore.notifications).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            kind: 'warning',
-            title:
-              'No child instances found for Ad Hoc Sub Process Inner Instance',
-          }),
-        ]),
+    it('should fetch first child and select with anchor when clicking collapsed inner instance', async () => {
+      const {businessObjects} = await parseBusinessObjects(
+        adHocSubProcessInnerInstance,
       );
+      const {user} = render(
+        <ElementInstancesTree
+          processInstance={mockAdHocSubProcessInnerInstanceProcessInstance}
+          businessObjects={businessObjects}
+        />,
+        {
+          wrapper: getWrapper(),
+        },
+      );
+
+      expect(
+        await screen.findByText('Ad Hoc Inner Subprocess Test'),
+      ).toBeInTheDocument();
+
+      mockServer.use(
+        http.post(
+          endpoints.queryElementInstances.getUrl(),
+          async ({request}) => {
+            const body = await request.json();
+            const result =
+              queryElementInstancesRequestBodySchema.safeParse(body);
+
+            if (
+              !result.success ||
+              result.data?.filter?.elementInstanceScopeKey !== 'inner-1'
+            ) {
+              return HttpResponse.json(
+                {
+                  error:
+                    'Invalid payload: elementInstanceScopeKey must be in filter',
+                },
+                {status: 400},
+              );
+            }
+
+            return HttpResponse.json(
+              adHocSubProcessInnerInstanceElementInstances.level2,
+            );
+          },
+          {once: true},
+        ),
+      );
+      await user.click(screen.getByText('Ad Hoc Inner Subprocess Test'));
+
+      await user.click(
+        await screen.findByLabelText('Ad Hoc Sub Process Inner Instance', {
+          selector: "[aria-expanded='false']",
+        }),
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('search')).toHaveTextContent(
+          '?elementId=ad_hoc_subprocess&elementInstanceKey=inner-1&anchorElementId=user_task_in_ad_hoc_subprocess',
+        );
+      });
+
+      expect(notificationsStore.notifications).toEqual([]);
     });
 
-    expect(screen.getByTestId('search')).toHaveTextContent(originalSearch);
-  });
-
-  it('should display warning notification when fetching first child fails', async () => {
-    const {businessObjects} = await parseBusinessObjects(
-      adHocSubProcessInnerInstance,
-    );
-    const {user} = render(
-      <ElementInstancesTree
-        processInstance={mockAdHocSubProcessInnerInstanceProcessInstance}
-        businessObjects={businessObjects}
-      />,
-      {
-        wrapper: getWrapper(),
-      },
-    );
-    const originalSearch = screen.getByTestId('search').textContent;
-
-    expect(
-      await screen.findByText('Ad Hoc Inner Subprocess Test'),
-    ).toBeInTheDocument();
-
-    mockSearchElementInstances().withNetworkError();
-
-    await user.click(
-      await screen.findByLabelText('Ad Hoc Sub Process Inner Instance', {
-        selector: "[aria-expanded='false']",
-      }),
-    );
-
-    await waitFor(() => {
-      expect(notificationsStore.notifications).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            kind: 'warning',
-            title:
-              'No child instances found for Ad Hoc Sub Process Inner Instance',
-          }),
-        ]),
+    it('should display warning notification when inner instance has no children', async () => {
+      const {businessObjects} = await parseBusinessObjects(
+        adHocSubProcessInnerInstance,
       );
+      const {user} = render(
+        <ElementInstancesTree
+          processInstance={mockAdHocSubProcessInnerInstanceProcessInstance}
+          businessObjects={businessObjects}
+        />,
+        {
+          wrapper: getWrapper(),
+        },
+      );
+      const originalSearch = screen.getByTestId('search').textContent;
+
+      expect(
+        await screen.findByText('Ad Hoc Inner Subprocess Test'),
+      ).toBeInTheDocument();
+
+      mockSearchElementInstances().withSuccess(searchResult([]));
+
+      await user.click(
+        await screen.findByLabelText('Ad Hoc Sub Process Inner Instance', {
+          selector: "[aria-expanded='false']",
+        }),
+      );
+
+      await waitFor(() => {
+        expect(notificationsStore.notifications).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              kind: 'warning',
+              title:
+                'No child instances found for Ad Hoc Sub Process Inner Instance',
+            }),
+          ]),
+        );
+      });
+
+      expect(screen.getByTestId('search')).toHaveTextContent(originalSearch);
     });
 
-    expect(screen.getByTestId('search')).toHaveTextContent(originalSearch);
-  });
-});
+    it('should display warning notification when fetching first child fails', async () => {
+      const {businessObjects} = await parseBusinessObjects(
+        adHocSubProcessInnerInstance,
+      );
+      const {user} = render(
+        <ElementInstancesTree
+          processInstance={mockAdHocSubProcessInnerInstanceProcessInstance}
+          businessObjects={businessObjects}
+        />,
+        {
+          wrapper: getWrapper(),
+        },
+      );
+      const originalSearch = screen.getByTestId('search').textContent;
+
+      expect(
+        await screen.findByText('Ad Hoc Inner Subprocess Test'),
+      ).toBeInTheDocument();
+
+      mockSearchElementInstances().withNetworkError();
+
+      await user.click(
+        await screen.findByLabelText('Ad Hoc Sub Process Inner Instance', {
+          selector: "[aria-expanded='false']",
+        }),
+      );
+
+      await waitFor(() => {
+        expect(notificationsStore.notifications).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              kind: 'warning',
+              title:
+                'No child instances found for Ad Hoc Sub Process Inner Instance',
+            }),
+          ]),
+        );
+      });
+
+      expect(screen.getByTestId('search')).toHaveTextContent(originalSearch);
+    });
+  },
+);

--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/elementInstancesTreeStore.test.ts
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/elementInstancesTreeStore.test.ts
@@ -107,7 +107,8 @@ const mockChildResponse = createMockResponse(mockChildInstances, 2);
 
 const mockEmptyResponse = createMockResponse([], 0);
 
-describe('elementInstancesTreeStore', () => {
+// TODO: https://github.com/camunda/camunda/issues/20862
+describe.todo('elementInstancesTreeStore', () => {
   afterEach(() => {
     elementInstancesTreeStore.reset();
     vi.clearAllTimers();

--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/eventSubprocess.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/eventSubprocess.test.tsx
@@ -22,7 +22,8 @@ import {mockFetchElementInstance} from 'modules/mocks/api/v2/elementInstances/fe
 import {mockQueryBatchOperationItems} from 'modules/mocks/api/v2/batchOperations/queryBatchOperationItems';
 import {mockFetchElementInstancesStatistics} from 'modules/mocks/api/v2/elementInstances/elementInstancesStatistics/fetchElementInstancesStatistics';
 
-describe('ElementInstancesTree - Event Subprocess', () => {
+// TODO: https://github.com/camunda/camunda/issues/20862
+describe.todo('ElementInstancesTree - Event Subprocess', () => {
   beforeEach(async () => {
     mockFetchProcessInstance().withSuccess(mockEventSubprocessInstance);
     mockFetchProcessDefinitionXml().withSuccess(eventSubProcess);

--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/modificationPlaceholders.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/modificationPlaceholders.test.tsx
@@ -33,7 +33,8 @@ import {mockSearchElementInstances} from 'modules/mocks/api/v2/elementInstances/
 import {mockFetchElementInstance} from 'modules/mocks/api/v2/elementInstances/fetchElementInstance';
 import {mockQueryBatchOperationItems} from 'modules/mocks/api/v2/batchOperations/queryBatchOperationItems';
 
-describe('ElementInstancesTree - Modification placeholders', () => {
+// TODO: https://github.com/camunda/camunda/issues/20862
+describe.todo('ElementInstancesTree - Modification placeholders', () => {
   beforeEach(async () => {
     mockFetchProcessDefinitionXml().withSuccess(multiInstanceProcess);
     mockFetchElementInstancesStatistics().withSuccess({items: []});

--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/multiInstanceSubprocess.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/multiInstanceSubprocess.test.tsx
@@ -56,7 +56,8 @@ const SUB_PROCESS_ELEMENT: ElementInstance = {
   rootProcessInstanceKey: null,
 };
 
-describe('ElementInstancesTree - Multi Instance Subprocess', () => {
+// TODO: https://github.com/camunda/camunda/issues/20862
+describe.todo('ElementInstancesTree - Multi Instance Subprocess', () => {
   beforeEach(async () => {
     mockFetchProcessDefinitionXml().withSuccess(multiInstanceProcess);
 

--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/nestedSubprocess.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/nestedSubprocess.test.tsx
@@ -25,7 +25,6 @@ import {mockQueryBatchOperationItems} from 'modules/mocks/api/v2/batchOperations
 
 const nestedSubProcessesXml = open('NestedSubProcesses.bpmn');
 
-
 // TODO: https://github.com/camunda/camunda/issues/20862
 describe.todo('ElementInstancesTree - Nested Subprocesses', () => {
   beforeEach(async () => {

--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/nestedSubprocess.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/nestedSubprocess.test.tsx
@@ -25,7 +25,9 @@ import {mockQueryBatchOperationItems} from 'modules/mocks/api/v2/batchOperations
 
 const nestedSubProcessesXml = open('NestedSubProcesses.bpmn');
 
-describe('ElementInstancesTree - Nested Subprocesses', () => {
+
+// TODO: https://github.com/camunda/camunda/issues/20862
+describe.todo('ElementInstancesTree - Nested Subprocesses', () => {
   beforeEach(async () => {
     mockFetchProcessInstance().withSuccess(mockNestedSubProcessesInstance);
     mockFetchProcessDefinitionXml().withSuccess(


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

These are very flaky since last week and are [running out of memory frequently](https://github.com/camunda/camunda/actions/runs/26230703690/job/77190053320)

I'm skipping these tests until we can stabilize them

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

related to #20862
