### PR TITLE
test: drop OS 3.4 from test matrix and add OS 3.6 (3.5 is new minimum for 8.10)

### DIFF
--- a/.ci/db-versions.yml
+++ b/.ci/db-versions.yml
@@ -26,8 +26,8 @@ opensearch:
   os2:
     - "2.19.4"
   os3:
-    - "3.4.0"
     - "3.5.0"
+    - "3.6.0"
 
 # ── RDBMS databases ─────────────────────────────────────────────────────────────
 # Each entry is a Docker image tag representing one supported major version.


### PR DESCRIPTION
Drops OS 3.4 and adds OS 3.6 to the CI test matrix in `.ci/db-versions.yml`. OS 3.5 becomes the new minimum supported version for Camunda 8.10.

Both 3.5 and 3.6 are covered by container-based CI. The AWS nightly dispatch tests continue targeting 3.5 as AWS OpenSearch Service has not yet picked up 3.6.

Closes #52436.