### PR TITLE
fix: CI / Lint / C8 REST OpenAPI Fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1942,6 +1942,12 @@ jobs:
     env:
       # renovate: datasource=npm depName=@stoplight/spectral-cli
       SPECTRAL_VERSION: '6.16.0'
+      # Pin the transitive @stoplight/spectral-rulesets to avoid a nimma
+      # null-deref triggered by the duplicated-entry-in-enum rule in
+      # spectral-rulesets >= 1.22.3 against null example values in the spec.
+      # Revisit once nimma releases past 0.7.2 or spectral-rulesets ships a fix.
+      # renovate: datasource=npm depName=@stoplight/spectral-rulesets
+      SPECTRAL_RULESETS_VERSION: '1.22.2'
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -1950,7 +1956,10 @@ jobs:
         with:
           node-version: 24
       - name: Install Spectral CLI
-        run: npm install -g "@stoplight/spectral-cli@${SPECTRAL_VERSION}"
+        run: |
+          npm install -g \
+            "@stoplight/spectral-cli@${SPECTRAL_VERSION}" \
+            "@stoplight/spectral-rulesets@${SPECTRAL_RULESETS_VERSION}"
         shell: bash
       - name: Run OpenAPI Linter (Structural pass)
         # Spectral provides comprehensive OpenAPI validation including:


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
`@stoplight/spectral-rulesets` version 1.22.3 used by `spectral-cli `(linter) was published on 21st May 2026, it is failing the CI / Lint / C8 REST.

###Solution
Pinning `@stoplight/spectral-rulesets` to 1.22.2 in `ci.yml`.

## Related issues
closes #53746
