### PR TITLE
fix: add delay to message completion handling in Worker

### DIFF
--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/worker/Worker.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/worker/Worker.java
@@ -106,6 +106,11 @@ public class Worker {
         //
         // On the next job/message published the chances are (partition count - 1 / partition
         // count) that we hit another partition where it works without issues.
+        //
+        // Apply the same completion delay as the success path before returning. Without it the
+        // handler returns immediately, the client re-polls at full speed, and we keep hammering
+        // the struggling partition, defeating the time-out-and-retry strategy above.
+        addDelayToCompletion(workerCfg.getCompletionDelay().toMillis(), startHandlingTime);
         return;
       }
     }


### PR DESCRIPTION
## Description

This pull request introduces a minor update to the job handling logic in the Zeebe worker. Now, when a specific condition is met, a delay is added before completing the job, which is based on the configured completion delay.

* Added a call to `addDelayToCompletion` using the value from `workerCfg.getCompletionDelay()` in the `handleJob` method to introduce a configurable delay before job completion.

## Checklist

<!--- Please delete options that are not relevant. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [x] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
