### PR TITLE
fix: extract and use ordinals for batch operation items

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -100,6 +100,7 @@ import io.camunda.exporter.store.IndexLocatorProvider;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
+import io.camunda.webapps.schema.descriptors.ProcessInstanceDependant;
 import io.camunda.webapps.schema.descriptors.index.AuditLogCleanupIndex;
 import io.camunda.webapps.schema.descriptors.index.AuthorizationIndex;
 import io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex;
@@ -144,6 +145,7 @@ import io.camunda.zeebe.util.VisibleForTesting;
 import io.camunda.zeebe.util.cache.CaffeineCacheStatsCounter;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
@@ -423,7 +425,27 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
             indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName(),
             ErrorHandlers.IGNORE_DOCUMENT_DOES_NOT_EXIST);
 
-    indexLocatorProvider = new FakeOrdinalIndexLocatorProvider();
+    final Set<String> ordinalBasedIndexes = new HashSet<>();
+    final var listViewName = indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName();
+    ordinalBasedIndexes.add(listViewName);
+
+    // TODO tmp exempt batch operation items from ordinal indexes - we will need to update
+    // BatchOperationUpdateTask and HistoryDeletionJob to handle ordinal suffixes if we want to use
+    // ordinal indexes for operations
+    final var operationIndexName =
+        indexDescriptors.get(OperationTemplate.class).getFullQualifiedName();
+    final var nonOrdinalIndexes = Set.of(operationIndexName);
+    for (final var indexDescriptor : indexDescriptors.templates()) {
+      final var indexName = indexDescriptor.getFullQualifiedName();
+      if (nonOrdinalIndexes.contains(indexName)) {
+        continue;
+      }
+      if (indexDescriptor instanceof ProcessInstanceDependant) {
+        ordinalBasedIndexes.add(indexName);
+      }
+    }
+
+    indexLocatorProvider = new FakeOrdinalIndexLocatorProvider(ordinalBasedIndexes);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedHandler.java
@@ -61,11 +61,7 @@ public class BatchOperationChunkCreatedHandler
 
   @Override
   public List<String> generateIds(final Record<BatchOperationChunkRecordValue> record) {
-    // Use a composite ID with a static suffix (batchOperationKey:chunk) so that all chunks for the
-    // same batch operation share a single cached entity in the ExporterBatchWriter, while still
-    // being separate from BatchOperationCreatedHandler (which uses just the batchOperationKey).
-    // This avoids double-counting of operationsTotalCount without inflating the batch size.
-    return List.of(record.getValue().getBatchOperationKey() + ":chunk");
+    return List.of(generateId(record.getValue()));
   }
 
   @Override
