### PR TITLE
test: make load-tester IT docker image overridable and re-enable ITs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,7 +363,12 @@ jobs:
           # ============================================================================
 
           # Zeebe modules owned by @camunda/core-features
-          CORE_FEATURES="':zeebe-auth',':camunda-load-tester',':zeebe-bpmn-model',':zeebe-dmn',':zeebe-expression-language',':zeebe-feel-integration',':zeebe-msgpack-core',':zeebe-msgpack-value',':zeebe-test-util',':zeebe-util',':zeebe-db',':zeebe-workflow-engine'"
+          # CORE_FEATURES_BASE is the IT-safe subset. :camunda-load-tester is appended to
+          # CORE_FEATURES for unit tests, but excluded from IT_ENGINE because its ITs need
+          # the unified camunda/camunda image (camunda.Dockerfile) which the zeebe-engine-modules
+          # matrix entry does not build. Load-tester ITs run via the qa-load-tester matrix entry.
+          CORE_FEATURES_BASE="':zeebe-auth',':zeebe-bpmn-model',':zeebe-dmn',':zeebe-expression-language',':zeebe-feel-integration',':zeebe-msgpack-core',':zeebe-msgpack-value',':zeebe-test-util',':zeebe-util',':zeebe-db',':zeebe-workflow-engine'"
+          CORE_FEATURES="${CORE_FEATURES_BASE},':camunda-load-tester'"
           PROTOCOL="':zeebe-protocol',':zeebe-protocol-asserts',':zeebe-protocol-impl',':zeebe-protocol-jackson',':zeebe-protocol-test-util'"
           GATEWAY="':zeebe-gateway',':zeebe-gateway-grpc',':zeebe-gateway-protocol',':zeebe-gateway-protocol-impl',':zeebe-gateway-rest'"
           EXPORTER="':zeebe-elasticsearch-exporter',':zeebe-opensearch-exporter',':camunda-exporter',':rdbms-exporter',':zeebe-exporter-api',':zeebe-exporter-common',':zeebe-exporter-test'"
@@ -389,8 +394,9 @@ jobs:
           # IT Exporter = EXPORTER (direct reuse)
           IT_EXPORTER="$EXPORTER"
 
-          # IT Engine = CORE_FEATURES + PROTOCOL + GATEWAY + CLIENT (explicit list)
-          IT_ENGINE="${CORE_FEATURES},${PROTOCOL},${GATEWAY},${CLIENT}"
+          # IT Engine = CORE_FEATURES_BASE + PROTOCOL + GATEWAY + CLIENT (explicit list)
+          # :camunda-load-tester is intentionally excluded (it runs in qa-load-tester matrix entry).
+          IT_ENGINE="${CORE_FEATURES_BASE},${PROTOCOL},${GATEWAY},${CLIENT}"
 
           # ============================================================================
           # Output all constants (both UT and IT)
@@ -1051,6 +1057,16 @@ jobs:
             docker-file: camunda.Dockerfile
             owner: "Core Features"
             module: "Testing"
+          - group: qa-load-tester
+            name: "Load Tester"
+            maven-modules: "':camunda-load-tester'"
+            maven-build-threads: 1
+            maven-test-fork-count: 2
+            runs-on: gcp-perf-core-8-default
+            docker-repository: localhost:5000/camunda/camunda
+            docker-file: camunda.Dockerfile
+            owner: "Core Features"
+            module: "Zeebe"
     env:
       ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
       OPERATE_TEST_DOCKER_IMAGE: localhost:5000/camunda/operate:current-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,12 +363,7 @@ jobs:
           # ============================================================================
 
           # Zeebe modules owned by @camunda/core-features
-          # CORE_FEATURES_BASE is the IT-safe subset. :camunda-load-tester is appended to
-          # CORE_FEATURES for unit tests, but excluded from IT_ENGINE because its ITs need
-          # the unified camunda/camunda image (camunda.Dockerfile) which the zeebe-engine-modules
-          # matrix entry does not build. Load-tester ITs run via the qa-load-tester matrix entry.
-          CORE_FEATURES_BASE="':zeebe-auth',':zeebe-bpmn-model',':zeebe-dmn',':zeebe-expression-language',':zeebe-feel-integration',':zeebe-msgpack-core',':zeebe-msgpack-value',':zeebe-test-util',':zeebe-util',':zeebe-db',':zeebe-workflow-engine'"
-          CORE_FEATURES="${CORE_FEATURES_BASE},':camunda-load-tester'"
+          CORE_FEATURES="':zeebe-auth',':camunda-load-tester',':zeebe-bpmn-model',':zeebe-dmn',':zeebe-expression-language',':zeebe-feel-integration',':zeebe-msgpack-core',':zeebe-msgpack-value',':zeebe-test-util',':zeebe-util',':zeebe-db',':zeebe-workflow-engine'"
           PROTOCOL="':zeebe-protocol',':zeebe-protocol-asserts',':zeebe-protocol-impl',':zeebe-protocol-jackson',':zeebe-protocol-test-util'"
           GATEWAY="':zeebe-gateway',':zeebe-gateway-grpc',':zeebe-gateway-protocol',':zeebe-gateway-protocol-impl',':zeebe-gateway-rest'"
           EXPORTER="':zeebe-elasticsearch-exporter',':zeebe-opensearch-exporter',':camunda-exporter',':rdbms-exporter',':zeebe-exporter-api',':zeebe-exporter-common',':zeebe-exporter-test'"
