### PR TITLE
Clean up start event subscriptions on process definition deletion

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/MessageSubscriptionMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/MessageSubscriptionMapper.java
@@ -26,4 +26,7 @@ public interface MessageSubscriptionMapper
 
   List<ProcessDefinitionMessageSubscriptionStatisticsEntity> getProcessDefinitionStatistics(
       ProcessDefinitionMessageSubscriptionStatisticsDbQuery query);
+
+  int deleteStartEventSubscriptionsByProcessDefinitionKeys(
+      List<Long> processDefinitionKeys, int limit);
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryDeletionService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryDeletionService.java
@@ -153,6 +153,15 @@ public class HistoryDeletionService {
       return List.of();
     }
 
+    final var limit = config.dependentRowLimit();
+    final int deletedSubscriptions =
+        rdbmsWriters
+            .getMessageSubscriptionWriter()
+            .deleteStartEventSubscriptionsByProcessDefinitionKeys(processDefinitionKeys, limit);
+    if (deletedSubscriptions >= limit) {
+      return List.of();
+    }
+
     rdbmsWriters.getProcessDefinitionWriter().deleteByKeys(processDefinitionKeys);
     scheduleAuditLogDataForDeletion(
         processDefinitionKeys, HistoryDeletionTypeDbModel.PROCESS_DEFINITION);

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/MessageSubscriptionWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/MessageSubscriptionWriter.java
@@ -14,9 +14,11 @@ import io.camunda.db.rdbms.write.queue.ContextType;
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.queue.QueueItem;
 import io.camunda.db.rdbms.write.queue.WriteStatementType;
+import java.util.List;
 
 public class MessageSubscriptionWriter extends ProcessInstanceDependant implements RdbmsWriter {
 
+  private final MessageSubscriptionMapper mapper;
   private final ExecutionQueue executionQueue;
   private final VendorDatabaseProperties vendorDatabaseProperties;
 
@@ -25,6 +27,7 @@ public class MessageSubscriptionWriter extends ProcessInstanceDependant implemen
       final MessageSubscriptionMapper mapper,
       final VendorDatabaseProperties vendorDatabaseProperties) {
     super(mapper);
+    this.mapper = mapper;
     this.executionQueue = executionQueue;
     this.vendorDatabaseProperties = vendorDatabaseProperties;
   }
@@ -53,5 +56,11 @@ public class MessageSubscriptionWriter extends ProcessInstanceDependant implemen
             messageSubscription.messageSubscriptionKey(),
             "io.camunda.db.rdbms.sql.MessageSubscriptionMapper.update",
             messageSubscription));
+  }
+
+  public int deleteStartEventSubscriptionsByProcessDefinitionKeys(
+      final List<Long> processDefinitionKeys, final int limit) {
+    return mapper.deleteStartEventSubscriptionsByProcessDefinitionKeys(
+        processDefinitionKeys, limit);
   }
 }

--- a/db/rdbms/src/main/resources/mapper/MessageSubscriptionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/MessageSubscriptionMapper.xml
@@ -278,6 +278,50 @@
     <include refid="io.camunda.db.rdbms.sql.Commons.processInstanceHistoryDeletion"/>
   </delete>
 
