### PR TITLE
fix: produce empty javadoc jar for webapp-server to satisfy Maven Central

### DIFF
--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -28,4 +28,28 @@
     <maven.javadoc.skip>true</maven.javadoc.skip>
   </properties>
 
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <executions>
+            <execution>
+              <id>empty-javadoc-jar</id>
+              <goals>
+                <goal>jar</goal>
+              </goals>
+              <phase>package</phase>
+              <configuration>
+                <classifier>javadoc</classifier>
+                <classesDirectory>${basedir}/javadoc</classesDirectory>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
 </project>


### PR DESCRIPTION
## Summary

- `webapp-server` was missing a `*-javadoc.jar` artifact, causing the Maven Central release job to reject the deployment with `Javadocs must be provided but not found in entries`
- Adds an `empty-javadoc-jar` execution of `maven-jar-plugin` in `webapp/pom.xml`, mirroring the existing pattern in `operate/pom.xml` and `tasklist/pom.xml`
- `maven.javadoc.skip=true` is retained; the placeholder jar satisfies Central without running actual javadoc generation

## Test plan

- [ ] Verify CI release job no longer fails on `webapp-server` javadoc validation