### PR TITLE
feat: add document download link to Operate

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/index.test.tsx
@@ -14,7 +14,11 @@ describe('<DocumentValueCell />', () => {
   it('should render a single document with filename and size', () => {
     const result: DocumentParseResult = {
       type: 'single',
-      document: {fileName: 'photo.png', size: 112640},
+      document: {
+        link: '/v2/documents/doc',
+        fileName: 'photo.png',
+        size: 112640,
+      },
     };
 
     render(<DocumentValueCell result={result} />);
@@ -26,7 +30,11 @@ describe('<DocumentValueCell />', () => {
   it('should render a single document without size', () => {
     const result: DocumentParseResult = {
       type: 'single',
-      document: {fileName: 'report.pdf', size: undefined},
+      document: {
+        link: '/v2/documents/doc',
+        fileName: 'report.pdf',
+        size: undefined,
+      },
     };
 
     render(<DocumentValueCell result={result} />);
@@ -39,7 +47,7 @@ describe('<DocumentValueCell />', () => {
     const longName = 'a'.repeat(40) + 'original-middle' + 'z'.repeat(40);
     const result: DocumentParseResult = {
       type: 'single',
-      document: {fileName: longName, size: 1000},
+      document: {link: '/v2/documents/doc', fileName: longName, size: 1000},
     };
 
     render(<DocumentValueCell result={result} />);
@@ -53,9 +61,9 @@ describe('<DocumentValueCell />', () => {
     const result: DocumentParseResult = {
       type: 'list',
       documents: [
-        {fileName: 'a.pdf', size: 1000},
-        {fileName: 'b.pdf', size: 2000},
-        {fileName: 'c.pdf', size: 3000},
+        {link: '/v2/documents/doc-1', fileName: 'a.pdf', size: 1000},
+        {link: '/v2/documents/doc-2', fileName: 'b.pdf', size: 2000},
+        {link: '/v2/documents/doc-3', fileName: 'c.pdf', size: 3000},
       ],
       isLowerBound: false,
     };
@@ -69,8 +77,8 @@ describe('<DocumentValueCell />', () => {
     const result: DocumentParseResult = {
       type: 'list',
       documents: [
-        {fileName: 'a.pdf', size: 1000},
-        {fileName: 'b.pdf', size: 2000},
+        {link: '/v2/documents/doc-1', fileName: 'a.pdf', size: 1000},
+        {link: '/v2/documents/doc-2', fileName: 'b.pdf', size: 2000},
       ],
       isLowerBound: true,
     };
@@ -83,7 +91,11 @@ describe('<DocumentValueCell />', () => {
   it('should set the filename as title attribute for tooltip', () => {
     const result: DocumentParseResult = {
       type: 'single',
-      document: {fileName: 'my-important-file.pdf', size: 5000},
+      document: {
+        link: '/v2/documents/doc',
+        fileName: 'my-important-file.pdf',
+        size: 5000,
+      },
     };
 
     render(<DocumentValueCell result={result} />);

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/parseDocumentVariable.test.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/parseDocumentVariable.test.ts
@@ -10,6 +10,7 @@ import {
   parseDocumentVariable,
   toHumanReadableBytes,
 } from './parseDocumentVariable';
+import * as clientConfig from 'modules/utils/getClientConfig';
 
 const makeDocRef = (overrides: Record<string, unknown> = {}) => ({
   'camunda.document.type': 'camunda',
@@ -36,6 +37,7 @@ describe('parseDocumentVariable', () => {
     expect(result).toEqual({
       type: 'single',
       document: {
+        link: '/v2/documents/doc-123?storeId=in-memory&contentHash=sha256%3Aabc',
         fileName: 'photo.png',
         size: 109748,
       },
@@ -49,6 +51,7 @@ describe('parseDocumentVariable', () => {
     expect(result).toEqual({
       type: 'single',
       document: {
+        link: '/v2/documents/doc-123?storeId=in-memory&contentHash=sha256%3Aabc',
         fileName: 'photo.png',
         size: 109748,
       },
@@ -58,12 +61,15 @@ describe('parseDocumentVariable', () => {
   it('should detect an array of document references', () => {
     const value = JSON.stringify([
       makeDocRef({
+        documentId: 'doc-123',
         metadata: {...makeDocRef().metadata, fileName: 'a.pdf', size: 1000},
       }),
       makeDocRef({
+        documentId: 'doc-124',
         metadata: {...makeDocRef().metadata, fileName: 'b.json', size: 500},
       }),
       makeDocRef({
+        documentId: 'doc-125',
         metadata: {...makeDocRef().metadata, fileName: 'c.txt', size: 200},
       }),
     ]);
@@ -72,11 +78,42 @@ describe('parseDocumentVariable', () => {
     expect(result).toEqual({
       type: 'list',
       documents: [
-        {fileName: 'a.pdf', size: 1000},
-        {fileName: 'b.json', size: 500},
-        {fileName: 'c.txt', size: 200},
+        {
+          link: '/v2/documents/doc-123?storeId=in-memory&contentHash=sha256%3Aabc',
+          fileName: 'a.pdf',
+          size: 1000,
+        },
+        {
+          link: '/v2/documents/doc-124?storeId=in-memory&contentHash=sha256%3Aabc',
+          fileName: 'b.json',
+          size: 500,
+        },
+        {
+          link: '/v2/documents/doc-125?storeId=in-memory&contentHash=sha256%3Aabc',
+          fileName: 'c.txt',
+          size: 200,
+        },
       ],
       isLowerBound: false,
+    });
+  });
+
+  it('should construct a document link with context path', () => {
+    vi.spyOn(clientConfig, 'getClientConfig').mockReturnValue({
+      ...clientConfig.getClientConfig(),
+      contextPath: '/some-context',
+    });
+
+    const value = JSON.stringify(makeDocRef());
+    const result = parseDocumentVariable(value, false);
+
+    expect(result).toEqual({
+      type: 'single',
+      document: {
+        link: '/some-context/v2/documents/doc-123?storeId=in-memory&contentHash=sha256%3Aabc',
+        fileName: 'photo.png',
+        size: 109748,
+      },
     });
   });
 
@@ -178,6 +215,7 @@ describe('parseDocumentVariable', () => {
     expect(result).toEqual({
       type: 'single',
       document: {
+        link: '/v2/documents/doc-no-meta?storeId=in-memory&contentHash=sha256%3Aabc',
         fileName: 'doc-no-meta',
         size: undefined,
       },

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/parseDocumentVariable.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/parseDocumentVariable.ts
@@ -9,9 +9,13 @@
 import {z} from 'zod';
 import {safeJsonParse} from 'modules/utils';
 import {untruncateJson} from 'modules/utils/editor/untruncateJSON';
+import {mergePathname} from 'modules/request/mergePathname';
+import {getClientConfig} from 'modules/utils/getClientConfig';
+import {endpoints} from '@camunda/camunda-api-zod-schemas/8.10';
 
 type DocumentInfo = {
   fileName: string;
+  link: string;
   size: number | undefined;
 };
 
@@ -23,6 +27,8 @@ const documentReferenceSchema = z
   .object({
     'camunda.document.type': z.literal('camunda'),
     documentId: z.string(),
+    storeId: z.string().optional(),
+    contentHash: z.string().optional(),
     metadata: z
       .object({
         fileName: z.string().optional(),
@@ -42,7 +48,12 @@ function isDocumentReference(
 }
 
 function toDocumentInfo(ref: DetectedDocumentReference): DocumentInfo {
+  const link = mergePathname(
+    getClientConfig().contextPath,
+    endpoints.getDocument.getUrl(ref),
+  );
   return {
+    link,
     fileName: ref.metadata?.fileName ?? ref.documentId,
     size: ref.metadata?.size,
   };

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/parseDocumentVariable.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/parseDocumentVariable.ts
@@ -28,7 +28,7 @@ const documentReferenceSchema = z
     'camunda.document.type': z.literal('camunda'),
     documentId: z.string(),
     storeId: z.string().optional(),
-    contentHash: z.string().optional(),
+    contentHash: z.string(),
     metadata: z
       .object({
         fileName: z.string().optional(),

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DownloadDocumentButton/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DownloadDocumentButton/index.tsx
@@ -32,6 +32,7 @@ const DownloadDocumentButton: React.FC<Props> = ({
       renderIcon={Download}
       iconDescription="Download"
       tooltipPosition="top"
+      tooltipAlignment="end"
       aria-label={`Download document for variable ${variableName}`}
     />
   );

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DownloadDocumentButton/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DownloadDocumentButton/index.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Button} from '@carbon/react';
+import {Download} from '@carbon/react/icons';
+
+type Props = {
+  fileName: string;
+  documentLink: string;
+  variableName: string;
+};
+
+const DownloadDocumentButton: React.FC<Props> = ({
+  fileName,
+  documentLink,
+  variableName,
+}) => {
+  return (
+    <Button
+      as="a"
+      href={documentLink}
+      download={fileName}
+      rel="noopener"
+      kind="ghost"
+      size="sm"
+      hasIconOnly
+      renderIcon={Download}
+      iconDescription="Download"
+      tooltipPosition="top"
+      aria-label={`Download document for variable ${variableName}`}
+    />
+  );
+};
+
+export {DownloadDocumentButton};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/VariableValueCell.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/VariableValueCell.tsx
@@ -6,17 +6,17 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {useMemo} from 'react';
 import {ViewFullVariableButton} from './ViewFullVariableButton';
 import {InlineJsonEditor} from 'modules/components/InlineJsonEditor';
 import {useVariable} from 'modules/queries/variables/useVariable';
-import {parseDocumentVariable} from './DocumentValueCell/parseDocumentVariable';
+import type {DocumentParseResult} from './DocumentValueCell/parseDocumentVariable';
 import {DocumentValueCell} from './DocumentValueCell';
 
 type Props = {
   variableKey: string;
   variableName: string;
   value: string;
+  documentResult: DocumentParseResult | null;
   isTruncated: boolean | null;
   isModificationModeEnabled: boolean | undefined;
   isProcessInstanceRunning: boolean | undefined;
@@ -26,16 +26,12 @@ const VariableValueCell: React.FC<Props> = ({
   variableKey,
   variableName,
   value,
+  documentResult,
   isTruncated,
   isModificationModeEnabled,
   isProcessInstanceRunning,
 }) => {
   const {refetch} = useVariable(variableKey, {enabled: false});
-
-  const documentResult = useMemo(
-    () => parseDocumentVariable(value, Boolean(isTruncated)),
-    [value, isTruncated],
-  );
 
   if (documentResult !== null) {
     return <DocumentValueCell result={documentResult} />;

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/VariablesTable.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/VariablesTable.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {useRef} from 'react';
+import {useMemo, useRef} from 'react';
 import {useForm, useFormState} from 'react-final-form';
 import {Button} from '@carbon/react';
 import {Edit} from '@carbon/react/icons';
@@ -25,6 +25,8 @@ import {ViewFullVariableButton} from './ViewFullVariableButton';
 import {useIsProcessInstanceRunning} from 'modules/queries/processInstance/useIsProcessInstanceRunning';
 import {useVariables} from 'modules/queries/variables/useVariables';
 import {VariableValueCell} from './VariableValueCell';
+import {parseDocumentVariable} from './DocumentValueCell/parseDocumentVariable';
+import {DownloadDocumentButton} from './DownloadDocumentButton';
 
 type Props = {
   scopeId: string | null;
@@ -49,92 +51,113 @@ const VariablesTable: React.FC<Props> = ({
     isFetchingNextPage,
   } = useVariables();
 
+  const processedVariables = useMemo(() => {
+    const allVariables =
+      variablesData?.pages.flatMap((page) => page.items) ?? [];
+
+    return allVariables.map((variable) => ({
+      name: variable.name,
+      value: variable.value,
+      variableKey: variable.variableKey,
+      isTruncated: Boolean(variable.isTruncated),
+      documentResult: parseDocumentVariable(
+        variable.value,
+        Boolean(variable.isTruncated),
+      ),
+    }));
+  }, [variablesData]);
+
   const isEditMode = (variableName: string) =>
     (initialValues?.name === variableName && isProcessInstanceRunning) ||
     isVariableModificationAllowed;
 
-  const rows =
-    variablesData?.pages?.flatMap((page) =>
-      page.items.map(({name, value, variableKey, isTruncated}) => ({
-        key: name,
-        dataTestId: `variable-${name}`,
-        columns: [
-          {
-            cellContent: (
-              <VariableName title={name} ref={variableNameRef}>
-                {name}
-              </VariableName>
-            ),
-            width: '35%',
-          },
-          {
-            cellContent: isEditMode(name) ? (
-              <ExistingVariableValue
-                id={variableKey}
+  const rows = processedVariables.map(
+    ({name, value, variableKey, isTruncated, documentResult}) => ({
+      key: name,
+      dataTestId: `variable-${name}`,
+      columns: [
+        {
+          cellContent: (
+            <VariableName title={name} ref={variableNameRef}>
+              {name}
+            </VariableName>
+          ),
+          width: '35%',
+        },
+        {
+          cellContent: isEditMode(name) ? (
+            <ExistingVariableValue
+              id={variableKey}
+              variableName={name}
+              variableValue={value}
+              // TODO #46571: Verify if it's really optional
+              isPreview={Boolean(isTruncated)}
+            />
+          ) : (
+            <VariableValueCell
+              variableKey={variableKey}
+              variableName={name}
+              value={value}
+              documentResult={documentResult}
+              isTruncated={isTruncated}
+              isModificationModeEnabled={isModificationModeEnabled}
+              isProcessInstanceRunning={isProcessInstanceRunning}
+            />
+          ),
+          width: 'auto',
+        },
+        {
+          cellContent: (
+            <Operations>
+              <ViewFullVariableButton
                 variableName={name}
-                variableValue={value}
-                // TODO #46571: Verify if it's really optional
-                isPreview={Boolean(isTruncated)}
-              />
-            ) : (
-              <VariableValueCell
                 variableKey={variableKey}
-                variableName={name}
-                value={value}
-                isTruncated={isTruncated}
-                isModificationModeEnabled={isModificationModeEnabled}
-                isProcessInstanceRunning={isProcessInstanceRunning}
+                variableValue={value}
+                mode={isEditMode(name) ? 'edit' : 'show'}
+                canEdit={
+                  !isModificationModeEnabled && !!isProcessInstanceRunning
+                }
               />
-            ),
-            width: 'auto',
-          },
-          {
-            cellContent: (
-              <Operations>
-                <ViewFullVariableButton
+              {(() => {
+                if (isModificationModeEnabled || !isProcessInstanceRunning) {
+                  return null;
+                }
+
+                if (initialValues?.name === name) {
+                  return <EditButtons />;
+                }
+
+                return (
+                  <Button
+                    kind="ghost"
+                    size="sm"
+                    tooltipPosition="top"
+                    iconDescription="Edit"
+                    aria-label={`Edit variable ${name}`}
+                    disabled={isFetchingNextPage || form.getState().submitting}
+                    onClick={async () => {
+                      form.reset({name, value, variableKey});
+                      form.change('value', value);
+                    }}
+                    hasIconOnly
+                    renderIcon={Edit}
+                  />
+                );
+              })()}
+              {documentResult?.type === 'single' && (
+                <DownloadDocumentButton
+                  documentLink={documentResult.document.link}
+                  fileName={documentResult.document.fileName}
                   variableName={name}
-                  variableKey={variableKey}
-                  variableValue={value}
-                  mode={isEditMode(name) ? 'edit' : 'show'}
-                  canEdit={
-                    !isModificationModeEnabled && !!isProcessInstanceRunning
-                  }
                 />
-                {(() => {
-                  if (isModificationModeEnabled || !isProcessInstanceRunning) {
-                    return null;
-                  }
-
-                  if (initialValues?.name === name) {
-                    return <EditButtons />;
-                  }
-
-                  return (
-                    <Button
-                      kind="ghost"
-                      size="sm"
-                      tooltipPosition="top"
-                      iconDescription="Edit"
-                      aria-label={`Edit variable ${name}`}
-                      disabled={
-                        isFetchingNextPage || form.getState().submitting
-                      }
-                      onClick={async () => {
-                        form.reset({name, value, variableKey});
-                        form.change('value', value);
-                      }}
-                      hasIconOnly
-                      renderIcon={Edit}
-                    />
-                  );
-                })()}
-              </Operations>
-            ),
-            width: '120px',
-          },
-        ],
-      })),
-    ) ?? [];
+              )}
+            </Operations>
+          ),
+          width: '150px',
+        },
+      ],
+    }),
+  );
 
   return (
     <StructuredList
@@ -142,7 +165,7 @@ const VariablesTable: React.FC<Props> = ({
       headerColumns={[
         {cellContent: 'Name', width: '35%'},
         {cellContent: 'Value', width: 'auto'},
-        {cellContent: '', width: '120px'},
+        {cellContent: '', width: '150px'},
       ]}
       headerSize="sm"
       verticalCellPadding="var(--cds-spacing-02)"
@@ -196,7 +219,7 @@ const VariablesTable: React.FC<Props> = ({
                             />
                           </Operations>
                         ),
-                        width: '120px',
+                        width: '150px',
                       },
                     ],
                   }))}

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/VariablesTable.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/VariablesTable.tsx
@@ -119,6 +119,20 @@ const VariablesTable: React.FC<Props> = ({
                 }
               />
               {(() => {
+                if (documentResult !== null) {
+                  return (
+                    <>
+                      {documentResult.type === 'single' && (
+                        <DownloadDocumentButton
+                          documentLink={documentResult.document.link}
+                          fileName={documentResult.document.fileName}
+                          variableName={name}
+                        />
+                      )}
+                    </>
+                  );
+                }
+
                 if (isModificationModeEnabled || !isProcessInstanceRunning) {
                   return null;
                 }
@@ -144,16 +158,9 @@ const VariablesTable: React.FC<Props> = ({
                   />
                 );
               })()}
-              {documentResult?.type === 'single' && (
-                <DownloadDocumentButton
-                  documentLink={documentResult.document.link}
-                  fileName={documentResult.document.fileName}
-                  variableName={name}
-                />
-              )}
             </Operations>
           ),
-          width: '150px',
+          width: '120px',
         },
       ],
     }),
@@ -165,7 +172,7 @@ const VariablesTable: React.FC<Props> = ({
       headerColumns={[
         {cellContent: 'Name', width: '35%'},
         {cellContent: 'Value', width: 'auto'},
-        {cellContent: '', width: '150px'},
+        {cellContent: '', width: '120px'},
       ]}
       headerSize="sm"
       verticalCellPadding="var(--cds-spacing-02)"
@@ -219,7 +226,7 @@ const VariablesTable: React.FC<Props> = ({
                             />
                           </Operations>
                         ),
-                        width: '150px',
+                        width: '120px',
                       },
                     ],
                   }))}

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/documentVariable.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/documentVariable.test.tsx
@@ -1,0 +1,100 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {VariablesTab} from '../index';
+import {render, screen, waitFor, within} from 'modules/testing-library';
+import {createVariable, searchResult} from 'modules/testUtils';
+import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
+import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
+import {mockSearchVariables} from 'modules/mocks/api/v2/variables/searchVariables';
+import {getWrapper, mockProcessInstance} from './mocks';
+
+const makeDocumentRef = (overrides: Record<string, unknown> = {}) => ({
+  'camunda.document.type': 'camunda',
+  documentId: 'doc-abc',
+  storeId: 'in-memory',
+  contentHash: 'sha256-xyz',
+  metadata: {
+    fileName: 'test-document.pdf',
+    contentType: 'application/pdf',
+    size: 1024,
+  },
+  ...overrides,
+});
+
+describe('VariablesTab document variables', () => {
+  beforeEach(() => {
+    mockFetchProcessInstance().withSuccess(mockProcessInstance);
+    mockFetchProcessDefinitionXml().withSuccess('');
+  });
+
+  it('should render a download button for variables with single documents', async () => {
+    mockSearchVariables().withSuccess(
+      searchResult([
+        createVariable({
+          name: 'myDocument',
+          value: JSON.stringify(makeDocumentRef()),
+        }),
+      ]),
+    );
+
+    render(<VariablesTab />, {wrapper: getWrapper()});
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
+
+    const variableRow = within(screen.getByTestId('variable-myDocument'));
+    const downloadButton = variableRow.getByLabelText(
+      'Download document for variable myDocument',
+    );
+    expect(downloadButton).toHaveAttribute(
+      'href',
+      '/v2/documents/doc-abc?storeId=in-memory&contentHash=sha256-xyz',
+    );
+    expect(downloadButton).toHaveAttribute('download', 'test-document.pdf');
+  });
+
+  it('should not render a download button for variables with multiple documents', async () => {
+    mockSearchVariables().withSuccess(
+      searchResult([
+        createVariable({
+          name: 'myDocumentList',
+          value: JSON.stringify([
+            makeDocumentRef({documentId: 'doc-1'}),
+            makeDocumentRef({documentId: 'doc-2'}),
+          ]),
+        }),
+      ]),
+    );
+
+    render(<VariablesTab />, {wrapper: getWrapper()});
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
+
+    const variableRow = within(screen.getByTestId('variable-myDocumentList'));
+    expect(
+      variableRow.queryByLabelText(/download document for variable/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should not render a download button for regular variables', async () => {
+    mockSearchVariables().withSuccess(searchResult([createVariable()]));
+
+    render(<VariablesTab />, {wrapper: getWrapper()});
+
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
+
+    const variableRow = within(screen.getByTestId('variable-testVariableName'));
+    expect(
+      variableRow.queryByLabelText(/download document for variable/i),
+    ).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Description

This PR adds a download button to variables with **single** document references. Following the Figma design, variables with multiple documents do not display a download button. Implementation notes:

- The download button is an anchor tag, that directly links to `GET /v2/documents/:documentId?storeId=...&contentHash=...`.
  - _Discarded approach: A button that fetches the document blob and constructs a object URL with `URL.createObjectURL`, which is attached to a temporary anchor._
  - Advantage: Avoids downloading the while document content first. Instead, the content is directly streamed to the users file system.
  - Authentication is always handled through a session cookie (right?), which gets sent along by the browser.
- Hoisted document variable parsing into `VariablesTable`, because it is needed for the variable operations buttons as well. Avoids double parsing for each variable.
- When parsing document variables, the `contentHash` is now required. Without it, downloading document content does not work.

## Related issues

closes #52202
