### PR TITLE
fix: coerce null errorCode/errorMessage to empty string in RDBMS job error statistics

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/JobMetricsBatchDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/JobMetricsBatchDbReader.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.db.rdbms.read.service;
 
+import static io.camunda.db.rdbms.read.NullSafeStrings.nullToEmpty;
 import static java.util.Optional.ofNullable;
 
 import io.camunda.db.rdbms.read.RdbmsReaderConfig;
@@ -251,8 +252,8 @@ public class JobMetricsBatchDbReader extends AbstractEntityReader<JobTypeStatist
             .map(
                 result ->
                     new JobErrorStatisticsEntity(
-                        result.errorCode(),
-                        result.errorMessage(),
+                        nullToEmpty(result.errorCode()),
+                        nullToEmpty(result.errorMessage()),
                         ofNullable(result.workers()).orElse(0)))
             .toList();
 


### PR DESCRIPTION
## Summary

- Oracle treats empty strings as `NULL` — when a job fails without an explicit error code or message, Oracle 26ai stores `NULL` in those columns.
- The RDBMS reader (`JobMetricsBatchDbReader`) was passing the raw `null` values through to `JobErrorStatisticsEntity`, which then reached the HTTP response as `null`.
- The OAS schema for `POST /jobs/statistics/errors` declares both `errorMessage` and `errorCode` as required non-nullable strings, causing the nightly contract validation test to fail on Oracle 26ai only.

**Fix:** Apply the same `nullToEmpty()` pattern already established in `FlowNodeInstanceEntityMapper`, `SequenceFlowEntityMapper`, `CorrelatedMessageSubscriptionEntityMapper`, and `MessageSubscriptionEntityMapper` in the same module — `NullSafeStrings.nullToEmpty()` converts Oracle-returned `null` back to `""` for required-but-possibly-empty string fields.

## Failing nightly run

https://github.com/camunda/camunda/actions/runs/26427385792

- **Workflow:** C8 Orchestration Cluster Nightly 8.9 - API Tests (RDBMS)
- **Failed job:** `nightly-api-tests-rdbms / API Tests (RDBMS) (stable/8.9 / Oracle 26ai)`
- **Test:** `Get error metrics for a job type - success`
- **Error:** `[TYPE] /items/0/errorMessage expected string but got null`
- All other 11 DB matrix cells passed (Postgres 17, Oracle 21c, etc.)

## Test plan

- [ ] Nightly RDBMS matrix re-run shows Oracle 26ai passing for `job-statistics-error-metrics-job-type-api-tests.spec.ts`
- [ ] All other DB matrix cells remain green (no regression from empty-string coercion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)