### PR TITLE
ci: add owner to lint task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1934,7 +1934,7 @@ jobs:
 
   openapi-lint:
     # Owner: CamundaEx
-    # Tag: @camunda-ex-medic
+    # Support: @camunda-ex-medic
     # Slack team: #team-camunda-ex
     name: "Lint / C8 REST OpenAPI"
     if: needs.detect-changes.outputs.openapi-changes == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1933,6 +1933,8 @@ jobs:
           user_description: "General"
 
   openapi-lint:
+    # Owner: CamundaEx
+    # Slack: #team-camunda-ex
     name: "Lint / C8 REST OpenAPI"
     if: needs.detect-changes.outputs.openapi-changes == 'true'
     needs: [ detect-changes ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1934,7 +1934,8 @@ jobs:
 
   openapi-lint:
     # Owner: CamundaEx
-    # Slack: #team-camunda-ex
+    # Tag: @camunda-ex-medic
+    # Slack team: #team-camunda-ex
     name: "Lint / C8 REST OpenAPI"
     if: needs.detect-changes.outputs.openapi-changes == 'true'
     needs: [ detect-changes ]


### PR DESCRIPTION
## Description

Add owner and contact details to OpenAPI Lint task for transparency.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
