### PR TITLE
fix: sequence Tasklist process-instance archiver deletes (#53786)

### DIFF
--- a/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/es/ProcessInstanceArchiverJobElasticSearch.java
+++ b/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/es/ProcessInstanceArchiverJobElasticSearch.java
@@ -96,14 +96,13 @@ public class ProcessInstanceArchiverJobElasticSearch extends AbstractArchiverJob
               FlowNodeInstanceIndex.PROCESS_INSTANCE_ID,
               archiveBatch.getIds());
 
-      final var deleteProcessInstanceFuture =
-          archiverUtil.deleteDocuments(
-              processInstanceIndex.getFullQualifiedName(),
-              ProcessInstanceIndex.ID,
-              archiveBatch.getIds());
-
-      CompletableFuture.allOf(
-              deleteVariablesFuture, deleteFlowNodesFuture, deleteProcessInstanceFuture)
+      CompletableFuture.allOf(deleteVariablesFuture, deleteFlowNodesFuture)
+          .thenCompose(
+              (v) ->
+                  archiverUtil.deleteDocuments(
+                      processInstanceIndex.getFullQualifiedName(),
+                      ProcessInstanceIndex.ID,
+                      archiveBatch.getIds()))
           .thenAccept(
               (v) ->
                   archiveBatchFuture.complete(

--- a/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/os/ProcessInstanceArchiverJobOpenSearch.java
+++ b/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/os/ProcessInstanceArchiverJobOpenSearch.java
@@ -93,14 +93,13 @@ public class ProcessInstanceArchiverJobOpenSearch extends AbstractArchiverJobOpe
               FlowNodeInstanceIndex.PROCESS_INSTANCE_ID,
               archiveBatch.getIds());
 
-      final var deleteProcessInstanceFuture =
-          archiverUtil.deleteDocuments(
-              processInstanceIndex.getFullQualifiedName(),
-              ProcessInstanceIndex.ID,
-              archiveBatch.getIds());
-
-      CompletableFuture.allOf(
-              deleteVariablesFuture, deleteFlowNodesFuture, deleteProcessInstanceFuture)
+      CompletableFuture.allOf(deleteVariablesFuture, deleteFlowNodesFuture)
+          .thenCompose(
+              (v) ->
+                  archiverUtil.deleteDocuments(
+                      processInstanceIndex.getFullQualifiedName(),
+                      ProcessInstanceIndex.ID,
+                      archiveBatch.getIds()))
           .thenAccept(
               (v) ->
                   archiveBatchFuture.complete(

--- a/tasklist/archiver/src/test/java/io/camunda/tasklist/archiver/es/ProcessInstanceArchiverJobElasticSearchTest.java
+++ b/tasklist/archiver/src/test/java/io/camunda/tasklist/archiver/es/ProcessInstanceArchiverJobElasticSearchTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.tasklist.archiver.es;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.tasklist.archiver.AbstractArchiverJob.ArchiveBatch;
+import io.camunda.tasklist.archiver.ArchiverUtil;
+import io.camunda.tasklist.schema.indices.FlowNodeInstanceIndex;
+import io.camunda.tasklist.schema.indices.ProcessInstanceIndex;
+import io.camunda.tasklist.schema.indices.VariableIndex;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Regression tests for the orphan documents bug documented in GitHub issue #53786. Verifies that
+ * the process-instance delete only fires after the dependents (variables, flow-nodes) succeed —
+ * otherwise a partial failure would orphan child documents because the parent end-date row is gone
+ * and the importer won't replay the records.
+ */
+@ExtendWith(MockitoExtension.class)
+public class ProcessInstanceArchiverJobElasticSearchTest {
+
+  private static final String VAR_INDEX = "tasklist-variable-index";
+  private static final String FLOW_NODE_INDEX = "tasklist-flownode-instance-index";
+  private static final String PROCESS_INSTANCE_INDEX = "tasklist-process-instance-index";
+  private static final Duration TIMEOUT = Duration.ofSeconds(5);
+
+  @InjectMocks
+  private ProcessInstanceArchiverJobElasticSearch underTest =
+      new ProcessInstanceArchiverJobElasticSearch(List.of(1));
+
+  @Mock private ArchiverUtil archiverUtil;
+  @Mock private VariableIndex variableIndex;
+  @Mock private FlowNodeInstanceIndex flowNodeInstanceIndex;
+  @Mock private ProcessInstanceIndex processInstanceIndex;
+
+  @BeforeEach
+  public void setUp() {
+    lenient().when(variableIndex.getFullQualifiedName()).thenReturn(VAR_INDEX);
+    lenient().when(flowNodeInstanceIndex.getFullQualifiedName()).thenReturn(FLOW_NODE_INDEX);
+    lenient().when(processInstanceIndex.getFullQualifiedName()).thenReturn(PROCESS_INSTANCE_INDEX);
+  }
+
+  @Test
+  public void archiveBatchSkipsProcessInstanceDeleteWhenVariablesDeleteFails() {
+    final CompletableFuture<Long> failed = new CompletableFuture<>();
+    failed.completeExceptionally(new RuntimeException("ES variables delete failed"));
+    when(archiverUtil.deleteDocuments(eq(VAR_INDEX), any(), any())).thenReturn(failed);
+    when(archiverUtil.deleteDocuments(eq(FLOW_NODE_INDEX), any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(1L));
+
+    final CompletableFuture<Map.Entry<String, Integer>> res =
+        underTest.archiveBatch(new ArchiveBatch(List.of("pi-1")));
+
+    assertThat(res).failsWithin(TIMEOUT);
+    verify(archiverUtil, never()).deleteDocuments(eq(PROCESS_INSTANCE_INDEX), any(), any());
+  }
+
+  @Test
+  public void archiveBatchSkipsProcessInstanceDeleteWhenFlowNodesDeleteFails() {
+    final CompletableFuture<Long> failed = new CompletableFuture<>();
+    failed.completeExceptionally(new RuntimeException("ES flow-nodes delete failed"));
+    when(archiverUtil.deleteDocuments(eq(VAR_INDEX), any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(1L));
+    when(archiverUtil.deleteDocuments(eq(FLOW_NODE_INDEX), any(), any())).thenReturn(failed);
+
+    final CompletableFuture<Map.Entry<String, Integer>> res =
+        underTest.archiveBatch(new ArchiveBatch(List.of("pi-1")));
+
+    assertThat(res).failsWithin(TIMEOUT);
+    verify(archiverUtil, never()).deleteDocuments(eq(PROCESS_INSTANCE_INDEX), any(), any());
+  }
+
+  @Test
+  public void archiveBatchDeletesDependentsBeforeParentOnSuccess() {
+    when(archiverUtil.deleteDocuments(eq(VAR_INDEX), any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(2L));
+    when(archiverUtil.deleteDocuments(eq(FLOW_NODE_INDEX), any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(3L));
+    when(archiverUtil.deleteDocuments(eq(PROCESS_INSTANCE_INDEX), any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(1L));
+
+    final CompletableFuture<Map.Entry<String, Integer>> res =
+        underTest.archiveBatch(new ArchiveBatch(List.of("pi-1")));
+
+    assertThat(res).succeedsWithin(TIMEOUT).extracting(Map.Entry::getValue).isEqualTo(1);
+
+    final InOrder varsThenParent = inOrder(archiverUtil);
+    varsThenParent.verify(archiverUtil).deleteDocuments(eq(VAR_INDEX), any(), any());
+    varsThenParent.verify(archiverUtil).deleteDocuments(eq(PROCESS_INSTANCE_INDEX), any(), any());
+    final InOrder flowNodesThenParent = inOrder(archiverUtil);
+    flowNodesThenParent.verify(archiverUtil).deleteDocuments(eq(FLOW_NODE_INDEX), any(), any());
+    flowNodesThenParent
+        .verify(archiverUtil)
+        .deleteDocuments(eq(PROCESS_INSTANCE_INDEX), any(), any());
+  }
+
+  @Test
+  public void archiveBatchReturnsNothingToArchiveWhenBatchIsNull() {
+    final CompletableFuture<Map.Entry<String, Integer>> res = underTest.archiveBatch(null);
+
+    assertThat(res).succeedsWithin(TIMEOUT).extracting(Map.Entry::getValue).isEqualTo(0);
+    verify(archiverUtil, never()).deleteDocuments(any(), any(), any());
+  }
+}

--- a/tasklist/archiver/src/test/java/io/camunda/tasklist/archiver/os/ProcessInstanceArchiverJobOpenSearchTest.java
+++ b/tasklist/archiver/src/test/java/io/camunda/tasklist/archiver/os/ProcessInstanceArchiverJobOpenSearchTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.tasklist.archiver.os;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.tasklist.archiver.AbstractArchiverJob.ArchiveBatch;
+import io.camunda.tasklist.archiver.ArchiverUtil;
+import io.camunda.tasklist.schema.indices.FlowNodeInstanceIndex;
+import io.camunda.tasklist.schema.indices.ProcessInstanceIndex;
+import io.camunda.tasklist.schema.indices.VariableIndex;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Regression tests for the orphan documents bug documented in GitHub issue #53786. Verifies that
+ * the process-instance delete only fires after the dependents (variables, flow-nodes) succeed —
+ * otherwise a partial failure would orphan child documents because the parent end-date row is gone
+ * and the importer won't replay the records.
+ */
+@ExtendWith(MockitoExtension.class)
+public class ProcessInstanceArchiverJobOpenSearchTest {
+
+  private static final String VAR_INDEX = "tasklist-variable-index";
+  private static final String FLOW_NODE_INDEX = "tasklist-flownode-instance-index";
+  private static final String PROCESS_INSTANCE_INDEX = "tasklist-process-instance-index";
+  private static final Duration TIMEOUT = Duration.ofSeconds(5);
+
+  @InjectMocks
+  private ProcessInstanceArchiverJobOpenSearch underTest =
+      new ProcessInstanceArchiverJobOpenSearch(List.of(1));
+
+  @Mock private ArchiverUtil archiverUtil;
+  @Mock private VariableIndex variableIndex;
+  @Mock private FlowNodeInstanceIndex flowNodeInstanceIndex;
+  @Mock private ProcessInstanceIndex processInstanceIndex;
+
+  @BeforeEach
+  public void setUp() {
+    lenient().when(variableIndex.getFullQualifiedName()).thenReturn(VAR_INDEX);
+    lenient().when(flowNodeInstanceIndex.getFullQualifiedName()).thenReturn(FLOW_NODE_INDEX);
+    lenient().when(processInstanceIndex.getFullQualifiedName()).thenReturn(PROCESS_INSTANCE_INDEX);
+  }
+
+  @Test
+  public void archiveBatchSkipsProcessInstanceDeleteWhenVariablesDeleteFails() {
+    final CompletableFuture<Long> failed = new CompletableFuture<>();
+    failed.completeExceptionally(new RuntimeException("OS variables delete failed"));
+    when(archiverUtil.deleteDocuments(eq(VAR_INDEX), any(), any())).thenReturn(failed);
+    when(archiverUtil.deleteDocuments(eq(FLOW_NODE_INDEX), any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(1L));
+
+    final CompletableFuture<Map.Entry<String, Integer>> res =
+        underTest.archiveBatch(new ArchiveBatch(List.of("pi-1")));
+
+    assertThat(res).failsWithin(TIMEOUT);
+    verify(archiverUtil, never()).deleteDocuments(eq(PROCESS_INSTANCE_INDEX), any(), any());
+  }
+
+  @Test
+  public void archiveBatchSkipsProcessInstanceDeleteWhenFlowNodesDeleteFails() {
+    final CompletableFuture<Long> failed = new CompletableFuture<>();
+    failed.completeExceptionally(new RuntimeException("OS flow-nodes delete failed"));
+    when(archiverUtil.deleteDocuments(eq(VAR_INDEX), any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(1L));
+    when(archiverUtil.deleteDocuments(eq(FLOW_NODE_INDEX), any(), any())).thenReturn(failed);
+
+    final CompletableFuture<Map.Entry<String, Integer>> res =
+        underTest.archiveBatch(new ArchiveBatch(List.of("pi-1")));
+
+    assertThat(res).failsWithin(TIMEOUT);
+    verify(archiverUtil, never()).deleteDocuments(eq(PROCESS_INSTANCE_INDEX), any(), any());
+  }
+
+  @Test
+  public void archiveBatchDeletesDependentsBeforeParentOnSuccess() {
+    when(archiverUtil.deleteDocuments(eq(VAR_INDEX), any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(2L));
+    when(archiverUtil.deleteDocuments(eq(FLOW_NODE_INDEX), any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(3L));
+    when(archiverUtil.deleteDocuments(eq(PROCESS_INSTANCE_INDEX), any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(1L));
+
+    final CompletableFuture<Map.Entry<String, Integer>> res =
+        underTest.archiveBatch(new ArchiveBatch(List.of("pi-1")));
+
+    assertThat(res).succeedsWithin(TIMEOUT).extracting(Map.Entry::getValue).isEqualTo(1);
+
+    final InOrder varsThenParent = inOrder(archiverUtil);
+    varsThenParent.verify(archiverUtil).deleteDocuments(eq(VAR_INDEX), any(), any());
+    varsThenParent.verify(archiverUtil).deleteDocuments(eq(PROCESS_INSTANCE_INDEX), any(), any());
+    final InOrder flowNodesThenParent = inOrder(archiverUtil);
+    flowNodesThenParent.verify(archiverUtil).deleteDocuments(eq(FLOW_NODE_INDEX), any(), any());
+    flowNodesThenParent
+        .verify(archiverUtil)
+        .deleteDocuments(eq(PROCESS_INSTANCE_INDEX), any(), any());
+  }
+
+  @Test
+  public void archiveBatchReturnsNothingToArchiveWhenBatchIsNull() {
+    final CompletableFuture<Map.Entry<String, Integer>> res = underTest.archiveBatch(null);
+
+    assertThat(res).succeedsWithin(TIMEOUT).extracting(Map.Entry::getValue).isEqualTo(0);
+    verify(archiverUtil, never()).deleteDocuments(any(), any(), any());
+  }
+}


### PR DESCRIPTION
## Summary
- Fixes #53786. `ProcessInstanceArchiverJob.archiveBatch` (ES and OS) fired the variables, flow-nodes and process-instance deletes concurrently via `CompletableFuture.allOf`. A partial failure (e.g. variables timeout while flow-nodes and process-instance succeed) deletes the parent end-date row while leaving dependents in place. Because the next archiver pass keys off `END_DATE` on the process-instance index, those orphans are never revisited and the Zeebe importer won't replay `ELEMENT_COMPLETED` records — making the orphans permanent.
- Sequences the deletes: dependents (variables, flow-nodes) run first; the parent process-instance delete only fires once both succeed. If either dependent fails, propagate the failure and skip the parent so the next archiver iteration can retry.
- Adds unit tests for both ES and OS variants covering the failure-skips-parent paths and the success ordering.

closes https://github.com/camunda/camunda/issues/53786