### PR TITLE
feat: add PDF support to document preview in Operate

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentPreview/DocumentPreviewModal.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentPreview/DocumentPreviewModal.tsx
@@ -9,7 +9,7 @@
 import {Modal} from '@carbon/react';
 import type {StateProps} from 'modules/components/ModalStateManager';
 import type {DocumentInfo} from '../DocumentValueCell/parseDocumentVariable';
-import {PreviewImage} from './styled';
+import {PreviewImage, PreviewPdf} from './styled';
 
 type DocumentPreviewProps = {
   document: DocumentInfo;
@@ -36,6 +36,10 @@ const DocumentPreviewModal: React.FC<StateProps & DocumentPreviewProps> = ({
 const ModalContent: React.FC<DocumentPreviewProps> = ({document}) => {
   if (document.type === 'image') {
     return <PreviewImage src={document.link} alt={document.fileName} />;
+  }
+
+  if (document.type === 'pdf') {
+    return <PreviewPdf src={document.link} title={document.fileName} />;
   }
 
   return <p>Preview not available for document "{document.fileName}".</p>;

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentPreview/PreviewDocumentButton.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentPreview/PreviewDocumentButton.test.tsx
@@ -20,8 +20,15 @@ const imageDocument: DocumentInfo = {
 const pdfDocument: DocumentInfo = {
   link: '/v2/documents/pdf',
   fileName: 'report.pdf',
-  type: 'unknown',
+  type: 'pdf',
   size: 2048,
+};
+
+const unknownDocument: DocumentInfo = {
+  link: '/v2/documents/archive',
+  fileName: 'archive.zip',
+  type: 'unknown',
+  size: 4096,
 };
 
 describe('<PreviewDocumentButton />', () => {
@@ -36,16 +43,46 @@ describe('<PreviewDocumentButton />', () => {
     expect(button).toBeEnabled();
   });
 
-  it('should render a disabled preview button for unsupported types', () => {
+  it('should render an enabled preview button for pdf documents', () => {
     render(
       <PreviewDocumentButton document={pdfDocument} variableName="myPdf" />,
     );
 
     const button = screen.getByLabelText('Preview document for variable myPdf');
+    expect(button).toBeEnabled();
+  });
+
+  it('should render a disabled preview button for unsupported types', () => {
+    render(
+      <PreviewDocumentButton
+        document={unknownDocument}
+        variableName="myArchive"
+      />,
+    );
+
+    const button = screen.getByLabelText(
+      'Preview document for variable myArchive',
+    );
     expect(button).toBeDisabled();
     expect(
       screen.getByText('Preview not available for this document type'),
     ).toBeInTheDocument();
+  });
+
+  it('should open the modal with the pdf when clicked', async () => {
+    const {user} = render(
+      <PreviewDocumentButton document={pdfDocument} variableName="myPdf" />,
+    );
+
+    await user.click(
+      screen.getByLabelText('Preview document for variable myPdf'),
+    );
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toBeInTheDocument();
+    const iframe = screen.getByTitle('report.pdf');
+    expect(iframe.tagName).toBe('IFRAME');
+    expect(iframe).toHaveAttribute('src', '/v2/documents/pdf');
   });
 
   it('should open the modal with the image when clicked', async () => {

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentPreview/styled.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentPreview/styled.tsx
@@ -11,9 +11,16 @@ import styled from 'styled-components';
 const PreviewImage = styled.img`
   display: block;
   max-width: 100%;
-  max-height: 70vh;
+  max-height: 80vh;
   object-fit: contain;
   margin: 0 auto;
 `;
 
-export {PreviewImage};
+const PreviewPdf = styled.iframe`
+  display: block;
+  width: 100%;
+  height: 80vh;
+  border: none;
+`;
+
+export {PreviewImage, PreviewPdf};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/parseDocumentVariable.test.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/parseDocumentVariable.test.ts
@@ -98,7 +98,7 @@ describe('parseDocumentVariable', () => {
         {
           link: '/v2/documents/doc-123?storeId=in-memory&contentHash=sha256%3Aabc',
           fileName: 'a.pdf',
-          type: 'unknown',
+          type: 'pdf',
           size: 1000,
         },
         {
@@ -159,6 +159,22 @@ describe('parseDocumentVariable', () => {
         }),
       });
     }
+  });
+
+  it('should parse a pdf document type for application/pdf', () => {
+    const value = JSON.stringify(
+      makeDocRef({
+        metadata: {...makeDocRef().metadata, contentType: 'application/pdf'},
+      }),
+    );
+    const result = parseDocumentVariable(value, false);
+
+    expect(result).toEqual({
+      type: 'single',
+      document: expect.objectContaining({
+        type: 'pdf',
+      }),
+    });
   });
 
   it('should return null for a plain string variable', () => {

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/parseDocumentVariable.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/parseDocumentVariable.ts
@@ -13,7 +13,7 @@ import {mergePathname} from 'modules/request/mergePathname';
 import {getClientConfig} from 'modules/utils/getClientConfig';
 import {endpoints} from '@camunda/camunda-api-zod-schemas/8.10';
 
-type DocumentType = 'image' | 'unknown';
+type DocumentType = 'image' | 'pdf' | 'unknown';
 
 type DocumentInfo = {
   fileName: string;
@@ -57,12 +57,15 @@ const SUPPORTED_IMAGE_MIME_TYPES = new Set([
   'image/gif',
   'image/webp',
 ]);
+const SUPPORTED_PDF_MIME_TYPES = new Set(['application/pdf']);
 
 function getDocumentType(contentType: string | undefined): DocumentType {
   if (!contentType) {
     return 'unknown';
   } else if (SUPPORTED_IMAGE_MIME_TYPES.has(contentType)) {
     return 'image';
+  } else if (SUPPORTED_PDF_MIME_TYPES.has(contentType)) {
+    return 'pdf';
   } else {
     return 'unknown';
   }


### PR DESCRIPTION
## Description

Extends the document preview infrastructure that has been established in #53826 with support for PDF documents.

## Checklist

- [ ] This PR is stacked on https://github.com/camunda/camunda/pull/53826.

## Related issues

closes #52204