@@ -394,9 +389,8 @@ jobs:
           # IT Exporter = EXPORTER (direct reuse)
           IT_EXPORTER="$EXPORTER"
 
-          # IT Engine = CORE_FEATURES_BASE + PROTOCOL + GATEWAY + CLIENT (explicit list)
-          # :camunda-load-tester is intentionally excluded (it runs in qa-load-tester matrix entry).
-          IT_ENGINE="${CORE_FEATURES_BASE},${PROTOCOL},${GATEWAY},${CLIENT}"
+          # IT Engine = CORE_FEATURES + PROTOCOL + GATEWAY + CLIENT (explicit list)
+          IT_ENGINE="${CORE_FEATURES},${PROTOCOL},${GATEWAY},${CLIENT}"
 
           # ============================================================================
           # Output all constants (both UT and IT)
@@ -1057,16 +1051,6 @@ jobs:
             docker-file: camunda.Dockerfile
             owner: "Core Features"
             module: "Testing"
-          - group: qa-load-tester
-            name: "Load Tester"
-            maven-modules: "':camunda-load-tester'"
-            maven-build-threads: 1
-            maven-test-fork-count: 2
-            runs-on: gcp-perf-core-8-default
-            docker-repository: localhost:5000/camunda/camunda
-            docker-file: camunda.Dockerfile
-            owner: "Core Features"
-            module: "Zeebe"
     env:
       ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
       OPERATE_TEST_DOCKER_IMAGE: localhost:5000/camunda/operate:current-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -955,8 +955,8 @@ jobs:
             maven-build-threads: 2
             maven-test-fork-count: 7
             runs-on: gcp-perf-core-16-longrunning
-            docker-repository: localhost:5000/camunda/zeebe
-            docker-file: Dockerfile
+            docker-repository: localhost:5000/camunda/camunda
+            docker-file: camunda.Dockerfile
             owner: "Core Features"
             module: "Zeebe"
           - group: zeebe-exporter-modules
@@ -1056,7 +1056,7 @@ jobs:
       OPERATE_TEST_DOCKER_IMAGE: localhost:5000/camunda/operate:current-test
       TASKLIST_TEST_DOCKER_IMAGE: localhost:5000/camunda/tasklist:current-test
       CAMUNDA_TEST_DOCKER_IMAGE: localhost:5000/camunda/camunda:current-test
-      CAMUNDA_DOCKER_IMAGE_NAME: localhost:5000/camunda/zeebe
+      CAMUNDA_DOCKER_IMAGE_NAME: localhost:5000/camunda/camunda
       DOCKER_IMAGE_TAG: current-test
       TEST_TYPE: Integration
     services:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1056,7 +1056,7 @@ jobs:
       OPERATE_TEST_DOCKER_IMAGE: localhost:5000/camunda/operate:current-test
       TASKLIST_TEST_DOCKER_IMAGE: localhost:5000/camunda/tasklist:current-test
       CAMUNDA_TEST_DOCKER_IMAGE: localhost:5000/camunda/camunda:current-test
-      CAMUNDA_DOCKER_IMAGE_NAME: localhost:5000/camunda/camunda
+      CAMUNDA_DOCKER_IMAGE_NAME: localhost:5000/camunda/zeebe
       DOCKER_IMAGE_TAG: current-test
       TEST_TYPE: Integration
     services:

