### PR TITLE
fix(identity): remove key field from UserFilter and GroupFilter builders

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/UserDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/UserDbReader.java
@@ -70,11 +70,6 @@ public class UserDbReader extends AbstractEntityReader<UserEntity> implements Us
     return Optional.ofNullable(result.items()).flatMap(items -> items.stream().findFirst());
   }
 
-  public Optional<UserEntity> findOne(final long userKey) {
-    final var result = search(UserQuery.of(b -> b.filter(f -> f.key(userKey))));
-    return Optional.ofNullable(result.items()).flatMap(items -> items.stream().findFirst());
-  }
-
   public SearchQueryResult<UserEntity> search(final UserQuery query) {
     return search(query, ResourceAccessChecks.disabled());
   }

--- a/db/rdbms/src/main/resources/mapper/GroupMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/GroupMapper.xml
@@ -87,7 +87,6 @@ SELECT
       </foreach>
     </if>
 
-    <if test="filter.groupKey != null">AND g.GROUP_KEY = #{filter.groupKey}</if>
     <if test="filter.groupIdOperations != null and !filter.groupIdOperations.isEmpty()">
       <foreach collection="filter.groupIdOperations" item="operation">
         AND g.GROUP_ID

--- a/db/rdbms/src/main/resources/mapper/UserMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/UserMapper.xml
@@ -55,7 +55,6 @@
         </foreach>
       </if>
       <!-- basic filters -->
-      <if test="filter.key != null">AND t.USER_KEY = #{filter.key}</if>
       <if test="filter.usernameOperations != null and !filter.usernameOperations.isEmpty()">
         <foreach collection="filter.usernameOperations" item="operation">
           AND t.USERNAME

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/group/GroupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/group/GroupIT.java
@@ -214,7 +214,7 @@ public class GroupIT {
     final var searchResult =
         groupReader.search(
             new GroupQuery(
-                new GroupFilter.Builder().groupKey(group.groupKey()).name(group.name()).build(),
+                new GroupFilter.Builder().name(group.name()).build(),
                 GroupSort.of(b -> b),
                 SearchQueryPage.of(b -> b.from(0).size(5))));
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/group/GroupSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/group/GroupSpecificFilterIT.java
@@ -86,11 +86,7 @@ public class GroupSpecificFilterIT {
     createAndSaveGroup(
         rdbmsWriters,
         GroupFixtures.createRandomized(
-            b ->
-                b.groupId("groupId")
-                    .groupKey(1337L)
-                    .name("Group 1337")
-                    .description("This is group 1337")));
+            b -> b.groupId("groupId").name("Group 1337").description("This is group 1337")));
     GroupMemberFixtures.createAndSaveRandomGroupMember(
         rdbmsWriters,
         b -> b.groupId("groupId").entityId("entityId").entityType(EntityType.USER.name()));
@@ -102,7 +98,7 @@ public class GroupSpecificFilterIT {
 
     assertThat(searchResult.total()).isEqualTo(1);
     assertThat(searchResult.items()).hasSize(1);
-    assertThat(searchResult.items().getFirst().groupKey()).isEqualTo(1337L);
+    assertThat(searchResult.items().getFirst().groupId()).isEqualTo("groupId");
   }
 
   @ParameterizedTest
@@ -111,8 +107,7 @@ public class GroupSpecificFilterIT {
     createAndSaveRandomGroups(rdbmsWriters);
     createAndSaveGroup(
         rdbmsWriters,
-        GroupFixtures.createRandomized(
-            b -> b.groupId("groupId1").groupKey(1337L).name("Group 1337")));
+        GroupFixtures.createRandomized(b -> b.groupId("groupId1").name("Group 1337")));
     GroupMemberFixtures.createAndSaveRandomGroupMember(
         rdbmsWriters,
         b -> b.groupId("groupId1").entityId("entityId1").entityType(EntityType.USER.name()));
