### PR TITLE
test: skip failing nightly tests on stable/8.8

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/identity-users-flows.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/identity-users-flows.spec.ts
@@ -118,7 +118,8 @@ test.describe('Identity User Flows', () => {
     });
   });
 
-  test('Admin user can grant and revoke component authorization for user', async ({
+  //Skipped due to bug 54020: https://github.com/camunda/camunda/issues/54020
+  test.skip('Admin user can grant and revoke component authorization for user', async ({
   page,
   loginPage,
   identityUsersPage,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
@@ -350,7 +350,8 @@ test.describe.serial('Process Instance Migration', () => {
     });
   });
 
-  test('Migrated ad hoc sub processes', async ({
+  //Skipped due to bug 54020: https://github.com/camunda/camunda/issues/54020
+  test.skip('Migrated ad hoc sub processes', async ({
     page,
     operateFiltersPanelPage,
     operateProcessesPage,
@@ -904,7 +905,8 @@ test.describe('Parallel job-based user task migration', () => {
     );
   });
 
-  test('Migrate parallel job-based user tasks to Camunda user tasks', async ({
+  //Skipped due to bug 54020: https://github.com/camunda/camunda/issues/54020
+  test.skip('Migrate parallel job-based user tasks to Camunda user tasks', async ({
     page,
     operateHomePage,
     operateFiltersPanelPage,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
@@ -266,7 +266,8 @@ test.describe('task details page', () => {
     await taskDetailsPage.assertFieldValue('Age', '21');
   });
 
-  test('task completion with deployed form', async ({
+  //Skipped due to bug 54020: https://github.com/camunda/camunda/issues/54020
+  test.skip('task completion with deployed form', async ({
     taskPanelPage,
     taskDetailsPage,
   }) => {


### PR DESCRIPTION
## Summary

Skips 4 tests that are failing in nightly CI runs on `stable/8.8` until the underlying issues are fixed.

Closes #54020

**Nightly run:**
- https://github.com/camunda/camunda/actions/runs/26426991206

**Skipped tests:**

| File | Test | Error |
|------|------|-------|
| `tests/common-flows/identity-users-flows.spec.ts` | `Admin user can grant and revoke component authorization for user` | Authorization dialog item not found within 20s timeout (v1 and v2 modes) |
| `tests/tasklist/task-details.spec.ts` | `task completion with deployed form` | `getByLabel('Item Name*').first()` has empty value, expected `"Laptop1"` (v1 only) |
| `tests/operate/processInstanceMigration.spec.ts` | `Migrated ad hoc sub processes` | Test failed without captured error message (v2 only) |
| `tests/operate/processInstanceMigration.spec.ts` | `Migrate parallel job-based user tasks to Camunda user tasks` | `getByLabel(/target element for camunda form/i)` expected `"camunda_form"`, got `""` (v2 only) |

🤖 Generated with [Claude Code](https://claude.ai/claude-code)