### PR TITLE
fix: do not look up on message on deletion

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageBatchExpireProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageBatchExpireProcessor.java
@@ -34,7 +34,7 @@ public final class MessageBatchExpireProcessor implements TypedRecordProcessor<M
   private final InstantSource clock;
 
   private final MessageRecord emptyDeleteMessageCommand =
-      new MessageRecord().setName("").setCorrelationKey("").setTimeToLive(-1L);
+      new MessageRecord();
 
   public MessageBatchExpireProcessor(
       final StateWriter stateWriter,
@@ -59,11 +59,7 @@ public final class MessageBatchExpireProcessor implements TypedRecordProcessor<M
             clock.millis(),
             null,
             (deadline, messageKey) -> {
-              final var expiredMessageRecord =
-                  appendMessageBodyOnExpired
-                      ? messageState.getMessage(messageKey).getMessage()
-                      : emptyDeleteMessageCommand;
-
+              final var expiredMessageRecord = emptyDeleteMessageCommand;
               final var requiredCapacity =
                   expiredMessageRecord.getLength() + FOLLOWUP_COMMAND_SAFETY_MARGIN;
               if (stateWriter.canWriteEventOfLength(requiredCapacity)


### PR DESCRIPTION
## Description

* refactor expired message handling to use a default empty message record instead of doing expensive look up in loop

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

related https://github.com/camunda/camunda/issues/50155
