### PR TITLE
feat: expose job priority via Search job API

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/JobSearchColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/JobSearchColumn.java
@@ -22,6 +22,7 @@ public enum JobSearchColumn implements SearchColumn<JobEntity> {
   JOB_KEY("jobKey"),
   KIND("kind"),
   LISTENER_EVENT_TYPE("listenerEventType"),
+  PRIORITY("priority"),
   PROCESS_DEFINITION_ID("processDefinitionId"),
   PROCESS_DEFINITION_KEY("processDefinitionKey"),
   PROCESS_INSTANCE_KEY("processInstanceKey"),

--- a/db/rdbms/src/main/resources/mapper/JobMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/JobMapper.xml
@@ -205,6 +205,12 @@
           <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
         </foreach>
       </if>
+      <if test="filter.priorityOperations != null and !filter.priorityOperations.isEmpty()">
+        <foreach collection="filter.priorityOperations" item="operation">
+          AND PRIORITY
+          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
       <if test="filter.creationTimeOperations != null and !filter.creationTimeOperations.isEmpty()">
         <foreach collection="filter.creationTimeOperations" item="operation">
           AND CREATION_TIME

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
@@ -251,6 +251,9 @@ public class SearchQueryFilterMapper {
       ofNullable(filter.getRetries())
           .map(mapToIntegerOperations("retries", validationErrors))
           .ifPresent(builder::retriesOperations);
+      ofNullable(filter.getPriority())
+          .map(mapToIntegerOperations("priority", validationErrors))
+          .ifPresent(builder::priorityOperations);
       ofNullable(filter.getCreationTime())
           .map(mapToOffsetDateTimeOperations("creationTime", validationErrors))
           .ifPresent(builder::creationTimeOperations);

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -783,6 +783,7 @@ public final class SearchQueryResponseMapper {
         .jobKey(keyToString(job.jobKey()))
         .kind(JobKindEnum.fromValue(job.kind().name()))
         .listenerEventType(JobListenerEventTypeEnum.fromValue(job.listenerEventType().name()))
+        .priority(requireNonNullElse(job.priority(), 0))
         .processDefinitionId(job.processDefinitionId())
         .processDefinitionKey(keyToString(job.processDefinitionKey()))
         .processInstanceKey(keyToString(job.processInstanceKey()))

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQuerySortRequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQuerySortRequestMapper.java
@@ -434,6 +434,7 @@ public class SearchQuerySortRequestMapper {
         case END_TIME -> builder.endTime();
         case TENANT_ID -> builder.tenantId();
         case RETRIES -> builder.retries();
+        case PRIORITY -> builder.priority();
         case IS_DENIED -> builder.isDenied();
         case DENIED_REASON -> builder.deniedReason();
         case HAS_FAILED_WITH_RETRIES_LEFT -> builder.hasFailedWithRetriesLeft();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/job/JobIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/job/JobIT.java
@@ -23,7 +23,9 @@ import io.camunda.it.rdbms.db.fixtures.ProcessDefinitionFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
 import io.camunda.search.entities.JobEntity;
+import io.camunda.search.filter.Operation;
 import io.camunda.search.query.JobQuery;
+import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.sort.JobSort;
 import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import java.time.OffsetDateTime;
@@ -443,5 +445,115 @@ public class JobIT {
     assertThat(searchResult.items()).hasSize(2);
     assertThat(searchResult.items().stream().map(JobEntity::jobKey))
         .containsExactlyInAnyOrder(item1.jobKey(), item3.jobKey());
+  }
+
+  @TestTemplate
+  public void shouldFindJobByPriorityFilter(final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final JobDbReader jobReader = rdbmsService.getJobReader();
+
+    final var processDefinitionKey = nextKey();
+    final var target =
+        createAndSaveJob(
+            rdbmsWriters, b -> b.priority(99).processDefinitionKey(processDefinitionKey));
+    for (int i = 0; i < 5; i++) {
+      createAndSaveJob(rdbmsWriters, b -> b.priority(5).processDefinitionKey(processDefinitionKey));
+    }
+
+    // when / then
+    final var exactResult = searchByPriority(jobReader, processDefinitionKey, Operation.eq(99));
+    assertThat(exactResult.total()).isEqualTo(1);
+    assertThat(exactResult.items().getFirst().jobKey()).isEqualTo(target.jobKey());
+    assertThat(exactResult.items().getFirst().priority()).isEqualTo(99);
+
+    // when / then
+    final var rangeResult = searchByPriority(jobReader, processDefinitionKey, Operation.gte(95));
+    assertThat(rangeResult.total()).isEqualTo(1);
+    assertThat(rangeResult.items().getFirst().jobKey()).isEqualTo(target.jobKey());
+  }
+
+  @TestTemplate
+  public void shouldFindJobSortedByPriority(final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final JobDbReader jobReader = rdbmsService.getJobReader();
+
+    final var processDefinitionKey = nextKey();
+    final var low =
+        createAndSaveJob(
+            rdbmsWriters, b -> b.priority(10).processDefinitionKey(processDefinitionKey));
+    final var mid =
+        createAndSaveJob(
+            rdbmsWriters, b -> b.priority(50).processDefinitionKey(processDefinitionKey));
+    final var high =
+        createAndSaveJob(
+            rdbmsWriters, b -> b.priority(90).processDefinitionKey(processDefinitionKey));
+
+    // when / then — descending
+    final var descResult = searchSortedByPriority(jobReader, processDefinitionKey, false);
+    assertThat(descResult.total()).isEqualTo(3);
+    assertThat(descResult.items().stream().map(JobEntity::jobKey))
+        .containsExactly(high.jobKey(), mid.jobKey(), low.jobKey());
+
+    // when / then — ascending
+    final var ascResult = searchSortedByPriority(jobReader, processDefinitionKey, true);
+    assertThat(ascResult.items().stream().map(JobEntity::jobKey))
+        .containsExactly(low.jobKey(), mid.jobKey(), high.jobKey());
+  }
+
+  @TestTemplate
+  public void shouldExcludeNullPriorityJobsFromPriorityFilter(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given — a job with NULL priority (pre-8.10) and a job with explicit priority
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final JobDbReader jobReader = rdbmsService.getJobReader();
+
+    final var processDefinitionKey = nextKey();
+    createAndSaveJob(
+        rdbmsWriters, b -> b.priority(null).processDefinitionKey(processDefinitionKey));
+    final var explicitPriorityJob =
+        createAndSaveJob(
+            rdbmsWriters, b -> b.priority(5).processDefinitionKey(processDefinitionKey));
+
+    // when — filter includes values that NULL would match if treated as 0 (e.g. lte(0))
+    final var lteZeroResult = searchByPriority(jobReader, processDefinitionKey, Operation.lte(0));
+
+    // then — the NULL-priority job is excluded; only explicit-priority jobs satisfying the
+    // comparison are returned
+    assertThat(lteZeroResult.total()).isEqualTo(0);
+
+    // when — filter that the explicit-priority job satisfies
+    final var gteOneResult = searchByPriority(jobReader, processDefinitionKey, Operation.gte(1));
+
+    // then — only the explicit-priority job is returned
+    assertThat(gteOneResult.total()).isEqualTo(1);
+    assertThat(gteOneResult.items().getFirst().jobKey()).isEqualTo(explicitPriorityJob.jobKey());
+  }
+
+  @SafeVarargs
+  private static SearchQueryResult<JobEntity> searchByPriority(
+      final JobDbReader reader, final long processDefinitionKey, final Operation<Integer>... ops) {
+    return reader.search(
+        JobQuery.of(
+            b ->
+                b.filter(
+                        f ->
+                            f.processDefinitionKeys(processDefinitionKey)
+                                .priorityOperations(List.of(ops)))
+                    .page(p -> p.from(0).size(20))));
+  }
+
+  private static SearchQueryResult<JobEntity> searchSortedByPriority(
+      final JobDbReader reader, final long processDefinitionKey, final boolean ascending) {
+    return reader.search(
+        JobQuery.of(
+            b ->
+                b.filter(f -> f.processDefinitionKeys(processDefinitionKey))
+                    .sort(s -> ascending ? s.priority().asc() : s.priority().desc())
+                    .page(p -> p.from(0).size(20))));
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/JobFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/JobFilterTransformer.java
@@ -9,6 +9,7 @@ package io.camunda.search.clients.transformers.filter;
 
 import static io.camunda.search.clients.query.SearchQueryBuilders.and;
 import static io.camunda.search.clients.query.SearchQueryBuilders.dateTimeOperations;
+import static io.camunda.search.clients.query.SearchQueryBuilders.exists;
 import static io.camunda.search.clients.query.SearchQueryBuilders.intOperations;
 import static io.camunda.search.clients.query.SearchQueryBuilders.longOperations;
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringOperations;
@@ -32,6 +33,7 @@ import static io.camunda.webapps.schema.descriptors.template.JobTemplate.JOB_TYP
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.JOB_WORKER;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.LAST_UPDATE_TIME;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.LISTENER_EVENT_TYPE;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.PRIORITY;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.PROCESS_DEFINITION_KEY;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.RETRIES;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.TENANT_ID;
@@ -41,6 +43,7 @@ import static java.util.Optional.ofNullable;
 
 import io.camunda.search.clients.query.SearchQuery;
 import io.camunda.search.filter.JobFilter;
+import io.camunda.search.filter.Operator;
 import io.camunda.security.auth.Authorization;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import java.util.ArrayList;
@@ -78,6 +81,18 @@ public class JobFilterTransformer extends IndexFilterTransformer<JobFilter> {
     of(longOperations(PROCESS_INSTANCE_KEY, filter.processInstanceKeyOperations()))
         .ifPresent(queries::addAll);
     of(intOperations(RETRIES, filter.retriesOperations())).ifPresent(queries::addAll);
+    final var priorityOps = filter.priorityOperations();
+    if (!priorityOps.isEmpty()) {
+      queries.addAll(intOperations(PRIORITY, priorityOps));
+      // NOT_EQUALS and NOT_IN match absent-field docs in ES/OS, so pre-8.10 jobs (which have no
+      // stored priority) would wrongly appear. Guard with exists() to enforce the API contract:
+      // "Jobs created before 8.10 are excluded from results when this filter is applied."
+      if (priorityOps.stream()
+          .anyMatch(
+              op -> op.operator() == Operator.NOT_EQUALS || op.operator() == Operator.NOT_IN)) {
+        queries.add(exists(PRIORITY));
+      }
+    }
     of(stringOperations(JOB_STATE, filter.stateOperations())).ifPresent(queries::addAll);
     of(stringOperations(TENANT_ID, filter.tenantIdOperations())).ifPresent(queries::addAll);
     of(stringOperations(JOB_TYPE, filter.typeOperations())).ifPresent(queries::addAll);

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/JobFieldSortingTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/JobFieldSortingTransformer.java
@@ -24,6 +24,7 @@ import static io.camunda.webapps.schema.descriptors.template.JobTemplate.JOB_TYP
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.JOB_WORKER;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.LAST_UPDATE_TIME;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.LISTENER_EVENT_TYPE;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.PRIORITY;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.PROCESS_DEFINITION_KEY;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.PROCESS_INSTANCE_KEY;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.RETRIES;
@@ -48,6 +49,7 @@ public class JobFieldSortingTransformer implements FieldSortingTransformer {
       case "endTime" -> TIME;
       case "tenantId" -> TENANT_ID;
       case "retries" -> RETRIES;
+      case "priority" -> PRIORITY;
       case "isDenied" -> JOB_DENIED;
       case "deniedReason" -> JOB_DENIED_REASON;
       case "hasFailedWithRetriesLeft" -> JOB_FAILED_WITH_RETRIES_LEFT;

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/JobQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/JobQueryTransformerTest.java
@@ -10,8 +10,10 @@ package io.camunda.search.clients.transformers.filter;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.search.clients.query.SearchBoolQuery;
+import io.camunda.search.clients.query.SearchExistsQuery;
 import io.camunda.search.clients.query.SearchMatchNoneQuery;
 import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.search.clients.query.SearchRangeQuery;
 import io.camunda.search.clients.query.SearchTermQuery;
 import io.camunda.search.clients.query.SearchTermsQuery;
 import io.camunda.search.clients.types.TypedValue;
@@ -379,6 +381,65 @@ public class JobQueryTransformerTest extends AbstractTransformerTest {
   }
 
   @Test
+  public void shouldQueryByPriorityGteAboveZero() {
+    // given
+    final var filter = FilterBuilders.job(b -> b.priorityOperations(Operation.gte(5)));
+
+    // when
+    final var searchQuery = transformQuery(filter);
+
+    // then
+    assertThat(searchQuery.queryOption())
+        .isNotNull()
+        .isInstanceOfSatisfying(
+            SearchRangeQuery.class,
+            q -> {
+              assertThat(q.field()).isEqualTo("priority");
+              assertThat(q.gte()).isEqualTo(5);
+            });
+  }
+
+  @Test
+  public void shouldQueryByPriorityGtZero() {
+    // given
+    final var filter = FilterBuilders.job(b -> b.priorityOperations(Operation.gt(0)));
+
+    // when
+    final var searchQuery = transformQuery(filter);
+
+    // then
+    assertThat(searchQuery.queryOption())
+        .isNotNull()
+        .isInstanceOfSatisfying(
+            SearchRangeQuery.class,
+            q -> {
+              assertThat(q.field()).isEqualTo("priority");
+              assertThat(q.gt()).isEqualTo(0);
+            });
+  }
+
+  @Test
+  public void shouldQueryByCompoundPriorityRange() {
+    // given — gte(1) AND lte(10) form the range [1,10]
+    final var filter =
+        FilterBuilders.job(b -> b.priorityOperations(Operation.gte(1), Operation.lte(10)));
+
+    // when
+    final var searchQuery = transformQuery(filter);
+
+    // then — a single range query with both bounds
+    assertThat(searchQuery.queryOption())
+        .isNotNull()
+        .isInstanceOfSatisfying(
+            SearchRangeQuery.class,
+            q -> {
+              assertThat(q.field()).isEqualTo("priority");
+              assertThat(q.gte()).isEqualTo(1);
+              assertThat(q.lte()).isEqualTo(10);
+            });
+  }
+
+  @Test
   public void shouldIgnoreTenantCheckWhenDisabled() {
     // given
     final var tenantCheck = TenantCheck.disabled();
@@ -411,5 +472,82 @@ public class JobQueryTransformerTest extends AbstractTransformerTest {
     final var queryVariant = searchQuery.queryOption();
     assertThat(queryVariant)
         .isInstanceOfSatisfying(SearchBoolQuery.class, t -> assertThat(t.must()).hasSize(3));
+  }
+
+  @Test
+  public void shouldIncludeExistsGuardForPriorityNotEquals() {
+    // given
+    final var filter = FilterBuilders.job(b -> b.priorityOperations(Operation.neq(5)));
+
+    // when
+    final var searchQuery = transformQuery(filter);
+
+    // then — must([mustNot(term(priority, 5)), exists(priority)]) to exclude pre-8.10 jobs
+    assertThat(searchQuery.queryOption())
+        .isNotNull()
+        .isInstanceOfSatisfying(
+            SearchBoolQuery.class,
+            boolQuery -> {
+              assertThat(boolQuery.must()).hasSize(2);
+              assertThat(boolQuery.must())
+                  .anySatisfy(
+                      q ->
+                          assertThat(q.queryOption())
+                              .isInstanceOfSatisfying(
+                                  SearchBoolQuery.class,
+                                  inner -> {
+                                    assertThat(inner.mustNot()).hasSize(1);
+                                    assertThat(inner.mustNot().getFirst().queryOption())
+                                        .isInstanceOfSatisfying(
+                                            SearchTermQuery.class,
+                                            term -> {
+                                              assertThat(term.field()).isEqualTo("priority");
+                                              assertThat(term.value().intValue()).isEqualTo(5);
+                                            });
+                                  }));
+              assertThat(boolQuery.must())
+                  .anySatisfy(
+                      q ->
+                          assertThat(q.queryOption())
+                              .isInstanceOfSatisfying(
+                                  SearchExistsQuery.class,
+                                  exists -> assertThat(exists.field()).isEqualTo("priority")));
+            });
+  }
+
+  @Test
+  public void shouldIncludeExistsGuardForPriorityNotIn() {
+    // given
+    final var filter = FilterBuilders.job(b -> b.priorityOperations(Operation.notIn(1, 2)));
+
+    // when
+    final var searchQuery = transformQuery(filter);
+
+    // then — must([mustNot(terms(priority, [1,2])), exists(priority)]) to exclude pre-8.10 jobs
+    assertThat(searchQuery.queryOption())
+        .isNotNull()
+        .isInstanceOfSatisfying(
+            SearchBoolQuery.class,
+            boolQuery -> {
+              assertThat(boolQuery.must()).hasSize(2);
+              assertThat(boolQuery.must())
+                  .anySatisfy(
+                      q ->
+                          assertThat(q.queryOption())
+                              .isInstanceOfSatisfying(
+                                  SearchBoolQuery.class,
+                                  inner -> {
+                                    assertThat(inner.mustNot()).hasSize(1);
+                                    assertThat(inner.mustNot().getFirst().queryOption())
+                                        .isInstanceOf(SearchTermsQuery.class);
+                                  }));
+              assertThat(boolQuery.must())
+                  .anySatisfy(
+                      q ->
+                          assertThat(q.queryOption())
+                              .isInstanceOfSatisfying(
+                                  SearchExistsQuery.class,
+                                  exists -> assertThat(exists.field()).isEqualTo("priority")));
+            });
   }
 }

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/JobSortTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/JobSortTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.sort;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.query.SearchQueryBuilders;
+import io.camunda.search.sort.SortOrder;
+import org.junit.jupiter.api.Test;
+
+public class JobSortTest extends AbstractSortTransformerTest {
+
+  @Test
+  public void shouldSortByPriorityDesc() {
+    // given
+    final var request = SearchQueryBuilders.jobSearchQuery(q -> q.sort(s -> s.priority().desc()));
+
+    // when
+    final var sort = transformRequest(request);
+
+    // then
+    assertThat(sort).hasSize(2); // [priority sort, default key sort]
+    assertThat(sort.getFirst().field().field()).isEqualTo("priority");
+    assertThat(sort.getFirst().field().order()).isEqualTo(SortOrder.DESC);
+    // Pre-8.10 jobs with no stored priority sort last (ES/OS _last default)
+    assertThat(sort.getFirst().field().missing()).isEqualTo("_last");
+  }
+
+  @Test
+  public void shouldSortByPriorityAsc() {
+    // given
+    final var request = SearchQueryBuilders.jobSearchQuery(q -> q.sort(s -> s.priority().asc()));
+
+    // when
+    final var sort = transformRequest(request);
+
+    // then
+    assertThat(sort).hasSize(2);
+    assertThat(sort.getFirst().field().field()).isEqualTo("priority");
+    assertThat(sort.getFirst().field().order()).isEqualTo(SortOrder.ASC);
+    assertThat(sort.getFirst().field().missing()).isEqualTo("_last");
+  }
+
+  @Test
+  public void shouldSortByOtherFieldsWithDefaultMissingLast() {
+    // given — retries is a comparable int field on jobs; it should keep the _last default
+    final var request = SearchQueryBuilders.jobSearchQuery(q -> q.sort(s -> s.retries().asc()));
+
+    // when
+    final var sort = transformRequest(request);
+
+    // then — missing is "_last" (the global default for forward pagination)
+    assertThat(sort).hasSize(2);
+    assertThat(sort.getFirst().field().field()).isEqualTo("retries");
+    assertThat(sort.getFirst().field().missing()).isEqualTo("_last");
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/filter/JobFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/JobFilter.java
@@ -34,6 +34,7 @@ public record JobFilter(
     List<Operation<String>> processDefinitionIdOperations,
     List<Operation<Long>> processInstanceKeyOperations,
     List<Operation<Integer>> retriesOperations,
+    List<Operation<Integer>> priorityOperations,
     List<Operation<String>> stateOperations,
     List<Operation<String>> tenantIdOperations,
     List<Operation<String>> typeOperations,
@@ -51,6 +52,7 @@ public record JobFilter(
     private Boolean hasFailedWithRetriesLeft;
     private Boolean isDenied;
     private List<Operation<Integer>> retriesOperations;
+    private List<Operation<Integer>> priorityOperations;
     private List<Operation<Long>> jobKeyOperations;
     private List<Operation<String>> kindOperations;
     private List<Operation<String>> listenerEventTypeOperations;
@@ -164,6 +166,21 @@ public record JobFilter(
 
     public Builder retries(final Integer value, final Integer... values) {
       return retriesOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder priorityOperations(final List<Operation<Integer>> operations) {
+      priorityOperations = addValuesToList(priorityOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder priorityOperations(
+        final Operation<Integer> operation, final Operation<Integer>... operations) {
+      return priorityOperations(collectValues(operation, operations));
+    }
+
+    public Builder priority(final Integer value, final Integer... values) {
+      return priorityOperations(FilterUtil.mapDefaultToOperation(value, values));
     }
 
     public Builder jobKeyOperations(final List<Operation<Long>> operations) {
@@ -395,6 +412,7 @@ public record JobFilter(
           Objects.requireNonNullElse(processDefinitionIdOperations, Collections.emptyList()),
           Objects.requireNonNullElse(processInstanceKeyOperations, Collections.emptyList()),
           Objects.requireNonNullElse(retriesOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(priorityOperations, Collections.emptyList()),
           Objects.requireNonNullElse(stateOperations, Collections.emptyList()),
           Objects.requireNonNullElse(tenantIdOperations, Collections.emptyList()),
           Objects.requireNonNullElse(typeOperations, Collections.emptyList()),

--- a/search/search-domain/src/main/java/io/camunda/search/sort/JobSort.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/JobSort.java
@@ -90,6 +90,11 @@ public record JobSort(List<FieldSorting> orderings) implements SortOption {
       return this;
     }
 
+    public JobSort.Builder priority() {
+      currentOrdering = new FieldSorting("priority", null);
+      return this;
+    }
+
     public JobSort.Builder isDenied() {
       currentOrdering = new FieldSorting("isDenied", null);
       return this;

--- a/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
@@ -552,6 +552,7 @@ components:
             - jobKey
             - kind
             - listenerEventType
+            - priority
             - processDefinitionId
             - processDefinitionKey
             - processInstanceKey
@@ -617,6 +618,12 @@ components:
           description: The listener event type of the job.
           allOf:
             - $ref: '#/components/schemas/JobListenerEventTypeFilterProperty'
+        priority:
+          description: >
+            The priority of the job. Jobs created before 8.10 have no stored priority
+            and are excluded from results when this filter is applied.
+          allOf:
+            - $ref: 'filters.yaml#/components/schemas/IntegerFilterProperty'
         processDefinitionId:
           description: The process definition ID associated with the job.
           allOf:
@@ -662,6 +669,8 @@ components:
           addedInVersion: "8.9"
         - propertyName: lastUpdateTime
           addedInVersion: "8.9"
+        - propertyName: priority
+          addedInVersion: "8.10"
 
     JobSearchQueryResult:
       description: Job search response.
@@ -687,6 +696,7 @@ components:
         - jobKey
         - kind
         - listenerEventType
+        - priority
         - processDefinitionId
         - processDefinitionKey
         - processInstanceKey
@@ -802,6 +812,14 @@ components:
           nullable: true
           type: string
           format: date-time
+        priority:
+          description: >
+            The priority of the job. Higher values indicate higher priority.
+            Jobs created before 8.10 have no stored priority; they appear last when sorting
+            by this field and are excluded when filtering by this field. The API returns 0
+            for such jobs.
+          type: integer
+          format: int32
       x-properties-added-in-version:
         - propertyName: rootProcessInstanceKey
           addedInVersion: "8.9"
@@ -809,6 +827,8 @@ components:
           addedInVersion: "8.9"
         - propertyName: lastUpdateTime
           addedInVersion: "8.9"
+        - propertyName: priority
+          addedInVersion: "8.10"
 
     JobFailRequest:
       type: object

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobQueryControllerTest.java
@@ -52,6 +52,7 @@ public class JobQueryControllerTest extends RestControllerTest {
                     "kind": "TASK_LISTENER",
                     "listenerEventType": "COMPLETING",
                     "retries": 3,
+                    "priority": 50,
                     "isDenied": true,
                     "deniedReason": "test denied reason",
                     "hasFailedWithRetriesLeft": false,
@@ -94,6 +95,7 @@ public class JobQueryControllerTest extends RestControllerTest {
                       .kind(JobKind.TASK_LISTENER)
                       .listenerEventType(ListenerEventType.COMPLETING)
                       .retries(3)
+                      .priority(50)
                       .isDenied(true)
                       .deniedReason("test denied reason")
                       .hasFailedWithRetriesLeft(false)
@@ -172,6 +174,7 @@ public class JobQueryControllerTest extends RestControllerTest {
         "processDefinitionKey": "2",
         "processInstanceKey": "3",
         "retries": 3,
+        "priority": -80,
         "state": "COMPLETED",
         "tenantId": "<default>",
         "type": "testJob",
@@ -219,6 +222,7 @@ public class JobQueryControllerTest extends RestControllerTest {
                             .processDefinitionKeys(2L)
                             .processInstanceKeys(3L)
                             .retries(3)
+                            .priority(-80)
                             .states(JobEntity.JobState.COMPLETED.name())
                             .tenantIds("<default>")
                             .types("testJob")
@@ -352,6 +356,7 @@ public class JobQueryControllerTest extends RestControllerTest {
       { "field": "state", "order": "desc" },
       { "field": "kind", "order": "asc" },
       { "field": "listenerEventType", "order": "desc" },
+      { "field": "priority", "order": "desc" },
       { "field": "retries", "order": "asc" },
       { "field": "isDenied", "order": "desc" },
       { "field": "deniedReason", "order": "asc" },
@@ -403,6 +408,8 @@ public class JobQueryControllerTest extends RestControllerTest {
                                 .asc()
                                 .listenerEventType()
                                 .desc()
+                                .priority()
+                                .desc()
                                 .retries()
                                 .asc()
                                 .isDenied()
@@ -433,5 +440,48 @@ public class JobQueryControllerTest extends RestControllerTest {
                                 .desc())
                     .build()),
             any());
+  }
+
+  @Test
+  void shouldReturnPriorityAsZeroWhenJobHasNoPriorityField() {
+    // given
+    final var jobWithNullPriority =
+        new JobEntity.Builder()
+            .jobKey(1L)
+            .type("testJob")
+            .worker("testWorker")
+            .state(JobState.COMPLETED)
+            .kind(JobKind.TASK_LISTENER)
+            .listenerEventType(ListenerEventType.COMPLETING)
+            .retries(3)
+            .hasFailedWithRetriesLeft(false)
+            .processDefinitionId("pd")
+            .processDefinitionKey(2L)
+            .processInstanceKey(3L)
+            .elementId("e")
+            .elementInstanceKey(4L)
+            .tenantId("<default>")
+            .creationTime(OffsetDateTime.parse("2025-06-05T09:00:00.000Z"))
+            .lastUpdateTime(OffsetDateTime.parse("2025-06-05T10:04:00.000Z"))
+            .build();
+    when(jobServices.search(any(JobQuery.class), any()))
+        .thenReturn(
+            new SearchQueryResult.Builder<JobEntity>()
+                .total(1L)
+                .items(List.of(jobWithNullPriority))
+                .startCursor("123base64")
+                .endCursor("456base64")
+                .build());
+
+    // when / then
+    webClient
+        .post()
+        .uri(JOB_SEARCH_URL)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$.items[0].priority")
+        .isEqualTo(0);
   }
 }


### PR DESCRIPTION
## Description

This PR exposes the new job `priority` field via the Search Jobs API.

This PR will require review from:
* Core Features Alpha: Ownining team
* Data Layer: We are introducing the `priority` field for jobs. Pre 8.10 jobs will not have that field populated (in ES/OS or RDBMS). This PR attempts to treat missing `priority` as 0 for API responses. It would be good to get feedback from the Data Layer team on this implementation
* API: Given that we are extending existing APIs we should get feedback from the API team

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes https://github.com/camunda/camunda/issues/53831
