### PR TITLE
[Backport stable/8.7] fix: prevent NPE when deleting latest process version with missing previous deployment

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
@@ -8,6 +8,8 @@
 package io.camunda.zeebe.engine.processing.resource;
 
 import static io.camunda.zeebe.engine.state.instance.TimerInstance.NO_ELEMENT_INSTANCE;
+import static io.camunda.zeebe.protocol.ZbColumnFamilies.PROCESS_CACHE_BY_ID_AND_VERSION;
+import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
 import io.camunda.zeebe.auth.impl.Authorization;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
@@ -57,10 +59,14 @@ import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.List;
 import java.util.Optional;
+import org.agrona.DirectBuffer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ResourceDeletionDeleteProcessor
     implements DistributedTypedRecordProcessor<ResourceDeletionRecord> {
 
+  private static final Logger LOG = LoggerFactory.getLogger(ResourceDeletionDeleteProcessor.class);
   private final StateWriter stateWriter;
   private final TypedResponseWriter responseWriter;
   private final TypedRejectionWriter rejectionWriter;
@@ -194,12 +200,11 @@ public class ResourceDeletionDeleteProcessor
 
     final var drgRecord =
         new DecisionRequirementsRecord()
-            .setDecisionRequirementsId(BufferUtil.bufferAsString(drg.getDecisionRequirementsId()))
-            .setDecisionRequirementsName(
-                BufferUtil.bufferAsString(drg.getDecisionRequirementsName()))
+            .setDecisionRequirementsId(bufferAsString(drg.getDecisionRequirementsId()))
+            .setDecisionRequirementsName(bufferAsString(drg.getDecisionRequirementsName()))
             .setDecisionRequirementsVersion(drg.getDecisionRequirementsVersion())
             .setDecisionRequirementsKey(drg.getDecisionRequirementsKey())
-            .setResourceName(BufferUtil.bufferAsString(drg.getResourceName()))
+            .setResourceName(bufferAsString(drg.getResourceName()))
             .setChecksum(drg.getChecksum())
             .setResource(drg.getResource())
             .setTenantId(drg.getTenantId());
@@ -211,13 +216,13 @@ public class ResourceDeletionDeleteProcessor
   private void deleteDecision(final PersistedDecision persistedDecision) {
     final var decisionRecord =
         new DecisionRecord()
-            .setDecisionId(BufferUtil.bufferAsString(persistedDecision.getDecisionId()))
-            .setDecisionName(BufferUtil.bufferAsString(persistedDecision.getDecisionName()))
+            .setDecisionId(bufferAsString(persistedDecision.getDecisionId()))
+            .setDecisionName(bufferAsString(persistedDecision.getDecisionName()))
             .setVersion(persistedDecision.getVersion())
             .setVersionTag(persistedDecision.getVersionTag())
             .setDecisionKey(persistedDecision.getDecisionKey())
             .setDecisionRequirementsId(
-                BufferUtil.bufferAsString(persistedDecision.getDecisionRequirementsId()))
+                bufferAsString(persistedDecision.getDecisionRequirementsId()))
             .setDecisionRequirementsKey(persistedDecision.getDecisionRequirementsKey())
             .setTenantId(persistedDecision.getTenantId())
             .setDeploymentKey(persistedDecision.getDeploymentKey());
@@ -228,6 +233,7 @@ public class ResourceDeletionDeleteProcessor
     // We don't add the checksum or resource in this event. The checksum is not easily available
     // and the resources are left out to prevent exceeding the maximum batch size.
     final var processIdBuffer = process.getBpmnProcessId();
+    final var tenantId = process.getTenantId();
     final var processRecord =
         new ProcessRecord()
             .setBpmnProcessId(processIdBuffer)
@@ -235,27 +241,30 @@ public class ResourceDeletionDeleteProcessor
             .setVersionTag(process.getVersionTag())
             .setKey(process.getKey())
             .setResourceName(process.getResourceName())
-            .setTenantId(process.getTenantId())
+            .setTenantId(tenantId)
             .setDeploymentKey(process.getDeploymentKey());
     stateWriter.appendFollowUpEvent(keyGenerator.nextKey(), ProcessIntent.DELETING, processRecord);
 
     final String processId = processRecord.getBpmnProcessId();
-    final var latestVersion =
-        processState.getLatestProcessVersion(processId, processRecord.getTenantId());
+    final var latestVersion = processState.getLatestProcessVersion(processId, tenantId);
 
     // If we are deleting the latest version we must unsubscribe the start events
     if (latestVersion == process.getVersion()) {
       unsubscribeStartEvents(process);
 
       final var previousVersion =
-          processState.findProcessVersionBefore(
-              processId, latestVersion, processRecord.getTenantId());
+          processState.findProcessVersionBefore(processId, latestVersion, tenantId);
       // If there is a previous version we must resubscribe to the previous version's start events.
       if (previousVersion.isPresent()) {
         final var previousProcess =
             processState.getProcessByProcessIdAndVersion(
-                processIdBuffer, previousVersion.get(), process.getTenantId());
-        resubscribeStartEvents(previousProcess);
+                processIdBuffer, previousVersion.get(), tenantId);
+        if (previousProcess == null) {
+          warnPreviousProcessNotFound(
+              processIdBuffer, previousVersion.get(), tenantId, processId, latestVersion);
+        } else {
+          resubscribeStartEvents(previousProcess);
+        }
       }
     }
 
@@ -347,6 +356,24 @@ public class ResourceDeletionDeleteProcessor
             .setVersionTag(persistedResource.getVersionTag())
             .setDeploymentKey(persistedResource.getDeploymentKey());
     stateWriter.appendFollowUpEvent(keyGenerator.nextKey(), ResourceIntent.DELETED, resource);
