### PR TITLE
feat: add Spectral lint rule for structure check of x-properties-added-in-version array

### DIFF
--- a/.github/scripts/x-added-in-version-check/README.md
+++ b/.github/scripts/x-added-in-version-check/README.md
@@ -43,7 +43,9 @@ artefacts/                # generated; gitignored (endpoint-map.json, version-ma
 The verifier checks two annotations:
 
 - `x-added-in-version` — set on **every operation** (`paths.<route>.<method>`). Value must equal the operation's added version from the version map. Operations listed in the version map's `deletedOperations` must **not** carry this annotation.
-- `x-properties-added-in-version` — a list set on a **schema object** (the node that owns a `properties:` map). Each entry has the form `{ propertyName, addedInVersion }` and records when a single property under that schema was introduced — unless that entry is suppressed by one of the rules below.
+- `x-properties-added-in-version` — a list set on a **schema object** (the node that owns a `properties:` map). Each entry has the form `{ propertyName, addedInVersion }`. The shape of each entry is enforced by the `properties-added-in-version-shape` Spectral rule (see [`zeebe/gateway-protocol/OPENAPI_VALIDATION.md`](../../../zeebe/gateway-protocol/OPENAPI_VALIDATION.md)); this verifier checks semantic correctness.
+
+Each entry of `x-properties-added-in-version` records when a single property under that schema was introduced — unless that entry is suppressed by one of the rules below.
 
 ### Rule 1 — Property version differs from its endpoint version
 

--- a/docs/rest-api-endpoint-guidelines.md
+++ b/docs/rest-api-endpoint-guidelines.md
@@ -822,7 +822,13 @@ If you add a new endpoint without this annotation, CI will fail with a message s
 Operation "createMyResource" (POST /my-resources) is missing x-added-in-version. Every endpoint must declare the Camunda version in which it was introduced.
 ```
 
-The shape of `x-properties-added-in-version` (see below) is enforced by the `properties-added-in-version-shape` Spectral rule (severity `error`): each entry must be an object with exactly `propertyName` (non-empty string) and `addedInVersion` (matching `^[0-9]+\.[0-9]+(\.[0-9]+)?$`), no other keys. Typos like `propertyame` or extra fields fail the file-level lint pass. Whether the annotation is _correct_ (right property, right version) is checked separately by the CI verifier linked below.
+The shape of `x-properties-added-in-version` (see below) is enforced by the
+`properties-added-in-version-shape` Spectral rule (severity `error`): each entry
+must be an object with exactly `propertyName` (non-empty string) and
+`addedInVersion` (matching `^[0-9]+\.[0-9]+(\.[0-9]+)?$`), no other keys.\
+Typos like `propertyame` or extra fields fail the file-level lint pass. Whether
+the annotation is _correct_ (right property, right version) is checked
+separately by the CI verifier linked below.
 
 #### Property-level annotation rules
 

--- a/docs/rest-api-endpoint-guidelines.md
+++ b/docs/rest-api-endpoint-guidelines.md
@@ -822,6 +822,8 @@ If you add a new endpoint without this annotation, CI will fail with a message s
 Operation "createMyResource" (POST /my-resources) is missing x-added-in-version. Every endpoint must declare the Camunda version in which it was introduced.
 ```
 
+The shape of `x-properties-added-in-version` (see below) is enforced by the `properties-added-in-version-shape` Spectral rule (severity `error`): each entry must be an object with exactly `propertyName` (non-empty string) and `addedInVersion` (matching `^[0-9]+\.[0-9]+(\.[0-9]+)?$`), no other keys. Typos like `propertyame` or extra fields fail the file-level lint pass. Whether the annotation is _correct_ (right property, right version) is checked separately by the CI verifier linked below.
+
 #### Property-level annotation rules
 
 The property-level rules are enforced in CI by the verifier under [`.github/scripts/x-added-in-version-check/`](../.github/scripts/x-added-in-version-check/README.md), which compares the spec against a generated version map.
@@ -1227,6 +1229,7 @@ The ruleset lives in `zeebe/gateway-protocol/.spectral.yaml`. Custom functions a
 | `no-eventually-consistent-on-commands`     | error    | Command operations must not have `x-eventually-consistent: true`                                  |
 | `valid-deprecated-enum-members`            | error    | `x-deprecated-enum-members` must be well-formed                                                   |
 | `require-added-in-version`                 | error    | Every operation must declare `x-added-in-version` (see §2.17)                                     |
+| `properties-added-in-version-shape`        | error    | `x-properties-added-in-version` entries must be `{propertyName, addedInVersion}` only (see §2.17) |
 | `oas3-valid-schema-example`                | error    | Schemas must be valid per OpenAPI 3.0 JSON Schema rules                                           |
 
 ### 3.4 Adding new Spectral rules

