### PR TITLE
Aggregate per physical tenant topology in Gateway

### DIFF
--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManager.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManager.java
@@ -14,10 +14,18 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 public interface BrokerTopologyManager extends ClusterConfigurationUpdateListener {
 
   /**
-   * Returns live topology that includes which brokers are available, who is leader for each
-   * partition, etc.
+   * Returns live topology for the default partition group. Equivalent to {@code
+   * getTopology("default")}.
    */
   BrokerClusterState getTopology();
+
+  /**
+   * Returns live topology for the given physical tenant (partition group). Returns an uninitialized
+   * topology if the group is unknown.
+   */
+  default BrokerClusterState getTopology(final String physicalTenantId) {
+    return getTopology();
+  }
 
   /**
    * Returns the current cluster topology. The topology contains the information about brokers which

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
@@ -20,13 +20,14 @@ import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import io.camunda.zeebe.broker.client.impl.BrokerClientTopologyImpl.ConfiguredClusterState;
 import io.camunda.zeebe.dynamic.config.ClusterConfigurationUpdateNotifier.ClusterConfigurationUpdateListener;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.scheduler.Actor;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,14 +38,20 @@ public final class BrokerTopologyManagerImpl extends Actor
         ClusterConfigurationUpdateListener {
 
   private static final Logger LOG = LoggerFactory.getLogger(BrokerTopologyManagerImpl.class);
-  private volatile BrokerClientTopologyImpl topology = BrokerClientTopologyImpl.uninitialized();
+
+  // Per-group live+configured topology; replaced atomically on updates.
+  // The outer key is partition group name; the inner key is broker member id.
+  private final Map<String, Map<BrokerMemberId, BrokerInfo>> memberPropertiesPerGroup =
+      new HashMap<>();
+
+  // Immutable snapshot replaced atomically; keyed by partition group name.
+  private volatile Map<String, BrokerClientTopologyImpl> topologyPerGroup = Map.of();
+
   private volatile ClusterConfiguration clusterConfiguration = ClusterConfiguration.uninitialized();
   private final Supplier<Set<Member>> membersSupplier;
   private final BrokerClientTopologyMetrics topologyMetrics;
 
   private final Set<BrokerTopologyListener> topologyListeners = new HashSet<>();
-
-  private final Map<BrokerMemberId, BrokerInfo> memberProperties = new HashMap<>();
 
   public BrokerTopologyManagerImpl(
       final Supplier<Set<Member>> membersSupplier,
@@ -53,12 +60,15 @@ public final class BrokerTopologyManagerImpl extends Actor
     this.topologyMetrics = topologyMetrics;
   }
 
-  /**
-   * @return a copy of the currently known topology
-   */
   @Override
   public BrokerClusterState getTopology() {
-    return topology;
+    return getTopology(Protocol.DEFAULT_PARTITION_GROUP_NAME);
+  }
+
+  @Override
+  public BrokerClusterState getTopology(final String physicalTenantId) {
+    return topologyPerGroup.getOrDefault(
+        physicalTenantId, BrokerClientTopologyImpl.uninitialized());
   }
 
   @Override
@@ -71,23 +81,17 @@ public final class BrokerTopologyManagerImpl extends Actor
     actor.run(
         () -> {
           topologyListeners.add(listener);
-          memberProperties.keySet().forEach(listener::brokerAdded);
+          // Backfill listener with all known broker IDs across all groups
+          memberPropertiesPerGroup.values().stream()
+              .flatMap(m -> m.keySet().stream())
+              .distinct()
+              .forEach(listener::brokerAdded);
         });
   }
 
   @Override
   public void removeTopologyListener(final BrokerTopologyListener listener) {
     actor.run(() -> topologyListeners.remove(listener));
-  }
-
-  private void updateTopology(
-      final Function<BrokerClientTopologyImpl, BrokerClientTopologyImpl> updater) {
-    actor.run(
-        () -> {
-          final var updated = updater.apply(topology);
-          topology = updated;
-          updateMetrics(updated);
-        });
   }
 
   /**
@@ -105,47 +109,81 @@ public final class BrokerTopologyManagerImpl extends Actor
     }
 
     for (final Member member : members) {
-      final BrokerInfo brokerInfo = BrokerInfo.fromProperties(member.properties());
-      if (brokerInfo != null) {
-        addBroker(member, brokerInfo);
+      for (final BrokerInfo brokerInfo : BrokerInfo.allFromProperties(member.properties())) {
+        addBroker(brokerInfo);
       }
     }
   }
 
-  private void addBroker(final Member member, final BrokerInfo brokerInfo) {
+  private void addBroker(final BrokerInfo brokerInfo) {
     final var brokerMemberId = BrokerMemberId.from(brokerInfo.getZone(), brokerInfo.getNodeId());
+    final var group = brokerInfo.getPartitionGroup();
     actor.run(
         () -> {
-          if (!memberProperties.containsKey(brokerMemberId)) {
+          // Notify listeners only on the first appearance of this broker across all groups.
+          final boolean isNew =
+              memberPropertiesPerGroup.values().stream()
+                  .noneMatch(m -> m.containsKey(brokerMemberId));
+          if (isNew) {
             topologyListeners.forEach(l -> l.brokerAdded(brokerMemberId));
           }
 
-          memberProperties.put(brokerMemberId, brokerInfo);
-
-          updateTopology(
-              oldTopology ->
-                  BrokerClientTopologyImpl.fromMemberProperties(
-                      memberProperties.values(), oldTopology.configuredClusterState()));
+          memberPropertiesPerGroup
+              .computeIfAbsent(group, g -> new HashMap<>())
+              .put(brokerMemberId, brokerInfo);
+          rebuildGroupTopology(group);
         });
   }
 
   private void removeBroker(final Member member) {
-    final var brokerInfo = BrokerInfo.fromProperties(member.properties());
-    if (brokerInfo == null) {
+    final List<BrokerInfo> allInfos = BrokerInfo.allFromProperties(member.properties());
+    final BrokerMemberId brokerMemberId;
+    if (!allInfos.isEmpty()) {
+      final var anyInfo = allInfos.getFirst();
+      brokerMemberId = BrokerMemberId.from(anyInfo.brokerIdStr());
+    } else {
+      // no brokerInfo means we have not added it to the topology yet, or it could be a gateway.
       return;
     }
 
-    final var brokerMemberId = BrokerMemberId.from(brokerInfo.getZone(), brokerInfo.getNodeId());
     actor.run(
         () -> {
-          memberProperties.remove(brokerMemberId);
-          topologyListeners.forEach(l -> l.brokerRemoved(brokerMemberId));
+          final Set<String> groupsToRebuild = new HashSet<>();
+          memberPropertiesPerGroup.forEach(
+              (group, groupMap) -> {
+                if (groupMap.remove(brokerMemberId) != null) {
+                  groupsToRebuild.add(group);
+                }
+              });
 
-          final var oldTopology = topology;
-          topology =
-              BrokerClientTopologyImpl.fromMemberProperties(
-                  memberProperties.values(), oldTopology.configuredClusterState());
+          if (!groupsToRebuild.isEmpty()) {
+            topologyListeners.forEach(l -> l.brokerRemoved(brokerMemberId));
+            groupsToRebuild.forEach(this::rebuildGroupTopology);
+          }
         });
+  }
+
+  private void rebuildGroupTopology(final String group) {
+    final var groupMembers = memberPropertiesPerGroup.getOrDefault(group, Map.of()).values();
+    final var configuredState = currentConfiguredState();
+    final var newGroupTopology =
+        BrokerClientTopologyImpl.fromMemberProperties(groupMembers, configuredState);
+
+    final Map<String, BrokerClientTopologyImpl> updated = new HashMap<>(topologyPerGroup);
+    updated.put(group, newGroupTopology);
+    topologyPerGroup = Map.copyOf(updated);
+
+    // temp: only update metrics for default group until we support group-specific metrics
+    if (Protocol.DEFAULT_PARTITION_GROUP_NAME.equals(group)) {
+      updateMetrics(newGroupTopology);
+    }
+  }
+
+  private ConfiguredClusterState currentConfiguredState() {
+    return topologyPerGroup.values().stream()
+        .findFirst()
+        .map(BrokerClientTopologyImpl::configuredClusterState)
+        .orElse(BrokerClientTopologyImpl.uninitialized().configuredClusterState());
   }
 
   @Override
@@ -155,9 +193,6 @@ public final class BrokerTopologyManagerImpl extends Actor
 
   @Override
   protected void onActorStarted() {
-    // Get the initial member state before the listener is registered.
-    // Also called AFTER registering this as a membership listener, to cover the window
-    // between the snapshot here and listener attachment.
     initializeTopologyFromMembership();
   }
 
@@ -165,34 +200,27 @@ public final class BrokerTopologyManagerImpl extends Actor
   public void event(final ClusterMembershipEvent event) {
     final Member subject = event.subject();
     final Type eventType = event.type();
-    final BrokerInfo brokerInfo = BrokerInfo.fromProperties(subject.properties());
+    final List<BrokerInfo> allInfos = BrokerInfo.allFromProperties(subject.properties());
 
-    if (brokerInfo == null) {
+    if (allInfos.isEmpty()) {
       return;
     }
-    final var brokerId = BrokerMemberId.from(brokerInfo.getZone(), brokerInfo.getNodeId());
+
+    final var brokerId = subject.id();
 
     switch (eventType) {
-      case MEMBER_ADDED -> {
+      case MEMBER_ADDED, METADATA_CHANGED -> {
         LOG.debug(
-            "Received new broker {} : partitions {}, terms {} and health {}",
-            brokerInfo,
-            brokerInfo.getPartitionRoles(),
-            brokerInfo.getPartitionLeaderTerms(),
-            brokerInfo.getPartitionHealthStatuses());
-        addBroker(subject, brokerInfo);
-      }
-      case METADATA_CHANGED -> {
-        LOG.debug(
-            "Received metadata change from Broker {}, partitions {}, terms {} and health {}.",
+            "Received {} from broker {}, updating {} group(s)",
+            eventType,
             brokerId,
-            brokerInfo.getPartitionRoles(),
-            brokerInfo.getPartitionLeaderTerms(),
-            brokerInfo.getPartitionHealthStatuses());
-        addBroker(subject, brokerInfo);
+            allInfos.size());
+        for (final BrokerInfo brokerInfo : allInfos) {
+          addBroker(brokerInfo);
+        }
       }
       case MEMBER_REMOVED -> {
-        LOG.debug("Received broker was removed {}.", brokerInfo);
+        LOG.debug("Received broker was removed {}.", brokerId);
         removeBroker(subject);
       }
       default -> LOG.debug("Received {} for broker {}, do nothing.", eventType, brokerId);
@@ -224,8 +252,35 @@ public final class BrokerTopologyManagerImpl extends Actor
       return;
     }
     clusterConfiguration = clusterTopology;
+    actor.run(() -> applyClusterConfiguration(clusterTopology));
+  }
 
-    updateTopology(oldTopology -> updateConfiguredClusterState(clusterTopology, oldTopology));
+  private void applyClusterConfiguration(final ClusterConfiguration clusterTopology) {
+    // Run the full comparison + listener-notification logic against the default group once.
+    final var oldDefault =
+        topologyPerGroup.getOrDefault(
+            Protocol.DEFAULT_PARTITION_GROUP_NAME, BrokerClientTopologyImpl.uninitialized());
+    final var updatedDefault = updateConfiguredClusterState(clusterTopology, oldDefault);
+    final var newConfiguredState = updatedDefault.configuredClusterState();
+
+    final Map<String, BrokerClientTopologyImpl> allGroups = new HashMap<>(topologyPerGroup);
+    allGroups.put(Protocol.DEFAULT_PARTITION_GROUP_NAME, updatedDefault);
+
+    // temp: apply the same configured state to all other known groups. This must be revisited when
+    // we add support for group-specific cluster configurations.
+    memberPropertiesPerGroup.keySet().stream()
+        .filter(group -> !group.equals(Protocol.DEFAULT_PARTITION_GROUP_NAME))
+        .forEach(
+            group -> {
+              final var oldGroup =
+                  topologyPerGroup.getOrDefault(group, BrokerClientTopologyImpl.uninitialized());
+              allGroups.put(
+                  group,
+                  new BrokerClientTopologyImpl(oldGroup.liveClusterState(), newConfiguredState));
+            });
+
+    topologyPerGroup = Map.copyOf(allGroups);
+    updateMetrics(updatedDefault);
   }
 
   private BrokerClientTopologyImpl updateConfiguredClusterState(

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
@@ -573,6 +573,72 @@ final class BrokerTopologyManagerTest {
     assertThat(capturedIds).containsExactly(zonedMemberId);
   }
 
+  @Test
+  void shouldAggregateTopologyPerPartitionGroup() {
+    // given — broker 0 publishes both a default-group and a tenant1-group BrokerInfo
+    final var brokerId = BrokerMemberId.from(0);
+    final int partitionDefault = 1;
+    final int partitionTenant1 = 1;
+
+    final BrokerInfo defaultInfo = createBroker(brokerId);
+    defaultInfo.setLeaderForPartition(partitionDefault, 1L);
+
+    final BrokerInfo tenant1Info = createBrokerWithGroup(brokerId, "tenant1");
+    tenant1Info.setFollowerForPartition(partitionTenant1);
+
+    // Write both groups into the same member properties
+    final Member member = new Member(new MemberConfig().setId(defaultInfo.brokerIdStr()));
+    defaultInfo.writeIntoProperties(member.properties());
+    tenant1Info.writeIntoProperties(member.properties());
+    members.add(member);
+
+    // when
+    notifyEvent(new ClusterMembershipEvent(Type.MEMBER_ADDED, member));
+
+    // then — default group topology reflects the default BrokerInfo
+    assertThat(topologyManager.getTopology().getLeaderForPartition(partitionDefault))
+        .isEqualTo(brokerId);
+    assertThat(topologyManager.getTopology().getFollowersForPartition(partitionDefault)).isEmpty();
+
+    // then — tenant1 group topology reflects the tenant1 BrokerInfo
+    final BrokerClusterState tenant1Topology = topologyManager.getTopology("tenant1");
+    assertThat(tenant1Topology.getFollowersForPartition(partitionTenant1)).contains(brokerId);
+    assertThat(tenant1Topology.getLeaderForPartition(partitionTenant1)).isNull();
+  }
+
+  @Test
+  void shouldRemoveBrokerFromAllGroupsOnMemberRemoved() {
+    // given — broker 0 is present in default and tenant1 groups
+    final var brokerId = BrokerMemberId.from(0);
+    final BrokerInfo defaultInfo = createBroker(brokerId);
+    defaultInfo.setFollowerForPartition(1);
+    final BrokerInfo tenant1Info = createBrokerWithGroup(brokerId, "tenant1");
+    tenant1Info.setLeaderForPartition(1, 1L);
+
+    final Member member = new Member(new MemberConfig().setId(defaultInfo.brokerIdStr()));
+    defaultInfo.writeIntoProperties(member.properties());
+    tenant1Info.writeIntoProperties(member.properties());
+    members.add(member);
+    notifyEvent(new ClusterMembershipEvent(Type.MEMBER_ADDED, member));
+
+    assertThat(topologyManager.getTopology().getBrokers()).contains(brokerId);
+    assertThat(topologyManager.getTopology("tenant1").getBrokers()).contains(brokerId);
+
+    // when
+    notifyEvent(createMemberRemoveEvent(defaultInfo));
+
+    // then — broker is gone from both groups
+    assertThat(topologyManager.getTopology().getBrokers()).doesNotContain(brokerId);
+    assertThat(topologyManager.getTopology("tenant1").getBrokers()).doesNotContain(brokerId);
+  }
+
+  @Test
+  void shouldReturnUninitializedTopologyForUnknownGroup() {
+    // given / when — no brokers added
+    // then
+    assertThat(topologyManager.getTopology("unknown-group").isInitialized()).isFalse();
+  }
+
   private void addTopologyListener(final BrokerTopologyListener listener) {
     topologyManager.addTopologyListener(listener);
     actorSchedulerRule.workUntilDone();
@@ -588,6 +654,10 @@ final class BrokerTopologyManagerTest {
     broker.setCommandApiAddress("localhost:1000");
     broker.setVersion("0.23.0-SNAPSHOT");
     return broker;
+  }
+
+  private BrokerInfo createBrokerWithGroup(final BrokerMemberId brokerId, final String group) {
+    return createBroker(brokerId).setPartitionGroup(group);
   }
 
   private ClusterMembershipEvent createMemberAddedEvent(final BrokerInfo broker) {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyManagerImpl.java
@@ -115,7 +115,9 @@ public final class TopologyManagerImpl extends Actor
   public void event(final ClusterMembershipEvent clusterMembershipEvent) {
     final Member eventSource = clusterMembershipEvent.subject();
 
-    final BrokerInfo brokerInfo = BrokerInfo.fromProperties(eventSource.properties());
+    final BrokerInfo brokerInfo =
+        BrokerInfo.fromProperties(
+            eventSource.properties(), localPartitionGroupInfo.getPartitionGroup());
 
     if (brokerInfo != null && !memberIdOf(brokerInfo).equals(memberIdOf(localPartitionGroupInfo))) {
       actor.run(

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
@@ -38,10 +38,12 @@ import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Base64.Decoder;
 import java.util.Base64.Encoder;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -502,6 +504,39 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
     } else {
       return null;
     }
+  }
+
+  /**
+   * Reads the {@link BrokerInfo} for the given {@code partitionGroup} from member properties. The
+   * default group uses the legacy key {@value #BROKER_INFO_PROPERTY_NAME}; other groups use a
+   * namespaced key of the form {@code "brokerInfo:<group>"}. Returns {@code null} if no entry
+   * exists for that group.
+   */
+  public static @Nullable BrokerInfo fromProperties(
+      final Properties properties, final String partitionGroup) {
+    final String key = brokerInfoPropertyName(partitionGroup);
+    final String property = properties.getProperty(key);
+    return property != null ? readFromString(property) : null;
+  }
+
+  /**
+   * Reads all {@link BrokerInfo} entries from member properties. Collects all keys equal to {@value
+   * #BROKER_INFO_PROPERTY_NAME} (legacy/default group) or starting with {@value
+   * #BROKER_INFO_PROPERTY_NAME}{@code ":"} (namespaced non-default groups). Used by the topology
+   * manager to aggregate per-group topology from a single member.
+   */
+  public static List<BrokerInfo> allFromProperties(final Properties properties) {
+    final List<BrokerInfo> result = new ArrayList<>();
+    for (final String key : properties.stringPropertyNames()) {
+      if (key.equals(BROKER_INFO_PROPERTY_NAME)
+          || key.startsWith(BROKER_INFO_PROPERTY_NAME + ":")) {
+        final String property = properties.getProperty(key);
+        if (property != null) {
+          result.add(readFromString(property));
+        }
+      }
+    }
+    return result;
   }
 
   private static BrokerInfo readFromString(final String property) {

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/BrokerInfoTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/BrokerInfoTest.java
@@ -28,6 +28,85 @@ import org.junit.jupiter.api.Test;
 final class BrokerInfoTest {
 
   @Test
+  void shouldReadBrokerInfoForSpecificPartitionGroup() {
+    // given
+    final BrokerInfo defaultBroker =
+        new BrokerInfo()
+            .setBrokerId(1, null)
+            .setPartitionsCount(1)
+            .setClusterSize(1)
+            .setReplicationFactor(1);
+
+    final BrokerInfo tenant1Broker =
+        new BrokerInfo()
+            .setBrokerId(1, null)
+            .setPartitionsCount(1)
+            .setClusterSize(1)
+            .setReplicationFactor(1)
+            .setPartitionGroup("tenant1");
+    tenant1Broker.setLeaderForPartition(1, 5L);
+
+    final Properties props = new Properties();
+    defaultBroker.writeIntoProperties(props);
+    tenant1Broker.writeIntoProperties(props);
+
+    // when / then
+    final BrokerInfo readDefault =
+        BrokerInfo.fromProperties(props, BrokerInfo.DEFAULT_PARTITION_GROUP);
+    assertThat(readDefault).isNotNull();
+    assertThat(readDefault.getPartitionGroup()).isEqualTo(BrokerInfo.DEFAULT_PARTITION_GROUP);
+
+    final BrokerInfo readTenant1 = BrokerInfo.fromProperties(props, "tenant1");
+    assertThat(readTenant1).isNotNull();
+    assertThat(readTenant1.getPartitionGroup()).isEqualTo("tenant1");
+    assertThat(readTenant1.getPartitionRoles()).containsKey(1);
+
+    assertThat(BrokerInfo.fromProperties(props, "unknown")).isNull();
+  }
+
+  @Test
+  void shouldReadAllBrokerInfosFromProperties() {
+    // given
+    final BrokerInfo defaultBroker =
+        new BrokerInfo()
+            .setBrokerId(1, null)
+            .setPartitionsCount(1)
+            .setClusterSize(1)
+            .setReplicationFactor(1);
+    final BrokerInfo tenant1Broker =
+        new BrokerInfo()
+            .setBrokerId(1, null)
+            .setPartitionsCount(1)
+            .setClusterSize(1)
+            .setReplicationFactor(1)
+            .setPartitionGroup("tenant1");
+
+    final Properties props = new Properties();
+    defaultBroker.writeIntoProperties(props);
+    tenant1Broker.writeIntoProperties(props);
+    props.setProperty("otherProperty", "value");
+
+    // when
+    final var all = BrokerInfo.allFromProperties(props);
+
+    // then
+    assertThat(all).hasSize(2);
+    assertThat(all)
+        .extracting(BrokerInfo::getPartitionGroup)
+        .containsExactlyInAnyOrder(BrokerInfo.DEFAULT_PARTITION_GROUP, "tenant1");
+  }
+
+  @Test
+  void shouldReturnEmptyListWhenNoBrokerInfoInProperties() {
+    // given
+    final Properties props = new Properties();
+    props.setProperty("otherProperty", "value");
+
+    // when / then
+    assertThat(BrokerInfo.allFromProperties(props)).isEmpty();
+  }
+
+  @Test
   void shouldReturnDefaultPropertyNameForDefaultPartitionGroup() {
     assertThat(BrokerInfo.brokerInfoPropertyName(BrokerInfo.DEFAULT_PARTITION_GROUP))
         .isEqualTo("brokerInfo");


### PR DESCRIPTION
## Description

This PR completes the topology gossip support for physical tenants by enabling each partition group's topology to be tracked independently. It builds on the previous change that added the `partitionGroup` field to `BrokerInfo` and started publishing a per-group property key.

### Changes

#### `BrokerInfo` (`protocol-impl`)
- `fromProperties(Properties, String partitionGroup)` — reads the group-specific property key.
- `allFromProperties(Properties)` — collects all `BrokerInfo` entries for a member (keys
  `"brokerInfo"` and `"brokerInfo:<group>"`). Used to aggregate per-tenant topology.

#### `TopologyManagerImpl` (`broker`)
- On membership change events now reads the group-scoped property key via   `fromProperties(props, localPartitionGroupInfo.getPartitionGroup())` instead of always reading   `"brokerInfo"`. Each `TopologyManagerImpl` instance only tracks leaders/followers for its own  partition group. Note that `TopologyManagerImpl` runs per partition group.

#### `BrokerTopologyManager` (`broker-client` API)
- New `default getTopology(String partitionGroup)` method. Falls back to `getTopology()` (default  group) for implementations that don't yet support physical tenants, preserving backward   compatibility.

#### `BrokerTopologyManagerImpl` (`broker-client`)
- Internal state changed from a single `BrokerClientTopologyImpl` to   `Map<String, BrokerClientTopologyImpl> topologyPerGroup` (keyed by partition group name), replaced atomically on each update.
- `event()` / `initializeTopologyFromMembership()` call `allFromProperties()` and route each  `BrokerInfo` into the correct group bucket.
- `getTopology()` → `getTopology("default")` — backward-compatible; existing callers see no change.
- `getTopology(String)` returns the group's topology, or `uninitialized()` if the group is unknown.
- Topology listeners are notified once per broker ID (on first appearance across all groups), preserving the same semantics as before.

### Rolling upgrade compatibility

| Scenario | Behaviour |
|---|---|
| Old broker (no `partitionGroup` field) read by new gateway | `allFromProperties` finds the `"brokerInfo"` key; absent field defaults to `"default"` in `getPartitionGroup()` |
| New broker read by old gateway | `"brokerInfo"` key still present; SBE `sinceVersion=9` bytes are trailing and old decoders ignore them |
| Mixed-version cluster during rolling upgrade | Default-group topology is always available via the legacy key; non-default groups are simply absent from old readers' view |

Alternative solution considered: Keep track of topology of all physical tenants with in a single instance of  BrokerClientTopologyImpl`. Since most usecase it to get topology for a single physical tenant, it is easier if we keep a BrokerClientTopology instance per physical tenant as all other usages of topology in BrokerClient and the transport are unaffected. 

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #50546
