### PR TITLE
refactor: introduce EngineSecurityConfig for the non-Spring engine/broker chain

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -38,6 +38,7 @@ import io.camunda.search.clients.UserSearchClient;
 import io.camunda.search.clients.UserTaskSearchClient;
 import io.camunda.search.clients.VariableSearchClient;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
+import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.security.impl.AuthorizationChecker;
 import io.camunda.service.AdHocSubProcessActivityServices;
@@ -94,7 +95,15 @@ public class CamundaServicesConfiguration {
   @Bean
   public BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter(
       final SecurityConfiguration securityConfiguration) {
-    return new BrokerRequestAuthorizationConverter(securityConfiguration);
+    final var engineSecurityConfig =
+        new EngineSecurityConfig(
+            securityConfiguration.getAuthentication(),
+            securityConfiguration.getAuthorizations().isEnabled(),
+            securityConfiguration.getMultiTenancy().isChecksEnabled(),
+            securityConfiguration.getInitialization(),
+            securityConfiguration.getCompiledIdValidationPattern(),
+            securityConfiguration.getCompiledGroupIdValidationPattern());
+    return new BrokerRequestAuthorizationConverter(engineSecurityConfig);
   }
 
   @Bean

--- a/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
@@ -13,6 +13,7 @@ import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
 import io.camunda.identity.sdk.IdentityConfiguration;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
+import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.security.oidc.NoopOidcClaimsProvider;
 import io.camunda.security.oidc.OidcClaimsProvider;
@@ -63,7 +64,7 @@ public class BrokerModuleConfiguration implements CloseableSilently {
   private final BrokerClient brokerClient;
   private final BrokerShutdownHelper shutdownHelper;
   private final MeterRegistry meterRegistry;
-  private final SecurityConfiguration securityConfiguration;
+  private final EngineSecurityConfig engineSecurityConfig;
   private final UserServices userServices;
   private final PasswordEncoder passwordEncoder;
   private final JwtDecoder jwtDecoder;
@@ -101,7 +102,14 @@ public class BrokerModuleConfiguration implements CloseableSilently {
     this.brokerClient = brokerClient;
     this.shutdownHelper = shutdownHelper;
     this.meterRegistry = meterRegistry;
-    this.securityConfiguration = securityConfiguration;
+    this.engineSecurityConfig =
+        new EngineSecurityConfig(
+            securityConfiguration.getAuthentication(),
+            securityConfiguration.getAuthorizations().isEnabled(),
+            securityConfiguration.getMultiTenancy().isChecksEnabled(),
+            securityConfiguration.getInitialization(),
+            securityConfiguration.getCompiledIdValidationPattern(),
+            securityConfiguration.getCompiledGroupIdValidationPattern());
     this.userServices = userServices;
     this.passwordEncoder = passwordEncoder;
     this.jwtDecoder = jwtDecoder;
@@ -134,13 +142,13 @@ public class BrokerModuleConfiguration implements CloseableSilently {
             cluster,
             brokerClient,
             meterRegistry,
-            securityConfiguration,
+            engineSecurityConfig,
             userServices,
             passwordEncoder,
             jwtDecoder,
             oidcClaimsProvider,
             searchClientsProxy,
-            new BrokerRequestAuthorizationConverter(securityConfiguration),
+            new BrokerRequestAuthorizationConverter(engineSecurityConfig),
             nodeIdProvider,
             List.copyOf(physicalTenantResolver.getAll().keySet()));
     springBrokerBridge.registerShutdownHelper(

--- a/dist/src/main/java/io/camunda/zeebe/gateway/GatewayModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/gateway/GatewayModuleConfiguration.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.gateway;
 
 import io.atomix.cluster.AtomixCluster;
 import io.camunda.application.commons.configuration.GatewayBasedConfiguration;
+import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.security.oidc.NoopOidcClaimsProvider;
 import io.camunda.security.oidc.OidcClaimsProvider;
@@ -53,7 +54,7 @@ public class GatewayModuleConfiguration implements CloseableSilently {
   private static final Logger LOGGER = Loggers.GATEWAY_LOGGER;
 
   private final GatewayBasedConfiguration configuration;
-  private final SecurityConfiguration securityConfiguration;
+  private final EngineSecurityConfig engineSecurityConfig;
   private final SpringGatewayBridge springGatewayBridge;
   private final ActorScheduler actorScheduler;
   private final AtomixCluster atomixCluster;
@@ -84,7 +85,14 @@ public class GatewayModuleConfiguration implements CloseableSilently {
       final MeterRegistry meterRegistry,
       final GatewayRestConfiguration gatewayRestConfiguration) {
     this.configuration = configuration;
-    this.securityConfiguration = securityConfiguration;
+    this.engineSecurityConfig =
+        new EngineSecurityConfig(
+            securityConfiguration.getAuthentication(),
+            securityConfiguration.getAuthorizations().isEnabled(),
+            securityConfiguration.getMultiTenancy().isChecksEnabled(),
+            securityConfiguration.getInitialization(),
+            securityConfiguration.getCompiledIdValidationPattern(),
+            securityConfiguration.getCompiledGroupIdValidationPattern());
     this.springGatewayBridge = springGatewayBridge;
     this.actorScheduler = actorScheduler;
     this.atomixCluster = atomixCluster;
@@ -119,7 +127,7 @@ public class GatewayModuleConfiguration implements CloseableSilently {
         new Gateway(
             configuration.shutdownTimeout(),
             configuration.config(),
-            securityConfiguration,
+            engineSecurityConfig,
             brokerClient,
             actorScheduler,
             jobStreamClient.streamer(),

--- a/security/security-core/src/main/java/io/camunda/security/auth/BrokerRequestAuthorizationConverter.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/BrokerRequestAuthorizationConverter.java
@@ -14,7 +14,7 @@ import static io.camunda.zeebe.auth.Authorization.USER_GROUPS_CLAIMS;
 import static io.camunda.zeebe.auth.Authorization.USER_TOKEN_CLAIMS;
 
 import io.camunda.security.api.model.CamundaAuthentication;
-import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.configuration.EngineSecurityConfig;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -36,13 +36,13 @@ public class BrokerRequestAuthorizationConverter {
   private final boolean groupsClaimConfigured;
   private final boolean shouldIncludeAuthorizationClaims;
 
-  public BrokerRequestAuthorizationConverter(final SecurityConfiguration securityConfiguration) {
+  public BrokerRequestAuthorizationConverter(final EngineSecurityConfig securityConfiguration) {
     camundaGroupsEnabled = securityConfiguration.getAuthentication().isCamundaGroupsEnabled();
     final var oidc = securityConfiguration.getAuthentication().getOidc();
     groupsClaimConfigured = oidc != null && oidc.isGroupsClaimConfigured();
     shouldIncludeAuthorizationClaims =
-        securityConfiguration.getAuthorizations().isEnabled()
-            || securityConfiguration.getMultiTenancy().isChecksEnabled();
+        securityConfiguration.isAuthorizationsEnabled()
+            || securityConfiguration.isMultiTenancyChecksEnabled();
   }
 
   /** Returns whether authorization claims (token claims, groups) are needed in broker requests. */

--- a/security/security-core/src/main/java/io/camunda/security/configuration/EngineSecurityConfig.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/EngineSecurityConfig.java
@@ -29,8 +29,8 @@ import java.util.regex.Pattern;
 public final class EngineSecurityConfig {
 
   private final AuthenticationConfiguration authentication;
-  private boolean authorizationsEnabled;
-  private boolean multiTenancyChecksEnabled;
+  private final boolean authorizationsEnabled;
+  private final boolean multiTenancyChecksEnabled;
   private final InitializationConfiguration initialization;
   private final Pattern idValidationPattern;
   private final Pattern groupIdValidationPattern;
@@ -58,16 +58,33 @@ public final class EngineSecurityConfig {
     return authorizationsEnabled;
   }
 
-  public void setAuthorizationsEnabled(final boolean authorizationsEnabled) {
-    this.authorizationsEnabled = authorizationsEnabled;
+  /** Returns a copy of this config with {@code authorizationsEnabled} set to the given value. */
+  public EngineSecurityConfig withAuthorizationsEnabled(final boolean authorizationsEnabled) {
+    return new EngineSecurityConfig(
+        authentication,
+        authorizationsEnabled,
+        multiTenancyChecksEnabled,
+        initialization,
+        idValidationPattern,
+        groupIdValidationPattern);
   }
 
   public boolean isMultiTenancyChecksEnabled() {
     return multiTenancyChecksEnabled;
   }
 
-  public void setMultiTenancyChecksEnabled(final boolean multiTenancyChecksEnabled) {
-    this.multiTenancyChecksEnabled = multiTenancyChecksEnabled;
+  /**
+   * Returns a copy of this config with {@code multiTenancyChecksEnabled} set to the given value.
+   */
+  public EngineSecurityConfig withMultiTenancyChecksEnabled(
+      final boolean multiTenancyChecksEnabled) {
+    return new EngineSecurityConfig(
+        authentication,
+        authorizationsEnabled,
+        multiTenancyChecksEnabled,
+        initialization,
+        idValidationPattern,
+        groupIdValidationPattern);
   }
 
   public InitializationConfiguration getInitialization() {

--- a/security/security-core/src/main/java/io/camunda/security/configuration/EngineSecurityConfig.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/EngineSecurityConfig.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.configuration;
+
+import io.camunda.security.api.model.config.AuthenticationConfiguration;
+import io.camunda.security.api.model.config.initialization.InitializationConfiguration;
+import java.util.regex.Pattern;
+
+/**
+ * Lightweight security config holder for the engine and broker processing chain. Replaces the
+ * former {@code SecurityConfiguration} in non-Spring contexts so that the engine and broker modules
+ * depend only on {@code camunda-security-library-api} — not on Spring Boot starter beans.
+ *
+ * <p>Constructed by the Spring entry-point ({@code BrokerModuleConfiguration}) from OC's {@code
+ * SecurityConfiguration} and passed down the non-Spring partition startup chain. A follow-up PR
+ * will switch the source to CSL's {@code CamundaSecurityLibraryProperties} and delete {@code
+ * SecurityConfiguration}.
+ *
+ * <p>Note: {@link AuthenticationConfiguration} and {@link InitializationConfiguration} are kept
+ * here as sub-objects as a temporary measure. They will be removed once the gRPC Gateway gets its
+ * own config path (removing the need for auth config here) and identity setup is extracted out of
+ * the engine. See: https://github.com/camunda/camunda-security-library/issues/274
+ */
+public final class EngineSecurityConfig {
+
+  private final AuthenticationConfiguration authentication;
+  private boolean authorizationsEnabled;
+  private boolean multiTenancyChecksEnabled;
+  private final InitializationConfiguration initialization;
+  private final Pattern idValidationPattern;
+  private final Pattern groupIdValidationPattern;
+
+  public EngineSecurityConfig(
+      final AuthenticationConfiguration authentication,
+      final boolean authorizationsEnabled,
+      final boolean multiTenancyChecksEnabled,
+      final InitializationConfiguration initialization,
+      final Pattern idValidationPattern,
+      final Pattern groupIdValidationPattern) {
+    this.authentication = authentication;
+    this.authorizationsEnabled = authorizationsEnabled;
+    this.multiTenancyChecksEnabled = multiTenancyChecksEnabled;
+    this.initialization = initialization;
+    this.idValidationPattern = idValidationPattern;
+    this.groupIdValidationPattern = groupIdValidationPattern;
+  }
+
+  public AuthenticationConfiguration getAuthentication() {
+    return authentication;
+  }
+
+  public boolean isAuthorizationsEnabled() {
+    return authorizationsEnabled;
+  }
+
+  public void setAuthorizationsEnabled(final boolean authorizationsEnabled) {
+    this.authorizationsEnabled = authorizationsEnabled;
+  }
+
+  public boolean isMultiTenancyChecksEnabled() {
+    return multiTenancyChecksEnabled;
+  }
+
+  public void setMultiTenancyChecksEnabled(final boolean multiTenancyChecksEnabled) {
+    this.multiTenancyChecksEnabled = multiTenancyChecksEnabled;
+  }
+
+  public InitializationConfiguration getInitialization() {
+    return initialization;
+  }
+
+  /**
+   * Returns the compiled regex {@link Pattern} used to validate user/resource identifier strings.
+   * Returns {@code null} if no pattern is configured (validation disabled).
+   */
+  public Pattern getIdValidationPattern() {
+    return idValidationPattern;
+  }
+
+  /**
+   * Returns the compiled regex {@link Pattern} used to validate group identifier strings. Returns
+   * {@code null} if no pattern is configured (validation disabled).
+   */
+  public Pattern getGroupIdValidationPattern() {
+    return groupIdValidationPattern;
+  }
+}

--- a/security/security-core/src/main/java/io/camunda/security/configuration/EngineSecurityConfigurations.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/EngineSecurityConfigurations.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.configuration;
+
+import io.camunda.security.api.model.config.AuthenticationConfiguration;
+import io.camunda.security.api.model.config.AuthenticationMethod;
+import io.camunda.security.api.model.config.initialization.InitializationConfiguration;
+import java.util.regex.Pattern;
+
+/** Factory methods for commonly used {@link EngineSecurityConfig} presets. */
+public class EngineSecurityConfigurations {
+
+  /** Default compiled pattern for validating user/resource identifier strings. */
+  public static final Pattern ID_VALIDATION_PATTERN = Pattern.compile("^[a-zA-Z0-9_~@.+-]+$");
+
+  /** Default compiled pattern for validating group identifier strings. */
+  public static final Pattern GROUP_ID_VALIDATION_PATTERN = Pattern.compile(".*", Pattern.DOTALL);
+
+  /**
+   * Creates an {@link EngineSecurityConfig} preset where neither authentication nor authorization
+   * checks are enforced. The API is unprotected and multi-tenancy checks are disabled. Useful for
+   * testing or environments where security is intentionally bypassed.
+   *
+   * @return an {@link EngineSecurityConfig} with authentication method {@code BASIC}, unprotected
+   *     API, and both authorization and multi-tenancy checks disabled
+   */
+  public static EngineSecurityConfig unauthenticatedAndUnauthorized() {
+    final var authentication = new AuthenticationConfiguration();
+    authentication.setMethod(AuthenticationMethod.BASIC);
+    authentication.setUnprotectedApi(true);
+    return new EngineSecurityConfig(
+        authentication,
+        /* authorizationsEnabled= */ false,
+        /* multiTenancyChecksEnabled= */ false,
+        new InitializationConfiguration(),
+        ID_VALIDATION_PATTERN,
+        GROUP_ID_VALIDATION_PATTERN);
+  }
+
+  /**
+   * Creates an {@link EngineSecurityConfig} preset representing the default security configuration.
+   * Authorization checks are enabled, while multi-tenancy checks are disabled. Uses the default
+   * {@link AuthenticationConfiguration} and validation patterns.
+   *
+   * @return an {@link EngineSecurityConfig} with authorizations enabled and multi-tenancy checks
+   *     disabled
+   */
+  public static EngineSecurityConfig defaultConfig() {
+    return new EngineSecurityConfig(
+        new AuthenticationConfiguration(),
+        /* authorizationsEnabled= */ true,
+        /* multiTenancyChecksEnabled= */ false,
+        new InitializationConfiguration(),
+        ID_VALIDATION_PATTERN,
+        GROUP_ID_VALIDATION_PATTERN);
+  }
+}

--- a/security/security-core/src/test/java/io/camunda/security/auth/BrokerRequestAuthorizationConverterTest.java
+++ b/security/security-core/src/test/java/io/camunda/security/auth/BrokerRequestAuthorizationConverterTest.java
@@ -16,11 +16,15 @@ import static io.camunda.zeebe.auth.Authorization.USER_TOKEN_CLAIMS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.security.api.model.CamundaAuthentication;
+import io.camunda.security.api.model.config.AuthenticationConfiguration;
+import io.camunda.security.api.model.config.initialization.InitializationConfiguration;
 import io.camunda.security.api.model.config.oidc.OidcConfiguration;
-import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.configuration.EngineSecurityConfig;
+import io.camunda.security.configuration.EngineSecurityConfigurations;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 
 public class BrokerRequestAuthorizationConverterTest {
@@ -29,10 +33,9 @@ public class BrokerRequestAuthorizationConverterTest {
   void shouldOnlyContainAuthenticationClaimsWhenAuthorizationAndMultiTenancyDisabled() {
     // given
     final var authentication = CamundaAuthentication.of(b -> b.user("foo"));
-    final var securityConfiguration = new SecurityConfiguration();
-    securityConfiguration.getAuthorizations().setEnabled(false);
-    securityConfiguration.getMultiTenancy().setChecksEnabled(false);
-    final var converter = new BrokerRequestAuthorizationConverter(securityConfiguration);
+    final var converter =
+        new BrokerRequestAuthorizationConverter(
+            EngineSecurityConfigurations.unauthenticatedAndUnauthorized());
 
     // when
     final var brokerRequestAuth = converter.convert(authentication);
@@ -48,7 +51,9 @@ public class BrokerRequestAuthorizationConverterTest {
   void shouldContainAnonymousClaim() {
     // given
     final var authentication = CamundaAuthentication.anonymous();
-    final var converter = new BrokerRequestAuthorizationConverter(new SecurityConfiguration());
+    final var converter =
+        new BrokerRequestAuthorizationConverter(
+            EngineSecurityConfigurations.unauthenticatedAndUnauthorized());
 
     // when
     final var brokerRequestAuth = converter.convert(authentication);
@@ -62,7 +67,9 @@ public class BrokerRequestAuthorizationConverterTest {
   void shouldContainUsername() {
     // given
     final var authentication = CamundaAuthentication.of(b -> b.user("foo"));
-    final var converter = new BrokerRequestAuthorizationConverter(new SecurityConfiguration());
+    final var converter =
+        new BrokerRequestAuthorizationConverter(
+            EngineSecurityConfigurations.unauthenticatedAndUnauthorized());
 
     // when
     final var brokerRequestAuth = converter.convert(authentication);
@@ -76,9 +83,8 @@ public class BrokerRequestAuthorizationConverterTest {
   void shouldContainClientID() {
     // given
     final var authentication = CamundaAuthentication.of(b -> b.clientId("foo"));
-    final var securityConfiguration = new SecurityConfiguration();
-    securityConfiguration.getAuthentication().setMethod(OIDC);
-    final var converter = new BrokerRequestAuthorizationConverter(securityConfiguration);
+    final var converter =
+        new BrokerRequestAuthorizationConverter(EngineSecurityConfigurations.defaultConfig());
 
     // when
     final var brokerRequestAuth = converter.convert(authentication);
@@ -93,9 +99,8 @@ public class BrokerRequestAuthorizationConverterTest {
     // given
     final Map<String, Object> claims = Map.of("sub", "foo");
     final var authentication = CamundaAuthentication.of(b -> b.claims(claims));
-    final var securityConfiguration = new SecurityConfiguration();
-    securityConfiguration.getAuthentication().setMethod(OIDC);
-    final var converter = new BrokerRequestAuthorizationConverter(securityConfiguration);
+    final var converter =
+        new BrokerRequestAuthorizationConverter(EngineSecurityConfigurations.defaultConfig());
 
     // when
     final var brokerRequestAuth = converter.convert(authentication);
@@ -113,11 +118,11 @@ public class BrokerRequestAuthorizationConverterTest {
 
     final var oidcConfiguration = new OidcConfiguration();
     oidcConfiguration.setGroupsClaim("groups");
-    final var securityConfiguration = new SecurityConfiguration();
-    securityConfiguration.getAuthentication().setOidc(oidcConfiguration);
-    securityConfiguration.getAuthentication().setMethod(OIDC);
-
-    final var converter = new BrokerRequestAuthorizationConverter(securityConfiguration);
+    final var auth = new AuthenticationConfiguration();
+    auth.setOidc(oidcConfiguration);
+    auth.setMethod(OIDC);
+    final var config = createEngineSecurityConfig(auth);
+    final var converter = new BrokerRequestAuthorizationConverter(config);
 
     // when
     final var brokerRequestAuth = converter.convert(authentication);
@@ -135,10 +140,10 @@ public class BrokerRequestAuthorizationConverterTest {
 
     final var oidcConfiguration = new OidcConfiguration();
     oidcConfiguration.setGroupsClaim("groups");
-    final var securityConfiguration = new SecurityConfiguration();
-    securityConfiguration.getAuthentication().setOidc(oidcConfiguration);
-
-    final var converter = new BrokerRequestAuthorizationConverter(securityConfiguration);
+    final var auth = new AuthenticationConfiguration();
+    auth.setOidc(oidcConfiguration);
+    final var config = createEngineSecurityConfig(auth);
+    final var converter = new BrokerRequestAuthorizationConverter(config);
 
     // when
     final var brokerRequestAuth = converter.convert(authentication);
@@ -152,10 +157,8 @@ public class BrokerRequestAuthorizationConverterTest {
     // given
     final var groups = List.of("group1", "group2");
     final var authentication = CamundaAuthentication.of(b -> b.groupIds(groups));
-
-    final var securityConfiguration = new SecurityConfiguration();
-    securityConfiguration.getAuthentication().setMethod(OIDC);
-    final var converter = new BrokerRequestAuthorizationConverter(securityConfiguration);
+    final var converter =
+        new BrokerRequestAuthorizationConverter(EngineSecurityConfigurations.defaultConfig());
 
     // when
     final var brokerRequestAuth = converter.convert(authentication);
@@ -176,12 +179,10 @@ public class BrokerRequestAuthorizationConverterTest {
     final var invoked = new AtomicBoolean();
     final var oidcConfiguration = new OidcConfiguration();
     // no groupsClaim set
-    final var securityConfiguration = new SecurityConfiguration();
-    securityConfiguration.getAuthentication().setMethod(OIDC);
-    securityConfiguration.getAuthentication().setOidc(oidcConfiguration);
-    // Authorizations explicitly enabled so shouldIncludeAuthorizationClaims is true; the gate
-    // under test (groupsClaimConfigured) is what must keep the supplier from firing.
-    securityConfiguration.getAuthorizations().setEnabled(true);
+    final var auth = new AuthenticationConfiguration();
+    auth.setMethod(OIDC);
+    auth.setOidc(oidcConfiguration);
+    final var config = createEngineSecurityConfig(auth);
 
     final var authentication =
         CamundaAuthentication.of(
@@ -192,7 +193,7 @@ public class BrokerRequestAuthorizationConverterTest {
                           invoked.set(true);
                           return List.of("group1");
                         }));
-    final var converter = new BrokerRequestAuthorizationConverter(securityConfiguration);
+    final var converter = new BrokerRequestAuthorizationConverter(config);
 
     // when
     final var brokerRequestAuth = converter.convert(authentication);
@@ -200,5 +201,16 @@ public class BrokerRequestAuthorizationConverterTest {
     // then
     assertThat(invoked).isFalse();
     assertThat(brokerRequestAuth).doesNotContainKey(USER_GROUPS_CLAIMS);
+  }
+
+  private static @NonNull EngineSecurityConfig createEngineSecurityConfig(
+      final AuthenticationConfiguration auth) {
+    return new EngineSecurityConfig(
+        auth,
+        /* authorizationsEnabled= */ true,
+        /* multiTenancyChecksEnabled= */ false,
+        new InitializationConfiguration(),
+        EngineSecurityConfigurations.ID_VALIDATION_PATTERN,
+        EngineSecurityConfigurations.GROUP_ID_VALIDATION_PATTERN);
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
@@ -11,7 +11,7 @@ import io.atomix.cluster.messaging.ManagedMessagingService;
 import io.camunda.identity.sdk.IdentityConfiguration;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
-import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.security.oidc.OidcClaimsProvider;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.PartitionListener;
@@ -148,7 +148,7 @@ public interface BrokerStartupContext {
 
   MeterRegistry getMeterRegistry();
 
-  SecurityConfiguration getSecurityConfiguration();
+  EngineSecurityConfig getSecurityConfiguration();
 
   UserServices getUserServices();
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
@@ -14,7 +14,7 @@ import io.atomix.cluster.messaging.ManagedMessagingService;
 import io.camunda.identity.sdk.IdentityConfiguration;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
-import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.security.oidc.OidcClaimsProvider;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.PartitionListener;
@@ -68,7 +68,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   private final List<PartitionRaftListener> partitionRaftListeners = new ArrayList<>();
   private final Duration shutdownTimeout;
   private final MeterRegistry meterRegistry;
-  private final SecurityConfiguration securityConfiguration;
+  private final EngineSecurityConfig securityConfiguration;
   private final UserServices userServices;
   private final PasswordEncoder passwordEncoder;
   private final JwtDecoder jwtDecoder;
@@ -107,7 +107,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
       final List<PartitionListener> additionalPartitionListeners,
       final Duration shutdownTimeout,
       final MeterRegistry meterRegistry,
-      final SecurityConfiguration securityConfiguration,
+      final EngineSecurityConfig securityConfiguration,
       final UserServices userServices,
       final PasswordEncoder passwordEncoder,
       final JwtDecoder jwtDecoder,
@@ -372,7 +372,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   }
 
   @Override
-  public SecurityConfiguration getSecurityConfiguration() {
+  public EngineSecurityConfig getSecurityConfiguration() {
     return securityConfiguration;
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -14,7 +14,7 @@ import io.atomix.primitive.partition.impl.DefaultPartitionManagementService;
 import io.atomix.raft.partition.RaftPartition;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
-import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.broker.PartitionRaftListener;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -104,7 +104,7 @@ public final class PartitionManagerImpl
       final MeterRegistry meterRegistry,
       final BrokerClient brokerClient,
       final RocksDbResources rocksDbResources,
-      final SecurityConfiguration securityConfig,
+      final EngineSecurityConfig securityConfig,
       final SearchClientsProxy searchClientsProxy,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     this.partitionGroup = partitionGroup;

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
@@ -11,7 +11,7 @@ import io.atomix.cluster.BrokerMemberId;
 import io.atomix.raft.partition.RaftPartition;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
-import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.broker.PartitionRaftListener;
 import io.camunda.zeebe.broker.clustering.ClusterServices;
@@ -103,7 +103,7 @@ public final class ZeebePartitionFactory {
   private final TopologyManagerImpl topologyManager;
   private final FeatureFlags featureFlags;
   private final List<PartitionRaftListener> partitionRaftListeners;
-  private final SecurityConfiguration securityConfig;
+  private final EngineSecurityConfig securityConfig;
   private final SearchClientsProxy searchClientsProxy;
   private final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter;
   private final ClusterConfigurationService clusterConfigurationService;
@@ -124,7 +124,7 @@ public final class ZeebePartitionFactory {
       final List<PartitionRaftListener> partitionRaftListeners,
       final TopologyManagerImpl topologyManager,
       final FeatureFlags featureFlags,
-      final SecurityConfiguration securityConfig,
+      final EngineSecurityConfig securityConfig,
       final SearchClientsProxy searchClientsProxy,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter,
       final ClusterConfigurationService clusterConfigurationService,

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/EmbeddedGatewayService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/EmbeddedGatewayService.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.broker.system;
 
-import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.security.oidc.OidcClaimsProvider;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -33,7 +33,7 @@ public final class EmbeddedGatewayService implements AutoCloseable {
   public EmbeddedGatewayService(
       final Duration shutdownTimeout,
       final BrokerCfg configuration,
-      final SecurityConfiguration securityConfiguration,
+      final EngineSecurityConfig securityConfiguration,
       final ActorSchedulingService actorScheduler,
       final ConcurrencyControl concurrencyControl,
       final JobStreamClient jobStreamClient,

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -13,7 +13,7 @@ import io.atomix.cluster.AtomixCluster;
 import io.camunda.identity.sdk.IdentityConfiguration;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
-import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.security.oidc.OidcClaimsProvider;
 import io.camunda.security.validation.AuthorizationValidator;
 import io.camunda.security.validation.GroupValidator;
@@ -129,7 +129,7 @@ public final class SystemContext {
   private final AtomixCluster cluster;
   private final BrokerClient brokerClient;
   private final MeterRegistry meterRegistry;
-  private final SecurityConfiguration securityConfiguration;
+  private final EngineSecurityConfig securityConfiguration;
   private final UserServices userServices;
   private final PasswordEncoder passwordEncoder;
   private final JwtDecoder jwtDecoder;
@@ -148,7 +148,7 @@ public final class SystemContext {
       final AtomixCluster cluster,
       final BrokerClient brokerClient,
       final MeterRegistry meterRegistry,
-      final SecurityConfiguration securityConfiguration,
+      final EngineSecurityConfig securityConfiguration,
       final UserServices userServices,
       final PasswordEncoder passwordEncoder,
       final JwtDecoder jwtDecoder,
@@ -491,8 +491,8 @@ public final class SystemContext {
   private void validateInitializationConfig() {
     final IdentifierValidator identifierValidator =
         new IdentifierValidator(
-            securityConfiguration.getCompiledIdValidationPattern(),
-            securityConfiguration.getCompiledGroupIdValidationPattern());
+            securityConfiguration.getIdValidationPattern(),
+            securityConfiguration.getGroupIdValidationPattern());
     final AuthorizationConfigurer authorizationConfigurer =
         new AuthorizationConfigurer(new AuthorizationValidator(identifierValidator));
     final TenantConfigurer tenantConfigurer =
@@ -704,7 +704,7 @@ public final class SystemContext {
     return meterRegistry;
   }
 
-  public SecurityConfiguration getSecurityConfiguration() {
+  public EngineSecurityConfig getSecurityConfiguration() {
     return securityConfiguration;
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
@@ -11,7 +11,7 @@ import io.atomix.cluster.BrokerMemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.partition.RaftPartition;
-import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.zeebe.backup.api.BackupManager;
 import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.backup.processing.CheckpointRecordsProcessor;
@@ -114,7 +114,7 @@ public class PartitionStartupAndTransitionContextImpl
   private ControllableStreamClock clock;
   private final HealthTreeMetrics healthGraphMetrics;
   private final BrokerHealthCheckService brokerHealthCheckService;
-  private final SecurityConfiguration securityConfig;
+  private final EngineSecurityConfig securityConfig;
   private final MeterRegistry startupMeterRegistry;
   private MeterRegistry transitionMeterRegistry;
   private volatile boolean migrationsPerformed = false;
@@ -143,7 +143,7 @@ public class PartitionStartupAndTransitionContextImpl
       final AtomixServerTransport gatewayBrokerTransport,
       final TopologyManager topologyManager,
       final BrokerHealthCheckService brokerHealthCheckService,
-      final SecurityConfiguration securityConfig,
+      final EngineSecurityConfig securityConfig,
       final MeterRegistry startupMeterRegistry) {
     this.memberId = memberId;
     this.partitionCount = partitionCount;
@@ -322,7 +322,7 @@ public class PartitionStartupAndTransitionContextImpl
   }
 
   @Override
-  public SecurityConfiguration getSecurityConfig() {
+  public EngineSecurityConfig getSecurityConfig() {
     return securityConfig;
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.broker.system.partitions;
 import io.atomix.cluster.BrokerMemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.atomix.raft.RaftServer.Role;
-import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.zeebe.backup.api.BackupManager;
 import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.backup.processing.CheckpointRecordsProcessor;
@@ -111,7 +111,7 @@ public interface PartitionTransitionContext extends PartitionContext {
 
   BrokerCfg getBrokerCfg();
 
-  SecurityConfiguration getSecurityConfig();
+  EngineSecurityConfig getSecurityConfig();
 
   QueryService getQueryService();
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/SimpleBrokerStartTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/SimpleBrokerStartTest.java
@@ -15,7 +15,7 @@ import static org.mockito.Mockito.mock;
 import io.atomix.cluster.AtomixCluster;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
-import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.configuration.EngineSecurityConfigurations;
 import io.camunda.security.oidc.NoopOidcClaimsProvider;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -79,7 +79,7 @@ public final class SimpleBrokerStartTest {
                       mock(AtomixCluster.class),
                       mock(BrokerClient.class),
                       new SimpleMeterRegistry(),
-                      new SecurityConfiguration(),
+                      EngineSecurityConfigurations.defaultConfig(),
                       mock(UserServices.class),
                       mock(PasswordEncoder.class),
                       mock(JwtDecoder.class),
@@ -116,7 +116,7 @@ public final class SimpleBrokerStartTest {
             atomixCluster,
             brokerClient,
             new SimpleMeterRegistry(),
-            new SecurityConfiguration(),
+            EngineSecurityConfigurations.defaultConfig(),
             mock(UserServices.class),
             mock(PasswordEncoder.class),
             mock(JwtDecoder.class),

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/MockBrokerStartupContext.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/MockBrokerStartupContext.java
@@ -14,7 +14,8 @@ import io.atomix.cluster.messaging.ManagedMessagingService;
 import io.camunda.identity.sdk.IdentityConfiguration;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
-import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.configuration.EngineSecurityConfig;
+import io.camunda.security.configuration.EngineSecurityConfigurations;
 import io.camunda.security.oidc.NoopOidcClaimsProvider;
 import io.camunda.security.oidc.OidcClaimsProvider;
 import io.camunda.service.UserServices;
@@ -83,7 +84,7 @@ public class MockBrokerStartupContext implements BrokerStartupContext {
   private Duration shutdownTimeout = Duration.ofSeconds(30);
   private SnowflakeIdGenerator requestIdGenerator = mock(SnowflakeIdGenerator.class);
   private MeterRegistry meterRegistry = new SimpleMeterRegistry();
-  private SecurityConfiguration securityConfiguration = new SecurityConfiguration();
+  private EngineSecurityConfig securityConfiguration = EngineSecurityConfigurations.defaultConfig();
   private UserServices userServices = mock(UserServices.class);
   private PasswordEncoder passwordEncoder = mock(PasswordEncoder.class);
   private JwtDecoder jwtDecoder = mock(JwtDecoder.class);
@@ -372,11 +373,11 @@ public class MockBrokerStartupContext implements BrokerStartupContext {
   }
 
   @Override
-  public SecurityConfiguration getSecurityConfiguration() {
+  public EngineSecurityConfig getSecurityConfiguration() {
     return securityConfiguration;
   }
 
-  public void setSecurityConfiguration(final SecurityConfiguration securityConfiguration) {
+  public void setSecurityConfiguration(final EngineSecurityConfig securityConfiguration) {
     this.securityConfiguration = securityConfiguration;
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionJoinTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionJoinTest.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.broker.partitioning;
 import static io.camunda.zeebe.broker.test.EmbeddedBrokerRule.assignSocketAddresses;
 
 import io.atomix.cluster.MemberId;
-import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.configuration.EngineSecurityConfigurations;
 import io.camunda.security.oidc.NoopOidcClaimsProvider;
 import io.camunda.zeebe.broker.Broker;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
@@ -121,7 +121,7 @@ final class PartitionJoinTest {
             atomixCluster,
             brokerClient,
             new SimpleMeterRegistry(),
-            new SecurityConfiguration(),
+            EngineSecurityConfigurations.defaultConfig(),
             null,
             null,
             null,

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionLeaveTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionLeaveTest.java
@@ -11,7 +11,7 @@ import static io.camunda.zeebe.broker.test.EmbeddedBrokerRule.assignSocketAddres
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.CamundaClient;
-import io.camunda.security.configuration.SecurityConfigurations;
+import io.camunda.security.configuration.EngineSecurityConfigurations;
 import io.camunda.security.oidc.NoopOidcClaimsProvider;
 import io.camunda.zeebe.broker.Broker;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
@@ -237,7 +237,7 @@ final class PartitionLeaveTest {
             atomixCluster,
             brokerClient,
             new SimpleMeterRegistry(),
-            SecurityConfigurations.unauthenticatedAndUnauthorized(),
+            EngineSecurityConfigurations.unauthenticatedAndUnauthorized(),
             null,
             null,
             null,

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PhysicalTenantPartitionManagerIT.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PhysicalTenantPartitionManagerIT.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.broker.partitioning;
 import static io.camunda.zeebe.broker.test.EmbeddedBrokerRule.assignSocketAddresses;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.security.configuration.SecurityConfigurations;
+import io.camunda.security.configuration.EngineSecurityConfigurations;
 import io.camunda.security.oidc.NoopOidcClaimsProvider;
 import io.camunda.zeebe.broker.Broker;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
@@ -83,7 +83,7 @@ final class PhysicalTenantPartitionManagerIT {
             atomixCluster,
             brokerClient,
             new SimpleMeterRegistry(),
-            SecurityConfigurations.unauthenticatedAndUnauthorized(),
+            EngineSecurityConfigurations.unauthenticatedAndUnauthorized(),
             null,
             null,
             null,

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
@@ -16,7 +16,7 @@ import static org.mockito.Mockito.mock;
 import io.atomix.cluster.AtomixCluster;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
-import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.configuration.EngineSecurityConfigurations;
 import io.camunda.security.oidc.NoopOidcClaimsProvider;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -385,7 +385,7 @@ final class SystemContextTest {
         mock(AtomixCluster.class),
         mock(BrokerClient.class),
         new SimpleMeterRegistry(),
-        new SecurityConfiguration(),
+        EngineSecurityConfigurations.defaultConfig(),
         mock(UserServices.class),
         mock(PasswordEncoder.class),
         mock(JwtDecoder.class),

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
@@ -11,7 +11,7 @@ import io.atomix.cluster.BrokerMemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.partition.RaftPartition;
-import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.zeebe.backup.api.BackupManager;
 import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.backup.processing.CheckpointRecordsProcessor;
@@ -87,7 +87,7 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
   private BackupStore backupStore;
   private DynamicPartitionConfig partitionConfig;
   private ControllableStreamClock clock;
-  private SecurityConfiguration securityConfig;
+  private EngineSecurityConfig securityConfig;
   private MeterRegistry transitionMeterRegistry;
   private String brokerVersion = PartitionTransitionContext.super.getBrokerVersion();
   private boolean migrationsPerformed;
@@ -286,7 +286,7 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
   }
 
   @Override
-  public SecurityConfiguration getSecurityConfig() {
+  public EngineSecurityConfig getSecurityConfig() {
     return securityConfig;
   }
 
@@ -399,7 +399,7 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
     this.diskSpaceUsageMonitor = diskSpaceUsageMonitor;
   }
 
-  public void setBrokerCfg(final SecurityConfiguration securityConfig) {
+  public void setSecurityConfig(final EngineSecurityConfig securityConfig) {
     this.securityConfig = securityConfig;
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
@@ -17,7 +17,7 @@ import static io.camunda.zeebe.broker.test.EmbeddedBrokerConfigurator.setInterna
 import io.atomix.cluster.AtomixCluster;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.impl.util.AddressUtil;
-import io.camunda.security.configuration.SecurityConfigurations;
+import io.camunda.security.configuration.EngineSecurityConfigurations;
 import io.camunda.security.oidc.NoopOidcClaimsProvider;
 import io.camunda.zeebe.broker.Broker;
 import io.camunda.zeebe.broker.PartitionListener;
@@ -249,7 +249,7 @@ public final class EmbeddedBrokerRule extends ExternalResource {
             atomixCluster,
             TestBrokerClientFactory.createBrokerClient(atomixCluster, scheduler),
             new SimpleMeterRegistry(),
-            SecurityConfigurations.unauthenticatedAndUnauthorized(),
+            EngineSecurityConfigurations.unauthenticatedAndUnauthorized(),
             null,
             null,
             null,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.engine;
 
-import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.zeebe.engine.processing.streamprocessor.RecordProcessorMap;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor.ProcessingError;
@@ -68,12 +68,12 @@ public class Engine implements RecordProcessor {
   private Writers writers;
   private final TypedRecordProcessorFactory typedRecordProcessorFactory;
   private final EngineConfiguration config;
-  private final SecurityConfiguration securityConfig;
+  private final EngineSecurityConfig securityConfig;
 
   public Engine(
       final TypedRecordProcessorFactory typedRecordProcessorFactory,
       final EngineConfiguration config,
-      final SecurityConfiguration securityConfig) {
+      final EngineSecurityConfig securityConfig) {
     this.typedRecordProcessorFactory = typedRecordProcessorFactory;
     this.config = config;
     this.securityConfig = securityConfig;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCreateProcessor.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.identity;
 
-import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
@@ -43,7 +43,7 @@ public class AuthorizationCreateProcessor
       final ProcessingState processingState,
       final CommandDistributionBehavior distributionBehavior,
       final AuthorizationCheckBehavior authCheckBehavior,
-      final SecurityConfiguration securityConfig) {
+      final EngineSecurityConfig securityConfig) {
     this.keyGenerator = keyGenerator;
     this.distributionBehavior = distributionBehavior;
     stateWriter = writers.state();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationEntityValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationEntityValidator.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.identity;
 
-import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.state.immutable.GroupState;
 import io.camunda.zeebe.engine.state.immutable.MappingRuleState;
@@ -45,10 +45,10 @@ public class AuthorizationEntityValidator {
   private final MappingRuleState mappingRuleState;
   private final GroupState groupState;
   private final RoleState roleState;
-  private final SecurityConfiguration securityConfig;
+  private final EngineSecurityConfig securityConfig;
 
   public AuthorizationEntityValidator(
-      final ProcessingState processingState, final SecurityConfiguration securityConfig) {
+      final ProcessingState processingState, final EngineSecurityConfig securityConfig) {
     userState = processingState.getUserState();
     mappingRuleState = processingState.getMappingRuleState();
     groupState = processingState.getGroupState();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationProcessors.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.identity;
 
-import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
@@ -26,7 +26,7 @@ public final class AuthorizationProcessors {
       final Writers writers,
       final CommandDistributionBehavior distributionBehavior,
       final AuthorizationCheckBehavior authCheckBehavior,
-      final SecurityConfiguration securityConfig) {
+      final EngineSecurityConfig securityConfig) {
     typedRecordProcessors.onCommand(
         ValueType.AUTHORIZATION,
         AuthorizationIntent.CREATE,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationUpdateProcessor.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.engine.processing.identity;
 
 import static io.camunda.zeebe.engine.processing.identity.PermissionsBehavior.AUTHORIZATION_DOES_NOT_EXIST_ERROR_MESSAGE_UPDATE;
 
-import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
@@ -44,7 +44,7 @@ public class AuthorizationUpdateProcessor
       final ProcessingState processingState,
       final CommandDistributionBehavior distributionBehavior,
       final AuthorizationCheckBehavior authCheckBehavior,
-      final SecurityConfiguration securityConfig) {
+      final EngineSecurityConfig securityConfig) {
     this.keyGenerator = keyGenerator;
     this.distributionBehavior = distributionBehavior;
     stateWriter = writers.state();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupAddEntityProcessor.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.identity;
 
-import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
@@ -44,7 +44,7 @@ public class GroupAddEntityProcessor implements DistributedTypedRecordProcessor<
   private final KeyGenerator keyGenerator;
   private final StateWriter stateWriter;
   private final TypedRejectionWriter rejectionWriter;
-  private final SecurityConfiguration securityConfig;
+  private final EngineSecurityConfig securityConfig;
   private final TypedResponseWriter responseWriter;
   private final CommandDistributionBehavior commandDistributionBehavior;
 
@@ -54,7 +54,7 @@ public class GroupAddEntityProcessor implements DistributedTypedRecordProcessor<
       final KeyGenerator keyGenerator,
       final Writers writers,
       final CommandDistributionBehavior commandDistributionBehavior,
-      final SecurityConfiguration securityConfig) {
+      final EngineSecurityConfig securityConfig) {
     this.commandDistributionBehavior = commandDistributionBehavior;
     this.keyGenerator = keyGenerator;
     this.authCheckBehavior = authCheckBehavior;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupProcessors.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.identity;
 
-import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
@@ -25,7 +25,7 @@ public class GroupProcessors {
       final KeyGenerator keyGenerator,
       final Writers writers,
       final CommandDistributionBehavior commandDistributionBehavior,
-      final SecurityConfiguration securityConfig) {
+      final EngineSecurityConfig securityConfig) {
     typedRecordProcessors.onCommand(
         ValueType.GROUP,
         GroupIntent.CREATE,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupProcessors.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.identity;
 
-import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.security.validation.AuthorizationValidator;
 import io.camunda.security.validation.GroupValidator;
 import io.camunda.security.validation.IdentifierValidator;
@@ -30,12 +30,11 @@ public final class IdentitySetupProcessors {
       final KeyGenerator keyGenerator,
       final TypedRecordProcessors typedRecordProcessors,
       final Writers writers,
-      final SecurityConfiguration securityConfig,
+      final EngineSecurityConfig securityConfig,
       final EngineConfiguration config) {
     final IdentifierValidator identifierValidator =
         new IdentifierValidator(
-            securityConfig.getCompiledIdValidationPattern(),
-            securityConfig.getCompiledGroupIdValidationPattern());
+            securityConfig.getIdValidationPattern(), securityConfig.getGroupIdValidationPattern());
     typedRecordProcessors
         .onCommand(
             ValueType.IDENTITY_SETUP,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleAddEntityProcessor.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.identity;
 
-import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
@@ -52,7 +52,7 @@ public class RoleAddEntityProcessor implements DistributedTypedRecordProcessor<R
   private final TypedRejectionWriter rejectionWriter;
   private final TypedResponseWriter responseWriter;
   private final CommandDistributionBehavior commandDistributionBehavior;
-  private final SecurityConfiguration securityConfig;
+  private final EngineSecurityConfig securityConfig;
 
   public RoleAddEntityProcessor(
       final ProcessingState processingState,
@@ -60,7 +60,7 @@ public class RoleAddEntityProcessor implements DistributedTypedRecordProcessor<R
       final KeyGenerator keyGenerator,
       final Writers writers,
       final CommandDistributionBehavior commandDistributionBehavior,
-      final SecurityConfiguration securityConfig) {
+      final EngineSecurityConfig securityConfig) {
     roleState = processingState.getRoleState();
     mappingRuleState = processingState.getMappingRuleState();
     membershipState = processingState.getMembershipState();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleProcessors.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.identity;
 
-import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
@@ -25,7 +25,7 @@ public class RoleProcessors {
       final KeyGenerator keyGenerator,
       final Writers writers,
       final CommandDistributionBehavior commandDistributionBehavior,
-      final SecurityConfiguration securityConfig) {
+      final EngineSecurityConfig securityConfig) {
     typedRecordProcessors.onCommand(
         ValueType.ROLE,
         RoleIntent.CREATE,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/AuthorizationCheckBehavior.java
@@ -11,7 +11,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import io.camunda.security.auth.MappingRuleMatcher;
-import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.identity.AuthorizedTenants;
@@ -65,14 +65,14 @@ public final class AuthorizationCheckBehavior {
 
   public AuthorizationCheckBehavior(
       final ProcessingState processingState,
-      final SecurityConfiguration securityConfig,
+      final EngineSecurityConfig securityConfig,
       final EngineConfiguration config) {
     final var authorizationState = processingState.getAuthorizationState();
     final var membershipState = processingState.getMembershipState();
 
     mappingRuleState = processingState.getMappingRuleState();
-    authorizationsEnabled = securityConfig.getAuthorizations().isEnabled();
-    multiTenancyEnabled = securityConfig.getMultiTenancy().isChecksEnabled();
+    authorizationsEnabled = securityConfig.isAuthorizationsEnabled();
+    multiTenancyEnabled = securityConfig.isMultiTenancyChecksEnabled();
     claimsExtractor = new ClaimsExtractor(membershipState);
     tenantResolver =
         new TenantResolver(membershipState, mappingRuleState, claimsExtractor, multiTenancyEnabled);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/initialize/IdentitySetupInitializer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/initialize/IdentitySetupInitializer.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.identity.initialize;
 
-import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.security.validation.IdentityInitializationException;
 import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.protocol.Protocol;
@@ -43,7 +43,7 @@ public final class IdentitySetupInitializer implements StreamProcessorLifecycleA
   public static final String INVALID_CONFIGURED_ENTITY_MESSAGE =
       "Found invalid %s. Aborting identity initialization! %n- %s";
   private static final Logger LOG = Loggers.PROCESS_PROCESSOR_LOGGER;
-  private final SecurityConfiguration securityConfig;
+  private final EngineSecurityConfig securityConfig;
   private final boolean enableIdentitySetup;
   private final AuthorizationConfigurer authorizationConfigurer;
   private final TenantConfigurer tenantConfigurer;
@@ -52,7 +52,7 @@ public final class IdentitySetupInitializer implements StreamProcessorLifecycleA
   private final RoleConfigurer roleConfigurer;
 
   public IdentitySetupInitializer(
-      final SecurityConfiguration securityConfig,
+      final EngineSecurityConfig securityConfig,
       final boolean enableIdentitySetup,
       final AuthorizationConfigurer authorizationConfigurer,
       final TenantConfigurer tenantConfigurer,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContext.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContext.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.streamprocessor;
 
-import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.ScheduledTaskState;
@@ -36,7 +36,7 @@ public interface TypedRecordProcessorContext {
 
   EngineConfiguration getConfig();
 
-  SecurityConfiguration getSecurityConfig();
+  EngineSecurityConfig getSecurityConfig();
 
   ControllableStreamClock getClock();
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContextImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContextImpl.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.streamprocessor;
 
-import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.el.impl.ExpressionLanguageMetricsImpl;
 import io.camunda.zeebe.engine.EngineConfiguration;
@@ -37,14 +37,14 @@ public class TypedRecordProcessorContextImpl implements TypedRecordProcessorCont
   private final TransientPendingSubscriptionState transientMessageSubscriptionState;
   private final TransientPendingSubscriptionState transientProcessMessageSubscriptionState;
   private final ControllableStreamClock clock;
-  private final SecurityConfiguration securityConfig;
+  private final EngineSecurityConfig securityConfig;
   private final MeterRegistry meterRegistry;
 
   public TypedRecordProcessorContextImpl(
       final RecordProcessorContext context,
       final Writers writers,
       final EngineConfiguration config,
-      final SecurityConfiguration securityConfig) {
+      final EngineSecurityConfig securityConfig) {
     partitionId = context.getPartitionId();
     scheduleService = context.getScheduleService();
     zeebeDb = context.getZeebeDb();
@@ -112,7 +112,7 @@ public class TypedRecordProcessorContextImpl implements TypedRecordProcessorCont
   }
 
   @Override
-  public SecurityConfiguration getSecurityConfig() {
+  public EngineSecurityConfig getSecurityConfig() {
     return securityConfig;
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.tenant;
 
-import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
@@ -54,7 +54,7 @@ public class TenantAddEntityProcessor implements DistributedTypedRecordProcessor
   private final TypedResponseWriter responseWriter;
   private final SideEffectWriter sideEffectWriter;
   private final CommandDistributionBehavior commandDistributionBehavior;
-  private final SecurityConfiguration securityConfig;
+  private final EngineSecurityConfig securityConfig;
   private final MembershipState membershipState;
 
   public TenantAddEntityProcessor(
@@ -63,7 +63,7 @@ public class TenantAddEntityProcessor implements DistributedTypedRecordProcessor
       final KeyGenerator keyGenerator,
       final Writers writers,
       final CommandDistributionBehavior commandDistributionBehavior,
-      final SecurityConfiguration securityConfig) {
+      final EngineSecurityConfig securityConfig) {
     tenantState = state.getTenantState();
     mappingRuleState = state.getMappingRuleState();
     groupState = state.getGroupState();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantProcessors.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.tenant;
 
-import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
@@ -26,7 +26,7 @@ public class TenantProcessors {
       final KeyGenerator keyGenerator,
       final Writers writers,
       final CommandDistributionBehavior commandDistributionBehavior,
-      final SecurityConfiguration securityConfig) {
+      final EngineSecurityConfig securityConfig) {
     typedRecordProcessors
         .onCommand(
             ValueType.TENANT,

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/perf/TestEngine.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/perf/TestEngine.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.engine.perf;
 
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
-import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.configuration.EngineSecurityConfigurations;
 import io.camunda.zeebe.engine.processing.EngineProcessors;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer;
@@ -89,7 +89,8 @@ public final class TestEngine {
                             featureFlags,
                             JobStreamer.noop(),
                             SearchClientsProxy.noop(),
-                            new BrokerRequestAuthorizationConverter(new SecurityConfiguration()))
+                            new BrokerRequestAuthorizationConverter(
+                                EngineSecurityConfigurations.defaultConfig()))
                         .withListener(
                             new ProcessingExporterTransistor(
                                 testStreams.getLogStream(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateAuthorizationTest.java
@@ -57,14 +57,14 @@ public final class AgentInstanceCreateAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
+          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {
                 final var defaultRoles = new HashMap<>(cfg.getInitialization().getDefaultRoles());
                 defaultRoles.put("admin", Map.of("users", List.of(DEFAULT_USER.getUsername())));
                 cfg.getInitialization().setDefaultRoles(defaultRoles);
-                cfg.getMultiTenancy().setChecksEnabled(true);
+                cfg.setMultiTenancyChecksEnabled(true);
               });
 
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateAuthorizationTest.java
@@ -57,14 +57,14 @@ public final class AgentInstanceCreateAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
+          .withAuthorizationsEnabled(true)
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
+          .withMultiTenancyChecksEnabled(true)
           .withSecurityConfig(
               cfg -> {
                 final var defaultRoles = new HashMap<>(cfg.getInitialization().getDefaultRoles());
                 defaultRoles.put("admin", Map.of("users", List.of(DEFAULT_USER.getUsername())));
                 cfg.getInitialization().setDefaultRoles(defaultRoles);
-                cfg.setMultiTenancyChecksEnabled(true);
               });
 
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateAuthorizationTest.java
@@ -62,14 +62,14 @@ public final class AgentInstanceUpdateAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
+          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {
                 final var defaultRoles = new HashMap<>(cfg.getInitialization().getDefaultRoles());
                 defaultRoles.put("admin", Map.of("users", List.of(DEFAULT_USER.getUsername())));
                 cfg.getInitialization().setDefaultRoles(defaultRoles);
-                cfg.getMultiTenancy().setChecksEnabled(true);
+                cfg.setMultiTenancyChecksEnabled(true);
               });
 
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateAuthorizationTest.java
@@ -62,14 +62,14 @@ public final class AgentInstanceUpdateAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
+          .withAuthorizationsEnabled(true)
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
+          .withMultiTenancyChecksEnabled(true)
           .withSecurityConfig(
               cfg -> {
                 final var defaultRoles = new HashMap<>(cfg.getInitialization().getDefaultRoles());
                 defaultRoles.put("admin", Map.of("users", List.of(DEFAULT_USER.getUsername())));
                 cfg.getInitialization().setDefaultRoles(defaultRoles);
-                cfg.setMultiTenancyChecksEnabled(true);
               });
 
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/auditlog/BatchEventsClaimsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/auditlog/BatchEventsClaimsTest.java
@@ -40,7 +40,7 @@ public class BatchEventsClaimsTest {
           .withIdentitySetup()
           .withSecurityConfig(
               cfg -> {
-                cfg.getAuthorizations().setEnabled(true);
+                cfg.setAuthorizationsEnabled(true);
                 cfg.getInitialization().setUsers(List.of(DEFAULT_USER));
                 final var defaultRoles = new HashMap<>(cfg.getInitialization().getDefaultRoles());
                 defaultRoles.put("admin", Map.of("users", List.of(DEFAULT_USER.getUsername())));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/auditlog/BatchEventsClaimsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/auditlog/BatchEventsClaimsTest.java
@@ -38,9 +38,9 @@ public class BatchEventsClaimsTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
+          .withAuthorizationsEnabled(true)
           .withSecurityConfig(
               cfg -> {
-                cfg.setAuthorizationsEnabled(true);
                 cfg.getInitialization().setUsers(List.of(DEFAULT_USER));
                 final var defaultRoles = new HashMap<>(cfg.getInitialization().getDefaultRoles());
                 defaultRoles.put("admin", Map.of("users", List.of(DEFAULT_USER.getUsername())));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/auditlog/IdentityEventsClaimsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/auditlog/IdentityEventsClaimsTest.java
@@ -50,7 +50,7 @@ public class IdentityEventsClaimsTest {
           .withIdentitySetup()
           .withSecurityConfig(
               cfg -> {
-                cfg.getAuthorizations().setEnabled(true);
+                cfg.setAuthorizationsEnabled(true);
                 cfg.getInitialization().setUsers(List.of(DEFAULT_USER));
                 final var defaultRoles = new HashMap<>(cfg.getInitialization().getDefaultRoles());
                 defaultRoles.put("admin", Map.of("users", List.of(DEFAULT_USER.getUsername())));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/auditlog/IdentityEventsClaimsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/auditlog/IdentityEventsClaimsTest.java
@@ -48,9 +48,9 @@ public class IdentityEventsClaimsTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
+          .withAuthorizationsEnabled(true)
           .withSecurityConfig(
               cfg -> {
-                cfg.setAuthorizationsEnabled(true);
                 cfg.getInitialization().setUsers(List.of(DEFAULT_USER));
                 final var defaultRoles = new HashMap<>(cfg.getInitialization().getDefaultRoles());
                 defaultRoles.put("admin", Map.of("users", List.of(DEFAULT_USER.getUsername())));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/auditlog/ProcessEventsClaimsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/auditlog/ProcessEventsClaimsTest.java
@@ -51,9 +51,9 @@ public class ProcessEventsClaimsTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
+          .withAuthorizationsEnabled(true)
           .withSecurityConfig(
               cfg -> {
-                cfg.setAuthorizationsEnabled(true);
                 cfg.getInitialization().setUsers(List.of(DEFAULT_USER));
                 final var defaultRoles = new HashMap<>(cfg.getInitialization().getDefaultRoles());
                 defaultRoles.put("admin", Map.of("users", List.of(DEFAULT_USER.getUsername())));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/auditlog/ProcessEventsClaimsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/auditlog/ProcessEventsClaimsTest.java
@@ -53,7 +53,7 @@ public class ProcessEventsClaimsTest {
           .withIdentitySetup()
           .withSecurityConfig(
               cfg -> {
-                cfg.getAuthorizations().setEnabled(true);
+                cfg.setAuthorizationsEnabled(true);
                 cfg.getInitialization().setUsers(List.of(DEFAULT_USER));
                 final var defaultRoles = new HashMap<>(cfg.getInitialization().getDefaultRoles());
                 defaultRoles.put("admin", Map.of("users", List.of(DEFAULT_USER.getUsername())));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/auditlog/ResourceEventsClaimsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/auditlog/ResourceEventsClaimsTest.java
@@ -42,9 +42,9 @@ public class ResourceEventsClaimsTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
+          .withAuthorizationsEnabled(true)
           .withSecurityConfig(
               cfg -> {
-                cfg.setAuthorizationsEnabled(true);
                 cfg.getInitialization().setUsers(List.of(DEFAULT_USER));
                 final var defaultRoles = new HashMap<>(cfg.getInitialization().getDefaultRoles());
                 defaultRoles.put("admin", Map.of("users", List.of(DEFAULT_USER.getUsername())));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/auditlog/ResourceEventsClaimsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/auditlog/ResourceEventsClaimsTest.java
@@ -44,7 +44,7 @@ public class ResourceEventsClaimsTest {
           .withIdentitySetup()
           .withSecurityConfig(
               cfg -> {
-                cfg.getAuthorizations().setEnabled(true);
+                cfg.setAuthorizationsEnabled(true);
                 cfg.getInitialization().setUsers(List.of(DEFAULT_USER));
                 final var defaultRoles = new HashMap<>(cfg.getInitialization().getDefaultRoles());
                 defaultRoles.put("admin", Map.of("users", List.of(DEFAULT_USER.getUsername())));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/auditlog/UserTaskEventsClaimsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/auditlog/UserTaskEventsClaimsTest.java
@@ -44,7 +44,7 @@ public class UserTaskEventsClaimsTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
+          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/auditlog/UserTaskEventsClaimsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/auditlog/UserTaskEventsClaimsTest.java
@@ -44,7 +44,7 @@ public class UserTaskEventsClaimsTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
+          .withAuthorizationsEnabled(true)
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AnonymousAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AnonymousAuthorizationTest.java
@@ -56,7 +56,7 @@ public class AnonymousAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(c -> c.getAuthorizations().setEnabled(true));
+          .withSecurityConfig(c -> c.setAuthorizationsEnabled(true));
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AnonymousAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AnonymousAuthorizationTest.java
@@ -54,9 +54,7 @@ public class AnonymousAuthorizationTest {
 
   @Rule
   public final EngineRule engine =
-      EngineRule.singlePartition()
-          .withIdentitySetup()
-          .withSecurityConfig(c -> c.setAuthorizationsEnabled(true));
+      EngineRule.singlePartition().withIdentitySetup().withAuthorizationsEnabled(true);
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorGroupsClaimsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorGroupsClaimsTest.java
@@ -14,8 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import io.camunda.security.api.model.config.AuthorizationsConfiguration;
-import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.configuration.EngineSecurityConfigurations;
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.property.UserTaskAuthorizationProperties;
@@ -70,13 +69,10 @@ final class AuthorizationCheckBehaviorGroupsClaimsTest {
 
   @BeforeEach
   public void before() {
-    final var securityConfig = new SecurityConfiguration();
-    final var authConfig = new AuthorizationsConfiguration();
     final var engineConfig = new EngineConfiguration();
-    authConfig.setEnabled(true);
-    securityConfig.setAuthorizations(authConfig);
     authorizationCheckBehavior =
-        new AuthorizationCheckBehavior(processingState, securityConfig, engineConfig);
+        new AuthorizationCheckBehavior(
+            processingState, EngineSecurityConfigurations.defaultConfig(), engineConfig);
 
     userCreatedApplier = new UserCreatedApplier(processingState.getUserState());
     mappingRuleCreatedApplier =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorMultiTenancyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorMultiTenancyTest.java
@@ -14,9 +14,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import io.camunda.security.api.model.config.AuthorizationsConfiguration;
-import io.camunda.security.api.model.config.MultiTenancyConfiguration;
-import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.api.model.config.AuthenticationConfiguration;
+import io.camunda.security.api.model.config.initialization.InitializationConfiguration;
+import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.identity.AuthorizedTenants;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
@@ -55,6 +55,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
+import java.util.regex.Pattern;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -79,14 +80,15 @@ final class AuthorizationCheckBehaviorMultiTenancyTest {
 
   @BeforeEach
   void before() {
-    final var securityConfig = new SecurityConfiguration();
-    final var authConfig = new AuthorizationsConfiguration();
     final var engineConfig = new EngineConfiguration();
-    authConfig.setEnabled(true);
-    securityConfig.setAuthorizations(authConfig);
-    final var multiTenancyConfig = new MultiTenancyConfiguration();
-    multiTenancyConfig.setChecksEnabled(true);
-    securityConfig.setMultiTenancy(multiTenancyConfig);
+    final var securityConfig =
+        new EngineSecurityConfig(
+            new AuthenticationConfiguration(),
+            /* authorizationsEnabled= */ true,
+            /* multiTenancyChecksEnabled= */ true,
+            new InitializationConfiguration(),
+            Pattern.compile("^[a-zA-Z0-9_~@.+-]+$"),
+            Pattern.compile(".*", Pattern.DOTALL));
     authorizationCheckBehavior =
         new AuthorizationCheckBehavior(processingState, securityConfig, engineConfig);
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
@@ -17,8 +17,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.common.util.concurrent.UncheckedExecutionException;
-import io.camunda.security.api.model.config.AuthorizationsConfiguration;
-import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.configuration.EngineSecurityConfigurations;
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.property.ResourceAuthorizationProperties;
@@ -80,13 +79,10 @@ final class AuthorizationCheckBehaviorTest {
 
   @BeforeEach
   public void before() {
-    final var securityConfig = new SecurityConfiguration();
-    final var authConfig = new AuthorizationsConfiguration();
     final var engineConfig = new EngineConfiguration();
-    authConfig.setEnabled(true);
-    securityConfig.setAuthorizations(authConfig);
     authorizationCheckBehavior =
-        new AuthorizationCheckBehavior(processingState, securityConfig, engineConfig);
+        new AuthorizationCheckBehavior(
+            processingState, EngineSecurityConfigurations.defaultConfig(), engineConfig);
 
     userCreatedApplier = new UserCreatedApplier(processingState.getUserState());
     mappingRuleCreatedApplier =
@@ -1497,14 +1493,10 @@ final class AuthorizationCheckBehaviorTest {
   @Test
   void shouldExpireAuthorizationCacheAfterConfiguredTtl() {
     // given: authorizations enabled and a very short cache TTL
-    final var securityConfig = new SecurityConfiguration();
-    final var authConfig = new AuthorizationsConfiguration();
-    authConfig.setEnabled(true);
-    securityConfig.setAuthorizations(authConfig);
-
     final var config = new EngineConfiguration().setAuthorizationsCacheTtl(Duration.ofSeconds(1));
     authorizationCheckBehavior =
-        new AuthorizationCheckBehavior(processingState, securityConfig, config);
+        new AuthorizationCheckBehavior(
+            processingState, EngineSecurityConfigurations.defaultConfig(), config);
 
     final var user = createUser();
     final var resourceType = AuthorizationResourceType.RESOURCE;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCreateAuthorizationTest.java
@@ -42,7 +42,7 @@ public class AuthorizationCreateAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
+          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCreateAuthorizationTest.java
@@ -42,7 +42,7 @@ public class AuthorizationCreateAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
+          .withAuthorizationsEnabled(true)
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationDeleteAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationDeleteAuthorizationTest.java
@@ -43,7 +43,7 @@ public class AuthorizationDeleteAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
+          .withAuthorizationsEnabled(true)
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationDeleteAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationDeleteAuthorizationTest.java
@@ -43,7 +43,7 @@ public class AuthorizationDeleteAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
+          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationUpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationUpdateAuthorizationTest.java
@@ -43,7 +43,7 @@ public class AuthorizationUpdateAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
+          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationUpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationUpdateAuthorizationTest.java
@@ -43,7 +43,7 @@ public class AuthorizationUpdateAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
+          .withAuthorizationsEnabled(true)
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/AbstractBatchOperationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/AbstractBatchOperationTest.java
@@ -83,7 +83,7 @@ abstract class AbstractBatchOperationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
+          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
           .withSecurityConfig(
               cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER, OTHER_USER)))
           .withSecurityConfig(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/AbstractBatchOperationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/AbstractBatchOperationTest.java
@@ -83,7 +83,7 @@ abstract class AbstractBatchOperationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
+          .withAuthorizationsEnabled(true)
           .withSecurityConfig(
               cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER, OTHER_USER)))
           .withSecurityConfig(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/JobWorkerElementMultiTenantTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/JobWorkerElementMultiTenantTest.java
@@ -50,11 +50,8 @@ public class JobWorkerElementMultiTenantTest {
   @ClassRule
   public static final EngineRule ENGINE =
       EngineRule.singlePartition()
-          .withSecurityConfig(
-              config -> {
-                config.setAuthorizationsEnabled(true);
-                config.setMultiTenancyChecksEnabled(true);
-              });
+          .withAuthorizationsEnabled(true)
+          .withMultiTenancyChecksEnabled(true);
 
   private static final String PROCESS_ID = "process";
   private static String tenantId;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/JobWorkerElementMultiTenantTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/JobWorkerElementMultiTenantTest.java
@@ -52,8 +52,8 @@ public class JobWorkerElementMultiTenantTest {
       EngineRule.singlePartition()
           .withSecurityConfig(
               config -> {
-                config.getAuthorizations().setEnabled(true);
-                config.getMultiTenancy().setChecksEnabled(true);
+                config.setAuthorizationsEnabled(true);
+                config.setMultiTenancyChecksEnabled(true);
               });
 
   private static final String PROCESS_ID = "process";

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clock/ClockPinAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clock/ClockPinAuthorizationTest.java
@@ -42,7 +42,7 @@ public class ClockPinAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
+          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clock/ClockPinAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clock/ClockPinAuthorizationTest.java
@@ -42,7 +42,7 @@ public class ClockPinAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
+          .withAuthorizationsEnabled(true)
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/CreateClusterVariableAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/CreateClusterVariableAuthorizationTest.java
@@ -47,7 +47,7 @@ public class CreateClusterVariableAuthorizationTest {
           .withResetRecordingExporterTestWatcherMode(
               ResetRecordingExporterTestWatcherMode.BEFORE_ALL_TESTS_AND_AFTER_EACH_TEST)
           .withIdentitySetup(ResetRecordingExporterMode.NO_RESET_AFTER_IDENTITY_SETUP)
-          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
+          .withAuthorizationsEnabled(true)
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/CreateClusterVariableAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/CreateClusterVariableAuthorizationTest.java
@@ -47,7 +47,7 @@ public class CreateClusterVariableAuthorizationTest {
           .withResetRecordingExporterTestWatcherMode(
               ResetRecordingExporterTestWatcherMode.BEFORE_ALL_TESTS_AND_AFTER_EACH_TEST)
           .withIdentitySetup(ResetRecordingExporterMode.NO_RESET_AFTER_IDENTITY_SETUP)
-          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
+          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/DeleteClusterVariableAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/DeleteClusterVariableAuthorizationTest.java
@@ -47,7 +47,7 @@ public class DeleteClusterVariableAuthorizationTest {
           .withResetRecordingExporterTestWatcherMode(
               ResetRecordingExporterTestWatcherMode.BEFORE_ALL_TESTS_AND_AFTER_EACH_TEST)
           .withIdentitySetup(ResetRecordingExporterMode.NO_RESET_AFTER_IDENTITY_SETUP)
-          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
+          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/DeleteClusterVariableAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/DeleteClusterVariableAuthorizationTest.java
@@ -47,7 +47,7 @@ public class DeleteClusterVariableAuthorizationTest {
           .withResetRecordingExporterTestWatcherMode(
               ResetRecordingExporterTestWatcherMode.BEFORE_ALL_TESTS_AND_AFTER_EACH_TEST)
           .withIdentitySetup(ResetRecordingExporterMode.NO_RESET_AFTER_IDENTITY_SETUP)
-          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
+          .withAuthorizationsEnabled(true)
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/UpdateClusterVariableAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/UpdateClusterVariableAuthorizationTest.java
@@ -48,7 +48,7 @@ public class UpdateClusterVariableAuthorizationTest {
           .withResetRecordingExporterTestWatcherMode(
               ResetRecordingExporterTestWatcherMode.BEFORE_ALL_TESTS_AND_AFTER_EACH_TEST)
           .withIdentitySetup(ResetRecordingExporterMode.NO_RESET_AFTER_IDENTITY_SETUP)
-          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
+          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/UpdateClusterVariableAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/UpdateClusterVariableAuthorizationTest.java
@@ -48,7 +48,7 @@ public class UpdateClusterVariableAuthorizationTest {
           .withResetRecordingExporterTestWatcherMode(
               ResetRecordingExporterTestWatcherMode.BEFORE_ALL_TESTS_AND_AFTER_EACH_TEST)
           .withIdentitySetup(ResetRecordingExporterMode.NO_RESET_AFTER_IDENTITY_SETUP)
-          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
+          .withAuthorizationsEnabled(true)
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/conditional/ConditionalEvaluationAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/conditional/ConditionalEvaluationAuthorizationTest.java
@@ -49,14 +49,14 @@ public class ConditionalEvaluationAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
+          .withAuthorizationsEnabled(true)
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
+          .withMultiTenancyChecksEnabled(true)
           .withSecurityConfig(
               cfg -> {
                 final var defaultRoles = new HashMap<>(cfg.getInitialization().getDefaultRoles());
                 defaultRoles.put("admin", Map.of("users", List.of(DEFAULT_USER.getUsername())));
                 cfg.getInitialization().setDefaultRoles(defaultRoles);
-                cfg.setMultiTenancyChecksEnabled(true);
               });
 
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/conditional/ConditionalEvaluationAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/conditional/ConditionalEvaluationAuthorizationTest.java
@@ -49,14 +49,14 @@ public class ConditionalEvaluationAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
+          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {
                 final var defaultRoles = new HashMap<>(cfg.getInitialization().getDefaultRoles());
                 defaultRoles.put("admin", Map.of("users", List.of(DEFAULT_USER.getUsername())));
                 cfg.getInitialization().setDefaultRoles(defaultRoles);
-                cfg.getMultiTenancy().setChecksEnabled(true);
+                cfg.setMultiTenancyChecksEnabled(true);
               });
 
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateAuthorizationTest.java
@@ -43,7 +43,7 @@ public class DeploymentCreateAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
+          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateAuthorizationTest.java
@@ -43,7 +43,7 @@ public class DeploymentCreateAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
+          .withAuthorizationsEnabled(true)
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/MultiTenantDeploymentCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/MultiTenantDeploymentCreateAuthorizationTest.java
@@ -45,14 +45,14 @@ public class MultiTenantDeploymentCreateAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
+          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {
                 final var defaultRoles = new HashMap<>(cfg.getInitialization().getDefaultRoles());
                 defaultRoles.put("admin", Map.of("users", List.of(DEFAULT_USER.getUsername())));
                 cfg.getInitialization().setDefaultRoles(defaultRoles);
-                cfg.getMultiTenancy().setChecksEnabled(true);
+                cfg.setMultiTenancyChecksEnabled(true);
               });
 
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/MultiTenantDeploymentCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/MultiTenantDeploymentCreateAuthorizationTest.java
@@ -45,14 +45,14 @@ public class MultiTenantDeploymentCreateAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
+          .withAuthorizationsEnabled(true)
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
+          .withMultiTenancyChecksEnabled(true)
           .withSecurityConfig(
               cfg -> {
                 final var defaultRoles = new HashMap<>(cfg.getInitialization().getDefaultRoles());
                 defaultRoles.put("admin", Map.of("users", List.of(DEFAULT_USER.getUsername())));
                 cfg.getInitialization().setDefaultRoles(defaultRoles);
-                cfg.setMultiTenancyChecksEnabled(true);
               });
 
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/dmn/DecisionEvaluationEvaluateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/dmn/DecisionEvaluationEvaluateAuthorizationTest.java
@@ -42,7 +42,7 @@ public class DecisionEvaluationEvaluateAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
+          .withAuthorizationsEnabled(true)
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/dmn/DecisionEvaluationEvaluateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/dmn/DecisionEvaluationEvaluateAuthorizationTest.java
@@ -42,7 +42,7 @@ public class DecisionEvaluationEvaluateAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
+          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/ResolveExpressionAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/ResolveExpressionAuthorizationTest.java
@@ -49,7 +49,7 @@ public class ResolveExpressionAuthorizationTest {
           .withResetRecordingExporterTestWatcherMode(
               ResetRecordingExporterTestWatcherMode.BEFORE_ALL_TESTS_AND_AFTER_EACH_TEST)
           .withIdentitySetup(ResetRecordingExporterMode.NO_RESET_AFTER_IDENTITY_SETUP)
-          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
+          .withAuthorizationsEnabled(true)
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/ResolveExpressionAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/ResolveExpressionAuthorizationTest.java
@@ -49,7 +49,7 @@ public class ResolveExpressionAuthorizationTest {
           .withResetRecordingExporterTestWatcherMode(
               ResetRecordingExporterTestWatcherMode.BEFORE_ALL_TESTS_AND_AFTER_EACH_TEST)
           .withIdentitySetup(ResetRecordingExporterMode.NO_RESET_AFTER_IDENTITY_SETUP)
-          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
+          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerCreateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerCreateTest.java
@@ -27,8 +27,7 @@ import org.junit.rules.TestWatcher;
 public class GlobalListenerCreateTest {
 
   @Rule
-  public final EngineRule engine =
-      EngineRule.singlePartition().withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true));
+  public final EngineRule engine = EngineRule.singlePartition().withAuthorizationsEnabled(true);
 
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerCreateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerCreateTest.java
@@ -28,8 +28,7 @@ public class GlobalListenerCreateTest {
 
   @Rule
   public final EngineRule engine =
-      EngineRule.singlePartition()
-          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true));
+      EngineRule.singlePartition().withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true));
 
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerDeleteTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerDeleteTest.java
@@ -25,8 +25,7 @@ public class GlobalListenerDeleteTest {
 
   @Rule
   public final EngineRule engine =
-      EngineRule.singlePartition()
-          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true));
+      EngineRule.singlePartition().withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true));
 
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerDeleteTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerDeleteTest.java
@@ -24,8 +24,7 @@ import org.junit.rules.TestWatcher;
 public class GlobalListenerDeleteTest {
 
   @Rule
-  public final EngineRule engine =
-      EngineRule.singlePartition().withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true));
+  public final EngineRule engine = EngineRule.singlePartition().withAuthorizationsEnabled(true);
 
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerUpdateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerUpdateTest.java
@@ -27,8 +27,7 @@ import org.junit.rules.TestWatcher;
 public class GlobalListenerUpdateTest {
 
   @Rule
-  public final EngineRule engine =
-      EngineRule.singlePartition().withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true));
+  public final EngineRule engine = EngineRule.singlePartition().withAuthorizationsEnabled(true);
 
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerUpdateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerUpdateTest.java
@@ -28,8 +28,7 @@ public class GlobalListenerUpdateTest {
 
   @Rule
   public final EngineRule engine =
-      EngineRule.singlePartition()
-          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true));
+      EngineRule.singlePartition().withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true));
 
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/AuthorizationEntityValidatorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/AuthorizationEntityValidatorTest.java
@@ -17,7 +17,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.camunda.security.api.model.config.AuthenticationConfiguration;
-import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.api.model.config.initialization.InitializationConfiguration;
+import io.camunda.security.configuration.EngineSecurityConfig;
+import io.camunda.security.configuration.EngineSecurityConfigurations;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.state.authorization.PersistedMappingRule;
 import io.camunda.zeebe.engine.state.authorization.PersistedRole;
@@ -67,8 +69,14 @@ class AuthorizationEntityValidatorTest {
     when(processingState.getGroupState()).thenReturn(groupState);
     when(processingState.getRoleState()).thenReturn(roleState);
 
-    final SecurityConfiguration securityConfig = new SecurityConfiguration();
-    securityConfig.setAuthentication(authConfig);
+    final EngineSecurityConfig securityConfig =
+        new EngineSecurityConfig(
+            authConfig,
+            /* authorizationsEnabled= */ true,
+            /* multiTenancyChecksEnabled= */ false,
+            new InitializationConfiguration(),
+            EngineSecurityConfigurations.ID_VALIDATION_PATTERN,
+            EngineSecurityConfigurations.GROUP_ID_VALIDATION_PATTERN);
     checker = new AuthorizationEntityValidator(processingState, securityConfig);
     lenient().when(userState.getUser("user1")).thenReturn(Optional.of(mock(PersistedUser.class)));
     lenient().when(roleState.getRole("role1")).thenReturn(Optional.of(mock(PersistedRole.class)));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveAuthorizationTest.java
@@ -46,7 +46,7 @@ public class IncidentResolveAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
+          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveAuthorizationTest.java
@@ -46,7 +46,7 @@ public class IncidentResolveAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
+          .withAuthorizationsEnabled(true)
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveRejectionCommandTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveRejectionCommandTest.java
@@ -33,7 +33,7 @@ public class IncidentResolveRejectionCommandTest {
       EngineRule.singlePartition()
           .withSecurityConfig(
               config -> {
-                config.getMultiTenancy().setChecksEnabled(true);
+                config.setMultiTenancyChecksEnabled(true);
               });
 
   private static final String TENANT = "custom-tenant";

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveRejectionCommandTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveRejectionCommandTest.java
@@ -30,11 +30,7 @@ public class IncidentResolveRejectionCommandTest {
 
   @ClassRule
   public static final EngineRule ENGINE =
-      EngineRule.singlePartition()
-          .withSecurityConfig(
-              config -> {
-                config.setMultiTenancyChecksEnabled(true);
-              });
+      EngineRule.singlePartition().withMultiTenancyChecksEnabled(true);
 
   private static final String TENANT = "custom-tenant";
   private static final String USERNAME = "tenant-user";

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/CompleteJobTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/CompleteJobTest.java
@@ -50,7 +50,7 @@ public final class CompleteJobTest {
   @ClassRule
   public static final EngineRule ENGINE =
       EngineRule.singlePartition()
-          .withSecurityConfig(config -> config.getAuthorizations().setEnabled(true));
+          .withSecurityConfig(config -> config.setAuthorizationsEnabled(true));
 
   private static final String PROCESS_ID = "process";
   private static String jobType;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/CompleteJobTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/CompleteJobTest.java
@@ -49,8 +49,7 @@ public final class CompleteJobTest {
 
   @ClassRule
   public static final EngineRule ENGINE =
-      EngineRule.singlePartition()
-          .withSecurityConfig(config -> config.setAuthorizationsEnabled(true));
+      EngineRule.singlePartition().withAuthorizationsEnabled(true);
 
   private static final String PROCESS_ID = "process";
   private static String jobType;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/FailJobTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/FailJobTest.java
@@ -50,8 +50,7 @@ public final class FailJobTest {
 
   @ClassRule
   public static final EngineRule ENGINE =
-      EngineRule.singlePartition()
-          .withSecurityConfig(config -> config.setAuthorizationsEnabled(true));
+      EngineRule.singlePartition().withAuthorizationsEnabled(true);
 
   private static final String PROCESS_ID = "process";
   private static String jobType;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/FailJobTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/FailJobTest.java
@@ -51,7 +51,7 @@ public final class FailJobTest {
   @ClassRule
   public static final EngineRule ENGINE =
       EngineRule.singlePartition()
-          .withSecurityConfig(config -> config.getAuthorizations().setEnabled(true));
+          .withSecurityConfig(config -> config.setAuthorizationsEnabled(true));
 
   private static final String PROCESS_ID = "process";
   private static String jobType;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateAuthorizationTest.java
@@ -46,7 +46,7 @@ public class JobBatchActivateAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
+          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateAuthorizationTest.java
@@ -46,7 +46,7 @@ public class JobBatchActivateAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
+          .withAuthorizationsEnabled(true)
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.engine.processing.job;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.security.configuration.SecurityConfigurations;
+import io.camunda.security.configuration.EngineSecurityConfigurations;
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.identity.AuthenticatedAuthorizedTenants;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
@@ -70,7 +70,7 @@ final class JobBatchCollectorTest {
     final var authorizationCheckBehavior =
         new AuthorizationCheckBehavior(
             state,
-            SecurityConfigurations.unauthenticatedAndUnauthorized(),
+            EngineSecurityConfigurations.unauthenticatedAndUnauthorized(),
             new EngineConfiguration());
     collector = new JobBatchCollector(state, lengthEvaluator, authorizationCheckBehavior, clock);
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobCompleteAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobCompleteAuthorizationTest.java
@@ -45,7 +45,7 @@ public class JobCompleteAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
+          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobCompleteAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobCompleteAuthorizationTest.java
@@ -45,7 +45,7 @@ public class JobCompleteAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
+          .withAuthorizationsEnabled(true)
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobFailAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobFailAuthorizationTest.java
@@ -45,7 +45,7 @@ public class JobFailAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
+          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobFailAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobFailAuthorizationTest.java
@@ -45,7 +45,7 @@ public class JobFailAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
+          .withAuthorizationsEnabled(true)
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobUpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobUpdateAuthorizationTest.java
@@ -45,7 +45,7 @@ public class JobUpdateAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
+          .withAuthorizationsEnabled(true)
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobUpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobUpdateAuthorizationTest.java
@@ -45,7 +45,7 @@ public class JobUpdateAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
+          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobUpdateTimeoutTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobUpdateTimeoutTest.java
@@ -41,7 +41,7 @@ public class JobUpdateTimeoutTest {
   @ClassRule
   public static final EngineRule ENGINE =
       EngineRule.singlePartition()
-          .withSecurityConfig(config -> config.getAuthorizations().setEnabled(true));
+          .withSecurityConfig(config -> config.setAuthorizationsEnabled(true));
 
   private static final String PROCESS_ID = "process";
   private static String jobType;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobUpdateTimeoutTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobUpdateTimeoutTest.java
@@ -40,8 +40,7 @@ public class JobUpdateTimeoutTest {
 
   @ClassRule
   public static final EngineRule ENGINE =
-      EngineRule.singlePartition()
-          .withSecurityConfig(config -> config.setAuthorizationsEnabled(true));
+      EngineRule.singlePartition().withAuthorizationsEnabled(true);
 
   private static final String PROCESS_ID = "process";
   private static String jobType;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/MultiTenancyActivatableJobsPushTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/MultiTenancyActivatableJobsPushTest.java
@@ -53,10 +53,7 @@ public class MultiTenancyActivatableJobsPushTest {
   public static final EngineRule ENGINE =
       EngineRule.singlePartition()
           .withJobStreamer(JOB_STREAMER)
-          .withSecurityConfig(
-              config -> {
-                config.setMultiTenancyChecksEnabled(true);
-              });
+          .withMultiTenancyChecksEnabled(true);
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/MultiTenancyActivatableJobsPushTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/MultiTenancyActivatableJobsPushTest.java
@@ -55,7 +55,7 @@ public class MultiTenancyActivatableJobsPushTest {
           .withJobStreamer(JOB_STREAMER)
           .withSecurityConfig(
               config -> {
-                config.getMultiTenancy().setChecksEnabled(true);
+                config.setMultiTenancyChecksEnabled(true);
               });
 
   @Rule

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/MultiTenantJobOperationsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/MultiTenantJobOperationsTest.java
@@ -47,11 +47,8 @@ public class MultiTenantJobOperationsTest {
   @ClassRule
   public static final EngineRule ENGINE =
       EngineRule.singlePartition()
-          .withSecurityConfig(
-              config -> {
-                config.setAuthorizationsEnabled(true);
-                config.setMultiTenancyChecksEnabled(true);
-              });
+          .withAuthorizationsEnabled(true)
+          .withMultiTenancyChecksEnabled(true);
 
   private static final int NEW_RETRIES = 20;
   private static final String PROCESS_ID = "process";

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/MultiTenantJobOperationsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/MultiTenantJobOperationsTest.java
@@ -49,8 +49,8 @@ public class MultiTenantJobOperationsTest {
       EngineRule.singlePartition()
           .withSecurityConfig(
               config -> {
-                config.getAuthorizations().setEnabled(true);
-                config.getMultiTenancy().setChecksEnabled(true);
+                config.setAuthorizationsEnabled(true);
+                config.setMultiTenancyChecksEnabled(true);
               });
 
   private static final int NEW_RETRIES = 20;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mappingrule/MappingRuleCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mappingrule/MappingRuleCreateAuthorizationTest.java
@@ -42,7 +42,7 @@ public class MappingRuleCreateAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
+          .withAuthorizationsEnabled(true)
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mappingrule/MappingRuleCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mappingrule/MappingRuleCreateAuthorizationTest.java
@@ -42,7 +42,7 @@ public class MappingRuleCreateAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
+          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mappingrule/MappingRuleUpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mappingrule/MappingRuleUpdateAuthorizationTest.java
@@ -41,7 +41,7 @@ public class MappingRuleUpdateAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
+          .withAuthorizationsEnabled(true)
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mappingrule/MappingRuleUpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mappingrule/MappingRuleUpdateAuthorizationTest.java
@@ -41,7 +41,7 @@ public class MappingRuleUpdateAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
+          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateAuthorizationTest.java
@@ -52,7 +52,7 @@ public class MessageCorrelationCorrelateAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
+          .withAuthorizationsEnabled(true)
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateAuthorizationTest.java
@@ -52,7 +52,7 @@ public class MessageCorrelationCorrelateAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
+          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessagePublishAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessagePublishAuthorizationTest.java
@@ -50,7 +50,7 @@ public class MessagePublishAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
+          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessagePublishAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessagePublishAuthorizationTest.java
@@ -50,7 +50,7 @@ public class MessagePublishAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
+          .withAuthorizationsEnabled(true)
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareActivateJobBatchTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareActivateJobBatchTest.java
@@ -25,7 +25,7 @@ public class TenantAwareActivateJobBatchTest {
   @ClassRule
   public static final EngineRule ENGINE =
       EngineRule.singlePartition()
-          .withSecurityConfig(config -> config.getMultiTenancy().setChecksEnabled(true));
+          .withSecurityConfig(config -> config.setMultiTenancyChecksEnabled(true));
 
   @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareActivateJobBatchTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareActivateJobBatchTest.java
@@ -24,8 +24,7 @@ public class TenantAwareActivateJobBatchTest {
 
   @ClassRule
   public static final EngineRule ENGINE =
-      EngineRule.singlePartition()
-          .withSecurityConfig(config -> config.setMultiTenancyChecksEnabled(true));
+      EngineRule.singlePartition().withMultiTenancyChecksEnabled(true);
 
   @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareBusinessRuleTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareBusinessRuleTaskTest.java
@@ -39,7 +39,7 @@ public class TenantAwareBusinessRuleTaskTest {
   @ClassRule
   public static final EngineRule ENGINE =
       EngineRule.singlePartition()
-          .withSecurityConfig(config -> config.getMultiTenancy().setChecksEnabled(true));
+          .withSecurityConfig(config -> config.setMultiTenancyChecksEnabled(true));
 
   private static final String DMN_DECISION_TABLE = "/dmn/decision-table.dmn";
   private static final String DMN_DECISION_TABLE_WITH_ASSERTION =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareBusinessRuleTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareBusinessRuleTaskTest.java
@@ -38,8 +38,7 @@ public class TenantAwareBusinessRuleTaskTest {
 
   @ClassRule
   public static final EngineRule ENGINE =
-      EngineRule.singlePartition()
-          .withSecurityConfig(config -> config.setMultiTenancyChecksEnabled(true));
+      EngineRule.singlePartition().withMultiTenancyChecksEnabled(true);
 
   private static final String DMN_DECISION_TABLE = "/dmn/decision-table.dmn";
   private static final String DMN_DECISION_TABLE_WITH_ASSERTION =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareCallActivityTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareCallActivityTest.java
@@ -33,7 +33,7 @@ public class TenantAwareCallActivityTest {
   @ClassRule
   public static final EngineRule ENGINE =
       EngineRule.singlePartition()
-          .withSecurityConfig(config -> config.getMultiTenancy().setChecksEnabled(true));
+          .withSecurityConfig(config -> config.setMultiTenancyChecksEnabled(true));
 
   private static final String PROCESS_ID_PARENT = "wf-parent";
   private static final String PROCESS_ID_CHILD = "wf-child";

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareCallActivityTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareCallActivityTest.java
@@ -32,8 +32,7 @@ public class TenantAwareCallActivityTest {
 
   @ClassRule
   public static final EngineRule ENGINE =
-      EngineRule.singlePartition()
-          .withSecurityConfig(config -> config.setMultiTenancyChecksEnabled(true));
+      EngineRule.singlePartition().withMultiTenancyChecksEnabled(true);
 
   private static final String PROCESS_ID_PARENT = "wf-parent";
   private static final String PROCESS_ID_CHILD = "wf-child";

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareCancelProcessInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareCancelProcessInstanceTest.java
@@ -26,7 +26,7 @@ public class TenantAwareCancelProcessInstanceTest {
   @ClassRule
   public static final EngineRule ENGINE =
       EngineRule.singlePartition()
-          .withSecurityConfig(config -> config.getMultiTenancy().setChecksEnabled(true));
+          .withSecurityConfig(config -> config.setMultiTenancyChecksEnabled(true));
 
   @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareCancelProcessInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareCancelProcessInstanceTest.java
@@ -25,8 +25,7 @@ public class TenantAwareCancelProcessInstanceTest {
 
   @ClassRule
   public static final EngineRule ENGINE =
-      EngineRule.singlePartition()
-          .withSecurityConfig(config -> config.setMultiTenancyChecksEnabled(true));
+      EngineRule.singlePartition().withMultiTenancyChecksEnabled(true);
 
   @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareClusterVariableTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareClusterVariableTest.java
@@ -44,7 +44,7 @@ public class TenantAwareClusterVariableTest {
   public static final EngineRule ENGINE =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(config -> config.setMultiTenancyChecksEnabled(true))
+          .withMultiTenancyChecksEnabled(true)
           .withSecurityConfig(config -> config.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareClusterVariableTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareClusterVariableTest.java
@@ -44,7 +44,7 @@ public class TenantAwareClusterVariableTest {
   public static final EngineRule ENGINE =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(config -> config.getMultiTenancy().setChecksEnabled(true))
+          .withSecurityConfig(config -> config.setMultiTenancyChecksEnabled(true))
           .withSecurityConfig(config -> config.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareFormLinkingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareFormLinkingTest.java
@@ -28,7 +28,7 @@ public class TenantAwareFormLinkingTest {
   @Rule
   public final EngineRule engine =
       EngineRule.singlePartition()
-          .withSecurityConfig(config -> config.getMultiTenancy().setChecksEnabled(true));
+          .withSecurityConfig(config -> config.setMultiTenancyChecksEnabled(true));
 
   @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareFormLinkingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareFormLinkingTest.java
@@ -26,9 +26,7 @@ public class TenantAwareFormLinkingTest {
   private static final String TENANT = "tenant";
 
   @Rule
-  public final EngineRule engine =
-      EngineRule.singlePartition()
-          .withSecurityConfig(config -> config.setMultiTenancyChecksEnabled(true));
+  public final EngineRule engine = EngineRule.singlePartition().withMultiTenancyChecksEnabled(true);
 
   @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareModifyProcessInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareModifyProcessInstanceTest.java
@@ -27,8 +27,7 @@ public class TenantAwareModifyProcessInstanceTest {
 
   @ClassRule
   public static final EngineRule ENGINE =
-      EngineRule.singlePartition()
-          .withSecurityConfig(config -> config.setMultiTenancyChecksEnabled(true));
+      EngineRule.singlePartition().withMultiTenancyChecksEnabled(true);
 
   @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareModifyProcessInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareModifyProcessInstanceTest.java
@@ -28,7 +28,7 @@ public class TenantAwareModifyProcessInstanceTest {
   @ClassRule
   public static final EngineRule ENGINE =
       EngineRule.singlePartition()
-          .withSecurityConfig(config -> config.getMultiTenancy().setChecksEnabled(true));
+          .withSecurityConfig(config -> config.setMultiTenancyChecksEnabled(true));
 
   @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareProcessInstanceVariableTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareProcessInstanceVariableTest.java
@@ -41,7 +41,7 @@ public class TenantAwareProcessInstanceVariableTest {
   public static final EngineRule ENGINE_RULE =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(config -> config.getMultiTenancy().setChecksEnabled(true))
+          .withSecurityConfig(config -> config.setMultiTenancyChecksEnabled(true))
           .withSecurityConfig(config -> config.getInitialization().setUsers(List.of(DEFAULT_USER)));
 
   public static final String PROCESS_ID = "process";

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareProcessInstanceVariableTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareProcessInstanceVariableTest.java
@@ -41,7 +41,7 @@ public class TenantAwareProcessInstanceVariableTest {
   public static final EngineRule ENGINE_RULE =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(config -> config.setMultiTenancyChecksEnabled(true))
+          .withMultiTenancyChecksEnabled(true)
           .withSecurityConfig(config -> config.getInitialization().setUsers(List.of(DEFAULT_USER)));
 
   public static final String PROCESS_ID = "process";

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareResourceDeletionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareResourceDeletionTest.java
@@ -44,7 +44,7 @@ public class TenantAwareResourceDeletionTest {
   public static final EngineRule ENGINE =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(config -> config.setMultiTenancyChecksEnabled(true))
+          .withMultiTenancyChecksEnabled(true)
           .withSecurityConfig(
               config ->
                   config

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareResourceDeletionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareResourceDeletionTest.java
@@ -44,7 +44,7 @@ public class TenantAwareResourceDeletionTest {
   public static final EngineRule ENGINE =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(config -> config.getMultiTenancy().setChecksEnabled(true))
+          .withSecurityConfig(config -> config.setMultiTenancyChecksEnabled(true))
           .withSecurityConfig(
               config ->
                   config

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareResourceFetchTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareResourceFetchTest.java
@@ -54,9 +54,9 @@ public class TenantAwareResourceFetchTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
+          .withMultiTenancyChecksEnabled(true)
           .withSecurityConfig(
               config -> {
-                config.setMultiTenancyChecksEnabled(true);
                 config
                     .getInitialization()
                     .setUsers(List.of(new ConfiguredUser(USERNAME, "password", "name", "email")));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareResourceFetchTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareResourceFetchTest.java
@@ -56,7 +56,7 @@ public class TenantAwareResourceFetchTest {
           .withIdentitySetup()
           .withSecurityConfig(
               config -> {
-                config.getMultiTenancy().setChecksEnabled(true);
+                config.setMultiTenancyChecksEnabled(true);
                 config
                     .getInitialization()
                     .setUsers(List.of(new ConfiguredUser(USERNAME, "password", "name", "email")));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareSignalEventTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareSignalEventTest.java
@@ -36,7 +36,7 @@ public class TenantAwareSignalEventTest {
   public static final EngineRule ENGINE =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(config -> config.setMultiTenancyChecksEnabled(true))
+          .withMultiTenancyChecksEnabled(true)
           .withSecurityConfig(
               config ->
                   config

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareSignalEventTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareSignalEventTest.java
@@ -36,7 +36,7 @@ public class TenantAwareSignalEventTest {
   public static final EngineRule ENGINE =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(config -> config.getMultiTenancy().setChecksEnabled(true))
+          .withSecurityConfig(config -> config.setMultiTenancyChecksEnabled(true))
           .withSecurityConfig(
               config ->
                   config

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareStandaloneDecisionEvaluationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareStandaloneDecisionEvaluationTest.java
@@ -30,7 +30,7 @@ public class TenantAwareStandaloneDecisionEvaluationTest {
   @ClassRule
   public static final EngineRule ENGINE =
       EngineRule.singlePartition()
-          .withSecurityConfig(config -> config.getMultiTenancy().setChecksEnabled(true));
+          .withSecurityConfig(config -> config.setMultiTenancyChecksEnabled(true));
 
   private static final String DMN_DECISION_TABLE = "/dmn/decision-table.dmn";
   private static final String DMN_DECISION_TABLE_WITH_ASSERTIONS =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareStandaloneDecisionEvaluationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareStandaloneDecisionEvaluationTest.java
@@ -29,8 +29,7 @@ public class TenantAwareStandaloneDecisionEvaluationTest {
 
   @ClassRule
   public static final EngineRule ENGINE =
-      EngineRule.singlePartition()
-          .withSecurityConfig(config -> config.setMultiTenancyChecksEnabled(true));
+      EngineRule.singlePartition().withMultiTenancyChecksEnabled(true);
 
   private static final String DMN_DECISION_TABLE = "/dmn/decision-table.dmn";
   private static final String DMN_DECISION_TABLE_WITH_ASSERTIONS =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareTimerCatchEventTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareTimerCatchEventTest.java
@@ -33,9 +33,7 @@ public class TenantAwareTimerCatchEventTest {
   private static final String TENANT = "tenant-a";
 
   @Rule
-  public final EngineRule engine =
-      EngineRule.singlePartition()
-          .withSecurityConfig(config -> config.setMultiTenancyChecksEnabled(true));
+  public final EngineRule engine = EngineRule.singlePartition().withMultiTenancyChecksEnabled(true);
 
   private static BpmnModelInstance processWithTimer(
       final Consumer<IntermediateCatchEventBuilder> consumer) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareTimerCatchEventTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareTimerCatchEventTest.java
@@ -35,7 +35,7 @@ public class TenantAwareTimerCatchEventTest {
   @Rule
   public final EngineRule engine =
       EngineRule.singlePartition()
-          .withSecurityConfig(config -> config.getMultiTenancy().setChecksEnabled(true));
+          .withSecurityConfig(config -> config.setMultiTenancyChecksEnabled(true));
 
   private static BpmnModelInstance processWithTimer(
       final Consumer<IntermediateCatchEventBuilder> consumer) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareTimerEventTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareTimerEventTest.java
@@ -29,7 +29,7 @@ public class TenantAwareTimerEventTest {
   @ClassRule
   public static final EngineRule ENGINE =
       EngineRule.singlePartition()
-          .withSecurityConfig(config -> config.getMultiTenancy().setChecksEnabled(true));
+          .withSecurityConfig(config -> config.setMultiTenancyChecksEnabled(true));
 
   @Rule public final TestWatcher testWatcher = new RecordingExporterTestWatcher();
   private String processId;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareTimerEventTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareTimerEventTest.java
@@ -28,8 +28,7 @@ public class TenantAwareTimerEventTest {
 
   @ClassRule
   public static final EngineRule ENGINE =
-      EngineRule.singlePartition()
-          .withSecurityConfig(config -> config.setMultiTenancyChecksEnabled(true));
+      EngineRule.singlePartition().withMultiTenancyChecksEnabled(true);
 
   @Rule public final TestWatcher testWatcher = new RecordingExporterTestWatcher();
   private String processId;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareTimerStartEventTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareTimerStartEventTest.java
@@ -43,7 +43,7 @@ public class TenantAwareTimerStartEventTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(config -> config.setMultiTenancyChecksEnabled(true))
+          .withMultiTenancyChecksEnabled(true)
           .withSecurityConfig(
               config ->
                   config

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareTimerStartEventTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareTimerStartEventTest.java
@@ -43,7 +43,7 @@ public class TenantAwareTimerStartEventTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(config -> config.getMultiTenancy().setChecksEnabled(true))
+          .withSecurityConfig(config -> config.setMultiTenancyChecksEnabled(true))
           .withSecurityConfig(
               config ->
                   config

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareUpdateVariablesTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareUpdateVariablesTest.java
@@ -40,7 +40,7 @@ public class TenantAwareUpdateVariablesTest {
   public static final EngineRule ENGINE =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(config -> config.setMultiTenancyChecksEnabled(true))
+          .withMultiTenancyChecksEnabled(true)
           .withSecurityConfig(config -> config.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareUpdateVariablesTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareUpdateVariablesTest.java
@@ -40,7 +40,7 @@ public class TenantAwareUpdateVariablesTest {
   public static final EngineRule ENGINE =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(config -> config.getMultiTenancy().setChecksEnabled(true))
+          .withSecurityConfig(config -> config.setMultiTenancyChecksEnabled(true))
           .withSecurityConfig(config -> config.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCancelAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCancelAuthorizationTest.java
@@ -47,7 +47,7 @@ public class ProcessInstanceCancelAuthorizationTest {
           .withResetRecordingExporterTestWatcherMode(
               ResetRecordingExporterTestWatcherMode.BEFORE_ALL_TESTS_AND_AFTER_EACH_TEST)
           .withIdentitySetup(ResetRecordingExporterMode.NO_RESET_AFTER_IDENTITY_SETUP)
-          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
+          .withAuthorizationsEnabled(true)
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCancelAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCancelAuthorizationTest.java
@@ -47,7 +47,7 @@ public class ProcessInstanceCancelAuthorizationTest {
           .withResetRecordingExporterTestWatcherMode(
               ResetRecordingExporterTestWatcherMode.BEFORE_ALL_TESTS_AND_AFTER_EACH_TEST)
           .withIdentitySetup(ResetRecordingExporterMode.NO_RESET_AFTER_IDENTITY_SETUP)
-          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
+          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreateAuthorizationTest.java
@@ -45,7 +45,7 @@ public class ProcessInstanceCreateAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
+          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreateAuthorizationTest.java
@@ -45,7 +45,7 @@ public class ProcessInstanceCreateAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
+          .withAuthorizationsEnabled(true)
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyAuthorizationTest.java
@@ -50,7 +50,7 @@ public class ProcessInstanceModificationModifyAuthorizationTest {
           .withResetRecordingExporterTestWatcherMode(
               ResetRecordingExporterTestWatcherMode.BEFORE_ALL_TESTS_AND_AFTER_EACH_TEST)
           .withIdentitySetup(ResetRecordingExporterMode.NO_RESET_AFTER_IDENTITY_SETUP)
-          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
+          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyAuthorizationTest.java
@@ -50,7 +50,7 @@ public class ProcessInstanceModificationModifyAuthorizationTest {
           .withResetRecordingExporterTestWatcherMode(
               ResetRecordingExporterTestWatcherMode.BEFORE_ALL_TESTS_AND_AFTER_EACH_TEST)
           .withIdentitySetup(ResetRecordingExporterMode.NO_RESET_AFTER_IDENTITY_SETUP)
-          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
+          .withAuthorizationsEnabled(true)
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/ProcessInstanceMigrationMigrateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/ProcessInstanceMigrationMigrateAuthorizationTest.java
@@ -49,7 +49,7 @@ public class ProcessInstanceMigrationMigrateAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
+          .withAuthorizationsEnabled(true)
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/ProcessInstanceMigrationMigrateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/ProcessInstanceMigrationMigrateAuthorizationTest.java
@@ -49,7 +49,7 @@ public class ProcessInstanceMigrationMigrateAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
+          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionAuthorizationTest.java
@@ -43,7 +43,7 @@ public class ResourceDeletionAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
+          .withAuthorizationsEnabled(true)
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionAuthorizationTest.java
@@ -43,7 +43,7 @@ public class ResourceDeletionAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
+          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceFetchAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceFetchAuthorizationTest.java
@@ -41,7 +41,7 @@ public class ResourceFetchAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
+          .withAuthorizationsEnabled(true)
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceFetchAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceFetchAuthorizationTest.java
@@ -41,7 +41,7 @@ public class ResourceFetchAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
+          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/RoleCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/RoleCreateAuthorizationTest.java
@@ -41,7 +41,7 @@ public class RoleCreateAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
+          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/RoleCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/RoleCreateAuthorizationTest.java
@@ -41,7 +41,7 @@ public class RoleCreateAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
+          .withAuthorizationsEnabled(true)
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/BroadcastSignalMultiplePartitionsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/BroadcastSignalMultiplePartitionsTest.java
@@ -58,7 +58,7 @@ public class BroadcastSignalMultiplePartitionsTest {
   public static final EngineRule ENGINE =
       EngineRule.multiplePartition(PARTITION_COUNT)
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
+          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/BroadcastSignalMultiplePartitionsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/BroadcastSignalMultiplePartitionsTest.java
@@ -58,7 +58,7 @@ public class BroadcastSignalMultiplePartitionsTest {
   public static final EngineRule ENGINE =
       EngineRule.multiplePartition(PARTITION_COUNT)
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
+          .withAuthorizationsEnabled(true)
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastAuthorizationTest.java
@@ -45,7 +45,7 @@ public class SignalBroadcastAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
+          .withAuthorizationsEnabled(true)
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastAuthorizationTest.java
@@ -45,7 +45,7 @@ public class SignalBroadcastAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
+          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/DeleteTenantAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/DeleteTenantAuthorizationTest.java
@@ -47,12 +47,12 @@ public class DeleteTenantAuthorizationTest {
           .withIdentitySetup()
           .withSecurityConfig(
               cfg -> {
-                cfg.getAuthorizations().setEnabled(true);
+                cfg.setAuthorizationsEnabled(true);
                 cfg.getInitialization().setUsers(List.of(DEFAULT_USER));
                 final var defaultRoles = new HashMap<>(cfg.getInitialization().getDefaultRoles());
                 defaultRoles.put("admin", Map.of("users", List.of(DEFAULT_USER.getUsername())));
                 cfg.getInitialization().setDefaultRoles(defaultRoles);
-                cfg.getMultiTenancy().setChecksEnabled(true);
+                cfg.setMultiTenancyChecksEnabled(true);
               });
 
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/DeleteTenantAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/DeleteTenantAuthorizationTest.java
@@ -45,14 +45,14 @@ public class DeleteTenantAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
+          .withAuthorizationsEnabled(true)
+          .withMultiTenancyChecksEnabled(true)
           .withSecurityConfig(
               cfg -> {
-                cfg.setAuthorizationsEnabled(true);
                 cfg.getInitialization().setUsers(List.of(DEFAULT_USER));
                 final var defaultRoles = new HashMap<>(cfg.getInitialization().getDefaultRoles());
                 defaultRoles.put("admin", Map.of("users", List.of(DEFAULT_USER.getUsername())));
                 cfg.getInitialization().setDefaultRoles(defaultRoles);
-                cfg.setMultiTenancyChecksEnabled(true);
               });
 
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/CreateInitialAdminUserAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/CreateInitialAdminUserAuthorizationTest.java
@@ -44,7 +44,7 @@ public class CreateInitialAdminUserAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
+          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/CreateInitialAdminUserAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/CreateInitialAdminUserAuthorizationTest.java
@@ -44,7 +44,7 @@ public class CreateInitialAdminUserAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
+          .withAuthorizationsEnabled(true)
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/UserCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/UserCreateAuthorizationTest.java
@@ -42,7 +42,7 @@ public class UserCreateAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
+          .withAuthorizationsEnabled(true)
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/UserCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/UserCreateAuthorizationTest.java
@@ -42,7 +42,7 @@ public class UserCreateAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
+          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/MultiTenantUserTaskOperationsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/MultiTenantUserTaskOperationsTest.java
@@ -39,11 +39,8 @@ public class MultiTenantUserTaskOperationsTest {
   @ClassRule
   public static final EngineRule ENGINE =
       EngineRule.singlePartition()
-          .withSecurityConfig(
-              config -> {
-                config.setAuthorizationsEnabled(true);
-                config.setMultiTenancyChecksEnabled(true);
-              });
+          .withAuthorizationsEnabled(true)
+          .withMultiTenancyChecksEnabled(true);
 
   private static final String PROCESS_ID = "process";
   private static String tenantId;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/MultiTenantUserTaskOperationsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/MultiTenantUserTaskOperationsTest.java
@@ -41,8 +41,8 @@ public class MultiTenantUserTaskOperationsTest {
       EngineRule.singlePartition()
           .withSecurityConfig(
               config -> {
-                config.getAuthorizations().setEnabled(true);
-                config.getMultiTenancy().setChecksEnabled(true);
+                config.setAuthorizationsEnabled(true);
+                config.setMultiTenancyChecksEnabled(true);
               });
 
   private static final String PROCESS_ID = "process";

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskAssignAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskAssignAuthorizationTest.java
@@ -56,7 +56,7 @@ public class UserTaskAssignAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
+          .withAuthorizationsEnabled(true)
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskAssignAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskAssignAuthorizationTest.java
@@ -56,7 +56,7 @@ public class UserTaskAssignAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
+          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskClaimAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskClaimAuthorizationTest.java
@@ -56,7 +56,7 @@ public class UserTaskClaimAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
+          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskClaimAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskClaimAuthorizationTest.java
@@ -56,7 +56,7 @@ public class UserTaskClaimAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
+          .withAuthorizationsEnabled(true)
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCompleteAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCompleteAuthorizationTest.java
@@ -56,7 +56,7 @@ public class UserTaskCompleteAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
+          .withAuthorizationsEnabled(true)
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCompleteAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCompleteAuthorizationTest.java
@@ -56,7 +56,7 @@ public class UserTaskCompleteAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
+          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskRejectionCommandTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskRejectionCommandTest.java
@@ -32,7 +32,7 @@ public class UserTaskRejectionCommandTest {
       EngineRule.singlePartition()
           .withSecurityConfig(
               config -> {
-                config.getMultiTenancy().setChecksEnabled(true);
+                config.setMultiTenancyChecksEnabled(true);
               });
 
   private static final String TENANT = "custom-tenant";

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskRejectionCommandTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskRejectionCommandTest.java
@@ -29,11 +29,7 @@ public class UserTaskRejectionCommandTest {
 
   @ClassRule
   public static final EngineRule ENGINE =
-      EngineRule.singlePartition()
-          .withSecurityConfig(
-              config -> {
-                config.setMultiTenancyChecksEnabled(true);
-              });
+      EngineRule.singlePartition().withMultiTenancyChecksEnabled(true);
 
   private static final String TENANT = "custom-tenant";
   private static final String USERNAME = "tenant-user";

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskUpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskUpdateAuthorizationTest.java
@@ -53,7 +53,7 @@ public class UserTaskUpdateAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
+          .withAuthorizationsEnabled(true)
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskUpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskUpdateAuthorizationTest.java
@@ -53,7 +53,7 @@ public class UserTaskUpdateAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
+          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateAuthorizationTest.java
@@ -45,7 +45,7 @@ public class VariableDocumentUpdateAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
+          .withAuthorizationsEnabled(true)
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateAuthorizationTest.java
@@ -45,7 +45,7 @@ public class VariableDocumentUpdateAuthorizationTest {
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withIdentitySetup()
-          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
+          .withSecurityConfig(cfg -> cfg.setAuthorizationsEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
           .withSecurityConfig(
               cfg -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
-import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.zeebe.db.DbKey;
 import io.camunda.zeebe.db.DbValue;
 import io.camunda.zeebe.engine.EngineConfiguration;
@@ -133,8 +133,8 @@ public final class EngineRule extends ExternalResource {
 
   private final FeatureFlags featureFlags = FeatureFlags.createDefaultForTests();
   private ArrayList<TestInterPartitionCommandSender> interPartitionCommandSenders;
-  private Consumer<SecurityConfiguration> securityConfigModifier =
-      cfg -> cfg.getAuthorizations().setEnabled(false);
+  private Consumer<EngineSecurityConfig> securityConfigModifier =
+      cfg -> cfg.setAuthorizationsEnabled(false);
   private Consumer<EngineConfiguration> engineConfigModifier =
       cfg -> {
         // identity setup is disabled by default so we can have deterministic writes
@@ -265,7 +265,7 @@ public final class EngineRule extends ExternalResource {
     return this;
   }
 
-  public EngineRule withSecurityConfig(final Consumer<SecurityConfiguration> modifier) {
+  public EngineRule withSecurityConfig(final Consumer<EngineSecurityConfig> modifier) {
     securityConfigModifier = securityConfigModifier.andThen(modifier);
     return this;
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.EngineSecurityConfig;
+import io.camunda.security.configuration.EngineSecurityConfigurations;
 import io.camunda.zeebe.db.DbKey;
 import io.camunda.zeebe.db.DbValue;
 import io.camunda.zeebe.engine.EngineConfiguration;
@@ -133,8 +134,9 @@ public final class EngineRule extends ExternalResource {
 
   private final FeatureFlags featureFlags = FeatureFlags.createDefaultForTests();
   private ArrayList<TestInterPartitionCommandSender> interPartitionCommandSenders;
-  private Consumer<EngineSecurityConfig> securityConfigModifier =
-      cfg -> cfg.setAuthorizationsEnabled(false);
+  private boolean securityAuthorizationsEnabled = false;
+  private boolean securityMultiTenancyChecksEnabled = false;
+  private Consumer<EngineSecurityConfig> securityConfigModifier = cfg -> {};
   private Consumer<EngineConfiguration> engineConfigModifier =
       cfg -> {
         // identity setup is disabled by default so we can have deterministic writes
@@ -270,6 +272,16 @@ public final class EngineRule extends ExternalResource {
     return this;
   }
 
+  public EngineRule withAuthorizationsEnabled(final boolean enabled) {
+    securityAuthorizationsEnabled = enabled;
+    return this;
+  }
+
+  public EngineRule withMultiTenancyChecksEnabled(final boolean enabled) {
+    securityMultiTenancyChecksEnabled = enabled;
+    return this;
+  }
+
   public EngineRule withEngineConfig(final Consumer<EngineConfiguration> modifier) {
     engineConfigModifier = engineConfigModifier.andThen(modifier);
     return this;
@@ -320,6 +332,12 @@ public final class EngineRule extends ExternalResource {
   private void startProcessors(final StreamProcessorMode mode, final boolean awaitOpening) {
     interPartitionCommandSenders = new ArrayList<>();
 
+    final var securityConfig =
+        EngineSecurityConfigurations.defaultConfig()
+            .withAuthorizationsEnabled(securityAuthorizationsEnabled)
+            .withMultiTenancyChecksEnabled(securityMultiTenancyChecksEnabled);
+    securityConfigModifier.accept(securityConfig);
+
     forEachPartition(
         partitionId -> {
           final var interPartitionCommandSender =
@@ -346,7 +364,6 @@ public final class EngineRule extends ExternalResource {
                   dbRoutingState.setDesiredPartitions(state.desiredPartitions(), 0L);
                 }
 
-                securityConfigModifier.accept(recordProcessorContext.getSecurityConfig());
                 engineConfigModifier.accept(recordProcessorContext.getConfig());
                 return EngineProcessors.createEngineProcessors(
                         recordProcessorContext,
@@ -376,7 +393,8 @@ public final class EngineRule extends ExternalResource {
                     }
                   }),
               cfg -> cfg.streamProcessorMode(mode),
-              awaitOpening);
+              awaitOpening,
+              securityConfig);
         });
     interPartitionCommandSenders.forEach(s -> s.initializeWriters(partitionCount));
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessingComposite.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessingComposite.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.engine.util;
 
+import io.camunda.security.configuration.EngineSecurityConfig;
+import io.camunda.security.configuration.EngineSecurityConfigurations;
 import io.camunda.zeebe.db.ZeebeDbFactory;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessorContext;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessorFactory;
@@ -98,6 +100,22 @@ public class StreamProcessingComposite implements CommandWriter {
       final Optional<StreamProcessorListener> streamProcessorListenerOpt,
       final Consumer<StreamProcessorBuilder> processorConfiguration,
       final boolean awaitOpening) {
+    return startTypedStreamProcessor(
+        partitionId,
+        factory,
+        streamProcessorListenerOpt,
+        processorConfiguration,
+        awaitOpening,
+        EngineSecurityConfigurations.defaultConfig());
+  }
+
+  public StreamProcessor startTypedStreamProcessor(
+      final int partitionId,
+      final TypedRecordProcessorFactory factory,
+      final Optional<StreamProcessorListener> streamProcessorListenerOpt,
+      final Consumer<StreamProcessorBuilder> processorConfiguration,
+      final boolean awaitOpening,
+      final EngineSecurityConfig securityConfig) {
     final var result =
         streams.startStreamProcessor(
             getLogName(partitionId),
@@ -109,7 +127,8 @@ public class StreamProcessingComposite implements CommandWriter {
             }),
             streamProcessorListenerOpt,
             processorConfiguration,
-            awaitOpening);
+            awaitOpening,
+            securityConfig);
 
     return result;
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.util;
 
 import static io.camunda.zeebe.engine.util.StreamProcessingComposite.getLogName;
 
+import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.zeebe.db.ZeebeDbFactory;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessorFactory;
 import io.camunda.zeebe.engine.state.DefaultZeebeDbFactory;
@@ -150,6 +151,22 @@ public final class StreamProcessorRule implements TestRule, CommandWriter {
       final boolean awaitOpening) {
     return streamProcessingComposite.startTypedStreamProcessor(
         partitionId, factory, streamProcessorListenerOpt, processorConfiguration, awaitOpening);
+  }
+
+  public StreamProcessor startTypedStreamProcessor(
+      final int partitionId,
+      final TypedRecordProcessorFactory factory,
+      final Optional<StreamProcessorListener> streamProcessorListenerOpt,
+      final Consumer<StreamProcessorBuilder> processorConfiguration,
+      final boolean awaitOpening,
+      final EngineSecurityConfig securityConfig) {
+    return streamProcessingComposite.startTypedStreamProcessor(
+        partitionId,
+        factory,
+        streamProcessorListenerOpt,
+        processorConfiguration,
+        awaitOpening,
+        securityConfig);
   }
 
   public void pauseProcessing(final int partitionId) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
@@ -13,7 +13,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.configuration.EngineSecurityConfigurations;
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.ZeebeDbFactory;
@@ -296,7 +296,9 @@ public final class TestStreams {
             .recordProcessors(
                 List.of(
                     new Engine(
-                        wrappedFactory, new EngineConfiguration(), new SecurityConfiguration())))
+                        wrappedFactory,
+                        new EngineConfiguration(),
+                        EngineSecurityConfigurations.defaultConfig())))
             .streamProcessorMode(streamProcessorMode)
             .maxCommandsInBatch(maxCommandsInBatch)
             .partitionCommandSender(isReplay ? null : mock(InterPartitionCommandSender.class))

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
@@ -13,6 +13,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.security.configuration.EngineSecurityConfigurations;
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
@@ -229,6 +230,24 @@ public final class TestStreams {
       final Optional<StreamProcessorListener> streamProcessorListenerOpt,
       final Consumer<StreamProcessorBuilder> processorConfiguration,
       final boolean awaitOpening) {
+    return startStreamProcessor(
+        log,
+        zeebeDbFactory,
+        typedRecordProcessorFactory,
+        streamProcessorListenerOpt,
+        processorConfiguration,
+        awaitOpening,
+        EngineSecurityConfigurations.defaultConfig());
+  }
+
+  public StreamProcessor startStreamProcessor(
+      final String log,
+      final ZeebeDbFactory zeebeDbFactory,
+      final TypedRecordProcessorFactory typedRecordProcessorFactory,
+      final Optional<StreamProcessorListener> streamProcessorListenerOpt,
+      final Consumer<StreamProcessorBuilder> processorConfiguration,
+      final boolean awaitOpening,
+      final EngineSecurityConfig securityConfig) {
     final TestLogStream stream = getLogStream(log);
     return buildStreamProcessor(
         stream,
@@ -236,7 +255,8 @@ public final class TestStreams {
         processorConfiguration,
         typedRecordProcessorFactory,
         awaitOpening,
-        streamProcessorListenerOpt);
+        streamProcessorListenerOpt,
+        securityConfig);
   }
 
   public StreamProcessor buildStreamProcessor(
@@ -246,6 +266,24 @@ public final class TestStreams {
       final TypedRecordProcessorFactory factory,
       final boolean awaitOpening,
       final Optional<StreamProcessorListener> streamProcessorListenerOpt) {
+    return buildStreamProcessor(
+        stream,
+        zeebeDbFactory,
+        processorConfiguration,
+        factory,
+        awaitOpening,
+        streamProcessorListenerOpt,
+        EngineSecurityConfigurations.defaultConfig());
+  }
+
+  public StreamProcessor buildStreamProcessor(
+      final TestLogStream stream,
+      final ZeebeDbFactory zeebeDbFactory,
+      final Consumer<StreamProcessorBuilder> processorConfiguration,
+      final TypedRecordProcessorFactory factory,
+      final boolean awaitOpening,
+      final Optional<StreamProcessorListener> streamProcessorListenerOpt,
+      final EngineSecurityConfig securityConfig) {
     final var storage = createRuntimeFolder(stream);
     final var snapshot = storage.getParent().resolve(SNAPSHOT_FOLDER);
 
@@ -294,11 +332,7 @@ public final class TestStreams {
             .commandResponseWriter(mockCommandResponseWriter)
             .listener(new StreamProcessorListenerRelay(streamProcessorListeners))
             .recordProcessors(
-                List.of(
-                    new Engine(
-                        wrappedFactory,
-                        new EngineConfiguration(),
-                        EngineSecurityConfigurations.defaultConfig())))
+                List.of(new Engine(wrappedFactory, new EngineConfiguration(), securityConfig)))
             .streamProcessorMode(streamProcessorMode)
             .maxCommandsInBatch(maxCommandsInBatch)
             .partitionCommandSender(isReplay ? null : mock(InterPartitionCommandSender.class))

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.gateway;
 import io.atomix.cluster.BrokerMemberId;
 import io.atomix.utils.net.Address;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
-import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
@@ -95,7 +95,7 @@ public final class EndpointManager {
       final BrokerClient brokerClient,
       final ActivateJobsHandler<ActivateJobsResponse> activateJobsHandler,
       final StreamJobsHandler streamJobsHandler,
-      final SecurityConfiguration securityConfiguration) {
+      final EngineSecurityConfig securityConfiguration) {
     this(
         brokerClient,
         activateJobsHandler,
@@ -108,14 +108,14 @@ public final class EndpointManager {
       final BrokerClient brokerClient,
       final ActivateJobsHandler<ActivateJobsResponse> activateJobsHandler,
       final StreamJobsHandler streamJobsHandler,
-      final SecurityConfiguration securityConfiguration,
+      final EngineSecurityConfig securityConfiguration,
       final int maxVariableNameLength) {
     this.brokerClient = brokerClient;
     this.activateJobsHandler = activateJobsHandler;
     this.streamJobsHandler = streamJobsHandler;
     topologyManager = brokerClient.getTopologyManager();
     requestRetryHandler = new RequestRetryHandler(brokerClient, topologyManager);
-    RequestMapper.setMultiTenancyEnabled(securityConfiguration.getMultiTenancy().isChecksEnabled());
+    RequestMapper.setMultiTenancyEnabled(securityConfiguration.isMultiTenancyChecksEnabled());
     RequestMapper.setMaxVariableNameLength(maxVariableNameLength);
     authorizationConverter = new BrokerRequestAuthorizationConverter(securityConfiguration);
   }

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/Gateway.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/Gateway.java
@@ -8,7 +8,7 @@
 package io.camunda.zeebe.gateway;
 
 import com.google.rpc.Code;
-import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.security.oidc.NoopOidcClaimsProvider;
 import io.camunda.security.oidc.OidcClaimsProvider;
 import io.camunda.service.UserServices;
@@ -90,7 +90,7 @@ public final class Gateway implements CloseableSilently {
   private static final Duration DEFAULT_SHUTDOWN_TIMEOUT = Duration.ofSeconds(30);
 
   private final GatewayCfg gatewayCfg;
-  private final SecurityConfiguration securityConfiguration;
+  private final EngineSecurityConfig securityConfiguration;
   private final ActorSchedulingService actorSchedulingService;
   private final GatewayHealthManager healthManager;
   private final ClientStreamer<JobActivationProperties> jobStreamer;
@@ -108,7 +108,7 @@ public final class Gateway implements CloseableSilently {
 
   public Gateway(
       final GatewayCfg gatewayCfg,
-      final SecurityConfiguration securityConfiguration,
+      final EngineSecurityConfig securityConfiguration,
       final BrokerClient brokerClient,
       final ActorSchedulingService actorSchedulingService,
       final ClientStreamer<JobActivationProperties> jobStreamer,
@@ -134,7 +134,7 @@ public final class Gateway implements CloseableSilently {
   public Gateway(
       final Duration shutdownDuration,
       final GatewayCfg gatewayCfg,
-      final SecurityConfiguration securityConfiguration,
+      final EngineSecurityConfig securityConfiguration,
       final BrokerClient brokerClient,
       final ActorSchedulingService actorSchedulingService,
       final ClientStreamer<JobActivationProperties> jobStreamer,
@@ -160,7 +160,7 @@ public final class Gateway implements CloseableSilently {
   public Gateway(
       final Duration shutdownDuration,
       final GatewayCfg gatewayCfg,
-      final SecurityConfiguration securityConfiguration,
+      final EngineSecurityConfig securityConfiguration,
       final BrokerClient brokerClient,
       final ActorSchedulingService actorSchedulingService,
       final ClientStreamer<JobActivationProperties> jobStreamer,
@@ -451,7 +451,7 @@ public final class Gateway implements CloseableSilently {
     Collections.reverse(interceptors);
     interceptors.add(new ContextInjectingInterceptor(queryApi));
 
-    if (securityConfiguration.isApiProtected()) {
+    if (!securityConfiguration.getAuthentication().isUnprotectedApi()) {
       final var authMethod = securityConfiguration.getAuthentication().getMethod();
       final var handler =
           switch (authMethod) {

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/UnavailableBrokersTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/UnavailableBrokersTest.java
@@ -17,7 +17,7 @@ import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.command.ClientStatusException;
 import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.impl.util.AddressUtil;
-import io.camunda.security.configuration.SecurityConfigurations;
+import io.camunda.security.configuration.EngineSecurityConfigurations;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.BrokerClientRequestMetrics;
@@ -106,7 +106,7 @@ class UnavailableBrokersTest {
     gateway =
         new Gateway(
             config,
-            SecurityConfigurations.unauthenticatedAndUnauthorized(),
+            EngineSecurityConfigurations.unauthenticatedAndUnauthorized(),
             brokerClient,
             actorScheduler,
             jobStreamClient.streamer(),

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/job/ActivateJobsTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/job/ActivateJobsTest.java
@@ -51,7 +51,7 @@ public final class ActivateJobsTest {
     public MultiTenancyDisabledTest(final boolean isLongPollingEnabled) {
       super(
           cfg -> cfg.getLongPolling().setEnabled(isLongPollingEnabled),
-          cfg -> cfg.getMultiTenancy().setChecksEnabled(false));
+          cfg -> cfg.setMultiTenancyChecksEnabled(false));
     }
 
     @Parameters(name = "{index}: longPolling.enabled[{0}]")
@@ -227,7 +227,7 @@ public final class ActivateJobsTest {
     public MultiTenancyEnabledTest(final boolean isLongPollingEnabled) {
       super(
           cfg -> cfg.getLongPolling().setEnabled(isLongPollingEnabled),
-          cfg -> cfg.getMultiTenancy().setChecksEnabled(true));
+          cfg -> cfg.setMultiTenancyChecksEnabled(true));
     }
 
     @Parameters(name = "{index}: longPolling.enabled[{0}]")

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/job/ActivateJobsTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/job/ActivateJobsTest.java
@@ -51,7 +51,7 @@ public final class ActivateJobsTest {
     public MultiTenancyDisabledTest(final boolean isLongPollingEnabled) {
       super(
           cfg -> cfg.getLongPolling().setEnabled(isLongPollingEnabled),
-          cfg -> cfg.setMultiTenancyChecksEnabled(false));
+          cfg -> cfg.withMultiTenancyChecksEnabled(false));
     }
 
     @Parameters(name = "{index}: longPolling.enabled[{0}]")
@@ -227,7 +227,7 @@ public final class ActivateJobsTest {
     public MultiTenancyEnabledTest(final boolean isLongPollingEnabled) {
       super(
           cfg -> cfg.getLongPolling().setEnabled(isLongPollingEnabled),
-          cfg -> cfg.setMultiTenancyChecksEnabled(true));
+          cfg -> cfg.withMultiTenancyChecksEnabled(true));
     }
 
     @Parameters(name = "{index}: longPolling.enabled[{0}]")

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/job/NonLongPollingActivateJobsTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/job/NonLongPollingActivateJobsTest.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.gateway.api.job;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.configuration.EngineSecurityConfigurations;
 import io.camunda.zeebe.gateway.api.util.GatewayTest;
 import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
@@ -23,7 +23,7 @@ import org.junit.Test;
 public final class NonLongPollingActivateJobsTest extends GatewayTest {
 
   public NonLongPollingActivateJobsTest() {
-    super(getConfig(), new SecurityConfiguration());
+    super(getConfig(), EngineSecurityConfigurations.defaultConfig());
   }
 
   private static GatewayCfg getConfig() {

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/util/GatewayTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/util/GatewayTest.java
@@ -7,7 +7,8 @@
  */
 package io.camunda.zeebe.gateway.api.util;
 
-import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.configuration.EngineSecurityConfig;
+import io.camunda.security.configuration.EngineSecurityConfigurations;
 import io.camunda.zeebe.gateway.api.util.StubbedGateway.StubbedJobStreamer;
 import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
 import io.camunda.zeebe.gateway.protocol.GatewayGrpc.GatewayBlockingStub;
@@ -33,7 +34,7 @@ public abstract class GatewayTest {
   protected StubbedBrokerClient brokerClient;
   protected StubbedJobStreamer jobStreamer;
 
-  public GatewayTest(final GatewayCfg config, final SecurityConfiguration securityConfiguration) {
+  public GatewayTest(final GatewayCfg config, final EngineSecurityConfig securityConfiguration) {
     actorClock = new ControlledActorClock();
     actorSchedulerRule = new ActorSchedulerRule(actorClock);
     gatewayRule = new StubbedGatewayRule(actorSchedulerRule, config, securityConfiguration);
@@ -41,17 +42,17 @@ public abstract class GatewayTest {
   }
 
   public GatewayTest() {
-    this(new GatewayCfg(), new SecurityConfiguration());
+    this(new GatewayCfg(), EngineSecurityConfigurations.defaultConfig());
   }
 
   private GatewayTest(
       final Supplier<GatewayCfg> configSupplier,
-      final Supplier<SecurityConfiguration> securitySupplier) {
+      final Supplier<EngineSecurityConfig> securitySupplier) {
     this(configSupplier.get(), securitySupplier.get());
   }
 
   public GatewayTest(
-      final Consumer<GatewayCfg> modifier, final Consumer<SecurityConfiguration> securityModifier) {
+      final Consumer<GatewayCfg> modifier, final Consumer<EngineSecurityConfig> securityModifier) {
     this(
         () -> {
           final GatewayCfg config = new GatewayCfg();
@@ -59,7 +60,8 @@ public abstract class GatewayTest {
           return config;
         },
         () -> {
-          final SecurityConfiguration securityConfiguration = new SecurityConfiguration();
+          final EngineSecurityConfig securityConfiguration =
+              EngineSecurityConfigurations.defaultConfig();
           securityModifier.accept(securityConfiguration);
           return securityConfiguration;
         });

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/util/GatewayTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/util/GatewayTest.java
@@ -16,7 +16,7 @@ import io.camunda.zeebe.gateway.protocol.GatewayGrpc.GatewayStub;
 import io.camunda.zeebe.scheduler.clock.ControlledActorClock;
 import io.camunda.zeebe.scheduler.testing.ActorSchedulerRule;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -45,26 +45,18 @@ public abstract class GatewayTest {
     this(new GatewayCfg(), EngineSecurityConfigurations.defaultConfig());
   }
 
-  private GatewayTest(
-      final Supplier<GatewayCfg> configSupplier,
-      final Supplier<EngineSecurityConfig> securitySupplier) {
-    this(configSupplier.get(), securitySupplier.get());
+  public GatewayTest(
+      final Consumer<GatewayCfg> modifier,
+      final UnaryOperator<EngineSecurityConfig> securityOperator) {
+    this(
+        applyGatewayCfg(modifier),
+        securityOperator.apply(EngineSecurityConfigurations.defaultConfig()));
   }
 
-  public GatewayTest(
-      final Consumer<GatewayCfg> modifier, final Consumer<EngineSecurityConfig> securityModifier) {
-    this(
-        () -> {
-          final GatewayCfg config = new GatewayCfg();
-          modifier.accept(config);
-          return config;
-        },
-        () -> {
-          final EngineSecurityConfig securityConfiguration =
-              EngineSecurityConfigurations.defaultConfig();
-          securityModifier.accept(securityConfiguration);
-          return securityConfiguration;
-        });
+  private static GatewayCfg applyGatewayCfg(final Consumer<GatewayCfg> modifier) {
+    final GatewayCfg config = new GatewayCfg();
+    modifier.accept(config);
+    return config;
   }
 
   @Before

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java
@@ -11,7 +11,7 @@ import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.interfaces.Claim;
 import io.camunda.security.api.model.config.AuthenticationMethod;
-import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.security.oidc.NoopOidcClaimsProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.gateway.EndpointManager;
@@ -77,7 +77,7 @@ public final class StubbedGateway {
   private final StubbedJobStreamer jobStreamer;
   private final ActorScheduler actorScheduler;
   private final GatewayCfg config;
-  private final SecurityConfiguration securityConfiguration;
+  private final EngineSecurityConfig securityConfiguration;
   private Server server;
 
   public StubbedGateway(
@@ -85,7 +85,7 @@ public final class StubbedGateway {
       final StubbedBrokerClient brokerClient,
       final StubbedJobStreamer jobStreamer,
       final GatewayCfg config,
-      final SecurityConfiguration securityConfiguration) {
+      final EngineSecurityConfig securityConfiguration) {
     this.actorScheduler = actorScheduler;
     this.brokerClient = brokerClient;
     this.jobStreamer = jobStreamer;

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGatewayRule.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGatewayRule.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.gateway.api.util;
 
-import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.zeebe.gateway.RequestMapper;
 import io.camunda.zeebe.gateway.api.util.StubbedGateway.StubbedJobStreamer;
 import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
@@ -23,14 +23,14 @@ public final class StubbedGatewayRule extends ExternalResource {
   protected GatewayStub asyncClient;
   private final ActorSchedulerRule actorSchedulerRule;
   private final GatewayCfg config;
-  private final SecurityConfiguration securityConfiguration;
+  private final EngineSecurityConfig securityConfiguration;
   private final StubbedBrokerClient brokerClient;
   private final StubbedJobStreamer jobStreamer;
 
   public StubbedGatewayRule(
       final ActorSchedulerRule actorSchedulerRule,
       final GatewayCfg config,
-      final SecurityConfiguration securityConfiguration) {
+      final EngineSecurityConfig securityConfiguration) {
     this.actorSchedulerRule = actorSchedulerRule;
     brokerClient = new StubbedBrokerClient();
     jobStreamer = new StubbedJobStreamer();

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/BrokerRequestWithoutAuthorizationInfoTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/BrokerRequestWithoutAuthorizationInfoTest.java
@@ -44,10 +44,7 @@ public class BrokerRequestWithoutAuthorizationInfoTest extends GatewayTest {
   public BrokerRequestWithoutAuthorizationInfoTest() {
     super(
         config -> {},
-        security -> {
-          security.setAuthorizationsEnabled(false);
-          security.setMultiTenancyChecksEnabled(false);
-        });
+        security -> security.withAuthorizationsEnabled(false).withMultiTenancyChecksEnabled(false));
   }
 
   @Before

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/BrokerRequestWithoutAuthorizationInfoTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/BrokerRequestWithoutAuthorizationInfoTest.java
@@ -45,8 +45,8 @@ public class BrokerRequestWithoutAuthorizationInfoTest extends GatewayTest {
     super(
         config -> {},
         security -> {
-          security.getAuthorizations().setEnabled(false);
-          security.getMultiTenancy().setChecksEnabled(false);
+          security.setAuthorizationsEnabled(false);
+          security.setMultiTenancyChecksEnabled(false);
         });
   }
 

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/MultiTenancyDisabledTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/MultiTenancyDisabledTest.java
@@ -52,7 +52,7 @@ public class MultiTenancyDisabledTest extends GatewayTest {
   private final ActivateJobsStub activateJobsStub = new ActivateJobsStub();
 
   public MultiTenancyDisabledTest() {
-    super(cfg -> {}, cfg -> cfg.getMultiTenancy().setChecksEnabled(false));
+    super(cfg -> {}, cfg -> cfg.setMultiTenancyChecksEnabled(false));
   }
 
   @Before

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/MultiTenancyDisabledTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/MultiTenancyDisabledTest.java
@@ -52,7 +52,7 @@ public class MultiTenancyDisabledTest extends GatewayTest {
   private final ActivateJobsStub activateJobsStub = new ActivateJobsStub();
 
   public MultiTenancyDisabledTest() {
-    super(cfg -> {}, cfg -> cfg.setMultiTenancyChecksEnabled(false));
+    super(cfg -> {}, cfg -> cfg.withMultiTenancyChecksEnabled(false));
   }
 
   @Before

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/MultiTenancyEnabledTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/MultiTenancyEnabledTest.java
@@ -51,7 +51,7 @@ public class MultiTenancyEnabledTest extends GatewayTest {
   private final ActivateJobsStub activateJobsStub = new ActivateJobsStub();
 
   public MultiTenancyEnabledTest() {
-    super(cfg -> {}, cfg -> cfg.setMultiTenancyChecksEnabled(true));
+    super(cfg -> {}, cfg -> cfg.withMultiTenancyChecksEnabled(true));
   }
 
   @Before

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/MultiTenancyEnabledTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/MultiTenancyEnabledTest.java
@@ -51,7 +51,7 @@ public class MultiTenancyEnabledTest extends GatewayTest {
   private final ActivateJobsStub activateJobsStub = new ActivateJobsStub();
 
   public MultiTenancyEnabledTest() {
-    super(cfg -> {}, cfg -> cfg.getMultiTenancy().setChecksEnabled(true));
+    super(cfg -> {}, cfg -> cfg.setMultiTenancyChecksEnabled(true));
   }
 
   @Before

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/InterceptorIT.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/InterceptorIT.java
@@ -16,7 +16,7 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ClientStatusException;
 import io.camunda.client.api.response.DeploymentEvent;
 import io.camunda.client.impl.util.AddressUtil;
-import io.camunda.security.configuration.SecurityConfigurations;
+import io.camunda.security.configuration.EngineSecurityConfigurations;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.BrokerClientRequestMetrics;
@@ -101,7 +101,7 @@ final class InterceptorIT {
     gateway =
         new Gateway(
             config,
-            SecurityConfigurations.unauthenticatedAndUnauthorized(),
+            EngineSecurityConfigurations.unauthenticatedAndUnauthorized(),
             brokerClient,
             scheduler,
             jobStreamClient.streamer(),

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/security/SecurityTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/security/SecurityTest.java
@@ -12,7 +12,7 @@ import static org.mockito.Mockito.mock;
 
 import io.atomix.cluster.AtomixCluster;
 import io.atomix.utils.net.Address;
-import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.configuration.EngineSecurityConfigurations;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.BrokerClientRequestMetrics;
@@ -198,7 +198,7 @@ final class SecurityTest {
     atomix.getMembershipService().addListener(topologyManager);
     return new Gateway(
         gatewayCfg,
-        new SecurityConfiguration(),
+        EngineSecurityConfigurations.defaultConfig(),
         brokerClient,
         actorScheduler,
         jobStreamClient.streamer(),

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerLongPollingTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerLongPollingTest.java
@@ -18,7 +18,7 @@ import io.camunda.gateway.protocol.model.JobActivationResult;
 import io.camunda.security.api.context.CamundaAuthenticationProvider;
 import io.camunda.security.api.model.config.MultiTenancyConfiguration;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
-import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.configuration.EngineSecurityConfigurations;
 import io.camunda.service.ApiServicesExecutorProvider;
 import io.camunda.service.JobServices;
 import io.camunda.service.security.SecurityContextProvider;
@@ -440,7 +440,8 @@ public class JobControllerLongPollingTest extends RestControllerTest {
           activateJobsHandler,
           null,
           new ApiServicesExecutorProvider(1, 1, 1, 1),
-          new BrokerRequestAuthorizationConverter(new SecurityConfiguration()));
+          new BrokerRequestAuthorizationConverter(
+              EngineSecurityConfigurations.unauthenticatedAndUnauthorized()));
     }
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerRoundRobinTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerRoundRobinTest.java
@@ -17,7 +17,7 @@ import io.camunda.gateway.protocol.model.JobActivationResult;
 import io.camunda.security.api.context.CamundaAuthenticationProvider;
 import io.camunda.security.api.model.config.MultiTenancyConfiguration;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
-import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.configuration.EngineSecurityConfigurations;
 import io.camunda.service.ApiServicesExecutorProvider;
 import io.camunda.service.JobServices;
 import io.camunda.service.security.SecurityContextProvider;
@@ -431,7 +431,8 @@ public class JobControllerRoundRobinTest extends RestControllerTest {
           activateJobsHandler,
           null,
           new ApiServicesExecutorProvider(1, 1, 1, 1),
-          new BrokerRequestAuthorizationConverter(new SecurityConfiguration()));
+          new BrokerRequestAuthorizationConverter(
+              EngineSecurityConfigurations.unauthenticatedAndUnauthorized()));
     }
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusteringRule.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusteringRule.java
@@ -37,7 +37,7 @@ import io.camunda.client.api.response.Topology;
 import io.camunda.client.impl.util.AddressUtil;
 import io.camunda.configuration.beans.BrokerBasedProperties;
 import io.camunda.configuration.beans.GatewayBasedProperties;
-import io.camunda.security.configuration.SecurityConfigurations;
+import io.camunda.security.configuration.EngineSecurityConfigurations;
 import io.camunda.security.oidc.NoopOidcClaimsProvider;
 import io.camunda.zeebe.broker.Broker;
 import io.camunda.zeebe.broker.PartitionListener;
@@ -388,7 +388,7 @@ public class ClusteringRule extends ExternalResource {
             atomixCluster,
             brokerClient,
             meterRegistry,
-            SecurityConfigurations.unauthenticatedAndUnauthorized(),
+            EngineSecurityConfigurations.unauthenticatedAndUnauthorized(),
             null,
             null,
             null,
@@ -533,7 +533,7 @@ public class ClusteringRule extends ExternalResource {
     final var gateway =
         new Gateway(
             gatewayCfg,
-            SecurityConfigurations.unauthenticatedAndUnauthorized(),
+            EngineSecurityConfigurations.unauthenticatedAndUnauthorized(),
             brokerClient,
             actorScheduler,
             jobStreamClient.streamer(),


### PR DESCRIPTION
## Why

`SecurityConfiguration` is an OC-owned `@ConfigurationProperties` class that duplicates the top-level security config already owned by `camunda-security-library`. The goal ([CSL#186](https://github.com/camunda/camunda-security-library/issues/186)) is to retire it in favour of CSL's `CamundaSecurityLibraryProperties`.

Before that deletion can happen, the non-Spring engine/broker chain must stop depending on it. Today `SystemContext`, `AuthorizationCheckBehavior`, `BrokerRequestAuthorizationConverter`, and related classes all receive `SecurityConfiguration` directly — meaning any Spring-level config abstraction leaks into pure-Java processing code. This PR cuts that dependency by introducing a dedicated plain-Java value object.

## Summary

- Adds `EngineSecurityConfig` (plain-Java, no Spring) to `security-core` as a lightweight config holder for the non-Spring broker/engine startup chain, decoupling the engine from `SecurityConfiguration`
- Flattens `AuthorizationsConfiguration`, `MultiTenancyConfiguration`, and identifier validation to primitive fields (booleans + Patterns) to further reduce coupling to Spring-level config abstractions
- `AuthenticationConfiguration` and `InitializationConfiguration` are retained as sub-objects temporarily (tracked in [CSL#274](https://github.com/camunda/camunda-security-library/issues/274))
- The three Spring entry points (`BrokerModuleConfiguration`, `GatewayModuleConfiguration`, `CamundaServicesConfiguration`) construct `EngineSecurityConfig` from the existing `SecurityConfiguration` and pass it down the chain — **no Spring beans are changed in this PR**

## What is NOT in this PR

- Spring bean migration (`authentication/`, `operate/`, `tasklist/`, etc.) — that is PR 2: #54052
- Deletion of `SecurityConfiguration` — that is PR 2: #54052

## Test plan

- [ ] `BrokerRequestAuthorizationConverterTest` passes
- [ ] `AuthorizationCheckBehaviorTest` + `AuthorizationEntityValidatorTest` + variants pass (114 total)
- [ ] `grep -r "SecurityConfiguration" --include="*.java" zeebe/engine/src/main/ security/security-core/src/main/` returns zero results for type usages in the engine chain