### PR TITLE
feat: Add Batch Operations Engine Ordinal Support

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -131,12 +131,12 @@ on:
         default: ""
         required: false
       scenario:
-        description: 'Choose the variant of workload to use for the load test. Options: custom, latency, realistic, typical, max. If specified, this will override the load-test-load input when not set to "custom".'
+        description: 'Workload scenario to run. Options: latency, realistic, typical, max, archiver.'
         type: string
         required: false
-        default: custom
+        default: "realistic"
       load-test-load:
-        description: 'Specifies which load test components to deploy. For example, `starter` can be assigned with the rate at which they start instances. Allows arbitrary helm arguments, like --set starter.rate=100. This is ignored when scenario is not "custom".'
+        description: 'Specifies which load test components to deploy. For example, `starter` can be assigned with the rate at which they start instances. Allows arbitrary helm arguments, like --set starter.rate=100. Can be combined with any scenario, or used alone when scenario is empty.'
         type: string
         required: false
       platform-helm-values:
@@ -203,6 +203,14 @@ env:
   # Namespaces MUST start with c8 due to access policy
   NAMESPACE: ${{ startsWith(inputs.name, 'c8-') && inputs.name || format('c8-{0}', inputs.name) }}
   IMAGE_REPOSITORY: registry.camunda.cloud/team-zeebe
+  # Workaround to prevent the Kubernetes client SDK from failing while
+  # https://github.com/gravitational/teleport/issues/64188 is opened.
+  # See https://app.incident.io/camunda/incidents/5624 for more details.
+  # This needs to be applied to all the subcommands run in this workflow.
+  # Consider removing this once
+  # https://github.com/gravitational/teleport/issues/64188 has been fixed and
+  # deployed.
+  KUBE_FEATURE_WatchListClient: "false"
 
 defaults:
   run:
@@ -464,6 +472,12 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.ref }}
+      # camunda-platform-8.10 requires Helm CLI v4; runners ship v3.x.
+      - name: Set up Helm
+        uses: asdf-vm/actions/install@b7bcd026f18772e44fe1026d729e1611cc435d47 # v4.0.1
+        with:
+          tool_versions: |
+            helm 4.2.0
       # Authenticate with Teleport
       - name: Set up Teleport
         uses: teleport-actions/setup@b638ff596557cc3959eb6b5287d5e58e0c8ac6a6 # v1.1.1
@@ -478,18 +492,44 @@ jobs:
             token: ${{ env.TELEPORT_JOIN_TOKEN }}
             kubernetes-cluster: ${{ env.CLUSTER }}
 
-      - name: Create namespace if not exists
+      - name: Print tool versions
+        run: |
+          helm_v=$(helm version --short 2>&1 || true)
+          kubectl_v=$(kubectl version --client -o json 2>/dev/null | jq -r '.clientVersion.gitVersion' || true)
+          tsh_v=$(tsh version --client --format=json 2>/dev/null | jq -r '.version' || tsh version 2>&1 | head -1)
+          git_v=$(git --version)
+          openssl_v=$(openssl version)
+          awk_v=$(awk --version 2>/dev/null | head -1 || awk -W version 2>&1 | head -1)
+          jq_v=$(jq --version)
+
+          {
+            echo "## Tool versions"
+            echo ""
+            echo "| Tool | Version |"
+            echo "|------|---------|"
+            echo "| helm | \`${helm_v}\` |"
+            echo "| kubectl | \`${kubectl_v}\` |"
+            echo "| tsh | \`${tsh_v}\` |"
+            echo "| git | \`${git_v}\` |"
+            echo "| openssl | \`${openssl_v}\` |"
+            echo "| awk | \`${awk_v}\` |"
+            echo "| jq | \`${jq_v}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "::group::Tool versions"
+          printf '%-10s %s\n' helm "${helm_v}" kubectl "${kubectl_v}" tsh "${tsh_v}" \
+            git "${git_v}" openssl "${openssl_v}" awk "${awk_v}" jq "${jq_v}"
+          echo "::endgroup::"
+
+      - name: Scaffold load-test folder
         run: |
           cd load-tests/setup
           # The namespace label created-by will not be able resolve the actual user which triggered
           # the GitHub action by default. We need to correctly configure the git user here to make it work
           git config user.name ${{ github.actor }}
-          # Create the namespace for the load test
+          # Render the load-test folder. newLoadTest.sh no longer creates the namespace — that
+          # happens on `make install` via `kubectl apply -f resources/namespace.yaml`.
           ./newLoadTest.sh ${{ env.NAMESPACE }} ${{ inputs.secondary-storage-type }} ${{ inputs.ttl }} ${{ inputs.enable-optimize }}
-          # Annotate namespace with the workflow run URL for traceability
-          kubectl annotate namespace ${{ env.NAMESPACE }} \
-            "github.com/workflow-run-url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-            --overwrite
       - name: Install latest Camunda Platform
         run: |
           cd load-tests/setup/${{ env.NAMESPACE }}
@@ -554,6 +594,12 @@ jobs:
             enable_optimize=${{ inputs.enable-optimize }} \
             additional_platform_configuration="$additional_platform_config" \
             additional_load_test_configuration="$load_test_config"
+      - name: Annotate namespace with workflow run URL
+        run: |
+          # Traceability annotation, applied after `make install` has created the namespace.
+          kubectl annotate namespace ${{ env.NAMESPACE }} \
+            "github.com/workflow-run-url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --overwrite
       - name: Summarize platform deployment
         if: success()
         run: |

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -381,6 +381,7 @@ public final class EngineProcessors {
         config,
         partitionId,
         routingInfo,
+        ordinalKeyProvider,
         batchOperationMetrics,
         brokerRequestAuthorizationConverter);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationChunkCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationChunkCreateProcessor.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.batchoperation;
 
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.ordinals.OrdinalKeyProvider;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -28,11 +29,15 @@ public final class BatchOperationChunkCreateProcessor
 
   private final StateWriter stateWriter;
   private final KeyGenerator keyGenerator;
+  private final OrdinalKeyProvider ordinalKeyProvider;
 
   public BatchOperationChunkCreateProcessor(
-      final Writers writers, final KeyGenerator keyGenerator) {
+      final Writers writers,
+      final KeyGenerator keyGenerator,
+      final OrdinalKeyProvider ordinalKeyProvider) {
     stateWriter = writers.state();
     this.keyGenerator = keyGenerator;
+    this.ordinalKeyProvider = ordinalKeyProvider;
   }
 
   @Override
@@ -43,7 +48,10 @@ public final class BatchOperationChunkCreateProcessor
         recordValue.getItems().size(),
         recordValue.getBatchOperationKey());
 
+    final long batchOperationKey = keyGenerator.nextKey();
     stateWriter.appendFollowUpEvent(
-        keyGenerator.nextKey(), BatchOperationChunkIntent.CREATED, recordValue);
+        batchOperationKey,
+        BatchOperationChunkIntent.CREATED,
+        recordValue.setOrdinalKey(ordinalKeyProvider.getOrdinal(batchOperationKey)));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCreationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCreationCreateProcessor.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
+import io.camunda.zeebe.engine.processing.ordinals.OrdinalKeyProvider;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.FollowUpEventMetadata;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
@@ -58,6 +59,7 @@ public final class BatchOperationCreationCreateProcessor
   private final TypedResponseWriter responseWriter;
   private final AuthorizationCheckBehavior authCheckBehavior;
   private final RoutingInfo routingInfo;
+  private final OrdinalKeyProvider ordinalKeyProvider;
   private final BatchOperationMetrics metrics;
   private final BatchOperationState batchOperationState;
 
@@ -68,6 +70,7 @@ public final class BatchOperationCreationCreateProcessor
       final CommandDistributionBehavior commandDistributionBehavior,
       final AuthorizationCheckBehavior authCheckBehavior,
       final RoutingInfo routingInfo,
+      final OrdinalKeyProvider ordinalKeyProvider,
       final BatchOperationMetrics metrics) {
     stateWriter = writers.state();
     batchOperationState = state.getBatchOperationState();
@@ -77,6 +80,7 @@ public final class BatchOperationCreationCreateProcessor
     this.commandDistributionBehavior = commandDistributionBehavior;
     this.authCheckBehavior = authCheckBehavior;
     this.routingInfo = routingInfo;
+    this.ordinalKeyProvider = ordinalKeyProvider;
     this.metrics = metrics;
   }
 
@@ -114,6 +118,7 @@ public final class BatchOperationCreationCreateProcessor
     final var recordWithKey = new BatchOperationCreationRecord();
     recordWithKey.wrap(recordValue);
     recordWithKey.setBatchOperationKey(key);
+    recordWithKey.setOrdinalKey(ordinalKeyProvider.getOrdinal(key));
     // we remember the partition ids of the batch operation, so that we can count the number of
     // finished partitions in the end.
     recordWithKey.setPartitionIds(routingInfo.partitions());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionExecuteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionExecuteProcessor.java
@@ -182,6 +182,7 @@ public final class BatchOperationExecutionExecuteProcessor
         command.getPartitionId());
     final var followupCommand = new BatchOperationExecutionRecord();
     followupCommand.setBatchOperationKey(batchKey);
