### PR TITLE
ci: verify monorepo-docs page was successfuly build

### DIFF
--- a/.github/workflows/docs-build-deploy.yml
+++ b/.github/workflows/docs-build-deploy.yml
@@ -51,6 +51,7 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: write
+      pages: read
     environment:
       name: github-pages
       url: https://camunda.github.io/camunda/
@@ -81,6 +82,49 @@ jobs:
           publish_dir: ./monorepo-docs-site/build
           keep_files: true
           enable_jekyll: false
+
+      # The deploy step above only confirms the push to gh-pages — the server-side Pages
+      # build runs separately and its outcome is not surfaced anywhere in the Actions UI
+      # (legacy Pages mode). Poll the Pages build API so a failed build becomes a visible
+      # job failure rather than a green workflow with a dead docs site.
+      - name: Verify Pages build
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          expected_sha=$(gh api "repos/${GITHUB_REPOSITORY}/branches/gh-pages" --jq '.commit.sha')
+          echo "Expecting Pages build for gh-pages HEAD: ${expected_sha}"
+          deadline=$(( $(date +%s) + 300 ))
+          while :; do
+            response=$(gh api "repos/${GITHUB_REPOSITORY}/pages/builds/latest")
+            status=$(jq -r '.status' <<< "${response}")
+            commit=$(jq -r '.commit' <<< "${response}")
+            error=$(jq -r '.error.message // ""' <<< "${response}")
+            if [[ "${commit}" != "${expected_sha}" ]]; then
+              echo "Latest build is for ${commit:0:12} (status=${status}); waiting for ${expected_sha:0:12}..."
+            else
+              echo "Pages build for ${commit:0:12}: status=${status}"
+              case "${status}" in
+                built)
+                  echo "::notice::Pages build succeeded for ${commit}"
+                  exit 0 ;;
+                errored)
+                  echo "::error::Pages build FAILED for ${commit}: ${error}"
+                  echo "::error::The API only exposes the generic message above; check Settings → Pages in the repo UI for any additional detail."
+                  exit 1 ;;
+                building|queued|"")
+                  : ;;
+                *)
+                  echo "::warning::Unknown Pages build status: ${status} — treating as failure"
+                  exit 1 ;;
+              esac
+            fi
+            if (( $(date +%s) >= deadline )); then
+              echo "::error::Timed out after 300s waiting for Pages build to complete."
+              exit 1
+            fi
+            sleep 10
+          done
 
       - name: Observe build status
         if: always()

--- a/docs/monorepo-docs/ci-runbooks.md
+++ b/docs/monorepo-docs/ci-runbooks.md
@@ -389,3 +389,24 @@ Incident Commander role as new information becomes available.
 
 As Incident Commander please analyze the slow Unified CI job and figure out how to make it faster,
 e.g. by eliminating bottlenecks, caching, or splitting it into multiple parallel jobs.
+
+---
+
+### Monorepo Docs Site Pages Build Failure
+
+The `Docs Build and Deploy` workflow includes a `Verify Pages build` step that polls the GitHub
+Pages build API after pushing to `gh-pages`. If this step fails, the deploy commit landed but
+GitHub Pages was unable to publish it, leaving https://camunda.github.io/camunda/ stale or broken.
+The Pages build outcome is otherwise not surfaced anywhere in the Actions UI (legacy Pages mode),
+so without this step a failed build leaves no trace in CI. (For PR previews, `Docs PR Preview`
+relies on `rossjrw/pr-preview-action`'s built-in `wait-for-pages-deployment`, which provides the
+same guarantee.)
+
+#### Troubleshooting
+
+1. Check the failed step's log — it prints the gh-pages commit SHA and the API status (`errored`
+   or `building` timeout). Note: the API only exposes the generic `"Page build failed."` message;
+   the underlying reason is not surfaced through the API.
+2. Inspect recent Pages build history
+3. Verify the `gh-pages` branch only contains build artifacts.
+


### PR DESCRIPTION
## Description

This pull request improves the reliability and visibility of the documentation deployment process by adding a verification step for GitHub Pages builds and updating the runbook documentation. The main focus is to ensure that failed Pages builds are detected and surfaced in CI, preventing silent failures that could leave the docs site stale or broken.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
