### PR TITLE
fix: stop admin-ui modal flicker when dropdown shows single entry

### DIFF
--- a/identity/client/src/components/modal/Modal.tsx
+++ b/identity/client/src/components/modal/Modal.tsx
@@ -35,6 +35,20 @@ const ModalWrapper = styled.div<{ $overflowVisible: boolean }>`
     margin-bottom: 0;
     padding-bottom: 3rem;
   }
+  /*
+   * Carbon's cds--modal-scroll-content adds border-block-end and a
+   * last-child margin that change the content's height. With max-height
+   * removed above, that toggles isScrollable on every render and produces
+   * a flicker when the content sits near the scroll threshold (e.g. a
+   * single dropdown entry). Neutralize those height contributions so the
+   * measurement stays stable.
+   */
+  & .cds--modal-content.cds--modal-scroll-content {
+    border-block-end-width: 0;
+  }
+  & .cds--modal-content.cds--modal-scroll-content > *:last-child {
+    margin-block-end: 0;
+  }
   `
       : ""}
 `;


### PR DESCRIPTION
## Description

The Assign-group-to-role dialog (and any other modal using `overflowVisible`) flickered violently when the inline dropdown contained exactly one match.

Root cause: Carbon's `Modal` toggles `cds--modal-scroll-content` based on `scrollHeight > clientHeight`. That class itself adds a `border-block-end` and a last-child `margin-block-end`, changing the content's height. With `overflowVisible` removing `max-height`, the class's own height contribution can flip the inequality on every render. When the dropdown has a single entry the content height lands right at that threshold, producing an infinite class-toggle loop (observed: >600 DOM mutations/sec and thousands of Carbon warnings per second). Many entries push the content well past the threshold so the measurement is stable; zero entries hide the dropdown entirely.

Fix: neutralize the height contributions of
`cds--modal-scroll-content` while `overflowVisible` is set, so adding the class no longer changes the measurement and Carbon's `isScrollable` check converges immediately.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #50090
