### PR TITLE
feat: topology recovery flag

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterIdInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterIdInitializer.java
@@ -47,14 +47,10 @@ public class ClusterIdInitializer implements ClusterConfigurationModifier {
     }
 
     final var withClusterId =
-        new ClusterConfiguration(
-            configuration.version(),
-            configuration.members(),
-            configuration.lastChange(),
-            configuration.pendingChanges(),
-            configuration.routingState(),
-            Optional.of(clusterId),
-            configuration.incarnationNumber());
+        ClusterConfiguration.builder()
+            .from(configuration)
+            .clusterId(Optional.of(clusterId))
+            .build();
     return CompletableActorFuture.completed(withClusterId);
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/RoutingStateInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/RoutingStateInitializer.java
@@ -11,7 +11,6 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
-import java.util.Optional;
 
 /**
  * Initializes the routing state of the cluster configuration if the partition scaling feature is
@@ -33,15 +32,7 @@ public class RoutingStateInitializer implements ClusterConfigurationModifier {
     }
 
     final var routingState = RoutingState.initializeWithPartitionCount(staticPartitionCount);
-    final var withRoutingState =
-        new ClusterConfiguration(
-            configuration.version(),
-            configuration.members(),
-            configuration.lastChange(),
-            configuration.pendingChanges(),
-            Optional.of(routingState),
-            configuration.clusterId(),
-            configuration.incarnationNumber());
+    final var withRoutingState = configuration.setRoutingState(routingState);
     return CompletableActorFuture.completed(withRoutingState);
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/AwaitRedistributionCompletionApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/AwaitRedistributionCompletionApplier.java
@@ -17,7 +17,6 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.util.Either;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.UnaryOperator;
 
 public class AwaitRedistributionCompletionApplier implements ClusterOperationApplier {
@@ -78,14 +77,7 @@ public class AwaitRedistributionCompletionApplier implements ClusterOperationApp
             .routingState()
             .map(state -> state.withRequestHandling(this::updateRequestHandling))
             .orElseThrow(() -> new IllegalStateException("Missing routingState"));
-    return new ClusterConfiguration(
-        config.version(),
-        config.members(),
-        config.lastChange(),
-        config.pendingChanges(),
-        Optional.of(routingState),
-        config.clusterId(),
-        config.incarnationNumber());
+    return config.setRoutingState(routingState);
   }
 
   private RequestHandling updateRequestHandling(final RequestHandling requestHandling) {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/StartPartitionScaleUpApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/StartPartitionScaleUpApplier.java
@@ -108,15 +108,11 @@ final class StartPartitionScaleUpApplier implements ClusterOperationApplier {
                 result.completeExceptionally(error);
               } else {
                 result.complete(
-                    config ->
-                        new ClusterConfiguration(
-                            config.version(),
-                            config.members(),
-                            config.lastChange(),
-                            config.pendingChanges(),
-                            config.routingState().map(this::updateRoutingState),
-                            config.clusterId(),
-                            config.incarnationNumber()));
+                    config -> {
+                      final var updatedRoutingState =
+                          config.routingState().map(this::updateRoutingState);
+                      return updatedRoutingState.map(config::setRoutingState).orElse(config);
+                    });
               }
             });
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -164,6 +164,7 @@ public class ProtoBufSerializer
             : Optional.of(encodedClusterTopology.getClusterId());
 
     final long incarnationNumber = encodedClusterTopology.getIncarnationNumber();
+    final boolean recovery = encodedClusterTopology.getRecovery();
 
     return new ClusterConfiguration(
         encodedClusterTopology.getVersion(),
@@ -172,7 +173,8 @@ public class ProtoBufSerializer
         currentChange,
         routingState,
         clusterId,
-        incarnationNumber);
+        incarnationNumber,
+        recovery);
   }
 
   private Map<MemberId, io.camunda.zeebe.dynamic.config.state.MemberState> decodeMemberStateMap(
@@ -189,7 +191,9 @@ public class ProtoBufSerializer
     final var builder =
         Topology.ClusterTopology.newBuilder()
             .setVersion(clusterConfiguration.version())
-            .putAllMembers(members);
+            .putAllMembers(members)
+            .setIncarnationNumber(clusterConfiguration.incarnationNumber())
+            .setRecovery(clusterConfiguration.recovery());
 
     clusterConfiguration
         .lastChange()
@@ -200,8 +204,7 @@ public class ProtoBufSerializer
     clusterConfiguration
         .routingState()
         .ifPresent(routingState -> builder.setRoutingState(encodeRoutingState(routingState)));
-    clusterConfiguration.clusterId().ifPresent(clusterId -> builder.setClusterId(clusterId));
-    builder.setIncarnationNumber(clusterConfiguration.incarnationNumber());
+    clusterConfiguration.clusterId().ifPresent(builder::setClusterId);
 
     return builder.build();
   }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfiguration.java
@@ -35,6 +35,7 @@ import java.util.stream.Stream;
  * @param incarnationNumber - represents the incarnation number of the cluster configuration
  *     <p>This class is immutable. Each mutable methods returns a new instance with the updated
  *     state.
+ * @param recovery - indicates whether the cluster is in recovery mode
  */
 public record ClusterConfiguration(
     long version,

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfiguration.java
@@ -43,7 +43,8 @@ public record ClusterConfiguration(
     Optional<ClusterChangePlan> pendingChanges,
     Optional<RoutingState> routingState,
     Optional<String> clusterId,
-    long incarnationNumber) {
+    long incarnationNumber,
+    boolean recovery) {
 
   public static final int INITIAL_VERSION = 1;
   public static final long INITIAL_INCARNATION_NUMBER = 0;
@@ -57,7 +58,8 @@ public record ClusterConfiguration(
       final Optional<ClusterChangePlan> pendingChanges,
       final Optional<RoutingState> routingState,
       final Optional<String> clusterId,
-      final long incarnationNumber) {
+      final long incarnationNumber,
+      final boolean recovery) {
     this(
         version,
         ImmutableSortedMap.copyOf(members),
@@ -65,7 +67,8 @@ public record ClusterConfiguration(
         pendingChanges,
         routingState,
         clusterId,
-        incarnationNumber);
+        incarnationNumber,
+        recovery);
   }
 
   public ClusterConfiguration {
@@ -92,7 +95,8 @@ public record ClusterConfiguration(
         Optional.empty(),
         Optional.empty(),
         Optional.empty(),
-        INITIAL_INCARNATION_NUMBER);
+        INITIAL_INCARNATION_NUMBER,
+        false);
   }
 
   public boolean isUninitialized() {
@@ -107,7 +111,8 @@ public record ClusterConfiguration(
         Optional.empty(),
         Optional.empty(),
         Optional.empty(),
-        INITIAL_INCARNATION_NUMBER);
+        INITIAL_INCARNATION_NUMBER,
+        false);
   }
 
   public ClusterConfiguration addMember(final MemberId memberId, final MemberState state) {
@@ -127,7 +132,8 @@ public record ClusterConfiguration(
         pendingChanges,
         routingState,
         clusterId,
-        incarnationNumber);
+        incarnationNumber,
+        recovery);
   }
 
   public ClusterConfiguration setRoutingState(final RoutingState updatedRoutingState) {
@@ -138,7 +144,8 @@ public record ClusterConfiguration(
         pendingChanges,
         Optional.of(updatedRoutingState),
         clusterId,
-        incarnationNumber);
+        incarnationNumber,
+        recovery);
   }
 
   /**
@@ -183,7 +190,8 @@ public record ClusterConfiguration(
         pendingChanges,
         routingState,
         clusterId,
-        incarnationNumber);
+        incarnationNumber,
+        recovery);
   }
 
   public ClusterConfiguration startConfigurationChange(
@@ -204,7 +212,8 @@ public record ClusterConfiguration(
           Optional.of(ClusterChangePlan.init(newVersion, operations)),
           routingState,
           clusterId,
-          incarnationNumber);
+          incarnationNumber,
+          recovery);
     }
   }
 
@@ -243,7 +252,8 @@ public record ClusterConfiguration(
           mergedChanges,
           mergedRoutingState,
           clusterId,
-          Math.max(incarnationNumber, other.incarnationNumber()));
+          Math.max(incarnationNumber, other.incarnationNumber()),
+          recovery || other.recovery());
     }
   }
 
@@ -312,7 +322,8 @@ public record ClusterConfiguration(
             Optional.of(pendingChanges.orElseThrow().advance()),
             routingState,
             clusterId,
-            incarnationNumber);
+            incarnationNumber,
+            recovery);
 
     if (!result.hasPendingChanges()) {
       // The last change has been applied. Clean up the members that are marked as LEFT in the
@@ -337,7 +348,8 @@ public record ClusterConfiguration(
           Optional.empty(),
           routingState,
           clusterId,
-          incarnationNumber);
+          incarnationNumber,
+          recovery);
     }
 
     return result;
@@ -440,7 +452,8 @@ public record ClusterConfiguration(
           Optional.empty(),
           routingState,
           clusterId,
-          incarnationNumber);
+          incarnationNumber,
+          recovery);
     } else {
       return this;
     }
@@ -460,6 +473,7 @@ public record ClusterConfiguration(
     private Optional<RoutingState> routingState = Optional.empty();
     private Optional<String> clusterId = Optional.empty();
     private long incarnationNumber = INITIAL_INCARNATION_NUMBER;
+    private boolean recovery = false;
 
     /**
      * Copies all properties from the given ClusterConfiguration.
@@ -475,6 +489,7 @@ public record ClusterConfiguration(
       routingState = config.routingState;
       clusterId = config.clusterId;
       incarnationNumber = config.incarnationNumber;
+      recovery = config.recovery;
       return this;
     }
 
@@ -556,13 +571,31 @@ public record ClusterConfiguration(
     }
 
     /**
+     * Set recovery mode
+     *
+     * @param recovery whether recovery mode is enabled
+     * @return this builder
+     */
+    public Builder recovery(final boolean recovery) {
+      this.recovery = recovery;
+      return this;
+    }
+
+    /**
      * Builds and returns a new ClusterConfiguration instance.
      *
      * @return the new ClusterConfiguration
      */
     public ClusterConfiguration build() {
       return new ClusterConfiguration(
-          version, members, lastChange, pendingChanges, routingState, clusterId, incarnationNumber);
+          version,
+          members,
+          lastChange,
+          pendingChanges,
+          routingState,
+          clusterId,
+          incarnationNumber,
+          recovery);
     }
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtil.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtil.java
@@ -50,14 +50,13 @@ public final class ConfigurationUtil {
     final var routingState =
         Optional.of(RoutingState.initializeWithPartitionCount(partitionDistribution.size()));
 
-    return new ClusterConfiguration(
-        ClusterConfiguration.INITIAL_VERSION,
-        Map.copyOf(memberStates),
-        Optional.empty(),
-        Optional.empty(),
-        routingState,
-        Optional.ofNullable(clusterId),
-        ClusterConfiguration.INITIAL_INCARNATION_NUMBER);
+    return ClusterConfiguration.builder()
+        .version(ClusterConfiguration.INITIAL_VERSION)
+        .members(Map.copyOf(memberStates))
+        .routingState(routingState)
+        .clusterId(Optional.ofNullable(clusterId))
+        .incarnationNumber(ClusterConfiguration.INITIAL_INCARNATION_NUMBER)
+        .build();
   }
 
   public static Set<PartitionMetadata> getPartitionDistributionFrom(

--- a/zeebe/dynamic-config/src/main/resources/proto/topology.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/topology.proto
@@ -15,6 +15,7 @@ message ClusterTopology {
   RoutingState routingState = 5;
   string clusterId = 6;
   int64 incarnationNumber = 7;
+  bool recovery = 8;
 }
 
 message RoutingState {

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationModifierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationModifierTest.java
@@ -426,16 +426,13 @@ final class ClusterConfigurationModifierTest {
 
     private static ClusterConfiguration withRestorePendingChange(
         final ClusterConfiguration base, final MemberId coordinatorId) {
-      return new ClusterConfiguration(
-          base.version(),
-          base.members(),
-          base.lastChange(),
-          Optional.of(
-              ClusterChangePlan.initForRestore(
-                  List.of(new UpdateRoutingState(coordinatorId, Optional.empty())))),
-          base.routingState(),
-          base.clusterId(),
-          base.incarnationNumber());
+      final var pendingChanges =
+          ClusterChangePlan.initForRestore(
+              List.of(new UpdateRoutingState(coordinatorId, Optional.empty())));
+      return ClusterConfiguration.builder()
+          .from(base)
+          .pendingChanges(Optional.of(pendingChanges))
+          .build();
     }
 
     private static ClusterConfiguration withTwoMembers(

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationTest.java
@@ -424,6 +424,29 @@ class ClusterConfigurationTest {
     assertThat(initialConfig.incarnationNumber()).isZero();
   }
 
+  @Test
+  void shouldMergeRecoveryMode() {
+    // given
+    final var oldConfig = ClusterConfiguration.builder().recovery(false).build();
+
+    final var newConfig = ClusterConfiguration.builder().recovery(true).build();
+
+    // when
+    final var merged = oldConfig.merge(newConfig);
+
+    // then
+    assertThat(merged.recovery()).isTrue();
+  }
+
+  @Test
+  void initialRecoveryModeIsDisabled() {
+    // given
+    final var initialConfig = ClusterConfiguration.init();
+
+    // then
+    assertThat(initialConfig.recovery()).isFalse();
+  }
+
   private MemberId member(final int id) {
     return MemberId.from(Integer.toString(id));
   }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ClusterTopologyDomain.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ClusterTopologyDomain.java
@@ -58,6 +58,7 @@ public final class ClusterTopologyDomain extends DomainContextBase {
     final var arbitraryRoutingState = routingStates().optional();
     final var arbitraryClusterId = Arbitraries.strings().ofMinLength(1).ofMaxLength(50).optional();
     final var arbitraryIncarnationNumber = Arbitraries.longs().greaterOrEqual(0);
+    final var arbitraryRecovery = Arbitraries.of(true, false);
     return Combinators.combine(
             arbitraryVersion,
             arbitraryMembers,
@@ -65,7 +66,8 @@ public final class ClusterTopologyDomain extends DomainContextBase {
             arbitraryChangePlan,
             arbitraryRoutingState,
             arbitraryClusterId,
-            arbitraryIncarnationNumber)
+            arbitraryIncarnationNumber,
+            arbitraryRecovery)
         .as(ClusterConfiguration::new);
   }
 

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
@@ -277,17 +277,11 @@ public class RestoreManager implements CloseableSilently {
     final var initializer = new StaticInitializer(staticConfiguration);
     // it's ok to block, it's not really async
     final var base = initializer.initialize().get();
+    final var changePlan =
+        ClusterChangePlan.initForRestore(
+            List.of(new UpdateRoutingState(coordinatorId, Optional.empty())));
     final var configuration =
-        new ClusterConfiguration(
-            base.version(),
-            base.members(),
-            base.lastChange(),
-            Optional.of(
-                ClusterChangePlan.initForRestore(
-                    List.of(new UpdateRoutingState(coordinatorId, Optional.empty())))),
-            base.routingState(),
-            base.clusterId(),
-            base.incarnationNumber());
+        ClusterConfiguration.builder().from(base).pendingChanges(Optional.of(changePlan)).build();
     final var persistedConfiguration =
         PersistedClusterConfiguration.ofFile(file, new ProtoBufSerializer());
     persistedConfiguration.update(configuration);


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Introduce a `recovery` property in the ClusterConfiguration to indicate that a broker/tenant has transitioned to a constrained state witt limited functionallity.

The `recovery` mode will serve as the baseline state for the in-process restore.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #54096
