### PR TITLE
fix: show inner instance data in details tab for ad-hoc sub-process inner instances

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.test.tsx
@@ -831,4 +831,44 @@ describe('<DetailsTab />', () => {
     expect(screen.getByText('inner-1')).toBeInTheDocument();
     expect(screen.getByText('Execution Duration')).toBeInTheDocument();
   });
+
+  it('should display child instance data when no anchorElementId is set', async () => {
+    const AD_HOC_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:adHocSubProcess id="ad_hoc_subprocess" name="Ad Hoc">
+      <bpmn:userTask id="user_task_in_ad_hoc_subprocess" name="User Task" />
+    </bpmn:adHocSubProcess>
+  </bpmn:process>
+</bpmn:definitions>`;
+
+    const mockChildInstance = {
+      elementInstanceKey: 'child-1',
+      elementId: 'user_task_in_ad_hoc_subprocess',
+      elementName: 'User Task',
+      type: 'USER_TASK',
+      state: 'ACTIVE',
+      startDate: '2023-01-15T10:00:00.000Z',
+      endDate: null,
+      processDefinitionId: 'process-def-1',
+      processInstanceKey: PROCESS_INSTANCE_ID,
+      processDefinitionKey: PROCESS_DEFINITION_KEY,
+      hasIncident: false,
+      tenantId: '<default>',
+      rootProcessInstanceKey: null,
+      incidentKey: null,
+    } satisfies ElementInstance;
+
+    mockFetchProcessDefinitionXml().withSuccess(AD_HOC_XML);
+    mockFetchElementInstance('child-1').withSuccess(mockChildInstance);
+
+    render(<DetailsTab />, {
+      wrapper: getWrapper(
+        'elementId=user_task_in_ad_hoc_subprocess&elementInstanceKey=child-1',
+      ),
+    });
+
+    expect(await screen.findByText('Element Instance Key')).toBeInTheDocument();
+    expect(screen.getByText('child-1')).toBeInTheDocument();
+  });
 });

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.test.tsx
@@ -790,4 +790,45 @@ describe('<DetailsTab />', () => {
     expect(screen.queryByText('Correlation Key')).not.toBeInTheDocument();
     expect(screen.queryByText('Subscription State')).not.toBeInTheDocument();
   });
+
+  it('should display inner instance data, not child data, when anchorElementId is set', async () => {
+    const AD_HOC_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:adHocSubProcess id="ad_hoc_subprocess" name="Ad Hoc">
+      <bpmn:userTask id="user_task_in_ad_hoc_subprocess" name="User Task" />
+    </bpmn:adHocSubProcess>
+  </bpmn:process>
+</bpmn:definitions>`;
+
+    const mockInnerInstance = {
+      elementInstanceKey: 'inner-1',
+      elementId: 'ad_hoc_subprocess',
+      elementName: 'Ad Hoc Sub Process Inner Instance',
+      type: 'AD_HOC_SUB_PROCESS_INNER_INSTANCE',
+      state: 'ACTIVE',
+      startDate: '2023-01-15T10:00:00.000Z',
+      endDate: null,
+      processDefinitionId: 'process-def-1',
+      processInstanceKey: PROCESS_INSTANCE_ID,
+      processDefinitionKey: PROCESS_DEFINITION_KEY,
+      hasIncident: false,
+      tenantId: '<default>',
+      rootProcessInstanceKey: null,
+      incidentKey: null,
+    } satisfies ElementInstance;
+
+    mockFetchProcessDefinitionXml().withSuccess(AD_HOC_XML);
+    mockFetchElementInstance('inner-1').withSuccess(mockInnerInstance);
+
+    render(<DetailsTab />, {
+      wrapper: getWrapper(
+        'elementId=ad_hoc_subprocess&elementInstanceKey=inner-1&anchorElementId=user_task_in_ad_hoc_subprocess',
+      ),
+    });
+
+    expect(await screen.findByText('Element Instance Key')).toBeInTheDocument();
+    expect(screen.getByText('inner-1')).toBeInTheDocument();
+    expect(screen.getByText('Execution Duration')).toBeInTheDocument();
+  });
 });

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.tsx
@@ -50,6 +50,7 @@ const DetailsTab: React.FC = () => {
   const {
     resolvedElementInstance,
     selectedElementId,
+    selectedAnchorElementId,
     selectedInstancesCount,
     isFetchingElement,
   } = useProcessInstanceElementSelection();
@@ -59,8 +60,9 @@ const DetailsTab: React.FC = () => {
     processDefinitionKey: processInstance?.processDefinitionKey,
   });
 
