### PR TITLE
chore: remove Teleport bug workaround from load tests automation

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -203,14 +203,6 @@ env:
   # Namespaces MUST start with c8 due to access policy
   NAMESPACE: ${{ startsWith(inputs.name, 'c8-') && inputs.name || format('c8-{0}', inputs.name) }}
   IMAGE_REPOSITORY: registry.camunda.cloud/team-zeebe
-  # Workaround to prevent the Kubernetes client SDK from failing while
-  # https://github.com/gravitational/teleport/issues/64188 is opened.
-  # See https://app.incident.io/camunda/incidents/5624 for more details.
-  # This needs to be applied to all the subcommands run in this workflow.
-  # Consider removing this once
-  # https://github.com/gravitational/teleport/issues/64188 has been fixed and
-  # deployed.
-  KUBE_FEATURE_WatchListClient: "false"
 
 defaults:
   run:

--- a/.github/workflows/camunda-verify-and-cleanup-load-test.yml
+++ b/.github/workflows/camunda-verify-and-cleanup-load-test.yml
@@ -15,14 +15,6 @@ on:
 env:
   CLUSTER: camunda-benchmark-prod
   TELEPORT_JOIN_TOKEN: infra-benchmark-prod-github-action-zeebe
-  # Workaround to prevent the Kubernetes client SDK from failing while
-  # https://github.com/gravitational/teleport/issues/64188 is opened.
-  # See https://app.incident.io/camunda/incidents/5624 for more details.
-  # This needs to be applied to all the subcommands run in this workflow.
-  # Consider removing this once
-  # https://github.com/gravitational/teleport/issues/64188 has been fixed and
-  # deployed.
-  KUBE_FEATURE_WatchListClient: "false"
 
 jobs:
   verify:

--- a/load-tests/setup/default/Makefile
+++ b/load-tests/setup/default/Makefile
@@ -1,11 +1,3 @@
-# Workaround to prevent the Kubernetes client SDK from failing while
-# https://github.com/gravitational/teleport/issues/64188 is opened.
-# See https://app.incident.io/camunda/incidents/5624 for more details.
-# Consider removing this once
-# https://github.com/gravitational/teleport/issues/64188 has been fixed and
-# deployed.
-export KUBE_FEATURE_WatchListClient = false
-
 namespace ?= __NAMESPACE__
 secondary_storage ?= __STORAGE_TYPE__
 helm_chart ?= camunda-platform-8.10


### PR DESCRIPTION
## Description

The original Teleport issue from https://github.com/gravitational/teleport/issues/64188 has been fixed, released and [deployed by the Infra team](https://github.com/camunda/infra-core/pull/12909). We don't need the workaround anymore.

Fix: #53604

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

* #53604
* https://github.com/gravitational/teleport/issues/64188
* https://github.com/camunda/camunda/pull/53523
* https://github.com/camunda/team-infrastructure/issues/1067