### PR TITLE
test: skip failing nightly tests on stable/8.7

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-panel.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-panel.spec.ts
@@ -104,7 +104,8 @@ test.describe('task panel page', () => {
     }).toPass({timeout: 5000});
   });
 
-  test('scrolling', async ({page, taskPanelPage}) => {
+  //Skipped due to bug 54020: https://github.com/camunda/camunda/issues/54020
+  test.skip('scrolling', async ({page, taskPanelPage}) => {
     test.slow();
 
     await expect(page.getByText('usertask_for_scrolling_1')).toHaveCount(1);


### PR DESCRIPTION
## Summary

Skips 1 test that is failing in nightly CI runs on `stable/8.7` until the underlying issue is fixed.

Closes #54020

**Nightly run:**
- https://github.com/camunda/camunda/actions/runs/26426724541

**Skipped tests:**

| File | Test | Error |
|------|------|-------|
| `tests/tasklist/task-panel.spec.ts` | `scrolling` | `getByText('usertask_for_scrolling_2')` expected count `49`, got `48` |

🤖 Generated with [Claude Code](https://claude.ai/claude-code)