### PR TITLE
fix: update preview environment chart values for camunda-platform 15.0.0-alphax

### DIFF
--- a/.ci/preview-environments/charts/c8sm/values.yaml
+++ b/.ci/preview-environments/charts/c8sm/values.yaml
@@ -129,7 +129,7 @@ camunda-platform:
     #   registry: camunda/console
     # Overrides the default service URL because the preview environment
     # is exposed through its own (separate)ingress controller.
-    overrideConfiguration: |
+    configuration: |
       camunda:
         console:
           managed:

--- a/.ci/preview-environments/charts/c8sm/values.yaml
+++ b/.ci/preview-environments/charts/c8sm/values.yaml
@@ -79,6 +79,11 @@ global:
         redirectUrl: https://{{ include "ingress.domain" . }}/modeler
     keycloak:
       contextPath: /auth
+      auth:
+        adminUser: admin
+        secret:
+          existingSecret: camunda-credentials
+          existingSecretKey: identity-keycloak-admin-password
 
   zeebeClusterName: zeebe-cluster
 

--- a/.ci/preview-environments/charts/c8sm/values.yaml
+++ b/.ci/preview-environments/charts/c8sm/values.yaml
@@ -140,26 +140,44 @@ camunda-platform:
             releases:
             - name: {{ .Release.Name }}
               namespace: {{ .Release.Namespace }}
+              version: 8.10.0-alphax
               components:
               - id: console
+                version: 8.10.0-alphax
                 url: https://{{ include "ingress.domain" . }}{{ .Values.console.contextPath }}
+                readiness: http://{{ .Values.console.fullnameOverride }}.{{ .Release.Namespace }}:{{ .Values.console.service.managementPort }}{{ .Values.console.readinessProbe.probePath }}
               - id: keycloak
+                version: 8.10.0-alphax
                 url: https://{{ include "ingress.domain" . }}{{ .Values.global.identity.keycloak.contextPath }}
               - id: identity
+                version: 8.10.0-alphax
                 url: https://{{ include "ingress.domain" . }}{{ .Values.identity.contextPath }}
+                readiness: http://{{ .Values.identity.fullnameOverride }}.{{ .Release.Namespace }}:{{ .Values.identity.service.metricsPort }}{{ .Values.identity.readinessProbe.probePath }}
               - id: webModelerWebApp
+                version: 8.10.0-alphax
                 url: https://{{ include "ingress.domain" . }}{{ .Values.webModeler.contextPath }}
+                readiness: http://{{ .Values.webModeler.fullnameOverride }}-restapi.{{ .Release.Namespace }}:{{ .Values.webModeler.restapi.service.managementPort }}{{ .Values.webModeler.contextPath }}{{ .Values.webModeler.restapi.readinessProbe.probePath }}
               - id: optimize
+                version: 8.10.0-alphax
                 url: https://{{ include "ingress.domain" . }}{{ .Values.optimize.contextPath }}
+                readiness: http://{{ .Values.optimize.fullnameOverride }}.{{ .Release.Namespace }}:{{ .Values.optimize.service.port }}{{ .Values.optimize.contextPath }}{{ .Values.optimize.readinessProbe.probePath }}
               - id: operate
+                version: 8.10.0-alphax
                 url: https://{{ include "ingress.domain" . }}{{ .Values.orchestration.contextPath }}/operate
+                readiness: http://{{ .Values.orchestration.fullnameOverride }}.{{ .Release.Namespace }}:{{ .Values.orchestration.service.managementPort }}{{ .Values.orchestration.contextPath }}{{ .Values.orchestration.readinessProbe.probePath }}
               - id: tasklist
+                version: 8.10.0-alphax
                 url: https://{{ include "ingress.domain" . }}{{ .Values.orchestration.contextPath }}/tasklist
+                readiness: http://{{ .Values.orchestration.fullnameOverride }}.{{ .Release.Namespace }}:{{ .Values.orchestration.service.managementPort }}{{ .Values.orchestration.contextPath }}{{ .Values.orchestration.readinessProbe.probePath }}
               - id: coreIdentity
+                version: 8.10.0-alphax
                 url: https://{{ include "ingress.domain" . }}{{ .Values.orchestration.contextPath }}/identity
               - id: connectors
+                version: 8.10.0-alphax
                 url: https://{{ include "ingress.domain" . }}{{ .Values.connectors.contextPath }}
+                readiness: http://{{ .Values.connectors.fullnameOverride }}.{{ .Release.Namespace }}:{{ .Values.connectors.service.serverPort }}{{ .Values.connectors.contextPath }}{{ .Values.connectors.readinessProbe.probePath }}
               - id: core
+                version: 8.10.0-alphax
                 urls:
                   http: https://{{ include "ingress.domain" . }}{{ .Values.orchestration.contextPath }}
     env:
@@ -378,14 +396,13 @@ camunda-platform:
       clusters:
         - id: "default-cluster"
           name: "Default Cluster"
-          version: "8.9.0"
+          version: "8.10.0-alphax"
           authentication: "BEARER_TOKEN"
           authorizations:
             enabled: true
           url:
             grpc: "grpc://orchestration-gateway:26500"
             rest: "http://orchestration-gateway:8080/orchestration"
-            web-app: "https://{{ include \"ingress.domain\" . }}/orchestration"
       resources:
         limits:
           cpu: "1"

--- a/.ci/preview-environments/charts/c8sm/values.yaml
+++ b/.ci/preview-environments/charts/c8sm/values.yaml
@@ -68,8 +68,6 @@ global:
         secret:
           existingSecret: camunda-credentials
           existingSecretKey: identity-console-client-token
-      orchestration:
-        redirectUrl: https://{{ include "ingress.domain" . }}/orchestration
       optimize:
         redirectUrl: https://{{ include "ingress.domain" . }}/optimize
         secret:
@@ -203,6 +201,7 @@ camunda-platform:
       authentication:
         method: oidc
         oidc:
+          redirectUrl: https://{{ include "ingress.domain" . }}/orchestration
           secret:
             existingSecret: camunda-credentials
             existingSecretKey: identity-orchestration-client-token


### PR DESCRIPTION
## Description

Related to https://camunda.slack.com/archives/C071KP5BTHB/p1779696452232159.

Fix the preview environment (8.10/main) deployment that broke after upgrading from camunda-platform chart 14.x to 15.0.0-alpha1.

### Changes

1. **Rename `console.overrideConfiguration` → `console.configuration`** — old key removed in chart v15
2. **Wire Keycloak admin secret to Identity** — v15 removed the helper that auto-derived the admin password
3. **Set orchestration OIDC redirect URL** — required for login flow
4. **Add version and readiness to Console managed components** — fixes "Object Conversion Error" caused by missing version fields; adds readiness probe URLs for health monitoring

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [x] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

N/A — fixes broken preview environment deployment on main after chart upgrade to 15.0.0-alpha1.