### PR TITLE
fix: publish ReadinessState in load-tester Starter

### DIFF
--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/starter/Starter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/starter/Starter.java
@@ -32,6 +32,7 @@ import io.grpc.Status.Code;
 import io.grpc.StatusRuntimeException;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
+import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import java.time.Duration;
 import java.time.Instant;
@@ -42,27 +43,25 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletionStage;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BooleanSupplier;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.CommandLineRunner;
-import org.springframework.boot.availability.AvailabilityChangeEvent;
-import org.springframework.boot.availability.ReadinessState;
-import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.boot.SpringApplication;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 @Component
 @Profile("starter")
-public class Starter implements CommandLineRunner {
+public class Starter {
 
   private static final Logger THROTTLED_LOGGER =
       new ThrottledLogger(LoggerFactory.getLogger(Starter.class), Duration.ofSeconds(5));
@@ -78,11 +77,12 @@ public class Starter implements CommandLineRunner {
   private final MeterRegistry registry;
   private final PayloadReader payloadReader;
   private final ConnectionMonitor connectionMonitor;
-  private final ApplicationEventPublisher eventPublisher;
+  private final ConfigurableApplicationContext context;
   private final AtomicLong businessKey = new AtomicLong(0);
   private final AtomicLong lastProcessInstanceKey = new AtomicLong(0);
   private final AtomicReference<Instant> lastProcessInstanceKeyTimestamp =
       new AtomicReference<>(Instant.now());
+  private final AtomicBoolean shutdownTriggered = new AtomicBoolean(false);
 
   private Timer responseLatencyTimer;
   private ScheduledExecutorService executorService;
@@ -95,18 +95,22 @@ public class Starter implements CommandLineRunner {
       final MeterRegistry registry,
       final PayloadReader payloadReader,
       final ConnectionMonitor connectionMonitor,
-      final ApplicationEventPublisher eventPublisher) {
+      final ConfigurableApplicationContext context) {
     this.client = client;
     this.properties = properties;
     starterCfg = properties.getStarter();
     this.registry = registry;
     this.payloadReader = payloadReader;
     this.connectionMonitor = connectionMonitor;
-    this.eventPublisher = eventPublisher;
+    this.context = context;
   }
 
-  @Override
-  public void run(final String... args) {
+  // Initialization runs as part of bean init (mirrors Worker.awaitTopologyAndLogConfig) so that
+  // Spring proceeds to publish ApplicationReadyEvent only after the starter is fully wired and
+  // scheduling is armed. That flips /health/readiness to UP automatically via Spring Boot's
+  // ApplicationAvailabilityBean — no manual AvailabilityChangeEvent publication needed.
+  @PostConstruct
+  void start() {
     connectionMonitor.awaitAndPrintTopology();
 
     responseLatencyTimer =
@@ -126,25 +130,8 @@ public class Starter implements CommandLineRunner {
       dataReadMeter.start();
     }
 
-    final CountDownLatch countDownLatch = new CountDownLatch(1);
     executorService = Executors.newScheduledThreadPool(starterCfg.getThreads());
-    final ScheduledFuture<?> scheduledTask =
-        scheduleProcessInstanceCreation(executorService, countDownLatch);
-
-    // Signal readiness so the /health/readiness probe flips to UP. CommandLineRunner.run()
-    // is invoked before ApplicationReadyEvent is published, and this method blocks on the
-    // latch below, so without an explicit signal the readiness state stays REFUSING_TRAFFIC.
-    AvailabilityChangeEvent.publish(eventPublisher, this, ReadinessState.ACCEPTING_TRAFFIC);
-
-    try {
-      countDownLatch.await();
-    } catch (final InterruptedException e) {
-      LOG.error("Awaiting of count down latch was interrupted.", e);
-    }
-
-    LOG.info("Starter finished");
-    scheduledTask.cancel(true);
-    shutdown();
+    scheduleProcessInstanceCreation(executorService);
   }
 
   @PreDestroy
@@ -208,7 +195,7 @@ public class Starter implements CommandLineRunner {
   }
 
   private ScheduledFuture<?> scheduleProcessInstanceCreation(
-      final ScheduledExecutorService executorService, final CountDownLatch countDownLatch) {
+      final ScheduledExecutorService executorService) {
 
     final long intervalNanos = (long) (NANOS_PER_SECOND / starterCfg.getRatePerSecond());
     LOG.info(
@@ -226,7 +213,7 @@ public class Starter implements CommandLineRunner {
     return executorService.scheduleAtFixedRate(
         () -> {
           if (!shouldContinue.getAsBoolean()) {
-            countDownLatch.countDown();
+            triggerShutdown();
             return;
           }
 
@@ -371,6 +358,24 @@ public class Starter implements CommandLineRunner {
       }
     }
     return deployCmd;
+  }
+
+  // Spawned on a dedicated thread so that the SpringApplication.exit path can call
+  // context.close() — which joins this executor in @PreDestroy — without the scheduled
+  // task self-joining itself and deadlocking.
+  private void triggerShutdown() {
+    if (shutdownTriggered.compareAndSet(false, true)) {
+      LOG.info("Duration limit reached, shutting down");
+      final Thread shutdownThread =
+          new Thread(
+              () -> {
+                final int code = SpringApplication.exit(context, () -> 0);
+                System.exit(code);
+              },
+              "starter-shutdown");
+      shutdownThread.setDaemon(false);
+      shutdownThread.start();
+    }
   }
 
   private BooleanSupplier createContinuationCondition() {

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/starter/Starter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/starter/Starter.java
@@ -54,6 +54,9 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.availability.AvailabilityChangeEvent;
+import org.springframework.boot.availability.ReadinessState;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
@@ -75,6 +78,7 @@ public class Starter implements CommandLineRunner {
   private final MeterRegistry registry;
   private final PayloadReader payloadReader;
   private final ConnectionMonitor connectionMonitor;
+  private final ApplicationEventPublisher eventPublisher;
   private final AtomicLong businessKey = new AtomicLong(0);
   private final AtomicLong lastProcessInstanceKey = new AtomicLong(0);
   private final AtomicReference<Instant> lastProcessInstanceKeyTimestamp =
@@ -90,13 +94,15 @@ public class Starter implements CommandLineRunner {
       final LoadTesterProperties properties,
       final MeterRegistry registry,
       final PayloadReader payloadReader,
-      final ConnectionMonitor connectionMonitor) {
+      final ConnectionMonitor connectionMonitor,
+      final ApplicationEventPublisher eventPublisher) {
     this.client = client;
     this.properties = properties;
     starterCfg = properties.getStarter();
     this.registry = registry;
     this.payloadReader = payloadReader;
     this.connectionMonitor = connectionMonitor;
+    this.eventPublisher = eventPublisher;
   }
 
   @Override
@@ -124,6 +130,11 @@ public class Starter implements CommandLineRunner {
     executorService = Executors.newScheduledThreadPool(starterCfg.getThreads());
     final ScheduledFuture<?> scheduledTask =
         scheduleProcessInstanceCreation(executorService, countDownLatch);
+
+    // Signal readiness so the /health/readiness probe flips to UP. CommandLineRunner.run()
+    // is invoked before ApplicationReadyEvent is published, and this method blocks on the
+    // latch below, so without an explicit signal the readiness state stays REFUSING_TRAFFIC.
+    AvailabilityChangeEvent.publish(eventPublisher, this, ReadinessState.ACCEPTING_TRAFFIC);
 
     try {
       countDownLatch.await();

--- a/load-tests/load-tester/src/test/java/io/camunda/zeebe/it/StarterWorkerIT.java
+++ b/load-tests/load-tester/src/test/java/io/camunda/zeebe/it/StarterWorkerIT.java
@@ -64,9 +64,11 @@ class StarterWorkerIT {
 
   @Test
   void shouldStartInstancesAndCompleteThem() {
-    // given — the starter has already run (CommandLineRunner blocks context startup for
-    //         duration-limit=5s) and produced ~5 instances of the "benchmark" process.
-    //         The worker is also active and subscribed to "benchmark-task".
+    // given — the starter's @PostConstruct armed its scheduler during context startup
+    //         and has produced ~5 instances of the "benchmark" process by the time
+    //         duration-limit=5s elapses. The worker is also active and subscribed to
+    //         "benchmark-task". Awaitility below covers the async gap between
+    //         "starter stopped scheduling" and "worker drained queue".
 
     // then — at least one instance should be queryable via REST and in COMPLETED state.
     //        Awaitility handles the async gap between "starter stopped" and "worker drained queue".


### PR DESCRIPTION
## Description
Starter ran its scheduling loop inside CommandLineRunner.run() which blocked on a CountDownLatch, so Spring never reached the point of publishing ApplicationReadyEvent. The readiness state therefore stayed at REFUSING_TRAFFIC and /health/readiness on port 9600 reported OUT_OF_SERVICE, breaking k8s rolling updates and readiness-gated tooling. Publish ReadinessState.ACCEPTING_TRAFFIC manually once the scheduled task is armed so the probe flips to UP.

## Checklist
<!--- Please delete options that are not relevant. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [x] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.


## Related issues

This is a Preparation PR for adding readiness and liveliness probes in starter and worker (https://github.com/camunda/camunda-load-tests-helm/pull/72)

closes #
