### PR TITLE
refactor: remove dead docker compose code paths from c8run

### DIFF
--- a/c8run/.env
+++ b/c8run/.env
@@ -1,9 +1,4 @@
 # this is the version of camunda/ zeebe
 CAMUNDA_VERSION=8.9.6
-# docker images moved to a shortened tag, override compose with this value when using --docker
-CAMUNDA_DOCKER_VERSION=8.9.6
 # Look here: https://artifacts.camunda.com/ui/native/connectors/io/camunda/connector/connector-runtime-bundle/
 CONNECTORS_VERSION=8.9.5
-# version of docker compose artifact (used for --docker option)
-COMPOSE_TAG=8.9
-COMPOSE_EXTRACTED_FOLDER=docker-compose-8.9

--- a/c8run/README.md
+++ b/c8run/README.md
@@ -1,6 +1,7 @@
 # Camunda 8 Run
 
 C8 Run is a packaged distribution of Camunda 8, which allows you to spin up Camunda 8 within seconds.
+It packages the local Java runtime only; the Docker Compose distribution is published separately.
 
 Please refer to the [local installation with Camunda 8 Run guide](https://docs.camunda.io/docs/next/self-managed/quickstart/developer-quickstart/c8run/) for further details.
 

--- a/c8run/cmd/c8run/main.go
+++ b/c8run/cmd/c8run/main.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"os/signal"
 	"path/filepath"
 	"runtime"
@@ -16,7 +15,6 @@ import (
 	"sync"
 	"syscall"
 
-	"github.com/camunda/camunda/c8run/internal/health"
 	"github.com/camunda/camunda/c8run/internal/processmanagement"
 	"github.com/camunda/camunda/c8run/internal/shutdown"
 	"github.com/camunda/camunda/c8run/internal/start"
@@ -63,35 +61,6 @@ func validatePort(port int) error {
 	return nil
 }
 
-func runDockerCommand(composeExtractedFolder string, args ...string) error {
-	err := os.Chdir(composeExtractedFolder)
-	if err != nil {
-		return fmt.Errorf("failed to chdir to %s: %w", composeExtractedFolder, err)
-	}
-
-	_, err = exec.LookPath("docker")
-	if err != nil {
-		return err
-	}
-
-	composeCmd := exec.Command("docker", append([]string{"compose"}, args...)...)
-	composeCmd.Stdout = os.Stdout
-	composeCmd.Stderr = os.Stderr
-	composeCmd.Env = dockerCommandEnv(os.Environ())
-
-	err = composeCmd.Run()
-	if err != nil {
-		return err
-	}
-
-	err = os.Chdir("..")
-	if err != nil {
-		return fmt.Errorf("failed to chdir back: %w", err)
-	}
-
-	return nil
-}
-
 var helpTemplate = `Usage:
   %[1]s [command] [options]
 
@@ -107,14 +76,11 @@ Options:
   --keystorePassword <pw>  Password for the provided keystore
   --port <number>           Set the main Camunda port (default: 8080)
   --log-level <level>       Set log level (e.g., info, debug)
-  --docker                  Start using Docker Compose
 
 Examples:
   %[1]s start
-  %[1]s start --docker
   %[1]s start --config ./my-config.yaml
   %[1]s stop
-  %[1]s stop --docker
 
 Docs & Support:
   https://docs.camunda.io/docs/guides/getting-started-java-spring/
@@ -125,27 +91,6 @@ Docs & Support:
 func usage(exitcode int) {
 	fmt.Printf(helpTemplate, os.Args[0])
 	os.Exit(exitcode)
-}
-
-func dockerCommandEnv(baseEnv []string) []string {
-	dockerVersion := strings.TrimSpace(os.Getenv("CAMUNDA_DOCKER_VERSION"))
-	if dockerVersion == "" {
-		return baseEnv
-	}
-
-	env := append([]string(nil), baseEnv...)
-	return overrideEnvVar(env, "CAMUNDA_VERSION", dockerVersion)
-}
-
-func overrideEnvVar(env []string, key, value string) []string {
-	prefix := key + "="
-	for i := range env {
-		if strings.HasPrefix(env[i], prefix) {
-			env[i] = prefix + value
-			return env
-		}
-	}
-	return append(env, prefix+value)
 }
 
 type stringSliceFlag []string
@@ -178,38 +123,6 @@ func getBaseCommand() (string, error) {
 	}
 
 	return "", nil
-}
-
-func handleDockerCommand(settings types.C8RunSettings, baseCommand string, composeExtractedFolder string) error {
-	if !settings.Docker {
-		return nil
-	}
-
-	var err error
-	switch baseCommand {
-	case "start":
-		err = runDockerCommand(composeExtractedFolder, "up", "-d")
-		if err != nil {
-			return err
-		}
-		err = health.PrintStatus(settings)
-		if err == nil {
-			if markerErr := startupurl.MarkSeen(settings.StartupMarkerPath); markerErr != nil {
-				log.Warn().Err(markerErr).Str("path", settings.StartupMarkerPath).Msg("Failed to persist quickstart marker")
-			}
-		}
-	case "stop":
-		err = runDockerCommand(composeExtractedFolder, "down")
-	default:
-		err = fmt.Errorf("command invalid, only start and stop supported")
-	}
-
-	if err != nil {
-		return err
-	}
-
-	os.Exit(0)
-	return nil // This line will never be reached, but it's required to satisfy the function signature
 }
 
 const docsStartupURL = startupurl.DocsURL
@@ -263,7 +176,6 @@ func createStartFlagSet(settings *types.C8RunSettings) *flag.FlagSet {
 	startFlagSet.StringVar(&settings.Keystore, "keystore", "", "Provide a JKS filepath to enable TLS")
 	startFlagSet.StringVar(&settings.KeystorePassword, "keystorePassword", "", "Provide a password to unlock your JKS keystore")
 	startFlagSet.StringVar(&settings.LogLevel, "log-level", "", "Adjust the log level of Camunda")
-	startFlagSet.BoolVar(&settings.Docker, "docker", false, "Run Camunda from docker-compose.")
 	startFlagSet.StringVar(&settings.Username, "username", "demo", "Change the first users username (default: demo)")
 	startFlagSet.StringVar(&settings.Password, "password", "demo", "Change the first users password (default: demo)")
 	startFlagSet.StringVar(&settings.StartupUrl, "startup-url", "", "The URL to open after startup.")
@@ -276,7 +188,6 @@ func createDefaultStartupUrl(settings *types.C8RunSettings, camundaVersion strin
 
 func createStopFlagSet(settings *types.C8RunSettings) *flag.FlagSet {
 	stopFlagSet := flag.NewFlagSet("stop", flag.ExitOnError)
-	stopFlagSet.BoolVar(&settings.Docker, "docker", false, "Stop docker-compose distribution of camunda.")
 	return stopFlagSet
 }
 
@@ -288,7 +199,6 @@ func initialize(baseCommand string, baseDir string) *types.State {
 
 	camundaVersion := os.Getenv("CAMUNDA_VERSION")
 	connectorsVersion := os.Getenv("CONNECTORS_VERSION")
-	composeExtractedFolder := os.Getenv("COMPOSE_EXTRACTED_FOLDER")
 
 	connectorsPidPath := filepath.Join(baseDir, "connectors.process")
 	camundaPidPath := filepath.Join(baseDir, "camunda.process")
@@ -327,12 +237,6 @@ func initialize(baseCommand string, baseDir string) *types.State {
 	}
 
 	err = validateKeystore(settings, baseDir)
-	if err != nil {
-		fmt.Println(err.Error())
-		os.Exit(1)
-	}
-
-	err = handleDockerCommand(settings, baseCommand, composeExtractedFolder)
 	if err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)

--- a/c8run/cmd/c8run/main_test.go
+++ b/c8run/cmd/c8run/main_test.go
@@ -188,31 +188,3 @@ func TestValidatePort(t *testing.T) {
 	}
 }
 
-func TestDockerCommandEnvOverridesVersion(t *testing.T) {
-	t.Setenv("CAMUNDA_DOCKER_VERSION", "8.9-SNAPSHOT")
-	base := []string{"CAMUNDA_VERSION=8.9.0-alpha4", "FOO=bar"}
-
-	result := dockerCommandEnv(base)
-
-	assert.Contains(t, result, "CAMUNDA_VERSION=8.9-SNAPSHOT")
-	assert.Equal(t, []string{"CAMUNDA_VERSION=8.9.0-alpha4", "FOO=bar"}, base)
-}
-
-func TestDockerCommandEnvAddsVersionWhenMissing(t *testing.T) {
-	t.Setenv("CAMUNDA_DOCKER_VERSION", "8.9-SNAPSHOT")
-	base := []string{"FOO=bar"}
-
-	result := dockerCommandEnv(base)
-
-	assert.Contains(t, result, "CAMUNDA_VERSION=8.9-SNAPSHOT")
-	assert.Equal(t, []string{"FOO=bar"}, base)
-}
-
-func TestDockerCommandEnvNoOverrideWithoutDockerVersion(t *testing.T) {
-	t.Setenv("CAMUNDA_DOCKER_VERSION", "")
-	base := []string{"CAMUNDA_VERSION=8.9.0-alpha4"}
-
-	result := dockerCommandEnv(base)
-
-	assert.Equal(t, base, result)
-}

--- a/c8run/cmd/packager/main.go
+++ b/c8run/cmd/packager/main.go
@@ -70,7 +70,6 @@ func main() {
 
 	camundaVersion := os.Getenv("CAMUNDA_VERSION")
 	connectorsVersion := os.Getenv("CONNECTORS_VERSION")
-	composeTag := os.Getenv("COMPOSE_TAG")
 
 	baseCommand, err := getBaseCommand()
 	if err != nil {
@@ -84,7 +83,7 @@ func main() {
 
 	switch baseCommand {
 	case "package":
-		err := packages.New(camundaVersion, connectorsVersion, composeTag)
+		err := packages.New(camundaVersion, connectorsVersion)
 		if err != nil {
 			fmt.Printf("%+v", err)
 			os.Exit(1)

--- a/c8run/internal/health/camunda.go
+++ b/c8run/internal/health/camunda.go
@@ -116,18 +116,7 @@ func isRunning(ctx context.Context, name, url string, retries int, delay time.Du
 }
 
 func PrintStatus(settings types.C8RunSettings) error {
-	// For non-docker mode we respect the --port flag for all apps (they share the same port).
-	// In docker mode we keep the predefined mapped ports and ignore any custom --port value.
 	operatePort, tasklistPort, adminPort, camundaPort := settings.Port, settings.Port, settings.Port, settings.Port
-	if settings.Docker {
-		operatePort = 8080
-		tasklistPort = 8080
-		adminPort = 8080
-		camundaPort = 8080
-		if settings.Port != 8080 { // warn that user provided port is ignored in docker mode
-			log.Warn().Int("provided_port", settings.Port).Msg("--port flag is ignored in docker mode; using fixed container port mappings")
-		}
-	}
 
 	username := settings.Username
 	if strings.TrimSpace(username) == "" {

--- a/c8run/internal/health/camunda_test.go
+++ b/c8run/internal/health/camunda_test.go
@@ -63,7 +63,7 @@ func (s *stubOpener) OpenBrowser(_ context.Context, url string) error {
 	return nil
 }
 
-func TestShouldUsePortFlagForStatusOutputOutsideDocker(t *testing.T) {
+func TestShouldUsePortFlagForStatusOutput(t *testing.T) {
 	cwd, err := os.Getwd()
 	if err != nil {
 		t.Fatalf("failed to get wd: %v", err)
@@ -74,7 +74,7 @@ func TestShouldUsePortFlagForStatusOutputOutsideDocker(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.Chdir(cwd) })
 
-	settings := types.C8RunSettings{Port: 9090, Docker: false}
+	settings := types.C8RunSettings{Port: 9090}
 
 	out := captureOutput(t, func() {
 		if err := PrintStatus(settings); err != nil {
@@ -91,44 +91,6 @@ func TestShouldUsePortFlagForStatusOutputOutsideDocker(t *testing.T) {
 	}
 	for label, endpoint := range expectedEndpoints {
 		assertEndpointForLabel(t, out, label, endpoint)
-	}
-}
-
-func TestShouldIgnorePortFlagForStatusOutputInDockerMode(t *testing.T) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("failed to get wd: %v", err)
-	}
-	root := filepath.Clean(filepath.Join(cwd, "../.."))
-	if err := os.Chdir(root); err != nil {
-		t.Fatalf("failed to chdir to module root: %v", err)
-	}
-	t.Cleanup(func() { _ = os.Chdir(cwd) })
-
-	settings := types.C8RunSettings{Port: 9090, Docker: true}
-
-	out := captureOutput(t, func() {
-		if err := PrintStatus(settings); err != nil {
-			t.Fatalf("PrintStatus failed: %v", err)
-		}
-	})
-
-	expectedEndpoints := map[string]string{
-		"Operate":                   "http://localhost:8080/operate",
-		"Tasklist":                  "http://localhost:8080/tasklist",
-		"Admin":                     "http://localhost:8080/admin",
-		"Orchestration Cluster API": "http://localhost:8080/v2/",
-		"Orchestration Cluster":     "http://localhost:8080/mcp/cluster",
-	}
-	for label, endpoint := range expectedEndpoints {
-		assertEndpointForLabel(t, out, label, endpoint)
-	}
-	if strings.Contains(out, "http://localhost:9090/operate") ||
-		strings.Contains(out, "http://localhost:9090/tasklist") ||
-		strings.Contains(out, "http://localhost:9090/admin") ||
-		strings.Contains(out, "http://localhost:9090/v2/") ||
-		strings.Contains(out, "http://localhost:9090/mcp/cluster") {
-		t.Fatalf("docker mode should ignore custom port 9090; output: %s", out)
 	}
 }
 

--- a/c8run/internal/packages/package.go
+++ b/c8run/internal/packages/package.go
@@ -136,7 +136,7 @@ func getJavaArtifactsToken() (string, error) {
 	return "Basic " + token, nil
 }
 
-func getFilesToArchive(osType, connectorsFilePath, camundaVersion, composeExtractionPath string) []string {
+func getFilesToArchive(osType, connectorsFilePath, camundaVersion string) []string {
 	commonFiles := []string{
 		filepath.Join("c8run", "README.md"),
 		filepath.Join("c8run", "connectors-application.properties"),
@@ -148,7 +148,6 @@ func getFilesToArchive(osType, connectorsFilePath, camundaVersion, composeExtrac
 		filepath.Join("c8run", "log"),
 		filepath.Join("c8run", "camunda-zeebe-"+camundaVersion),
 		filepath.Join("c8run", ".env"),
-		filepath.Join("c8run", composeExtractionPath),
 		filepath.Join("c8run", "configuration", "application.yaml"),
 	}
 
@@ -217,7 +216,7 @@ func BuildJavaScripts() error {
 	return nil
 }
 
-func New(camundaVersion, connectorsVersion, composeTag string) error {
+func New(camundaVersion, connectorsVersion string) error {
 	osType, architecture, pkgName, finalOutputExtension, extractFunc, err := setOsSpecificValues()
 	if err != nil {
 		fmt.Printf("%+v", err)
@@ -230,13 +229,6 @@ func New(camundaVersion, connectorsVersion, composeTag string) error {
 	connectorsUrl := "https://repository.nexus.camunda.cloud/content/groups/internal/io/camunda/connector/connector-runtime-bundle/" + connectorsVersion + "/" + connectorsFilePath
 	sqlZipFilePath := "camunda-db-rdbms-schema-" + camundaVersion + ".zip"
 	sqlZipUrl := "https://repository.nexus.camunda.cloud/content/groups/internal/io/camunda/camunda-db-rdbms-schema/" + camundaVersion + "/" + "camunda-db-rdbms-schema-" + camundaVersion + ".zip"
-
-	composeUrl := "https://github.com/camunda/camunda-distributions/releases/download/docker-compose-" + composeTag + "/docker-compose-" + composeTag + ".zip"
-	composeFilePath := "docker-compose-" + composeTag + ".zip"
-	// just a file to check to see if it was already extracted
-	composeExtractionPath := "docker-compose-" + composeTag
-
-	authToken := os.Getenv("GH_TOKEN")
 
 	// build JavaVersion and JavaHome
 	err = BuildJavaScripts()
@@ -262,11 +254,6 @@ func New(camundaVersion, connectorsVersion, composeTag string) error {
 		return fmt.Errorf("Package "+osType+": failed to fetch connectors: %w\n%s", err, debug.Stack())
 	}
 
-	err = downloadAndExtract(composeFilePath, composeUrl, composeExtractionPath, composeExtractionPath, authToken, archive.UnzipSource)
-	if err != nil {
-		return fmt.Errorf("Package "+osType+": failed to fetch compose release %w\n%s", err, debug.Stack())
-	}
-
 	err = downloadAndExtract(sqlZipFilePath, sqlZipUrl, "camunda-db-rdbms-schema-"+camundaVersion, "rdbms-schema", javaArtifactsToken, archive.UnzipSource)
 	if err != nil {
 		log.Warn().Msg("Package " + osType + ": failed to download camunda-db-rdbms-schema, continuing without unpacking it")
@@ -281,7 +268,7 @@ func New(camundaVersion, connectorsVersion, composeTag string) error {
 	sourceRoot := "c8run"
 	archiveRoot := "c8run-" + camundaVersion
 
-	filesToArchive := getFilesToArchive(osType, connectorsFilePath, camundaVersion, composeExtractionPath)
+	filesToArchive := getFilesToArchive(osType, connectorsFilePath, camundaVersion)
 	outputFileName := "camunda8-run-" + camundaVersion + "-" + osType + "-" + architecture + finalOutputExtension
 	outputPath := filepath.Join(sourceRoot, outputFileName)
 

--- a/c8run/internal/types/types.go
+++ b/c8run/internal/types/types.go
@@ -24,7 +24,6 @@ type C8RunSettings struct {
 	SecondaryStorageType string
 	Username             string
 	Password             string
-	Docker               bool
 	StartupUrl           string
 	StartupMarkerPath    string
 	ExtraDrivers         []string


### PR DESCRIPTION
## Summary

The c8run build on `stable/8.9` no longer ships docker-compose files in the build/ bundle (matching what was done on `main` / 8.10 in c6fbaf41d86 / 1045963867e). This removes the now-dead code paths so the source matches what's actually shipped.

- `.env`: drop `CAMUNDA_DOCKER_VERSION`, `COMPOSE_TAG`, `COMPOSE_EXTRACTED_FOLDER`
- `c8run/cmd/c8run/main.go`: drop `runDockerCommand`, `handleDockerCommand`, `dockerCommandEnv`, `overrideEnvVar`, the `--docker` flag (start + stop), the `--docker` help-text lines, the `COMPOSE_EXTRACTED_FOLDER` lookup, and unused `os/exec` + `internal/health` imports
- `c8run/cmd/c8run/main_test.go`: drop the three `TestDockerCommandEnv*` tests
- `c8run/cmd/packager/main.go`: drop the `COMPOSE_TAG` env read; update the `packages.New` call site
- `c8run/internal/packages/package.go`: drop `composeTag` parameter on `New`, the compose URL/download, and `composeExtractionPath` from the archive contents (also drops the now-unused `GH_TOKEN` lookup)
- `c8run/internal/health/camunda.go`: drop the docker-mode port-override branch in `PrintStatus`
- `c8run/internal/health/camunda_test.go`: drop `TestShouldIgnorePortFlagForStatusOutputInDockerMode`; rename the sibling to `TestShouldUsePortFlagForStatusOutput`
- `c8run/internal/types/types.go`: drop `C8RunSettings.Docker`

Net: 8 files, +6 / -199 lines.

Deliberately **out of scope** (can ship as a follow-up if desired):
- The `GH_TOKEN` env entries in `.github/actions/setup-c8run/action.yml` and `.github/workflows/c8run-build.yaml` (now unused but harmless)
- The defensive `Clean()` cleanup main added for stale `docker-compose-*` artifacts in dev workspaces
- The `syncEnvFile` feature main added to the packager
- The README addendum noting that the Docker Compose distribution is published separately

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./...` — 51 passed across 14 packages
- [ ] CI green
- [ ] Smoke-test a `c8run start` / `c8run stop` on a packaged bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)