### PR TITLE
chore(optimize): document id/key naming conventions

### DIFF
--- a/optimize/AGENTS.md
+++ b/optimize/AGENTS.md
@@ -25,14 +25,11 @@ C8 (Zeebe) world **inverts** the meaning of "Key" and "Id":
 This naming is **intentionally kept** and must not be changed. The decision is documented in
 [`docs/adr/001-c7-naming-conventions.md`](docs/adr/001-c7-naming-conventions.md).
 
-This convention applies to Optimize fields that represent Zeebe-derived process, decision, and
-instance identifiers, not to every `...Id` / `...Key` field in the codebase. In those cases,
-`...Id` typically holds the unique Zeebe `Long` key (often stored as `String`), while `...Key`
-holds the non-unique BPMN/DMN identifier string. For example, `flowNodeInstanceId` is the unique
-Long key for a flow node instance, not a human-readable string. Generic identifiers such as
-`tenantId`, `userId`, and similar fields are exceptions and must be interpreted according to their
-own domain semantics. When in doubt, verify the specific field usage instead of assuming the C7
-convention always applies.
+This convention applies across the entire Optimize codebase, not just process definitions. Any
+field whose name ends in `...Id` holds a unique identifier, and any field whose name ends in
+`...Key` holds a non-unique string — regardless of entity type. For example,
+`flowNodeInstanceId` is the unique Long key for a flow node instance, not a human-readable string.
+When in doubt, assume the C7 convention applies.
 
 When you see `processDefinitionKey` holding a string like `"invoice-process"`, that is **correct**
 C7 usage. Do **not** rename it to `processDefinitionId` or add

--- a/optimize/AGENTS.md
+++ b/optimize/AGENTS.md
@@ -1,0 +1,59 @@
+# Optimize Module — Agent Instructions
+
+Read the monorepo-wide agent instructions first:
+
+@../AGENTS.md
+
+---
+
+## Optimize-Specific Notes
+
+### C7/C8 Terminology Warning
+
+**Do not confuse `...Id` fields with `...Key` fields, they hold opposite types of values to what C8
+developers may expect. Do not rename Optimize's DTO fields or ES/OS index field constants to match
+C8 naming conventions.**
+
+Optimize was built for Camunda 7 and retains C7 identifier terminology throughout its backend. The
+C8 (Zeebe) world **inverts** the meaning of "Key" and "Id":
+
+|   Term   |                C7 meaning (used in Optimize)                |        C8 / Zeebe meaning         |
+|----------|-------------------------------------------------------------|-----------------------------------|
+| `...Key` | Non-unique BPMN process ID string, e.g. `"invoice-process"` | Unique `Long` identifier          |
+| `...Id`  | Unique `Long` identifier (often stored as `String`)         | Non-unique BPMN process ID string |
+
+This naming is **intentionally kept** and must not be changed. The decision is documented in
+[`docs/adr/001-c7-naming-conventions.md`](docs/adr/001-c7-naming-conventions.md).
+
+This convention applies to Optimize fields that represent Zeebe-derived process, decision, and
+instance identifiers, not to every `...Id` / `...Key` field in the codebase. In those cases,
+`...Id` typically holds the unique Zeebe `Long` key (often stored as `String`), while `...Key`
+holds the non-unique BPMN/DMN identifier string. For example, `flowNodeInstanceId` is the unique
+Long key for a flow node instance, not a human-readable string. Generic identifiers such as
+`tenantId`, `userId`, and similar fields are exceptions and must be interpreted according to their
+own domain semantics. When in doubt, verify the specific field usage instead of assuming the C7
+convention always applies.
+
+When you see `processDefinitionKey` holding a string like `"invoice-process"`, that is **correct**
+C7 usage. Do **not** rename it to `processDefinitionId` or add
+`@JsonProperty("processDefinitionKey")` in an attempt to "fix" it.
+
+For the complete field-by-field mapping between Optimize names and C8 Zeebe names, you can use the
+Zeebe import service code as reference.
+
+### Build
+
+Optimize is skipped by `-Dquickly` at the monorepo level. To build only Optimize:
+
+```bash
+./mvnw install -pl optimize -am -T1C
+```
+
+Frontend (Yarn — see `.github/instructions/frontend.instructions.md` for details):
+
+```bash
+cd optimize/client
+yarn install
+yarn build
+```
+

--- a/optimize/CLAUDE.md
+++ b/optimize/CLAUDE.md
@@ -1,31 +1,5 @@
-# Optimize Module — AI Agent Notes
+# CLAUDE.md
 
