### PR TITLE
Patch Elasticsearch to 8.19.15

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/filter/util/DateHistogramFilterUtilES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/filter/util/DateHistogramFilterUtilES.java
@@ -188,19 +188,17 @@ public final class DateHistogramFilterUtilES {
                             FieldDateMath.of(
                                 f ->
                                     f.value(
-                                        (double)
-                                            start
-                                                .atZoneSameInstant(context.getTimezone())
-                                                .toInstant()
-                                                .toEpochMilli())))
+                                        start
+                                            .atZoneSameInstant(context.getTimezone())
+                                            .toInstant()
+                                            .toEpochMilli())))
                         .max(
                             FieldDateMath.of(
                                 f ->
                                     f.value(
-                                        (double)
-                                            filterEnd
-                                                .atZoneSameInstant(context.getTimezone())
-                                                .toInstant()
-                                                .toEpochMilli())))));
+                                        filterEnd
+                                            .atZoneSameInstant(context.getTimezone())
+                                            .toInstant()
+                                            .toEpochMilli())))));
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/service/DateAggregationServiceES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/service/DateAggregationServiceES.java
@@ -203,8 +203,8 @@ public class DateAggregationServiceES extends DateAggregationService {
 
       builder.extendedBounds(
           e ->
-              e.min(FieldDateMath.of(f -> f.value(context.getMinMaxStats().getMin())))
-                  .max(FieldDateMath.of(f -> f.value(context.getMinMaxStats().getMax()))));
+              e.min(FieldDateMath.of(f -> f.value((long) context.getMinMaxStats().getMin())))
+                  .max(FieldDateMath.of(f -> f.value((long) context.getMinMaxStats().getMax()))));
     }
 
     return Pair.of(context.getDateAggregationName().orElse(DATE_AGGREGATION), builder);

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -61,7 +61,7 @@
     <!-- DATABASE -->
     <!-- Elasticsearch-->
     <version.elasticsearch>8.19.15</version.elasticsearch>
-    <version.elasticsearch-java-client>8.19.14</version.elasticsearch-java-client>
+    <version.elasticsearch-java-client>8.19.15</version.elasticsearch-java-client>
     <!-- The least supported elasticsearch version we should test against-->
     <elasticsearch.test.version>8.19.11</elasticsearch.test.version>
     <!-- The least supported opensearch version we should test against-->

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -59,7 +59,7 @@
     <version.cron-utils>9.2.1</version.cron-utils>
     <version.docker-java-api>3.7.1</version.docker-java-api>
     <version.elasticsearch>8.19.15</version.elasticsearch>
-    <version.elasticsearch-java-client>8.19.14</version.elasticsearch-java-client>
+    <version.elasticsearch-java-client>8.19.15</version.elasticsearch-java-client>
     <version.error-prone>2.49.0</version.error-prone>
     <version.nullaway>0.13.4</version.nullaway>
     <version.grpc>1.81.0</version.grpc>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Patch Elasticsearch to 8.19.15 and update methods affected by the signature change for `FieldDateMath.Builder.value()`.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #54002 
