### PR TITLE
test: move cross-module arch tests into qa/archunit-tests via test-jar deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1177,11 +1177,13 @@ jobs:
         run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> "$GITHUB_ENV"
       - name: Maven Test Build
         shell: bash
+        # ArchUnit rules are deterministic; rerunning a violation would only mask it, so this job
+        # runs with surefire.rerunFailingTestsCount=0 to ensure real violations fail the build.
         # we use the verify goal here as flaky test extraction is bound to the post-integration-test
         # phase of Maven https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html#default-lifecycle
         run: >
           ./mvnw -B --no-snapshot-updates
-          -D skipITs -D skipQaBuild=false -D skipChecks -Dsurefire.rerunFailingTestsCount=${{ env.FLAKY_TEST_RERUN_COUNT }}
+          -D skipITs -D skipQaBuild=false -D skipChecks -Dsurefire.rerunFailingTestsCount=0
           -P skipFrontendBuild,extract-flaky-tests
           -pl :camunda-archunit-tests
           -am

--- a/qa/acceptance-tests/pom.xml
+++ b/qa/acceptance-tests/pom.xml
@@ -679,6 +679,21 @@
 
   <build>
     <plugins>
+      <!--
+        Publish a test-jar so qa/archunit-tests can analyze our test classes
+        (rules like MultiDbTestArchTest scan @MultiDbTest-annotated test code).
+      -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>

--- a/qa/acceptance-tests/pom.xml
+++ b/qa/acceptance-tests/pom.xml
@@ -624,24 +624,6 @@
       <artifactId>configuration</artifactId>
       <scope>test</scope>
     </dependency>
-
-    <dependency>
-      <groupId>com.tngtech.archunit</groupId>
-      <artifactId>archunit</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>com.tngtech.archunit</groupId>
-      <artifactId>archunit-junit5-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>com.tngtech.archunit</groupId>
-      <artifactId>archunit-junit5-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers-localstack</artifactId>

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ResourceSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ResourceSearchIT.java
@@ -16,7 +16,6 @@ import io.camunda.it.util.TestHelper;
 import io.camunda.qa.util.auth.TenantDefinition;
 import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.cluster.TestCamundaApplication;
