### PR TITLE
fix: typo createDefeaultElasticsearchContainer -> createDefaultElasticsearchContainer

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/backup/AbstractBackupRestoreIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/backup/AbstractBackupRestoreIT.java
@@ -98,7 +98,7 @@ public abstract class AbstractBackupRestoreIT {
         switch (databaseType) {
           case ELASTICSEARCH -> {
             final var container =
-                TestSearchContainers.createDefeaultElasticsearchContainer()
+                TestSearchContainers.createDefaultElasticsearchContainer()
                     .withStartupTimeout(Duration.ofMinutes(5))
                     .withEnv("path.repo", "~/");
             container.start();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/document/usagemetrics/UsageMetricsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/document/usagemetrics/UsageMetricsIT.java
@@ -79,7 +79,7 @@ public class UsageMetricsIT {
         switch (config.databaseType) {
           case ELASTICSEARCH -> {
             final var container =
-                TestSearchContainers.createDefeaultElasticsearchContainer()
+                TestSearchContainers.createDefaultElasticsearchContainer()
                     .withStartupTimeout(Duration.ofMinutes(5))
                     // location of the repository that will be used for snapshots
                     .withEnv("path.repo", "~/");

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/exporter/MultiExporterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/exporter/MultiExporterIT.java
@@ -189,7 +189,7 @@ public class MultiExporterIT {
               .withStartupTimeout(Duration.ofMinutes(5));
     } else {
       searchContainer =
-          TestSearchContainers.createDefeaultElasticsearchContainer()
+          TestSearchContainers.createDefaultElasticsearchContainer()
               .withStartupTimeout(Duration.ofMinutes(5))
               .withEnv("path.repo", "~/");
     }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/network/SecuredClusterMessagingIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/network/SecuredClusterMessagingIT.java
@@ -53,7 +53,7 @@ final class SecuredClusteredMessagingIT {
   @SuppressWarnings("unused")
   @Container
   private static final ElasticsearchContainer ELASTIC =
-      TestSearchContainers.createDefeaultElasticsearchContainer()
+      TestSearchContainers.createDefaultElasticsearchContainer()
           .withNetwork(NETWORK)
           .withNetworkAliases("elastic")
           .withStartupTimeout(Duration.ofMinutes(5));

--- a/qa/util/src/main/java/io/camunda/qa/util/compatibility/CompatibilityTestExtension.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/compatibility/CompatibilityTestExtension.java
@@ -203,7 +203,7 @@ public class CompatibilityTestExtension
     LOGGER.info("Starting Elasticsearch container");
 
     elasticsearchContainer =
-        TestSearchContainers.createDefeaultElasticsearchContainer()
+        TestSearchContainers.createDefaultElasticsearchContainer()
             .withNetwork(network)
             .withNetworkAliases("elasticsearch")
             .withEnv("indices.lifecycle.poll_interval", "1s");

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
@@ -630,7 +630,7 @@ public class CamundaMultiDBExtension
 
   private ElasticsearchContainer setupElasticsearch() {
     final ElasticsearchContainer elasticsearchContainer =
-        TestSearchContainers.createDefeaultElasticsearchContainer()
+        TestSearchContainers.createDefaultElasticsearchContainer()
             // We need to configure ILM to run more often, to make sure data is cleaned up earlier
             // Useful for tests where we verify history clean up
             // Default is 10m

--- a/qa/util/src/test/java/io/camunda/qa/util/multidb/ElasticsearchSetupHelperTest.java
+++ b/qa/util/src/test/java/io/camunda/qa/util/multidb/ElasticsearchSetupHelperTest.java
@@ -35,7 +35,7 @@ public class ElasticsearchSetupHelperTest {
 
   @BeforeAll
   public static void setUpEs() {
-    elasticsearchContainer = TestSearchContainers.createDefeaultElasticsearchContainer();
+    elasticsearchContainer = TestSearchContainers.createDefaultElasticsearchContainer();
     elasticsearchContainer.start();
     elasticSearchUrl = "http://" + elasticsearchContainer.getHttpHostAddress();
   }

--- a/schema-manager/src/test/java/io/camunda/search/schema/ElasticsearchEngineClientIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/ElasticsearchEngineClientIT.java
@@ -43,7 +43,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 public class ElasticsearchEngineClientIT {
   @Container
   private static final ElasticsearchContainer CONTAINER =
-      TestSearchContainers.createDefeaultElasticsearchContainer();
+      TestSearchContainers.createDefaultElasticsearchContainer();
 
   private static ElasticsearchClient elsClient;
   private static ElasticsearchEngineClient elsEngineClient;

--- a/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerStartupIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerStartupIT.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.search.schema;
 
-import static io.camunda.zeebe.test.util.testcontainers.TestSearchContainers.createDefeaultElasticsearchContainer;
+import static io.camunda.zeebe.test.util.testcontainers.TestSearchContainers.createDefaultElasticsearchContainer;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import co.elastic.clients.elasticsearch._types.mapping.DynamicMapping;
@@ -72,7 +72,7 @@ class SchemaManagerStartupIT {
 
   @Container
   private final ElasticsearchContainer es =
-      createDefeaultElasticsearchContainer()
+      createDefaultElasticsearchContainer()
           .withNetwork(Network.SHARED)
           .withNetworkAliases("test-elasticsearch");
 

--- a/schema-manager/src/test/java/io/camunda/search/schema/utils/SchemaManagerITInvocationProvider.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/utils/SchemaManagerITInvocationProvider.java
@@ -47,7 +47,7 @@ public class SchemaManagerITInvocationProvider
   protected SearchClientAdapter elsClientAdapter;
   protected SearchClientAdapter osClientAdapter;
   private final ElasticsearchContainer elsContainer =
-      TestSearchContainers.createDefeaultElasticsearchContainer()
+      TestSearchContainers.createDefaultElasticsearchContainer()
           .withNetwork(Network.SHARED)
           .withNetworkAliases(ELASTICSEARCH_NETWORK_ALIAS);
   private final OpenSearchContainer<?> osContainer =

--- a/search/search-test-utils/src/main/java/io/camunda/search/test/utils/ContainerizedSearchDBExtension.java
+++ b/search/search-test-utils/src/main/java/io/camunda/search/test/utils/ContainerizedSearchDBExtension.java
@@ -38,7 +38,7 @@ import org.testcontainers.elasticsearch.ElasticsearchContainer;
 public class ContainerizedSearchDBExtension extends SearchDBExtension {
   private final LazySearchContainer<ElasticsearchContainer, ElasticsearchClient> elasticsearch =
       new LazySearchContainer<>(
-          TestSearchContainers::createDefeaultElasticsearchContainer,
+          TestSearchContainers::createDefaultElasticsearchContainer,
           ContainerizedSearchDBExtension::createElasticSearchClient,
           ElasticsearchClient::close);
   private final LazySearchContainer<OpenSearchContainer<?>, OpenSearchClient> opensearch =

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterAuthenticationIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterAuthenticationIT.java
@@ -33,7 +33,7 @@ public class CamundaExporterAuthenticationIT {
 
   @Container
   private static final ElasticsearchContainer CONTAINER =
-      TestSearchContainers.createDefeaultElasticsearchContainer()
+      TestSearchContainers.createDefaultElasticsearchContainer()
           .withPassword(ELASTIC_PASSWORD)
           .withEnv("xpack.security.enabled", "true");
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -479,7 +479,7 @@ final class CamundaExporterIT {
 
   private static Stream<Arguments> containerProvider() {
     return Stream.of(
-        Arguments.of(TestSearchContainers.createDefeaultElasticsearchContainer()),
+        Arguments.of(TestSearchContainers.createDefaultElasticsearchContainer()),
         Arguments.of(TestSearchContainers.createDefaultOpensearchContainer()));
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepositoryIT.java
@@ -38,7 +38,7 @@ final class ElasticsearchIncidentUpdateRepositoryIT extends IncidentUpdateReposi
 
   @Container
   private static final ElasticsearchContainer CONTAINER =
-      TestSearchContainers.createDefeaultElasticsearchContainer();
+      TestSearchContainers.createDefaultElasticsearchContainer();
 
   @AutoClose private final RestClientTransport transport = createTransport();
   private final ElasticsearchAsyncClient client = new ElasticsearchAsyncClient(transport);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/utils/ReschedulingTaskLoggerIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/utils/ReschedulingTaskLoggerIT.java
@@ -27,7 +27,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 public class ReschedulingTaskLoggerIT {
   @Container
   private static final ElasticsearchContainer CONTAINER =
-      TestSearchContainers.createDefeaultElasticsearchContainer();
+      TestSearchContainers.createDefaultElasticsearchContainer();
 
   @Test
   void shouldSuppressAllShardsFailedTransientError() {

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterClientIT.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterClientIT.java
@@ -38,7 +38,7 @@ final class ElasticsearchExporterClientIT {
   // authentication
   @Container
   private static final ElasticsearchContainer CONTAINER =
-      TestSearchContainers.createDefeaultElasticsearchContainer()
+      TestSearchContainers.createDefaultElasticsearchContainer()
           .withEnv("xpack.license.self_generated.type", "trial")
           .withEnv("xpack.security.enabled", "true")
           .withEnv("xpack.security.authc.anonymous.username", "anon")

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
@@ -66,7 +66,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 final class ElasticsearchExporterIT {
   @Container
   private static final ElasticsearchContainer CONTAINER =
-      TestSearchContainers.createDefeaultElasticsearchContainer()
+      TestSearchContainers.createDefaultElasticsearchContainer()
           .withEnv("action.destructive_requires_name", "false");
 
   private static ElasticsearchExporterConfiguration config;

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/FaultToleranceIT.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/FaultToleranceIT.java
@@ -56,7 +56,7 @@ final class FaultToleranceIT {
                 .withNetwork(network)
                 .withNetworkAliases("proxy")) {
       try (final ElasticsearchContainer container =
-          TestSearchContainers.createDefeaultElasticsearchContainer()
+          TestSearchContainers.createDefaultElasticsearchContainer()
               .withNetwork(network)
               .withNetworkAliases("elastic")) {
         // fix the ports beforehand - since we don't know the container port until it starts, and we

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/SchemaManagerIT.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/SchemaManagerIT.java
@@ -25,7 +25,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 public class SchemaManagerIT {
   @Container
   private static final ElasticsearchContainer CONTAINER =
-      TestSearchContainers.createDefeaultElasticsearchContainer()
+      TestSearchContainers.createDefaultElasticsearchContainer()
           .withEnv("action.destructive_requires_name", "false");
 
   private static final ElasticsearchExporterConfiguration CONFIG =

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/authorization/BasicAuthOverGrpcIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/authorization/BasicAuthOverGrpcIT.java
@@ -39,7 +39,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 public class BasicAuthOverGrpcIT {
   @Container
   private static final ElasticsearchContainer CONTAINER =
-      TestSearchContainers.createDefeaultElasticsearchContainer();
+      TestSearchContainers.createDefaultElasticsearchContainer();
 
   private static AuthorizationsUtil authUtil;
   @AutoClose private static CamundaClient defaultUserClient;

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/authorization/BasicAuthOverRestIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/authorization/BasicAuthOverRestIT.java
@@ -38,7 +38,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 final class BasicAuthOverRestIT {
   @Container
   private static final ElasticsearchContainer CONTAINER =
-      TestSearchContainers.createDefeaultElasticsearchContainer();
+      TestSearchContainers.createDefaultElasticsearchContainer();
 
   private static AuthorizationsUtil authUtil;
   @AutoClose private static CamundaClient defaultUserClient;

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/authorization/OidcAuthOverGrpcIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/authorization/OidcAuthOverGrpcIT.java
@@ -59,7 +59,7 @@ public class OidcAuthOverGrpcIT {
 
   @Container
   private static final ElasticsearchContainer CONTAINER =
-      TestSearchContainers.createDefeaultElasticsearchContainer();
+      TestSearchContainers.createDefaultElasticsearchContainer();
 
   @Container
   private static final KeycloakContainer KEYCLOAK = DefaultTestContainers.createDefaultKeycloak();

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/authorization/OidcAuthOverRestIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/authorization/OidcAuthOverRestIT.java
@@ -59,7 +59,7 @@ public class OidcAuthOverRestIT {
 
   @Container
   private static final ElasticsearchContainer CONTAINER =
-      TestSearchContainers.createDefeaultElasticsearchContainer();
+      TestSearchContainers.createDefaultElasticsearchContainer();
 
   @Container
   private static final KeycloakContainer KEYCLOAK = DefaultTestContainers.createDefaultKeycloak();

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/authorization/OidcAuthOverRestInitializerIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/authorization/OidcAuthOverRestInitializerIT.java
@@ -39,7 +39,7 @@ public class OidcAuthOverRestInitializerIT {
 
   @Container
   private static final ElasticsearchContainer CONTAINER =
-      TestSearchContainers.createDefeaultElasticsearchContainer();
+      TestSearchContainers.createDefaultElasticsearchContainer();
 
   @Container
   private static final KeycloakContainer KEYCLOAK = DefaultTestContainers.createDefaultKeycloak();

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/authorization/OidcAuthOverRestStartupIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/authorization/OidcAuthOverRestStartupIT.java
@@ -30,7 +30,7 @@ public class OidcAuthOverRestStartupIT {
 
   @Container
   private static final ElasticsearchContainer CONTAINER =
-      TestSearchContainers.createDefeaultElasticsearchContainer();
+      TestSearchContainers.createDefaultElasticsearchContainer();
 
   private static final String UNREACHABLE_ISSUER_URI =
       "http://localhost:1000/realms/" + KEYCLOAK_REALM;

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/multitenancy/MultiTenancyIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/multitenancy/MultiTenancyIT.java
@@ -79,7 +79,7 @@ public class MultiTenancyIT {
 
   @Container
   private static final ElasticsearchContainer CONTAINER =
-      TestSearchContainers.createDefeaultElasticsearchContainer();
+      TestSearchContainers.createDefaultElasticsearchContainer();
 
   private static final String DEFAULT_TENANT = TenantOwned.DEFAULT_TENANT_IDENTIFIER;
   private static final String TENANT_A = "tenantA";

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/shared/security/headers/SecurityHeadersBaseIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/shared/security/headers/SecurityHeadersBaseIT.java
@@ -43,7 +43,7 @@ public abstract class SecurityHeadersBaseIT {
   // Common infrastructure
   @Container
   protected static final ElasticsearchContainer CONTAINER =
-      TestSearchContainers.createDefeaultElasticsearchContainer();
+      TestSearchContainers.createDefaultElasticsearchContainer();
 
   @AutoClose protected static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
 

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/testcontainers/TestSearchContainers.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/testcontainers/TestSearchContainers.java
@@ -67,8 +67,13 @@ public final class TestSearchContainers {
    *
    * <p>Additionally, security is explicitly disabled to avoid having tons of warning printed out.
    */
-  public static ElasticsearchContainer createDefeaultElasticsearchContainer() {
+  public static ElasticsearchContainer createDefaultElasticsearchContainer() {
     return createElasticsearchContainer(ELASTIC_IMAGE);
+  }
+
+  @Deprecated(since = "2026-05", forRemoval = true)
+  public static ElasticsearchContainer createDefeaultElasticsearchContainer() {
+    return createDefaultElasticsearchContainer();
   }
 
   /**


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Fixes a typo in a method.
NOTE: I'm keeping the old method because it appears to be part of some sort of API that might break. I marked it as deprecated for removal.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