-## C7/C8 Terminology Warning
+Read `AGENTS.md` for monorepo-wide commands, rules, and Optimize-specific agent instructions.
 
-**Do not confuse `...Id` fields with `...Key` fields, they hold opposite types of values to what C8
-developers may expect. Do not rename Optimize's DTO fields or ES/OS index field constants to match
-C8 naming conventions.**
-
-Optimize was built for Camunda 7 and retains C7 identifier terminology throughout its backend. The
-C8 (Zeebe) world **inverts** the meaning of "Key" and "Id":
-
-|   Term   |                C7 meaning (used in Optimize)                |        C8 / Zeebe meaning         |
-|----------|-------------------------------------------------------------|-----------------------------------|
-| `...Key` | Non-unique BPMN process ID string, e.g. `"invoice-process"` | Unique `Long` identifier          |
-| `...Id`  | Unique `Long` identifier (often stored as `String`)         | Non-unique BPMN process ID string |
-
-This naming is **intentionally kept** and must not be changed. The decision is documented in
-[`docs/adr/001-c7-naming-conventions.md`](docs/adr/001-c7-naming-conventions.md).
-
-This convention applies across the entire Optimize codebase, not just process definitions. Any
-field whose name ends in `...Id` holds a unique identifier, and any field whose name ends in
-`...Key` holds a non-unique string — regardless of entity type. For example,
-`flowNodeInstanceId` is the unique Long key for a flow node instance, not a human-readable string.
-When in doubt, assume the C7 convention applies.
-
-When you see `processDefinitionKey` holding a string like `"invoice-process"`, that is **correct**
-C7 usage. Do **not** rename it to `processDefinitionId` or add
-`@JsonProperty("processDefinitionKey")` in an attempt to "fix" it.
-
-For the complete field-by-field mapping between Optimize names and C8 Zeebe names, you can use the
-Zeebe import service code as reference.
+@AGENTS.md

--- a/optimize/CLAUDE.md
+++ b/optimize/CLAUDE.md
@@ -1,0 +1,31 @@
+# Optimize Module — AI Agent Notes
+
+## C7/C8 Terminology Warning
+
+**Do not confuse `...Id` fields with `...Key` fields, they hold opposite types of values to what C8
+developers may expect. Do not rename Optimize's DTO fields or ES/OS index field constants to match
+C8 naming conventions.**
+
+Optimize was built for Camunda 7 and retains C7 identifier terminology throughout its backend. The
+C8 (Zeebe) world **inverts** the meaning of "Key" and "Id":
+
+|   Term   |                C7 meaning (used in Optimize)                |        C8 / Zeebe meaning         |
+|----------|-------------------------------------------------------------|-----------------------------------|
+| `...Key` | Non-unique BPMN process ID string, e.g. `"invoice-process"` | Unique `Long` identifier          |
+| `...Id`  | Unique `Long` identifier (often stored as `String`)         | Non-unique BPMN process ID string |
+
+This naming is **intentionally kept** and must not be changed. The decision is documented in
+[`docs/adr/001-c7-naming-conventions.md`](docs/adr/001-c7-naming-conventions.md).
+
+This convention applies across the entire Optimize codebase, not just process definitions. Any
+field whose name ends in `...Id` holds a unique identifier, and any field whose name ends in
+`...Key` holds a non-unique string — regardless of entity type. For example,
+`flowNodeInstanceId` is the unique Long key for a flow node instance, not a human-readable string.
+When in doubt, assume the C7 convention applies.
+
+When you see `processDefinitionKey` holding a string like `"invoice-process"`, that is **correct**
+C7 usage. Do **not** rename it to `processDefinitionId` or add
+`@JsonProperty("processDefinitionKey")` in an attempt to "fix" it.
+
+For the complete field-by-field mapping between Optimize names and C8 Zeebe names, you can use the
+Zeebe import service code as reference.

--- a/optimize/README.md
+++ b/optimize/README.md
@@ -72,8 +72,8 @@ CAMUNDA_OPTIMIZE_IDENTITY_AUDIENCE=[audience]
 Key design decisions are recorded in [`docs/adr/`](docs/adr/):
 
 - [ADR-001: Retain Camunda 7 Naming Conventions](docs/adr/001-c7-naming-conventions.md) — why
-  Optimize's DTO fields and ES/OS index names use C7 terminology (eg `processDefinitionKey`
-  for the BPMN string, `processDefinitionId` for the unique Long) rather than C8/Zeebe
+  Optimize's DTO fields and ES/OS index names use C7 terminology (e.g. `processDefinitionKey`
+  for the BPMN string, `processDefinitionId` for the unique `Long`) rather than C8/Zeebe
   conventions.
 
 ## F.A.Q

