### PR TITLE
feat: add zone to AdminRequest/BackupStatusReponse

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/FlowControlServiceImpl.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/FlowControlServiceImpl.java
@@ -93,8 +93,7 @@ public class FlowControlServiceImpl implements FlowControlService {
             .map(
                 brokerId -> {
                   final var request = new BrokerAdminRequest();
-                  // TODO: https://github.com/camunda/camunda/issues/52807
-                  request.setBrokerId(brokerId.nodeIdx());
+                  request.setBrokerId(brokerId);
                   request.setPartitionId(partitionId);
                   configureRequest.accept(request);
                   return client.sendRequest(request);
@@ -111,8 +110,7 @@ public class FlowControlServiceImpl implements FlowControlService {
           new IllegalStateException("No leader for partition " + partitionId));
     }
     final var request = new BrokerAdminRequest();
-    // TODO: https://github.com/camunda/camunda/issues/52807
-    request.setBrokerId(brokerId.nodeIdx());
+    request.setBrokerId(brokerId);
     request.setPartitionId(partitionId);
     request.getFLowControlConfiguration();
 

--- a/zeebe/backup-stores/azure/src/test/java/io/camunda/zeebe/backup/azure/AzureBackupStoreIT.java
+++ b/zeebe/backup-stores/azure/src/test/java/io/camunda/zeebe/backup/azure/AzureBackupStoreIT.java
@@ -111,7 +111,7 @@ public class AzureBackupStoreIT implements BackupStoreTestKit {
         .withMessageContaining(
             """
                 Cannot delete Backup with id \
-                'BackupId{node=1, partition=2, checkpoint=3}'\
+                'BackupId{node=1, zone=null, partition=2, checkpoint=3}'\
                 , must be marked as deleted.""");
   }
 
@@ -129,7 +129,7 @@ public class AzureBackupStoreIT implements BackupStoreTestKit {
         .withMessageContaining(
             """
                 Expected to restore from completed backup with id \
-                'BackupId{node=1, partition=2, checkpoint=3}', \
+                'BackupId{node=1, zone=null, partition=2, checkpoint=3}', \
                 but was in state 'IN_PROGRESS'""");
   }
 

--- a/zeebe/backup-stores/azure/src/test/java/io/camunda/zeebe/backup/azure/AzureBackupStoreIT.java
+++ b/zeebe/backup-stores/azure/src/test/java/io/camunda/zeebe/backup/azure/AzureBackupStoreIT.java
@@ -110,9 +110,9 @@ public class AzureBackupStoreIT implements BackupStoreTestKit {
         .withRootCauseInstanceOf(UnexpectedManifestState.class)
         .withMessageContaining(
             """
-                Cannot delete Backup with id \
-                'BackupId{node=1, zone=null, partition=2, checkpoint=3}'\
-                , must be marked as deleted.""");
+                Cannot delete Backup with id '%s'\
+                , must be marked as deleted."""
+                .formatted(backup.id()));
   }
 
   @ParameterizedTest
@@ -128,9 +128,9 @@ public class AzureBackupStoreIT implements BackupStoreTestKit {
         .withRootCauseInstanceOf(UnexpectedManifestState.class)
         .withMessageContaining(
             """
-                Expected to restore from completed backup with id \
-                'BackupId{node=1, zone=null, partition=2, checkpoint=3}', \
-                but was in state 'IN_PROGRESS'""");
+                Expected to restore from completed backup with id '%s', \
+                but was in state 'IN_PROGRESS'"""
+                .formatted(backup.id()));
   }
 
   @Test

--- a/zeebe/backup-stores/filesystem/src/test/java/io/camunda/zeebe/backup/filesystem/FilesystemBackupStoreIT.java
+++ b/zeebe/backup-stores/filesystem/src/test/java/io/camunda/zeebe/backup/filesystem/FilesystemBackupStoreIT.java
@@ -104,9 +104,9 @@ public class FilesystemBackupStoreIT implements BackupStoreTestKit {
         .withRootCauseInstanceOf(UnexpectedManifestState.class)
         .withMessageContaining(
             """
-                Cannot delete Backup with id \
-                'BackupId{node=1, zone=null, partition=2, checkpoint=3}'\
-                , must be marked as deleted.""");
+                Cannot delete Backup with id '%s'\
+                , must be marked as deleted."""
+                .formatted(backup.id()));
   }
 
   @ParameterizedTest
@@ -122,9 +122,9 @@ public class FilesystemBackupStoreIT implements BackupStoreTestKit {
         .withRootCauseInstanceOf(UnexpectedManifestState.class)
         .withMessageContaining(
             """
-                Expected to restore from completed backup with id \
-                'BackupId{node=1, zone=null, partition=2, checkpoint=3}', \
-                but was in state 'IN_PROGRESS'""");
+                Expected to restore from completed backup with id '%s', \
+                but was in state 'IN_PROGRESS'"""
+                .formatted(backup.id()));
   }
 
   @ParameterizedTest

