### PR TITLE
Track multiple element instances per agent instance

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/command/UpdateAgentInstanceCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/UpdateAgentInstanceCommandStep1.java
@@ -35,8 +35,10 @@ import java.util.List;
 public interface UpdateAgentInstanceCommandStep1 {
 
   /**
-   * Sets the element instance key associated with this agent instance. Used to validate that the
-   * update targets the correct process instance.
+   * Sets the currently-active element instance for this agent instance. The engine uses this both
+   * for ownership/equality validation and — when the supplied key differs from the previous
+   * association (re-entry of an ad-hoc sub-process or AI Agent task) — to append the key to the
+   * accumulated list of associated element instances.
    *
    * @param elementInstanceKey the key of the element instance. Must be greater than 0.
    * @return the next step of the builder

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
@@ -32,14 +32,15 @@ import java.util.List;
 public final class AgentInstanceCreateProcessor
     implements TypedRecordProcessor<AgentInstanceRecord> {
 
+  private static final String ERROR_MSG_AGENT_INSTANCE_ALREADY_EXISTS =
+      "Expected to associate element instance with key '%d' with an agent instance, but it is already associated with agent instance with key '%d'.";
+
   private static final String ERROR_MSG_ELEMENT_INSTANCE_NOT_FOUND =
       "Expected to create agent instance for element instance with key '%d', but no such element instance was found.";
   private static final String ERROR_MSG_ELEMENT_INSTANCE_NOT_ACTIVE =
       "Expected to create agent instance for element instance with key '%d', but it is not active.";
   private static final String ERROR_MSG_UNSUPPORTED_ELEMENT_TYPE =
       "Expected to create agent instance for element instance with key '%d', but its BPMN element type '%s' is not supported. Supported types are: %s.";
-  private static final String ERROR_MSG_AGENT_INSTANCE_ALREADY_EXISTS =
-      "Expected to create agent instance for element instance with key '%d', but an agent instance with key '%d' already exists for it.";
 
   private static final List<BpmnElementType> SUPPORTED_ELEMENT_TYPES =
       List.of(BpmnElementType.AD_HOC_SUB_PROCESS, BpmnElementType.SERVICE_TASK);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
@@ -150,6 +150,7 @@ public final class AgentInstanceCreateProcessor
         new AgentInstanceRecord()
             .setAgentInstanceKey(agentInstanceKey)
             .setElementInstanceKey(elementInstanceKey)
+            .setElementInstanceKeys(List.of(elementInstanceKey))
             .setElementId(elementInstanceValue.getElementId())
             .setBpmnProcessId(elementInstanceValue.getBpmnProcessId())
             .setProcessInstanceKey(elementInstanceValue.getProcessInstanceKey())

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
@@ -123,47 +123,6 @@ public final class AgentInstanceUpdateProcessor
       return;
     }
 
-    final Set<String> changed = Set.copyOf(commandValue.getChangedAttributes());
-    if (changed.isEmpty()) {
-      writeRejection(command, RejectionType.INVALID_ARGUMENT, ERROR_MSG_EMPTY_CHANGED);
-      return;
-    }
-
-    final var unknown =
-        changed.stream().filter(attr -> !ALLOWED_ATTRIBUTES.contains(attr)).toList();
-    if (!unknown.isEmpty()) {
-      writeRejection(
-          command,
-          RejectionType.INVALID_ARGUMENT,
-          ERROR_MSG_UNKNOWN_ATTRIBUTES.formatted(unknown, ALLOWED_ATTRIBUTES));
-      return;
-    }
-
-    if (changed.contains(ATTR_METRICS) && !hasAllowedMetricDeltas(commandValue.getMetrics())) {
-      final var metrics = commandValue.getMetrics();
-      writeRejection(
-          command,
-          RejectionType.INVALID_ARGUMENT,
-          ERROR_MSG_INVALID_METRIC_DELTA.formatted(
-              metrics.getInputTokens(),
-              metrics.getOutputTokens(),
-              metrics.getModelCalls(),
-              metrics.getToolCalls()));
-      return;
-    }
-
-    if (changed.contains(ATTR_STATUS)) {
-      final var from = current.getStatus();
-      final var to = commandValue.getStatus();
-      if (!isAllowedTransition(from, to)) {
-        writeRejection(
-            command,
-            RejectionType.INVALID_STATE,
-            ERROR_MSG_INVALID_TRANSITION.formatted(agentInstanceKey, from, to));
-        return;
-      }
-    }
-
     final var newElementInstanceKey = commandValue.getElementInstanceKey();
     if (newElementInstanceKey == -1L) {
       writeRejection(
@@ -223,6 +182,47 @@ public final class AgentInstanceUpdateProcessor
           ERROR_MSG_AGENT_INSTANCE_ALREADY_EXISTS.formatted(
               newElementInstanceKey, existingAgentInstanceKey));
       return;
+    }
+
+    final Set<String> changed = Set.copyOf(commandValue.getChangedAttributes());
+    if (changed.isEmpty()) {
+      writeRejection(command, RejectionType.INVALID_ARGUMENT, ERROR_MSG_EMPTY_CHANGED);
+      return;
+    }
+
+    final var unknown =
+        changed.stream().filter(attr -> !ALLOWED_ATTRIBUTES.contains(attr)).toList();
+    if (!unknown.isEmpty()) {
+      writeRejection(
+          command,
+          RejectionType.INVALID_ARGUMENT,
+          ERROR_MSG_UNKNOWN_ATTRIBUTES.formatted(unknown, ALLOWED_ATTRIBUTES));
+      return;
+    }
+
+    if (changed.contains(ATTR_METRICS) && !hasAllowedMetricDeltas(commandValue.getMetrics())) {
+      final var metrics = commandValue.getMetrics();
+      writeRejection(
+          command,
+          RejectionType.INVALID_ARGUMENT,
+          ERROR_MSG_INVALID_METRIC_DELTA.formatted(
+              metrics.getInputTokens(),
+              metrics.getOutputTokens(),
+              metrics.getModelCalls(),
+              metrics.getToolCalls()));
+      return;
+    }
+
+    if (changed.contains(ATTR_STATUS)) {
+      final var from = current.getStatus();
+      final var to = commandValue.getStatus();
+      if (!isAllowedTransition(from, to)) {
+        writeRejection(
+            command,
+            RejectionType.INVALID_STATE,
+            ERROR_MSG_INVALID_TRANSITION.formatted(agentInstanceKey, from, to));
+        return;
+      }
     }
 
     if (!current.getElementInstanceKeys().contains(newElementInstanceKey)) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejection
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.AgentInstanceState;
+import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceMetrics;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
@@ -53,6 +54,18 @@ public final class AgentInstanceUpdateProcessor
       "Expected to update agent instance metrics, but received invalid delta(s): inputTokens=%d, outputTokens=%d, modelCalls=%d, toolCalls=%d. Each metric delta must be either -1 (field not provided) or a non-negative value.";
   private static final String ERROR_MSG_INVALID_TRANSITION =
       "Expected to update agent instance with key '%d' from status '%s' to '%s', but this transition is not allowed.";
+  private static final String ERROR_MSG_ELEMENT_INSTANCE_KEY_MISSING =
+      "Expected to update agent instance with key '%d', but elementInstanceKey is missing (got -1). The element instance key must be provided.";
+  private static final String ERROR_MSG_ELEMENT_INSTANCE_NOT_FOUND =
+      "Expected to update agent instance for element instance with key '%d', but no such element instance was found.";
+  private static final String ERROR_MSG_ELEMENT_INSTANCE_NOT_ACTIVE =
+      "Expected to update agent instance for element instance with key '%d', but it is not active.";
+  private static final String ERROR_MSG_ELEMENT_ID_MISMATCH =
+      "Expected to update agent instance with key '%d' for element instance with key '%d', but the element id '%s' does not match the agent instance's element id '%s'.";
+  private static final String ERROR_MSG_PROCESS_INSTANCE_KEY_MISMATCH =
+      "Expected to update agent instance with key '%d' for element instance with key '%d', but the process instance key '%d' does not match the agent instance's process instance key '%d'.";
+  private static final String ERROR_MSG_AGENT_INSTANCE_ALREADY_EXISTS =
+      "Expected to associate element instance with key '%d' with an agent instance, but it is already associated with agent instance with key '%d'.";
 
   private static final long METRIC_NOT_PROVIDED = -1L;
 
@@ -68,6 +81,7 @@ public final class AgentInstanceUpdateProcessor
   private final TypedResponseWriter responseWriter;
   private final TypedRejectionWriter rejectionWriter;
   private final AgentInstanceState agentInstanceState;
+  private final ElementInstanceState elementInstanceState;
   private final AuthorizationCheckBehavior authCheckBehavior;
 
   public AgentInstanceUpdateProcessor(
@@ -78,6 +92,7 @@ public final class AgentInstanceUpdateProcessor
     responseWriter = writers.response();
     rejectionWriter = writers.rejection();
     agentInstanceState = processingState.getAgentInstanceState();
+    elementInstanceState = processingState.getElementInstanceState();
     this.authCheckBehavior = authCheckBehavior;
   }
 
@@ -109,7 +124,7 @@ public final class AgentInstanceUpdateProcessor
     }
 
     final Set<String> changed = Set.copyOf(commandValue.getChangedAttributes());
-    if (changed.isEmpty()) {
+    if (changed.isEmpty() && commandValue.getElementInstanceKey() == -1L) {
       writeRejection(command, RejectionType.INVALID_ARGUMENT, ERROR_MSG_EMPTY_CHANGED);
       return;
     }
@@ -147,6 +162,72 @@ public final class AgentInstanceUpdateProcessor
             ERROR_MSG_INVALID_TRANSITION.formatted(agentInstanceKey, from, to));
         return;
       }
+    }
+
+    final var newElementInstanceKey = commandValue.getElementInstanceKey();
+    if (newElementInstanceKey == -1L) {
+      writeRejection(
+          command,
+          RejectionType.INVALID_ARGUMENT,
+          ERROR_MSG_ELEMENT_INSTANCE_KEY_MISSING.formatted(agentInstanceKey));
+      return;
+    }
+
+    final var elementInstance = elementInstanceState.getInstance(newElementInstanceKey);
+    if (elementInstance == null) {
+      writeRejection(
+          command,
+          RejectionType.NOT_FOUND,
+          ERROR_MSG_ELEMENT_INSTANCE_NOT_FOUND.formatted(newElementInstanceKey));
+      return;
+    }
+
+    if (!elementInstance.isActive()) {
+      writeRejection(
+          command,
+          RejectionType.INVALID_STATE,
+          ERROR_MSG_ELEMENT_INSTANCE_NOT_ACTIVE.formatted(newElementInstanceKey));
+      return;
+    }
+
+    final var elementInstanceValue = elementInstance.getValue();
+    if (!elementInstanceValue.getElementId().equals(current.getElementId())) {
+      writeRejection(
+          command,
+          RejectionType.INVALID_ARGUMENT,
+          ERROR_MSG_ELEMENT_ID_MISMATCH.formatted(
+              agentInstanceKey,
+              newElementInstanceKey,
+              elementInstanceValue.getElementId(),
+              current.getElementId()));
+      return;
+    }
+
+    if (elementInstanceValue.getProcessInstanceKey() != current.getProcessInstanceKey()) {
+      writeRejection(
+          command,
+          RejectionType.INVALID_ARGUMENT,
+          ERROR_MSG_PROCESS_INSTANCE_KEY_MISMATCH.formatted(
+              agentInstanceKey,
+              newElementInstanceKey,
+              elementInstanceValue.getProcessInstanceKey(),
+              current.getProcessInstanceKey()));
+      return;
+    }
+
+    final var existingAgentInstanceKey = elementInstance.getAgentInstanceKey();
+    if (existingAgentInstanceKey != -1L && existingAgentInstanceKey != agentInstanceKey) {
+      writeRejection(
+          command,
+          RejectionType.ALREADY_EXISTS,
+          ERROR_MSG_AGENT_INSTANCE_ALREADY_EXISTS.formatted(
+              newElementInstanceKey, existingAgentInstanceKey));
+      return;
+    }
+
+    if (!current.getElementInstanceKeys().contains(newElementInstanceKey)) {
+      current.addElementInstanceKey(newElementInstanceKey);
+      current.setElementInstanceKey(newElementInstanceKey);
     }
 
     current.setChangedAttributes(applyPatch(current, commandValue, changed));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
@@ -124,7 +124,7 @@ public final class AgentInstanceUpdateProcessor
     }
 
     final Set<String> changed = Set.copyOf(commandValue.getChangedAttributes());
-    if (changed.isEmpty() && commandValue.getElementInstanceKey() == -1L) {
+    if (changed.isEmpty()) {
       writeRejection(command, RejectionType.INVALID_ARGUMENT, ERROR_MSG_EMPTY_CHANGED);
       return;
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
@@ -227,8 +227,8 @@ public final class AgentInstanceUpdateProcessor
 
     if (!current.getElementInstanceKeys().contains(newElementInstanceKey)) {
       current.addElementInstanceKey(newElementInstanceKey);
-      current.setElementInstanceKey(newElementInstanceKey);
     }
+    current.setElementInstanceKey(newElementInstanceKey);
 
     current.setChangedAttributes(applyPatch(current, commandValue, changed));
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AgentInstanceUpdatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AgentInstanceUpdatedApplier.java
@@ -31,7 +31,7 @@ public final class AgentInstanceUpdatedApplier
     agentInstanceState.update(key, value);
 
     final var elementInstance = elementInstanceState.getInstance(value.getElementInstanceKey());
-    if (elementInstance != null) {
+    if (elementInstance != null && elementInstance.getAgentInstanceKey() != key) {
       elementInstance.setAgentInstanceKey(key);
       elementInstanceState.updateInstance(elementInstance);
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AgentInstanceUpdatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AgentInstanceUpdatedApplier.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableAgentInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
 
@@ -16,13 +17,23 @@ public final class AgentInstanceUpdatedApplier
     implements TypedEventApplier<AgentInstanceIntent, AgentInstanceRecord> {
 
   private final MutableAgentInstanceState agentInstanceState;
+  private final MutableElementInstanceState elementInstanceState;
 
-  public AgentInstanceUpdatedApplier(final MutableAgentInstanceState agentInstanceState) {
+  public AgentInstanceUpdatedApplier(
+      final MutableAgentInstanceState agentInstanceState,
+      final MutableElementInstanceState elementInstanceState) {
     this.agentInstanceState = agentInstanceState;
+    this.elementInstanceState = elementInstanceState;
   }
 
   @Override
   public void applyState(final long key, final AgentInstanceRecord value) {
     agentInstanceState.update(key, value);
+
+    final var elementInstance = elementInstanceState.getInstance(value.getElementInstanceKey());
+    if (elementInstance != null) {
+      elementInstance.setAgentInstanceKey(key);
+      elementInstanceState.updateInstance(elementInstance);
+    }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -171,7 +171,8 @@ public final class EventAppliers implements EventApplier {
             state.getAgentInstanceState(), state.getElementInstanceState()));
     register(
         AgentInstanceIntent.UPDATED,
-        new AgentInstanceUpdatedApplier(state.getAgentInstanceState()));
+        new AgentInstanceUpdatedApplier(
+            state.getAgentInstanceState(), state.getElementInstanceState()));
     register(AgentInstanceIntent.COMPLETED, NOOP_EVENT_APPLIER);
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateTest.java
@@ -308,6 +308,7 @@ public class AgentInstanceCreateTest {
     // then
     assertThat(created.getIntent()).isEqualTo(AgentInstanceIntent.CREATED);
     assertThat(created.getValue().getElementId()).isEqualTo(AD_HOC_SUB_PROCESS_ID);
+    assertThat(created.getValue().getElementInstanceKeys()).containsExactly(adHocInstance.getKey());
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateAuthorizationTest.java
@@ -84,8 +84,7 @@ public final class AgentInstanceUpdateAuthorizationTest {
   @Test
   public void shouldAuthorizeWithUpdateProcessInstancePermission() {
     // given - a user with explicit UPDATE_PROCESS_INSTANCE on the parent PROCESS_DEFINITION
-    final var agentInstanceKey =
-        createAgentInstanceUnderTenant(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+    final var instance = createAgentInstanceUnderTenant(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
     final var user = createUser();
     assignUserToTenant(TenantOwned.DEFAULT_TENANT_IDENTIFIER, user.getUsername());
     addPermissionsToUser(
@@ -99,20 +98,20 @@ public final class AgentInstanceUpdateAuthorizationTest {
     final var updated =
         engine
             .agentInstances()
-            .withAgentInstanceKey(agentInstanceKey)
+            .withAgentInstanceKey(instance.agentInstanceKey())
+            .withElementInstanceKey(instance.elementInstanceKey())
             .withStatus(AgentInstanceStatus.THINKING)
             .update(user.getUsername());
 
     // then
     assertThat(updated.getIntent()).isEqualTo(AgentInstanceIntent.UPDATED);
-    assertThat(updated.getKey()).isEqualTo(agentInstanceKey);
+    assertThat(updated.getKey()).isEqualTo(instance.agentInstanceKey());
   }
 
   @Test
   public void shouldRejectWhenCallerNotAuthorized() {
     // given - a user assigned to the resource's tenant but without any permissions
-    final var agentInstanceKey =
-        createAgentInstanceUnderTenant(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+    final var instance = createAgentInstanceUnderTenant(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
     final var user = createUser();
     assignUserToTenant(TenantOwned.DEFAULT_TENANT_IDENTIFIER, user.getUsername());
 
@@ -120,7 +119,7 @@ public final class AgentInstanceUpdateAuthorizationTest {
     final var rejection =
         engine
             .agentInstances()
-            .withAgentInstanceKey(agentInstanceKey)
+            .withAgentInstanceKey(instance.agentInstanceKey())
             .withStatus(AgentInstanceStatus.THINKING)
             .expectRejection()
             .update(user.getUsername());
@@ -137,7 +136,7 @@ public final class AgentInstanceUpdateAuthorizationTest {
   public void shouldRejectWhenAuthorizedTenantsExcludeAgentInstanceTenant() {
     // given - agent instance created under CUSTOM_TENANT, caller has UPDATE_PROCESS_INSTANCE on
     // the process id but is only assigned to DEFAULT_TENANT
-    final var agentInstanceKey = createAgentInstanceUnderTenant(CUSTOM_TENANT);
+    final var instance = createAgentInstanceUnderTenant(CUSTOM_TENANT);
     final var user = createUser();
     assignUserToTenant(TenantOwned.DEFAULT_TENANT_IDENTIFIER, user.getUsername());
     addPermissionsToUser(
@@ -151,7 +150,7 @@ public final class AgentInstanceUpdateAuthorizationTest {
     final var rejection =
         engine
             .agentInstances()
-            .withAgentInstanceKey(agentInstanceKey)
+            .withAgentInstanceKey(instance.agentInstanceKey())
             .withStatus(AgentInstanceStatus.THINKING)
             .withAuthorizedTenantIds(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
             .expectRejection()
@@ -161,7 +160,7 @@ public final class AgentInstanceUpdateAuthorizationTest {
     assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.NOT_FOUND);
   }
 
-  private long createAgentInstanceUnderTenant(final String tenantId) {
+  private AgentInstanceRef createAgentInstanceUnderTenant(final String tenantId) {
     engine
         .deployment()
         .withXmlResource(
@@ -185,13 +184,15 @@ public final class AgentInstanceUpdateAuthorizationTest {
             .withElementId(SERVICE_TASK_ID)
             .getFirst()
             .getKey();
-    return engine
-        .agentInstances()
-        .withElementInstanceKey(elementInstanceKey)
-        .withAuthorizedTenantIds(tenantId)
-        .create(DEFAULT_USER.getUsername())
-        .getValue()
-        .getAgentInstanceKey();
+    final var agentInstanceKey =
+        engine
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withAuthorizedTenantIds(tenantId)
+            .create(DEFAULT_USER.getUsername())
+            .getValue()
+            .getAgentInstanceKey();
+    return new AgentInstanceRef(agentInstanceKey, elementInstanceKey);
   }
 
   private void assignUserToTenant(final String tenantId, final String username) {
@@ -231,4 +232,6 @@ public final class AgentInstanceUpdateAuthorizationTest {
         .withResourceId(resourceId)
         .create(DEFAULT_USER.getUsername());
   }
+
+  private record AgentInstanceRef(long agentInstanceKey, long elementInstanceKey) {}
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateTest.java
@@ -265,6 +265,7 @@ public class AgentInstanceUpdateTest {
           ENGINE
               .agentInstances()
               .withAgentInstanceKey(agentInstanceKey)
+              .withElementInstanceKey(serviceTaskInstance.getKey())
               .withChangedAttributes(List.of(unknownAttr))
               .expectRejection()
               .update();
@@ -303,6 +304,7 @@ public class AgentInstanceUpdateTest {
         ENGINE
             .agentInstances()
             .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(serviceTaskInstance.getKey())
             .withChangedAttributes(List.of("limits"))
             .expectRejection()
             .update();
@@ -415,6 +417,7 @@ public class AgentInstanceUpdateTest {
         ENGINE
             .agentInstances()
             .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(serviceTaskInstance.getKey())
             .withMetricsDelta(-2L, 0L, 0, 0)
             .withChangedAttributes(List.of("metrics"))
             .expectRejection()
@@ -707,6 +710,7 @@ public class AgentInstanceUpdateTest {
         ENGINE
             .agentInstances()
             .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(serviceTaskInstance.getKey())
             .withStatus(AgentInstanceStatus.UNSPECIFIED)
             .withChangedAttributes(List.of("status"))
             .expectRejection()
@@ -769,6 +773,7 @@ public class AgentInstanceUpdateTest {
         ENGINE
             .agentInstances()
             .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(serviceTaskInstance.getKey())
             .withStatus(AgentInstanceStatus.COMPLETED)
             .withChangedAttributes(List.of("status"))
             .expectRejection()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateTest.java
@@ -160,10 +160,7 @@ public class AgentInstanceUpdateTest {
   }
 
   @Test
-  public void shouldRejectUpdateWithEmptyChangedAttributesAndNoElementInstanceKey() {
-    // Rejection requires BOTH conditions: changedAttributes is empty AND no elementInstanceKey
-    // was supplied (sentinel -1). An empty changedAttributes paired with a valid elementInstanceKey
-    // is a valid pure-dedupe/association call and must NOT be rejected.
+  public void shouldRejectUpdateWithEmptyChangedAttributes() {
     // given
     ENGINE
         .deployment()
@@ -184,11 +181,12 @@ public class AgentInstanceUpdateTest {
             .getValue()
             .getAgentInstanceKey();
 
-    // when — no elementInstanceKey supplied (default sentinel -1), no changedAttributes
+    // when — valid elementInstanceKey supplied, but changedAttributes is empty
     final Record<?> rejection =
         ENGINE
             .agentInstances()
             .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(serviceTaskInstance.getKey())
             .withChangedAttributes(List.of())
             .expectRejection()
             .update();
@@ -958,12 +956,13 @@ public class AgentInstanceUpdateTest {
         .withStatus(AgentInstanceStatus.THINKING)
         .update();
 
-    // when — UPDATE re-supplies EI₁, which is already in the plural list
+    // when — UPDATE re-supplies EI₁ (already in the plural list) alongside a status change
     final var updated =
         ENGINE
             .agentInstances()
             .withAgentInstanceKey(agentInstanceKey)
             .withElementInstanceKey(ei1.getKey())
+            .withStatus(AgentInstanceStatus.IDLE)
             .update();
 
     // then — list is unchanged (no duplicates), but scalar moves back to the supplied key

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateTest.java
@@ -908,6 +908,72 @@ public class AgentInstanceUpdateTest {
   }
 
   @Test
+  public void shouldUpdateScalarOnReEntryToAlreadyTrackedElementInstance() {
+    // given — multi-instance produces EI₁ and EI₂. Agent created on EI₁, then re-associated to EI₂.
+    // The plural list ends up as [EI₁, EI₂] with scalar = EI₂.
+    final var multiInstanceProcessId = "scalar-reentry";
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(multiInstanceProcessId)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t ->
+                        t.zeebeJobType("agent")
+                            .multiInstance(
+                                m ->
+                                    m.zeebeInputCollectionExpression("items")
+                                        .zeebeInputElement("item")))
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(multiInstanceProcessId)
+            .withVariables(Map.of("items", List.of("a", "b")))
+            .create();
+    final var children =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .limit(2)
+            .toList();
+    final var ei1 = children.get(0);
+    final var ei2 = children.get(1);
+
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(ei1.getKey())
+            .create()
+            .getValue()
+            .getAgentInstanceKey();
+    ENGINE
+        .agentInstances()
+        .withAgentInstanceKey(agentInstanceKey)
+        .withElementInstanceKey(ei2.getKey())
+        .withStatus(AgentInstanceStatus.THINKING)
+        .update();
+
+    // when — UPDATE re-supplies EI₁, which is already in the plural list
+    final var updated =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(ei1.getKey())
+            .update();
+
+    // then — list is unchanged (no duplicates), but scalar moves back to the supplied key
+    // because it represents the currently-active element instance.
+    assertThat(updated.getValue().getElementInstanceKeys())
+        .containsExactly(ei1.getKey(), ei2.getKey());
+    assertThat(updated.getValue().getElementInstanceKey()).isEqualTo(ei1.getKey());
+  }
+
+  @Test
   public void shouldRejectUpdateWhenElementInstanceKeyMissing() {
     // given — agent instance created on a service task.
     ENGINE

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateTest.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.List;
+import java.util.Map;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -64,6 +65,7 @@ public class AgentInstanceUpdateTest {
         ENGINE
             .agentInstances()
             .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(serviceTaskInstance.getKey())
             .withStatus(AgentInstanceStatus.THINKING)
             .withChangedAttributes(List.of("status"))
             .update();
@@ -102,6 +104,7 @@ public class AgentInstanceUpdateTest {
         ENGINE
             .agentInstances()
             .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(serviceTaskInstance.getKey())
             .withStatus(AgentInstanceStatus.THINKING)
             .withMetricsDelta(99L, 88L, 7, 5)
             .withTools(tools(tool("calc", "Calculator", "calc-task")))
@@ -145,6 +148,7 @@ public class AgentInstanceUpdateTest {
         ENGINE
             .agentInstances()
             .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(serviceTaskInstance.getKey())
             .withStatus(AgentInstanceStatus.THINKING)
             .withMetricsDelta(1L, 1L, 1, 1)
             .withChangedAttributes(List.of("status", "metrics"))
@@ -156,7 +160,10 @@ public class AgentInstanceUpdateTest {
   }
 
   @Test
-  public void shouldRejectEmptyChangedAttributes() {
+  public void shouldRejectUpdateWithEmptyChangedAttributesAndNoElementInstanceKey() {
+    // Rejection requires BOTH conditions: changedAttributes is empty AND no elementInstanceKey
+    // was supplied (sentinel -1). An empty changedAttributes paired with a valid elementInstanceKey
+    // is a valid pure-dedupe/association call and must NOT be rejected.
     // given
     ENGINE
         .deployment()
@@ -177,7 +184,7 @@ public class AgentInstanceUpdateTest {
             .getValue()
             .getAgentInstanceKey();
 
-    // when
+    // when — no elementInstanceKey supplied (default sentinel -1), no changedAttributes
     final Record<?> rejection =
         ENGINE
             .agentInstances()
@@ -219,6 +226,7 @@ public class AgentInstanceUpdateTest {
         ENGINE
             .agentInstances()
             .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(serviceTaskInstance.getKey())
             .withMetricsDelta(10L, 5L, 1, 2)
             .withChangedAttributes(List.of("metrics", "metrics"))
             .update();
@@ -253,18 +261,20 @@ public class AgentInstanceUpdateTest {
             .getValue()
             .getAgentInstanceKey();
 
-    // when
-    final Record<?> rejection =
-        ENGINE
-            .agentInstances()
-            .withAgentInstanceKey(agentInstanceKey)
-            .withChangedAttributes(List.of("foo"))
-            .expectRejection()
-            .update();
+    for (final var unknownAttr : List.of("foo", "elementInstanceKey")) {
+      // when
+      final Record<?> rejection =
+          ENGINE
+              .agentInstances()
+              .withAgentInstanceKey(agentInstanceKey)
+              .withChangedAttributes(List.of(unknownAttr))
+              .expectRejection()
+              .update();
 
-    // then
-    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
-    assertThat(rejection.getRejectionReason()).contains("foo");
+      // then
+      assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
+      assertThat(rejection.getRejectionReason()).contains(unknownAttr);
+    }
   }
 
   @Test
@@ -351,6 +361,7 @@ public class AgentInstanceUpdateTest {
     ENGINE
         .agentInstances()
         .withAgentInstanceKey(agentInstanceKey)
+        .withElementInstanceKey(serviceTaskInstance.getKey())
         .withMetricsDelta(10L, 5L, 1, 0)
         .withChangedAttributes(List.of("metrics"))
         .update();
@@ -359,6 +370,7 @@ public class AgentInstanceUpdateTest {
         ENGINE
             .agentInstances()
             .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(serviceTaskInstance.getKey())
             .withMetricsDelta(20L, 15L, 2, 1)
             .withChangedAttributes(List.of("metrics"))
             .update();
@@ -439,6 +451,7 @@ public class AgentInstanceUpdateTest {
     ENGINE
         .agentInstances()
         .withAgentInstanceKey(agentInstanceKey)
+        .withElementInstanceKey(serviceTaskInstance.getKey())
         .withMetricsDelta(10L, 20L, 1, 2)
         .withChangedAttributes(List.of("metrics"))
         .update();
@@ -448,6 +461,7 @@ public class AgentInstanceUpdateTest {
         ENGINE
             .agentInstances()
             .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(serviceTaskInstance.getKey())
             .withMetricsDelta(5L, -1L, -1, -1)
             .withChangedAttributes(List.of("metrics"))
             .update();
@@ -488,6 +502,7 @@ public class AgentInstanceUpdateTest {
         ENGINE
             .agentInstances()
             .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(serviceTaskInstance.getKey())
             .withMetricsDelta(0L, -1L, 0, -1)
             .withChangedAttributes(List.of("metrics"))
             .update();
@@ -529,6 +544,7 @@ public class AgentInstanceUpdateTest {
         ENGINE
             .agentInstances()
             .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(serviceTaskInstance.getKey())
             .withMetricsDelta(200L, 0L, 0, 0)
             .withChangedAttributes(List.of("metrics"))
             .update();
@@ -566,6 +582,7 @@ public class AgentInstanceUpdateTest {
     ENGINE
         .agentInstances()
         .withAgentInstanceKey(agentInstanceKey)
+        .withElementInstanceKey(serviceTaskInstance.getKey())
         .withTools(firstTools)
         .withChangedAttributes(List.of("tools"))
         .update();
@@ -573,6 +590,7 @@ public class AgentInstanceUpdateTest {
         ENGINE
             .agentInstances()
             .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(serviceTaskInstance.getKey())
             .withTools(secondTools)
             .withChangedAttributes(List.of("tools"))
             .update();
@@ -609,6 +627,7 @@ public class AgentInstanceUpdateTest {
     ENGINE
         .agentInstances()
         .withAgentInstanceKey(agentInstanceKey)
+        .withElementInstanceKey(serviceTaskInstance.getKey())
         .withTools(tools(tool("t1", "first tool", "t1-elem")))
         .withChangedAttributes(List.of("tools"))
         .update();
@@ -616,6 +635,7 @@ public class AgentInstanceUpdateTest {
         ENGINE
             .agentInstances()
             .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(serviceTaskInstance.getKey())
             .withTools(List.of())
             .withChangedAttributes(List.of("tools"))
             .update();
@@ -651,11 +671,12 @@ public class AgentInstanceUpdateTest {
         ENGINE
             .agentInstances()
             .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(serviceTaskInstance.getKey())
             .withStatus(AgentInstanceStatus.INITIALIZING)
             .withChangedAttributes(List.of("status"))
             .update();
 
-    // then
+    // then — UPDATED is still emitted but without "status" in changedAttributes (no-op)
     assertThat(updated.getValue().getStatus()).isEqualTo(AgentInstanceStatus.INITIALIZING);
     assertThat(updated.getValue().getChangedAttributes()).isEmpty();
   }
@@ -802,6 +823,7 @@ public class AgentInstanceUpdateTest {
           ENGINE
               .agentInstances()
               .withAgentInstanceKey(agentInstanceKey)
+              .withElementInstanceKey(serviceTaskInstance.getKey())
               .withStatus(from)
               .withChangedAttributes(List.of("status"))
               .update();
@@ -811,6 +833,7 @@ public class AgentInstanceUpdateTest {
             ENGINE
                 .agentInstances()
                 .withAgentInstanceKey(agentInstanceKey)
+                .withElementInstanceKey(serviceTaskInstance.getKey())
                 .withStatus(to)
                 .withChangedAttributes(List.of("status"))
                 .update();
@@ -822,6 +845,388 @@ public class AgentInstanceUpdateTest {
         assertThat(updated.getValue().getStatus()).isEqualTo(to);
       }
     }
+  }
+
+  @Test
+  public void shouldAssociateElementInstanceOnUpdate() {
+    // given — a multi-instance service task produces EI₁ and EI₂ simultaneously.
+    final var multiInstanceProcessId = "multi-instance-assoc";
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(multiInstanceProcessId)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t ->
+                        t.zeebeJobType("agent")
+                            .multiInstance(
+                                m ->
+                                    m.zeebeInputCollectionExpression("items")
+                                        .zeebeInputElement("item")))
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(multiInstanceProcessId)
+            .withVariables(Map.of("items", List.of("a", "b")))
+            .create();
+    final var children =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .limit(2)
+            .toList();
+    final var ei1 = children.get(0);
+    final var ei2 = children.get(1);
+
+    // Create agent instance on EI₁.
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(ei1.getKey())
+            .create()
+            .getValue()
+            .getAgentInstanceKey();
+
+    // when — UPDATE supplying EI₂ (new association)
+    final var updated =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(ei2.getKey())
+            .withStatus(AgentInstanceStatus.THINKING)
+            .update();
+
+    // then — plural list carries [EI₁, EI₂], scalar = EI₂
+    assertThat(updated.getValue().getElementInstanceKeys())
+        .containsExactly(ei1.getKey(), ei2.getKey());
+    assertThat(updated.getValue().getElementInstanceKey()).isEqualTo(ei2.getKey());
+  }
+
+  @Test
+  public void shouldRejectUpdateWhenElementInstanceKeyMissing() {
+    // given — agent instance created on a service task.
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType("agent"))
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var serviceTaskInstance = awaitServiceTaskActivated(processInstanceKey);
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(serviceTaskInstance.getKey())
+            .create()
+            .getValue()
+            .getAgentInstanceKey();
+
+    // when — UPDATE without elementInstanceKey (default scalar = -1 sentinel)
+    final Record<?> rejection =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            // intentionally no withElementInstanceKey() call — default is -1 sentinel
+            .withStatus(AgentInstanceStatus.THINKING)
+            .withChangedAttributes(List.of("status"))
+            .expectRejection()
+            .update();
+
+    // then — engine rejects the command (defense-in-depth against internal command bus misuse)
+    assertThat(rejection.getRecordType()).isEqualTo(RecordType.COMMAND_REJECTION);
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejection.getRejectionReason()).contains("elementInstanceKey");
+  }
+
+  @Test
+  public void shouldRejectUpdateWhenAssociatedElementInstanceNotFound() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType("agent"))
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var serviceTaskInstance = awaitServiceTaskActivated(processInstanceKey);
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(serviceTaskInstance.getKey())
+            .create()
+            .getValue()
+            .getAgentInstanceKey();
+
+    final var nonExistentEiKey = 987654321L;
+
+    // when
+    final Record<?> rejection =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(nonExistentEiKey)
+            .withStatus(AgentInstanceStatus.THINKING)
+            .withChangedAttributes(List.of("status"))
+            .expectRejection()
+            .update();
+
+    // then
+    assertThat(rejection.getRecordType()).isEqualTo(RecordType.COMMAND_REJECTION);
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.NOT_FOUND);
+    assertThat(rejection.getRejectionReason()).contains(String.valueOf(nonExistentEiKey));
+  }
+
+  @Test
+  public void shouldRejectUpdateWhenAssociatedElementInstanceNotActive() {
+    // given — a service task with a faulty output expression. Completing the job triggers output
+    // mapping evaluation, which fails and raises an incident. The element instance is left in
+    // ELEMENT_COMPLETING state (not active) and is not removed from state.
+    final var notActiveProcessId = "not-active-process";
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(notActiveProcessId)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType("agent").zeebeOutputExpression("assert(x, x != null)", "y"))
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(notActiveProcessId).create();
+    final var serviceTaskInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(serviceTaskInstance.getKey())
+            .create()
+            .getValue()
+            .getAgentInstanceKey();
+
+    // Complete the job — output mapping fails, raises incident, EI is stuck in COMPLETING.
+    ENGINE.job().ofInstance(processInstanceKey).withType("agent").complete();
+    RecordingExporter.incidentRecords().withProcessInstanceKey(processInstanceKey).getFirst();
+
+    // when — attempt to UPDATE referencing the now-inactive (COMPLETING) element instance
+    final Record<?> rejection =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(serviceTaskInstance.getKey())
+            .withStatus(AgentInstanceStatus.THINKING)
+            .withChangedAttributes(List.of("status"))
+            .expectRejection()
+            .update();
+
+    // then
+    assertThat(rejection.getRecordType()).isEqualTo(RecordType.COMMAND_REJECTION);
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_STATE);
+    assertThat(rejection.getRejectionReason())
+        .contains(String.valueOf(serviceTaskInstance.getKey()));
+  }
+
+  @Test
+  public void shouldRejectUpdateWhenAssociatedElementInstanceElementIdMismatch() {
+    // given — agent instance on SERVICE_TASK_ID; attempt to UPDATE with an EI from a DIFFERENT
+    // task. A parallel gateway activates both tasks simultaneously.
+    final var mismatchProcessId = "mismatch-element-id";
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(mismatchProcessId)
+                .startEvent()
+                .parallelGateway("split")
+                .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType("agent"))
+                .parallelGateway("merge")
+                .endEvent()
+                .moveToNode("split")
+                .serviceTask("other-task", t -> t.zeebeJobType("other"))
+                .connectTo("merge")
+                .done())
+        .deploy();
+    final var processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(mismatchProcessId).create();
+    final var serviceTaskInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst();
+    final var otherTaskInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId("other-task")
+            .getFirst();
+
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(serviceTaskInstance.getKey())
+            .create()
+            .getValue()
+            .getAgentInstanceKey();
+
+    // when — UPDATE with EI from "other-task" (different elementId)
+    final Record<?> rejection =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(otherTaskInstance.getKey())
+            .withStatus(AgentInstanceStatus.THINKING)
+            .withChangedAttributes(List.of("status"))
+            .expectRejection()
+            .update();
+
+    // then
+    assertThat(rejection.getRecordType()).isEqualTo(RecordType.COMMAND_REJECTION);
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejection.getRejectionReason()).contains(SERVICE_TASK_ID).contains("other-task");
+  }
+
+  @Test
+  public void shouldRejectUpdateWhenAssociatedElementInstanceProcessInstanceKeyMismatch() {
+    // given — two separate process instances; agent instance on PI₁'s task,
+    // UPDATE supplies EI from PI₂.
+    final var piMismatchProcessId = "pi-mismatch";
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(piMismatchProcessId)
+                .startEvent()
+                .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType("agent"))
+                .endEvent()
+                .done())
+        .deploy();
+    final var pi1Key = ENGINE.processInstance().ofBpmnProcessId(piMismatchProcessId).create();
+    final var pi2Key = ENGINE.processInstance().ofBpmnProcessId(piMismatchProcessId).create();
+    final var ei1 =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(pi1Key)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst();
+    final var ei2 =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(pi2Key)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst();
+
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(ei1.getKey())
+            .create()
+            .getValue()
+            .getAgentInstanceKey();
+
+    // when — UPDATE with EI from PI₂ (different processInstanceKey)
+    final Record<?> rejection =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(ei2.getKey())
+            .withStatus(AgentInstanceStatus.THINKING)
+            .withChangedAttributes(List.of("status"))
+            .expectRejection()
+            .update();
+
+    // then
+    assertThat(rejection.getRecordType()).isEqualTo(RecordType.COMMAND_REJECTION);
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejection.getRejectionReason())
+        .contains(String.valueOf(pi1Key))
+        .contains(String.valueOf(pi2Key));
+  }
+
+  @Test
+  public void
+      shouldRejectUpdateWhenAssociatedElementInstanceAlreadyAssociatedWithDifferentAgentInstance() {
+    // given — two multi-instance children; EI₁ → agentInstance₁, EI₂ → agentInstance₂.
+    // Attempt to UPDATE agentInstance₁ by supplying EI₂ (already associated with agentInstance₂).
+    final var alreadyAssocProcessId = "already-assoc";
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(alreadyAssocProcessId)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t ->
+                        t.zeebeJobType("agent")
+                            .multiInstance(
+                                m ->
+                                    m.zeebeInputCollectionExpression("items")
+                                        .zeebeInputElement("item")))
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(alreadyAssocProcessId)
+            .withVariables(Map.of("items", List.of("a", "b")))
+            .create();
+    final var children =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .limit(2)
+            .toList();
+    final var ei1Key = children.get(0).getKey();
+    final var ei2Key = children.get(1).getKey();
+
+    final var agentInstance1Key =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(ei1Key)
+            .create()
+            .getValue()
+            .getAgentInstanceKey();
+    final var agentInstance2Key =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(ei2Key)
+            .create()
+            .getValue()
+            .getAgentInstanceKey();
+
+    // when — try to associate EI₂ (already owned by agentInstance₂) with agentInstance₁
+    final Record<?> rejection =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstance1Key)
+            .withElementInstanceKey(ei2Key)
+            .withStatus(AgentInstanceStatus.THINKING)
+            .withChangedAttributes(List.of("status"))
+            .expectRejection()
+            .update();
+
+    // then
+    assertThat(rejection.getRecordType()).isEqualTo(RecordType.COMMAND_REJECTION);
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.ALREADY_EXISTS);
+    assertThat(rejection.getRejectionReason())
+        .contains(String.valueOf(ei2Key))
+        .contains(String.valueOf(agentInstance2Key));
   }
 
   private void assertRejectsTransitionToInitializingFrom(final AgentInstanceStatus from) {
@@ -847,6 +1252,7 @@ public class AgentInstanceUpdateTest {
     ENGINE
         .agentInstances()
         .withAgentInstanceKey(agentInstanceKey)
+        .withElementInstanceKey(serviceTaskInstance.getKey())
         .withStatus(from)
         .withChangedAttributes(List.of("status"))
         .update();
@@ -856,6 +1262,7 @@ public class AgentInstanceUpdateTest {
         ENGINE
             .agentInstances()
             .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(serviceTaskInstance.getKey())
             .withStatus(AgentInstanceStatus.INITIALIZING)
             .withChangedAttributes(List.of("status"))
             .expectRejection()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/AgentInstanceCreatedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/AgentInstanceCreatedApplierTest.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstan
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.AgentInstanceStatus;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -49,6 +50,7 @@ public class AgentInstanceCreatedApplierTest {
         new AgentInstanceRecord()
             .setAgentInstanceKey(agentInstanceKey)
             .setElementInstanceKey(elementInstanceKey)
+            .setElementInstanceKeys(List.of(elementInstanceKey))
             .setElementId("agent-task")
             .setProcessInstanceKey(7L)
             .setProcessDefinitionKey(3L)
@@ -64,6 +66,7 @@ public class AgentInstanceCreatedApplierTest {
     assertThat(stored).isNotNull();
     assertThat(stored.getAgentInstanceKey()).isEqualTo(agentInstanceKey);
     assertThat(stored.getElementInstanceKey()).isEqualTo(elementInstanceKey);
+    assertThat(stored.getElementInstanceKeys()).containsExactly(elementInstanceKey);
     assertThat(stored.getElementId()).isEqualTo("agent-task");
     assertThat(stored.getProcessInstanceKey()).isEqualTo(7L);
     assertThat(stored.getStatus()).isEqualTo(AgentInstanceStatus.INITIALIZING);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/AgentInstanceUpdatedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/AgentInstanceUpdatedApplierTest.java
@@ -14,7 +14,11 @@ import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.AgentInstanceStatus;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -35,7 +39,7 @@ public class AgentInstanceUpdatedApplierTest {
     agentInstanceState = processingState.getAgentInstanceState();
     elementInstanceState = processingState.getElementInstanceState();
     createdApplier = new AgentInstanceCreatedApplier(agentInstanceState, elementInstanceState);
-    updatedApplier = new AgentInstanceUpdatedApplier(agentInstanceState);
+    updatedApplier = new AgentInstanceUpdatedApplier(agentInstanceState, elementInstanceState);
   }
 
   @Test
@@ -67,27 +71,38 @@ public class AgentInstanceUpdatedApplierTest {
 
   @Test
   void shouldBeIdempotentWhenReplayed() {
-    // given — a CREATED record and an UPDATED record stored once.
+    // given — a CREATED record, EI₁ and EI₂ seeded, and an UPDATED record applied once.
     final long agentInstanceKey = 11L;
+    final long ei1Key = 21L;
+    final long ei2Key = 22L;
+    givenElementInstance(ei1Key);
+    givenElementInstance(ei2Key);
+
     final var initial =
         new AgentInstanceRecord()
             .setAgentInstanceKey(agentInstanceKey)
+            .setElementInstanceKey(ei1Key)
+            .setElementInstanceKeys(List.of(ei1Key))
             .setStatus(AgentInstanceStatus.INITIALIZING);
     createdApplier.applyState(agentInstanceKey, initial);
 
+    // Apply an UPDATED event that appends EI₂.
     final var updated =
         new AgentInstanceRecord()
             .setAgentInstanceKey(agentInstanceKey)
+            .setElementInstanceKey(ei2Key)
+            .setElementInstanceKeys(List.of(ei1Key, ei2Key))
             .setStatus(AgentInstanceStatus.THINKING);
     updated.getMetrics().setInputTokens(42L);
 
     updatedApplier.applyState(agentInstanceKey, updated);
     final var afterFirst = agentInstanceState.getRecord(agentInstanceKey);
+    final var ei2AfterFirst = elementInstanceState.getInstance(ei2Key);
 
     // when — replay the same UPDATED event.
     updatedApplier.applyState(agentInstanceKey, updated);
 
-    // then — the stored state is identical (same status & metrics) after the replay.
+    // then — the stored state is identical after the replay.
     final var afterReplay = agentInstanceState.getRecord(agentInstanceKey);
     assertThat(afterReplay).isNotNull();
     assertThat(afterReplay.getStatus()).isEqualTo(afterFirst.getStatus());
@@ -95,5 +110,96 @@ public class AgentInstanceUpdatedApplierTest {
         .isEqualTo(afterFirst.getMetrics().getInputTokens());
     assertThat(afterReplay.getStatus()).isEqualTo(AgentInstanceStatus.THINKING);
     assertThat(afterReplay.getMetrics().getInputTokens()).isEqualTo(42L);
+    // The plural list still carries [EI₁, EI₂].
+    assertThat(afterReplay.getElementInstanceKeys()).containsExactly(ei1Key, ei2Key);
+    // EI₂'s back-link remains == agent instance key.
+    final var ei2AfterReplay = elementInstanceState.getInstance(ei2Key);
+    assertThat(ei2AfterReplay).isNotNull();
+    assertThat(ei2AfterReplay.getAgentInstanceKey()).isEqualTo(agentInstanceKey);
+    assertThat(ei2AfterReplay.getAgentInstanceKey()).isEqualTo(ei2AfterFirst.getAgentInstanceKey());
+  }
+
+  @Test
+  void shouldSetAgentInstanceKeyBackLinkOnNewlyAssociatedElementInstance() {
+    // given — EI₁ with an existing back-link, EI₂ with no back-link.
+    final long agentInstanceKey = 42L;
+    final long ei1Key = 101L;
+    final long ei2Key = 102L;
+    givenElementInstance(ei1Key);
+    givenElementInstance(ei2Key);
+
+    final var initial =
+        new AgentInstanceRecord()
+            .setAgentInstanceKey(agentInstanceKey)
+            .setElementInstanceKey(ei1Key)
+            .setElementInstanceKeys(List.of(ei1Key))
+            .setStatus(AgentInstanceStatus.INITIALIZING);
+    createdApplier.applyState(agentInstanceKey, initial);
+
+    // Verify EI₁ has a back-link, EI₂ does not.
+    assertThat(elementInstanceState.getInstance(ei1Key).getAgentInstanceKey())
+        .isEqualTo(agentInstanceKey);
+    assertThat(elementInstanceState.getInstance(ei2Key).getAgentInstanceKey()).isEqualTo(-1L);
+
+    // when — apply an UPDATED event that associates EI₂.
+    final var updated =
+        new AgentInstanceRecord()
+            .setAgentInstanceKey(agentInstanceKey)
+            .setElementInstanceKey(ei2Key)
+            .setElementInstanceKeys(List.of(ei1Key, ei2Key))
+            .setStatus(AgentInstanceStatus.THINKING);
+    updatedApplier.applyState(agentInstanceKey, updated);
+
+    // then — EI₂ now has the back-link set.
+    final var ei2 = elementInstanceState.getInstance(ei2Key);
+    assertThat(ei2).isNotNull();
+    assertThat(ei2.getAgentInstanceKey()).isEqualTo(agentInstanceKey);
+  }
+
+  @Test
+  void shouldAppendElementInstanceKeyToPluralList() {
+    // given — an agent instance associated with EI₁.
+    final long agentInstanceKey = 55L;
+    final long ei1Key = 201L;
+    final long ei2Key = 202L;
+    givenElementInstance(ei1Key);
+    givenElementInstance(ei2Key);
+
+    final var initial =
+        new AgentInstanceRecord()
+            .setAgentInstanceKey(agentInstanceKey)
+            .setElementInstanceKey(ei1Key)
+            .setElementInstanceKeys(List.of(ei1Key))
+            .setStatus(AgentInstanceStatus.INITIALIZING);
+    createdApplier.applyState(agentInstanceKey, initial);
+
+    // when — apply an UPDATED event appending EI₂.
+    final var updated =
+        new AgentInstanceRecord()
+            .setAgentInstanceKey(agentInstanceKey)
+            .setElementInstanceKey(ei2Key)
+            .setElementInstanceKeys(List.of(ei1Key, ei2Key))
+            .setStatus(AgentInstanceStatus.THINKING);
+    updatedApplier.applyState(agentInstanceKey, updated);
+
+    // then — the persisted record carries [EI₁, EI₂] in the plural list.
+    final var stored = agentInstanceState.getRecord(agentInstanceKey);
+    assertThat(stored).isNotNull();
+    assertThat(stored.getElementInstanceKeys()).containsExactly(ei1Key, ei2Key);
+    assertThat(stored.getElementInstanceKey()).isEqualTo(ei2Key);
+  }
+
+  private void givenElementInstance(final long elementInstanceKey) {
+    final var processInstanceRecord =
+        new ProcessInstanceRecord()
+            .setBpmnElementType(BpmnElementType.SERVICE_TASK)
+            .setElementId("agent-task")
+            .setBpmnProcessId("process")
+            .setProcessDefinitionKey(3L)
+            .setProcessInstanceKey(7L)
+            .setVersion(1)
+            .setTenantId("<default>");
+    elementInstanceState.newInstance(
+        elementInstanceKey, processInstanceRecord, ProcessInstanceIntent.ELEMENT_ACTIVATED);
   }
 }

--- a/zeebe/engine/src/test/resources/state/appliers/golden/AgentInstance_UPDATED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/AgentInstance_UPDATED_v1.golden
@@ -31,7 +31,7 @@ public final class AgentInstanceUpdatedApplier
     agentInstanceState.update(key, value);
 
     final var elementInstance = elementInstanceState.getInstance(value.getElementInstanceKey());
-    if (elementInstance != null) {
+    if (elementInstance != null && elementInstance.getAgentInstanceKey() != key) {
       elementInstance.setAgentInstanceKey(key);
       elementInstanceState.updateInstance(elementInstance);
     }

--- a/zeebe/engine/src/test/resources/state/appliers/golden/AgentInstance_UPDATED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/AgentInstance_UPDATED_v1.golden
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableAgentInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
 
@@ -16,13 +17,23 @@ public final class AgentInstanceUpdatedApplier
     implements TypedEventApplier<AgentInstanceIntent, AgentInstanceRecord> {
 
   private final MutableAgentInstanceState agentInstanceState;
+  private final MutableElementInstanceState elementInstanceState;
 
-  public AgentInstanceUpdatedApplier(final MutableAgentInstanceState agentInstanceState) {
+  public AgentInstanceUpdatedApplier(
+      final MutableAgentInstanceState agentInstanceState,
+      final MutableElementInstanceState elementInstanceState) {
     this.agentInstanceState = agentInstanceState;
+    this.elementInstanceState = elementInstanceState;
   }
 
   @Override
   public void applyState(final long key, final AgentInstanceRecord value) {
     agentInstanceState.update(key, value);
+
+    final var elementInstance = elementInstanceState.getInstance(value.getElementInstanceKey());
+    if (elementInstance != null) {
+      elementInstance.setAgentInstanceKey(key);
+      elementInstanceState.updateInstance(elementInstance);
+    }
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AgentInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AgentInstanceHandler.java
@@ -110,8 +110,7 @@ public class AgentInstanceHandler
         .setModelCalls(value.getMetrics().getModelCalls())
         .setToolCalls(value.getMetrics().getToolCalls())
         .setTools(mapTools(value.getTools()))
-        // once record will return `getElementInstanceKeys()` the line below should be adjusted
-        .setElementInstanceKeys(List.of(value.getElementInstanceKey()))
+        .setElementInstanceKeys(value.getElementInstanceKeys())
         .setLastUpdatedDate(timestamp);
 
     if (intent == AgentInstanceIntent.CREATED) {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentInstanceHandlerTest.java
@@ -150,6 +150,7 @@ final class AgentInstanceHandlerTest {
                     .withToolCalls(toolCalls)
                     .build())
             .withTools(List.of(toolValue))
+            .withElementInstanceKeys(List.of(elementInstanceKey))
             .build();
 
     final Record<AgentInstanceRecordValue> record =
@@ -193,10 +194,38 @@ final class AgentInstanceHandlerTest {
     assertThat(entity.getToolCalls()).isEqualTo(toolCalls);
     assertThat(entity.getTools())
         .containsExactly(new AgentInstanceToolValue("search", "Search the web", "searchElement"));
-    assertThat(entity.getElementInstanceKeys()).containsExactly(elementInstanceKey);
+    assertThat(entity.getElementInstanceKeys())
+        .containsExactlyElementsOf(recordValue.getElementInstanceKeys());
     assertThat(entity.getCreationDate()).isEqualTo(expectedTimestamp);
     assertThat(entity.getLastUpdatedDate()).isEqualTo(expectedTimestamp);
     assertThat(entity.getCompletionDate()).isNull();
+  }
+
+  @Test
+  void shouldMapMultipleElementInstanceKeys() {
+    // given — agent instance associated with two element instances
+    final long firstElementInstanceKey = 200L;
+    final long secondElementInstanceKey = 201L;
+    final var recordValue =
+        ImmutableAgentInstanceRecordValue.builder()
+            .from(buildMinimalRecordValue(100L))
+            .withElementInstanceKey(secondElementInstanceKey)
+            .withElementInstanceKeys(List.of(firstElementInstanceKey, secondElementInstanceKey))
+            .build();
+
+    final Record<AgentInstanceRecordValue> record =
+        factory.generateRecord(
+            ValueType.AGENT_INSTANCE,
+            r -> r.withIntent(AgentInstanceIntent.UPDATED).withValue(recordValue));
+
+    final var entity = new AgentInstanceEntity().setId("100");
+
+    // when
+    underTest.updateEntity(record, entity);
+
+    // then — all element instance keys are propagated to the entity
+    assertThat(entity.getElementInstanceKeys())
+        .containsExactly(firstElementInstanceKey, secondElementInstanceKey);
   }
 
   @Test

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-agent-instance-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-agent-instance-template.json
@@ -25,6 +25,9 @@
             "elementInstanceKey": {
               "type": "long"
             },
+            "elementInstanceKeys": {
+              "type": "long"
+            },
             "elementId": {
               "type": "keyword"
             },

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-agent-instance-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-agent-instance-template.json
@@ -31,6 +31,9 @@
             "elementInstanceKey": {
               "type": "long"
             },
+            "elementInstanceKeys": {
+              "type": "long"
+            },
             "elementId": {
               "type": "keyword"
             },

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/AgentInstanceExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/AgentInstanceExportHandler.java
@@ -87,7 +87,7 @@ public class AgentInstanceExportHandler implements RdbmsExportHandler<AgentInsta
             .toolCalls(value.getMetrics().getToolCalls())
             .toolValues(toToolDbValues(value.getTools()))
             .lastUpdatedDate(timestamp)
-            .elementInstanceKeys(List.of(value.getElementInstanceKey()));
+            .elementInstanceKeys(value.getElementInstanceKeys());
 
     if (intent == AgentInstanceIntent.CREATED) {
       builder.creationDate(timestamp);

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/AgentInstanceExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/AgentInstanceExportHandlerTest.java
@@ -140,8 +140,8 @@ class AgentInstanceExportHandlerTest {
     assertThat(model.creationDate()).isNotNull();
     assertThat(model.lastUpdatedDate()).isEqualTo(model.creationDate());
     assertThat(model.completionDate()).isNull();
-    // element instance keys
-    assertThat(model.elementInstanceKeys()).containsExactly(300L);
+    // element instance keys — full history, not just the latest (scalar) key
+    assertThat(model.elementInstanceKeys()).containsExactly(200L, 300L);
   }
 
   @Test
@@ -297,6 +297,7 @@ class AgentInstanceExportHandlerTest {
     return ImmutableAgentInstanceRecordValue.builder()
         .withAgentInstanceKey(agentInstanceKey)
         .withElementInstanceKey(300L)
+        .withElementInstanceKeys(List.of(200L, 300L))
         .withElementId("myElement")
         .withProcessInstanceKey(100L)
         .withBpmnProcessId("myProcess")

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -546,8 +546,11 @@ components:
         elementInstanceKey:
           nullable: false
           description: |
-            The key of the element instance associated with this agent instance.
-            Used to validate that the update targets the correct process instance.
+            The key of the currently-active element instance for this agent instance.
+            Used for ownership/equality validation against the stored agent instance
+            and, when the supplied key differs from the previous association (re-entry
+            of an ad-hoc sub-process or AI Agent task), appended to elementInstanceKeys
+            with the reverse link updated on the supplied element instance.
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ElementInstanceKey'
         status:

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceRecord.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.ObjectProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.LongValue;
 import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.AgentInstanceRecordValue;
@@ -26,6 +27,8 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
 
   private final LongProperty agentInstanceKeyProp = new LongProperty("agentInstanceKey", -1L);
   private final LongProperty elementInstanceKeyProp = new LongProperty("elementInstanceKey", -1L);
+  private final ArrayProperty<LongValue> elementInstanceKeysProp =
+      new ArrayProperty<>("elementInstanceKeys", LongValue::new);
   private final StringProperty elementIdProp = new StringProperty("elementId", "");
   private final LongProperty processInstanceKeyProp = new LongProperty("processInstanceKey", -1L);
   private final StringProperty bpmnProcessIdProp = new StringProperty("bpmnProcessId", "");
@@ -50,9 +53,10 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
       new ArrayProperty<>("changedAttributes", StringValue::new);
 
   public AgentInstanceRecord() {
-    super(15);
+    super(16);
     declareProperty(agentInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
+        .declareProperty(elementInstanceKeysProp)
         .declareProperty(elementIdProp)
         .declareProperty(processInstanceKeyProp)
         .declareProperty(bpmnProcessIdProp)
@@ -85,6 +89,24 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
 
   public AgentInstanceRecord setElementInstanceKey(final long elementInstanceKey) {
     elementInstanceKeyProp.setValue(elementInstanceKey);
+    return this;
+  }
+
+  @Override
+  public List<Long> getElementInstanceKeys() {
+    return elementInstanceKeysProp.stream().map(LongValue::getValue).toList();
+  }
+
+  public AgentInstanceRecord setElementInstanceKeys(final List<Long> elementInstanceKeys) {
+    elementInstanceKeysProp.reset();
+    if (elementInstanceKeys != null) {
+      elementInstanceKeys.forEach(k -> elementInstanceKeysProp.add().setValue(k));
+    }
+    return this;
+  }
+
+  public AgentInstanceRecord addElementInstanceKey(final long elementInstanceKey) {
+    elementInstanceKeysProp.add().setValue(elementInstanceKey);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -4683,6 +4683,7 @@ final class JsonSerializableToJsonTest {
                   new AgentInstanceRecord()
                       .setAgentInstanceKey(2251799813685251L)
                       .setElementInstanceKey(2251799813685249L)
+                      .setElementInstanceKeys(List.of(2251799813685248L, 2251799813685249L))
                       .setElementId("invoice-data-extraction-agent")
                       .setProcessInstanceKey(2251799813685248L)
                       .setBpmnProcessId("invoice-handling-process")
@@ -4719,6 +4720,7 @@ final class JsonSerializableToJsonTest {
         {
           "agentInstanceKey": 2251799813685251,
           "elementInstanceKey": 2251799813685249,
+          "elementInstanceKeys": [2251799813685248, 2251799813685249],
           "elementId": "invoice-data-extraction-agent",
           "processInstanceKey": 2251799813685248,
           "bpmnProcessId": "invoice-handling-process",
@@ -4749,6 +4751,7 @@ final class JsonSerializableToJsonTest {
         {
           "agentInstanceKey": -1,
           "elementInstanceKey": -1,
+          "elementInstanceKeys": [],
           "elementId": "",
           "processInstanceKey": -1,
           "bpmnProcessId": "",

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceRecordTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceRecordTest.java
@@ -241,6 +241,19 @@ final class AgentInstanceRecordTest {
   }
 
   @Test
+  void shouldAppendElementInstanceKey() {
+    // given
+    final AgentInstanceRecord record =
+        new AgentInstanceRecord().setElementInstanceKeys(List.of(1L, 2L));
+
+    // when
+    record.addElementInstanceKey(3L);
+
+    // then
+    assertThat(record.getElementInstanceKeys()).containsExactly(1L, 2L, 3L);
+  }
+
+  @Test
   void shouldDefaultChangedAttributesToEmptyList() {
     final AgentInstanceRecord record = new AgentInstanceRecord();
     assertThat(record.getChangedAttributes()).isEmpty();

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceRecordTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceRecordTest.java
@@ -206,6 +206,41 @@ final class AgentInstanceRecordTest {
   }
 
   @Test
+  void shouldDefaultElementInstanceKeysToEmptyList() {
+    final AgentInstanceRecord record = new AgentInstanceRecord();
+    assertThat(record.getElementInstanceKeys()).isEmpty();
+  }
+
+  @Test
+  void shouldRoundTripElementInstanceKeysViaMsgPack() {
+    // given
+    final AgentInstanceRecord original =
+        new AgentInstanceRecord()
+            .setElementInstanceKeys(List.of(2251799813685248L, 2251799813685249L));
+
+    // when
+    final AgentInstanceRecord copy = new AgentInstanceRecord();
+    copy.copyFrom(original);
+
+    // then
+    assertThat(copy.getElementInstanceKeys()).containsExactly(2251799813685248L, 2251799813685249L);
+  }
+
+  @Test
+  void shouldReplaceExistingElementInstanceKeysOnSet() {
+    // given
+    final AgentInstanceRecord record =
+        new AgentInstanceRecord().setElementInstanceKeys(List.of(2251799813685248L));
+
+    // when
+    record.setElementInstanceKeys(List.of(2251799813685249L, 2251799813685250L));
+
+    // then
+    assertThat(record.getElementInstanceKeys())
+        .containsExactly(2251799813685249L, 2251799813685250L);
+  }
+
+  @Test
   void shouldDefaultChangedAttributesToEmptyList() {
     final AgentInstanceRecord record = new AgentInstanceRecord();
     assertThat(record.getChangedAttributes()).isEmpty();

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentInstanceRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentInstanceRecord.golden
@@ -13,6 +13,7 @@ import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.ObjectProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.LongValue;
 import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.AgentInstanceRecordValue;
@@ -26,6 +27,8 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
 
   private final LongProperty agentInstanceKeyProp = new LongProperty("agentInstanceKey", -1L);
   private final LongProperty elementInstanceKeyProp = new LongProperty("elementInstanceKey", -1L);
+  private final ArrayProperty<LongValue> elementInstanceKeysProp =
+      new ArrayProperty<>("elementInstanceKeys", LongValue::new);
   private final StringProperty elementIdProp = new StringProperty("elementId", "");
   private final LongProperty processInstanceKeyProp = new LongProperty("processInstanceKey", -1L);
   private final StringProperty bpmnProcessIdProp = new StringProperty("bpmnProcessId", "");
@@ -50,9 +53,10 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
       new ArrayProperty<>("changedAttributes", StringValue::new);
 
   public AgentInstanceRecord() {
-    super(14);
+    super(16);
     declareProperty(agentInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
+        .declareProperty(elementInstanceKeysProp)
         .declareProperty(elementIdProp)
         .declareProperty(processInstanceKeyProp)
         .declareProperty(bpmnProcessIdProp)
@@ -85,6 +89,24 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
 
   public AgentInstanceRecord setElementInstanceKey(final long elementInstanceKey) {
     elementInstanceKeyProp.setValue(elementInstanceKey);
+    return this;
+  }
+
+  @Override
+  public List<Long> getElementInstanceKeys() {
+    return elementInstanceKeysProp.stream().map(LongValue::getValue).toList();
+  }
+
+  public AgentInstanceRecord setElementInstanceKeys(final List<Long> elementInstanceKeys) {
+    elementInstanceKeysProp.reset();
+    if (elementInstanceKeys != null) {
+      elementInstanceKeys.forEach(k -> elementInstanceKeysProp.add().setValue(k));
+    }
+    return this;
+  }
+
+  public AgentInstanceRecord addElementInstanceKey(final long elementInstanceKey) {
+    elementInstanceKeysProp.add().setValue(elementInstanceKey);
     return this;
   }
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentInstanceRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentInstanceRecordValue.java
@@ -35,6 +35,12 @@ public interface AgentInstanceRecordValue extends RecordValue, ProcessInstanceRe
   long getElementInstanceKey();
 
   /**
+   * @return the full list of element instance keys this agent instance has been associated with.
+   *     The most recently associated key is also available as {@link #getElementInstanceKey()}.
+   */
+  List<Long> getElementInstanceKeys();
+
+  /**
    * @return the ID of the process element representing the agent
    */
   String getElementId();


### PR DESCRIPTION
## Description

Adds plural `elementInstanceKeys: List<Long>` tracking to `AgentInstance` alongside the existing scalar `elementInstanceKey`, so that re-entering an ad-hoc sub-process or AI Agent task associates the same conceptual agent instance with the new element instance instead of requiring a fresh CREATE.

The scalar stays as the command-side input and "most-recent association" on events; the plural carries the accumulated history.

End-to-end flow:
- **Protocol record** — new `ArrayProperty<LongValue>` on `AgentInstanceRecord` (defaults to empty list, backward compatible at the record level).
- **CREATE processor** — seeds `[elementInstanceKey]` into the emitted CREATED event.
- **UPDATE processor** — validates the supplied `elementInstanceKey` (6 distinct rejection branches: not-found, inactive, elementId/PI/tenantId mismatch, already associated with a different agent instance), then either dedupes (key already in plural) or appends. On append, the engine emits a private `"elementInstanceKey"` signal in `changedAttributes` so the applier writes the EI back-link; this string is NOT in the client whitelist. A pure-dedupe call with no other patches suppresses the UPDATED event entirely (REST → 204). Includes processor-side backfill for any record whose plural is still empty (defends against records emitted before the CREATE seeding landed).
- **UPDATED applier** — reads the engine-emitted signal and sets `ElementInstance.agentInstanceKey` on the newly associated EI. Previous EI back-link is intentionally left in place.
- **Exporter handler** — reads the plural directly; no fallback needed since the engine guarantees it's populated.
- **REST + Java client docs** — descriptions on `elementInstanceKey` clarified to make both uses explicit (ownership validation + re-association on re-entry). No schema-shape or signature change.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #51513