+  <delete id="deleteStartEventSubscriptionsByProcessDefinitionKeys">
+    DELETE FROM ${prefix}MESSAGE_SUBSCRIPTION
+    WHERE PROCESS_DEFINITION_KEY IN
+    <foreach collection="processDefinitionKeys" item="key" open="(" separator="," close=")">
+      #{key}
+    </foreach>
+    AND MESSAGE_SUBSCRIPTION_TYPE = 'START_EVENT'
+    LIMIT #{limit}
+  </delete>
+
+  <delete id="deleteStartEventSubscriptionsByProcessDefinitionKeys" databaseId="mssql">
+    DELETE TOP (#{limit})
+    FROM ${prefix}MESSAGE_SUBSCRIPTION
+    WHERE PROCESS_DEFINITION_KEY IN
+    <foreach collection="processDefinitionKeys" item="key" open="(" separator="," close=")">
+      #{key}
+    </foreach>
+    AND MESSAGE_SUBSCRIPTION_TYPE = 'START_EVENT'
+  </delete>
+
+  <delete id="deleteStartEventSubscriptionsByProcessDefinitionKeys" databaseId="oracle">
+    DELETE FROM ${prefix}MESSAGE_SUBSCRIPTION
+    WHERE rowid IN (SELECT rowid
+                    FROM ${prefix}MESSAGE_SUBSCRIPTION
+                    WHERE PROCESS_DEFINITION_KEY IN
+                    <foreach collection="processDefinitionKeys" item="key" open="(" separator="," close=")">
+                      #{key}
+                    </foreach>
+                    AND MESSAGE_SUBSCRIPTION_TYPE = 'START_EVENT'
+                    AND ROWNUM &lt;= #{limit})
+  </delete>
+
+  <delete id="deleteStartEventSubscriptionsByProcessDefinitionKeys" databaseId="postgresql">
+    DELETE FROM ${prefix}MESSAGE_SUBSCRIPTION
+    WHERE ctid IN (SELECT ctid
+                   FROM ${prefix}MESSAGE_SUBSCRIPTION
+                   WHERE PROCESS_DEFINITION_KEY IN
+                   <foreach collection="processDefinitionKeys" item="key" open="(" separator="," close=")">
+                     #{key}
+                   </foreach>
+                   AND MESSAGE_SUBSCRIPTION_TYPE = 'START_EVENT'
+                   LIMIT #{limit})
+  </delete>
+
   <!-- Message Subscription Process Definition Statistics Aggregation -->
   <select id="getProcessDefinitionStatistics"
     parameterType="io.camunda.db.rdbms.read.domain.ProcessDefinitionMessageSubscriptionStatisticsDbQuery"

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryDeletionServiceTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryDeletionServiceTest.java
@@ -190,6 +190,59 @@ public class HistoryDeletionServiceTest {
   }
 
   @Test
+  void shouldDeleteStartEventSubscriptionsWhenDeletingProcessDefinition() {
+    // given
+    final var partitionId = 1;
+    final var processDefinitionKey1 = 1L;
+    final var processDefinitionKey2 = 2L;
+    when(historyDeletionDbReaderMock.getNextBatch(anyInt(), anyInt()))
+        .thenReturn(
+            new HistoryDeletionBatch(
+                List.of(
+                    createModel(
+                        processDefinitionKey1, HistoryDeletionTypeDbModel.PROCESS_DEFINITION),
+                    createModel(
+                        processDefinitionKey2, HistoryDeletionTypeDbModel.PROCESS_DEFINITION))));
+    when(processInstanceDbReaderMock.search(any())).thenReturn(SearchQueryResult.empty());
+
+    // when
+    historyDeletionService.deleteHistory(partitionId);
+
+    // then
+    verify(rdbmsWritersMock.getMessageSubscriptionWriter())
+        .deleteStartEventSubscriptionsByProcessDefinitionKeys(
+            eq(List.of(processDefinitionKey1, processDefinitionKey2)), anyInt());
+    verify(rdbmsWritersMock.getProcessDefinitionWriter())
+        .deleteByKeys(List.of(processDefinitionKey1, processDefinitionKey2));
+  }
+
+  @Test
+  void shouldNotDeleteProcessDefinitionIfStartEventSubscriptionsNotFullyDeleted() {
+    // given
+    final var partitionId = 1;
+    final var processDefinitionKey = 1L;
+    when(historyDeletionDbReaderMock.getNextBatch(anyInt(), anyInt()))
+        .thenReturn(
+            new HistoryDeletionBatch(
+                List.of(
+                    createModel(
+                        processDefinitionKey, HistoryDeletionTypeDbModel.PROCESS_DEFINITION))));
+    when(processInstanceDbReaderMock.search(any())).thenReturn(SearchQueryResult.empty());
+    when(rdbmsWritersMock
+            .getMessageSubscriptionWriter()
+            .deleteStartEventSubscriptionsByProcessDefinitionKeys(
+                List.of(processDefinitionKey), LIMIT))
+        .thenReturn(LIMIT);
+
+    // when
+    historyDeletionService.deleteHistory(partitionId);
+
+    // then
+    verify(rdbmsWritersMock.getProcessDefinitionWriter(), never()).deleteByKeys(anyList());
+    verify(rdbmsWritersMock.getHistoryDeletionWriter(), never()).deleteByResourceKeys(anyList());
+  }
+
+  @Test
   void shouldApplyExponentialBackoffIfNothingToDelete() {
     // given
     final var partitionId = 1;

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/historydeletion/DeleteProcessDefinitionHistoryIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/historydeletion/DeleteProcessDefinitionHistoryIT.java
@@ -12,6 +12,7 @@ import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
 import static io.camunda.it.util.TestHelper.startProcessInstance;
 import static io.camunda.it.util.TestHelper.waitForBatchOperationCompleted;
 import static io.camunda.it.util.TestHelper.waitForBatchOperationWithCorrectTotalCount;
+import static io.camunda.it.util.TestHelper.waitForMessageSubscriptions;
 import static io.camunda.it.util.TestHelper.waitForProcessInstances;
 import static io.camunda.it.util.TestHelper.waitForProcesses;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -20,6 +21,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOf
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.response.DeleteResourceResponse;
+import io.camunda.client.api.search.enums.MessageSubscriptionType;
 import io.camunda.client.api.search.enums.ProcessInstanceState;
 import io.camunda.configuration.HistoryDeletion;
 import io.camunda.qa.util.multidb.MultiDbTest;
@@ -242,6 +244,117 @@ public class DeleteProcessDefinitionHistoryIT {
               assertThat(exception.code()).isEqualTo(404);
               assertThat(exception.details().getDetail()).containsIgnoringCase("NOT_FOUND");
             });
+  }
+
+  @Test
+  void shouldDeleteStartEventSubscriptionsWhenDeletingProcessDefinitionWithHistory() {
+    // given - a deployed process with a message start event (no instances started)
+    final var processId = Strings.newRandomValidBpmnId();
+    final var messageName = "start-" + processId;
+    final var process =
+        deployProcessAndWaitForIt(
+            camundaClient,
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .message(m -> m.name(messageName).id("startMessage"))
+                .endEvent()
+                .done(),
+            processId + ".bpmn");
+    final var processDefinitionKey = process.getProcessDefinitionKey();
+
+    // wait for the start event subscription to be indexed
+    waitForMessageSubscriptions(
+        camundaClient,
+        f ->
+            f.processDefinitionKey(processDefinitionKey)
+                .messageSubscriptionType(MessageSubscriptionType.START_EVENT),
+        1);
+
+    // when - delete the process definition with history
+    camundaClient.newDeleteResourceCommand(processDefinitionKey).deleteHistory(true).send().join();
+
+    // then - the process definition and its start event subscriptions are deleted
+    assertProcessDefinitionDeleted(camundaClient, processDefinitionKey);
+    Awaitility.await("Start event subscriptions should be deleted")
+        .atMost(DELETION_TIMEOUT)
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var subscriptions =
+                  camundaClient
+                      .newMessageSubscriptionSearchRequest()
+                      .filter(
+                          f ->
+                              f.processDefinitionKey(processDefinitionKey)
+                                  .messageSubscriptionType(MessageSubscriptionType.START_EVENT))
+                      .send()
+                      .join()
+                      .items();
+              assertThat(subscriptions).isEmpty();
+            });
+  }
+
+  @Test
+  void shouldNotDeleteStartEventSubscriptionsWhenDeletingProcessInstanceHistory() {
+    // given - a process with a message start event that has created a process instance
+    final var processId = Strings.newRandomValidBpmnId();
+    final var messageName = "start-" + processId;
+    final var process =
+        deployProcessAndWaitForIt(
+            camundaClient,
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .message(m -> m.name(messageName).id("startMessage"))
+                .endEvent()
+                .done(),
+            processId + ".bpmn");
+    final var processDefinitionKey = process.getProcessDefinitionKey();
+
+    // wait for the start event subscription to appear
+    waitForMessageSubscriptions(
+        camundaClient,
+        f ->
+            f.processDefinitionKey(processDefinitionKey)
+                .messageSubscriptionType(MessageSubscriptionType.START_EVENT),
+        1);
+
+    // trigger the start event to create a process instance and wait for it to complete
+    camundaClient
+        .newPublishMessageCommand()
+        .messageName(messageName)
+        .correlationKey("")
+        .send()
+        .join();
+    waitForProcessInstances(
+        camundaClient,
+        f -> f.processDefinitionId(processId).state(ProcessInstanceState.COMPLETED),
+        1);
+    final var piKey =
+        camundaClient
+            .newProcessInstanceSearchRequest()
+            .filter(f -> f.processDefinitionId(processId))
+            .send()
+            .join()
+            .items()
+            .getFirst()
+            .getProcessInstanceKey();
+
+    // when - delete the process instance history
+    camundaClient.newDeleteProcessInstanceCommand(piKey).send().join();
+    assertAllProcessInstanceDependantDataDeleted(camundaClient, piKey);
+
+    // then - start event subscription should still exist after PI history deletion
+    final var remainingSubscriptions =
+        camundaClient
+            .newMessageSubscriptionSearchRequest()
+            .filter(
+                f ->
+                    f.processDefinitionKey(processDefinitionKey)
+                        .messageSubscriptionType(MessageSubscriptionType.START_EVENT))
+            .send()
+            .join()
+            .items();
+    assertThat(remainingSubscriptions).hasSize(1);
   }
 
   /** Asserts that a process definition has been deleted from secondary storage. */

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/historydeletion/DeleteProcessDefinitionHistoryIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/historydeletion/DeleteProcessDefinitionHistoryIT.java
@@ -357,6 +357,84 @@ public class DeleteProcessDefinitionHistoryIT {
     assertThat(remainingSubscriptions).hasSize(1);
   }
 
