### PR TITLE
doc: add spring-conventions.md doc for users and agents

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -20,6 +20,8 @@ Before modifying code in any module:
 2. Check `docs/` for cross-cutting guides (e.g., `docs/testing.md`, `docs/rest-controller.md`, or
    documents `docs/data-layer` when there are changes relating to secondary storage).
 3. If working on the workflow engine, read `zeebe/engine/README.md`.
+4. If working on a Spring-based module (e.g., `dist/`, `clients/`, `gateways/`,
+   `authentication/`), read `docs/spring-conventions.md`.
 
 Not every module has a README yet — when one exists, treat it as the primary reference for that
 module.

--- a/docs/spring-conventions.md
+++ b/docs/spring-conventions.md
@@ -1,0 +1,44 @@
+# Spring Conventions
+
+Conventions for Spring-based modules in this monorepo (e.g., `dist/`, `clients/`,
+`gateways/`, `authentication/`).
+
+## Avoid `@ConditionalOnBean` / `@ConditionalOnMissingBean` on `@Configuration` classes
+
+Per [Spring's documentation](https://docs.spring.io/spring-boot/reference/features/developing-auto-configuration.html#features.developing-auto-configuration.condition-annotations),
+these annotations should be limited to **auto-configuration** classes and not used on
+regular `@Configuration` classes.
+
+On a regular `@Configuration`, the result depends on bean-loading order. Because the
+order is not guaranteed, an unrelated change elsewhere can silently flip which branch
+applies. The "wrong" branch is often a no-op, so startup still succeeds and the bug only
+surfaces later, when the feature is actually exercised — and the configuration class
+itself looks untouched, making it hard to trace.
+
+### Do this instead
+
+Inject an `ObjectProvider<T>` and resolve the bean lazily:
+
+```java
+@Configuration
+class MyConfiguration {
+
+  @Bean
+  MyService myService(final ObjectProvider<OptionalDependency> dependency) {
+    final var dep = dependency.getIfAvailable();
+    if (dep == null) {
+      return MyService.noop(); // or: throw, return a default, log and degrade — pick per use case
+    }
+    return new MyService(dep);
+  }
+}
+```
+
+`ObjectProvider#getIfAvailable()` is evaluated after all bean definitions are
+registered, so bean-load order does not affect the outcome.
+
+> Note: these annotations exist for use on auto-configuration classes (registered via
+> `META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports`),
+> where Spring loads them after user beans. Unless you are writing an auto-configuration,
+> use `ObjectProvider`.
+


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Context: [Slack(internal)](https://camunda.slack.com/archives/C08F5RD5X8B/p1779088973368169)

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