--- a/optimize/README.md
+++ b/optimize/README.md
@@ -67,6 +67,15 @@ CAMUNDA_OPTIMIZE_IDENTITY_CLIENTSECRET=[must match the one in docker-compose.ccs
 CAMUNDA_OPTIMIZE_IDENTITY_AUDIENCE=[audience]
 ```
 
+## Architecture Decisions
+
+Key design decisions are recorded in [`docs/adr/`](docs/adr/):
+
+- [ADR-001: Retain Camunda 7 Naming Conventions](docs/adr/001-c7-naming-conventions.md) — why
+  Optimize's DTO fields and ES/OS index names use C7 terminology (eg `processDefinitionKey`
+  for the BPMN string, `processDefinitionId` for the unique Long) rather than C8/Zeebe
+  conventions.
+
 ## F.A.Q
 
 # Docker is telling me that I do not have the rights to pull the images

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/importing/engine/service/zeebe/ZeebeProcessDefinitionImportService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/importing/engine/service/zeebe/ZeebeProcessDefinitionImportService.java
@@ -103,6 +103,16 @@ public class ZeebeProcessDefinitionImportService
     return procDefImportJob;
   }
 
+  /**
+   * Maps a single Zeebe process definition record to an Optimize DTO.
+   *
+   * <p><b>Terminology note:</b> Optimize uses C7 conventions where {@code id} is the unique
+   * identifier and {@code key} is the non-unique BPMN string. This is the <em>inverse</em> of C8
+   * conventions.
+   *
+   * <p>Do not rename the DTO fields or swap these assignments. See {@code
+   * optimize/docs/adr/001-c7-naming-conventions.md} for the full rationale.
+   */
   private ProcessDefinitionOptimizeDto mapZeebeRecordsToOptimizeEntities(
       final ZeebeProcessDefinitionRecordDto zeebeProcessDefinitionRecord) {
     final ZeebeProcessDefinitionDataDto recordData = zeebeProcessDefinitionRecord.getValue();

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/importing/engine/service/zeebe/ZeebeProcessInstanceSubEntityImportService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/importing/engine/service/zeebe/ZeebeProcessInstanceSubEntityImportService.java
@@ -68,6 +68,24 @@ public abstract class ZeebeProcessInstanceSubEntityImportService<T> implements I
     return databaseImportJobExecutor;
   }
 
+  /**
+   * Creates a skeleton {@link ProcessInstanceDto} from Zeebe identifiers, translating them into
+   * Optimize's C7-based field naming convention.
+   *
+   * <p><b>Terminology note:</b> Optimize uses C7 naming throughout its data model and ES/OS
+   * indices, which is the <em>inverse</em> of C8 conventions.
+   *
+   * <p>This mapping is intentional. Do not rename the DTO fields. See {@code
+   * optimize/docs/adr/001-c7-naming-conventions.md} for the full rationale.
+   *
+   * @param processDefinitionKey the Zeebe {@code bpmnProcessId} — the non-unique BPMN process ID
+   *     string (e.g. {@code "invoice-process"})
+   * @param processInstanceId the Zeebe {@code processInstanceKey} — the unique {@code Long} key for
+   *     this process instance
+   * @param processDefinitionId the Zeebe {@code processDefinitionKey} — the unique {@code Long} key
+   *     for the process definition version
+   * @param tenantId the tenant identifier
+   */
   protected ProcessInstanceDto createSkeletonProcessInstance(
       final String processDefinitionKey,
       final Long processInstanceId,

--- a/optimize/docs/adr/001-c7-naming-conventions.md
+++ b/optimize/docs/adr/001-c7-naming-conventions.md
@@ -1,0 +1,58 @@
+# Optimize retains Camunda 7 identifier naming conventions
+
+**DRI**: BI team
+
+**Status**: Accepted (8.x)
+
+**Purpose**: Explain why Optimize's DTO fields and ES/OS index field names use C7
+terminology rather than C8/Zeebe conventions
+
+**Audience**: Engineers and AI coding agents working on the Optimize BE
+
+## Context
+
+Optimize was originally built for Camunda 7 and uses C7 identifier terminology throughout its data
+model, ES/OS index field names, and REST API responses.
+
+C7 and C8 use opposite conventions for the terms "Key" and "Id":
+
+|   Term   |                C7 meaning (used in Optimize)                |           C8 / Zeebe meaning            |
+|----------|-------------------------------------------------------------|-----------------------------------------|
+| `...Key` | Non-unique BPMN process ID string, e.g. `"invoice-process"` | Unique `Long` auto-generated identifier |
+| `...Id`  | Unique `Long` auto-generated identifier                     | Non-unique BPMN process ID string       |
+
+For example, `ProcessInstanceDto.processDefinitionKey` holds the `bpmnProcessId` string from
+Zeebe, while `ProcessInstanceDto.processDefinitionId` holds the unique `processDefinitionKey`
+Long from Zeebe (stored as `String`). This is directly visible at the Zeebe import layer in
+`ZeebeProcessInstanceSubEntityImportService` and `ZeebeProcessDefinitionImportService`.
+
+## Decision
+
+**D1. Optimize's DTO field names, ES/OS index field constants, etc. are not renamed.**
+
+The C7 naming is kept as-is across all layers: index mappings, Java DTOs, and REST API responses.
+Instead, additional documentation is added to avoid confusion.
+
+## Alternatives considered
+
+- **Full rename to C8 conventions.** Would align Optimize with the rest of the C8 codebase
+  but requires migrating all existing customer indices (a customer-visible breaking change) and
+  updating the public REST API (breaking change for all API consumers). Not viable without a
+  large, explicitly resourced migration effort.
+- **Partial renames of any code that does not have a customer impact.** Avoids breaking the REST
+  API, export/import format, or requiring a migration. However, it would not completely resolve
+  terminology confusion and instead just move the mismatch to different places.
+
+## Consequences
+
+- Engineers and AI coding agents working at the Zeebe import layer must be aware of the C7/C8
+  name inversion. Javadoc and inline comments on the import service methods document the mapping at
+  the point of translation.
+- `CLAUDE.md` in the `optimize/` module enforces this constraint for AI coding agents.
+- The naming stays until a future migration is explicitly scoped and resourced.
+
+## Source
+
+- [Decision Document](https://docs.google.com/document/d/1SQmYhuhzlVRrymkZKAXPGGO47LDsDf5YQE7ba5eXTEo/edit?usp=sharing)
+- [GitHub issue #53375](https://github.com/camunda/camunda/issues/53375)
+

--- a/optimize/docs/adr/001-c7-naming-conventions.md
+++ b/optimize/docs/adr/001-c7-naming-conventions.md
@@ -48,7 +48,8 @@ Instead, additional documentation is added to avoid confusion.
 - Engineers and AI coding agents working at the Zeebe import layer must be aware of the C7/C8
   name inversion. Javadoc and inline comments on the import service methods document the mapping at
   the point of translation.
-- `CLAUDE.md` in the `optimize/` module enforces this constraint for AI coding agents.
+- The root `AGENTS.md` is the canonical instruction entry point for AI coding agents, and
+  `optimize/CLAUDE.md` provides module-specific guidance reinforcing this constraint.
 - The naming stays until a future migration is explicitly scoped and resourced.
 
 ## Source

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/DefinitionOptimizeResponseDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/DefinitionOptimizeResponseDto.java
@@ -12,10 +12,34 @@ import io.camunda.optimize.dto.optimize.datasource.DataSourceDto;
 import java.io.Serializable;
 import java.util.Objects;
 
+/**
+ * Base DTO for process and decision definitions as stored in Optimize's ES/OS index.
+ *
+ * <p><b>Terminology note:</b> Optimize retains C7 identifier conventions, which are the
+ * <em>inverse</em> of C8 / Zeebe conventions. The table below shows how Optimize field names map to
+ * their C8 equivalents:
+ *
+ * <table border="1">
+ *   <tr><th>Optimize field name</th><th>Zeebe field name</th><th>Meaning</th></tr>
+ *   <tr><td>{@link #id}</td><td>{@code processDefinitionKey}</td>
+ *       <td>Unique {@code Long} key for a specific definition version (stored as {@code String})</td></tr>
+ *   <tr><td>{@link #key}</td><td>{@code bpmnProcessId}</td>
+ *       <td>Non-unique BPMN process ID string, e.g. {@code "invoice-process"}</td></tr>
+ * </table>
+ *
+ * <p>This naming is intentional and must not be changed. See {@code
+ * optimize/docs/adr/001-c7-naming-conventions.md} for the full rationale.
+ */
 public abstract class DefinitionOptimizeResponseDto implements Serializable, OptimizeDto {
 
+  /**
+   * Maps to Zeebe's {@code processDefinitionKey}. See class-level Javadoc for the naming rationale.
+   */
   private String id;
+
+  /** Maps to Zeebe's {@code bpmnProcessId}. See class-level Javadoc. */
   private String key;
+
   private String version;
   private String versionTag;
   private String name;

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/DefinitionOptimizeResponseDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/DefinitionOptimizeResponseDto.java
@@ -20,11 +20,11 @@ import java.util.Objects;
  * their C8 equivalents:
  *
  * <table border="1">
- *   <tr><th>Optimize field name</th><th>Zeebe field name</th><th>Meaning</th></tr>
- *   <tr><td>{@link #id}</td><td>{@code processDefinitionKey}</td>
+ *   <tr><th>Optimize field name</th><th>Zeebe reference</th><th>Meaning</th></tr>
+ *   <tr><td>{@link #id}</td><td>{@code process/decision definition Key}</td>
  *       <td>Unique {@code Long} key for a specific definition version (stored as {@code String})</td></tr>
- *   <tr><td>{@link #key}</td><td>{@code bpmnProcessId}</td>
- *       <td>Non-unique BPMN process ID string, e.g. {@code "invoice-process"}</td></tr>
+ *   <tr><td>{@link #key}</td><td>{@code process/decision ID (eg bpmnProcessId)}</td>
+ *       <td>Non-unique BPMN process or decision ID string, e.g. {@code "invoice-process"}</td></tr>
  * </table>
  *
  * <p>This naming is intentional and must not be changed. See {@code
@@ -33,11 +33,15 @@ import java.util.Objects;
 public abstract class DefinitionOptimizeResponseDto implements Serializable, OptimizeDto {
 
   /**
-   * Maps to Zeebe's {@code processDefinitionKey}. See class-level Javadoc for the naming rationale.
+   * Maps to Zeebe's process or decision definition key (for example, {@code processDefinitionKey}
+   * or {@code decisionDefinitionKey}). See class-level Javadoc for the naming rationale.
    */
   private String id;
 
-  /** Maps to Zeebe's {@code bpmnProcessId}. See class-level Javadoc. */
+  /**
+   * Maps to the Zeebe process or decision identifier (for example, {@code bpmnProcessId} or {@code
+   * decisionId}). See class-level Javadoc.
+   */
   private String key;
 
   private String version;

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/ProcessInstanceDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/ProcessInstanceDto.java
@@ -19,12 +19,39 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+/**
+ * Represents a process instance as stored in Optimize's ES/OS index.
+ *
+ * <p><b>Terminology note:</b> Optimize retains C7 identifier conventions, which are the
+ * <em>inverse</em> of C8 / Zeebe conventions. The table below shows how Optimize field names map to
+ * their C8 equivalents:
+ *
+ * <table border="1">
+ *   <tr><th>Optimize field name</th><th>Zeebe field name</th><th>Meaning</th></tr>
+ *   <tr><td>{@link #processDefinitionKey}</td><td>{@code bpmnProcessId}</td>
+ *       <td>Non-unique BPMN process ID string, e.g. {@code "invoice-process"}</td></tr>
+ *   <tr><td>{@link #processDefinitionId}</td><td>{@code processDefinitionKey}</td>
+ *       <td>Unique {@code Long} key for a specific definition version (stored as {@code String})</td></tr>
+ *   <tr><td>{@link #processInstanceId}</td><td>{@code processInstanceKey}</td>
+ *       <td>Unique {@code Long} key for this process instance (stored as {@code String})</td></tr>
+ * </table>
+ *
+ * <p>This naming is intentional and must not be changed. See {@code
+ * optimize/docs/adr/001-c7-naming-conventions.md} for the full rationale.
+ */
 public class ProcessInstanceDto implements OptimizeDto {
 
+  /** Maps to Zeebe's {@code bpmnProcessId}. See class-level Javadoc for the naming rationale. */
   private String processDefinitionKey;
+
   private String processDefinitionVersion;
+
+  /** Maps to Zeebe's {@code processDefinitionKey}. See class-level Javadoc. */
   private String processDefinitionId;
+
+  /** Maps to Zeebe's {@code processInstanceKey}. See class-level Javadoc. */
   private String processInstanceId;
+
   private String businessKey;
   private OffsetDateTime startDate;
   private OffsetDateTime endDate;


### PR DESCRIPTION
related to #53375

## Description

Adds documentation explaining the ID/Key terminology in Optimize to minimise the risk of devs or AI agents misunderstanding naming conventions .

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
