### PR TITLE
Implement CamundaClient support for agent-instance Get/Search endpoints

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -142,6 +142,7 @@ import io.camunda.client.api.fetch.UserTaskGetRequest;
 import io.camunda.client.api.fetch.VariableGetRequest;
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.response.DocumentReferenceResponse;
+import io.camunda.client.api.search.request.AgentInstanceSearchRequest;
 import io.camunda.client.api.search.request.AuditLogSearchRequest;
 import io.camunda.client.api.search.request.BatchOperationItemSearchRequest;
 import io.camunda.client.api.search.request.BatchOperationSearchRequest;
@@ -3561,4 +3562,21 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder for fetching an agent instance
    */
   AgentInstanceGetRequest newAgentInstanceGetRequest(long agentInstanceKey);
+
+  /**
+   * Creates a request to search for agent instances.
+   *
+   * <p>Agent instances can be searched with filtering and sorting capabilities:
+   *
+   * <pre>
+   *   camundaClient
+   *       .newAgentInstanceSearchRequest()
+   *       .filter(f -> f.status(AgentInstanceStatus.COMPLETED))
+   *       .sort(s -> s.creationDate().desc())
+   *       .send();
+   * </pre>
+   *
+   * @return a builder for searching agent instances
+   */
+  AgentInstanceSearchRequest newAgentInstanceSearchRequest();
 }

--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -107,6 +107,7 @@ import io.camunda.client.api.command.UpdateTenantCommandStep1;
 import io.camunda.client.api.command.UpdateTimeoutJobCommandStep1;
 import io.camunda.client.api.command.UpdateUserCommandStep1;
 import io.camunda.client.api.command.UpdateUserTaskCommandStep1;
+import io.camunda.client.api.fetch.AgentInstanceGetRequest;
 import io.camunda.client.api.fetch.AuditLogGetRequest;
 import io.camunda.client.api.fetch.AuthorizationGetRequest;
 import io.camunda.client.api.fetch.AuthorizationsSearchRequest;
@@ -3546,4 +3547,18 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder for searching global task listeners
    */
   GlobalTaskListenerSearchRequest newGlobalTaskListenerSearchRequest();