@@ -104,5 +100,13 @@ public class BatchOperationChunkCreatedHandler
   @Override
   public String getIndexName() {
     return indexName;
+  }
+
+  public static String generateId(final BatchOperationChunkRecordValue chunk) {
+    // Use a composite ID with a static suffix (batchOperationKey:chunk) so that all chunks for the
+    // same batch operation share a single cached entity in the ExporterBatchWriter, while still
+    // being separate from BatchOperationCreatedHandler (which uses just the batchOperationKey).
+    // This avoids double-counting of operationsTotalCount without inflating the batch size.
+    return chunk.getBatchOperationKey() + ":chunk";
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/FakeOrdinalIndexLocatorProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/FakeOrdinalIndexLocatorProvider.java
@@ -8,17 +8,24 @@
 package io.camunda.exporter.store;
 
 import com.google.common.base.Strings;
+import io.camunda.exporter.handlers.batchoperation.BatchOperationChunkCreatedHandler;
+import io.camunda.exporter.handlers.batchoperation.BatchOperationChunkCreatedItemHandler;
+import io.camunda.exporter.handlers.batchoperation.listview.ListViewFromChunkItemHandler;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.value.AuditLogProcessInstanceRelated;
+import io.camunda.zeebe.protocol.record.value.BatchOperationChunkRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationChunkRecordValue.BatchOperationItemValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationRelated;
 import io.camunda.zeebe.protocol.record.value.OrdinalKeyBased;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRelated;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,7 +41,15 @@ public class FakeOrdinalIndexLocatorProvider implements IndexLocatorProvider {
 
   @Override
   public IndexLocator createIndexLocator(final Record<?> record) {
-    if (record.getValue() instanceof final OrdinalKeyBased ordinalKeyBased) {
+    if (record.getValue() instanceof final BatchOperationChunkRecordValue chunks) {
+      final var ordinalsByKey = extractOrdinalsByKey(chunks);
+      final var suffixesByKey =
+          ordinalsByKey.entrySet().stream()
+              .collect(
+                  Collectors.toMap(
+                      Map.Entry::getKey, e -> getOrCreateOrdinalSuffix("ord", e.getValue())));
+      return new MultiSuffixOrdinalIndexLocator(suffixesByKey);
+    } else if (record.getValue() instanceof final OrdinalKeyBased ordinalKeyBased) {
       final var suffix = getOrCreateOrdinalSuffix("ord", ordinalKeyBased.getOrdinalKey());
       return new SingleSuffixOrdinalIndexLocator(suffix);
     }
@@ -55,6 +70,23 @@ public class FakeOrdinalIndexLocatorProvider implements IndexLocatorProvider {
         record.getValueType());
 
     return noopIndexLocator;
+  }
+
+  private Map<String, Integer> extractOrdinalsByKey(final BatchOperationChunkRecordValue chunks) {
+    // TODO this is not a great approach. In the future we will want to handlers to deal with this
+    // themselves.
+    final Map<String, Integer> idsToPIs = new HashMap<>();
+    idsToPIs.put(String.valueOf(chunks.getBatchOperationKey()), chunks.getOrdinalKey());
+    idsToPIs.put(BatchOperationChunkCreatedHandler.generateId(chunks), chunks.getOrdinalKey());
+    for (final var item : chunks.getItems()) {
+      final var ordinal = item.getOrdinalKey();
+      idsToPIs.put(
+          BatchOperationChunkCreatedItemHandler.generateId(
+              chunks.getBatchOperationKey(), item.getItemKey()),
+          ordinal);
+      idsToPIs.put(ListViewFromChunkItemHandler.generateId(chunks, item), ordinal);
+    }
+    return idsToPIs;
   }
 
   private long getOrdinalBaseKey(final RecordValue recordValue) {
@@ -107,6 +139,19 @@ public class FakeOrdinalIndexLocatorProvider implements IndexLocatorProvider {
     @Override
     public String getIndexLocation(final ExporterEntity<?> entity, final String baseIndexName) {
       return baseIndexName + suffix;
+    }
+  }
+
+  static class MultiSuffixOrdinalIndexLocator implements IndexLocator {
+    private final Map<String, String> suffixesById;
+
+    public MultiSuffixOrdinalIndexLocator(final Map<String, String> suffixesById) {
+      this.suffixesById = suffixesById;
+    }
+
+    @Override
+    public String getIndexLocation(final ExporterEntity<?> entity, final String baseIndexName) {
+      return baseIndexName + Objects.requireNonNull(suffixesById.get(entity.getId()));
     }
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/FakeOrdinalIndexLocatorProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/FakeOrdinalIndexLocatorProvider.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.protocol.record.value.ProcessInstanceRelated;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -36,8 +37,13 @@ public class FakeOrdinalIndexLocatorProvider implements IndexLocatorProvider {
   // aim for roughly 1 hours worth at 300 PI/s (across 3 partitions)
   private static final long IDS_PER_ORDINAL =
       100 * 60 * 60 * APPROX_IDS_BETWEEN_ROOT_PROCESS_INSTANCES;
+  private final Set<String> ordinalBasedIndexes;
   private final NoopIndexLocator noopIndexLocator = new NoopIndexLocator();
   private final Map<Integer, String> ordinalSuffixes = new ConcurrentHashMap<>();
+
+  public FakeOrdinalIndexLocatorProvider(final Set<String> ordinalBasedIndexes) {
+    this.ordinalBasedIndexes = ordinalBasedIndexes;
+  }
 
   @Override
   public IndexLocator createIndexLocator(final Record<?> record) {
@@ -129,7 +135,7 @@ public class FakeOrdinalIndexLocatorProvider implements IndexLocatorProvider {
     }
   }
 
-  static class SingleSuffixOrdinalIndexLocator implements IndexLocator {
+  class SingleSuffixOrdinalIndexLocator implements IndexLocator {
     private final String suffix;
 
     public SingleSuffixOrdinalIndexLocator(final String suffix) {
@@ -138,11 +144,14 @@ public class FakeOrdinalIndexLocatorProvider implements IndexLocatorProvider {
 
     @Override
     public String getIndexLocation(final ExporterEntity<?> entity, final String baseIndexName) {
+      if (!ordinalBasedIndexes.contains(baseIndexName)) {
+        return baseIndexName;
+      }
       return baseIndexName + suffix;
     }
   }
 
-  static class MultiSuffixOrdinalIndexLocator implements IndexLocator {
+  class MultiSuffixOrdinalIndexLocator implements IndexLocator {
     private final Map<String, String> suffixesById;
 
     public MultiSuffixOrdinalIndexLocator(final Map<String, String> suffixesById) {
@@ -151,6 +160,9 @@ public class FakeOrdinalIndexLocatorProvider implements IndexLocatorProvider {
 
     @Override
     public String getIndexLocation(final ExporterEntity<?> entity, final String baseIndexName) {
+      if (!ordinalBasedIndexes.contains(baseIndexName)) {
+        return baseIndexName;
+      }
       return baseIndexName + Objects.requireNonNull(suffixesById.get(entity.getId()));
     }
   }


### PR DESCRIPTION
as they might not match those from the parent batch operation (or each other)

I've also temporarily made the operations and batch operations bypass ordinal indexes (from the exporters POV), so we do not have to make changes to `BatchOperationUpdateTask` and `HistoryDeletionJob`.  I did start fixing those, but it started getting very involved and we don't really need them for the PoC.

refs: #47707
