### PR TITLE
fix(ci): include .mvn directory changes in Unified CI trigger

### DIFF
--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -184,6 +184,7 @@ runs:
           - 'dist/**'
           - 'parent/**'
           - '**/pom.xml'
+          - '.mvn/**'
 
         validate-pom-metadata-extra-change:
           - 'mvnw'


### PR DESCRIPTION
## Description

Related to https://camunda.slack.com/archives/C071KP5BTHB/p1779445065793179.

The `.mvn/` directory (containing Maven build cache extension configuration and other Maven wrapper settings) was not included in the `maven-change` path filter of the Unified CI trigger. This meant that Renovate PRs modifying files under `.mvn/` (e.g. upgrading `org.apache.maven.extensions:maven-build-cache-extension`) did not trigger the Unified CI pipeline, allowing them to automerge without proper validation.

This caused [PR #53773](https://github.com/camunda/camunda/pull/53773) to merge undetected, upgrading `maven-build-cache-extension` to v1.2.3 which is not yet available in the Google Maven mirror used by CI — breaking subsequent builds.

This fix adds `'.mvn/**'` to the `maven-change` filter in `.github/actions/paths-filter/action.yml`, ensuring any change to `.mvn/` files triggers Unified CI.

## Checklist

- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
