### PR TITLE
Allow no-op Agent Instance updates

### DIFF
--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidator.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.gateway.mapping.http.validator;
 
-import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_AT_LEAST_ONE_FIELD;
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_EMPTY_ATTRIBUTE;
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_INVALID_ATTRIBUTE_VALUE;
 import static io.camunda.gateway.mapping.http.validator.RequestValidator.validate;
@@ -83,12 +82,6 @@ public class AgentInstanceRequestValidator {
             validateKeyFormat(request.getElementInstanceKey(), "elementInstanceKey", violations);
           }
 
-          if (request.getStatus() == null
-              && !hasMetricsDelta(request)
-              && request.getTools() == null) {
-            violations.add(ERROR_MESSAGE_AT_LEAST_ONE_FIELD.formatted("status, metrics, tools"));
-          }
-
           if (request.getMetrics() != null) {
             final var metrics = request.getMetrics();
             violations.addAll(validateDelta("metrics.inputTokens", metrics.getInputTokens()));
@@ -122,13 +115,5 @@ public class AgentInstanceRequestValidator {
       return List.of(ERROR_MESSAGE_INVALID_ATTRIBUTE_VALUE.formatted(fieldName, value, ">= 0"));
     }
     return Collections.emptyList();
-  }
-
-  private boolean hasMetricsDelta(final AgentInstanceUpdateRequest request) {
-    return request.getMetrics() != null
-        && (request.getMetrics().getInputTokens() != null
-            || request.getMetrics().getOutputTokens() != null
-            || request.getMetrics().getModelCalls() != null
-            || request.getMetrics().getToolCalls() != null);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
@@ -46,8 +46,6 @@ public final class AgentInstanceUpdateProcessor
 
   private static final String ERROR_MSG_NOT_FOUND =
       "Expected to update agent instance with key '%d', but no such agent instance was found.";
-  private static final String ERROR_MSG_EMPTY_CHANGED =
-      "Expected to update agent instance, but changedAttributes is empty.";
   private static final String ERROR_MSG_UNKNOWN_ATTRIBUTES =
       "Expected to update agent instance, but changedAttributes contained unknown attribute(s) %s. Allowed attributes are: %s.";
   private static final String ERROR_MSG_INVALID_METRIC_DELTA =
@@ -185,10 +183,6 @@ public final class AgentInstanceUpdateProcessor
     }
 
     final Set<String> changed = Set.copyOf(commandValue.getChangedAttributes());
-    if (changed.isEmpty()) {
-      writeRejection(command, RejectionType.INVALID_ARGUMENT, ERROR_MSG_EMPTY_CHANGED);
-      return;
-    }
 
     final var unknown =
         changed.stream().filter(attr -> !ALLOWED_ATTRIBUTES.contains(attr)).toList();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateTest.java
@@ -160,43 +160,6 @@ public class AgentInstanceUpdateTest {
   }
 
   @Test
-  public void shouldRejectUpdateWithEmptyChangedAttributes() {
-    // given
-    ENGINE
-        .deployment()
-        .withXmlResource(
-            Bpmn.createExecutableProcess(PROCESS_ID)
-                .startEvent()
-                .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType("agent"))
-                .endEvent()
-                .done())
-        .deploy();
-    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
-    final var serviceTaskInstance = awaitServiceTaskActivated(processInstanceKey);
-    final var agentInstanceKey =
-        ENGINE
-            .agentInstances()
-            .withElementInstanceKey(serviceTaskInstance.getKey())
-            .create()
-            .getValue()
-            .getAgentInstanceKey();
-
-    // when — valid elementInstanceKey supplied, but changedAttributes is empty
-    final Record<?> rejection =
-        ENGINE
-            .agentInstances()
-            .withAgentInstanceKey(agentInstanceKey)
-            .withElementInstanceKey(serviceTaskInstance.getKey())
-            .withChangedAttributes(List.of())
-            .expectRejection()
-            .update();
-
-    // then
-    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
-    assertThat(rejection.getRejectionReason()).contains("changedAttributes");
-  }
-
-  @Test
   public void shouldDedupeDuplicateAttributesInChangedAttributes() {
     // given — a duplicated "metrics" entry in changedAttributes. Without dedup the delta would
     // be applied twice; the processor iterates the validated set so each attribute is patched once.

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -95,8 +95,7 @@ paths:
       description: |
         Updates the mutable fields of an agent instance: status, metric counters, and
         tools. Metric values are treated as deltas and applied immediately to the
-        aggregate counters. Tool updates replace the existing tool list. At least one of
-        status, metrics, or tools must be provided.
+        aggregate counters. Tool updates replace the existing tool list.
       parameters:
         - name: agentInstanceKey
           in: path
@@ -537,8 +536,7 @@ components:
 
     AgentInstanceUpdateRequest:
       description: |
-        Request to update the mutable state of an agent instance. At least one of
-        status, metrics, or tools must be provided.
+        Request to update the mutable state of an agent instance.
       type: object
       required:
         - elementInstanceKey

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
@@ -476,6 +476,40 @@ class AgentInstanceControllerTest extends RestControllerTest {
             any());
   }
 
