### PR TITLE
test: fix flaky Identity authorization owner dropdown click in E2E test

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityAuthorizationsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityAuthorizationsPage.ts
@@ -247,11 +247,18 @@ export class IdentityAuthorizationsPage {
       await this.createAuthorizationOwnerSearchInput.fill(
         authorization.ownerId,
       );
-      await this.createAuthorizationModal
+      // The owner search is debounced + server-driven; a just-created user
+      // can take longer than 20s to surface under load. Separate the
+      // visibility wait from the click so we know the item exists before
+      // attempting to interact with it.  Use force:true to prevent transient
+      // Carbon dropdown re-renders (loading overlays, list-box animations)
+      // from blocking the click after the item is confirmed visible.
+      const ownerOption = this.createAuthorizationModal
         .locator('.cds--list-box__menu-item')
         .filter({hasText: authorization.ownerId})
-        .first()
-        .click({timeout: 20000});
+        .first();
+      await expect(ownerOption).toBeVisible({timeout: 60000});
+      await ownerOption.click({force: true});
       return;
     }
 


### PR DESCRIPTION
## Summary

- The `Create authorization` dialog in Identity uses a Carbon Design System listbox for owner search — it is debounced and server-driven.
- The previous code chained `.click({timeout: 20000})` directly on the `.cds--list-box__menu-item` locator, which failed in two ways:
  1. Under CI load a just-created user can take >20s to appear in the dropdown search results.
  2. Even when the item appeared, a transient Carbon re-render (loading overlay, list-box animation) caused Playwright's actionability pre-checks to time out before the click could dispatch.
- The test (`Admin user can grant and revoke component authorization for user`) failed on **every** retry attempt in both v1 and v2 matrix cells.

**Fix:**
- Separate the visibility wait (`expect(ownerOption).toBeVisible({timeout: 60000})`) from the click action so the item is confirmed present before attempting interaction.
- Use `force: true` on the click to bypass Playwright's actionability checks that were blocking on transient overlays — the preceding `toBeVisible` already confirms the item exists and is rendered.

## Failing nightly run

https://github.com/camunda/camunda/actions/runs/26427922021

- **Workflow:** C8 Orchestration Cluster Nightly 8.9 - E2E Tests
- **Failed jobs:** `nightly-e2e-tests-v1` and `nightly-e2e-tests-v2`
- **Test:** `Admin user can grant and revoke component authorization for user`
- **Error:** `Failed to create authorization for Auth Test <username> after 3 attempts. Last error: locator.click: Timeout 20000ms exceeded`

## Test plan

- [ ] Nightly E2E re-run shows `identity-users-flows.spec.ts` passing in both v1 and v2 matrix cells
- [ ] No regression in other authorization-related tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)