### PR TITLE
refactor: make DirectBufferWriter immutable with non null fields

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/entry/SerializedApplicationEntry.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/entry/SerializedApplicationEntry.java
@@ -45,6 +45,6 @@ public record SerializedApplicationEntry(
 
   @Override
   public BufferWriter dataWriter() {
-    return new DirectBufferWriter().wrap(data);
+    return new DirectBufferWriter(data);
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/backup/ConcurrentBackupCompactionTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/backup/ConcurrentBackupCompactionTest.java
@@ -201,7 +201,7 @@ public class ConcurrentBackupCompactionTest extends DynamicAutoCloseable {
   }
 
   private void appendRecord(final long asqn, final String data) {
-    journal.append(asqn, new DirectBufferWriter().wrap(new UnsafeBuffer(data.getBytes())));
+    journal.append(asqn, new DirectBufferWriter(new UnsafeBuffer(data.getBytes())));
   }
 
   private PersistedSnapshot takeSnapshot(final long index, final long lastWrittenPosition) {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/commandapi/CommandResponseWriterImplTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/commandapi/CommandResponseWriterImplTest.java
@@ -18,7 +18,6 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.util.buffer.DirectBufferWriter;
 import org.agrona.concurrent.UnsafeBuffer;
-import org.junit.Before;
 import org.junit.Test;
 
 public final class CommandResponseWriterImplTest {
@@ -29,20 +28,12 @@ public final class CommandResponseWriterImplTest {
   private final MessageHeaderDecoder messageHeaderDecoder = new MessageHeaderDecoder();
   private final ExecuteCommandResponseDecoder responseDecoder = new ExecuteCommandResponseDecoder();
 
-  private CommandResponseWriterImpl responseWriter;
-  private DirectBufferWriter eventWriter;
-
-  @Before
-  public void setup() {
-    eventWriter = new DirectBufferWriter();
-  }
-
   @Test
   public void shouldWriteResponse() {
     // given
-    responseWriter = new CommandResponseWriterImpl(null);
+    final var responseWriter = new CommandResponseWriterImpl(null);
 
-    eventWriter.wrap(new UnsafeBuffer(EVENT), 0, EVENT.length);
+    final var eventWriter = new DirectBufferWriter(new UnsafeBuffer(EVENT), 0, EVENT.length);
 
     responseWriter
         .partitionId(PARTITION_ID)

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentWriter.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentWriter.java
@@ -116,7 +116,7 @@ final class SegmentWriter {
   Either<SegmentFull, JournalRecord> append(final JournalRecord record) {
     final var entryIndex = record.index();
     final var asqn = record.asqn();
-    final var recordDataWriter = new DirectBufferWriter().wrap(record.data());
+    final var recordDataWriter = new DirectBufferWriter(record.data());
     final var expectedChecksum = record.checksum();
 
     verifyAsqnIsIncreasing(asqn);

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/record/JournalRecordSerializer.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/record/JournalRecordSerializer.java
@@ -28,11 +28,7 @@ public interface JournalRecordSerializer {
   default Either<BufferOverflowException, Integer> writeData(
       final RecordData record, final MutableDirectBuffer buffer, final int offset) {
     return writeData(
-        record.index(),
-        record.asqn(),
-        new DirectBufferWriter().wrap(record.data()),
-        buffer,
-        offset);
+        record.index(), record.asqn(), new DirectBufferWriter(record.data()), buffer, offset);
   }
 
   Either<BufferOverflowException, Integer> writeData(

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/JournalAppendTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/JournalAppendTest.java
@@ -37,18 +37,18 @@ final class JournalAppendTest {
   @TempDir Path directory;
   final JournalMetaStore metaStore = new MockJournalMetastore();
   @AutoClose private final MeterRegistry meterRegistry = new SimpleMeterRegistry();
+  private DirectBufferWriter recordDataWriter;
+  private DirectBufferWriter otherRecordDataWriter;
 
-  private final DirectBufferWriter recordDataWriter = new DirectBufferWriter();
-  private final DirectBufferWriter otherRecordDataWriter = new DirectBufferWriter();
   private Journal journal;
 
   @BeforeEach
   void setup() {
     final byte[] entry = "TestData".getBytes();
-    recordDataWriter.wrap(new UnsafeBuffer(entry));
+    recordDataWriter = new DirectBufferWriter(new UnsafeBuffer(entry));
 
     final var entryOther = "TestData".getBytes();
-    otherRecordDataWriter.wrap(new UnsafeBuffer(entryOther));
+    otherRecordDataWriter = new DirectBufferWriter(new UnsafeBuffer(entryOther));
 
     journal = openJournal();
   }

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/JournalReaderTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/JournalReaderTest.java
@@ -33,7 +33,7 @@ final class JournalReaderTest {
 
   @AutoClose private final MeterRegistry meterRegistry = new SimpleMeterRegistry();
   private final UnsafeBuffer data = new UnsafeBuffer("test".getBytes(StandardCharsets.UTF_8));
-  private final BufferWriter recordDataWriter = new DirectBufferWriter().wrap(data);
+  private final BufferWriter recordDataWriter = new DirectBufferWriter(data);
   private JournalReader reader;
   private SegmentedJournal journal;
 

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/JournalTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/JournalTest.java
@@ -43,17 +43,17 @@ final class JournalTest {
   final JournalMetaStore metaStore = new MockJournalMetastore();
   @AutoClose private final MeterRegistry meterRegistry = new SimpleMeterRegistry();
   private byte[] entry;
-  private final DirectBufferWriter recordDataWriter = new DirectBufferWriter();
-  private final DirectBufferWriter otherRecordDataWriter = new DirectBufferWriter();
+  private DirectBufferWriter recordDataWriter;
+  private DirectBufferWriter otherRecordDataWriter;
   private Journal journal;
 
   @BeforeEach
   void setup() {
     entry = "TestData".getBytes();
-    recordDataWriter.wrap(new UnsafeBuffer(entry));
+    recordDataWriter = new DirectBufferWriter(new UnsafeBuffer(entry));
 
     final var entryOther = "TestData".getBytes();
-    otherRecordDataWriter.wrap(new UnsafeBuffer(entryOther));
+    otherRecordDataWriter = new DirectBufferWriter(new UnsafeBuffer(entryOther));
 
     journal = openJournal();
   }
@@ -148,7 +148,7 @@ final class JournalTest {
     for (int i = 0; i < 10; i++) {
       // given
       entry = ("TestData" + i).getBytes();
-      recordDataWriter.wrap(new UnsafeBuffer(entry));
+      recordDataWriter = new DirectBufferWriter(new UnsafeBuffer(entry));
 
       // when
       final var recordAppended = journal.append(i + 10, recordDataWriter);
@@ -481,7 +481,8 @@ final class JournalTest {
   @Test
   void shouldInvalidateAllEntries() throws Exception {
     // given
-    recordDataWriter.wrap(new UnsafeBuffer("000".getBytes(StandardCharsets.UTF_8)));
+    recordDataWriter =
+        new DirectBufferWriter(new UnsafeBuffer("000".getBytes(StandardCharsets.UTF_8)));
     final var firstRecord = copyRecord(journal.append(recordDataWriter));
 
     journal.append(recordDataWriter);
@@ -489,7 +490,8 @@ final class JournalTest {
 
     // when
     journal.deleteAfter(firstRecord.index());
-    recordDataWriter.wrap(new UnsafeBuffer("111".getBytes(StandardCharsets.UTF_8)));
+    recordDataWriter =
+        new DirectBufferWriter(new UnsafeBuffer("111".getBytes(StandardCharsets.UTF_8)));
     final var secondRecord = copyRecord(journal.append(recordDataWriter));
 
     journal.close();
@@ -505,7 +507,8 @@ final class JournalTest {
   @Test
   void shouldDetectCorruptedEntry() throws Exception {
     // given
-    recordDataWriter.wrap(new UnsafeBuffer("000".getBytes(StandardCharsets.UTF_8)));
+    recordDataWriter =
+        new DirectBufferWriter(new UnsafeBuffer("000".getBytes(StandardCharsets.UTF_8)));
     journal.append(recordDataWriter);
     final var secondRecord = copyRecord(journal.append(recordDataWriter));
     final File dataFile = Objects.requireNonNull(directory.toFile().listFiles())[0];
@@ -524,7 +527,8 @@ final class JournalTest {
   @Test
   void shouldDeletePartiallyWrittenEntry() throws Exception {
     // given
-    recordDataWriter.wrap(new UnsafeBuffer("000".getBytes(StandardCharsets.UTF_8)));
+    recordDataWriter =
+        new DirectBufferWriter(new UnsafeBuffer("000".getBytes(StandardCharsets.UTF_8)));
     final var firstRecord = copyRecord(journal.append(recordDataWriter));
     final var secondRecord = copyRecord(journal.append(recordDataWriter));
     final File dataFile = Objects.requireNonNull(directory.toFile().listFiles())[0];
@@ -535,7 +539,8 @@ final class JournalTest {
     assertThat(LogCorrupter.corruptRecord(log, secondRecord.index())).isTrue();
     metaStore.storeLastFlushedIndex(firstRecord.index());
     journal = openJournal();
-    recordDataWriter.wrap(new UnsafeBuffer("111".getBytes(StandardCharsets.UTF_8)));
+    recordDataWriter =
+        new DirectBufferWriter(new UnsafeBuffer("111".getBytes(StandardCharsets.UTF_8)));
     final var lastRecord = journal.append(recordDataWriter);
     final var reader = journal.openReader();
 

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalReaderTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalReaderTest.java
@@ -45,7 +45,7 @@ class SegmentedJournalReaderTest {
 
   @AutoClose private final MeterRegistry meterRegistry = new SimpleMeterRegistry();
   private final UnsafeBuffer data = new UnsafeBuffer("test".getBytes(StandardCharsets.UTF_8));
-  private final BufferWriter recordDataWriter = new DirectBufferWriter().wrap(data);
+  private final BufferWriter recordDataWriter = new DirectBufferWriter(data);
 
   private JournalReader reader;
   private SegmentedJournal journal;

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
@@ -466,9 +466,7 @@ class SegmentedJournalTest {
     journal.deleteAfter(first - 1);
     final var lastRecord =
         journal.append(
-            3,
-            new DirectBufferWriter()
-                .wrap(new UnsafeBuffer("new".getBytes(StandardCharsets.UTF_8))));
+            3, new DirectBufferWriter(new UnsafeBuffer("new".getBytes(StandardCharsets.UTF_8))));
 
     // then
     assertThat(first).isEqualTo(lastRecord.index());
@@ -484,11 +482,11 @@ class SegmentedJournalTest {
 
     // when
     final var firstRecord =
-        journal.append(new DirectBufferWriter().wrap(new UnsafeBuffer("12345".getBytes())));
+        journal.append(new DirectBufferWriter(new UnsafeBuffer("12345".getBytes())));
     final var secondRecord =
-        journal.append(new DirectBufferWriter().wrap(new UnsafeBuffer("1234567".getBytes())));
+        journal.append(new DirectBufferWriter(new UnsafeBuffer("1234567".getBytes())));
     final var thirdRecord =
-        journal.append(new DirectBufferWriter().wrap(new UnsafeBuffer("1234567890".getBytes())));
+        journal.append(new DirectBufferWriter(new UnsafeBuffer("1234567890".getBytes())));
 
     // then
     assertThat(reader.next()).isEqualTo(firstRecord);

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/TestJournalFactory.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/TestJournalFactory.java
@@ -71,7 +71,7 @@ final class TestJournalFactory {
 
   TestJournalFactory(final String data, final int maxEntryCount, final SegmentAllocator allocator) {
     entryData = BufferUtil.wrapString(data);
-    entry = new DirectBufferWriter().wrap(entryData);
+    entry = new DirectBufferWriter(entryData);
     size = getSerializedSize(entryData);
     this.maxEntryCount = maxEntryCount;
 

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/storage/LogStorage.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/storage/LogStorage.java
@@ -74,7 +74,7 @@ public interface LogStorage {
     append(
         lowestPosition,
         highestPosition,
-        new DirectBufferWriter().wrap(new UnsafeBuffer(blockBuffer)),
+        new DirectBufferWriter(new UnsafeBuffer(blockBuffer)),
         listener);
   }
 

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/PartitionRestoreService.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/PartitionRestoreService.java
@@ -179,10 +179,9 @@ public class PartitionRestoreService {
       final Journal targetJournal,
       final JournalReader sourceReader,
       final long checkpointPosition) {
-    final var recordWriter = new DirectBufferWriter();
     while (sourceReader.hasNext()) {
       final var record = sourceReader.next();
-      targetJournal.append(record.asqn(), recordWriter.wrap(record.data()));
+      targetJournal.append(record.asqn(), new DirectBufferWriter(record.data()));
       if (record.asqn() == checkpointPosition) {
         LOG.debug("Copied up to checkpoint record {} from source journal", record);
         return;

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
@@ -265,7 +265,7 @@ class PartitionRestoreServiceTest {
   }
 
   private void appendRecord(final long asqn, final String data) {
-    journal.append(asqn, new DirectBufferWriter().wrap(new UnsafeBuffer(data.getBytes())));
+    journal.append(asqn, new DirectBufferWriter(new UnsafeBuffer(data.getBytes())));
   }
 
   private PersistedSnapshot takeSnapshot(final long index, final long lastWrittenPosition) {

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/impl/ServerResponseImpl.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/impl/ServerResponseImpl.java
@@ -11,13 +11,10 @@ import static java.util.Objects.requireNonNull;
 
 import io.camunda.zeebe.transport.ServerResponse;
 import io.camunda.zeebe.util.buffer.BufferWriter;
-import io.camunda.zeebe.util.buffer.DirectBufferWriter;
-import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
 import org.jspecify.annotations.Nullable;
 
 public final class ServerResponseImpl implements ServerResponse {
-  private final DirectBufferWriter writerAdapter = new DirectBufferWriter();
   private @Nullable BufferWriter writer;
   private int partitionId;
   private long requestId;
@@ -25,14 +22,6 @@ public final class ServerResponseImpl implements ServerResponse {
   public ServerResponseImpl writer(final BufferWriter writer) {
     this.writer = writer;
     return this;
-  }
-
-  public ServerResponseImpl buffer(final DirectBuffer buffer) {
-    return buffer(buffer, 0, buffer.capacity());
-  }
-
-  public ServerResponseImpl buffer(final DirectBuffer buffer, final int offset, final int length) {
-    return writer(writerAdapter.wrap(buffer, offset, length));
   }
 
   public ServerResponseImpl reset() {

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/AddStreamRequest.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/AddStreamRequest.java
@@ -28,14 +28,14 @@ public final class AddStreamRequest implements BufferReader, BufferWriter {
 
   private UUID streamId;
   private final DirectBuffer metadataReader = new UnsafeBuffer();
-  private BufferWriter metadataWriter = new DirectBufferWriter().wrap(metadataReader);
+  private BufferWriter metadataWriter = new DirectBufferWriter(metadataReader);
 
   @Override
   public void wrap(final DirectBuffer buffer, final int offset, final int length) {
     messageDecoder.wrapAndApplyHeader(buffer, offset, headerDecoder);
     messageDecoder.wrapStreamType(streamType);
     messageDecoder.wrapMetadata(metadataReader);
-    metadataWriter = new DirectBufferWriter().wrap(metadataReader);
+    metadataWriter = new DirectBufferWriter(metadataReader);
     streamId = new UUID(messageDecoder.id().high(), messageDecoder.id().low());
   }
 
@@ -85,7 +85,7 @@ public final class AddStreamRequest implements BufferReader, BufferWriter {
 
   public AddStreamRequest metadata(final DirectBuffer metadata) {
     metadataReader.wrap(metadata);
-    metadataWriter = new DirectBufferWriter().wrap(metadata);
+    metadataWriter = new DirectBufferWriter(metadata);
     return this;
   }
 

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/PushStreamRequest.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/PushStreamRequest.java
@@ -25,7 +25,7 @@ public final class PushStreamRequest implements BufferReader, BufferWriter {
   private final PushStreamRequestDecoder messageDecoder = new PushStreamRequestDecoder();
 
   private final DirectBuffer payloadReader = new UnsafeBuffer();
-  private BufferWriter payloadWriter = new DirectBufferWriter().wrap(payloadReader);
+  private BufferWriter payloadWriter = new DirectBufferWriter(payloadReader);
   private UUID streamId;
 
   @Override
@@ -34,7 +34,7 @@ public final class PushStreamRequest implements BufferReader, BufferWriter {
     messageDecoder.wrapAndApplyHeader(buffer, 0, headerDecoder);
     streamId = new UUID(messageDecoder.id().high(), messageDecoder.id().low());
     messageDecoder.wrapPayload(payloadReader);
-    payloadWriter = new DirectBufferWriter().wrap(payloadReader);
+    payloadWriter = new DirectBufferWriter(payloadReader);
   }
 
   @Override
@@ -98,7 +98,7 @@ public final class PushStreamRequest implements BufferReader, BufferWriter {
 
   public PushStreamRequest payload(final DirectBuffer payload) {
     payloadReader.wrap(payload);
-    payloadWriter = new DirectBufferWriter().wrap(payload);
+    payloadWriter = new DirectBufferWriter(payload);
     return this;
   }
 

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/impl/AtomixTransportTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/impl/AtomixTransportTest.java
@@ -26,6 +26,7 @@ import io.camunda.zeebe.transport.ServerOutput;
 import io.camunda.zeebe.transport.ServerTransport;
 import io.camunda.zeebe.transport.TransportFactory;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport.TopicSupplier;
+import io.camunda.zeebe.util.buffer.DirectBufferWriter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.net.ConnectException;
@@ -489,9 +490,10 @@ public class AtomixTransportTest {
         final DirectBuffer buffer,
         final int offset,
         final int length) {
+      final var writer = new DirectBufferWriter(buffer, offset, length);
       serverResponse =
           new ServerResponseImpl()
-              .buffer(buffer, 0, length)
+              .writer(writer)
               .setRequestId(requestId)
               .setPartitionId(partitionId);
       requestConsumer.accept(buffer.byteArray());

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/messages/SerializationTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/messages/SerializationTest.java
@@ -53,7 +53,7 @@ final class SerializationTest {
         new AddStreamRequest()
             .streamId(streamId)
             .streamType(BufferUtil.wrapString("foo"))
-            .metadata(new DirectBufferWriter().wrap(metadata));
+            .metadata(new DirectBufferWriter(metadata));
 
     // when
     request.write(buffer, 0);

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/buffer/DirectBufferWriter.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/buffer/DirectBufferWriter.java
@@ -7,16 +7,23 @@
  */
 package io.camunda.zeebe.util.buffer;
 
-import static java.util.Objects.requireNonNull;
-
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
-import org.jspecify.annotations.Nullable;
 
 public final class DirectBufferWriter implements BufferWriter {
-  protected @Nullable DirectBuffer buffer;
-  protected int offset;
-  protected int length;
+  private final DirectBuffer buffer;
+  private final int offset;
+  private final int length;
+
+  public DirectBufferWriter(final DirectBuffer buffer, final int offset, final int length) {
+    this.buffer = buffer;
+    this.offset = offset;
+    this.length = length;
+  }
+
+  public DirectBufferWriter(final DirectBuffer buffer) {
+    this(buffer, 0, buffer.capacity());
+  }
 
   @Override
   public int getLength() {
@@ -25,25 +32,7 @@ public final class DirectBufferWriter implements BufferWriter {
 
   @Override
   public int write(final MutableDirectBuffer writeBuffer, final int writeOffset) {
-    writeBuffer.putBytes(writeOffset, requireNonNull(buffer, "No buffer wrapped"), offset, length);
+    writeBuffer.putBytes(writeOffset, buffer, offset, length);
     return length;
-  }
-
-  public DirectBufferWriter wrap(final DirectBuffer buffer, final int offset, final int length) {
-    this.buffer = buffer;
-    this.offset = offset;
-    this.length = length;
-
-    return this;
-  }
-
-  public DirectBufferWriter wrap(final DirectBuffer buffer) {
-    return wrap(buffer, 0, buffer.capacity());
-  }
-
-  public void reset() {
-    buffer = null;
-    offset = -1;
-    length = 0;
   }
 }


### PR DESCRIPTION
## Description
Replacing the `wrap()` methods we can avoid adding `@Nullable` to buffer and we can also make all the fields final.

This was possible because the API was always used in this pattern except for one occurrence in restore:
```java
new DirectBufferWriter.wrap(buffer)
```
One occurence was not using that pattern in ServerResponseImpl, but it was actually dead code, so I removed it


Followup from #53273 