--- a/zeebe/backup-stores/filesystem/src/test/java/io/camunda/zeebe/backup/filesystem/FilesystemBackupStoreIT.java
+++ b/zeebe/backup-stores/filesystem/src/test/java/io/camunda/zeebe/backup/filesystem/FilesystemBackupStoreIT.java
@@ -105,7 +105,7 @@ public class FilesystemBackupStoreIT implements BackupStoreTestKit {
         .withMessageContaining(
             """
                 Cannot delete Backup with id \
-                'BackupId{node=1, partition=2, checkpoint=3}'\
+                'BackupId{node=1, zone=null, partition=2, checkpoint=3}'\
                 , must be marked as deleted.""");
   }
 
@@ -123,7 +123,7 @@ public class FilesystemBackupStoreIT implements BackupStoreTestKit {
         .withMessageContaining(
             """
                 Expected to restore from completed backup with id \
-                'BackupId{node=1, partition=2, checkpoint=3}', \
+                'BackupId{node=1, zone=null, partition=2, checkpoint=3}', \
                 but was in state 'IN_PROGRESS'""");
   }
 

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/ManifestMetadata.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/ManifestMetadata.java
@@ -38,6 +38,7 @@ final class ManifestMetadata {
   static final String CHECKPOINT_POSITION = "checkpoint-position";
   static final String NUMBER_OF_PARTITIONS = "number-of-partitions";
   static final String BROKER_VERSION = "broker-version";
+  static final String ZONE = "zone";
   static final String CHECKPOINT_TIMESTAMP = "checkpoint-timestamp";
   static final String CHECKPOINT_TYPE = "checkpoint-type";
 
@@ -59,6 +60,10 @@ final class ManifestMetadata {
       if (failureReason != null) {
         metadata.put(FAILURE_REASON, failureReason);
       }
+    }
+
+    if (manifest.id().zone() != null) {
+      metadata.put(ZONE, manifest.id().zone());
     }
 
     final var descriptor = manifest.descriptor();
@@ -96,7 +101,7 @@ final class ManifestMetadata {
       return Optional.empty();
     }
 
-    final var id = parseIdentifierFromPath(blob.getName(), basePath, manifestBlobName);
+    final var id = parseIdentifierFromPath(blob.getName(), basePath, manifestBlobName, metadata);
     final var statusCode = BackupStatusCode.valueOf(metadata.get(STATUS_CODE));
     final var failureReason = Optional.ofNullable(metadata.get(FAILURE_REASON));
     final var created = Optional.ofNullable(metadata.get(CREATED_AT)).map(Instant::parse);
@@ -108,7 +113,10 @@ final class ManifestMetadata {
   }
 
   private static BackupIdentifier parseIdentifierFromPath(
-      final String blobName, final String basePath, final String manifestBlobName) {
+      final String blobName,
+      final String basePath,
+      final String manifestBlobName,
+      final Map<String, String> metadata) {
     // Path format: {basePath}manifests/{partitionId}/{checkpointId}/{nodeId}/manifest.json
     final var manifestsPrefix = basePath + "manifests/";
     final var relativePath =
@@ -116,7 +124,10 @@ final class ManifestMetadata {
     // relativePath is now: {partitionId}/{checkpointId}/{nodeId}/
     final var parts = relativePath.split("/");
     return new BackupIdentifierImpl(
-        Integer.parseInt(parts[2]), Integer.parseInt(parts[0]), Long.parseLong(parts[1]));
+        Integer.parseInt(parts[2]),
+        metadata.get(ZONE),
+        Integer.parseInt(parts[0]),
+        Long.parseLong(parts[1]));
   }
 
   private static Optional<BackupDescriptor> parseDescriptor(final Map<String, String> metadata) {

--- a/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ManifestMetadataTest.java
+++ b/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ManifestMetadataTest.java
@@ -208,6 +208,31 @@ final class ManifestMetadataTest {
           .doesNotContainKey(ManifestMetadata.CHECKPOINT_POSITION)
           .doesNotContainKey(ManifestMetadata.BROKER_VERSION);
     }
+
+    @Test
+    void shouldIncludeZoneWhenPresent() {
+      // given
+      final var backup =
+          new BackupImpl(
+              new BackupIdentifierImpl(1, "zone-a", 2, 3),
+              new BackupDescriptorImpl(
+                  Optional.of("snap-1"),
+                  OptionalLong.of(100L),
+                  500L,
+                  3,
+                  "8.5.0",
+                  Instant.parse("2025-01-15T10:30:00Z"),
+                  CheckpointType.MANUAL_BACKUP),
+              new NamedFileSetImpl(Map.of("file1", Path.of("f1"))),
+              new NamedFileSetImpl(Map.of("seg1", Path.of("s1"))));
+      final var manifest = Manifest.createInProgress(backup);
+
+      // when
+      final var metadata = ManifestMetadata.fromManifest(manifest);
+
+      // then
+      assertThat(metadata).containsEntry(ManifestMetadata.ZONE, "zone-a");
+    }
   }
 
   @Nested
@@ -258,6 +283,26 @@ final class ManifestMetadataTest {
       assertThat(status.id().partitionId()).isEqualTo(2);
       assertThat(status.id().checkpointId()).isEqualTo(3L);
       assertThat(status.id().nodeId()).isEqualTo(1);
+    }
+
+    @Test
+    void shouldParseZoneFromMetadata() {
+      // given
+      final var metadata =
+          Map.of(
+              ManifestMetadata.STATUS_CODE, "COMPLETED",
+              ManifestMetadata.CHECKPOINT_POSITION, "500",
+              ManifestMetadata.NUMBER_OF_PARTITIONS, "3",
+              ManifestMetadata.BROKER_VERSION, "8.5.0",
+              ManifestMetadata.ZONE, "zone-a");
+      final var blob = mockBlob(blobPath(2, 3, 1), metadata);
+
+      // when
+      final var result = ManifestMetadata.toBackupStatus(blob, BASE_PATH, MANIFEST_BLOB_NAME);
+
+      // then
+      assertThat(result).isPresent();
+      assertThat(result.orElseThrow().id().zone()).isEqualTo("zone-a");
     }
 
     @Test

--- a/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/util/S3TestBackupProvider.java
+++ b/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/util/S3TestBackupProvider.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.backup.testkit.support.TestBackupProvider.simpleB
 import static org.junit.jupiter.api.Named.named;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
+import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
 import io.camunda.zeebe.backup.testkit.support.TestBackupProvider;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.provider.Arguments;
@@ -20,6 +21,10 @@ public class S3TestBackupProvider extends TestBackupProvider {
   public static Stream<? extends Arguments> provideArguments() throws Exception {
     return Stream.of(
         arguments(named("stub", simpleBackup())),
+        arguments(
+            named(
+                "stub zone aware",
+                simpleBackupWithId(new BackupIdentifierImpl(1, "zone-a", 2, 3)))),
         arguments(named("stub without snapshot", backupWithoutSnapshot())));
   }
 }

--- a/zeebe/backup-stores/testkit/src/test/java/io/camunda/zeebe/backup/testkit/support/TestBackupProvider.java
+++ b/zeebe/backup-stores/testkit/src/test/java/io/camunda/zeebe/backup/testkit/support/TestBackupProvider.java
@@ -53,6 +53,10 @@ public class TestBackupProvider {
   public static Stream<? extends Arguments> provideArguments() throws Exception {
     return Stream.of(
         arguments(named("stub", simpleBackup())),
+        arguments(
+            named(
+                "stub zone aware",
+                simpleBackupWithId(new BackupIdentifierImpl(1, "zone-a", 2, 3)))),
         arguments(named("stub without snapshot", backupWithoutSnapshot())));
   }
 

--- a/zeebe/backup/pom.xml
+++ b/zeebe/backup/pom.xml
@@ -28,6 +28,11 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>zeebe-atomix-cluster</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>zeebe-stream-platform</artifactId>
     </dependency>
 

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupIdentifier.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupIdentifier.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.backup.api;
 
+import org.jspecify.annotations.Nullable;
+
 /** Uniquely identifies a backup stored in the BackupStore. */
 public interface BackupIdentifier {
 
@@ -14,6 +16,12 @@ public interface BackupIdentifier {
    * @return id of the broker which took this backup
    */
   int nodeId();
+
+  /**
+   * @return zone of the broker which took this backup, or {@code null} when the cluster is not
+   *     zone-aware
+   */
+  @Nullable String zone();
 
   /**
    * @return id of the partition of which the backup is taken

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/common/BackupIdentifierImpl.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/common/BackupIdentifierImpl.java
@@ -8,12 +8,18 @@
 package io.camunda.zeebe.backup.common;
 
 import io.camunda.zeebe.backup.api.BackupIdentifier;
+import org.jspecify.annotations.Nullable;
 
-public record BackupIdentifierImpl(int nodeId, int partitionId, long checkpointId)
+public record BackupIdentifierImpl(
+    int nodeId, @Nullable String zone, int partitionId, long checkpointId)
     implements BackupIdentifier {
 
+  public BackupIdentifierImpl(final int nodeId, final int partitionId, final long checkpointId) {
+    this(nodeId, null, partitionId, checkpointId);
+  }
+
   public static BackupIdentifierImpl from(final BackupIdentifier id) {
-    return new BackupIdentifierImpl(id.nodeId(), id.partitionId(), id.checkpointId());
+    return new BackupIdentifierImpl(id.nodeId(), id.zone(), id.partitionId(), id.checkpointId());
   }
 
   @Override
@@ -21,6 +27,8 @@ public record BackupIdentifierImpl(int nodeId, int partitionId, long checkpointI
     return "BackupId{"
         + "node="
         + nodeId
+        + ", zone="
+        + zone
         + ", partition="
         + partitionId
         + ", checkpoint="

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupService.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupService.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.backup.management;
 
+import io.atomix.cluster.BrokerMemberId;
 import io.camunda.zeebe.backup.api.BackupDescriptor;
 import io.camunda.zeebe.backup.api.BackupManager;
 import io.camunda.zeebe.backup.api.BackupRange;
@@ -39,7 +40,7 @@ public final class BackupService extends Actor implements BackupManager {
   private static final Logger LOG = LoggerFactory.getLogger(BackupService.class);
   private final String actorName;
   private final JournalInfoProvider journalInfoProvider;
-  private final int nodeId;
+  private final BrokerMemberId brokerMemberId;
   private final int partitionId;
   private final BackupServiceImpl internalBackupManager;
   private final PersistedSnapshotStore snapshotStore;
@@ -47,7 +48,7 @@ public final class BackupService extends Actor implements BackupManager {
   private final BackupManagerMetrics metrics;
 
   public BackupService(
-      final int nodeId,
+      final BrokerMemberId brokerMemberId,
       final int partitionId,
       final BackupStore backupStore,
       final PersistedSnapshotStore snapshotStore,
@@ -57,7 +58,7 @@ public final class BackupService extends Actor implements BackupManager {
       final LogStreamWriter logStreamWriter,
       final DbBackupRangeState backupRangeState,
       final DbCheckpointMetadataState checkpointMetadataState) {
-    this.nodeId = nodeId;
+    this.brokerMemberId = brokerMemberId;
     this.partitionId = partitionId;
     this.snapshotStore = snapshotStore;
     this.segmentsDirectory = segmentsDirectory;
@@ -239,6 +240,7 @@ public final class BackupService extends Actor implements BackupManager {
   }
 
   private BackupIdentifierImpl getBackupId(final long checkpointId) {
-    return new BackupIdentifierImpl(nodeId, partitionId, checkpointId);
+    return new BackupIdentifierImpl(
+        brokerMemberId.nodeIdx(), brokerMemberId.zone(), partitionId, checkpointId);
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupServiceTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupServiceTransitionStep.java
@@ -109,7 +109,7 @@ public final class BackupServiceTransitionStep implements PartitionTransitionSte
 
     final BackupService backupManager =
         new BackupService(
-            context.getMemberId().nodeIdx(),
+            context.getMemberId(),
             context.getPartitionId(),
             context.getBackupStore(),
             context.getPersistedSnapshotStore(),

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandler.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandler.java
@@ -375,7 +375,7 @@ public final class BackupApiRequestHandler
     final var response =
         new BackupStatusResponse()
             .setBackupId(status.id().checkpointId())
-            .setBrokerId(status.id().nodeId())
+            .setBrokerId(status.id().nodeId(), status.id().zone())
             .setPartitionId(status.id().partitionId())
             .setStatus(encodeStatusCode(status.statusCode()));
     status

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/backup/ConcurrentBackupCompactionTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/backup/ConcurrentBackupCompactionTest.java
@@ -13,6 +13,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.atomix.cluster.BrokerMemberId;
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionId;
 import io.atomix.primitive.partition.PartitionMetadata;
@@ -118,7 +119,7 @@ public class ConcurrentBackupCompactionTest extends DynamicAutoCloseable {
     backupService =
         manage(
             new BackupService(
-                nodeId,
+                BrokerMemberId.from(nodeId),
                 partitionId,
                 backupStore,
                 snapshotStore,

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandlerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandlerTest.java
@@ -68,7 +68,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-final class BackupApiRequestHandlerTest {
+class BackupApiRequestHandlerTest {
 
   private static final Instant NOW = Instant.ofEpochMilli(Instant.now().toEpochMilli());
 
@@ -84,10 +84,13 @@ final class BackupApiRequestHandlerTest {
   @Mock CheckpointState checkpointState;
   @Mock DbCheckpointMetadataState checkpointMetadataState;
   @Mock DbBackupRangeState backupRangeState;
-
   BackupApiRequestHandler handler;
   private ResponseReader serverOutput;
   private CompletableFuture<Either<ErrorResponse, BufferReader>> responseFuture;
+
+  protected String brokerZone() {
+    return null;
+  }
 
   @BeforeEach
   void setup() {
@@ -207,7 +210,7 @@ final class BackupApiRequestHandlerTest {
     final Instant lastModified = Instant.ofEpochMilli(2000);
     final BackupStatus status =
         new BackupStatusImpl(
-            new BackupIdentifierImpl(1, 1, checkpointId),
+            new BackupIdentifierImpl(1, brokerZone(), 1, checkpointId),
             Optional.of(
                 new BackupDescriptorImpl(
                     "s-id", 100, 3, "test", Instant.now(), CheckpointType.MANUAL_BACKUP)),
@@ -230,6 +233,7 @@ final class BackupApiRequestHandlerTest {
         .returns(checkpointId, BackupStatusResponse::getBackupId)
         .returns(1, BackupStatusResponse::getPartitionId)
         .returns(1, BackupStatusResponse::getBrokerId)
+        .returns(brokerZone(), BackupStatusResponse::getZone)
         .returns(100L, BackupStatusResponse::getCheckpointPosition)
         .returns(3, BackupStatusResponse::getNumberOfPartitions)
         .returns("s-id", BackupStatusResponse::getSnapshotId)
@@ -252,7 +256,7 @@ final class BackupApiRequestHandlerTest {
 
     final BackupStatus status =
         new BackupStatusImpl(
-            new BackupIdentifierImpl(1, 1, checkpointId),
+            new BackupIdentifierImpl(1, brokerZone(), 1, checkpointId),
             Optional.empty(),
             io.camunda.zeebe.backup.api.BackupStatusCode.FAILED,
             Optional.of("Expected"),
@@ -273,6 +277,7 @@ final class BackupApiRequestHandlerTest {
         .returns(checkpointId, BackupStatusResponse::getBackupId)
         .returns(1, BackupStatusResponse::getPartitionId)
         .returns(1, BackupStatusResponse::getBrokerId)
+        .returns(brokerZone(), BackupStatusResponse::getZone)
         .returns(
             BackupStatusResponseEncoder.backupIdNullValue(),
             BackupStatusResponse::getCheckpointPosition)
@@ -319,7 +324,7 @@ final class BackupApiRequestHandlerTest {
     final Instant lastModified = Instant.ofEpochMilli(2000);
     final BackupStatus status =
         new BackupStatusImpl(
-            new BackupIdentifierImpl(1, 1, 2),
+            new BackupIdentifierImpl(1, brokerZone(), 1, 2),
             Optional.of(
                 new BackupDescriptorImpl(
                     "s-id", 100, 3, "test", Instant.now(), CheckpointType.MANUAL_BACKUP)),
@@ -355,7 +360,7 @@ final class BackupApiRequestHandlerTest {
                 i ->
                     (BackupStatus)
                         new BackupStatusImpl(
-                            new BackupIdentifierImpl(1, 1, i),
+                            new BackupIdentifierImpl(1, brokerZone(), 1, i),
                             Optional.empty(),
                             io.camunda.zeebe.backup.api.BackupStatusCode.FAILED,
                             Optional.empty(),

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/backupapi/ZonedBackupApiRequestHandlerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/backupapi/ZonedBackupApiRequestHandlerTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.transport.backupapi;
+
+public class ZonedBackupApiRequestHandlerTest extends BackupApiRequestHandlerTest {
+
+  @Override
+  protected String brokerZone() {
+    return "zone-a";
+  }
+}

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/BrokerAdminRequest.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/BrokerAdminRequest.java
@@ -13,7 +13,6 @@ import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.encoding.AdminRequest;
 import io.camunda.zeebe.protocol.impl.encoding.AdminResponse;
-import io.camunda.zeebe.protocol.management.AdminRequestEncoder;
 import io.camunda.zeebe.protocol.management.AdminRequestType;
 import io.camunda.zeebe.protocol.management.AdminResponseEncoder;
 import io.camunda.zeebe.transport.RequestType;
@@ -64,16 +63,12 @@ public class BrokerAdminRequest extends BrokerRequest<AdminResponse> {
 
   @Override
   public Optional<BrokerMemberId> getBrokerId() {
-    final var brokerId = request.getBrokerId();
-    if (brokerId != AdminRequestEncoder.brokerIdNullValue()) {
-      return Optional.of(BrokerMemberId.from(null, brokerId));
-    } else {
-      return Optional.empty();
-    }
+    final var brokerId = request.getBrokerIdString();
+    return brokerId != null ? Optional.of(BrokerMemberId.from(brokerId)) : Optional.empty();
   }
 
-  public void setBrokerId(final int brokerId) {
-    request.setBrokerId(brokerId);
+  public void setBrokerId(final BrokerMemberId brokerId) {
+    request.setBrokerId(brokerId.nodeIdx(), brokerId.zone());
   }
 
   @Override

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/exporting/ExportingControlService.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/exporting/ExportingControlService.java
@@ -84,7 +84,7 @@ public class ExportingControlService implements ExportingControlApi {
             .map(
                 brokerId -> {
                   final var request = new BrokerAdminRequest();
-                  request.setBrokerId(brokerId.nodeIdx());
+                  request.setBrokerId(brokerId);
                   request.setPartitionId(partitionId);
                   configureRequest.accept(request);
                   return brokerClient.sendRequest(request);

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/admin/BrokerAdminRequestTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/admin/BrokerAdminRequestTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.admin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.BrokerMemberId;
+import org.junit.jupiter.api.Test;
+
+class BrokerAdminRequestTest {
+
+  @Test
+  void shouldReturnZoneAwareBrokerId() {
+    // given
+    final var brokerId = BrokerMemberId.from("zone-a", 1);
+    final var request = new BrokerAdminRequest();
+
+    // when
+    request.setBrokerId(brokerId);
+
+    // then
+    assertThat(request.getBrokerId()).contains(brokerId);
+  }
+}

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/admin/backup/BackupQueryStub.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/admin/backup/BackupQueryStub.java
@@ -24,6 +24,9 @@ import java.util.function.Function;
 public class BackupQueryStub
     implements RequestStub<BackupStatusRequest, BrokerResponse<BackupStatusResponse>> {
 
+  private static final int BROKER_ID = 1;
+  private static final String BROKER_ZONE = "zone-a";
+
   private final Map<Integer, Function<BackupStatusRequest, BrokerResponse<BackupStatusResponse>>>
       responses = new HashMap<>();
 
@@ -47,7 +50,7 @@ public class BackupQueryStub
         .setSnapshotId("sid")
         .setFailureReason("")
         .setCheckpointPosition(100)
-        .setBrokerId(1)
+        .setBrokerId(BROKER_ID, BROKER_ZONE)
         .setPartitionId(request.getPartitionId())
         .setBrokerVersion("test")
         .setCreatedAt(Instant.now().toString())
@@ -59,7 +62,7 @@ public class BackupQueryStub
         .setBackupId(request.getBackupId())
         .setStatus(BackupStatusCode.FAILED)
         .setFailureReason("FAILED")
-        .setBrokerId(1)
+        .setBrokerId(BROKER_ID, BROKER_ZONE)
         .setPartitionId(request.getPartitionId());
   }
 
@@ -70,7 +73,7 @@ public class BackupQueryStub
         .setSnapshotId("sid")
         .setFailureReason("")
         .setCheckpointPosition(100)
-        .setBrokerId(1)
+        .setBrokerId(BROKER_ID, BROKER_ZONE)
         .setPartitionId(request.getPartitionId())
         .setCreatedAt(Instant.now().toString())
         .setLastUpdated(Instant.now().toString());
@@ -90,7 +93,7 @@ public class BackupQueryStub
         .setSnapshotId("sid")
         .setFailureReason("")
         .setCheckpointPosition(100)
-        .setBrokerId(1)
+        .setBrokerId(BROKER_ID, BROKER_ZONE)
         .setPartitionId(request.getPartitionId())
         .setBrokerVersion("test")
         .setCreatedAt(Instant.now().toString())

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AdminRequest.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AdminRequest.java
@@ -7,15 +7,20 @@
  */
 package io.camunda.zeebe.protocol.impl.encoding;
 
+import static org.agrona.collections.ArrayUtil.EMPTY_BYTE_ARRAY;
+
 import io.camunda.zeebe.protocol.management.AdminRequestDecoder;
 import io.camunda.zeebe.protocol.management.AdminRequestEncoder;
 import io.camunda.zeebe.protocol.management.AdminRequestType;
 import io.camunda.zeebe.protocol.management.MessageHeaderDecoder;
 import io.camunda.zeebe.protocol.management.MessageHeaderEncoder;
+import io.camunda.zeebe.util.MemberIdUtil;
 import io.camunda.zeebe.util.buffer.BufferReader;
 import io.camunda.zeebe.util.buffer.BufferWriter;
+import java.nio.charset.StandardCharsets;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
+import org.jspecify.annotations.Nullable;
 
 public class AdminRequest implements BufferReader, BufferWriter {
   private final MessageHeaderEncoder headerEncoder = new MessageHeaderEncoder();
@@ -26,8 +31,8 @@ public class AdminRequest implements BufferReader, BufferWriter {
   private int partitionId = AdminRequestEncoder.partitionIdNullValue();
   private AdminRequestType type = AdminRequestType.NULL_VAL;
   private long key = AdminRequestEncoder.keyNullValue();
-  private byte[] payload = null;
-  private boolean hasPayload = false;
+  private byte[] payload = EMPTY_BYTE_ARRAY;
+  private @Nullable String zone;
 
   @Override
   public void wrap(final DirectBuffer buffer, final int offset, final int length) {
@@ -35,7 +40,12 @@ public class AdminRequest implements BufferReader, BufferWriter {
     brokerId = bodyDecoder.brokerId();
     partitionId = bodyDecoder.partitionId();
     type = bodyDecoder.type();
-    bodyDecoder.getPayload(payload, 0, length - bodyDecoder.limit());
+    key = bodyDecoder.key();
+
+    payload = new byte[bodyDecoder.payloadLength()];
+    bodyDecoder.getPayload(payload, 0, payload.length);
+
+    zone = emptyStringAsNull(bodyDecoder.zone());
   }
 
   @Override
@@ -43,7 +53,9 @@ public class AdminRequest implements BufferReader, BufferWriter {
     return headerEncoder.encodedLength()
         + bodyEncoder.sbeBlockLength()
         + AdminRequestEncoder.payloadHeaderLength()
-        + (hasPayload ? payload.length : 0);
+        + payload.length
+        + AdminRequestEncoder.zoneHeaderLength()
+        + (zone != null ? zone.getBytes(StandardCharsets.UTF_8).length : 0);
   }
 
   @Override
@@ -53,11 +65,11 @@ public class AdminRequest implements BufferReader, BufferWriter {
         .brokerId(brokerId)
         .partitionId(partitionId)
         .type(type)
-        .key(key);
+        .key(key)
+        .putPayload(payload, 0, payload.length);
 
-    if (hasPayload) {
-      bodyEncoder.putPayload(payload, 0, payload.length);
-    }
+    bodyEncoder.zone(zone);
+
     return headerEncoder.encodedLength() + bodyEncoder.encodedLength();
   }
 
@@ -65,8 +77,20 @@ public class AdminRequest implements BufferReader, BufferWriter {
     return brokerId;
   }
 
-  public void setBrokerId(final int brokerId) {
+  public @Nullable String getZone() {
+    return zone;
+  }
+
+  public @Nullable String getBrokerIdString() {
+    if (brokerId == AdminRequestEncoder.brokerIdNullValue()) {
+      return null;
+    }
+    return MemberIdUtil.memberIdString(zone, brokerId);
+  }
+
+  public void setBrokerId(final int brokerId, final @Nullable String zone) {
     this.brokerId = brokerId;
+    this.zone = zone;
   }
 
   public int getPartitionId() {
@@ -94,7 +118,10 @@ public class AdminRequest implements BufferReader, BufferWriter {
   }
 
   public void setPayload(final byte[] payload) {
-    this.payload = payload;
-    hasPayload = true;
+    this.payload = payload != null ? payload : EMPTY_BYTE_ARRAY;
+  }
+
+  private static @Nullable String emptyStringAsNull(final String value) {
+    return value.isEmpty() ? null : value;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BackupStatusResponse.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BackupStatusResponse.java
@@ -14,11 +14,13 @@ import io.camunda.zeebe.protocol.management.BackupStatusResponseDecoder;
 import io.camunda.zeebe.protocol.management.BackupStatusResponseEncoder;
 import io.camunda.zeebe.protocol.management.MessageHeaderDecoder;
 import io.camunda.zeebe.protocol.management.MessageHeaderEncoder;
+import io.camunda.zeebe.util.MemberIdUtil;
 import io.camunda.zeebe.util.buffer.BufferReader;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.io.UnsupportedEncodingException;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
+import org.jspecify.annotations.Nullable;
 
 public class BackupStatusResponse implements BufferReader, BufferWriter {
   private final MessageHeaderEncoder headerEncoder = new MessageHeaderEncoder();
@@ -46,6 +48,7 @@ public class BackupStatusResponse implements BufferReader, BufferWriter {
   private byte[] encodedCreatedAt = EMPTY_BYTE_ARRAY;
   private String lastUpdated = "";
   private byte[] encodedLastUpdated = EMPTY_BYTE_ARRAY;
+  private @Nullable String zone;
 
   public long getBackupId() {
     return backupId;
@@ -69,13 +72,25 @@ public class BackupStatusResponse implements BufferReader, BufferWriter {
     return brokerId;
   }
 
-  public BackupStatusResponse setBrokerId(final int brokerId) {
+  public @Nullable String getZone() {
+    return zone;
+  }
+
+  public @Nullable String getBrokerIdString() {
+    if (!hasBrokerId()) {
+      return null;
+    }
+    return MemberIdUtil.memberIdString(zone, brokerId);
+  }
+
+  public BackupStatusResponse setBrokerId(final int brokerId, final @Nullable String zone) {
     this.brokerId = brokerId;
+    this.zone = zone;
     return this;
   }
 
   public boolean hasBrokerId() {
-    return brokerId == BackupStatusResponseEncoder.brokerIdNullValue();
+    return brokerId != BackupStatusResponseEncoder.brokerIdNullValue();
   }
 
   public BackupStatusCode getStatus() {
@@ -220,6 +235,8 @@ public class BackupStatusResponse implements BufferReader, BufferWriter {
     lastUpdated =
         decodeString(
             encodedLastUpdated, BackupStatusResponseDecoder.lastUpdatedCharacterEncoding());
+
+    zone = emptyStringAsNull(bodyDecoder.zone());
   }
 
   private String decodeString(final byte[] encodedSnapshotId, final String charsetName) {
@@ -243,7 +260,9 @@ public class BackupStatusResponse implements BufferReader, BufferWriter {
         + BackupStatusResponseEncoder.createdAtHeaderLength()
         + encodedCreatedAt.length
         + BackupStatusResponseEncoder.lastUpdatedHeaderLength()
-        + encodedLastUpdated.length;
+        + encodedLastUpdated.length
+        + BackupStatusResponseEncoder.zoneHeaderLength()
+        + encodeString(zone, BackupStatusResponseEncoder.zoneCharacterEncoding()).length;
   }
 
   @Override
@@ -261,7 +280,8 @@ public class BackupStatusResponse implements BufferReader, BufferWriter {
         .putFailureReason(encodedFailureReason, 0, encodedFailureReason.length)
         .putBrokerVersion(encodedBrokerVersion, 0, encodedBrokerVersion.length)
         .putCreatedAt(encodedCreatedAt, 0, encodedCreatedAt.length)
-        .putLastUpdated(encodedLastUpdated, 0, encodedLastUpdated.length);
+        .putLastUpdated(encodedLastUpdated, 0, encodedLastUpdated.length)
+        .zone(zone);
     return headerEncoder.encodedLength() + bodyEncoder.encodedLength();
   }
 
@@ -271,5 +291,9 @@ public class BackupStatusResponse implements BufferReader, BufferWriter {
     } catch (final UnsupportedEncodingException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  private static @Nullable String emptyStringAsNull(final String value) {
+    return value.isEmpty() ? null : value;
   }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/encoding/AdminRequestTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/encoding/AdminRequestTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.encoding;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.protocol.management.AdminRequestType;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+
+class AdminRequestTest {
+
+  @Test
+  void shouldEncodeAndDecodeZoneAwareBrokerId() {
+    // given
+    final var request = new AdminRequest();
+    request.setBrokerId(1, "zone-a");
+    request.setPartitionId(3);
+    request.setType(AdminRequestType.PAUSE_EXPORTING);
+    request.setPayload(new byte[] {1, 2, 3});
+
+    // when
+    final var buffer = new UnsafeBuffer(new byte[request.getLength()]);
+    request.write(buffer, 0);
+
+    final var decoded = new AdminRequest();
+    decoded.wrap(buffer, 0, buffer.capacity());
+
+    // then
+    assertThat(decoded.getBrokerId()).isEqualTo(1);
+    assertThat(decoded.getBrokerIdString()).isEqualTo("zone-a/1");
+  }
+}

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/encoding/BackupStatusResponseTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/encoding/BackupStatusResponseTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.encoding;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.protocol.management.BackupStatusCode;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+
+class BackupStatusResponseTest {
+
+  @Test
+  void shouldEncodeAndDecodeZoneAwareBrokerId() {
+    // given
+    final var response =
+        new BackupStatusResponse()
+            .setBackupId(1)
+            .setStatus(BackupStatusCode.COMPLETED)
+            .setBrokerId(1, "zone-a")
+            .setPartitionId(2)
+            .setSnapshotId("sid")
+            .setCreatedAt("2024-01-01T00:00:00Z")
+            .setLastUpdated("2024-01-01T00:00:00Z");
+
+    // when
+    final var buffer = new UnsafeBuffer(new byte[response.getLength()]);
+    response.write(buffer, 0);
+
+    final var decoded = new BackupStatusResponse();
+    decoded.wrap(buffer, 0, buffer.capacity());
+
+    // then
+    assertThat(decoded.getBrokerId()).isEqualTo(1);
+    assertThat(decoded.getBrokerIdString()).isEqualTo("zone-a/1");
+    assertThat(decoded.hasBrokerId()).isTrue();
+  }
+}

--- a/zeebe/protocol/src/main/resources/cluster-management-protocol.xml
+++ b/zeebe/protocol/src/main/resources/cluster-management-protocol.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
   xmlns:xi="http://www.w3.org/2001/XInclude" package="io.camunda.zeebe.protocol.management"
-  id="1" version="1"
+  id="1" version="2"
   description="Zeebe Cluster Management Protocol" byteOrder="littleEndian">
 
   <xi:include href="common-types.xml"/>
@@ -60,6 +60,7 @@
     <field name="brokerId" id="3" type="uint16" presence="optional"/>
     <field name="key" id="4" type="uint64" presence="optional"/>
     <data name="payload" id="5" type="varDataEncoding"/>
+    <data name="zone" id="6" type="varDataEncoding" sinceVersion="2"/>
   </sbe:message>
 
   <sbe:message name="AdminResponse" id="2">
@@ -92,6 +93,7 @@
     <data name="lastUpdated" id="10" type="varDataEncoding"/>
     <!-- Broker version which created this backup -->
     <data name="brokerVersion" id="11" type="varDataEncoding"/>
+    <data name="zone" id="13" type="varDataEncoding" sinceVersion="2"/>
   </sbe:message>
 
   <sbe:message name="BackupListResponse" id="5">

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
+import io.atomix.cluster.BrokerMemberId;
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionId;
 import io.atomix.primitive.partition.PartitionMetadata;
@@ -114,7 +115,7 @@ class PartitionRestoreServiceTest {
 
     backupService =
         new BackupService(
-            nodeId,
+            BrokerMemberId.from(nodeId),
             partitionId,
             backupStore,
             snapshotStore,


### PR DESCRIPTION
## Description
Add zone to:
- AdminRequest
- BackupStatusResponse
- Backup Manifest

The change is mostly mechanical and it's backward compatible as zone is null. 
Using a non-zoned backup from a migrated zoned cluster is not yet supported/tested 

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #52807 
relates #52809
