### PR TITLE
feat: add agent metric constants, ViewProperty entries, and groupBy DTOs

### DIFF
--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/ReportConstants.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/ReportConstants.java
@@ -19,11 +19,18 @@ public final class ReportConstants {
   public static final String VIEW_PROCESS_INSTANCE_ENTITY = "processInstance";
   public static final String VIEW_VARIABLE_ENTITY = "variable";
   public static final String VIEW_INCIDENT_ENTITY = "incident";
+  public static final String VIEW_AGENT_INSTANCE_ENTITY = "agentInstance";
 
   public static final String VIEW_FREQUENCY_PROPERTY = "frequency";
   public static final String VIEW_DURATION_PROPERTY = "duration";
   public static final String VIEW_PERCENTAGE_PROPERTY = "percentage";
   public static final String VIEW_RAW_DATA_PROPERTY = "rawData";
+  public static final String VIEW_INPUT_TOKENS_PROPERTY = "inputTokens";
+  public static final String VIEW_OUTPUT_TOKENS_PROPERTY = "outputTokens";
+  public static final String VIEW_MODEL_CALLS_PROPERTY = "modelCalls";
+  public static final String VIEW_TOOL_CALLS_PROPERTY = "toolCalls";
+  public static final String VIEW_TOTAL_TOKENS_PROPERTY = "totalTokens";
+  public static final String VIEW_AVG_TOKENS_PER_CALL_PROPERTY = "avgTokensPerCall";
 
   public static final String GROUP_BY_FLOW_NODES_TYPE = "flowNodes";
   public static final String GROUP_BY_USER_TASKS_TYPE = "userTasks";
@@ -35,6 +42,8 @@ public final class ReportConstants {
   public static final String GROUP_BY_ASSIGNEE = "assignee";
   public static final String GROUP_BY_CANDIDATE_GROUP = "candidateGroup";
   public static final String GROUP_BY_DURATION = "duration";
+  public static final String GROUP_BY_PROCESS_DEFINITION_KEY = "processDefinitionKey";
+  public static final String GROUP_BY_PROCESS_DEFINITION_VERSION = "processDefinitionVersion";
 
   public static final String GROUP_BY_EVALUATION_DATE_TYPE = "evaluationDateTime";
   public static final String GROUP_BY_INPUT_VARIABLE_TYPE = "inputVariable";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/ViewProperty.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/ViewProperty.java
@@ -7,10 +7,16 @@
  */
 package io.camunda.optimize.dto.optimize.query.report.single;
 
+import static io.camunda.optimize.dto.optimize.ReportConstants.VIEW_AVG_TOKENS_PER_CALL_PROPERTY;
 import static io.camunda.optimize.dto.optimize.ReportConstants.VIEW_DURATION_PROPERTY;
 import static io.camunda.optimize.dto.optimize.ReportConstants.VIEW_FREQUENCY_PROPERTY;
+import static io.camunda.optimize.dto.optimize.ReportConstants.VIEW_INPUT_TOKENS_PROPERTY;
+import static io.camunda.optimize.dto.optimize.ReportConstants.VIEW_MODEL_CALLS_PROPERTY;
+import static io.camunda.optimize.dto.optimize.ReportConstants.VIEW_OUTPUT_TOKENS_PROPERTY;
 import static io.camunda.optimize.dto.optimize.ReportConstants.VIEW_PERCENTAGE_PROPERTY;
 import static io.camunda.optimize.dto.optimize.ReportConstants.VIEW_RAW_DATA_PROPERTY;
+import static io.camunda.optimize.dto.optimize.ReportConstants.VIEW_TOOL_CALLS_PROPERTY;
+import static io.camunda.optimize.dto.optimize.ReportConstants.VIEW_TOTAL_TOKENS_PROPERTY;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -30,6 +36,13 @@ public class ViewProperty implements Combinable {
   public static final ViewProperty DURATION = new ViewProperty(VIEW_DURATION_PROPERTY);
   public static final ViewProperty PERCENTAGE = new ViewProperty(VIEW_PERCENTAGE_PROPERTY);
   public static final ViewProperty RAW_DATA = new ViewProperty(VIEW_RAW_DATA_PROPERTY);
+  public static final ViewProperty INPUT_TOKENS = new ViewProperty(VIEW_INPUT_TOKENS_PROPERTY);
+  public static final ViewProperty OUTPUT_TOKENS = new ViewProperty(VIEW_OUTPUT_TOKENS_PROPERTY);
+  public static final ViewProperty MODEL_CALLS = new ViewProperty(VIEW_MODEL_CALLS_PROPERTY);
+  public static final ViewProperty TOOL_CALLS = new ViewProperty(VIEW_TOOL_CALLS_PROPERTY);
+  public static final ViewProperty TOTAL_TOKENS = new ViewProperty(VIEW_TOTAL_TOKENS_PROPERTY);
+  public static final ViewProperty AVG_TOKENS_PER_CALL =
+      new ViewProperty(VIEW_AVG_TOKENS_PER_CALL_PROPERTY);
   private final TypedViewPropertyDto viewPropertyDto;
 
   @JsonCreator

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/group/ProcessDefinitionKeyGroupByDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/group/ProcessDefinitionKeyGroupByDto.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.dto.optimize.query.report.single.process.group;
+
+import io.camunda.optimize.dto.optimize.query.report.single.process.group.value.NoneGroupByValueDto;
+
+public class ProcessDefinitionKeyGroupByDto extends ProcessGroupByDto<NoneGroupByValueDto> {
+
+  public ProcessDefinitionKeyGroupByDto() {
+    this.type = ProcessGroupByType.PROCESS_DEFINITION_KEY;
+  }
+}

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/group/ProcessDefinitionVersionGroupByDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/group/ProcessDefinitionVersionGroupByDto.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.dto.optimize.query.report.single.process.group;
+
+import io.camunda.optimize.dto.optimize.query.report.single.process.group.value.NoneGroupByValueDto;
+
+public class ProcessDefinitionVersionGroupByDto extends ProcessGroupByDto<NoneGroupByValueDto> {
+
+  public ProcessDefinitionVersionGroupByDto() {
+    this.type = ProcessGroupByType.PROCESS_DEFINITION_VERSION;
+  }
+}

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/group/ProcessGroupByDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/group/ProcessGroupByDto.java
@@ -13,6 +13,8 @@ import static io.camunda.optimize.dto.optimize.ReportConstants.GROUP_BY_DURATION
 import static io.camunda.optimize.dto.optimize.ReportConstants.GROUP_BY_END_DATE_TYPE;
 import static io.camunda.optimize.dto.optimize.ReportConstants.GROUP_BY_FLOW_NODES_TYPE;
 import static io.camunda.optimize.dto.optimize.ReportConstants.GROUP_BY_NONE_TYPE;
+import static io.camunda.optimize.dto.optimize.ReportConstants.GROUP_BY_PROCESS_DEFINITION_KEY;
+import static io.camunda.optimize.dto.optimize.ReportConstants.GROUP_BY_PROCESS_DEFINITION_VERSION;
 import static io.camunda.optimize.dto.optimize.ReportConstants.GROUP_BY_RUNNING_DATE_TYPE;
 import static io.camunda.optimize.dto.optimize.ReportConstants.GROUP_BY_START_DATE_TYPE;
 import static io.camunda.optimize.dto.optimize.ReportConstants.GROUP_BY_USER_TASKS_TYPE;
@@ -45,6 +47,12 @@ import java.util.Objects;
   @JsonSubTypes.Type(value = AssigneeGroupByDto.class, name = GROUP_BY_ASSIGNEE),
   @JsonSubTypes.Type(value = CandidateGroupGroupByDto.class, name = GROUP_BY_CANDIDATE_GROUP),
   @JsonSubTypes.Type(value = DurationGroupByDto.class, name = GROUP_BY_DURATION),
+  @JsonSubTypes.Type(
+      value = ProcessDefinitionKeyGroupByDto.class,
+      name = GROUP_BY_PROCESS_DEFINITION_KEY),
+  @JsonSubTypes.Type(
+      value = ProcessDefinitionVersionGroupByDto.class,
+      name = GROUP_BY_PROCESS_DEFINITION_VERSION),
 })
 public abstract class ProcessGroupByDto<VALUE extends ProcessGroupByValueDto>
     implements Combinable {

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/group/ProcessGroupByType.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/group/ProcessGroupByType.java
@@ -13,6 +13,8 @@ import static io.camunda.optimize.dto.optimize.ReportConstants.GROUP_BY_DURATION
 import static io.camunda.optimize.dto.optimize.ReportConstants.GROUP_BY_END_DATE_TYPE;
 import static io.camunda.optimize.dto.optimize.ReportConstants.GROUP_BY_FLOW_NODES_TYPE;
 import static io.camunda.optimize.dto.optimize.ReportConstants.GROUP_BY_NONE_TYPE;
+import static io.camunda.optimize.dto.optimize.ReportConstants.GROUP_BY_PROCESS_DEFINITION_KEY;
+import static io.camunda.optimize.dto.optimize.ReportConstants.GROUP_BY_PROCESS_DEFINITION_VERSION;
 import static io.camunda.optimize.dto.optimize.ReportConstants.GROUP_BY_RUNNING_DATE_TYPE;
 import static io.camunda.optimize.dto.optimize.ReportConstants.GROUP_BY_START_DATE_TYPE;
 import static io.camunda.optimize.dto.optimize.ReportConstants.GROUP_BY_USER_TASKS_TYPE;
@@ -30,7 +32,9 @@ public enum ProcessGroupByType {
   VARIABLE(GROUP_BY_VARIABLE_TYPE),
   ASSIGNEE(GROUP_BY_ASSIGNEE),
   CANDIDATE_GROUP(GROUP_BY_CANDIDATE_GROUP),
-  DURATION(GROUP_BY_DURATION);
+  DURATION(GROUP_BY_DURATION),
+  PROCESS_DEFINITION_KEY(GROUP_BY_PROCESS_DEFINITION_KEY),
+  PROCESS_DEFINITION_VERSION(GROUP_BY_PROCESS_DEFINITION_VERSION);
 
   private final String id;
 

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/view/ProcessViewEntity.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/view/ProcessViewEntity.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.optimize.dto.optimize.query.report.single.process.view;
 
+import static io.camunda.optimize.dto.optimize.ReportConstants.VIEW_AGENT_INSTANCE_ENTITY;
 import static io.camunda.optimize.dto.optimize.ReportConstants.VIEW_FLOW_NODE_ENTITY;
 import static io.camunda.optimize.dto.optimize.ReportConstants.VIEW_INCIDENT_ENTITY;
 import static io.camunda.optimize.dto.optimize.ReportConstants.VIEW_PROCESS_INSTANCE_ENTITY;
@@ -20,7 +21,8 @@ public enum ProcessViewEntity {
   USER_TASK(VIEW_USER_TASK_ENTITY),
   PROCESS_INSTANCE(VIEW_PROCESS_INSTANCE_ENTITY),
   VARIABLE(VIEW_VARIABLE_ENTITY),
-  INCIDENT(VIEW_INCIDENT_ENTITY);
+  INCIDENT(VIEW_INCIDENT_ENTITY),
+  AGENT_INSTANCE(VIEW_AGENT_INSTANCE_ENTITY);
 
   private final String id;
 

--- a/optimize/util/optimize-commons/src/test/java/io/camunda/optimize/dto/optimize/query/report/single/process/group/ProcessGroupByDtoDeserializationTest.java
+++ b/optimize/util/optimize-commons/src/test/java/io/camunda/optimize/dto/optimize/query/report/single/process/group/ProcessGroupByDtoDeserializationTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.dto.optimize.query.report.single.process.group;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.optimize.service.util.mapper.ObjectMapperFactory;
+import org.junit.jupiter.api.Test;
+
+class ProcessGroupByDtoDeserializationTest {
+
+  private final ObjectMapper objectMapper = ObjectMapperFactory.OPTIMIZE_MAPPER;
+
+  @Test
+  void shouldRoundTripDeserializeProcessDefinitionKeyGroupBy() throws Exception {
+    // given
+    final var original = new ProcessDefinitionKeyGroupByDto();
+
+    // when
+    final String json = objectMapper.writeValueAsString(original);
+    final ProcessGroupByDto<?> result = objectMapper.readValue(json, ProcessGroupByDto.class);
+
+    // then
+    assertThat(json).contains("\"type\":\"processDefinitionKey\"");
+    assertThat(result).isInstanceOf(ProcessDefinitionKeyGroupByDto.class);
+  }
+
+  @Test
+  void shouldRoundTripDeserializeProcessDefinitionVersionGroupBy() throws Exception {
+    // given
+    final var original = new ProcessDefinitionVersionGroupByDto();
+
+    // when
+    final String json = objectMapper.writeValueAsString(original);
+    final ProcessGroupByDto<?> result = objectMapper.readValue(json, ProcessGroupByDto.class);
+
+    // then
+    assertThat(json).contains("\"type\":\"processDefinitionVersion\"");
+    assertThat(result).isInstanceOf(ProcessDefinitionVersionGroupByDto.class);
+  }
+}


### PR DESCRIPTION
- Add VIEW_AGENT_INSTANCE_ENTITY and 6 VIEW_*_PROPERTY constants to ReportConstants
- Add GROUP_BY_PROCESS_DEFINITION_KEY/VERSION constants to ReportConstants
- Add INPUT_TOKENS, OUTPUT_TOKENS, MODEL_CALLS, TOOL_CALLS, TOTAL_TOKENS, AVG_TOKENS_PER_CALL static instances to ViewProperty
- Add AGENT_INSTANCE to ProcessViewEntity enum
- Add PROCESS_DEFINITION_KEY/VERSION to ProcessGroupByType enum
- Add ProcessDefinitionKeyGroupByDto and ProcessDefinitionVersionGroupByDto
- Wire new DTOs into ProcessGroupByDto @JsonSubTypes

## Description

Adds the foundational constants and DTO classes required by the agent metric report infrastructure in Optimize. 
This is the first of the 4 tickets for task s-engine-plans.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #https://github.com/camunda/camunda/issues/54072
