### PR TITLE
Implement agent instance search with RDBMS secondary storage

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsService.java
@@ -9,6 +9,7 @@ package io.camunda.db.rdbms;
 
 import io.camunda.db.rdbms.read.replication.ReplicationLogStatusProvider;
 import io.camunda.db.rdbms.read.replication.ReplicationLogStatusProviderFactory;
+import io.camunda.db.rdbms.read.service.AgentInstanceDbReader;
 import io.camunda.db.rdbms.read.service.AuditLogDbReader;
 import io.camunda.db.rdbms.read.service.AuthorizationDbReader;
 import io.camunda.db.rdbms.read.service.BatchOperationDbReader;
@@ -57,6 +58,7 @@ import java.util.function.Consumer;
 public class RdbmsService {
 
   private final RdbmsWriterFactory rdbmsWriterFactory;
+  private final AgentInstanceDbReader agentInstanceDbReader;
   private final AuditLogDbReader auditLogReader;
   private final AuthorizationDbReader authorizationReader;
   private final DecisionDefinitionDbReader decisionDefinitionReader;
@@ -104,6 +106,7 @@ public class RdbmsService {
 
   public RdbmsService(
       final RdbmsWriterFactory rdbmsWriterFactory,
+      final AgentInstanceDbReader agentInstanceDbReader,
       final AuditLogDbReader auditLogReader,
       final AuthorizationDbReader authorizationReader,
       final DecisionDefinitionDbReader decisionDefinitionReader,
@@ -148,6 +151,7 @@ public class RdbmsService {
       final DeployedResourceDbReader deployedResourceDbReader,
       final ReplicationLogStatusProviderFactory replicationLogStatusProviderFactory) {
     this.rdbmsWriterFactory = rdbmsWriterFactory;
+    this.agentInstanceDbReader = agentInstanceDbReader;
     this.auditLogReader = auditLogReader;
     this.authorizationReader = authorizationReader;
     this.decisionRequirementsReader = decisionRequirementsReader;
@@ -344,6 +348,10 @@ public class RdbmsService {
   public IncidentProcessInstanceStatisticsByDefinitionDbReader
       getIncidentProcessInstanceStatisticsByDefinitionReader() {
     return incidentProcessInstanceStatisticsByDefinitionDbReader;
+  }
+
+  public AgentInstanceDbReader getAgentInstanceDbReader() {
+    return agentInstanceDbReader;
   }
 
   public GlobalListenerDbReader getGlobalListenerDbReader() {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/AgentInstanceDbQuery.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/AgentInstanceDbQuery.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.domain;
+
+import io.camunda.search.entities.AgentInstanceEntity;
+import io.camunda.search.filter.AgentInstanceFilter;
+import io.camunda.search.filter.FilterBuilders;
+import io.camunda.util.ObjectBuilder;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+
+public record AgentInstanceDbQuery(
+    AgentInstanceFilter filter,
+    List<String> authorizedResourceIds,
+    List<String> authorizedTenantIds,
+    DbQuerySorting<AgentInstanceEntity> sort,
+    DbQueryPage page) {
+
+  public static AgentInstanceDbQuery of(
+      final Function<AgentInstanceDbQuery.Builder, ObjectBuilder<AgentInstanceDbQuery>> fn) {
+    return fn.apply(new AgentInstanceDbQuery.Builder()).build();
+  }
+
+  public static final class Builder implements ObjectBuilder<AgentInstanceDbQuery> {
+
+    private static final AgentInstanceFilter EMPTY_FILTER = FilterBuilders.agentInstance().build();
+
+    private AgentInstanceFilter filter;
+    private List<String> authorizedResourceIds;
+    private List<String> authorizedTenantIds;
+    private DbQuerySorting<AgentInstanceEntity> sort;
+    private DbQueryPage page;
+
+    public Builder filter(final AgentInstanceFilter value) {
+      filter = value;
+      return this;
+    }
+
+    public Builder authorizedResourceIds(final List<String> value) {
+      authorizedResourceIds = value;
+      return this;
+    }
+
+    public Builder authorizedTenantIds(final List<String> value) {
+      authorizedTenantIds = value;
+      return this;
+    }
+
+    public Builder sort(final DbQuerySorting<AgentInstanceEntity> value) {
+      sort = value;
+      return this;
+    }
+
+    public Builder page(final DbQueryPage value) {
+      page = value;
+      return this;
+    }
+
+    public Builder filter(
+        final Function<AgentInstanceFilter.Builder, ObjectBuilder<AgentInstanceFilter>> fn) {
+      return filter(FilterBuilders.agentInstance(fn));
+    }
+
+    public Builder sort(
+        final Function<
+                DbQuerySorting.Builder<AgentInstanceEntity>,
+                ObjectBuilder<DbQuerySorting<AgentInstanceEntity>>>
+            fn) {
+      return sort(DbQuerySorting.of(fn));
+    }
+
+    @Override
+    public AgentInstanceDbQuery build() {
+      filter = Objects.requireNonNullElse(filter, EMPTY_FILTER);
+      sort = Objects.requireNonNullElse(sort, new DbQuerySorting<>(Collections.emptyList()));
+      authorizedResourceIds = Objects.requireNonNullElse(authorizedResourceIds, List.of());
+      authorizedTenantIds = Objects.requireNonNullElse(authorizedTenantIds, List.of());
+      return new AgentInstanceDbQuery(
+          filter, authorizedResourceIds, authorizedTenantIds, sort, page);
+    }
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/AgentInstanceEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/AgentInstanceEntityMapper.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.mapper;
+
+import io.camunda.db.rdbms.write.domain.AgentInstanceDbModel;
+import io.camunda.db.rdbms.write.domain.AgentInstanceDbModel.AgentInstanceToolDbValue;
+import io.camunda.search.entities.AgentInstanceEntity;
+import io.camunda.search.entities.AgentInstanceEntity.AgentInstanceDefinition;
+import io.camunda.search.entities.AgentInstanceEntity.AgentInstanceLimits;
+import io.camunda.search.entities.AgentInstanceEntity.AgentInstanceMetrics;
+import io.camunda.search.entities.AgentInstanceEntity.AgentInstanceStatus;
+import io.camunda.search.entities.AgentInstanceEntity.AgentInstanceTool;
+import java.util.Collections;
+import java.util.List;
+
+public class AgentInstanceEntityMapper {
+
+  public static AgentInstanceEntity toEntity(final AgentInstanceDbModel dbModel) {
+    if (dbModel == null) {
+      return null;
+    }
+    return new AgentInstanceEntity(
+        dbModel.agentInstanceKey(),
+        dbModel.elementInstanceKeys() != null ? dbModel.elementInstanceKeys() : List.of(),
+        toStatus(dbModel.status()),
+        new AgentInstanceDefinition(dbModel.model(), dbModel.provider(), dbModel.systemPrompt()),
+        new AgentInstanceMetrics(
+            dbModel.inputTokens(),
+            dbModel.outputTokens(),
+            dbModel.modelCalls(),
+            dbModel.toolCalls()),
+        new AgentInstanceLimits(
+            dbModel.maxTokens(), dbModel.maxModelCalls(), dbModel.maxToolCalls()),
+        toTools(dbModel.toolValues()),
+        dbModel.elementId(),
+        dbModel.processInstanceKey(),
+        dbModel.rootProcessInstanceKey() == -1L ? null : dbModel.rootProcessInstanceKey(),
+        dbModel.processDefinitionKey(),
+        dbModel.processDefinitionId(),
+        dbModel.processDefinitionVersion(),
+        dbModel.versionTag(),
+        dbModel.tenantId(),
+        dbModel.creationDate(),
+        dbModel.lastUpdatedDate(),
+        dbModel.completionDate());
+  }
+
+  private static AgentInstanceStatus toStatus(final AgentInstanceStatus status) {
+    return status != null ? status : AgentInstanceStatus.UNKNOWN;
+  }
+
+  private static List<AgentInstanceTool> toTools(final List<AgentInstanceToolDbValue> tools) {
+    if (tools == null) {
+      return Collections.emptyList();
+    }
+    return tools.stream()
+        .map(t -> new AgentInstanceTool(t.name(), t.description(), t.elementId()))
+        .toList();
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/AgentInstanceEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/AgentInstanceEntityMapper.java
@@ -38,7 +38,7 @@ public class AgentInstanceEntityMapper {
         toTools(dbModel.toolValues()),
         dbModel.elementId(),
         dbModel.processInstanceKey(),
-        dbModel.rootProcessInstanceKey() == -1L ? null : dbModel.rootProcessInstanceKey(),
+        dbModel.rootProcessInstanceKey(),
         dbModel.processDefinitionKey(),
         dbModel.processDefinitionId(),
         dbModel.processDefinitionVersion(),

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/AgentInstanceEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/AgentInstanceEntityMapper.java
@@ -13,7 +13,6 @@ import io.camunda.search.entities.AgentInstanceEntity;
 import io.camunda.search.entities.AgentInstanceEntity.AgentInstanceDefinition;
 import io.camunda.search.entities.AgentInstanceEntity.AgentInstanceLimits;
 import io.camunda.search.entities.AgentInstanceEntity.AgentInstanceMetrics;
-import io.camunda.search.entities.AgentInstanceEntity.AgentInstanceStatus;
 import io.camunda.search.entities.AgentInstanceEntity.AgentInstanceTool;
 import java.util.Collections;
 import java.util.List;
@@ -27,7 +26,7 @@ public class AgentInstanceEntityMapper {
     return new AgentInstanceEntity(
         dbModel.agentInstanceKey(),
         dbModel.elementInstanceKeys() != null ? dbModel.elementInstanceKeys() : List.of(),
-        toStatus(dbModel.status()),
+        dbModel.status(),
         new AgentInstanceDefinition(dbModel.model(), dbModel.provider(), dbModel.systemPrompt()),
         new AgentInstanceMetrics(
             dbModel.inputTokens(),
@@ -48,10 +47,6 @@ public class AgentInstanceEntityMapper {
         dbModel.creationDate(),
         dbModel.lastUpdatedDate(),
         dbModel.completionDate());
-  }
-
-  private static AgentInstanceStatus toStatus(final AgentInstanceStatus status) {
-    return status != null ? status : AgentInstanceStatus.UNKNOWN;
   }
 
   private static List<AgentInstanceTool> toTools(final List<AgentInstanceToolDbValue> tools) {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AgentInstanceDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AgentInstanceDbReader.java
@@ -54,7 +54,7 @@ public class AgentInstanceDbReader extends AbstractEntityReader<AgentInstanceEnt
   @Override
   public SearchQueryResult<AgentInstanceEntity> search(
       final AgentInstanceQuery query, final ResourceAccessChecks resourceAccessChecks) {
-    final var dbSort = convertSort(query.sort(), AgentInstanceSearchColumn.KEY);
+    final var dbSort = convertSort(query.sort(), AgentInstanceSearchColumn.AGENT_INSTANCE_KEY);
 
     if (shouldReturnEmptyResult(resourceAccessChecks)) {
       return buildSearchQueryResult(0, List.of(), dbSort);

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AgentInstanceDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AgentInstanceDbReader.java
@@ -8,37 +8,83 @@
 package io.camunda.db.rdbms.read.service;
 
 import io.camunda.db.rdbms.read.RdbmsReaderConfig;
+import io.camunda.db.rdbms.read.domain.AgentInstanceDbQuery;
+import io.camunda.db.rdbms.read.mapper.AgentInstanceEntityMapper;
+import io.camunda.db.rdbms.sql.AgentInstanceMapper;
+import io.camunda.db.rdbms.sql.columns.AgentInstanceSearchColumn;
 import io.camunda.search.clients.reader.AgentInstanceReader;
 import io.camunda.search.entities.AgentInstanceEntity;
 import io.camunda.search.query.AgentInstanceQuery;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import io.camunda.security.reader.ResourceAccessChecks;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-/**
- * RDBMS-backed reader for agent instances.
- *
- * <p>Full implementation will be covered in <a
- * href="https://github.com/camunda/camunda/issues/52820">#52820</a>.
- */
 public class AgentInstanceDbReader extends AbstractEntityReader<AgentInstanceEntity>
     implements AgentInstanceReader {
 
-  public AgentInstanceDbReader(final RdbmsReaderConfig readerConfig) {
-    // FIXME when implementing #52820 substitute `null` with `AgentInstanceSearchColumn.values()`
-    super(null, readerConfig);
+  private static final Logger LOG = LoggerFactory.getLogger(AgentInstanceDbReader.class);
+
+  private final AgentInstanceMapper agentInstanceMapper;
+
+  public AgentInstanceDbReader(
+      final AgentInstanceMapper agentInstanceMapper, final RdbmsReaderConfig readerConfig) {
+    super(AgentInstanceSearchColumn.values(), readerConfig);
+    this.agentInstanceMapper = agentInstanceMapper;
   }
 
   @Override
   public AgentInstanceEntity getByKey(
       final long key, final ResourceAccessChecks resourceAccessChecks) {
-    throw new UnsupportedOperationException(
-        "AgentInstanceDbReader is not yet implemented; see https://github.com/camunda/camunda/issues/52820");
+    return findOne(key);
+  }
+
+  public AgentInstanceEntity findOne(final long key) {
+    return search(
+            AgentInstanceQuery.of(
+                b -> b.filter(f -> f.agentInstanceKeys(key)).page(p -> p.from(0).size(1))))
+        .items()
+        .stream()
+        .findFirst()
+        .orElse(null);
   }
 
   @Override
   public SearchQueryResult<AgentInstanceEntity> search(
       final AgentInstanceQuery query, final ResourceAccessChecks resourceAccessChecks) {
-    throw new UnsupportedOperationException(
-        "AgentInstanceDbReader is not yet implemented; see https://github.com/camunda/camunda/issues/52820");
+    final var dbSort = convertSort(query.sort(), AgentInstanceSearchColumn.KEY);
+
+    if (shouldReturnEmptyResult(resourceAccessChecks)) {
+      return buildSearchQueryResult(0, List.of(), dbSort);
+    }
+    final var authorizedResourceIds =
+        resourceAccessChecks
+            .getAuthorizedResourceIdsByType()
+            .getOrDefault(AuthorizationResourceType.PROCESS_DEFINITION.name(), List.of());
+    final var dbPage = convertPaging(dbSort, query.page());
+    final var dbQuery =
+        AgentInstanceDbQuery.of(
+            b ->
+                b.filter(query.filter())
+                    .authorizedResourceIds(authorizedResourceIds)
+                    .authorizedTenantIds(resourceAccessChecks.getAuthorizedTenantIds())
+                    .sort(dbSort)
+                    .page(dbPage));
+
+    LOG.trace("[RDBMS DB] Search for agent instances with filter {}", dbQuery);
+    return executePagedQuery(
+        () -> agentInstanceMapper.count(dbQuery),
+        () ->
+            agentInstanceMapper.search(dbQuery).stream()
+                .map(AgentInstanceEntityMapper::toEntity)
+                .toList(),
+        dbPage,
+        dbSort);
+  }
+
+  public SearchQueryResult<AgentInstanceEntity> search(final AgentInstanceQuery query) {
+    return search(query, ResourceAccessChecks.disabled());
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/AgentInstanceMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/AgentInstanceMapper.java
@@ -7,7 +7,9 @@
  */
 package io.camunda.db.rdbms.sql;
 
+import io.camunda.db.rdbms.read.domain.AgentInstanceDbQuery;
 import io.camunda.db.rdbms.write.domain.AgentInstanceDbModel;
+import java.util.List;
 
 public interface AgentInstanceMapper extends ProcessInstanceDependantMapper {
 
@@ -18,4 +20,8 @@ public interface AgentInstanceMapper extends ProcessInstanceDependantMapper {
   void deleteElementInstanceKeys(long agentInstanceKey);
 
   void insertElementInstanceKeys(AgentInstanceDbModel agentInstance);
+
+  Long count(AgentInstanceDbQuery query);
+
+  List<AgentInstanceDbModel> search(AgentInstanceDbQuery query);
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/AgentInstanceSearchColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/AgentInstanceSearchColumn.java
@@ -10,7 +10,7 @@ package io.camunda.db.rdbms.sql.columns;
 import io.camunda.search.entities.AgentInstanceEntity;
 
 public enum AgentInstanceSearchColumn implements SearchColumn<AgentInstanceEntity> {
-  KEY("agentInstanceKey"),
+  AGENT_INSTANCE_KEY("agentInstanceKey"),
   CREATION_DATE("creationDate"),
   LAST_UPDATED_DATE("lastUpdatedDate"),
   COMPLETION_DATE("completionDate"),

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/AgentInstanceSearchColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/AgentInstanceSearchColumn.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.sql.columns;
+
+import io.camunda.search.entities.AgentInstanceEntity;
+
+public enum AgentInstanceSearchColumn implements SearchColumn<AgentInstanceEntity> {
+  KEY("agentInstanceKey"),
+  CREATION_DATE("creationDate"),
+  LAST_UPDATED_DATE("lastUpdatedDate"),
+  COMPLETION_DATE("completionDate"),
+  STATUS("status"),
+  PROCESS_INSTANCE_KEY("processInstanceKey"),
+  PROCESS_DEFINITION_KEY("processDefinitionKey"),
+  ELEMENT_ID("elementId"),
+  TENANT_ID("tenantId");
+
+  private final String property;
+
+  AgentInstanceSearchColumn(final String property) {
+    this.property = property;
+  }
+
+  @Override
+  public String property() {
+    return property;
+  }
+
+  @Override
+  public Class<AgentInstanceEntity> getEntityClass() {
+    return AgentInstanceEntity.class;
+  }
+}

--- a/db/rdbms/src/main/resources/mapper/AgentInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/AgentInstanceMapper.xml
@@ -12,6 +12,8 @@
 
 <mapper namespace="io.camunda.db.rdbms.sql.AgentInstanceMapper">
 
+  <!-- ===== WRITE operations ===== -->
+
   <!-- default: PostgreSQL, H2, MariaDB, MySQL -->
   <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.AgentInstanceDbModel">
     INSERT INTO ${prefix}AGENT_INSTANCE (
@@ -124,5 +126,206 @@
     <bind name="primaryKeyColumn" value="'AGENT_INSTANCE_KEY'"/>
     <include refid="io.camunda.db.rdbms.sql.Commons.processInstanceHistoryDeletion"/>
   </delete>
+
+  <!-- ===== READ operations ===== -->
+
+  <!--
+    Tools are stored as a JSON CLOB in AGENT_INSTANCE.TOOLS and are deserialized lazily
+    by AgentInstanceDbModel.toolValues(). No separate tool table exists in the schema.
+  -->
+  <resultMap id="searchResultMap"
+    type="io.camunda.db.rdbms.write.domain.AgentInstanceDbModel">
+    <id property="agentInstanceKey" column="AGENT_INSTANCE_KEY" javaType="long"/>
+    <result property="elementId" column="ELEMENT_ID" javaType="java.lang.String"/>
+    <result property="processInstanceKey" column="PROCESS_INSTANCE_KEY" javaType="long"/>
+    <result property="rootProcessInstanceKey" column="ROOT_PROCESS_INSTANCE_KEY" javaType="long"/>
+    <result property="processDefinitionId" column="PROCESS_DEFINITION_ID" javaType="java.lang.String"/>
+    <result property="processDefinitionKey" column="PROCESS_DEFINITION_KEY" javaType="long"/>
+    <result property="processDefinitionVersion" column="PROCESS_DEFINITION_VERSION"
+      javaType="java.lang.Integer"/>
+    <result property="versionTag" column="VERSION_TAG" javaType="java.lang.String"/>
+    <result property="tenantId" column="TENANT_ID" javaType="java.lang.String"/>
+    <result property="partitionId" column="PARTITION_ID" javaType="java.lang.Integer"/>
+    <result property="status" column="STATUS" javaType="java.lang.String"/>
+    <result property="model" column="MODEL" javaType="java.lang.String"/>
+    <result property="provider" column="PROVIDER" javaType="java.lang.String"/>
+    <result property="systemPrompt" column="SYSTEM_PROMPT" javaType="java.lang.String"/>
+    <result property="maxTokens" column="MAX_TOKENS" javaType="long"/>
+    <result property="maxModelCalls" column="MAX_MODEL_CALLS" javaType="java.lang.Integer"/>
+    <result property="maxToolCalls" column="MAX_TOOL_CALLS" javaType="java.lang.Integer"/>
+    <result property="inputTokens" column="INPUT_TOKENS" javaType="long"/>
+    <result property="outputTokens" column="OUTPUT_TOKENS" javaType="long"/>
+    <result property="modelCalls" column="MODEL_CALLS" javaType="java.lang.Integer"/>
+    <result property="toolCalls" column="TOOL_CALLS" javaType="java.lang.Integer"/>
+    <result property="tools" column="TOOLS" javaType="java.lang.String"/>
+    <result property="creationDate" column="CREATION_DATE" javaType="java.time.OffsetDateTime"/>
+    <result property="lastUpdatedDate" column="LAST_UPDATED_DATE"
+      javaType="java.time.OffsetDateTime"/>
+    <result property="completionDate" column="COMPLETION_DATE" javaType="java.time.OffsetDateTime"/>
+    <collection property="elementInstanceKeys" ofType="java.lang.Long" javaType="java.util.List">
+      <id column="ELEMENT_INSTANCE_KEY"/>
+    </collection>
+  </resultMap>
+
+  <select id="search"
+    parameterType="io.camunda.db.rdbms.read.domain.AgentInstanceDbQuery"
+    resultMap="io.camunda.db.rdbms.sql.AgentInstanceMapper.searchResultMap">
+    SELECT * FROM (
+      SELECT
+        ai.*,
+        eik.ELEMENT_INSTANCE_KEY
+      FROM (
+        SELECT * FROM (
+          SELECT
+            ai.AGENT_INSTANCE_KEY,
+            ai.ELEMENT_ID,
+            ai.PROCESS_INSTANCE_KEY,
+            ai.ROOT_PROCESS_INSTANCE_KEY,
+            ai.PROCESS_DEFINITION_ID,
+            ai.PROCESS_DEFINITION_KEY,
+            ai.PROCESS_DEFINITION_VERSION,
+            ai.VERSION_TAG,
+            ai.TENANT_ID,
+            ai.PARTITION_ID,
+            ai.STATUS,
+            ai.MODEL,
+            ai.PROVIDER,
+            ai.SYSTEM_PROMPT,
+            ai.MAX_TOKENS,
+            ai.MAX_MODEL_CALLS,
+            ai.MAX_TOOL_CALLS,
+            ai.INPUT_TOKENS,
+            ai.OUTPUT_TOKENS,
+            ai.MODEL_CALLS,
+            ai.TOOL_CALLS,
+            ai.TOOLS,
+            ai.CREATION_DATE,
+            ai.LAST_UPDATED_DATE,
+            ai.COMPLETION_DATE
+          FROM ${prefix}AGENT_INSTANCE ai
+          <include refid="io.camunda.db.rdbms.sql.AgentInstanceMapper.searchAndAuthFilter"/>
+        ) filtered
+        <include refid="io.camunda.db.rdbms.sql.Commons.keySetPageFilter"/>
+        <include refid="io.camunda.db.rdbms.sql.Commons.orderBy"/>
+        <include refid="io.camunda.db.rdbms.sql.Commons.paging"/>
+      ) ai
+      LEFT JOIN ${prefix}AGENT_INSTANCE_ELEMENT_INSTANCE eik
+        ON eik.AGENT_INSTANCE_KEY = ai.AGENT_INSTANCE_KEY
+    ) sorted
+    <include refid="io.camunda.db.rdbms.sql.Commons.orderBy"/>
+  </select>
+
+  <select id="count" resultType="java.lang.Long">
+    SELECT COUNT(*) FROM (
+      SELECT 1 as col
+      FROM ${prefix}AGENT_INSTANCE ai
+      <include refid="io.camunda.db.rdbms.sql.AgentInstanceMapper.searchAndAuthFilter"/>
+      ${count.limit}
+    ) t
+  </select>
+
+  <sql id="searchAndAuthFilter">
+    <where>
+      <if test="authorizedResourceIds != null and !authorizedResourceIds.isEmpty()">
+        AND ai.PROCESS_DEFINITION_ID IN
+        <foreach collection="authorizedResourceIds" item="resourceId" open="(" separator="," close=")">
+          #{resourceId}
+        </foreach>
+      </if>
+      <if test="authorizedTenantIds != null and !authorizedTenantIds.isEmpty()">
+        AND ai.TENANT_ID IN
+        <foreach collection="authorizedTenantIds" item="tenantId" open="(" separator="," close=")">
+          #{tenantId}
+        </foreach>
+      </if>
+      <include refid="io.camunda.db.rdbms.sql.AgentInstanceMapper.searchFilter"/>
+    </where>
+  </sql>
+
+  <sql id="searchFilter">
+      <if test="filter.agentInstanceKeyOperations != null and !filter.agentInstanceKeyOperations.isEmpty()">
+        <foreach collection="filter.agentInstanceKeyOperations" item="operation">
+          AND ai.AGENT_INSTANCE_KEY
+          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
+      <if test="filter.processInstanceKeyOperations != null and !filter.processInstanceKeyOperations.isEmpty()">
+        <foreach collection="filter.processInstanceKeyOperations" item="operation">
+          AND ai.PROCESS_INSTANCE_KEY
+          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
+      <if test="filter.processDefinitionKeyOperations != null and !filter.processDefinitionKeyOperations.isEmpty()">
+        <foreach collection="filter.processDefinitionKeyOperations" item="operation">
+          AND ai.PROCESS_DEFINITION_KEY
+          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
+      <if test="filter.processDefinitionIdOperations != null and !filter.processDefinitionIdOperations.isEmpty()">
+        <foreach collection="filter.processDefinitionIdOperations" item="operation">
+          AND ai.PROCESS_DEFINITION_ID
+          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
+      <if test="filter.processDefinitionVersionOperations != null and !filter.processDefinitionVersionOperations.isEmpty()">
+        <foreach collection="filter.processDefinitionVersionOperations" item="operation">
+          AND ai.PROCESS_DEFINITION_VERSION
+          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
+      <if test="filter.versionTagOperations != null and !filter.versionTagOperations.isEmpty()">
+        <foreach collection="filter.versionTagOperations" item="operation">
+          AND ai.VERSION_TAG
+          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
+      <if test="filter.elementIdOperations != null and !filter.elementIdOperations.isEmpty()">
+        <foreach collection="filter.elementIdOperations" item="operation">
+          AND ai.ELEMENT_ID
+          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
+      <if test="filter.statusOperations != null and !filter.statusOperations.isEmpty()">
+        <foreach collection="filter.statusOperations" item="operation">
+          AND ai.STATUS
+          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
+      <if test="filter.tenantIdOperations != null and !filter.tenantIdOperations.isEmpty()">
+        <foreach collection="filter.tenantIdOperations" item="operation">
+          AND ai.TENANT_ID
+          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
+      <if test="filter.creationDateOperations != null and !filter.creationDateOperations.isEmpty()">
+        <foreach collection="filter.creationDateOperations" item="operation">
+          AND ai.CREATION_DATE
+          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
+      <if test="filter.lastUpdatedDateOperations != null and !filter.lastUpdatedDateOperations.isEmpty()">
+        <foreach collection="filter.lastUpdatedDateOperations" item="operation">
+          AND ai.LAST_UPDATED_DATE
+          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
+      <if test="filter.completionDateOperations != null and !filter.completionDateOperations.isEmpty()">
+        <foreach collection="filter.completionDateOperations" item="operation">
+          AND ai.COMPLETION_DATE
+          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
+      <!-- elementInstanceKey filter uses EXISTS subquery against the junction table -->
+      <if test="filter.elementInstanceKeyOperations != null and !filter.elementInstanceKeyOperations.isEmpty()">
+        AND EXISTS (
+          SELECT 1 FROM ${prefix}AGENT_INSTANCE_ELEMENT_INSTANCE eik
+          WHERE eik.AGENT_INSTANCE_KEY = ai.AGENT_INSTANCE_KEY
+          <foreach collection="filter.elementInstanceKeyOperations" item="operation">
+            AND eik.ELEMENT_INSTANCE_KEY
+            <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+          </foreach>
+        )
+      </if>
+  </sql>
 
 </mapper>

--- a/db/rdbms/src/main/resources/mapper/AgentInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/AgentInstanceMapper.xml
@@ -146,7 +146,7 @@
     <result property="versionTag" column="VERSION_TAG" javaType="java.lang.String"/>
     <result property="tenantId" column="TENANT_ID" javaType="java.lang.String"/>
     <result property="partitionId" column="PARTITION_ID" javaType="java.lang.Integer"/>
-    <result property="status" column="STATUS" javaType="java.lang.String"/>
+    <result property="status" column="STATUS" javaType="io.camunda.search.entities.AgentInstanceEntity$AgentInstanceStatus"/>
     <result property="model" column="MODEL" javaType="java.lang.String"/>
     <result property="provider" column="PROVIDER" javaType="java.lang.String"/>
     <result property="systemPrompt" column="SYSTEM_PROMPT" javaType="java.lang.String"/>

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/AgentInstanceEntityMapperTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/AgentInstanceEntityMapperTest.java
@@ -38,7 +38,7 @@ class AgentInstanceEntityMapperTest {
               key.versionTag("v1");
               key.tenantId("<default>");
               key.partitionId(1);
-              key.status("THINKING");
+              key.status(AgentInstanceStatus.THINKING);
               key.model("gpt-4");
               key.provider("openai");
               key.systemPrompt("You are an assistant.");
@@ -100,7 +100,7 @@ class AgentInstanceEntityMapperTest {
               m.processDefinitionKey(20L);
               m.processDefinitionVersion(1);
               m.tenantId("t");
-              m.status("COMPLETED");
+              m.status(AgentInstanceStatus.COMPLETED);
               m.model("gpt");
               m.provider("openai");
               m.systemPrompt("s");
@@ -151,7 +151,7 @@ class AgentInstanceEntityMapperTest {
               m.processDefinitionKey(20L);
               m.processDefinitionVersion(1);
               m.tenantId("t");
-              m.status("IDLE");
+              m.status(AgentInstanceStatus.IDLE);
               m.model("gpt");
               m.provider("openai");
               m.systemPrompt("s");

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/AgentInstanceEntityMapperTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/AgentInstanceEntityMapperTest.java
@@ -89,32 +89,6 @@ class AgentInstanceEntityMapperTest {
   }
 
   @Test
-  void shouldMapRootProcessInstanceKeySentinelToNull() {
-    final var dbModel =
-        buildModel(
-            m -> {
-              m.agentInstanceKey(1L);
-              m.processDefinitionId("p");
-              m.elementId("e");
-              m.processInstanceKey(10L);
-              m.processDefinitionKey(20L);
-              m.processDefinitionVersion(1);
-              m.tenantId("t");
-              m.status(AgentInstanceStatus.COMPLETED);
-              m.model("gpt");
-              m.provider("openai");
-              m.systemPrompt("s");
-              m.creationDate(OffsetDateTime.parse("2024-01-01T00:00:00Z"));
-              m.lastUpdatedDate(OffsetDateTime.parse("2024-01-01T00:00:00Z"));
-              m.rootProcessInstanceKey(-1L);
-            });
-
-    final AgentInstanceEntity entity = AgentInstanceEntityMapper.toEntity(dbModel);
-
-    assertThat(entity.rootProcessInstanceKey()).isNull();
-  }
-
-  @Test
   void shouldMapNullToolsToEmptyList() {
     final var dbModel =
         buildModel(

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/AgentInstanceEntityMapperTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/AgentInstanceEntityMapperTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.db.rdbms.write.domain.AgentInstanceDbModel;
+import io.camunda.db.rdbms.write.domain.AgentInstanceDbModel.AgentInstanceToolDbValue;
+import io.camunda.search.entities.AgentInstanceEntity;
+import io.camunda.search.entities.AgentInstanceEntity.AgentInstanceStatus;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class AgentInstanceEntityMapperTest {
+
+  @Test
+  void shouldMapAllFields() {
+    final var creationDate = OffsetDateTime.parse("2024-01-01T00:00:00Z");
+    final var lastUpdatedDate = OffsetDateTime.parse("2024-01-02T00:00:00Z");
+    final var completionDate = OffsetDateTime.parse("2024-01-03T00:00:00Z");
+
+    final var dbModel =
+        buildModel(
+            key -> {
+              key.agentInstanceKey(100L);
+              key.elementId("Task_1");
+              key.processInstanceKey(200L);
+              key.rootProcessInstanceKey(300L);
+              key.processDefinitionId("myProcess");
+              key.processDefinitionKey(400L);
+              key.processDefinitionVersion(2);
+              key.versionTag("v1");
+              key.tenantId("<default>");
+              key.partitionId(1);
+              key.status("THINKING");
+              key.model("gpt-4");
+              key.provider("openai");
+              key.systemPrompt("You are an assistant.");
+              key.maxTokens(10000L);
+              key.maxModelCalls(100);
+              key.maxToolCalls(50);
+              key.inputTokens(500L);
+              key.outputTokens(300L);
+              key.modelCalls(5);
+              key.toolCalls(3);
+              key.creationDate(creationDate);
+              key.lastUpdatedDate(lastUpdatedDate);
+              key.completionDate(completionDate);
+              key.elementInstanceKeys(List.of(1L, 2L, 3L));
+              key.toolValues(List.of(new AgentInstanceToolDbValue("myTool", "A tool", "Task_2")));
+            });
+
+    final AgentInstanceEntity entity = AgentInstanceEntityMapper.toEntity(dbModel);
+
+    assertThat(entity.agentInstanceKey()).isEqualTo(100L);
+    assertThat(entity.elementId()).isEqualTo("Task_1");
+    assertThat(entity.processInstanceKey()).isEqualTo(200L);
+    assertThat(entity.rootProcessInstanceKey()).isEqualTo(300L);
+    assertThat(entity.processDefinitionId()).isEqualTo("myProcess");
+    assertThat(entity.processDefinitionKey()).isEqualTo(400L);
+    assertThat(entity.processDefinitionVersion()).isEqualTo(2);
+    assertThat(entity.versionTag()).isEqualTo("v1");
+    assertThat(entity.tenantId()).isEqualTo("<default>");
+    assertThat(entity.status()).isEqualTo(AgentInstanceStatus.THINKING);
+    assertThat(entity.definition().model()).isEqualTo("gpt-4");
+    assertThat(entity.definition().provider()).isEqualTo("openai");
+    assertThat(entity.definition().systemPrompt()).isEqualTo("You are an assistant.");
+    assertThat(entity.limits().maxTokens()).isEqualTo(10000L);
+    assertThat(entity.limits().maxModelCalls()).isEqualTo(100);
+    assertThat(entity.limits().maxToolCalls()).isEqualTo(50);
+    assertThat(entity.metrics().inputTokens()).isEqualTo(500L);
+    assertThat(entity.metrics().outputTokens()).isEqualTo(300L);
+    assertThat(entity.metrics().modelCalls()).isEqualTo(5);
+    assertThat(entity.metrics().toolCalls()).isEqualTo(3);
+    assertThat(entity.creationDate()).isEqualTo(creationDate);
+    assertThat(entity.lastUpdatedDate()).isEqualTo(lastUpdatedDate);
+    assertThat(entity.completionDate()).isEqualTo(completionDate);
+    assertThat(entity.elementInstanceKeys()).containsExactly(1L, 2L, 3L);
+    assertThat(entity.tools()).hasSize(1);
+    assertThat(entity.tools().get(0).name()).isEqualTo("myTool");
+    assertThat(entity.tools().get(0).description()).isEqualTo("A tool");
+    assertThat(entity.tools().get(0).elementId()).isEqualTo("Task_2");
+  }
+
+  @Test
+  void shouldMapRootProcessInstanceKeySentinelToNull() {
+    final var dbModel =
+        buildModel(
+            m -> {
+              m.agentInstanceKey(1L);
+              m.processDefinitionId("p");
+              m.elementId("e");
+              m.processInstanceKey(10L);
+              m.processDefinitionKey(20L);
+              m.processDefinitionVersion(1);
+              m.tenantId("t");
+              m.status("COMPLETED");
+              m.model("gpt");
+              m.provider("openai");
+              m.systemPrompt("s");
+              m.creationDate(OffsetDateTime.parse("2024-01-01T00:00:00Z"));
+              m.lastUpdatedDate(OffsetDateTime.parse("2024-01-01T00:00:00Z"));
+              m.rootProcessInstanceKey(-1L);
+            });
+
+    final AgentInstanceEntity entity = AgentInstanceEntityMapper.toEntity(dbModel);
+
+    assertThat(entity.rootProcessInstanceKey()).isNull();
+  }
+
+  @Test
+  void shouldMapNullStatusToUnknown() {
+    final var dbModel =
+        buildModel(
+            m -> {
+              m.agentInstanceKey(1L);
+              m.processDefinitionId("p");
+              m.elementId("e");
+              m.processInstanceKey(10L);
+              m.processDefinitionKey(20L);
+              m.processDefinitionVersion(1);
+              m.tenantId("t");
+              m.status(null);
+              m.model("gpt");
+              m.provider("openai");
+              m.systemPrompt("s");
+              m.creationDate(OffsetDateTime.parse("2024-01-01T00:00:00Z"));
+              m.lastUpdatedDate(OffsetDateTime.parse("2024-01-01T00:00:00Z"));
+            });
+
+    final AgentInstanceEntity entity = AgentInstanceEntityMapper.toEntity(dbModel);
+
+    assertThat(entity.status()).isEqualTo(AgentInstanceStatus.UNKNOWN);
+  }
+
+  @Test
+  void shouldMapNullToolsToEmptyList() {
+    final var dbModel =
+        buildModel(
+            m -> {
+              m.agentInstanceKey(1L);
+              m.processDefinitionId("p");
+              m.elementId("e");
+              m.processInstanceKey(10L);
+              m.processDefinitionKey(20L);
+              m.processDefinitionVersion(1);
+              m.tenantId("t");
+              m.status("IDLE");
+              m.model("gpt");
+              m.provider("openai");
+              m.systemPrompt("s");
+              m.creationDate(OffsetDateTime.parse("2024-01-01T00:00:00Z"));
+              m.lastUpdatedDate(OffsetDateTime.parse("2024-01-01T00:00:00Z"));
+              m.toolValues(null);
+            });
+
+    final AgentInstanceEntity entity = AgentInstanceEntityMapper.toEntity(dbModel);
+
+    assertThat(entity.tools()).isEmpty();
+  }
+
+  @Test
+  void shouldReturnNullForNullDbModel() {
+    assertThat(AgentInstanceEntityMapper.toEntity(null)).isNull();
+  }
+
+  private AgentInstanceDbModel buildModel(
+      final java.util.function.Consumer<AgentInstanceDbModel> config) {
+    final var model = new AgentInstanceDbModel();
+    config.accept(model);
+    return model;
+  }
+}

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/AgentInstanceEntityMapperTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/AgentInstanceEntityMapperTest.java
@@ -115,31 +115,6 @@ class AgentInstanceEntityMapperTest {
   }
 
   @Test
-  void shouldMapNullStatusToUnknown() {
-    final var dbModel =
-        buildModel(
-            m -> {
-              m.agentInstanceKey(1L);
-              m.processDefinitionId("p");
-              m.elementId("e");
-              m.processInstanceKey(10L);
-              m.processDefinitionKey(20L);
-              m.processDefinitionVersion(1);
-              m.tenantId("t");
-              m.status(null);
-              m.model("gpt");
-              m.provider("openai");
-              m.systemPrompt("s");
-              m.creationDate(OffsetDateTime.parse("2024-01-01T00:00:00Z"));
-              m.lastUpdatedDate(OffsetDateTime.parse("2024-01-01T00:00:00Z"));
-            });
-
-    final AgentInstanceEntity entity = AgentInstanceEntityMapper.toEntity(dbModel);
-
-    assertThat(entity.status()).isEqualTo(AgentInstanceStatus.UNKNOWN);
-  }
-
-  @Test
   void shouldMapNullToolsToEmptyList() {
     final var dbModel =
         buildModel(

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/AgentInstanceDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/AgentInstanceDbReaderTest.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.db.rdbms.sql.AgentInstanceMapper;
+import io.camunda.db.rdbms.write.domain.AgentInstanceDbModel;
+import io.camunda.search.entities.AgentInstanceEntity.AgentInstanceStatus;
+import io.camunda.search.query.AgentInstanceQuery;
+import io.camunda.security.auth.Authorization;
+import io.camunda.security.reader.AuthorizationCheck;
+import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.security.reader.TenantCheck;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class AgentInstanceDbReaderTest {
+
+  private final AgentInstanceMapper agentInstanceMapper = mock(AgentInstanceMapper.class);
+  private final AgentInstanceDbReader agentInstanceDbReader =
+      new AgentInstanceDbReader(agentInstanceMapper, AbstractEntityReaderTest.TEST_CONFIG);
+
+  // ===== Authorization early-exit =====
+
+  @Test
+  void shouldReturnEmptyResultWhenAuthorizedResourceIdsIsNull() {
+    // Auth enabled but no resource IDs granted → reader must short-circuit before hitting DB
+    final var result =
+        agentInstanceDbReader.search(
+            AgentInstanceQuery.of(b -> b),
+            ResourceAccessChecks.of(
+                AuthorizationCheck.enabled(
+                    Authorization.of(a -> a.processDefinition().readProcessInstance())),
+                TenantCheck.disabled()));
+
+    assertThat(result.items()).isEmpty();
+    verify(agentInstanceMapper, times(0)).search(any());
+    verify(agentInstanceMapper, times(0)).count(any());
+  }
+
+  @Test
+  void shouldInjectAuthorizedProcessDefinitionIdsIntoQuery() {
+    final var authorizedIds = List.of("process-a", "process-b");
+    when(agentInstanceMapper.count(any())).thenReturn(1L);
+    when(agentInstanceMapper.search(any())).thenReturn(List.of(buildModel(1L)));
+
+    agentInstanceDbReader.search(
+        AgentInstanceQuery.of(b -> b),
+        ResourceAccessChecks.of(
+            AuthorizationCheck.enabled(
+                Authorization.of(
+                    a -> a.processDefinition().readProcessInstance().resourceIds(authorizedIds))),
+            TenantCheck.disabled()));
+
+    verify(agentInstanceMapper)
+        .search(argThat(q -> q.authorizedResourceIds().equals(authorizedIds)));
+  }
+
+  @Test
+  void shouldInjectAuthorizedTenantIdsIntoQuery() {
+    final var tenantIds = List.of("tenant-1", "tenant-2");
+    when(agentInstanceMapper.count(any())).thenReturn(1L);
+    when(agentInstanceMapper.search(any())).thenReturn(List.of(buildModel(1L)));
+
+    agentInstanceDbReader.search(
+        AgentInstanceQuery.of(b -> b),
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.enabled(tenantIds)));
+
+    verify(agentInstanceMapper).search(argThat(q -> q.authorizedTenantIds().equals(tenantIds)));
+  }
+
+  @Test
+  void shouldReturnEmptyResultWhenAuthorizedTenantIdsIsEmpty() {
+    final var result =
+        agentInstanceDbReader.search(
+            AgentInstanceQuery.of(b -> b),
+            ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.enabled(List.of())));
+
+    assertThat(result.items()).isEmpty();
+    verify(agentInstanceMapper, times(0)).search(any());
+    verify(agentInstanceMapper, times(0)).count(any());
+  }
+
+  // ===== Page-size edge case =====
+
+  @Test
+  void shouldReturnEmptyItemsButCorrectTotalWhenPageSizeIsZero() {
+    when(agentInstanceMapper.count(any())).thenReturn(42L);
+
+    final var result =
+        agentInstanceDbReader.search(
+            AgentInstanceQuery.of(b -> b.page(p -> p.size(0))),
+            ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
+
+    assertThat(result.total()).isEqualTo(42L);
+    assertThat(result.items()).isEmpty();
+    verify(agentInstanceMapper, times(0)).search(any());
+  }
+
+  // ===== getByKey =====
+
+  @Test
+  void shouldReturnEntityForGetByKey() {
+    when(agentInstanceMapper.count(any())).thenReturn(1L);
+    when(agentInstanceMapper.search(any())).thenReturn(List.of(buildModel(42L)));
+
+    final var entity = agentInstanceDbReader.getByKey(42L, ResourceAccessChecks.disabled());
+
+    assertThat(entity).isNotNull();
+    assertThat(entity.agentInstanceKey()).isEqualTo(42L);
+    verify(agentInstanceMapper)
+        .search(
+            argThat(
+                q ->
+                    q.filter().agentInstanceKeyOperations().stream()
+                        .anyMatch(op -> op.value().equals(42L))));
+  }
+
+  @Test
+  void shouldReturnNullForGetByKeyWhenNotFound() {
+    when(agentInstanceMapper.count(any())).thenReturn(0L);
+    when(agentInstanceMapper.search(any())).thenReturn(List.of());
+
+    final var entity = agentInstanceDbReader.getByKey(99L, ResourceAccessChecks.disabled());
+
+    assertThat(entity).isNull();
+  }
+
+  // ===== Filter pass-through =====
+
+  @Test
+  void shouldPassAgentInstanceKeyFilterToMapper() {
+    when(agentInstanceMapper.count(any())).thenReturn(1L);
+    when(agentInstanceMapper.search(any())).thenReturn(List.of(buildModel(1L)));
+
+    agentInstanceDbReader.search(
+        AgentInstanceQuery.of(b -> b.filter(f -> f.agentInstanceKeys(1L))),
+        ResourceAccessChecks.disabled());
+
+    verify(agentInstanceMapper)
+        .search(
+            argThat(
+                q ->
+                    q.filter().agentInstanceKeyOperations().stream()
+                        .anyMatch(op -> op.value().equals(1L))));
+  }
+
+  @Test
+  void shouldPassStatusFilterToMapper() {
+    when(agentInstanceMapper.count(any())).thenReturn(1L);
+    when(agentInstanceMapper.search(any())).thenReturn(List.of(buildModel(1L)));
+
+    agentInstanceDbReader.search(
+        AgentInstanceQuery.of(b -> b.filter(f -> f.statuses("THINKING"))),
+        ResourceAccessChecks.disabled());
+
+    verify(agentInstanceMapper)
+        .search(
+            argThat(
+                q ->
+                    q.filter().statusOperations().stream()
+                        .anyMatch(op -> "THINKING".equals(op.value()))));
+  }
+
+  @Test
+  void shouldPassProcessInstanceKeyFilterToMapper() {
+    when(agentInstanceMapper.count(any())).thenReturn(1L);
+    when(agentInstanceMapper.search(any())).thenReturn(List.of(buildModel(1L)));
+
+    agentInstanceDbReader.search(
+        AgentInstanceQuery.of(b -> b.filter(f -> f.processInstanceKeys(200L))),
+        ResourceAccessChecks.disabled());
+
+    verify(agentInstanceMapper)
+        .search(
+            argThat(
+                q ->
+                    q.filter().processInstanceKeyOperations().stream()
+                        .anyMatch(op -> op.value().equals(200L))));
+  }
+
+  @Test
+  void shouldPassTenantIdFilterToMapper() {
+    when(agentInstanceMapper.count(any())).thenReturn(1L);
+    when(agentInstanceMapper.search(any())).thenReturn(List.of(buildModel(1L)));
+
+    agentInstanceDbReader.search(
+        AgentInstanceQuery.of(b -> b.filter(f -> f.tenantIds("my-tenant"))),
+        ResourceAccessChecks.disabled());
+
+    verify(agentInstanceMapper)
+        .search(
+            argThat(
+                q ->
+                    q.filter().tenantIdOperations().stream()
+                        .anyMatch(op -> "my-tenant".equals(op.value()))));
+  }
+
+  @Test
+  void shouldReturnMappedEntitiesFromSearch() {
+    when(agentInstanceMapper.count(any())).thenReturn(2L);
+    when(agentInstanceMapper.search(any())).thenReturn(List.of(buildModel(1L), buildModel(2L)));
+
+    final var result =
+        agentInstanceDbReader.search(
+            AgentInstanceQuery.of(b -> b), ResourceAccessChecks.disabled());
+
+    assertThat(result.total()).isEqualTo(2L);
+    assertThat(result.items()).hasSize(2);
+    assertThat(result.items()).extracting(e -> e.agentInstanceKey()).containsExactly(1L, 2L);
+  }
+
+  // ===== Helpers =====
+
+  private AgentInstanceDbModel buildModel(final long key) {
+    return new AgentInstanceDbModel.Builder()
+        .agentInstanceKey(key)
+        .elementId("element-" + key)
+        .processInstanceKey(100L)
+        .rootProcessInstanceKey(-1L)
+        .processDefinitionId("myProcess")
+        .processDefinitionKey(10L)
+        .processDefinitionVersion(1)
+        .tenantId("<default>")
+        .partitionId(1)
+        .status(AgentInstanceStatus.IDLE)
+        .model("gpt-4o")
+        .provider("openai")
+        .systemPrompt("You are an assistant.")
+        .maxTokens(10000L)
+        .maxModelCalls(100)
+        .maxToolCalls(50)
+        .inputTokens(0L)
+        .outputTokens(0L)
+        .modelCalls(0)
+        .toolCalls(0)
+        .creationDate(OffsetDateTime.parse("2024-01-01T00:00:00Z"))
+        .lastUpdatedDate(OffsetDateTime.parse("2024-01-01T00:00:00Z"))
+        .elementInstanceKeys(List.of())
+        .build();
+  }
+}

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/sql/columns/SearchColumnTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/sql/columns/SearchColumnTest.java
@@ -10,6 +10,7 @@ package io.camunda.db.rdbms.sql.columns;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
+import io.camunda.search.entities.AgentInstanceEntity.AgentInstanceStatus;
 import io.camunda.search.entities.AuditLogEntity.AuditLogActorType;
 import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
 import io.camunda.search.entities.AuditLogEntity.AuditLogOperationCategory;
@@ -188,7 +189,12 @@ public class SearchColumnTest {
               GlobalListenerType.class,
               List.of(
                   Tuple.of(GlobalListenerType.USER_TASK, GlobalListenerType.USER_TASK),
-                  Tuple.of(GlobalListenerType.USER_TASK, "USER_TASK"))));
+                  Tuple.of(GlobalListenerType.USER_TASK, "USER_TASK"))),
+          Map.entry(
+              AgentInstanceStatus.class,
+              List.of(
+                  Tuple.of(AgentInstanceStatus.IDLE, AgentInstanceStatus.IDLE),
+                  Tuple.of(AgentInstanceStatus.IDLE, "IDLE"))));
 
   private static List<Object[]> provideSearchColumns() {
     return SearchColumnUtils.findAll().stream()

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/MyBatisConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/MyBatisConfiguration.java
@@ -375,6 +375,12 @@ public class MyBatisConfiguration {
   }
 
   @Bean
+  public MapperFactoryBean<AgentInstanceMapper> agentInstanceMapper(
+      final SqlSessionFactory sqlSessionFactory) {
+    return createMapperFactoryBean(sqlSessionFactory, AgentInstanceMapper.class);
+  }
+
+  @Bean
   public MapperFactoryBean<GlobalListenerMapper> globalListenerMapper(
       final SqlSessionFactory sqlSessionFactory) {
     return createMapperFactoryBean(sqlSessionFactory, GlobalListenerMapper.class);

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/MyBatisConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/MyBatisConfiguration.java
@@ -375,12 +375,6 @@ public class MyBatisConfiguration {
   }
 
   @Bean
-  public MapperFactoryBean<AgentInstanceMapper> agentInstanceMapper(
-      final SqlSessionFactory sqlSessionFactory) {
-    return createMapperFactoryBean(sqlSessionFactory, AgentInstanceMapper.class);
-  }
-
-  @Bean
   public MapperFactoryBean<GlobalListenerMapper> globalListenerMapper(
       final SqlSessionFactory sqlSessionFactory) {
     return createMapperFactoryBean(sqlSessionFactory, GlobalListenerMapper.class);

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
@@ -131,8 +131,9 @@ public class RdbmsConfiguration {
   }
 
   @Bean
-  public AgentInstanceDbReader agentInstanceReader(final RdbmsReaderConfig readerConfig) {
-    return new AgentInstanceDbReader(readerConfig);
+  public AgentInstanceDbReader agentInstanceReader(
+      final AgentInstanceMapper agentInstanceMapper, final RdbmsReaderConfig readerConfig) {
+    return new AgentInstanceDbReader(agentInstanceMapper, readerConfig);
   }
 
   @Bean
@@ -491,6 +492,7 @@ public class RdbmsConfiguration {
   @Bean
   public RdbmsService rdbmsService(
       final RdbmsWriterFactory rdbmsWriterFactory,
+      final AgentInstanceDbReader agentInstanceDbReader,
       final VariableDbReader variableReader,
       final ClusterVariableDbReader clusterVariableDbReader,
       final AuditLogDbReader auditLogReader,
@@ -536,6 +538,7 @@ public class RdbmsConfiguration {
       final ReplicationLogStatusProviderFactory replicationLogStatusProviderFactory) {
     return new RdbmsService(
         rdbmsWriterFactory,
+        agentInstanceDbReader,
         auditLogReader,
         authorizationReader,
         decisionDefinitionReader,

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agentinstance/AgentInstanceFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agentinstance/AgentInstanceFilterIT.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.agentinstance;
+
+import static io.camunda.it.rdbms.db.fixtures.AgentInstanceFixtures.createAndSaveRandomAgentInstance;
+import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextKey;
+import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextStringId;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.search.entities.AgentInstanceEntity;
+import io.camunda.search.entities.AgentInstanceEntity.AgentInstanceStatus;
+import io.camunda.search.filter.AgentInstanceFilter;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.query.AgentInstanceQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.search.sort.AgentInstanceSort;
+import io.camunda.security.reader.ResourceAccessChecks;
+import java.util.List;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Tag("rdbms")
+@ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
+public class AgentInstanceFilterIT {
+
+  @TestTemplate
+  public void shouldFilterByAgentInstanceKey(final CamundaRdbmsTestApplication testApplication) {
+    final var model = createAndSaveRandomAgentInstance(testApplication, b -> b);
+    createAndSaveRandomAgentInstance(testApplication, b -> b);
+
+    final var result =
+        search(
+            testApplication,
+            new AgentInstanceFilter.Builder().agentInstanceKeys(model.agentInstanceKey()).build());
+
+    assertThat(result.total()).isEqualTo(1);
+    assertThat(result.items().getFirst().agentInstanceKey()).isEqualTo(model.agentInstanceKey());
+  }
+
+  @TestTemplate
+  public void shouldFilterByProcessInstanceKey(final CamundaRdbmsTestApplication testApplication) {
+    final long piKey = nextKey();
+    final var model =
+        createAndSaveRandomAgentInstance(testApplication, b -> b.processInstanceKey(piKey));
+    createAndSaveRandomAgentInstance(testApplication, b -> b);
+
+    final var result =
+        search(
+            testApplication, new AgentInstanceFilter.Builder().processInstanceKeys(piKey).build());
+
+    assertThat(result.total()).isEqualTo(1);
+    assertThat(result.items().getFirst().processInstanceKey()).isEqualTo(piKey);
+  }
+
+  @TestTemplate
+  public void shouldFilterByProcessDefinitionId(final CamundaRdbmsTestApplication testApplication) {
+    final String procDefId = "myProcess-" + nextStringId();
+    createAndSaveRandomAgentInstance(testApplication, b -> b.processDefinitionId(procDefId));
+    createAndSaveRandomAgentInstance(testApplication, b -> b.processDefinitionId(procDefId));
+    createAndSaveRandomAgentInstance(testApplication, b -> b);
+
+    final var result =
+        search(
+            testApplication,
+            new AgentInstanceFilter.Builder().processDefinitionIds(procDefId).build());
+
+    assertThat(result.total()).isEqualTo(2);
+    assertThat(result.items()).allMatch(e -> procDefId.equals(e.processDefinitionId()));
+  }
+
+  @TestTemplate
+  public void shouldFilterByStatus(final CamundaRdbmsTestApplication testApplication) {
+    final String procDefId = "proc-status-" + nextStringId();
+    createAndSaveRandomAgentInstance(
+        testApplication,
+        b -> b.processDefinitionId(procDefId).status(AgentInstanceStatus.THINKING));
+    createAndSaveRandomAgentInstance(
+        testApplication, b -> b.processDefinitionId(procDefId).status(AgentInstanceStatus.IDLE));
+    createAndSaveRandomAgentInstance(
+        testApplication, b -> b.processDefinitionId(procDefId).status(AgentInstanceStatus.IDLE));
+
+    final var result =
+        search(
+            testApplication,
+            new AgentInstanceFilter.Builder()
+                .processDefinitionIds(procDefId)
+                .statuses(AgentInstanceStatus.IDLE.name())
+                .build());
+
+    assertThat(result.total()).isEqualTo(2);
+    assertThat(result.items()).allMatch(e -> e.status() == AgentInstanceStatus.IDLE);
+  }
+
+  @TestTemplate
+  public void shouldFilterByTenantId(final CamundaRdbmsTestApplication testApplication) {
+    final String tenantId = "tenant-" + nextStringId();
+    createAndSaveRandomAgentInstance(testApplication, b -> b.tenantId(tenantId));
+    createAndSaveRandomAgentInstance(testApplication, b -> b.tenantId(tenantId));
+    createAndSaveRandomAgentInstance(testApplication, b -> b.tenantId("<other>"));
+
+    final var result =
+        search(testApplication, new AgentInstanceFilter.Builder().tenantIds(tenantId).build());
+
+    assertThat(result.total()).isEqualTo(2);
+    assertThat(result.items()).allMatch(e -> tenantId.equals(e.tenantId()));
+  }
+
+  @TestTemplate
+  public void shouldFilterByElementId(final CamundaRdbmsTestApplication testApplication) {
+    final String elementId = "Task_specificElement";
+    final var model =
+        createAndSaveRandomAgentInstance(testApplication, b -> b.elementId(elementId));
+    createAndSaveRandomAgentInstance(testApplication, b -> b);
+
+    final var result =
+        search(testApplication, new AgentInstanceFilter.Builder().elementIds(elementId).build());
+
+    assertThat(result.total()).isEqualTo(1);
+    assertThat(result.items().getFirst().elementId()).isEqualTo(elementId);
+  }
+
+  @TestTemplate
+  public void shouldFilterByElementInstanceKey(final CamundaRdbmsTestApplication testApplication) {
+    final long elementInstanceKey = nextKey();
+    final var model =
+        createAndSaveRandomAgentInstance(
+            testApplication, b -> b.elementInstanceKeys(List.of(elementInstanceKey)));
+    createAndSaveRandomAgentInstance(testApplication, b -> b);
+
+    final var result =
+        search(
+            testApplication,
+            new AgentInstanceFilter.Builder().elementInstanceKeys(elementInstanceKey).build());
+
+    assertThat(result.total()).isEqualTo(1);
+    assertThat(result.items().getFirst().agentInstanceKey()).isEqualTo(model.agentInstanceKey());
+    assertThat(result.items().getFirst().elementInstanceKeys()).contains(elementInstanceKey);
+  }
+
+  private SearchQueryResult<AgentInstanceEntity> search(
+      final CamundaRdbmsTestApplication testApplication, final AgentInstanceFilter filter) {
+    return testApplication
+        .getRdbmsService()
+        .getAgentInstanceDbReader()
+        .search(
+            new AgentInstanceQuery(
+                filter, AgentInstanceSort.of(b -> b), SearchQueryPage.of(b -> b)),
+            ResourceAccessChecks.disabled());
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agentinstance/AgentInstanceIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agentinstance/AgentInstanceIT.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.agentinstance;
+
+import static io.camunda.it.rdbms.db.fixtures.AgentInstanceFixtures.createAndSaveRandomAgentInstance;
+import static io.camunda.it.rdbms.db.fixtures.AgentInstanceFixtures.createAndSaveRandomAgentInstances;
+import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextStringId;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.db.rdbms.write.domain.AgentInstanceDbModel;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.search.entities.AgentInstanceEntity;
+import io.camunda.search.entities.AgentInstanceEntity.AgentInstanceStatus;
+import io.camunda.search.filter.AgentInstanceFilter;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.query.AgentInstanceQuery;
+import io.camunda.search.sort.AgentInstanceSort;
+import io.camunda.security.reader.ResourceAccessChecks;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Tag("rdbms")
+@ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
+public class AgentInstanceIT {
+
+  @TestTemplate
+  public void shouldCreateAndGetAgentInstanceByKey(
+      final CamundaRdbmsTestApplication testApplication) {
+    final AgentInstanceDbModel model = createAndSaveRandomAgentInstance(testApplication, b -> b);
+
+    final var entity =
+        testApplication
+            .getRdbmsService()
+            .getAgentInstanceDbReader()
+            .getByKey(model.agentInstanceKey(), ResourceAccessChecks.disabled());
+
+    assertThat(entity).isNotNull();
+    assertThat(entity.agentInstanceKey()).isEqualTo(model.agentInstanceKey());
+    assertFieldsMatch(model, entity);
+  }
+
+  @TestTemplate
+  public void shouldReturnNullForUnknownKey(final CamundaRdbmsTestApplication testApplication) {
+    final var entity =
+        testApplication
+            .getRdbmsService()
+            .getAgentInstanceDbReader()
+            .getByKey(Long.MIN_VALUE, ResourceAccessChecks.disabled());
+
+    assertThat(entity).isNull();
+  }
+
+  @TestTemplate
+  public void shouldFindAllAgentInstancesPaged(final CamundaRdbmsTestApplication testApplication) {
+    final String processId = "process-paged-" + nextStringId();
+    createAndSaveRandomAgentInstances(testApplication, 20, b -> b.processDefinitionId(processId));
+
+    final var result =
+        testApplication
+            .getRdbmsService()
+            .getAgentInstanceDbReader()
+            .search(
+                new AgentInstanceQuery(
+                    new AgentInstanceFilter.Builder().processDefinitionIds(processId).build(),
+                    AgentInstanceSort.of(b -> b),
+                    SearchQueryPage.of(b -> b.from(0).size(5))),
+                ResourceAccessChecks.disabled());
+
+    assertThat(result).isNotNull();
+    assertThat(result.total()).isEqualTo(20);
+    assertThat(result.items()).hasSize(5);
+  }
+
+  @TestTemplate
+  public void shouldReturnEmptyResultForPageSizeZero(
+      final CamundaRdbmsTestApplication testApplication) {
+    final String processId = "process-zero-" + nextStringId();
+    createAndSaveRandomAgentInstances(testApplication, 3, b -> b.processDefinitionId(processId));
+
+    final var result =
+        testApplication
+            .getRdbmsService()
+            .getAgentInstanceDbReader()
+            .search(
+                new AgentInstanceQuery(
+                    new AgentInstanceFilter.Builder().processDefinitionIds(processId).build(),
+                    AgentInstanceSort.of(b -> b),
+                    SearchQueryPage.of(b -> b.from(0).size(0))),
+                ResourceAccessChecks.disabled());
+
+    assertThat(result.total()).isEqualTo(3);
+    assertThat(result.items()).isEmpty();
+  }
+
+  private void assertFieldsMatch(
+      final AgentInstanceDbModel dbModel, final AgentInstanceEntity entity) {
+    assertThat(entity.agentInstanceKey()).isEqualTo(dbModel.agentInstanceKey());
+    assertThat(entity.elementId()).isEqualTo(dbModel.elementId());
+    assertThat(entity.processInstanceKey()).isEqualTo(dbModel.processInstanceKey());
+    assertThat(entity.processDefinitionKey()).isEqualTo(dbModel.processDefinitionKey());
+    assertThat(entity.processDefinitionId()).isEqualTo(dbModel.processDefinitionId());
+    assertThat(entity.tenantId()).isEqualTo(dbModel.tenantId());
+    assertThat(entity.status())
+        .isEqualTo(dbModel.status() != null ? dbModel.status() : AgentInstanceStatus.UNKNOWN);
+    assertThat(entity.definition().model()).isEqualTo(dbModel.model());
+    assertThat(entity.definition().provider()).isEqualTo(dbModel.provider());
+    assertThat(entity.definition().systemPrompt()).isEqualTo(dbModel.systemPrompt());
+    assertThat(entity.limits().maxTokens()).isEqualTo(dbModel.maxTokens());
+    assertThat(entity.limits().maxModelCalls()).isEqualTo(dbModel.maxModelCalls());
+    assertThat(entity.limits().maxToolCalls()).isEqualTo(dbModel.maxToolCalls());
+    assertThat(entity.metrics().inputTokens()).isEqualTo(dbModel.inputTokens());
+    assertThat(entity.metrics().outputTokens()).isEqualTo(dbModel.outputTokens());
+    assertThat(entity.metrics().modelCalls()).isEqualTo(dbModel.modelCalls());
+    assertThat(entity.metrics().toolCalls()).isEqualTo(dbModel.toolCalls());
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agentinstance/AgentInstanceSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agentinstance/AgentInstanceSortIT.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.agentinstance;
+
+import static io.camunda.it.rdbms.db.fixtures.AgentInstanceFixtures.createAndSaveRandomAgentInstances;
+import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextStringId;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.search.entities.AgentInstanceEntity;
+import io.camunda.search.entities.AgentInstanceEntity.AgentInstanceStatus;
+import io.camunda.search.filter.AgentInstanceFilter;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.query.AgentInstanceQuery;
+import io.camunda.search.sort.AgentInstanceSort;
+import io.camunda.search.sort.AgentInstanceSort.Builder;
+import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.util.ObjectBuilder;
+import java.time.OffsetDateTime;
+import java.util.Comparator;
+import java.util.function.Function;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Tag("rdbms")
+@ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
+public class AgentInstanceSortIT {
+
+  @TestTemplate
+  public void shouldSortByCreationDateAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication,
+        b -> b.creationDate().asc(),
+        Comparator.comparing(AgentInstanceEntity::creationDate));
+  }
+
+  @TestTemplate
+  public void shouldSortByCreationDateDesc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication,
+        b -> b.creationDate().desc(),
+        Comparator.comparing(AgentInstanceEntity::creationDate).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortByLastUpdatedDateAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication,
+        b -> b.lastUpdatedDate().asc(),
+        Comparator.comparing(AgentInstanceEntity::lastUpdatedDate));
+  }
+
+  @TestTemplate
+  public void shouldSortByLastUpdatedDateDesc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication,
+        b -> b.lastUpdatedDate().desc(),
+        Comparator.comparing(AgentInstanceEntity::lastUpdatedDate).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortByStatusAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication, b -> b.status().asc(), Comparator.comparing(e -> e.status().name()));
+  }
+
+  @TestTemplate
+  public void shouldSortByStatusDesc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication,
+        b -> b.status().desc(),
+        Comparator.comparing((AgentInstanceEntity e) -> e.status().name()).reversed());
+  }
+
+  private void testSorting(
+      final CamundaRdbmsTestApplication testApplication,
+      final Function<Builder, ObjectBuilder<AgentInstanceSort>> sortBuilder,
+      final Comparator<AgentInstanceEntity> comparator) {
+    final String procDefId = "proc-sort-" + nextStringId();
+
+    // Create instances with distinct timestamps so sort is deterministic
+    final var now = OffsetDateTime.now();
+    createAndSaveRandomAgentInstances(
+        testApplication,
+        5,
+        b ->
+            b.processDefinitionId(procDefId)
+                .status(AgentInstanceStatus.IDLE)
+                .creationDate(now)
+                .lastUpdatedDate(now));
+
+    final var items =
+        testApplication
+            .getRdbmsService()
+            .getAgentInstanceDbReader()
+            .search(
+                new AgentInstanceQuery(
+                    new AgentInstanceFilter.Builder().processDefinitionIds(procDefId).build(),
+                    AgentInstanceSort.of(sortBuilder),
+                    SearchQueryPage.of(b -> b.from(0).size(20))),
+                ResourceAccessChecks.disabled())
+            .items();
+
+    assertThat(items).hasSize(5);
+    assertThat(items).isSortedAccordingTo(comparator);
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/AgentInstanceFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/AgentInstanceFixtures.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.fixtures;
+
+import io.camunda.db.rdbms.write.RdbmsWriters;
+import io.camunda.db.rdbms.write.domain.AgentInstanceDbModel;
+import io.camunda.db.rdbms.write.domain.AgentInstanceDbModel.Builder;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.search.entities.AgentInstanceEntity.AgentInstanceStatus;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+public final class AgentInstanceFixtures extends CommonFixtures {
+
+  private AgentInstanceFixtures() {}
+
+  public static AgentInstanceDbModel createRandomAgentInstance(
+      final Function<Builder, Builder> builderFunction) {
+    final var key = nextKey();
+    final var builder =
+        new Builder()
+            .agentInstanceKey(key)
+            .elementId("element-" + key)
+            .processInstanceKey(nextKey())
+            .rootProcessInstanceKey(-1L)
+            .processDefinitionId("process-" + nextStringKey())
+            .processDefinitionKey(nextKey())
+            .processDefinitionVersion(1)
+            .tenantId("<default>")
+            .partitionId(1)
+            .status(AgentInstanceStatus.IDLE)
+            .model("gpt-4o")
+            .provider("openai")
+            .systemPrompt("You are an assistant.")
+            .maxTokens(10000L)
+            .maxModelCalls(100)
+            .maxToolCalls(50)
+            .inputTokens(0L)
+            .outputTokens(0L)
+            .modelCalls(0)
+            .toolCalls(0)
+            .creationDate(OffsetDateTime.now())
+            .lastUpdatedDate(OffsetDateTime.now())
+            .elementInstanceKeys(List.of(nextKey()));
+    return builderFunction.apply(builder).build();
+  }
+
+  public static List<AgentInstanceDbModel> createAndSaveRandomAgentInstances(
+      final CamundaRdbmsTestApplication testApplication,
+      final int count,
+      final Function<Builder, Builder> builderFunction) {
+    final RdbmsWriters rdbmsWriters = testApplication.getRdbmsService().createWriter(0);
+    final List<AgentInstanceDbModel> models = new ArrayList<>();
+    for (int i = 0; i < count; i++) {
+      final AgentInstanceDbModel model = createRandomAgentInstance(builderFunction);
+      models.add(model);
+      rdbmsWriters.getAgentInstanceWriter().create(model);
+    }
+    rdbmsWriters.flush();
+    return models;
+  }
+
+  public static AgentInstanceDbModel createAndSaveRandomAgentInstance(
+      final CamundaRdbmsTestApplication testApplication,
+      final Function<Builder, Builder> builderFunction) {
+    return createAndSaveRandomAgentInstances(testApplication, 1, builderFunction).getFirst();
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/AgentInstanceEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/AgentInstanceEntityTransformer.java
@@ -42,9 +42,6 @@ public class AgentInstanceEntityTransformer
 
     final var tools = toTools(source.getTools());
 
-    final Long rootProcessInstanceKey =
-        source.getRootProcessInstanceKey() == -1L ? null : source.getRootProcessInstanceKey();
-
     return new AgentInstanceEntity(
         source.getKey(),
         source.getElementInstanceKeys(),
@@ -55,7 +52,7 @@ public class AgentInstanceEntityTransformer
         tools,
         source.getElementId(),
         source.getProcessInstanceKey(),
-        rootProcessInstanceKey,
+        source.getRootProcessInstanceKey(),
         source.getProcessDefinitionKey(),
         source.getBpmnProcessId(),
         source.getProcessDefinitionVersion(),

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/entity/AgentInstanceEntityTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/entity/AgentInstanceEntityTransformerTest.java
@@ -93,16 +93,6 @@ class AgentInstanceEntityTransformerTest {
   }
 
   @Test
-  void shouldMapRootProcessInstanceKeyMinusOneToNull() {
-    final var source = buildSource();
-    source.setRootProcessInstanceKey(-1L);
-
-    final var result = transformer.apply(source);
-
-    assertThat(result.rootProcessInstanceKey()).isNull();
-  }
-
-  @Test
   void shouldMapNullToolsToEmptyList() {
     final var source = buildSource();
     source.setTools(null);


### PR DESCRIPTION
**Description**

Implements the RDBMS secondary storage reader for agent instances, replacing the `UnsupportedOperationException` stubs introduced when the writer was merged.

**What was introduced:**

- `AgentInstanceDbQuery` — MyBatis query record wrapping filter, authorized resource IDs, authorized tenant IDs, sort, and page; mirrors the pattern used by `FlowNodeInstanceDbQuery`

- `AgentInstanceSearchColumn` — sortable column enum (`KEY`, `STATUS`, `CREATION_DATE`, `LAST_UPDATED_DATE`, `COMPLETION_DATE`, `PROCESS_INSTANCE_KEY`, `PROCESS_DEFINITION_KEY`, `ELEMENT_ID`, `TENANT_ID`)

- `AgentInstanceEntityMapper` — maps `AgentInstanceDbModel` to domain `AgentInstanceEntity`, handling the `rootProcessInstanceKey` sentinel (-1 → null), null tools → empty list, and lazy JSON CLOB deserialization via `toolValues()`

- `AgentInstanceMapper` (read methods) — adds `count()` and `search()` to the existing write-only MyBatis mapper interface

- `AgentInstanceMapper.xml` (read SQL) — `search` query with LEFT JOIN on `AGENT_INSTANCE_ELEMENT_INSTANCE` to populate `elementInstanceKeys`; `count` query; `searchAndAuthFilter` fragment injecting `PROCESS_DEFINITION_ID IN (…)` and `TENANT_ID IN (…)` authorization clauses; `searchFilter` fragment covering all 13 filter fields

- `AgentInstanceDbReader` — replaces the `UnsupportedOperationException` stubs with real `getByKey` / `search` implementations; authorization follows the `READ_PROCESS_INSTANCE` pattern (same as `FlowNodeInstanceDbReader`); `getByKey` delegates to `findOne()` which issues a filtered `search` with `size(1)` rather than a dedicated mapper method

- Wiring — `MyBatisConfiguration` registers `AgentInstanceMapper` as a Spring bean; `RdbmsConfiguration` injects it into `AgentInstanceDbReader`; `RdbmsService` exposes `getAgentInstanceDbReader()`

- `AgentInstanceEntityMapperTest` — unit tests for field-by-field mapping, null-safety, tool deserialization, and sentinel handling

- `AgentInstanceDbReaderTest` — unit tests for authorization early-exit (null resource IDs, empty tenant list), auth injection into mapper query, page-size-zero behavior, `getByKey` happy path and not-found, and filter pass-through for all key filter fields

**Out of scope:**

- Integration / acceptance tests (will be implemented as @MultiDbTest for both ES/OS and RDBMS)

**Checklist**

- [ ] Enable backports when necessary

**Related issues**

closes #52820
