### PR TITLE
ci: add release E2E tests workflow on stable/8.8 (backport of #53772, simplified)

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
@@ -1,0 +1,559 @@
+# description: Runs End to End tests on the C8 Orchestration Cluster (ie, Tasklist, Operate) during monoRepo releases
+# type: CI
+# owner: @camunda/qa-engineering
+---
+name: C8 Orchestration Cluster E2E Tests Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      monorepo_release:
+        description: "Enter the monorepo release version (e.g., 8.8.0, 8.8.1, 8.8.0-alpha8, 8.8.0-alpha8-rc1)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  validate-release:
+    runs-on: ubuntu-latest
+    outputs:
+      release_version: ${{ steps.get-release.outputs.release_version }}
+      base: ${{ steps.detect-base.outputs.base }}
+      # Git ref to check out test code / source from. We prefer the
+      # release branch (e.g. "release-8.10.0-alpha1") over the stable
+      # branch (e.g. "stable/8.10") because stable keeps moving after a
+      # release is cut and naturally contains commits for the next
+      # patch. The release branch is forked from main/stable at the
+      # release point and may carry post-tag commits the team wants
+      # tested (e.g. test stabilization for this specific release). If
+      # the release branch has been cleaned up, fall back to the
+      # release tag, which is immutable.
+      ref: ${{ steps.detect-base.outputs.ref }}
+    steps:
+      - name: Get release version
+        id: get-release
+        run: |
+          release_version="${{ github.event.inputs.monorepo_release }}"
+
+          echo "Release version: $release_version"
+          echo "release_version=$release_version" >> "$GITHUB_OUTPUT"
+
+          # Validate version format (x.y.z or x.y.z-suffix)
+          if [[ ! "$release_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)*(-[a-zA-Z0-9]+)*$ ]]; then
+            echo "Error: Invalid release version format. Expected format: x.y.z or x.y.z-suffix (e.g., 8.8.0, 8.8.0-alpha8, 8.8.0-alpha8-rc1)"
+            exit 1
+          fi
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      # Resolves two outputs:
+      #   * `base`  — stable/x.y or main, used by the rest of the workflow
+      #               for routing decisions (which test directories, V1/V2
+      #               matrix, RDBMS gating, etc).
+      #   * `ref`   — fully-qualified git ref used by every source-code
+      #               checkout. Prefers refs/heads/release-<version> if the
+      #               branch exists (typical for a fresh or in-flight
+      #               release, which may also carry post-tag fixes the team
+      #               wants tested), otherwise falls back to refs/tags/
+      #               <version>. Fails fast if neither exists.
+      #
+      # Note: we deliberately do NOT require the tag to exist when the
+      # release branch is present, so this workflow can be used to test
+      # an in-flight release (pre-tag).
+      - name: Detect base branch and resolve source ref
+        id: detect-base
+        run: |
+          release_version="${{ steps.get-release.outputs.release_version }}"
+          echo "Detecting base branch for release version: $release_version"
+
+          # This workflow lives on `stable/8.8` and only ever tests 8.8.x
+          # releases — `base` is a constant. The branch-name cascade that
+          # exists on `main` was removed because it has no effect here;
+          # any 8.x patch testing for other stable lines should be
+          # triggered from that line's own copy of this workflow.
+          base="stable/8.8"
+
+          echo "Base branch: $base"
+          echo "base=$base" >> "$GITHUB_OUTPUT"
+
+          # Sanity check: refuse to run if someone passes a non-8.8
+          # version against this workflow by mistake.
+          major_minor=$(echo "$release_version" | cut -d. -f1-2)
+          if [[ "$major_minor" != "8.8" ]]; then
+            echo "Error: this workflow lives on stable/8.8 and only accepts 8.8.x release versions; got '$release_version'."
+            exit 1
+          fi
+
+          # Resolve the git ref to check source code out from:
+          #   1) the release branch `release-<version>` if it exists
+          #      (preferred — picks up post-tag fixes on that branch);
+          #   2) otherwise fall back to the immutable tag `<version>`
+          #      (camunda/camunda tags match the version string exactly,
+          #      e.g. "8.8.0", "8.8.0-alpha8-rc1");
+          #   3) otherwise fail fast.
+          #
+          # Refs are fully qualified (`refs/heads/...`, `refs/tags/...`)
+          # so a tag and a branch with the same name can never be
+          # resolved ambiguously by actions/checkout.
+          #
+          # This is what the upstream release pipeline produces — see
+          # camunda-platform-release.yml:
+          #   RELEASE_BRANCH = release-${releaseVersion}
+          #   tag            = ${releaseVersion}
+          release_branch="release-$release_version"
+          repo_url="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:-camunda/camunda}"
+          echo "Looking for release branch: $release_branch"
+          if git ls-remote --exit-code --heads origin "refs/heads/$release_branch" >/dev/null; then
+            ref="refs/heads/$release_branch"
+            echo "Using release branch as ref: $ref"
+          else
+            echo "Release branch '$release_branch' not found; falling back to tag."
+            if git ls-remote --exit-code --tags origin "refs/tags/$release_version" >/dev/null; then
+              ref="refs/tags/$release_version"
+              echo "Using release tag as ref: $ref"
+            else
+              echo "Error: neither branch 'release-$release_version' nor tag '$release_version' exist on $repo_url."
+              exit 1
+            fi
+          fi
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          job_name: c8-orchestration-cluster-e2e-tests-validate-release
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+
+  c8-orchestration-cluster-api-tests:
+    name: C8 Orchestration Cluster API Tests
+    needs: validate-release
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions: {}
+    steps:
+      - name: Print release info
+        shell: bash
+        run: |
+          echo "Release version: ${{ needs.validate-release.outputs.release_version }}"
+          echo "Base branch (routing): ${{ needs.validate-release.outputs.base }}"
+          echo "Source ref (checkout): ${{ needs.validate-release.outputs.ref }}"
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Check out the release branch (or tag fallback), not the
+          # stable branch — see validate-release for rationale.
+          ref: ${{ needs.validate-release.outputs.ref }}
+
+      - name: Log checked-out commit
+        shell: bash
+        run: |
+          echo "Configured ref: ${{ needs.validate-release.outputs.ref }}"
+          echo "Resolved HEAD : $(git rev-parse HEAD)"
+          echo "Refs at HEAD  : $(git log -1 --format='%D' HEAD)"
+
+      - name: Update docker-compose with release version
+        shell: bash
+        run: |
+          release_version="${{ needs.validate-release.outputs.release_version }}"
+          compose_file="qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml"
+
+          echo "Updating docker image to version: $release_version"
+          # Replace the camunda image tag in docker-compose.yml; match
+          # both direct image references and variable-default syntax.
+          sed -i.bak "s|image:.*camunda/camunda:.*|image: camunda/camunda:$release_version|g" "$compose_file"
+
+          echo "Updated docker-compose.yml:"
+          grep "image: camunda/camunda:" "$compose_file"
+
+      - name: Start Camunda
+        shell: bash
+        run: DATABASE=elasticsearch docker compose up -d camunda
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
+
+      - name: List running Docker containers
+        shell: bash
+        run: docker ps -a
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
+
+      - name: Wait for services to be ready
+        shell: bash
+        id: wait-for-services
+        run: |
+          echo "Checking if services are up..."
+          ready=false
+          for i in {1..90}; do
+            tasklist_status=$(curl -s -m 5 http://localhost:8080/tasklist || echo "Failed")
+            operate_status=$(curl -s -m 5 http://localhost:8080/operate || echo "Failed")
+            identity_status=$(curl -s -m 5 http://localhost:8080/identity || echo "Failed")
+            if [[ "$tasklist_status" != "Failed" && "$operate_status" != "Failed" && "$identity_status" != "Failed" ]]; then
+              echo "Services are ready!"
+              ready=true
+              break
+            fi
+            echo "Waiting for services... ($i/90)"
+            sleep 10
+          done
+          if [ "$ready" = true ]; then
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Services failed to start in time."
+            exit 1
+          fi
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
+
+      - name: Print Docker logs before failing
+        shell: bash
+        if: failure()
+        run: docker compose logs camunda
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: qa/c8-orchestration-cluster-e2e-test-suite/package-lock.json
+
+      - name: Clean install dependencies
+        shell: bash
+        run: |
+          rm -rf node_modules package-lock.json
+          npm install
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@79632e33d6953d190b940ffa440bf97821cabd80
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false # we rely on step outputs, no need for environment variables
+          secrets: |
+            secret/data/github.com/organizations/camunda TESTRAIL_QA_EMAIL;
+            secret/data/github.com/organizations/camunda TESTRAIL_QA_PSW;
+
+      - name: Install Playwright Browsers
+        shell: bash
+        run: npx playwright install --with-deps chromium
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+
+      - name: Python setup
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.x"
+
+      - name: Run API tests
+        shell: bash
+        env:
+          LOCAL_TEST: "false"
+          CAMUNDA_AUTH_STRATEGY: "BASIC"
+          CAMUNDA_BASIC_AUTH_USERNAME: "demo"
+          CAMUNDA_BASIC_AUTH_PASSWORD: "demo"
+          CAMUNDA_PROCESSINSTANCECREATION_BUSINESSIDUNIQUENESSENABLED: "true"
+        run: |
+          export CORE_APPLICATION_URL="http://localhost:8080"
+          export ZEEBE_REST_ADDRESS="http://localhost:8080"
+
+          echo "Running API tests"
+          npm run test -- --project=api-tests
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+
+      - name: Publish test results to TestRail
+        if: always()
+        shell: bash
+        env:
+          TESTRAIL_HOST: "https://camunda.testrail.com/"
+          TESTRAIL_USERNAME: ${{ steps.secrets.outputs.TESTRAIL_QA_EMAIL }} # Use the imported secret
+          TESTRAIL_KEY: ${{ steps.secrets.outputs.TESTRAIL_QA_PSW }} # Use the imported secret
+          JUNIT_RESULTS_FILE: "qa/c8-orchestration-cluster-e2e-test-suite/test-results/junit-report.xml"
+        run: |
+          pip install trcli==1.14.1
+          trcli -y -h "$TESTRAIL_HOST" \
+            --project 'C8' \
+            --username "$TESTRAIL_USERNAME" \
+            --key "$TESTRAIL_KEY" \
+            --batch-size 500 \
+            parse_junit --suite-id 17050 \
+            --title "Release C8 Orchestration Cluster API Test Run Results - v${{ needs.validate-release.outputs.release_version }} - $(date '+%Y-%m-%d %H:%M:%S')" \
+            --close-run \
+            -f "$JUNIT_RESULTS_FILE"
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: failure()
+        with:
+          name: C8 Orchestration Cluster E2E API Test Result Release v${{ needs.validate-release.outputs.release_version }}
+          path: qa/c8-orchestration-cluster-e2e-test-suite/html-report
+          retention-days: 10
+
+      - name: Upload json report to GitHub Actions Artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: json-report-release-api
+          path: qa/c8-orchestration-cluster-e2e-test-suite/json-report/**
+          retention-days: 60
+
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          job_name: c8-orchestration-cluster-e2e-api-tests-release
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+
+  c8-orchestration-cluster-e2e-tests:
+    name: C8 Orchestration Cluster E2E Tests Release (Tasklist ${{ matrix.tasklist_mode }} mode)
+    strategy:
+      fail-fast: false
+      matrix:
+        # stable/8.8 ships both Tasklist V1 and V2.
+        tasklist_mode: ["v1", "v2"]
+    needs: validate-release
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions: {}
+    steps:
+      - name: Print release info
+        run: |
+          echo "Release version: ${{ needs.validate-release.outputs.release_version }}"
+          echo "Base branch (routing): ${{ needs.validate-release.outputs.base }}"
+          echo "Source ref (checkout): ${{ needs.validate-release.outputs.ref }}"
+          echo "Tasklist mode: ${{ matrix.tasklist_mode }}"
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Check out the release branch (or tag fallback), not the
+          # stable branch — see validate-release for rationale.
+          ref: ${{ needs.validate-release.outputs.ref }}
+
+      - name: Log checked-out commit
+        shell: bash
+        run: |
+          echo "Configured ref: ${{ needs.validate-release.outputs.ref }}"
+          echo "Resolved HEAD : $(git rev-parse HEAD)"
+          echo "Refs at HEAD  : $(git log -1 --format='%D' HEAD)"
+
+      - name: Update docker-compose with release version
+        run: |
+          release_version="${{ needs.validate-release.outputs.release_version }}"
+          compose_file="qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml"
+
+          echo "Updating docker image to version: $release_version"
+          sed -i.bak "s|image:.*camunda/camunda:.*|image: camunda/camunda:$release_version|g" "$compose_file"
+
+      - name: Start Camunda
+        run: |
+          if [[ "${{ matrix.tasklist_mode }}" == "v1" ]]; then
+            echo "Starting with Tasklist V1 mode enabled"
+            CAMUNDA_TASKLIST_V2_MODE_ENABLED=false DATABASE=elasticsearch docker compose up -d camunda
+          else
+            echo "Starting with default Tasklist V2 mode"
+            DATABASE=elasticsearch docker compose up -d camunda
+          fi
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
+
+      - name: List running Docker containers
+        run: docker ps -a
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
+
+      - name: Wait for services to be ready
+        id: wait-for-services
+        run: |
+          echo "Checking if services are up..."
+          ready=false
+          for i in {1..90}; do
+            tasklist_status=$(curl -s -m 5 http://localhost:8080/tasklist || echo "Failed")
+            operate_status=$(curl -s -m 5 http://localhost:8080/operate || echo "Failed")
+            identity_status=$(curl -s -m 5 http://localhost:8080/identity || echo "Failed")
+            if [[ "$tasklist_status" != "Failed" && "$operate_status" != "Failed" && "$identity_status" != "Failed" ]]; then
+              echo "Services are ready!"
+              ready=true
+              break
+            fi
+            echo "Waiting for services... ($i/90)"
+            sleep 10
+          done
+          if [ "$ready" = true ]; then
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Services failed to start in time."
+            exit 1
+          fi
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
+
+      - name: Print Docker logs before failing
+        if: failure()
+        run: docker compose logs camunda
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: qa/c8-orchestration-cluster-e2e-test-suite/package-lock.json
+
+      - name: Clean install dependencies
+        shell: bash
+        run: |
+          rm -rf node_modules package-lock.json
+          npm install
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@79632e33d6953d190b940ffa440bf97821cabd80
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false # we rely on step outputs, no need for environment variables
+          secrets: |
+            secret/data/github.com/organizations/camunda TESTRAIL_QA_EMAIL;
+            secret/data/github.com/organizations/camunda TESTRAIL_QA_PSW;
+
+      - name: Install Playwright Browsers
+        shell: bash
+        run: npx playwright install --with-deps chromium
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+
+      - name: Python setup
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.x"
+
+      - name: Run tests
+        shell: bash
+        env:
+          LOCAL_TEST: "false"
+          CAMUNDA_AUTH_STRATEGY: "BASIC"
+          CAMUNDA_BASIC_AUTH_USERNAME: "demo"
+          CAMUNDA_BASIC_AUTH_PASSWORD: "demo"
+          CAMUNDA_TASKLIST_V2_MODE_ENABLED: ${{ matrix.tasklist_mode == 'v2' && 'true' || 'false' }}
+        run: |
+          export CORE_APPLICATION_URL="http://localhost:8080"
+          export ZEEBE_REST_ADDRESS="http://localhost:8080"
+          TEST_ARGS=(--project=chromium)
+
+          # stable/8.8 layout: V1 and V2 tests live in the same shared
+          # directories; V1-mode runs filter to the @v1-only tagged tests
+          # and V2-mode runs filter them out.
+          if [[ "${{ matrix.tasklist_mode }}" == "v2" ]]; then
+            echo "Running V2 mode tests"
+            TEST_ARGS+=(tests/ --grep-invert '@v1-only')
+          else
+            echo "Running V1 mode tests"
+            TEST_ARGS+=(tests/tasklist/ tests/common-flows/)
+          fi
+
+          echo "Running tests with args: ${TEST_ARGS[*]}"
+          npm run test -- "${TEST_ARGS[@]}"
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+
+      - name: Publish test results to TestRail
+        if: always()
+        shell: bash
+        env:
+          TESTRAIL_HOST: "https://camunda.testrail.com/"
+          TESTRAIL_USERNAME: ${{ steps.secrets.outputs.TESTRAIL_QA_EMAIL }} # Use the imported secret
+          TESTRAIL_KEY: ${{ steps.secrets.outputs.TESTRAIL_QA_PSW }} # Use the imported secret
+          JUNIT_RESULTS_FILE: "qa/c8-orchestration-cluster-e2e-test-suite/test-results/junit-report.xml"
+        run: |
+          pip install trcli==1.14.1
+          trcli -y -h "$TESTRAIL_HOST" \
+            --project 'C8' \
+            --username "$TESTRAIL_USERNAME" \
+            --key "$TESTRAIL_KEY" \
+            --batch-size 500 \
+            parse_junit --suite-id 17050 \
+            --title "Release C8 Orchestration Cluster Test Run Results - v${{ needs.validate-release.outputs.release_version }} (Tasklist ${{ matrix.tasklist_mode }} mode) - $(date '+%Y-%m-%d %H:%M:%S')" \
+            --close-run \
+            -f "$JUNIT_RESULTS_FILE"
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: failure()
+        with:
+          name: C8 Orchestration Cluster E2E Test Result Release v${{ needs.validate-release.outputs.release_version }} (Tasklist ${{ matrix.tasklist_mode }} mode)
+          path: qa/c8-orchestration-cluster-e2e-test-suite/html-report
+          retention-days: 10
+
+      - name: Upload json report to GitHub Actions Artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: json-report-release-e2e-${{ needs.validate-release.outputs.release_version }}${{ matrix.tasklist_mode && format('-{0}', matrix.tasklist_mode) || '' }}
+          path: qa/c8-orchestration-cluster-e2e-test-suite/json-report/**
+          retention-days: 60
+
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          job_name: c8-orchestration-cluster-e2e-tests-release
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+
+  notify-result:
+    name: Send notification based on test results
+    runs-on: ubuntu-latest
+    needs: [validate-release, c8-orchestration-cluster-e2e-tests, c8-orchestration-cluster-api-tests]
+    if: always()
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@79632e33d6953d190b940ffa440bf97821cabd80
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/camunda/ci/github-actions SLACK_TOPMONOREPORELEASE_WEBHOOK_URL;
+
+      - name: Send Slack notification
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+        with:
+          webhook: ${{ steps.secrets.outputs.SLACK_TOPMONOREPORELEASE_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "${{ needs.c8-orchestration-cluster-e2e-tests.result == 'success' && format('<!subteam^S071S7HSWF7|qa-automated-release-manager> :test_tube: C8 Orchestration Cluster E2E Tests for {0} succeeded. See <https://github.com/camunda/camunda/actions/runs/{1}|test run overview> for details.', needs.validate-release.outputs.release_version, github.run_id) || format('<!subteam^S071S7HSWF7|qa-automated-release-manager> :warning: C8 Orchestration Cluster E2E Tests for {0} failed. See <https://github.com/camunda/camunda/actions/runs/{1}|test run overview> for details.', needs.validate-release.outputs.release_version, github.run_id) }}"
+                  }
+                }
+              ]
+            }
+
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          job_name: c8-orchestration-cluster-e2e-tests-notify-result
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
@@ -18,6 +18,9 @@ permissions:
 jobs:
   validate-release:
     runs-on: ubuntu-latest
+    # Cap runtime so a hung `git ls-remote`/shell step can't block the
+    # whole release-tests workflow indefinitely.
+    timeout-minutes: 5
     outputs:
       release_version: ${{ steps.get-release.outputs.release_version }}
       base: ${{ steps.detect-base.outputs.base }}


### PR DESCRIPTION
**Draft — depends on #53772 landing on main first.** Sibling of #53807 (stable/8.9 backport).

## Summary

Backport of the release-tests workflow added on main in #53772, simplified for `stable/8.8`. Adds `.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml` to this branch so 8.8.x patch testing is insulated from `main` drift (per tracking issue #53795).

## What changed vs the version on main

| Concern | On main | On this branch |
| --- | --- | --- |
| `validate-release` base detection | `if/elif` cascade across `stable/8.6 → 8.9 → main` | Hardcoded `base="stable/8.8"`. Sanity check rejects non-8.8 versions. |
| `NON_STANDALONE` (separate zeebe/operate/tasklist images for 8.6/8.7) | conditional | Removed — 8.8 uses the unified `camunda/camunda` image. |
| `Set NON_STANDALONE variable` step | exists | Deleted. |
| `Print Docker logs before failing` | conditional | Just `docker compose logs camunda`. |
| `build-rdbms-dist` + `c8-orchestration-cluster-api-tests-rdbms` jobs | gated on `base == 'stable/8.9' \|\| 'main'` | **Deleted entirely** — RDBMS support isn't on 8.8. |
| `notify-result` `needs:` | includes RDBMS job | RDBMS job removed from `needs:`. |
| Tasklist V1/V2 matrix | `fromJSON(cascade)` | Constant `["v1", "v2"]`. |
| E2E test routing | branches across main/8.8/8.9 layouts | Just the stable/8.8 case: V2 mode = `tests/ --grep-invert '@v1-only'`, V1 mode = `tests/tasklist/ tests/common-flows/`. |

Source-of-truth ref resolution from #53772 is preserved untouched: `refs/heads/release-<version>` preferred, `refs/tags/<version>` fallback, fail-fast otherwise.

## Diff stats

`+559 -0` (new file). Equivalent file on main is 1078 lines — ~520 fewer lines here (~50% smaller) because of the deleted RDBMS jobs plus the cross-version conditional removal.

## Test plan

- [x] `actionlint` clean (only the pre-existing self-hosted-runner-label warning).
- [ ] Once merged, smoke-test via `gh workflow run c8-orchestration-cluster-e2e-tests-release.yml --repo camunda/camunda --ref stable/8.8 -f monorepo_release=<recent-8.8.x-version>`.
- [ ] Confirm sanity check: trigger with a non-8.8 version (e.g. `8.9.0`) and verify `validate-release` rejects it.

## Related

- Parent PR: #53772 (lands on main first)
- Sibling: #53807 (stable/8.9 backport)
- Tracking issue: #53795

🤖 Generated with [Claude Code](https://claude.com/claude-code)