@@ -137,7 +132,6 @@ public class GroupSpecificFilterIT {
 
   static List<GroupFilter> shouldFindWithSpecificFilterParameters() {
     return List.of(
-        new GroupFilter.Builder().groupKey(1337L).build(),
         new GroupFilter.Builder().name("Group 1337").build(),
         new GroupFilter.Builder().description("This is group 1337").build(),
         new GroupFilter.Builder().memberId("entityId").childMemberType(EntityType.USER).build());

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/user/UserIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/user/UserIT.java
@@ -38,20 +38,6 @@ public class UserIT {
   public static final OffsetDateTime NOW = OffsetDateTime.now();
 
   @TestTemplate
-  public void shouldSaveAndFindByKey(final CamundaRdbmsTestApplication testApplication) {
-    final RdbmsService rdbmsService = testApplication.getRdbmsService();
-    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
-    final UserDbReader userReader = rdbmsService.getUserReader();
-
-    final var user = UserFixtures.createRandomized(b -> b);
-    createAndSaveUser(rdbmsWriters, user);
-
-    final var instance = userReader.findOneByUsername(user.username()).orElse(null);
-
-    compareUsers(instance, user);
-  }
-
-  @TestTemplate
   public void shouldSaveAndUpdate(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/user/UserIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/user/UserIT.java
@@ -46,7 +46,7 @@ public class UserIT {
     final var user = UserFixtures.createRandomized(b -> b);
     createAndSaveUser(rdbmsWriters, user);
 
-    final var instance = userReader.findOne(user.userKey()).orElse(null);
+    final var instance = userReader.findOneByUsername(user.username()).orElse(null);
 
     compareUsers(instance, user);
   }
@@ -65,7 +65,7 @@ public class UserIT {
     rdbmsWriters.getUserWriter().update(userUpdate);
     rdbmsWriters.flush();
 
-    final var instance = userReader.findOne(user.userKey()).orElse(null);
+    final var instance = userReader.findOneByUsername(user.username()).orElse(null);
 
     compareUsers(instance, userUpdate);
   }
@@ -78,13 +78,13 @@ public class UserIT {
 
     final var user = UserFixtures.createRandomized(b -> b);
     createAndSaveUser(rdbmsWriters, user);
-    final var instance = userReader.findOne(user.userKey()).orElse(null);
+    final var instance = userReader.findOneByUsername(user.username()).orElse(null);
     compareUsers(instance, user);
 
     rdbmsWriters.getUserWriter().delete(user.username());
     rdbmsWriters.flush();
 
-    final var deletedInstance = userReader.findOne(user.userKey()).orElse(null);
+    final var deletedInstance = userReader.findOneByUsername(user.username()).orElse(null);
     assertThat(deletedInstance).isNull();
   }
 
@@ -222,7 +222,6 @@ public class UserIT {
         userReader.search(
             new UserQuery(
                 new UserFilter.Builder()
-                    .key(user.userKey())
                     .usernames(user.username())
                     .names(user.name())
                     .emails(user.email())

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/user/UserSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/user/UserSpecificFilterIT.java
@@ -174,7 +174,6 @@ public class UserSpecificFilterIT {
 
   static List<UserFilter> shouldFindWithSpecificFilterParameters() {
     return List.of(
-        new UserFilter.Builder().key(1337L).build(),
         new UserFilter.Builder().usernames("user-1337").build(),
         new UserFilter.Builder().names("User 1337").build(),
         new UserFilter.Builder().emails("user-1337@camunda-test.com").build());

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
@@ -519,7 +519,7 @@ class RdbmsExporterIT {
     exporter.export(userRecord);
 
     // then
-    final var user = rdbmsService.getUserReader().findOne(userRecord.getKey());
+    final var user = rdbmsService.getUserReader().findOneByUsername(userRecordValue.getUsername());
     assertThat(user).isNotEmpty();
     assertThat(user.get().userKey()).isEqualTo(userRecordValue.getUserKey());
     assertThat(user.get().username()).isEqualTo(userRecordValue.getUsername());
@@ -535,7 +535,8 @@ class RdbmsExporterIT {
     exporter.export(updateUserRecord);
 
     // then
-    final var updatedUser = rdbmsService.getUserReader().findOne(userRecord.getKey());
+    final var updatedUser =
+        rdbmsService.getUserReader().findOneByUsername(updateUserRecordValue.getUsername());
     assertThat(updatedUser).isNotEmpty();
     assertThat(updatedUser.get().userKey()).isEqualTo(updateUserRecordValue.getUserKey());
     assertThat(updatedUser.get().username()).isEqualTo(updateUserRecordValue.getUsername());
@@ -547,7 +548,8 @@ class RdbmsExporterIT {
     exporter.export(FIXTURES.getUserRecord(42L, "test", UserIntent.DELETED));
 
     // then
-    final var deletedUser = rdbmsService.getUserReader().findOne(userRecord.getKey());
+    final var deletedUser =
+        rdbmsService.getUserReader().findOneByUsername(userRecordValue.getUsername());
     assertThat(deletedUser).isEmpty();
   }
 

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/GroupFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/GroupFilterTransformer.java
@@ -15,7 +15,6 @@ import static io.camunda.search.clients.query.SearchQueryBuilders.stringOperatio
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
 import static io.camunda.search.clients.query.SearchQueryBuilders.term;
 import static io.camunda.webapps.schema.descriptors.index.GroupIndex.GROUP_ID;
-import static io.camunda.webapps.schema.descriptors.index.GroupIndex.KEY;
 import static io.camunda.webapps.schema.descriptors.index.GroupIndex.MEMBER_ID;
 import static io.camunda.webapps.schema.descriptors.index.GroupIndex.NAME;
 
@@ -38,9 +37,6 @@ public class GroupFilterTransformer extends IndexFilterTransformer<GroupFilter> 
       return createMultipleMemberTypeQuery(filter);
     }
     final var queries = new ArrayList<SearchQuery>();
-    if (filter.groupKey() != null) {
-      queries.add(term(KEY, filter.groupKey()));
-    }
     if (filter.groupIdOperations() != null && !filter.groupIdOperations().isEmpty()) {
       queries.addAll(stringOperations(GROUP_ID, filter.groupIdOperations()));
     }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UserFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UserFilterTransformer.java
@@ -10,9 +10,7 @@ package io.camunda.search.clients.transformers.filter;
 import static io.camunda.search.clients.query.SearchQueryBuilders.and;
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringOperations;
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
-import static io.camunda.search.clients.query.SearchQueryBuilders.term;
 import static io.camunda.webapps.schema.descriptors.index.UserIndex.EMAIL;
-import static io.camunda.webapps.schema.descriptors.index.UserIndex.KEY;
 import static io.camunda.webapps.schema.descriptors.index.UserIndex.NAME;
 import static io.camunda.webapps.schema.descriptors.index.UserIndex.USERNAME;
 
@@ -31,9 +29,6 @@ public class UserFilterTransformer extends IndexFilterTransformer<UserFilter> {
   @Override
   public SearchQuery toSearchQuery(final UserFilter filter) {
     final var queries = new ArrayList<SearchQuery>();
-    if (filter.key() != null) {
-      queries.add(term(KEY, filter.key()));
-    }
     queries.addAll(stringOperations(USERNAME, filter.usernameOperations()));
     queries.addAll(stringOperations(NAME, filter.nameOperations()));
     queries.addAll(stringOperations(EMAIL, filter.emailOperations()));

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/GroupQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/GroupQueryTransformerTest.java
@@ -29,28 +29,6 @@ import org.junit.jupiter.api.Test;
 public class GroupQueryTransformerTest extends AbstractTransformerTest {
 
   @Test
-  public void shouldQueryByGroupKey() {
-    // given
-    final var filter = FilterBuilders.group((f) -> f.groupKey(12345L));
-
-    // when
-    final var searchRequest = transformQuery(filter);
-
-    // then
-    assertThat(searchRequest)
-        .isEqualTo(
-            SearchQuery.of(
-                q ->
-                    q.bool(
-                        b ->
-                            b.must(
-                                List.of(
-                                    SearchQuery.of(q1 -> q.term(t -> t.field("key").value(12345L))),
-                                    SearchQuery.of(
-                                        q1 -> q.term(t -> t.field("join").value("group"))))))));
-  }
-
-  @Test
   public void shouldQueryByGroupId() {
     // given
     final var filter = FilterBuilders.group((f) -> f.groupIdOperations(Operation.eq("group1")));
@@ -181,8 +159,7 @@ public class GroupQueryTransformerTest extends AbstractTransformerTest {
   public void shouldQueryByMultipleGroupFields() {
     // given
     final var filter =
-        FilterBuilders.group(
-            (f) -> f.groupKey(12345L).groupIdOperations(Operation.eq("group1")).name("TestGroup"));
+        FilterBuilders.group((f) -> f.groupIdOperations(Operation.eq("group1")).name("TestGroup"));
 
     // when
     final var searchRequest = transformQuery(filter);
@@ -196,7 +173,6 @@ public class GroupQueryTransformerTest extends AbstractTransformerTest {
                         b ->
                             b.must(
                                 List.of(
-                                    SearchQuery.of(q -> q.term(t -> t.field("key").value(12345L))),
                                     SearchQuery.of(
                                         q -> q.term(t -> t.field("groupId").value("group1"))),
                                     SearchQuery.of(

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/UserQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/UserQueryTransformerTest.java
@@ -59,7 +59,6 @@ public class UserQueryTransformerTest extends AbstractTransformerTest {
 
   public static Stream<Arguments> queryFilterParameters() {
     return Stream.of(
-        Arguments.of((Function<Builder, ObjectBuilder<UserFilter>>) f -> f.key(1L), "key", 1L),
         Arguments.of(
             (Function<Builder, ObjectBuilder<UserFilter>>)
                 f -> f.usernameOperations(List.of(Operation.eq("username1"))),

--- a/search/search-domain/src/main/java/io/camunda/search/filter/GroupFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/GroupFilter.java
@@ -20,7 +20,6 @@ import java.util.Set;
 import java.util.function.Function;
 
 public record GroupFilter(
-    Long groupKey,
     List<Operation<String>> groupIdOperations,
     String name,
     String description,
@@ -38,7 +37,6 @@ public record GroupFilter(
 
   public Builder toBuilder() {
     return new Builder()
-        .groupKey(groupKey)
         .groupIdOperations(groupIdOperations)
         .name(name)
         .description(description)
@@ -50,7 +48,6 @@ public record GroupFilter(
   }
 
   public static final class Builder implements ObjectBuilder<GroupFilter> {
-    private Long groupKey;
     private List<Operation<String>> groupIdOperations;
     private String name;
     private String description;
@@ -59,11 +56,6 @@ public record GroupFilter(
     private EntityType childMemberType;
     private String roleId;
     private Map<EntityType, Set<String>> memberIdsByType;
-
-    public Builder groupKey(final Long value) {
-      groupKey = value;
-      return this;
-    }
 
     public Builder groupIdOperations(final List<Operation<String>> operations) {
       if (operations != null) {
@@ -136,7 +128,6 @@ public record GroupFilter(
     @Override
     public GroupFilter build() {
       return new GroupFilter(
-          groupKey,
           groupIdOperations,
           name,
           description,

--- a/search/search-domain/src/main/java/io/camunda/search/filter/UserFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/UserFilter.java
@@ -19,7 +19,6 @@ import java.util.Objects;
 import java.util.Set;
 
 public record UserFilter(
-    Long key,
     List<Operation<String>> usernameOperations,
     List<Operation<String>> nameOperations,
     List<Operation<String>> emailOperations,
@@ -30,7 +29,6 @@ public record UserFilter(
 
   public Builder toBuilder() {
     return new Builder()
-        .key(key)
         .usernameOperations(usernameOperations)
         .nameOperations(nameOperations)
         .emailOperations(emailOperations)
@@ -40,18 +38,12 @@ public record UserFilter(
   }
 
   public static final class Builder implements ObjectBuilder<UserFilter> {
-    private Long key;
     private List<Operation<String>> usernameOperations;
     private List<Operation<String>> nameOperations;
     private List<Operation<String>> emailOperations;
     private String tenantId;
     private String groupId;
     private String roleId;
-
-    public Builder key(final Long value) {
-      key = value;
-      return this;
-    }
 
     public Builder usernameOperations(final List<Operation<String>> operations) {
       usernameOperations = addValuesToList(usernameOperations, operations);
@@ -128,7 +120,6 @@ public record UserFilter(
     @Override
     public UserFilter build() {
       return new UserFilter(
-          key,
           Objects.requireNonNullElse(usernameOperations, Collections.emptyList()),
           nameOperations,
           emailOperations,


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #51088