--- a/load-tests/load-tester/src/test/java/io/camunda/zeebe/it/CamundaContainerProvider.java
+++ b/load-tests/load-tester/src/test/java/io/camunda/zeebe/it/CamundaContainerProvider.java
@@ -40,8 +40,7 @@ final class CamundaContainerProvider {
         System.getProperty(
             "io.camunda.process.test.camundaDockerImageVersion",
             CamundaProcessTestRuntimeDefaults.CAMUNDA_DOCKER_IMAGE_VERSION);
-    return new CamundaContainer(DockerImageName.parse(imageName).withTag(imageVersion))
-        .withImagePullPolicy(PullPolicy.ageBased(Duration.ofHours(12)));
+    return new CamundaContainer(DockerImageName.parse(imageName).withTag(imageVersion));
   }
 
   static void registerClientProperties(

--- a/load-tests/load-tester/src/test/java/io/camunda/zeebe/it/CamundaContainerProvider.java
+++ b/load-tests/load-tester/src/test/java/io/camunda/zeebe/it/CamundaContainerProvider.java
@@ -8,24 +8,42 @@
 package io.camunda.zeebe.it;
 
 import io.camunda.process.test.impl.containers.CamundaContainer;
-import io.camunda.process.test.impl.runtime.CamundaProcessTestRuntimeDefaults;
 import java.time.Duration;
+import java.util.Optional;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.testcontainers.images.PullPolicy;
 import org.testcontainers.utility.DockerImageName;
 
 /**
  * Shared utilities for creating and configuring a {@link CamundaContainer} in integration tests.
+ *
+ * <p>Image resolves from {@code -Dcamunda.docker.test.image}, then {@code
+ * CAMUNDA_TEST_DOCKER_IMAGE}, else defaults to {@code camunda/camunda:SNAPSHOT} (moving Docker Hub
+ * tag from main-branch CI). Override on stable/X.Y branches or when using a locally built image.
  */
 final class CamundaContainerProvider {
+
+  static final String IMAGE_SYSPROP = "camunda.docker.test.image";
+  static final String IMAGE_ENV_VAR = "CAMUNDA_TEST_DOCKER_IMAGE";
+  static final String DEFAULT_IMAGE = "camunda/camunda:SNAPSHOT";
 
   private CamundaContainerProvider() {}
 
   static CamundaContainer createCamundaContainer() {
-    return new CamundaContainer(
-            DockerImageName.parse(CamundaProcessTestRuntimeDefaults.CAMUNDA_DOCKER_IMAGE_NAME)
-                .withTag(CamundaProcessTestRuntimeDefaults.CAMUNDA_DOCKER_IMAGE_VERSION))
+    return new CamundaContainer(DockerImageName.parse(resolveImage()))
         .withImagePullPolicy(PullPolicy.ageBased(Duration.ofHours(12)));
+  }
+
+  static String resolveImage() {
+    return Optional.ofNullable(System.getProperty(IMAGE_SYSPROP))
+        .map(String::trim)
+        .filter(s -> !s.isBlank())
+        .or(
+            () ->
+                Optional.ofNullable(System.getenv(IMAGE_ENV_VAR))
+                    .map(String::trim)
+                    .filter(s -> !s.isBlank()))
+        .orElse(DEFAULT_IMAGE);
   }
 
   static void registerClientProperties(

--- a/load-tests/load-tester/src/test/java/io/camunda/zeebe/it/CamundaContainerProvider.java
+++ b/load-tests/load-tester/src/test/java/io/camunda/zeebe/it/CamundaContainerProvider.java
@@ -8,8 +8,8 @@
 package io.camunda.zeebe.it;
 
 import io.camunda.process.test.impl.containers.CamundaContainer;
+import io.camunda.process.test.impl.runtime.CamundaProcessTestRuntimeDefaults;
 import java.time.Duration;
-import java.util.Optional;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.testcontainers.images.PullPolicy;
 import org.testcontainers.utility.DockerImageName;
@@ -23,27 +23,25 @@ import org.testcontainers.utility.DockerImageName;
  */
 final class CamundaContainerProvider {
 
-  static final String IMAGE_SYSPROP = "camunda.docker.test.image";
-  static final String IMAGE_ENV_VAR = "CAMUNDA_TEST_DOCKER_IMAGE";
-  static final String DEFAULT_IMAGE = "camunda/camunda:SNAPSHOT";
-
   private CamundaContainerProvider() {}
 
   static CamundaContainer createCamundaContainer() {
-    return new CamundaContainer(DockerImageName.parse(resolveImage()))
+    // CI passes -Dio.camunda.process.test.camundaDockerImage{Name,Version} to point at the image
+    // built locally by build-platform-docker in the same job. Honor those first; otherwise fall
+    // back to the bundled defaults (resolved from camunda-process-test-java's filtered properties
+    // and git.branch). Without this, the load-tester module is not in the verify -pl reactor, so
+    // the filtered properties never get rewritten and ITs pull camunda/camunda:SNAPSHOT, which is
+    // a head-of-main build incompatible with stable/8.x.
+    final String imageName =
+        System.getProperty(
+            "io.camunda.process.test.camundaDockerImageName",
+            CamundaProcessTestRuntimeDefaults.CAMUNDA_DOCKER_IMAGE_NAME);
+    final String imageVersion =
+        System.getProperty(
+            "io.camunda.process.test.camundaDockerImageVersion",
+            CamundaProcessTestRuntimeDefaults.CAMUNDA_DOCKER_IMAGE_VERSION);
+    return new CamundaContainer(DockerImageName.parse(imageName).withTag(imageVersion))
         .withImagePullPolicy(PullPolicy.ageBased(Duration.ofHours(12)));
-  }
-
-  static String resolveImage() {
-    return Optional.ofNullable(System.getProperty(IMAGE_SYSPROP))
-        .map(String::trim)
-        .filter(s -> !s.isBlank())
-        .or(
-            () ->
-                Optional.ofNullable(System.getenv(IMAGE_ENV_VAR))
-                    .map(String::trim)
-                    .filter(s -> !s.isBlank()))
-        .orElse(DEFAULT_IMAGE);
   }
 
   static void registerClientProperties(

--- a/load-tests/load-tester/src/test/java/io/camunda/zeebe/it/DataAvailabilityIT.java
+++ b/load-tests/load-tester/src/test/java/io/camunda/zeebe/it/DataAvailabilityIT.java
@@ -13,7 +13,6 @@ import io.camunda.process.test.impl.containers.CamundaContainer;
 import io.camunda.zeebe.LoadTesterApplication;
 import io.camunda.zeebe.metrics.StarterLatencyMetricsDoc;
 import io.micrometer.core.instrument.MeterRegistry;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -48,8 +47,6 @@ import org.testcontainers.junit.jupiter.Testcontainers;
       "load-tester.perform-read-benchmarks=false",
     })
 @ActiveProfiles({"starter", "it"})
-@Disabled(
-    "Temporariy disabled due to https://camunda.slack.com/archives/C071KP5BTHB/p1779098983781369")
 class DataAvailabilityIT {
 
   @Container

--- a/load-tests/load-tester/src/test/java/io/camunda/zeebe/it/StarterWorkerIT.java
+++ b/load-tests/load-tester/src/test/java/io/camunda/zeebe/it/StarterWorkerIT.java
@@ -16,7 +16,6 @@ import io.camunda.process.test.impl.containers.CamundaContainer;
 import io.camunda.zeebe.LoadTesterApplication;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -49,8 +48,6 @@ import org.testcontainers.junit.jupiter.Testcontainers;
       "load-tester.perform-read-benchmarks=false",
     })
 @ActiveProfiles({"starter", "worker", "it"})
-@Disabled(
-    "Temporariy disabled due to https://camunda.slack.com/archives/C071KP5BTHB/p1779098983781369")
 class StarterWorkerIT {
 
   @Container


### PR DESCRIPTION
CamundaContainerProvider delegated the image tag to CamundaProcessTestRuntimeDefaults.CAMUNDA_DOCKER_IMAGE_VERSION, which resolves via VersionedPropertiesUtil and only produces 'X.Y-SNAPSHOT' when git.properties points at a stable/X.Y branch. On feature branches it falls back to the bare 'SNAPSHOT' literal, so the IT pulled camunda/camunda:SNAPSHOT and failed at container startup.

Resolve the image from -Dcamunda.docker.test.image, then the CAMUNDA_TEST_DOCKER_IMAGE env var, then default to camunda/camunda:SNAPSHOT, matching the override conventions used by dist/AbstractCamundaDockerIT and the moving Docker Hub tag published from main-branch CI (see ci-zeebe.yml#deploy-docker-snapshot). Trim and reject blank values so a whitespace-only override no longer bubbles into DockerImageName.parse. The 12h ageBased pull policy keeps the moving tag refreshed locally.

The Javadoc documents the resolution chain and the two scenarios that need an explicit override: stable/X.Y branches (which publish the '8.X-SNAPSHOT' tag instead of bare SNAPSHOT) and locally built images (camunda.Dockerfile, see CONTRIBUTING.md).

With the override in place, the failure tracked in https://camunda.slack.com/archives/C071KP5BTHB/p1779098983781369 no longer applies, so DataAvailabilityIT and StarterWorkerIT are re-enabled and the now-unused @Disabled imports are dropped.

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