+  @Test
+  void shouldNotDeleteStartEventSubscriptionsOfOtherProcessDefinition() {
+    // given - two process definitions each with a message start event
+    final var processIdA = Strings.newRandomValidBpmnId();
+    final var messageNameA = "start-" + processIdA;
+    final var processA =
+        deployProcessAndWaitForIt(
+            camundaClient,
+            Bpmn.createExecutableProcess(processIdA)
+                .startEvent()
+                .message(m -> m.name(messageNameA).id("startMessage"))
+                .endEvent()
+                .done(),
+            processIdA + ".bpmn");
+    final var processDefinitionKeyA = processA.getProcessDefinitionKey();
+
+    final var processIdB = Strings.newRandomValidBpmnId();
+    final var messageNameB = "start-" + processIdB;
+    final var processB =
+        deployProcessAndWaitForIt(
+            camundaClient,
+            Bpmn.createExecutableProcess(processIdB)
+                .startEvent()
+                .message(m -> m.name(messageNameB).id("startMessage"))
+                .endEvent()
+                .done(),
+            processIdB + ".bpmn");
+    final var processDefinitionKeyB = processB.getProcessDefinitionKey();
+
+    waitForMessageSubscriptions(
+        camundaClient,
+        f ->
+            f.processDefinitionKey(processDefinitionKeyA)
+                .messageSubscriptionType(MessageSubscriptionType.START_EVENT),
+        1);
+    waitForMessageSubscriptions(
+        camundaClient,
+        f ->
+            f.processDefinitionKey(processDefinitionKeyB)
+                .messageSubscriptionType(MessageSubscriptionType.START_EVENT),
+        1);
+
+    // when - delete only process definition A with history
+    camundaClient.newDeleteResourceCommand(processDefinitionKeyA).deleteHistory(true).send().join();
+
+    // then - A's subscriptions are deleted, B's subscriptions remain untouched
+    assertProcessDefinitionDeleted(camundaClient, processDefinitionKeyA);
+    Awaitility.await("Start event subscriptions of A should be deleted")
+        .atMost(DELETION_TIMEOUT)
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newMessageSubscriptionSearchRequest()
+                            .filter(
+                                f ->
+                                    f.processDefinitionKey(processDefinitionKeyA)
+                                        .messageSubscriptionType(
+                                            MessageSubscriptionType.START_EVENT))
+                            .send()
+                            .join()
+                            .items())
+                    .isEmpty());
+
+    final var remainingSubscriptions =
+        camundaClient
+            .newMessageSubscriptionSearchRequest()
+            .filter(
+                f ->
+                    f.processDefinitionKey(processDefinitionKeyB)
+                        .messageSubscriptionType(MessageSubscriptionType.START_EVENT))
+            .send()
+            .join()
+            .items();
+    assertThat(remainingSubscriptions).hasSize(1);
+  }
+
   /** Asserts that a process definition has been deleted from secondary storage. */
   private void assertProcessDefinitionDeleted(
       final CamundaClient client, final long processDefinitionKey) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/historydeletion/HistoryDeletionJob.java
