### PR TITLE
ci: add skip_slack_notification input to release E2E workflow

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
@@ -11,6 +11,11 @@ on:
         description: "Enter the monorepo release version (e.g., 8.8.0, 8.8.1, 8.8.0-alpha8, 8.8.0-alpha8-rc1)"
         required: true
         type: string
+      skip_slack_notification:
+        description: "Skip sending the Slack notification after tests complete"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -1073,6 +1078,7 @@ jobs:
             secret/data/products/camunda/ci/github-actions SLACK_TOPMONOREPORELEASE_WEBHOOK_URL;
 
       - name: Send Slack notification
+        if: ${{ !inputs.skip_slack_notification }}
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
           webhook: ${{ steps.secrets.outputs.SLACK_TOPMONOREPORELEASE_WEBHOOK_URL }}


### PR DESCRIPTION
## Summary

- Adds a `skip_slack_notification` boolean input (default: `false`) to the `workflow_dispatch` trigger of `c8-orchestration-cluster-e2e-tests-release.yml`
- Gates the **Send Slack notification** step with `if: ${{ !inputs.skip_slack_notification }}` so it is skipped when the flag is set

## Why

Useful when re-running the workflow manually during debugging or release validation, where spamming the release Slack channel is undesirable.

## Test plan

- [ ] Trigger the workflow with `skip_slack_notification: true` and confirm no Slack message is sent
- [ ] Trigger with default (`false`) and confirm Slack message is sent as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)