### PR TITLE
feat: add Membership Simulator (SWIM) to monorepo docs

### DIFF
--- a/docs/monorepo-docs/architecture/components/orchestration-cluster/swim-membership-simulator.md
+++ b/docs/monorepo-docs/architecture/components/orchestration-cluster/swim-membership-simulator.md
@@ -1,0 +1,31 @@
+# Membership Simulator (SWIM)
+
+import SwimMembershipSimulator from '@site/src/components/SwimMembershipSimulator';
+
+Use the simulator below to explore how Zeebe's SWIM membership protocol propagates cluster state
+changes and detects node failures.
+
+<SwimMembershipSimulator />
+
+## How it works
+
+Zeebe uses a variant of the
+[SWIM protocol](https://www.cs.cornell.edu/projects/Quicksilver/public_pdfs/SWIM.pdf)
+([`SwimMembershipProtocol`](https://github.com/camunda/camunda/blob/main/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocol.java))
+to maintain cluster membership. Every node periodically gossips membership updates to a random
+subset of peers and probes a random peer to detect failures.
+
+## What gets gossiped
+
+Beyond liveness (alive / suspect / dead), SWIM gossips arbitrary `Member#properties`. Zeebe uses
+this to propagate `BrokerInfo` — each broker's partition roles, partition health, leader terms,
+and cluster topology — and event-service topic subscriptions. Any change to a member's properties
+triggers a gossip update.
+
+## Failure detection and indirect probes
+
+_(Text to be revised with the author after implementation.)_
+
+## Parameters
+
+_(Text to be revised with the author after implementation.)_

--- a/docs/superpowers/specs/2026-05-22-swim-membership-simulator-design.md
+++ b/docs/superpowers/specs/2026-05-22-swim-membership-simulator-design.md
@@ -1,0 +1,356 @@
+# SWIM Membership Simulator — Design Spec
+
+## Goal
+
+An interactive, browser-based simulator embedded in the monorepo docs site that lets engineers
+explore how Zeebe's SWIM membership protocol gossips both liveness changes and property updates
+across a cluster, and how each parameter affects detection speed, convergence time, and message
+volume.
+
+## Placement
+
+`Architecture → Components → Orchestration Cluster → Membership Simulator (SWIM)`
+
+File: `docs/monorepo-docs/architecture/components/orchestration-cluster/swim-membership-simulator.md`
+
+Same page structure as the Partition Distributor: one-sentence intro → simulator component →
+explanatory sections below (text to be written with the author post-implementation).
+
+---
+
+## What the Simulator Models
+
+### Two types of gossiped updates (faithful to Zeebe)
+
+**1. Property update** — simulates a `BrokerInfo` change (e.g. a partition leadership change,
+health status flip). The originating node queues the update; it spreads via gossip only
+(fanout + interval, or to all peers if `broadcastUpdates=true`). No probing involved. Each node
+tracks a simplified "property version" counter per peer (standing in for the full SBE-encoded
+`BrokerInfo` blob). The event log and stale-view indicator show when each node learns of the change.
+
+**2. Node crash** — removes a node from the network. Other nodes probe it, fail to get a response;
+after `suspectProbes` consecutive failures they mark it suspect; after `failureTimeout` in suspect
+state it is declared dead. Failure news then propagates via gossip. If `broadcastDisputes=true` the
+suspect/dead notification is immediately sent to all peers instead of waiting for the next gossip
+round. If `notifySuspect=true` the suspected node is pinged directly and can refute the suspicion
+by incrementing its incarnation number.
+
+**3. Network partition** — a directed link between two nodes is blocked (messages in that
+direction are dropped). Asymmetric partitions are supported: A→B can be blocked while B→A is open.
+Multiple partition pairs can be active simultaneously. Gossip can route around single-link
+partitions through other nodes; the simulator makes this visible.
+
+### Anti-entropy sync
+
+Every `syncInterval` ms each node picks a random peer and exchanges its full membership view
+(bidirectional). This is the catch-up mechanism that matters after a partition heals: the
+simulator shows the time-to-convergence improvement from sync.
+
+### Incarnation numbers
+
+Simulated. When `notifySuspect=true` and the suspected node is alive and reachable, it responds
+with an incremented incarnation number, overriding the suspicion. This is visible in the event log.
+
+### Simulation fidelity
+
+Illustrative, not production-accurate. The algorithm's behavioral structure is correct (probe
+pipeline, gossip fanout, suspect/dead state machine, incarnation-number refutation, sync
+anti-entropy). Message sizes, serialization overhead, and network jitter are not modeled. The
+goal is parameter intuition, not performance benchmarking.
+
+---
+
+## Parameters
+
+All parameters are exposed in the UI. Defaults match `SwimMembershipProtocolConfig.java`.
+
+### Gossip
+| Parameter | Default | Range | Notes |
+|-----------|---------|-------|-------|
+| `gossipInterval` | 250 ms | 50–2000 ms | |
+| `gossipFanout` | 2 | 1–N-1 | capped to node count minus 1 |
+| `broadcastUpdates` | false | toggle | sends to ALL peers; disables fanout |
+
+### Failure detection
+| Parameter | Default | Range | Notes |
+|-----------|---------|-------|-------|
+| `probeInterval` | 1000 ms | 100–5000 ms | |
+| `probeTimeout` | 100 ms | 50–2000 ms | must be < probeInterval |
+| `suspectProbes` | 3 | 1–10 | total probers: 1 direct + (N-1) indirect |
+| `failureTimeout` | 10 000 ms | 1000–30 000 ms | |
+| `broadcastDisputes` | true | toggle | |
+| `notifySuspect` | false | toggle | |
+
+### Anti-entropy
+| Parameter | Default | Range | Notes |
+|-----------|---------|-------|-------|
+| `syncInterval` | 10 000 ms | 1000–60 000 ms | |
+
+### Cluster
+| Parameter | Default | Range |
+|-----------|---------|-------|
+| Node count | 6 | 2–16 |
+
+---
+
+## Simulation Engine
+
+### Clock model
+
+Discrete-event simulation with simulated time. A priority queue holds scheduled events sorted by
+`simTime`. The animation loop (requestAnimationFrame) advances the clock by
+`tickMs × speedMultiplier` per frame (tickMs = 10 ms sim time). Speed multipliers: ×1, ×5, ×20.
+Pause freezes the clock. Step advances by one `probeInterval` of sim time.
+
+### Per-node state
+
+```
+{
+  id: number,                           // 0-indexed
+  state: 'alive' | 'suspect' | 'dead' | 'crashed',
+  incarnationNumber: number,
+  propertyVersion: number,              // bumps on injected property update
+  membershipView: Map<id, {
+    state, incarnation, propertyVersion, // what this node believes about each peer
+  }>,
+  gossipQueue: Array<{                  // updates pending for gossip
+    memberId, state, incarnation, propertyVersion, sendCount
+  }>,
+  probeFailCounts: Map<id, number>,     // consecutive probe failures per target
+  suspectSince: Map<id, simTime>,       // when did we first suspect each peer
+  probeTarget: id | null,              // current probe in flight
+  probeSentAt: simTime | null,
+}
+```
+
+### Scheduled event types
+
+| Event | Fires at | Action |
+|-------|----------|--------|
+| `GOSSIP_TICK(node)` | every `gossipInterval` | pick fanout peers, send gossip |
+| `PROBE_TICK(node)` | every `probeInterval` | pick random peer, send direct probe |
+| `PROBE_TIMEOUT(from, to)` | `probeSentAt + probeTimeout` | direct probe failed — send indirect probe requests to `suspectProbes-1` peers |
+| `INDIRECT_TIMEOUT(coordinator, suspect)` | `probeTimeout × 2` after requests sent | all indirect probes also failed — mark suspect |
+| `FAILURE_TIMEOUT(node, target)` | `suspectSince + failureTimeout` | declare target dead |
+| `SYNC_TICK(node)` | every `syncInterval` | full view exchange with random peer |
+| `MSG_DELIVER(from, to, payload)` | now (0 sim-time delay) | apply message |
+
+Messages between partitioned pairs are dropped at send time (no `MSG_DELIVER` scheduled).
+
+### Gossip update selection
+
+Each node's gossip queue entries are sorted by `sendCount` ascending (least recently sent first).
+On each gossip tick, the top `min(gossipFanout, queue.length)` entries are included in the
+message. `sendCount` is incremented; entries are removed after `⌈log₂(N)⌉` sends.
+If `broadcastUpdates=true`: send to all alive peers regardless of fanout.
+If `broadcastDisputes=true` and the queued entry is a suspect/dead state change: send to all peers
+regardless of fanout (overrides fanout for that entry only).
+
+### Probe pipeline (indirect probes — the core SWIM mechanism)
+
+`suspectProbes` is the **total number of probers**: 1 direct probe (from A) plus
+`suspectProbes - 1` indirect probe requests (sent by A to random peers C, D, … who then probe B
+on A's behalf). A node is only marked suspect when *all* of these fail. This avoids false
+positives from single-link network issues: if A cannot reach B but C can, B is not suspected.
+
+```
+PROBE_TICK fires for node A:
+  pick random peer B (round-robin through membership view)
+  send P→ to B (direct probe, timeout = probeTimeout)
+
+B receives P→:
+  if B is alive: send P✓ back to A
+  if B is crashed / link B→A partitioned: response is dropped
+
+A receives P✓:
+  update A's view of B; done
+
+A's direct probe times out (no P✓ within probeTimeout):
+  select (suspectProbes - 1) random peers C, D, … (excluding A and B)
+  send PR→ to each (probe request: "please probe B for me")
+  timeout for each indirect probe = probeTimeout × 2
+
+C receives PR→(B):
+  send P→ to B (on behalf of A)
+  if B responds: C sends success back to A
+  if B times out: C sends failure back to A
+
+A collects indirect probe results:
+  if ANY indirect probe succeeds: B is reachable, no action
+  if ALL fail (or suspectProbes == 1, no indirect probers available):
+    mark B suspect in A's view; suspectSince[B] = now
+    add suspect entry to A's gossip queue
+    if broadcastDisputes: send to all alive peers immediately
+    schedule FAILURE_TIMEOUT(A, B)
+
+FAILURE_TIMEOUT fires (A, B):
+  if B is still suspect in A's view:
+    mark B dead in A's view
+    add dead entry to gossip queue
+    if broadcastDisputes: send to all immediately
+```
+
+When `notifySuspect=true`: the suspect node receives the probe carrying its own suspect state,
+increments its incarnation number, and broadcasts a correction overriding the suspicion.
+
+### Receiving gossip
+
+For each entry `(memberId, state, incarnation, propertyVersion)` in the message:
+- If `incarnation > local incarnation` for that member: accept, update view, enqueue for re-gossip
+- If same incarnation and state is "worse" (alive < suspect < dead): accept
+- If `notifySuspect=true` and `memberId == self` and state is suspect and self is alive:
+  increment own `incarnationNumber`, override with alive state, enqueue correction
+
+### Convergence detection
+
+After every event, check: do all alive (non-crashed) nodes hold identical membership views?
+Record the sim time of first convergence after each fault injection. Reset on next fault.
+
+---
+
+## Layout
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  PARAMETERS  (collapsible, 3 groups: Gossip | FD | Sync)    │
+│  + Node count slider                                        │
+└─────────────────────────────────────────────────────────────┘
+┌───────────────────────────────────┬─────────────────────────┐
+│                                   │  EVENT LOG              │
+│       NODE GRAPH  (SVG)           │  (state transitions     │
+│       ~380px, circular layout     │   only, auto-scroll,    │
+│       animated message circles    │   max 100 entries)      │
+│                                   │                         │
+└───────────────────────────────────┴─────────────────────────┘
+┌─────────────────────────────────────────────────────────────┐
+│  STATS: sim-time · round · msgs sent · detect · converge    │
+├─────────────────────────────────────────────────────────────┤
+│  [▶ Play] [⏸ Pause] [⏭ Step]  Speed: ×1 ×5 ×20   [Reset]  │
+│  Inject: [Crash node ▼]  [Restore node ▼]                   │
+│          [Property update ▼]  [Partition A→B ▼▼]           │
+│          [Clear all partitions]                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+The node graph is an SVG element. Nodes are arranged in a fixed circle (center + radius computed
+from node count). Edges are SVG lines drawn between all pairs; partitioned directed links are
+rendered as dashed red lines with a direction indicator.
+
+---
+
+## Node Visual States
+
+| State | Appearance |
+|-------|-----------|
+| Alive, view current | Filled circle, neutral (`--ifm-color-emphasis-200`), dark border |
+| Alive, stale view | Same fill, dashed border — at least one peer's state differs from ground truth |
+| Suspect | Orange border (`#f57c00`), light orange fill |
+| Dead | Red fill (`var(--viz-leader)`), white label |
+| Crashed | Dark grey fill, label struck-through |
+
+Node label: `N{id}` (e.g. `N0`, `N1`). Small property-version badge below label.
+
+---
+
+## Message Visualization
+
+Medium circles (~18px diameter) that travel along the SVG line between source and destination
+over ~300ms wall time (independent of sim speed — always visible). Each carries a letter + symbol:
+
+| Circle contents | Color | Meaning |
+|----------------|-------|---------|
+| `G~` | Grey | Routine gossip (heartbeat / no news) |
+| `G↑` | Green (`#2e7d32`) | Gossip carrying a property update |
+| `G✗` | Red (`var(--viz-leader)`) | Gossip carrying failure news |
+| `P→` | Amber (`#f57c00`) | Direct probe outgoing |
+| `P✓` | Green | Probe ACK |
+| `P✗` | Red | Probe timeout (no ACK) |
+| `PR→` | Orange (`#e65100`) | Indirect probe request (ask peer to probe suspect) |
+| `S⇄` | Blue (`#1565c0`) | Full sync |
+
+Multiple message circles can be in flight on the same edge simultaneously. Routine `G~` messages
+use 60% opacity to visually de-emphasize background traffic. A small legend is rendered in the
+bottom-right corner of the SVG.
+
+---
+
+## Stats Bar
+
+| Stat | Description |
+|------|-------------|
+| Sim time | Current simulated time (ms) |
+| Round | Number of gossip ticks fired |
+| Messages sent | Total messages dispatched since last reset |
+| Time to detect | Sim time from fault injection to first node marking the target suspect/dead |
+| Time to converge | Sim time from fault injection to all nodes agreeing on the same view |
+| Status chip | `Converged ✓` / `Converging…` / `Partitioned ⚠` |
+
+---
+
+## Fault Injection
+
+### Crash / Restore
+Dropdown selects target node. Crash: set state to `crashed`, stop all scheduled events for that
+node, drop all in-flight messages to/from it. Restore: set state to `alive`, increment incarnation
+number, restart `GOSSIP_TICK`, `PROBE_TICK`, `SYNC_TICK` events.
+
+### Property update
+Dropdown selects source node. Bumps that node's `propertyVersion`, adds update entry to its
+gossip queue, records injection time for convergence measurement.
+
+### Network partition
+Two dropdowns: source node and target node. Adds a directed block `{from, to}`. Direction matters:
+`A→B` blocked means A's messages to B are dropped, but B can still send to A (asymmetric).
+Multiple pairs can be blocked. "Clear all partitions" removes all blocks.
+
+Partitioned directed links are shown as dashed red SVG lines with a small arrow indicating
+direction. Bidirectional partitions render two overlapping dashed lines.
+
+---
+
+## Files
+
+| File | Action |
+|------|--------|
+| `monorepo-docs-site/src/components/SwimMembershipSimulator.js` | Create (~500 lines) |
+| `monorepo-docs-site/src/components/SwimMembershipSimulator.module.css` | Create (~400 lines) |
+| `docs/monorepo-docs/architecture/components/orchestration-cluster/swim-membership-simulator.md` | Create |
+| `monorepo-docs-site/sidebars.js` | Modify — add entry under Orchestration Cluster |
+
+Algorithm functions are inlined in `SwimMembershipSimulator.js` (no separate module — no test
+suite exists for the docs site, consistent with PartitionDistributionVisualizer.js).
+
+CSS follows the same pattern as `PartitionDistributionVisualizer.module.css`: CSS Modules with
+`--ifm-*` Infima variables for structural elements, `--viz-*` custom properties (already defined
+in `custom.css`) for the data viz palette, and `[data-theme='dark']` overrides.
+
+---
+
+## Color additions to `custom.css`
+
+New `--viz-*` variables needed (append to existing block):
+
+```css
+:root {
+  --viz-suspect: #f57c00;
+  --viz-suspect-light: #fff3e0;
+  --viz-msg-gossip-update: #2e7d32;
+  --viz-msg-probe: #f57c00;
+  --viz-msg-sync: #1565c0;
+}
+[data-theme='dark'] {
+  --viz-suspect: #ffb74d;
+  --viz-suspect-light: #3e2000;
+  --viz-msg-gossip-update: #66bb6a;
+  --viz-msg-probe: #ffb74d;
+  --viz-msg-sync: #42a5f5;
+}
+```
+
+---
+
+## Open items (post-implementation)
+
+- Prose in the doc page (intro paragraph, "How it works" and "Parameters" sections) — to be
+  written with the author after implementation.
+- Whether to add a "scenario presets" feature (e.g. "Show me an asymmetric partition") — deferred.

--- a/docs/superpowers/specs/2026-05-22-swim-membership-simulator-design.md
+++ b/docs/superpowers/specs/2026-05-22-swim-membership-simulator-design.md
@@ -116,10 +116,10 @@ Pause freezes the clock. Step advances by one `probeInterval` of sim time.
   gossipQueue: Array<{                  // updates pending for gossip
     memberId, state, incarnation, propertyVersion, sendCount
   }>,
-  probeFailCounts: Map<id, number>,     // consecutive probe failures per target
+  probeOrder: id[],                     // shuffled probe list; round-robined via probeCounter
+  probeCounter: number,                 // incremented each probe tick, mod probeOrder.length
   suspectSince: Map<id, simTime>,       // when did we first suspect each peer
-  probeTarget: id | null,              // current probe in flight
-  probeSentAt: simTime | null,
+  gossipExcluded: boolean,              // injectable fault: other nodes skip this node in fanout
 }
 ```
 
@@ -140,11 +140,27 @@ Messages between partitioned pairs are dropped at send time (no `MSG_DELIVER` sc
 ### Gossip update selection
 
 Each node's gossip queue entries are sorted by `sendCount` ascending (least recently sent first).
-On each gossip tick, the top `min(gossipFanout, queue.length)` entries are included in the
-message. `sendCount` is incremented; entries are removed after `⌈log₂(N)⌉` sends.
-If `broadcastUpdates=true`: send to all alive peers regardless of fanout.
+On each gossip tick, pick `gossipFanout` random peers from the alive member list, **excluding any
+node with `gossipExcluded=true`**. Send those peers the top entries from the gossip queue.
+`sendCount` is incremented; entries are removed after `⌈log₂(N)⌉` sends.
+If `broadcastUpdates=true`: send to all alive peers regardless of fanout (gossip-excluded nodes
+are still excluded, as `broadcastUpdates` only bypasses the fanout count, not the exclude flag).
 If `broadcastDisputes=true` and the queued entry is a suspect/dead state change: send to all peers
-regardless of fanout (overrides fanout for that entry only).
+regardless of fanout (overrides fanout for that entry only; gossip-excluded nodes are still
+excluded).
+
+### Probe target selection (shuffle + round-robin)
+
+Each node maintains a `probeOrder` list: all other known alive nodes in shuffled order.
+The list is re-shuffled whenever membership changes (node added, removed, or declared dead).
+On each `PROBE_TICK`, the next target is `probeOrder[probeCounter % probeOrder.length]`;
+`probeCounter` increments each tick. This matches the actual implementation.
+
+Dead nodes are removed from `probeOrder` when declared dead. However, they are re-added to a
+separate `deadNodes` set. Each `PROBE_TICK` also probes one dead node (selected round-robin from
+`deadNodes`) to detect resurrection — if it responds, it is re-added to `probeOrder` with alive
+state and a new incarnation number. This mirrors how Zeebe re-probes discovery-service nodes that
+are not present in the live members map.
 
 ### Probe pipeline (indirect probes — the core SWIM mechanism)
 
@@ -155,8 +171,10 @@ positives from single-link network issues: if A cannot reach B but C can, B is n
 
 ```
 PROBE_TICK fires for node A:
-  pick random peer B (round-robin through membership view)
+  pick next alive peer B via round-robin through shuffled probeOrder
   send P→ to B (direct probe, timeout = probeTimeout)
+  if deadNodes is non-empty: also probe one dead node D (round-robin through deadNodes)
+    if D responds: resurrect D (add to probeOrder, remove from deadNodes, new incarnation)
 
 B receives P→:
   if B is alive: send P✓ back to A
@@ -228,7 +246,7 @@ Record the sim time of first convergence after each fault injection. Reset on ne
 │  [▶ Play] [⏸ Pause] [⏭ Step]  Speed: ×1 ×5 ×20   [Reset]  │
 │  Inject: [Crash node ▼]  [Restore node ▼]                   │
 │          [Property update ▼]  [Partition A→B ▼▼]           │
-│          [Clear all partitions]                             │
+│          [Gossip exclude ▼]  [Clear all faults]             │
 └─────────────────────────────────────────────────────────────┘
 ```
 
@@ -247,6 +265,7 @@ rendered as dashed red lines with a direction indicator.
 | Suspect | Orange border (`#f57c00`), light orange fill |
 | Dead | Red fill (`var(--viz-leader)`), white label |
 | Crashed | Dark grey fill, label struck-through |
+| Gossip-excluded (overlay) | Yellow dashed outer ring — combinable with any liveness state |
 
 Node label: `N{id}` (e.g. `N0`, `N1`). Small property-version badge below label.
 
@@ -305,6 +324,14 @@ Multiple pairs can be blocked. "Clear all partitions" removes all blocks.
 
 Partitioned directed links are shown as dashed red SVG lines with a small arrow indicating
 direction. Bidirectional partitions render two overlapping dashed lines.
+
+### Gossip exclude
+Dropdown selects a target node. Sets `gossipExcluded=true` on that node: all other nodes skip it
+when selecting gossip fanout targets. The node can still be probed and synced — it is not
+network-isolated, just systematically unlucky in gossip selection. This demonstrates the
+worst-case scenario where a node never happens to be picked by any peer's random fanout, leaving
+it stale until `syncInterval` fires or `broadcastUpdates=true`. Toggle off to restore normal
+selection. Gossip-excluded nodes are visually marked with a dashed yellow outline in the graph.
 
 ---
 

--- a/monorepo-docs-site/sidebars.js
+++ b/monorepo-docs-site/sidebars.js
@@ -87,6 +87,7 @@ const sidebars = {
               type: 'category',
               label: 'Orchestration Cluster',
               items: [
+                'architecture/components/orchestration-cluster/swim-membership-simulator',
                 {
                   type: 'category',
                   label: 'ADRs',

--- a/monorepo-docs-site/src/components/SwimMembershipSimulator.js
+++ b/monorepo-docs-site/src/components/SwimMembershipSimulator.js
@@ -1,0 +1,467 @@
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import styles from './SwimMembershipSimulator.module.css';
+import {
+  createSim, advanceSim, captureSnapshot,
+  crashNode, restoreNode, injectPropertyUpdate,
+  addPartition, clearPartitions, setGossipExcluded,
+} from './swimSimEngine';
+
+// ── SVG node graph ────────────────────────────────────────────────────────────
+
+const GRAPH_H = 380;
+const NODE_R = 22;
+
+function nodePositions(count, width) {
+  const cx = width / 2;
+  const cy = GRAPH_H / 2;
+  const r = Math.min(cx, cy) * (count <= 4 ? 0.5 : count <= 8 ? 0.62 : 0.72);
+  return Array.from({ length: count }, (_, i) => {
+    const angle = (2 * Math.PI * i / count) - Math.PI / 2;
+    return { x: cx + r * Math.cos(angle), y: cy + r * Math.sin(angle) };
+  });
+}
+
+function nodeColor(state) {
+  switch (state) {
+    case 'suspect': return 'var(--viz-suspect-light)';
+    case 'dead':    return 'var(--viz-leader)';
+    case 'crashed': return 'var(--ifm-color-emphasis-300)';
+    default:        return 'var(--ifm-color-emphasis-100)';
+  }
+}
+
+function nodeBorderColor(state) {
+  switch (state) {
+    case 'suspect': return 'var(--viz-suspect)';
+    case 'dead':    return 'var(--viz-leader)';
+    case 'crashed': return 'var(--ifm-color-emphasis-400)';
+    default:        return 'var(--ifm-color-emphasis-600)';
+  }
+}
+
+const LEGEND_ENTRIES = [
+  ['G~',  'var(--ifm-color-emphasis-400)', 'Gossip (routine)'],
+  ['G↑',  'var(--viz-gossip-update)',      'Gossip (update)'],
+  ['G✗',  'var(--viz-leader)',             'Gossip (failure)'],
+  ['P→',  'var(--viz-msg-probe)',          'Probe'],
+  ['PR→', '#e65100',                       'Indirect probe'],
+  ['S⇄',  'var(--viz-msg-sync)',           'Sync'],
+];
+
+function NodeGraph({ snapshot, nodeCount, svgWidth }) {
+  const positions = nodePositions(nodeCount, svgWidth);
+
+  return (
+    <svg width={svgWidth} height={GRAPH_H} className={styles.graph}>
+      <defs>
+        <marker id="swim-arrow-red" markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto">
+          <path d="M0,0 L0,6 L6,3 z" fill="var(--viz-leader)" />
+        </marker>
+      </defs>
+
+      {/* Normal edges */}
+      {Array.from({ length: nodeCount }, (_, i) =>
+        Array.from({ length: nodeCount }, (_, j) => {
+          if (j <= i) return null;
+          const blocked = snapshot?.partitions.includes(`${i}-${j}`) || snapshot?.partitions.includes(`${j}-${i}`);
+          if (blocked) return null;
+          return (
+            <line key={`e${i}-${j}`}
+              x1={positions[i].x} y1={positions[i].y}
+              x2={positions[j].x} y2={positions[j].y}
+              stroke="var(--ifm-color-emphasis-200)" strokeWidth="1"
+            />
+          );
+        })
+      )}
+
+      {/* Partition indicators */}
+      {snapshot?.partitions.map(p => {
+        const [a, b] = p.split('-').map(Number);
+        if (a >= nodeCount || b >= nodeCount) return null;
+        return (
+          <line key={`p-${p}`}
+            x1={positions[a].x} y1={positions[a].y}
+            x2={positions[b].x} y2={positions[b].y}
+            stroke="var(--viz-leader)" strokeWidth="2" strokeDasharray="5,4"
+            markerEnd="url(#swim-arrow-red)" opacity="0.8"
+          />
+        );
+      })}
+
+      {/* In-flight message circles */}
+      {snapshot?.messages.map(m => {
+        if (m.from >= nodeCount || m.to >= nodeCount) return null;
+        const p1 = positions[m.from];
+        const p2 = positions[m.to];
+        const x = p1.x + (p2.x - p1.x) * m.progress;
+        const y = p1.y + (p2.y - p1.y) * m.progress;
+        return (
+          <g key={m.id} transform={`translate(${x},${y})`}>
+            <circle r="10" fill={m.color} opacity={m.label === 'G~' ? 0.5 : 0.9} />
+            <text textAnchor="middle" dominantBaseline="central"
+              fontSize="6.5" fontWeight="700" fill="white">{m.label}</text>
+          </g>
+        );
+      })}
+
+      {/* Nodes */}
+      {snapshot?.nodes.map(n => {
+        const pos = positions[n.id];
+        return (
+          <g key={n.id} transform={`translate(${pos.x},${pos.y})`}>
+            {n.gossipExcluded && (
+              <circle r={NODE_R + 5} fill="none"
+                stroke="var(--viz-gossip-exclude)" strokeWidth="2" strokeDasharray="4,3" />
+            )}
+            <circle r={NODE_R}
+              fill={nodeColor(n.state)}
+              stroke={nodeBorderColor(n.state)}
+              strokeWidth="2"
+            />
+            <text textAnchor="middle" y="-3"
+              fontSize="11" fontWeight="700"
+              fill={n.state === 'dead' ? 'white' : 'var(--ifm-color-emphasis-900)'}
+              textDecoration={n.state === 'crashed' ? 'line-through' : 'none'}>
+              N{n.id}
+            </text>
+            {n.propertyVersion > 0 && (
+              <text textAnchor="middle" y="10"
+                fontSize="8"
+                fill={n.state === 'dead' ? 'white' : 'var(--ifm-color-emphasis-600)'}>
+                v{n.propertyVersion}
+              </text>
+            )}
+          </g>
+        );
+      })}
+
+      {/* Legend */}
+      <g transform={`translate(${svgWidth - 136}, ${GRAPH_H - 126})`}>
+        <rect width="128" height="118" rx="5"
+          fill="var(--ifm-background-surface-color)"
+          stroke="var(--ifm-color-emphasis-300)" />
+        {LEGEND_ENTRIES.map(([label, color, desc], i) => (
+          <g key={label} transform={`translate(6, ${8 + i * 17})`}>
+            <circle cx="8" cy="6" r="7" fill={color} opacity="0.9" />
+            <text x="8" y="9" textAnchor="middle" fontSize="5.5" fontWeight="700" fill="white">{label}</text>
+            <text x="20" y="9" fontSize="8" fill="var(--ifm-color-emphasis-700)">{desc}</text>
+          </g>
+        ))}
+      </g>
+    </svg>
+  );
+}
+
+// ── Default parameters (match SwimMembershipProtocolConfig.java defaults) ─────
+
+const DEFAULT_PARAMS = {
+  gossipInterval: 250,
+  gossipFanout: 2,
+  broadcastUpdates: false,
+  probeInterval: 1000,
+  probeTimeout: 100,
+  suspectProbes: 3,
+  failureTimeout: 10000,
+  broadcastDisputes: true,
+  notifySuspect: false,
+  syncInterval: 10000,
+};
+
+const SPEEDS = [1, 5, 20];
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+export default function SwimMembershipSimulator() {
+  const [nodeCount, setNodeCount] = useState(6);
+  const [params, setParams] = useState(DEFAULT_PARAMS);
+  const [paused, setPaused] = useState(false);
+  const [speed, setSpeed] = useState(5);
+  const [paramsOpen, setParamsOpen] = useState(true);
+  const [snapshot, setSnapshot] = useState(null);
+  const [crashTarget, setCrashTarget]     = useState(0);
+  const [restoreTarget, setRestoreTarget] = useState(0);
+  const [propTarget, setPropTarget]       = useState(0);
+  const [partFrom, setPartFrom]           = useState(0);
+  const [partTo, setPartTo]               = useState(1);
+  const [excludeTarget, setExcludeTarget] = useState(0);
+
+  const simRef    = useRef(null);
+  const paramsRef = useRef(params);
+  const rafRef    = useRef(null);
+  const svgRef    = useRef(null);
+  const [svgWidth, setSvgWidth] = useState(600);
+
+  useEffect(() => {
+    if (!svgRef.current) return;
+    const ro = new ResizeObserver(([entry]) => setSvgWidth(entry.contentRect.width));
+    ro.observe(svgRef.current);
+    return () => ro.disconnect();
+  }, []);
+
+  useEffect(() => {
+    simRef.current = createSim(nodeCount, paramsRef.current);
+    setSnapshot(captureSnapshot(simRef.current, performance.now()));
+  }, [nodeCount]);
+
+  useEffect(() => { paramsRef.current = params; }, [params]);
+
+  useEffect(() => {
+    const tick = (wallTime) => {
+      if (simRef.current && !paused) {
+        const targetSimTime = simRef.current.simTime + 10 * speed;
+        advanceSim(simRef.current, targetSimTime, wallTime);
+      }
+      if (simRef.current) setSnapshot(captureSnapshot(simRef.current, performance.now()));
+      rafRef.current = requestAnimationFrame(tick);
+    };
+    rafRef.current = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(rafRef.current);
+  }, [paused, speed]);
+
+  const step = useCallback(() => {
+    if (!simRef.current) return;
+    const targetSimTime = simRef.current.simTime + paramsRef.current.probeInterval;
+    advanceSim(simRef.current, targetSimTime, performance.now());
+    setSnapshot(captureSnapshot(simRef.current, performance.now()));
+  }, []);
+
+  const reset = useCallback(() => {
+    simRef.current = createSim(nodeCount, paramsRef.current);
+    setSnapshot(captureSnapshot(simRef.current, performance.now()));
+  }, [nodeCount]);
+
+  const nodeIds = Array.from({ length: nodeCount }, (_, i) => i);
+
+  if (!snapshot) return null;
+
+  const { simTime, roundCount, msgCount, firstDetectTime, convergeTime, hasPartitions } = snapshot;
+
+  return (
+    <div className={styles.widget}>
+      {/* Parameters panel */}
+      <div className={styles.paramsPanel}>
+        <div className={styles.paramsPanelHeader} onClick={() => setParamsOpen(o => !o)}>
+          {paramsOpen ? '▾' : '▸'} Parameters
+        </div>
+        {paramsOpen && (
+          <div className={styles.paramsBody}>
+            <div className={styles.paramGroup}>
+              <div className={styles.paramGroupLabel}>Gossip</div>
+              {[
+                ['Interval (ms)', 'gossipInterval', 50, 2000, 50],
+                ['Fanout', 'gossipFanout', 1, nodeCount - 1, 1],
+              ].map(([label, key, min, max, s]) => (
+                <div key={key} className={styles.paramRow}>
+                  <span className={styles.paramLabel}>{label}</span>
+                  <input type="range" className={styles.paramSlider}
+                    min={min} max={max} step={s} value={params[key]}
+                    onChange={e => setParams(p => ({ ...p, [key]: Number(e.target.value) }))} />
+                  <span className={styles.paramVal}>{params[key]}</span>
+                </div>
+              ))}
+              {[
+                ['Broadcast updates', 'broadcastUpdates'],
+              ].map(([label, key]) => (
+                <div key={key} className={styles.paramRow}>
+                  <span className={styles.paramLabel}>{label}</span>
+                  <label className={styles.toggle}>
+                    <input type="checkbox" checked={params[key]}
+                      onChange={e => setParams(p => ({ ...p, [key]: e.target.checked }))} />
+                    <div className={styles.toggleTrack} />
+                    <div className={styles.toggleKnob} />
+                  </label>
+                </div>
+              ))}
+            </div>
+
+            <div className={styles.paramGroup}>
+              <div className={styles.paramGroupLabel}>Failure Detection</div>
+              {[
+                ['Probe interval (ms)', 'probeInterval', 100, 5000, 100],
+                ['Probe timeout (ms)',  'probeTimeout',  50,  2000, 50],
+                ['Suspect probes',      'suspectProbes', 1,   10,   1],
+                ['Failure timeout (ms)','failureTimeout',1000,30000,1000],
+              ].map(([label, key, min, max, s]) => (
+                <div key={key} className={styles.paramRow}>
+                  <span className={styles.paramLabel}>{label}</span>
+                  <input type="range" className={styles.paramSlider}
+                    min={min} max={max} step={s} value={params[key]}
+                    onChange={e => setParams(p => ({ ...p, [key]: Number(e.target.value) }))} />
+                  <span className={styles.paramVal}>{params[key]}</span>
+                </div>
+              ))}
+              {[
+                ['Broadcast disputes', 'broadcastDisputes'],
+                ['Notify suspect',     'notifySuspect'],
+              ].map(([label, key]) => (
+                <div key={key} className={styles.paramRow}>
+                  <span className={styles.paramLabel}>{label}</span>
+                  <label className={styles.toggle}>
+                    <input type="checkbox" checked={params[key]}
+                      onChange={e => setParams(p => ({ ...p, [key]: e.target.checked }))} />
+                    <div className={styles.toggleTrack} />
+                    <div className={styles.toggleKnob} />
+                  </label>
+                </div>
+              ))}
+            </div>
+
+            <div className={styles.paramGroup}>
+              <div className={styles.paramGroupLabel}>Sync</div>
+              <div className={styles.paramRow}>
+                <span className={styles.paramLabel}>Sync interval (ms)</span>
+                <input type="range" className={styles.paramSlider}
+                  min={1000} max={60000} step={1000} value={params.syncInterval}
+                  onChange={e => setParams(p => ({ ...p, syncInterval: Number(e.target.value) }))} />
+                <span className={styles.paramVal}>{params.syncInterval}</span>
+              </div>
+              <div className={styles.paramGroupLabel} style={{ marginTop: 8 }}>Cluster</div>
+              <div className={styles.paramRow}>
+                <span className={styles.paramLabel}>Node count</span>
+                <input type="range" className={styles.paramSlider}
+                  min={2} max={16} step={1} value={nodeCount}
+                  onChange={e => setNodeCount(Number(e.target.value))} />
+                <span className={styles.paramVal}>{nodeCount}</span>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Graph + event log */}
+      <div className={styles.graphRow}>
+        <div className={styles.graphWrap} ref={svgRef}>
+          <NodeGraph snapshot={snapshot} nodeCount={nodeCount} svgWidth={svgWidth || 600} />
+        </div>
+        <div className={styles.eventLog}>
+          <div className={styles.eventLogTitle}>Event log</div>
+          {snapshot.eventLog.length === 0 ? (
+            <div style={{ color: 'var(--ifm-color-emphasis-500)', fontSize: '0.72rem' }}>
+              No events yet — inject a fault to start.
+            </div>
+          ) : snapshot.eventLog.map((e, i) => (
+            <div key={i} className={styles.eventEntry}>
+              <span className={styles.eventTime}>{(e.simTime / 1000).toFixed(2)}s</span>
+              <span>{e.text}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Stats bar */}
+      <div className={styles.statsBar}>
+        {[
+          ['Sim time', `${(simTime / 1000).toFixed(1)}s`],
+          ['Rounds',   roundCount],
+          ['Messages', msgCount],
+          ['Detect',   firstDetectTime !== null ? `${(firstDetectTime / 1000).toFixed(2)}s` : '—'],
+          ['Converge', convergeTime    !== null ? `${(convergeTime / 1000).toFixed(2)}s`    : '—'],
+        ].map(([label, val]) => (
+          <div key={label} className={styles.statItem}>
+            <span className={styles.statLabel}>{label}</span>
+            <span className={styles.statVal}>{val}</span>
+          </div>
+        ))}
+        <div className={styles.statItem}>
+          <span className={`${styles.chip} ${
+            hasPartitions ? styles.chipWarn :
+            convergeTime !== null ? styles.chipOk : styles.chipInfo
+          }`}>
+            {hasPartitions ? 'Partitioned ⚠' : convergeTime !== null ? 'Converged ✓' : 'Running…'}
+          </span>
+        </div>
+      </div>
+
+      {/* Controls bar */}
+      <div className={styles.controlsBar}>
+        <div className={styles.ctrlGroup}>
+          <button type="button" className={`${styles.btn} ${!paused ? styles.btnActive : ''}`}
+            onClick={() => setPaused(false)}>▶ Play</button>
+          <button type="button" className={`${styles.btn} ${paused ? styles.btnActive : ''}`}
+            onClick={() => setPaused(true)}>⏸ Pause</button>
+          <button type="button" className={styles.btn} onClick={step}>⏭ Step</button>
+        </div>
+        <div className={styles.sep} />
+        <div className={styles.ctrlGroup}>
+          <span className={styles.ctrlGroupLabel}>Speed</span>
+          <div className={styles.speedGroup}>
+            {SPEEDS.map(s => (
+              <button type="button" key={s}
+                className={`${styles.speedBtn} ${speed === s ? styles.speedBtnActive : ''}`}
+                onClick={() => setSpeed(s)}>×{s}</button>
+            ))}
+          </div>
+        </div>
+        <div className={styles.sep} />
+        <div className={styles.ctrlGroup}>
+          <span className={styles.ctrlGroupLabel}>Inject</span>
+          <select className={styles.injectSelect} value={crashTarget}
+            onChange={e => setCrashTarget(Number(e.target.value))}>
+            {nodeIds.map(id => <option key={id} value={id}>N{id}</option>)}
+          </select>
+          <button type="button" className={`${styles.btn} ${styles.btnDanger}`}
+            onClick={() => { if (simRef.current) crashNode(simRef.current, crashTarget); }}>
+            Crash
+          </button>
+          <select className={styles.injectSelect} value={restoreTarget}
+            onChange={e => setRestoreTarget(Number(e.target.value))}>
+            {nodeIds.map(id => <option key={id} value={id}>N{id}</option>)}
+          </select>
+          <button type="button" className={styles.btn}
+            onClick={() => { if (simRef.current) restoreNode(simRef.current, restoreTarget); }}>
+            Restore
+          </button>
+        </div>
+        <div className={styles.sep} />
+        <div className={styles.ctrlGroup}>
+          <select className={styles.injectSelect} value={propTarget}
+            onChange={e => setPropTarget(Number(e.target.value))}>
+            {nodeIds.map(id => <option key={id} value={id}>N{id}</option>)}
+          </select>
+          <button type="button" className={styles.btn}
+            onClick={() => { if (simRef.current) injectPropertyUpdate(simRef.current, propTarget); }}>
+            Prop update
+          </button>
+        </div>
+        <div className={styles.sep} />
+        <div className={styles.ctrlGroup}>
+          <select className={styles.injectSelect} value={partFrom}
+            onChange={e => setPartFrom(Number(e.target.value))}>
+            {nodeIds.map(id => <option key={id} value={id}>N{id}</option>)}
+          </select>
+          <span style={{ fontSize: '0.75rem' }}>→</span>
+          <select className={styles.injectSelect} value={partTo}
+            onChange={e => setPartTo(Number(e.target.value))}>
+            {nodeIds.map(id => <option key={id} value={id}>N{id}</option>)}
+          </select>
+          <button type="button" className={`${styles.btn} ${styles.btnDanger}`}
+            onClick={() => { if (simRef.current && partFrom !== partTo) addPartition(simRef.current, partFrom, partTo); }}>
+            Partition
+          </button>
+        </div>
+        <div className={styles.sep} />
+        <div className={styles.ctrlGroup}>
+          <select className={styles.injectSelect} value={excludeTarget}
+            onChange={e => setExcludeTarget(Number(e.target.value))}>
+            {nodeIds.map(id => <option key={id} value={id}>N{id}</option>)}
+          </select>
+          <button type="button" className={styles.btn}
+            onClick={() => {
+              if (!simRef.current) return;
+              const n = simRef.current.nodes.get(excludeTarget);
+              if (n) setGossipExcluded(simRef.current, excludeTarget, !n.gossipExcluded);
+            }}>
+            Toggle gossip exclude
+          </button>
+        </div>
+        <div className={styles.sep} />
+        <button type="button" className={`${styles.btn} ${styles.btnDanger}`}
+          onClick={() => { if (simRef.current) clearPartitions(simRef.current); }}>
+          Clear partitions
+        </button>
+        <button type="button" className={styles.btn} onClick={reset}>Reset</button>
+      </div>
+    </div>
+  );
+}

--- a/monorepo-docs-site/src/components/SwimMembershipSimulator.module.css
+++ b/monorepo-docs-site/src/components/SwimMembershipSimulator.module.css
@@ -1,0 +1,243 @@
+/* SwimMembershipSimulator.module.css */
+
+.widget {
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 8px;
+  overflow: hidden;
+  font-family: var(--ifm-font-family-base);
+}
+
+/* ── Parameters panel ──────────────────────────────────────── */
+
+.paramsPanel {
+  background: var(--ifm-color-emphasis-100);
+  border-bottom: 1px solid var(--ifm-color-emphasis-300);
+  padding: 12px 16px;
+}
+
+.paramsPanelHeader {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  user-select: none;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--ifm-color-emphasis-700);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.paramsPanelHeader:hover { color: var(--ifm-color-emphasis-900); }
+
+.paramsBody {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 10px 20px;
+  margin-top: 12px;
+}
+
+.paramGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.paramGroupLabel {
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: var(--ifm-color-emphasis-600);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  border-bottom: 1px solid var(--ifm-color-emphasis-300);
+  padding-bottom: 3px;
+  margin-bottom: 2px;
+}
+
+.paramRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.78rem;
+}
+
+.paramLabel {
+  flex: 1;
+  color: var(--ifm-color-emphasis-800);
+  white-space: nowrap;
+}
+
+.paramVal {
+  font-variant-numeric: tabular-nums;
+  min-width: 48px;
+  text-align: right;
+  font-size: 0.75rem;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.paramSlider { width: 90px; }
+
+.toggle { position: relative; display: inline-flex; width: 32px; height: 18px; cursor: pointer; }
+.toggle input { opacity: 0; width: 0; height: 0; }
+.toggleTrack {
+  position: absolute;
+  inset: 0;
+  border-radius: 9px;
+  background: var(--ifm-color-emphasis-300);
+  transition: background 0.2s;
+}
+.toggle input:checked ~ .toggleTrack { background: var(--viz-leader); }
+.toggleKnob {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: white;
+  transition: transform 0.2s;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+}
+.toggle input:checked ~ .toggleTrack ~ .toggleKnob { transform: translateX(14px); }
+
+/* ── Graph + event log ─────────────────────────────────────── */
+
+.graphRow {
+  display: grid;
+  grid-template-columns: 1fr 220px;
+}
+
+.graphWrap {
+  position: relative;
+  border-right: 1px solid var(--ifm-color-emphasis-300);
+}
+
+.graph { display: block; width: 100%; height: 380px; }
+
+.eventLog {
+  padding: 8px;
+  overflow-y: auto;
+  max-height: 380px;
+  font-size: 0.72rem;
+  background: var(--ifm-background-color);
+}
+
+.eventLogTitle {
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--ifm-color-emphasis-600);
+  margin-bottom: 4px;
+}
+
+.eventEntry {
+  display: flex;
+  gap: 6px;
+  padding: 2px 0;
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+  line-height: 1.4;
+}
+
+.eventTime {
+  color: var(--ifm-color-emphasis-500);
+  flex-shrink: 0;
+  font-variant-numeric: tabular-nums;
+  font-size: 0.65rem;
+}
+
+/* ── Stats bar ─────────────────────────────────────────────── */
+
+.statsBar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 16px;
+  padding: 8px 16px;
+  background: var(--ifm-color-emphasis-100);
+  border-top: 1px solid var(--ifm-color-emphasis-300);
+  border-bottom: 1px solid var(--ifm-color-emphasis-300);
+  font-size: 0.75rem;
+}
+
+.statItem { display: flex; gap: 5px; align-items: center; }
+.statLabel { color: var(--ifm-color-emphasis-600); }
+.statVal { font-variant-numeric: tabular-nums; font-weight: 600; }
+
+.chip {
+  display: inline-block;
+  padding: 1px 8px;
+  border-radius: 10px;
+  font-size: 0.7rem;
+  font-weight: 600;
+}
+.chipOk { background: var(--viz-gossip-update-light); color: var(--viz-gossip-update); }
+.chipWarn { background: var(--viz-suspect-light); color: var(--viz-suspect); }
+.chipInfo { background: var(--ifm-color-emphasis-200); color: var(--ifm-color-emphasis-700); }
+
+/* ── Controls bar ──────────────────────────────────────────── */
+
+.controlsBar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px 12px;
+  padding: 10px 16px;
+  background: var(--ifm-background-color);
+}
+
+.ctrlGroup { display: flex; align-items: center; gap: 6px; }
+.ctrlGroupLabel {
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: var(--ifm-color-emphasis-600);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.btn {
+  padding: 4px 12px;
+  border-radius: 4px;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  background: var(--ifm-background-surface-color);
+  color: var(--ifm-color-emphasis-800);
+  font-size: 0.78rem;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.btn:hover { background: var(--ifm-color-emphasis-200); }
+.btnActive {
+  background: var(--viz-leader);
+  color: white;
+  border-color: var(--viz-leader);
+}
+.btnDanger {
+  border-color: var(--viz-leader);
+  color: var(--viz-leader);
+}
+.btnDanger:hover { background: var(--viz-leader-light); }
+
+.speedGroup { display: flex; gap: 0; }
+.speedBtn {
+  padding: 3px 8px;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  background: var(--ifm-background-surface-color);
+  color: var(--ifm-color-emphasis-700);
+  font-size: 0.72rem;
+  cursor: pointer;
+  border-radius: 0;
+}
+.speedBtn:first-child { border-radius: 4px 0 0 4px; }
+.speedBtn:last-child  { border-radius: 0 4px 4px 0; }
+.speedBtnActive { background: var(--viz-leader); color: white; border-color: var(--viz-leader); }
+
+.injectSelect {
+  padding: 4px 8px;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 4px;
+  background: var(--ifm-background-surface-color);
+  color: var(--ifm-color-emphasis-800);
+  font-size: 0.78rem;
+  cursor: pointer;
+}
+
+.sep { width: 1px; height: 24px; background: var(--ifm-color-emphasis-300); margin: 0 2px; }

--- a/monorepo-docs-site/src/components/swimSimEngine.js
+++ b/monorepo-docs-site/src/components/swimSimEngine.js
@@ -503,8 +503,12 @@ export function crashNode(sim, nodeId) {
   const node = sim.nodes.get(nodeId);
   if (!node || node.state === 'crashed') return;
   node.state = 'crashed';
-  sim.eventQueue.removeWhere(e => e.nodeId === nodeId);
+  sim.eventQueue.removeWhere(e => e.nodeId === nodeId || e.from === nodeId || e.to === nodeId);
   sim.inFlightMessages = sim.inFlightMessages.filter(m => m.from !== nodeId && m.to !== nodeId);
+  sim.nodes.forEach(n => {
+    n.probeOrder = n.probeOrder.filter(id => id !== nodeId);
+    n.deadNodes = n.deadNodes.filter(id => id !== nodeId);
+  });
   sim.faultInjectedAt = sim.simTime;
   sim.firstDetectTime = null;
   sim.convergeTime = null;

--- a/monorepo-docs-site/src/components/swimSimEngine.js
+++ b/monorepo-docs-site/src/components/swimSimEngine.js
@@ -130,7 +130,9 @@ function enqueueGossipUpdate(node, entry) {
   const existing = node.gossipQueue.find(e => e.memberId === entry.memberId);
   if (existing) {
     if (entry.incarnation > existing.incarnation ||
-        (entry.incarnation === existing.incarnation && stateRank(entry.state) > stateRank(existing.state))) {
+        (entry.incarnation === existing.incarnation && stateRank(entry.state) > stateRank(existing.state)) ||
+        (entry.incarnation === existing.incarnation && entry.state === existing.state &&
+         (entry.propertyVersion ?? 0) > (existing.propertyVersion ?? 0))) {
       Object.assign(existing, entry, { sendCount: 0 });
     }
   } else {
@@ -486,6 +488,7 @@ function checkConvergence(sim) {
   const ref = aliveNodes[0];
   for (const node of aliveNodes.slice(1)) {
     for (const [id, refEntry] of ref.membershipView.entries()) {
+      if (id === node.id) continue;
       const target = sim.nodes.get(id);
       if (!target || target.state === 'crashed') continue;
       const entry = node.membershipView.get(id);
@@ -503,7 +506,7 @@ export function crashNode(sim, nodeId) {
   const node = sim.nodes.get(nodeId);
   if (!node || node.state === 'crashed') return;
   node.state = 'crashed';
-  sim.eventQueue.removeWhere(e => e.nodeId === nodeId || e.from === nodeId || e.to === nodeId);
+  sim.eventQueue.removeWhere(e => e.nodeId === nodeId || e.from === nodeId);
   sim.inFlightMessages = sim.inFlightMessages.filter(m => m.from !== nodeId && m.to !== nodeId);
   sim.nodes.forEach(n => {
     n.probeOrder = n.probeOrder.filter(id => id !== nodeId);
@@ -519,6 +522,11 @@ export function restoreNode(sim, nodeId) {
   const node = sim.nodes.get(nodeId);
   if (!node || node.state !== 'crashed') return;
   node.state = 'alive';
+  sim.nodes.forEach(n => {
+    if (n.id !== nodeId && n.state === 'alive' && !n.probeOrder.includes(nodeId)) {
+      n.probeOrder.push(nodeId);
+    }
+  });
   node.incarnationNumber++;
   node.suspectSince.clear();
   sim.eventQueue.push({ type: 'GOSSIP_TICK', simTime: sim.simTime + sim.params.gossipInterval, nodeId });

--- a/monorepo-docs-site/src/components/swimSimEngine.js
+++ b/monorepo-docs-site/src/components/swimSimEngine.js
@@ -119,3 +119,96 @@ export function createSim(nodeCount, params) {
   });
   return sim;
 }
+
+// ── Gossip ────────────────────────────────────────────────────────────────────
+
+function stateRank(state) {
+  return state === 'alive' ? 0 : state === 'suspect' ? 1 : 2;
+}
+
+function enqueueGossipUpdate(node, entry) {
+  const existing = node.gossipQueue.find(e => e.memberId === entry.memberId);
+  if (existing) {
+    if (entry.incarnation > existing.incarnation ||
+        (entry.incarnation === existing.incarnation && stateRank(entry.state) > stateRank(existing.state))) {
+      Object.assign(existing, entry, { sendCount: 0 });
+    }
+  } else {
+    node.gossipQueue.push({ ...entry, sendCount: 0 });
+  }
+}
+
+function selectGossipTargets(sim, node) {
+  const alive = [...sim.nodes.values()].filter(n =>
+    n.id !== node.id && n.state === 'alive' && !n.gossipExcluded
+  ).map(n => n.id);
+  if (sim.params.broadcastUpdates) return alive;
+  return pickN(alive, sim.params.gossipFanout, []);
+}
+
+function sendGossip(sim, from, to, entries, wallTime) {
+  if (isPartitioned(sim, from, to)) return;
+  sim.msgCount++;
+  const hasFailure = entries.some(e => e.state === 'dead' || e.state === 'suspect');
+  const hasUpdate = entries.some(e => e.isPropertyUpdate);
+  const label = hasFailure ? 'G✗' : hasUpdate ? 'G↑' : 'G~';
+  const color = label === 'G✗' ? 'var(--viz-leader)'
+    : label === 'G↑' ? 'var(--viz-gossip-update)'
+    : 'var(--ifm-color-emphasis-400)';
+  sim.inFlightMessages.push({
+    id: sim.nextMsgId++, from, to, label, color,
+    startWallTime: wallTime, durationMs: 300,
+    payload: { type: 'GOSSIP', entries },
+  });
+  sim.eventQueue.push({
+    type: 'MSG_DELIVER', simTime: sim.simTime + 1, from, to,
+    payload: { type: 'GOSSIP', entries },
+  });
+}
+
+function handleGossipTick(sim, node, wallTime) {
+  sim.roundCount++;
+  const maxSends = Math.ceil(Math.log2(sim.nodes.size + 1));
+  const entries = [...node.gossipQueue]
+    .sort((a, b) => a.sendCount - b.sendCount)
+    .slice(0, 8);
+  entries.forEach(e => e.sendCount++);
+  node.gossipQueue = node.gossipQueue.filter(e => e.sendCount < maxSends);
+  const targets = selectGossipTargets(sim, node);
+  targets.forEach(tid => sendGossip(sim, node.id, tid, entries, wallTime));
+  sim.eventQueue.push({ type: 'GOSSIP_TICK', simTime: sim.simTime + sim.params.gossipInterval, nodeId: node.id });
+}
+
+function handleGossipReceived(sim, from, to, entries) {
+  const node = sim.nodes.get(to);
+  if (!node || node.state === 'crashed') return;
+  for (const entry of entries) {
+    if (entry.memberId === to) {
+      if (entry.state === 'suspect' && node.state === 'alive') {
+        node.incarnationNumber++;
+        const correction = { memberId: to, state: 'alive', incarnation: node.incarnationNumber };
+        enqueueGossipUpdate(node, correction);
+        if (sim.params.broadcastDisputes) {
+          [...sim.nodes.values()]
+            .filter(n => n.id !== to && n.state === 'alive' && !isPartitioned(sim, to, n.id))
+            .forEach(n => sendGossip(sim, to, n.id, [correction], 0));
+        }
+      }
+      continue;
+    }
+    const view = node.membershipView.get(entry.memberId);
+    if (!view) continue;
+    const acceptNew = entry.incarnation > view.incarnation ||
+      (entry.incarnation === view.incarnation && stateRank(entry.state) > stateRank(view.state));
+    const propChanged = entry.incarnation === view.incarnation &&
+      entry.state === view.state &&
+      entry.propertyVersion !== undefined &&
+      entry.propertyVersion > (view.propertyVersion ?? 0);
+    if (acceptNew || propChanged) {
+      view.state = entry.state;
+      view.incarnation = entry.incarnation;
+      if (entry.propertyVersion !== undefined) view.propertyVersion = entry.propertyVersion;
+      enqueueGossipUpdate(node, entry);
+    }
+  }
+}

--- a/monorepo-docs-site/src/components/swimSimEngine.js
+++ b/monorepo-docs-site/src/components/swimSimEngine.js
@@ -372,4 +372,236 @@ function handleProbeReceived(sim, event, wallTime) {
     payload: { type: 'PROBE_ACK' },
   });
 }
+
+// ── Sync ──────────────────────────────────────────────────────────────────────
+
+function serializeView(node) {
+  return [...node.membershipView.entries()].map(([id, v]) => ({ memberId: id, ...v }));
+}
+
+function handleSyncTick(sim, node, wallTime) {
+  const target = pick(node.probeOrder, []);
+  if (target !== null && !isPartitioned(sim, node.id, target)) {
+    sim.msgCount++;
+    const view = serializeView(node);
+    sim.inFlightMessages.push({
+      id: sim.nextMsgId++, from: node.id, to: target, label: 'S⇄', color: 'var(--viz-msg-sync)',
+      startWallTime: wallTime, durationMs: 400,
+      payload: { type: 'SYNC', view },
+    });
+    sim.eventQueue.push({
+      type: 'MSG_DELIVER', simTime: sim.simTime + 1, from: node.id, to: target,
+      payload: { type: 'SYNC', view },
+    });
+  }
+  sim.eventQueue.push({ type: 'SYNC_TICK', simTime: sim.simTime + sim.params.syncInterval, nodeId: node.id });
+}
+
+function handleSyncReceived(sim, from, to, view, wallTime) {
+  const node = sim.nodes.get(to);
+  if (!node || node.state === 'crashed') return;
+  for (const entry of view) {
+    if (entry.memberId !== to) handleGossipReceived(sim, from, to, [entry]);
+  }
+  if (!isPartitioned(sim, to, from)) {
+    sim.msgCount++;
+    const responseView = serializeView(node);
+    sim.inFlightMessages.push({
+      id: sim.nextMsgId++, from: to, to: from, label: 'S⇄', color: 'var(--viz-msg-sync)',
+      startWallTime: wallTime, durationMs: 400,
+      payload: { type: 'SYNC_RESPONSE', view: responseView },
+    });
+    sim.eventQueue.push({
+      type: 'MSG_DELIVER', simTime: sim.simTime + 1, from: to, to: from,
+      payload: { type: 'SYNC_RESPONSE', view: responseView },
+    });
+  }
+}
+
+// ── Message dispatch ──────────────────────────────────────────────────────────
+
+function handleMsgDeliver(sim, event, wallTime) {
+  const { from, to, payload } = event;
+  const node = sim.nodes.get(to);
+  if (!node || node.state === 'crashed' || isPartitioned(sim, from, to)) return;
+
+  switch (payload.type) {
+    case 'GOSSIP': handleGossipReceived(sim, from, to, payload.entries); break;
+    case 'PROBE':  handleProbeReceived(sim, event, wallTime); break;
+    case 'PROBE_ACK': {
+      // `from` = node that ACKed (was probed), `to` = original prober
+      const prober = sim.nodes.get(to);
+      if (!prober) break;
+      // Resurrection: prober had `from` in its deadNodes list
+      const deadIdx = prober.deadNodes.indexOf(from);
+      if (deadIdx !== -1) {
+        prober.deadNodes.splice(deadIdx, 1);
+        const newIncarnation = (sim.nodes.get(from)?.incarnationNumber ?? 0) + 1;
+        prober.membershipView.set(from, { state: 'alive', incarnation: newIncarnation, propertyVersion: 0 });
+        if (!prober.probeOrder.includes(from)) { prober.probeOrder.push(from); shuffle(prober.probeOrder); }
+        logEvent(sim, `N${to}: N${from} resurrected`);
+        enqueueGossipUpdate(prober, { memberId: from, state: 'alive', incarnation: newIncarnation });
+      } else {
+        // Normal ACK — clear any pending suspicion
+        const view = prober.membershipView.get(from);
+        if (view && view.state === 'suspect') {
+          view.state = 'alive';
+          prober.suspectSince.delete(from);
+          logEvent(sim, `N${to} cleared suspicion of N${from}`);
+        }
+      }
+      break;
+    }
+    case 'PROBE_REQUEST': {
+      // We are an indirect prober — probe `suspect` on behalf of `coordinator`
+      const { suspect } = payload;
+      if (isPartitioned(sim, to, suspect)) break;
+      sim.msgCount++;
+      sim.inFlightMessages.push({
+        id: sim.nextMsgId++, from: to, to: suspect, label: 'P→', color: 'var(--viz-msg-probe)',
+        startWallTime: wallTime, durationMs: 300,
+        payload: { type: 'PROBE' },
+      });
+      sim.eventQueue.push({
+        type: 'MSG_DELIVER', simTime: sim.simTime + 1, from: to, to: suspect,
+        payload: { type: 'PROBE' },
+      });
+      break;
+    }
+    case 'SYNC':          handleSyncReceived(sim, from, to, payload.view, wallTime); break;
+    case 'SYNC_RESPONSE': {
+      for (const entry of payload.view) handleGossipReceived(sim, from, to, [entry]);
+      break;
+    }
+  }
+}
+
+// ── Convergence ───────────────────────────────────────────────────────────────
+
+function checkConvergence(sim) {
+  if (sim.convergeTime !== null || sim.faultInjectedAt === null) return;
+  const aliveNodes = [...sim.nodes.values()].filter(n => n.state === 'alive');
+  if (aliveNodes.length < 2) return;
+
+  const ref = aliveNodes[0];
+  for (const node of aliveNodes.slice(1)) {
+    for (const [id, refEntry] of ref.membershipView.entries()) {
+      const target = sim.nodes.get(id);
+      if (!target || target.state === 'crashed') continue;
+      const entry = node.membershipView.get(id);
+      if (!entry || entry.state !== refEntry.state || (entry.propertyVersion ?? 0) !== (refEntry.propertyVersion ?? 0)) return;
+    }
+  }
+
+  sim.convergeTime = sim.simTime - sim.faultInjectedAt;
+  logEvent(sim, `Cluster converged (all nodes agree)`);
+}
+
+// ── Fault injection ───────────────────────────────────────────────────────────
+
+export function crashNode(sim, nodeId) {
+  const node = sim.nodes.get(nodeId);
+  if (!node || node.state === 'crashed') return;
+  node.state = 'crashed';
+  sim.eventQueue.removeWhere(e => e.nodeId === nodeId);
+  sim.inFlightMessages = sim.inFlightMessages.filter(m => m.from !== nodeId && m.to !== nodeId);
+  sim.faultInjectedAt = sim.simTime;
+  sim.firstDetectTime = null;
+  sim.convergeTime = null;
+  logEvent(sim, `N${nodeId} crashed`);
+}
+
+export function restoreNode(sim, nodeId) {
+  const node = sim.nodes.get(nodeId);
+  if (!node || node.state !== 'crashed') return;
+  node.state = 'alive';
+  node.incarnationNumber++;
+  node.suspectSince.clear();
+  sim.eventQueue.push({ type: 'GOSSIP_TICK', simTime: sim.simTime + sim.params.gossipInterval, nodeId });
+  sim.eventQueue.push({ type: 'PROBE_TICK',  simTime: sim.simTime + sim.params.probeInterval,  nodeId });
+  sim.eventQueue.push({ type: 'SYNC_TICK',   simTime: sim.simTime + sim.params.syncInterval,   nodeId });
+  enqueueGossipUpdate(node, { memberId: nodeId, state: 'alive', incarnation: node.incarnationNumber });
+  logEvent(sim, `N${nodeId} restored (incarnation ${node.incarnationNumber})`);
+}
+
+export function injectPropertyUpdate(sim, nodeId) {
+  const node = sim.nodes.get(nodeId);
+  if (!node || node.state !== 'alive') return;
+  node.propertyVersion++;
+  enqueueGossipUpdate(node, {
+    memberId: nodeId, state: 'alive', incarnation: node.incarnationNumber,
+    propertyVersion: node.propertyVersion, isPropertyUpdate: true,
+  });
+  sim.faultInjectedAt = sim.simTime;
+  sim.firstDetectTime = null;
+  sim.convergeTime = null;
+  logEvent(sim, `N${nodeId} property update v${node.propertyVersion}`);
+}
+
+export function addPartition(sim, from, to) {
+  sim.partitions.add(`${from}-${to}`);
+  logEvent(sim, `Partition: N${from} → N${to} blocked`);
+}
+
+export function clearPartitions(sim) {
+  sim.partitions.clear();
+  logEvent(sim, 'All partitions cleared');
+}
+
+export function setGossipExcluded(sim, nodeId, excluded) {
+  const node = sim.nodes.get(nodeId);
+  if (node) {
+    node.gossipExcluded = excluded;
+    logEvent(sim, `N${nodeId} gossip ${excluded ? 'excluded' : 'restored'}`);
+  }
+}
+
+// ── Main simulation loop ──────────────────────────────────────────────────────
+
+export function advanceSim(sim, targetSimTime, wallTime) {
+  while (!sim.eventQueue.isEmpty() && sim.eventQueue.peek().simTime <= targetSimTime) {
+    const event = sim.eventQueue.pop();
+    sim.simTime = event.simTime;
+    const node = event.nodeId !== undefined ? sim.nodes.get(event.nodeId) : null;
+    if (node && node.state === 'crashed' && event.type !== 'MSG_DELIVER') continue;
+
+    switch (event.type) {
+      case 'GOSSIP_TICK':      if (node) handleGossipTick(sim, node, wallTime); break;
+      case 'PROBE_TICK':       if (node) handleProbeTick(sim, node, wallTime); break;
+      case 'PROBE_TIMEOUT':    handleProbeTimeout(sim, event, wallTime); break;
+      case 'INDIRECT_TIMEOUT': handleIndirectTimeout(sim, event, wallTime); break;
+      case 'FAILURE_TIMEOUT':  handleFailureTimeout(sim, event); break;
+      case 'SYNC_TICK':        if (node) handleSyncTick(sim, node, wallTime); break;
+      case 'MSG_DELIVER':      handleMsgDeliver(sim, event, wallTime); break;
+    }
+    checkConvergence(sim);
+  }
+  sim.simTime = targetSimTime;
+  sim.inFlightMessages = sim.inFlightMessages.filter(m => wallTime - m.startWallTime < m.durationMs + 100);
+}
+
+// ── Snapshot (for React rendering) ───────────────────────────────────────────
+
+export function captureSnapshot(sim, wallTime) {
+  return {
+    simTime: sim.simTime,
+    roundCount: sim.roundCount,
+    msgCount: sim.msgCount,
+    firstDetectTime: sim.firstDetectTime,
+    convergeTime: sim.convergeTime,
+    hasPartitions: sim.partitions.size > 0,
+    partitions: [...sim.partitions],
+    eventLog: [...sim.eventLog],
+    nodes: [...sim.nodes.values()].map(n => ({
+      id: n.id,
+      state: n.state,
+      propertyVersion: n.propertyVersion,
+      gossipExcluded: n.gossipExcluded,
+      view: new Map([...n.membershipView.entries()]),
+    })),
+    messages: sim.inFlightMessages.map(m => {
+      const progress = Math.min(1, (wallTime - m.startWallTime) / m.durationMs);
+      return { ...m, progress };
+    }).filter(m => m.progress >= 0 && m.progress <= 1),
+  };
 }

--- a/monorepo-docs-site/src/components/swimSimEngine.js
+++ b/monorepo-docs-site/src/components/swimSimEngine.js
@@ -1,0 +1,121 @@
+// swimSimEngine.js — SWIM membership protocol simulation engine
+// No React imports. All state is plain JS objects mutated directly.
+
+// ── Priority queue (min-heap by simTime) ─────────────────────────────────────
+
+function createEventQueue() {
+  const h = [];
+  const swap = (i, j) => { [h[i], h[j]] = [h[j], h[i]]; };
+  const up = (i) => {
+    while (i > 0) {
+      const p = (i - 1) >> 1;
+      if (h[p].simTime <= h[i].simTime) break;
+      swap(p, i); i = p;
+    }
+  };
+  const down = (i) => {
+    for (;;) {
+      let s = i, l = 2*i+1, r = 2*i+2;
+      if (l < h.length && h[l].simTime < h[s].simTime) s = l;
+      if (r < h.length && h[r].simTime < h[s].simTime) s = r;
+      if (s === i) break;
+      swap(i, s); i = s;
+    }
+  };
+  return {
+    push(e) { h.push(e); up(h.length - 1); },
+    pop() {
+      if (!h.length) return null;
+      const min = h[0];
+      const last = h.pop();
+      if (h.length) { h[0] = last; down(0); }
+      return min;
+    },
+    peek() { return h[0] ?? null; },
+    isEmpty() { return h.length === 0; },
+    removeWhere(pred) {
+      for (let i = h.length - 1; i >= 0; i--) {
+        if (pred(h[i])) h.splice(i, 1);
+      }
+      for (let i = (h.length >> 1) - 1; i >= 0; i--) down(i);
+    },
+  };
+}
+
+// ── Utilities ─────────────────────────────────────────────────────────────────
+
+export function shuffle(arr) {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+
+function pick(arr, exclude = []) {
+  const pool = arr.filter(x => !exclude.includes(x));
+  if (!pool.length) return null;
+  return pool[Math.floor(Math.random() * pool.length)];
+}
+
+function pickN(arr, n, exclude = []) {
+  const pool = shuffle(arr.filter(x => !exclude.includes(x)));
+  return pool.slice(0, n);
+}
+
+function isPartitioned(sim, from, to) {
+  return sim.partitions.has(`${from}-${to}`);
+}
+
+function logEvent(sim, text) {
+  sim.eventLog.unshift({ simTime: sim.simTime, text });
+  if (sim.eventLog.length > 100) sim.eventLog.length = 100;
+}
+
+// ── Node state factory ────────────────────────────────────────────────────────
+
+function createNode(id, nodeCount) {
+  const peers = Array.from({ length: nodeCount }, (_, i) => i).filter(i => i !== id);
+  return {
+    id,
+    state: 'alive',
+    incarnationNumber: 0,
+    propertyVersion: 0,
+    membershipView: new Map(peers.map(p => [p, { state: 'alive', incarnation: 0, propertyVersion: 0 }])),
+    gossipQueue: [],
+    probeOrder: shuffle([...peers]),
+    probeCounter: 0,
+    deadNodes: [],
+    deadProbeCounter: 0,
+    suspectSince: new Map(),
+    gossipExcluded: false,
+  };
+}
+
+// ── Simulation state factory ──────────────────────────────────────────────────
+
+export function createSim(nodeCount, params) {
+  const nodes = new Map();
+  for (let i = 0; i < nodeCount; i++) nodes.set(i, createNode(i, nodeCount));
+  const sim = {
+    nodes,
+    partitions: new Set(),
+    eventQueue: createEventQueue(),
+    inFlightMessages: [],
+    simTime: 0,
+    roundCount: 0,
+    msgCount: 0,
+    eventLog: [],
+    faultInjectedAt: null,
+    firstDetectTime: null,
+    convergeTime: null,
+    nextMsgId: 0,
+    params,
+  };
+  nodes.forEach((_, id) => {
+    sim.eventQueue.push({ type: 'GOSSIP_TICK', simTime: params.gossipInterval, nodeId: id });
+    sim.eventQueue.push({ type: 'PROBE_TICK',  simTime: params.probeInterval,  nodeId: id });
+    sim.eventQueue.push({ type: 'SYNC_TICK',   simTime: params.syncInterval,   nodeId: id });
+  });
+  return sim;
+}

--- a/monorepo-docs-site/src/components/swimSimEngine.js
+++ b/monorepo-docs-site/src/components/swimSimEngine.js
@@ -212,3 +212,164 @@ function handleGossipReceived(sim, from, to, entries) {
     }
   }
 }
+
+// ── Failure detection ─────────────────────────────────────────────────────────
+
+function sendProbe(sim, from, to, wallTime) {
+  if (isPartitioned(sim, from, to)) return;
+  sim.msgCount++;
+  sim.inFlightMessages.push({
+    id: sim.nextMsgId++, from, to, label: 'P→', color: 'var(--viz-msg-probe)',
+    startWallTime: wallTime, durationMs: 300,
+    payload: { type: 'PROBE' },
+  });
+  sim.eventQueue.push({ type: 'MSG_DELIVER', simTime: sim.simTime + 1, from, to, payload: { type: 'PROBE' } });
+}
+
+function handleProbeTick(sim, node, wallTime) {
+  // Probe one alive peer via shuffle + round-robin through probeOrder
+  if (node.probeOrder.length > 0) {
+    const idx = node.probeCounter % node.probeOrder.length;
+    node.probeCounter++;
+    const targetId = node.probeOrder[idx];
+    const target = sim.nodes.get(targetId);
+    if (target && target.state !== 'crashed') {
+      sendProbe(sim, node.id, targetId, wallTime);
+      sim.eventQueue.push({
+        type: 'PROBE_TIMEOUT', simTime: sim.simTime + sim.params.probeTimeout,
+        from: node.id, to: targetId,
+      });
+    }
+  }
+  // Also probe one dead node per tick (resurrection check).
+  // If it responds, the PROBE_ACK handler detects it's in deadNodes and resurrects it.
+  if (node.deadNodes.length > 0) {
+    const idx = node.deadProbeCounter % node.deadNodes.length;
+    node.deadProbeCounter++;
+    const deadId = node.deadNodes[idx];
+    sendProbe(sim, node.id, deadId, wallTime);
+  }
+  sim.eventQueue.push({ type: 'PROBE_TICK', simTime: sim.simTime + sim.params.probeInterval, nodeId: node.id });
+}
+
+function handleProbeTimeout(sim, event, wallTime) {
+  const { from, to } = event;
+  const prober = sim.nodes.get(from);
+  if (!prober || prober.state === 'crashed') return;
+  const target = sim.nodes.get(to);
+  if (!target) return;
+
+  // Send indirect probe requests to suspectProbes-1 random peers.
+  // Each peer receives a PROBE_REQUEST carrying the suspect's ID.
+  const indirectPeers = pickN(
+    [...sim.nodes.values()]
+      .filter(n => n.id !== from && n.id !== to && n.state === 'alive')
+      .map(n => n.id),
+    sim.params.suspectProbes - 1
+  );
+
+  if (indirectPeers.length === 0) {
+    markSuspect(sim, prober, to, wallTime);
+    return;
+  }
+
+  indirectPeers.forEach(pid => {
+    if (isPartitioned(sim, from, pid)) return;
+    sim.msgCount++;
+    sim.inFlightMessages.push({
+      id: sim.nextMsgId++, from, to: pid, label: 'PR→', color: '#e65100',
+      startWallTime: wallTime, durationMs: 300,
+      payload: { type: 'PROBE_REQUEST', suspect: to, coordinator: from },
+    });
+    sim.eventQueue.push({
+      type: 'MSG_DELIVER', simTime: sim.simTime + 1, from, to: pid,
+      payload: { type: 'PROBE_REQUEST', suspect: to, coordinator: from },
+    });
+  });
+
+  sim.eventQueue.push({
+    type: 'INDIRECT_TIMEOUT', simTime: sim.simTime + sim.params.probeTimeout * 2,
+    from, to,
+  });
+}
+
+function handleIndirectTimeout(sim, event, wallTime) {
+  const { from, to } = event;
+  const prober = sim.nodes.get(from);
+  if (!prober || prober.state === 'crashed') return;
+  markSuspect(sim, prober, to, wallTime);
+}
+
+function markSuspect(sim, prober, targetId, wallTime) {
+  const view = prober.membershipView.get(targetId);
+  if (!view || view.state !== 'alive') return;
+
+  view.state = 'suspect';
+  prober.suspectSince.set(targetId, sim.simTime);
+  logEvent(sim, `N${prober.id} suspects N${targetId}`);
+
+  if (sim.faultInjectedAt !== null && sim.firstDetectTime === null) {
+    sim.firstDetectTime = sim.simTime - sim.faultInjectedAt;
+  }
+
+  const entry = { memberId: targetId, state: 'suspect', incarnation: view.incarnation };
+  enqueueGossipUpdate(prober, entry);
+
+  if (sim.params.broadcastDisputes) {
+    [...sim.nodes.values()]
+      .filter(n => n.id !== prober.id && n.state === 'alive' && !isPartitioned(sim, prober.id, n.id))
+      .forEach(n => sendGossip(sim, prober.id, n.id, [entry], wallTime));
+  }
+
+  if (sim.params.notifySuspect) {
+    sendProbe(sim, prober.id, targetId, wallTime);
+  }
+
+  sim.eventQueue.push({
+    type: 'FAILURE_TIMEOUT', simTime: sim.simTime + sim.params.failureTimeout,
+    from: prober.id, to: targetId,
+  });
+}
+
+function handleFailureTimeout(sim, event) {
+  const { from, to } = event;
+  const prober = sim.nodes.get(from);
+  if (!prober || prober.state === 'crashed') return;
+  const view = prober.membershipView.get(to);
+  if (!view || view.state !== 'suspect') return;
+
+  view.state = 'dead';
+  logEvent(sim, `N${from} declares N${to} DEAD`);
+
+  prober.probeOrder = prober.probeOrder.filter(id => id !== to);
+  shuffle(prober.probeOrder);
+  if (!prober.deadNodes.includes(to)) prober.deadNodes.push(to);
+
+  const entry = { memberId: to, state: 'dead', incarnation: view.incarnation };
+  enqueueGossipUpdate(prober, entry);
+
+  if (sim.params.broadcastDisputes) {
+    [...sim.nodes.values()]
+      .filter(n => n.id !== from && n.state === 'alive' && !isPartitioned(sim, from, n.id))
+      .forEach(n => sendGossip(sim, from, n.id, [entry], 0));
+  }
+}
+
+function handleProbeReceived(sim, event, wallTime) {
+  const { from, to } = event;
+  // `from` = prober, `to` = us (the probed node)
+  const target = sim.nodes.get(to);
+  if (!target || target.state === 'crashed' || isPartitioned(sim, to, from)) return;
+
+  sim.msgCount++;
+  sim.inFlightMessages.push({
+    id: sim.nextMsgId++, from: to, to: from, label: 'P✓', color: 'var(--viz-gossip-update)',
+    startWallTime: wallTime, durationMs: 300,
+    payload: { type: 'PROBE_ACK' },
+  });
+  sim.eventQueue.push({
+    type: 'MSG_DELIVER', simTime: sim.simTime + 1, from: to, to: from,
+    payload: { type: 'PROBE_ACK' },
+  });
+}
+}

--- a/monorepo-docs-site/src/css/custom.css
+++ b/monorepo-docs-site/src/css/custom.css
@@ -37,3 +37,23 @@ body {
         roboto, oxygen, ubuntu, cantarell, fira sans, droid sans, helvetica neue,
         sans-serif !important;
 }
+
+/* SWIM simulator palette */
+:root {
+    --viz-suspect: #f57c00;
+    --viz-suspect-light: #fff3e0;
+    --viz-gossip-update: #2e7d32;
+    --viz-gossip-update-light: #e8f5e9;
+    --viz-msg-probe: #f57c00;
+    --viz-msg-sync: #1565c0;
+    --viz-gossip-exclude: #f9a825;
+}
+[data-theme='dark'] {
+    --viz-suspect: #ffb74d;
+    --viz-suspect-light: #3e2000;
+    --viz-gossip-update: #66bb6a;
+    --viz-gossip-update-light: #1b2e1b;
+    --viz-msg-probe: #ffb74d;
+    --viz-msg-sync: #42a5f5;
+    --viz-gossip-exclude: #ffe082;
+}

--- a/monorepo-docs-site/src/css/custom.css
+++ b/monorepo-docs-site/src/css/custom.css
@@ -57,3 +57,13 @@ body {
     --viz-msg-sync: #42a5f5;
     --viz-gossip-exclude: #ffe082;
 }
+
+/* Shared viz palette (also defined in partition-distribution-viz branch — merge-safe) */
+:root {
+    --viz-leader: #c62828;
+    --viz-leader-light: #ffebee;
+}
+[data-theme='dark'] {
+    --viz-leader: #ef9a9a;
+    --viz-leader-light: #3e0a0a;
+}


### PR DESCRIPTION
## Summary

- Adds an interactive SWIM membership protocol simulator to the monorepo docs site under **Architecture → Components → Orchestration Cluster → Membership Simulator (SWIM)**
- Simulator lets engineers explore gossip propagation, failure detection, and anti-entropy sync with real-time animation and injectable faults
- Faithful to `SwimMembershipProtocol.java`: indirect probes (`suspectProbes-1` delegates), shuffle+round-robin probe selection, dead-node resurrection, gossip of `BrokerInfo`-style property updates, all 10 configurable parameters exposed

## What's included

- `swimSimEngine.js` — pure-JS discrete-event simulation engine (no React, no external deps)
- `SwimMembershipSimulator.js` — React component with SVG node graph, animated message circles, collapsible parameter panel, stats bar, event log, fault injection controls
- `SwimMembershipSimulator.module.css` — full stylesheet using `--ifm-*` and `--viz-*` CSS variables for light/dark mode

## Fault injection

- **Crash / Restore** — triggers the full probe → indirect probe → suspect → dead pipeline
- **Property update** — gossips a `BrokerInfo`-style change and shows convergence time
- **Network partition** — directed asymmetric link blocking (A→B but not B→A)
- **Gossip exclude** — simulates a node being consistently unlucky in fanout selection (shows sync-interval as safety net)

## Notes

- Prose in "Failure detection and indirect probes" and "Parameters" sections is placeholder — to be revised with the author
- `--viz-leader*` variables are also defined in PR #53750 (partition distributor); the duplicate `:root` blocks are merge-safe (CSS last-write wins; they'll be de-duped when both PRs land)

## Test plan

- [ ] Start docs site with `cd monorepo-docs-site && npm start`
- [ ] Navigate to Architecture → Components → Orchestration Cluster → Membership Simulator (SWIM)
- [ ] Confirm simulator renders with node graph and controls
- [ ] Click ▶ Play — verify `G~` message circles animate and round counter increments
- [ ] Crash a node — verify it goes grey, then other nodes show orange suspect → red dead states
- [ ] Restore the crashed node — verify it rejoins probe rotations
- [ ] Inject a property update — verify `G↑` circles spread and convergence time appears
- [ ] Add a directed partition (A→B) — verify dashed red arrow appears on that edge
- [ ] Toggle gossip exclude on a node — verify yellow dashed ring appears and node stops receiving gossip
- [ ] Adjust parameters (lower gossipInterval, higher fanout) — verify visual changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)