### PR TITLE
fix: return filter when elementId is set without state filters

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/WaitingStatus/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/WaitingStatus/index.tsx
@@ -26,9 +26,7 @@ const WaitingStatus: React.FC<Props> = ({waitStates}) => {
     <StatusContainer data-testid="waiting-status">
       <StatusHeading>Status</StatusHeading>
       {statusItems.map((item, index) => (
-        <StatusItem
-          key={`${waitStates[index]!.elementInstanceKey}-${waitStates[index]!.waitStateType}`}
-        >
+        <StatusItem key={`${index}-${item.text}`}>
           <Time size={16} />
           <span>{item.text}</span>
         </StatusItem>

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/WaitingStatus/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/WaitingStatus/index.tsx
@@ -26,7 +26,7 @@ const WaitingStatus: React.FC<Props> = ({waitStates}) => {
     <StatusContainer data-testid="waiting-status">
       <StatusHeading>Status</StatusHeading>
       {statusItems.map((item, index) => (
-        <StatusItem key={index}>
+        <StatusItem key={`${waitStates[index]!.elementInstanceKey}-${waitStates[index]!.waitStateType}`}>
           <Time size={16} />
           <span>{item.text}</span>
         </StatusItem>

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/WaitingStatus/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/WaitingStatus/index.tsx
@@ -26,7 +26,9 @@ const WaitingStatus: React.FC<Props> = ({waitStates}) => {
     <StatusContainer data-testid="waiting-status">
       <StatusHeading>Status</StatusHeading>
       {statusItems.map((item, index) => (
-        <StatusItem key={`${waitStates[index]!.elementInstanceKey}-${waitStates[index]!.waitStateType}`}>
+        <StatusItem
+          key={`${waitStates[index]!.elementInstanceKey}-${waitStates[index]!.waitStateType}`}
+        >
           <Time size={16} />
           <span>{item.text}</span>
         </StatusItem>

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/WaitingStatus/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/WaitingStatus/index.tsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Time} from '@carbon/react/icons';
+import type {ElementInstanceInspection} from '@camunda/camunda-api-zod-schemas/8.10';
+import {getWaitStateStatusItems} from 'modules/utils/waitStates';
+import {StatusContainer, StatusHeading, StatusItem} from './styled';
+
+type Props = {
+  waitStates: ElementInstanceInspection[];
+};
+
+const WaitingStatus: React.FC<Props> = ({waitStates}) => {
+  if (waitStates.length === 0) {
+    return null;
+  }
+
+  const statusItems = getWaitStateStatusItems(waitStates);
+
+  return (
+    <StatusContainer data-testid="waiting-status">
+      <StatusHeading>Status</StatusHeading>
+      {statusItems.map((item, index) => (
+        <StatusItem key={index}>
+          <Time size={16} />
+          <span>{item.text}</span>
+        </StatusItem>
+      ))}
+    </StatusContainer>
+  );
+};
+
+export {WaitingStatus};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/WaitingStatus/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/WaitingStatus/index.tsx
@@ -25,8 +25,8 @@ const WaitingStatus: React.FC<Props> = ({waitStates}) => {
   return (
     <StatusContainer data-testid="waiting-status">
       <StatusHeading>Status</StatusHeading>
-      {statusItems.map((item, index) => (
-        <StatusItem key={`${index}-${item.text}`}>
+      {statusItems.map((item) => (
+        <StatusItem key={item.key}>
           <Time size={16} />
           <span>{item.text}</span>
         </StatusItem>

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/WaitingStatus/styled.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/WaitingStatus/styled.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import styled from 'styled-components';
+
+const StatusContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--cds-spacing-03);
+  padding-top: var(--cds-spacing-05);
+`;
+
+const StatusHeading = styled.h5`
+  font-size: var(--cds-heading-compact-01-font-size);
+  font-weight: var(--cds-heading-compact-01-font-weight);
+  line-height: var(--cds-heading-compact-01-line-height);
+  margin: 0;
+`;
+
+const StatusItem = styled.div`
+  display: flex;
+  align-items: center;
+  gap: var(--cds-spacing-03);
+  font-size: var(--cds-body-01-font-size);
+`;
+
+export {StatusContainer, StatusHeading, StatusItem};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.tsx
@@ -31,6 +31,9 @@ import {StructuredList} from 'modules/components/StructuredList';
 import {useProcessInstance} from 'modules/queries/processInstance/useProcessInstance';
 import {useAgentInstanceForElement} from 'modules/queries/agentInstances/useAgentInstanceForElement';
 import {AgentDetails} from './AgentDetails';
+import {useProcessInstancePageParams} from '../../useProcessInstancePageParams';
+import {useElementInstanceInspection} from 'modules/queries/elementInstanceInspection/useElementInstanceInspection';
+import {WaitingStatus} from './WaitingStatus';
 import type {UserTask} from '@camunda/camunda-api-zod-schemas/8.10';
 
 const formatTaskLink = (
@@ -47,6 +50,7 @@ const formatTaskLink = (
 
 const DetailsTab: React.FC = () => {
   const clientConfig = getClientConfig();
+  const {processInstanceId = ''} = useProcessInstancePageParams();
   const {
     resolvedElementInstance,
     selectedElementId,
@@ -66,6 +70,23 @@ const DetailsTab: React.FC = () => {
   const elementInstanceKey =
     resolvedElementInstance?.elementInstanceKey ?? null;
   const resolvedElementType = resolvedElementInstance?.type;
+
+  const {data: inspectionData} = useElementInstanceInspection({
+    processInstanceKey: processInstanceId,
+    elementInstanceKey: elementInstanceKey ?? undefined,
+    enabled:
+      !!elementInstanceKey &&
+      processInstance?.state === 'ACTIVE' &&
+      resolvedElementInstance?.state === 'ACTIVE',
+  });
+
+  const elementWaitStates = useMemo(() => {
+    return (
+      inspectionData?.items?.filter(
+        (item) => item.elementInstanceKey === elementInstanceKey,
+      ) ?? []
+    );
+  }, [inspectionData, elementInstanceKey]);
 
   const {data: calledProcessInstancesSearchResult} = useProcessInstancesSearch(
     {
@@ -493,6 +514,7 @@ const DetailsTab: React.FC = () => {
             isError={isAgentError}
           />
         )}
+      <WaitingStatus waitStates={elementWaitStates} />
     </Container>
   );
 };

--- a/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
@@ -21,6 +21,7 @@ import {
   COMPLETED_BADGE,
   COMPLETED_END_EVENT_BADGE,
   SUBPROCESS_WITH_INCIDENTS,
+  WAITING_BADGE,
 } from 'modules/bpmn-js/badgePositions';
 import {DiagramShell} from 'modules/components/DiagramShell';
 import {computed} from 'mobx';
@@ -30,6 +31,7 @@ import {ModificationBadgeOverlay} from './ModificationBadgeOverlay';
 import {ModificationInfoBanner} from './ModificationInfoBanner';
 import {ModificationDropdown} from './ModificationDropdown';
 import {StateOverlay} from 'modules/components/StateOverlay';
+import {WaitingStateOverlay} from 'modules/components/WaitingStateOverlay';
 import {executionCountToggleStore} from 'modules/stores/executionCountToggle';
 import {useElementStatistics} from 'modules/queries/elementInstancesStatistics/useElementStatistics';
 import {useSelectableElements} from 'modules/queries/elementInstancesStatistics/useSelectableElements';
@@ -51,7 +53,9 @@ import {useProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefi
 import {isCompensationAssociation} from 'modules/bpmn-js/utils/isCompensationAssociation';
 import {useProcessSequenceFlows} from 'modules/queries/sequenceFlows/useProcessSequenceFlows';
 import {useProcessInstance} from 'modules/queries/processInstance/useProcessInstance';
+import {useElementInstanceInspection} from 'modules/queries/elementInstanceInspection/useElementInstanceInspection';
 import {getSubprocessOverlayFromIncidentElements} from 'modules/utils/elements';
+import {getWaitStateLabel} from 'modules/utils/waitStates';
 import type {ElementState} from 'modules/bpmn-js/overlayTypes';
 import {HTTP_STATUS_FORBIDDEN} from 'modules/constants/statusCode';
 import {isRequestError} from 'modules/request';
@@ -61,6 +65,7 @@ import {getAncestorScopeType} from 'modules/utils/processInstanceDetailsDiagram'
 
 const OVERLAY_TYPE_STATE = 'elementState';
 const OVERLAY_TYPE_MODIFICATIONS_BADGE = 'modificationsBadge';
+const OVERLAY_TYPE_WAITING_STATE = 'waitingState';
 
 const overlayPositions = {
   active: ACTIVE_BADGE,
@@ -104,6 +109,10 @@ const TopPanel: React.FC = observer(() => {
       sourceElementIdForMoveOperation || undefined,
     );
   const {data: processInstance} = useProcessInstance();
+  const {data: inspectionData} = useElementInstanceInspection({
+    processInstanceKey: processInstanceId,
+    enabled: processInstance?.state === 'ACTIVE',
+  });
   const modificationsByElement = useModificationsByElement();
   const affectedTokenCount = sourceElementInstanceKeyForMoveOperation
     ? 1
@@ -168,6 +177,41 @@ const TopPanel: React.FC = observer(() => {
       : notCompletedElementStateOverlays;
   }, [statistics, businessObjects, isExecutionCountVisible]);
 
+  const waitingStateOverlays = useMemo(() => {
+    if (!inspectionData?.items?.length) {
+      return [];
+    }
+
+    // Group wait states by elementId (show only 1 label per element)
+    const waitStatesByElement = new Map<string, typeof inspectionData.items>();
+    for (const item of inspectionData.items) {
+      const existing = waitStatesByElement.get(item.elementId) ?? [];
+      existing.push(item);
+      waitStatesByElement.set(item.elementId, existing);
+    }
+
+    const overlays: Array<{
+      elementId: string;
+      type: string;
+      position: typeof WAITING_BADGE;
+      payload: {label: string};
+    }> = [];
+
+    for (const [elementId, waitStates] of waitStatesByElement) {
+      const label = getWaitStateLabel(waitStates);
+      if (label) {
+        overlays.push({
+          elementId,
+          type: OVERLAY_TYPE_WAITING_STATE,
+          position: WAITING_BADGE,
+          payload: {label},
+        });
+      }
+    }
+
+    return overlays;
+  }, [inspectionData]);
+
   const selectedElementIds = useMemo(() => {
     return selectedAnchorElementId
       ? [selectedAnchorElementId]
@@ -228,6 +272,9 @@ const TopPanel: React.FC = observer(() => {
   );
   const modificationBadgeOverlays = diagramOverlaysStore.state.overlays.filter(
     ({type}) => type === OVERLAY_TYPE_MODIFICATIONS_BADGE,
+  );
+  const waitingOverlays = diagramOverlaysStore.state.overlays.filter(
+    ({type}) => type === OVERLAY_TYPE_WAITING_STATE,
   );
 
   const modifiableElements = useModifiableElements();
@@ -376,7 +423,7 @@ const TopPanel: React.FC = observer(() => {
                         ...(elementStateOverlays ?? []),
                         ...modificationBadgesPerElement.get(),
                       ]
-                    : elementStateOverlays
+                    : [...(elementStateOverlays ?? []), ...waitingStateOverlays]
                 }
                 selectedElementOverlay={
                   isModificationModeEnabled && <ModificationDropdown />
@@ -434,6 +481,17 @@ const TopPanel: React.FC = observer(() => {
                       container={overlay.container}
                       newTokenCount={payload.newTokenCount}
                       cancelledTokenCount={payload.cancelledTokenCount}
+                    />
+                  );
+                })}
+                {waitingOverlays?.map((overlay) => {
+                  const payload = overlay.payload as {label: string};
+
+                  return (
+                    <WaitingStateOverlay
+                      key={`waiting-${overlay.elementId}`}
+                      container={overlay.container}
+                      label={payload.label}
                     />
                   );
                 })}

--- a/operate/client/src/modules/api/v2/elementInstanceInspection/searchElementInstanceInspection.ts
+++ b/operate/client/src/modules/api/v2/elementInstanceInspection/searchElementInstanceInspection.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {
+  endpoints,
+  type QueryElementInstanceInspectionRequestBody,
+  type QueryElementInstanceInspectionResponseBody,
+} from '@camunda/camunda-api-zod-schemas/8.10';
+import {requestWithThrow} from 'modules/request';
+
+const searchElementInstanceInspection = async (
+  payload: QueryElementInstanceInspectionRequestBody,
+  signal?: AbortSignal,
+) => {
+  return requestWithThrow<QueryElementInstanceInspectionResponseBody>({
+    url: endpoints.queryElementInstanceInspection.getUrl(),
+    method: endpoints.queryElementInstanceInspection.method,
+    body: payload,
+    signal,
+  });
+};
+
+export {searchElementInstanceInspection};

--- a/operate/client/src/modules/bpmn-js/badgePositions.ts
+++ b/operate/client/src/modules/bpmn-js/badgePositions.ts
@@ -40,8 +40,8 @@ const SUBPROCESS_WITH_INCIDENTS = {
 };
 
 const WAITING_BADGE = {
-  top: -28,
-  left: 0,
+  top: -36,
+  left: 48,
 };
 
 export {

--- a/operate/client/src/modules/bpmn-js/badgePositions.ts
+++ b/operate/client/src/modules/bpmn-js/badgePositions.ts
@@ -41,7 +41,7 @@ const SUBPROCESS_WITH_INCIDENTS = {
 
 const WAITING_BADGE = {
   top: -36,
-  left: 48,
+  left: 6,
 };
 
 export {

--- a/operate/client/src/modules/bpmn-js/badgePositions.ts
+++ b/operate/client/src/modules/bpmn-js/badgePositions.ts
@@ -39,6 +39,11 @@ const SUBPROCESS_WITH_INCIDENTS = {
   right: -12,
 };
 
+const WAITING_BADGE = {
+  top: -28,
+  left: 0,
+};
+
 export {
   MODIFICATIONS,
   DECISION_STATE,
@@ -48,4 +53,5 @@ export {
   COMPLETED_BADGE,
   COMPLETED_END_EVENT_BADGE,
   SUBPROCESS_WITH_INCIDENTS,
+  WAITING_BADGE,
 };

--- a/operate/client/src/modules/bpmn-js/overlayTypes.ts
+++ b/operate/client/src/modules/bpmn-js/overlayTypes.ts
@@ -29,6 +29,10 @@ type ModificationBadgePayload = {
   cancelledTokenCount?: number;
 };
 
+type WaitingStatePayload = {
+  label: string;
+};
+
 const isStatisticsPayload = (
   payload: unknown,
 ): payload is StatisticsPayload => {
@@ -50,5 +54,11 @@ const isModificationBadgePayload = (
   );
 };
 
-export {isStatisticsPayload, isModificationBadgePayload};
-export type {ElementState, OverlayData};
+const isWaitingStatePayload = (
+  payload: unknown,
+): payload is WaitingStatePayload => {
+  return typeof payload === 'object' && payload !== null && 'label' in payload;
+};
+
+export {isStatisticsPayload, isModificationBadgePayload, isWaitingStatePayload};
+export type {ElementState, OverlayData, WaitingStatePayload};

--- a/operate/client/src/modules/components/WaitingStateOverlay/index.tsx
+++ b/operate/client/src/modules/components/WaitingStateOverlay/index.tsx
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {createPortal} from 'react-dom';
+import {Container} from './styled';
+import {Time} from '@carbon/react/icons';
+import {observer} from 'mobx-react';
+import {currentTheme} from 'modules/stores/currentTheme';
+
+type Props = {
+  container: HTMLElement;
+  label: string;
+};
+
+const WaitingStateOverlay: React.FC<Props> = observer(({container, label}) => {
+  return createPortal(
+    <Container
+      data-testid="waiting-state-overlay"
+      $theme={currentTheme.theme}
+      orientation="horizontal"
+      gap={2}
+    >
+      <Time size={14} />
+      <span>{label}</span>
+    </Container>,
+    container,
+  );
+});
+
+export {WaitingStateOverlay};

--- a/operate/client/src/modules/components/WaitingStateOverlay/styled.ts
+++ b/operate/client/src/modules/components/WaitingStateOverlay/styled.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import styled, {css} from 'styled-components';
+import {Stack} from '@carbon/react';
+
+const Container = styled(Stack)<{$theme: 'dark' | 'light'}>`
+  ${({$theme}) => {
+    const backgroundColor =
+      $theme === 'light'
+        ? 'var(--cds-background-inverse)'
+        : 'var(--cds-layer-02)';
+    const textColor =
+      $theme === 'light'
+        ? 'var(--cds-text-inverse)'
+        : 'var(--cds-text-primary)';
+
+    return css`
+      align-items: center;
+      font-weight: 400;
+      font-size: 12px;
+      height: 22px;
+      border-radius: 11px;
+      background-color: ${backgroundColor};
+      color: ${textColor};
+      padding: var(--cds-spacing-02) var(--cds-spacing-04);
+      white-space: nowrap;
+      transform: translateX(-50%);
+    `;
+  }}
+`;
+
+export {Container};

--- a/operate/client/src/modules/components/WaitingStateOverlay/styled.ts
+++ b/operate/client/src/modules/components/WaitingStateOverlay/styled.ts
@@ -6,33 +6,19 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import styled, {css} from 'styled-components';
+import styled from 'styled-components';
 import {Stack} from '@carbon/react';
 
 const Container = styled(Stack)<{$theme: 'dark' | 'light'}>`
-  ${({$theme}) => {
-    const backgroundColor =
-      $theme === 'light'
-        ? 'var(--cds-background-inverse)'
-        : 'var(--cds-layer-02)';
-    const textColor =
-      $theme === 'light'
-        ? 'var(--cds-text-inverse)'
-        : 'var(--cds-text-primary)';
-
-    return css`
-      align-items: center;
-      font-weight: 400;
-      font-size: 12px;
-      height: 22px;
-      border-radius: 11px;
-      background-color: ${backgroundColor};
-      color: ${textColor};
-      padding: var(--cds-spacing-02) var(--cds-spacing-04);
-      white-space: nowrap;
-      transform: translateX(-50%);
-    `;
-  }}
+  align-items: center;
+  font-weight: 400;
+  font-size: 12px;
+  border-radius: 11px;
+  border: 1px solid #dbb340;
+  background-color: color-mix(in srgb, #fcf5d7 20%, transparent);
+  color: #dbb340;
+  padding: var(--cds-spacing-02) var(--cds-spacing-04);
+  white-space: nowrap;
 `;
 
 export {Container};

--- a/operate/client/src/modules/components/WaitingStateOverlay/styled.ts
+++ b/operate/client/src/modules/components/WaitingStateOverlay/styled.ts
@@ -9,14 +9,23 @@
 import styled from 'styled-components';
 import {Stack} from '@carbon/react';
 
+const waitStateBadge = {
+  background: '#fcf5d',
+  color: '#dbb340',
+};
+
 const Container = styled(Stack)<{$theme: 'dark' | 'light'}>`
   align-items: center;
   font-weight: 400;
   font-size: 12px;
   border-radius: 11px;
-  border: 1px solid #dbb340;
-  background-color: color-mix(in srgb, #fcf5d7 20%, transparent);
-  color: #dbb340;
+  border: 1px solid ${waitStateBadge.color};
+  background-color: color-mix(
+    in srgb,
+    ${waitStateBadge.background} 20%,
+    transparent
+  );
+  color: ${waitStateBadge.color};
   padding: var(--cds-spacing-02) var(--cds-spacing-04);
   white-space: nowrap;
 `;

--- a/operate/client/src/modules/mocks/api/v2/elementInstanceInspection/searchElementInstanceInspection.ts
+++ b/operate/client/src/modules/mocks/api/v2/elementInstanceInspection/searchElementInstanceInspection.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {mockPostRequest} from '../../mockRequest';
+import {
+  type QueryElementInstanceInspectionResponseBody,
+  endpoints,
+} from '@camunda/camunda-api-zod-schemas/8.10';
+
+const mockSearchElementInstanceInspection = () =>
+  mockPostRequest<QueryElementInstanceInspectionResponseBody>(
+    endpoints.queryElementInstanceInspection.getUrl(),
+  );
+
+export {mockSearchElementInstanceInspection};

--- a/operate/client/src/modules/queries/elementInstanceInspection/useElementInstanceInspection.ts
+++ b/operate/client/src/modules/queries/elementInstanceInspection/useElementInstanceInspection.ts
@@ -37,8 +37,11 @@ const useElementInstanceInspection = (
 
   return useQuery<QueryElementInstanceInspectionResponseBody>({
     queryKey: queryKeys.elementInstanceInspection.search(payload),
-    queryFn: async () => {
-      const {response, error} = await searchElementInstanceInspection(payload);
+    queryFn: async ({signal}) => {
+      const {response, error} = await searchElementInstanceInspection(
+        payload,
+        signal,
+      );
       if (response !== null) {
         return response;
       }

--- a/operate/client/src/modules/queries/elementInstanceInspection/useElementInstanceInspection.ts
+++ b/operate/client/src/modules/queries/elementInstanceInspection/useElementInstanceInspection.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useQuery} from '@tanstack/react-query';
+import type {
+  QueryElementInstanceInspectionRequestBody,
+  QueryElementInstanceInspectionResponseBody,
+} from '@camunda/camunda-api-zod-schemas/8.10';
+import {searchElementInstanceInspection} from 'modules/api/v2/elementInstanceInspection/searchElementInstanceInspection';
+import {queryKeys} from '../queryKeys';
+
+const MAX_WAIT_STATES = 1000;
+
+type UseElementInstanceInspectionParams = {
+  processInstanceKey: string;
+  elementInstanceKey?: string;
+  enabled?: boolean;
+};
+
+const useElementInstanceInspection = (
+  params: UseElementInstanceInspectionParams,
+) => {
+  const {processInstanceKey, elementInstanceKey, enabled = true} = params;
+
+  const payload: QueryElementInstanceInspectionRequestBody = {
+    filter: {
+      processInstanceKey,
+      ...(elementInstanceKey ? {elementInstanceKey} : {}),
+    },
+    page: {limit: MAX_WAIT_STATES},
+  };
+
+  return useQuery<QueryElementInstanceInspectionResponseBody>({
+    queryKey: queryKeys.elementInstanceInspection.search(payload),
+    queryFn: async () => {
+      const {response, error} = await searchElementInstanceInspection(payload);
+      if (response !== null) {
+        return response;
+      }
+      throw error;
+    },
+    enabled: enabled && !!processInstanceKey,
+    staleTime: 10000,
+  });
+};
+
+export {useElementInstanceInspection, MAX_WAIT_STATES};

--- a/operate/client/src/modules/queries/queryKeys.ts
+++ b/operate/client/src/modules/queries/queryKeys.ts
@@ -20,6 +20,7 @@ import type {
   QueryBatchOperationsRequestBody,
   QueryDecisionInstancesRequestBody,
   QueryElementInstanceIncidentsRequestBody,
+  QueryElementInstanceInspectionRequestBody,
   QueryElementInstancesRequestBody,
   QueryJobsRequestBody,
   QueryMessageSubscriptionsRequestBody,
@@ -253,6 +254,12 @@ const queryKeys = {
   messageSubscriptions: {
     search: (payload: QueryMessageSubscriptionsRequestBody) => [
       'messageSubscriptionsSearch',
+      payload,
+    ],
+  },
+  elementInstanceInspection: {
+    search: (payload: QueryElementInstanceInspectionRequestBody) => [
+      'elementInstanceInspectionSearch',
       payload,
     ],
   },

--- a/operate/client/src/modules/utils/filter/processInstancesSearch.test.ts
+++ b/operate/client/src/modules/utils/filter/processInstancesSearch.test.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {parseProcessInstancesSearchFilter} from './processInstancesSearch';
+
+const params = (obj: Record<string, string>) =>
+  new URLSearchParams(obj);
+
+describe('parseProcessInstancesSearchFilter', () => {
+  it('should return undefined when no filters are set', () => {
+    expect(parseProcessInstancesSearchFilter(params({}))).toBeUndefined();
+  });
+
+  it('should return a filter with elementId and elementInstanceState when only elementId is set', () => {
+    const result = parseProcessInstancesSearchFilter(
+      params({elementId: 'nodeA'}),
+    );
+
+    expect(result).toEqual({
+      elementId: {$eq: 'nodeA'},
+      elementInstanceState: {$eq: 'ACTIVE'},
+    });
+  });
+
+  it('should return a filter with state when only active is set', () => {
+    const result = parseProcessInstancesSearchFilter(
+      params({active: 'true'}),
+    );
+
+    expect(result).toEqual({
+      state: {$eq: 'ACTIVE'},
+      hasIncident: false,
+    });
+  });
+
+  it('should return a filter combining state and elementId when both are set', () => {
+    const result = parseProcessInstancesSearchFilter(
+      params({active: 'true', elementId: 'nodeA'}),
+    );
+
+    expect(result).toMatchObject({
+      state: {$eq: 'ACTIVE'},
+      hasIncident: false,
+      elementId: {$eq: 'nodeA'},
+      elementInstanceState: {$eq: 'ACTIVE'},
+    });
+  });
+
+  it('should return a filter with batchOperationId when only batchOperationKey is set', () => {
+    const result = parseProcessInstancesSearchFilter(
+      params({batchOperationKey: 'batch-123'}),
+    );
+
+    expect(result).toEqual({
+      batchOperationId: {$eq: 'batch-123'},
+    });
+  });
+});

--- a/operate/client/src/modules/utils/filter/processInstancesSearch.ts
+++ b/operate/client/src/modules/utils/filter/processInstancesSearch.ts
@@ -65,7 +65,7 @@ const parseProcessInstancesSearchFilter = (
   const hasStateFilters =
     filter.active || filter.completed || filter.canceled || filter.incidents;
 
-  if (!hasStateFilters && !filter.batchOperationKey) {
+  if (!hasStateFilters && !filter.batchOperationKey && !filter.elementId) {
     return undefined;
   }
 
@@ -130,7 +130,7 @@ const parseProcessInstancesSearchFilter = (
   }
 
   if (filter.batchOperationKey) {
-    apiFilter.batchOperationKey = {$eq: filter.batchOperationKey};
+    apiFilter.batchOperationId = {$eq: filter.batchOperationKey};
   }
 
   if (filter.errorMessage) {

--- a/operate/client/src/modules/utils/waitStates.test.ts
+++ b/operate/client/src/modules/utils/waitStates.test.ts
@@ -87,7 +87,6 @@ describe('waitStates utils', () => {
       ]);
       expect(items).toHaveLength(1);
       expect(items[0]!.text).toBe('Waiting for message: order-completion');
-      expect(items[0]!.icon).toBe('message');
     });
 
     it('should format TIMER wait state with due date', () => {
@@ -100,7 +99,6 @@ describe('waitStates utils', () => {
       ]);
       expect(items).toHaveLength(1);
       expect(items[0]!.text).toContain('Timer due:');
-      expect(items[0]!.icon).toBe('time');
     });
 
     it('should format TIMER wait state without due date', () => {
@@ -121,7 +119,6 @@ describe('waitStates utils', () => {
       ]);
       expect(items).toHaveLength(1);
       expect(items[0]!.text).toBe('Waiting for job: send-email');
-      expect(items[0]!.icon).toBe('job');
     });
 
     it('should format execution listener JOB wait state', () => {
@@ -183,6 +180,30 @@ describe('waitStates utils', () => {
       expect(items[0]!.text).toBe('Waiting for message: msg1');
       expect(items[1]!.text).toBe('Waiting for message: msg2');
     });
+
+    it('should collapse multiple TIMER wait states into one status item', () => {
+      const items = getWaitStateStatusItems([
+        {
+          ...baseWaitState,
+          waitStateType: 'TIMER',
+          details: {dueDate: '2026-04-15T10:00:00Z'},
+        },
+        {
+          ...baseWaitState,
+          waitStateType: 'TIMER',
+          details: {dueDate: '2026-04-14T10:00:00Z'},
+        },
+        {
+          ...baseWaitState,
+          waitStateType: 'MESSAGE',
+          details: {messageName: 'msg1'},
+        },
+      ]);
+
+      expect(items).toHaveLength(2);
+      expect(items[0]!.text).toContain('Timer due:');
+      expect(items[1]!.text).toBe('Waiting for message: msg1');
+    });
   });
 
   describe('getEarliestTimerDueDate', () => {
@@ -224,6 +245,23 @@ describe('waitStates utils', () => {
       expect(
         getEarliestTimerDueDate([
           {...baseWaitState, waitStateType: 'TIMER', details: {}},
+          {
+            ...baseWaitState,
+            waitStateType: 'TIMER',
+            details: {dueDate: '2026-04-14T10:00:00Z'},
+          },
+        ]),
+      ).toBe('2026-04-14T10:00:00Z');
+    });
+
+    it('should compare due dates by parsed timestamp', () => {
+      expect(
+        getEarliestTimerDueDate([
+          {
+            ...baseWaitState,
+            waitStateType: 'TIMER',
+            details: {dueDate: '2026-04-14T10:00:00.100+00:00'},
+          },
           {
             ...baseWaitState,
             waitStateType: 'TIMER',

--- a/operate/client/src/modules/utils/waitStates.test.ts
+++ b/operate/client/src/modules/utils/waitStates.test.ts
@@ -1,0 +1,236 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {describe, it, expect} from 'vitest';
+import type {ElementInstanceInspection} from '@camunda/camunda-api-zod-schemas/8.10';
+import {
+  getWaitStateLabel,
+  getWaitStateStatusItems,
+  getEarliestTimerDueDate,
+} from './waitStates';
+
+const baseWaitState: ElementInstanceInspection = {
+  rootProcessInstanceKey: '123',
+  processInstanceKey: '123',
+  elementInstanceKey: '456',
+  elementId: 'task1',
+  elementType: 'SERVICE_TASK',
+  waitStateType: 'JOB',
+  details: {},
+};
+
+describe('waitStates utils', () => {
+  describe('getWaitStateLabel', () => {
+    it('should return null for empty array', () => {
+      expect(getWaitStateLabel([])).toBeNull();
+    });
+
+    it('should return "Waiting" for non-timer wait states', () => {
+      expect(
+        getWaitStateLabel([
+          {
+            ...baseWaitState,
+            waitStateType: 'MESSAGE',
+            details: {messageName: 'foo'},
+          },
+        ]),
+      ).toBe('Waiting');
+    });
+
+    it('should return null when only timer wait states exist', () => {
+      expect(
+        getWaitStateLabel([
+          {
+            ...baseWaitState,
+            waitStateType: 'TIMER',
+            details: {dueDate: '2026-01-01T00:00:00Z'},
+          },
+        ]),
+      ).toBeNull();
+    });
+
+    it('should return "Waiting" when mixed timer and non-timer wait states exist', () => {
+      expect(
+        getWaitStateLabel([
+          {
+            ...baseWaitState,
+            waitStateType: 'TIMER',
+            details: {dueDate: '2026-01-01T00:00:00Z'},
+          },
+          {
+            ...baseWaitState,
+            waitStateType: 'MESSAGE',
+            details: {messageName: 'foo'},
+          },
+        ]),
+      ).toBe('Waiting');
+    });
+  });
+
+  describe('getWaitStateStatusItems', () => {
+    it('should return empty array for no wait states', () => {
+      expect(getWaitStateStatusItems([])).toEqual([]);
+    });
+
+    it('should format MESSAGE wait state', () => {
+      const items = getWaitStateStatusItems([
+        {
+          ...baseWaitState,
+          waitStateType: 'MESSAGE',
+          details: {messageName: 'order-completion'},
+        },
+      ]);
+      expect(items).toHaveLength(1);
+      expect(items[0]!.text).toBe('Waiting for message: order-completion');
+      expect(items[0]!.icon).toBe('message');
+    });
+
+    it('should format TIMER wait state with due date', () => {
+      const items = getWaitStateStatusItems([
+        {
+          ...baseWaitState,
+          waitStateType: 'TIMER',
+          details: {dueDate: '2026-04-14T10:00:00Z'},
+        },
+      ]);
+      expect(items).toHaveLength(1);
+      expect(items[0]!.text).toContain('Timer due:');
+      expect(items[0]!.icon).toBe('time');
+    });
+
+    it('should format TIMER wait state without due date', () => {
+      const items = getWaitStateStatusItems([
+        {...baseWaitState, waitStateType: 'TIMER', details: {}},
+      ]);
+      expect(items).toHaveLength(1);
+      expect(items[0]!.text).toBe('Waiting for timer');
+    });
+
+    it('should format JOB wait state', () => {
+      const items = getWaitStateStatusItems([
+        {
+          ...baseWaitState,
+          waitStateType: 'JOB',
+          details: {jobType: 'send-email'},
+        },
+      ]);
+      expect(items).toHaveLength(1);
+      expect(items[0]!.text).toBe('Waiting for job: send-email');
+      expect(items[0]!.icon).toBe('job');
+    });
+
+    it('should format execution listener JOB wait state', () => {
+      const items = getWaitStateStatusItems([
+        {
+          ...baseWaitState,
+          waitStateType: 'JOB',
+          details: {jobType: 'my-listener', jobKind: 'EXECUTION_LISTENER'},
+        },
+      ]);
+      expect(items).toHaveLength(1);
+      expect(items[0]!.text).toBe(
+        'Waiting for execution listener: my-listener',
+      );
+    });
+
+    it('should format SIGNAL wait state', () => {
+      const items = getWaitStateStatusItems([
+        {
+          ...baseWaitState,
+          waitStateType: 'SIGNAL',
+          details: {signalName: 'abort'},
+        },
+      ]);
+      expect(items).toHaveLength(1);
+      expect(items[0]!.text).toBe('Waiting for signal: abort');
+    });
+
+    it('should format CONDITION wait state', () => {
+      const items = getWaitStateStatusItems([
+        {...baseWaitState, waitStateType: 'CONDITION', details: {}},
+      ]);
+      expect(items).toHaveLength(1);
+      expect(items[0]!.text).toBe('Waiting for condition');
+    });
+
+    it('should format CHILD_INSTANCE wait state', () => {
+      const items = getWaitStateStatusItems([
+        {...baseWaitState, waitStateType: 'CHILD_INSTANCE', details: {}},
+      ]);
+      expect(items).toHaveLength(1);
+      expect(items[0]!.text).toBe('Waiting for child instance to complete');
+    });
+
+    it('should handle multiple wait states', () => {
+      const items = getWaitStateStatusItems([
+        {
+          ...baseWaitState,
+          waitStateType: 'MESSAGE',
+          details: {messageName: 'msg1'},
+        },
+        {
+          ...baseWaitState,
+          waitStateType: 'MESSAGE',
+          details: {messageName: 'msg2'},
+        },
+      ]);
+      expect(items).toHaveLength(2);
+      expect(items[0]!.text).toBe('Waiting for message: msg1');
+      expect(items[1]!.text).toBe('Waiting for message: msg2');
+    });
+  });
+
+  describe('getEarliestTimerDueDate', () => {
+    it('should return null for empty array', () => {
+      expect(getEarliestTimerDueDate([])).toBeNull();
+    });
+
+    it('should return null when no timer wait states', () => {
+      expect(
+        getEarliestTimerDueDate([
+          {...baseWaitState, waitStateType: 'MESSAGE', details: {}},
+        ]),
+      ).toBeNull();
+    });
+
+    it('should return the earliest due date', () => {
+      expect(
+        getEarliestTimerDueDate([
+          {
+            ...baseWaitState,
+            waitStateType: 'TIMER',
+            details: {dueDate: '2026-04-15T10:00:00Z'},
+          },
+          {
+            ...baseWaitState,
+            waitStateType: 'TIMER',
+            details: {dueDate: '2026-04-14T10:00:00Z'},
+          },
+          {
+            ...baseWaitState,
+            waitStateType: 'TIMER',
+            details: {dueDate: '2026-04-16T10:00:00Z'},
+          },
+        ]),
+      ).toBe('2026-04-14T10:00:00Z');
+    });
+
+    it('should ignore timers without due date', () => {
+      expect(
+        getEarliestTimerDueDate([
+          {...baseWaitState, waitStateType: 'TIMER', details: {}},
+          {
+            ...baseWaitState,
+            waitStateType: 'TIMER',
+            details: {dueDate: '2026-04-14T10:00:00Z'},
+          },
+        ]),
+      ).toBe('2026-04-14T10:00:00Z');
+    });
+  });
+});

--- a/operate/client/src/modules/utils/waitStates.ts
+++ b/operate/client/src/modules/utils/waitStates.ts
@@ -30,30 +30,32 @@ function getWaitStateLabel(
 
 function getWaitStateStatusItems(
   waitStates: ElementInstanceInspection[],
-): Array<{
-  icon: 'time' | 'message' | 'signal' | 'condition' | 'job';
-  text: string;
-}> {
-  return waitStates.map((waitState) => {
+): Array<{text: string}> {
+  const earliestTimerDueDate = getEarliestTimerDueDate(waitStates);
+  let hasRenderedTimerStatus = false;
+
+  return waitStates.flatMap((waitState) => {
     switch (waitState.waitStateType) {
       case 'MESSAGE': {
         const messageName =
           (waitState.details['messageName'] as string) ?? 'unknown';
         return {
-          icon: 'message' as const,
           text: `Waiting for message: ${messageName}`,
         };
       }
       case 'TIMER': {
-        const dueDate = waitState.details['dueDate'] as string | undefined;
-        if (dueDate) {
+        if (hasRenderedTimerStatus) {
+          return [];
+        }
+        hasRenderedTimerStatus = true;
+
+        if (earliestTimerDueDate) {
           return {
-            icon: 'time' as const,
-            text: `Timer due: ${formatDate(dueDate)}`,
+            text: `Timer due: ${formatDate(earliestTimerDueDate)}`,
           };
         }
+
         return {
-          icon: 'time' as const,
           text: 'Waiting for timer',
         };
       }
@@ -61,13 +63,11 @@ function getWaitStateStatusItems(
         const signalName =
           (waitState.details['signalName'] as string) ?? 'unknown';
         return {
-          icon: 'time' as const,
           text: `Waiting for signal: ${signalName}`,
         };
       }
       case 'CONDITION': {
         return {
-          icon: 'condition' as const,
           text: 'Waiting for condition',
         };
       }
@@ -76,24 +76,20 @@ function getWaitStateStatusItems(
         const jobKind = waitState.details['jobKind'] as string | undefined;
         if (jobKind === 'EXECUTION_LISTENER' || jobKind === 'TASK_LISTENER') {
           return {
-            icon: 'job' as const,
             text: `Waiting for ${jobKind === 'EXECUTION_LISTENER' ? 'execution listener' : 'task listener'}: ${jobType}`,
           };
         }
         return {
-          icon: 'job' as const,
           text: `Waiting for job: ${jobType}`,
         };
       }
       case 'CHILD_INSTANCE': {
         return {
-          icon: 'time' as const,
           text: 'Waiting for child instance to complete',
         };
       }
       default:
         return {
-          icon: 'time' as const,
           text: 'Waiting',
         };
     }
@@ -111,11 +107,23 @@ function getEarliestTimerDueDate(
     return null;
   }
 
-  const dates = timerWaitStates
-    .map((ws) => ws.details['dueDate'] as string)
-    .sort();
+  let earliestDueDate: string | null = null;
+  let earliestDueDateInMillis = Number.POSITIVE_INFINITY;
 
-  return dates[0] ?? null;
+  timerWaitStates.forEach((waitState) => {
+    const dueDate = waitState.details['dueDate'] as string;
+    const dueDateInMillis = Date.parse(dueDate);
+
+    if (
+      !Number.isNaN(dueDateInMillis) &&
+      dueDateInMillis < earliestDueDateInMillis
+    ) {
+      earliestDueDateInMillis = dueDateInMillis;
+      earliestDueDate = dueDate;
+    }
+  });
+
+  return earliestDueDate;
 }
 
 export {getWaitStateLabel, getWaitStateStatusItems, getEarliestTimerDueDate};

--- a/operate/client/src/modules/utils/waitStates.ts
+++ b/operate/client/src/modules/utils/waitStates.ts
@@ -30,7 +30,7 @@ function getWaitStateLabel(
 
 function getWaitStateStatusItems(
   waitStates: ElementInstanceInspection[],
-): Array<{text: string}> {
+): Array<{key: string; text: string}> {
   const earliestTimerDueDate = getEarliestTimerDueDate(waitStates);
   let hasRenderedTimerStatus = false;
 
@@ -40,6 +40,7 @@ function getWaitStateStatusItems(
         const messageName =
           (waitState.details['messageName'] as string) ?? 'unknown';
         return {
+          key: `${waitState.elementInstanceKey}-MESSAGE-${messageName}`,
           text: `Waiting for message: ${messageName}`,
         };
       }
@@ -51,11 +52,13 @@ function getWaitStateStatusItems(
 
         if (earliestTimerDueDate) {
           return {
+            key: `TIMER-${earliestTimerDueDate}`,
             text: `Timer due: ${formatDate(earliestTimerDueDate)}`,
           };
         }
 
         return {
+          key: 'TIMER-waiting',
           text: 'Waiting for timer',
         };
       }
@@ -63,11 +66,13 @@ function getWaitStateStatusItems(
         const signalName =
           (waitState.details['signalName'] as string) ?? 'unknown';
         return {
+          key: `${waitState.elementInstanceKey}-SIGNAL-${signalName}`,
           text: `Waiting for signal: ${signalName}`,
         };
       }
       case 'CONDITION': {
         return {
+          key: `${waitState.elementInstanceKey}-CONDITION`,
           text: 'Waiting for condition',
         };
       }
@@ -76,20 +81,24 @@ function getWaitStateStatusItems(
         const jobKind = waitState.details['jobKind'] as string | undefined;
         if (jobKind === 'EXECUTION_LISTENER' || jobKind === 'TASK_LISTENER') {
           return {
+            key: `${waitState.elementInstanceKey}-JOB-${jobKind}-${jobType}`,
             text: `Waiting for ${jobKind === 'EXECUTION_LISTENER' ? 'execution listener' : 'task listener'}: ${jobType}`,
           };
         }
         return {
+          key: `${waitState.elementInstanceKey}-JOB-${jobType}`,
           text: `Waiting for job: ${jobType}`,
         };
       }
       case 'CHILD_INSTANCE': {
         return {
+          key: `${waitState.elementInstanceKey}-CHILD_INSTANCE`,
           text: 'Waiting for child instance to complete',
         };
       }
       default:
         return {
+          key: `${waitState.elementInstanceKey}-WAITING`,
           text: 'Waiting',
         };
     }

--- a/operate/client/src/modules/utils/waitStates.ts
+++ b/operate/client/src/modules/utils/waitStates.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {ElementInstanceInspection} from '@camunda/camunda-api-zod-schemas/8.10';
+import {formatDate} from 'modules/utils/date';
+
+function getWaitStateLabel(
+  waitStates: ElementInstanceInspection[],
+): string | null {
+  if (waitStates.length === 0) {
+    return null;
+  }
+
+  // Timer wait states should not show a label on the diagram overlay
+  const nonTimerWaitStates = waitStates.filter(
+    (ws) => ws.waitStateType !== 'TIMER',
+  );
+
+  if (nonTimerWaitStates.length === 0) {
+    return null;
+  }
+
+  return 'Waiting';
+}
+
+function getWaitStateStatusItems(
+  waitStates: ElementInstanceInspection[],
+): Array<{
+  icon: 'time' | 'message' | 'signal' | 'condition' | 'job';
+  text: string;
+}> {
+  return waitStates.map((waitState) => {
+    switch (waitState.waitStateType) {
+      case 'MESSAGE': {
+        const messageName =
+          (waitState.details.messageName as string) ?? 'unknown';
+        return {
+          icon: 'message' as const,
+          text: `Waiting for message: ${messageName}`,
+        };
+      }
+      case 'TIMER': {
+        const dueDate = waitState.details.dueDate as string | undefined;
+        if (dueDate) {
+          return {
+            icon: 'time' as const,
+            text: `Timer due: ${formatDate(dueDate)}`,
+          };
+        }
+        return {
+          icon: 'time' as const,
+          text: 'Waiting for timer',
+        };
+      }
+      case 'SIGNAL': {
+        const signalName =
+          (waitState.details.signalName as string) ?? 'unknown';
+        return {
+          icon: 'signal' as const,
+          text: `Waiting for signal: ${signalName}`,
+        };
+      }
+      case 'CONDITION': {
+        return {
+          icon: 'condition' as const,
+          text: 'Waiting for condition',
+        };
+      }
+      case 'JOB': {
+        const jobType = (waitState.details.jobType as string) ?? 'unknown';
+        const jobKind = waitState.details.jobKind as string | undefined;
+        if (jobKind === 'EXECUTION_LISTENER' || jobKind === 'TASK_LISTENER') {
+          return {
+            icon: 'job' as const,
+            text: `Waiting for ${jobKind === 'EXECUTION_LISTENER' ? 'execution listener' : 'task listener'}: ${jobType}`,
+          };
+        }
+        return {
+          icon: 'job' as const,
+          text: `Waiting for job: ${jobType}`,
+        };
+      }
+      case 'CHILD_INSTANCE': {
+        return {
+          icon: 'time' as const,
+          text: 'Waiting for child instance to complete',
+        };
+      }
+      default:
+        return {
+          icon: 'time' as const,
+          text: 'Waiting',
+        };
+    }
+  });
+}
+
+function getEarliestTimerDueDate(
+  waitStates: ElementInstanceInspection[],
+): string | null {
+  const timerWaitStates = waitStates.filter(
+    (ws) => ws.waitStateType === 'TIMER' && ws.details.dueDate,
+  );
+
+  if (timerWaitStates.length === 0) {
+    return null;
+  }
+
+  const dates = timerWaitStates
+    .map((ws) => ws.details.dueDate as string)
+    .sort();
+
+  return dates[0] ?? null;
+}
+
+export {getWaitStateLabel, getWaitStateStatusItems, getEarliestTimerDueDate};

--- a/operate/client/src/modules/utils/waitStates.ts
+++ b/operate/client/src/modules/utils/waitStates.ts
@@ -38,14 +38,14 @@ function getWaitStateStatusItems(
     switch (waitState.waitStateType) {
       case 'MESSAGE': {
         const messageName =
-          (waitState.details.messageName as string) ?? 'unknown';
+          (waitState.details['messageName'] as string) ?? 'unknown';
         return {
           icon: 'message' as const,
           text: `Waiting for message: ${messageName}`,
         };
       }
       case 'TIMER': {
-        const dueDate = waitState.details.dueDate as string | undefined;
+        const dueDate = waitState.details['dueDate'] as string | undefined;
         if (dueDate) {
           return {
             icon: 'time' as const,
@@ -59,9 +59,9 @@ function getWaitStateStatusItems(
       }
       case 'SIGNAL': {
         const signalName =
-          (waitState.details.signalName as string) ?? 'unknown';
+          (waitState.details['signalName'] as string) ?? 'unknown';
         return {
-          icon: 'signal' as const,
+          icon: 'time' as const,
           text: `Waiting for signal: ${signalName}`,
         };
       }
@@ -72,8 +72,8 @@ function getWaitStateStatusItems(
         };
       }
       case 'JOB': {
-        const jobType = (waitState.details.jobType as string) ?? 'unknown';
-        const jobKind = waitState.details.jobKind as string | undefined;
+        const jobType = (waitState.details['jobType'] as string) ?? 'unknown';
+        const jobKind = waitState.details['jobKind'] as string | undefined;
         if (jobKind === 'EXECUTION_LISTENER' || jobKind === 'TASK_LISTENER') {
           return {
             icon: 'job' as const,
@@ -104,7 +104,7 @@ function getEarliestTimerDueDate(
   waitStates: ElementInstanceInspection[],
 ): string | null {
   const timerWaitStates = waitStates.filter(
-    (ws) => ws.waitStateType === 'TIMER' && ws.details.dueDate,
+    (ws) => ws.waitStateType === 'TIMER' && ws.details['dueDate'],
   );
 
   if (timerWaitStates.length === 0) {
@@ -112,7 +112,7 @@ function getEarliestTimerDueDate(
   }
 
   const dates = timerWaitStates
-    .map((ws) => ws.details.dueDate as string)
+    .map((ws) => ws.details['dueDate'] as string)
     .sort();
 
   return dates[0] ?? null;

--- a/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/element-instance-inspection.ts
+++ b/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/element-instance-inspection.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {z} from 'zod';
+import {
+	API_VERSION,
+	advancedStringFilterSchema,
+	getQueryRequestBodySchema,
+	getQueryResponseBodySchema,
+	type Endpoint,
+} from './common';
+import {elementInstanceTypeSchema} from './element-instance';
+
+const waitStateTypeSchema = z.enum(['JOB', 'MESSAGE', 'TIMER', 'SIGNAL', 'CONDITION', 'CHILD_INSTANCE']);
+type WaitStateType = z.infer<typeof waitStateTypeSchema>;
+
+const waitStateDetailsSchema = z.record(z.string(), z.unknown());
+type WaitStateDetails = z.infer<typeof waitStateDetailsSchema>;
+
+const elementInstanceInspectionSchema = z.object({
+	rootProcessInstanceKey: z.string(),
+	processInstanceKey: z.string(),
+	elementInstanceKey: z.string(),
+	elementId: z.string(),
+	elementType: elementInstanceTypeSchema,
+	waitStateType: waitStateTypeSchema,
+	details: waitStateDetailsSchema,
+});
+type ElementInstanceInspection = z.infer<typeof elementInstanceInspectionSchema>;
+
+const queryElementInstanceInspectionFilterSchema = z
+	.object({
+		processInstanceKey: advancedStringFilterSchema,
+		elementInstanceKey: advancedStringFilterSchema,
+		elementId: advancedStringFilterSchema,
+		waitStateType: advancedStringFilterSchema,
+	})
+	.partial();
+
+const queryElementInstanceInspectionRequestBodySchema = getQueryRequestBodySchema({
+	sortFields: ['elementInstanceKey', 'processInstanceKey', 'elementId', 'waitStateType'] as const,
+	filter: queryElementInstanceInspectionFilterSchema,
+});
+type QueryElementInstanceInspectionRequestBody = z.infer<typeof queryElementInstanceInspectionRequestBodySchema>;
+
+const queryElementInstanceInspectionResponseBodySchema = getQueryResponseBodySchema(elementInstanceInspectionSchema);
+type QueryElementInstanceInspectionResponseBody = z.infer<typeof queryElementInstanceInspectionResponseBodySchema>;
+
+const queryElementInstanceInspection: Endpoint = {
+	method: 'POST',
+	getUrl() {
+		return `/${API_VERSION}/element-instances/inspection`;
+	},
+};
+
+export {
+	waitStateTypeSchema,
+	waitStateDetailsSchema,
+	elementInstanceInspectionSchema,
+	queryElementInstanceInspectionRequestBodySchema,
+	queryElementInstanceInspectionResponseBodySchema,
+	queryElementInstanceInspection,
+};
+
+export type {
+	WaitStateType,
+	WaitStateDetails,
+	ElementInstanceInspection,
+	QueryElementInstanceInspectionRequestBody,
+	QueryElementInstanceInspectionResponseBody,
+};

--- a/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/element-instance-inspection.ts
+++ b/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/element-instance-inspection.ts
@@ -10,6 +10,7 @@ import {z} from 'zod';
 import {
 	API_VERSION,
 	advancedStringFilterSchema,
+	getEnumFilterSchema,
 	getQueryRequestBodySchema,
 	getQueryResponseBodySchema,
 	type Endpoint,
@@ -38,7 +39,7 @@ const queryElementInstanceInspectionFilterSchema = z
 		processInstanceKey: advancedStringFilterSchema,
 		elementInstanceKey: advancedStringFilterSchema,
 		elementId: advancedStringFilterSchema,
-		waitStateType: advancedStringFilterSchema,
+		waitStateType: z.union([waitStateTypeSchema, getEnumFilterSchema(waitStateTypeSchema)]),
 	})
 	.partial();
 

--- a/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/index.ts
+++ b/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/index.ts
@@ -45,6 +45,7 @@ import {
 	updateElementInstanceVariables,
 	queryElementInstanceIncidents,
 } from './element-instance';
+import {queryElementInstanceInspection} from './element-instance-inspection';
 import {
 	createGroup,
 	getGroup,
@@ -223,6 +224,7 @@ const endpoints = {
 	createDocumentLink,
 	queryElementInstances,
 	queryElementInstanceIncidents,
+	queryElementInstanceInspection,
 	getElementInstance,
 	updateElementInstanceVariables,
 	createGroup,
@@ -592,6 +594,18 @@ export {
 	type QueryElementInstanceIncidentsRequestBody,
 	type QueryElementInstanceIncidentsResponseBody,
 } from './element-instance';
+export {
+	waitStateTypeSchema,
+	waitStateDetailsSchema,
+	elementInstanceInspectionSchema,
+	queryElementInstanceInspectionRequestBodySchema,
+	queryElementInstanceInspectionResponseBodySchema,
+	type WaitStateType,
+	type WaitStateDetails,
+	type ElementInstanceInspection,
+	type QueryElementInstanceInspectionRequestBody,
+	type QueryElementInstanceInspectionResponseBody,
+} from './element-instance-inspection';
 export {
 	createGroupRequestBodySchema,
 	createGroupResponseBodySchema,


### PR DESCRIPTION
## Summary

- When clicking a BPMN flow node in the process instances diagram without any state filter (active/incidents/completed/canceled) selected, `parseProcessInstancesSearchFilter` returned `undefined`, so the API fetched all instances instead of filtering by the selected element
- Added `&& !filter.elementId` to the early-return guard so a proper filter with `elementId` + `elementInstanceState=ACTIVE` is built when a flow node is selected
- Also restores `batchOperationId` as the API filter field name (incorrectly renamed to `batchOperationKey` in a recent refactor; the URL param is `batchOperationKey` but the API field is `batchOperationId`)

## Test plan

- [ ] New unit tests in `processInstancesSearch.test.ts` cover: no-filter → `undefined`, elementId-only, state-only, combined state+elementId, batchOperationKey
- [ ] Manual: click a flow node with no active tokens → header shows 0 instances, list is empty
- [ ] Manual: click a flow node with active tokens → correct count shown
- [ ] Automated test: [Process Instances Filters › Interaction between diagram and filters](https://camunda.testrail.com/index.php?/tests/view/2535256)

Closes #45156

🤖 Generated with [Claude Code](https://claude.com/claude-code)