-  const businessObject = selectedElementId
-    ? xmlData?.businessObjects[selectedElementId]
+  const effectiveElementId = selectedAnchorElementId ?? selectedElementId;
+  const businessObject = effectiveElementId
+    ? xmlData?.businessObjects[effectiveElementId]
     : null;
 
   const elementInstanceKey =
@@ -134,7 +136,7 @@ const DetailsTab: React.FC = () => {
     agentInstance,
     isLoading: isAgentLoading,
     isError: isAgentError,
-  } = useAgentInstanceForElement(selectedElementId, elementInstanceKey);
+  } = useAgentInstanceForElement(effectiveElementId, elementInstanceKey);
 
   const calledDecisionInstance = decisionInstanceSearchResult?.items?.find(
     (instance) =>

--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/adHocSubProcessInnerInstance.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/adHocSubProcessInnerInstance.test.tsx
@@ -67,6 +67,8 @@ describe('ElementInstancesTree - Ad Hoc Sub Process Inner Instance', () => {
       await screen.findByText('Ad Hoc Inner Subprocess Test'),
     ).toBeInTheDocument();
 
+    // Two one-time handlers needed: JSDOM fires an implicit node selection on the arrow-key
+    // press (triggering a child fetch), then the manual reset-click triggers another fetch.
     mockSearchElementInstances().withSuccess(
       adHocSubProcessInnerInstanceElementInstances.level2,
     );

--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/adHocSubProcessInnerInstance.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/adHocSubProcessInnerInstance.test.tsx
@@ -29,220 +29,216 @@ import {
   queryElementInstancesRequestBodySchema,
 } from '@camunda/camunda-api-zod-schemas/8.10';
 
-describe(
-  'ElementInstancesTree - Ad Hoc Sub Process Inner Instance',
-  () => {
-    beforeEach(async () => {
-      mockFetchProcessInstance().withSuccess(
-        mockAdHocSubProcessInnerInstanceProcessInstance,
-      );
-      mockFetchProcessDefinitionXml().withSuccess(adHocSubProcessInnerInstance);
-      mockFetchElementInstancesStatistics().withSuccess({items: []});
-      mockQueryBatchOperationItems().withSuccess(searchResult([]));
-      mockSearchElementInstances().withSuccess(
-        adHocSubProcessInnerInstanceElementInstances.level1,
-      );
-      mockFetchElementInstance('inner-1').withSuccess(
-        adHocSubProcessInnerInstanceElementInstances.level1.items[1]!,
+describe('ElementInstancesTree - Ad Hoc Sub Process Inner Instance', () => {
+  beforeEach(async () => {
+    mockFetchProcessInstance().withSuccess(
+      mockAdHocSubProcessInnerInstanceProcessInstance,
+    );
+    mockFetchProcessDefinitionXml().withSuccess(adHocSubProcessInnerInstance);
+    mockFetchElementInstancesStatistics().withSuccess({items: []});
+    mockQueryBatchOperationItems().withSuccess(searchResult([]));
+    mockSearchElementInstances().withSuccess(
+      adHocSubProcessInnerInstanceElementInstances.level1,
+    );
+    mockFetchElementInstance('inner-1').withSuccess(
+      adHocSubProcessInnerInstanceElementInstances.level1.items[1]!,
+    );
+  });
+
+  afterEach(() => {
+    notificationsStore.reset();
+  });
+
+  it('should select inner instance with first child as anchor when node is expanded and has children', async () => {
+    const {businessObjects} = await parseBusinessObjects(
+      adHocSubProcessInnerInstance,
+    );
+    const {user} = render(
+      <ElementInstancesTree
+        processInstance={mockAdHocSubProcessInnerInstanceProcessInstance}
+        businessObjects={businessObjects}
+      />,
+      {
+        wrapper: getWrapper(),
+      },
+    );
+
+    expect(
+      await screen.findByText('Ad Hoc Inner Subprocess Test'),
+    ).toBeInTheDocument();
+
+    mockSearchElementInstances().withSuccess(
+      adHocSubProcessInnerInstanceElementInstances.level2,
+    );
+    mockSearchElementInstances().withSuccess(
+      adHocSubProcessInnerInstanceElementInstances.level2,
+    );
+
+    await user.type(
+      await screen.findByLabelText('Ad Hoc Sub Process Inner Instance', {
+        selector: "[aria-expanded='false']",
+      }),
+      '{arrowright}',
+    );
+    // The right arrow press triggers a node selection on JSDOM so we need to reset the selection. This doesn't happeng in the browser
+    await user.click(screen.getByText('Ad Hoc Inner Subprocess Test'));
+
+    await user.click(
+      await screen.findByLabelText('Ad Hoc Sub Process Inner Instance', {
+        selector: "[aria-expanded='true']",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('search')).toHaveTextContent(
+        '?elementId=ad_hoc_subprocess&elementInstanceKey=inner-1&anchorElementId=user_task_in_ad_hoc_subprocess',
       );
     });
+  });
 
-    afterEach(() => {
-      notificationsStore.reset();
-    });
+  it('should fetch first child and select with anchor when clicking collapsed inner instance', async () => {
+    const {businessObjects} = await parseBusinessObjects(
+      adHocSubProcessInnerInstance,
+    );
+    const {user} = render(
+      <ElementInstancesTree
+        processInstance={mockAdHocSubProcessInnerInstanceProcessInstance}
+        businessObjects={businessObjects}
+      />,
+      {
+        wrapper: getWrapper(),
+      },
+    );
 
-    it('should select inner instance with first child as anchor when node is expanded and has children', async () => {
-      const {businessObjects} = await parseBusinessObjects(
-        adHocSubProcessInnerInstance,
-      );
-      const {user} = render(
-        <ElementInstancesTree
-          processInstance={mockAdHocSubProcessInnerInstanceProcessInstance}
-          businessObjects={businessObjects}
-        />,
-        {
-          wrapper: getWrapper(),
-        },
-      );
+    expect(
+      await screen.findByText('Ad Hoc Inner Subprocess Test'),
+    ).toBeInTheDocument();
 
-      expect(
-        await screen.findByText('Ad Hoc Inner Subprocess Test'),
-      ).toBeInTheDocument();
+    mockServer.use(
+      http.post(
+        endpoints.queryElementInstances.getUrl(),
+        async ({request}) => {
+          const body = await request.json();
+          const result = queryElementInstancesRequestBodySchema.safeParse(body);
 
-      mockSearchElementInstances().withSuccess(
-        adHocSubProcessInnerInstanceElementInstances.level2,
-      );
-      mockSearchElementInstances().withSuccess(
-        adHocSubProcessInnerInstanceElementInstances.level2,
-      );
-
-      await user.type(
-        await screen.findByLabelText('Ad Hoc Sub Process Inner Instance', {
-          selector: "[aria-expanded='false']",
-        }),
-        '{arrowright}',
-      );
-      // The right arrow press triggers a node selection on JSDOM so we need to reset the selection. This doesn't happeng in the browser
-      await user.click(screen.getByText('Ad Hoc Inner Subprocess Test'));
-
-      await user.click(
-        await screen.findByLabelText('Ad Hoc Sub Process Inner Instance', {
-          selector: "[aria-expanded='true']",
-        }),
-      );
-
-      await waitFor(() => {
-        expect(screen.getByTestId('search')).toHaveTextContent(
-          '?elementId=ad_hoc_subprocess&elementInstanceKey=inner-1&anchorElementId=user_task_in_ad_hoc_subprocess',
-        );
-      });
-    });
-
-    it('should fetch first child and select with anchor when clicking collapsed inner instance', async () => {
-      const {businessObjects} = await parseBusinessObjects(
-        adHocSubProcessInnerInstance,
-      );
-      const {user} = render(
-        <ElementInstancesTree
-          processInstance={mockAdHocSubProcessInnerInstanceProcessInstance}
-          businessObjects={businessObjects}
-        />,
-        {
-          wrapper: getWrapper(),
-        },
-      );
-
-      expect(
-        await screen.findByText('Ad Hoc Inner Subprocess Test'),
-      ).toBeInTheDocument();
-
-      mockServer.use(
-        http.post(
-          endpoints.queryElementInstances.getUrl(),
-          async ({request}) => {
-            const body = await request.json();
-            const result =
-              queryElementInstancesRequestBodySchema.safeParse(body);
-
-            if (
-              !result.success ||
-              result.data?.filter?.elementInstanceScopeKey !== 'inner-1'
-            ) {
-              return HttpResponse.json(
-                {
-                  error:
-                    'Invalid payload: elementInstanceScopeKey must be in filter',
-                },
-                {status: 400},
-              );
-            }
-
+          if (
+            !result.success ||
+            result.data?.filter?.elementInstanceScopeKey !== 'inner-1'
+          ) {
             return HttpResponse.json(
-              adHocSubProcessInnerInstanceElementInstances.level2,
+              {
+                error:
+                  'Invalid payload: elementInstanceScopeKey must be in filter',
+              },
+              {status: 400},
             );
-          },
-          {once: true},
-        ),
-      );
-      await user.click(screen.getByText('Ad Hoc Inner Subprocess Test'));
+          }
 
-      await user.click(
-        await screen.findByLabelText('Ad Hoc Sub Process Inner Instance', {
-          selector: "[aria-expanded='false']",
-        }),
-      );
-
-      await waitFor(() => {
-        expect(screen.getByTestId('search')).toHaveTextContent(
-          '?elementId=ad_hoc_subprocess&elementInstanceKey=inner-1&anchorElementId=user_task_in_ad_hoc_subprocess',
-        );
-      });
-
-      expect(notificationsStore.notifications).toEqual([]);
-    });
-
-    it('should display warning notification when inner instance has no children', async () => {
-      const {businessObjects} = await parseBusinessObjects(
-        adHocSubProcessInnerInstance,
-      );
-      const {user} = render(
-        <ElementInstancesTree
-          processInstance={mockAdHocSubProcessInnerInstanceProcessInstance}
-          businessObjects={businessObjects}
-        />,
-        {
-          wrapper: getWrapper(),
+          return HttpResponse.json(
+            adHocSubProcessInnerInstanceElementInstances.level2,
+          );
         },
+        {once: true},
+      ),
+    );
+    await user.click(screen.getByText('Ad Hoc Inner Subprocess Test'));
+
+    await user.click(
+      await screen.findByLabelText('Ad Hoc Sub Process Inner Instance', {
+        selector: "[aria-expanded='false']",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('search')).toHaveTextContent(
+        '?elementId=ad_hoc_subprocess&elementInstanceKey=inner-1&anchorElementId=user_task_in_ad_hoc_subprocess',
       );
-      const originalSearch = screen.getByTestId('search').textContent;
-
-      expect(
-        await screen.findByText('Ad Hoc Inner Subprocess Test'),
-      ).toBeInTheDocument();
-
-      mockSearchElementInstances().withSuccess(searchResult([]));
-
-      await user.click(
-        await screen.findByLabelText('Ad Hoc Sub Process Inner Instance', {
-          selector: "[aria-expanded='false']",
-        }),
-      );
-
-      await waitFor(() => {
-        expect(notificationsStore.notifications).toEqual(
-          expect.arrayContaining([
-            expect.objectContaining({
-              kind: 'warning',
-              title:
-                'No child instances found for Ad Hoc Sub Process Inner Instance',
-            }),
-          ]),
-        );
-      });
-
-      expect(screen.getByTestId('search')).toHaveTextContent(originalSearch);
     });
 
-    it('should display warning notification when fetching first child fails', async () => {
-      const {businessObjects} = await parseBusinessObjects(
-        adHocSubProcessInnerInstance,
+    expect(notificationsStore.notifications).toEqual([]);
+  });
+
+  it('should display warning notification when inner instance has no children', async () => {
+    const {businessObjects} = await parseBusinessObjects(
+      adHocSubProcessInnerInstance,
+    );
+    const {user} = render(
+      <ElementInstancesTree
+        processInstance={mockAdHocSubProcessInnerInstanceProcessInstance}
+        businessObjects={businessObjects}
+      />,
+      {
+        wrapper: getWrapper(),
+      },
+    );
+    const originalSearch = screen.getByTestId('search').textContent;
+
+    expect(
+      await screen.findByText('Ad Hoc Inner Subprocess Test'),
+    ).toBeInTheDocument();
+
+    mockSearchElementInstances().withSuccess(searchResult([]));
+
+    await user.click(
+      await screen.findByLabelText('Ad Hoc Sub Process Inner Instance', {
+        selector: "[aria-expanded='false']",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(notificationsStore.notifications).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            kind: 'warning',
+            title:
+              'No child instances found for Ad Hoc Sub Process Inner Instance',
+          }),
+        ]),
       );
-      const {user} = render(
-        <ElementInstancesTree
-          processInstance={mockAdHocSubProcessInnerInstanceProcessInstance}
-          businessObjects={businessObjects}
-        />,
-        {
-          wrapper: getWrapper(),
-        },
-      );
-      const originalSearch = screen.getByTestId('search').textContent;
-
-      expect(
-        await screen.findByText('Ad Hoc Inner Subprocess Test'),
-      ).toBeInTheDocument();
-
-      mockSearchElementInstances().withNetworkError();
-
-      await user.click(
-        await screen.findByLabelText('Ad Hoc Sub Process Inner Instance', {
-          selector: "[aria-expanded='false']",
-        }),
-      );
-
-      await waitFor(() => {
-        expect(notificationsStore.notifications).toEqual(
-          expect.arrayContaining([
-            expect.objectContaining({
-              kind: 'warning',
-              title:
-                'No child instances found for Ad Hoc Sub Process Inner Instance',
-            }),
-          ]),
-        );
-      });
-
-      expect(screen.getByTestId('search')).toHaveTextContent(originalSearch);
     });
-  },
-);
+
+    expect(screen.getByTestId('search')).toHaveTextContent(originalSearch);
+  });
+
+  it('should display warning notification when fetching first child fails', async () => {
+    const {businessObjects} = await parseBusinessObjects(
+      adHocSubProcessInnerInstance,
+    );
+    const {user} = render(
+      <ElementInstancesTree
+        processInstance={mockAdHocSubProcessInnerInstanceProcessInstance}
+        businessObjects={businessObjects}
+      />,
+      {
+        wrapper: getWrapper(),
+      },
+    );
+    const originalSearch = screen.getByTestId('search').textContent;
+
+    expect(
+      await screen.findByText('Ad Hoc Inner Subprocess Test'),
+    ).toBeInTheDocument();
+
+    mockSearchElementInstances().withNetworkError();
+
+    await user.click(
+      await screen.findByLabelText('Ad Hoc Sub Process Inner Instance', {
+        selector: "[aria-expanded='false']",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(notificationsStore.notifications).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            kind: 'warning',
+            title:
+              'No child instances found for Ad Hoc Sub Process Inner Instance',
+          }),
+        ]),
+      );
+    });
+
+    expect(screen.getByTestId('search')).toHaveTextContent(originalSearch);
+  });
+});

--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/adHocSubProcessInnerInstance.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/adHocSubProcessInnerInstance.test.tsx
@@ -29,8 +29,7 @@ import {
   queryElementInstancesRequestBodySchema,
 } from '@camunda/camunda-api-zod-schemas/8.10';
 
-// TODO: https://github.com/camunda/camunda/issues/20862
-describe.todo(
+describe(
   'ElementInstancesTree - Ad Hoc Sub Process Inner Instance',
   () => {
     beforeEach(async () => {


### PR DESCRIPTION
## Summary

- When an `AD_HOC_SUB_PROCESS_INNER_INSTANCE` is selected in the history tree, the bottom panel was displaying the first child instance's data instead of the inner instance's own data
- Fixed `DetailsTab` to use `anchorElementId` (when present) for the BPMN `businessObject` lookup, so type-specific rows are derived from the correct element
- Enabled the previously skipped `adHocSubProcessInnerInstance` tree selection tests (blocked by #20862, now passing)
- Added a `DetailsTab` test verifying the inner instance's own key is shown when `anchorElementId` is set

## Test plan

- [ ] All 4 ad-hoc inner instance tree selection tests pass (`adHocSubProcessInnerInstance.test.tsx`)
- [ ] All 26 DetailsTab tests pass including the new inner-instance scenario
- [ ] Spotless formatting check passes

Closes #39141

🤖 Generated with [Claude Code](https://claude.com/claude-code)