+    followupCommand.setOrdinalKey(batchOperation.getOrdinalKey());
     commandWriter.appendFollowUpCommand(
         command.getKey(),
         BatchOperationExecutionIntent.EXECUTE,
@@ -196,6 +197,7 @@ public final class BatchOperationExecutionExecuteProcessor
     final var batchExecute = new BatchOperationExecutionRecord();
     batchExecute.setBatchOperationKey(executionRecord.getBatchOperationKey());
     batchExecute.setItemKeys(keys);
+    batchExecute.setOrdinalKey(executionRecord.getOrdinalKey());
     stateWriter.appendFollowUpEvent(
         executionRecord.getBatchOperationKey(),
         BatchOperationExecutionIntent.EXECUTING,
@@ -220,6 +222,7 @@ public final class BatchOperationExecutionExecuteProcessor
 
     batchExecute.setBatchOperationKey(batchOperation.getKey());
     batchExecute.setItemKeys(keys);
+    batchExecute.setOrdinalKey(batchOperation.getOrdinalKey());
     stateWriter.appendFollowUpEvent(
         batchOperation.getKey(),
         BatchOperationExecutionIntent.EXECUTED,
@@ -233,6 +236,7 @@ public final class BatchOperationExecutionExecuteProcessor
     final var batchInternalComplete =
         new BatchOperationPartitionLifecycleRecord()
             .setBatchOperationKey(executionRecord.getBatchOperationKey())
+            .setOrdinalKey(executionRecord.getOrdinalKey())
             .setSourcePartitionId(command.getPartitionId());
 
     LOGGER.debug(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationLifecycleManagementCancelProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationLifecycleManagementCancelProcessor.java
@@ -98,9 +98,10 @@ public final class BatchOperationLifecycleManagementCancelProcessor
 
     final var batchOperation = batchOperationState.get(batchOperationKey);
     if (batchOperation.isPresent() && batchOperation.get().canCancel()) {
+      recordValue.setOrdinalKey(batchOperation.get().getOrdinalKey());
       cancelBatchOperationEvent(cancelKey, recordValue);
       responseWriter.writeEventOnCommand(
-          cancelKey, BatchOperationIntent.CANCELED, command.getValue(), command);
+          cancelKey, BatchOperationIntent.CANCELED, recordValue, command);
       commandDistributionBehavior
           .withKey(cancelKey)
           .inQueue(DistributionQueue.BATCH_OPERATION)
@@ -132,6 +133,8 @@ public final class BatchOperationLifecycleManagementCancelProcessor
       commandDistributionBehavior.acknowledgeCommand(command);
       return;
     }
+
+    recordValue.setOrdinalKey(batchOperation.get().getOrdinalKey());
 
     LOGGER.debug(
         "Processing distributed command to cancel a batch operation with key '{}': {}",

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationLifecycleManagementResumeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationLifecycleManagementResumeProcessor.java
@@ -108,28 +108,31 @@ public final class BatchOperationLifecycleManagementResumeProcessor
     LOGGER.debug("Resuming batch operation with key {}", command.getValue().getBatchOperationKey());
 
     // validation
-    final var batchOperation = batchOperationState.get(batchOperationKey);
-    if (batchOperation.isEmpty()) {
+    final var oBatchOperation = batchOperationState.get(batchOperationKey);
+    if (oBatchOperation.isEmpty()) {
       rejectNotFound(command, batchOperationKey, recordValue);
       return;
     }
 
     // check if the batch operation can be resumed
-    if (!batchOperation.get().canResume()) {
-      final var batchOperationStatus = batchOperation.get().getStatus().name();
+    final PersistedBatchOperation bo = oBatchOperation.get();
+    recordValue.setOrdinalKey(bo.getOrdinalKey());
+
+    if (!bo.canResume()) {
+      final var batchOperationStatus = bo.getStatus().name();
       rejectInvalidState(command, batchOperationKey, batchOperationStatus, recordValue);
       return;
     }
 
-    resumeBatchOperation(resumeKey, batchOperation.get(), command.getValue());
+    resumeBatchOperation(resumeKey, bo, recordValue);
     responseWriter.writeEventOnCommand(
-        resumeKey, BatchOperationIntent.RESUMED, command.getValue(), command);
+        resumeKey, BatchOperationIntent.RESUMED, recordValue, command);
     commandDistributionBehavior
         .withKey(resumeKey)
         .inQueue(DistributionQueue.BATCH_OPERATION)
         .distribute(command);
 
-    metrics.recordResumed(batchOperation.get().getBatchOperationType());
+    metrics.recordResumed(bo.getBatchOperationType());
   }
 
   @Override
@@ -139,13 +142,14 @@ public final class BatchOperationLifecycleManagementResumeProcessor
     final var batchOperationKey = recordValue.getBatchOperationKey();
 
     // Validation
-    final var batchOperation = batchOperationState.get(batchOperationKey);
-    if (batchOperation.isPresent() && batchOperation.get().canResume()) {
+    final var oBatchOperation = batchOperationState.get(batchOperationKey);
+    if (oBatchOperation.isPresent() && oBatchOperation.get().canResume()) {
       LOGGER.debug(
           "Processing distributed command to resume with key '{}': {}",
           batchOperationKey,
           recordValue);
-      resumeBatchOperation(batchOperationKey, batchOperation.get(), recordValue);
+      recordValue.setOrdinalKey(oBatchOperation.get().getOrdinalKey());
+      resumeBatchOperation(batchOperationKey, oBatchOperation.get(), recordValue);
     } else {
       LOGGER.debug(
           "Distributed command to resume a batch operation with key '{}' will be ignored: {}",
@@ -168,6 +172,7 @@ public final class BatchOperationLifecycleManagementResumeProcessor
 
     final var batchExecute = new BatchOperationExecutionRecord();
     batchExecute.setBatchOperationKey(batchOperation.getKey());
+    batchExecute.setOrdinalKey(batchOperation.getOrdinalKey());
     if (batchOperation.isInitialized()) {
       commandWriter.appendFollowUpCommand(
           batchOperation.getKey(),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationLifecycleManagementSuspendProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationLifecycleManagementSuspendProcessor.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation;
 import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
 import io.camunda.zeebe.engine.state.immutable.BatchOperationState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
@@ -94,34 +95,36 @@ public final class BatchOperationLifecycleManagementSuspendProcessor
     }
 
     final var recordValue = command.getValue();
-    final var batchOperationKey = command.getValue().getBatchOperationKey();
+    final var batchOperationKey = recordValue.getBatchOperationKey();
     final var suspendKey = keyGenerator.nextKey();
-    LOGGER.debug(
-        "Suspending batch operation with key {}", command.getValue().getBatchOperationKey());
+    LOGGER.debug("Suspending batch operation with key {}", recordValue.getBatchOperationKey());
 
     // validation
-    final var batchOperation = batchOperationState.get(batchOperationKey);
-    if (batchOperation.isEmpty()) {
+    final var oBatchOperation = batchOperationState.get(batchOperationKey);
+    if (oBatchOperation.isEmpty()) {
       rejectNotFound(command, batchOperationKey, recordValue);
       return;
     }
 
     // check if the batch operation can be suspended
-    if (!batchOperation.get().canSuspend()) {
-      final var batchOperationStatus = batchOperation.get().getStatus().name();
+    final PersistedBatchOperation bo = oBatchOperation.get();
+    recordValue.setOrdinalKey(bo.getOrdinalKey());
+
+    if (!bo.canSuspend()) {
+      final var batchOperationStatus = bo.getStatus().name();
       rejectInvalidState(command, batchOperationKey, batchOperationStatus, recordValue);
       return;
     }
 
     suspendBatchOperation(suspendKey, recordValue);
     responseWriter.writeEventOnCommand(
-        suspendKey, BatchOperationIntent.SUSPENDED, command.getValue(), command);
+        suspendKey, BatchOperationIntent.SUSPENDED, recordValue, command);
     commandDistributionBehavior
         .withKey(suspendKey)
         .inQueue(DistributionQueue.BATCH_OPERATION)
         .distribute(command);
 
-    metrics.recordSuspended(batchOperation.get().getBatchOperationType());
+    metrics.recordSuspended(bo.getBatchOperationType());
   }
 
   @Override
@@ -131,12 +134,13 @@ public final class BatchOperationLifecycleManagementSuspendProcessor
     final var batchOperationKey = recordValue.getBatchOperationKey();
 
     // Validation
-    final var batchOperation = batchOperationState.get(batchOperationKey);
-    if (batchOperation.isPresent() && batchOperation.get().canSuspend()) {
+    final var oBatchOperation = batchOperationState.get(batchOperationKey);
+    if (oBatchOperation.isPresent() && oBatchOperation.get().canSuspend()) {
       LOGGER.debug(
           "Processing distributed command to suspend with key '{}': {}",
           batchOperationKey,
           recordValue);
+      recordValue.setOrdinalKey(oBatchOperation.get().getOrdinalKey());
       suspendBatchOperation(batchOperationKey, recordValue);
     } else {
       LOGGER.debug(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationPartitionLifecycleCompletePartitionProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationPartitionLifecycleCompletePartitionProcessor.java
@@ -80,11 +80,12 @@ public final class BatchOperationPartitionLifecycleCompletePartitionProcessor
   }
 
   private void doProcessRecord(final TypedRecord<BatchOperationPartitionLifecycleRecord> command) {
-    final var batchOperationKey = command.getValue().getBatchOperationKey();
+    final var recordValue = command.getValue();
+    final var batchOperationKey = recordValue.getBatchOperationKey();
     LOGGER.debug(
         "Processing command from partition {} to mark batch operation {} as completed",
-        command.getValue().getSourcePartitionId(),
-        command.getValue().getBatchOperationKey());
+        recordValue.getSourcePartitionId(),
+        recordValue.getBatchOperationKey());
 
     final var oBatchOperation = batchOperationState.get(batchOperationKey);
     if (oBatchOperation.isEmpty()) {
@@ -92,22 +93,24 @@ public final class BatchOperationPartitionLifecycleCompletePartitionProcessor
     }
 
     final var bo = oBatchOperation.get();
-    if (bo.getFinishedPartitions().contains(command.getValue().getSourcePartitionId())) {
+    if (bo.getFinishedPartitions().contains(recordValue.getSourcePartitionId())) {
       LOGGER.debug(
           "Batch operation {} already contains partition {}, ignoring command",
           batchOperationKey,
-          command.getValue().getSourcePartitionId());
+          recordValue.getSourcePartitionId());
       return;
     }
+
+    recordValue.setOrdinalKey(bo.getOrdinalKey());
 
     // mark the source partition as finished. This information is directly applied and present
     // in the batch operation state
     stateWriter.appendFollowUpEvent(
         batchOperationKey,
         BatchOperationIntent.PARTITION_COMPLETED,
-        command.getValue(),
+        recordValue,
         FollowUpEventMetadata.of(
-            b -> b.batchOperationReference(command.getValue().getBatchOperationKey())));
+            b -> b.batchOperationReference(recordValue.getBatchOperationKey())));
 
     // after the source partition is marked as finished, we check if now all partitions are
     // finished (either completed or failed). If yes, we can append the final COMPLETED event
@@ -126,6 +129,7 @@ public final class BatchOperationPartitionLifecycleCompletePartitionProcessor
 
     final var batchCompleted = new BatchOperationLifecycleManagementRecord();
     batchCompleted.setBatchOperationKey(batchOperationKey);
+    batchCompleted.setOrdinalKey(bo.getOrdinalKey());
     if (!bo.getErrors().isEmpty()) {
       LOGGER.debug(
           "Some partitions ({}) finished with errors, appending them to COMPLETED event for batch operation {}",

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationPartitionLifecycleFailPartitionProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationPartitionLifecycleFailPartitionProcessor.java
@@ -117,6 +117,7 @@ public final class BatchOperationPartitionLifecycleFailPartitionProcessor
           batchOperationKey);
       final var batchFinished = new BatchOperationLifecycleManagementRecord();
       batchFinished.setBatchOperationKey(batchOperationKey);
+      batchFinished.setOrdinalKey(bo.getOrdinalKey());
       batchFinished.setErrors(bo.getErrors());
       stateWriter.appendFollowUpEvent(
           batchOperationKey,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationPartitionLifecycleFailProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationPartitionLifecycleFailProcessor.java
@@ -71,6 +71,7 @@ public final class BatchOperationPartitionLifecycleFailProcessor
         new BatchOperationPartitionLifecycleRecord()
             .setBatchOperationKey(batchOperationKey)
             .setSourcePartitionId(command.getPartitionId())
+            .setOrdinalKey(command.getValue().getOrdinalKey())
             .setError(recordValue.getError());
 
     LOGGER.debug(
@@ -79,13 +80,17 @@ public final class BatchOperationPartitionLifecycleFailProcessor
         boLeadPartitionId);
 
     if (boLeadPartitionId == command.getPartitionId()) {
+      final var oBatchOperation = batchOperationState.get(batchOperationKey);
+
+      // override if present, but not an issue as this intent is not handled by exporters
+      oBatchOperation.ifPresent(bo -> batchInternalFail.setOrdinalKey(bo.getOrdinalKey()));
+
       commandWriter.appendFollowUpCommand(
           batchOperationKey,
           BatchOperationIntent.FAIL_PARTITION,
           batchInternalFail,
           FollowUpCommandMetadata.of(b -> b.batchOperationReference(batchOperationKey)));
 
-      final var oBatchOperation = batchOperationState.get(batchOperationKey);
       oBatchOperation.ifPresent(
           persistedBatchOperation ->
               metrics.recordFailed(persistedBatchOperation.getBatchOperationType()));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSetupProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSetupProcessors.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperatio
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationRetryPolicy;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
+import io.camunda.zeebe.engine.processing.ordinals.OrdinalKeyProvider;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
@@ -53,6 +54,7 @@ public final class BatchOperationSetupProcessors {
       final EngineConfiguration engineConfiguration,
       final int partitionId,
       final RoutingInfo routingInfo,
+      final OrdinalKeyProvider ordinalKeyProvider,
       final BatchOperationMetrics batchOperationMetrics,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     final var batchExecutionHandlers =
@@ -83,8 +85,9 @@ public final class BatchOperationSetupProcessors {
     final var batchOperationInitializer =
         new BatchOperationInitializationBehavior(
             new ItemProviderFactory(searchClientsProxy, batchOperationMetrics, partitionId),
-            new BatchOperationChunkAppender(engineConfiguration.getBatchOperationChunkSize()),
-            new BatchOperationCommands(partitionId),
+            new BatchOperationChunkAppender(
+                engineConfiguration.getBatchOperationChunkSize(), ordinalKeyProvider),
+            new BatchOperationCommands(partitionId, ordinalKeyProvider),
             batchOperationMetrics);
 
     final var retryHandler =
@@ -105,6 +108,7 @@ public final class BatchOperationSetupProcessors {
                 commandDistributionBehavior,
                 authorizationCheckBehavior,
                 routingInfo,
+                ordinalKeyProvider,
                 batchOperationMetrics))
         .onCommand(
             ValueType.BATCH_OPERATION_INITIALIZATION,
@@ -127,7 +131,7 @@ public final class BatchOperationSetupProcessors {
         .onCommand(
             ValueType.BATCH_OPERATION_CHUNK,
             BatchOperationChunkIntent.CREATE,
-            new BatchOperationChunkCreateProcessor(writers, keyGenerator))
+            new BatchOperationChunkCreateProcessor(writers, keyGenerator, ordinalKeyProvider))
         .onCommand(
             ValueType.BATCH_OPERATION_EXECUTION,
             BatchOperationExecutionIntent.EXECUTE,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationChunkAppender.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationChunkAppender.java
@@ -11,6 +11,7 @@ import com.google.common.collect.Lists;
 import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProvider;
 import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProvider.Item;
 import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProvider.ItemPage;
+import io.camunda.zeebe.engine.processing.ordinals.OrdinalKeyProvider;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationChunkRecord;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationExecutionRecord;
@@ -46,9 +47,12 @@ public class BatchOperationChunkAppender {
           .setSearchResultCursor(RandomStringUtils.insecure().next(1024));
 
   private final int chunkSize;
+  private final OrdinalKeyProvider ordinalKeyProvider;
 
-  public BatchOperationChunkAppender(final int chunkSize) {
+  public BatchOperationChunkAppender(
+      final int chunkSize, final OrdinalKeyProvider ordinalKeyProvider) {
     this.chunkSize = chunkSize;
+    this.ordinalKeyProvider = ordinalKeyProvider;
   }
 
   /**
@@ -144,20 +148,23 @@ public class BatchOperationChunkAppender {
     return taskResultBuilder.canAppendRecords(sizeCheckRecords, metadata);
   }
 
-  private static BatchOperationChunkRecord createChunkRecord(
+  private BatchOperationChunkRecord createChunkRecord(
       final long batchOperationKey, final List<Item> chunkItems) {
     final var command = new BatchOperationChunkRecord();
     command.setBatchOperationKey(batchOperationKey);
-    command.setItems(
-        chunkItems.stream().map(BatchOperationChunkAppender::mapItem).collect(Collectors.toSet()));
+    command.setOrdinalKey(ordinalKeyProvider.getOrdinal(batchOperationKey));
+    command.setItems(chunkItems.stream().map(this::mapItem).collect(Collectors.toSet()));
     return command;
   }
 
-  private static BatchOperationItem mapItem(final Item item) {
+  private BatchOperationItem mapItem(final Item item) {
+    final long rootProcessInstanceKey =
+        Optional.ofNullable(item.rootProcessInstanceKey()).orElse(-1L);
     return new BatchOperationItem()
         .setItemKey(item.itemKey())
         .setProcessInstanceKey(item.processInstanceKey())
-        .setRootProcessInstanceKey(Optional.ofNullable(item.rootProcessInstanceKey()).orElse(-1L));
+        .setRootProcessInstanceKey(rootProcessInstanceKey)
+        .setOrdinalKey(ordinalKeyProvider.getOrdinal(rootProcessInstanceKey));
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationCommands.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationCommands.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.batchoperation.scheduler;
 
 import com.google.common.base.Strings;
+import io.camunda.zeebe.engine.processing.ordinals.OrdinalKeyProvider;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationError;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationExecutionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationInitializationRecord;
@@ -26,9 +27,12 @@ import org.slf4j.LoggerFactory;
 public class BatchOperationCommands {
   private static final Logger LOG = LoggerFactory.getLogger(BatchOperationCommands.class);
   private final int partitionId;
+  private final OrdinalKeyProvider ordinalKeyProvider;
 
-  public BatchOperationCommands(final int partitionId) {
+  public BatchOperationCommands(
+      final int partitionId, final OrdinalKeyProvider ordinalKeyProvider) {
     this.partitionId = partitionId;
+    this.ordinalKeyProvider = ordinalKeyProvider;
   }
 
   public void appendInitializationCommand(
@@ -39,6 +43,7 @@ public class BatchOperationCommands {
     final var command =
         new BatchOperationInitializationRecord()
             .setBatchOperationKey(batchOperationKey)
+            .setOrdinalKey(ordinalKeyProvider.getOrdinal(batchOperationKey))
             .setSearchResultCursor(Strings.nullToEmpty(searchResultCursor))
             .setSearchQueryPageSize(pageSize);
 
@@ -51,9 +56,11 @@ public class BatchOperationCommands {
   }
 
   public void appendFinishInitializationCommand(
-      final TaskResultBuilder builder, final long batchOperationKey) {
+      final TaskResultBuilder builder, final long batchOperationKey, final int ordinalKey) {
     final var command =
-        new BatchOperationInitializationRecord().setBatchOperationKey(batchOperationKey);
+        new BatchOperationInitializationRecord()
+            .setBatchOperationKey(batchOperationKey)
+            .setOrdinalKey(ordinalKey);
     LOG.trace("Appending batch operation {} initializing finished command", batchOperationKey);
 
     builder.appendCommandRecord(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehavior.java
@@ -158,7 +158,8 @@ public class BatchOperationInitializationBehavior {
 
   private void finishInitialization(
       final PersistedBatchOperation batchOperation, final TaskResultBuilder resultBuilder) {
-    commands.appendFinishInitializationCommand(resultBuilder, batchOperation.getKey());
+    commands.appendFinishInitializationCommand(
+        resultBuilder, batchOperation.getKey(), batchOperation.getOrdinalKey());
     metrics.recordInitialized(batchOperation.getBatchOperationType());
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/PersistedBatchOperation.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/PersistedBatchOperation.java
@@ -132,8 +132,11 @@ public class PersistedBatchOperation extends UnpackedObject implements DbValue {
   private final ObjectProperty<NestedRecord> followUpCommandProp =
       new ObjectProperty<>("followUpCommand", new NestedRecord());
 
+  /** The ordinal key of the batch operation. */
+  private final IntegerProperty ordinalKeyProp = new IntegerProperty("ordinalKey", 0);
+
   public PersistedBatchOperation() {
-    super(17);
+    super(18);
     declareProperty(keyProp)
         .declareProperty(batchOperationTypeProp)
         .declareProperty(statusProp)
@@ -150,7 +153,8 @@ public class PersistedBatchOperation extends UnpackedObject implements DbValue {
         .declareProperty(numTotalItemsProp)
         .declareProperty(numExecutedItemsProp)
         .declareProperty(errorsProp)
-        .declareProperty(followUpCommandProp);
+        .declareProperty(followUpCommandProp)
+        .declareProperty(ordinalKeyProp);
   }
 
   public PersistedBatchOperation wrap(final BatchOperationCreationRecord record) {
@@ -162,6 +166,7 @@ public class PersistedBatchOperation extends UnpackedObject implements DbValue {
     setAuthentication(record.getAuthenticationBuffer());
     setPartitions(record.getPartitionIds());
     setFollowUpCommand(record.getFollowUpCommand());
+    setOrdinalKey(record.getOrdinalKey());
     return this;
   }
 
@@ -340,6 +345,15 @@ public class PersistedBatchOperation extends UnpackedObject implements DbValue {
 
   public boolean hasFollowUpCommand() {
     return !followUpCommandProp.getValue().getValueType().equals(ValueType.NULL_VAL);
+  }
+
+  public int getOrdinalKey() {
+    return ordinalKeyProp.getValue();
+  }
+
+  public PersistedBatchOperation setOrdinalKey(final int ordinalKey) {
+    ordinalKeyProp.setValue(ordinalKey);
+    return this;
   }
 
   public PersistedBatchOperation addFinishedPartition(final int partitionId) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/CreateBatchOperationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/CreateBatchOperationTest.java
@@ -212,9 +212,9 @@ public final class CreateBatchOperationTest extends AbstractBatchOperationTest {
                 .onlyEvents()
                 .limitByCount(
                     record -> record.getIntent().equals(BatchOperationIntent.INITIALIZING),
-                    4)) // reduce to 5000, 2500, 1250 and then one more init-phase
+                    4)) // reduce to 5000, 2500, 1250, 625 (ordinalKey adds bytes per record)
         .extracting(r -> r.getValue().getSearchQueryPageSize())
-        .containsSequence(5000, 2500, 1250, 1250);
+        .containsSequence(5000, 2500, 1250, 625);
 
     assertThat(
             RecordingExporter.batchOperationExecutionRecords()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationChunkAppenderTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationChunkAppenderTest.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProvid
 import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProvider.Item;
 import io.camunda.zeebe.engine.processing.batchoperation.itemprovider.ItemProvider.ItemPage;
 import io.camunda.zeebe.engine.processing.batchoperation.scheduler.BatchOperationChunkAppender.ChunkingOutcome;
+import io.camunda.zeebe.engine.processing.ordinals.OrdinalKeyProvider;
 import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationChunkRecord;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationItem;
@@ -39,10 +40,11 @@ class BatchOperationChunkAppenderTest {
   private BatchOperationChunkAppender processor;
   private ItemProvider mockItemProvider;
   private TaskResultBuilder mockTaskResultBuilder;
+  private final OrdinalKeyProvider mockOrdinalKeyProvider = mock(OrdinalKeyProvider.class);
 
   @BeforeEach
   void setUp() {
-    processor = new BatchOperationChunkAppender(CHUNK_SIZE);
+    processor = new BatchOperationChunkAppender(CHUNK_SIZE, mockOrdinalKeyProvider);
     mockItemProvider = mock(ItemProvider.class);
     mockTaskResultBuilder = mock(TaskResultBuilder.class);
   }
@@ -211,7 +213,7 @@ class BatchOperationChunkAppenderTest {
   @Test
   void shouldHandleDifferentChunkSizes() {
     // given
-    final var largeChunkProcessor = new BatchOperationChunkAppender(10);
+    final var largeChunkProcessor = new BatchOperationChunkAppender(10, mockOrdinalKeyProvider);
     final var items =
         List.of(new Item(100L, 200L, null), new Item(101L, 201L, null), new Item(102L, 202L, null));
     final var page = new ItemPage(items, "cursor", 3L, false);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationCommandsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationCommandsTest.java
@@ -13,6 +13,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import io.camunda.zeebe.engine.processing.ordinals.OrdinalKeyProvider;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationExecutionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationInitializationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationPartitionLifecycleRecord;
@@ -29,13 +30,15 @@ class BatchOperationCommandsTest {
 
   private static final int PARTITION_ID = 1;
   private static final long BATCH_OPERATION_KEY = 123L;
+  private static final int ORDINAL_KEY = 789;
 
   private BatchOperationCommands appender;
   private TaskResultBuilder mockBuilder;
+  private final OrdinalKeyProvider mockOrdinalKeyProvider = mock(OrdinalKeyProvider.class);
 
   @BeforeEach
   void setUp() {
-    appender = new BatchOperationCommands(PARTITION_ID);
+    appender = new BatchOperationCommands(PARTITION_ID, mockOrdinalKeyProvider);
     mockBuilder = mock(TaskResultBuilder.class);
   }
 
@@ -90,7 +93,7 @@ class BatchOperationCommandsTest {
   @Test
   void shouldAppendFinishInitializationCommand() {
     // when
-    appender.appendFinishInitializationCommand(mockBuilder, BATCH_OPERATION_KEY);
+    appender.appendFinishInitializationCommand(mockBuilder, BATCH_OPERATION_KEY, ORDINAL_KEY);
 
     // then
     final var commandCaptor = ArgumentCaptor.forClass(BatchOperationInitializationRecord.class);
@@ -177,7 +180,8 @@ class BatchOperationCommandsTest {
   void shouldUseCorrectPartitionIdInFailureCommand() {
     // given
     final int differentPartitionId = 5;
-    final var differentAppender = new BatchOperationCommands(differentPartitionId);
+    final var differentAppender =
+        new BatchOperationCommands(differentPartitionId, mockOrdinalKeyProvider);
     final String errorMessage = "Partition specific error";
     final BatchOperationErrorType errorType = BatchOperationErrorType.UNKNOWN;
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/scheduler/BatchOperationInitializationBehaviorTest.java
@@ -83,7 +83,8 @@ class BatchOperationInitializationBehaviorTest {
     assertThat(success.cursor()).isEqualTo(NEXT_SEARCH_CURSOR);
 
     verify(commandBuilder)
-        .appendFinishInitializationCommand(taskResultBuilder, BATCH_OPERATION_KEY);
+        .appendFinishInitializationCommand(
+            taskResultBuilder, BATCH_OPERATION_KEY, batchOperation.getOrdinalKey());
     verify(commandBuilder).appendExecutionCommand(taskResultBuilder, BATCH_OPERATION_KEY);
     verify(metrics).recordItemsPerPartition(2, BatchOperationType.CANCEL_PROCESS_INSTANCE);
     verify(metrics)
@@ -110,7 +111,8 @@ class BatchOperationInitializationBehaviorTest {
     assertThat(success.cursor()).isEqualTo("cursor2");
 
     verify(commandBuilder)
-        .appendFinishInitializationCommand(taskResultBuilder, BATCH_OPERATION_KEY);
+        .appendFinishInitializationCommand(
+            taskResultBuilder, BATCH_OPERATION_KEY, batchOperation.getOrdinalKey());
     verify(commandBuilder).appendExecutionCommand(taskResultBuilder, BATCH_OPERATION_KEY);
     verify(metrics).recordItemsPerPartition(4, BatchOperationType.CANCEL_PROCESS_INSTANCE);
   }
@@ -231,7 +233,8 @@ class BatchOperationInitializationBehaviorTest {
     assertThat(success.cursor()).isEqualTo(NEXT_SEARCH_CURSOR);
 
     verify(commandBuilder)
-        .appendFinishInitializationCommand(taskResultBuilder, BATCH_OPERATION_KEY);
+        .appendFinishInitializationCommand(
+            taskResultBuilder, BATCH_OPERATION_KEY, batchOperation.getOrdinalKey());
     verify(commandBuilder).appendExecutionCommand(taskResultBuilder, BATCH_OPERATION_KEY);
     verify(metrics).recordItemsPerPartition(0, BatchOperationType.CANCEL_PROCESS_INSTANCE);
   }
@@ -265,7 +268,8 @@ class BatchOperationInitializationBehaviorTest {
     final var success = (InitializationOutcome.Success) result;
     assertThat(success.cursor()).isEqualTo(NEXT_SEARCH_CURSOR);
     verify(commandBuilder)
-        .appendFinishInitializationCommand(taskResultBuilder, BATCH_OPERATION_KEY);
+        .appendFinishInitializationCommand(
+            taskResultBuilder, BATCH_OPERATION_KEY, batchOperation.getOrdinalKey());
     verify(commandBuilder).appendExecutionCommand(taskResultBuilder, BATCH_OPERATION_KEY);
     verify(metrics).recordItemsPerPartition(2, BatchOperationType.DELETE_PROCESS_INSTANCE);
     verify(metrics)

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -100,7 +100,6 @@ import io.camunda.exporter.store.IndexLocatorProvider;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
-import io.camunda.webapps.schema.descriptors.ProcessInstanceDependant;
 import io.camunda.webapps.schema.descriptors.index.AuditLogCleanupIndex;
 import io.camunda.webapps.schema.descriptors.index.AuthorizationIndex;
 import io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex;
@@ -145,7 +144,6 @@ import io.camunda.zeebe.util.VisibleForTesting;
 import io.camunda.zeebe.util.cache.CaffeineCacheStatsCounter;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
@@ -425,27 +423,7 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
             indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName(),
             ErrorHandlers.IGNORE_DOCUMENT_DOES_NOT_EXIST);
 
-    final Set<String> ordinalBasedIndexes = new HashSet<>();
-    final var listViewName = indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName();
-    ordinalBasedIndexes.add(listViewName);
-
-    // TODO tmp exempt batch operation items from ordinal indexes (history deletion jobs would need
-    // updating to be ordinal aware for this to work properly or we do exempt and then need
-    // different archiving strategy)
-    final var operationIndexName =
-        indexDescriptors.get(OperationTemplate.class).getFullQualifiedName();
-    final var nonOrdinalIndexes = Set.of(operationIndexName);
-    for (final var indexDescriptor : indexDescriptors.templates()) {
-      final var indexName = indexDescriptor.getFullQualifiedName();
-      if (nonOrdinalIndexes.contains(indexName)) {
-        continue;
-      }
-      if (indexDescriptor instanceof ProcessInstanceDependant) {
-        ordinalBasedIndexes.add(indexName);
-      }
-    }
-
-    indexLocatorProvider = new FakeOrdinalIndexLocatorProvider(ordinalBasedIndexes);
+    indexLocatorProvider = new FakeOrdinalIndexLocatorProvider();
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/FakeOrdinalIndexLocatorProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/FakeOrdinalIndexLocatorProvider.java
@@ -8,21 +8,17 @@
 package io.camunda.exporter.store;
 
 import com.google.common.base.Strings;
-import io.camunda.exporter.handlers.batchoperation.BatchOperationChunkCreatedItemHandler;
-import io.camunda.exporter.handlers.batchoperation.listview.ListViewFromChunkItemHandler;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.value.AuditLogProcessInstanceRelated;
-import io.camunda.zeebe.protocol.record.value.BatchOperationChunkRecordValue;
+import io.camunda.zeebe.protocol.record.value.BatchOperationChunkRecordValue.BatchOperationItemValue;
+import io.camunda.zeebe.protocol.record.value.BatchOperationRelated;
 import io.camunda.zeebe.protocol.record.value.OrdinalKeyBased;
-import java.util.HashMap;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRelated;
 import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Objects;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,72 +29,42 @@ public class FakeOrdinalIndexLocatorProvider implements IndexLocatorProvider {
   // aim for roughly 1 hours worth at 300 PI/s (across 3 partitions)
   private static final long IDS_PER_ORDINAL =
       100 * 60 * 60 * APPROX_IDS_BETWEEN_ROOT_PROCESS_INSTANCES;
-  private final Set<String> ordinalBasedIndexes;
   private final NoopIndexLocator noopIndexLocator = new NoopIndexLocator();
   private final Map<Integer, String> ordinalSuffixes = new ConcurrentHashMap<>();
-
-  public FakeOrdinalIndexLocatorProvider(final Set<String> ordinalBasedIndexes) {
-    this.ordinalBasedIndexes = ordinalBasedIndexes;
-  }
 
   @Override
   public IndexLocator createIndexLocator(final Record<?> record) {
     if (record.getValue() instanceof final OrdinalKeyBased ordinalKeyBased) {
       final var suffix = getOrCreateOrdinalSuffix("ord", ordinalKeyBased.getOrdinalKey());
       return new SingleSuffixOrdinalIndexLocator(suffix);
-    } else {
-      LOGGER.warn(
-          "Processing a record that is not an instance of OrdinalKeyBased. Record key: {}, "
-              + "position: {}, type: {}, value type: {}. This may lead to suboptimal index usage.",
-          record.getKey(),
-          record.getPosition(),
-          record.getRecordType(),
-          record.getValueType());
     }
 
-    // TODO(yohanfernando): Remove this and revert to only use the above ^^^
-    if (record.getValue() instanceof final AuditLogProcessInstanceRelated processInstanceRelated) {
-      final long rootProcessInstanceKey = processInstanceRelated.getRootProcessInstanceKey();
-      if (rootProcessInstanceKey > 0) {
-        final int ordinal = getOrdinal(rootProcessInstanceKey);
-        final var suffix = getOrCreateOrdinalSuffix("exp", ordinal);
-        return new SingleSuffixOrdinalIndexLocator(suffix);
-      }
-    } else {
-      final var rootProcessInstanceIdsByKey = extractRootProcessInstanceIdsByKey(record);
-      if (!rootProcessInstanceIdsByKey.isEmpty()) {
-        final var suffixesByKey =
-            rootProcessInstanceIdsByKey.entrySet().stream()
-                .collect(
-                    Collectors.toMap(
-                        Entry::getKey,
-                        entry -> getOrdinalSuffixForRootPI("exp", entry.getValue())));
-        return new MultiSuffixOrdinalIndexLocator(suffixesByKey);
-      }
+    final long ordinalBaseKey = getOrdinalBaseKey(record.getValue());
+    if (ordinalBaseKey > 0) {
+      final int ordinal = getOrdinal(ordinalBaseKey);
+      final var suffix = getOrCreateOrdinalSuffix("exporter", ordinal);
+      return new SingleSuffixOrdinalIndexLocator(suffix);
     }
+
+    LOGGER.warn(
+        "Processing a record that is not an instance of OrdinalKeyBased. Record key: {}, "
+            + "position: {}, type: {}, value type: {}. This may lead to suboptimal index usage.",
+        record.getKey(),
+        record.getPosition(),
+        record.getRecordType(),
+        record.getValueType());
+
     return noopIndexLocator;
   }
 
-  private Map<String, Long> extractRootProcessInstanceIdsByKey(final Record<?> record) {
-    if (record.getValue() instanceof final BatchOperationChunkRecordValue chunks) {
-      // TODO probably need to void tying this to specific handlers in the future
-      final Map<String, Long> idsToPIs = new HashMap<>();
-      for (final var item : chunks.getItems()) {
-        final var rootPi = item.getRootProcessInstanceKey();
-        idsToPIs.put(
-            BatchOperationChunkCreatedItemHandler.generateId(
-                chunks.getBatchOperationKey(), item.getItemKey()),
-            rootPi);
-        idsToPIs.put(ListViewFromChunkItemHandler.generateId(chunks, item), rootPi);
-      }
-      return idsToPIs;
-    }
-    return Map.of();
-  }
-
-  private String getOrdinalSuffixForRootPI(final String prefix, final long rootProcessInstanceKey) {
-    final int ordinal = getOrdinal(rootProcessInstanceKey);
-    return getOrCreateOrdinalSuffix(prefix, ordinal);
+  private long getOrdinalBaseKey(final RecordValue recordValue) {
+    return switch (recordValue) {
+      case final ProcessInstanceRelated pi -> pi.getProcessInstanceKey();
+      case final AuditLogProcessInstanceRelated audit -> audit.getRootProcessInstanceKey();
+      case final BatchOperationItemValue boi -> boi.getRootProcessInstanceKey();
+      case final BatchOperationRelated bo -> bo.getBatchOperationKey();
+      default -> -1L;
+    };
   }
 
   private static int getOrdinal(final long rootProcessInstanceKey) {
@@ -131,7 +97,7 @@ public class FakeOrdinalIndexLocatorProvider implements IndexLocatorProvider {
     }
   }
 
-  class SingleSuffixOrdinalIndexLocator implements IndexLocator {
+  static class SingleSuffixOrdinalIndexLocator implements IndexLocator {
     private final String suffix;
 
     public SingleSuffixOrdinalIndexLocator(final String suffix) {
@@ -140,28 +106,7 @@ public class FakeOrdinalIndexLocatorProvider implements IndexLocatorProvider {
 
     @Override
     public String getIndexLocation(final ExporterEntity<?> entity, final String baseIndexName) {
-      if (!ordinalBasedIndexes.contains(baseIndexName)) {
-        return baseIndexName;
-      }
-
       return baseIndexName + suffix;
-    }
-  }
-
-  class MultiSuffixOrdinalIndexLocator implements IndexLocator {
-    private final Map<String, String> suffixesById;
-
-    public MultiSuffixOrdinalIndexLocator(final Map<String, String> suffixesById) {
-      this.suffixesById = suffixesById;
-    }
-
-    @Override
-    public String getIndexLocation(final ExporterEntity<?> entity, final String baseIndexName) {
-      if (!ordinalBasedIndexes.contains(baseIndexName)) {
-        return baseIndexName;
-      }
-
-      return baseIndexName + Objects.requireNonNull(suffixesById.get(entity.getId()));
     }
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationChunkRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationChunkRecord.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.protocol.impl.record.value.batchoperation;
 
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationChunkRecordValue;
@@ -24,10 +25,13 @@ public final class BatchOperationChunkRecord extends UnifiedRecordValue
   private final LongProperty batchOperationKeyProp = new LongProperty(PROP_BATCH_OPERATION_KEY);
   private final ArrayProperty<BatchOperationItem> itemsProp =
       new ArrayProperty<>(PROP_ITEMS_LIST, BatchOperationItem::new);
+  private final IntegerProperty ordinalKeyProp = new IntegerProperty("ordinalKey", 0);
 
   public BatchOperationChunkRecord() {
-    super(2);
-    declareProperty(batchOperationKeyProp).declareProperty(itemsProp);
+    super(3);
+    declareProperty(batchOperationKeyProp)
+        .declareProperty(itemsProp)
+        .declareProperty(ordinalKeyProp);
   }
 
   @Override
@@ -52,8 +56,19 @@ public final class BatchOperationChunkRecord extends UnifiedRecordValue
     return this;
   }
 
+  @Override
+  public int getOrdinalKey() {
+    return ordinalKeyProp.getValue();
+  }
+
+  public BatchOperationChunkRecord setOrdinalKey(final int ordinalKey) {
+    ordinalKeyProp.setValue(ordinalKey);
+    return this;
+  }
+
   public void wrap(final BatchOperationChunkRecord record) {
     setBatchOperationKey(record.getBatchOperationKey());
+    setOrdinalKey(record.getOrdinalKey());
     setItems(record.getItems());
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationCreationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationCreationRecord.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.BinaryProperty;
 import io.camunda.zeebe.msgpack.property.DocumentProperty;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.ObjectProperty;
 import io.camunda.zeebe.msgpack.value.IntegerValue;
@@ -58,9 +59,10 @@ public final class BatchOperationCreationRecord extends UnifiedRecordValue
       new ArrayProperty<>(PROP_PARTITION_IDS, IntegerValue::new);
   private final ObjectProperty<NestedRecord> followUpCommandProp =
       new ObjectProperty<>(PROP_FOLLOWUP_COMMAND, new NestedRecord());
+  private final IntegerProperty ordinalKeyProp = new IntegerProperty("ordinalKey", 0);
 
   public BatchOperationCreationRecord() {
-    super(9);
+    super(10);
     declareProperty(batchOperationKeyProp)
         .declareProperty(batchOperationTypeProp)
         .declareProperty(entityFilterProp)
@@ -69,7 +71,8 @@ public final class BatchOperationCreationRecord extends UnifiedRecordValue
         .declareProperty(authenticationProp)
         .declareProperty(authorizationCheckProp)
         .declareProperty(partitionIdsProp)
-        .declareProperty(followUpCommandProp);
+        .declareProperty(followUpCommandProp)
+        .declareProperty(ordinalKeyProp);
   }
 
   @Override
@@ -175,6 +178,16 @@ public final class BatchOperationCreationRecord extends UnifiedRecordValue
     return this;
   }
 
+  @Override
+  public int getOrdinalKey() {
+    return ordinalKeyProp.getValue();
+  }
+
+  public BatchOperationCreationRecord setOrdinalKey(final int ordinalKey) {
+    ordinalKeyProp.setValue(ordinalKey);
+    return this;
+  }
+
   public BatchOperationCreationRecord wrap(final BatchOperationCreationRecord record) {
     batchOperationKeyProp.setValue(record.getBatchOperationKey());
     batchOperationTypeProp.setValue(record.getBatchOperationType());
@@ -184,7 +197,7 @@ public final class BatchOperationCreationRecord extends UnifiedRecordValue
     authenticationProp.setValue(record.getAuthenticationBuffer());
     setPartitionIds(record.getPartitionIds());
     followUpCommandProp.getValue().wrap(record.getFollowUpCommand());
-
+    setOrdinalKey(record.getOrdinalKey());
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationExecutionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationExecutionRecord.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.protocol.impl.record.value.batchoperation;
 
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.value.LongValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
@@ -24,10 +25,13 @@ public final class BatchOperationExecutionRecord extends UnifiedRecordValue
   private final LongProperty batchOperationKeyProp = new LongProperty(PROP_BATCH_OPERATION_KEY);
   private final ArrayProperty<LongValue> itemKeysProp =
       new ArrayProperty<>(PROP_ITEM_KEY_LIST, LongValue::new);
+  private final IntegerProperty ordinalKeyProp = new IntegerProperty("ordinalKey", 0);
 
   public BatchOperationExecutionRecord() {
-    super(2);
-    declareProperty(batchOperationKeyProp).declareProperty(itemKeysProp);
+    super(3);
+    declareProperty(batchOperationKeyProp)
+        .declareProperty(itemKeysProp)
+        .declareProperty(ordinalKeyProp);
   }
 
   @Override
@@ -52,9 +56,20 @@ public final class BatchOperationExecutionRecord extends UnifiedRecordValue
     return this;
   }
 
+  @Override
+  public int getOrdinalKey() {
+    return ordinalKeyProp.getValue();
+  }
+
+  public BatchOperationExecutionRecord setOrdinalKey(final int ordinalKey) {
+    ordinalKeyProp.setValue(ordinalKey);
+    return this;
+  }
+
   public BatchOperationExecutionRecord wrap(final BatchOperationExecutionRecord record) {
     setBatchOperationKey(record.getBatchOperationKey());
     setItemKeys(record.getItemKeys());
+    setOrdinalKey(record.getOrdinalKey());
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationInitializationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationInitializationRecord.java
@@ -28,12 +28,14 @@ public final class BatchOperationInitializationRecord extends UnifiedRecordValue
       new StringProperty(PROP_SEARCH_RESULT_CURSOR_KEY, "");
   private final IntegerProperty searchQueryPageSize =
       new IntegerProperty(PROP_SEARCH_QUERY_PAGE_SIZE, 0);
+  private final IntegerProperty ordinalKeyProp = new IntegerProperty("ordinalKey", 0);
 
   public BatchOperationInitializationRecord() {
-    super(3);
+    super(4);
     declareProperty(batchOperationKeyProp)
         .declareProperty(searchResultCursorProp)
-        .declareProperty(searchQueryPageSize);
+        .declareProperty(searchQueryPageSize)
+        .declareProperty(ordinalKeyProp);
   }
 
   @Override
@@ -69,9 +71,20 @@ public final class BatchOperationInitializationRecord extends UnifiedRecordValue
     return this;
   }
 
+  @Override
+  public int getOrdinalKey() {
+    return ordinalKeyProp.getValue();
+  }
+
+  public BatchOperationInitializationRecord setOrdinalKey(final int ordinalKey) {
+    ordinalKeyProp.setValue(ordinalKey);
+    return this;
+  }
+
   public void wrap(final BatchOperationInitializationRecord record) {
     setBatchOperationKey(record.getBatchOperationKey());
     setSearchResultCursor(record.getSearchResultCursor());
     setSearchQueryPageSize(record.getSearchQueryPageSize());
+    setOrdinalKey(record.getOrdinalKey());
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationItem.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationItem.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.protocol.impl.record.value.batchoperation;
 
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.value.ObjectValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationChunkRecordValue.BatchOperationItemValue;
@@ -18,12 +19,14 @@ public final class BatchOperationItem extends ObjectValue implements BatchOperat
       new LongProperty("processInstanceKey", -1);
   private final LongProperty rootProcessInstanceKeyProperty =
       new LongProperty("rootProcessInstanceKey", -1);
+  private final IntegerProperty ordinalKeyProperty = new IntegerProperty("ordinalKey", 0);
 
   public BatchOperationItem() {
-    super(3);
+    super(4);
     declareProperty(itemKeyProperty)
         .declareProperty(processInstanceKeyProperty)
-        .declareProperty(rootProcessInstanceKeyProperty);
+        .declareProperty(rootProcessInstanceKeyProperty)
+        .declareProperty(ordinalKeyProperty);
   }
 
   public BatchOperationItem(
@@ -64,10 +67,21 @@ public final class BatchOperationItem extends ObjectValue implements BatchOperat
     return this;
   }
 
+  @Override
+  public int getOrdinalKey() {
+    return ordinalKeyProperty.getValue();
+  }
+
+  public BatchOperationItem setOrdinalKey(final int ordinalKey) {
+    ordinalKeyProperty.setValue(ordinalKey);
+    return this;
+  }
+
   public BatchOperationItem wrap(final BatchOperationItemValue value) {
     setItemKey(value.getItemKey());
     setProcessInstanceKey(value.getProcessInstanceKey());
     setRootProcessInstanceKey(value.getRootProcessInstanceKey());
+    setOrdinalKey(value.getOrdinalKey());
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationLifecycleManagementRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationLifecycleManagementRecord.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.protocol.impl.record.value.batchoperation;
 
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationLifecycleManagementRecordValue;
@@ -23,11 +24,13 @@ public final class BatchOperationLifecycleManagementRecord extends UnifiedRecord
 
   private final ArrayProperty<BatchOperationError> errorsProp =
       new ArrayProperty<>("errors", BatchOperationError::new);
+  private final IntegerProperty ordinalKeyProp = new IntegerProperty("ordinalKey", 0);
 
   public BatchOperationLifecycleManagementRecord() {
-    super(2);
+    super(3);
     declareProperty(batchOperationKeyProp);
     declareProperty(errorsProp);
+    declareProperty(ordinalKeyProp);
   }
 
   @Override
@@ -46,6 +49,7 @@ public final class BatchOperationLifecycleManagementRecord extends UnifiedRecord
       final BatchOperationLifecycleManagementRecord record) {
     setBatchOperationKey(record.getBatchOperationKey());
     setErrors(record.getErrors().stream().map(BatchOperationError.class::cast).toList());
+    setOrdinalKey(record.getOrdinalKey());
     return this;
   }
 
@@ -59,6 +63,16 @@ public final class BatchOperationLifecycleManagementRecord extends UnifiedRecord
     for (final var error : errors) {
       errorsProp.add().wrap(error);
     }
+    return this;
+  }
+
+  @Override
+  public int getOrdinalKey() {
+    return ordinalKeyProp.getValue();
+  }
+
+  public BatchOperationLifecycleManagementRecord setOrdinalKey(final int ordinalKey) {
+    ordinalKeyProp.setValue(ordinalKey);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationPartitionLifecycleRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationPartitionLifecycleRecord.java
@@ -24,12 +24,14 @@ public final class BatchOperationPartitionLifecycleRecord extends UnifiedRecordV
       new IntegerProperty(PROP_SOURCE_PARTITION_ID, -1);
   private final ObjectProperty<BatchOperationError> errorProp =
       new ObjectProperty<>("error", new BatchOperationError());
+  private final IntegerProperty ordinalKeyProp = new IntegerProperty("ordinalKey", 0);
 
   public BatchOperationPartitionLifecycleRecord() {
-    super(3);
+    super(4);
     declareProperty(batchOperationKeyProp);
     declareProperty(sourcePartitionIdProp);
     declareProperty(errorProp);
+    declareProperty(ordinalKeyProp);
   }
 
   @Override
@@ -63,10 +65,21 @@ public final class BatchOperationPartitionLifecycleRecord extends UnifiedRecordV
     return this;
   }
 
+  @Override
+  public int getOrdinalKey() {
+    return ordinalKeyProp.getValue();
+  }
+
+  public BatchOperationPartitionLifecycleRecord setOrdinalKey(final int ordinalKey) {
+    ordinalKeyProp.setValue(ordinalKey);
+    return this;
+  }
+
   public BatchOperationPartitionLifecycleRecord wrap(
       final BatchOperationPartitionLifecycleRecord record) {
     setBatchOperationKey(record.getBatchOperationKey());
     setSourcePartitionId(record.getSourcePartitionId());
+    setOrdinalKey(record.getOrdinalKey());
     setError(record.getError());
     return this;
   }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -3843,7 +3843,8 @@ final class JsonSerializableToJsonTest {
                     "valueType": "NULL_VAL",
                     "intent": "UNKNOWN",
                     "recordValue": null
-                  }
+                  },
+                  "ordinalKey": 0
                 }
                 """
       },
@@ -3968,7 +3969,8 @@ final class JsonSerializableToJsonTest {
                         "tenantId": "<default>",
                         "decisionDefinitionId": ""
                       }
-                    }
+                    },
+                    "ordinalKey": 0
                  }
                 """
       },
@@ -3984,7 +3986,8 @@ final class JsonSerializableToJsonTest {
         """
                 {
                   "batchOperationKey": 12345,
-                  "items": []
+                  "items": [],
+                  "ordinalKey": 0
                 }
                 """
       },
@@ -4013,18 +4016,21 @@ final class JsonSerializableToJsonTest {
                       "itemKey": 1,
                       "processInstanceKey": 2,
                       "rootProcessInstanceKey": 3,
+                      "ordinalKey": 0,
                       "empty": false,
-                      "encodedLength": 54
+                      "encodedLength": 66
                     },
                     {
                       "itemKey": 2,
                       "processInstanceKey": 2,
                       "rootProcessInstanceKey": -1,
+                      "ordinalKey": 0,
                       "empty": false,
-                      "encodedLength": 54
+                      "encodedLength": 66
                     }
                   ],
-                  "batchOperationKey": 12345
+                  "batchOperationKey": 12345,
+                  "ordinalKey": 0
                 }
                 """
       },
@@ -4043,7 +4049,8 @@ final class JsonSerializableToJsonTest {
         """
                 {
                   "batchOperationKey": 12345,
-                  "itemKeys": [1, 2]
+                  "itemKeys": [1, 2],
+                  "ordinalKey": 0
                 }
                 """
       },
@@ -4059,7 +4066,8 @@ final class JsonSerializableToJsonTest {
         """
                 {
                   "batchOperationKey": 12345,
-                  "itemKeys": []
+                  "itemKeys": [],
+                  "ordinalKey": 0
                 }
                 """
       },
@@ -4075,7 +4083,8 @@ final class JsonSerializableToJsonTest {
         """
                 {
                   "batchOperationKey": 12345,
-                  "errors":[]
+                  "errors":[],
+                  "ordinalKey": 0
                 }
                 """
       },

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/BatchOperationChunkRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/BatchOperationChunkRecord.golden
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.protocol.impl.record.value.batchoperation;
 
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationChunkRecordValue;
@@ -24,10 +25,13 @@ public final class BatchOperationChunkRecord extends UnifiedRecordValue
   private final LongProperty batchOperationKeyProp = new LongProperty(PROP_BATCH_OPERATION_KEY);
   private final ArrayProperty<BatchOperationItem> itemsProp =
       new ArrayProperty<>(PROP_ITEMS_LIST, BatchOperationItem::new);
+  private final IntegerProperty ordinalKeyProp = new IntegerProperty("ordinalKey", 0);
 
   public BatchOperationChunkRecord() {
-    super(2);
-    declareProperty(batchOperationKeyProp).declareProperty(itemsProp);
+    super(3);
+    declareProperty(batchOperationKeyProp)
+        .declareProperty(itemsProp)
+        .declareProperty(ordinalKeyProp);
   }
 
   @Override
@@ -52,8 +56,19 @@ public final class BatchOperationChunkRecord extends UnifiedRecordValue
     return this;
   }
 
+  @Override
+  public int getOrdinalKey() {
+    return ordinalKeyProp.getValue();
+  }
+
+  public BatchOperationChunkRecord setOrdinalKey(final int ordinalKey) {
+    ordinalKeyProp.setValue(ordinalKey);
+    return this;
+  }
+
   public void wrap(final BatchOperationChunkRecord record) {
     setBatchOperationKey(record.getBatchOperationKey());
+    setOrdinalKey(record.getOrdinalKey());
     setItems(record.getItems());
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/BatchOperationCreationRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/BatchOperationCreationRecord.golden
@@ -11,6 +11,7 @@ import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.BinaryProperty;
 import io.camunda.zeebe.msgpack.property.DocumentProperty;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.ObjectProperty;
 import io.camunda.zeebe.msgpack.value.IntegerValue;
@@ -58,9 +59,10 @@ public final class BatchOperationCreationRecord extends UnifiedRecordValue
       new ArrayProperty<>(PROP_PARTITION_IDS, IntegerValue::new);
   private final ObjectProperty<NestedRecord> followUpCommandProp =
       new ObjectProperty<>(PROP_FOLLOWUP_COMMAND, new NestedRecord());
+  private final IntegerProperty ordinalKeyProp = new IntegerProperty("ordinalKey", 0);
 
   public BatchOperationCreationRecord() {
-    super(9);
+    super(10);
     declareProperty(batchOperationKeyProp)
         .declareProperty(batchOperationTypeProp)
         .declareProperty(entityFilterProp)
@@ -69,7 +71,8 @@ public final class BatchOperationCreationRecord extends UnifiedRecordValue
         .declareProperty(authenticationProp)
         .declareProperty(authorizationCheckProp)
         .declareProperty(partitionIdsProp)
-        .declareProperty(followUpCommandProp);
+        .declareProperty(followUpCommandProp)
+        .declareProperty(ordinalKeyProp);
   }
 
   @Override
@@ -175,6 +178,16 @@ public final class BatchOperationCreationRecord extends UnifiedRecordValue
     return this;
   }
 
+  @Override
+  public int getOrdinalKey() {
+    return ordinalKeyProp.getValue();
+  }
+
+  public BatchOperationCreationRecord setOrdinalKey(final int ordinalKey) {
+    ordinalKeyProp.setValue(ordinalKey);
+    return this;
+  }
+
   public BatchOperationCreationRecord wrap(final BatchOperationCreationRecord record) {
     batchOperationKeyProp.setValue(record.getBatchOperationKey());
     batchOperationTypeProp.setValue(record.getBatchOperationType());
@@ -184,7 +197,7 @@ public final class BatchOperationCreationRecord extends UnifiedRecordValue
     authenticationProp.setValue(record.getAuthenticationBuffer());
     setPartitionIds(record.getPartitionIds());
     followUpCommandProp.getValue().wrap(record.getFollowUpCommand());
-
+    setOrdinalKey(record.getOrdinalKey());
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/BatchOperationExecutionRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/BatchOperationExecutionRecord.golden
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.protocol.impl.record.value.batchoperation;
 
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.value.LongValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
@@ -24,10 +25,13 @@ public final class BatchOperationExecutionRecord extends UnifiedRecordValue
   private final LongProperty batchOperationKeyProp = new LongProperty(PROP_BATCH_OPERATION_KEY);
   private final ArrayProperty<LongValue> itemKeysProp =
       new ArrayProperty<>(PROP_ITEM_KEY_LIST, LongValue::new);
+  private final IntegerProperty ordinalKeyProp = new IntegerProperty("ordinalKey", 0);
 
   public BatchOperationExecutionRecord() {
-    super(2);
-    declareProperty(batchOperationKeyProp).declareProperty(itemKeysProp);
+    super(3);
+    declareProperty(batchOperationKeyProp)
+        .declareProperty(itemKeysProp)
+        .declareProperty(ordinalKeyProp);
   }
 
   @Override
@@ -52,9 +56,20 @@ public final class BatchOperationExecutionRecord extends UnifiedRecordValue
     return this;
   }
 
+  @Override
+  public int getOrdinalKey() {
+    return ordinalKeyProp.getValue();
+  }
+
+  public BatchOperationExecutionRecord setOrdinalKey(final int ordinalKey) {
+    ordinalKeyProp.setValue(ordinalKey);
+    return this;
+  }
+
   public BatchOperationExecutionRecord wrap(final BatchOperationExecutionRecord record) {
     setBatchOperationKey(record.getBatchOperationKey());
     setItemKeys(record.getItemKeys());
+    setOrdinalKey(record.getOrdinalKey());
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/BatchOperationInitializationRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/BatchOperationInitializationRecord.golden
@@ -28,12 +28,14 @@ public final class BatchOperationInitializationRecord extends UnifiedRecordValue
       new StringProperty(PROP_SEARCH_RESULT_CURSOR_KEY, "");
   private final IntegerProperty searchQueryPageSize =
       new IntegerProperty(PROP_SEARCH_QUERY_PAGE_SIZE, 0);
+  private final IntegerProperty ordinalKeyProp = new IntegerProperty("ordinalKey", 0);
 
   public BatchOperationInitializationRecord() {
-    super(3);
+    super(4);
     declareProperty(batchOperationKeyProp)
         .declareProperty(searchResultCursorProp)
-        .declareProperty(searchQueryPageSize);
+        .declareProperty(searchQueryPageSize)
+        .declareProperty(ordinalKeyProp);
   }
 
   @Override
@@ -69,9 +71,20 @@ public final class BatchOperationInitializationRecord extends UnifiedRecordValue
     return this;
   }
 
+  @Override
+  public int getOrdinalKey() {
+    return ordinalKeyProp.getValue();
+  }
+
+  public BatchOperationInitializationRecord setOrdinalKey(final int ordinalKey) {
+    ordinalKeyProp.setValue(ordinalKey);
+    return this;
+  }
+
   public void wrap(final BatchOperationInitializationRecord record) {
     setBatchOperationKey(record.getBatchOperationKey());
     setSearchResultCursor(record.getSearchResultCursor());
     setSearchQueryPageSize(record.getSearchQueryPageSize());
+    setOrdinalKey(record.getOrdinalKey());
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/BatchOperationItem.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/BatchOperationItem.golden
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.protocol.impl.record.value.batchoperation;
 
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.value.ObjectValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationChunkRecordValue.BatchOperationItemValue;
@@ -18,12 +19,14 @@ public final class BatchOperationItem extends ObjectValue implements BatchOperat
       new LongProperty("processInstanceKey", -1);
   private final LongProperty rootProcessInstanceKeyProperty =
       new LongProperty("rootProcessInstanceKey", -1);
+  private final IntegerProperty ordinalKeyProperty = new IntegerProperty("ordinalKey", 0);
 
   public BatchOperationItem() {
-    super(3);
+    super(4);
     declareProperty(itemKeyProperty)
         .declareProperty(processInstanceKeyProperty)
-        .declareProperty(rootProcessInstanceKeyProperty);
+        .declareProperty(rootProcessInstanceKeyProperty)
+        .declareProperty(ordinalKeyProperty);
   }
 
   public BatchOperationItem(
@@ -64,10 +67,21 @@ public final class BatchOperationItem extends ObjectValue implements BatchOperat
     return this;
   }
 
+  @Override
+  public int getOrdinalKey() {
+    return ordinalKeyProperty.getValue();
+  }
+
+  public BatchOperationItem setOrdinalKey(final int ordinalKey) {
+    ordinalKeyProperty.setValue(ordinalKey);
+    return this;
+  }
+
   public BatchOperationItem wrap(final BatchOperationItemValue value) {
     setItemKey(value.getItemKey());
     setProcessInstanceKey(value.getProcessInstanceKey());
     setRootProcessInstanceKey(value.getRootProcessInstanceKey());
+    setOrdinalKey(value.getOrdinalKey());
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/BatchOperationLifecycleManagementRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/BatchOperationLifecycleManagementRecord.golden
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.protocol.impl.record.value.batchoperation;
 
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationLifecycleManagementRecordValue;
@@ -23,11 +24,13 @@ public final class BatchOperationLifecycleManagementRecord extends UnifiedRecord
 
   private final ArrayProperty<BatchOperationError> errorsProp =
       new ArrayProperty<>("errors", BatchOperationError::new);
+  private final IntegerProperty ordinalKeyProp = new IntegerProperty("ordinalKey", 0);
 
   public BatchOperationLifecycleManagementRecord() {
-    super(2);
+    super(3);
     declareProperty(batchOperationKeyProp);
     declareProperty(errorsProp);
+    declareProperty(ordinalKeyProp);
   }
 
   @Override
@@ -46,6 +49,7 @@ public final class BatchOperationLifecycleManagementRecord extends UnifiedRecord
       final BatchOperationLifecycleManagementRecord record) {
     setBatchOperationKey(record.getBatchOperationKey());
     setErrors(record.getErrors().stream().map(BatchOperationError.class::cast).toList());
+    setOrdinalKey(record.getOrdinalKey());
     return this;
   }
 
@@ -59,6 +63,16 @@ public final class BatchOperationLifecycleManagementRecord extends UnifiedRecord
     for (final var error : errors) {
       errorsProp.add().wrap(error);
     }
+    return this;
+  }
+
+  @Override
+  public int getOrdinalKey() {
+    return ordinalKeyProp.getValue();
+  }
+
+  public BatchOperationLifecycleManagementRecord setOrdinalKey(final int ordinalKey) {
+    ordinalKeyProp.setValue(ordinalKey);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/BatchOperationPartitionLifecycleRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/BatchOperationPartitionLifecycleRecord.golden
@@ -24,12 +24,14 @@ public final class BatchOperationPartitionLifecycleRecord extends UnifiedRecordV
       new IntegerProperty(PROP_SOURCE_PARTITION_ID, -1);
   private final ObjectProperty<BatchOperationError> errorProp =
       new ObjectProperty<>("error", new BatchOperationError());
+  private final IntegerProperty ordinalKeyProp = new IntegerProperty("ordinalKey", 0);
 
   public BatchOperationPartitionLifecycleRecord() {
-    super(3);
+    super(4);
     declareProperty(batchOperationKeyProp);
     declareProperty(sourcePartitionIdProp);
     declareProperty(errorProp);
+    declareProperty(ordinalKeyProp);
   }
 
   @Override
@@ -63,10 +65,21 @@ public final class BatchOperationPartitionLifecycleRecord extends UnifiedRecordV
     return this;
   }
 
+  @Override
+  public int getOrdinalKey() {
+    return ordinalKeyProp.getValue();
+  }
+
+  public BatchOperationPartitionLifecycleRecord setOrdinalKey(final int ordinalKey) {
+    ordinalKeyProp.setValue(ordinalKey);
+    return this;
+  }
+
   public BatchOperationPartitionLifecycleRecord wrap(
       final BatchOperationPartitionLifecycleRecord record) {
     setBatchOperationKey(record.getBatchOperationKey());
     setSourcePartitionId(record.getSourcePartitionId());
+    setOrdinalKey(record.getOrdinalKey());
     setError(record.getError());
     return this;
   }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationChunkRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationChunkRecordValue.java
@@ -29,7 +29,8 @@ import org.immutables.value.Value;
  */
 @Value.Immutable
 @ImmutableProtocol(builder = ImmutableBatchOperationChunkRecordValue.Builder.class)
-public interface BatchOperationChunkRecordValue extends BatchOperationRelated, RecordValue {
+public interface BatchOperationChunkRecordValue
+    extends BatchOperationRelated, OrdinalKeyBased, RecordValue {
 
   /**
    * @return subset of items for the batch operation
@@ -38,7 +39,7 @@ public interface BatchOperationChunkRecordValue extends BatchOperationRelated, R
 
   @Value.Immutable
   @ImmutableProtocol(builder = ImmutableBatchOperationItemValue.Builder.class)
-  interface BatchOperationItemValue {
+  interface BatchOperationItemValue extends OrdinalKeyBased {
     long getItemKey();
 
     long getProcessInstanceKey();

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationCreationRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationCreationRecordValue.java
@@ -29,7 +29,8 @@ import org.immutables.value.Value;
  */
 @Value.Immutable
 @ImmutableProtocol(builder = ImmutableBatchOperationCreationRecordValue.Builder.class)
-public interface BatchOperationCreationRecordValue extends BatchOperationRelated, RecordValue {
+public interface BatchOperationCreationRecordValue
+    extends BatchOperationRelated, OrdinalKeyBased, RecordValue {
   /**
    * @return batch operation type which defines the batch operation which should operate on the keys
    */

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationExecutionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationExecutionRecordValue.java
@@ -26,7 +26,8 @@ import org.immutables.value.Value;
  */
 @Value.Immutable
 @ImmutableProtocol(builder = ImmutableBatchOperationExecutionRecordValue.Builder.class)
-public interface BatchOperationExecutionRecordValue extends BatchOperationRelated, RecordValue {
+public interface BatchOperationExecutionRecordValue
+    extends BatchOperationRelated, OrdinalKeyBased, RecordValue {
 
   /**
    * @return subset of entity keys for the batch operation which are being or were processed

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationInitializationRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationInitializationRecordValue.java
@@ -27,7 +27,7 @@ import org.immutables.value.Value;
 @Value.Immutable
 @ImmutableProtocol(builder = ImmutableBatchOperationInitializationRecordValue.Builder.class)
 public interface BatchOperationInitializationRecordValue
-    extends BatchOperationRelated, RecordValue {
+    extends BatchOperationRelated, OrdinalKeyBased, RecordValue {
   /**
    * The last search result cursor that was used to find items for the batch operation.
    *

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationLifecycleManagementRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationLifecycleManagementRecordValue.java
@@ -25,7 +25,7 @@ import org.immutables.value.Value;
 @Value.Immutable
 @ImmutableProtocol(builder = ImmutableBatchOperationLifecycleManagementRecordValue.Builder.class)
 public interface BatchOperationLifecycleManagementRecordValue
-    extends BatchOperationRelated, RecordValue {
+    extends BatchOperationRelated, OrdinalKeyBased, RecordValue {
 
   List<BatchOperationErrorValue> getErrors();
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationPartitionLifecycleRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationPartitionLifecycleRecordValue.java
@@ -23,7 +23,7 @@ import org.immutables.value.Value;
 @Value.Immutable
 @ImmutableProtocol(builder = ImmutableBatchOperationPartitionLifecycleRecordValue.Builder.class)
 public interface BatchOperationPartitionLifecycleRecordValue
-    extends BatchOperationRelated, RecordValue {
+    extends BatchOperationRelated, OrdinalKeyBased, RecordValue {
 
   /**
    * Returns the partition id of the source partition where this record was created.


### PR DESCRIPTION

## Description

Add support from engine to handle batch operations including adding ordinal to the parent batch-ops and carrying it throughout by saving it in the state, and then using ordinal from process instance when adding batch operation items.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
