### PR TITLE
test: RingBufferTest test case is following production access patterns

### DIFF
--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RingBufferTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RingBufferTest.java
@@ -378,7 +378,9 @@ final class RingBufferTest {
 
     /**
      * Simulates the full lifecycle: writer puts entries, a second thread finds and removes them
-     * (like onProcessed). Verifies findAndRemove works correctly.
+     * (like onProcessed). The processor only advances once the writer has published the position,
+     * mirroring the production ordering where onProcessed cannot outrun the producer. Verifies
+     * findAndRemove works correctly.
      */
     @Test
     void findAndRemoveWorksAcrossThreads() {
@@ -386,6 +388,7 @@ final class RingBufferTest {
       final var buffer = new RingBuffer(CAPACITY);
       final var failures = new ConcurrentLinkedQueue<Throwable>();
       final var startLatch = new CountDownLatch(1);
+      final var publishedPosition = new AtomicLong(0);
 
       final var writer =
           new Thread(
@@ -393,6 +396,7 @@ final class RingBufferTest {
                 awaitLatch(startLatch);
                 for (long pos = 1; pos <= ITERATIONS; pos++) {
                   buffer.put(newEntry(pos));
+                  publishedPosition.set(pos);
                 }
               });
 
@@ -401,6 +405,10 @@ final class RingBufferTest {
               () -> {
                 awaitLatch(startLatch);
                 for (long pos = 1; pos <= ITERATIONS; pos++) {
+                  while (pos > publishedPosition.get()) {
+                    LockSupport.parkNanos(1);
+                  }
+
                   InFlightEntry entry = null;
                   while (entry == null) {
                     entry = buffer.findAndRemove(pos);
@@ -547,7 +555,7 @@ final class RingBufferTest {
       startLatch.countDown();
 
       Awaitility.await("threads complete")
-          .atMost(Duration.ofSeconds(30))
+          .atMost(Duration.ofSeconds(60))
           .untilAsserted(
               () -> {
                 for (final var thread : threads) {


### PR DESCRIPTION
## Description
Before this change, the reader could read past the producer, which in production it cannot happen.
The fix is similar to what was done in another test case. The test could fail if run on a machine with high load. Managed to reproduce it locally with 3 JVM running each with 5% of cpu allocated to the cgroup.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #53291 
