### PR TITLE
fix: prefill and lock resource type in create authorization modal

### DIFF
--- a/identity/client/src/pages/authorizations/modals/add-modal/AddModal.tsx
+++ b/identity/client/src/pages/authorizations/modals/add-modal/AddModal.tsx
@@ -183,6 +183,7 @@ export const AddModal: FC<
           render={({ field }) => (
             <Dropdown<ResourceType>
               id="resource-type-dropdown"
+              disabled
               label={t("selectResourceType")}
               titleText={t("resourceType")}
               items={resourceTypeItems}
@@ -315,7 +316,7 @@ function createEmptyAuthorization(
     return {
       ownerType: "USER",
       ownerId: "",
-      resourceType: "USER",
+      resourceType,
       resourceId: "",
       resourcePropertyName: null,
       permissionTypes: [],

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityAuthorizationsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityAuthorizationsPage.ts
@@ -178,6 +178,7 @@ export class IdentityAuthorizationsPage {
 
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
       try {
+        await this.selectResourceTypeTab(authorization.resourceType);
         await this.createAuthorizationButton.click();
         await expect(this.createAuthorizationModal).toBeVisible({
           timeout: 15000,
@@ -188,7 +189,6 @@ export class IdentityAuthorizationsPage {
         await this.selectAuthorizationOwner({
           ownerId: authorization.ownerId,
         });
-        await this.selectResourceType(authorization.resourceType);
         await this.fillResourceId(authorization.resourceId);
         await this.selectAccessPermissions(authorization.accessPermissions);
         await this.createAuthorizationSubmitButton.click({timeout: 15000});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/authorizations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/authorizations.spec.ts
@@ -76,6 +76,9 @@ test.describe.serial('component authorizations CRUD', () => {
   test('tries to create an authorization with invalid id', async ({
     identityAuthorizationsPage,
   }) => {
+    await identityAuthorizationsPage.selectResourceTypeTab(
+      NEW_COMPONENT_AUTHORIZATION.resourceType,
+    );
     await identityAuthorizationsPage.createAuthorizationButton.click();
     await identityAuthorizationsPage.selectAuthorizationOwnerType({
       ownerType: NEW_COMPONENT_AUTHORIZATION.ownerType,
@@ -83,9 +86,6 @@ test.describe.serial('component authorizations CRUD', () => {
     await identityAuthorizationsPage.selectAuthorizationOwner({
       ownerId: NEW_COMPONENT_AUTHORIZATION.ownerId,
     });
-    await identityAuthorizationsPage.selectResourceType(
-      NEW_COMPONENT_AUTHORIZATION.resourceType,
-    );
     await identityAuthorizationsPage.fillResourceId('invalid!!%');
     await expect(
       identityAuthorizationsPage.createAuthorizationModal,
@@ -292,5 +292,39 @@ test.describe('authorization scenarios', () => {
       await loginPage.login(testUser.username, testUser.password);
       await expect(identityUsersPage.userCell(testUser.email)).toBeVisible();
     });
+  });
+});
+
+test.describe('create authorization modal — resource type field', () => {
+  test.beforeEach(async ({page, loginPage, identityAuthorizationsPage}) => {
+    await identityAuthorizationsPage.navigateToAuthorizations();
+    await loginPage.login(
+      LOGIN_CREDENTIALS.username,
+      LOGIN_CREDENTIALS.password,
+    );
+    await expect(page).toHaveURL(relativizePath(Paths.authorizations()));
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('prefills resource type from the active tab and disables the dropdown', async ({
+    identityAuthorizationsPage,
+  }) => {
+    await identityAuthorizationsPage.selectResourceTypeTab('Component');
+
+    await identityAuthorizationsPage.createAuthorizationButton.click();
+    await expect(
+      identityAuthorizationsPage.createAuthorizationModal,
+    ).toBeVisible();
+
+    await expect(identityAuthorizationsPage.resourceTypeComboBox).toHaveText(
+      /Component/i,
+    );
+    await expect(
+      identityAuthorizationsPage.resourceTypeComboBox,
+    ).toBeDisabled();
   });
 });


### PR DESCRIPTION
When opening the Create Authorization modal from a resource-type tab, the "Resource type" dropdown was hard-coded to USER (except for USER_TASK) and remained editable. Users could create authorizations under a different tab than the one they were on, which was confusing and easy to do by accident.

Pass the active tab's resource type through to the form's default values and disable the dropdown so the choice expressed by the tab can no longer be changed inside the modal. Update the e2e page object to drive resource type via the tab (the only way now), and add a Playwright test asserting both the prefill and the disabled state.

Closes #34889

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
