### PR TITLE
feat: add Membership Simulator (SWIM) to monorepo docs

### DIFF
--- a/docs/monorepo-docs/architecture/components/orchestration-cluster/swim-membership-simulator.md
+++ b/docs/monorepo-docs/architecture/components/orchestration-cluster/swim-membership-simulator.md
@@ -1,0 +1,61 @@
+# Membership Simulator (SWIM)
+
+import SwimMembershipSimulator from '@site/src/components/SwimMembershipSimulator';
+
+Use the simulator below to explore how Zeebe's SWIM membership protocol propagates cluster state
+changes and detects node failures.
+
+:::note
+This is an educational simulator. It is designed to build intuition about SWIM as implemented in
+the Orchestration Cluster, not to be a 1:1 reproduction of the Java implementation. We aim to keep
+the behaviour faithful to [`SwimMembershipProtocol`](https://github.com/camunda/camunda/blob/main/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocol.java),
+but some details may differ.
+:::
+
+**How to use:**
+
+- **Tooltips** — every parameter and control has a tooltip; hover over anything to learn what it does.
+- **Clock** — the simulator starts paused and slowed down by default. Use the play/pause/step controls
+  and the speed selector to move through time at your own pace.
+- **Fault injection** — use the Faults row to crash nodes, cut links between nodes, or exclude a
+  node from gossip fanout.
+- **Event log** — the log shows simulated protocol events alongside the corresponding Java events
+  fired by the membership service (e.g. `MEMBER_ADDED`, `REACHABILITY_CHANGED`, `MEMBER_REMOVED`),
+  so you can connect what you see visually to what happens internally in the cluster.
+
+## Simulator
+
+<SwimMembershipSimulator />
+
+## How it works
+
+Zeebe uses a variant of the
+[SWIM](https://arxiv.org/abs/2004.03461) (Scalable Weakly-consistent Infection-style process
+group Membership) protocol
+([`SwimMembershipProtocol`](https://github.com/camunda/camunda/blob/main/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocol.java))
+to maintain cluster membership.
+
+Every node periodically probes a random peer to check reachability, and gossips membership state
+changes to a random subset of peers. A failed node is first marked _suspect_, then _dead_ after a
+configurable timeout, at which point a `MEMBER_REMOVED` event is fired to all local listeners.
+
+The membership view is used across many subsystems: topology propagation, job streaming, routing
+in the `ClusterCommunicationService` (which gates communication such that nodes only talk to known
+alive members — preventing messages from being sent to evicted nodes), and any feature that needs
+to know which brokers are currently reachable.
+
+SWIM failure detection is completely separate from the Raft consensus algorithm, which has its own
+failure detection. They are complementary but test different things: SWIM asks "is this node
+generally alive and responsive?", whereas Raft replicas ask "is the leader actually fulfilling its
+role?" — which covers cases where a node is alive and responding but the leader has stalled or is
+no longer making progress on the log. This also makes SWIM particularly valuable for ephemeral
+nodes such as gateways that participate in the cluster but are not part of any Raft partition.
+
+## What gets gossiped
+
+Beyond liveness (alive / suspect / dead), SWIM gossips arbitrary `Member#properties`. Zeebe uses
+this to propagate `BrokerInfo` — each broker's partition roles, partition health, leader terms,
+and cluster topology — and event-service topic subscriptions. Any change to a member's properties
+triggers a gossip update.
+
+

--- a/monorepo-docs-site/sidebars.js
+++ b/monorepo-docs-site/sidebars.js
@@ -87,6 +87,7 @@ const sidebars = {
               type: 'category',
               label: 'Orchestration Cluster',
               items: [
+                'architecture/components/orchestration-cluster/swim-membership-simulator',
                 {
                   type: 'category',
                   label: 'ADRs',

--- a/monorepo-docs-site/src/components/SwimMembershipSimulator.js
+++ b/monorepo-docs-site/src/components/SwimMembershipSimulator.js
@@ -1,0 +1,599 @@
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import styles from './SwimMembershipSimulator.module.css';
+import {
+  createSim, advanceSim, captureSnapshot,
+  crashNode, restoreNode, injectPropertyUpdate,
+  addPartition, setGossipExcluded, logEventDirect,
+} from './swimSimEngine';
+
+// ── SVG node graph ────────────────────────────────────────────────────────────
+
+const GRAPH_H = 380;
+const NODE_R = 22;
+
+function nodePositions(count, width) {
+  const cx = width / 2;
+  const cy = GRAPH_H / 2;
+  const r = Math.min(cx, cy) * (count <= 4 ? 0.5 : count <= 8 ? 0.62 : 0.72);
+  return Array.from({ length: count }, (_, i) => {
+    const angle = (2 * Math.PI * i / count) - Math.PI / 2;
+    return {
+      x: cx + r * Math.cos(angle),
+      y: cy + r * Math.sin(angle),
+      ux: Math.cos(angle), // outward unit vector — opposite to where edges come from
+      uy: Math.sin(angle),
+    };
+  });
+}
+
+function nodeColor(state) {
+  switch (state) {
+    case 'suspect': return 'var(--viz-suspect-light)';
+    case 'dead':    return 'var(--viz-leader)';
+    case 'crashed': return 'var(--ifm-color-emphasis-300)';
+    default:        return 'var(--ifm-color-emphasis-100)';
+  }
+}
+
+function nodeBorderColor(state) {
+  switch (state) {
+    case 'suspect': return 'var(--viz-suspect)';
+    case 'dead':    return 'var(--viz-leader)';
+    case 'crashed': return 'var(--ifm-color-emphasis-400)';
+    default:        return 'var(--ifm-color-emphasis-600)';
+  }
+}
+
+const LEGEND_ENTRIES = [
+  ['P→',  'var(--viz-msg-probe)',          'Probe',                         'Direct probe sent to a peer to check it is alive'],
+  ['P✓',  'var(--viz-msg-probe-ack)',      'Probe ACK',                     'Acknowledgement sent back by the probed node — confirms it is reachable'],
+  ['I→',  'var(--viz-msg-probe-indirect)', 'Indirect probe',                'Probe request forwarded to another node — sent when a direct probe times out, to rule out false positives'],
+  ['S⇄',  'var(--viz-msg-sync)',           'Sync',                          'Full membership state exchange with a random peer — anti-entropy mechanism that catches nodes which missed gossip'],
+  ['U↑',  'var(--viz-gossip-update)',      'Update',                        'Gossip message carrying a non-failure update — property change (e.g. BrokerInfo) or alive-state refutation after an incarnation bump'],
+  ['U⚠',  'var(--viz-leader)',             'Update (failure news: suspect/dead)', 'Gossip message carrying failure news — a node has been marked suspect or dead'],
+];
+
+function NodeGraph({ snapshot, svgWidth }) {
+  const nodeCount = snapshot?.nodes.length ?? 0;
+  const positions = nodePositions(nodeCount, svgWidth);
+
+  return (
+    <svg width={svgWidth} height={GRAPH_H} className={styles.graph}>
+
+      {/* Normal edges */}
+      {Array.from({ length: nodeCount }, (_, i) =>
+        Array.from({ length: nodeCount }, (_, j) => {
+          if (j <= i) return null;
+          const blocked = snapshot?.partitions.includes(`${i}-${j}`) || snapshot?.partitions.includes(`${j}-${i}`);
+          if (blocked) return null;
+          return (
+            <line key={`e${i}-${j}`}
+              x1={positions[i].x} y1={positions[i].y}
+              x2={positions[j].x} y2={positions[j].y}
+              stroke="var(--ifm-color-emphasis-200)" strokeWidth="1"
+            />
+          );
+        })
+      )}
+
+      {/* Partition indicators — deduplicated (a<b) since faults are symmetric */}
+      {snapshot?.partitions
+        .filter(p => { const [a, b] = p.split('-').map(Number); return a < b; })
+        .map(p => {
+          const [a, b] = p.split('-').map(Number);
+          if (a >= nodeCount || b >= nodeCount) return null;
+          return (
+            <line key={`p-${p}`}
+              x1={positions[a].x} y1={positions[a].y}
+              x2={positions[b].x} y2={positions[b].y}
+              stroke="var(--viz-leader)" strokeWidth="2" strokeDasharray="5,4" opacity="0.8"
+            />
+          );
+        })}
+
+      {/* In-flight message circles */}
+      {snapshot?.messages.map(m => {
+        if (m.from >= nodeCount || m.to >= nodeCount) return null;
+        const p1 = positions[m.from];
+        const p2 = positions[m.to];
+        const x = p1.x + (p2.x - p1.x) * m.progress;
+        const y = p1.y + (p2.y - p1.y) * m.progress;
+        return (
+          <g key={m.id} transform={`translate(${x},${y})`}>
+            <circle r="10" fill={m.color} opacity={0.9} />
+            <text textAnchor="middle" dominantBaseline="central"
+              fontSize="6.5" fontWeight="700" fill="white">{m.label}</text>
+          </g>
+        );
+      })}
+
+      {/* Nodes */}
+      {snapshot?.nodes.map(n => {
+        const pos = positions[n.id];
+        return (
+          <g key={n.id} transform={`translate(${pos.x},${pos.y})`}>
+            {n.gossipExcluded && (
+              <circle r={NODE_R + 5} fill="none"
+                stroke="var(--viz-gossip-exclude)" strokeWidth="2" strokeDasharray="4,3" />
+            )}
+            <circle r={NODE_R}
+              fill={nodeColor(n.state)}
+              stroke={nodeBorderColor(n.state)}
+              strokeWidth="2"
+            />
+            <text textAnchor="middle" y="-3"
+              fontSize="11" fontWeight="700"
+              fill={n.state === 'dead' ? 'white' : 'var(--ifm-color-emphasis-900)'}
+              textDecoration={n.state === 'crashed' ? 'line-through' : 'none'}>
+              N{n.id}
+            </text>
+            {n.propertyVersion > 0 && (
+              <text textAnchor="middle" y="10"
+                fontSize="8"
+                fill={n.state === 'dead' ? 'white' : 'var(--ifm-color-emphasis-600)'}>
+                v{n.propertyVersion}
+              </text>
+            )}
+            {n.incarnationNumber > 0 && (
+              <g transform={`translate(${Math.round(pos.ux * (NODE_R + 10))},${Math.round(pos.uy * (NODE_R + 10))})`}>
+                <title>Incarnation {n.incarnationNumber} — bumps each time this node refutes a suspicion or restarts. Peers with a lower incarnation number will accept this node&apos;s alive state as more recent.</title>
+                <circle r="9" fill="var(--ifm-background-surface-color)"
+                  stroke="var(--ifm-color-emphasis-400)" strokeWidth="1.5" />
+                <text textAnchor="middle" dominantBaseline="central"
+                  fontSize="8" fontWeight="700" fill="var(--ifm-color-emphasis-700)">
+                  {n.incarnationNumber}
+                </text>
+              </g>
+            )}
+          </g>
+        );
+      })}
+
+    </svg>
+  );
+}
+
+function Legend() {
+  return (
+    <div className={styles.legend}>
+      {LEGEND_ENTRIES.map(([label, color, desc, tip]) => (
+        <div key={label} className={styles.legendItem} title={tip}>
+          <span className={styles.legendDot} style={{ background: color }}>{label}</span>
+          <span className={styles.legendDesc}>{desc}</span>
+        </div>
+      ))}
+      <div className={styles.legendSep} />
+      <div className={styles.legendItem}
+        title="Incarnation number — each node's monotonically increasing version counter. Bumps when a node refutes a suspicion or restarts. Peers use it to decide which state is more recent: higher incarnation wins.">
+        <span className={styles.legendBadge}>3</span>
+        <span className={styles.legendDesc}>Incarnation (shown when &gt; 0)</span>
+      </div>
+    </div>
+  );
+}
+
+// ── Default parameters (match SwimMembershipProtocolConfig.java defaults) ─────
+
+const DEFAULT_PARAMS = {
+  gossipInterval: 250,
+  gossipFanout: 2,
+  broadcastUpdates: false,
+  probeInterval: 1000,
+  probeTimeout: 100,
+  suspectProbes: 3,
+  failureTimeout: 3000,
+  broadcastDisputes: true,
+  notifySuspect: false,
+  syncInterval: 10000,
+};
+
+const SPEEDS = [0.25, 0.5, 1, 2];
+const STEP_SIZES = [{ label: '50ms', ms: 50 }, { label: '250ms', ms: 250 }, { label: '1s', ms: 1000 }, { label: '5s', ms: 5000 }];
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+export default function SwimMembershipSimulator() {
+  const [nodeCount, setNodeCount] = useState(3);
+  const [params, setParams] = useState(DEFAULT_PARAMS);
+  const [paused, setPaused] = useState(true);
+  const [speed, setSpeed] = useState(0.25);
+  const [stepSize, setStepSize] = useState(1000);
+  const isMobile = typeof window !== 'undefined' && window.innerWidth < 768;
+  const [paramsOpen, setParamsOpen] = useState(!isMobile);
+  const [eventLogOpen, setEventLogOpen] = useState(!isMobile);
+  const [snapshot, setSnapshot] = useState(null);
+  const [crashTarget, setCrashTarget] = useState(0);
+  const [propTarget, setPropTarget]   = useState(0);
+  const [partFrom, setPartFrom]           = useState(0);
+  const [partTo, setPartTo]               = useState(1);
+  const [excludeTarget, setExcludeTarget] = useState(0);
+
+  const simRef    = useRef(null);
+  const paramsRef = useRef(params);
+  const rafRef    = useRef(null);
+  const svgRef    = useRef(null);
+  const [svgWidth, setSvgWidth] = useState(600);
+
+  useEffect(() => {
+    if (!svgRef.current) return;
+    const ro = new ResizeObserver(([entry]) => setSvgWidth(entry.contentRect.width));
+    ro.observe(svgRef.current);
+    return () => ro.disconnect();
+  }, []);
+
+  useEffect(() => {
+    simRef.current = createSim(nodeCount, paramsRef.current);
+    setSnapshot(captureSnapshot(simRef.current, performance.now(), speed));
+  }, [nodeCount]);
+
+  useEffect(() => {
+    const prevParams = paramsRef.current;
+    paramsRef.current = params;
+    const sim = simRef.current;
+    if (!sim) return;
+    sim.params = params;
+    // When an interval changes, cancel stale pending tick events and reschedule
+    // from now — otherwise the old scheduled time would still be used
+    const reschedule = (type, interval, prevInterval) => {
+      if (interval === prevInterval) return;
+      sim.eventQueue.removeWhere(e => e.type === type);
+      sim.nodes.forEach((node, id) => {
+        if (node.state !== 'crashed') {
+          sim.eventQueue.push({ type, simTime: sim.simTime + interval, nodeId: id });
+        }
+      });
+    };
+    reschedule('GOSSIP_TICK', params.gossipInterval, prevParams.gossipInterval);
+    reschedule('PROBE_TICK',  params.probeInterval,  prevParams.probeInterval);
+    reschedule('SYNC_TICK',   params.syncInterval,   prevParams.syncInterval);
+  }, [params]);
+
+  useEffect(() => {
+    const tick = (wallTime) => {
+      const sim = simRef.current;
+      if (sim) {
+        if (!paused) {
+          advanceSim(sim, sim.simTime + 10 * speed, wallTime, speed);
+          setSnapshot(captureSnapshot(sim, wallTime, speed));
+        } else {
+          const eff = Math.min(800, 250 / speed);
+          const hasAnimating = sim.inFlightMessages.some(m => {
+            if (m.startWallTime <= 0) return false;
+            const totalDuration = ((m.replyDepth ?? 0) + 1) * eff;
+            return wallTime - m.startWallTime < totalDuration;
+          });
+          if (hasAnimating) setSnapshot(captureSnapshot(sim, wallTime, speed));
+        }
+      }
+      rafRef.current = requestAnimationFrame(tick);
+    };
+    rafRef.current = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(rafRef.current);
+  }, [paused, speed]);
+
+  const stepSizeRef = useRef(stepSize);
+  useEffect(() => { stepSizeRef.current = stepSize; }, [stepSize]);
+
+  const step = useCallback(() => {
+    if (!simRef.current) return;
+    advanceSim(simRef.current, simRef.current.simTime + stepSizeRef.current, performance.now());
+    setSnapshot(captureSnapshot(simRef.current, performance.now(), speed));
+  }, [speed]);
+
+  const reset = useCallback(() => {
+    simRef.current = createSim(nodeCount, paramsRef.current);
+    setSnapshot(captureSnapshot(simRef.current, performance.now(), speed));
+  }, [nodeCount, speed]);
+
+  const nodeIds = Array.from({ length: nodeCount }, (_, i) => i);
+
+  if (!snapshot) return null;
+
+  const { simTime, roundCount, msgCount, firstDetectTime, convergeTime, hasPartitions, hasDiverged } = snapshot;
+
+  return (
+    <div className={styles.widget}>
+      {/* Parameters panel */}
+      <div className={styles.paramsPanel}>
+        <div className={styles.paramsPanelHeader} onClick={() => setParamsOpen(o => !o)}>
+          {paramsOpen ? '▾' : '▸'} Parameters
+          <span title="Hover any parameter name for details" style={{ marginLeft: 6, fontSize: '0.7rem', opacity: 0.6, cursor: 'help' }}>ⓘ</span>
+        </div>
+        {paramsOpen && (
+          <div className={styles.paramsBody}>
+            <div className={styles.paramGroup}>
+              <div className={styles.paramGroupLabel}>Cluster</div>
+              <div className={styles.paramRow}>
+                <span className={styles.paramLabel} title="Number of nodes in the simulated cluster — resets the simulation">Node count</span>
+                <div className={styles.paramRowControls}>
+                  <input type="range" className={styles.paramSlider}
+                    min={2} max={9} step={1} value={nodeCount}
+                    onChange={e => setNodeCount(Number(e.target.value))} />
+                  <span className={styles.paramVal}>{nodeCount}</span>
+                </div>
+              </div>
+              <div className={styles.paramRow}>
+                <span className={styles.paramLabel} title="Full membership state exchange with a random peer — anti-entropy safety net that catches nodes which missed gossip (e.g. after a partition heals)">Sync interval (ms)</span>
+                <div className={styles.paramRowControls}>
+                  <input type="range" className={styles.paramSlider}
+                    min={1000} max={60000} step={1000} value={params.syncInterval}
+                    onChange={e => setParams(p => ({ ...p, syncInterval: Number(e.target.value) }))} />
+                  <span className={styles.paramVal}>{params.syncInterval}</span>
+                </div>
+              </div>
+            </div>
+
+            <div className={styles.paramGroup}>
+              <div className={styles.paramGroupLabel}>Gossip</div>
+              {[
+                ['Interval (ms)', 'gossipInterval', 50, 2000, 50, 'How often each node sends pending membership updates to random peers'],
+                ['Fanout', 'gossipFanout', 1, nodeCount - 1, 1, 'Number of random peers that receive gossip each interval — higher fanout spreads news faster but increases traffic'],
+              ].map(([label, key, min, max, s, tip]) => (
+                <div key={key} className={styles.paramRow}>
+                  <span className={styles.paramLabel} title={tip}>{label}</span>
+                  <div className={styles.paramRowControls}>
+                    <input type="range" className={styles.paramSlider}
+                      min={min} max={max} step={s} value={params[key]}
+                      onChange={e => setParams(p => ({ ...p, [key]: Number(e.target.value) }))} />
+                    <span className={styles.paramVal}>{params[key]}</span>
+                  </div>
+                </div>
+              ))}
+              {[['Broadcast updates', 'broadcastUpdates', 'Send ANY membership update (property changes, suspect, dead) to ALL peers immediately instead of spreading via fanout gossip — faster propagation, higher traffic']].map(([label, key, tip]) => (
+                <div key={key} className={styles.paramRow}>
+                  <div className={styles.paramRowControls}>
+                    <span className={styles.paramLabel} title={tip}>{label}</span>
+                    <label className={styles.toggle}>
+                      <input type="checkbox" checked={params[key]}
+                        onChange={e => setParams(p => ({ ...p, [key]: e.target.checked }))} />
+                      <div className={styles.toggleTrack} />
+                      <div className={styles.toggleKnob} />
+                    </label>
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <div className={styles.paramGroupWide}>
+              <div className={styles.paramGroupLabel}>Failure Detection</div>
+              <div className={styles.paramGroupInner}>
+                {[
+                  ['Probe interval (ms)', 'probeInterval', 100, 5000, 100, 'How often each node pings a random peer to check it is alive — lower = faster detection, more traffic'],
+                  ['Probe timeout (ms)',  'probeTimeout',  50,  2000, 50,  'How long to wait for a probe ACK before triggering indirect probes — lower = faster but more false positives on slow networks'],
+                  ['Suspect probes',      'suspectProbes', 1,   10,   1,   'Upper bound on total probers: 1 direct + up to (N-1) indirect. All must fail before the node is suspected. Fewer indirect probes are used when not enough alive peers are available — e.g. with 3 nodes and suspectProbes=3, only 1 indirect prober exists so suspicion requires 2 failures, not 3'],
+                  ['Failure timeout (ms)','failureTimeout',1000,30000,1000,'How long a suspected node can stay unresponsive before being declared dead — gives it time to refute'],
+                ].map(([label, key, min, max, s, tip]) => (
+                  <div key={key} className={styles.paramRow} title={tip}>
+                    <span className={styles.paramLabel}>{label}</span>
+                    <div className={styles.paramRowControls}>
+                      <input type="range" className={styles.paramSlider}
+                        min={min} max={max} step={s} value={params[key]}
+                        onChange={e => setParams(p => ({ ...p, [key]: Number(e.target.value) }))} />
+                      <span className={styles.paramVal}>{params[key]}</span>
+                    </div>
+                  </div>
+                ))}
+                {[
+                  ['Broadcast disputes', 'broadcastDisputes', 'When a node learns via a probe that it is being suspected, it immediately broadcasts its own alive state (with bumped incarnation) to ALL peers to refute the suspicion'],
+                  ['Notify suspect',     'notifySuspect',     'Send the suspect state directly to the suspected node so it knows it is being suspected and can refute immediately'],
+                ].map(([label, key, tip]) => (
+                  <div key={key} className={styles.paramRow} title={tip}>
+                    <div className={styles.paramRowControls}>
+                      <span className={styles.paramLabel}>{label}</span>
+                      <label className={styles.toggle}>
+                        <input type="checkbox" checked={params[key]}
+                          onChange={e => setParams(p => ({ ...p, [key]: e.target.checked }))} />
+                        <div className={styles.toggleTrack} />
+                        <div className={styles.toggleKnob} />
+                      </label>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+          </div>
+        )}
+      </div>
+
+      {/* Graph + event log */}
+      <div className={`${styles.graphRow} ${!eventLogOpen ? styles.graphRowFull : ''}`}>
+        <div className={styles.graphWrap} ref={svgRef}>
+          <NodeGraph snapshot={snapshot} svgWidth={svgWidth || 600} />
+        </div>
+        <div className={`${styles.eventLog} ${!eventLogOpen ? styles.eventLogCollapsed : ''}`}
+          onClick={!eventLogOpen ? () => setEventLogOpen(true) : undefined}
+          title={!eventLogOpen ? 'Expand event log' : undefined}
+          style={!eventLogOpen ? { cursor: 'pointer' } : undefined}>
+          {!eventLogOpen ? (
+            <span className={styles.eventLogCollapsedLabel}>📋 Events</span>
+          ) : (<>
+          <div className={styles.eventLogTitle}>
+            <span className={styles.eventLogTitleText}
+              title="Collapse event log"
+              style={{ cursor: 'pointer', userSelect: 'none' }}
+              onClick={() => setEventLogOpen(false)}>
+              ▾ Event log
+            </span>
+            <button type="button" className={styles.clearLogBtn}
+              title="Clear event log"
+              onClick={() => { if (simRef.current) { simRef.current.eventLog = []; setSnapshot(captureSnapshot(simRef.current, performance.now())); } }}>
+              🗑
+            </button>
+          </div>
+          {snapshot.eventLog.length === 0 ? (
+            <div style={{ color: 'var(--ifm-color-emphasis-500)', fontSize: '0.72rem' }}>
+              No events yet — inject a fault to start.
+            </div>
+          ) : snapshot.eventLog.map((e, i) => (
+            <div key={i} className={styles.eventEntry}>
+              <span className={styles.eventTime}>{(e.simTime / 1000).toFixed(2)}s</span>
+              <span>{e.text}</span>
+            </div>
+          ))}
+          </>)}
+        </div>
+      </div>
+      <Legend />
+
+      {/* Stats bar */}
+      <div className={styles.statsBar}>
+        {[
+          ['Sim time', `${(simTime / 1000).toFixed(1)}s`, 'Total simulated time elapsed — advances when running or stepping'],
+          ['Messages', msgCount, 'Total messages sent since last reset, including probes, gossip, and sync'],
+          ['Failure Detection', firstDetectTime !== null ? `${(firstDetectTime / 1000).toFixed(2)}s` : '—',
+            'Time from fault injection until the first node\'s view differed from another\'s (e.g. one node suspected a crashed peer while others still saw it as alive). Driven by probe-interval, probe-timeout, and suspect-probes.'],
+          ['Converge', convergeTime !== null ? `${(convergeTime / 1000).toFixed(2)}s` : '—',
+            'Time from fault injection until all alive nodes hold an identical view of the cluster. Includes failure detection time plus the time for failure news to propagate via gossip, and for the failure-timeout to expire before declaring a node dead.'],
+        ].map(([label, val, tip]) => (
+          <div key={label} className={styles.statItem} title={tip}>
+            <span className={styles.statLabel}>{label}</span>
+            <span className={styles.statVal}>{val}</span>
+          </div>
+        ))}
+        <div className={styles.statItem}>
+          <span title="Cluster view state: Stable = all nodes agree, Diverged = views differ after a fault, Converged = all nodes agree again after a fault, Partitioned = active link faults"
+            className={`${styles.chip} ${
+            hasPartitions ? styles.chipWarn :
+            convergeTime !== null ? styles.chipOk :
+            hasDiverged ? styles.chipWarn :
+            styles.chipInfo
+          }`}>
+            {hasPartitions ? 'Partitioned ⚠' :
+             convergeTime !== null ? 'Converged ✓' :
+             hasDiverged ? 'Diverged…' :
+             'Stable'}
+          </span>
+        </div>
+      </div>
+
+      {/* Controls row */}
+      <div className={styles.controlsBar}>
+        <div className={styles.ctrlGroup}>
+          <button type="button" title="Resume the simulation" className={`${styles.btn} ${!paused ? styles.btnActive : ''}`}
+            onClick={() => setPaused(false)}>▶ Play</button>
+          <button type="button" title="Pause the simulation" className={`${styles.btn} ${paused ? styles.btnActive : ''}`}
+            onClick={() => setPaused(true)}>⏸ Pause</button>
+          <button type="button" title={paused ? `Advance simulation by ${stepSize >= 1000 ? `${stepSize / 1000}s` : `${stepSize}ms`}` : 'Pause first to step'} className={styles.btn} disabled={!paused} onClick={step}>⏭ Step</button>
+          <div className={styles.speedGroup}>
+            {STEP_SIZES.map(({ label, ms }) => (
+              <button type="button" key={ms} title={`Step by ${label} of simulated time`}
+                className={`${styles.speedBtn} ${stepSize === ms ? styles.speedBtnActive : ''}`}
+                onClick={() => setStepSize(ms)}>{label}</button>
+            ))}
+          </div>
+        </div>
+        <div className={styles.sep} />
+        <div className={styles.ctrlGroup}>
+          <span className={styles.ctrlGroupLabel}>Speed</span>
+          <div className={styles.speedGroup}>
+            {SPEEDS.map(s => (
+              <button type="button" key={s} title={`Run at ${s}× real-time speed`}
+                className={`${styles.speedBtn} ${speed === s ? styles.speedBtnActive : ''}`}
+                onClick={() => setSpeed(s)}>{s}×</button>
+            ))}
+          </div>
+        </div>
+        <div className={styles.sep} />
+        <div className={styles.ctrlGroup}>
+          <span className={styles.ctrlGroupLabel} title="Publish a BrokerInfo-style property change on a node and watch it spread via gossip">Prop update</span>
+          <select className={styles.injectSelect} value={propTarget}
+            onChange={e => setPropTarget(Number(e.target.value))}>
+            {nodeIds.map(id => <option key={id} value={id}>N{id}</option>)}
+          </select>
+          <button type="button" title="Publish a property update on the selected node — triggers a U↑ gossip wave"
+            className={styles.btn}
+            onClick={() => { if (simRef.current) injectPropertyUpdate(simRef.current, propTarget); }}>
+            Update
+          </button>
+        </div>
+      </div>
+
+      {/* Faults row */}
+      <div className={`${styles.controlsBar} ${styles.faultsBar}`}>
+        <span className={styles.ctrlGroupLabel} title="Inject faults to observe how the cluster detects and recovers from failures">Faults</span>
+        <div className={styles.sep} />
+        <div className={styles.ctrlGroup} title="Crash a node to simulate a process failure — other nodes detect it via probe timeouts, then gossip the failure">
+          <span className={styles.ctrlGroupLabel}>Node</span>
+          <select className={styles.injectSelect} value={crashTarget}
+            onChange={e => setCrashTarget(Number(e.target.value))}>
+            {nodeIds.map(id => <option key={id} value={id}>N{id}</option>)}
+          </select>
+          {(() => {
+            const isCrashed = snapshot.nodes.find(n => n.id === crashTarget)?.state === 'crashed';
+            return (
+              <button type="button"
+                title={isCrashed ? 'Bring this node back online with a new incarnation number' : 'Remove this node from the network — triggers the suspect → dead pipeline on other nodes'}
+                className={`${styles.btn} ${isCrashed ? styles.btnActive : styles.btnDanger}`}
+                onClick={() => {
+                  if (!simRef.current) return;
+                  if (isCrashed) restoreNode(simRef.current, crashTarget);
+                  else crashNode(simRef.current, crashTarget);
+                }}>
+                {isCrashed ? '↺ Restore' : '✕ Crash'}
+              </button>
+            );
+          })()}
+        </div>
+        <div className={styles.sep} />
+        <div className={styles.ctrlGroup} title="Block or restore a network link between two nodes — both directions are cut simultaneously">
+          <span className={styles.ctrlGroupLabel}>Link fault</span>
+          <select className={styles.injectSelect} value={partFrom}
+            onChange={e => setPartFrom(Number(e.target.value))}>
+            {nodeIds.map(id => <option key={id} value={id}>N{id}</option>)}
+          </select>
+          <select className={styles.injectSelect} value={partTo}
+            onChange={e => setPartTo(Number(e.target.value))}>
+            {nodeIds.map(id => <option key={id} value={id}>N{id}</option>)}
+          </select>
+          {(() => {
+            const isBlocked = snapshot.partitions.includes(`${partFrom}-${partTo}`) ||
+                              snapshot.partitions.includes(`${partTo}-${partFrom}`);
+            return (
+              <button type="button"
+                title={isBlocked
+                  ? `Restore the link between N${partFrom} and N${partTo}`
+                  : `Block all messages between N${partFrom} and N${partTo} in both directions`}
+                className={`${styles.btn} ${isBlocked ? styles.btnActive : styles.btnDanger}`}
+                onClick={() => {
+                  if (!simRef.current || partFrom === partTo) return;
+                  if (isBlocked) {
+                    simRef.current.partitions.delete(`${partFrom}-${partTo}`);
+                    simRef.current.partitions.delete(`${partTo}-${partFrom}`);
+                    logEventDirect(simRef.current, `Link N${partFrom} ↔ N${partTo} restored`);
+                  } else {
+                    addPartition(simRef.current, partFrom, partTo);
+                  }
+                }}>
+                {isBlocked ? '↺ Restore link' : '✕ Cut link'}
+              </button>
+            );
+          })()}
+        </div>
+        <div className={styles.sep} />
+        <div className={styles.ctrlGroup} title="Simulate a node being consistently skipped in gossip fanout selection — it only receives updates via sync, showing sync-interval as the safety net">
+          <span className={styles.ctrlGroupLabel}>Gossip exclude</span>
+          <select className={styles.injectSelect} value={excludeTarget}
+            onChange={e => setExcludeTarget(Number(e.target.value))}>
+            {nodeIds.map(id => <option key={id} value={id}>N{id}</option>)}
+          </select>
+          {(() => {
+            const isExcluded = snapshot.nodes.find(n => n.id === excludeTarget)?.gossipExcluded;
+            return (
+              <button type="button"
+                title={isExcluded ? 'Re-include this node in gossip fanout selection' : 'Exclude this node from others\' gossip fanout — it will only receive updates when sync fires'}
+                className={`${styles.btn} ${isExcluded ? styles.btnActive : styles.btnDanger}`}
+                onClick={() => {
+                  if (!simRef.current) return;
+                  const n = simRef.current.nodes.get(excludeTarget);
+                  if (n) setGossipExcluded(simRef.current, excludeTarget, !n.gossipExcluded);
+                }}>
+                {isExcluded ? '↺ Re-include' : 'Exclude'}
+              </button>
+            );
+          })()}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/monorepo-docs-site/src/components/SwimMembershipSimulator.js
+++ b/monorepo-docs-site/src/components/SwimMembershipSimulator.js
@@ -8,19 +8,25 @@ import {
 
 // ── SVG node graph ────────────────────────────────────────────────────────────
 
-const GRAPH_H = 380;
-const NODE_R = 22;
+function graphMetrics(svgWidth) {
+  const mobile = svgWidth > 0 && svgWidth < 500;
+  return {
+    graphH: mobile ? 260 : 380,
+    nodeR:  mobile ? 14  : 22,
+  };
+}
 
-function nodePositions(count, width) {
+function nodePositions(count, width, graphH) {
   const cx = width / 2;
-  const cy = GRAPH_H / 2;
-  const r = Math.min(cx, cy) * (count <= 4 ? 0.5 : count <= 8 ? 0.62 : 0.72);
+  const cy = graphH / 2;
+  // Slightly tighter radius on mobile (higher factor) to fill the smaller canvas
+  const r = Math.min(cx, cy) * (count <= 4 ? 0.58 : count <= 8 ? 0.68 : 0.76);
   return Array.from({ length: count }, (_, i) => {
     const angle = (2 * Math.PI * i / count) - Math.PI / 2;
     return {
       x: cx + r * Math.cos(angle),
       y: cy + r * Math.sin(angle),
-      ux: Math.cos(angle), // outward unit vector — opposite to where edges come from
+      ux: Math.cos(angle),
       uy: Math.sin(angle),
     };
   });
@@ -55,10 +61,11 @@ const LEGEND_ENTRIES = [
 
 function NodeGraph({ snapshot, svgWidth }) {
   const nodeCount = snapshot?.nodes.length ?? 0;
-  const positions = nodePositions(nodeCount, svgWidth);
+  const { graphH, nodeR } = graphMetrics(svgWidth);
+  const positions = nodePositions(nodeCount, svgWidth, graphH);
 
   return (
-    <svg width={svgWidth} height={GRAPH_H} className={styles.graph}>
+    <svg width={svgWidth} height={graphH} className={styles.graph}>
 
       {/* Normal edges */}
       {Array.from({ length: nodeCount }, (_, i) =>
@@ -113,10 +120,10 @@ function NodeGraph({ snapshot, svgWidth }) {
         return (
           <g key={n.id} transform={`translate(${pos.x},${pos.y})`}>
             {n.gossipExcluded && (
-              <circle r={NODE_R + 5} fill="none"
+              <circle r={nodeR + 5} fill="none"
                 stroke="var(--viz-gossip-exclude)" strokeWidth="2" strokeDasharray="4,3" />
             )}
-            <circle r={NODE_R}
+            <circle r={nodeR}
               fill={nodeColor(n.state)}
               stroke={nodeBorderColor(n.state)}
               strokeWidth="2"
@@ -135,7 +142,7 @@ function NodeGraph({ snapshot, svgWidth }) {
               </text>
             )}
             {n.incarnationNumber > 0 && (
-              <g transform={`translate(${Math.round(pos.ux * (NODE_R + 10))},${Math.round(pos.uy * (NODE_R + 10))})`}>
+              <g transform={`translate(${Math.round(pos.ux * (nodeR + 10))},${Math.round(pos.uy * (nodeR + 10))})`}>
                 <title>Incarnation {n.incarnationNumber} — bumps each time this node refutes a suspicion or restarts. Peers with a lower incarnation number will accept this node&apos;s alive state as more recent.</title>
                 <circle r="9" fill="var(--ifm-background-surface-color)"
                   stroke="var(--ifm-color-emphasis-400)" strokeWidth="1.5" />

--- a/monorepo-docs-site/src/components/SwimMembershipSimulator.module.css
+++ b/monorepo-docs-site/src/components/SwimMembershipSimulator.module.css
@@ -139,7 +139,7 @@
   border-right: 1px solid var(--ifm-color-emphasis-300);
 }
 
-.graph { display: block; width: 100%; height: 380px; }
+.graph { display: block; width: 100%; }
 
 .eventLog {
   padding: 8px;
@@ -335,8 +335,8 @@
 }
 .btn:not(.btnActive):hover { background: var(--ifm-color-emphasis-200); }
 .btn:disabled { opacity: 0.4; cursor: not-allowed; }
-.btnActive:hover { filter: brightness(0.85); }
-.btnActive {
+.btn.btnActive:hover { filter: brightness(0.85); }
+.btn.btnActive {
   background: var(--viz-leader);
   color: white;
   border-color: var(--viz-leader);
@@ -359,7 +359,7 @@
 }
 .speedBtn:first-child { border-radius: 4px 0 0 4px; }
 .speedBtn:last-child  { border-radius: 0 4px 4px 0; }
-.speedBtnActive { background: var(--viz-leader); color: white; border-color: var(--viz-leader); }
+.speedBtn.speedBtnActive { background: var(--viz-leader); color: white; border-color: var(--viz-leader); }
 
 .injectSelect {
   padding: 4px 8px;
@@ -388,6 +388,10 @@
   .graphWrap {
     border-right: none;
     border-bottom: 1px solid var(--ifm-color-emphasis-300);
+    overflow: auto; /* allow scroll if SVG overflows on very small screens */
+  }
+  .graph {
+    min-width: 280px; /* prevent graph from becoming unusably narrow */
   }
 
   /* On mobile, collapsed state is vertical — restore normal width */
@@ -414,8 +418,8 @@
     grid-template-columns: 1fr;
   }
 
-  /* Smaller event log on mobile */
+  /* Event log height matches the smaller mobile graph */
   .eventLog {
-    max-height: 200px;
+    max-height: 260px;
   }
 }

--- a/monorepo-docs-site/src/components/SwimMembershipSimulator.module.css
+++ b/monorepo-docs-site/src/components/SwimMembershipSimulator.module.css
@@ -1,0 +1,421 @@
+/* SwimMembershipSimulator.module.css */
+
+.widget {
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 8px;
+  overflow: hidden;
+  font-family: var(--ifm-font-family-base);
+}
+
+/* ── Parameters panel ──────────────────────────────────────── */
+
+.paramsPanel {
+  background: var(--ifm-color-emphasis-100);
+  border-bottom: 1px solid var(--ifm-color-emphasis-300);
+  padding: 12px 16px;
+}
+
+.paramsPanelHeader {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  user-select: none;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--ifm-color-emphasis-700);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.paramsPanelHeader:hover { color: var(--ifm-color-emphasis-900); }
+
+.paramsBody {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px 20px;
+  margin-top: 12px;
+}
+
+.paramGroupWide {
+  grid-column: span 2;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.paramGroupInner {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px 16px;
+}
+
+.paramGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.paramGroupLabel {
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: var(--ifm-color-emphasis-600);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  border-bottom: 1px solid var(--ifm-color-emphasis-300);
+  padding-bottom: 3px;
+  margin-bottom: 2px;
+}
+
+.paramRow {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  font-size: 0.78rem;
+}
+
+.paramLabel {
+  color: var(--ifm-color-emphasis-700);
+  font-size: 0.75rem;
+  line-height: 1.2;
+  cursor: help;
+}
+
+.paramRowControls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.paramVal {
+  font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
+  min-width: 36px;
+  text-align: right;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--ifm-color-emphasis-800);
+}
+
+.paramSlider {
+  flex: 1;
+  min-width: 60px;
+  accent-color: var(--viz-leader);
+  cursor: pointer;
+}
+
+.toggle { position: relative; display: inline-flex; width: 32px; height: 18px; cursor: pointer; }
+.toggle input { opacity: 0; width: 0; height: 0; }
+.toggleTrack {
+  position: absolute;
+  inset: 0;
+  border-radius: 9px;
+  background: var(--ifm-color-emphasis-300);
+  transition: background 0.2s;
+}
+.toggle input:checked ~ .toggleTrack { background: var(--viz-leader); }
+.toggleKnob {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: white;
+  transition: transform 0.2s;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+}
+.toggle input:checked ~ .toggleTrack ~ .toggleKnob { transform: translateX(14px); }
+
+/* ── Graph + event log ─────────────────────────────────────── */
+
+.graphRow {
+  display: grid;
+  grid-template-columns: 1fr 220px;
+}
+
+.graphWrap {
+  position: relative;
+  border-right: 1px solid var(--ifm-color-emphasis-300);
+}
+
+.graph { display: block; width: 100%; height: 380px; }
+
+.eventLog {
+  padding: 8px;
+  overflow-y: auto;
+  max-height: 380px;
+  font-size: 0.72rem;
+  background: var(--ifm-background-color);
+}
+
+.eventLogTitleText {
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--ifm-color-emphasis-600);
+}
+
+.eventEntry {
+  display: flex;
+  gap: 6px;
+  padding: 2px 0;
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+  line-height: 1.4;
+}
+
+.eventTime {
+  color: var(--ifm-color-emphasis-500);
+  flex-shrink: 0;
+  font-variant-numeric: tabular-nums;
+  font-size: 0.65rem;
+}
+
+/* ── Stats bar ─────────────────────────────────────────────── */
+
+.statsBar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 16px;
+  padding: 8px 16px;
+  background: var(--ifm-color-emphasis-100);
+  border-top: 1px solid var(--ifm-color-emphasis-300);
+  border-bottom: 1px solid var(--ifm-color-emphasis-300);
+  font-size: 0.75rem;
+}
+
+.statItem { display: flex; gap: 5px; align-items: center; }
+.statLabel { color: var(--ifm-color-emphasis-600); }
+.statVal { font-variant-numeric: tabular-nums; font-weight: 600; }
+
+.chip {
+  display: inline-block;
+  padding: 1px 8px;
+  border-radius: 10px;
+  font-size: 0.7rem;
+  font-weight: 600;
+}
+.chipOk   { background: var(--viz-gossip-update-light); color: var(--viz-gossip-update); }
+.chipWarn { background: var(--viz-suspect-light); color: var(--viz-suspect); }
+.chipInfo { background: var(--ifm-color-emphasis-200); color: var(--ifm-color-emphasis-700); }
+
+/* ── Legend ────────────────────────────────────────────────── */
+
+.legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 16px;
+  padding: 6px 16px;
+  border-top: 1px solid var(--ifm-color-emphasis-300);
+  background: var(--ifm-color-emphasis-100);
+}
+
+.legendItem {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 0.72rem;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.legendDot {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 16px;
+  border-radius: 8px;
+  font-size: 0.6rem;
+  font-weight: 700;
+  color: white;
+  flex-shrink: 0;
+}
+
+.legendDesc { white-space: nowrap; }
+
+.legendSep {
+  width: 1px;
+  height: 16px;
+  background: var(--ifm-color-emphasis-300);
+  flex-shrink: 0;
+}
+
+.graphRowFull {
+  grid-template-columns: 1fr auto;
+}
+
+.eventLogCollapsed {
+  width: 36px;
+  min-width: 36px;
+  padding: 0;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.eventLogCollapsedLabel {
+  writing-mode: vertical-lr;
+  transform: rotate(180deg);
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--ifm-color-emphasis-600);
+  user-select: none;
+  white-space: nowrap;
+  padding: 12px 0;
+}
+.eventLogCollapsed:hover .eventLogCollapsedLabel {
+  color: var(--ifm-color-emphasis-900);
+}
+
+.legendBadge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 1.5px solid var(--ifm-color-emphasis-400);
+  background: var(--ifm-background-surface-color);
+  font-size: 0.65rem;
+  font-weight: 700;
+  color: var(--ifm-color-emphasis-700);
+  flex-shrink: 0;
+}
+
+/* ── Event log clear button ────────────────────────────────── */
+
+.eventLogTitle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.clearLogBtn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 0.9rem;
+  padding: 0 2px;
+  line-height: 1;
+  opacity: 0.6;
+}
+.clearLogBtn:hover { opacity: 1; }
+
+/* ── Controls bar ──────────────────────────────────────────── */
+
+.controlsBar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px 12px;
+  padding: 10px 16px;
+  background: var(--ifm-background-color);
+}
+
+.ctrlGroup { display: flex; align-items: center; gap: 6px; }
+.ctrlGroupLabel {
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: var(--ifm-color-emphasis-600);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.btn {
+  padding: 4px 12px;
+  border-radius: 4px;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  background: var(--ifm-background-surface-color);
+  color: var(--ifm-color-emphasis-800);
+  font-size: 0.78rem;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.btn:not(.btnActive):hover { background: var(--ifm-color-emphasis-200); }
+.btn:disabled { opacity: 0.4; cursor: not-allowed; }
+.btnActive:hover { filter: brightness(0.85); }
+.btnActive {
+  background: var(--viz-leader);
+  color: white;
+  border-color: var(--viz-leader);
+}
+.btnDanger {
+  border-color: var(--viz-leader);
+  color: var(--viz-leader);
+}
+.btnDanger:hover { background: var(--viz-leader-light); }
+
+.speedGroup { display: flex; gap: 0; }
+.speedBtn {
+  padding: 3px 8px;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  background: var(--ifm-background-surface-color);
+  color: var(--ifm-color-emphasis-700);
+  font-size: 0.72rem;
+  cursor: pointer;
+  border-radius: 0;
+}
+.speedBtn:first-child { border-radius: 4px 0 0 4px; }
+.speedBtn:last-child  { border-radius: 0 4px 4px 0; }
+.speedBtnActive { background: var(--viz-leader); color: white; border-color: var(--viz-leader); }
+
+.injectSelect {
+  padding: 4px 8px;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 4px;
+  background: var(--ifm-background-surface-color);
+  color: var(--ifm-color-emphasis-800);
+  font-size: 0.78rem;
+  cursor: pointer;
+}
+
+.sep { width: 1px; height: 24px; background: var(--ifm-color-emphasis-300); margin: 0 2px; }
+
+.faultsBar {
+  background: var(--ifm-color-emphasis-100);
+  border-top: 1px solid var(--ifm-color-emphasis-300);
+}
+
+/* ── Mobile layout ─────────────────────────────────────────── */
+
+@media (max-width: 767px) {
+  /* Stack graph and event log vertically */
+  .graphRow, .graphRowFull {
+    grid-template-columns: 1fr;
+  }
+  .graphWrap {
+    border-right: none;
+    border-bottom: 1px solid var(--ifm-color-emphasis-300);
+  }
+
+  /* On mobile, collapsed state is vertical — restore normal width */
+  .eventLogCollapsed {
+    width: auto;
+    min-width: 0;
+    padding: 8px;
+    flex-direction: row;
+  }
+  .eventLogCollapsedLabel {
+    writing-mode: horizontal-tb;
+    transform: none;
+    padding: 0;
+  }
+
+  /* Params panel: single column */
+  .paramsBody {
+    grid-template-columns: 1fr;
+  }
+  .paramGroupWide {
+    grid-column: span 1;
+  }
+  .paramGroupInner {
+    grid-template-columns: 1fr;
+  }
+
+  /* Smaller event log on mobile */
+  .eventLog {
+    max-height: 200px;
+  }
+}

--- a/monorepo-docs-site/src/components/swimSimEngine.js
+++ b/monorepo-docs-site/src/components/swimSimEngine.js
@@ -1,0 +1,742 @@
+// swimSimEngine.js — SWIM membership protocol simulation engine
+// No React imports. All state is plain JS objects mutated directly.
+
+// ── Priority queue (min-heap by simTime) ─────────────────────────────────────
+
+function createEventQueue() {
+  const h = [];
+  const swap = (i, j) => { [h[i], h[j]] = [h[j], h[i]]; };
+  const up = (i) => {
+    while (i > 0) {
+      const p = (i - 1) >> 1;
+      if (h[p].simTime <= h[i].simTime) break;
+      swap(p, i); i = p;
+    }
+  };
+  const down = (i) => {
+    for (;;) {
+      let s = i, l = 2*i+1, r = 2*i+2;
+      if (l < h.length && h[l].simTime < h[s].simTime) s = l;
+      if (r < h.length && h[r].simTime < h[s].simTime) s = r;
+      if (s === i) break;
+      swap(i, s); i = s;
+    }
+  };
+  return {
+    push(e) { h.push(e); up(h.length - 1); },
+    pop() {
+      if (!h.length) return null;
+      const min = h[0];
+      const last = h.pop();
+      if (h.length) { h[0] = last; down(0); }
+      return min;
+    },
+    peek() { return h[0] ?? null; },
+    isEmpty() { return h.length === 0; },
+    removeWhere(pred) {
+      for (let i = h.length - 1; i >= 0; i--) {
+        if (pred(h[i])) h.splice(i, 1);
+      }
+      for (let i = (h.length >> 1) - 1; i >= 0; i--) down(i);
+    },
+  };
+}
+
+// ── Utilities ─────────────────────────────────────────────────────────────────
+
+function shuffle(arr) {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+
+function pick(arr) {
+  if (!arr.length) return null;
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+function pickN(arr, n) {
+  return shuffle([...arr]).slice(0, n);
+}
+
+function isPartitioned(sim, from, to) {
+  return sim.partitions.has(`${from}-${to}`);
+}
+
+function logEvent(sim, text) {
+  sim.eventLog.unshift({ simTime: sim.simTime, text });
+  if (sim.eventLog.length > 100) sim.eventLog.length = 100;
+}
+
+// ── Node state factory ────────────────────────────────────────────────────────
+
+function createNode(id, nodeCount) {
+  const peers = Array.from({ length: nodeCount }, (_, i) => i).filter(i => i !== id);
+  return {
+    id,
+    state: 'alive',
+    incarnationNumber: 0,
+    propertyVersion: 0,
+    membershipView: new Map(peers.map(p => [p, { state: 'alive', incarnation: 0, propertyVersion: 0 }])),
+    gossipQueue: [],
+    probeOrder: shuffle([...peers]),
+    probeCounter: 0,
+    deadNodes: [],
+    deadProbeCounter: 0,
+    suspectSince: new Map(),
+    gossipExcluded: false,
+    lastAckFrom: new Map(),       // nodeId → simTime; cancels pending PROBE/INDIRECT timeouts
+    pendingIndirectFor: new Map(), // suspectId → coordinatorId; set while acting as indirect prober
+  };
+}
+
+// ── Simulation state factory ──────────────────────────────────────────────────
+
+export function createSim(nodeCount, params) {
+  const nodes = new Map();
+  for (let i = 0; i < nodeCount; i++) nodes.set(i, createNode(i, nodeCount));
+  const sim = {
+    nodes,
+    partitions: new Set(),
+    eventQueue: createEventQueue(),
+    inFlightMessages: [],
+    simTime: 0,
+    roundCount: 0,
+    msgCount: 0,
+    eventLog: [],
+    faultInjectedAt: null,
+    hasDiverged: false,   // true once any two alive nodes' views differ after a fault
+    firstDetectTime: null,
+    convergeTime: null,
+    nextMsgId: 0,
+    params,
+  };
+  nodes.forEach((_, id) => {
+    sim.eventQueue.push({ type: 'GOSSIP_TICK', simTime: params.gossipInterval, nodeId: id });
+    sim.eventQueue.push({ type: 'PROBE_TICK',  simTime: params.probeInterval,  nodeId: id });
+    sim.eventQueue.push({ type: 'SYNC_TICK',   simTime: params.syncInterval,   nodeId: id });
+  });
+  return sim;
+}
+
+// ── Gossip ────────────────────────────────────────────────────────────────────
+
+function stateRank(state) {
+  return state === 'alive' ? 0 : state === 'suspect' ? 1 : 2;
+}
+
+function enqueueGossipUpdate(node, entry) {
+  const existing = node.gossipQueue.find(e => e.memberId === entry.memberId);
+  if (existing) {
+    if (entry.incarnation > existing.incarnation ||
+        (entry.incarnation === existing.incarnation && stateRank(entry.state) > stateRank(existing.state)) ||
+        (entry.incarnation === existing.incarnation && entry.state === existing.state &&
+         (entry.propertyVersion ?? 0) > (existing.propertyVersion ?? 0))) {
+      Object.assign(existing, entry, { sendCount: 0 });
+    }
+  } else {
+    node.gossipQueue.push({ ...entry, sendCount: 0 });
+  }
+}
+
+function selectGossipTargets(sim, node) {
+  const alive = [...sim.nodes.values()].filter(n =>
+    n.id !== node.id && n.state === 'alive' && !n.gossipExcluded
+  ).map(n => n.id);
+  if (sim.params.broadcastUpdates) return alive;
+  return pickN(alive, sim.params.gossipFanout);
+}
+
+function sendGossip(sim, from, to, entries, wallTime) {
+  if (isPartitioned(sim, from, to)) return;
+  sim.msgCount++;
+  const hasFailure = entries.some(e => e.state === 'dead' || e.state === 'suspect');
+  const label = hasFailure ? 'U⚠' : 'U↑';
+  const color = hasFailure ? 'var(--viz-leader)' : 'var(--viz-gossip-update)';
+  sim.inFlightMessages.push({
+    id: sim.nextMsgId++, from, to, label, color,
+    startWallTime: wallTime, durationMs: 300,
+    payload: { type: 'GOSSIP', entries },
+  });
+  sim.eventQueue.push({
+    type: 'MSG_DELIVER', simTime: sim.simTime + 1, from, to,
+    payload: { type: 'GOSSIP', entries },
+  });
+}
+
+function handleGossipTick(sim, node, wallTime) {
+  sim.roundCount++;
+  const maxSends = 1; // each node gossips each update once (to gossipFanout peers), matching Java
+  const entries = [...node.gossipQueue]
+    .sort((a, b) => a.sendCount - b.sendCount)
+    .slice(0, 8);
+  entries.forEach(e => e.sendCount++);
+  node.gossipQueue = node.gossipQueue.filter(e => e.sendCount < maxSends);
+  // Only gossip when there is something to propagate — matches real SWIM behavior
+  if (entries.length > 0) {
+    const targets = selectGossipTargets(sim, node);
+    targets.forEach(tid => sendGossip(sim, node.id, tid, entries, wallTime));
+  }
+  sim.eventQueue.push({ type: 'GOSSIP_TICK', simTime: sim.simTime + sim.params.gossipInterval, nodeId: node.id });
+}
+
+function handleGossipReceived(sim, _from, to, entries, wallTime = 0) {
+  const node = sim.nodes.get(to);
+  if (!node || node.state === 'crashed') return;
+  for (const entry of entries) {
+    if (entry.memberId === to) {
+      if (entry.state === 'suspect' && node.state === 'alive') {
+        node.incarnationNumber++;
+        logEvent(sim, `N${to} (self): incarnation → ${node.incarnationNumber} (refuting suspect via gossip)`);
+        const correction = { memberId: to, state: 'alive', incarnation: node.incarnationNumber };
+        enqueueGossipUpdate(node, correction);
+        if (sim.params.broadcastDisputes) {
+          [...sim.nodes.values()]
+            .filter(n => n.id !== to && n.state === 'alive' && !isPartitioned(sim, to, n.id))
+            .forEach(n => sendGossip(sim, to, n.id, [correction], wallTime));
+        }
+      }
+      continue;
+    }
+    const view = node.membershipView.get(entry.memberId);
+    if (!view) continue;
+    const acceptNew = entry.incarnation > view.incarnation ||
+      (entry.incarnation === view.incarnation && stateRank(entry.state) > stateRank(view.state));
+    const propChanged = entry.incarnation === view.incarnation &&
+      entry.state === view.state &&
+      entry.propertyVersion !== undefined &&
+      entry.propertyVersion > (view.propertyVersion ?? 0);
+    if (acceptNew || propChanged) {
+      const prevState = view.state;
+      view.state = entry.state;
+      view.incarnation = entry.incarnation;
+      if (entry.propertyVersion !== undefined) view.propertyVersion = entry.propertyVersion;
+      enqueueGossipUpdate(node, entry);
+      // Log the Java-equivalent event this state change would fire
+      if (acceptNew && entry.state !== prevState) {
+        if (entry.state === 'suspect') {
+          logEvent(sim, `N${to} → N${entry.memberId}: REACHABILITY_CHANGED (suspect, via gossip)`);
+        } else if (entry.state === 'dead') {
+          logEvent(sim, `N${to} → N${entry.memberId}: REACHABILITY_CHANGED (dead) + MEMBER_REMOVED (via gossip)`);
+        } else if (entry.state === 'alive' && prevState === 'dead') {
+          // Member was removed when dead; re-discovering it as alive fires MEMBER_ADDED per peer
+          logEvent(sim, `N${to} → N${entry.memberId}: MEMBER_ADDED (rediscovered via gossip)`);
+        } else if (entry.state === 'alive' && prevState === 'suspect') {
+          logEvent(sim, `N${to} → N${entry.memberId}: REACHABILITY_CHANGED (alive, via gossip)`);
+        }
+      } else if (propChanged) {
+        logEvent(sim, `N${to} → N${entry.memberId}: METADATA_CHANGED (v${entry.propertyVersion})`);
+      }
+    }
+  }
+}
+
+// ── Failure detection ─────────────────────────────────────────────────────────
+
+function sendProbe(sim, from, to, wallTime) {
+  // No partition check here — let the probe animate even if it will be dropped at delivery,
+  // so the prober's attempt is visible and the PROBE_TIMEOUT can fire to trigger failure detection.
+  sim.msgCount++;
+  sim.inFlightMessages.push({
+    id: sim.nextMsgId++, from, to, label: 'P→', color: 'var(--viz-msg-probe)',
+    startWallTime: wallTime, durationMs: 300, replyDepth: 0,
+    payload: { type: 'PROBE' },
+  });
+  // Include prober's current view of the target so the target can detect if it's suspected
+  const probersView = sim.nodes.get(from)?.membershipView.get(to);
+  sim.eventQueue.push({ type: 'MSG_DELIVER', simTime: sim.simTime + 1, from, to,
+    payload: { type: 'PROBE', probeSentWallTime: wallTime, replyDepth: 0,
+      probersViewOfTarget: probersView?.state } });
+}
+
+function handleProbeTick(sim, node, wallTime) {
+  // Probe next peer via shuffle + round-robin through probeOrder (includes suspects, excludes dead)
+  if (node.probeOrder.length > 0) {
+    const idx = node.probeCounter % node.probeOrder.length;
+    node.probeCounter++;
+    const targetId = node.probeOrder[idx];
+    // Use local membership view, not ground truth — faithful to the real protocol
+    // where a node only learns about failures through timeouts, not omniscience
+    const localView = node.membershipView.get(targetId);
+    if (localView && localView.state !== 'dead') {
+      sendProbe(sim, node.id, targetId, wallTime);
+      sim.eventQueue.push({
+        type: 'PROBE_TIMEOUT', simTime: sim.simTime + sim.params.probeTimeout,
+        from: node.id, to: targetId, probeSentSimTime: sim.simTime, probeSentWallTime: wallTime,
+      });
+    }
+  }
+  // Also probe one dead node per tick (resurrection check).
+  // If it responds, the PROBE_ACK handler detects it's in deadNodes and resurrects it.
+  if (node.deadNodes.length > 0) {
+    const idx = node.deadProbeCounter % node.deadNodes.length;
+    node.deadProbeCounter++;
+    const deadId = node.deadNodes[idx];
+    sendProbe(sim, node.id, deadId, wallTime);
+  }
+  sim.eventQueue.push({ type: 'PROBE_TICK', simTime: sim.simTime + sim.params.probeInterval, nodeId: node.id });
+}
+
+function handleProbeTimeout(sim, event, wallTime) {
+  const { from, to, probeSentSimTime, probeSentWallTime } = event;
+  const prober = sim.nodes.get(from);
+  if (!prober || prober.state === 'crashed') return;
+  // ACK received after probe was sent — cancel this timeout
+  if ((prober.lastAckFrom.get(to) ?? -Infinity) >= probeSentSimTime) return;
+  const target = sim.nodes.get(to);
+  if (!target) return;
+
+  // Send indirect probe requests to suspectProbes-1 random peers.
+  // Each peer receives a PROBE_REQUEST carrying the suspect's ID.
+  const indirectPeers = pickN(
+    [...sim.nodes.values()]
+      .filter(n => n.id !== from && n.id !== to && n.state === 'alive')
+      .map(n => n.id),
+    sim.params.suspectProbes - 1
+  );
+
+  if (indirectPeers.length === 0) {
+    markSuspect(sim, prober, to, wallTime);
+    return;
+  }
+
+  indirectPeers.forEach(pid => {
+    if (isPartitioned(sim, from, pid)) return;
+    sim.msgCount++;
+    sim.inFlightMessages.push({
+      id: sim.nextMsgId++, from, to: pid, label: 'I→', color: 'var(--viz-msg-probe-indirect)',
+      // replyDepth=1: I→ starts when P→ has visually arrived.
+      // Only inherit probeSentWallTime if the probe is still fresh (< 800ms ago in wall time);
+      // if stale (e.g. sim was playing then stepped much later), start from now instead.
+      startWallTime: (wallTime - (probeSentWallTime ?? wallTime) < 800)
+        ? (probeSentWallTime ?? wallTime)
+        : wallTime,
+      durationMs: 300, replyDepth: 1,
+      payload: { type: 'PROBE_REQUEST', suspect: to, coordinator: from },
+    });
+    sim.eventQueue.push({
+      type: 'MSG_DELIVER', simTime: sim.simTime + 1, from, to: pid,
+      // Pass wallTime so the forwarded P→ starts animating only after I→ visually arrives
+      payload: { type: 'PROBE_REQUEST', suspect: to, coordinator: from,
+        indirectSentWallTime: (wallTime - (probeSentWallTime ?? wallTime) < 800)
+          ? (probeSentWallTime ?? wallTime)
+          : wallTime },
+    });
+  });
+
+  sim.eventQueue.push({
+    type: 'INDIRECT_TIMEOUT', simTime: sim.simTime + sim.params.probeTimeout * 2,
+    from, to, probeSentSimTime: sim.simTime,
+  });
+}
+
+function handleIndirectTimeout(sim, event, wallTime) {
+  const { from, to, probeSentSimTime } = event;
+  const prober = sim.nodes.get(from);
+  if (!prober || prober.state === 'crashed') return;
+  // Any indirect prober reported success — cancel
+  if ((prober.lastAckFrom.get(to) ?? -Infinity) >= probeSentSimTime) return;
+  markSuspect(sim, prober, to, wallTime);
+}
+
+function markSuspect(sim, prober, targetId, wallTime) {
+  const view = prober.membershipView.get(targetId);
+  if (!view || view.state !== 'alive') return;
+
+  view.state = 'suspect';
+  prober.suspectSince.set(targetId, sim.simTime);
+  logEvent(sim, `N${prober.id} → N${targetId}: REACHABILITY_CHANGED (suspect)`);
+
+  const entry = { memberId: targetId, state: 'suspect', incarnation: view.incarnation };
+  enqueueGossipUpdate(prober, entry);
+
+  // broadcastUpdates: prober immediately floods failure news to all peers (not just fanout)
+  if (sim.params.broadcastUpdates) {
+    [...sim.nodes.values()]
+      .filter(n => n.id !== prober.id && n.state === 'alive' && !isPartitioned(sim, prober.id, n.id))
+      .forEach(n => sendGossip(sim, prober.id, n.id, [entry], wallTime));
+  }
+
+  // notifySuspect: send the suspect state directly to the suspect so it can refute
+  // In Java: gossip(swimMember, [swimMember.copy()]) — a direct unicast carrying suspect state
+  if (sim.params.notifySuspect) {
+    sendGossip(sim, prober.id, targetId, [entry], wallTime);
+  }
+
+  sim.eventQueue.push({
+    type: 'FAILURE_TIMEOUT', simTime: sim.simTime + sim.params.failureTimeout,
+    from: prober.id, to: targetId,
+  });
+}
+
+function handleFailureTimeout(sim, event, wallTime) {
+  const { from, to } = event;
+  const prober = sim.nodes.get(from);
+  if (!prober || prober.state === 'crashed') return;
+  const view = prober.membershipView.get(to);
+  if (!view || view.state !== 'suspect') return;
+
+  view.state = 'dead';
+  logEvent(sim, `N${from} → N${to}: REACHABILITY_CHANGED (dead) + MEMBER_REMOVED`);
+
+  prober.probeOrder = prober.probeOrder.filter(id => id !== to);
+  shuffle(prober.probeOrder);
+  if (!prober.deadNodes.includes(to)) prober.deadNodes.push(to);
+
+  const entry = { memberId: to, state: 'dead', incarnation: view.incarnation };
+  enqueueGossipUpdate(prober, entry);
+
+  // broadcastUpdates: immediately flood the dead news to all peers
+  if (sim.params.broadcastUpdates) {
+    [...sim.nodes.values()]
+      .filter(n => n.id !== from && n.state === 'alive' && !isPartitioned(sim, from, n.id))
+      .forEach(n => sendGossip(sim, from, n.id, [entry], wallTime));
+  }
+}
+
+function handleProbeReceived(sim, event, wallTime) {
+  const { from, to } = event;
+  // `from` = prober, `to` = us (the probed node)
+  const target = sim.nodes.get(to);
+  if (!target || target.state === 'crashed' || isPartitioned(sim, to, from)) return;
+
+  // broadcastDisputes: if the probe reveals the prober suspects us, refute by bumping incarnation
+  // and broadcasting our alive state to all peers (Java: probe handler lines 629-635)
+  const probersViewOfUs = event.payload?.probersViewOfTarget;
+  if (probersViewOfUs === 'suspect') {
+    target.incarnationNumber++;
+    logEvent(sim, `N${to} (self): incarnation → ${target.incarnationNumber} (refuting suspect via probe)`);
+    const refutation = { memberId: to, state: 'alive', incarnation: target.incarnationNumber };
+    enqueueGossipUpdate(target, refutation);
+    if (sim.params.broadcastDisputes) {
+      [...sim.nodes.values()]
+        .filter(n => n.id !== to && n.state === 'alive' && !isPartitioned(sim, to, n.id))
+        .forEach(n => sendGossip(sim, to, n.id, [refutation], wallTime));
+      logEvent(sim, `N${to} (self): REACHABILITY_CHANGED (alive) + broadcastDisputes`);
+    }
+  }
+
+  sim.msgCount++;
+  // isReply: true tells captureSnapshot to start this animation only after P→ has visually arrived
+  const probeSentWallTime = event.payload?.probeSentWallTime ?? wallTime;
+  const ackDepth = (event.payload?.replyDepth ?? 0) + 1;
+  sim.inFlightMessages.push({
+    id: sim.nextMsgId++, from: to, to: from, label: 'P✓', color: 'var(--viz-msg-probe-ack)',
+    startWallTime: probeSentWallTime, durationMs: 300, replyDepth: ackDepth,
+    payload: { type: 'PROBE_ACK' },
+  });
+  sim.eventQueue.push({
+    type: 'MSG_DELIVER', simTime: sim.simTime + 1, from: to, to: from,
+    payload: { type: 'PROBE_ACK' },
+  });
+}
+
+// ── Sync ──────────────────────────────────────────────────────────────────────
+
+function serializeView(node) {
+  return [...node.membershipView.entries()].map(([id, v]) => ({ memberId: id, ...v }));
+}
+
+function handleSyncTick(sim, node, wallTime) {
+  const target = pick(node.probeOrder);
+  if (target !== null && !isPartitioned(sim, node.id, target)) {
+    sim.msgCount++;
+    const view = serializeView(node);
+    sim.inFlightMessages.push({
+      id: sim.nextMsgId++, from: node.id, to: target, label: 'S⇄', color: 'var(--viz-msg-sync)',
+      startWallTime: wallTime, durationMs: 400,
+      payload: { type: 'SYNC', view },
+    });
+    sim.eventQueue.push({
+      type: 'MSG_DELIVER', simTime: sim.simTime + 1, from: node.id, to: target,
+      payload: { type: 'SYNC', view },
+    });
+  }
+  sim.eventQueue.push({ type: 'SYNC_TICK', simTime: sim.simTime + sim.params.syncInterval, nodeId: node.id });
+}
+
+function handleSyncReceived(sim, from, to, view, wallTime) {
+  const node = sim.nodes.get(to);
+  if (!node || node.state === 'crashed') return;
+  for (const entry of view) {
+    if (entry.memberId !== to) handleGossipReceived(sim, from, to, [entry], wallTime);
+  }
+  if (!isPartitioned(sim, to, from)) {
+    sim.msgCount++;
+    const responseView = serializeView(node);
+    sim.inFlightMessages.push({
+      id: sim.nextMsgId++, from: to, to: from, label: 'S⇄', color: 'var(--viz-msg-sync)',
+      startWallTime: wallTime, durationMs: 400,
+      payload: { type: 'SYNC_RESPONSE', view: responseView },
+    });
+    sim.eventQueue.push({
+      type: 'MSG_DELIVER', simTime: sim.simTime + 1, from: to, to: from,
+      payload: { type: 'SYNC_RESPONSE', view: responseView },
+    });
+  }
+}
+
+// ── Message dispatch ──────────────────────────────────────────────────────────
+
+function handleMsgDeliver(sim, event, wallTime) {
+  const { from, to, payload } = event;
+  const node = sim.nodes.get(to);
+  if (!node || node.state === 'crashed' || isPartitioned(sim, from, to)) return;
+
+  switch (payload.type) {
+    case 'GOSSIP': handleGossipReceived(sim, from, to, payload.entries, wallTime); break;
+    case 'PROBE':  handleProbeReceived(sim, event, wallTime); break;
+    case 'PROBE_ACK': {
+      // `from` = node that ACKed (was probed), `to` = prober (direct or indirect)
+      const prober = sim.nodes.get(to);
+      if (!prober) break;
+
+      // Record that `from` responded; cancels pending PROBE/INDIRECT timeouts
+      prober.lastAckFrom.set(from, sim.simTime);
+
+      // If we were acting as indirect prober for a coordinator, update coordinator too
+      const coordId = prober.pendingIndirectFor.get(from);
+      if (coordId !== undefined) {
+        prober.pendingIndirectFor.delete(from);
+        const coord = sim.nodes.get(coordId);
+        if (coord && coord.state !== 'crashed') coord.lastAckFrom.set(from, sim.simTime);
+      }
+
+      // Resurrection check
+      const deadIdx = prober.deadNodes.indexOf(from);
+      if (deadIdx !== -1) {
+        prober.deadNodes.splice(deadIdx, 1);
+        const newIncarnation = (sim.nodes.get(from)?.incarnationNumber ?? 0) + 1;
+        prober.membershipView.set(from, { state: 'alive', incarnation: newIncarnation, propertyVersion: 0 });
+        if (!prober.probeOrder.includes(from)) { prober.probeOrder.push(from); shuffle(prober.probeOrder); }
+        logEvent(sim, `N${to} → N${from}: MEMBER_REMOVED + MEMBER_ADDED (resurrected, incarnation ${newIncarnation})`);
+        enqueueGossipUpdate(prober, { memberId: from, state: 'alive', incarnation: newIncarnation });
+      } else {
+        // Clear suspicion if already marked
+        const view = prober.membershipView.get(from);
+        if (view && view.state === 'suspect') {
+          view.state = 'alive';
+          prober.suspectSince.delete(from);
+          logEvent(sim, `N${to} → N${from}: REACHABILITY_CHANGED (alive, refuted suspicion)`);
+        }
+      }
+      break;
+    }
+    case 'PROBE_REQUEST': {
+      // We are an indirect prober — probe `suspect` on behalf of `coordinator`
+      const { suspect, coordinator, indirectSentWallTime } = payload;
+      if (isPartitioned(sim, to, suspect)) break;
+      // Track who we're probing for so we can forward the ACK result
+      const indirectProber = sim.nodes.get(to);
+      if (indirectProber) indirectProber.pendingIndirectFor.set(suspect, coordinator);
+      sim.msgCount++;
+      const baseWallTime = indirectSentWallTime ?? wallTime;
+      sim.inFlightMessages.push({
+        id: sim.nextMsgId++, from: to, to: suspect, label: 'P→', color: 'var(--viz-msg-probe)',
+        // replyDepth 2: P→ is two hops from original — starts when I→ has visually arrived at N2
+        startWallTime: baseWallTime, durationMs: 300, replyDepth: 2,
+        payload: { type: 'PROBE' },
+      });
+      sim.eventQueue.push({
+        type: 'MSG_DELIVER', simTime: sim.simTime + 1, from: to, to: suspect,
+        // replyDepth 2 so P✓ gets ackDepth=3, starting after this forwarded P→ visually arrives
+        payload: { type: 'PROBE', probeSentWallTime: baseWallTime, replyDepth: 2 },
+      });
+      break;
+    }
+    case 'SYNC':          handleSyncReceived(sim, from, to, payload.view, wallTime); break;
+    case 'SYNC_RESPONSE': {
+      for (const entry of payload.view) handleGossipReceived(sim, from, to, [entry], wallTime);
+      break;
+    }
+  }
+}
+
+// ── Convergence ───────────────────────────────────────────────────────────────
+
+function checkConvergence(sim) {
+  if (sim.faultInjectedAt === null) return;
+  const aliveNodes = [...sim.nodes.values()].filter(n => n.state === 'alive');
+  if (aliveNodes.length < 2) return;
+
+  // consistent: alive nodes agree with each other — drives diverge/converge detection.
+  // settled:    for crashed nodes, all alive nodes also see them as 'dead' (not just consistent).
+  //             "all agree the node is suspect" is consistent but not yet settled.
+  let consistent = true;
+  let settled = true;
+
+  outer: for (const nodeX of sim.nodes.values()) {
+    if (nodeX.state === 'alive') {
+      // Every alive peer must see nodeX as alive with the current propertyVersion
+      for (const nodeY of aliveNodes) {
+        if (nodeY.id === nodeX.id) continue;
+        const v = nodeY.membershipView.get(nodeX.id);
+        if (!v || v.state !== 'alive' || (v.propertyVersion ?? 0) !== nodeX.propertyVersion) {
+          consistent = false;
+          settled = false;
+          break outer;
+        }
+      }
+    } else if (nodeX.state === 'crashed') {
+      // Crashed nodes are no longer part of the cluster — don't compare against ground truth.
+      // Instead check that alive nodes agree WITH EACH OTHER about this node.
+      const ref = aliveNodes[0].membershipView.get(nodeX.id);
+      if (!ref) continue;
+      for (const nodeY of aliveNodes.slice(1)) {
+        const v = nodeY.membershipView.get(nodeX.id);
+        if (!v || v.state !== ref.state) { consistent = false; settled = false; break outer; }
+      }
+      // Consistent but still intermediate if peers haven't marked it dead yet
+      if (ref.state !== 'dead') settled = false;
+    }
+  }
+
+  if (!consistent) {
+    if (!sim.hasDiverged) {
+      sim.hasDiverged = true;
+      sim.firstDetectTime = sim.simTime - sim.faultInjectedAt;
+      logEvent(sim, 'Cluster views diverged');
+    }
+    sim.convergeTime = null;
+    return;
+  }
+
+  // Consistent — converge only once views are also settled (crashed nodes seen as dead)
+  if (sim.hasDiverged && settled && sim.convergeTime === null) {
+    sim.convergeTime = sim.simTime - sim.faultInjectedAt;
+    logEvent(sim, 'Cluster converged (all nodes agree)');
+  }
+}
+
+// ── Fault injection ───────────────────────────────────────────────────────────
+
+export function crashNode(sim, nodeId) {
+  const node = sim.nodes.get(nodeId);
+  if (!node || node.state === 'crashed') return;
+  node.state = 'crashed';
+  sim.eventQueue.removeWhere(e => e.nodeId === nodeId || e.from === nodeId);
+  sim.inFlightMessages = sim.inFlightMessages.filter(m => m.from !== nodeId && m.to !== nodeId);
+  sim.nodes.forEach(n => {
+    // Keep crashed node in probeOrder so peers still probe it and PROBE_TIMEOUT fires
+    // (failure detection requires seeing no ACK, not skipping the probe entirely)
+    n.deadNodes = n.deadNodes.filter(id => id !== nodeId);
+  });
+  sim.faultInjectedAt = sim.simTime;
+  sim.hasDiverged = false;
+  sim.firstDetectTime = null;
+  sim.convergeTime = null;
+  logEvent(sim, `N${nodeId} crashed (fault injected)`);
+}
+
+export function restoreNode(sim, nodeId) {
+  const node = sim.nodes.get(nodeId);
+  if (!node || node.state !== 'crashed') return;
+  node.state = 'alive';
+  sim.nodes.forEach(n => {
+    if (n.id !== nodeId && n.state === 'alive' && !n.probeOrder.includes(nodeId)) {
+      n.probeOrder.push(nodeId);
+    }
+  });
+  node.incarnationNumber++;
+  node.suspectSince.clear();
+  sim.eventQueue.push({ type: 'GOSSIP_TICK', simTime: sim.simTime + sim.params.gossipInterval, nodeId });
+  sim.eventQueue.push({ type: 'PROBE_TICK',  simTime: sim.simTime + sim.params.probeInterval,  nodeId });
+  sim.eventQueue.push({ type: 'SYNC_TICK',   simTime: sim.simTime + sim.params.syncInterval,   nodeId });
+  // No explicit gossip on restore — matches Java join() behaviour.
+  // The restored node will probe peers on its next PROBE_TICK; other nodes probe it via
+  // their probeOrder or deadNodes resurrection check. Discovery propagates through probing.
+  logEvent(sim, `N${nodeId} (self): MEMBER_ADDED (restored, incarnation ${node.incarnationNumber})`);
+}
+
+export function injectPropertyUpdate(sim, nodeId) {
+  const node = sim.nodes.get(nodeId);
+  if (!node || node.state !== 'alive') return;
+  node.propertyVersion++;
+  enqueueGossipUpdate(node, {
+    memberId: nodeId, state: 'alive', incarnation: node.incarnationNumber,
+    propertyVersion: node.propertyVersion,
+  });
+  sim.faultInjectedAt = sim.simTime;
+  sim.hasDiverged = false;
+  sim.firstDetectTime = null;
+  sim.convergeTime = null;
+  logEvent(sim, `N${nodeId} property update v${node.propertyVersion}`);
+}
+
+export function addPartition(sim, from, to) {
+  sim.partitions.add(`${from}-${to}`);
+  sim.partitions.add(`${to}-${from}`);
+  logEvent(sim, `Link fault: N${from} ↔ N${to} blocked`);
+}
+
+export function logEventDirect(sim, text) {
+  logEvent(sim, text);
+}
+
+export function setGossipExcluded(sim, nodeId, excluded) {
+  const node = sim.nodes.get(nodeId);
+  if (node) {
+    node.gossipExcluded = excluded;
+    logEvent(sim, `N${nodeId} gossip ${excluded ? 'excluded' : 'restored'}`);
+  }
+}
+
+// ── Main simulation loop ──────────────────────────────────────────────────────
+
+export function advanceSim(sim, targetSimTime, wallTime, uiSpeed = 1) {
+  while (!sim.eventQueue.isEmpty() && sim.eventQueue.peek().simTime <= targetSimTime) {
+    const event = sim.eventQueue.pop();
+    sim.simTime = event.simTime;
+    const node = event.nodeId !== undefined ? sim.nodes.get(event.nodeId) : null;
+    if (node && node.state === 'crashed' && event.type !== 'MSG_DELIVER') continue;
+
+    switch (event.type) {
+      case 'GOSSIP_TICK':      if (node) handleGossipTick(sim, node, wallTime); break;
+      case 'PROBE_TICK':       if (node) handleProbeTick(sim, node, wallTime); break;
+      case 'PROBE_TIMEOUT':    handleProbeTimeout(sim, event, wallTime); break;
+      case 'INDIRECT_TIMEOUT': handleIndirectTimeout(sim, event, wallTime); break;
+      case 'FAILURE_TIMEOUT':  handleFailureTimeout(sim, event, wallTime); break;
+      case 'SYNC_TICK':        if (node) handleSyncTick(sim, node, wallTime); break;
+      case 'MSG_DELIVER':      handleMsgDeliver(sim, event, wallTime); break;
+    }
+    checkConvergence(sim);
+  }
+  sim.simTime = targetSimTime;
+  const eff = (m) => Math.min(800, m.durationMs / uiSpeed);
+  sim.inFlightMessages = sim.inFlightMessages.filter(m =>
+    m.startWallTime > 0 && wallTime - m.startWallTime < eff(m) * ((m.replyDepth ?? 0) + 1) + 100
+  );
+}
+
+// ── Snapshot (for React rendering) ───────────────────────────────────────────
+
+export function captureSnapshot(sim, wallTime, uiSpeed = 1) {
+  const animDuration = (m) => Math.min(800, m.durationMs / uiSpeed);
+  return {
+    simTime: sim.simTime,
+    roundCount: sim.roundCount,
+    msgCount: sim.msgCount,
+    firstDetectTime: sim.firstDetectTime,
+    convergeTime: sim.convergeTime,
+    hasPartitions: sim.partitions.size > 0,
+    hasDiverged: sim.hasDiverged,
+    partitions: [...sim.partitions],
+    eventLog: [...sim.eventLog],
+    nodes: [...sim.nodes.values()].map(n => ({
+      id: n.id,
+      state: n.state,
+      propertyVersion: n.propertyVersion,
+      incarnationNumber: n.incarnationNumber,
+      gossipExcluded: n.gossipExcluded,
+      view: new Map([...n.membershipView.entries()]),
+    })),
+    messages: sim.inFlightMessages.map(m => {
+      const eff = animDuration(m);
+      const actualStart = m.startWallTime + (m.replyDepth ?? 0) * eff;
+      const progress = Math.min(1, (wallTime - actualStart) / eff);
+      return { ...m, progress };
+    }).filter(m => m.progress >= 0 && m.progress <= 1),
+  };
+}

--- a/monorepo-docs-site/src/css/custom.css
+++ b/monorepo-docs-site/src/css/custom.css
@@ -37,3 +37,37 @@ body {
         roboto, oxygen, ubuntu, cantarell, fira sans, droid sans, helvetica neue,
         sans-serif !important;
 }
+
+/* SWIM simulator palette */
+:root {
+    --viz-suspect: #f57c00;
+    --viz-suspect-light: #fff3e0;
+    --viz-gossip-update: #00838f;
+    --viz-gossip-update-light: #e0f2f1;
+    --viz-msg-probe: #f57c00;
+    --viz-msg-sync: #1565c0;
+    --viz-gossip-exclude: #f9a825;
+    --viz-msg-probe-ack: #2e7d32;
+    --viz-msg-probe-indirect: #6a1b9a;
+}
+[data-theme='dark'] {
+    --viz-suspect: #ffb74d;
+    --viz-suspect-light: #3e2000;
+    --viz-gossip-update: #4db6ac;
+    --viz-gossip-update-light: #1a3535;
+    --viz-msg-probe: #ffb74d;
+    --viz-msg-sync: #42a5f5;
+    --viz-gossip-exclude: #ffe082;
+    --viz-msg-probe-ack: #66bb6a;
+    --viz-msg-probe-indirect: #ce93d8;
+}
+
+/* Shared viz palette (also defined in partition-distribution-viz branch — merge-safe) */
+:root {
+    --viz-leader: #c62828;
+    --viz-leader-light: #ffebee;
+}
+[data-theme='dark'] {
+    --viz-leader: #ef9a9a;
+    --viz-leader-light: #3e0a0a;
+}


### PR DESCRIPTION
## Summary

Adds an interactive SWIM membership protocol simulator to the monorepo docs site under **Architecture → Components → Orchestration Cluster → Membership Simulator (SWIM)**.

- Discrete-event simulation engine faithful to `SwimMembershipProtocol.java`: gossip epidemic (maxSends=1 per cycle matching Java), probe pipeline with indirect probes, incarnation-number refutation, sync anti-entropy, convergence detection
- Animated SVG node graph with causal message ordering (P→ waits for ACK before I→ flies, etc.), incarnation badge, fault injection (crash, symmetric link fault, gossip exclude)
- Collapsible parameter panel with tooltips on every control, stats bar, event log showing corresponding Java `GroupMembershipEvent` names
- Documentation covering SWIM overview, what gets gossiped, and contrast with Raft failure detection

Backup of the iterative branch at `feat/npp/swim-membership-simulator-backup` if needed.

## Test plan

- [ ] `cd monorepo-docs-site && npm start` — verify page loads at Architecture → Orchestration Cluster → Membership Simulator (SWIM)
- [ ] Crash a node — observe P→ / I→ / P✓ causal chain, suspect → dead pipeline, MEMBER_REMOVED in event log
- [ ] Restore a node — verify MEMBER_ADDED (self) fires, peers rediscover via probing
- [ ] Inject property update — observe U↑ gossip spreading and convergence
- [ ] Cut link between two nodes — verify symmetric block, gossip routes around via third node
- [ ] Adjust gossip interval and fanout — verify changes take effect immediately
- [ ] Pause + step — verify causal message ordering is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)