### PR TITLE
Implement agent instance search with ES/OS secondary storage

### DIFF
--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/AgentInstanceDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/AgentInstanceDocumentReader.java
@@ -14,12 +14,6 @@ import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.reader.ResourceAccessChecks;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 
-/**
- * Elasticsearch/OpenSearch-backed document reader for agent instances.
- *
- * <p>Full implementation will be covered in <a
- * href="https://github.com/camunda/camunda/issues/52817">#52817</a>.
- */
 public class AgentInstanceDocumentReader extends DocumentBasedReader
     implements AgentInstanceReader {
 
@@ -31,14 +25,19 @@ public class AgentInstanceDocumentReader extends DocumentBasedReader
   @Override
   public AgentInstanceEntity getByKey(
       final long key, final ResourceAccessChecks resourceAccessChecks) {
-    throw new UnsupportedOperationException(
-        "AgentInstanceDocumentReader is not yet implemented; see https://github.com/camunda/camunda/issues/52817");
+    return getSearchExecutor()
+        .getByQuery(
+            AgentInstanceQuery.of(b -> b.filter(f -> f.agentInstanceKeys(key)).singleResult()),
+            io.camunda.webapps.schema.entities.agentinstance.AgentInstanceEntity.class);
   }
 
   @Override
   public SearchQueryResult<AgentInstanceEntity> search(
       final AgentInstanceQuery query, final ResourceAccessChecks resourceAccessChecks) {
-    throw new UnsupportedOperationException(
-        "AgentInstanceDocumentReader is not yet implemented; see https://github.com/camunda/camunda/issues/52817");
+    return getSearchExecutor()
+        .search(
+            query,
+            io.camunda.webapps.schema.entities.agentinstance.AgentInstanceEntity.class,
+            resourceAccessChecks);
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
@@ -79,6 +79,7 @@ import io.camunda.search.clients.transformers.aggregation.result.ProcessDefiniti
 import io.camunda.search.clients.transformers.aggregation.result.ProcessInstanceFlowNodeStatisticsAggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.UsageMetricsAggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.UsageMetricsTUAggregationResultTransformer;
+import io.camunda.search.clients.transformers.entity.AgentInstanceEntityTransformer;
 import io.camunda.search.clients.transformers.entity.AuditLogEntityTransformer;
 import io.camunda.search.clients.transformers.entity.AuthorizationEntityTransformer;
 import io.camunda.search.clients.transformers.entity.BatchOperationEntityTransformer;
@@ -108,6 +109,7 @@ import io.camunda.search.clients.transformers.entity.TenantMemberEntityTransform
 import io.camunda.search.clients.transformers.entity.UserEntityTransformer;
 import io.camunda.search.clients.transformers.entity.UserTaskEntityTransformer;
 import io.camunda.search.clients.transformers.entity.VariableEntityTransformer;
+import io.camunda.search.clients.transformers.filter.AgentInstanceFilterTransformer;
 import io.camunda.search.clients.transformers.filter.AuditLogFilterTransformer;
 import io.camunda.search.clients.transformers.filter.AuthorizationFilterTransformer;
 import io.camunda.search.clients.transformers.filter.BatchOperationFilterTransformer;
@@ -156,6 +158,7 @@ import io.camunda.search.clients.transformers.result.DecisionRequirementsResultC
 import io.camunda.search.clients.transformers.result.DeployedResourceResultConfigTransformer;
 import io.camunda.search.clients.transformers.result.ProcessDefinitionResultConfigTransformer;
 import io.camunda.search.clients.transformers.result.ProcessInstanceResultConfigTransformer;
+import io.camunda.search.clients.transformers.sort.AgentInstanceFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.AuditLogSortTransformer;
 import io.camunda.search.clients.transformers.sort.AuthorizationFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.BatchOperationFieldSortingTransformer;
@@ -186,6 +189,7 @@ import io.camunda.search.clients.transformers.sort.UsageMetricsFieldSortingTrans
 import io.camunda.search.clients.transformers.sort.UserFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.UserTaskFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.VariableFieldSortingTransformer;
+import io.camunda.search.filter.AgentInstanceFilter;
 import io.camunda.search.filter.AuditLogFilter;
 import io.camunda.search.filter.AuthorizationFilter;
 import io.camunda.search.filter.BatchOperationFilter;
@@ -228,6 +232,7 @@ import io.camunda.search.filter.UserFilter;
 import io.camunda.search.filter.UserTaskFilter;
 import io.camunda.search.filter.VariableFilter;
 import io.camunda.search.filter.VariableValueFilter;
+import io.camunda.search.query.AgentInstanceQuery;
 import io.camunda.search.query.AuditLogQuery;
 import io.camunda.search.query.AuthorizationQuery;
 import io.camunda.search.query.BatchOperationItemQuery;
@@ -277,6 +282,7 @@ import io.camunda.search.result.DecisionRequirementsQueryResultConfig;
 import io.camunda.search.result.DeployedResourceQueryResultConfig;
 import io.camunda.search.result.ProcessDefinitionQueryResultConfig;
 import io.camunda.search.result.ProcessInstanceQueryResultConfig;
+import io.camunda.search.sort.AgentInstanceSort;
 import io.camunda.search.sort.AuditLogSort;
 import io.camunda.search.sort.AuthorizationSort;
 import io.camunda.search.sort.BatchOperationItemSort;
@@ -322,6 +328,7 @@ import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
 import io.camunda.webapps.schema.descriptors.index.RoleIndex;
 import io.camunda.webapps.schema.descriptors.index.TenantIndex;
 import io.camunda.webapps.schema.descriptors.index.UserIndex;
+import io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.template.AuditLogTemplate;
 import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
 import io.camunda.webapps.schema.descriptors.template.CorrelatedMessageSubscriptionTemplate;
@@ -343,6 +350,7 @@ import io.camunda.webapps.schema.entities.JobEntity;
 import io.camunda.webapps.schema.entities.ProcessEntity;
 import io.camunda.webapps.schema.entities.SequenceFlowEntity;
 import io.camunda.webapps.schema.entities.VariableEntity;
+import io.camunda.webapps.schema.entities.agentinstance.AgentInstanceEntity;
 import io.camunda.webapps.schema.entities.auditlog.AuditLogEntity;
 import io.camunda.webapps.schema.entities.clustervariable.ClusterVariableEntity;
 import io.camunda.webapps.schema.entities.dmn.DecisionInstanceEntity;
@@ -433,6 +441,7 @@ public final class ServiceTransformers {
         new TypedSearchQueryTransformer<>(mappers);
     // query -> request
     Stream.of(
+            AgentInstanceQuery.class,
             AuthorizationQuery.class,
             BatchOperationQuery.class,
             BatchOperationItemQuery.class,
@@ -479,6 +488,7 @@ public final class ServiceTransformers {
         .forEach(cls -> mappers.put(cls, searchQueryTransformer));
 
     // document entity -> domain entity
+    mappers.put(AgentInstanceEntity.class, new AgentInstanceEntityTransformer());
     mappers.put(AuthorizationEntity.class, new AuthorizationEntityTransformer());
     mappers.put(BatchOperationEntity.class, new BatchOperationEntityTransformer());
     mappers.put(
@@ -512,6 +522,7 @@ public final class ServiceTransformers {
     mappers.put(DeployedResourceEntity.class, new DeployedResourceEntityTransformer());
 
     // domain field sorting -> database field sorting
+    mappers.put(AgentInstanceSort.class, new AgentInstanceFieldSortingTransformer());
     mappers.put(AuthorizationSort.class, new AuthorizationFieldSortingTransformer());
     mappers.put(BatchOperationSort.class, new BatchOperationFieldSortingTransformer());
     mappers.put(BatchOperationItemSort.class, new BatchOperationItemFieldSortingTransformer());
@@ -549,6 +560,9 @@ public final class ServiceTransformers {
     mappers.put(DeployedResourceSort.class, new DeployedResourceFieldSortingTransformer());
 
     // filters -> search query
+    mappers.put(
+        AgentInstanceFilter.class,
+        new AgentInstanceFilterTransformer(indexDescriptors.get(AgentInstanceTemplate.class)));
     mappers.put(
         ProcessInstanceFilter.class,
         new ProcessInstanceFilterTransformer(

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/AgentInstanceEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/AgentInstanceEntityTransformer.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.entity;
+
+import io.camunda.search.clients.transformers.ServiceTransformer;
+import io.camunda.search.entities.AgentInstanceEntity;
+import io.camunda.search.entities.AgentInstanceEntity.AgentInstanceDefinition;
+import io.camunda.search.entities.AgentInstanceEntity.AgentInstanceLimits;
+import io.camunda.search.entities.AgentInstanceEntity.AgentInstanceMetrics;
+import io.camunda.search.entities.AgentInstanceEntity.AgentInstanceStatus;
+import io.camunda.search.entities.AgentInstanceEntity.AgentInstanceTool;
+import io.camunda.webapps.schema.entities.agentinstance.AgentInstanceEntity.AgentInstanceToolValue;
+import java.util.List;
+
+public class AgentInstanceEntityTransformer
+    implements ServiceTransformer<
+        io.camunda.webapps.schema.entities.agentinstance.AgentInstanceEntity, AgentInstanceEntity> {
+
+  @Override
+  public AgentInstanceEntity apply(
+      final io.camunda.webapps.schema.entities.agentinstance.AgentInstanceEntity source) {
+
+    final var definition =
+        new AgentInstanceDefinition(
+            source.getModel(), source.getProvider(), source.getSystemPrompt());
+
+    final var metrics =
+        new AgentInstanceMetrics(
+            source.getInputTokens(),
+            source.getOutputTokens(),
+            source.getModelCalls(),
+            source.getToolCalls());
+
+    final var limits =
+        new AgentInstanceLimits(
+            source.getMaxTokens(), source.getMaxModelCalls(), source.getMaxToolCalls());
+
+    final var tools = toTools(source.getTools());
+
+    final Long rootProcessInstanceKey =
+        source.getRootProcessInstanceKey() == -1L ? null : source.getRootProcessInstanceKey();
+
+    return new AgentInstanceEntity(
+        source.getKey(),
+        source.getElementInstanceKeys(),
+        toStatus(source.getStatus()),
+        definition,
+        metrics,
+        limits,
+        tools,
+        source.getElementId(),
+        source.getProcessInstanceKey(),
+        rootProcessInstanceKey,
+        source.getProcessDefinitionKey(),
+        source.getBpmnProcessId(),
+        source.getProcessDefinitionVersion(),
+        source.getVersionTag(),
+        source.getTenantId(),
+        source.getCreationDate(),
+        source.getLastUpdatedDate(),
+        source.getCompletionDate());
+  }
+
+  private static List<AgentInstanceTool> toTools(final List<AgentInstanceToolValue> source) {
+    if (source == null) {
+      return List.of();
+    }
+    return source.stream()
+        .map(t -> new AgentInstanceTool(t.name(), t.description(), t.elementId()))
+        .toList();
+  }
+
+  private static AgentInstanceStatus toStatus(
+      final io.camunda.webapps.schema.entities.agentinstance.AgentInstanceStatus source) {
+    if (source == null) {
+      return AgentInstanceStatus.UNKNOWN;
+    }
+    return switch (source) {
+      case INITIALIZING -> AgentInstanceStatus.INITIALIZING;
+      case TOOL_DISCOVERY -> AgentInstanceStatus.TOOL_DISCOVERY;
+      case THINKING -> AgentInstanceStatus.THINKING;
+      case TOOL_CALLING -> AgentInstanceStatus.TOOL_CALLING;
+      case IDLE -> AgentInstanceStatus.IDLE;
+      case COMPLETED -> AgentInstanceStatus.COMPLETED;
+      case UNKNOWN -> AgentInstanceStatus.UNKNOWN;
+    };
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/AgentInstanceFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/AgentInstanceFilterTransformer.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.filter;
+
+import static io.camunda.search.clients.query.SearchQueryBuilders.and;
+import static io.camunda.search.clients.query.SearchQueryBuilders.dateTimeOperations;
+import static io.camunda.search.clients.query.SearchQueryBuilders.intOperations;
+import static io.camunda.search.clients.query.SearchQueryBuilders.longOperations;
+import static io.camunda.search.clients.query.SearchQueryBuilders.stringOperations;
+import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
+import static io.camunda.webapps.schema.descriptors.ProcessInstanceDependant.PROCESS_INSTANCE_KEY;
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.BPMN_PROCESS_ID;
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.COMPLETION_DATE;
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.CREATION_DATE;
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.ELEMENT_ID;
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.ELEMENT_INSTANCE_KEYS;
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.KEY;
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.LAST_UPDATED_DATE;
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.PROCESS_DEFINITION_KEY;
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.PROCESS_DEFINITION_VERSION;
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.STATUS;
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.TENANT_ID;
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.VERSION_TAG;
+
+import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.search.filter.AgentInstanceFilter;
+import io.camunda.security.auth.Authorization;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import java.util.ArrayList;
+
+public class AgentInstanceFilterTransformer extends IndexFilterTransformer<AgentInstanceFilter> {
+
+  public AgentInstanceFilterTransformer(final IndexDescriptor indexDescriptor) {
+    super(indexDescriptor);
+  }
+
+  @Override
+  public SearchQuery toSearchQuery(final AgentInstanceFilter filter) {
+    final var queries = new ArrayList<SearchQuery>();
+    queries.addAll(longOperations(KEY, filter.agentInstanceKeyOperations()));
+    queries.addAll(longOperations(ELEMENT_INSTANCE_KEYS, filter.elementInstanceKeyOperations()));
+    queries.addAll(longOperations(PROCESS_INSTANCE_KEY, filter.processInstanceKeyOperations()));
+    queries.addAll(longOperations(PROCESS_DEFINITION_KEY, filter.processDefinitionKeyOperations()));
+    queries.addAll(stringOperations(BPMN_PROCESS_ID, filter.processDefinitionIdOperations()));
+    queries.addAll(
+        intOperations(PROCESS_DEFINITION_VERSION, filter.processDefinitionVersionOperations()));
+    queries.addAll(stringOperations(VERSION_TAG, filter.versionTagOperations()));
+    queries.addAll(stringOperations(ELEMENT_ID, filter.elementIdOperations()));
+    queries.addAll(stringOperations(STATUS, filter.statusOperations()));
+    queries.addAll(stringOperations(TENANT_ID, filter.tenantIdOperations()));
+    queries.addAll(dateTimeOperations(CREATION_DATE, filter.creationDateOperations()));
+    queries.addAll(dateTimeOperations(LAST_UPDATED_DATE, filter.lastUpdatedDateOperations()));
+    queries.addAll(dateTimeOperations(COMPLETION_DATE, filter.completionDateOperations()));
+    return and(queries);
+  }
+
+  @Override
+  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization<?> authorization) {
+    return stringTerms(BPMN_PROCESS_ID, authorization.resourceIds());
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/AgentInstanceFieldSortingTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/AgentInstanceFieldSortingTransformer.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.sort;
+
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.COMPLETION_DATE;
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.CREATION_DATE;
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.LAST_UPDATED_DATE;
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.STATUS;
+
+public class AgentInstanceFieldSortingTransformer implements FieldSortingTransformer {
+
+  @Override
+  public String apply(final String domainField) {
+    return switch (domainField) {
+      case "creationDate" -> CREATION_DATE;
+      case "lastUpdatedDate" -> LAST_UPDATED_DATE;
+      case "completionDate" -> COMPLETION_DATE;
+      case "status" -> STATUS;
+      default -> throw new IllegalArgumentException("Unknown sortField: " + domainField);
+    };
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/entity/AgentInstanceEntityTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/entity/AgentInstanceEntityTransformerTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.entities.AgentInstanceEntity.AgentInstanceStatus;
+import io.camunda.webapps.schema.entities.agentinstance.AgentInstanceEntity.AgentInstanceToolValue;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+class AgentInstanceEntityTransformerTest {
+
+  private final AgentInstanceEntityTransformer transformer = new AgentInstanceEntityTransformer();
+
+  private io.camunda.webapps.schema.entities.agentinstance.AgentInstanceEntity buildSource() {
+    final var source = new io.camunda.webapps.schema.entities.agentinstance.AgentInstanceEntity();
+    source.setKey(100L);
+    source.setElementInstanceKeys(List.of(1L, 2L));
+    source.setStatus(
+        io.camunda.webapps.schema.entities.agentinstance.AgentInstanceStatus.COMPLETED);
+    source.setModel("gpt-4o");
+    source.setProvider("openai");
+    source.setSystemPrompt("You are helpful.");
+    source.setInputTokens(50L);
+    source.setOutputTokens(30L);
+    source.setModelCalls(2);
+    source.setToolCalls(3);
+    source.setMaxTokens(1000L);
+    source.setMaxModelCalls(10);
+    source.setMaxToolCalls(20);
+    source.setTools(
+        List.of(
+            new AgentInstanceToolValue("searchTool", "searches things", "elem-1"),
+            new AgentInstanceToolValue("calcTool", null, null)));
+    source.setElementId("Task_1");
+    source.setProcessInstanceKey(200L);
+    source.setRootProcessInstanceKey(300L);
+    source.setProcessDefinitionKey(400L);
+    source.setBpmnProcessId("myProcess");
+    source.setProcessDefinitionVersion(2);
+    source.setVersionTag("v2");
+    source.setTenantId("<default>");
+    source.setCreationDate(OffsetDateTime.parse("2024-01-01T00:00:00Z"));
+    source.setLastUpdatedDate(OffsetDateTime.parse("2024-01-02T00:00:00Z"));
+    source.setCompletionDate(OffsetDateTime.parse("2024-01-03T00:00:00Z"));
+    return source;
+  }
+
+  @Test
+  void shouldMapAllFields() {
+    final var result = transformer.apply(buildSource());
+
+    assertThat(result.agentInstanceKey()).isEqualTo(100L);
+    assertThat(result.elementInstanceKeys()).containsExactly(1L, 2L);
+    assertThat(result.status()).isEqualTo(AgentInstanceStatus.COMPLETED);
+    assertThat(result.definition().model()).isEqualTo("gpt-4o");
+    assertThat(result.definition().provider()).isEqualTo("openai");
+    assertThat(result.definition().systemPrompt()).isEqualTo("You are helpful.");
+    assertThat(result.metrics().inputTokens()).isEqualTo(50L);
+    assertThat(result.metrics().outputTokens()).isEqualTo(30L);
+    assertThat(result.metrics().modelCalls()).isEqualTo(2);
+    assertThat(result.metrics().toolCalls()).isEqualTo(3);
+    assertThat(result.limits().maxTokens()).isEqualTo(1000L);
+    assertThat(result.limits().maxModelCalls()).isEqualTo(10);
+    assertThat(result.limits().maxToolCalls()).isEqualTo(20);
+    assertThat(result.tools()).hasSize(2);
+    assertThat(result.tools().get(0).name()).isEqualTo("searchTool");
+    assertThat(result.tools().get(0).description()).isEqualTo("searches things");
+    assertThat(result.tools().get(0).elementId()).isEqualTo("elem-1");
+    assertThat(result.tools().get(1).name()).isEqualTo("calcTool");
+    assertThat(result.tools().get(1).description()).isNull();
+    assertThat(result.tools().get(1).elementId()).isNull();
+    assertThat(result.elementId()).isEqualTo("Task_1");
+    assertThat(result.processInstanceKey()).isEqualTo(200L);
+    assertThat(result.rootProcessInstanceKey()).isEqualTo(300L);
+    assertThat(result.processDefinitionKey()).isEqualTo(400L);
+    assertThat(result.processDefinitionId()).isEqualTo("myProcess");
+    assertThat(result.processDefinitionVersion()).isEqualTo(2);
+    assertThat(result.versionTag()).isEqualTo("v2");
+    assertThat(result.tenantId()).isEqualTo("<default>");
+    assertThat(result.creationDate()).isEqualTo(OffsetDateTime.parse("2024-01-01T00:00:00Z"));
+    assertThat(result.lastUpdatedDate()).isEqualTo(OffsetDateTime.parse("2024-01-02T00:00:00Z"));
+    assertThat(result.completionDate()).isEqualTo(OffsetDateTime.parse("2024-01-03T00:00:00Z"));
+  }
+
+  @Test
+  void shouldMapRootProcessInstanceKeyMinusOneToNull() {
+    final var source = buildSource();
+    source.setRootProcessInstanceKey(-1L);
+
+    final var result = transformer.apply(source);
+
+    assertThat(result.rootProcessInstanceKey()).isNull();
+  }
+
+  @Test
+  void shouldMapNullToolsToEmptyList() {
+    final var source = buildSource();
+    source.setTools(null);
+
+    final var result = transformer.apply(source);
+
+    assertThat(result.tools()).isEmpty();
+  }
+
+  @Test
+  void shouldMapNullStatusToUnknown() {
+    final var source = buildSource();
+    source.setStatus(null);
+
+    final var result = transformer.apply(source);
+
+    assertThat(result.status()).isEqualTo(AgentInstanceStatus.UNKNOWN);
+  }
+
+  @Test
+  void shouldMapNullCompletionDate() {
+    final var source = buildSource();
+    source.setCompletionDate(null);
+
+    final var result = transformer.apply(source);
+
+    assertThat(result.completionDate()).isNull();
+  }
+
+  @ParameterizedTest
+  @EnumSource(io.camunda.webapps.schema.entities.agentinstance.AgentInstanceStatus.class)
+  void shouldMapEveryStatus(
+      final io.camunda.webapps.schema.entities.agentinstance.AgentInstanceStatus webappsStatus) {
+    final var source = buildSource();
+    source.setStatus(webappsStatus);
+
+    final var result = transformer.apply(source);
+
+    assertThat(result.status()).isNotNull();
+    assertThat(result.status().name()).isEqualTo(webappsStatus.name());
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/AgentInstanceFilterTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/AgentInstanceFilterTransformerTest.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.clients.query.SearchBoolQuery;
+import io.camunda.search.clients.query.SearchTermQuery;
+import io.camunda.search.filter.FilterBuilders;
+import io.camunda.search.filter.Operation;
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.Test;
+
+class AgentInstanceFilterTransformerTest extends AbstractTransformerTest {
+
+  @Test
+  void shouldQueryByAgentInstanceKey() {
+    final var filter = FilterBuilders.agentInstance(f -> f.agentInstanceKeys(100L));
+
+    final var searchRequest = transformQuery(filter);
+
+    assertThat(searchRequest.queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("key");
+              assertThat(t.value().longValue()).isEqualTo(100L);
+            });
+  }
+
+  @Test
+  void shouldQueryByElementInstanceKey() {
+    final var filter = FilterBuilders.agentInstance(f -> f.elementInstanceKeys(1L));
+
+    final var searchRequest = transformQuery(filter);
+
+    assertThat(searchRequest.queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("elementInstanceKeys");
+              assertThat(t.value().longValue()).isEqualTo(1L);
+            });
+  }
+
+  @Test
+  void shouldQueryByProcessInstanceKey() {
+    final var filter = FilterBuilders.agentInstance(f -> f.processInstanceKeys(200L));
+
+    final var searchRequest = transformQuery(filter);
+
+    assertThat(searchRequest.queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("processInstanceKey");
+              assertThat(t.value().longValue()).isEqualTo(200L);
+            });
+  }
+
+  @Test
+  void shouldQueryByProcessDefinitionKey() {
+    final var filter = FilterBuilders.agentInstance(f -> f.processDefinitionKeys(400L));
+
+    final var searchRequest = transformQuery(filter);
+
+    assertThat(searchRequest.queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("processDefinitionKey");
+              assertThat(t.value().longValue()).isEqualTo(400L);
+            });
+  }
+
+  @Test
+  void shouldQueryByProcessDefinitionId() {
+    final var filter = FilterBuilders.agentInstance(f -> f.processDefinitionIds("myProcess"));
+
+    final var searchRequest = transformQuery(filter);
+
+    assertThat(searchRequest.queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("bpmnProcessId");
+              assertThat(t.value().stringValue()).isEqualTo("myProcess");
+            });
+  }
+
+  @Test
+  void shouldQueryByProcessDefinitionVersion() {
+    final var filter = FilterBuilders.agentInstance(f -> f.processDefinitionVersions(2));
+
+    final var searchRequest = transformQuery(filter);
+
+    assertThat(searchRequest.queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("processDefinitionVersion");
+              assertThat(t.value().intValue()).isEqualTo(2);
+            });
+  }
+
+  @Test
+  void shouldQueryByVersionTag() {
+    final var filter = FilterBuilders.agentInstance(f -> f.versionTags("v1"));
+
+    final var searchRequest = transformQuery(filter);
+
+    assertThat(searchRequest.queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("versionTag");
+              assertThat(t.value().stringValue()).isEqualTo("v1");
+            });
+  }
+
+  @Test
+  void shouldQueryByElementId() {
+    final var filter = FilterBuilders.agentInstance(f -> f.elementIds("Task_1"));
+
+    final var searchRequest = transformQuery(filter);
+
+    assertThat(searchRequest.queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("elementId");
+              assertThat(t.value().stringValue()).isEqualTo("Task_1");
+            });
+  }
+
+  @Test
+  void shouldQueryByStatus() {
+    final var filter = FilterBuilders.agentInstance(f -> f.statuses("RUNNING"));
+
+    final var searchRequest = transformQuery(filter);
+
+    assertThat(searchRequest.queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("status");
+              assertThat(t.value().stringValue()).isEqualTo("RUNNING");
+            });
+  }
+
+  @Test
+  void shouldQueryByTenantId() {
+    final var filter = FilterBuilders.agentInstance(f -> f.tenantIds("<default>"));
+
+    final var searchRequest = transformQuery(filter);
+
+    assertThat(searchRequest.queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("tenantId");
+              assertThat(t.value().stringValue()).isEqualTo("<default>");
+            });
+  }
+
+  @Test
+  void shouldQueryByCreationDate() {
+    final var date = OffsetDateTime.parse("2024-01-01T00:00:00Z");
+    final var filter =
+        FilterBuilders.agentInstance(f -> f.creationDateOperations(Operation.eq(date)));
+
+    final var searchRequest = transformQuery(filter);
+
+    assertThat(searchRequest.queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("creationDate");
+              assertThat(t.value().stringValue()).contains("2024-01-01");
+            });
+  }
+
+  @Test
+  void shouldQueryByLastUpdatedDate() {
+    final var date = OffsetDateTime.parse("2024-01-02T00:00:00Z");
+    final var filter =
+        FilterBuilders.agentInstance(f -> f.lastUpdatedDateOperations(Operation.eq(date)));
+
+    final var searchRequest = transformQuery(filter);
+
+    assertThat(searchRequest.queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("lastUpdatedDate");
+              assertThat(t.value().stringValue()).contains("2024-01-02");
+            });
+  }
+
+  @Test
+  void shouldQueryByCompletionDate() {
+    final var date = OffsetDateTime.parse("2024-01-03T00:00:00Z");
+    final var filter =
+        FilterBuilders.agentInstance(f -> f.completionDateOperations(Operation.eq(date)));
+
+    final var searchRequest = transformQuery(filter);
+
+    assertThat(searchRequest.queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("completionDate");
+              assertThat(t.value().stringValue()).contains("2024-01-03");
+            });
+  }
+
+  @Test
+  void shouldQueryByAllFields() {
+    final var filter =
+        FilterBuilders.agentInstance(
+            f ->
+                f.agentInstanceKeys(100L)
+                    .elementInstanceKeys(1L)
+                    .processInstanceKeys(200L)
+                    .processDefinitionKeys(400L)
+                    .processDefinitionIds("myProcess")
+                    .processDefinitionVersions(2)
+                    .versionTags("v1")
+                    .elementIds("Task_1")
+                    .statuses("RUNNING")
+                    .tenantIds("<default>")
+                    .creationDateOperations(
+                        Operation.eq(OffsetDateTime.parse("2024-01-01T00:00:00Z")))
+                    .lastUpdatedDateOperations(
+                        Operation.eq(OffsetDateTime.parse("2024-01-02T00:00:00Z")))
+                    .completionDateOperations(
+                        Operation.eq(OffsetDateTime.parse("2024-01-03T00:00:00Z"))));
+
+    final var searchRequest = transformQuery(filter);
+
+    assertThat(searchRequest.queryOption()).isInstanceOf(SearchBoolQuery.class);
+    assertThat(((SearchBoolQuery) searchRequest.queryOption()).must()).hasSize(13);
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/AgentInstanceFieldSortingTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/AgentInstanceFieldSortingTransformerTest.java
@@ -83,5 +83,10 @@ public class AgentInstanceFieldSortingTransformerTest extends AbstractSortTransf
     public Object[] get() {
       return new Object[] {expectedField, sortOrder, fn};
     }
+
+    @Override
+    public String toString() {
+      return expectedField + " " + sortOrder;
+    }
   }
 }

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/AgentInstanceFieldSortingTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/AgentInstanceFieldSortingTransformerTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.sort;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.search.query.SearchQueryBuilders;
+import io.camunda.search.sort.AgentInstanceSort;
+import io.camunda.search.sort.SearchSortOptions;
+import io.camunda.search.sort.SortOrder;
+import io.camunda.util.ObjectBuilder;
+import io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class AgentInstanceFieldSortingTransformerTest extends AbstractSortTransformerTest {
+
+  private static Stream<Arguments> provideSortParameters() {
+    return Stream.of(
+        new TestArguments(
+            AgentInstanceTemplate.CREATION_DATE, SortOrder.ASC, s -> s.creationDate().asc()),
+        new TestArguments(
+            AgentInstanceTemplate.LAST_UPDATED_DATE,
+            SortOrder.DESC,
+            s -> s.lastUpdatedDate().desc()),
+        new TestArguments(
+            AgentInstanceTemplate.COMPLETION_DATE, SortOrder.ASC, s -> s.completionDate().asc()),
+        new TestArguments(AgentInstanceTemplate.STATUS, SortOrder.DESC, s -> s.status().desc()));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideSortParameters")
+  void shouldSortByField(
+      final String expectedField,
+      final SortOrder sortOrder,
+      final Function<AgentInstanceSort.Builder, ObjectBuilder<AgentInstanceSort>> fn) {
+    final var request = SearchQueryBuilders.agentInstanceSearchQuery(q -> q.sort(fn));
+    final var sort = transformRequest(request);
+
+    assertThat(sort).hasSize(2);
+    assertThat(sort.get(0))
+        .isInstanceOfSatisfying(
+            SearchSortOptions.class,
+            t -> {
+              assertThat(t.field().field()).isEqualTo(expectedField);
+              assertThat(t.field().order()).isEqualTo(sortOrder);
+            });
+    assertThat(sort.get(1))
+        .isInstanceOfSatisfying(
+            SearchSortOptions.class,
+            t -> {
+              assertThat(t.field().field()).isEqualTo(AgentInstanceTemplate.KEY);
+              assertThat(t.field().order()).isEqualTo(SortOrder.ASC);
+            });
+  }
+
+  @Test
+  void shouldThrowForUnknownSortField() {
+    final var transformer = new AgentInstanceFieldSortingTransformer();
+
+    assertThatThrownBy(() -> transformer.apply("unknownField"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("unknownField");
+  }
+
+  private record TestArguments(
+      String expectedField,
+      SortOrder sortOrder,
+      Function<AgentInstanceSort.Builder, ObjectBuilder<AgentInstanceSort>> fn)
+      implements Arguments {
+
+    @Override
+    public Object[] get() {
+      return new Object[] {expectedField, sortOrder, fn};
+    }
+  }
+}


### PR DESCRIPTION
## Description

Implements the Elasticsearch/OpenSearch secondary storage reader for agent instances.
**What was introduced:**

- `AgentInstanceEntityTransformer` — maps the flat webapps `AgentInstanceEntity` (ES/OS document) to the nested domain `AgentInstanceEntity`, handling `rootProcessInstanceKey` sentinel (-1 → null), null `status` → `UNKNOWN`, and null tools → empty list
- `AgentInstanceFilterTransformer` — maps all 13 `AgentInstanceFilter` fields to ES/OS query clauses; authorization check uses `bpmnProcessId` terms
- `AgentInstanceFieldSortingTransformer` — maps sort fields (`creationDate`, `lastUpdatedDate`, `completionDate`, `status`) with `key` as the default tiebreaker
- `AgentInstanceDocumentReader` — replaces the `UnsupportedOperationException` stubs with real `getByKey` / `search` implementations backed by the ES/OS query executor
- `ServiceTransformers` — registers the entity transformer, filter transformer, sort transformer, and query stream for `AgentInstanceQuery`
- Unit tests for each component following existing transformer test conventions

**Out of scope:**

- RDBMS reader implementation (covered by #52820)
- Integration/acceptance tests (depend on working secondary-storage backends with indexed data)

## Checklist

- [ ] Enable backports when necessary

## Related issues

closes #52817
