### PR TITLE
docs: add ci-push-workflow-health skill to analyze CI health

### DIFF
--- a/.claude/skills/ci-push-workflow-health/SKILL.md
+++ b/.claude/skills/ci-push-workflow-health/SKILL.md
@@ -1,0 +1,291 @@
+---
+
+name: ci-push-workflow-health
+description: Analyze CI failure patterns for push-triggered workflow jobs on main and stable/* branches using BigQuery CI Analytics data (ci-30-162810.prod_ci_analytics.build_status_v2). Use when asked about CI health, broken jobs, flaky workflows, failure rates, or push-trigger problems on main or stable branches.
+
+---
+
+# CI Push Workflow Health Analysis
+
+Analyzes failure patterns for `push`-triggered GitHub Actions workflow runs on `main` and `stable/*` branches using BigQuery CI Analytics data.
+
+## Prerequisites
+
+- `bq` CLI available and authenticated (`bq show ci-30-162810:prod_ci_analytics.build_status_v2` should work)
+- BigQuery table: `ci-30-162810.prod_ci_analytics.build_status_v2`
+
+## Analysis approach
+
+Run the following queries in sequence. Each builds on the previous to drill from broad summary down to specific broken jobs. Adjust `INTERVAL 14 DAY` if a shorter or longer window is needed. Longer windows are costlier (maximum 90 days) and less impacted by recent trends/changes.
+
+---
+
+### Step 1 — Overview: total runs and failure counts per branch
+
+Establishes the scope and identifies which branches have significant failure volume.
+
+```sql
+SELECT
+  build_ref,
+  COUNT(*) AS total,
+  COUNTIF(build_status != 'success') AS failures,
+  MIN(report_time) AS earliest,
+  MAX(report_time) AS latest
+FROM `ci-30-162810.prod_ci_analytics.build_status_v2`
+WHERE
+  ci_url = 'https://github.com/camunda/camunda'
+  AND build_trigger = 'push'
+  AND (
+    build_ref = 'refs/heads/main'
+    OR build_ref LIKE 'refs/heads/stable/%'
+  )
+  AND report_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 14 DAY)
+GROUP BY build_ref
+ORDER BY build_ref
+```
+
+---
+
+### Step 2 — Workflow breakdown: failure rate per workflow per branch
+
+Identifies which workflows are the problem areas. Key signals:
+- `failure_pct` > 10% on a high-volume workflow = high impact
+- `failure_pct` = 100% = completely broken
+- High `cancellations` relative to `failures` = concurrency issue (not real test failures) or timeouts (they are a problem)
+
+```sql
+SELECT
+  build_ref,
+  workflow_name,
+  COUNT(*) AS total_runs,
+  COUNTIF(build_status != 'success') AS failures,
+  ROUND(100.0 * COUNTIF(build_status != 'success') / COUNT(*), 1) AS failure_pct,
+  COUNTIF(build_status = 'failure') AS hard_failures,
+  COUNTIF(build_status = 'cancelled') AS cancellations,
+  COUNTIF(build_status = 'aborted') AS aborts
+FROM `ci-30-162810.prod_ci_analytics.build_status_v2`
+WHERE
+  ci_url = 'https://github.com/camunda/camunda'
+  AND build_trigger = 'push'
+  AND (
+    build_ref = 'refs/heads/main'
+    OR build_ref LIKE 'refs/heads/stable/%'
+  )
+  AND report_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 14 DAY)
+GROUP BY build_ref, workflow_name
+HAVING failures > 5
+ORDER BY build_ref, failures DESC
+```
+
+---
+
+### Step 3 — Job-level failures in high-failure-rate workflows (excluding Unified CI)
+
+Drills into specific jobs that are broken. Focus on workflows identified as problematic in step 2. A job at 100% failure rate over many runs is permanently broken (not flaky).
+
+```sql
+SELECT
+  build_ref,
+  workflow_name,
+  job_name,
+  COUNT(*) AS total_runs,
+  COUNTIF(build_status != 'success') AS failures,
+  ROUND(100.0 * COUNTIF(build_status != 'success') / COUNT(*), 1) AS failure_pct,
+  COUNTIF(build_status = 'failure') AS hard_failures,
+  COUNTIF(build_status = 'cancelled') AS cancellations
+FROM `ci-30-162810.prod_ci_analytics.build_status_v2`
+WHERE
+  ci_url = 'https://github.com/camunda/camunda'
+  AND build_trigger = 'push'
+  AND (
+    build_ref = 'refs/heads/main'
+    OR build_ref LIKE 'refs/heads/stable/%'
+  )
+  AND report_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 14 DAY)
+  AND build_status != 'success'
+  AND workflow_name NOT IN ('CI', 'Check Licenses')
+GROUP BY build_ref, workflow_name, job_name
+HAVING failures >= 5
+ORDER BY build_ref, failures DESC
+LIMIT 80
+```
+
+---
+
+### Step 4 — Job-level failures within the Unified CI workflow
+
+The `CI` workflow runs on nearly every push so its absolute failure count is high even at low failure rates. It is the required status check so impact is high. Look for jobs at with high failure rate — those are specific test areas that are broken, not representative of the overall CI health.
+
+```sql
+SELECT
+  build_ref,
+  job_name,
+  COUNT(*) AS total_runs,
+  COUNTIF(build_status != 'success') AS failures,
+  ROUND(100.0 * COUNTIF(build_status != 'success') / COUNT(*), 1) AS failure_pct,
+  COUNTIF(build_status = 'failure') AS hard_failures,
+  COUNTIF(build_status = 'cancelled') AS cancellations,
+  ROUND(AVG(build_duration_milliseconds) / 60000, 1) AS avg_duration_min
+FROM `ci-30-162810.prod_ci_analytics.build_status_v2`
+WHERE
+  ci_url = 'https://github.com/camunda/camunda'
+  AND build_trigger = 'push'
+  AND (
+    build_ref = 'refs/heads/main'
+    OR build_ref LIKE 'refs/heads/stable/%'
+  )
+  AND report_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 14 DAY)
+  AND workflow_name = 'CI'
+  AND build_status != 'success'
+GROUP BY build_ref, job_name
+HAVING failures >= 3
+ORDER BY build_ref, failures DESC
+LIMIT 60
+```
+
+---
+
+### Step 5 — Weekly trend on main
+
+Shows whether the overall failure rate is improving or degrading. A spike in one week can be traced back to a bad commit window.
+
+```sql
+SELECT
+  DATE_TRUNC(DATE(report_time), WEEK) AS week,
+  COUNT(*) AS total_runs,
+  COUNTIF(build_status != 'success') AS failures,
+  ROUND(100.0 * COUNTIF(build_status != 'success') / COUNT(*), 2) AS failure_pct
+FROM `ci-30-162810.prod_ci_analytics.build_status_v2`
+WHERE
+  ci_url = 'https://github.com/camunda/camunda'
+  AND build_trigger = 'push'
+  AND build_ref = 'refs/heads/main'
+  AND report_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 14 DAY)
+GROUP BY week
+ORDER BY week
+```
+
+---
+
+### Step 6 — Daily trend for specific suspect workflows
+
+Use this to check whether a workflow's failures are chronic (broken since day 1) or a recent regression. Replace the `workflow_name` list with the workflows identified as problematic in step 2.
+
+```sql
+SELECT
+  build_ref,
+  workflow_name,
+  DATE(report_time) AS day,
+  COUNT(*) AS total_runs,
+  COUNTIF(build_status != 'success') AS failures,
+  ROUND(100.0 * COUNTIF(build_status != 'success') / COUNT(*), 0) AS failure_pct
+FROM `ci-30-162810.prod_ci_analytics.build_status_v2`
+WHERE
+  ci_url = 'https://github.com/camunda/camunda'
+  AND build_trigger = 'push'
+  AND build_ref IN ('refs/heads/main', 'refs/heads/stable/8.7', 'refs/heads/stable/8.8', 'refs/heads/stable/8.9')
+  AND report_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 14 DAY)
+  AND workflow_name IN (
+    '[Legacy] Operate / E2E Tests',
+    '[Legacy] Tasklist / E2E Tests',
+    '[Legacy] Tasklist',
+    '[Legacy] Operate'
+    -- add other suspect workflows here
+  )
+GROUP BY build_ref, workflow_name, day
+HAVING total_runs > 0
+ORDER BY build_ref, workflow_name, day
+```
+
+---
+
+### Step 7 — Per-commit check status via GitHub Checks API (optional, high GitHub API quota cost)
+
+> **WARNING — High GitHub API quota usage.** This step uses the GitHub Checks API to fetch check suites and check runs for every commit in the window. Each commit can consume 10–50+ API requests depending on the number of check suites. A 3-hour window on `main` can easily use 500–2000+ requests against a PAT's 5000/hour limit. **Always ask the user for confirmation before running this step**, and keep the `--hours` window as small as possible (3–6 hours recommended, never more than 24).
+
+This step uses the `main_branch_health.py` script (bundled in this scripts subfolder) to query the GitHub Checks API directly. Unlike the BigQuery-based steps above, this provides the **exact same check status view as GitHub's UI** on each commit — including check suite names, individual check run conclusions, and per-commit pass/fail summaries. Use this when you need to:
+
+- Verify exactly which checks failed on specific recent commits (matching what the user sees on GitHub)
+- Cross-reference BigQuery aggregate data with actual commit-level check results
+- Debug check runs that may not appear in BigQuery (e.g., third-party checks, non-workflow checks)
+
+#### Prerequisites
+
+- Python 3.9+ with `requests` installed (`pip install requests`)
+- `GITHUB_TOKEN` or `GH_TOKEN` environment variable set with a PAT or fine-grained token that has repo read access
+
+#### Before running — confirm with the user
+
+**You MUST ask the user for confirmation before executing this script.** Present them with:
+1. The branch and time window you plan to query
+2. A warning that this will consume significant GitHub API quota
+3. Ask if they want to proceed
+
+Example prompt: _"I'd like to run the commit-level checks script for `main` over the last 6 hours. This will use the GitHub Checks API which consumes significant API quota (potentially hundreds of requests). Should I proceed?"_
+
+#### Usage
+
+```bash
+# Table output (default) — last 6 hours on main
+python .claude/skills/ci-push-workflow-health/scripts/main_branch_health.py \
+  --branch main --hours 6 --output table --fallback-to-statuses
+
+# JSON output for programmatic analysis
+python .claude/skills/ci-push-workflow-health/scripts/main_branch_health.py \
+  --branch main --hours 6 --output json --fallback-to-statuses
+
+# Stable branch, minimal window
+python .claude/skills/ci-push-workflow-health/scripts/main_branch_health.py \
+  --branch stable/8.8 --hours 3 --output table --fallback-to-statuses
+```
+
+#### Key flags
+
+|           Flag           |                         Description                         |
+|--------------------------|-------------------------------------------------------------|
+| `--hours N`              | Look back N hours (default 3). **Keep this small** (1–3).   |
+| `--branch NAME`          | Branch to scan (default `main`). Use `stable/8.8` etc.      |
+| `--output table\|json`   | Output format. Use `json` when you need to process results. |
+| `--fallback-to-statuses` | Fall back to commit status API if no check runs found.      |
+| `--workers N`            | Parallel workers (default 8).                               |
+
+#### Output
+
+The table output shows per-commit health:
+
+```
+sha      committed_at              summary  overall  source  failed_jobs
+-------  ------------------------  -------  -------  ------  -----------
+abc1234  2025-05-26T10:30:00+00:00  45/47   failure  checks  CI / java-checks (failure), ...
+def5678  2025-05-26T10:15:00+00:00  47/47   success  checks  -
+```
+
+Followed by aggregated failed job totals across all commits in the window.
+
+---
+
+## How to run queries
+
+```bash
+bq query --use_legacy_sql=false --format=pretty '<SQL>'
+```
+
+## How to interpret results
+
+|                  Signal                   |                                         Interpretation                                         |
+|-------------------------------------------|------------------------------------------------------------------------------------------------|
+| `failure_pct` = 100% over many runs       | Permanently broken — needs immediate fix or disable                                            |
+| `failure_pct` = 100% over few runs        | Could be flaky or a recent commit broke it — check trend                                       |
+| High `cancellations`, low `hard_failures` | Concurrency problem ( workflow triggered too often, cancels in-flight runs) or timeout problem |
+| `failure_pct` improving in recent weeks   | Fix landed on main but may not be backported to stable                                         |
+
+## Report structure
+
+Summarize findings in this order:
+
+1. **Overview table** — failure % per branch
+2. **Critical: permanently broken jobs** — 100% failure rate, high run count
+3. **High-impact problems by area** — grouped by root cause pattern
+4. **Trend** — improving, degrading, or stable
+5. **Recommendations** — concrete next steps (backport, disable, add concurrency guard, etc.)
+

--- a/.claude/skills/ci-push-workflow-health/scripts/main_branch_health.py
+++ b/.claude/skills/ci-push-workflow-health/scripts/main_branch_health.py
@@ -1,0 +1,557 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, asdict
+from datetime import datetime, timedelta, timezone
+from functools import partial
+from typing import Any, Dict, List, Optional, Tuple
+
+import requests
+
+GITHUB_API = "https://api.github.com"
+DEFAULT_ACCEPT = "application/vnd.github+json"
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def parse_github_datetime(s: str) -> datetime:
+    if s.endswith("Z"):
+        s = s[:-1] + "+00:00"
+    return datetime.fromisoformat(s)
+
+
+class GitHubAPIError(RuntimeError):
+    pass
+
+
+class GitHubClient:
+    def __init__(self, token: Optional[str], base_url: str = GITHUB_API, timeout: int = 30):
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Accept": DEFAULT_ACCEPT, "User-Agent": "main-branch-health-script"}
+        )
+        if token:
+            self.session.headers["Authorization"] = f"Bearer {token}"
+
+    def get(self, path: str, params: Optional[dict] = None) -> requests.Response:
+        url = f"{self.base_url}{path}"
+        resp = self.session.get(url, params=params, timeout=self.timeout)
+        if resp.status_code >= 400:
+            try:
+                body = resp.json()
+            except Exception:
+                body = resp.text[:500]
+            raise GitHubAPIError(f"GitHub API error {resp.status_code} for {url}: {body}")
+        return resp
+
+    def get_json(self, path: str, params: Optional[dict] = None) -> Any:
+        return self.get(path, params=params).json()
+
+
+@dataclass(frozen=True)
+class CommitRef:
+    sha: str
+    committed_at: datetime
+    html_url: str
+
+
+@dataclass
+class CommitHealth:
+    sha: str
+    short_sha: str
+    committed_at: str
+    commit_url: str
+    success: int
+    total: int
+    overall: str  # success|failure|nodata
+    conclusions: Dict[str, int]
+    failed_jobs: List[str]
+    source: str  # checks|statuses|none
+
+
+def past_hours_window_utc(hours: int) -> Tuple[datetime, datetime]:
+    """Returns [start,end) in UTC for the past N hours."""
+    end_utc = utc_now()
+    start_utc = end_utc - timedelta(hours=hours)
+    return start_utc, end_utc
+
+
+def list_commits_page(
+    gh: GitHubClient, owner: str, repo: str, branch: str, page: int, per_page: int
+) -> List[CommitRef]:
+    data = gh.get_json(
+        f"/repos/{owner}/{repo}/commits",
+        params={"sha": branch, "page": page, "per_page": per_page},
+    )
+    if not isinstance(data, list):
+        raise GitHubAPIError(f"Expected list response for commits page, got: {type(data)}")
+
+    out: List[CommitRef] = []
+    for c in data:
+        sha = c["sha"]
+        html_url = c.get("html_url", f"https://github.com/{owner}/{repo}/commit/{sha}")
+
+        commit = c["commit"]
+        dt_str = (commit.get("committer") or {}).get("date") or (commit.get("author") or {}).get("date")
+        if not dt_str:
+            continue
+        committed_at = parse_github_datetime(dt_str)
+
+        out.append(CommitRef(sha=sha, committed_at=committed_at, html_url=html_url))
+    return out
+
+
+def list_commits_from_window(
+    gh: GitHubClient,
+    owner: str,
+    repo: str,
+    branch: str,
+    start_utc: datetime,
+    end_utc: datetime,
+    per_page: int,
+    max_pages: int,
+) -> Tuple[List[CommitRef], int]:
+    """
+    Pages through commits newest->older, collects all commits in [start_utc,end_utc),
+    and stops once we are older than start_utc (i.e., once the window is fully covered).
+    Returns (commits, pages_scanned).
+    """
+    results: List[CommitRef] = []
+    pages_scanned = 0
+
+    for page in range(1, max_pages + 1):
+        commits = list_commits_page(gh, owner, repo, branch, page=page, per_page=per_page)
+        pages_scanned = page
+
+        if not commits:
+            break
+
+        stop = False
+        for c in commits:
+            if c.committed_at >= end_utc:
+                # today (or later) in the chosen tz -> ignore
+                continue
+            if start_utc <= c.committed_at < end_utc:
+                results.append(c)
+                continue
+            if c.committed_at < start_utc:
+                # we've gone older than yesterday -> we can stop scanning
+                stop = True
+                break
+
+        if stop:
+            break
+
+    # Keep newest->oldest ordering in output (same as scan order already)
+    return results, pages_scanned
+
+
+def list_completed_check_runs_for_commit(
+    gh: GitHubClient, owner: str, repo: str, sha: str
+) -> List[Dict[str, Any]]:
+    suites = gh.get_json(
+        f"/repos/{owner}/{repo}/commits/{sha}/check-suites",
+        params={"per_page": 100},
+    )
+    check_suites = suites.get("check_suites", []) or []
+
+    all_runs: List[Dict[str, Any]] = []
+    for suite in check_suites:
+        suite_id = suite["id"]
+        workflow_name = suite.get("workflow_name")
+        suite_runs = list_check_runs_for_suite(gh, owner, repo, suite_id)
+        if workflow_name:
+            for run in suite_runs:
+                run.setdefault("workflow_name", workflow_name)
+        all_runs.extend(suite_runs)
+
+    return [r for r in all_runs if r.get("status") == "completed"]
+
+
+def list_check_runs_for_suite(
+    gh: GitHubClient, owner: str, repo: str, suite_id: int, per_page: int = 100
+) -> List[Dict[str, Any]]:
+    runs: List[Dict[str, Any]] = []
+    for page in range(1, 51):
+        payload = gh.get_json(
+            f"/repos/{owner}/{repo}/check-suites/{suite_id}/check-runs",
+            params={"per_page": per_page, "page": page},
+        )
+        page_runs = payload.get("check_runs", []) or []
+        runs.extend(page_runs)
+        if len(page_runs) < per_page:
+            break
+    return runs
+
+
+def debug_check_metadata(gh: GitHubClient, owner: str, repo: str, sha: str) -> None:
+    suites = gh.get_json(
+        f"/repos/{owner}/{repo}/commits/{sha}/check-suites",
+        params={"per_page": 100},
+    )
+    check_suites = suites.get("check_suites", []) or []
+    if not check_suites:
+        print("No check suites found for debug.")
+        return
+
+    print(f"Check suites found: {len(check_suites)}")
+    suites_with_runs = []
+    total_runs = 0
+    for suite in check_suites:
+        suite_id = suite["id"]
+        suite_runs = list_check_runs_for_suite(gh, owner, repo, suite_id)
+        total_runs += len(suite_runs)
+        suites_with_runs.append((suite, suite_runs))
+
+    print(f"Total check runs found across suites: {total_runs}")
+
+    suite = next((s for s, runs in suites_with_runs if runs), check_suites[0])
+    suite_keys = sorted(suite.keys())
+    print("Sample check suite keys:")
+    print(", ".join(suite_keys))
+    print()
+    print("Sample check suite workflow/app info:")
+    print(
+        json.dumps(
+            {
+                "workflow_name": suite.get("workflow_name"),
+                "workflow_run": (suite.get("workflow_run") or {}),
+                "app": (suite.get("app") or {}),
+            },
+            indent=2,
+        )
+    )
+
+    check_runs = next((runs for _, runs in suites_with_runs if runs), [])
+    if not check_runs:
+        print("No check runs found for debug.")
+        return
+
+    run = check_runs[0]
+    run_keys = sorted(run.keys())
+    print("Sample check run keys:")
+    print(", ".join(run_keys))
+    print()
+    print("Sample check run workflow/app info:")
+    print(
+        json.dumps(
+            {
+                "name": run.get("name"),
+                "workflow_name": run.get("workflow_name"),
+                "workflow_run": (run.get("workflow_run") or {}),
+                "app": (run.get("app") or {}),
+                "check_suite": (run.get("check_suite") or {}),
+            },
+            indent=2,
+        )
+    )
+
+
+def summarize_check_runs(
+    check_runs: List[Dict[str, Any]]
+) -> Tuple[int, int, Dict[str, int], List[str]]:
+    conclusions: Dict[str, int] = {}
+    total = 0
+    success = 0
+    failed_jobs: List[str] = []
+    for r in check_runs:
+        if r.get("status") != "completed":
+            continue
+        conc = r.get("conclusion") or "unknown"
+        conclusions[conc] = conclusions.get(conc, 0) + 1
+        if conc == "skipped":
+            continue
+        total += 1
+        if conc == "success":
+            success += 1
+        else:
+            name = r.get("name") or "unknown"
+            check_suite = r.get("check_suite") or {}
+            run_app_name = (r.get("app") or {}).get("name")
+            suite_app_name = (check_suite.get("app") or {}).get("name")
+            workflow = (
+                r.get("workflow_name")
+                or (r.get("workflow_run") or {}).get("name")
+                or (run_app_name if run_app_name and run_app_name != "GitHub Actions" else None)
+                or check_suite.get("workflow_name")
+                or (check_suite.get("workflow_run") or {}).get("name")
+                or (suite_app_name if suite_app_name and suite_app_name != "GitHub Actions" else None)
+            )
+            if workflow:
+                failed_jobs.append(f"{workflow} / {name} ({conc})")
+            else:
+                failed_jobs.append(f"{name} ({conc})")
+    return success, total, conclusions, failed_jobs
+
+
+def get_combined_status_summary(
+    gh: GitHubClient, owner: str, repo: str, sha: str
+) -> Optional[Tuple[int, int, Dict[str, int], List[str]]]:
+    combined = gh.get_json(f"/repos/{owner}/{repo}/commits/{sha}/status")
+    statuses = combined.get("statuses", []) or []
+    if not statuses:
+        return None
+
+    total = 0
+    success = 0
+    conclusions: Dict[str, int] = {}
+    failed_jobs: List[str] = []
+    for s in statuses:
+        state = s.get("state") or "unknown"
+        total += 1
+        conclusions[state] = conclusions.get(state, 0) + 1
+        if state == "success":
+            success += 1
+        else:
+            context = s.get("context") or "unknown"
+            failed_jobs.append(f"{context} ({state})")
+    return success, total, conclusions, failed_jobs
+
+
+def overall_from_counts(total: int, success: int) -> str:
+    if total == 0:
+        return "nodata"
+    return "success" if success == total else "failure"
+
+
+def compute_health_for_commit(
+    gh: GitHubClient, owner: str, repo: str, commit: CommitRef, fallback_to_statuses: bool
+) -> CommitHealth:
+    sha = commit.sha
+    short_sha = sha[:7]
+
+    try:
+        check_runs = list_completed_check_runs_for_commit(gh, owner, repo, sha)
+        success, total, conclusions, failed_jobs = summarize_check_runs(check_runs)
+
+        if total == 0 and fallback_to_statuses:
+            fb = get_combined_status_summary(gh, owner, repo, sha)
+            if fb is not None:
+                s2, t2, conc2, failed2 = fb
+                return CommitHealth(
+                    sha=sha,
+                    short_sha=short_sha,
+                    committed_at=commit.committed_at.isoformat(),
+                    commit_url=commit.html_url,
+                    success=s2,
+                    total=t2,
+                    overall=overall_from_counts(t2, s2),
+                    conclusions=conc2,
+                    failed_jobs=failed2,
+                    source="statuses",
+                )
+
+        return CommitHealth(
+            sha=sha,
+            short_sha=short_sha,
+            committed_at=commit.committed_at.isoformat(),
+            commit_url=commit.html_url,
+            success=success,
+            total=total,
+            overall=overall_from_counts(total, success),
+            conclusions=conclusions,
+            failed_jobs=failed_jobs,
+            source="checks",
+        )
+    except GitHubAPIError:
+        if fallback_to_statuses:
+            fb = get_combined_status_summary(gh, owner, repo, sha)
+            if fb is not None:
+                s2, t2, conc2, failed2 = fb
+                return CommitHealth(
+                    sha=sha,
+                    short_sha=short_sha,
+                    committed_at=commit.committed_at.isoformat(),
+                    commit_url=commit.html_url,
+                    success=s2,
+                    total=t2,
+                    overall=overall_from_counts(t2, s2),
+                    conclusions=conc2,
+                    failed_jobs=failed2,
+                    source="statuses",
+                )
+        raise
+
+
+def compute_health_for_commit_with_client(
+    token: Optional[str],
+    base_url: str,
+    timeout: int,
+    owner: str,
+    repo: str,
+    commit: CommitRef,
+    fallback_to_statuses: bool,
+) -> CommitHealth:
+    gh = GitHubClient(token=token, base_url=base_url, timeout=timeout)
+    return compute_health_for_commit(
+        gh=gh,
+        owner=owner,
+        repo=repo,
+        commit=commit,
+        fallback_to_statuses=fallback_to_statuses,
+    )
+
+
+def fmt_table(rows: List[CommitHealth]) -> str:
+    headers = ["sha", "committed_at", "summary", "overall", "source", "failed_jobs"]
+    body = [
+        [
+            r.short_sha,
+            r.committed_at,
+            f"{r.success}/{r.total}",
+            r.overall,
+            r.source,
+            ", ".join(r.failed_jobs) if r.failed_jobs else "-",
+        ]
+        for r in rows
+    ]
+    widths = [len(h) for h in headers]
+    for row in body:
+        for i, cell in enumerate(row):
+            widths[i] = max(widths[i], len(str(cell)))
+
+    def line(cols: List[str]) -> str:
+        return "  ".join(str(c).ljust(widths[i]) for i, c in enumerate(cols))
+
+    out = [line(headers), line(["-" * w for w in widths])]
+    out += [line(r) for r in body]
+    return "\n".join(out)
+
+
+def format_failed_job_totals(rows: List[CommitHealth]) -> str:
+    totals: Dict[str, int] = {}
+    for r in rows:
+        for job in r.failed_jobs:
+            totals[job] = totals.get(job, 0) + 1
+
+    if not totals:
+        return "No failed jobs detected."
+
+    lines = ["Failed jobs totals:"]
+    for job, count in sorted(totals.items(), key=lambda item: (-item[1], item[0])):
+        lines.append(f"  {job}: {count}")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Compute health for all commits from the past N hours.")
+    ap.add_argument("--owner", default="camunda")
+    ap.add_argument("--repo", default="camunda")
+    ap.add_argument("--branch", default="main")
+    ap.add_argument("--hours", type=int, default=3, help="Look back this many hours (default 3).")
+    ap.add_argument("--per-page", type=int, default=100)
+    ap.add_argument("--max-pages", type=int, default=50, help="Safety cap; increase if repo is extremely active.")
+    ap.add_argument("--fallback-to-statuses", action="store_true")
+    ap.add_argument("--output", choices=["json", "table"], default="table")
+    ap.add_argument("--sleep-between", type=float, default=0.0)
+    ap.add_argument(
+        "--debug-checks",
+        nargs="?",
+        const="",
+        help="Print sample check suite/run fields for a commit SHA (or first commit) and exit.",
+    )
+    ap.add_argument(
+        "--workers",
+        type=int,
+        default=8,
+        help="Number of parallel workers for commit checks (default 8).",
+    )
+
+    args = ap.parse_args()
+
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    gh = GitHubClient(token=token)
+
+    start_utc, end_utc = past_hours_window_utc(args.hours)
+
+    commits, pages_scanned = list_commits_from_window(
+        gh=gh,
+        owner=args.owner,
+        repo=args.repo,
+        branch=args.branch,
+        start_utc=start_utc,
+        end_utc=end_utc,
+        per_page=args.per_page,
+        max_pages=args.max_pages,
+    )
+
+    if not commits:
+        msg = (
+            f"No commits found in past {args.hours} hours for {args.owner}/{args.repo}@{args.branch}.\n"
+            f"Window (UTC): [{start_utc.isoformat()} .. {end_utc.isoformat()})\n"
+            f"Pages scanned: {pages_scanned} (per_page={args.per_page}, max_pages={args.max_pages})."
+        )
+        print(msg)
+        return 0
+
+    if args.debug_checks is not None:
+        debug_sha = args.debug_checks or commits[0].sha
+        debug_check_metadata(gh, args.owner, args.repo, debug_sha)
+        return 0
+
+    results: List[CommitHealth] = []
+    if args.workers <= 1:
+        for c in commits:
+            results.append(
+                compute_health_for_commit(
+                    gh=gh,
+                    owner=args.owner,
+                    repo=args.repo,
+                    commit=c,
+                    fallback_to_statuses=args.fallback_to_statuses,
+                )
+            )
+            if args.sleep_between > 0:
+                time.sleep(args.sleep_between)
+    else:
+        if args.sleep_between > 0:
+            print("--sleep-between ignored when --workers > 1", file=sys.stderr)
+        task = partial(
+            compute_health_for_commit_with_client,
+            token,
+            gh.base_url,
+            gh.timeout,
+            args.owner,
+            args.repo,
+            fallback_to_statuses=args.fallback_to_statuses,
+        )
+        with ThreadPoolExecutor(max_workers=args.workers) as executor:
+            results = list(executor.map(task, commits))
+
+    if args.output == "table":
+        print(fmt_table(results))
+        print()
+        print(format_failed_job_totals(results))
+    else:
+        failed_job_totals: Dict[str, int] = {}
+        for r in results:
+            for job in r.failed_jobs:
+                failed_job_totals[job] = failed_job_totals.get(job, 0) + 1
+        payload = {
+            "repo": f"{args.owner}/{args.repo}",
+            "branch": args.branch,
+            "hours": args.hours,
+            "window_utc": {"start": start_utc.isoformat(), "end": end_utc.isoformat()},
+            "generated_at_utc": utc_now().isoformat(),
+            "pages_scanned": pages_scanned,
+            "commits_found": len(commits),
+            "results": [asdict(r) for r in results],
+            "failed_job_totals": failed_job_totals,
+        }
+        print(json.dumps(payload, indent=2))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.codeowners
+++ b/.codeowners
@@ -52,6 +52,7 @@ buf.yaml                    @camunda/orchestration-cluster
 ## @camunda/monorepo-devops-team
 ################################
 
+/.claude/skills/ci-push-workflow-health/ @camunda/monorepo-devops-team
 /.claude/skills/ci-scheduled-workflow-health/ @camunda/monorepo-devops-team
 
 /.ci/                       @camunda/monorepo-devops-team


### PR DESCRIPTION
## Description

This pull request introduces a new skill for analyzing CI push workflow health and updates code ownership for the new skill. The main focus is to provide a documented, query-driven approach for diagnosing and reporting on CI failures for push-triggered workflows on the `main` and `stable/*` branches using BigQuery analytics data (fast) and GitHub Checks API (slow, mirrors exactly what is shown in GitHub UI).

**Skill documentation and ownership:**

* Adds a new skill documentation file, `ci-push-workflow-health`, which details a step-by-step process (with SQL queries) for analyzing CI failure patterns, identifying problematic workflows and jobs, and interpreting results to guide remediation.
* Updates `.codeowners` to assign ownership of the new `.claude/skills/ci-push-workflow-health/` directory to the `@camunda/monorepo-devops-team`.

**Example:**

* This skill was used to identify several action items in https://github.com/camunda/product-hub/issues/3667

The new skill serves a similar purpose as https://github.com/camunda/camunda/pull/53626 but for a different kind of workflows.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)) - not needed
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

None
