### PR TITLE
fix: remove hardcoded worker poll-interval override in load-tester

### DIFF
--- a/load-tests/load-tester/src/main/resources/application.yaml
+++ b/load-tests/load-tester/src/main/resources/application.yaml
@@ -62,7 +62,6 @@ camunda:
         type: ${LOAD_TESTER_WORKER_JOB_TYPE:benchmark-task}
         stream-enabled: true
         max-jobs-active: ${LOAD_TESTER_WORKER_CAPACITY:30}
-        poll-interval: ${LOAD_TESTER_WORKER_POLLING_DELAY:1s}
         # Default: completionDelay(300ms) * 6 = 1800ms. The old HOCON app computed
         # this dynamically; here it's static. Update if completionDelay changes.
         timeout: 1800ms

--- a/load-tests/load-tester/src/test/java/io/camunda/zeebe/it/CamundaClientConfigIT.java
+++ b/load-tests/load-tester/src/test/java/io/camunda/zeebe/it/CamundaClientConfigIT.java
@@ -60,7 +60,6 @@ class CamundaClientConfigIT {
     assertThat(workerDefaults.getType()).isEqualTo("benchmark-task");
     assertThat(workerDefaults.getStreamEnabled()).isTrue();
     assertThat(workerDefaults.getMaxJobsActive()).isEqualTo(30);
-    assertThat(workerDefaults.getPollInterval()).hasSeconds(1);
     assertThat(workerDefaults.getTimeout()).hasMillis(1800);
   }
 }


### PR DESCRIPTION
## Description
The poll-interval override forced a 1s polling delay regardless of the LOAD_TESTER_WORKER_POLLING_DELAY env var default behavior, masking the client default and skewing load-test backpressure characteristics.

## Checklist

<!--- Please delete options that are not relevant. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [x] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

Related PR: https://github.com/camunda/camunda-load-tests-helm/pull/71

closes #https://camunda.slack.com/archives/C0B3VTY272L/p1779445049283559
