### PR TITLE
fix: use verifyAndDecode instead of verifyToken in IdentityInterceptor

### DIFF
--- a/zeebe/gateway-grpc/pom.xml
+++ b/zeebe/gateway-grpc/pom.xml
@@ -175,6 +175,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.auth0</groupId>
+      <artifactId>java-jwt</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-cluster-config</artifactId>
     </dependency>

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/IdentityInterceptor.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/IdentityInterceptor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.gateway.interceptors.impl;
 
+import com.auth0.jwt.exceptions.JWTVerificationException;
 import io.camunda.identity.sdk.Identity;
 import io.camunda.identity.sdk.IdentityConfiguration;
 import io.camunda.identity.sdk.authentication.exception.TokenVerificationException;
@@ -37,9 +38,11 @@ public final class IdentityInterceptor implements ServerInterceptor {
   private final Identity identity;
   private final IdentityTenantService tenantService;
   private final MultiTenancyCfg multiTenancy;
+  private final String audience;
 
   public IdentityInterceptor(final IdentityCfg config, final GatewayCfg gatewayCfg) {
     this(
+        config.getAudience(),
         createIdentity(config),
         gatewayCfg.getMultiTenancy(),
         gatewayCfg.getExperimental().getIdentityRequest());
@@ -48,15 +51,18 @@ public final class IdentityInterceptor implements ServerInterceptor {
   public IdentityInterceptor(
       final IdentityConfiguration configuration, final GatewayCfg gatewayCfg) {
     this(
+        configuration.getAudience(),
         new Identity(configuration),
         gatewayCfg.getMultiTenancy(),
         gatewayCfg.getExperimental().getIdentityRequest());
   }
 
   public IdentityInterceptor(
+      final String audience,
       final Identity identity,
       final MultiTenancyCfg multiTenancy,
       final IdentityServiceCfg identityServiceCfg) {
+    this.audience = audience;
     this.identity = identity;
     this.multiTenancy = multiTenancy;
     tenantService = new IdentityTenantService(identity, identityServiceCfg);
@@ -92,8 +98,8 @@ public final class IdentityInterceptor implements ServerInterceptor {
 
     final String token = authorization.replaceFirst("^Bearer ", "");
     try {
-      identity.authentication().verifyToken(token);
-    } catch (final TokenVerificationException e) {
+      identity.authentication().verifyAndDecode(token, audience);
+    } catch (final JWTVerificationException | TokenVerificationException e) {
       LOGGER.debug(
           "Denying call {} as the token could not be verified successfully. Error message: {}",
           methodDescriptor.getFullMethodName(),

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/IdentityInterceptor.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/IdentityInterceptor.java
@@ -7,10 +7,8 @@
  */
 package io.camunda.zeebe.gateway.interceptors.impl;
 
-import com.auth0.jwt.exceptions.JWTVerificationException;
 import io.camunda.identity.sdk.Identity;
 import io.camunda.identity.sdk.IdentityConfiguration;
-import io.camunda.identity.sdk.authentication.exception.TokenVerificationException;
 import io.camunda.identity.sdk.tenants.dto.Tenant;
 import io.camunda.zeebe.gateway.cmd.ConcurrentRequestException;
 import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
@@ -99,7 +97,7 @@ public final class IdentityInterceptor implements ServerInterceptor {
     final String token = authorization.replaceFirst("^Bearer ", "");
     try {
       identity.authentication().verifyAndDecode(token, audience);
-    } catch (final JWTVerificationException | TokenVerificationException e) {
+    } catch (final Exception e) {
       LOGGER.debug(
           "Denying call {} as the token could not be verified successfully. Error message: {}",
           methodDescriptor.getFullMethodName(),

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java
@@ -100,7 +100,11 @@ public final class StubbedGateway {
             .addService(
                 ServerInterceptors.intercept(
                     gatewayGrpcService,
-                    new IdentityInterceptor(null, identity, multiTenancy, identityServiceCfg)));
+                    new IdentityInterceptor(
+                        config.getSecurity().getAuthentication().getIdentity().getAudience(),
+                        identity,
+                        multiTenancy,
+                        identityServiceCfg)));
     server = serverBuilder.build();
     server.start();
   }

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java
@@ -100,7 +100,7 @@ public final class StubbedGateway {
             .addService(
                 ServerInterceptors.intercept(
                     gatewayGrpcService,
-                    new IdentityInterceptor(identity, multiTenancy, identityServiceCfg)));
+                    new IdentityInterceptor(null, identity, multiTenancy, identityServiceCfg)));
     server = serverBuilder.build();
     server.start();
   }

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/IdentityInterceptorTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/IdentityInterceptorTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.gateway.interceptors.impl;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -33,6 +34,7 @@ import org.junit.jupiter.api.Test;
 
 public class IdentityInterceptorTest {
 
+  private static final String AUDIENCE = "zeebe-api-special-audience";
   private final MultiTenancyCfg multiTenancy = new MultiTenancyCfg();
   private final IdentityServiceCfg identityServiceCfg = new IdentityServiceCfg();
 
@@ -44,7 +46,7 @@ public class IdentityInterceptorTest {
     // when
     final CloseStatusCapturingServerCall closeStatusCapturingServerCall =
         new CloseStatusCapturingServerCall();
-    new IdentityInterceptor(identityMock, multiTenancy, identityServiceCfg)
+    new IdentityInterceptor(AUDIENCE, identityMock, multiTenancy, identityServiceCfg)
         .interceptCall(closeStatusCapturingServerCall, new Metadata(), failingNextHandler());
 
     // then
@@ -62,13 +64,13 @@ public class IdentityInterceptorTest {
   public void invalidTokenIsRejected() {
     // given
     final Identity identityMock = mock(Identity.class, RETURNS_DEEP_STUBS);
-    when(identityMock.authentication().verifyToken(anyString()))
+    when(identityMock.authentication().verifyAndDecode(anyString(), eq(AUDIENCE)))
         .thenThrow(TokenVerificationException.class);
 
     // when
     final CloseStatusCapturingServerCall closeStatusCapturingServerCall =
         new CloseStatusCapturingServerCall();
-    new IdentityInterceptor(identityMock, multiTenancy, identityServiceCfg)
+    new IdentityInterceptor(AUDIENCE, identityMock, multiTenancy, identityServiceCfg)
         .interceptCall(closeStatusCapturingServerCall, createAuthHeader(), failingNextHandler());
 
     // then
@@ -86,12 +88,13 @@ public class IdentityInterceptorTest {
   public void genericRuntimeFailure() {
     // given
     final Identity identityMock = mock(Identity.class, RETURNS_DEEP_STUBS);
-    when(identityMock.authentication().verifyToken(anyString())).thenThrow(RuntimeException.class);
+    when(identityMock.authentication().verifyAndDecode(anyString(), eq(AUDIENCE)))
+        .thenThrow(RuntimeException.class);
 
     // when
     assertThatThrownBy(
             () ->
-                new IdentityInterceptor(identityMock, multiTenancy, identityServiceCfg)
+                new IdentityInterceptor(AUDIENCE, identityMock, multiTenancy, identityServiceCfg)
                     .interceptCall(
                         new NoopServerCall<>(), createAuthHeader(), failingNextHandler()))
         // then
@@ -102,12 +105,12 @@ public class IdentityInterceptorTest {
   public void validTokenIsAccepted() {
     // given
     final Identity identityMock = mock(Identity.class, RETURNS_DEEP_STUBS);
-    when(identityMock.authentication().verifyToken(anyString())).thenReturn(null);
+    when(identityMock.authentication().verifyAndDecode(anyString(), eq(AUDIENCE))).thenReturn(null);
 
     // when
     final CloseStatusCapturingServerCall closeStatusCapturingServerCall =
         new CloseStatusCapturingServerCall();
-    new IdentityInterceptor(identityMock, multiTenancy, identityServiceCfg)
+    new IdentityInterceptor(AUDIENCE, identityMock, multiTenancy, identityServiceCfg)
         .interceptCall(
             closeStatusCapturingServerCall,
             createAuthHeader(),
@@ -131,7 +134,8 @@ public class IdentityInterceptorTest {
 
     // when
     final var interceptor =
-        new IdentityInterceptor(identity, multiTenancy.setEnabled(true), identityServiceCfg);
+        new IdentityInterceptor(
+            AUDIENCE, identity, multiTenancy.setEnabled(true), identityServiceCfg);
     interceptor.interceptCall(
         capturingServerCall,
         createAuthHeader(),
@@ -173,7 +177,8 @@ public class IdentityInterceptorTest {
 
     // when
     final var interceptor =
-        new IdentityInterceptor(identity, multiTenancy.setEnabled(false), identityServiceCfg);
+        new IdentityInterceptor(
+            AUDIENCE, identity, multiTenancy.setEnabled(false), identityServiceCfg);
     interceptor.interceptCall(
         capturingServerCall,
         createAuthHeader(),


### PR DESCRIPTION
## Description
The interceptor only needs to validate the JWT (signature, expiry, audience)
and discards the returned AccessToken. With GenericAuthentication and MicrosoftAuthentication, verifyToken additionally calls Identity's /api/permissions/for-token endpoint to populate permissions on the AccessToken. Switching to verifyAndDecode performs only local JWKS-based validation and removes that per-request REST call.

Plumb the audience through the constructors so verifyAndDecode can enforce
the audience claim, and broaden the catch to include JWTVerificationException
(auth0) and TokenVerificationException (SDK), as verifyAndDecode does not wrap auth0 exceptions the way verifyToken did.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

relates #53751
