### PR TITLE
feat: add GET and search endpoints for agent instances

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AgentInstanceDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AgentInstanceDbReader.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.service;
+
+import io.camunda.db.rdbms.read.RdbmsReaderConfig;
+import io.camunda.search.clients.reader.AgentInstanceReader;
+import io.camunda.search.entities.AgentInstanceEntity;
+import io.camunda.search.query.AgentInstanceQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.reader.ResourceAccessChecks;
+
+/**
+ * RDBMS-backed reader for agent instances.
+ *
+ * <p>Full implementation will be covered in <a
+ * href="https://github.com/camunda/camunda/issues/52820">#52820</a>.
+ */
+public class AgentInstanceDbReader extends AbstractEntityReader<AgentInstanceEntity>
+    implements AgentInstanceReader {
+
+  public AgentInstanceDbReader(final RdbmsReaderConfig readerConfig) {
+    // FIXME when implementing #52820 substitute `null` with `AgentInstanceSearchColumn.values()`
+    super(null, readerConfig);
+  }
+
+  @Override
+  public AgentInstanceEntity getByKey(
+      final long key, final ResourceAccessChecks resourceAccessChecks) {
+    throw new UnsupportedOperationException(
+        "AgentInstanceDbReader is not yet implemented; see https://github.com/camunda/camunda/issues/52820");
+  }
+
+  @Override
+  public SearchQueryResult<AgentInstanceEntity> search(
+      final AgentInstanceQuery query, final ResourceAccessChecks resourceAccessChecks) {
+    throw new UnsupportedOperationException(
+        "AgentInstanceDbReader is not yet implemented; see https://github.com/camunda/camunda/issues/52820");
+  }
+}

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
@@ -14,6 +14,7 @@ import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.read.replication.ReplicationLogStatusProviderFactory;
+import io.camunda.db.rdbms.read.service.AgentInstanceDbReader;
 import io.camunda.db.rdbms.read.service.AuditLogDbReader;
 import io.camunda.db.rdbms.read.service.AuthorizationDbReader;
 import io.camunda.db.rdbms.read.service.BatchOperationDbReader;
