### PR TITLE
test: skip failing nightly tests on stable/8.9

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-statistics-error-metrics-job-type-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-statistics-error-metrics-job-type-api-tests.spec.ts
@@ -57,7 +57,8 @@ test.describe.parallel('Get error metrics for a job type API Tests', () => {
     });
   });
 
-  test('Get error metrics for a job type - success', async ({request}) => {
+  //Skipped due to bug 54020: https://github.com/camunda/camunda/issues/54020
+  test.skip('Get error metrics for a job type - success', async ({request}) => {
     let failedItems: string[] = [];
 
     await test.step('General Search', async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/identity-users-flows.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/identity-users-flows.spec.ts
@@ -126,7 +126,8 @@ test.describe('Identity User Flows', () => {
     });
   });
 
-  test('Admin user can grant and revoke component authorization for user', async ({
+  //Skipped due to bug 54020: https://github.com/camunda/camunda/issues/54020
+  test.skip('Admin user can grant and revoke component authorization for user', async ({
     page,
     loginPage,
     identityUsersPage,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/v1/identity-users-flows.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/v1/identity-users-flows.spec.ts
@@ -134,7 +134,8 @@ test.describe('Identity User Flows', () => {
     });
   });
 
-  test('Admin user can grant and revoke component authorization for user', async ({
+  //Skipped due to bug 54020: https://github.com/camunda/camunda/issues/54020
+  test.skip('Admin user can grant and revoke component authorization for user', async ({
     page,
     loginPage,
     identityUsersPage,


### PR DESCRIPTION
## Summary

Skips 3 tests that are failing in nightly CI runs on `stable/8.9` until the underlying issues are fixed.

Closes #54020

**Nightly runs:**
- https://github.com/camunda/camunda/actions/runs/26427385792
- https://github.com/camunda/camunda/actions/runs/26427922021

**Skipped tests:**

| File | Test | Error |
|------|------|-------|
| `tests/common-flows/identity-users-flows.spec.ts` | `Admin user can grant and revoke component authorization for user` | Authorization dialog item not found within 20s timeout (v2 mode) |
| `tests/common-flows/v1/identity-users-flows.spec.ts` | `Admin user can grant and revoke component authorization for user` | Authorization dialog item not found within 20s timeout (v1 mode) |
| `tests/api/v2/job/job-statistics-error-metrics-job-type-api-tests.spec.ts` | `Get error metrics for a job type - success` | Response shape error: `/items/0/errorMessage` expected `string` but got `null` (Oracle 26ai) |

🤖 Generated with [Claude Code](https://claude.ai/claude-code)