### PR TITLE
ci: add release E2E tests workflow on stable/8.9 (backport of #53772, simplified)

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
@@ -18,6 +18,9 @@ permissions:
 jobs:
   validate-release:
     runs-on: ubuntu-latest
+    # Cap runtime so a hung `git ls-remote`/shell step can't block the
+    # whole release-tests workflow indefinitely.
+    timeout-minutes: 5
     outputs:
       release_version: ${{ steps.get-release.outputs.release_version }}
       base: ${{ steps.detect-base.outputs.base }}
@@ -371,6 +374,17 @@ jobs:
           path: dev-dist/
           retention-days: 1
 
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          job_name: c8-orchestration-cluster-build-rdbms-dist-release
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+
   c8-orchestration-cluster-api-tests-rdbms:
     name: API Tests (RDBMS) (${{ needs.validate-release.outputs.base }} / ${{ matrix.database.database-name }})
     needs: [validate-release, build-rdbms-dist]
@@ -427,8 +441,8 @@ jobs:
             jdbc-url: "jdbc:sqlserver://localhost:1433;Encrypt=false"
             jdbc-username: "sa"
             jdbc-password: "Camunda#8_demo"
-          # Oracle - Supported versions: 21c, 26ai
-          - database-name: "Oracle 26ai"
+          # Oracle - Supported versions: 21c, 23ai
+          - database-name: "Oracle 23ai"
             database-type: "oracle"
             database-image-version: "23.26.1-slim-faststart"
             jdbc-url: "jdbc:oracle:thin:@localhost:1521/FREEPDB1"
@@ -477,20 +491,6 @@ jobs:
           echo "Updating docker image to version: $release_version"
           sed -i.bak "s|image:.*camunda/camunda:.*|image: camunda/camunda:$release_version|g" "$compose_file"
 
-      - name: Import Secrets
-        id: secrets
-        uses: hashicorp/vault-action@79632e33d6953d190b940ffa440bf97821cabd80
-        with:
-          url: ${{ secrets.VAULT_ADDR }}
-          method: approle
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-          exportEnv: false # we rely on step outputs, no need for environment variables
-          secrets: |
-            secret/data/github.com/organizations/camunda TESTRAIL_QA_EMAIL;
-            secret/data/github.com/organizations/camunda TESTRAIL_QA_PSW;
-            secret/data/products/camunda/ci/github-actions SLACK_CORE_DOMAIN_BOT_TOKEN;
-
       - name: Setup Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
@@ -538,14 +538,22 @@ jobs:
 
           echo "Waiting for DB on port $PORT..."
 
+          ready=false
           for i in {1..90}; do
             if (echo > "/dev/tcp/localhost/$PORT") >/dev/null 2>&1; then
               echo "DB port open"
+              ready=true
               break
             fi
             echo "Attempt $i: DB not ready"
             sleep 2
           done
+
+          if [ "$ready" != true ]; then
+            echo "DB on port $PORT did not become reachable in time."
+            docker compose -f db/docker-compose.yml logs "${{ env.DATABASE_CONTAINER }}" || true
+            exit 1
+          fi
 
           sleep 10
 
@@ -686,6 +694,22 @@ jobs:
           if [ -f dev-dist/camunda.pid ]; then
             kill "$(cat dev-dist/camunda.pid)" 2>/dev/null || true
           fi
+
+      - name: Tear down database service
+        if: always()
+        run: docker compose -f db/docker-compose.yml down --remove-orphans -v || true
+
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          job_name: c8-orchestration-cluster-api-tests-rdbms-release
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+
   c8-orchestration-cluster-e2e-tests:
     name: C8 Orchestration Cluster E2E Tests Release (Tasklist ${{ matrix.tasklist_mode }} mode)
     strategy:

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
@@ -1,0 +1,931 @@
+# description: Runs End to End tests on the C8 Orchestration Cluster (ie, Tasklist, Operate) during monoRepo releases
+# type: CI
+# owner: @camunda/qa-engineering
+---
+name: C8 Orchestration Cluster E2E Tests Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      monorepo_release:
+        description: "Enter the monorepo release version (e.g., 8.8.0, 8.8.1, 8.8.0-alpha8, 8.8.0-alpha8-rc1)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  validate-release:
+    runs-on: ubuntu-latest
+    outputs:
+      release_version: ${{ steps.get-release.outputs.release_version }}
+      base: ${{ steps.detect-base.outputs.base }}
+      # Git ref to check out test code / source from. We prefer the
+      # release branch (e.g. "release-8.10.0-alpha1") over the stable
+      # branch (e.g. "stable/8.10") because stable keeps moving after a
+      # release is cut and naturally contains commits for the next
+      # patch. The release branch is forked from main/stable at the
+      # release point and may carry post-tag commits the team wants
+      # tested (e.g. test stabilization for this specific release). If
+      # the release branch has been cleaned up, fall back to the
+      # release tag, which is immutable.
+      ref: ${{ steps.detect-base.outputs.ref }}
+    steps:
+      - name: Get release version
+        id: get-release
+        run: |
+          release_version="${{ github.event.inputs.monorepo_release }}"
+
+          echo "Release version: $release_version"
+          echo "release_version=$release_version" >> "$GITHUB_OUTPUT"
+
+          # Validate version format (x.y.z or x.y.z-suffix)
+          if [[ ! "$release_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)*(-[a-zA-Z0-9]+)*$ ]]; then
+            echo "Error: Invalid release version format. Expected format: x.y.z or x.y.z-suffix (e.g., 8.8.0, 8.8.0-alpha8, 8.8.0-alpha8-rc1)"
+            exit 1
+          fi
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      # Resolves two outputs:
+      #   * `base`  — stable/x.y or main, used by the rest of the workflow
+      #               for routing decisions (which test directories, V1/V2
+      #               matrix, RDBMS gating, etc).
+      #   * `ref`   — fully-qualified git ref used by every source-code
+      #               checkout. Prefers refs/heads/release-<version> if the
+      #               branch exists (typical for a fresh or in-flight
+      #               release, which may also carry post-tag fixes the team
+      #               wants tested), otherwise falls back to refs/tags/
+      #               <version>. Fails fast if neither exists.
+      #
+      # Note: we deliberately do NOT require the tag to exist when the
+      # release branch is present, so this workflow can be used to test
+      # an in-flight release (pre-tag).
+      - name: Detect base branch and resolve source ref
+        id: detect-base
+        run: |
+          release_version="${{ steps.get-release.outputs.release_version }}"
+          echo "Detecting base branch for release version: $release_version"
+
+          # This workflow lives on `stable/8.9` and only ever tests 8.9.x
+          # releases — `base` is a constant. The branch-name cascade that
+          # exists on `main` was removed because it has no effect here;
+          # any 8.x patch testing for other stable lines should be
+          # triggered from that line's own copy of this workflow.
+          base="stable/8.9"
+
+          echo "Base branch: $base"
+          echo "base=$base" >> "$GITHUB_OUTPUT"
+
+          # Sanity check: refuse to run if someone passes a non-8.9
+          # version against this workflow by mistake.
+          major_minor=$(echo "$release_version" | cut -d. -f1-2)
+          if [[ "$major_minor" != "8.9" ]]; then
+            echo "Error: this workflow lives on stable/8.9 and only accepts 8.9.x release versions; got '$release_version'."
+            exit 1
+          fi
+
+          # Resolve the git ref to check source code out from:
+          #   1) the release branch `release-<version>` if it exists
+          #      (preferred — picks up post-tag fixes on that branch);
+          #   2) otherwise fall back to the immutable tag `<version>`
+          #      (camunda/camunda tags match the version string exactly,
+          #      e.g. "8.8.0", "8.8.0-alpha8-rc1");
+          #   3) otherwise fail fast.
+          #
+          # Refs are fully qualified (`refs/heads/...`, `refs/tags/...`)
+          # so a tag and a branch with the same name can never be
+          # resolved ambiguously by actions/checkout.
+          #
+          # This is what the upstream release pipeline produces — see
+          # camunda-platform-release.yml:
+          #   RELEASE_BRANCH = release-${releaseVersion}
+          #   tag            = ${releaseVersion}
+          release_branch="release-$release_version"
+          repo_url="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:-camunda/camunda}"
+          echo "Looking for release branch: $release_branch"
+          if git ls-remote --exit-code --heads origin "refs/heads/$release_branch" >/dev/null; then
+            ref="refs/heads/$release_branch"
+            echo "Using release branch as ref: $ref"
+          else
+            echo "Release branch '$release_branch' not found; falling back to tag."
+            if git ls-remote --exit-code --tags origin "refs/tags/$release_version" >/dev/null; then
+              ref="refs/tags/$release_version"
+              echo "Using release tag as ref: $ref"
+            else
+              echo "Error: neither branch 'release-$release_version' nor tag '$release_version' exist on $repo_url."
+              exit 1
+            fi
+          fi
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          job_name: c8-orchestration-cluster-e2e-tests-validate-release
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+
+  c8-orchestration-cluster-api-tests:
+    name: C8 Orchestration Cluster API Tests
+    needs: validate-release
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions: {}
+    steps:
+      - name: Print release info
+        shell: bash
+        run: |
+          echo "Release version: ${{ needs.validate-release.outputs.release_version }}"
+          echo "Base branch (routing): ${{ needs.validate-release.outputs.base }}"
+          echo "Source ref (checkout): ${{ needs.validate-release.outputs.ref }}"
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Check out the release branch (or tag fallback), not the
+          # stable branch — see validate-release for rationale.
+          ref: ${{ needs.validate-release.outputs.ref }}
+
+      - name: Log checked-out commit
+        shell: bash
+        run: |
+          echo "Configured ref: ${{ needs.validate-release.outputs.ref }}"
+          echo "Resolved HEAD : $(git rev-parse HEAD)"
+          echo "Refs at HEAD  : $(git log -1 --format='%D' HEAD)"
+
+      - name: Update docker-compose with release version
+        shell: bash
+        run: |
+          release_version="${{ needs.validate-release.outputs.release_version }}"
+          compose_file="qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml"
+
+          echo "Updating docker image to version: $release_version"
+          # Replace the camunda image tag in docker-compose.yml; match
+          # both direct image references and variable-default syntax.
+          sed -i.bak "s|image:.*camunda/camunda:.*|image: camunda/camunda:$release_version|g" "$compose_file"
+
+          echo "Updated docker-compose.yml:"
+          grep "image: camunda/camunda:" "$compose_file"
+
+      - name: Start Camunda
+        shell: bash
+        run: DATABASE=elasticsearch docker compose up -d camunda
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
+
+      - name: List running Docker containers
+        shell: bash
+        run: docker ps -a
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
+
+      - name: Wait for services to be ready
+        shell: bash
+        id: wait-for-services
+        run: |
+          echo "Checking if services are up..."
+          ready=false
+          for i in {1..90}; do
+            tasklist_status=$(curl -s -m 5 http://localhost:8080/tasklist || echo "Failed")
+            operate_status=$(curl -s -m 5 http://localhost:8080/operate || echo "Failed")
+            identity_status=$(curl -s -m 5 http://localhost:8080/identity || echo "Failed")
+            if [[ "$tasklist_status" != "Failed" && "$operate_status" != "Failed" && "$identity_status" != "Failed" ]]; then
+              echo "Services are ready!"
+              ready=true
+              break
+            fi
+            echo "Waiting for services... ($i/90)"
+            sleep 10
+          done
+          if [ "$ready" = true ]; then
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Services failed to start in time."
+            exit 1
+          fi
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
+
+      - name: Print Docker logs before failing
+        shell: bash
+        if: failure()
+        run: docker compose logs camunda
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: qa/c8-orchestration-cluster-e2e-test-suite/package-lock.json
+
+      - name: Clean install dependencies
+        shell: bash
+        run: |
+          rm -rf node_modules package-lock.json
+          npm install
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@79632e33d6953d190b940ffa440bf97821cabd80
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false # we rely on step outputs, no need for environment variables
+          secrets: |
+            secret/data/github.com/organizations/camunda TESTRAIL_QA_EMAIL;
+            secret/data/github.com/organizations/camunda TESTRAIL_QA_PSW;
+
+      - name: Install Playwright Browsers
+        shell: bash
+        run: npx playwright install --with-deps chromium
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+
+      - name: Python setup
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.x"
+
+      - name: Run API tests
+        shell: bash
+        env:
+          LOCAL_TEST: "false"
+          CAMUNDA_AUTH_STRATEGY: "BASIC"
+          CAMUNDA_BASIC_AUTH_USERNAME: "demo"
+          CAMUNDA_BASIC_AUTH_PASSWORD: "demo"
+          CAMUNDA_PROCESSINSTANCECREATION_BUSINESSIDUNIQUENESSENABLED: "true"
+        run: |
+          export CORE_APPLICATION_URL="http://localhost:8080"
+          export ZEEBE_REST_ADDRESS="http://localhost:8080"
+
+          echo "Running API tests"
+          npm run test -- --project=api-tests
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+
+      - name: Publish test results to TestRail
+        if: always()
+        shell: bash
+        env:
+          TESTRAIL_HOST: "https://camunda.testrail.com/"
+          TESTRAIL_USERNAME: ${{ steps.secrets.outputs.TESTRAIL_QA_EMAIL }} # Use the imported secret
+          TESTRAIL_KEY: ${{ steps.secrets.outputs.TESTRAIL_QA_PSW }} # Use the imported secret
+          JUNIT_RESULTS_FILE: "qa/c8-orchestration-cluster-e2e-test-suite/test-results/junit-report.xml"
+        run: |
+          pip install trcli==1.14.1
+          trcli -y -h "$TESTRAIL_HOST" \
+            --project 'C8' \
+            --username "$TESTRAIL_USERNAME" \
+            --key "$TESTRAIL_KEY" \
+            --batch-size 500 \
+            parse_junit --suite-id 17050 \
+            --title "Release C8 Orchestration Cluster API Test Run Results - v${{ needs.validate-release.outputs.release_version }} - $(date '+%Y-%m-%d %H:%M:%S')" \
+            --close-run \
+            -f "$JUNIT_RESULTS_FILE"
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: failure()
+        with:
+          name: C8 Orchestration Cluster E2E API Test Result Release v${{ needs.validate-release.outputs.release_version }}
+          path: qa/c8-orchestration-cluster-e2e-test-suite/html-report
+          retention-days: 10
+
+      - name: Upload json report to GitHub Actions Artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: json-report-release-api
+          path: qa/c8-orchestration-cluster-e2e-test-suite/json-report/**
+          retention-days: 60
+
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          job_name: c8-orchestration-cluster-e2e-api-tests-release
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+
+  build-rdbms-dist:
+    name: "Build Camunda distribution"
+    needs: [validate-release]
+    runs-on: gcp-perf-core-16-default
+    permissions:
+      contents: read
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Check out the release branch (or tag fallback), not the
+          # stable branch — see validate-release for rationale.
+          ref: ${{ needs.validate-release.outputs.ref }}
+
+      - name: Log checked-out commit
+        shell: bash
+        run: |
+          echo "Configured ref: ${{ needs.validate-release.outputs.ref }}"
+          echo "Resolved HEAD : $(git rev-parse HEAD)"
+          echo "Refs at HEAD  : $(git log -1 --format='%D' HEAD)"
+
+      - uses: ./.github/actions/setup-build
+        with:
+          maven-cache-key-modifier: "api-tests-rdbms-build"
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+
+      - name: Build Camunda distribution
+        run: ./mvnw install -Dquickly -T1C -PskipFrontendBuild
+
+      - name: Extract distribution
+        run: |
+          mkdir -p dev-dist
+          exploded="dist/target/camunda-zeebe"
+          if [ -d "$exploded/bin" ]; then
+            cp -a "$exploded"/. dev-dist/
+          else
+            tarball=$(find dist/target -maxdepth 1 -name 'camunda-zeebe-*.tar.gz' | head -1)
+            tar xzf "$tarball" --strip-components=1 -C dev-dist
+          fi
+
+      - name: Sanitize branch name
+        id: sanitize
+        run: |
+          safe_branch="${{ needs.validate-release.outputs.base }}"
+          safe_branch="${safe_branch//\//-}"
+          echo "safe_branch=$safe_branch" >> "$GITHUB_OUTPUT"
+
+      - name: Upload distribution artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: camunda-dist-${{ steps.sanitize.outputs.safe_branch }}
+          path: dev-dist/
+          retention-days: 1
+
+  c8-orchestration-cluster-api-tests-rdbms:
+    name: API Tests (RDBMS) (${{ needs.validate-release.outputs.base }} / ${{ matrix.database.database-name }})
+    needs: [validate-release, build-rdbms-dist]
+    runs-on: gcp-perf-core-16-default
+    timeout-minutes: 60
+    permissions: {}
+    strategy:
+      fail-fast: false
+      matrix:
+        database:
+          # PostgreSQL - Supported versions: 15, 18
+          - database-name: "Postgres 15"
+            database-type: "postgres"
+            database-image-version: "15-alpine"
+            jdbc-url: "jdbc:postgresql://localhost:5432/camunda"
+            jdbc-username: "camunda"
+            jdbc-password: "camunda"
+          - database-name: "Postgres 18"
+            database-type: "postgres"
+            database-image-version: "18-alpine"
+            jdbc-url: "jdbc:postgresql://localhost:5432/camunda"
+            jdbc-username: "camunda"
+            jdbc-password: "camunda"
+          # MySQL - Supported version: 8.4
+          - database-name: "MySQL 8.4"
+            database-type: "mysql"
+            database-image-version: "8.4"
+            jdbc-url: "jdbc:mysql://localhost:3306/camunda"
+            jdbc-username: "camunda"
+            jdbc-password: "camunda"
+          # MariaDB - Supported versions: 10.11, 11.8
+          - database-name: "MariaDB 10.11"
+            database-type: "mariadb"
+            database-image-version: "10.11"
+            jdbc-url: "jdbc:mariadb://localhost:3306/camunda"
+            jdbc-username: "camunda"
+            jdbc-password: "camunda"
+          - database-name: "MariaDB 11.8"
+            database-type: "mariadb"
+            database-image-version: "11.8"
+            jdbc-url: "jdbc:mariadb://localhost:3306/camunda"
+            jdbc-username: "camunda"
+            jdbc-password: "camunda"
+          # Microsoft SQL Server - Supported versions: 2022, 2025
+          - database-name: "MSSQL 2022"
+            database-type: "mssql"
+            database-image-version: "2022-latest"
+            jdbc-url: "jdbc:sqlserver://localhost:1433;Encrypt=false"
+            jdbc-username: "sa"
+            jdbc-password: "Camunda#8_demo"
+          - database-name: "MSSQL 2025"
+            database-type: "mssql"
+            database-image-version: "2025-latest"
+            jdbc-url: "jdbc:sqlserver://localhost:1433;Encrypt=false"
+            jdbc-username: "sa"
+            jdbc-password: "Camunda#8_demo"
+          # Oracle - Supported versions: 21c, 26ai
+          - database-name: "Oracle 26ai"
+            database-type: "oracle"
+            database-image-version: "23.26.1-slim-faststart"
+            jdbc-url: "jdbc:oracle:thin:@localhost:1521/FREEPDB1"
+            jdbc-username: "camunda"
+            jdbc-password: "camunda"
+          - database-name: "Oracle 21c"
+            database-type: "oracle-21"
+            database-image-version: "21-slim-faststart"
+            jdbc-url: "jdbc:oracle:thin:@localhost:1521/xepdb1"
+            jdbc-username: "camunda"
+            jdbc-password: "camunda"
+    env:
+      IMAGE_VERSION: ${{ matrix.database.database-image-version }}
+    steps:
+      - name: Print release info
+        shell: bash
+        run: |
+          echo "Release version: ${{ needs.validate-release.outputs.release_version }}"
+          echo "Base branch (routing): ${{ needs.validate-release.outputs.base }}"
+          echo "Source ref (checkout): ${{ needs.validate-release.outputs.ref }}"
+
+      - name: Resolve database container name
+        run: echo "DATABASE_CONTAINER=${{ matrix.database.database-type }}" >> "$GITHUB_ENV"
+
+      - name: Checkout Code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Check out the release branch (or tag fallback), not the
+          # stable branch — see validate-release for rationale.
+          ref: ${{ needs.validate-release.outputs.ref }}
+
+      - name: Log checked-out commit
+        shell: bash
+        run: |
+          echo "Configured ref: ${{ needs.validate-release.outputs.ref }}"
+          echo "Resolved HEAD : $(git rev-parse HEAD)"
+          echo "Refs at HEAD  : $(git log -1 --format='%D' HEAD)"
+
+      # If this job needs the docker-compose image tag changed too, keep this step
+      - name: Update docker-compose with release version
+        shell: bash
+        run: |
+          release_version="${{ needs.validate-release.outputs.release_version }}"
+          compose_file="qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml"
+
+          echo "Updating docker image to version: $release_version"
+          sed -i.bak "s|image:.*camunda/camunda:.*|image: camunda/camunda:$release_version|g" "$compose_file"
+
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@79632e33d6953d190b940ffa440bf97821cabd80
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false # we rely on step outputs, no need for environment variables
+          secrets: |
+            secret/data/github.com/organizations/camunda TESTRAIL_QA_EMAIL;
+            secret/data/github.com/organizations/camunda TESTRAIL_QA_PSW;
+            secret/data/products/camunda/ci/github-actions SLACK_CORE_DOMAIN_BOT_TOKEN;
+
+      - name: Setup Java
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Python setup
+        if: always()
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.x"
+
+      - name: Sanitize branch name
+        id: sanitize
+        run: |
+          safe_branch="${{ needs.validate-release.outputs.base }}"
+          safe_branch="${safe_branch//\//-}"
+          echo "safe_branch=$safe_branch" >> "$GITHUB_OUTPUT"
+
+      - name: Download distribution artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: camunda-dist-${{ steps.sanitize.outputs.safe_branch }}
+          path: dev-dist/
+
+      - name: Restore distribution permissions
+        run: chmod +x dev-dist/bin/camunda
+
+      # ── Database ────────────────────────────────────────────────────────────
+      - name: Start database service
+        run: |
+          docker compose -f db/docker-compose.yml up -d --wait ${{ env.DATABASE_CONTAINER }} || {
+            docker compose -f db/docker-compose.yml logs
+            exit 1
+          }
+
+      - name: Wait for database readiness
+        run: |
+          case "${{ matrix.database.database-type }}" in
+            postgres) PORT=5432 ;;
+            mysql|mariadb) PORT=3306 ;;
+            mssql) PORT=1433 ;;
+            oracle*) PORT=1521 ;;
+          esac
+
+          echo "Waiting for DB on port $PORT..."
+
+          for i in {1..90}; do
+            if (echo > "/dev/tcp/localhost/$PORT") >/dev/null 2>&1; then
+              echo "DB port open"
+              break
+            fi
+            echo "Attempt $i: DB not ready"
+            sleep 2
+          done
+
+          sleep 10
+
+          # Auth configuration
+      - name: Install JDBC driver
+        run: |
+          mkdir -p dev-dist/lib
+
+          case "${{ matrix.database.database-type }}" in
+            mysql)
+              echo "Installing MySQL driver"
+              curl -L -o dev-dist/lib/mysql-connector.jar \
+                https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/8.4.0/mysql-connector-j-8.4.0.jar
+              ;;
+
+            mariadb)
+              echo "Installing MariaDB driver"
+              curl -L -o dev-dist/lib/mariadb.jar \
+                https://repo1.maven.org/maven2/org/mariadb/jdbc/mariadb-java-client/3.4.1/mariadb-java-client-3.4.1.jar
+              ;;
+
+            mssql)
+              echo "Installing SQL Server driver"
+              curl -L -o dev-dist/lib/mssql-jdbc.jar \
+                https://repo1.maven.org/maven2/com/microsoft/sqlserver/mssql-jdbc/12.6.3.jre11/mssql-jdbc-12.6.3.jre11.jar
+              ;;
+
+            oracle*)
+              echo "Installing Oracle driver"
+              curl -L -o dev-dist/lib/ojdbc11.jar \
+                https://repo1.maven.org/maven2/com/oracle/database/jdbc/ojdbc11/23.3.0.23.09/ojdbc11-23.3.0.23.09.jar
+              ;;
+
+            *)
+              echo "No JDBC driver mapping for ${{ matrix.database.database-type }}"
+              ;;
+          esac
+
+      # ── Start Camunda wired to the matrix DB ────────────────────────────────
+      - name: Start Camunda with ${{ needs.validate-release.outputs.base }} / ${{ matrix.database.database-name }}
+        run: |
+          export SPRING_PROFILES_ACTIVE="broker,consolidated-auth,admin,operate,tasklist"
+          export ZEEBE_CLOCK_CONTROLLED="true"
+          export CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI="false"
+          export CAMUNDA_SECURITY_AUTHORIZATIONS_ENABLED="true"
+          export CAMUNDA_SECURITY_AUTHENTICATION_METHOD="BASIC"
+          export CAMUNDA_SECURITY_MULTITENANCY_CHECKSENABLED="false"
+          export CAMUNDA_SECURITY_INITIALIZATION_USERS_0_USERNAME="demo"
+          export CAMUNDA_SECURITY_INITIALIZATION_USERS_0_PASSWORD="demo"
+          export CAMUNDA_SECURITY_INITIALIZATION_USERS_0_NAME="Demo"
+          export CAMUNDA_SECURITY_INITIALIZATION_USERS_0_EMAIL="demo@example.com"
+          export CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_USERS_0="demo"
+          export CAMUNDA_SECURITY_INITIALIZATION_USERS_1_USERNAME="lisa"
+          export CAMUNDA_SECURITY_INITIALIZATION_USERS_1_PASSWORD="lisa"
+          export CAMUNDA_SECURITY_INITIALIZATION_USERS_1_NAME="lisa"
+          export CAMUNDA_SECURITY_INITIALIZATION_USERS_1_EMAIL="lisa@example.com"
+          export CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_USERS_1="lisa"
+
+          # RDBMS secondary storage — wired to the matrix database
+          export CAMUNDA_DATA_SECONDARY_STORAGE_TYPE="rdbms"
+          export CAMUNDA_DATA_SECONDARY_STORAGE_RDBMS_URL="${{ matrix.database.jdbc-url }}"
+          export CAMUNDA_DATA_SECONDARY_STORAGE_RDBMS_USERNAME="${{ matrix.database.jdbc-username }}"
+          export CAMUNDA_DATA_SECONDARY_STORAGE_RDBMS_PASSWORD="${{ matrix.database.jdbc-password }}"
+          export CAMUNDA_DATA_SECONDARY_STORAGE_RDBMS_AUTO_DDL="true"
+          export CAMUNDA_DATA_SECONDARY_STORAGE_RDBMS_FLUSH_INTERVAL="PT0S"
+          export CAMUNDA_DATA_SECONDARY_STORAGE_RDBMS_HISTORY_DEFAULT_HISTORY_TTL="PT60S"
+          export CAMUNDA_DATA_SECONDARY_STORAGE_RDBMS_HISTORY_MIN_HISTORY_CLEANUP_INTERVAL="PT10S"
+          export CAMUNDA_DATA_SECONDARY_STORAGE_RDBMS_HISTORY_MAX_HISTORY_CLEANUP_INTERVAL="PT60S"
+
+          # Audit log
+          export CAMUNDA_DATA_AUDITLOG_ENABLED="true"
+          export CAMUNDA_DATA_AUDITLOG_USER_CATEGORIES_0="ADMIN"
+          export CAMUNDA_DATA_AUDITLOG_USER_CATEGORIES_1="DEPLOYED_RESOURCES"
+          export CAMUNDA_DATA_AUDITLOG_USER_CATEGORIES_2="USER_TASKS"
+          export CAMUNDA_DATA_AUDITLOG_USER_EXCLUDES_0="VARIABLE"
+          export CAMUNDA_DATA_AUDITLOG_USER_EXCLUDES_1="BATCH"
+          export CAMUNDA_DATA_AUDITLOG_CLIENT_CATEGORIES_0="ADMIN"
+          export CAMUNDA_DATA_AUDITLOG_CLIENT_EXCLUDES_0="PROCESS_INSTANCE"
+
+          # Business ID uniqueness enforcement toggle
+          export CAMUNDA_PROCESSINSTANCECREATION_BUSINESSIDUNIQUENESSENABLED="true"
+
+          dev-dist/bin/camunda > dev-dist/camunda.log 2>&1 &
+          echo $! > dev-dist/camunda.pid
+          echo "Camunda starting (PID $(cat dev-dist/camunda.pid))..."
+
+      - name: Wait for Camunda to be ready
+        run: |
+          echo "Waiting for Camunda to be ready..."
+          for i in $(seq 1 90); do
+            if curl -sf -u demo:demo http://localhost:8080/v2/topology >/dev/null 2>&1; then
+              echo "Camunda is ready!"
+              exit 0
+            fi
+            echo "Waiting... ($i/90)"
+            sleep 5
+          done
+          echo "Camunda failed to start in time."
+          echo "=== Last 100 lines of log ==="
+          tail -100 dev-dist/camunda.log
+          exit 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: qa/c8-orchestration-cluster-e2e-test-suite/package-lock.json
+
+      - name: Clean install dependencies
+        run: |
+          rm -rf node_modules package-lock.json
+          npm install
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps chromium
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+
+      - name: Run API tests
+        env:
+          LOCAL_TEST: "false"
+          CORE_APPLICATION_URL: "http://localhost:8080"
+          ZEEBE_REST_ADDRESS: "http://localhost:8080"
+          CAMUNDA_AUTH_STRATEGY: "BASIC"
+          CAMUNDA_BASIC_AUTH_USERNAME: "demo"
+          CAMUNDA_BASIC_AUTH_PASSWORD: "demo"
+          CAMUNDA_PROCESSINSTANCECREATION_BUSINESSIDUNIQUENESSENABLED: "true"
+          DB_NAME: ${{ matrix.database.database-name }}
+          VERSION: ${{ steps.sanitize.outputs.safe_branch  }}
+          DATABASE: "RDBMS"
+        run: npm run test -- --project=api-tests
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+
+      - name: Stop Camunda
+        if: always()
+        run: |
+          if [ -f dev-dist/camunda.pid ]; then
+            kill "$(cat dev-dist/camunda.pid)" 2>/dev/null || true
+          fi
+  c8-orchestration-cluster-e2e-tests:
+    name: C8 Orchestration Cluster E2E Tests Release (Tasklist ${{ matrix.tasklist_mode }} mode)
+    strategy:
+      fail-fast: false
+      matrix:
+        # stable/8.9 ships both Tasklist V1 and V2.
+        tasklist_mode: ["v1", "v2"]
+    needs: validate-release
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions: {}
+    steps:
+      - name: Print release info
+        run: |
+          echo "Release version: ${{ needs.validate-release.outputs.release_version }}"
+          echo "Base branch (routing): ${{ needs.validate-release.outputs.base }}"
+          echo "Source ref (checkout): ${{ needs.validate-release.outputs.ref }}"
+          echo "Tasklist mode: ${{ matrix.tasklist_mode }}"
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Check out the release branch (or tag fallback), not the
+          # stable branch — see validate-release for rationale.
+          ref: ${{ needs.validate-release.outputs.ref }}
+
+      - name: Log checked-out commit
+        shell: bash
+        run: |
+          echo "Configured ref: ${{ needs.validate-release.outputs.ref }}"
+          echo "Resolved HEAD : $(git rev-parse HEAD)"
+          echo "Refs at HEAD  : $(git log -1 --format='%D' HEAD)"
+
+      - name: Update docker-compose with release version
+        run: |
+          release_version="${{ needs.validate-release.outputs.release_version }}"
+          compose_file="qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml"
+
+          echo "Updating docker image to version: $release_version"
+          sed -i.bak "s|image:.*camunda/camunda:.*|image: camunda/camunda:$release_version|g" "$compose_file"
+
+      - name: Start Camunda
+        run: |
+          if [[ "${{ matrix.tasklist_mode }}" == "v1" ]]; then
+            echo "Starting with Tasklist V1 mode enabled"
+            CAMUNDA_TASKLIST_V2_MODE_ENABLED=false DATABASE=elasticsearch docker compose up -d camunda
+          else
+            echo "Starting with default Tasklist V2 mode"
+            DATABASE=elasticsearch docker compose up -d camunda
+          fi
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
+
+      - name: List running Docker containers
+        run: docker ps -a
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
+
+      - name: Wait for services to be ready
+        id: wait-for-services
+        run: |
+          echo "Checking if services are up..."
+          ready=false
+          for i in {1..90}; do
+            tasklist_status=$(curl -s -m 5 http://localhost:8080/tasklist || echo "Failed")
+            operate_status=$(curl -s -m 5 http://localhost:8080/operate || echo "Failed")
+            identity_status=$(curl -s -m 5 http://localhost:8080/identity || echo "Failed")
+            if [[ "$tasklist_status" != "Failed" && "$operate_status" != "Failed" && "$identity_status" != "Failed" ]]; then
+              echo "Services are ready!"
+              ready=true
+              break
+            fi
+            echo "Waiting for services... ($i/90)"
+            sleep 10
+          done
+          if [ "$ready" = true ]; then
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Services failed to start in time."
+            exit 1
+          fi
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
+
+      - name: Print Docker logs before failing
+        if: failure()
+        run: docker compose logs camunda
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: qa/c8-orchestration-cluster-e2e-test-suite/package-lock.json
+
+      - name: Clean install dependencies
+        shell: bash
+        run: |
+          rm -rf node_modules package-lock.json
+          npm install
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@79632e33d6953d190b940ffa440bf97821cabd80
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false # we rely on step outputs, no need for environment variables
+          secrets: |
+            secret/data/github.com/organizations/camunda TESTRAIL_QA_EMAIL;
+            secret/data/github.com/organizations/camunda TESTRAIL_QA_PSW;
+
+      - name: Install Playwright Browsers
+        shell: bash
+        run: npx playwright install --with-deps chromium
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+
+      - name: Python setup
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.x"
+
+      - name: Run tests
+        shell: bash
+        env:
+          LOCAL_TEST: "false"
+          CAMUNDA_AUTH_STRATEGY: "BASIC"
+          CAMUNDA_BASIC_AUTH_USERNAME: "demo"
+          CAMUNDA_BASIC_AUTH_PASSWORD: "demo"
+          CAMUNDA_TASKLIST_V2_MODE_ENABLED: ${{ matrix.tasklist_mode == 'v2' && 'true' || 'false' }}
+        run: |
+          export CORE_APPLICATION_URL="http://localhost:8080"
+          export ZEEBE_REST_ADDRESS="http://localhost:8080"
+          TEST_ARGS=(--project=chromium)
+
+          # stable/8.9 layout: V1 tests live under v1/ subdirs; V2 tests
+          # are everything else under tests/.
+          if [[ "${{ matrix.tasklist_mode }}" == "v2" ]]; then
+            echo "Running V2 mode tests"
+            TEST_ARGS+=(tests/ --grep-invert 'v1/')
+          else
+            echo "Running V1 mode tests"
+            TEST_ARGS+=(tests/tasklist/v1/ tests/common-flows/v1/)
+          fi
+
+          echo "Running tests with args: ${TEST_ARGS[*]}"
+          npm run test -- "${TEST_ARGS[@]}"
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+
+      - name: Publish test results to TestRail
+        if: always()
+        shell: bash
+        env:
+          TESTRAIL_HOST: "https://camunda.testrail.com/"
+          TESTRAIL_USERNAME: ${{ steps.secrets.outputs.TESTRAIL_QA_EMAIL }} # Use the imported secret
+          TESTRAIL_KEY: ${{ steps.secrets.outputs.TESTRAIL_QA_PSW }} # Use the imported secret
+          JUNIT_RESULTS_FILE: "qa/c8-orchestration-cluster-e2e-test-suite/test-results/junit-report.xml"
+        run: |
+          pip install trcli==1.14.1
+          trcli -y -h "$TESTRAIL_HOST" \
+            --project 'C8' \
+            --username "$TESTRAIL_USERNAME" \
+            --key "$TESTRAIL_KEY" \
+            --batch-size 500 \
+            parse_junit --suite-id 17050 \
+            --title "Release C8 Orchestration Cluster Test Run Results - v${{ needs.validate-release.outputs.release_version }} (Tasklist ${{ matrix.tasklist_mode }} mode) - $(date '+%Y-%m-%d %H:%M:%S')" \
+            --close-run \
+            -f "$JUNIT_RESULTS_FILE"
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: failure()
+        with:
+          name: C8 Orchestration Cluster E2E Test Result Release v${{ needs.validate-release.outputs.release_version }} (Tasklist ${{ matrix.tasklist_mode }} mode)
+          path: qa/c8-orchestration-cluster-e2e-test-suite/html-report
+          retention-days: 10
+
+      - name: Upload json report to GitHub Actions Artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: json-report-release-e2e-${{ needs.validate-release.outputs.release_version }}${{ matrix.tasklist_mode && format('-{0}', matrix.tasklist_mode) || '' }}
+          path: qa/c8-orchestration-cluster-e2e-test-suite/json-report/**
+          retention-days: 60
+
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          job_name: c8-orchestration-cluster-e2e-tests-release
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+
+  notify-result:
+    name: Send notification based on test results
+    runs-on: ubuntu-latest
+    needs: [validate-release, c8-orchestration-cluster-e2e-tests, c8-orchestration-cluster-api-tests, c8-orchestration-cluster-api-tests-rdbms]
+    if: always()
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@79632e33d6953d190b940ffa440bf97821cabd80
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/camunda/ci/github-actions SLACK_TOPMONOREPORELEASE_WEBHOOK_URL;
+
+      - name: Send Slack notification
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+        with:
+          webhook: ${{ steps.secrets.outputs.SLACK_TOPMONOREPORELEASE_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "${{ needs.c8-orchestration-cluster-e2e-tests.result == 'success' && format('<!subteam^S071S7HSWF7|qa-automated-release-manager> :test_tube: C8 Orchestration Cluster E2E Tests for {0} succeeded. See <https://github.com/camunda/camunda/actions/runs/{1}|test run overview> for details.', needs.validate-release.outputs.release_version, github.run_id) || format('<!subteam^S071S7HSWF7|qa-automated-release-manager> :warning: C8 Orchestration Cluster E2E Tests for {0} failed. See <https://github.com/camunda/camunda/actions/runs/{1}|test run overview> for details.', needs.validate-release.outputs.release_version, github.run_id) }}"
+                  }
+                }
+              ]
+            }
+
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          job_name: c8-orchestration-cluster-e2e-tests-notify-result
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
@@ -481,7 +481,9 @@ jobs:
           echo "Resolved HEAD : $(git rev-parse HEAD)"
           echo "Refs at HEAD  : $(git log -1 --format='%D' HEAD)"
 
-      # If this job needs the docker-compose image tag changed too, keep this step
+      # Re-tag the docker-compose image to the release version under test
+      # so the RDBMS API tests run against the same Camunda build as the
+      # other release-tests jobs (the upstream compose file pins :latest).
       - name: Update docker-compose with release version
         shell: bash
         run: |
@@ -937,7 +939,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "${{ needs.c8-orchestration-cluster-e2e-tests.result == 'success' && format('<!subteam^S071S7HSWF7|qa-automated-release-manager> :test_tube: C8 Orchestration Cluster E2E Tests for {0} succeeded. See <https://github.com/camunda/camunda/actions/runs/{1}|test run overview> for details.', needs.validate-release.outputs.release_version, github.run_id) || format('<!subteam^S071S7HSWF7|qa-automated-release-manager> :warning: C8 Orchestration Cluster E2E Tests for {0} failed. See <https://github.com/camunda/camunda/actions/runs/{1}|test run overview> for details.', needs.validate-release.outputs.release_version, github.run_id) }}"
+                    "text": "${{ (needs.c8-orchestration-cluster-e2e-tests.result == 'success' && needs.c8-orchestration-cluster-api-tests.result == 'success' && (needs.c8-orchestration-cluster-api-tests-rdbms.result == 'success' || needs.c8-orchestration-cluster-api-tests-rdbms.result == 'skipped')) && format('<!subteam^S071S7HSWF7|qa-automated-release-manager> :test_tube: C8 Orchestration Cluster release tests for {0} succeeded. See <https://github.com/camunda/camunda/actions/runs/{1}|test run overview> for details.', needs.validate-release.outputs.release_version, github.run_id) || format('<!subteam^S071S7HSWF7|qa-automated-release-manager> :warning: C8 Orchestration Cluster release tests for {0} failed. See <https://github.com/camunda/camunda/actions/runs/{1}|test run overview> for details.', needs.validate-release.outputs.release_version, github.run_id) }}"
                   }
                 }
               ]


### PR DESCRIPTION
**Draft — depends on #53772 landing on main first.** Opening as a draft so the diff is reviewable in parallel.

## Summary

Backport of the release-tests workflow added on main in #53772, simplified for `stable/8.9`. Adds `.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml` to this branch so 8.9.x patch testing is insulated from `main` drift (per tracking issue #53795).

## What changed vs the version on main

| Concern | On main | On this branch |
| --- | --- | --- |
| `validate-release` base detection | `if/elif` cascade across `stable/8.6 → 8.9 → main` | Hardcoded `base="stable/8.9"`. Sanity check rejects non-8.9 versions. |
| `NON_STANDALONE` (separate zeebe/operate/tasklist images for 8.6/8.7) | conditional | Removed — 8.9 always uses the unified `camunda/camunda` image. |
| `Set NON_STANDALONE variable` step | exists | Deleted (not needed). |
| `Print Docker logs before failing` | conditional `docker compose logs zeebe/tasklist/operate` vs `camunda` | Just `docker compose logs camunda`. |
| RDBMS job gate (`build-rdbms-dist`, `c8-orchestration-cluster-api-tests-rdbms`) | `if: base == 'stable/8.9' \|\| 'main'` | Removed — jobs always run. |
| Tasklist V1/V2 matrix | `fromJSON(cascade)` over stable/main | Constant `["v1", "v2"]`. |
| E2E test routing | `if main → tests/; elif stable/8.8 → @v1-only filter; else stable/8.9 → v1/ filter` | Just the stable/8.9 case (`v1/` directory split). |

Source-of-truth ref resolution from #53772 is preserved untouched: `refs/heads/release-<version>` preferred, `refs/tags/<version>` fallback, fail-fast otherwise.

## Diff stats

`+931 -0` (new file). Equivalent file on main is 1078 lines — ~150 fewer lines of cross-version conditionals here.

## Test plan

- [x] `actionlint` clean (only the pre-existing self-hosted-runner-label warning).
- [ ] Once merged, smoke-test via `gh workflow run c8-orchestration-cluster-e2e-tests-release.yml --repo camunda/camunda --ref stable/8.9 -f monorepo_release=<recent-8.9.x-version>` and confirm the run uses the stable/8.9 copy.
- [ ] Confirm the negative path: trigger with a non-8.9 version (e.g. `8.8.0`) and verify `validate-release` rejects it with the new sanity-check error.

## Related

- Parent PR: #53772 (lands on main first)
- Tracking issue: #53795
- Companion: a matching backport for `stable/8.8` will follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)