### PR TITLE
fix: return filter when elementId is set without state filters

### DIFF
--- a/operate/client/src/modules/utils/filter/processInstancesSearch.test.ts
+++ b/operate/client/src/modules/utils/filter/processInstancesSearch.test.ts
@@ -12,7 +12,9 @@ const params = (obj: Record<string, string>) => new URLSearchParams(obj);
 
 describe('parseProcessInstancesSearchFilter', () => {
   it('should return undefined when no filters are set', () => {
-    expect(parseProcessInstancesSearchFilter(new URLSearchParams())).toBeUndefined();
+    expect(
+      parseProcessInstancesSearchFilter(new URLSearchParams()),
+    ).toBeUndefined();
   });
 
   it('should return a filter with elementId and elementInstanceState when only elementId is set', () => {

--- a/operate/client/src/modules/utils/filter/processInstancesSearch.test.ts
+++ b/operate/client/src/modules/utils/filter/processInstancesSearch.test.ts
@@ -12,7 +12,7 @@ const params = (obj: Record<string, string>) => new URLSearchParams(obj);
 
 describe('parseProcessInstancesSearchFilter', () => {
   it('should return undefined when no filters are set', () => {
-    expect(parseProcessInstancesSearchFilter(params({}))).toBeUndefined();
+    expect(parseProcessInstancesSearchFilter(new URLSearchParams())).toBeUndefined();
   });
 
   it('should return a filter with elementId and elementInstanceState when only elementId is set', () => {

--- a/operate/client/src/modules/utils/filter/processInstancesSearch.test.ts
+++ b/operate/client/src/modules/utils/filter/processInstancesSearch.test.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {parseProcessInstancesSearchFilter} from './processInstancesSearch';
+
+const params = (obj: Record<string, string>) =>
+  new URLSearchParams(obj);
+
+describe('parseProcessInstancesSearchFilter', () => {
+  it('should return undefined when no filters are set', () => {
+    expect(parseProcessInstancesSearchFilter(params({}))).toBeUndefined();
+  });
+
+  it('should return a filter with elementId and elementInstanceState when only elementId is set', () => {
+    const result = parseProcessInstancesSearchFilter(
+      params({elementId: 'nodeA'}),
+    );
+
+    expect(result).toEqual({
+      elementId: {$eq: 'nodeA'},
+      elementInstanceState: {$eq: 'ACTIVE'},
+    });
+  });
+
+  it('should return a filter with state when only active is set', () => {
+    const result = parseProcessInstancesSearchFilter(
+      params({active: 'true'}),
+    );
+
+    expect(result).toEqual({
+      state: {$eq: 'ACTIVE'},
+      hasIncident: false,
+    });
+  });
+
+  it('should return a filter combining state and elementId when both are set', () => {
+    const result = parseProcessInstancesSearchFilter(
+      params({active: 'true', elementId: 'nodeA'}),
+    );
+
+    expect(result).toMatchObject({
+      state: {$eq: 'ACTIVE'},
+      hasIncident: false,
+      elementId: {$eq: 'nodeA'},
+      elementInstanceState: {$eq: 'ACTIVE'},
+    });
+  });
+
+  it('should return a filter with batchOperationKey when only batchOperationKey is set', () => {
+    const result = parseProcessInstancesSearchFilter(
+      params({batchOperationKey: 'batch-123'}),
+    );
+
+    expect(result).toEqual({
+      batchOperationKey: {$eq: 'batch-123'},
+    });
+  });
+});

--- a/operate/client/src/modules/utils/filter/processInstancesSearch.test.ts
+++ b/operate/client/src/modules/utils/filter/processInstancesSearch.test.ts
@@ -8,8 +8,7 @@
 
 import {parseProcessInstancesSearchFilter} from './processInstancesSearch';
 
-const params = (obj: Record<string, string>) =>
-  new URLSearchParams(obj);
+const params = (obj: Record<string, string>) => new URLSearchParams(obj);
 
 describe('parseProcessInstancesSearchFilter', () => {
   it('should return undefined when no filters are set', () => {
@@ -28,9 +27,7 @@ describe('parseProcessInstancesSearchFilter', () => {
   });
 
   it('should return a filter with state when only active is set', () => {
-    const result = parseProcessInstancesSearchFilter(
-      params({active: 'true'}),
-    );
+    const result = parseProcessInstancesSearchFilter(params({active: 'true'}));
 
     expect(result).toEqual({
       state: {$eq: 'ACTIVE'},

--- a/operate/client/src/modules/utils/filter/processInstancesSearch.ts
+++ b/operate/client/src/modules/utils/filter/processInstancesSearch.ts
@@ -65,7 +65,7 @@ const parseProcessInstancesSearchFilter = (
   const hasStateFilters =
     filter.active || filter.completed || filter.canceled || filter.incidents;
 
-  if (!hasStateFilters && !filter.batchOperationKey) {
+  if (!hasStateFilters && !filter.batchOperationKey && !filter.elementId) {
     return undefined;
   }
 


### PR DESCRIPTION
## Summary

- When clicking a BPMN flow node without any state filter (active/incidents/completed/canceled) selected, `parseProcessInstancesSearchFilter` returned `undefined` — causing both the instances list and count to show all process instances instead of only those with an active token at the selected element
- Added `&& !filter.elementId` to the early-return guard so a proper filter with `elementId` + `elementInstanceState=ACTIVE` is built when a flow node is selected

## Test plan

- [ ] New unit tests in `processInstancesSearch.test.ts` cover: no-filter → `undefined`, elementId-only, state-only, combined state+elementId, batchOperationKey
- [ ] Manual: click a flow node with no active tokens → header shows 0 instances, list is empty
- [ ] Manual: click a flow node with active tokens → correct count shown
- [ ] Automated test: [Process Instances Filters › Interaction between diagram and filters](https://camunda.testrail.com/index.php?/tests/view/2535256)

Closes #45156

🤖 Generated with [Claude Code](https://claude.com/claude-code)