+  }
+
+  private void warnPreviousProcessNotFound(
+      final DirectBuffer processIdBuffer,
+      final int previousVersion,
+      final String tenantId,
+      final String processId,
+      final int latestVersion) {
+    LOG.warn(
+        "Expected to find previous process: {} with version: {} and tenant: '{}' to "
+            + "resubscribe start events, but no row exists in {}. "
+            + "knownVersions: {}, current latest version: {}.",
+        bufferAsString(processIdBuffer),
+        previousVersion,
+        tenantId,
+        PROCESS_CACHE_BY_ID_AND_VERSION.name(),
+        processState.getKnownProcessVersions(processId, tenantId),
+        latestVersion);
   }
 
   private List<String> getAuthorizedTenants(final TypedRecord<ResourceDeletionRecord> command) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
@@ -286,6 +286,10 @@ public class ResourceDeletionDeleteProcessor
   }
 
   private void resubscribeStartEvents(final DeployedProcess deployedProcess) {
+    if (deployedProcess == null) {
+      return;
+    }
+
     final var process = deployedProcess.getProcess();
     if (process.hasTimerStartEvent()) {
       process.getStartEvents().stream()

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
@@ -487,6 +487,11 @@ public final class DbProcessState implements MutableProcessState {
   }
 
   @Override
+  public List<Long> getKnownProcessVersions(final String bpmnProcessId, final String tenantId) {
+    return versionManager.getKnownResourceVersions(bpmnProcessId, tenantId);
+  }
+
+  @Override
   public <T extends ExecutableFlowElement> T getFlowElement(
       final long processDefinitionKey,
       final String tenantId,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/VersionManager.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/VersionManager.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.db.impl.DbString;
 import io.camunda.zeebe.db.impl.DbTenantAwareKey;
 import io.camunda.zeebe.db.impl.DbTenantAwareKey.PlacementType;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import java.util.List;
 import java.util.Optional;
 import org.agrona.DirectBuffer;
 import org.agrona.collections.Object2ObjectHashMap;
@@ -153,6 +154,12 @@ public final class VersionManager {
     tenantIdKey.wrapString(tenantId);
     idKey.wrapString(resourceId);
     return getVersionInfo().findVersionBefore(version);
+  }
+
+  public List<Long> getKnownResourceVersions(final String resourceId, final String tenantId) {
+    tenantIdKey.wrapString(tenantId);
+    idKey.wrapString(resourceId);
+    return getVersionInfo().getKnownVersions();
   }
 
   private record TenantIdAndResourceId(String tenantId, String resourceId) {}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessState.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.state.immutable;
 
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
 import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
+import java.util.List;
 import java.util.Optional;
 import org.agrona.DirectBuffer;
 
@@ -58,6 +59,8 @@ public interface ProcessState {
    */
   Optional<Integer> findProcessVersionBefore(
       String bpmnProcessId, long version, final String tenantId);
+
+  List<Long> getKnownProcessVersions(String bpmnProcessId, String tenantId);
 
   <T extends ExecutableFlowElement> T getFlowElement(
       long processDefinitionKey, String tenantId, DirectBuffer elementId, Class<T> elementType);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/ProcessStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/ProcessStateTest.java
@@ -200,6 +200,63 @@ public final class ProcessStateTest {
   }
 
   @Test
+  public void shouldReturnEmptyListForUnknownProcessIdOnGetKnownProcessVersions() {
+    // given / when
+    final var versions = processState.getKnownProcessVersions("unknownProcess", TENANT_ID);
+
+    // then
+    assertThat(versions).isEmpty();
+  }
+
+  @Test
+  public void shouldReturnAllVersionsOnGetKnownProcessVersions() {
+    // given
+    final var v1 = creatingProcessRecord(processingState, "processId", 1);
+    final var v2 = creatingProcessRecord(processingState, "processId", 2);
+    final var v3 = creatingProcessRecord(processingState, "processId", 3);
+    processState.putProcess(v1.getKey(), v1);
+    processState.putProcess(v2.getKey(), v2);
+    processState.putProcess(v3.getKey(), v3);
+
+    // when
+    final var versions = processState.getKnownProcessVersions("processId", TENANT_ID);
+
+    // then
+    assertThat(versions).containsExactlyInAnyOrder(1L, 2L, 3L);
+  }
+
+  @Test
+  public void shouldNotReturnVersionsForDifferentProcessIdOnGetKnownProcessVersions() {
+    // given
+    final var processRecord = creatingProcessRecord(processingState, "processId", 1);
+    final var otherRecord = creatingProcessRecord(processingState, "otherProcess", 1);
+    processState.putProcess(processRecord.getKey(), processRecord);
+    processState.putProcess(otherRecord.getKey(), otherRecord);
+
+    // when
+    final var versions = processState.getKnownProcessVersions("processId", TENANT_ID);
+
+    // then
+    assertThat(versions).containsExactly(1L);
+  }
+
+  @Test
+  public void shouldNotReturnDeletedVersionOnGetKnownProcessVersions() {
+    // given
+    final var v1 = creatingProcessRecord(processingState, "processId", 1);
+    final var v2 = creatingProcessRecord(processingState, "processId", 2);
+    processState.putProcess(v1.getKey(), v1);
+    processState.putProcess(v2.getKey(), v2);
+
+    // when
+    processState.deleteProcess(v1);
+    final var versions = processState.getKnownProcessVersions("processId", TENANT_ID);
+
+    // then
+    assertThat(versions).containsExactly(2L);
+  }
+
+  @Test
   public void shouldNotIncrementNextProcessVersionForDifferentProcessId() {
     // given
     final var processRecord = creatingProcessRecord(processingState);


### PR DESCRIPTION
## Description

Backport for 8.7 of 53502

## Related issues

relates #53502