### PR TITLE
deps: bump openapi-generator-maven-plugin to 7.22.0

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -1133,7 +1133,7 @@
       <plugin>
         <groupId>org.openapitools</groupId>
         <artifactId>openapi-generator-maven-plugin</artifactId>
-        <version>7.21.0</version>
+        <version>7.22.0</version>
         <executions>
           <execution>
             <id>backups</id>
@@ -1159,8 +1159,10 @@
               <modelPackage>io.camunda.zeebe.management.cluster</modelPackage>
               <minimalUpdate>true</minimalUpdate>
               <ignoreFileOverride>${project.basedir}/src/main/resources/api/cluster/.openapi-generator-ignore</ignoreFileOverride>
+              <openapiNormalizer>SIMPLIFY_ONEOF_ANYOF=false</openapiNormalizer>
               <configOptions>
                 <hideGenerationTimestamp>true</hideGenerationTimestamp>
+                <useSealed>true</useSealed>
               </configOptions>
             </configuration>
           </execution>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -2896,7 +2896,7 @@
         <plugin>
           <groupId>org.openapitools</groupId>
           <artifactId>openapi-generator-maven-plugin</artifactId>
-          <version>7.21.0</version>
+          <version>7.22.0</version>
           <configuration>
             <!-- https://github.com/OpenAPITools/openapi-generator/tree/master/modules/openapi-generator-maven-plugin -->
             <!-- https://github.com/OpenAPITools/openapi-generator/blob/master/docs/generators/spring.md -->


### PR DESCRIPTION
- Bumps `org.openapitools:openapi-generator-maven-plugin` from `7.21.0` to `7.22.0` (same version as renovate PR #53367, which fails CI)
- Fixes a compilation failure caused by a breaking change in 7.22.0's `oneOf` handling

Closes #53367 (supersedes the Renovate PR)