### PR TITLE
fix: add missing x-added-in-version annotation to ElementInstanceFilter

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/element-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/element-instances.yaml
@@ -262,6 +262,9 @@ components:
       allOf:
         - $ref: '#/components/schemas/ElementInstanceFilterFields'
         - type: object
+          x-properties-added-in-version:
+            - propertyName: "$or"
+              addedInVersion: "8.10"
           properties:
             $or:
               description: |


### PR DESCRIPTION
## Description

Add missing required `x-added-in-version` annotation to ElementInstanceFilter for `$or` property added in 8.10.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