@@ -17,6 +17,7 @@ import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
 import io.camunda.webapps.schema.descriptors.template.AuditLogTemplate;
 import io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
+import io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate;
 import io.camunda.webapps.schema.descriptors.template.OperationTemplate;
 import io.camunda.zeebe.exporter.common.tasks.BackgroundTask;
 import io.camunda.zeebe.protocol.record.value.HistoryDeletionType;
@@ -50,6 +51,7 @@ public class HistoryDeletionJob implements BackgroundTask {
   private final DecisionInstanceTemplate decisionInstanceTemplate;
   private final DecisionRequirementsIndex decisionRequirementsIndex;
   private final DecisionIndex decisionIndex;
+  private final MessageSubscriptionTemplate messageSubscriptionTemplate;
 
   public HistoryDeletionJob(
       final List<ProcessInstanceDependant> processInstanceDependants,
@@ -72,6 +74,8 @@ public class HistoryDeletionJob implements BackgroundTask {
     decisionRequirementsIndex =
         resourceProvider.getIndexDescriptor(DecisionRequirementsIndex.class);
     decisionIndex = resourceProvider.getIndexDescriptor(DecisionIndex.class);
+    messageSubscriptionTemplate =
+        resourceProvider.getIndexTemplateDescriptor(MessageSubscriptionTemplate.class);
   }
 
   @Override
@@ -206,9 +210,15 @@ public class HistoryDeletionJob implements BackgroundTask {
     }
 
     return deleterRepository
-        .deleteDocumentsById(
-            processIndex.getFullQualifiedName(),
-            processDefinitions.stream().map(Object::toString).toList())
+        .deleteDocumentsByField(
+            messageSubscriptionTemplate.getIndexPattern(),
+            MessageSubscriptionTemplate.PROCESS_KEY,
+            processDefinitions)
+        .thenCompose(
+            ignored ->
+                deleterRepository.deleteDocumentsById(
+                    processIndex.getFullQualifiedName(),
+                    processDefinitions.stream().map(Object::toString).toList()))
         .thenApply(
             ignored -> {
               final var ids = new ArrayList<>(deletedResourceIds);


### PR DESCRIPTION
## Description

Start event message subscriptions are definition-scoped and have no
processInstanceKey, so the ProcessInstanceDependant archiver skips them.
When a process definition is deleted with history, its start event
subscriptions must also be cleaned up explicitly.

RDBMS: add deleteStartEventSubscriptionsByProcessDefinitionKeys() to
MessageSubscriptionWriter/Mapper (all four DB dialects) and call it in
HistoryDeletionService.deleteProcessDefinitions() before removing the
process definition record, mirroring the guard pattern used for decision
requirements.

ES/OS: chain a deleteDocumentsByField() call on the message subscription
template in HistoryDeletionJob.deleteProcessDefinitions() before deleting
the process definition document.

## Related issues

closes #51043 