### PR TITLE
CI: make missing x-property-added-in-version check blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1806,6 +1806,8 @@ jobs:
     # annotation. The verifier exits non-zero on findings, and
     # PR authors get early feedback via
     # inline annotations.
+    # KNOWN LIMITATION: this check does not run on fork PRs, as it requires
+    # the ability to clone cross-repo in the Camunda org.
     if: |
       needs.detect-changes.outputs.openapi-changes == 'true'
       && (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1799,17 +1799,12 @@ jobs:
           user_description: "General"
 
   openapi-x-added-in-version-check:
-    name: "Lint / C8 REST OpenAPI x-added-in-version (non-blocking)"
-    # Non-blocking PR check that runs the in-repo verifier under
+    name: "Lint / C8 REST OpenAPI x-added-in-version"
+    # Blocking PR check that runs the in-repo verifier under
     # .github/scripts/x-added-in-version-check against the spec files in this
     # PR and surfaces each finding as a GitHub Actions `::error::`
-    # annotation. The verifier exits non-zero on findings, and any of the
-    # preparatory steps (checkout, dependency install, artefact build) can
-    # also fail (e.g., missing CROSS_REPO_TOKEN on fork PRs). The job is
-    # marked `continue-on-error: true` at the job level so no failure mode
-    # can block merges — even though it is listed in `check-results.needs`
-    # (as required by Unified CI policy), its result is always reported as
-    # `success` to downstream jobs. PR authors still get early feedback via
+    # annotation. The verifier exits non-zero on findings, and
+    # PR authors get early feedback via
     # inline annotations.
     if: |
       needs.detect-changes.outputs.openapi-changes == 'true'
@@ -1817,7 +1812,6 @@ jobs:
     needs: [ detect-changes ]
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    continue-on-error: true
     permissions:
       contents: read
     steps:
@@ -1860,8 +1854,8 @@ jobs:
           RETURN_OF_API_REF: v0.1.1
         run: npm run build:artefacts
       - name: Run PR verifier
-        # Verifier exits non-zero on findings; the job-level
-        # `continue-on-error: true` keeps the overall check non-blocking.
+        # Verifier exits non-zero on findings, which fails the job and
+        # therefore the `check-results` aggregate gate.
         working-directory: ${{ github.workspace }}/.github/scripts/x-added-in-version-check
         env:
           OCA_SPEC_PATH: ${{ github.workspace }}/zeebe/gateway-protocol/src/main/proto/v2


### PR DESCRIPTION
## Description

This PR makes the "missing `x-property-added-in-version`" check blocking on incoming PRs. 

Yesterday, with the gate in non-blocking mode, a schema change requiring this property was merged to main. The gate correctly fired, but did not block the merge. The result is that every subsequent PR then fires the gate, leading to elevated failure rate being detected. 

The gate should block the schema from being merged to main until the schema is correctly annotated, meaning that the failure and its remediation pathway is presented to the schema author at the moment of integration. 

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