@@ -126,6 +127,11 @@ public class RdbmsConfiguration {
   public VariableDbReader variableRdbmsReader(
       final VariableMapper variableMapper, final RdbmsReaderConfig readerConfig) {
     return new VariableDbReader(variableMapper, readerConfig);
+  }
+
+  @Bean
+  public AgentInstanceDbReader agentInstanceReader(final RdbmsReaderConfig readerConfig) {
+    return new AgentInstanceDbReader(readerConfig);
   }
 
   @Bean

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchClientConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchClientConfiguration.java
@@ -13,6 +13,7 @@ import io.camunda.configuration.conditions.ConditionalOnSecondaryStorageType;
 import io.camunda.search.clients.CamundaSearchClients;
 import io.camunda.search.clients.auth.ResourceAccessDelegatingController;
 import io.camunda.search.clients.impl.NoDBSearchClientsProxy;
+import io.camunda.search.clients.reader.AgentInstanceReader;
 import io.camunda.search.clients.reader.AuditLogReader;
 import io.camunda.search.clients.reader.AuthorizationReader;
 import io.camunda.search.clients.reader.BatchOperationItemReader;
@@ -105,6 +106,7 @@ public class SearchClientConfiguration {
   @Bean
   @ConditionalOnSecondaryStorageType(SecondaryStorageType.rdbms)
   public SearchClientReaders searchClientReaders(
+      final AgentInstanceReader agentInstanceReader,
       final AuthorizationReader authorizationReader,
       final BatchOperationReader batchOperationReader,
       final BatchOperationItemReader batchOperationItemReader,
@@ -149,6 +151,7 @@ public class SearchClientConfiguration {
       final GlobalListenerReader globalListenerReader,
       final DeployedResourceReader deployedResourceReader) {
     return new SearchClientReaders(
+        agentInstanceReader,
         authorizationReader,
         batchOperationReader,
         batchOperationItemReader,

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchClientReadersFactory.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchClientReadersFactory.java
@@ -9,6 +9,7 @@ package io.camunda.application.commons.search;
 
 import io.camunda.search.clients.SearchClientBasedQueryExecutor;
 import io.camunda.search.clients.cache.ProcessCache;
+import io.camunda.search.clients.reader.AgentInstanceDocumentReader;
 import io.camunda.search.clients.reader.AuditLogDocumentReader;
 import io.camunda.search.clients.reader.AuthorizationDocumentReader;
 import io.camunda.search.clients.reader.BatchOperationDocumentReader;
@@ -64,6 +65,7 @@ import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
 import io.camunda.webapps.schema.descriptors.index.RoleIndex;
 import io.camunda.webapps.schema.descriptors.index.TenantIndex;
 import io.camunda.webapps.schema.descriptors.index.UserIndex;
+import io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.template.AuditLogTemplate;
 import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
 import io.camunda.webapps.schema.descriptors.template.CorrelatedMessageSubscriptionTemplate;
@@ -93,6 +95,8 @@ public final class SearchClientReadersFactory {
       final ProcessCache.Configuration processCacheConfig) {
 
     // --- Phase 1: Simple readers (no cross-reader dependencies) ---
+    final var agentInstanceReader =
+        new AgentInstanceDocumentReader(executor, descriptors.get(AgentInstanceTemplate.class));
     final var authorizationReader =
         new AuthorizationDocumentReader(executor, descriptors.get(AuthorizationIndex.class));
     final var batchOperationReader =
@@ -205,6 +209,7 @@ public final class SearchClientReadersFactory {
 
     // --- Assemble ---
     return new SearchClientReaders(
+        agentInstanceReader,
         authorizationReader,
         batchOperationReader,
         batchOperationItemReader,

--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -11,6 +11,7 @@ import io.camunda.application.commons.condition.ConditionalOnAnyHttpGatewayEnabl
 import io.camunda.document.store.EnvironmentConfigurationLoader;
 import io.camunda.document.store.SimpleDocumentStoreRegistry;
 import io.camunda.gateway.protocol.model.JobActivationResult;
+import io.camunda.search.clients.AgentInstanceSearchClient;
 import io.camunda.search.clients.AuditLogSearchClient;
 import io.camunda.search.clients.AuthorizationSearchClient;
 import io.camunda.search.clients.BatchOperationSearchClient;
@@ -251,11 +252,13 @@ public class CamundaServicesConfiguration {
   public AgentInstanceServices agentInstanceServices(
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
+      final AgentInstanceSearchClient agentInstanceSearchClient,
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     return new AgentInstanceServices(
         brokerClient,
         securityContextProvider,
+        agentInstanceSearchClient,
         executorProvider,
         brokerRequestAuthorizationConverter);
   }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
@@ -44,6 +44,7 @@ import io.camunda.search.entities.DecisionInstanceEntity.DecisionDefinitionType;
 import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeType;
 import io.camunda.search.entities.GlobalListenerType;
 import io.camunda.search.entities.IncidentEntity.IncidentState;
+import io.camunda.search.filter.AgentInstanceFilter;
 import io.camunda.search.filter.AuditLogFilter;
 import io.camunda.search.filter.AuthorizationFilter;
 import io.camunda.search.filter.BatchOperationFilter;
@@ -1443,6 +1444,52 @@ public class SearchQueryFilterMapper {
           .map(mapToKeyOperations("deploymentKey", validationErrors))
           .ifPresent(builder::deploymentKeyOperations);
       ofNullable(filter.getTenantId()).ifPresent(builder::tenantIds);
+    }
+
+    return validationErrors.isEmpty()
+        ? Either.right(builder.build())
+        : Either.left(validationErrors);
+  }
+
+  static Either<List<String>, AgentInstanceFilter> toAgentInstanceFilter(
+      final io.camunda.gateway.protocol.model.@Nullable AgentInstanceFilter filter) {
+    final var builder = FilterBuilders.agentInstance();
+    final List<String> validationErrors = new ArrayList<>();
+    if (filter != null) {
+      ofNullable(filter.getAgentInstanceKey())
+          .map(mapToKeyOperations("agentInstanceKey", validationErrors))
+          .ifPresent(builder::agentInstanceKeyOperations);
+      ofNullable(filter.getStatus())
+          .map(mapToStringOperations())
+          .ifPresent(builder::statusOperations);
+      ofNullable(filter.getElementId())
+          .map(mapToStringOperations())
+          .ifPresent(builder::elementIdOperations);
+      ofNullable(filter.getProcessInstanceKey())
+          .map(mapToKeyOperations("processInstanceKey", validationErrors))
+          .ifPresent(builder::processInstanceKeyOperations);
+      ofNullable(filter.getProcessDefinitionKey())
+          .map(mapToKeyOperations("processDefinitionKey", validationErrors))
+          .ifPresent(builder::processDefinitionKeyOperations);
+      ofNullable(filter.getTenantId())
+          .map(mapToStringOperations())
+          .ifPresent(builder::tenantIdOperations);
+      ofNullable(filter.getCreationDate())
+          .map(mapToOffsetDateTimeOperations("creationDate", validationErrors))
+          .ifPresent(builder::creationDateOperations);
+      ofNullable(filter.getLastUpdatedDate())
+          .map(mapToOffsetDateTimeOperations("lastUpdatedDate", validationErrors))
+          .ifPresent(builder::lastUpdatedDateOperations);
+      ofNullable(filter.getCompletionDate())
+          .map(mapToOffsetDateTimeOperations("completionDate", validationErrors))
+          .ifPresent(builder::completionDateOperations);
+      if (!CollectionUtils.isEmpty(filter.getElementInstanceKeys())) {
+        final var elementInstanceKeyMapper =
+            mapToKeyOperations("elementInstanceKeys", validationErrors);
+        filter.getElementInstanceKeys().stream()
+            .map(elementInstanceKeyMapper)
+            .forEach(builder::elementInstanceKeyOperations);
+      }
     }
 
     return validationErrors.isEmpty()

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryRequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryRequestMapper.java
@@ -24,6 +24,7 @@ import io.camunda.search.filter.FilterBuilders;
 import io.camunda.search.filter.ProcessDefinitionStatisticsFilter;
 import io.camunda.search.filter.UsageMetricsFilter;
 import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.query.AgentInstanceQuery;
 import io.camunda.search.query.AuditLogQuery;
 import io.camunda.search.query.AuthorizationQuery;
 import io.camunda.search.query.BatchOperationItemQuery;
@@ -244,6 +245,22 @@ public final class SearchQueryRequestMapper {
             SearchQuerySortRequestMapper::applyProcessInstanceSortField);
     final var filter = toProcessInstanceFilter(request.getFilter());
     return buildSearchQuery(filter, sort, page, SearchQueryBuilders::processInstanceSearchQuery);
+  }
+
+  public static Either<ProblemDetail, AgentInstanceQuery> toAgentInstanceQuery(
+      final AgentInstanceSearchQuery request) {
+    if (request == null) {
+      return Either.right(SearchQueryBuilders.agentInstanceSearchQuery().build());
+    }
+
+    final var page = toSearchQueryPage(request.getPage());
+    final var sort =
+        SearchQuerySortRequestMapper.toSearchQuerySort(
+            SearchQuerySortRequestMapper.fromAgentInstanceSearchQuerySortRequest(request.getSort()),
+            SortOptionBuilders::agentInstance,
+            SearchQuerySortRequestMapper::applyAgentInstanceSortField);
+    final var filter = SearchQueryFilterMapper.toAgentInstanceFilter(request.getFilter());
+    return buildSearchQuery(filter, sort, page, SearchQueryBuilders::agentInstanceSearchQuery);
   }
 
   public static Either<ProblemDetail, JobQuery> toJobQuery(final JobSearchQuery request) {

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -19,6 +19,13 @@ import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
 
 import io.camunda.authentication.entity.CamundaUserDTO;
 import io.camunda.gateway.mapping.http.util.KeyUtil;
+import io.camunda.gateway.protocol.model.AgentInstanceDefinition;
+import io.camunda.gateway.protocol.model.AgentInstanceLimits;
+import io.camunda.gateway.protocol.model.AgentInstanceMetrics;
+import io.camunda.gateway.protocol.model.AgentInstanceResult;
+import io.camunda.gateway.protocol.model.AgentInstanceSearchQueryResult;
+import io.camunda.gateway.protocol.model.AgentInstanceStatusEnum;
+import io.camunda.gateway.protocol.model.AgentTool;
 import io.camunda.gateway.protocol.model.AuditLogActorTypeEnum;
 import io.camunda.gateway.protocol.model.AuditLogCategoryEnum;
 import io.camunda.gateway.protocol.model.AuditLogEntityTypeEnum;
@@ -147,6 +154,7 @@ import io.camunda.gateway.protocol.model.UserTaskStateEnum;
 import io.camunda.gateway.protocol.model.VariableResult;
 import io.camunda.gateway.protocol.model.VariableSearchQueryResult;
 import io.camunda.gateway.protocol.model.VariableSearchResult;
+import io.camunda.search.entities.AgentInstanceEntity;
 import io.camunda.search.entities.AuditLogEntity;
 import io.camunda.search.entities.AuthorizationEntity;
 import io.camunda.search.entities.BatchOperationEntity;
@@ -1898,6 +1906,90 @@ public final class SearchQueryResponseMapper {
         .resourceId(entity.resourceId())
         .tenantId(entity.tenantId())
         .resourceKey(KeyUtil.keyToString(entity.resourceKey()))
+        .build();
+  }
+
+  public static AgentInstanceResult toAgentInstanceResult(final AgentInstanceEntity entity) {
+    final var d = entity.definition();
+    final var definition =
+        AgentInstanceDefinition.Builder.create()
+            .model(d.model())
+            .provider(d.provider())
+            .systemPrompt(d.systemPrompt())
+            .build();
+
+    final var m = entity.metrics();
+    final var metrics =
+        AgentInstanceMetrics.Builder.create()
+            .inputTokens(m.inputTokens())
+            .outputTokens(m.outputTokens())
+            .modelCalls(m.modelCalls())
+            .toolCalls(m.toolCalls())
+            .build();
+
+    final var l = entity.limits();
+    final var limits =
+        AgentInstanceLimits.Builder.create()
+            .maxModelCalls(l.maxModelCalls())
+            .maxTokens(l.maxTokens())
+            .maxToolCalls(l.maxToolCalls())
+            .build();
+
+    final var tools =
+        ofNullable(entity.tools())
+            .map(
+                ts ->
+                    ts.stream()
+                        .map(
+                            t ->
+                                AgentTool.Builder.create()
+                                    .name(t.name())
+                                    .description(t.description())
+                                    .elementId(t.elementId())
+                                    .build())
+                        .toList())
+            .orElseGet(Collections::emptyList);
+
+    final var elementInstanceKeys =
+        ofNullable(entity.elementInstanceKeys())
+            .map(keys -> keys.stream().map(k -> keyToString(k)).toList())
+            .orElseGet(Collections::emptyList);
+
+    return AgentInstanceResult.Builder.create()
+        .agentInstanceKey(keyToString(entity.agentInstanceKey()))
+        .status(AgentInstanceStatusEnum.fromValue(entity.status().name()))
+        .definition(definition)
+        .metrics(metrics)
+        .limits(limits)
+        .tools(tools)
+        .elementId(entity.elementId())
+        .processInstanceKey(keyToString(entity.processInstanceKey()))
+        .rootProcessInstanceKey(keyToStringOrNull(entity.rootProcessInstanceKey()))
+        .processDefinitionKey(keyToString(entity.processDefinitionKey()))
+        .processDefinitionId(entity.processDefinitionId())
+        .processDefinitionVersion(entity.processDefinitionVersion())
+        .processDefinitionVersionTag(entity.versionTag())
+        .tenantId(entity.tenantId())
+        .creationDate(formatDate(entity.creationDate()))
+        .lastUpdatedDate(formatDate(entity.lastUpdatedDate()))
+        .completionDate(formatDateOrNull(entity.completionDate()))
+        .elementInstanceKeys(elementInstanceKeys)
+        .build();
+  }
+
+  public static AgentInstanceSearchQueryResult toAgentInstanceSearchQueryResponse(
+      final SearchQueryResult<AgentInstanceEntity> result) {
+    final var page = toSearchQueryPageResponse(result);
+    return AgentInstanceSearchQueryResult.Builder.create()
+        .page(page)
+        .items(
+            ofNullable(result.items())
+                .map(
+                    items ->
+                        items.stream()
+                            .map(SearchQueryResponseMapper::toAgentInstanceResult)
+                            .toList())
+                .orElseGet(Collections::emptyList))
         .build();
   }
 

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQuerySortRequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQuerySortRequestMapper.java
@@ -12,6 +12,7 @@ import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_UNKN
 
 import io.camunda.gateway.protocol.model.*;
 import io.camunda.gateway.protocol.model.GlobalTaskListenerSearchQuerySortRequest.FieldEnum;
+import io.camunda.search.sort.AgentInstanceSort;
 import io.camunda.search.sort.AuthorizationSort;
 import io.camunda.search.sort.BatchOperationItemSort;
 import io.camunda.search.sort.BatchOperationSort;
@@ -1004,6 +1005,30 @@ public class SearchQuerySortRequestMapper {
         case AFTER_NON_GLOBAL -> builder.afterNonGlobal();
         case PRIORITY -> builder.priority();
         case SOURCE -> builder.source();
+        default -> validationErrors.add(ERROR_UNKNOWN_SORT_BY.formatted(field));
+      }
+    }
+    return validationErrors;
+  }
+
+  static List<SearchQuerySortRequest<AgentInstanceSearchQuerySortRequest.FieldEnum>>
+      fromAgentInstanceSearchQuerySortRequest(
+          final List<AgentInstanceSearchQuerySortRequest> requests) {
+    return requests.stream().map(r -> createFrom(r.getField(), r.getOrder())).toList();
+  }
+
+  static List<String> applyAgentInstanceSortField(
+      final AgentInstanceSearchQuerySortRequest.FieldEnum field,
+      final AgentInstanceSort.Builder builder) {
+    final List<String> validationErrors = new ArrayList<>();
+    if (field == null) {
+      validationErrors.add(ERROR_SORT_FIELD_MUST_NOT_BE_NULL);
+    } else {
+      switch (field) {
+        case CREATION_DATE -> builder.creationDate();
+        case LAST_UPDATED_DATE -> builder.lastUpdatedDate();
+        case COMPLETION_DATE -> builder.completionDate();
+        case STATUS -> builder.status();
         default -> validationErrors.add(ERROR_UNKNOWN_SORT_BY.formatted(field));
       }
     }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/AgentInstanceDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/AgentInstanceDocumentReader.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.reader;
+
+import io.camunda.search.clients.SearchClientBasedQueryExecutor;
+import io.camunda.search.entities.AgentInstanceEntity;
+import io.camunda.search.query.AgentInstanceQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+
+/**
+ * Elasticsearch/OpenSearch-backed document reader for agent instances.
+ *
+ * <p>Full implementation will be covered in <a
+ * href="https://github.com/camunda/camunda/issues/52817">#52817</a>.
+ */
+public class AgentInstanceDocumentReader extends DocumentBasedReader
+    implements AgentInstanceReader {
+
+  public AgentInstanceDocumentReader(
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptor indexDescriptor) {
+    super(executor, indexDescriptor);
+  }
+
+  @Override
+  public AgentInstanceEntity getByKey(
+      final long key, final ResourceAccessChecks resourceAccessChecks) {
+    throw new UnsupportedOperationException(
+        "AgentInstanceDocumentReader is not yet implemented; see https://github.com/camunda/camunda/issues/52817");
+  }
+
+  @Override
+  public SearchQueryResult<AgentInstanceEntity> search(
+      final AgentInstanceQuery query, final ResourceAccessChecks resourceAccessChecks) {
+    throw new UnsupportedOperationException(
+        "AgentInstanceDocumentReader is not yet implemented; see https://github.com/camunda/camunda/issues/52817");
+  }
+}

--- a/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/AgentInstanceReader.java
+++ b/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/AgentInstanceReader.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.reader;
+
+import io.camunda.search.entities.AgentInstanceEntity;
+import io.camunda.search.query.AgentInstanceQuery;
+
+public interface AgentInstanceReader
+    extends SearchEntityReader<AgentInstanceEntity, AgentInstanceQuery> {}

--- a/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/SearchClientReaders.java
+++ b/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/SearchClientReaders.java
@@ -8,6 +8,7 @@
 package io.camunda.search.clients.reader;
 
 public record SearchClientReaders(
+    AgentInstanceReader agentInstanceReader,
     AuthorizationReader authorizationReader,
     BatchOperationReader batchOperationReader,
     BatchOperationItemReader batchOperationItemReader,

--- a/search/search-client/src/main/java/io/camunda/search/clients/AgentInstanceSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/AgentInstanceSearchClient.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients;
+
+import io.camunda.search.entities.AgentInstanceEntity;
+import io.camunda.search.query.AgentInstanceQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.SecurityContext;
+
+public interface AgentInstanceSearchClient {
+
+  AgentInstanceEntity getAgentInstance(long key);
+
+  SearchQueryResult<AgentInstanceEntity> searchAgentInstances(AgentInstanceQuery query);
+
+  AgentInstanceSearchClient withSecurityContext(SecurityContext securityContext);
+}

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -14,6 +14,7 @@ import static io.camunda.search.exception.ErrorMessages.ERROR_ENTITY_BY_MULTIPLE
 import io.camunda.search.clients.reader.SearchClientReaders;
 import io.camunda.search.clients.reader.SearchEntityReader;
 import io.camunda.search.clients.reader.SearchQueryStatisticsReader;
+import io.camunda.search.entities.AgentInstanceEntity;
 import io.camunda.search.entities.AuditLogEntity;
 import io.camunda.search.entities.AuthorizationEntity;
 import io.camunda.search.entities.BatchOperationEntity;
@@ -64,6 +65,7 @@ import io.camunda.search.exception.TenantAccessDeniedException;
 import io.camunda.search.filter.ProcessDefinitionStatisticsFilter;
 import io.camunda.search.filter.ProcessInstanceStatisticsFilter;
 import io.camunda.search.page.SearchQueryPage.SearchQueryResultType;
+import io.camunda.search.query.AgentInstanceQuery;
 import io.camunda.search.query.AuditLogQuery;
 import io.camunda.search.query.AuthorizationQuery;
 import io.camunda.search.query.BatchOperationItemQuery;
@@ -155,6 +157,18 @@ public class CamundaSearchClients implements SearchClientsProxy {
     this.currentPhysicalTenantId = currentPhysicalTenantId;
     this.resourceAccessController = resourceAccessController;
     this.securityContext = securityContext;
+  }
+
+  @Override
+  public AgentInstanceEntity getAgentInstance(final long key) {
+    return doGetWithReader(readers.agentInstanceReader(), key)
+        .orElseThrow(() -> entityByKeyNotFoundException("Agent Instance", key));
+  }
+
+  @Override
+  public SearchQueryResult<AgentInstanceEntity> searchAgentInstances(
+      final AgentInstanceQuery query) {
+    return doSearchWithReader(readers.agentInstanceReader(), query);
   }
 
   @Override

--- a/search/search-client/src/main/java/io/camunda/search/clients/SearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/SearchClientsProxy.java
@@ -12,7 +12,8 @@ import io.camunda.search.clients.tenant.PhysicalTenantScoped;
 import io.camunda.security.auth.SecurityContext;
 
 public interface SearchClientsProxy
-    extends AuditLogSearchClient,
+    extends AgentInstanceSearchClient,
+        AuditLogSearchClient,
         AuthorizationSearchClient,
         BatchOperationSearchClient,
         DecisionDefinitionSearchClient,

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
@@ -8,6 +8,7 @@
 package io.camunda.search.clients.impl;
 
 import io.camunda.search.clients.SearchClientsProxy;
+import io.camunda.search.entities.AgentInstanceEntity;
 import io.camunda.search.entities.AuditLogEntity;
 import io.camunda.search.entities.AuthorizationEntity;
 import io.camunda.search.entities.BatchOperationEntity;
@@ -53,6 +54,7 @@ import io.camunda.search.entities.UserTaskEntity;
 import io.camunda.search.entities.VariableEntity;
 import io.camunda.search.exception.NoSecondaryStorageException;
 import io.camunda.search.filter.ProcessDefinitionStatisticsFilter;
+import io.camunda.search.query.AgentInstanceQuery;
 import io.camunda.search.query.AuditLogQuery;
 import io.camunda.search.query.AuthorizationQuery;
 import io.camunda.search.query.BatchOperationItemQuery;
@@ -99,6 +101,17 @@ import io.camunda.security.auth.SecurityContext;
 import java.util.List;
 
 public class NoDBSearchClientsProxy implements SearchClientsProxy {
+
+  @Override
+  public AgentInstanceEntity getAgentInstance(final long key) {
+    throw new NoSecondaryStorageException();
+  }
+
+  @Override
+  public SearchQueryResult<AgentInstanceEntity> searchAgentInstances(
+      final AgentInstanceQuery query) {
+    throw new NoSecondaryStorageException();
+  }
 
   @Override
   public AuthorizationEntity getAuthorization(final long key) {

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
@@ -10,6 +10,7 @@ package io.camunda.search.clients.impl;
 import static java.util.Collections.emptyList;
 
 import io.camunda.search.clients.SearchClientsProxy;
+import io.camunda.search.entities.AgentInstanceEntity;
 import io.camunda.search.entities.AuditLogEntity;
 import io.camunda.search.entities.AuthorizationEntity;
 import io.camunda.search.entities.BatchOperationEntity;
@@ -54,6 +55,7 @@ import io.camunda.search.entities.UserEntity;
 import io.camunda.search.entities.UserTaskEntity;
 import io.camunda.search.entities.VariableEntity;
 import io.camunda.search.filter.ProcessDefinitionStatisticsFilter;
+import io.camunda.search.query.AgentInstanceQuery;
 import io.camunda.search.query.AuditLogQuery;
 import io.camunda.search.query.AuthorizationQuery;
 import io.camunda.search.query.BatchOperationItemQuery;
@@ -101,6 +103,17 @@ import java.util.List;
 import java.util.Map;
 
 public class NoopSearchClientsProxy implements SearchClientsProxy {
+
+  @Override
+  public AgentInstanceEntity getAgentInstance(final long key) {
+    return null;
+  }
+
+  @Override
+  public SearchQueryResult<AgentInstanceEntity> searchAgentInstances(
+      final AgentInstanceQuery query) {
+    return SearchQueryResult.empty();
+  }
 
   @Override
   public AuthorizationEntity getAuthorization(final long key) {

--- a/service/src/main/java/io/camunda/service/AgentInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/AgentInstanceServices.java
@@ -7,8 +7,15 @@
  */
 package io.camunda.service;
 
+import static io.camunda.service.authorization.Authorizations.AGENT_INSTANCE_READ_AUTHORIZATION;
+
+import io.camunda.search.clients.AgentInstanceSearchClient;
+import io.camunda.search.entities.AgentInstanceEntity;
+import io.camunda.search.query.AgentInstanceQuery;
+import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.api.model.CamundaAuthentication;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
+import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerCreateAgentInstanceRequest;
@@ -16,11 +23,15 @@ import io.camunda.zeebe.gateway.impl.broker.request.BrokerUpdateAgentInstanceReq
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
 import java.util.concurrent.CompletableFuture;
 
-public final class AgentInstanceServices extends ApiServices<AgentInstanceServices> {
+public final class AgentInstanceServices
+    extends SearchQueryService<AgentInstanceServices, AgentInstanceQuery, AgentInstanceEntity> {
+
+  private final AgentInstanceSearchClient agentInstanceSearchClient;
 
   public AgentInstanceServices(
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
+      final AgentInstanceSearchClient agentInstanceSearchClient,
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     super(
@@ -28,6 +39,7 @@ public final class AgentInstanceServices extends ApiServices<AgentInstanceServic
         securityContextProvider,
         executorProvider,
         brokerRequestAuthorizationConverter);
+    this.agentInstanceSearchClient = agentInstanceSearchClient;
   }
 
   public CompletableFuture<AgentInstanceRecord> createAgentInstance(
@@ -38,5 +50,28 @@ public final class AgentInstanceServices extends ApiServices<AgentInstanceServic
   public CompletableFuture<AgentInstanceRecord> updateAgentInstance(
       final AgentInstanceRecord record, final CamundaAuthentication authentication) {
     return sendBrokerRequest(new BrokerUpdateAgentInstanceRequest(record), authentication);
+  }
+
+  @Override
+  public SearchQueryResult<AgentInstanceEntity> search(
+      final AgentInstanceQuery query, final CamundaAuthentication authentication) {
+    return executeSearchRequest(
+        () ->
+            agentInstanceSearchClient
+                .withSecurityContext(
+                    securityContextProvider.provideSecurityContext(
+                        authentication, AGENT_INSTANCE_READ_AUTHORIZATION))
+                .searchAgentInstances(query));
+  }
+
+  public AgentInstanceEntity getByKey(
+      final long agentInstanceKey, final CamundaAuthentication authentication) {
+    return executeSearchRequest(
+        () ->
+            agentInstanceSearchClient
+                .withSecurityContext(
+                    securityContextProvider.provideSecurityContext(
+                        authentication, AGENT_INSTANCE_READ_AUTHORIZATION))
+                .getAgentInstance(agentInstanceKey));
   }
 }

--- a/service/src/main/java/io/camunda/service/AgentInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/AgentInstanceServices.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.service;
 
+import static io.camunda.security.auth.Authorization.withAuthorization;
 import static io.camunda.service.authorization.Authorizations.AGENT_INSTANCE_READ_AUTHORIZATION;
 
 import io.camunda.search.clients.AgentInstanceSearchClient;
@@ -71,7 +72,10 @@ public final class AgentInstanceServices
             agentInstanceSearchClient
                 .withSecurityContext(
                     securityContextProvider.provideSecurityContext(
-                        authentication, AGENT_INSTANCE_READ_AUTHORIZATION))
+                        authentication,
+                        withAuthorization(
+                            AGENT_INSTANCE_READ_AUTHORIZATION,
+                            AgentInstanceEntity::processDefinitionId)))
                 .getAgentInstance(agentInstanceKey));
   }
 }

--- a/service/src/main/java/io/camunda/service/authorization/Authorizations.java
+++ b/service/src/main/java/io/camunda/service/authorization/Authorizations.java
@@ -11,6 +11,7 @@ import static io.camunda.security.api.model.authz.AuthorizationResourceType.COMP
 import static io.camunda.security.api.model.authz.PermissionType.ACCESS;
 import static io.camunda.security.api.model.authz.PermissionType.READ_TASK_LISTENER;
 
+import io.camunda.search.entities.AgentInstanceEntity;
 import io.camunda.search.entities.AuditLogEntity;
 import io.camunda.search.entities.AuthorizationEntity;
 import io.camunda.search.entities.BatchOperationEntity;
@@ -37,6 +38,9 @@ import io.camunda.search.entities.VariableEntity;
 import io.camunda.security.auth.Authorization;
 
 public abstract class Authorizations {
+
+  public static final Authorization<AgentInstanceEntity> AGENT_INSTANCE_READ_AUTHORIZATION =
+      Authorization.of(a -> a.processDefinition().readProcessInstance());
 
   public static final Authorization<AuthorizationEntity> AUTHORIZATION_READ_AUTHORIZATION =
       Authorization.of(a -> a.authorization().read());

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -273,7 +273,11 @@ components:
         - tools
         - elementId
         - processInstanceKey
+        - rootProcessInstanceKey
         - processDefinitionKey
+        - processDefinitionId
+        - processDefinitionVersion
+        - processDefinitionVersionTag
         - tenantId
         - creationDate
         - lastUpdatedDate
@@ -311,10 +315,29 @@ components:
           description: The key of the process instance that owns this agent instance.
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
+        rootProcessInstanceKey:
+          description: |
+            The key of the root process instance. The root process instance is the top-level
+            ancestor in the process instance hierarchy.
+          nullable: true
+          allOf:
+            - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
         processDefinitionKey:
           description: The key of the process definition associated with this agent instance.
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessDefinitionKey'
+        processDefinitionId:
+          description: The BPMN process ID of the process definition associated with this agent instance.
+          allOf:
+            - $ref: 'identifiers.yaml#/components/schemas/ProcessDefinitionId'
+        processDefinitionVersion:
+          type: integer
+          format: int32
+          description: The version of the process definition associated with this agent instance.
+        processDefinitionVersionTag:
+          type: string
+          nullable: true
+          description: The version tag of the process definition associated with this agent instance.
         tenantId:
           description: The tenant ID of this agent instance.
           allOf:
@@ -428,6 +451,7 @@ components:
       description: The current status of an agent instance.
       type: string
       enum:
+        - UNKNOWN
         - COMPLETED
         - IDLE
         - INITIALIZING

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/JacksonConfig.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/JacksonConfig.java
@@ -16,6 +16,7 @@ import com.fasterxml.jackson.databind.cfg.CoercionInputShape;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.camunda.gateway.protocol.model.AgentInstanceStatusFilterProperty;
 import io.camunda.gateway.protocol.model.AuditLogActorTypeFilterProperty;
 import io.camunda.gateway.protocol.model.AuditLogResultFilterProperty;
 import io.camunda.gateway.protocol.model.AuthorizationRequest;
@@ -45,6 +46,7 @@ import io.camunda.gateway.protocol.model.ProcessInstanceStateFilterProperty;
 import io.camunda.gateway.protocol.model.SearchQueryPageRequest;
 import io.camunda.gateway.protocol.model.StringFilterProperty;
 import io.camunda.gateway.protocol.model.UserTaskStateFilterProperty;
+import io.camunda.zeebe.gateway.rest.deserializer.AgentInstanceStatusFilterPropertyDeserializer;
 import io.camunda.zeebe.gateway.rest.deserializer.AuditLogActorTypeFilterPropertyDeserializer;
 import io.camunda.zeebe.gateway.rest.deserializer.AuditLogCategoryFilterPropertyDeserializer;
 import io.camunda.zeebe.gateway.rest.deserializer.AuditLogEntityTypeFilterPropertyDeserializer;
@@ -147,6 +149,9 @@ public class JacksonConfig {
     module.addDeserializer(
         ProcessInstanceModificationTerminateInstruction.class,
         new ProcessInstanceModificationTerminateInstructionDeserializer());
+    module.addDeserializer(
+        AgentInstanceStatusFilterProperty.class,
+        new AgentInstanceStatusFilterPropertyDeserializer());
     return builder -> builder.modulesToInstall(modules -> modules.add(module));
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceController.java
@@ -7,14 +7,24 @@
  */
 package io.camunda.zeebe.gateway.rest.controller;
 
+import static io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper.mapErrorToResponse;
+
 import io.camunda.gateway.mapping.http.mapper.AgentInstanceMapper;
+import io.camunda.gateway.mapping.http.search.SearchQueryRequestMapper;
+import io.camunda.gateway.mapping.http.search.SearchQueryResponseMapper;
 import io.camunda.gateway.mapping.http.validator.AgentInstanceRequestValidator;
 import io.camunda.gateway.protocol.model.AgentInstanceCreationRequest;
+import io.camunda.gateway.protocol.model.AgentInstanceResult;
+import io.camunda.gateway.protocol.model.AgentInstanceSearchQuery;
+import io.camunda.gateway.protocol.model.AgentInstanceSearchQueryResult;
 import io.camunda.gateway.protocol.model.AgentInstanceUpdateRequest;
+import io.camunda.search.query.AgentInstanceQuery;
 import io.camunda.security.api.context.CamundaAuthenticationProvider;
 import io.camunda.service.AgentInstanceServices;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPatchMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
+import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
@@ -49,14 +59,6 @@ public class AgentInstanceController {
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::create);
   }
 
-  private CompletableFuture<ResponseEntity<Object>> create(final AgentInstanceRecord record) {
-    final var authentication = authenticationProvider.getCamundaAuthentication();
-    return RequestExecutor.executeServiceMethod(
-        () -> agentInstanceServices.createAgentInstance(record, authentication),
-        mapper::toAgentInstanceCreationResult,
-        HttpStatus.OK);
-  }
-
   @CamundaPatchMapping(path = "/{agentInstanceKey}")
   public CompletableFuture<ResponseEntity<Object>> updateAgentInstance(
       @PathVariable final String agentInstanceKey,
@@ -66,9 +68,50 @@ public class AgentInstanceController {
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::update);
   }
 
+  @RequiresSecondaryStorage
+  @CamundaGetMapping(path = "/{agentInstanceKey}")
+  public ResponseEntity<AgentInstanceResult> getAgentInstance(
+      @PathVariable("agentInstanceKey") final long agentInstanceKey) {
+    try {
+      final var agentInstance =
+          agentInstanceServices.getByKey(
+              agentInstanceKey, authenticationProvider.getCamundaAuthentication());
+      return ResponseEntity.ok(SearchQueryResponseMapper.toAgentInstanceResult(agentInstance));
+    } catch (final Exception e) {
+      return mapErrorToResponse(e);
+    }
+  }
+
+  @RequiresSecondaryStorage
+  @CamundaPostMapping(path = "/search")
+  public ResponseEntity<AgentInstanceSearchQueryResult> searchAgentInstances(
+      @RequestBody(required = false) final AgentInstanceSearchQuery request) {
+    return SearchQueryRequestMapper.toAgentInstanceQuery(request)
+        .fold(RestErrorMapper::mapProblemToResponse, this::search);
+  }
+
+  private CompletableFuture<ResponseEntity<Object>> create(final AgentInstanceRecord record) {
+    final var authentication = authenticationProvider.getCamundaAuthentication();
+    return RequestExecutor.executeServiceMethod(
+        () -> agentInstanceServices.createAgentInstance(record, authentication),
+        mapper::toAgentInstanceCreationResult,
+        HttpStatus.OK);
+  }
+
   private CompletableFuture<ResponseEntity<Object>> update(final AgentInstanceRecord record) {
     final var authentication = authenticationProvider.getCamundaAuthentication();
     return RequestExecutor.executeServiceMethodWithNoContentResult(
         () -> agentInstanceServices.updateAgentInstance(record, authentication));
+  }
+
+  private ResponseEntity<AgentInstanceSearchQueryResult> search(final AgentInstanceQuery query) {
+    try {
+      final var result =
+          agentInstanceServices.search(query, authenticationProvider.getCamundaAuthentication());
+      return ResponseEntity.ok(
+          SearchQueryResponseMapper.toAgentInstanceSearchQueryResponse(result));
+    } catch (final Exception e) {
+      return mapErrorToResponse(e);
+    }
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/deserializer/AgentInstanceStatusFilterPropertyDeserializer.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/deserializer/AgentInstanceStatusFilterPropertyDeserializer.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.deserializer;
+
+import io.camunda.gateway.protocol.model.AdvancedAgentInstanceStatusFilter;
+import io.camunda.gateway.protocol.model.AgentInstanceStatusEnum;
+import io.camunda.gateway.protocol.model.AgentInstanceStatusFilterProperty;
+
+public class AgentInstanceStatusFilterPropertyDeserializer
+    extends FilterDeserializer<AgentInstanceStatusFilterProperty, AgentInstanceStatusEnum> {
+
+  @Override
+  protected Class<? extends AgentInstanceStatusFilterProperty> getFinalType() {
+    return AdvancedAgentInstanceStatusFilter.class;
+  }
+
+  @Override
+  protected Class<AgentInstanceStatusEnum> getImplicitValueType() {
+    return AgentInstanceStatusEnum.class;
+  }
+
+  @Override
+  protected AgentInstanceStatusFilterProperty createFromImplicitValue(
+      final AgentInstanceStatusEnum value) {
+    return AdvancedAgentInstanceStatusFilter.Builder.create().$eq(value).build();
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
@@ -11,27 +11,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Named.named;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.assertArg;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import io.camunda.search.entities.AgentInstanceEntity;
-import io.camunda.search.entities.AgentInstanceEntity.AgentInstanceDefinition;
-import io.camunda.search.entities.AgentInstanceEntity.AgentInstanceLimits;
-import io.camunda.search.entities.AgentInstanceEntity.AgentInstanceMetrics;
-import io.camunda.search.entities.AgentInstanceEntity.AgentInstanceStatus;
-import io.camunda.search.entities.AgentInstanceEntity.AgentInstanceTool;
-import io.camunda.search.exception.CamundaSearchException;
-import io.camunda.search.query.AgentInstanceQuery;
-import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.api.context.CamundaAuthenticationProvider;
 import io.camunda.service.AgentInstanceServices;
-import io.camunda.service.exception.ErrorMapper;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
-import java.time.OffsetDateTime;
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
@@ -50,36 +37,6 @@ class AgentInstanceControllerTest extends RestControllerTest {
   private static final String AGENT_INSTANCES_URL = "/v2/agent-instances";
   private static final long ELEMENT_INSTANCE_KEY = 2251799813685248L;
   private static final long AGENT_INSTANCE_KEY = 9007199254741017L;
-  private static final long PROCESS_INSTANCE_KEY = 9007199254741001L;
-  private static final long ROOT_PROCESS_INSTANCE_KEY = 9007199254741000L;
-  private static final long PROCESS_DEFINITION_KEY = 9007199254740992L;
-  private static final OffsetDateTime CREATION_DATE =
-      OffsetDateTime.parse("2024-01-01T10:00:00+00:00");
-  private static final OffsetDateTime LAST_UPDATED_DATE =
-      OffsetDateTime.parse("2024-01-01T10:05:00+00:00");
-  private static final OffsetDateTime COMPLETION_DATE =
-      OffsetDateTime.parse("2024-01-01T10:05:00+00:00");
-
-  private static final AgentInstanceEntity AGENT_INSTANCE_ENTITY =
-      new AgentInstanceEntity(
-          AGENT_INSTANCE_KEY,
-          List.of(ELEMENT_INSTANCE_KEY),
-          AgentInstanceStatus.COMPLETED,
-          new AgentInstanceDefinition("gpt-4o", "openai", "You are a helpful assistant."),
-          new AgentInstanceMetrics(100L, 200L, 3, 5),
-          new AgentInstanceLimits(10000L, 10, 50),
-          List.of(new AgentInstanceTool("search", "Search the web", "searchElement")),
-          "AgentTask",
-          PROCESS_INSTANCE_KEY,
-          ROOT_PROCESS_INSTANCE_KEY,
-          PROCESS_DEFINITION_KEY,
-          "myProcessId",
-          1,
-          "v1",
-          "<default>",
-          CREATION_DATE,
-          LAST_UPDATED_DATE,
-          COMPLETION_DATE);
 
   @MockitoBean private AgentInstanceServices agentInstanceServices;
   @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
@@ -88,184 +45,6 @@ class AgentInstanceControllerTest extends RestControllerTest {
   void setUp() {
     when(authenticationProvider.getCamundaAuthentication())
         .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
-  }
-
-  @Test
-  void shouldGetAgentInstance() {
-    // given
-    when(agentInstanceServices.getByKey(eq(AGENT_INSTANCE_KEY), any()))
-        .thenReturn(AGENT_INSTANCE_ENTITY);
-
-    // when / then
-    webClient
-        .get()
-        .uri("%s/%d".formatted(AGENT_INSTANCES_URL, AGENT_INSTANCE_KEY))
-        .accept(MediaType.APPLICATION_JSON)
-        .exchange()
-        .expectStatus()
-        .isOk()
-        .expectBody()
-        .json(
-            """
-            {
-              "agentInstanceKey": "%d",
-              "status": "COMPLETED",
-              "definition": {
-                "model": "gpt-4o",
-                "provider": "openai",
-                "systemPrompt": "You are a helpful assistant."
-              },
-              "metrics": {
-                "inputTokens": 100,
-                "outputTokens": 200,
-                "modelCalls": 3,
-                "toolCalls": 5
-              },
-              "limits": {
-                "maxModelCalls": 10,
-                "maxTokens": 10000,
-                "maxToolCalls": 50
-              },
-              "tools": [
-                {
-                  "name": "search",
-                  "description": "Search the web",
-                  "elementId": "searchElement"
-                }
-              ],
-              "elementId": "AgentTask",
-              "processInstanceKey": "%d",
-              "rootProcessInstanceKey": "%d",
-              "processDefinitionKey": "%d",
-              "processDefinitionId": "myProcessId",
-              "processDefinitionVersion": 1,
-              "processDefinitionVersionTag": "v1",
-              "tenantId": "<default>",
-              "creationDate": "2024-01-01T10:00:00.000Z",
-              "lastUpdatedDate": "2024-01-01T10:05:00.000Z",
-              "completionDate": "2024-01-01T10:05:00.000Z",
-              "elementInstanceKeys": ["%d"]
-            }
-            """
-                .formatted(
-                    AGENT_INSTANCE_KEY,
-                    PROCESS_INSTANCE_KEY,
-                    ROOT_PROCESS_INSTANCE_KEY,
-                    PROCESS_DEFINITION_KEY,
-                    ELEMENT_INSTANCE_KEY),
-            JsonCompareMode.LENIENT);
-  }
-
-  @Test
-  void shouldReturnNotFoundForUnknownAgentInstanceKey() {
-    // given
-    final var path = "%s/%d".formatted(AGENT_INSTANCES_URL, AGENT_INSTANCE_KEY);
-    when(agentInstanceServices.getByKey(eq(AGENT_INSTANCE_KEY), any()))
-        .thenThrow(
-            ErrorMapper.mapSearchError(
-                new CamundaSearchException(
-                    "agent instance not found", CamundaSearchException.Reason.NOT_FOUND)));
-
-    // when / then
-    webClient
-        .get()
-        .uri(path)
-        .accept(MediaType.APPLICATION_JSON)
-        .exchange()
-        .expectStatus()
-        .isNotFound()
-        .expectBody()
-        .json(
-            """
-            {
-              "type": "about:blank",
-              "title": "NOT_FOUND",
-              "status": 404,
-              "detail": "agent instance not found",
-              "instance": "%s"
-            }"""
-                .formatted(path),
-            JsonCompareMode.STRICT);
-  }
-
-  @Test
-  void shouldSearchAgentInstancesWithEmptyBody() {
-    // given
-    when(agentInstanceServices.search(any(AgentInstanceQuery.class), any()))
-        .thenReturn(
-            new SearchQueryResult.Builder<AgentInstanceEntity>().total(0).items(List.of()).build());
-
-    // when / then
-    webClient
-        .post()
-        .uri("%s/search".formatted(AGENT_INSTANCES_URL))
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .exchange()
-        .expectStatus()
-        .isOk()
-        .expectBody()
-        .json(
-            """
-            {
-              "items": [],
-              "page": { "totalItems": 0 }
-            }
-            """,
-            JsonCompareMode.LENIENT);
-  }
-
-  @Test
-  void shouldSearchAgentInstances() {
-    // given
-    when(agentInstanceServices.search(any(AgentInstanceQuery.class), any()))
-        .thenReturn(
-            new SearchQueryResult.Builder<AgentInstanceEntity>()
-                .total(1)
-                .startCursor("f")
-                .endCursor("v")
-                .items(List.of(AGENT_INSTANCE_ENTITY))
-                .build());
-
-    // when / then
-    webClient
-        .post()
-        .uri("%s/search".formatted(AGENT_INSTANCES_URL))
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(
-            """
-            {
-              "filter": {
-                "status": { "$eq": "COMPLETED" }
-              }
-            }
-            """)
-        .exchange()
-        .expectStatus()
-        .isOk()
-        .expectBody()
-        .json(
-            """
-            {
-              "items": [
-                {
-                  "agentInstanceKey": "%d",
-                  "status": "COMPLETED",
-                  "processDefinitionId": "myProcessId",
-                  "processDefinitionVersion": 1,
-                  "processDefinitionVersionTag": "v1"
-                }
-              ],
-              "page": {
-                "totalItems": 1,
-                "startCursor": "f",
-                "endCursor": "v"
-              }
-            }
-            """
-                .formatted(AGENT_INSTANCE_KEY),
-            JsonCompareMode.LENIENT);
   }
 
   @Test

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
@@ -11,14 +11,27 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Named.named;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.assertArg;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import io.camunda.search.entities.AgentInstanceEntity;
+import io.camunda.search.entities.AgentInstanceEntity.AgentInstanceDefinition;
+import io.camunda.search.entities.AgentInstanceEntity.AgentInstanceLimits;
+import io.camunda.search.entities.AgentInstanceEntity.AgentInstanceMetrics;
+import io.camunda.search.entities.AgentInstanceEntity.AgentInstanceStatus;
+import io.camunda.search.entities.AgentInstanceEntity.AgentInstanceTool;
+import io.camunda.search.exception.CamundaSearchException;
+import io.camunda.search.query.AgentInstanceQuery;
+import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.api.context.CamundaAuthenticationProvider;
 import io.camunda.service.AgentInstanceServices;
+import io.camunda.service.exception.ErrorMapper;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
+import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,6 +50,36 @@ class AgentInstanceControllerTest extends RestControllerTest {
   private static final String AGENT_INSTANCES_URL = "/v2/agent-instances";
   private static final long ELEMENT_INSTANCE_KEY = 2251799813685248L;
   private static final long AGENT_INSTANCE_KEY = 9007199254741017L;
+  private static final long PROCESS_INSTANCE_KEY = 9007199254741001L;
+  private static final long ROOT_PROCESS_INSTANCE_KEY = 9007199254741000L;
+  private static final long PROCESS_DEFINITION_KEY = 9007199254740992L;
+  private static final OffsetDateTime CREATION_DATE =
+      OffsetDateTime.parse("2024-01-01T10:00:00+00:00");
+  private static final OffsetDateTime LAST_UPDATED_DATE =
+      OffsetDateTime.parse("2024-01-01T10:05:00+00:00");
+  private static final OffsetDateTime COMPLETION_DATE =
+      OffsetDateTime.parse("2024-01-01T10:05:00+00:00");
+
+  private static final AgentInstanceEntity AGENT_INSTANCE_ENTITY =
+      new AgentInstanceEntity(
+          AGENT_INSTANCE_KEY,
+          List.of(ELEMENT_INSTANCE_KEY),
+          AgentInstanceStatus.COMPLETED,
+          new AgentInstanceDefinition("gpt-4o", "openai", "You are a helpful assistant."),
+          new AgentInstanceMetrics(100L, 200L, 3, 5),
+          new AgentInstanceLimits(10000L, 10, 50),
+          List.of(new AgentInstanceTool("search", "Search the web", "searchElement")),
+          "AgentTask",
+          PROCESS_INSTANCE_KEY,
+          ROOT_PROCESS_INSTANCE_KEY,
+          PROCESS_DEFINITION_KEY,
+          "myProcessId",
+          1,
+          "v1",
+          "<default>",
+          CREATION_DATE,
+          LAST_UPDATED_DATE,
+          COMPLETION_DATE);
 
   @MockitoBean private AgentInstanceServices agentInstanceServices;
   @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
@@ -45,6 +88,184 @@ class AgentInstanceControllerTest extends RestControllerTest {
   void setUp() {
     when(authenticationProvider.getCamundaAuthentication())
         .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
+  }
+
+  @Test
+  void shouldGetAgentInstance() {
+    // given
+    when(agentInstanceServices.getByKey(eq(AGENT_INSTANCE_KEY), any()))
+        .thenReturn(AGENT_INSTANCE_ENTITY);
+
+    // when / then
+    webClient
+        .get()
+        .uri("%s/%d".formatted(AGENT_INSTANCES_URL, AGENT_INSTANCE_KEY))
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .json(
+            """
+            {
+              "agentInstanceKey": "%d",
+              "status": "COMPLETED",
+              "definition": {
+                "model": "gpt-4o",
+                "provider": "openai",
+                "systemPrompt": "You are a helpful assistant."
+              },
+              "metrics": {
+                "inputTokens": 100,
+                "outputTokens": 200,
+                "modelCalls": 3,
+                "toolCalls": 5
+              },
+              "limits": {
+                "maxModelCalls": 10,
+                "maxTokens": 10000,
+                "maxToolCalls": 50
+              },
+              "tools": [
+                {
+                  "name": "search",
+                  "description": "Search the web",
+                  "elementId": "searchElement"
+                }
+              ],
+              "elementId": "AgentTask",
+              "processInstanceKey": "%d",
+              "rootProcessInstanceKey": "%d",
+              "processDefinitionKey": "%d",
+              "processDefinitionId": "myProcessId",
+              "processDefinitionVersion": 1,
+              "processDefinitionVersionTag": "v1",
+              "tenantId": "<default>",
+              "creationDate": "2024-01-01T10:00:00.000Z",
+              "lastUpdatedDate": "2024-01-01T10:05:00.000Z",
+              "completionDate": "2024-01-01T10:05:00.000Z",
+              "elementInstanceKeys": ["%d"]
+            }
+            """
+                .formatted(
+                    AGENT_INSTANCE_KEY,
+                    PROCESS_INSTANCE_KEY,
+                    ROOT_PROCESS_INSTANCE_KEY,
+                    PROCESS_DEFINITION_KEY,
+                    ELEMENT_INSTANCE_KEY),
+            JsonCompareMode.LENIENT);
+  }
+
+  @Test
+  void shouldReturnNotFoundForUnknownAgentInstanceKey() {
+    // given
+    final var path = "%s/%d".formatted(AGENT_INSTANCES_URL, AGENT_INSTANCE_KEY);
+    when(agentInstanceServices.getByKey(eq(AGENT_INSTANCE_KEY), any()))
+        .thenThrow(
+            ErrorMapper.mapSearchError(
+                new CamundaSearchException(
+                    "agent instance not found", CamundaSearchException.Reason.NOT_FOUND)));
+
+    // when / then
+    webClient
+        .get()
+        .uri(path)
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isNotFound()
+        .expectBody()
+        .json(
+            """
+            {
+              "type": "about:blank",
+              "title": "NOT_FOUND",
+              "status": 404,
+              "detail": "agent instance not found",
+              "instance": "%s"
+            }"""
+                .formatted(path),
+            JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldSearchAgentInstancesWithEmptyBody() {
+    // given
+    when(agentInstanceServices.search(any(AgentInstanceQuery.class), any()))
+        .thenReturn(
+            new SearchQueryResult.Builder<AgentInstanceEntity>().total(0).items(List.of()).build());
+
+    // when / then
+    webClient
+        .post()
+        .uri("%s/search".formatted(AGENT_INSTANCES_URL))
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .json(
+            """
+            {
+              "items": [],
+              "page": { "totalItems": 0 }
+            }
+            """,
+            JsonCompareMode.LENIENT);
+  }
+
+  @Test
+  void shouldSearchAgentInstances() {
+    // given
+    when(agentInstanceServices.search(any(AgentInstanceQuery.class), any()))
+        .thenReturn(
+            new SearchQueryResult.Builder<AgentInstanceEntity>()
+                .total(1)
+                .startCursor("f")
+                .endCursor("v")
+                .items(List.of(AGENT_INSTANCE_ENTITY))
+                .build());
+
+    // when / then
+    webClient
+        .post()
+        .uri("%s/search".formatted(AGENT_INSTANCES_URL))
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(
+            """
+            {
+              "filter": {
+                "status": { "$eq": "COMPLETED" }
+              }
+            }
+            """)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .json(
+            """
+            {
+              "items": [
+                {
+                  "agentInstanceKey": "%d",
+                  "status": "COMPLETED",
+                  "processDefinitionId": "myProcessId",
+                  "processDefinitionVersion": 1,
+                  "processDefinitionVersionTag": "v1"
+                }
+              ],
+              "page": {
+                "totalItems": 1,
+                "startCursor": "f",
+                "endCursor": "v"
+              }
+            }
+            """
+                .formatted(AGENT_INSTANCE_KEY),
+            JsonCompareMode.LENIENT);
   }
 
   @Test

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceQueryControllerTest.java
@@ -1,0 +1,322 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.search.entities.AgentInstanceEntity;
+import io.camunda.search.entities.AgentInstanceEntity.AgentInstanceDefinition;
+import io.camunda.search.entities.AgentInstanceEntity.AgentInstanceLimits;
+import io.camunda.search.entities.AgentInstanceEntity.AgentInstanceMetrics;
+import io.camunda.search.entities.AgentInstanceEntity.AgentInstanceStatus;
+import io.camunda.search.entities.AgentInstanceEntity.AgentInstanceTool;
+import io.camunda.search.exception.CamundaSearchException;
+import io.camunda.search.filter.AgentInstanceFilter;
+import io.camunda.search.filter.Operation;
+import io.camunda.search.query.AgentInstanceQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.api.context.CamundaAuthenticationProvider;
+import io.camunda.service.AgentInstanceServices;
+import io.camunda.service.exception.ErrorMapper;
+import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
+
+@WebMvcTest(AgentInstanceController.class)
+class AgentInstanceQueryControllerTest extends RestControllerTest {
+
+  static final String AGENT_INSTANCES_URL = "/v2/agent-instances";
+  static final String AGENT_INSTANCES_SEARCH_URL = AGENT_INSTANCES_URL + "/search";
+
+  private static final long ELEMENT_INSTANCE_KEY = 2251799813685248L;
+  private static final long AGENT_INSTANCE_KEY = 9007199254741017L;
+  private static final long PROCESS_INSTANCE_KEY = 9007199254741001L;
+  private static final long ROOT_PROCESS_INSTANCE_KEY = 9007199254741000L;
+  private static final long PROCESS_DEFINITION_KEY = 9007199254740992L;
+  private static final OffsetDateTime CREATION_DATE =
+      OffsetDateTime.parse("2024-01-01T10:00:00+00:00");
+  private static final OffsetDateTime LAST_UPDATED_DATE =
+      OffsetDateTime.parse("2024-01-01T10:05:00+00:00");
+  private static final OffsetDateTime COMPLETION_DATE =
+      OffsetDateTime.parse("2024-01-01T10:05:00+00:00");
+
+  private static final AgentInstanceEntity AGENT_INSTANCE_ENTITY =
+      new AgentInstanceEntity(
+          AGENT_INSTANCE_KEY,
+          List.of(ELEMENT_INSTANCE_KEY),
+          AgentInstanceStatus.COMPLETED,
+          new AgentInstanceDefinition("gpt-4o", "openai", "You are a helpful assistant."),
+          new AgentInstanceMetrics(100L, 200L, 3, 5),
+          new AgentInstanceLimits(10000L, 10, 50),
+          List.of(new AgentInstanceTool("search", "Search the web", "searchElement")),
+          "AgentTask",
+          PROCESS_INSTANCE_KEY,
+          ROOT_PROCESS_INSTANCE_KEY,
+          PROCESS_DEFINITION_KEY,
+          "myProcessId",
+          1,
+          "v1",
+          "<default>",
+          CREATION_DATE,
+          LAST_UPDATED_DATE,
+          COMPLETION_DATE);
+
+  private static final String EXPECTED_SEARCH_RESPONSE =
+      """
+      {
+        "items": [
+          {
+            "agentInstanceKey": "%d",
+            "status": "COMPLETED",
+            "definition": {
+              "model": "gpt-4o",
+              "provider": "openai",
+              "systemPrompt": "You are a helpful assistant."
+            },
+            "metrics": {
+              "inputTokens": 100,
+              "outputTokens": 200,
+              "modelCalls": 3,
+              "toolCalls": 5
+            },
+            "limits": {
+              "maxModelCalls": 10,
+              "maxTokens": 10000,
+              "maxToolCalls": 50
+            },
+            "tools": [
+              {
+                "name": "search",
+                "description": "Search the web",
+                "elementId": "searchElement"
+              }
+            ],
+            "elementId": "AgentTask",
+            "processInstanceKey": "%d",
+            "rootProcessInstanceKey": "%d",
+            "processDefinitionKey": "%d",
+            "processDefinitionId": "myProcessId",
+            "processDefinitionVersion": 1,
+            "processDefinitionVersionTag": "v1",
+            "tenantId": "<default>",
+            "creationDate": "2024-01-01T10:00:00.000Z",
+            "lastUpdatedDate": "2024-01-01T10:05:00.000Z",
+            "completionDate": "2024-01-01T10:05:00.000Z",
+            "elementInstanceKeys": ["%d"]
+          }
+        ],
+        "page": {
+          "totalItems": 1,
+          "startCursor": "f",
+          "endCursor": "v",
+          "hasMoreTotalItems": false
+        }
+      }
+      """
+          .formatted(
+              AGENT_INSTANCE_KEY,
+              PROCESS_INSTANCE_KEY,
+              ROOT_PROCESS_INSTANCE_KEY,
+              PROCESS_DEFINITION_KEY,
+              ELEMENT_INSTANCE_KEY);
+
+  @MockitoBean private AgentInstanceServices agentInstanceServices;
+  @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
+
+  @BeforeEach
+  void setUp() {
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
+  }
+
+  @Test
+  void shouldGetAgentInstance() {
+    // given
+    when(agentInstanceServices.getByKey(eq(AGENT_INSTANCE_KEY), any()))
+        .thenReturn(AGENT_INSTANCE_ENTITY);
+
+    // when / then
+    webClient
+        .get()
+        .uri("%s/%d".formatted(AGENT_INSTANCES_URL, AGENT_INSTANCE_KEY))
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(
+            """
+            {
+              "agentInstanceKey": "%d",
+              "status": "COMPLETED",
+              "definition": {
+                "model": "gpt-4o",
+                "provider": "openai",
+                "systemPrompt": "You are a helpful assistant."
+              },
+              "metrics": {
+                "inputTokens": 100,
+                "outputTokens": 200,
+                "modelCalls": 3,
+                "toolCalls": 5
+              },
+              "limits": {
+                "maxModelCalls": 10,
+                "maxTokens": 10000,
+                "maxToolCalls": 50
+              },
+              "tools": [
+                {
+                  "name": "search",
+                  "description": "Search the web",
+                  "elementId": "searchElement"
+                }
+              ],
+              "elementId": "AgentTask",
+              "processInstanceKey": "%d",
+              "rootProcessInstanceKey": "%d",
+              "processDefinitionKey": "%d",
+              "processDefinitionId": "myProcessId",
+              "processDefinitionVersion": 1,
+              "processDefinitionVersionTag": "v1",
+              "tenantId": "<default>",
+              "creationDate": "2024-01-01T10:00:00.000Z",
+              "lastUpdatedDate": "2024-01-01T10:05:00.000Z",
+              "completionDate": "2024-01-01T10:05:00.000Z",
+              "elementInstanceKeys": ["%d"]
+            }
+            """
+                .formatted(
+                    AGENT_INSTANCE_KEY,
+                    PROCESS_INSTANCE_KEY,
+                    ROOT_PROCESS_INSTANCE_KEY,
+                    PROCESS_DEFINITION_KEY,
+                    ELEMENT_INSTANCE_KEY),
+            JsonCompareMode.STRICT);
+
+    verify(agentInstanceServices).getByKey(eq(AGENT_INSTANCE_KEY), any());
+  }
+
+  @Test
+  void shouldReturnNotFoundForUnknownAgentInstanceKey() {
+    // given
+    final var path = "%s/%d".formatted(AGENT_INSTANCES_URL, AGENT_INSTANCE_KEY);
+    when(agentInstanceServices.getByKey(eq(AGENT_INSTANCE_KEY), any()))
+        .thenThrow(
+            ErrorMapper.mapSearchError(
+                new CamundaSearchException(
+                    "agent instance not found", CamundaSearchException.Reason.NOT_FOUND)));
+
+    // when / then
+    webClient
+        .get()
+        .uri(path)
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isNotFound()
+        .expectBody()
+        .json(
+            """
+            {
+              "type": "about:blank",
+              "title": "NOT_FOUND",
+              "status": 404,
+              "detail": "agent instance not found",
+              "instance": "%s"
+            }"""
+                .formatted(path),
+            JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldSearchAgentInstancesWithEmptyBody() {
+    // given
+    when(agentInstanceServices.search(any(AgentInstanceQuery.class), any()))
+        .thenReturn(
+            new SearchQueryResult.Builder<AgentInstanceEntity>()
+                .total(1)
+                .startCursor("f")
+                .endCursor("v")
+                .items(List.of(AGENT_INSTANCE_ENTITY))
+                .build());
+
+    // when / then
+    webClient
+        .post()
+        .uri(AGENT_INSTANCES_SEARCH_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
+
+    verify(agentInstanceServices).search(eq(new AgentInstanceQuery.Builder().build()), any());
+  }
+
+  @Test
+  void shouldSearchAgentInstancesWithStatusFilter() {
+    // given
+    when(agentInstanceServices.search(any(AgentInstanceQuery.class), any()))
+        .thenReturn(
+            new SearchQueryResult.Builder<AgentInstanceEntity>()
+                .total(1)
+                .startCursor("f")
+                .endCursor("v")
+                .items(List.of(AGENT_INSTANCE_ENTITY))
+                .build());
+
+    // when / then
+    webClient
+        .post()
+        .uri(AGENT_INSTANCES_SEARCH_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(
+            """
+            {
+              "filter": {
+                "status": { "$eq": "COMPLETED" }
+              }
+            }
+            """)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
+
+    verify(agentInstanceServices)
+        .search(
+            eq(
+                new AgentInstanceQuery.Builder()
+                    .filter(
+                        new AgentInstanceFilter.Builder()
+                            .statusOperations(List.of(Operation.eq("COMPLETED")))
+                            .build())
+                    .build()),
+            any());
+  }
+}


### PR DESCRIPTION
## Description

Implements GET by key and search endpoints for agent instances as part of #51510 (#53686).

**What was introduced:**

- Enriched `AgentInstanceResult` with 4 new fields: `processDefinitionId`, `processDefinitionVersion`, `versionTag`, and `rootProcessInstanceKey`
- `AgentInstanceSearchClient` interface and `AgentInstanceReader` interface — the full search client/reader contracts for agent instances
- Stub implementations `AgentInstanceDocumentReader` (ES/OS) and `AgentInstanceDbReader` (RDBMS) that throw `UnsupportedOperationException`, wired into all required construction sites (`SearchClientReaders`, `SearchClientReadersFactory`, `SearchClientConfiguration`, `RdbmsConfiguration`)
- `GET /v2/agent-instances/{agentInstanceKey}` and `POST /v2/agent-instances/search` endpoints in `AgentInstanceController`
- Full mapper support: filter, sort, request, and response mappers for agent instances
- `AgentInstanceServices` extended to `SearchQueryService` with `getByKey()` and `search()` using `AGENT_INSTANCE_READ_AUTHORIZATION`
- `AgentInstanceStatusFilterPropertyDeserializer` registered in `JacksonConfig` to support structured status filters (e.g. `{"$eq": "COMPLETED"}`)
- Controller tests covering GET (happy path + 404), search with empty body, and search with status filter

The stub readers are introduced now to unblock parallel work on the actual secondary-storage implementations:
- ES/OS reader: https://github.com/camunda/camunda/issues/52817
- RDBMS reader: https://github.com/camunda/camunda/issues/52820

**Out of scope:**
- Actual ES/OS and RDBMS query implementations (covered by #52817 and #52820)
- Integration/acceptance tests (depend on working secondary-storage backends)

## Checklist

- [ ] Enable backports when necessary

## Related issues

closes #53686