### PR TITLE
feat: send UUID correlation key in process MCP calls

### DIFF
--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/processes/ProcessesToolRepository.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/processes/ProcessesToolRepository.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.stream.Stream;
 import org.jspecify.annotations.NonNull;
 
@@ -127,7 +128,10 @@ public class ProcessesToolRepository implements ToolRepository {
                   return CallToolResultMapper.from(
                       messageServices.correlateMessage(
                           new CorrelateMessageRequest(
-                              entity.messageName(), "", arguments, entity.tenantId()),
+                              entity.messageName(),
+                              UUID.randomUUID().toString(),
+                              arguments,
+                              entity.tenantId()),
                           authenticationProvider.getCamundaAuthentication()),
                       record -> Map.of("processInstanceKey", record.getProcessInstanceKey()));
                 })

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/processes/ProcessesToolRepository.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/processes/ProcessesToolRepository.java
@@ -22,13 +22,15 @@ import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.collection.Tuple;
 import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.JsonSchema;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.UUID;
+import java.util.function.BiFunction;
 import java.util.stream.Stream;
 import org.jspecify.annotations.NonNull;
 
@@ -39,15 +41,31 @@ public class ProcessesToolRepository implements ToolRepository {
   protected static final String PROPERTY_RESULTS = "io.camunda.tool:results";
   protected static final String PROPERTY_WHEN_NOT_TO_USE = "io.camunda.tool:when_not_to_use";
   protected static final String PROPERTY_WHEN_TO_USE = "io.camunda.tool:when_to_use";
-
   protected static final String LABEL_INPUTS = "## Inputs";
   protected static final String LABEL_RESULTS = "## Results";
   protected static final String LABEL_WHEN_NOT_TO_USE = "## When not to use";
   protected static final String LABEL_WHEN_TO_USE = "## When to use";
 
+  private static final char TOOL_NAME_DELIMITER = '_';
+  private static final Map<String, Object> TOOL_OUTPUT_SCHEMA =
+      Map.of(
+          "type",
+          "object",
+          "properties",
+          Map.of(
+              "processInstanceKey",
+              Map.of(
+                  "type",
+                  "integer",
+                  "format",
+                  "int64",
+                  "description",
+                  "The key of the started process instance. Use this to investigate the state of the started instance.")),
+          "required",
+          List.of("processInstanceKey"));
   private static final List<Tuple<String, String>> DESCRIPTION_PARTS =
       List.of(
-          Tuple.of(PROPERTY_PURPOSE, null),
+          Tuple.of(PROPERTY_PURPOSE, ""),
           Tuple.of(PROPERTY_INPUTS, LABEL_INPUTS),
           Tuple.of(PROPERTY_WHEN_TO_USE, LABEL_WHEN_TO_USE),
           Tuple.of(PROPERTY_WHEN_NOT_TO_USE, LABEL_WHEN_NOT_TO_USE),
@@ -72,6 +90,7 @@ public class ProcessesToolRepository implements ToolRepository {
   @Override
   public @NonNull List<Tool> getTools(@NonNull final McpTransportContext transportContext) {
     final var auth = authenticationProvider.getCamundaAuthentication();
+    // fetch open start message subscriptions with tool names
     final var query =
         MessageSubscriptionQuery.of(
             b ->
@@ -82,8 +101,11 @@ public class ProcessesToolRepository implements ToolRepository {
                                     Operation.neq(MessageSubscriptionState.DELETED.name()))
                                 .toolNameOperations(Operation.exists(true)))
                     .unlimited());
+
+    // combine static and dynamic tools
     return Stream.concat(
-            messageSubscriptionServices.search(query, auth).items().stream().map(this::buildTool),
+            messageSubscriptionServices.search(query, auth).items().stream()
+                .map(ProcessesToolRepository::buildTool),
             staticTools.stream().map(SyncToolSpecification::tool))
         .toList();
   }
@@ -91,23 +113,35 @@ public class ProcessesToolRepository implements ToolRepository {
   @Override
   public @NonNull Either<String, SyncToolSpecification> findTool(
       @NonNull final McpTransportContext transportContext, @NonNull final String toolName) {
-    final Optional<SyncToolSpecification> staticTool =
+    // check static tools first
+    final var staticTool =
         staticTools.stream().filter(spec -> spec.tool().name().equals(toolName)).findFirst();
     if (staticTool.isPresent()) {
       return Either.right(staticTool.get());
     }
+    return findMessageSubscription(toolName)
+        .map(
+            entity ->
+                SyncToolSpecification.builder()
+                    .tool(buildTool(entity))
+                    .callHandler(buildCallHandler(entity))
+                    .build());
+  }
 
-    final int lastUnderscore = toolName.lastIndexOf('_');
-    if (lastUnderscore < 0) {
+  private Either<String, MessageSubscriptionEntity> findMessageSubscription(final String toolName) {
+    // extract the message subscription key encoded in the tool name
+    final int subscriptionKeyIndex = toolName.lastIndexOf(TOOL_NAME_DELIMITER);
+    if (subscriptionKeyIndex < 0) {
       return Either.left("Tool not found: " + toolName);
     }
     final long subscriptionKey;
     try {
-      subscriptionKey = Long.parseLong(toolName.substring(lastUnderscore + 1));
+      subscriptionKey = Long.parseLong(toolName.substring(subscriptionKeyIndex + 1));
     } catch (final NumberFormatException e) {
       return Either.left("Tool not found: " + toolName);
     }
 
+    // find the message subscription based on the key
     final var auth = authenticationProvider.getCamundaAuthentication();
     final var entity = messageSubscriptionServices.getByKey(subscriptionKey, auth);
 
@@ -118,54 +152,43 @@ public class ProcessesToolRepository implements ToolRepository {
       return Either.left("Tool " + toolName + " has been removed. Please refresh the tool list.");
     }
 
-    return Either.right(
-        SyncToolSpecification.builder()
-            .tool(buildTool(entity))
-            .callHandler(
-                (ctx, req) -> {
-                  final Map<String, Object> arguments =
-                      req.arguments() != null ? req.arguments() : Map.of();
-                  return CallToolResultMapper.from(
-                      messageServices.correlateMessage(
-                          new CorrelateMessageRequest(
-                              entity.messageName(),
-                              UUID.randomUUID().toString(),
-                              arguments,
-                              entity.tenantId()),
-                          authenticationProvider.getCamundaAuthentication()),
-                      record -> Map.of("processInstanceKey", record.getProcessInstanceKey()));
-                })
-            .build());
+    return Either.right(entity);
   }
 
-  private Tool buildTool(final MessageSubscriptionEntity entity) {
-    final String name = entity.toolName() + "_" + entity.messageSubscriptionKey();
-    final String description = buildDescription(entity.toolProperties());
+  private @NonNull BiFunction<McpTransportContext, CallToolRequest, CallToolResult>
+      buildCallHandler(final MessageSubscriptionEntity entity) {
+    return (ctx, req) -> {
+      final Map<String, Object> arguments = req.arguments() != null ? req.arguments() : Map.of();
+      return CallToolResultMapper.from(
+          messageServices.correlateMessage(
+              new CorrelateMessageRequest(
+                  entity.messageName(),
+                  // UUID: distribute messages across partitions, support parallel process instances
+                  UUID.randomUUID().toString(),
+                  arguments,
+                  entity.tenantId()),
+              authenticationProvider.getCamundaAuthentication()),
+          record -> Map.of("processInstanceKey", record.getProcessInstanceKey()));
+    };
+  }
+
+  private static Tool buildTool(final MessageSubscriptionEntity entity) {
+    final var name = buildToolName(entity);
+    final var description = buildDescription(entity.toolProperties());
     return Tool.builder()
         .name(name)
         .title(entity.toolName())
         .description(description)
         .inputSchema(new JsonSchema("object", Map.of(), List.of(), false, Map.of(), Map.of()))
-        .outputSchema(
-            Map.of(
-                "type",
-                "object",
-                "properties",
-                Map.of(
-                    "processInstanceKey",
-                    Map.of(
-                        "type",
-                        "integer",
-                        "format",
-                        "int64",
-                        "description",
-                        "The key of the started process instance. Use this to investigate the state of the started instance.")),
-                "required",
-                List.of("processInstanceKey")))
+        .outputSchema(TOOL_OUTPUT_SCHEMA)
         .build();
   }
 
-  private String buildDescription(final Map<String, String> props) {
+  private static @NonNull String buildToolName(final MessageSubscriptionEntity entity) {
+    return entity.toolName() + TOOL_NAME_DELIMITER + entity.messageSubscriptionKey();
+  }
+
+  private static String buildDescription(final Map<String, String> props) {
     return String.join(
         "\n\n",
         DESCRIPTION_PARTS.stream()
@@ -175,7 +198,7 @@ public class ProcessesToolRepository implements ToolRepository {
                   if (value == null || value.isBlank()) {
                     return null;
                   }
-                  if (part.getRight() == null) {
+                  if (part.getRight().isBlank()) {
                     return value;
                   }
                   return part.getRight() + "\n" + value;

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/processes/ProcessesToolRepositoryTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/processes/ProcessesToolRepositoryTest.java
@@ -9,7 +9,7 @@ package io.camunda.gateway.mcp.processes;
 
 import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -322,7 +322,8 @@ class ProcessesToolRepositoryTest {
       assertThat(reqCaptor.getValue().name()).isEqualTo("deploy.start");
       assertThat(reqCaptor.getValue().tenantId()).isEqualTo("tenant-a");
       assertThat(reqCaptor.getValue().correlationKey()).isNotBlank();
-      assertDoesNotThrow(() -> UUID.fromString(reqCaptor.getValue().correlationKey()));
+      assertThatCode(() -> UUID.fromString(reqCaptor.getValue().correlationKey()))
+          .doesNotThrowAnyException();
       assertThat(reqCaptor.getValue().variables()).containsExactly(entry("foo", "bar"));
     }
 
@@ -444,7 +445,8 @@ class ProcessesToolRepositoryTest {
       assertThat(captor.getValue().name()).isEqualTo("message");
       assertThat(captor.getValue().tenantId()).isEqualTo("<default>");
       assertThat(captor.getValue().correlationKey()).isNotBlank();
-      assertDoesNotThrow(() -> UUID.fromString(captor.getValue().correlationKey()));
+      assertThatCode(() -> UUID.fromString(captor.getValue().correlationKey()))
+          .doesNotThrowAnyException();
       assertThat(captor.getValue().variables()).isEmpty();
     }
 

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/processes/ProcessesToolRepositoryTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/processes/ProcessesToolRepositoryTest.java
@@ -9,9 +9,11 @@ package io.camunda.gateway.mcp.processes;
 
 import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -26,7 +28,6 @@ import io.camunda.service.MessageServices;
 import io.camunda.service.MessageServices.CorrelateMessageRequest;
 import io.camunda.service.MessageSubscriptionServices;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageCorrelationRecord;
-import io.camunda.zeebe.util.Either;
 import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
@@ -34,6 +35,7 @@ import io.modelcontextprotocol.spec.McpSchema.JsonSchema;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -140,7 +142,7 @@ class ProcessesToolRepositoryTest {
       final var tools = repository.getTools(transportContext);
 
       // then
-      final String description = tools.getFirst().description();
+      final var description = tools.getFirst().description();
       assertThat(description)
           .isEqualTo(
               """
@@ -173,7 +175,7 @@ class ProcessesToolRepositoryTest {
       final var tools = repository.getTools(transportContext);
 
       // then
-      final String description = tools.getFirst().description();
+      final var description = tools.getFirst().description();
       assertThat(description).isEqualTo("Core purpose only");
     }
 
@@ -241,8 +243,7 @@ class ProcessesToolRepositoryTest {
       repository.getTools(transportContext);
 
       // then
-      final ArgumentCaptor<MessageSubscriptionQuery> queryCaptor =
-          ArgumentCaptor.forClass(MessageSubscriptionQuery.class);
+      final var queryCaptor = ArgumentCaptor.forClass(MessageSubscriptionQuery.class);
       verify(messageSubscriptionServices).search(queryCaptor.capture(), any());
 
       final var filter = queryCaptor.getValue().filter();
@@ -280,8 +281,7 @@ class ProcessesToolRepositoryTest {
       final var toolSpec = repository.getTools(transportContext).getFirst();
 
       // when
-      final Either<String, SyncToolSpecification> result =
-          repository.findTool(transportContext, "deploy_77");
+      final var result = repository.findTool(transportContext, "deploy_77");
 
       // then
       assertThat(result.isRight()).isTrue();
@@ -306,8 +306,7 @@ class ProcessesToolRepositoryTest {
       when(messageServices.correlateMessage(any(), any()))
           .thenReturn(CompletableFuture.completedFuture(correlationRecord));
 
-      final Either<String, SyncToolSpecification> result =
-          repository.findTool(transportContext, "deploy_77");
+      final var result = repository.findTool(transportContext, "deploy_77");
 
       // when
       result
@@ -317,13 +316,13 @@ class ProcessesToolRepositoryTest {
               transportContext,
               CallToolRequest.builder().name("deploy_77").arguments(Map.of("foo", "bar")).build());
 
-      final ArgumentCaptor<CorrelateMessageRequest> reqCaptor =
-          ArgumentCaptor.forClass(CorrelateMessageRequest.class);
+      final var reqCaptor = ArgumentCaptor.forClass(CorrelateMessageRequest.class);
       verify(messageServices).correlateMessage(reqCaptor.capture(), any());
 
       assertThat(reqCaptor.getValue().name()).isEqualTo("deploy.start");
       assertThat(reqCaptor.getValue().tenantId()).isEqualTo("tenant-a");
       assertThat(reqCaptor.getValue().correlationKey()).isNotBlank();
+      assertDoesNotThrow(() -> UUID.fromString(reqCaptor.getValue().correlationKey()));
       assertThat(reqCaptor.getValue().variables()).containsExactly(entry("foo", "bar"));
     }
 
@@ -440,13 +439,53 @@ class ProcessesToolRepositoryTest {
 
       assertThat(incident).containsExactly(entry("processInstanceKey", 12345678910L));
 
-      final ArgumentCaptor<CorrelateMessageRequest> captor =
-          ArgumentCaptor.forClass(CorrelateMessageRequest.class);
+      final var captor = ArgumentCaptor.forClass(CorrelateMessageRequest.class);
       verify(messageServices).correlateMessage(captor.capture(), any());
       assertThat(captor.getValue().name()).isEqualTo("message");
       assertThat(captor.getValue().tenantId()).isEqualTo("<default>");
-      assertThat(captor.getValue().variables()).isEmpty();
       assertThat(captor.getValue().correlationKey()).isNotBlank();
+      assertDoesNotThrow(() -> UUID.fromString(captor.getValue().correlationKey()));
+      assertThat(captor.getValue().variables()).isEmpty();
+    }
+
+    @Test
+    void shouldUseUniqueCorrelationKeyPerToolCall() {
+      // given
+      final var entity =
+          buildStartSubscriptionEntity(
+              88L,
+              "myTool",
+              Map.of(ProcessesToolRepository.PROPERTY_PURPOSE, "does things"),
+              "message",
+              "<default>",
+              MessageSubscriptionState.CREATED);
+      when(messageSubscriptionServices.getByKey(eq(88L), any())).thenReturn(entity);
+      when(messageServices.correlateMessage(any(), any()))
+          .thenReturn(
+              CompletableFuture.completedFuture(
+                  new MessageCorrelationRecord().setProcessInstanceKey(12345678910L)));
+
+      final var tool = repository.findTool(transportContext, "myTool_88");
+      final var callHandler = tool.get().callHandler();
+
+      callHandler.apply(
+          transportContext,
+          CallToolRequest.builder().name("myTool_88").arguments(Map.of()).build());
+      final var firstCaptor = ArgumentCaptor.forClass(CorrelateMessageRequest.class);
+      verify(messageServices).correlateMessage(firstCaptor.capture(), any());
+
+      // when
+      callHandler.apply(
+          transportContext,
+          CallToolRequest.builder().name("myTool_88").arguments(Map.of()).build());
+
+      // then
+      final var secondCaptor = ArgumentCaptor.forClass(CorrelateMessageRequest.class);
+      verify(messageServices, times(2)).correlateMessage(secondCaptor.capture(), any());
+      assertThat(firstCaptor.getValue().correlationKey()).isNotBlank();
+      assertThat(secondCaptor.getValue().correlationKey()).isNotBlank();
+      assertThat(secondCaptor.getValue().correlationKey())
+          .isNotEqualTo(firstCaptor.getValue().correlationKey());
     }
   }
 

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/processes/ProcessesToolRepositoryTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/processes/ProcessesToolRepositoryTest.java
@@ -323,7 +323,7 @@ class ProcessesToolRepositoryTest {
 
       assertThat(reqCaptor.getValue().name()).isEqualTo("deploy.start");
       assertThat(reqCaptor.getValue().tenantId()).isEqualTo("tenant-a");
-      assertThat(reqCaptor.getValue().correlationKey()).isEmpty();
+      assertThat(reqCaptor.getValue().correlationKey()).isNotBlank();
       assertThat(reqCaptor.getValue().variables()).containsExactly(entry("foo", "bar"));
     }
 
@@ -440,9 +440,13 @@ class ProcessesToolRepositoryTest {
 
       assertThat(incident).containsExactly(entry("processInstanceKey", 12345678910L));
 
-      verify(messageServices)
-          .correlateMessage(
-              eq(new CorrelateMessageRequest("message", "", Map.of(), "<default>")), any());
+      final ArgumentCaptor<CorrelateMessageRequest> captor =
+          ArgumentCaptor.forClass(CorrelateMessageRequest.class);
+      verify(messageServices).correlateMessage(captor.capture(), any());
+      assertThat(captor.getValue().name()).isEqualTo("message");
+      assertThat(captor.getValue().tenantId()).isEqualTo("<default>");
+      assertThat(captor.getValue().variables()).isEmpty();
+      assertThat(captor.getValue().correlationKey()).isNotBlank();
     }
   }
 


### PR DESCRIPTION
## Description

Tool calls for processes exposed as MCP tools correlate a message to the brokers. Without correlation key, all messages land on partition 1.
Adding a generated UUID correlation key to all tool calls allows message routing to different partitions.
Idempotency of tool calls is not a concern currently. If it arises, the correlation key should become an optional input parameter of all processes as tool, so it can be provided externally.

## Related issues

closes #50288 