--- a/zeebe/gateway-protocol/.spectral.yaml
+++ b/zeebe/gateway-protocol/.spectral.yaml
@@ -251,6 +251,32 @@ rules:
     then:
       function: verifySemanticKindsRegistered
 
+  properties-added-in-version-shape:
+    description: "`x-properties-added-in-version` must be a non-empty array of `{propertyName, addedInVersion}` objects with no other keys."
+    severity: error
+    # Report at the schema's source location, not at every $ref consumer.
+    resolved: false
+    given: $..x-properties-added-in-version
+    then:
+      function: schema
+      functionOptions:
+        schema:
+          type: array
+          minItems: 1
+          items:
+            type: object
+            required: [propertyName, addedInVersion]
+            additionalProperties: false
+            properties:
+              propertyName:
+                type: string
+                minLength: 1
+                description: Name of the property (or filter operator like "$eq") this version annotation applies to.
+              addedInVersion:
+                type: string
+                pattern: "^[0-9]+\\.[0-9]+(\\.[0-9]+)?$"
+                description: Camunda version in which the property was introduced, e.g. "8.8".
+
   # Guard against new schemas introducing ambiguous bare identifier properties.
   # Existing schemas are grandfathered via the allowlist below — do not add new
   # entries without discussion. See https://github.com/camunda/camunda/issues/52510

