### PR TITLE
feat: add image document preview to Operate

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentPreview/DocumentPreviewModal.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentPreview/DocumentPreviewModal.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Modal} from '@carbon/react';
+import type {StateProps} from 'modules/components/ModalStateManager';
+import type {DocumentInfo} from '../DocumentValueCell/parseDocumentVariable';
+import {PreviewImage} from './styled';
+
+type DocumentPreviewProps = {
+  document: DocumentInfo;
+};
+
+const DocumentPreviewModal: React.FC<StateProps & DocumentPreviewProps> = ({
+  open,
+  setOpen,
+  document,
+}) => {
+  return (
+    <Modal
+      open={open}
+      onRequestClose={() => setOpen(false)}
+      modalHeading={`Preview: ${document.fileName}`}
+      size="lg"
+      passiveModal
+    >
+      <ModalContent document={document} />
+    </Modal>
+  );
+};
+
+const ModalContent: React.FC<DocumentPreviewProps> = ({document}) => {
+  if (document.type === 'image') {
+    return <PreviewImage src={document.link} alt={document.fileName} />;
+  }
+
+  return <p>Preview not available for document "{document.fileName}".</p>;
+};
+
+export {DocumentPreviewModal};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentPreview/PreviewDocumentButton.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentPreview/PreviewDocumentButton.test.tsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {render, screen} from 'modules/testing-library';
+import {PreviewDocumentButton} from './PreviewDocumentButton';
+import type {DocumentInfo} from '../DocumentValueCell/parseDocumentVariable';
+
+const imageDocument: DocumentInfo = {
+  link: '/v2/documents/img',
+  fileName: 'photo.png',
+  type: 'image',
+  size: 1024,
+};
+
+const pdfDocument: DocumentInfo = {
+  link: '/v2/documents/pdf',
+  fileName: 'report.pdf',
+  type: 'unknown',
+  size: 2048,
+};
+
+describe('<PreviewDocumentButton />', () => {
+  it('should render an enabled preview button for image documents', () => {
+    render(
+      <PreviewDocumentButton document={imageDocument} variableName="myImage" />,
+    );
+
+    const button = screen.getByLabelText(
+      'Preview document for variable myImage',
+    );
+    expect(button).toBeEnabled();
+  });
+
+  it('should render a disabled preview button for unsupported types', () => {
+    render(
+      <PreviewDocumentButton document={pdfDocument} variableName="myPdf" />,
+    );
+
+    const button = screen.getByLabelText('Preview document for variable myPdf');
+    expect(button).toBeDisabled();
+    expect(
+      screen.getByText('Preview not available for this document type'),
+    ).toBeInTheDocument();
+  });
+
+  it('should open the modal with the image when clicked', async () => {
+    const {user} = render(
+      <PreviewDocumentButton document={imageDocument} variableName="myImage" />,
+    );
+
+    await user.click(
+      screen.getByLabelText('Preview document for variable myImage'),
+    );
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toBeInTheDocument();
+    const image = screen.getByRole('img', {name: 'photo.png'});
+    expect(image).toHaveAttribute('src', '/v2/documents/img');
+  });
+
+  it('should show the file name as the modal heading', async () => {
+    const {user} = render(
+      <PreviewDocumentButton document={imageDocument} variableName="myImage" />,
+    );
+
+    await user.click(
+      screen.getByLabelText('Preview document for variable myImage'),
+    );
+
+    expect(
+      screen.getByRole('heading', {name: 'Preview: photo.png'}),
+    ).toBeInTheDocument();
+  });
+});

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentPreview/PreviewDocumentButton.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentPreview/PreviewDocumentButton.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Button} from '@carbon/react';
+import {View} from '@carbon/react/icons';
+import {ModalStateManager} from 'modules/components/ModalStateManager';
+import type {DocumentInfo} from '../DocumentValueCell/parseDocumentVariable';
+import {DocumentPreviewModal} from './DocumentPreviewModal';
+
+type Props = {
+  document: DocumentInfo;
+  variableName: string;
+};
+
+const PreviewDocumentButton: React.FC<Props> = ({document, variableName}) => {
+  const tooltipText =
+    document.type !== 'unknown'
+      ? 'Preview'
+      : 'Preview not available for this document type';
+
+  return (
+    <ModalStateManager
+      renderLauncher={({setOpen}) => (
+        <Button
+          kind="ghost"
+          size="sm"
+          hasIconOnly
+          renderIcon={View}
+          iconDescription={tooltipText}
+          tooltipPosition="top"
+          aria-label={`Preview document for variable ${variableName}`}
+          disabled={document.type === 'unknown'}
+          onClick={() => setOpen(true)}
+        />
+      )}
+    >
+      {({open, setOpen}) => (
+        <DocumentPreviewModal
+          open={open}
+          setOpen={setOpen}
+          document={document}
+        />
+      )}
+    </ModalStateManager>
+  );
+};
+
+export {PreviewDocumentButton};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentPreview/styled.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentPreview/styled.tsx
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import styled from 'styled-components';
+
+const PreviewImage = styled.img`
+  display: block;
+  max-width: 100%;
+  max-height: 70vh;
+  object-fit: contain;
+  margin: 0 auto;
+`;
+
+export {PreviewImage};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/index.test.tsx
@@ -17,6 +17,7 @@ describe('<DocumentValueCell />', () => {
       document: {
         link: '/v2/documents/doc',
         fileName: 'photo.png',
+        type: 'image',
         size: 112640,
       },
     };
@@ -33,6 +34,7 @@ describe('<DocumentValueCell />', () => {
       document: {
         link: '/v2/documents/doc',
         fileName: 'report.pdf',
+        type: 'unknown',
         size: undefined,
       },
     };
@@ -47,7 +49,12 @@ describe('<DocumentValueCell />', () => {
     const longName = 'a'.repeat(40) + 'original-middle' + 'z'.repeat(40);
     const result: DocumentParseResult = {
       type: 'single',
-      document: {link: '/v2/documents/doc', fileName: longName, size: 1000},
+      document: {
+        link: '/v2/documents/doc',
+        fileName: longName,
+        type: 'unknown',
+        size: 1000,
+      },
     };
 
     render(<DocumentValueCell result={result} />);
@@ -61,9 +68,24 @@ describe('<DocumentValueCell />', () => {
     const result: DocumentParseResult = {
       type: 'list',
       documents: [
-        {link: '/v2/documents/doc-1', fileName: 'a.pdf', size: 1000},
-        {link: '/v2/documents/doc-2', fileName: 'b.pdf', size: 2000},
-        {link: '/v2/documents/doc-3', fileName: 'c.pdf', size: 3000},
+        {
+          link: '/v2/documents/doc-1',
+          fileName: 'a.pdf',
+          type: 'unknown',
+          size: 1000,
+        },
+        {
+          link: '/v2/documents/doc-2',
+          fileName: 'b.pdf',
+          type: 'unknown',
+          size: 2000,
+        },
+        {
+          link: '/v2/documents/doc-3',
+          fileName: 'c.pdf',
+          type: 'unknown',
+          size: 3000,
+        },
       ],
       isLowerBound: false,
     };
@@ -77,8 +99,18 @@ describe('<DocumentValueCell />', () => {
     const result: DocumentParseResult = {
       type: 'list',
       documents: [
-        {link: '/v2/documents/doc-1', fileName: 'a.pdf', size: 1000},
-        {link: '/v2/documents/doc-2', fileName: 'b.pdf', size: 2000},
+        {
+          link: '/v2/documents/doc-1',
+          fileName: 'a.pdf',
+          type: 'unknown',
+          size: 1000,
+        },
+        {
+          link: '/v2/documents/doc-2',
+          fileName: 'b.pdf',
+          type: 'unknown',
+          size: 2000,
+        },
       ],
       isLowerBound: true,
     };
@@ -94,6 +126,7 @@ describe('<DocumentValueCell />', () => {
       document: {
         link: '/v2/documents/doc',
         fileName: 'my-important-file.pdf',
+        type: 'unknown',
         size: 5000,
       },
     };

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/parseDocumentVariable.test.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/parseDocumentVariable.test.ts
@@ -39,6 +39,7 @@ describe('parseDocumentVariable', () => {
       document: {
         link: '/v2/documents/doc-123?storeId=in-memory&contentHash=sha256%3Aabc',
         fileName: 'photo.png',
+        type: 'image',
         size: 109748,
       },
     });
@@ -53,6 +54,7 @@ describe('parseDocumentVariable', () => {
       document: {
         link: '/v2/documents/doc-123?storeId=in-memory&contentHash=sha256%3Aabc',
         fileName: 'photo.png',
+        type: 'image',
         size: 109748,
       },
     });
@@ -62,15 +64,30 @@ describe('parseDocumentVariable', () => {
     const value = JSON.stringify([
       makeDocRef({
         documentId: 'doc-123',
-        metadata: {...makeDocRef().metadata, fileName: 'a.pdf', size: 1000},
+        metadata: {
+          ...makeDocRef().metadata,
+          fileName: 'a.pdf',
+          contentType: 'application/pdf',
+          size: 1000,
+        },
       }),
       makeDocRef({
         documentId: 'doc-124',
-        metadata: {...makeDocRef().metadata, fileName: 'b.json', size: 500},
+        metadata: {
+          ...makeDocRef().metadata,
+          fileName: 'b.json',
+          contentType: 'application/json',
+          size: 500,
+        },
       }),
       makeDocRef({
         documentId: 'doc-125',
-        metadata: {...makeDocRef().metadata, fileName: 'c.txt', size: 200},
+        metadata: {
+          ...makeDocRef().metadata,
+          fileName: 'c.txt',
+          contentType: 'text/plain',
+          size: 200,
+        },
       }),
     ]);
     const result = parseDocumentVariable(value, false);
@@ -81,16 +98,19 @@ describe('parseDocumentVariable', () => {
         {
           link: '/v2/documents/doc-123?storeId=in-memory&contentHash=sha256%3Aabc',
           fileName: 'a.pdf',
+          type: 'unknown',
           size: 1000,
         },
         {
           link: '/v2/documents/doc-124?storeId=in-memory&contentHash=sha256%3Aabc',
           fileName: 'b.json',
+          type: 'unknown',
           size: 500,
         },
         {
           link: '/v2/documents/doc-125?storeId=in-memory&contentHash=sha256%3Aabc',
           fileName: 'c.txt',
+          type: 'unknown',
           size: 200,
         },
       ],
@@ -112,9 +132,33 @@ describe('parseDocumentVariable', () => {
       document: {
         link: '/some-context/v2/documents/doc-123?storeId=in-memory&contentHash=sha256%3Aabc',
         fileName: 'photo.png',
+        type: 'image',
         size: 109748,
       },
     });
+  });
+
+  it('should parse a image document type for supported image formats', () => {
+    for (const format of [
+      'image/jpeg',
+      'image/png',
+      'image/gif',
+      'image/webp',
+    ]) {
+      const value = JSON.stringify(
+        makeDocRef({
+          metadata: {...makeDocRef().metadata, contentType: format},
+        }),
+      );
+      const result = parseDocumentVariable(value, false);
+
+      expect(result).toEqual({
+        type: 'single',
+        document: expect.objectContaining({
+          type: 'image',
+        }),
+      });
+    }
   });
 
   it('should return null for a plain string variable', () => {
@@ -217,6 +261,7 @@ describe('parseDocumentVariable', () => {
       document: {
         link: '/v2/documents/doc-no-meta?storeId=in-memory&contentHash=sha256%3Aabc',
         fileName: 'doc-no-meta',
+        type: 'unknown',
         size: undefined,
       },
     });

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/parseDocumentVariable.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/parseDocumentVariable.ts
@@ -13,9 +13,12 @@ import {mergePathname} from 'modules/request/mergePathname';
 import {getClientConfig} from 'modules/utils/getClientConfig';
 import {endpoints} from '@camunda/camunda-api-zod-schemas/8.10';
 
+type DocumentType = 'image' | 'unknown';
+
 type DocumentInfo = {
   fileName: string;
   link: string;
+  type: DocumentType;
   size: number | undefined;
 };
 
@@ -32,6 +35,7 @@ const documentReferenceSchema = z
     metadata: z
       .object({
         fileName: z.string().optional(),
+        contentType: z.string().optional(),
         size: z.number().optional(),
       })
       .catchall(z.unknown())
@@ -47,6 +51,23 @@ function isDocumentReference(
   return documentReferenceSchema.safeParse(value).success;
 }
 
+const SUPPORTED_IMAGE_MIME_TYPES = new Set([
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+]);
+
+function getDocumentType(contentType: string | undefined): DocumentType {
+  if (!contentType) {
+    return 'unknown';
+  } else if (SUPPORTED_IMAGE_MIME_TYPES.has(contentType)) {
+    return 'image';
+  } else {
+    return 'unknown';
+  }
+}
+
 function toDocumentInfo(ref: DetectedDocumentReference): DocumentInfo {
   const link = mergePathname(
     getClientConfig().contextPath,
@@ -55,6 +76,7 @@ function toDocumentInfo(ref: DetectedDocumentReference): DocumentInfo {
   return {
     link,
     fileName: ref.metadata?.fileName ?? ref.documentId,
+    type: getDocumentType(ref.metadata?.contentType),
     size: ref.metadata?.size,
   };
 }
@@ -127,4 +149,4 @@ function toHumanReadableBytes(bytes: number): string {
 }
 
 export {parseDocumentVariable, toHumanReadableBytes};
-export type {DocumentParseResult};
+export type {DocumentInfo, DocumentParseResult};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/VariablesTable.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/VariablesTable.tsx
@@ -27,6 +27,7 @@ import {useVariables} from 'modules/queries/variables/useVariables';
 import {VariableValueCell} from './VariableValueCell';
 import {parseDocumentVariable} from './DocumentValueCell/parseDocumentVariable';
 import {DownloadDocumentButton} from './DownloadDocumentButton';
+import {PreviewDocumentButton} from './DocumentPreview/PreviewDocumentButton';
 
 type Props = {
   scopeId: string | null;
@@ -123,11 +124,17 @@ const VariablesTable: React.FC<Props> = ({
                   return (
                     <>
                       {documentResult.type === 'single' && (
-                        <DownloadDocumentButton
-                          documentLink={documentResult.document.link}
-                          fileName={documentResult.document.fileName}
-                          variableName={name}
-                        />
+                        <>
+                          <PreviewDocumentButton
+                            document={documentResult.document}
+                            variableName={name}
+                          />
+                          <DownloadDocumentButton
+                            documentLink={documentResult.document.link}
+                            fileName={documentResult.document.fileName}
+                            variableName={name}
+                          />
+                        </>
                       )}
                     </>
                   );

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/documentVariable.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/documentVariable.test.tsx
@@ -7,7 +7,7 @@
  */
 
 import {VariablesTab} from '../index';
-import {render, screen, waitFor, within} from 'modules/testing-library';
+import {render, screen, within} from 'modules/testing-library';
 import {createVariable, searchResult} from 'modules/testUtils';
 import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
 import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
@@ -44,9 +44,7 @@ describe('VariablesTab document variables', () => {
     );
 
     render(<VariablesTab />, {wrapper: getWrapper()});
-    await waitFor(() => {
-      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
-    });
+    await screen.findByTestId('variables-list');
 
     const variableRow = within(screen.getByTestId('variable-myDocument'));
     const downloadButton = variableRow.getByLabelText(
@@ -73,9 +71,7 @@ describe('VariablesTab document variables', () => {
     );
 
     render(<VariablesTab />, {wrapper: getWrapper()});
-    await waitFor(() => {
-      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
-    });
+    await screen.findByTestId('variables-list');
 
     const variableRow = within(screen.getByTestId('variable-myDocumentList'));
     expect(
@@ -101,9 +97,7 @@ describe('VariablesTab document variables', () => {
     );
 
     render(<VariablesTab />, {wrapper: getWrapper()});
-    await waitFor(() => {
-      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
-    });
+    await screen.findByTestId('variables-list');
 
     const variableRow = within(screen.getByTestId('variable-myImage'));
     const previewButton = variableRow.getByLabelText(
@@ -130,9 +124,7 @@ describe('VariablesTab document variables', () => {
     );
 
     render(<VariablesTab />, {wrapper: getWrapper()});
-    await waitFor(() => {
-      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
-    });
+    await screen.findByTestId('variables-list');
 
     const variableRow = within(screen.getByTestId('variable-myDocument'));
     const previewButton = variableRow.getByLabelText(
@@ -155,9 +147,7 @@ describe('VariablesTab document variables', () => {
     );
 
     render(<VariablesTab />, {wrapper: getWrapper()});
-    await waitFor(() => {
-      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
-    });
+    await screen.findByTestId('variables-list');
 
     const variableRow = within(screen.getByTestId('variable-myDocumentList'));
     expect(
@@ -169,10 +159,7 @@ describe('VariablesTab document variables', () => {
     mockSearchVariables().withSuccess(searchResult([createVariable()]));
 
     render(<VariablesTab />, {wrapper: getWrapper()});
-
-    await waitFor(() => {
-      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
-    });
+    await screen.findByTestId('variables-list');
 
     const variableRow = within(screen.getByTestId('variable-testVariableName'));
     expect(

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/documentVariable.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/documentVariable.test.tsx
@@ -83,6 +83,88 @@ describe('VariablesTab document variables', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('should render an enabled preview button for image documents', async () => {
+    mockSearchVariables().withSuccess(
+      searchResult([
+        createVariable({
+          name: 'myImage',
+          value: JSON.stringify(
+            makeDocumentRef({
+              metadata: {
+                fileName: 'photo.png',
+                contentType: 'image/png',
+              },
+            }),
+          ),
+        }),
+      ]),
+    );
+
+    render(<VariablesTab />, {wrapper: getWrapper()});
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
+
+    const variableRow = within(screen.getByTestId('variable-myImage'));
+    const previewButton = variableRow.getByLabelText(
+      'Preview document for variable myImage',
+    );
+    expect(previewButton).toBeEnabled();
+  });
+
+  it('should render a disabled preview button for unsupported document types', async () => {
+    mockSearchVariables().withSuccess(
+      searchResult([
+        createVariable({
+          name: 'myDocument',
+          value: JSON.stringify(
+            makeDocumentRef({
+              metadata: {
+                fileName: 'document.docx',
+                contentType: 'application/docx',
+              },
+            }),
+          ),
+        }),
+      ]),
+    );
+
+    render(<VariablesTab />, {wrapper: getWrapper()});
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
+
+    const variableRow = within(screen.getByTestId('variable-myDocument'));
+    const previewButton = variableRow.getByLabelText(
+      'Preview document for variable myDocument',
+    );
+    expect(previewButton).toBeDisabled();
+  });
+
+  it('should not render a preview button for variables with multiple documents', async () => {
+    mockSearchVariables().withSuccess(
+      searchResult([
+        createVariable({
+          name: 'myDocumentList',
+          value: JSON.stringify([
+            makeDocumentRef({documentId: 'doc-1'}),
+            makeDocumentRef({documentId: 'doc-2'}),
+          ]),
+        }),
+      ]),
+    );
+
+    render(<VariablesTab />, {wrapper: getWrapper()});
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
+
+    const variableRow = within(screen.getByTestId('variable-myDocumentList'));
+    expect(
+      variableRow.queryByLabelText(/preview document for variable/i),
+    ).not.toBeInTheDocument();
+  });
+
   it('should not render a download button for regular variables', async () => {
     mockSearchVariables().withSuccess(searchResult([createVariable()]));
 


### PR DESCRIPTION
## Description

Adds a "Preview" button to document variables, which opens a document preview modal. Currently, the modal only support image previews, and will be expanded with more content-types in later stories. To keep the UI as dump as possible, the type of document is already inferred from the MIME `contentType` metadata during variable parsing in `parseDocumentVariable`. The UI can simply work with a type-safe `type` discriminated union.

## Checklist

- [ ] This PR is stacked on https://github.com/camunda/camunda/pull/53800.

## Related issues

closes #52203
