### PR TITLE
test: refactor TestCluster to support natively multi zone clusters

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ZoneAwarePartitionDistributionIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ZoneAwarePartitionDistributionIT.java
@@ -10,98 +10,38 @@ package io.camunda.zeebe.it.cluster.clustering;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
-import io.camunda.configuration.Partitioning;
 import io.camunda.configuration.Zone;
-import io.camunda.configuration.ZoneAware;
 import io.camunda.zeebe.qa.util.actuator.PartitionsActuator;
 import io.camunda.zeebe.qa.util.actuator.PartitionsActuator.PartitionStatus;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
-import io.camunda.zeebe.qa.util.cluster.TestZeebePort;
-import java.time.Duration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-import java.util.stream.Stream;
-import org.junit.jupiter.api.AutoClose;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 /**
- * Verifies zone-aware partition distribution across two physically separate zone clusters that
- * discover each other via cross-zone initial contact points.
+ * Verifies zone-aware partition distribution for a cluster with two zones.
  *
  * <p>Zone A: 2 brokers, priority 1000. Zone B: 1 broker, priority 500. Partitions: 2, RF: 3.
  */
+@ZeebeIntegration
 final class ZoneAwarePartitionDistributionIT {
 
-  private static final ZoneAware ZONE_AWARE_CFG =
-      new ZoneAware(List.of(new Zone("zoneA", 2, 2, 1000), new Zone("zoneB", 1, 1, 500)));
+  private static final String ZONE_A = "zoneA";
+  private static final String ZONE_B = "zoneB";
+  private static final List<Zone> ZONE_CONFIGS =
+      List.of(new Zone(ZONE_A, 2, 2, 1000), new Zone(ZONE_B, 1, 1, 500));
 
-  // Zone A: 2 brokers, us-east1, priority 1000. Gateway enabled for topology checks.
-  @AutoClose
-  private static final TestCluster ZONE_A =
+  @TestZeebe(purgeAfterEach = false)
+  private static final TestCluster CLUSTER =
       TestCluster.builder()
-          .withBrokersCount(2)
+          .withBrokersCount(3)
           .withEmbeddedGateway(true)
           .withPartitionsCount(2)
           .withReplicationFactor(3)
-          .withoutNodeId()
-          .multiZone()
-          .withBrokerConfig(
-              (id, broker) -> {
-                final int localId = Integer.parseInt(id.id());
-                broker.withUnifiedConfig(
-                    uc -> {
-                      uc.getCluster().setSize(3);
-                      uc.getCluster().setZone("zoneA");
-                      uc.getCluster().setNodeId(localId);
-                      applyRegionAwarePartitioning(uc.getCluster().getPartitioning());
-                    });
-              })
+          .multiZone(ZONE_CONFIGS)
           .build();
-
-  // Zone B: 1 broker, us-west1, priority 500.
-  @AutoClose
-  private static final TestCluster ZONE_B =
-      TestCluster.builder()
-          .withBrokersCount(1)
-          .withPartitionsCount(2)
-          .withReplicationFactor(3)
-          .withoutNodeId()
-          .multiZone()
-          .withBrokerConfig(
-              (id, broker) ->
-                  broker.withUnifiedConfig(
-                      uc -> {
-                        uc.getCluster().setSize(3);
-                        uc.getCluster().setZone("zoneB");
-                        uc.getCluster().setNodeId(0);
-                        applyRegionAwarePartitioning(uc.getCluster().getPartitioning());
-                      }))
-          .build();
-
-  @BeforeAll
-  static void startClusters() {
-    final List<String> allContactPoints =
-        Stream.concat(ZONE_A.brokers().values().stream(), ZONE_B.brokers().values().stream())
-            .map(b -> b.address(TestZeebePort.CLUSTER))
-            .toList();
-
-    Stream.concat(ZONE_A.brokers().values().stream(), ZONE_B.brokers().values().stream())
-        .forEach(
-            b ->
-                b.withUnifiedConfig(
-                    uc -> uc.getCluster().setInitialContactPoints(allContactPoints)));
-
-    assertThat(
-            CompletableFuture.allOf(
-                CompletableFuture.runAsync(ZONE_A::start),
-                CompletableFuture.runAsync(ZONE_B::start)))
-        .succeedsWithin(Duration.ofSeconds(60));
-
-    // await topology from zone A's embedded gateway; total cluster size = 3 (2 + 1)
-    ZONE_A.awaitCompleteTopology(3, 2, 3, Duration.ofMinutes(3));
-  }
 
   @Test
   void shouldDistributePartitionsAcrossZones() {
@@ -129,18 +69,12 @@ final class ZoneAwarePartitionDistributionIT {
   }
 
   private static Map<Integer, PartitionStatus> partitionsOf(
-      final TestCluster cluster, final int idx) {
-    // local cluster memberId without zone
-    final var broker = cluster.brokers().get(MemberId.from(idx));
+      final String zone, final int localNodeId) {
+    final var broker = CLUSTER.brokers().get(MemberId.from(zone, localNodeId));
     return PartitionsActuator.of(broker).query();
   }
 
   private static boolean isLeader(final PartitionStatus status) {
     return status != null && "Leader".equalsIgnoreCase(status.role());
-  }
-
-  private static void applyRegionAwarePartitioning(final Partitioning partitioning) {
-    partitioning.setScheme(Partitioning.Scheme.ZONE_AWARE);
-    partitioning.setZoneAware(ZONE_AWARE_CFG);
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ClusterEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ClusterEndpointIT.java
@@ -263,7 +263,7 @@ abstract class ClusterEndpointIT {
     try (final var cluster = createCluster(brokerCount())) {
       // given
       cluster.awaitCompleteTopology();
-      cluster.brokers().get(MemberId.from("1")).close();
+      cluster.brokers().get(memberIdForBroker(1)).close();
       final var actuator = ClusterActuator.of(cluster.availableGateway());
 
       // when - force remove broker 1

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ZoneAwareClusterEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ZoneAwareClusterEndpointIT.java
@@ -11,9 +11,8 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 
 import feign.FeignException;
 import io.atomix.cluster.BrokerMemberId;
-import io.camunda.configuration.Partitioning.Scheme;
+import io.atomix.cluster.MemberId;
 import io.camunda.configuration.Zone;
-import io.camunda.configuration.ZoneAware;
 import io.camunda.zeebe.management.cluster.BrokerId;
 import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequest;
 import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequestBrokers;
@@ -45,36 +44,29 @@ final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
   @SuppressWarnings("resource")
   protected TestCluster createCluster(
       final int brokerCount, final int partitionCount, final int replicationFactor) {
-    final var replicasZoneB = replicationFactor / 2;
-    final var replicasZoneA = replicationFactor - replicasZoneB;
     return TestCluster.builder()
         .withEmbeddedGateway(true)
         .withBrokersCount(brokerCount)
         .withPartitionsCount(partitionCount)
         .withReplicationFactor(replicationFactor)
-        .withoutNodeId()
-        .multiZone()
-        .withBrokerConfig(
-            (id, broker) -> {
-              final int localId = Integer.parseInt(id.id());
-              final String zone = ZONES[localId % ZONES.length];
-              broker.withUnifiedConfig(
-                  uc -> {
-                    uc.getCluster().setZone(zone);
-                    uc.getCluster().setNodeId(localId / 2); // 2 zones: 0->0, 1-> 0, 2 -> 1, 3 -> 1
-                    uc.getCluster().setSize(brokerCount);
-                    final var half = brokerCount / 2;
-                    final var zoneAware =
-                        new ZoneAware(
-                            List.of(
-                                new Zone(ZONES[0], brokerCount - half, replicasZoneA, 100),
-                                new Zone(ZONES[1], half, replicasZoneB, 10)));
-                    uc.getCluster().getPartitioning().setScheme(Scheme.ZONE_AWARE);
-                    uc.getCluster().getPartitioning().setZoneAware(zoneAware);
-                  });
-            })
+        .multiZone(zoneConfigs(brokerCount, replicationFactor))
         .build()
         .start();
+  }
+
+  @Override
+  protected MemberId memberIdForBroker(final int nodeIdx) {
+    return MemberId.from(ZONES[nodeIdx % ZONES.length], nodeIdx / ZONES.length);
+  }
+
+  private static List<Zone> zoneConfigs(final int brokerCount, final int replicationFactor) {
+    final var replicasZoneB = replicationFactor / 2;
+    final var replicasZoneA = replicationFactor - replicasZoneB;
+    final var brokersZoneB = brokerCount / ZONES.length;
+    final var brokersZoneA = brokerCount - brokersZoneB;
+    return List.of(
+        new Zone(ZONES[0], brokersZoneA, replicasZoneA, 100),
+        new Zone(ZONES[1], brokersZoneB, replicasZoneB, 10));
   }
 
   @Override

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestClusterBuilder.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestClusterBuilder.java
@@ -44,7 +44,6 @@ public final class TestClusterBuilder {
   private final Map<MemberId, TestStandaloneGateway> gateways = new HashMap<>();
   private final Map<MemberId, TestStandaloneBroker> brokers = new HashMap<>();
   private boolean setNodeId = true;
-  private boolean multiZone = false;
   private List<Zone> multiZoneConfigs = List.of();
 
   /**
@@ -304,7 +303,7 @@ public final class TestClusterBuilder {
   }
 
   private void validate() {
-    if (!multiZone && replicationFactor > brokersCount) {
+    if (multiZoneConfigs.isEmpty() && replicationFactor > brokersCount) {
       throw new IllegalStateException(
           "Expected replicationFactor to be less than or equal to brokersCount, but was "
               + replicationFactor
@@ -431,21 +430,11 @@ public final class TestClusterBuilder {
   }
 
   /**
-   * Marks this cluster as part of a multiple zone cluster. There are other brokers are configured
-   * in another TestCluster.
-   */
-  public TestClusterBuilder multiZone() {
-    multiZone = true;
-    return this;
-  }
-
-  /**
    * Configures this cluster as a zone-aware cluster where the brokers are distributed round-robin
    * across the configured zones.
    */
   public TestClusterBuilder multiZone(final List<Zone> zoneConfigs) {
     multiZoneConfigs = List.copyOf(zoneConfigs);
-    multiZone = !multiZoneConfigs.isEmpty();
     return this;
   }
 }

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestClusterBuilder.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestClusterBuilder.java
@@ -9,12 +9,16 @@ package io.camunda.zeebe.qa.util.cluster;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.configuration.Camunda;
+import io.camunda.configuration.Partitioning.Scheme;
+import io.camunda.configuration.Zone;
+import io.camunda.configuration.ZoneAware;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.stream.IntStream;
 
 @SuppressWarnings({"unused", "resource"})
 public final class TestClusterBuilder {
@@ -41,6 +45,7 @@ public final class TestClusterBuilder {
   private final Map<MemberId, TestStandaloneBroker> brokers = new HashMap<>();
   private boolean setNodeId = true;
   private boolean multiZone = false;
+  private List<Zone> multiZoneConfigs = List.of();
 
   /**
    * If true, the brokers created by this cluster will use embedded gateways. By default this is
@@ -328,9 +333,10 @@ public final class TestClusterBuilder {
     for (int i = 0; i < brokersCount; i++) {
       final var memberId = MemberId.from(String.valueOf(i));
       final var broker = createBroker(i);
+      final var brokerId = multiZoneConfigs.isEmpty() ? memberId : broker.nodeId();
 
-      applyConfigFunctions(memberId, broker);
-      brokers.put(memberId, broker);
+      applyConfigFunctions(brokerId, broker);
+      brokers.put(brokerId, broker);
     }
 
     // since initial contact points has to contain all known brokers, we can only configure it
@@ -356,6 +362,7 @@ public final class TestClusterBuilder {
                   cluster.setSize(brokersCount);
                   cluster.setName(name);
                 })
+            .withUnifiedConfig(uc -> applyMultiZoneConfig(index, uc))
             .withUnifiedConfig(
                 uc -> {
                   final var replicas = (partitionsCount * replicationFactor) / brokersCount;
@@ -367,6 +374,31 @@ public final class TestClusterBuilder {
             .withGatewayEnabled(useEmbeddedGateway)
             .withRecordingExporter(useRecordingExporter);
     return broker;
+  }
+
+  private void applyMultiZoneConfig(final int brokerIndex, final Camunda config) {
+    final var zoneCount = zoneCount();
+    if (zoneCount == 0) {
+      return;
+    }
+
+    final var zoneIndex = brokerIndex % zoneCount;
+    final var cluster = config.getCluster();
+    cluster.setZone(multiZoneConfigs.get(zoneIndex).name());
+    cluster.setNodeId(brokerIndex / zoneCount);
+    cluster.getPartitioning().setScheme(Scheme.ZONE_AWARE);
+    cluster
+        .getPartitioning()
+        .setZoneAware(
+            new ZoneAware(IntStream.range(0, zoneCount).mapToObj(this::zoneConfig).toList()));
+  }
+
+  private Zone zoneConfig(final int zoneIndex) {
+    return multiZoneConfigs.get(zoneIndex);
+  }
+
+  private int zoneCount() {
+    return multiZoneConfigs.size();
   }
 
   private void createGateways() {
@@ -404,6 +436,16 @@ public final class TestClusterBuilder {
    */
   public TestClusterBuilder multiZone() {
     multiZone = true;
+    return this;
+  }
+
+  /**
+   * Configures this cluster as a zone-aware cluster where the brokers are distributed round-robin
+   * across the configured zones.
+   */
+  public TestClusterBuilder multiZone(final List<Zone> zoneConfigs) {
+    multiZoneConfigs = List.copyOf(zoneConfigs);
+    multiZone = !multiZoneConfigs.isEmpty();
     return this;
   }
 }

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/junit/ZeebeIntegrationExtension.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/junit/ZeebeIntegrationExtension.java
@@ -212,7 +212,7 @@ final class ZeebeIntegrationExtension
     // and not when the broker is shutdown. this allows to introspect or move the data around even
     // after stopping a broker
     if (resource.app() instanceof final TestStandaloneBroker broker) {
-      final var directory = createManagedDirectory(store, "broker-" + broker.nodeId().id());
+      final var directory = createManagedDirectory(store, workingDirectoryName(broker.nodeId()));
       setWorkingDirectory(directory, broker.nodeId(), broker);
     }
 
@@ -256,7 +256,7 @@ final class ZeebeIntegrationExtension
     // With fixed node IDs, each broker gets its own unique directory.
     final Path workingDirectory;
     if (broker.unifiedConfig().getCluster().getNodeIdProvider().getType() == Type.FIXED) {
-      workingDirectory = directory.resolve("broker-" + id.id());
+      workingDirectory = directory.resolve(workingDirectoryName(id));
       try {
         Files.createDirectory(workingDirectory);
       } catch (final IOException e) {
@@ -279,6 +279,10 @@ final class ZeebeIntegrationExtension
     } catch (final IOException e) {
       throw new UncheckedIOException(e);
     }
+  }
+
+  private String workingDirectoryName(final MemberId id) {
+    return "broker-" + id.id().replace("/", "-");
   }
 
   private ClusterResource asClusterResource(final Object testInstance, final Field field) {

--- a/zeebe/qa/util/src/test/java/io/camunda/zeebe/qa/util/cluster/TestClusterBuilderTest.java
+++ b/zeebe/qa/util/src/test/java/io/camunda/zeebe/qa/util/cluster/TestClusterBuilderTest.java
@@ -8,9 +8,12 @@
 package io.camunda.zeebe.qa.util.cluster;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import io.atomix.cluster.MemberId;
+import io.camunda.configuration.Zone;
 import java.util.Collections;
+import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 import org.assertj.core.api.Condition;
@@ -129,6 +132,38 @@ final class TestClusterBuilderTest {
           .as("every broker has a unique node ID configured")
           .isEqualTo(nodeId);
     }
+  }
+
+  @Test
+  void shouldConfigureZoneAwareBrokers() {
+    // given
+    final var builder = new TestClusterBuilder();
+
+    // when
+    builder
+        .withEmbeddedGateway(false)
+        .withBrokersCount(3)
+        .withReplicationFactor(2)
+        .multiZone(List.of(new Zone("zoneA", 2, 1, 100), new Zone("zoneB", 1, 1, 10)));
+    final var cluster = builder.build();
+
+    // then
+    assertThat(cluster.brokers().keySet())
+        .containsExactlyInAnyOrder(
+            MemberId.from("zoneA", 0), MemberId.from("zoneB", 0), MemberId.from("zoneA", 1));
+    assertThat(cluster.brokers())
+        .allSatisfy((memberId, broker) -> assertThat(broker.nodeId()).isEqualTo(memberId));
+
+    final var partitioning =
+        cluster
+            .brokers()
+            .get(MemberId.from("zoneA", 0))
+            .unifiedConfig()
+            .getCluster()
+            .getPartitioning();
+    assertThat(partitioning.getZoneAware().zones())
+        .extracting(Zone::name, Zone::numberOfBrokers, Zone::numberOfReplicas, Zone::priority)
+        .containsExactly(tuple("zoneA", 2, 1, 100), tuple("zoneB", 1, 1, 10));
   }
 
   @Test

--- a/zeebe/qa/util/src/test/java/io/camunda/zeebe/qa/util/junit/ZeebeIntegrationExtensionTest.java
+++ b/zeebe/qa/util/src/test/java/io/camunda/zeebe/qa/util/junit/ZeebeIntegrationExtensionTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.qa.util.junit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.configuration.Zone;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+@ZeebeIntegration
+final class ZeebeIntegrationExtensionTest {
+
+  private static final List<Zone> ZONE_CONFIGS =
+      List.of(new Zone("zoneA", 2, 2, 1000), new Zone("zoneB", 1, 1, 500));
+
+  @TestZeebe(
+      autoStart = false,
+      awaitStarted = false,
+      awaitReady = false,
+      awaitCompleteTopology = false,
+      purgeAfterEach = false)
+  private static final TestCluster CLUSTER =
+      TestCluster.builder()
+          .withBrokersCount(3)
+          .withPartitionsCount(2)
+          .withReplicationFactor(3)
+          .multiZone(ZONE_CONFIGS)
+          .build();
+
+  @TestZeebe(
+      autoStart = false,
+      awaitStarted = false,
+      awaitReady = false,
+      awaitCompleteTopology = false,
+      purgeAfterEach = false)
+  private static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker()
+          .withUnifiedConfig(
+              uc -> {
+                uc.getCluster().setZone("zoneA");
+                uc.getCluster().setNodeId(1);
+              });
+
+  @Test
+  void shouldCreateWorkingDirectoriesForZoneAwareClusterBrokers() {
+    // given
+    final var brokerA0 = CLUSTER.brokers().get(MemberId.from("zoneA", 0));
+    final var brokerA1 = CLUSTER.brokers().get(MemberId.from("zoneA", 1));
+    final var brokerB0 = CLUSTER.brokers().get(MemberId.from("zoneB", 0));
+
+    // then
+    assertWorkingDirectory(brokerA0, "broker-zoneA-0");
+    assertWorkingDirectory(brokerA1, "broker-zoneA-1");
+    assertWorkingDirectory(brokerB0, "broker-zoneB-0");
+  }
+
+  @Test
+  void shouldCreateManagedDirectoryForZoneAwareStandaloneBroker() {
+    // given
+    final var workingDirectory = BROKER.getWorkingDirectory();
+
+    // then
+    assertThat(workingDirectory).isNotNull().exists().isDirectory();
+    assertThat(workingDirectory.getFileName()).hasToString("broker-zoneA-1");
+    assertThat(workingDirectory.getParent().getFileName().toString())
+        .startsWith("junit-broker-zoneA-1");
+  }
+
+  private static void assertWorkingDirectory(
+      final TestStandaloneBroker broker, final String expectedDirectoryName) {
+    assertThat(broker.getWorkingDirectory()).isNotNull().exists().isDirectory();
+    assertThat(broker.getWorkingDirectory().getFileName()).hasToString(expectedDirectoryName);
+  }
+}


### PR DESCRIPTION
## Description
This PR refactors `TestCluster` so that it can be used with a simple `.multiZone(List<ZoneSpec>)` combinator to create a cluster with multiple zones.
The combinator creates the brokers in the numbers of zones configured and sets the nodeIdx accordingly. 

ZeebeIntegration needed to be fixed to use an escaped path when setting the broker working directory

- ZoneAwareClusterEndpointIT was used for inspiration and it's modified to use this new helper
- ZoneAwarePartitionDistributorIT was using 2 instances of TestCluster and it's now using just one with @TestZeebe 

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