--- a/zeebe/gateway-protocol/OPENAPI_VALIDATION.md
+++ b/zeebe/gateway-protocol/OPENAPI_VALIDATION.md
@@ -19,9 +19,10 @@ We use [Spectral CLI](https://docs.stoplight.io/docs/spectral/) to validate the 
   - Eventually-consistent annotation validation (command operations must not be marked as eventually consistent)
   - Required property existence validation (entries in required array must exist in properties)
   - Operation versioning annotation validation (every operation must declare `x-added-in-version`)
+  - Property versioning annotation shape validation (`x-properties-added-in-version` entries must be `{propertyName, addedInVersion}` only)
   - Semantic graph annotation shape + cross-reference validation (`x-semantic-establishes`, `x-semantic-requires`, `semantic-kinds.json` registry)
 
-> Property-level version annotations (`x-properties-added-in-version`) are validated by a separate Node verifier under [`.github/scripts/x-added-in-version-check/`](../../.github/scripts/x-added-in-version-check/README.md), not by Spectral. See §2.17 of [`docs/rest-api-endpoint-guidelines.md`](../../docs/rest-api-endpoint-guidelines.md) for the rules.
+> Property-level version annotations (`x-properties-added-in-version`) have their shape checked by the Spectral rule `properties-added-in-version-shape` (see below). Their semantic correctness (property exists, version is right) is validated in CI by a separate Node verifier under [`.github/scripts/x-added-in-version-check/`](../../.github/scripts/x-added-in-version-check/README.md). See §2.17 of [`docs/rest-api-endpoint-guidelines.md`](../../docs/rest-api-endpoint-guidelines.md) for the rules.
 
 ## Running Validation Locally
 
@@ -157,6 +158,32 @@ paths:
 ```
 
 Set the value to the version in which the endpoint **first** ships and do not update it on later changes. See §2.17 of [`docs/rest-api-endpoint-guidelines.md`](../../docs/rest-api-endpoint-guidelines.md) for the full convention.
+
+### Malformed `x-properties-added-in-version`
+
+The `properties-added-in-version-shape` rule (severity `error`) checks the shape of every `x-properties-added-in-version` annotation. It must be a non-empty array of `{propertyName, addedInVersion}` objects with no other keys, where `addedInVersion` matches `^[0-9]+\.[0-9]+(\.[0-9]+)?$` (e.g. `"8.8"`).
+
+The rule runs with `resolved: false` so paths point at the schema's source file. It fires in the file-level pass (`spectral lint "...*.yaml"`), not the entry-point pass on `rest-api.yaml`.
+
+**Wrong:**
+
+```yaml
+ProcessInstanceModificationInstruction:
+  x-properties-added-in-version:
+    - propertyame: moveInstructions   # ❌ typo: should be propertyName
+      addedInVersion: "8.8"
+```
+
+**Correct:**
+
+```yaml
+ProcessInstanceModificationInstruction:
+  x-properties-added-in-version:
+    - propertyName: moveInstructions
+      addedInVersion: "8.8"
+```
+
+Semantic correctness of these annotations (does the property actually exist? was it really introduced in that version?) is still validated in CI by the verifier under [`.github/scripts/x-added-in-version-check/`](../../.github/scripts/x-added-in-version-check/README.md) — the Spectral rule only checks shape.
 
 ### Semantic graph annotations (`x-semantic-establishes`, `x-semantic-requires`)
 

--- a/zeebe/gateway-protocol/spectral-tests/README.md
+++ b/zeebe/gateway-protocol/spectral-tests/README.md
@@ -36,5 +36,8 @@ spectral-tests/
    new `describe` block to an existing test file when the rule is closely
    related (e.g. `properties-added-in-version-shape` lives in
    `verifyAddedInVersion.test.js`).
-3. Run `node --test spectral-tests/<ruleName>.test.js` to verify.
+3. Run the test file you touched to verify — either the new
+   `node --test spectral-tests/<ruleName>.test.js`, or the existing one you
+   added the `describe` block to (e.g.
+   `node --test spectral-tests/verifyAddedInVersion.test.js`).
 

--- a/zeebe/gateway-protocol/spectral-tests/README.md
+++ b/zeebe/gateway-protocol/spectral-tests/README.md
@@ -32,6 +32,9 @@ spectral-tests/
 
 1. Create a fixture directory under `fixtures/<rule-name>/` with a multi-part
    YAML spec that exercises both valid and invalid cases.
-2. Create `<ruleName>.test.js` using the helpers from `helpers.js`.
+2. Create `<ruleName>.test.js` using the helpers from `helpers.js`, or add a
+   new `describe` block to an existing test file when the rule is closely
+   related (e.g. `properties-added-in-version-shape` lives in
+   `verifyAddedInVersion.test.js`).
 3. Run `node --test spectral-tests/<ruleName>.test.js` to verify.
 

--- a/zeebe/gateway-protocol/spectral-tests/fixtures/properties-added-in-version/rest-api.yaml
+++ b/zeebe/gateway-protocol/spectral-tests/fixtures/properties-added-in-version/rest-api.yaml
@@ -1,0 +1,141 @@
+# Test fixture for the `properties-added-in-version-shape` rule.
+# Each schema below isolates one valid or invalid shape so tests can
+# filter violations by schema name (which appears in the JSON path).
+openapi: "3.0.3"
+info:
+  title: Test Fixture — properties-added-in-version-shape
+  version: "1.0"
+tags:
+  - name: Test
+
+paths:
+  # A trivial operation so the spec parses as a valid OpenAPI document.
+  /noop:
+    get:
+      operationId: noop
+      summary: Noop
+      description: Noop
+      x-added-in-version: "8.8"
+      tags:
+        - Test
+      responses:
+        '200':
+          description: OK
+
+components:
+  schemas:
+    # ── Valid cases ──────────────────────────────────────────────
+
+    ValidPropsAddedInVersion:
+      description: Valid — single well-formed entry.
+      type: object
+      properties:
+        foo:
+          type: string
+          description: Foo.
+      x-properties-added-in-version:
+        - propertyName: foo
+          addedInVersion: "8.8"
+
+    ValidPropsAddedInVersionMultiple:
+      description: Valid — multiple entries with patch-level version.
+      type: object
+      properties:
+        foo:
+          type: string
+          description: Foo.
+        bar:
+          type: string
+          description: Bar.
+      x-properties-added-in-version:
+        - propertyName: foo
+          addedInVersion: "8.8"
+        - propertyName: bar
+          addedInVersion: "8.9.1"
+
+    ValidPropsAddedInVersionDollarOperator:
+      description: Valid — filter operator (e.g. "$eq") is allowed as propertyName.
+      type: object
+      properties:
+        foo:
+          type: string
+          description: Foo.
+      x-properties-added-in-version:
+        - propertyName: "$eq"
+          addedInVersion: "8.8"
+
+    # ── Invalid cases ────────────────────────────────────────────
+
+    InvalidPropsAddedInVersionNotArray:
+      description: Invalid — value is an object, not an array.
+      type: object
+      properties:
+        foo:
+          type: string
+          description: Foo.
+      x-properties-added-in-version:
+        propertyName: foo
+        addedInVersion: "8.8"
+
+    InvalidPropsAddedInVersionEmptyArray:
+      description: Invalid — empty array.
+      type: object
+      properties:
+        foo:
+          type: string
+          description: Foo.
+      x-properties-added-in-version: []
+
+    InvalidPropsAddedInVersionMissingPropertyName:
+      description: Invalid — entry is missing `propertyName`.
+      type: object
+      properties:
+        foo:
+          type: string
+          description: Foo.
+      x-properties-added-in-version:
+        - addedInVersion: "8.8"
+
+    InvalidPropsAddedInVersionMissingAddedInVersion:
+      description: Invalid — entry is missing `addedInVersion`.
+      type: object
+      properties:
+        foo:
+          type: string
+          description: Foo.
+      x-properties-added-in-version:
+        - propertyName: foo
+
+    InvalidPropsAddedInVersionExtraKey:
+      description: Invalid — entry has an unrecognised extra key.
+      type: object
+      properties:
+        foo:
+          type: string
+          description: Foo.
+      x-properties-added-in-version:
+        - propertyName: foo
+          addedInVersion: "8.8"
+          extra: nope
+
+    InvalidPropsAddedInVersionBadVersionFormat:
+      description: Invalid — `addedInVersion` does not match the semver-ish pattern.
+      type: object
+      properties:
+        foo:
+          type: string
+          description: Foo.
+      x-properties-added-in-version:
+        - propertyName: foo
+          addedInVersion: bogus
+
+    InvalidPropsAddedInVersionEmptyPropertyName:
+      description: Invalid — `propertyName` is the empty string.
+      type: object
+      properties:
+        foo:
+          type: string
+          description: Foo.
+      x-properties-added-in-version:
+        - propertyName: ""
+          addedInVersion: "8.8"

--- a/zeebe/gateway-protocol/spectral-tests/verifyAddedInVersion.test.js
+++ b/zeebe/gateway-protocol/spectral-tests/verifyAddedInVersion.test.js
@@ -2,10 +2,13 @@
 
 const { describe, it, before } = require('node:test');
 const assert = require('node:assert/strict');
-const { lintFixture, filterByRule } = require('./helpers');
+const { lintFixture, filterByRule, filterByPathSegment } = require('./helpers');
 
 const RULE = 'require-added-in-version';
 const FIXTURE = 'added-in-version';
+
+const PROPS_RULE = 'properties-added-in-version-shape';
+const PROPS_FIXTURE = 'properties-added-in-version';
 
 describe('verifyAddedInVersion', () => {
   let violations;
@@ -59,6 +62,97 @@ describe('verifyAddedInVersion', () => {
 
     it('produces exactly 2 violations total', () => {
       assert.equal(violations.length, 2);
+    });
+  });
+});
+
+describe('properties-added-in-version-shape', () => {
+  let violations;
+
+  before(() => {
+    const allResults = lintFixture(PROPS_FIXTURE);
+    violations = filterByRule(allResults, PROPS_RULE);
+  });
+
+  // ── Valid cases (should produce zero violations) ─────────────────
+
+  describe('valid shapes', () => {
+    it('accepts a single well-formed entry', () => {
+      assert.equal(
+        filterByPathSegment(violations, 'ValidPropsAddedInVersion').length,
+        0,
+      );
+    });
+
+    it('accepts multiple entries including patch-level versions', () => {
+      assert.equal(
+        filterByPathSegment(violations, 'ValidPropsAddedInVersionMultiple').length,
+        0,
+      );
+    });
+
+    it('accepts filter operator names (e.g. "$eq") as propertyName', () => {
+      assert.equal(
+        filterByPathSegment(violations, 'ValidPropsAddedInVersionDollarOperator').length,
+        0,
+      );
+    });
+  });
+
+  // ── Invalid cases ────────────────────────────────────────────────
+
+  describe('invalid shapes', () => {
+    it('rejects an object value instead of an array', () => {
+      assert.equal(
+        filterByPathSegment(violations, 'InvalidPropsAddedInVersionNotArray').length,
+        1,
+      );
+    });
+
+    it('rejects an empty array', () => {
+      assert.equal(
+        filterByPathSegment(violations, 'InvalidPropsAddedInVersionEmptyArray').length,
+        1,
+      );
+    });
+
+    it('rejects an entry missing propertyName', () => {
+      assert.equal(
+        filterByPathSegment(violations, 'InvalidPropsAddedInVersionMissingPropertyName').length,
+        1,
+      );
+    });
+
+    it('rejects an entry missing addedInVersion', () => {
+      assert.equal(
+        filterByPathSegment(violations, 'InvalidPropsAddedInVersionMissingAddedInVersion').length,
+        1,
+      );
+    });
+
+    it('rejects an entry with an unrecognised extra key', () => {
+      assert.equal(
+        filterByPathSegment(violations, 'InvalidPropsAddedInVersionExtraKey').length,
+        1,
+      );
+    });
+
+    it('rejects addedInVersion that is not in semver-ish form', () => {
+      assert.equal(
+        filterByPathSegment(violations, 'InvalidPropsAddedInVersionBadVersionFormat').length,
+        1,
+      );
+    });
+
+    it('rejects an empty propertyName', () => {
+      assert.equal(
+        filterByPathSegment(violations, 'InvalidPropsAddedInVersionEmptyPropertyName').length,
+        1,
+      );
+    });
+
+    it('produces exactly one violation per invalid schema (7 total)', () => {
+      assert.equal(violations.length, 7);
     });
   });
 });


### PR DESCRIPTION
Added a Spectral lint rule: `properties-added-in-version-shape` for structure check of x-properties-added-in-version array

## Description

<!-- Describe the goal and purpose of this PR. -->

The `properties-added-in-version-shape` rule checks that `x-properties-added-in-version` if present, must be a non-empty array of `{propertyName, addedInVersion}` objects with no other keys.

## Related issues
closes #53761
