### PR TITLE
feat: add JSON support to document preview in Operate

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentPreview/DocumentPreviewModal.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentPreview/DocumentPreviewModal.tsx
@@ -10,6 +10,7 @@ import {Modal} from '@carbon/react';
 import type {StateProps} from 'modules/components/ModalStateManager';
 import type {DocumentInfo} from '../DocumentValueCell/parseDocumentVariable';
 import {PreviewImage, PreviewPdf} from './styled';
+import {PreviewJson} from './PreviewJson';
 
 type DocumentPreviewProps = {
   document: DocumentInfo;
@@ -40,6 +41,10 @@ const ModalContent: React.FC<DocumentPreviewProps> = ({document}) => {
 
   if (document.type === 'pdf') {
     return <PreviewPdf src={document.link} title={document.fileName} />;
+  }
+
+  if (document.type === 'json') {
+    return <PreviewJson document={document} />;
   }
 
   return <p>Preview not available for document "{document.fileName}".</p>;

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentPreview/PreviewDocumentButton.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentPreview/PreviewDocumentButton.test.tsx
@@ -7,8 +7,19 @@
  */
 
 import {render, screen} from 'modules/testing-library';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {http, HttpResponse} from 'msw';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {mockServer} from 'modules/mock-server/node';
 import {PreviewDocumentButton} from './PreviewDocumentButton';
 import type {DocumentInfo} from '../DocumentValueCell/parseDocumentVariable';
+
+const createWrapper = (): React.FC<{children?: React.ReactNode}> => {
+  const client = getMockQueryClient();
+  return ({children}) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+};
 
 const imageDocument: DocumentInfo = {
   link: '/v2/documents/img',
@@ -22,6 +33,13 @@ const pdfDocument: DocumentInfo = {
   fileName: 'report.pdf',
   type: 'pdf',
   size: 2048,
+};
+
+const jsonDocument: DocumentInfo = {
+  link: '/v2/documents/json',
+  fileName: 'data.json',
+  type: 'json',
+  size: 256,
 };
 
 const unknownDocument: DocumentInfo = {
@@ -49,6 +67,18 @@ describe('<PreviewDocumentButton />', () => {
     );
 
     const button = screen.getByLabelText('Preview document for variable myPdf');
+    expect(button).toBeEnabled();
+  });
+
+  it('should render an enabled preview button for json documents', () => {
+    render(
+      <PreviewDocumentButton document={jsonDocument} variableName="myJson" />,
+      {wrapper: createWrapper()},
+    );
+
+    const button = screen.getByLabelText(
+      'Preview document for variable myJson',
+    );
     expect(button).toBeEnabled();
   });
 
@@ -98,6 +128,56 @@ describe('<PreviewDocumentButton />', () => {
     expect(dialog).toBeInTheDocument();
     const image = screen.getByRole('img', {name: 'photo.png'});
     expect(image).toHaveAttribute('src', '/v2/documents/img');
+  });
+
+  it('should open the modal and render pretty-printed JSON when clicked', async () => {
+    mockServer.use(
+      http.get(
+        '/v2/documents/json',
+        () => HttpResponse.text('{"foo":"bar","nested":{"baz":1}}'),
+        {once: true},
+      ),
+    );
+
+    const {user} = render(
+      <PreviewDocumentButton document={jsonDocument} variableName="myJson" />,
+      {wrapper: createWrapper()},
+    );
+
+    await user.click(
+      screen.getByLabelText('Preview document for variable myJson'),
+    );
+
+    const editor = await screen.findByTestId('monaco-editor');
+    expect(editor).toHaveValue(
+      '{\n\t"foo": "bar",\n\t"nested": {\n\t\t"baz": 1\n\t}\n}',
+    );
+  });
+
+  it('should show an error notification when the JSON document fails to load', async () => {
+    mockServer.use(
+      http.get(
+        '/v2/documents/json',
+        () => new HttpResponse(null, {status: 500}),
+        {once: true},
+      ),
+    );
+
+    const {user} = render(
+      <PreviewDocumentButton document={jsonDocument} variableName="myJson" />,
+      {wrapper: createWrapper()},
+    );
+
+    await user.click(
+      screen.getByLabelText('Preview document for variable myJson'),
+    );
+
+    expect(
+      await screen.findByText(
+        `Failed to prepare JSON preview for document "${jsonDocument.fileName}".`,
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId('monaco-editor')).not.toBeInTheDocument();
   });
 
   it('should show the file name as the modal heading', async () => {

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentPreview/PreviewDocumentButton.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentPreview/PreviewDocumentButton.test.tsx
@@ -8,9 +8,8 @@
 
 import {render, screen} from 'modules/testing-library';
 import {QueryClientProvider} from '@tanstack/react-query';
-import {http, HttpResponse} from 'msw';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
-import {mockServer} from 'modules/mock-server/node';
+import {mockDownloadDocument} from 'modules/mocks/api/v2/documents/downloadDocument';
 import {PreviewDocumentButton} from './PreviewDocumentButton';
 import type {DocumentInfo} from '../DocumentValueCell/parseDocumentVariable';
 
@@ -131,13 +130,7 @@ describe('<PreviewDocumentButton />', () => {
   });
 
   it('should open the modal and render pretty-printed JSON when clicked', async () => {
-    mockServer.use(
-      http.get(
-        '/v2/documents/json',
-        () => HttpResponse.text('{"foo":"bar","nested":{"baz":1}}'),
-        {once: true},
-      ),
-    );
+    mockDownloadDocument().withSuccess('{"foo":"bar","nested":{"baz":1}}');
 
     const {user} = render(
       <PreviewDocumentButton document={jsonDocument} variableName="myJson" />,
@@ -155,13 +148,7 @@ describe('<PreviewDocumentButton />', () => {
   });
 
   it('should show an error notification when the JSON document fails to load', async () => {
-    mockServer.use(
-      http.get(
-        '/v2/documents/json',
-        () => new HttpResponse(null, {status: 500}),
-        {once: true},
-      ),
-    );
+    mockDownloadDocument().withServerError();
 
     const {user} = render(
       <PreviewDocumentButton document={jsonDocument} variableName="myJson" />,

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentPreview/PreviewJson.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentPreview/PreviewJson.tsx
@@ -1,0 +1,83 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {lazy, Suspense} from 'react';
+import {useQuery} from '@tanstack/react-query';
+import {InlineLoading, InlineNotification} from '@carbon/react';
+import {beautifyJSON} from 'modules/utils/editor/beautifyJSON';
+import type {DocumentInfo} from '../DocumentValueCell/parseDocumentVariable';
+import {PreviewJSONContainer} from './styled';
+import {queryKeys} from 'modules/queries/queryKeys';
+
+const RichTextEditor = lazy(async () => {
+  const [{loadMonaco}, {RichTextEditor}] = await Promise.all([
+    import('modules/loadMonaco'),
+    import('modules/components/RichTextEditor'),
+  ]);
+  loadMonaco();
+  return {default: RichTextEditor};
+});
+
+type PreviewJsonProps = {
+  document: DocumentInfo;
+};
+
+const PreviewJson: React.FC<PreviewJsonProps> = ({document}) => {
+  const {data, isPending, isError} = useQuery({
+    queryKey: queryKeys.documents.content(document.link),
+    staleTime: 'static',
+    queryFn: async ({signal}) => {
+      // Note: Cannot use one of the request helpers here, because the link is
+      // already prefixed with a configured context-path.
+      const response = await fetch(document.link, {
+        credentials: 'include',
+        headers: {Accept: 'application/json'},
+        signal,
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to load document (status ${response.status})`);
+      }
+
+      return beautifyJSON(await response.text());
+    },
+  });
+
+  return (
+    <PreviewJSONContainer>
+      {isPending && (
+        <InlineLoading
+          data-testid="json-document-preview-spinner"
+          description="Preparing JSON preview…"
+        />
+      )}
+      {isError && (
+        <InlineNotification
+          kind="error"
+          subtitle={`Failed to prepare JSON preview for document "${document.fileName}".`}
+          hideCloseButton
+          lowContrast
+        />
+      )}
+      {data !== undefined && (
+        <Suspense
+          fallback={
+            <InlineLoading
+              data-testid="json-document-preview-spinner"
+              description="Preparing JSON preview…"
+            />
+          }
+        >
+          <RichTextEditor value={data} language="json" readOnly height="80vh" />
+        </Suspense>
+      )}
+    </PreviewJSONContainer>
+  );
+};
+
+export {PreviewJson};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentPreview/styled.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentPreview/styled.tsx
@@ -23,4 +23,8 @@ const PreviewPdf = styled.iframe`
   border: none;
 `;
 
-export {PreviewImage, PreviewPdf};
+const PreviewJSONContainer = styled.div`
+  min-height: 80vh;
+`;
+
+export {PreviewImage, PreviewPdf, PreviewJSONContainer};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/parseDocumentVariable.test.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/parseDocumentVariable.test.ts
@@ -104,7 +104,7 @@ describe('parseDocumentVariable', () => {
         {
           link: '/v2/documents/doc-124?storeId=in-memory&contentHash=sha256%3Aabc',
           fileName: 'b.json',
-          type: 'unknown',
+          type: 'json',
           size: 500,
         },
         {
@@ -159,6 +159,22 @@ describe('parseDocumentVariable', () => {
         }),
       });
     }
+  });
+
+  it('should parse a json document type for application/json', () => {
+    const value = JSON.stringify(
+      makeDocRef({
+        metadata: {...makeDocRef().metadata, contentType: 'application/json'},
+      }),
+    );
+    const result = parseDocumentVariable(value, false);
+
+    expect(result).toEqual({
+      type: 'single',
+      document: expect.objectContaining({
+        type: 'json',
+      }),
+    });
   });
 
   it('should parse a pdf document type for application/pdf', () => {

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/parseDocumentVariable.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/parseDocumentVariable.ts
@@ -51,27 +51,20 @@ function isDocumentReference(
   return documentReferenceSchema.safeParse(value).success;
 }
 
-const SUPPORTED_IMAGE_MIME_TYPES = new Set([
-  'image/jpeg',
-  'image/png',
-  'image/gif',
-  'image/webp',
-]);
-const SUPPORTED_PDF_MIME_TYPES = new Set(['application/pdf']);
-const SUPPORTED_JSON_MIME_TYPES = new Set(['application/json']);
+const MIME_TYPE_MAP: Record<string, DocumentType> = {
+  'image/jpeg': 'image',
+  'image/png': 'image',
+  'image/gif': 'image',
+  'image/webp': 'image',
+  'application/pdf': 'pdf',
+  'application/json': 'json',
+};
 
 function getDocumentType(contentType: string | undefined): DocumentType {
   if (!contentType) {
     return 'unknown';
-  } else if (SUPPORTED_IMAGE_MIME_TYPES.has(contentType)) {
-    return 'image';
-  } else if (SUPPORTED_PDF_MIME_TYPES.has(contentType)) {
-    return 'pdf';
-  } else if (SUPPORTED_JSON_MIME_TYPES.has(contentType)) {
-    return 'json';
-  } else {
-    return 'unknown';
   }
+  return MIME_TYPE_MAP[contentType] ?? 'unknown';
 }
 
 function toDocumentInfo(ref: DetectedDocumentReference): DocumentInfo {

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/parseDocumentVariable.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/parseDocumentVariable.ts
@@ -13,7 +13,7 @@ import {mergePathname} from 'modules/request/mergePathname';
 import {getClientConfig} from 'modules/utils/getClientConfig';
 import {endpoints} from '@camunda/camunda-api-zod-schemas/8.10';
 
-type DocumentType = 'image' | 'pdf' | 'unknown';
+type DocumentType = 'image' | 'pdf' | 'json' | 'unknown';
 
 type DocumentInfo = {
   fileName: string;
@@ -58,6 +58,7 @@ const SUPPORTED_IMAGE_MIME_TYPES = new Set([
   'image/webp',
 ]);
 const SUPPORTED_PDF_MIME_TYPES = new Set(['application/pdf']);
+const SUPPORTED_JSON_MIME_TYPES = new Set(['application/json']);
 
 function getDocumentType(contentType: string | undefined): DocumentType {
   if (!contentType) {
@@ -66,6 +67,8 @@ function getDocumentType(contentType: string | undefined): DocumentType {
     return 'image';
   } else if (SUPPORTED_PDF_MIME_TYPES.has(contentType)) {
     return 'pdf';
+  } else if (SUPPORTED_JSON_MIME_TYPES.has(contentType)) {
+    return 'json';
   } else {
     return 'unknown';
   }

--- a/operate/client/src/modules/mocks/api/mockRequest.ts
+++ b/operate/client/src/modules/mocks/api/mockRequest.ts
@@ -265,6 +265,9 @@ const mockGetRequest = function <Type extends DefaultBodyType>(url: string) {
               req: request,
               expectPolling: options?.expectPolling,
             });
+            if (typeof responseData === 'string') {
+              return HttpResponse.text(responseData);
+            }
             return HttpResponse.json(responseData);
           },
           {once: true},

--- a/operate/client/src/modules/mocks/api/v2/documents/downloadDocument.ts
+++ b/operate/client/src/modules/mocks/api/v2/documents/downloadDocument.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {
+  endpoints,
+  type GetDocumentResponseBody,
+} from '@camunda/camunda-api-zod-schemas/8.10';
+import {mockGetRequest} from '../../mockRequest';
+
+const mockDownloadDocument = (contextPath = '') =>
+  mockGetRequest<GetDocumentResponseBody>(
+    `${contextPath}${endpoints.getDocument.getUrl({documentId: ':documentId'})}`,
+  );
+
+export {mockDownloadDocument};

--- a/operate/client/src/modules/queries/queryKeys.ts
+++ b/operate/client/src/modules/queries/queryKeys.ts
@@ -78,6 +78,9 @@ const queryKeys = {
       decisionDefinitionKey,
     ],
   },
+  documents: {
+    content: (link: string) => ['documentContent', link],
+  },
   processDefinitionXml: {
     get: (processDefinitionKey?: string) => [
       'processDefinitionXml',


### PR DESCRIPTION
## Description

Adds JSON supports via the `RichTextEditor` for document references. The document content is fetched via a static query. Since the query hook fetches the `document.link` URL, it is coupled to the semantics behavior of `parseDocumentVariable` and less to general API query hooks. Thus, I decided against abstracting the query in the `modules/queries` folder - only a query key is included there.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] This PR is stacked on https://github.com/camunda/camunda/pull/54015.

## Related issues

closes #52205