+  @Test
+  void shouldUpdateAgentInstanceWithOnlyElementInstanceKey() {
+    // given
+    when(agentInstanceServices.updateAgentInstance(any(AgentInstanceRecord.class), any()))
+        .thenReturn(CompletableFuture.completedFuture(new AgentInstanceRecord()));
+
+    final var requestBody =
+        """
+        {
+          "elementInstanceKey": "%d"
+        }
+        """
+            .formatted(ELEMENT_INSTANCE_KEY);
+
+    // when / then
+    webClient
+        .patch()
+        .uri(AGENT_INSTANCES_URL + "/%d".formatted(AGENT_INSTANCE_KEY))
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(requestBody)
+        .exchange()
+        .expectStatus()
+        .isNoContent();
+
+    verify(agentInstanceServices)
+        .updateAgentInstance(
+            assertArg(
+                record -> {
+                  assertThat(record.getChangedAttributes()).isEmpty();
+                }),
+            any());
+  }
+
   @ParameterizedTest(name = "[{index}] {0}")
   @MethodSource("invalidUpdateRequests")
   void shouldRejectInvalidUpdateRequest(final String requestBody, final String expectedDetail) {

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
@@ -535,14 +535,6 @@ class AgentInstanceControllerTest extends RestControllerTest {
                 + " Did you pass an entity id instead of an entity key?."),
         Arguments.of(
             named(
-                "no mutable fields provided",
-                """
-                { "elementInstanceKey": "%d" }
-                """
-                    .formatted(ELEMENT_INSTANCE_KEY)),
-            "At least one of status, metrics, tools is required."),
-        Arguments.of(
-            named(
                 "negative inputTokens delta",
                 """
                 { "elementInstanceKey": "%d", "metrics": { "inputTokens": -1 } }
@@ -573,14 +565,6 @@ class AgentInstanceControllerTest extends RestControllerTest {
                 """
                     .formatted(ELEMENT_INSTANCE_KEY)),
             "The value for metrics.toolCalls is '-2' but must be >= 0."),
-        Arguments.of(
-            named(
-                "only empty metrics object",
-                """
-                { "elementInstanceKey": "%d", "metrics": {} }
-                """
-                    .formatted(ELEMENT_INSTANCE_KEY)),
-            "At least one of status, metrics, tools is required."),
         Arguments.of(
             named(
                 "tool without name",


### PR DESCRIPTION
## Description

This pull request removes the requirement that at least one of `status`, `metrics`, or `tools` must be provided in an `AgentInstanceUpdateRequest`. It updates the validation logic, error messages, and test cases to reflect this change, simplifying the update request handling logic.

### Validation and business logic changes:

* Removed the check in `AgentInstanceRequestValidator` that enforced at least one of `status`, `metrics`, or `tools` must be present in an update request.
* Removed the corresponding error message and rejection logic in `AgentInstanceUpdateProcessor` that rejected updates with empty changed attributes.

### API documentation updates:

* Updated the OpenAPI YAML documentation to remove references to the requirement for at least one mutable field in both the endpoint and the request object descriptions. 

### Test updates:

* Removed test cases that expected a validation error when no mutable fields or only an empty metrics object were provided in the update request. 

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #54091 
