### PR TITLE
fix: stop PhysicalTenantRequestMappingHandlerMapping excessive logging

### DIFF
--- a/dist/src/main/resources/application.properties
+++ b/dist/src/main/resources/application.properties
@@ -6,6 +6,7 @@ server.shutdown=graceful
 spring.http.converters.preferred-json-mapper=jackson2
 spring.lifecycle.timeout-per-shutdown-phase=30s
 logging.register-shutdown-hook=true
+logging.level.io.camunda.zeebe.gateway.rest.mapper.PhysicalTenantRequestMappingHandlerMapping=INFO
 # The application name is the default name used by various services like OpenTelemetry
 spring.application.name=camunda
 spring.application.version=@project.version@


### PR DESCRIPTION
## Description

`PhysicalTenantRequestMappingHandlerMapping` is leading to excessive logging.
`AbstractHandlerMapping.getHandler` ended up with tons of logs ([ref](https://camunda.slack.com/archives/C0ANMGS3D4Y/p1779255529454719))

Temporary fix to stop excessive logging, should be fixed by related issue

## Related issues

relates #53670
