### PR TITLE
refactor: adopt Option B naming convention for OTel attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,4 @@ scripts/codeowners-utils/output/
 
 # playwright test output
 **/test-results
+.claude/settings.local.json

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsAttributes.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsAttributes.java
@@ -27,28 +27,30 @@ public final class AnalyticsAttributes {
   // OTel semantic convention for events (until Event API is stable)
   public static final AttributeKey<String> EVENT_NAME = AttributeKey.stringKey("event.name");
 
-  // Common
+  // Log domain
   public static final AttributeKey<Long> LOG_POSITION =
       AttributeKey.longKey("camunda.log.position");
-  public static final AttributeKey<Long> SEQUENCE_NUMBER =
-      AttributeKey.longKey("camunda.sequence_number");
-  public static final AttributeKey<String> TENANT_ID = AttributeKey.stringKey("camunda.tenant_id");
+  public static final AttributeKey<Long> LOG_SEQUENCE_NUMBER =
+      AttributeKey.longKey("camunda.log.sequence_number");
 
-  // Process instance
+  // Tenant domain
+  public static final AttributeKey<String> TENANT_ID = AttributeKey.stringKey("camunda.tenant.id");
+
+  // Process domain
   public static final AttributeKey<String> BPMN_PROCESS_ID =
-      AttributeKey.stringKey("camunda.bpmn_process_id");
+      AttributeKey.stringKey("camunda.process.id");
   public static final AttributeKey<Long> PROCESS_VERSION =
-      AttributeKey.longKey("camunda.process_version");
+      AttributeKey.longKey("camunda.process.version");
   public static final AttributeKey<Long> PROCESS_DEFINITION_KEY =
-      AttributeKey.longKey("camunda.process_definition_key");
+      AttributeKey.longKey("camunda.process.definition_key");
   public static final AttributeKey<Long> PROCESS_INSTANCE_KEY =
-      AttributeKey.longKey("camunda.process_instance_key");
+      AttributeKey.longKey("camunda.process.instance_key");
   public static final AttributeKey<Long> ROOT_PROCESS_INSTANCE_KEY =
-      AttributeKey.longKey("camunda.root_process_instance_key");
+      AttributeKey.longKey("camunda.process.root_instance_key");
 
-  // Adhoc subprocess
+  // Element domain
   public static final AttributeKey<String> ELEMENT_ID =
-      AttributeKey.stringKey("camunda.element_id");
+      AttributeKey.stringKey("camunda.element.id");
 
   // Event names
   public static final String EVENT_PROCESS_INSTANCE_CREATED = "process_instance_created";

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/OtelSdkManager.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/OtelSdkManager.java
@@ -10,8 +10,8 @@ package io.camunda.exporter.analytics;
 import static io.camunda.exporter.analytics.AnalyticsAttributes.CLUSTER_ID;
 import static io.camunda.exporter.analytics.AnalyticsAttributes.EVENT_NAME;
 import static io.camunda.exporter.analytics.AnalyticsAttributes.LOG_POSITION;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.LOG_SEQUENCE_NUMBER;
 import static io.camunda.exporter.analytics.AnalyticsAttributes.PARTITION_ID;
-import static io.camunda.exporter.analytics.AnalyticsAttributes.SEQUENCE_NUMBER;
 import static io.camunda.exporter.analytics.AnalyticsAttributes.SERVICE_NAME;
 
 import io.opentelemetry.api.logs.LogRecordBuilder;
@@ -60,7 +60,7 @@ public class OtelSdkManager {
             .setSeverityText("INFO")
             .setAttribute(EVENT_NAME, eventName)
             .setAttribute(LOG_POSITION, logPosition)
-            .setAttribute(SEQUENCE_NUMBER, metadata.incrementAndGetRawEventSequenceNumber());
+            .setAttribute(LOG_SEQUENCE_NUMBER, metadata.incrementAndGetRawEventSequenceNumber());
     builder.accept(record);
     record.emit();
   }

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterOtelIT.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterOtelIT.java
@@ -68,9 +68,9 @@ class AnalyticsExporterOtelIT {
     // then
     awaitCollectorLogs(
         EVENT_PROCESS_INSTANCE_CREATED,
-        "camunda.cluster.id",
+        AnalyticsAttributes.CLUSTER_ID.getKey(),
         "test-cluster",
-        "camunda.bpmn_process_id");
+        AnalyticsAttributes.BPMN_PROCESS_ID.getKey());
   }
 
   /**

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterTest.java
@@ -100,7 +100,7 @@ class AnalyticsExporterTest {
                   //                      value.getRootProcessInstanceKey())
                   .containsEntry(AnalyticsAttributes.TENANT_ID, value.getTenantId())
                   .containsEntry(AnalyticsAttributes.LOG_POSITION, record.getPosition())
-                  .containsEntry(AnalyticsAttributes.SEQUENCE_NUMBER, 1L);
+                  .containsEntry(AnalyticsAttributes.LOG_SEQUENCE_NUMBER, 1L);
             });
   }
 
@@ -209,7 +209,7 @@ class AnalyticsExporterTest {
     // then
     assertThat(freshMemoryExporter.getFinishedLogRecordItems())
         .singleElement()
-        .extracting(log -> log.getAttributes().get(AnalyticsAttributes.SEQUENCE_NUMBER))
+        .extracting(log -> log.getAttributes().get(AnalyticsAttributes.LOG_SEQUENCE_NUMBER))
         .isEqualTo(6L);
   }
 

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/OtelSdkManagerTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/OtelSdkManagerTest.java
@@ -213,11 +213,11 @@ class OtelSdkManagerTest {
 
     // then
     assertThat(received).hasSize(3);
-    assertThat(received.get(0).getAttributes().get(AnalyticsAttributes.SEQUENCE_NUMBER))
+    assertThat(received.get(0).getAttributes().get(AnalyticsAttributes.LOG_SEQUENCE_NUMBER))
         .isEqualTo(1L);
-    assertThat(received.get(1).getAttributes().get(AnalyticsAttributes.SEQUENCE_NUMBER))
+    assertThat(received.get(1).getAttributes().get(AnalyticsAttributes.LOG_SEQUENCE_NUMBER))
         .isEqualTo(2L);
-    assertThat(received.get(2).getAttributes().get(AnalyticsAttributes.SEQUENCE_NUMBER))
+    assertThat(received.get(2).getAttributes().get(AnalyticsAttributes.LOG_SEQUENCE_NUMBER))
         .isEqualTo(3L);
   }
 
@@ -249,7 +249,7 @@ class OtelSdkManagerTest {
     // then — sequence continues from 5, so first event gets 6
     assertThat(received)
         .singleElement()
-        .extracting(log -> log.getAttributes().get(AnalyticsAttributes.SEQUENCE_NUMBER))
+        .extracting(log -> log.getAttributes().get(AnalyticsAttributes.LOG_SEQUENCE_NUMBER))
         .isEqualTo(6L);
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/exporter/AnalyticsExporterIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/exporter/AnalyticsExporterIT.java
@@ -115,8 +115,7 @@ final class AnalyticsExporterIT {
 
               // bpmn process id matches the deployed process
               assertThat(COLLECTOR_LOGS)
-                  .anyMatch(
-                      line -> line.contains("camunda.bpmn_process_id: Str(" + PROCESS_ID + ")"));
+                  .anyMatch(line -> line.contains("camunda.process.id: Str(" + PROCESS_ID + ")"));
 
               // resource attributes
               assertThat(COLLECTOR_LOGS)


### PR DESCRIPTION
## Summary

Establishes a consistent OTel attribute naming convention (Option B — domain entity namespaces) as discussed in #53815.

**Rule:** Dots separate domain entities (namespaces). Snake_case for multi-word attribute names within a namespace. Known domains: `process`, `element`, `tenant`, `log`, `usage_metric`, `cluster`, `partition`.

### Renames

| Old | New |
|---|---|
| `camunda.tenant_id` | `camunda.tenant.id` |
| `camunda.bpmn_process_id` | `camunda.process.id` |
| `camunda.process_version` | `camunda.process.version` |
| `camunda.process_definition_key` | `camunda.process.definition_key` |
| `camunda.process_instance_key` | `camunda.process.instance_key` |
| `camunda.root_process_instance_key` | `camunda.process.root_instance_key` |
| `camunda.element_id` | `camunda.element.id` |
| `camunda.sequence_number` | `camunda.log.sequence_number` |

**Unchanged** (already correct): `camunda.cluster.id`, `camunda.partition.id`, `camunda.log.position`, all `camunda.usage_metric.*`, `event.name`, `service.name`.

Closes #53815

## Test plan

- [x] All attribute key strings updated in `AnalyticsAttributes.java`
- [x] Hardcoded strings in IT replaced with `.getKey()` constants
- [x] Java constant `SEQUENCE_NUMBER` renamed to `LOG_SEQUENCE_NUMBER`
- [x] `bpmn.process_id` → `process.id` per review feedback (all process attrs under `camunda.process.*`)
- [x] Compiles cleanly
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)