### PR TITLE
fix: update batch operation API tests to match new error message wording (key→id)

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-cancel-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-cancel-api-tests.spec.ts
@@ -116,7 +116,7 @@ test.describe.parallel('Cancel Batch Operation Tests', () => {
       );
       await assertBadRequest(
         res,
-        "Batch operation key 'not-a-valid-key' is not a valid number. Legacy Batch Operation Keys are not supported!",
+        "Batch operation id 'not-a-valid-key' is not a valid number. Legacy Batch Operation IDs are not supported!",
       );
     });
   });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts
@@ -112,7 +112,7 @@ test.describe('Suspend & Resume Batch Operation Tests', () => {
     );
     await assertBadRequest(
       res,
-      "Batch operation key 'not-a-valid-key' is not a valid number. Legacy Batch Operation Keys are not supported!",
+      "Batch operation id 'not-a-valid-key' is not a valid number. Legacy Batch Operation IDs are not supported!",
     );
   });
 


### PR DESCRIPTION
## Summary

- Two nightly API tests were asserting the old error message wording `"key"`/`"Keys"` but the API now returns `"id"`/`"IDs"`.
- Updates the hardcoded expected string in both failing tests so the assertions match the current API response.

## Root cause

Nightly run [camunda/camunda#52847](https://github.com/camunda/camunda/actions/runs/26428431483) failed on 2026-05-26 with:

```
Expected substring: "Batch operation key 'not-a-valid-key' is not a valid number. Legacy Batch Operation Keys are not supported!"
Received string:    "Batch operation id 'not-a-valid-key' is not a valid number. Legacy Batch Operation IDs are not supported!"
```

The product changed the error message terminology from "key"/"Keys" to "id"/"IDs". Both affected tests hardcoded the old string:

- `qa/.../batch-operations-cancel-api-tests.spec.ts` — "Cancel batch operation with invalid key format returns 400"
- `qa/.../batch-operations-suspend-api-tests.spec.ts` — "Suspend batch operation with invalid key returns 400"

## Files changed

- `qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-cancel-api-tests.spec.ts`
- `qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts`

## Test plan

- [x] API tests passed on [C8 Orchestration Cluster E2E Tests On Demand](https://github.com/camunda/camunda/actions/runs/26450802512) run against this branch — all jobs green ✅
- [x] No other assertions reference the old `"key"`/`"Keys"` wording in these files

🤖 Generated with [Claude Code](https://claude.com/claude-code)