-import io.camunda.qa.util.multidb.CamundaMultiDBExtension.DatabaseType;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.security.api.model.config.initialization.InitializationConfiguration;
@@ -28,7 +27,7 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-@MultiDbTest(DatabaseType.RDBMS_MSSQL)
+@MultiDbTest
 class ResourceSearchIT {
 
   private static CamundaClient camundaClient;

--- a/qa/archunit-tests/pom.xml
+++ b/qa/archunit-tests/pom.xml
@@ -20,6 +20,45 @@
       <scope>test</scope>
     </dependency>
 
+    <!--
+      Test-jar dependencies so arch rules can scan test classes from other modules:
+      - camunda-qa-acceptance-tests-tests.jar: classes annotated with @MultiDbTest
+        (covered by MultiDbTestArchTest)
+      - zeebe-gateway-rest-tests.jar: REST controller tests scanned for
+        WebTestClient.BodyContentSpec#json calls (ControllerStrictJsonCompareArchTest)
+      The custom ImportOption (IncludeTestClassesAndTestJars) recognizes -tests.jar
+      entries which ImportOption.OnlyIncludeTests does not.
+    -->
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-qa-acceptance-tests</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-gateway-rest</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- Provides @MultiDbTest used by MultiDbTestArchTest -->
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-qa-util</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- Provides WebTestClient used by ControllerStrictJsonCompareArchTest -->
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>org.camunda.bpm.model</groupId>
       <artifactId>camunda-xml-model</artifactId>
@@ -111,9 +150,11 @@
         <configuration>
           <ignoredUnusedDeclaredDependencies>
             <dep>io.camunda:camunda-zeebe</dep>
+            <!-- Test-jar deps used only by ArchUnit at runtime to load test classes  -->
+            <dep>io.camunda:camunda-qa-acceptance-tests</dep>
+            <dep>io.camunda:zeebe-gateway-rest</dep>
           </ignoredUnusedDeclaredDependencies>
           <ignoredUsedUndeclaredDependencies>
-            <dep>io.camunda:zeebe-gateway-rest</dep>
             <dep>io.camunda:camunda-gateway-mcp</dep>
             <dep>io.camunda:camunda-client-java</dep>
             <dep>io.camunda:camunda-service</dep>

--- a/qa/archunit-tests/pom.xml
+++ b/qa/archunit-tests/pom.xml
@@ -45,6 +45,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-gateway-rest</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <!-- Provides @MultiDbTest used by MultiDbTestArchTest -->
     <dependency>
       <groupId>io.camunda</groupId>
@@ -151,8 +157,8 @@
           <ignoredUnusedDeclaredDependencies>
             <dep>io.camunda:camunda-zeebe</dep>
             <!-- Test-jar deps used only by ArchUnit at runtime to load test classes  -->
-            <dep>io.camunda:camunda-qa-acceptance-tests</dep>
-            <dep>io.camunda:zeebe-gateway-rest</dep>
+            <dep>io.camunda:camunda-qa-acceptance-tests:test-jar</dep>
+            <dep>io.camunda:zeebe-gateway-rest:test-jar</dep>
           </ignoredUnusedDeclaredDependencies>
           <ignoredUsedUndeclaredDependencies>
             <dep>io.camunda:camunda-gateway-mcp</dep>

--- a/qa/archunit-tests/src/test/java/io/camunda/archunit/DoNotIncludeTestsOrTestJars.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/archunit/DoNotIncludeTestsOrTestJars.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.archunit;
+
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.core.importer.Location;
+
+/**
+ * Excludes classes from the standard test source directories AND from Maven test-jars ({@code
+ * *-tests.jar}).
+ *
+ * <p>Companion to {@link IncludeTestClassesAndTestJars}. Use this for production-code rules in
+ * modules whose {@code pom.xml} pulls in {@code <type>test-jar</type>} dependencies: plain {@link
+ * ImportOption.DoNotIncludeTests} only filters by directory path, so classes loaded from a {@code
+ * *-tests.jar} would otherwise be treated as production code.
+ */
+public final class DoNotIncludeTestsOrTestJars implements ImportOption {
+
+  private static final ImportOption DO_NOT_INCLUDE_TESTS = new ImportOption.DoNotIncludeTests();
+
+  @Override
+  public boolean includes(final Location location) {
+    return DO_NOT_INCLUDE_TESTS.includes(location) && !location.contains("-tests.jar");
+  }
+}

--- a/qa/archunit-tests/src/test/java/io/camunda/archunit/IncludeTestClassesAndTestJars.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/archunit/IncludeTestClassesAndTestJars.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.archunit;
+
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.core.importer.Location;
+
+/**
+ * Includes classes from the standard test source directories ({@code target/test-classes}, {@code
+ * build/classes/test}, {@code out/test}) and from Maven test-jars ({@code *-tests.jar}).
+ *
+ * <p>Use this option for ArchUnit rules that scan test code from other modules pulled in as
+ * test-jar dependencies. {@link ImportOption.OnlyIncludeTests} alone does not match the location
+ * URIs of classes loaded from a Maven test-jar.
+ *
+ * <p>The companion {@link DoNotIncludeTestsOrTestJars} should be used by rules in this module that
+ * scan production code in packages overlapping with such test-jars (e.g. {@code
+ * io.camunda.zeebe.gateway.rest..}); plain {@link ImportOption.DoNotIncludeTests} treats test-jar
+ * entries as production code and would let test classes leak into the analysis.
+ */
+public final class IncludeTestClassesAndTestJars implements ImportOption {
+
+  private static final ImportOption ONLY_INCLUDE_TESTS = new ImportOption.OnlyIncludeTests();
+
+  @Override
+  public boolean includes(final Location location) {
+    return ONLY_INCLUDE_TESTS.includes(location) || location.contains("-tests.jar");
+  }
+}

--- a/qa/archunit-tests/src/test/java/io/camunda/it/MultiDbTestArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/it/MultiDbTestArchTest.java
@@ -10,13 +10,13 @@ package io.camunda.it;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 
 import com.tngtech.archunit.base.DescribedPredicate;
-import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.lang.ArchRule;
+import io.camunda.archunit.IncludeTestClassesAndTestJars;
 import io.camunda.qa.util.multidb.MultiDbTest;
 
-@AnalyzeClasses(packages = "io.camunda", importOptions = ImportOption.OnlyIncludeTests.class)
+@AnalyzeClasses(packages = "io.camunda", importOptions = IncludeTestClassesAndTestJars.class)
 final class MultiDbTestArchTest {
 
   /**

--- a/qa/archunit-tests/src/test/java/io/camunda/zeebe/ForbidWebStereotypeArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/zeebe/ForbidWebStereotypeArchTest.java
@@ -11,10 +11,10 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.JavaAnnotation;
-import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.lang.ArchRule;
+import io.camunda.archunit.DoNotIncludeTestsOrTestJars;
 import org.springframework.stereotype.Controller;
 
 /**
@@ -35,9 +35,12 @@ import org.springframework.stereotype.Controller;
  * As all the REST endpoints will mapped in their own modules, the only endpoints in the packages
  * below should be actuators.
  */
+// DoNotIncludeTestsOrTestJars (not the built-in DoNotIncludeTests) because
+// qa/archunit-tests pulls in zeebe-gateway-rest as a test-jar; without filtering
+// test-jar entries, gateway test classes would be analyzed as production code.
 @AnalyzeClasses(
     packages = {"io.camunda.zeebe.broker", "io.camunda.zeebe.gateway", "io.camunda.zeebe.shared"},
-    importOptions = {ImportOption.DoNotIncludeTests.class})
+    importOptions = {DoNotIncludeTestsOrTestJars.class})
 public final class ForbidWebStereotypeArchTest {
   private static final DescribedPredicate<? super JavaAnnotation<?>> WEB_STEREOTYPES =
       new DescribedPredicate<>("spring web annotations") {

--- a/qa/archunit-tests/src/test/java/io/camunda/zeebe/gateway/rest/ControllerStrictJsonCompareArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/zeebe/gateway/rest/ControllerStrictJsonCompareArchTest.java
@@ -7,21 +7,21 @@
  */
 package io.camunda.zeebe.gateway.rest;
 
-import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.lang.ArchRule;
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
+import io.camunda.archunit.IncludeTestClassesAndTestJars;
 import org.springframework.test.web.reactive.server.WebTestClient.BodyContentSpec;
 
 /**
- * PS: This his arch test specifically tests the condition only for test classes. Since the
- * qa/archunit-tests will not scan test directories in the rest of the codebase, this test should
- * stay in its original location
+ * Scans test classes from {@code zeebe-gateway-rest} (pulled in as a test-jar dependency); the
+ * {@link IncludeTestClassesAndTestJars} import option ensures classes inside {@code *-tests.jar}
+ * entries are picked up alongside this module's own {@code target/test-classes}.
  */
 @AnalyzeClasses(
     packages = "io.camunda.zeebe.gateway.rest",
-    importOptions = ImportOption.OnlyIncludeTests.class)
+    importOptions = IncludeTestClassesAndTestJars.class)
 public class ControllerStrictJsonCompareArchTest {
 
   /** This ArchUnit test ensures that any REST API controller tests use JsonCompareMode.STRICT */

--- a/qa/archunit-tests/src/test/java/io/camunda/zeebe/gateway/rest/RequiresSecondaryStorageAnnotationArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/zeebe/gateway/rest/RequiresSecondaryStorageAnnotationArchTest.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.gateway.rest;
 
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaMethod;
-import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.lang.ArchCondition;
@@ -17,6 +16,7 @@ import com.tngtech.archunit.lang.ArchRule;
 import com.tngtech.archunit.lang.ConditionEvents;
 import com.tngtech.archunit.lang.SimpleConditionEvent;
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
+import io.camunda.archunit.DoNotIncludeTestsOrTestJars;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -37,9 +37,12 @@ import java.util.stream.Collectors;
  *       annotated with it.
  * </ul>
  */
+// DoNotIncludeTestsOrTestJars (not the built-in DoNotIncludeTests) because
+// qa/archunit-tests pulls in zeebe-gateway-rest as a test-jar; without filtering
+// test-jar entries, controller test classes would be analyzed as production code.
 @AnalyzeClasses(
     packages = "io.camunda.zeebe.gateway.rest",
-    importOptions = ImportOption.DoNotIncludeTests.class)
+    importOptions = DoNotIncludeTestsOrTestJars.class)
 public class RequiresSecondaryStorageAnnotationArchTest {
 
   /**

--- a/qa/archunit-tests/src/test/java/io/camunda/zeebe/gateway/rest/RestControllerAnnotationArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/zeebe/gateway/rest/RestControllerAnnotationArchTest.java
@@ -7,17 +7,21 @@
  */
 package io.camunda.zeebe.gateway.rest;
 
-import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.lang.ArchRule;
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
+import io.camunda.archunit.DoNotIncludeTestsOrTestJars;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RestController;
 
+// DoNotIncludeTestsOrTestJars (not the built-in DoNotIncludeTests) because
+// qa/archunit-tests pulls in zeebe-gateway-rest as a test-jar; without filtering
+// test-jar entries, @RestController classes declared inside controller tests would
+// be analyzed as production code.
 @AnalyzeClasses(
     packages = "io.camunda.zeebe.gateway.rest",
-    importOptions = ImportOption.DoNotIncludeTests.class)
+    importOptions = DoNotIncludeTestsOrTestJars.class)
 public class RestControllerAnnotationArchTest {
 
   /**

--- a/zeebe/gateway-rest/pom.xml
+++ b/zeebe/gateway-rest/pom.xml
@@ -491,6 +491,22 @@
 
   <build>
     <plugins>
+      <!--
+        Publish a test-jar so qa/archunit-tests can analyze our test classes
+        (e.g. ControllerStrictJsonCompareArchTest scans REST controller tests
+        for WebTestClient.BodyContentSpec#json calls).
+      -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>

--- a/zeebe/gateway-rest/pom.xml
+++ b/zeebe/gateway-rest/pom.xml
@@ -445,7 +445,6 @@
       <scope>test</scope>
     </dependency>
 
-    <!-- required due to ArchUnit presence -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
@@ -461,24 +460,6 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>com.tngtech.archunit</groupId>
-      <artifactId>archunit</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>com.tngtech.archunit</groupId>
-      <artifactId>archunit-junit5-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>com.tngtech.archunit</groupId>
-      <artifactId>archunit-junit5-engine</artifactId>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
## Summary

- Move `MultiDbTestArchTest` (from `qa/acceptance-tests`) and `ControllerStrictJsonCompareArchTest` (from `zeebe/gateway-rest`) into `qa/archunit-tests`, pulling the analyzed test classes in as `<type>test-jar</type>` dependencies. Both modules now publish a test-jar via `maven-jar-plugin`.
- Add two custom `ImportOption`s in `qa/archunit-tests`:
  - `IncludeTestClassesAndTestJars` — used by the moved arch tests. ArchUnit's built-in `OnlyIncludeTests` only matches `target/test-classes/` paths and ignores classes loaded from `*-tests.jar` URIs, so the rules would otherwise see no classes.
  - `DoNotIncludeTestsOrTestJars` — applied to `RestControllerAnnotationArchTest`, `RequiresSecondaryStorageAnnotationArchTest`, `ForbidWebStereotypeArchTest`. Without it, test classes pulled in via the new test-jar dep would be analyzed as production code (regression caught locally on `ResponseValidationSpringMvcIntegrationTest`'s inner `@RestController`).
- The `archunit-tests` CI job stays at a single `-pl :camunda-archunit-tests` invocation, with `surefire.rerunFailingTestsCount=0` so deterministic ArchUnit violations red the build instead of being masked by reruns.

## Why

Grafana reports hidden failures of `MultiDbTestArchTest::FORBID_MULTI_DB_SPECIFIED_DB` on otherwise-green CI runs. Two issues compounded:
1. The arch test ran under Failsafe with `rerunFailingTestsCount > 0`, masking deterministic violations.
2. The `me.fabriciorby:maven-surefire-junit5-tree-reporter` (1.5.1) crashes with `NoSuchElementException` when post-processing ArchUnit failure descriptors. The crash happens after the per-class `TEST-*.xml` is written but before Failsafe writes `failsafe-summary.xml`, so `failsafe:verify` reports "No tests to run" and the Maven build exits 0 even on a real violation.

Moving the rules into `qa/archunit-tests` (already the canonical home, enforced by `ArchTestsArchTest.REQUIRE_ARCH_TESTS_TO_BE_IN_THE_QA_MODULE`) routes them through the dedicated archunit-tests job with zero reruns and the default Surefire reporter — both root causes sidestepped.

## Result
The job now correctly reports the failure https://github.com/camunda/camunda/actions/runs/26411253377/job/77746010814?pr=53920 