### PR TITLE
deps: align Renovate Maven registry with CI Google mirror

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -44,12 +44,12 @@
   ],
   "packageRules": [
     {
-      "description": "This rule is a Renovate performance optimization specifying only one URL to avoid redundant Maven Central lookups in mirrors.",
+      "description": "Use the Google Maven Central mirror to match CI (setup-build). .mvn/extensions.xml has no repository declarations so Renovate cannot auto-discover the mirror; applying to all Maven deps for consistency.",
       "matchDatasources": [
         "maven"
       ],
       "registryUrls": [
-        "https://repo.maven.apache.org/maven2"
+        "https://maven-central.storage-download.googleapis.com/maven2"
       ]
     },
     {


### PR DESCRIPTION
## Description

Related to https://camunda.slack.com/archives/C071KP5BTHB/p1779445065793179.

Align Renovate's Maven registry lookup with the Google Maven Central mirror used by CI (`setup-build` action).

## Checklist

- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