+
+  /**
+   * Creates a request to fetch an agent instance by its key.
+   *
+   * <pre>
+   *   camundaClient
+   *       .newAgentInstanceGetRequest(agentInstanceKey)
+   *       .send();
+   * </pre>
+   *
+   * @param agentInstanceKey the key of the agent instance to retrieve
+   * @return a builder for fetching an agent instance
+   */
+  AgentInstanceGetRequest newAgentInstanceGetRequest(long agentInstanceKey);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/fetch/AgentInstanceGetRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/fetch/AgentInstanceGetRequest.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.fetch;
+
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.search.response.AgentInstance;
+
+public interface AgentInstanceGetRequest extends FinalCommandStep<AgentInstance> {}

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/AgentInstanceFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/AgentInstanceFilter.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.filter;
+
+import io.camunda.client.api.search.enums.AgentInstanceStatus;
+import io.camunda.client.api.search.filter.builder.AgentInstanceStatusProperty;
+import io.camunda.client.api.search.filter.builder.BasicLongProperty;
+import io.camunda.client.api.search.filter.builder.DateTimeProperty;
+import io.camunda.client.api.search.filter.builder.IntegerProperty;
+import io.camunda.client.api.search.filter.builder.StringProperty;
+import io.camunda.client.api.search.request.TypedFilterableRequest.SearchRequestFilter;
+import java.util.function.Consumer;
+
+public interface AgentInstanceFilter extends SearchRequestFilter {
+
+  /**
+   * Filter agent instances by their unique key.
+   *
+   * @param value the agent instance key
+   * @return the updated filter
+   */
+  AgentInstanceFilter agentInstanceKey(long value);
+
+  /**
+   * Filter agent instances by their unique key using a {@link BasicLongProperty} consumer.
+   *
+   * @param fn the key filter consumer
+   * @return the updated filter
+   */
+  AgentInstanceFilter agentInstanceKey(Consumer<BasicLongProperty> fn);
+
+  /**
+   * Filter agent instances by their current status.
+   *
+   * @param value the status to match
+   * @return the updated filter
+   */
+  AgentInstanceFilter status(AgentInstanceStatus value);
+
+  /**
+   * Filter agent instances by their current status using an {@link AgentInstanceStatusProperty}
+   * consumer.
+   *
+   * @param fn the status filter consumer
+   * @return the updated filter
+   */
+  AgentInstanceFilter status(Consumer<AgentInstanceStatusProperty> fn);
+
+  /**
+   * Filter agent instances by the BPMN element ID.
+   *
+   * @param value the BPMN element ID
+   * @return the updated filter
+   */
+  AgentInstanceFilter elementId(String value);
+
+  /**
+   * Filter agent instances by the BPMN element ID using a {@link StringProperty} consumer.
+   *
+   * @param fn the element ID filter consumer
+   * @return the updated filter
+   */
+  AgentInstanceFilter elementId(Consumer<StringProperty> fn);
+
+  /**
+   * Filter agent instances by the owning process instance key.
+   *
+   * @param value the process instance key
+   * @return the updated filter
+   */
+  AgentInstanceFilter processInstanceKey(long value);
+
+  /**
+   * Filter agent instances by the owning process instance key using a {@link BasicLongProperty}
+   * consumer.
+   *
+   * @param fn the process instance key filter consumer
+   * @return the updated filter
+   */
+  AgentInstanceFilter processInstanceKey(Consumer<BasicLongProperty> fn);
+
+  /**
+   * Filter agent instances by the process definition key.
+   *
+   * @param value the process definition key
+   * @return the updated filter
+   */
+  AgentInstanceFilter processDefinitionKey(long value);
+
+  /**
+   * Filter agent instances by the process definition key using a {@link BasicLongProperty}
+   * consumer.
+   *
+   * @param fn the process definition key filter consumer
+   * @return the updated filter
+   */
+  AgentInstanceFilter processDefinitionKey(Consumer<BasicLongProperty> fn);
+
+  /**
+   * Filter agent instances by the BPMN process ID.
+   *
+   * @param value the BPMN process ID
+   * @return the updated filter
+   */
+  AgentInstanceFilter processDefinitionId(String value);
+
+  /**
+   * Filter agent instances by the BPMN process ID using a {@link StringProperty} consumer.
+   *
+   * @param fn the process definition ID filter consumer
+   * @return the updated filter
+   */
+  AgentInstanceFilter processDefinitionId(Consumer<StringProperty> fn);
+
+  /**
+   * Filter agent instances by the process definition version.
+   *
+   * @param value the version number
+   * @return the updated filter
+   */
+  AgentInstanceFilter processDefinitionVersion(int value);
+
+  /**
+   * Filter agent instances by the process definition version using an {@link IntegerProperty}
+   * consumer.
+   *
+   * @param fn the version filter consumer
+   * @return the updated filter
+   */
+  AgentInstanceFilter processDefinitionVersion(Consumer<IntegerProperty> fn);
+
+  /**
+   * Filter agent instances by the process definition version tag.
+   *
+   * @param value the version tag string
+   * @return the updated filter
+   */
+  AgentInstanceFilter processDefinitionVersionTag(String value);
+
+  /**
+   * Filter agent instances by the process definition version tag using a {@link StringProperty}
+   * consumer.
+   *
+   * @param fn the version tag filter consumer
+   * @return the updated filter
+   */
+  AgentInstanceFilter processDefinitionVersionTag(Consumer<StringProperty> fn);
+
+  /**
+   * Filter agent instances by their tenant ID.
+   *
+   * @param value the tenant ID
+   * @return the updated filter
+   */
+  AgentInstanceFilter tenantId(String value);
+
+  /**
+   * Filter agent instances by their tenant ID using a {@link StringProperty} consumer.
+   *
+   * @param fn the tenant ID filter consumer
+   * @return the updated filter
+   */
+  AgentInstanceFilter tenantId(Consumer<StringProperty> fn);
+
+  /**
+   * Filter agent instances by their creation date using a {@link DateTimeProperty} consumer.
+   *
+   * @param fn the creation date filter consumer
+   * @return the updated filter
+   */
+  AgentInstanceFilter creationDate(Consumer<DateTimeProperty> fn);
+
+  /**
+   * Filter agent instances by their last-updated date using a {@link DateTimeProperty} consumer.
+   *
+   * @param fn the last-updated date filter consumer
+   * @return the updated filter
+   */
+  AgentInstanceFilter lastUpdatedDate(Consumer<DateTimeProperty> fn);
+
+  /**
+   * Filter agent instances by their completion date using a {@link DateTimeProperty} consumer.
+   *
+   * @param fn the completion date filter consumer
+   * @return the updated filter
+   */
+  AgentInstanceFilter completionDate(Consumer<DateTimeProperty> fn);
+
+  /**
+   * Filter agent instances by an associated element instance key.
+   *
+   * @param value the element instance key to match
+   * @return the updated filter
+   */
+  AgentInstanceFilter elementInstanceKey(long value);
+
+  /**
+   * Filter agent instances by an associated element instance key using a {@link BasicLongProperty}
+   * consumer.
+   *
+   * @param fn the element instance key filter consumer
+   * @return the updated filter
+   */
+  AgentInstanceFilter elementInstanceKey(Consumer<BasicLongProperty> fn);
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/builder/AgentInstanceStatusProperty.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/builder/AgentInstanceStatusProperty.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.filter.builder;
+
+import io.camunda.client.api.search.enums.AgentInstanceStatus;
+
+public interface AgentInstanceStatusProperty
+    extends LikeProperty<AgentInstanceStatus, String, AgentInstanceStatusProperty> {}

--- a/clients/java/src/main/java/io/camunda/client/api/search/request/AgentInstanceSearchRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/AgentInstanceSearchRequest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.request;
+
+import io.camunda.client.api.search.filter.AgentInstanceFilter;
+import io.camunda.client.api.search.page.AnyPage;
+import io.camunda.client.api.search.response.AgentInstance;
+import io.camunda.client.api.search.sort.AgentInstanceSort;
+
+public interface AgentInstanceSearchRequest
+    extends TypedSearchRequest<
+            AgentInstanceFilter, AgentInstanceSort, AnyPage, AgentInstanceSearchRequest>,
+        TypedPageableRequest<AnyPage, AgentInstanceSearchRequest>,
+        FinalSearchRequestStep<AgentInstance> {}

--- a/clients/java/src/main/java/io/camunda/client/api/search/request/SearchRequestBuilders.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/SearchRequestBuilders.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.client.api.search.request;
 
+import io.camunda.client.api.search.filter.AgentInstanceFilter;
 import io.camunda.client.api.search.filter.AuditLogFilter;
 import io.camunda.client.api.search.filter.AuthorizationFilter;
 import io.camunda.client.api.search.filter.BatchOperationFilter;
@@ -47,6 +48,7 @@ import io.camunda.client.api.search.page.CursorBackwardPage;
 import io.camunda.client.api.search.page.CursorForwardPage;
 import io.camunda.client.api.search.page.LimitPage;
 import io.camunda.client.api.search.page.OffsetPage;
+import io.camunda.client.api.search.sort.AgentInstanceSort;
 import io.camunda.client.api.search.sort.AuditLogSort;
 import io.camunda.client.api.search.sort.AuthorizationSort;
 import io.camunda.client.api.search.sort.BatchOperationItemSort;
@@ -80,6 +82,7 @@ import io.camunda.client.api.search.sort.VariableSort;
 import io.camunda.client.api.statistics.filter.JobErrorStatisticsFilter;
 import io.camunda.client.api.statistics.filter.JobTypeStatisticsFilter;
 import io.camunda.client.api.statistics.filter.ProcessDefinitionStatisticsFilter;
+import io.camunda.client.impl.search.filter.AgentInstanceFilterImpl;
 import io.camunda.client.impl.search.filter.AuthorizationFilterImpl;
 import io.camunda.client.impl.search.filter.BatchOperationFilterImpl;
 import io.camunda.client.impl.search.filter.BatchOperationItemFilterImpl;
@@ -112,6 +115,7 @@ import io.camunda.client.impl.search.page.CursorForwardPageImpl;
 import io.camunda.client.impl.search.page.LimitPageImpl;
 import io.camunda.client.impl.search.page.OffsetPageImpl;
 import io.camunda.client.impl.search.request.SearchRequestPageImpl;
+import io.camunda.client.impl.search.sort.AgentInstanceSortImpl;
 import io.camunda.client.impl.search.sort.AuditLogSortImpl;
 import io.camunda.client.impl.search.sort.AuthorizationSortImpl;
 import io.camunda.client.impl.search.sort.BatchOperationItemSortImpl;
@@ -562,6 +566,18 @@ public final class SearchRequestBuilders {
   public static GlobalTaskListenerSort globalTaskListenerSort(
       final Consumer<GlobalTaskListenerSort> fn) {
     final GlobalTaskListenerSort sort = new GlobalTaskListenerSortImpl();
+    fn.accept(sort);
+    return sort;
+  }
+
+  public static AgentInstanceFilter agentInstanceFilter(final Consumer<AgentInstanceFilter> fn) {
+    final AgentInstanceFilter filter = new AgentInstanceFilterImpl();
+    fn.accept(filter);
+    return filter;
+  }
+
+  public static AgentInstanceSort agentInstanceSort(final Consumer<AgentInstanceSort> fn) {
+    final AgentInstanceSort sort = new AgentInstanceSortImpl();
     fn.accept(sort);
     return sort;
   }

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/AgentInstance.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/AgentInstance.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.response;
+
+import io.camunda.client.api.search.enums.AgentInstanceStatus;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+/** Represents an agent instance returned from the Camunda REST API. */
+public interface AgentInstance {
+
+  /** Returns the unique key identifying this agent instance. */
+  long getAgentInstanceKey();
+
+  /** Returns the current execution status of the agent instance. */
+  AgentInstanceStatus getStatus();
+
+  /**
+   * Returns the static definition of the agent, containing model, provider, and system prompt set
+   * at creation time.
+   */
+  Definition getDefinition();
+
+  /** Returns the aggregated runtime metrics for this agent instance. */
+  Metrics getMetrics();
+
+  /** Returns the configured execution limits for this agent instance, set once at creation time. */
+  Limits getLimits();
+
+  /** Returns the list of tools available to this agent. */
+  List<Tool> getTools();
+
+  /** Returns the BPMN element ID of the ad-hoc sub-process or AI agent task. */
+  String getElementId();
+
+  /** Returns the key of the process instance that owns this agent instance. */
+  long getProcessInstanceKey();
+
+  /** Returns the key of the root process instance. */
+  Long getRootProcessInstanceKey();
+
+  /** Returns the key of the process definition associated with this agent instance. */
+  long getProcessDefinitionKey();
+
+  /** Returns the BPMN process ID of the associated process definition. */
+  String getProcessDefinitionId();
+
+  /** Returns the version number of the associated process definition. */
+  int getProcessDefinitionVersion();
+
+  /**
+   * Returns the version tag of the associated process definition, or {@code null} if none was
+   * configured.
+   */
+  String getProcessDefinitionVersionTag();
+
+  /** Returns the tenant ID of this agent instance. */
+  String getTenantId();
+
+  /** Returns the timestamp when this agent instance was created. */
+  OffsetDateTime getCreationDate();
+
+  /** Returns the timestamp of the most recent update to this agent instance. */
+  OffsetDateTime getLastUpdatedDate();
+
+  /** Returns the timestamp when this agent instance completed, or {@code null} if still running. */
+  OffsetDateTime getCompletionDate();
+
+  /** Returns the keys of all element instances associated with this agent instance. */
+  List<Long> getElementInstanceKeys();
+
+  /** Static definition of the agent, set once at creation time. */
+  interface Definition {
+
+    /** Returns the LLM model identifier (e.g. {@code gpt-4o}). */
+    String getModel();
+
+    /** Returns the LLM provider (e.g. {@code openai} or {@code anthropic}). */
+    String getProvider();
+
+    /** Returns the system prompt configured for this agent instance. */
+    String getSystemPrompt();
+  }
+
+  /** Aggregated runtime metrics for this agent instance. */
+  interface Metrics {
+
+    /** Returns the total number of input tokens consumed across all model calls. */
+    long getInputTokens();
+
+    /** Returns the total number of output tokens produced across all model calls. */
+    long getOutputTokens();
+
+    /** Returns the total number of LLM calls made. */
+    int getModelCalls();
+
+    /** Returns the total number of tool calls made. */
+    int getToolCalls();
+  }
+
+  /** Configured execution limits for this agent instance. */
+  interface Limits {
+
+    /** Returns the maximum number of LLM calls allowed, or {@code -1} for no limit. */
+    int getMaxModelCalls();
+
+    /** Returns the maximum number of tool calls allowed, or {@code -1} for no limit. */
+    int getMaxToolCalls();
+
+    /** Returns the maximum total tokens allowed, or {@code -1} for no limit. */
+    long getMaxTokens();
+  }
+
+  /** A tool available to the agent. */
+  interface Tool {
+
+    /** Returns the tool name as visible to the LLM. */
+    String getName();
+
+    /** Returns a human-readable description of the tool, or {@code null} if none was configured. */
+    String getDescription();
+
+    /**
+     * Returns the BPMN element ID of the tool element within the ad-hoc sub-process, or {@code
+     * null} if not applicable.
+     */
+    String getElementId();
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/sort/AgentInstanceSort.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/sort/AgentInstanceSort.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.sort;
+
+import io.camunda.client.api.search.request.TypedSortableRequest.SearchRequestSort;
+
+public interface AgentInstanceSort extends SearchRequestSort<AgentInstanceSort> {
+
+  AgentInstanceSort creationDate();
+
+  AgentInstanceSort lastUpdatedDate();
+
+  AgentInstanceSort completionDate();
+
+  AgentInstanceSort status();
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -118,6 +118,7 @@ import io.camunda.client.api.command.UpdateTenantCommandStep1;
 import io.camunda.client.api.command.UpdateTimeoutJobCommandStep1;
 import io.camunda.client.api.command.UpdateUserCommandStep1;
 import io.camunda.client.api.command.UpdateUserTaskCommandStep1;
+import io.camunda.client.api.fetch.AgentInstanceGetRequest;
 import io.camunda.client.api.fetch.AuditLogGetRequest;
 import io.camunda.client.api.fetch.AuthorizationGetRequest;
 import io.camunda.client.api.fetch.AuthorizationsSearchRequest;
@@ -300,6 +301,7 @@ import io.camunda.client.impl.command.UpdateRoleCommandImpl;
 import io.camunda.client.impl.command.UpdateTenantCommandImpl;
 import io.camunda.client.impl.command.UpdateUserCommandImpl;
 import io.camunda.client.impl.command.UpdateUserTaskCommandImpl;
+import io.camunda.client.impl.fetch.AgentInstanceGetRequestImpl;
 import io.camunda.client.impl.fetch.AuditLogGetRequestImpl;
 import io.camunda.client.impl.fetch.AuthorizationGetRequestImpl;
 import io.camunda.client.impl.fetch.BatchOperationGetRequestImpl;
@@ -1748,6 +1750,11 @@ public final class CamundaClientImpl implements CamundaClient {
   @Override
   public GlobalTaskListenerSearchRequest newGlobalTaskListenerSearchRequest() {
     return new GlobalTaskListenerSearchRequestImpl(httpClient, jsonMapper);
+  }
+
+  @Override
+  public AgentInstanceGetRequest newAgentInstanceGetRequest(final long agentInstanceKey) {
+    return new AgentInstanceGetRequestImpl(httpClient, agentInstanceKey);
   }
 
   private JobClient newJobClient() {

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -153,6 +153,7 @@ import io.camunda.client.api.fetch.UserTaskGetRequest;
 import io.camunda.client.api.fetch.VariableGetRequest;
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.response.DocumentReferenceResponse;
+import io.camunda.client.api.search.request.AgentInstanceSearchRequest;
 import io.camunda.client.api.search.request.AuditLogSearchRequest;
 import io.camunda.client.api.search.request.BatchOperationItemSearchRequest;
 import io.camunda.client.api.search.request.BatchOperationSearchRequest;
@@ -335,6 +336,7 @@ import io.camunda.client.impl.fetch.UserTaskGetRequestImpl;
 import io.camunda.client.impl.fetch.VariableGetRequestImpl;
 import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.http.HttpClientFactory;
+import io.camunda.client.impl.search.request.AgentInstanceSearchRequestImpl;
 import io.camunda.client.impl.search.request.AuditLogSearchRequestImpl;
 import io.camunda.client.impl.search.request.AuthorizationsSearchRequestImpl;
 import io.camunda.client.impl.search.request.BatchOperationItemSearchRequestImpl;
@@ -1755,6 +1757,11 @@ public final class CamundaClientImpl implements CamundaClient {
   @Override
   public AgentInstanceGetRequest newAgentInstanceGetRequest(final long agentInstanceKey) {
     return new AgentInstanceGetRequestImpl(httpClient, agentInstanceKey);
+  }
+
+  @Override
+  public AgentInstanceSearchRequest newAgentInstanceSearchRequest() {
+    return new AgentInstanceSearchRequestImpl(httpClient, jsonMapper);
   }
 
   private JobClient newJobClient() {

--- a/clients/java/src/main/java/io/camunda/client/impl/fetch/AgentInstanceGetRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/fetch/AgentInstanceGetRequestImpl.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.fetch;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.fetch.AgentInstanceGetRequest;
+import io.camunda.client.api.search.response.AgentInstance;
+import io.camunda.client.impl.command.ArgumentUtil;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.search.response.AgentInstanceImpl;
+import io.camunda.client.protocol.rest.AgentInstanceResult;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class AgentInstanceGetRequestImpl implements AgentInstanceGetRequest {
+
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+  private final long agentInstanceKey;
+
+  public AgentInstanceGetRequestImpl(final HttpClient httpClient, final long agentInstanceKey) {
+    this.httpClient = httpClient;
+    httpRequestConfig = httpClient.newRequestConfig();
+    ArgumentUtil.ensureGreaterThan("agentInstanceKey", agentInstanceKey, 0);
+    this.agentInstanceKey = agentInstanceKey;
+  }
+
+  @Override
+  public FinalCommandStep<AgentInstance> requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<AgentInstance> send() {
+    final HttpCamundaFuture<AgentInstance> result = new HttpCamundaFuture<>();
+    httpClient.get(
+        "/agent-instances/" + agentInstanceKey,
+        httpRequestConfig.build(),
+        AgentInstanceResult.class,
+        AgentInstanceImpl::new,
+        result);
+    return result;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/AgentInstanceFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/AgentInstanceFilterImpl.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.filter;
+
+import io.camunda.client.api.search.enums.AgentInstanceStatus;
+import io.camunda.client.api.search.filter.AgentInstanceFilter;
+import io.camunda.client.api.search.filter.builder.AgentInstanceStatusProperty;
+import io.camunda.client.api.search.filter.builder.BasicLongProperty;
+import io.camunda.client.api.search.filter.builder.DateTimeProperty;
+import io.camunda.client.api.search.filter.builder.IntegerProperty;
+import io.camunda.client.api.search.filter.builder.StringProperty;
+import io.camunda.client.impl.search.filter.builder.AgentInstanceStatusPropertyImpl;
+import io.camunda.client.impl.search.filter.builder.BasicLongPropertyImpl;
+import io.camunda.client.impl.search.filter.builder.DateTimePropertyImpl;
+import io.camunda.client.impl.search.filter.builder.IntegerPropertyImpl;
+import io.camunda.client.impl.search.filter.builder.StringPropertyImpl;
+import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
+import io.camunda.client.protocol.rest.AgentInstanceKeyFilterProperty;
+import io.camunda.client.protocol.rest.BasicStringFilterProperty;
+import java.util.function.Consumer;
+
+public class AgentInstanceFilterImpl
+    extends TypedSearchRequestPropertyProvider<io.camunda.client.protocol.rest.AgentInstanceFilter>
+    implements AgentInstanceFilter {
+
+  private final io.camunda.client.protocol.rest.AgentInstanceFilter filter;
+
+  public AgentInstanceFilterImpl() {
+    filter = new io.camunda.client.protocol.rest.AgentInstanceFilter();
+  }
+
+  @Override
+  protected io.camunda.client.protocol.rest.AgentInstanceFilter getSearchRequestProperty() {
+    return filter;
+  }
+
+  @Override
+  public AgentInstanceFilter agentInstanceKey(final long value) {
+    return agentInstanceKey(f -> f.eq(value));
+  }
+
+  @Override
+  public AgentInstanceFilter agentInstanceKey(final Consumer<BasicLongProperty> fn) {
+    final BasicLongPropertyImpl property = new BasicLongPropertyImpl();
+    fn.accept(property);
+    filter.setAgentInstanceKey(
+        toAgentInstanceKeyFilterProperty(provideSearchRequestProperty(property)));
+    return this;
+  }
+
+  @Override
+  public AgentInstanceFilter status(final AgentInstanceStatus value) {
+    return status(f -> f.eq(value));
+  }
+
+  @Override
+  public AgentInstanceFilter status(final Consumer<AgentInstanceStatusProperty> fn) {
+    final AgentInstanceStatusProperty property = new AgentInstanceStatusPropertyImpl();
+    fn.accept(property);
+    filter.setStatus(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
+  public AgentInstanceFilter elementId(final String value) {
+    return elementId(f -> f.eq(value));
+  }
+
+  @Override
+  public AgentInstanceFilter elementId(final Consumer<StringProperty> fn) {
+    final StringProperty property = new StringPropertyImpl();
+    fn.accept(property);
+    filter.setElementId(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
+  public AgentInstanceFilter processInstanceKey(final long value) {
+    return processInstanceKey(f -> f.eq(value));
+  }
+
+  @Override
+  public AgentInstanceFilter processInstanceKey(final Consumer<BasicLongProperty> fn) {
+    final BasicLongProperty property = new BasicLongPropertyImpl();
+    fn.accept(property);
+    filter.setProcessInstanceKey(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
+  public AgentInstanceFilter processDefinitionKey(final long value) {
+    return processDefinitionKey(f -> f.eq(value));
+  }
+
+  @Override
+  public AgentInstanceFilter processDefinitionKey(final Consumer<BasicLongProperty> fn) {
+    final BasicLongProperty property = new BasicLongPropertyImpl();
+    fn.accept(property);
+    filter.setProcessDefinitionKey(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
+  public AgentInstanceFilter processDefinitionId(final String value) {
+    return processDefinitionId(f -> f.eq(value));
+  }
+
+  @Override
+  public AgentInstanceFilter processDefinitionId(final Consumer<StringProperty> fn) {
+    final StringProperty property = new StringPropertyImpl();
+    fn.accept(property);
+    filter.setProcessDefinitionId(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
+  public AgentInstanceFilter processDefinitionVersion(final int value) {
+    return processDefinitionVersion(f -> f.eq(value));
+  }
+
+  @Override
+  public AgentInstanceFilter processDefinitionVersion(final Consumer<IntegerProperty> fn) {
+    final IntegerProperty property = new IntegerPropertyImpl();
+    fn.accept(property);
+    filter.setProcessDefinitionVersion(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
+  public AgentInstanceFilter processDefinitionVersionTag(final String value) {
+    return processDefinitionVersionTag(f -> f.eq(value));
+  }
+
+  @Override
+  public AgentInstanceFilter processDefinitionVersionTag(final Consumer<StringProperty> fn) {
+    final StringProperty property = new StringPropertyImpl();
+    fn.accept(property);
+    filter.setProcessDefinitionVersionTag(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
+  public AgentInstanceFilter tenantId(final String value) {
+    return tenantId(f -> f.eq(value));
+  }
+
+  @Override
+  public AgentInstanceFilter tenantId(final Consumer<StringProperty> fn) {
+    final StringProperty property = new StringPropertyImpl();
+    fn.accept(property);
+    filter.setTenantId(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
+  public AgentInstanceFilter creationDate(final Consumer<DateTimeProperty> fn) {
+    final DateTimeProperty property = new DateTimePropertyImpl();
+    fn.accept(property);
+    filter.setCreationDate(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
+  public AgentInstanceFilter lastUpdatedDate(final Consumer<DateTimeProperty> fn) {
+    final DateTimeProperty property = new DateTimePropertyImpl();
+    fn.accept(property);
+    filter.setLastUpdatedDate(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
+  public AgentInstanceFilter completionDate(final Consumer<DateTimeProperty> fn) {
+    final DateTimeProperty property = new DateTimePropertyImpl();
+    fn.accept(property);
+    filter.setCompletionDate(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
+  public AgentInstanceFilter elementInstanceKey(final long value) {
+    return elementInstanceKey(f -> f.eq(value));
+  }
+
+  @Override
+  public AgentInstanceFilter elementInstanceKey(final Consumer<BasicLongProperty> fn) {
+    final BasicLongProperty property = new BasicLongPropertyImpl();
+    fn.accept(property);
+    filter.addElementInstanceKeysItem(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  private AgentInstanceKeyFilterProperty toAgentInstanceKeyFilterProperty(
+      final BasicStringFilterProperty src) {
+    final AgentInstanceKeyFilterProperty dest = new AgentInstanceKeyFilterProperty();
+    dest.set$Eq(src.get$Eq());
+    dest.set$Neq(src.get$Neq());
+    dest.set$Exists(src.get$Exists());
+    dest.set$In(src.get$In());
+    dest.set$NotIn(src.get$NotIn());
+    return dest;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/builder/AgentInstanceStatusPropertyImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/builder/AgentInstanceStatusPropertyImpl.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.filter.builder;
+
+import io.camunda.client.api.search.enums.AgentInstanceStatus;
+import io.camunda.client.api.search.filter.builder.AgentInstanceStatusProperty;
+import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
+import io.camunda.client.impl.util.CollectionUtil;
+import io.camunda.client.impl.util.EnumUtil;
+import io.camunda.client.protocol.rest.AgentInstanceStatusEnum;
+import io.camunda.client.protocol.rest.AgentInstanceStatusFilterProperty;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class AgentInstanceStatusPropertyImpl
+    extends TypedSearchRequestPropertyProvider<AgentInstanceStatusFilterProperty>
+    implements AgentInstanceStatusProperty {
+
+  private final AgentInstanceStatusFilterProperty filterProperty =
+      new AgentInstanceStatusFilterProperty();
+
+  @Override
+  public AgentInstanceStatusProperty eq(final AgentInstanceStatus value) {
+    filterProperty.set$Eq(EnumUtil.convert(value, AgentInstanceStatusEnum.class));
+    return this;
+  }
+
+  @Override
+  public AgentInstanceStatusProperty neq(final AgentInstanceStatus value) {
+    filterProperty.set$Neq(EnumUtil.convert(value, AgentInstanceStatusEnum.class));
+    return this;
+  }
+
+  @Override
+  public AgentInstanceStatusProperty exists(final boolean value) {
+    filterProperty.set$Exists(value);
+    return this;
+  }
+
+  @Override
+  public AgentInstanceStatusProperty in(final List<AgentInstanceStatus> values) {
+    filterProperty.set$In(
+        values.stream()
+            .map(status -> EnumUtil.convert(status, AgentInstanceStatusEnum.class))
+            .collect(Collectors.toList()));
+    return this;
+  }
+
+  @Override
+  public AgentInstanceStatusProperty in(final AgentInstanceStatus... values) {
+    return in(CollectionUtil.toList(values));
+  }
+
+  @Override
+  protected AgentInstanceStatusFilterProperty getSearchRequestProperty() {
+    return filterProperty;
+  }
+
+  @Override
+  public AgentInstanceStatusProperty like(final String value) {
+    filterProperty.set$Like(value);
+    return this;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/AgentInstanceSearchRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/AgentInstanceSearchRequestImpl.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.request;
+
+import static io.camunda.client.api.search.request.SearchRequestBuilders.agentInstanceFilter;
+import static io.camunda.client.api.search.request.SearchRequestBuilders.agentInstanceSort;
+import static io.camunda.client.api.search.request.SearchRequestBuilders.anyPage;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.search.filter.AgentInstanceFilter;
+import io.camunda.client.api.search.page.AnyPage;
+import io.camunda.client.api.search.request.AgentInstanceSearchRequest;
+import io.camunda.client.api.search.request.FinalSearchRequestStep;
+import io.camunda.client.api.search.response.AgentInstance;
+import io.camunda.client.api.search.response.SearchResponse;
+import io.camunda.client.api.search.sort.AgentInstanceSort;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.search.response.SearchResponseMapper;
+import io.camunda.client.protocol.rest.AgentInstanceSearchQuery;
+import io.camunda.client.protocol.rest.AgentInstanceSearchQueryResult;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class AgentInstanceSearchRequestImpl
+    extends TypedSearchRequestPropertyProvider<AgentInstanceSearchQuery>
+    implements AgentInstanceSearchRequest {
+
+  private final AgentInstanceSearchQuery request;
+  private final HttpClient httpClient;
+  private final JsonMapper jsonMapper;
+  private final RequestConfig.Builder httpRequestConfig;
+
+  public AgentInstanceSearchRequestImpl(final HttpClient httpClient, final JsonMapper jsonMapper) {
+    this.httpClient = httpClient;
+    this.jsonMapper = jsonMapper;
+    httpRequestConfig = httpClient.newRequestConfig();
+    request = new AgentInstanceSearchQuery();
+  }
+
+  @Override
+  public FinalSearchRequestStep<AgentInstance> requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<SearchResponse<AgentInstance>> send() {
+    final HttpCamundaFuture<SearchResponse<AgentInstance>> result = new HttpCamundaFuture<>();
+    httpClient.post(
+        "/agent-instances/search",
+        jsonMapper.toJson(request),
+        httpRequestConfig.build(),
+        AgentInstanceSearchQueryResult.class,
+        SearchResponseMapper::toAgentInstanceSearchResponse,
+        result);
+    return result;
+  }
+
+  @Override
+  public AgentInstanceSearchRequest filter(final AgentInstanceFilter value) {
+    request.setFilter(provideSearchRequestProperty(value));
+    return this;
+  }
+
+  @Override
+  public AgentInstanceSearchRequest filter(final Consumer<AgentInstanceFilter> fn) {
+    return filter(agentInstanceFilter(fn));
+  }
+
+  @Override
+  public AgentInstanceSearchRequest page(final AnyPage value) {
+    request.setPage(provideSearchRequestProperty(value));
+    return this;
+  }
+
+  @Override
+  public AgentInstanceSearchRequest page(final Consumer<AnyPage> fn) {
+    return page(anyPage(fn));
+  }
+
+  @Override
+  public AgentInstanceSearchRequest sort(final AgentInstanceSort value) {
+    request.setSort(
+        SearchRequestSortMapper.toAgentInstanceSearchQuerySortRequest(
+            provideSearchRequestProperty(value)));
+    return this;
+  }
+
+  @Override
+  public AgentInstanceSearchRequest sort(final Consumer<AgentInstanceSort> fn) {
+    return sort(agentInstanceSort(fn));
+  }
+
+  @Override
+  protected AgentInstanceSearchQuery getSearchRequestProperty() {
+    return request;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/SearchRequestSortMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/SearchRequestSortMapper.java
@@ -645,6 +645,21 @@ public class SearchRequestSortMapper {
         .collect(Collectors.toList());
   }
 
+  public static List<AgentInstanceSearchQuerySortRequest> toAgentInstanceSearchQuerySortRequest(
+      final List<SearchRequestSort> requests) {
+    return requests.stream()
+        .map(
+            r -> {
+              final AgentInstanceSearchQuerySortRequest request =
+                  new AgentInstanceSearchQuerySortRequest();
+              request.setField(
+                  AgentInstanceSearchQuerySortRequest.FieldEnum.fromValue(r.getField()));
+              request.setOrder(r.getOrder());
+              return request;
+            })
+        .collect(Collectors.toList());
+  }
+
   public static List<ResourceSearchQuerySortRequest> toResourceSearchQuerySortRequest(
       final List<SearchRequestSort> requests) {
     return requests.stream()

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/AgentInstanceImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/AgentInstanceImpl.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.response;
+
+import io.camunda.client.api.search.enums.AgentInstanceStatus;
+import io.camunda.client.api.search.response.AgentInstance;
+import io.camunda.client.impl.util.EnumUtil;
+import io.camunda.client.impl.util.ParseUtil;
+import io.camunda.client.protocol.rest.AgentInstanceResult;
+import io.camunda.client.protocol.rest.AgentTool;
+import java.time.OffsetDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class AgentInstanceImpl implements AgentInstance {
+
+  private final long agentInstanceKey;
+  private final AgentInstanceStatus status;
+  private final Definition definition;
+  private final Metrics metrics;
+  private final Limits limits;
+  private final List<Tool> tools;
+  private final String elementId;
+  private final long processInstanceKey;
+  private final Long rootProcessInstanceKey;
+  private final long processDefinitionKey;
+  private final String processDefinitionId;
+  private final int processDefinitionVersion;
+  private final String processDefinitionVersionTag;
+  private final String tenantId;
+  private final OffsetDateTime creationDate;
+  private final OffsetDateTime lastUpdatedDate;
+  private final OffsetDateTime completionDate;
+  private final List<Long> elementInstanceKeys;
+
+  public AgentInstanceImpl(final AgentInstanceResult result) {
+    agentInstanceKey = Long.parseLong(result.getAgentInstanceKey());
+    status = EnumUtil.convert(result.getStatus(), AgentInstanceStatus.class);
+    definition = new DefinitionImpl(result.getDefinition());
+    metrics = new MetricsImpl(result.getMetrics());
+    limits = new LimitsImpl(result.getLimits());
+    tools =
+        result.getTools() != null
+            ? result.getTools().stream().map(ToolImpl::new).collect(Collectors.toList())
+            : Collections.emptyList();
+    elementId = result.getElementId();
+    processInstanceKey = Long.parseLong(result.getProcessInstanceKey());
+    rootProcessInstanceKey = ParseUtil.parseLongOrNull(result.getRootProcessInstanceKey());
+    processDefinitionKey = Long.parseLong(result.getProcessDefinitionKey());
+    processDefinitionId = result.getProcessDefinitionId();
+    processDefinitionVersion = result.getProcessDefinitionVersion();
+    processDefinitionVersionTag = result.getProcessDefinitionVersionTag();
+    tenantId = result.getTenantId();
+    creationDate = ParseUtil.parseOffsetDateTimeOrNull(result.getCreationDate());
+    lastUpdatedDate = ParseUtil.parseOffsetDateTimeOrNull(result.getLastUpdatedDate());
+    completionDate = ParseUtil.parseOffsetDateTimeOrNull(result.getCompletionDate());
+    elementInstanceKeys =
+        result.getElementInstanceKeys() != null
+            ? result.getElementInstanceKeys().stream()
+                .map(Long::parseLong)
+                .collect(Collectors.toList())
+            : Collections.emptyList();
+  }
+
+  @Override
+  public long getAgentInstanceKey() {
+    return agentInstanceKey;
+  }
+
+  @Override
+  public AgentInstanceStatus getStatus() {
+    return status;
+  }
+
+  @Override
+  public Definition getDefinition() {
+    return definition;
+  }
+
+  @Override
+  public Metrics getMetrics() {
+    return metrics;
+  }
+
+  @Override
+  public Limits getLimits() {
+    return limits;
+  }
+
+  @Override
+  public List<Tool> getTools() {
+    return tools;
+  }
+
+  @Override
+  public String getElementId() {
+    return elementId;
+  }
+
+  @Override
+  public long getProcessInstanceKey() {
+    return processInstanceKey;
+  }
+
+  @Override
+  public Long getRootProcessInstanceKey() {
+    return rootProcessInstanceKey;
+  }
+
+  @Override
+  public long getProcessDefinitionKey() {
+    return processDefinitionKey;
+  }
+
+  @Override
+  public String getProcessDefinitionId() {
+    return processDefinitionId;
+  }
+
+  @Override
+  public int getProcessDefinitionVersion() {
+    return processDefinitionVersion;
+  }
+
+  @Override
+  public String getProcessDefinitionVersionTag() {
+    return processDefinitionVersionTag;
+  }
+
+  @Override
+  public String getTenantId() {
+    return tenantId;
+  }
+
+  @Override
+  public OffsetDateTime getCreationDate() {
+    return creationDate;
+  }
+
+  @Override
+  public OffsetDateTime getLastUpdatedDate() {
+    return lastUpdatedDate;
+  }
+
+  @Override
+  public OffsetDateTime getCompletionDate() {
+    return completionDate;
+  }
+
+  @Override
+  public List<Long> getElementInstanceKeys() {
+    return elementInstanceKeys;
+  }
+
+  private static class DefinitionImpl implements Definition {
+
+    private final String model;
+    private final String provider;
+    private final String systemPrompt;
+
+    DefinitionImpl(final io.camunda.client.protocol.rest.AgentInstanceDefinition proto) {
+      model = proto.getModel();
+      provider = proto.getProvider();
+      systemPrompt = proto.getSystemPrompt();
+    }
+
+    @Override
+    public String getModel() {
+      return model;
+    }
+
+    @Override
+    public String getProvider() {
+      return provider;
+    }
+
+    @Override
+    public String getSystemPrompt() {
+      return systemPrompt;
+    }
+  }
+
+  private static class MetricsImpl implements Metrics {
+
+    private final long inputTokens;
+    private final long outputTokens;
+    private final int modelCalls;
+    private final int toolCalls;
+
+    MetricsImpl(final io.camunda.client.protocol.rest.AgentInstanceMetrics proto) {
+      inputTokens = proto.getInputTokens();
+      outputTokens = proto.getOutputTokens();
+      modelCalls = proto.getModelCalls();
+      toolCalls = proto.getToolCalls();
+    }
+
+    @Override
+    public long getInputTokens() {
+      return inputTokens;
+    }
+
+    @Override
+    public long getOutputTokens() {
+      return outputTokens;
+    }
+
+    @Override
+    public int getModelCalls() {
+      return modelCalls;
+    }
+
+    @Override
+    public int getToolCalls() {
+      return toolCalls;
+    }
+  }
+
+  private static class LimitsImpl implements Limits {
+
+    private final int maxModelCalls;
+    private final int maxToolCalls;
+    private final long maxTokens;
+
+    LimitsImpl(final io.camunda.client.protocol.rest.AgentInstanceLimits proto) {
+      maxModelCalls = proto.getMaxModelCalls();
+      maxToolCalls = proto.getMaxToolCalls();
+      maxTokens = proto.getMaxTokens();
+    }
+
+    @Override
+    public int getMaxModelCalls() {
+      return maxModelCalls;
+    }
+
+    @Override
+    public int getMaxToolCalls() {
+      return maxToolCalls;
+    }
+
+    @Override
+    public long getMaxTokens() {
+      return maxTokens;
+    }
+  }
+
+  private static class ToolImpl implements Tool {
+
+    private final String name;
+    private final String description;
+    private final String elementId;
+
+    ToolImpl(final AgentTool proto) {
+      name = proto.getName();
+      description = proto.getDescription();
+      elementId = proto.getElementId();
+    }
+
+    @Override
+    public String getName() {
+      return name;
+    }
+
+    @Override
+    public String getDescription() {
+      return description;
+    }
+
+    @Override
+    public String getElementId() {
+      return elementId;
+    }
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
@@ -20,6 +20,7 @@ import io.camunda.client.api.response.Resource;
 import io.camunda.client.api.search.enums.OwnerType;
 import io.camunda.client.api.search.enums.PermissionType;
 import io.camunda.client.api.search.enums.ResourceType;
+import io.camunda.client.api.search.response.AgentInstance;
 import io.camunda.client.api.search.response.AuditLogResult;
 import io.camunda.client.api.search.response.Authorization;
 import io.camunda.client.api.search.response.BatchOperation;
@@ -69,6 +70,18 @@ import java.util.stream.Collectors;
 public final class SearchResponseMapper {
 
   private SearchResponseMapper() {}
+
+  public static AgentInstance toAgentInstanceGetResponse(final AgentInstanceResult result) {
+    return new AgentInstanceImpl(result);
+  }
+
+  public static SearchResponse<AgentInstance> toAgentInstanceSearchResponse(
+      final AgentInstanceSearchQueryResult response) {
+    final SearchResponsePage page = toSearchResponsePage(response.getPage());
+    final List<AgentInstance> instances =
+        toSearchResponseInstances(response.getItems(), AgentInstanceImpl::new);
+    return new SearchResponseImpl<>(instances, page);
+  }
 
   public static SearchResponse<ProcessDefinition> toProcessDefinitionSearchResponse(
       final ProcessDefinitionSearchQueryResult response) {

--- a/clients/java/src/main/java/io/camunda/client/impl/search/sort/AgentInstanceSortImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/sort/AgentInstanceSortImpl.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.sort;
+
+import io.camunda.client.api.search.sort.AgentInstanceSort;
+import io.camunda.client.impl.search.request.SearchRequestSortBase;
+
+public class AgentInstanceSortImpl extends SearchRequestSortBase<AgentInstanceSort>
+    implements AgentInstanceSort {
+
+  @Override
+  protected AgentInstanceSort self() {
+    return this;
+  }
+
+  @Override
+  public AgentInstanceSort creationDate() {
+    return field("creationDate");
+  }
+
+  @Override
+  public AgentInstanceSort lastUpdatedDate() {
+    return field("lastUpdatedDate");
+  }
+
+  @Override
+  public AgentInstanceSort completionDate() {
+    return field("completionDate");
+  }
+
+  @Override
+  public AgentInstanceSort status() {
+    return field("status");
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/agentinstance/GetAgentInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/agentinstance/GetAgentInstanceTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.agentinstance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.api.search.enums.AgentInstanceStatus;
+import io.camunda.client.api.search.response.AgentInstance;
+import io.camunda.client.protocol.rest.AgentInstanceDefinition;
+import io.camunda.client.protocol.rest.AgentInstanceLimits;
+import io.camunda.client.protocol.rest.AgentInstanceMetrics;
+import io.camunda.client.protocol.rest.AgentInstanceResult;
+import io.camunda.client.protocol.rest.AgentInstanceStatusEnum;
+import io.camunda.client.protocol.rest.AgentTool;
+import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayService;
+import java.time.OffsetDateTime;
+import java.util.Collections;
+import org.instancio.Instancio;
+import org.junit.jupiter.api.Test;
+
+class GetAgentInstanceTest extends ClientRestTest {
+
+  @Test
+  void shouldGetAgentInstanceByKey() {
+    // given
+    final long agentInstanceKey = 1234L;
+    final OffsetDateTime now = OffsetDateTime.now();
+    final AgentTool tool =
+        new AgentTool().name("search").description("A web search tool").elementId("searchTask");
+
+    gatewayService.onAgentInstanceGetRequest(
+        agentInstanceKey,
+        Instancio.create(AgentInstanceResult.class)
+            .agentInstanceKey(String.valueOf(agentInstanceKey))
+            .status(AgentInstanceStatusEnum.IDLE)
+            .processInstanceKey("9000")
+            .rootProcessInstanceKey("50")
+            .processDefinitionKey("5000")
+            .elementId("agentElement")
+            .processDefinitionId("testProcess")
+            .processDefinitionVersion(2)
+            .processDefinitionVersionTag("v2")
+            .tenantId("<default>")
+            .creationDate(now.toString())
+            .lastUpdatedDate(now.toString())
+            .completionDate(null)
+            .elementInstanceKeys(Collections.singletonList("6000"))
+            .tools(Collections.singletonList(tool))
+            .definition(
+                new AgentInstanceDefinition()
+                    .model("gpt-4o")
+                    .provider("openai")
+                    .systemPrompt("You are a helpful agent"))
+            .metrics(
+                new AgentInstanceMetrics()
+                    .inputTokens(100L)
+                    .outputTokens(200L)
+                    .modelCalls(5)
+                    .toolCalls(3))
+            .limits(new AgentInstanceLimits().maxModelCalls(10).maxToolCalls(20).maxTokens(5000L)));
+
+    // when
+    final AgentInstance result = client.newAgentInstanceGetRequest(agentInstanceKey).send().join();
+
+    // then it sends the correct request
+    final LoggedRequest request = RestGatewayService.getLastRequest();
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.GET);
+    assertThat(request.getUrl()).isEqualTo("/v2/agent-instances/1234");
+    assertThat(request.getBodyAsString()).isEmpty();
+
+    // and maps the response correctly
+    assertSoftly(
+        softly -> {
+          softly
+              .assertThat(result.getAgentInstanceKey())
+              .as("agentInstanceKey")
+              .isEqualTo(agentInstanceKey);
+          softly.assertThat(result.getStatus()).as("status").isEqualTo(AgentInstanceStatus.IDLE);
+          softly
+              .assertThat(result.getProcessInstanceKey())
+              .as("processInstanceKey")
+              .isEqualTo(9000L);
+          softly
+              .assertThat(result.getRootProcessInstanceKey())
+              .as("rootProcessInstanceKey")
+              .isEqualTo(50L);
+          softly
+              .assertThat(result.getProcessDefinitionKey())
+              .as("processDefinitionKey")
+              .isEqualTo(5000L);
+          softly.assertThat(result.getElementId()).as("elementId").isEqualTo("agentElement");
+          softly
+              .assertThat(result.getProcessDefinitionId())
+              .as("processDefinitionId")
+              .isEqualTo("testProcess");
+          softly
+              .assertThat(result.getProcessDefinitionVersion())
+              .as("processDefinitionVersion")
+              .isEqualTo(2);
+          softly
+              .assertThat(result.getProcessDefinitionVersionTag())
+              .as("processDefinitionVersionTag")
+              .isEqualTo("v2");
+          softly.assertThat(result.getTenantId()).as("tenantId").isEqualTo("<default>");
+          softly.assertThat(result.getCreationDate()).as("creationDate").isEqualTo(now);
+          softly.assertThat(result.getLastUpdatedDate()).as("lastUpdatedDate").isEqualTo(now);
+          softly.assertThat(result.getCompletionDate()).as("completionDate").isNull();
+          softly
+              .assertThat(result.getElementInstanceKeys())
+              .as("elementInstanceKeys")
+              .containsExactly(6000L);
+
+          final AgentInstance.Definition definition = result.getDefinition();
+          softly.assertThat(definition.getModel()).as("model").isEqualTo("gpt-4o");
+          softly.assertThat(definition.getProvider()).as("provider").isEqualTo("openai");
+          softly
+              .assertThat(definition.getSystemPrompt())
+              .as("systemPrompt")
+              .isEqualTo("You are a helpful agent");
+
+          final AgentInstance.Metrics metrics = result.getMetrics();
+          softly.assertThat(metrics.getInputTokens()).as("inputTokens").isEqualTo(100L);
+          softly.assertThat(metrics.getOutputTokens()).as("outputTokens").isEqualTo(200L);
+          softly.assertThat(metrics.getModelCalls()).as("modelCalls").isEqualTo(5);
+          softly.assertThat(metrics.getToolCalls()).as("toolCalls").isEqualTo(3);
+
+          final AgentInstance.Limits limits = result.getLimits();
+          softly.assertThat(limits.getMaxModelCalls()).as("maxModelCalls").isEqualTo(10);
+          softly.assertThat(limits.getMaxToolCalls()).as("maxToolCalls").isEqualTo(20);
+          softly.assertThat(limits.getMaxTokens()).as("maxTokens").isEqualTo(5000L);
+
+          softly.assertThat(result.getTools()).as("tools").hasSize(1);
+          final AgentInstance.Tool resultTool = result.getTools().get(0);
+          softly.assertThat(resultTool.getName()).as("tool[0].name").isEqualTo("search");
+          softly
+              .assertThat(resultTool.getDescription())
+              .as("tool[0].description")
+              .isEqualTo("A web search tool");
+          softly
+              .assertThat(resultTool.getElementId())
+              .as("tool[0].elementId")
+              .isEqualTo("searchTask");
+        });
+  }
+
+  @Test
+  void shouldThrowOnInvalidAgentInstanceKey() {
+    assertThatThrownBy(() -> client.newAgentInstanceGetRequest(0).send().join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("agentInstanceKey must be greater than 0");
+
+    assertThatThrownBy(() -> client.newAgentInstanceGetRequest(-1).send().join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("agentInstanceKey must be greater than 0");
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/agentinstance/SearchAgentInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/agentinstance/SearchAgentInstanceTest.java
@@ -1,0 +1,308 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.agentinstance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.assertj.core.groups.Tuple.tuple;
+
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.api.search.enums.AgentInstanceStatus;
+import io.camunda.client.api.search.response.AgentInstance;
+import io.camunda.client.protocol.rest.AgentInstanceDefinition;
+import io.camunda.client.protocol.rest.AgentInstanceLimits;
+import io.camunda.client.protocol.rest.AgentInstanceMetrics;
+import io.camunda.client.protocol.rest.AgentInstanceResult;
+import io.camunda.client.protocol.rest.AgentInstanceSearchQuery;
+import io.camunda.client.protocol.rest.AgentInstanceSearchQueryResult;
+import io.camunda.client.protocol.rest.AgentInstanceSearchQuerySortRequest;
+import io.camunda.client.protocol.rest.AgentInstanceStatusEnum;
+import io.camunda.client.protocol.rest.AgentTool;
+import io.camunda.client.protocol.rest.SearchQueryPageResponse;
+import io.camunda.client.protocol.rest.SortOrderEnum;
+import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayService;
+import java.time.OffsetDateTime;
+import java.util.Collections;
+import org.instancio.Instancio;
+import org.junit.jupiter.api.Test;
+
+class SearchAgentInstanceTest extends ClientRestTest {
+
+  @Test
+  void shouldSearchAgentInstances() {
+    // when
+    client
+        .newAgentInstanceSearchRequest()
+        .filter(f -> f.status(AgentInstanceStatus.IDLE))
+        .sort(s -> s.creationDate().asc())
+        .send()
+        .join();
+
+    // then
+    final LoggedRequest restRequest = RestGatewayService.getLastRequest();
+    assertThat(restRequest.getMethod()).isEqualTo(RequestMethod.POST);
+    assertThat(restRequest.getUrl()).isEqualTo("/v2/agent-instances/search");
+  }
+
+  @Test
+  void shouldSearchAgentInstancesWithoutFilter() {
+    // when
+    client.newAgentInstanceSearchRequest().send().join();
+
+    // then
+    final AgentInstanceSearchQuery request =
+        gatewayService.getLastRequest(AgentInstanceSearchQuery.class);
+    assertThat(request.getFilter()).isNull();
+  }
+
+  @Test
+  void shouldSearchAgentInstancesWithStatusFilter() {
+    // when
+    client
+        .newAgentInstanceSearchRequest()
+        .filter(f -> f.status(AgentInstanceStatus.COMPLETED))
+        .send()
+        .join();
+
+    // then
+    final AgentInstanceSearchQuery request =
+        gatewayService.getLastRequest(AgentInstanceSearchQuery.class);
+    assertThat(request.getFilter()).isNotNull();
+    assertThat(request.getFilter().getStatus().get$Eq())
+        .isEqualTo(io.camunda.client.protocol.rest.AgentInstanceStatusEnum.COMPLETED);
+  }
+
+  @Test
+  void shouldSearchAgentInstancesWithAgentInstanceKeyFilter() {
+    // when
+    client.newAgentInstanceSearchRequest().filter(f -> f.agentInstanceKey(1234L)).send().join();
+
+    // then
+    final AgentInstanceSearchQuery request =
+        gatewayService.getLastRequest(AgentInstanceSearchQuery.class);
+    assertThat(request.getFilter().getAgentInstanceKey().get$Eq()).isEqualTo("1234");
+  }
+
+  @Test
+  void shouldSearchAgentInstancesWithProcessInstanceKeyFilter() {
+    // when
+    client.newAgentInstanceSearchRequest().filter(f -> f.processInstanceKey(9000L)).send().join();
+
+    // then
+    final AgentInstanceSearchQuery request =
+        gatewayService.getLastRequest(AgentInstanceSearchQuery.class);
+    assertThat(request.getFilter().getProcessInstanceKey().get$Eq()).isEqualTo("9000");
+  }
+
+  @Test
+  void shouldSearchAgentInstancesWithProcessDefinitionKeyFilter() {
+    // when
+    client.newAgentInstanceSearchRequest().filter(f -> f.processDefinitionKey(5000L)).send().join();
+
+    // then
+    final AgentInstanceSearchQuery request =
+        gatewayService.getLastRequest(AgentInstanceSearchQuery.class);
+    assertThat(request.getFilter().getProcessDefinitionKey().get$Eq()).isEqualTo("5000");
+  }
+
+  @Test
+  void shouldSearchAgentInstancesWithElementInstanceKeyFilter() {
+    // when
+    client.newAgentInstanceSearchRequest().filter(f -> f.elementInstanceKey(6000L)).send().join();
+
+    // then
+    final AgentInstanceSearchQuery request =
+        gatewayService.getLastRequest(AgentInstanceSearchQuery.class);
+    assertThat(request.getFilter().getElementInstanceKeys()).hasSize(1);
+    assertThat(request.getFilter().getElementInstanceKeys().get(0).get$Eq()).isEqualTo("6000");
+  }
+
+  @Test
+  void shouldSearchAgentInstancesWithProcessDefinitionFilters() {
+    // when
+    client
+        .newAgentInstanceSearchRequest()
+        .filter(
+            f ->
+                f.processDefinitionId("testProcess")
+                    .processDefinitionVersion(2)
+                    .processDefinitionVersionTag("v2"))
+        .send()
+        .join();
+
+    // then
+    final AgentInstanceSearchQuery request =
+        gatewayService.getLastRequest(AgentInstanceSearchQuery.class);
+    assertThat(request.getFilter().getProcessDefinitionId().get$Eq()).isEqualTo("testProcess");
+    assertThat(request.getFilter().getProcessDefinitionVersion().get$Eq()).isEqualTo(2);
+    assertThat(request.getFilter().getProcessDefinitionVersionTag().get$Eq()).isEqualTo("v2");
+  }
+
+  @Test
+  void shouldSearchAgentInstancesWithFullSorting() {
+    // when
+    client
+        .newAgentInstanceSearchRequest()
+        .sort(
+            s ->
+                s.creationDate()
+                    .asc()
+                    .lastUpdatedDate()
+                    .desc()
+                    .completionDate()
+                    .asc()
+                    .status()
+                    .asc())
+        .send()
+        .join();
+
+    // then
+    final AgentInstanceSearchQuery request =
+        gatewayService.getLastRequest(AgentInstanceSearchQuery.class);
+    assertThat(request.getSort())
+        .as("sort fields and orders")
+        .extracting(
+            AgentInstanceSearchQuerySortRequest::getField,
+            AgentInstanceSearchQuerySortRequest::getOrder)
+        .containsExactly(
+            tuple(AgentInstanceSearchQuerySortRequest.FieldEnum.CREATION_DATE, SortOrderEnum.ASC),
+            tuple(
+                AgentInstanceSearchQuerySortRequest.FieldEnum.LAST_UPDATED_DATE,
+                SortOrderEnum.DESC),
+            tuple(AgentInstanceSearchQuerySortRequest.FieldEnum.COMPLETION_DATE, SortOrderEnum.ASC),
+            tuple(AgentInstanceSearchQuerySortRequest.FieldEnum.STATUS, SortOrderEnum.ASC));
+  }
+
+  @Test
+  void shouldMapSearchAgentInstancesResponse() {
+    // given
+    final OffsetDateTime now = OffsetDateTime.now();
+    final AgentTool tool =
+        new AgentTool().name("search").description("A web search tool").elementId("searchTask");
+    final AgentInstanceResult provided =
+        Instancio.create(AgentInstanceResult.class)
+            .agentInstanceKey("42")
+            .status(AgentInstanceStatusEnum.COMPLETED)
+            .processInstanceKey("10")
+            .rootProcessInstanceKey("5")
+            .processDefinitionKey("100")
+            .processDefinitionId("testProcess")
+            .processDefinitionVersion(1)
+            .processDefinitionVersionTag("v1")
+            .tenantId("<default>")
+            .elementId("agentElement")
+            .elementInstanceKeys(Collections.singletonList("6000"))
+            .tools(Collections.singletonList(tool))
+            .definition(
+                new AgentInstanceDefinition()
+                    .model("gpt-4o")
+                    .provider("openai")
+                    .systemPrompt("You are helpful"))
+            .metrics(
+                new AgentInstanceMetrics()
+                    .inputTokens(50L)
+                    .outputTokens(100L)
+                    .modelCalls(2)
+                    .toolCalls(1))
+            .limits(new AgentInstanceLimits().maxTokens(1000L).maxModelCalls(5).maxToolCalls(10))
+            .creationDate(now.toString())
+            .lastUpdatedDate(now.toString())
+            .completionDate(now.toString());
+
+    gatewayService.onAgentInstanceSearchRequest(
+        Instancio.create(AgentInstanceSearchQueryResult.class)
+            .page(
+                Instancio.create(SearchQueryPageResponse.class)
+                    .totalItems(1L)
+                    .hasMoreTotalItems(false))
+            .items(Collections.singletonList(provided)));
+
+    // when
+    final io.camunda.client.api.search.response.SearchResponse<AgentInstance> result =
+        client.newAgentInstanceSearchRequest().send().join();
+
+    // then
+    assertSoftly(
+        softly -> {
+          softly.assertThat(result.page().totalItems()).isEqualTo(1);
+          softly.assertThat(result.items()).hasSize(1);
+
+          final AgentInstance item = result.items().get(0);
+          softly.assertThat(item.getAgentInstanceKey()).as("agentInstanceKey").isEqualTo(42L);
+          softly.assertThat(item.getStatus()).as("status").isEqualTo(AgentInstanceStatus.COMPLETED);
+          softly.assertThat(item.getProcessInstanceKey()).as("processInstanceKey").isEqualTo(10L);
+          softly
+              .assertThat(item.getRootProcessInstanceKey())
+              .as("rootProcessInstanceKey")
+              .isEqualTo(5L);
+          softly
+              .assertThat(item.getProcessDefinitionKey())
+              .as("processDefinitionKey")
+              .isEqualTo(100L);
+          softly
+              .assertThat(item.getProcessDefinitionId())
+              .as("processDefinitionId")
+              .isEqualTo("testProcess");
+          softly
+              .assertThat(item.getProcessDefinitionVersion())
+              .as("processDefinitionVersion")
+              .isEqualTo(1);
+          softly
+              .assertThat(item.getProcessDefinitionVersionTag())
+              .as("processDefinitionVersionTag")
+              .isEqualTo("v1");
+          softly.assertThat(item.getTenantId()).as("tenantId").isEqualTo("<default>");
+          softly.assertThat(item.getElementId()).as("elementId").isEqualTo("agentElement");
+          softly
+              .assertThat(item.getElementInstanceKeys())
+              .as("elementInstanceKeys")
+              .containsExactly(6000L);
+          softly.assertThat(item.getCreationDate()).as("creationDate").isEqualTo(now);
+          softly.assertThat(item.getLastUpdatedDate()).as("lastUpdatedDate").isEqualTo(now);
+          softly.assertThat(item.getCompletionDate()).as("completionDate").isEqualTo(now);
+
+          final AgentInstance.Definition definition = item.getDefinition();
+          softly.assertThat(definition.getModel()).as("model").isEqualTo("gpt-4o");
+          softly.assertThat(definition.getProvider()).as("provider").isEqualTo("openai");
+          softly
+              .assertThat(definition.getSystemPrompt())
+              .as("systemPrompt")
+              .isEqualTo("You are helpful");
+
+          final AgentInstance.Metrics metrics = item.getMetrics();
+          softly.assertThat(metrics.getInputTokens()).as("inputTokens").isEqualTo(50L);
+          softly.assertThat(metrics.getOutputTokens()).as("outputTokens").isEqualTo(100L);
+          softly.assertThat(metrics.getModelCalls()).as("modelCalls").isEqualTo(2);
+          softly.assertThat(metrics.getToolCalls()).as("toolCalls").isEqualTo(1);
+
+          final AgentInstance.Limits limits = item.getLimits();
+          softly.assertThat(limits.getMaxTokens()).as("maxTokens").isEqualTo(1000L);
+          softly.assertThat(limits.getMaxModelCalls()).as("maxModelCalls").isEqualTo(5);
+          softly.assertThat(limits.getMaxToolCalls()).as("maxToolCalls").isEqualTo(10);
+
+          softly.assertThat(item.getTools()).as("tools").hasSize(1);
+          final AgentInstance.Tool resultTool = item.getTools().get(0);
+          softly.assertThat(resultTool.getName()).as("tool.name").isEqualTo("search");
+          softly
+              .assertThat(resultTool.getDescription())
+              .as("tool.description")
+              .isEqualTo("A web search tool");
+          softly.assertThat(resultTool.getElementId()).as("tool.elementId").isEqualTo("searchTask");
+        });
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
@@ -21,6 +21,9 @@ public class RestGatewayPaths {
 
   private static final String URL_AUTHORIZATION = REST_API_PATH + "/authorizations/%s";
   private static final String URL_AUTHORIZATIONS = REST_API_PATH + "/authorizations";
+  private static final String URL_AGENT_INSTANCE = REST_API_PATH + "/agent-instances/%s";
+  private static final String URL_AGENT_INSTANCES_SEARCH =
+      REST_API_PATH + "/agent-instances/search";
   private static final String URL_BATCH_OPERATION = REST_API_PATH + "/batch-operations/%s";
   private static final String URL_BATCH_OPERATIONS_SEARCH =
       REST_API_PATH + "/batch-operations/search";
@@ -484,6 +487,14 @@ public class RestGatewayPaths {
 
   public static String getJobErrorStatisticsUrl() {
     return URL_JOB_ERROR_STATISTICS;
+  }
+
+  public static String getAgentInstanceUrl(final long agentInstanceKey) {
+    return String.format(URL_AGENT_INSTANCE, agentInstanceKey);
+  }
+
+  public static String getAgentInstancesSearchUrl() {
+    return URL_AGENT_INSTANCES_SEARCH;
   }
 
   public static String getResourceDeletionUrl(final long resourceKey) {

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
@@ -21,6 +21,8 @@ import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import io.camunda.client.impl.CamundaObjectMapper;
+import io.camunda.client.protocol.rest.AgentInstanceResult;
+import io.camunda.client.protocol.rest.AgentInstanceSearchQueryResult;
 import io.camunda.client.protocol.rest.AuditLogResult;
 import io.camunda.client.protocol.rest.AuditLogSearchQueryResult;
 import io.camunda.client.protocol.rest.AuthorizationCreateResult;
@@ -363,6 +365,15 @@ public class RestGatewayService {
   public void onBatchOperationRequest(
       final String batchOperationKey, final BatchOperationResponse response) {
     registerGet(RestGatewayPaths.getBatchOperationUrl(batchOperationKey), response);
+  }
+
+  public void onAgentInstanceGetRequest(
+      final long agentInstanceKey, final AgentInstanceResult response) {
+    registerGet(RestGatewayPaths.getAgentInstanceUrl(agentInstanceKey), response);
+  }
+
+  public void onAgentInstanceSearchRequest(final AgentInstanceSearchQueryResult response) {
+    registerPost(RestGatewayPaths.getAgentInstancesSearchUrl(), response);
   }
 
   public void onSearchBatchOperationsRequest(final BatchOperationSearchQueryResult response) {

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
@@ -1542,6 +1542,15 @@ public class SearchQueryFilterMapper {
             .map(elementInstanceKeyMapper)
             .forEach(builder::elementInstanceKeyOperations);
       }
+      ofNullable(filter.getProcessDefinitionId())
+          .map(mapToStringOperations())
+          .ifPresent(builder::processDefinitionIdOperations);
+      ofNullable(filter.getProcessDefinitionVersion())
+          .map(mapToIntegerOperations("processDefinitionVersion", validationErrors))
+          .ifPresent(builder::processDefinitionVersionOperations);
+      ofNullable(filter.getProcessDefinitionVersionTag())
+          .map(mapToStringOperations())
+          .ifPresent(builder::versionTagOperations);
     }
 
     return validationErrors.isEmpty()

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceFetchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceFetchIT.java
@@ -1,0 +1,278 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForAgentInstanceToBeIndexed;
+import static io.camunda.it.util.TestHelper.waitForAgentInstanceWithStatusToBeIndexed;
+import static io.camunda.it.util.TestHelper.waitForElementInstances;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.assertj.core.groups.Tuple.tuple;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.ProblemDetail;
+import io.camunda.client.api.command.AgentInstanceUpdateStatus;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.command.UpdateAgentInstanceCommandStep1.AgentTool;
+import io.camunda.client.api.search.enums.AgentInstanceStatus;
+import io.camunda.client.api.search.response.AgentInstance.Tool;
+import io.camunda.qa.util.compatibility.CompatibilityTest;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import java.util.List;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@CompatibilityTest
+// TODO: Remove @DisabledIfSystemProperty once RDBMS AgentInstance search is implemented (PR #53922)
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
+public class AgentInstanceFetchIT {
+
+  private static final String AGENT_ELEMENT_ID = "agentAhsp";
+
+  private static CamundaClient camundaClient;
+
+  // agentInstance1: created with required fields only (no limits, no tools)
+  private static long agentInstanceKey1;
+  private static long processInstanceKey1;
+
+  // agentInstance2: created with limits and updated with tools
+  private static long agentInstanceKey2;
+  private static long processInstanceKey2;
+
+  private static String bpmnProcessId;
+
+  @BeforeAll
+  static void setup() {
+    final var processModel =
+        Bpmn.createExecutableProcess("AgentInstanceFetchProcess")
+            .startEvent()
+            .adHocSubProcess(AGENT_ELEMENT_ID, p -> p.task("agentTask"))
+            .zeebeJobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
+            .moveToActivity(AGENT_ELEMENT_ID)
+            .endEvent("end")
+            .done();
+
+    final var process = deployProcessAndWaitForIt(camundaClient, processModel, "agent-fetch.bpmn");
+    bpmnProcessId = process.getBpmnProcessId();
+
+    // — agentInstance1: minimal CREATE (no limits, no tools) —
+    final var pi1 = startProcessInstance(camundaClient, bpmnProcessId);
+    processInstanceKey1 = pi1.getProcessInstanceKey();
+    waitForElementInstances(
+        camundaClient,
+        f -> f.elementId(AGENT_ELEMENT_ID).processInstanceKey(processInstanceKey1),
+        1);
+    final var ei1 =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .filter(f -> f.elementId(AGENT_ELEMENT_ID).processInstanceKey(processInstanceKey1))
+            .execute()
+            .items()
+            .getFirst()
+            .getElementInstanceKey();
+
+    agentInstanceKey1 =
+        camundaClient
+            .newCreateAgentInstanceCommand()
+            .elementInstanceKey(ei1)
+            .model("gpt-4o")
+            .provider("openai")
+            .systemPrompt("You are a helpful assistant.")
+            .send()
+            .join()
+            .getAgentInstanceKey();
+
+    // — agentInstance2: CREATE with limits + UPDATE with tools —
+    final var pi2 = startProcessInstance(camundaClient, bpmnProcessId);
+    processInstanceKey2 = pi2.getProcessInstanceKey();
+    waitForElementInstances(
+        camundaClient,
+        f -> f.elementId(AGENT_ELEMENT_ID).processInstanceKey(processInstanceKey2),
+        1);
+    final var ei2 =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .filter(f -> f.elementId(AGENT_ELEMENT_ID).processInstanceKey(processInstanceKey2))
+            .execute()
+            .items()
+            .getFirst()
+            .getElementInstanceKey();
+
+    agentInstanceKey2 =
+        camundaClient
+            .newCreateAgentInstanceCommand()
+            .elementInstanceKey(ei2)
+            .model("gpt-4o")
+            .provider("openai")
+            .systemPrompt("You are a helpful assistant.")
+            .maxTokens(5000L)
+            .maxModelCalls(10)
+            .maxToolCalls(20)
+            .send()
+            .join()
+            .getAgentInstanceKey();
+
+    camundaClient
+        .newUpdateAgentInstanceCommand(agentInstanceKey2)
+        .elementInstanceKey(ei2)
+        .status(AgentInstanceUpdateStatus.THINKING)
+        .tools(
+            List.of(
+                AgentTool.of("search", "Search the web", "searchTask"), AgentTool.of("summarize")))
+        .inputTokens(150L)
+        .outputTokens(300L)
+        .modelCalls(3)
+        .toolCalls(2)
+        .send()
+        .join();
+
+    // Wait until both are indexed
+    waitForAgentInstanceToBeIndexed(camundaClient, agentInstanceKey1);
+    waitForAgentInstanceWithStatusToBeIndexed(
+        camundaClient, agentInstanceKey2, AgentInstanceStatus.THINKING);
+  }
+
+  @Test
+  void shouldGetAgentInstanceWithRequiredProperties() {
+    // when
+    final var response = camundaClient.newAgentInstanceGetRequest(agentInstanceKey1).execute();
+
+    // then — verifies identity and engine-derived properties
+    assertSoftly(
+        softly -> {
+          softly
+              .assertThat(response.getAgentInstanceKey())
+              .as("agentInstanceKey")
+              .isEqualTo(agentInstanceKey1);
+          softly.assertThat(response.getElementId()).as("elementId").isEqualTo(AGENT_ELEMENT_ID);
+          softly
+              .assertThat(response.getProcessInstanceKey())
+              .as("processInstanceKey")
+              .isEqualTo(processInstanceKey1);
+          softly
+              .assertThat(response.getRootProcessInstanceKey())
+              .as("rootProcessInstanceKey")
+              .isEqualTo(-1L);
+          softly
+              .assertThat(response.getProcessDefinitionId())
+              .as("processDefinitionId")
+              .isEqualTo(bpmnProcessId);
+          softly
+              .assertThat(response.getProcessDefinitionVersion())
+              .as("processDefinitionVersion")
+              .isGreaterThan(0);
+          softly
+              .assertThat(response.getProcessDefinitionVersionTag())
+              .as("processDefinitionVersionTag")
+              .isNull();
+          softly.assertThat(response.getTenantId()).as("tenantId").isNotNull();
+          softly.assertThat(response.getCreationDate()).as("creationDate").isNotNull();
+          softly.assertThat(response.getLastUpdatedDate()).as("lastUpdatedDate").isNotNull();
+          softly.assertThat(response.getCompletionDate()).as("completionDate").isNull();
+
+          final var definition = response.getDefinition();
+          softly.assertThat(definition.getModel()).as("definition.model").isEqualTo("gpt-4o");
+          softly.assertThat(definition.getProvider()).as("definition.provider").isEqualTo("openai");
+          softly
+              .assertThat(definition.getSystemPrompt())
+              .as("definition.systemPrompt")
+              .isEqualTo("You are a helpful assistant.");
+
+          final var metrics = response.getMetrics();
+          softly.assertThat(metrics).as("metrics").isNotNull();
+          softly.assertThat(metrics.getInputTokens()).as("metrics.inputTokens").isEqualTo(0L);
+          softly.assertThat(metrics.getOutputTokens()).as("metrics.outputTokens").isEqualTo(0L);
+          softly.assertThat(metrics.getModelCalls()).as("metrics.modelCalls").isEqualTo(0);
+          softly.assertThat(metrics.getToolCalls()).as("metrics.toolCalls").isEqualTo(0);
+
+          softly.assertThat(response.getTools()).as("tools").isEmpty();
+        });
+  }
+
+  @Test
+  void shouldGetAgentInstanceWithAllProperties() {
+    // when
+    final var response = camundaClient.newAgentInstanceGetRequest(agentInstanceKey2).execute();
+
+    // then — verifies all user-provided (CREATE + UPDATE) and engine-derived properties
+    assertSoftly(
+        softly -> {
+          softly
+              .assertThat(response.getAgentInstanceKey())
+              .as("agentInstanceKey")
+              .isEqualTo(agentInstanceKey2);
+          softly.assertThat(response.getElementId()).as("elementId").isEqualTo(AGENT_ELEMENT_ID);
+          softly
+              .assertThat(response.getProcessInstanceKey())
+              .as("processInstanceKey")
+              .isEqualTo(processInstanceKey2);
+          softly
+              .assertThat(response.getRootProcessInstanceKey())
+              .as("rootProcessInstanceKey")
+              .isEqualTo(-1L);
+          softly
+              .assertThat(response.getProcessDefinitionId())
+              .as("processDefinitionId")
+              .isEqualTo(bpmnProcessId);
+          softly.assertThat(response.getTenantId()).as("tenantId").isNotNull();
+          softly.assertThat(response.getCreationDate()).as("creationDate").isNotNull();
+          softly.assertThat(response.getLastUpdatedDate()).as("lastUpdatedDate").isNotNull();
+          softly.assertThat(response.getCompletionDate()).as("completionDate").isNull();
+
+          final var definition = response.getDefinition();
+          softly.assertThat(definition.getModel()).as("definition.model").isEqualTo("gpt-4o");
+          softly.assertThat(definition.getProvider()).as("definition.provider").isEqualTo("openai");
+          softly
+              .assertThat(definition.getSystemPrompt())
+              .as("definition.systemPrompt")
+              .isEqualTo("You are a helpful assistant.");
+
+          final var limits = response.getLimits();
+          softly.assertThat(limits.getMaxTokens()).as("limits.maxTokens").isEqualTo(5000L);
+          softly.assertThat(limits.getMaxModelCalls()).as("limits.maxModelCalls").isEqualTo(10);
+          softly.assertThat(limits.getMaxToolCalls()).as("limits.maxToolCalls").isEqualTo(20);
+
+          final var metrics = response.getMetrics();
+          softly.assertThat(metrics.getInputTokens()).as("metrics.inputTokens").isEqualTo(150L);
+          softly.assertThat(metrics.getOutputTokens()).as("metrics.outputTokens").isEqualTo(300L);
+          softly.assertThat(metrics.getModelCalls()).as("metrics.modelCalls").isEqualTo(3);
+          softly.assertThat(metrics.getToolCalls()).as("metrics.toolCalls").isEqualTo(2);
+
+          final var tools = response.getTools();
+          softly.assertThat(tools).as("tools").hasSize(2);
+          softly
+              .assertThat(tools)
+              .as("tools")
+              .extracting(Tool::getName, Tool::getElementId, Tool::getDescription)
+              .containsExactly(
+                  tuple("search", "searchTask", "Search the web"), tuple("summarize", null, null));
+        });
+  }
+
+  @Test
+  void shouldReturnNotFoundForUnknownKey() {
+    // when
+    final var problemException =
+        assertThatExceptionOfType(ProblemException.class)
+            .isThrownBy(() -> camundaClient.newAgentInstanceGetRequest(Long.MAX_VALUE).execute())
+            .actual();
+
+    // then
+    assertThat(problemException.code()).isEqualTo(404);
+    final ProblemDetail details = problemException.details();
+    assertThat(details.getDetail())
+        .contains("Agent Instance with key '%d' not found".formatted(Long.MAX_VALUE));
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceFetchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceFetchIT.java
@@ -31,12 +31,9 @@ import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import java.util.List;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @MultiDbTest
 @CompatibilityTest
-// TODO: Remove @DisabledIfSystemProperty once RDBMS AgentInstance search is implemented (PR #53922)
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
 public class AgentInstanceFetchIT {
 
   private static final String AGENT_ELEMENT_ID = "agentAhsp";

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceSearchIT.java
@@ -26,12 +26,9 @@ import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @MultiDbTest
 @CompatibilityTest
-// TODO: Remove @DisabledIfSystemProperty once RDBMS AgentInstance search is implemented (PR #53922)
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
 public class AgentInstanceSearchIT {
 
   private static final String AGENT_ELEMENT_ID = "agentAhsp";

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceSearchIT.java
@@ -1,0 +1,385 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForAgentInstanceToBeIndexed;
+import static io.camunda.it.util.TestHelper.waitForAgentInstanceWithStatusToBeIndexed;
+import static io.camunda.it.util.TestHelper.waitForElementInstances;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.AgentInstanceUpdateStatus;
+import io.camunda.client.api.search.enums.AgentInstanceStatus;
+import io.camunda.client.api.search.response.AgentInstance;
+import io.camunda.qa.util.compatibility.CompatibilityTest;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@CompatibilityTest
+// TODO: Remove @DisabledIfSystemProperty once RDBMS AgentInstance search is implemented (PR #53922)
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
+public class AgentInstanceSearchIT {
+
+  private static final String AGENT_ELEMENT_ID = "agentAhsp";
+
+  private static CamundaClient camundaClient;
+
+  // Three separate process instances so each CREATE targets a unique elementInstanceKey.
+  // ai1 + ai2 belong to processDefinition1; ai3 belongs to processDefinition2.
+  private static long agentInstanceKey1;
+  private static long agentInstanceKey2;
+  private static long agentInstanceKey3;
+  private static long processInstanceKey1;
+  private static long processDefinitionKey;
+  private static String processDefinitionId;
+  private static long processDefinitionKey2;
+  private static String processDefinitionId2;
+
+  @BeforeAll
+  static void setup() {
+    // Process definition 1 — ai1 (CREATE + UPDATE) and ai2 (CREATE only) belong here.
+    final var processModel1 =
+        Bpmn.createExecutableProcess("AgentInstanceSearchProcess1")
+            .startEvent()
+            .adHocSubProcess(AGENT_ELEMENT_ID, p -> p.task("agentTask"))
+            .zeebeJobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
+            .moveToActivity(AGENT_ELEMENT_ID)
+            .endEvent("end")
+            .done();
+
+    final var process1 =
+        deployProcessAndWaitForIt(camundaClient, processModel1, "agent-search-1.bpmn");
+    processDefinitionKey = process1.getProcessDefinitionKey();
+    processDefinitionId = process1.getBpmnProcessId();
+
+    // Process definition 2 — ai3 (CREATE only) belongs here.
+    final var processModel2 =
+        Bpmn.createExecutableProcess("AgentInstanceSearchProcess2")
+            .startEvent()
+            .adHocSubProcess(AGENT_ELEMENT_ID, p -> p.task("agentTask"))
+            .zeebeJobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
+            .moveToActivity(AGENT_ELEMENT_ID)
+            .endEvent("end")
+            .done();
+
+    final var process2 =
+        deployProcessAndWaitForIt(camundaClient, processModel2, "agent-search-2.bpmn");
+    processDefinitionKey2 = process2.getProcessDefinitionKey();
+    processDefinitionId2 = process2.getBpmnProcessId();
+
+    // — pi1 → ei1 → ai1: CREATE + UPDATE (THINKING) —
+    final var pi1 = startProcessInstance(camundaClient, processDefinitionId);
+    processInstanceKey1 = pi1.getProcessInstanceKey();
+    waitForElementInstances(
+        camundaClient,
+        f -> f.elementId(AGENT_ELEMENT_ID).processInstanceKey(processInstanceKey1),
+        1);
+    final long ei1 =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .filter(f -> f.elementId(AGENT_ELEMENT_ID).processInstanceKey(processInstanceKey1))
+            .execute()
+            .items()
+            .getFirst()
+            .getElementInstanceKey();
+
+    agentInstanceKey1 =
+        camundaClient
+            .newCreateAgentInstanceCommand()
+            .elementInstanceKey(ei1)
+            .model("gpt-4o")
+            .provider("openai")
+            .systemPrompt("You are a search assistant.")
+            .send()
+            .join()
+            .getAgentInstanceKey();
+
+    camundaClient
+        .newUpdateAgentInstanceCommand(agentInstanceKey1)
+        .elementInstanceKey(ei1)
+        .status(AgentInstanceUpdateStatus.THINKING)
+        .send()
+        .join();
+
+    // — pi2 → ei2 → ai2: CREATE only (INITIALIZING) —
+    final var pi2 = startProcessInstance(camundaClient, processDefinitionId);
+    final long processInstanceKey2 = pi2.getProcessInstanceKey();
+    waitForElementInstances(
+        camundaClient,
+        f -> f.elementId(AGENT_ELEMENT_ID).processInstanceKey(processInstanceKey2),
+        1);
+    final long ei2 =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .filter(f -> f.elementId(AGENT_ELEMENT_ID).processInstanceKey(processInstanceKey2))
+            .execute()
+            .items()
+            .getFirst()
+            .getElementInstanceKey();
+
+    agentInstanceKey2 =
+        camundaClient
+            .newCreateAgentInstanceCommand()
+            .elementInstanceKey(ei2)
+            .model("claude-3-5-sonnet")
+            .provider("anthropic")
+            .systemPrompt("You are a code reviewer.")
+            .send()
+            .join()
+            .getAgentInstanceKey();
+
+    // — pi3 → ei3 → ai3: CREATE only (INITIALIZING), from processDefinition2 —
+    final var pi3 = startProcessInstance(camundaClient, processDefinitionId2);
+    final long processInstanceKey3 = pi3.getProcessInstanceKey();
+    waitForElementInstances(
+        camundaClient,
+        f -> f.elementId(AGENT_ELEMENT_ID).processInstanceKey(processInstanceKey3),
+        1);
+    final long ei3 =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .filter(f -> f.elementId(AGENT_ELEMENT_ID).processInstanceKey(processInstanceKey3))
+            .execute()
+            .items()
+            .getFirst()
+            .getElementInstanceKey();
+
+    agentInstanceKey3 =
+        camundaClient
+            .newCreateAgentInstanceCommand()
+            .elementInstanceKey(ei3)
+            .model("gpt-4o-mini")
+            .provider("openai")
+            .systemPrompt("You are a summarizer.")
+            .send()
+            .join()
+            .getAgentInstanceKey();
+
+    // Wait until all are indexed
+    waitForAgentInstanceWithStatusToBeIndexed(
+        camundaClient, agentInstanceKey1, AgentInstanceStatus.THINKING);
+    waitForAgentInstanceToBeIndexed(camundaClient, agentInstanceKey2);
+    waitForAgentInstanceToBeIndexed(camundaClient, agentInstanceKey3);
+  }
+
+  @Test
+  void shouldSearchReturnAgentInstances() {
+    // when
+    final var response = camundaClient.newAgentInstanceSearchRequest().execute();
+
+    // then
+    assertThat(response.items())
+        .extracting(AgentInstance::getAgentInstanceKey)
+        .containsExactlyInAnyOrder(agentInstanceKey1, agentInstanceKey2, agentInstanceKey3);
+  }
+
+  @Test
+  void shouldFilterByAgentInstanceKey() {
+    // when
+    final var response =
+        camundaClient
+            .newAgentInstanceSearchRequest()
+            .filter(f -> f.agentInstanceKey(agentInstanceKey2))
+            .execute();
+
+    // then
+    assertThat(response.items())
+        .singleElement()
+        .satisfies(ai -> assertThat(ai.getAgentInstanceKey()).isEqualTo(agentInstanceKey2));
+  }
+
+  @Test
+  void shouldFilterByStatus() {
+    // when
+    final var response =
+        camundaClient
+            .newAgentInstanceSearchRequest()
+            .filter(
+                f ->
+                    f.processDefinitionKey(processDefinitionKey)
+                        .status(AgentInstanceStatus.THINKING))
+            .execute();
+
+    // then
+    assertThat(response.items())
+        .singleElement()
+        .satisfies(
+            ai -> {
+              assertThat(ai.getAgentInstanceKey()).isEqualTo(agentInstanceKey1);
+              assertThat(ai.getStatus()).isEqualTo(AgentInstanceStatus.THINKING);
+            });
+  }
+
+  @Test
+  void shouldFilterByProcessInstanceKey() {
+    // when
+    final var response =
+        camundaClient
+            .newAgentInstanceSearchRequest()
+            .filter(f -> f.processInstanceKey(processInstanceKey1))
+            .execute();
+
+    // then
+    assertThat(response.items())
+        .singleElement()
+        .satisfies(
+            ai -> {
+              assertThat(ai.getAgentInstanceKey()).isEqualTo(agentInstanceKey1);
+              assertThat(ai.getProcessInstanceKey()).isEqualTo(processInstanceKey1);
+            });
+  }
+
+  @Test
+  void shouldFilterByProcessDefinitionKey() {
+    // when — pd1 has 2 agent instances
+    final var responsePd1 =
+        camundaClient
+            .newAgentInstanceSearchRequest()
+            .filter(f -> f.processDefinitionKey(processDefinitionKey))
+            .execute();
+
+    // then
+    assertThat(responsePd1.items())
+        .extracting(AgentInstance::getAgentInstanceKey)
+        .containsExactlyInAnyOrder(agentInstanceKey1, agentInstanceKey2);
+
+    // when — pd2 has 1 agent instance
+    final var responsePd2 =
+        camundaClient
+            .newAgentInstanceSearchRequest()
+            .filter(f -> f.processDefinitionKey(processDefinitionKey2))
+            .execute();
+
+    // then
+    assertThat(responsePd2.items())
+        .singleElement()
+        .satisfies(ai -> assertThat(ai.getAgentInstanceKey()).isEqualTo(agentInstanceKey3));
+  }
+
+  @Test
+  void shouldFilterByProcessDefinitionId() {
+    // when — pd1 has 2 agent instances
+    final var responsePd1 =
+        camundaClient
+            .newAgentInstanceSearchRequest()
+            .filter(f -> f.processDefinitionId(processDefinitionId))
+            .execute();
+
+    // then
+    assertThat(responsePd1.items())
+        .extracting(AgentInstance::getAgentInstanceKey)
+        .containsExactlyInAnyOrder(agentInstanceKey1, agentInstanceKey2);
+
+    // when — pd2 has 1 agent instance
+    final var responsePd2 =
+        camundaClient
+            .newAgentInstanceSearchRequest()
+            .filter(f -> f.processDefinitionId(processDefinitionId2))
+            .execute();
+
+    // then
+    assertThat(responsePd2.items())
+        .singleElement()
+        .satisfies(ai -> assertThat(ai.getAgentInstanceKey()).isEqualTo(agentInstanceKey3));
+  }
+
+  @Test
+  void shouldFilterByTenantId() {
+    // when
+    final var response =
+        camundaClient
+            .newAgentInstanceSearchRequest()
+            .filter(f -> f.tenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER))
+            .execute();
+
+    // then
+    assertThat(response.items())
+        .extracting(AgentInstance::getAgentInstanceKey, AgentInstance::getTenantId)
+        .containsExactlyInAnyOrder(
+            tuple(agentInstanceKey1, TenantOwned.DEFAULT_TENANT_IDENTIFIER),
+            tuple(agentInstanceKey2, TenantOwned.DEFAULT_TENANT_IDENTIFIER),
+            tuple(agentInstanceKey3, TenantOwned.DEFAULT_TENANT_IDENTIFIER));
+  }
+
+  @Test
+  void shouldReturnEmptyForUnknownTenant() {
+    // when
+    final var response =
+        camundaClient
+            .newAgentInstanceSearchRequest()
+            .filter(f -> f.tenantId("unknown-tenant"))
+            .execute();
+
+    // then
+    assertThat(response.items()).isEmpty();
+  }
+
+  @Test
+  void shouldSortByCreationDateDescending() {
+    // when
+    final var response =
+        camundaClient.newAgentInstanceSearchRequest().sort(s -> s.creationDate().desc()).execute();
+
+    // then — ai3 was created last, so it should appear before ai2 and ai1
+    assertThat(response.items())
+        .extracting(AgentInstance::getAgentInstanceKey)
+        .containsExactly(agentInstanceKey3, agentInstanceKey2, agentInstanceKey1);
+  }
+
+  @Test
+  void shouldSortByStatusAscending() {
+    // when
+    final var response =
+        camundaClient.newAgentInstanceSearchRequest().sort(s -> s.status().asc()).execute();
+
+    // then
+    assertThat(response.items())
+        .extracting(AgentInstance::getStatus)
+        .containsExactly(
+            AgentInstanceStatus.INITIALIZING,
+            AgentInstanceStatus.INITIALIZING,
+            AgentInstanceStatus.THINKING);
+  }
+
+  @Test
+  void shouldPaginateResults() {
+    // when — pd1 has 2 agent instances; request them one at a time
+    final var page1 =
+        camundaClient
+            .newAgentInstanceSearchRequest()
+            .filter(f -> f.processDefinitionKey(processDefinitionKey))
+            .sort(s -> s.creationDate().asc())
+            .page(p -> p.limit(1))
+            .execute();
+
+    assertThat(page1.items()).hasSize(1);
+
+    final var page2 =
+        camundaClient
+            .newAgentInstanceSearchRequest()
+            .filter(f -> f.processDefinitionKey(processDefinitionKey))
+            .sort(s -> s.creationDate().asc())
+            .page(p -> p.limit(1).from(1))
+            .execute();
+
+    // then — page1 + page2 cover all 2 agent instances in pd1 without overlap
+    assertThat(page2.items()).hasSize(1);
+    final var page1Keys = page1.items().stream().map(AgentInstance::getAgentInstanceKey).toList();
+    final var page2Keys = page2.items().stream().map(AgentInstance::getAgentInstanceKey).toList();
+    assertThat(page1Keys).doesNotContainAnyElementsOf(page2Keys);
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
@@ -23,6 +23,7 @@ import io.camunda.client.api.response.DeploymentEvent;
 import io.camunda.client.api.response.EvaluateDecisionResponse;
 import io.camunda.client.api.response.Process;
 import io.camunda.client.api.response.ProcessInstanceEvent;
+import io.camunda.client.api.search.enums.AgentInstanceStatus;
 import io.camunda.client.api.search.enums.BatchOperationState;
 import io.camunda.client.api.search.enums.IncidentState;
 import io.camunda.client.api.search.enums.ProcessInstanceState;
@@ -2072,6 +2073,49 @@ public final class TestHelper {
                       .page(p -> p.limit(listenerIds.size()))
                       .execute();
               assertThat(result.items()).hasSize(listenerIds.size());
+            });
+  }
+
+  /**
+   * Waits for an agent instance to be indexed in secondary storage after creation.
+   *
+   * @param camundaClient CamundaClient
+   * @param agentInstanceKey the key of the agent instance to wait for
+   */
+  public static void waitForAgentInstanceToBeIndexed(
+      final CamundaClient camundaClient, final long agentInstanceKey) {
+    Awaitility.await("should index agent instance")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var result =
+                  camundaClient.newAgentInstanceGetRequest(agentInstanceKey).execute();
+              assertThat(result).isNotNull();
+            });
+  }
+
+  /**
+   * Waits for an agent instance with a provided {@code status} to be indexed in secondary storage
+   * after creation.
+   *
+   * @param camundaClient CamundaClient
+   * @param agentInstanceKey the key of the agent instance to wait for
+   * @param status expected AgentInstanceStatus
+   */
+  public static void waitForAgentInstanceWithStatusToBeIndexed(
+      final CamundaClient camundaClient,
+      final long agentInstanceKey,
+      final AgentInstanceStatus status) {
+    Awaitility.await("should index agent instance with '%s' status".formatted(status))
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var result =
+                  camundaClient.newAgentInstanceGetRequest(agentInstanceKey).execute();
+              assertThat(result).isNotNull();
+              assertThat(result.getStatus()).isEqualTo(status);
             });
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AgentInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AgentInstanceHandler.java
@@ -18,6 +18,7 @@ import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTempla
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.TOOL_CALLS;
 
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.exporter.utils.ExporterUtil;
 import io.camunda.webapps.schema.entities.agentinstance.AgentInstanceEntity;
 import io.camunda.webapps.schema.entities.agentinstance.AgentInstanceEntity.AgentInstanceToolValue;
 import io.camunda.webapps.schema.entities.agentinstance.AgentInstanceStatus;
@@ -96,7 +97,7 @@ public class AgentInstanceHandler
         .setBpmnProcessId(value.getBpmnProcessId())
         .setProcessDefinitionKey(value.getProcessDefinitionKey())
         .setProcessDefinitionVersion(value.getProcessDefinitionVersion())
-        .setVersionTag(value.getVersionTag())
+        .setVersionTag(ExporterUtil.emptyToNull(value.getVersionTag()))
         .setTenantId(value.getTenantId())
         .setStatus(mapStatus(value.getStatus()))
         .setModel(value.getDefinition().getModel())
@@ -166,7 +167,12 @@ public class AgentInstanceHandler
   private static List<AgentInstanceToolValue> mapTools(
       final List<? extends AgentInstanceRecordValue.AgentInstanceToolValue> protocolTools) {
     return protocolTools.stream()
-        .map(t -> new AgentInstanceToolValue(t.getName(), t.getDescription(), t.getElementId()))
+        .map(
+            t ->
+                new AgentInstanceToolValue(
+                    t.getName(),
+                    ExporterUtil.emptyToNull(t.getDescription()),
+                    ExporterUtil.emptyToNull(t.getElementId())))
         .toList();
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/utils/ExporterUtil.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/utils/ExporterUtil.java
@@ -44,6 +44,10 @@ public final class ExporterUtil {
     return toStringOrDefault(object, null);
   }
 
+  public static String emptyToNull(final String value) {
+    return isEmpty(value) ? null : value;
+  }
+
   public static String toStringOrDefault(final Object object, final String defaultString) {
     return object == null ? defaultString : object.toString();
   }

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -246,6 +246,18 @@ components:
             items:
               allOf:
                 - $ref: 'keys.yaml#/components/schemas/ElementInstanceKeyFilterProperty'
+        processDefinitionId:
+          description: The BPMN process ID of the process definition associated with this agent instance.
+          allOf:
+            - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
+        processDefinitionVersion:
+          description: The version of the process definition associated with this agent instance.
+          allOf:
+            - $ref: 'filters.yaml#/components/schemas/IntegerFilterProperty'
+        processDefinitionVersionTag:
+          description: The version tag of the process definition associated with this agent instance.
+          allOf:
+            - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
 
     AgentInstanceSearchQueryResult:
       description: Agent instance search response.

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceQueryControllerTest.java
@@ -319,4 +319,54 @@ class AgentInstanceQueryControllerTest extends RestControllerTest {
                     .build()),
             any());
   }
+
+  @Test
+  void shouldSearchAgentInstancesWithProcessDefinitionFilters() {
+    // given
+    when(agentInstanceServices.search(any(AgentInstanceQuery.class), any()))
+        .thenReturn(
+            new SearchQueryResult.Builder<AgentInstanceEntity>()
+                .total(1)
+                .startCursor("f")
+                .endCursor("v")
+                .items(List.of(AGENT_INSTANCE_ENTITY))
+                .build());
+
+    // when / then
+    webClient
+        .post()
+        .uri(AGENT_INSTANCES_SEARCH_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(
+            """
+            {
+              "filter": {
+                "processDefinitionId": { "$eq": "myProcessId" },
+                "processDefinitionVersion": { "$eq": 1 },
+                "processDefinitionVersionTag": { "$eq": "v1" }
+              }
+            }
+            """)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
+
+    verify(agentInstanceServices)
+        .search(
+            eq(
+                new AgentInstanceQuery.Builder()
+                    .filter(
+                        new AgentInstanceFilter.Builder()
+                            .processDefinitionIdOperations(List.of(Operation.eq("myProcessId")))
+                            .processDefinitionVersionOperations(List.of(Operation.eq(1)))
+                            .versionTagOperations(List.of(Operation.eq("v1")))
+                            .build())
+                    .build()),
+            any());
+  }
 }


### PR DESCRIPTION
## Description

Implements `CamundaClient` support for the `GET /v2/agent-instances/{agentInstanceKey}` and `POST /v2/agent-instances/search` endpoints introduced in #53791, as part of issue #52821.

### What is in scope

**OpenAPI / mapping layer**
- Extended `agent-instances.yaml` with three filter fields missing from the REST layer (`processDefinitionId`, `processDefinitionVersion`, `processDefinitionVersionTag`) that were already present in the backend domain
- Updated `SearchQueryFilterMapper.toAgentInstanceFilter()` to wire the new fields through to the search domain

**`fix:` normalize optional strings in CamundaExporter**
- `AgentInstanceHandler` now maps empty MsgPack `StringProperty` defaults to `null`, aligning with the RDBMS `AgentInstanceExportHandler` for nullable fields (`versionTag`, tool `description`, tool `elementId`)
- `ExportUtil.emptyToNull()` utility method added for reuse across handlers

**Client API**
- `AgentInstanceGetRequest` — fluent GET-by-key request
- `AgentInstance` response interface with four sub-interfaces: `Definition`, `Metrics`, `Limits`, `Tool`
- `AgentInstanceFilter` — 13 filter fields
- `AgentInstanceSort` — sort by `creationDate`, `lastUpdatedDate`, `completionDate`, `status`
- `AgentInstanceSearchRequest` — typed search request
- Wired `newAgentInstanceGetRequest()` and `newAgentInstanceSearchRequest()` into `CamundaClient` / `CamundaClientImpl`

**Unit tests (`clients/java`)**
- `GetAgentInstanceTest` — verifies the GET request path, field mapping, and error handling for invalid keys
- `SearchAgentInstanceTest` — verifies search request serialisation for all filter fields, sort fields, and response mapping including tools

**Integration tests (`qa/acceptance-tests`)**
- `AgentInstanceFetchIT` — verifies `GET` against two agent instances differing in optionality: one created with required fields only, and one created with all optional fields set (limits, tools, metrics via UPDATE)
- `AgentInstanceSearchIT` — verifies search across two process definitions; covers all supported filter fields, sort by `creationDate` and `status`, pagination, and empty results for unknown tenant

**Acceptance test helpers**
- `TestHelper.waitForAgentInstanceToBeIndexed()` — polls until an agent instance is visible in the search index

### What is out of scope

| Excluded | Covered by |
|----------|------------|
| Additional filter/sort fields not yet in backend domain | [#53823](https://github.com/camunda/camunda/issues/53823) |
| `rootProcessInstanceKey` population | [#53236](https://github.com/camunda/camunda/issues/53236) |
| `AgentInstanceCommandIT`, command unit tests, engine RecordingExporter tests | [#54094](https://github.com/camunda/camunda/issues/54094) |

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #52821
