### PR TITLE
feat: tighten zone validation (charset, max length, alphanumeric start)

### DIFF
--- a/configuration/pom.xml
+++ b/configuration/pom.xml
@@ -113,6 +113,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/configuration/src/main/java/io/camunda/configuration/Cluster.java
+++ b/configuration/src/main/java/io/camunda/configuration/Cluster.java
@@ -15,6 +15,7 @@ import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.
 import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
 import io.camunda.zeebe.broker.system.configuration.engine.GlobalListenersCfg;
 import io.camunda.zeebe.broker.system.configuration.partitioning.Scheme;
+import io.camunda.zeebe.util.MemberIdUtil;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -154,6 +155,10 @@ public class Cluster implements Cloneable {
   /**
    * The zone this broker belongs to. Used for zone-aware routing and replication. If not set, the
    * broker is considered to be in a single-zone setup.
+   *
+   * <p>Zone must be at most 63 characters, starting with an * alphanumeric character, and
+   * containing only alphanumeric characters and hyphens {@code * [A-Za-z0-9-]}. It must start with
+   * an alphanumeric character (no hyphen)
    */
   private String zone;
 
@@ -349,7 +354,11 @@ public class Cluster implements Cloneable {
   }
 
   public void setZone(final String zone) {
-    this.zone = zone;
+    try {
+      this.zone = MemberIdUtil.validateZone(zone);
+    } catch (final IllegalArgumentException e) {
+      throw new UnifiedConfigurationException(e);
+    }
   }
 
   @Override

--- a/configuration/src/main/java/io/camunda/configuration/UnifiedConfigurationException.java
+++ b/configuration/src/main/java/io/camunda/configuration/UnifiedConfigurationException.java
@@ -7,8 +7,15 @@
  */
 package io.camunda.configuration;
 
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
 public class UnifiedConfigurationException extends RuntimeException {
-  public UnifiedConfigurationException(String message) {
+  public UnifiedConfigurationException(final Exception cause) {
+    super(cause.getMessage(), cause);
+  }
+
+  public UnifiedConfigurationException(final String message) {
     super(message);
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/Zone.java
+++ b/configuration/src/main/java/io/camunda/configuration/Zone.java
@@ -10,7 +10,15 @@ package io.camunda.configuration;
 import io.camunda.zeebe.broker.system.configuration.partitioning.ZoneCfg;
 import io.camunda.zeebe.util.MemberIdUtil;
 
-/** Per-region configuration for the {@link Partitioning.Scheme#ZONE_AWARE} partitioning scheme. */
+/**
+ * Per-region configuration for the {@link Partitioning.Scheme#ZONE_AWARE} partitioning scheme.
+ *
+ * @param name the name of the zone. see {@link Cluster#getZone()} for more information
+ * @param numberOfBrokers the total number of brokers deployed in that zone
+ * @param numberOfReplicas the number of replicas for each replication group in the zone
+ * @param priority the priority of the zone: higher priorities are translated to higher raft
+ *     priorities.
+ */
 public record Zone(String name, int numberOfBrokers, int numberOfReplicas, int priority) {
 
   public Zone {

--- a/configuration/src/main/java/io/camunda/configuration/Zone.java
+++ b/configuration/src/main/java/io/camunda/configuration/Zone.java
@@ -8,9 +8,21 @@
 package io.camunda.configuration;
 
 import io.camunda.zeebe.broker.system.configuration.partitioning.ZoneCfg;
+import io.camunda.zeebe.util.MemberIdUtil;
 
 /** Per-region configuration for the {@link Partitioning.Scheme#ZONE_AWARE} partitioning scheme. */
 public record Zone(String name, int numberOfBrokers, int numberOfReplicas, int priority) {
+
+  public Zone {
+    try {
+      if (name == null) {
+        throw new IllegalArgumentException("name is null");
+      }
+      MemberIdUtil.validateZone(name);
+    } catch (final IllegalArgumentException e) {
+      throw new UnifiedConfigurationException(e);
+    }
+  }
 
   public ZoneCfg toZoneCfg() {
     return new ZoneCfg(name, numberOfBrokers, numberOfReplicas, priority);

--- a/configuration/src/test/java/io/camunda/configuration/ClusterBrokerPropertiesTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ClusterBrokerPropertiesTest.java
@@ -8,6 +8,7 @@
 package io.camunda.configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.atomix.cluster.messaging.MessagingConfig.CompressionAlgorithm;
 import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
@@ -30,6 +31,16 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 })
 @ActiveProfiles("broker")
 public class ClusterBrokerPropertiesTest {
+  @Test
+  void shouldRejectInvalidZoneAtConfigTime() {
+    // given
+    final var cluster = new Cluster();
+
+    // when / then
+    assertThatThrownBy(() -> cluster.setZone("zone_with_underscores"))
+        .isInstanceOf(UnifiedConfigurationException.class);
+  }
+
   @Test
   public void shouldMatchThePropertyNamesInClusterCfg() {
     /*

--- a/configuration/src/test/java/io/camunda/configuration/ZoneTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ZoneTest.java
@@ -8,11 +8,19 @@
 package io.camunda.configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.zeebe.broker.system.configuration.partitioning.ZoneCfg;
 import org.junit.jupiter.api.Test;
 
 public class ZoneTest {
+  @Test
+  void shouldRejectInvalidZoneNameAtConfigTime() {
+    // when / then
+    assertThatThrownBy(() -> new Zone("zone_with_underscores", 1, 1, 100))
+        .isInstanceOf(UnifiedConfigurationException.class);
+  }
+
   @Test
   public void shouldMapRegionCorrectly() {
     // given

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/MemberId.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/MemberId.java
@@ -16,6 +16,8 @@
  */
 package io.atomix.cluster;
 
+import static io.camunda.zeebe.util.MemberIdUtil.validateZone;
+
 import io.camunda.zeebe.util.MemberIdUtil;
 import io.camunda.zeebe.util.VisibleForTesting;
 import java.util.Objects;
@@ -26,6 +28,7 @@ import org.jspecify.annotations.Nullable;
 /** Controller cluster identity. */
 @NullMarked
 public class MemberId extends NodeId {
+
   /**
    * Null when the member is anonymous When a zone is present, this is the node index in the local
    * cluster (e.g. 0, 1, 2, 3...) If a zone is not present, it's equal to the id
@@ -84,7 +87,7 @@ public class MemberId extends NodeId {
    * Creates a zone-aware member identifier.
    *
    * <p>When {@code zone} is {@code null} the result is the bare form {@code "$nodeId"}; otherwise
-   * it is {@code "$zone/$nodeId"}. Leading/trailing whitespace is stripped from {@code zone}.
+   * it is {@code "$zone/$nodeId"}.
    */
   public static MemberId from(final @Nullable String zone, final int nodeId) {
     return new MemberId(zone, nodeId, buildMemberIdString(zone, nodeId));
@@ -118,13 +121,6 @@ public class MemberId extends NodeId {
       throw new IllegalArgumentException("Expected nodeIdx to be >= 0, but got " + nodeIdx);
     }
     return nodeIdx;
-  }
-
-  private static @Nullable String validateZone(final @Nullable String zone) {
-    if (zone != null && zone.isBlank()) {
-      throw new IllegalArgumentException("Expected zone to be non-empty, but was empty");
-    }
-    return zone != null ? zone.strip() : null;
   }
 
   private static String buildMemberIdString(final @Nullable String zone, final int nodeIdx) {

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/MemberIdTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/MemberIdTest.java
@@ -54,16 +54,66 @@ final class MemberIdTest {
   }
 
   @Test
-  void shouldStripSurroundingWhitespaceFromZone() {
+  void shouldThrowWhenZoneContainsUnderscore() {
+    // given / when / then
+    assertThatThrownBy(() -> MemberId.from("zone_a", 7))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void shouldThrowWhenZoneContainsSlash() {
+    // given / when / then
+    assertThatThrownBy(() -> MemberId.from("zone/a", 7))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void shouldThrowWhenZoneContainsSpecialChars() {
+    // given / when / then
+    assertThatThrownBy(() -> MemberId.from("zone.a", 7))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void shouldThrowWhenZoneStartsWithHyphen() {
+    // given / when / then
+    assertThatThrownBy(() -> MemberId.from("-zone", 7))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void shouldThrowWhenZoneExceedsMaxLength() {
+    // given
+    final var longZone = "a".repeat(64);
+
+    // when / then
+    assertThatThrownBy(() -> MemberId.from(longZone, 7))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void shouldAcceptZoneAtMaxLength() {
+    // given
+    final var zone = "a".repeat(63);
+
+    // when / then
+    assertThatNoException().isThrownBy(() -> MemberId.from(zone, 7));
+  }
+
+  @Test
+  void shouldAcceptZoneWithAlphanumericAndHyphens() {
     // given / when
-    final var memberId = MemberId.from("  eu-west  ", 7);
+    final var memberId = MemberId.from("eu-west-1", 7);
 
     // then
-    assertThat(memberId)
-        .returns(7, MemberId::nodeIdx)
-        .returns("eu-west", MemberId::zone)
-        .returns("eu-west/7", MemberId::id);
-    assertEncodeDecode(memberId);
+    assertThat(memberId).returns("eu-west-1", MemberId::zone);
+  }
+
+  @Test
+  void shouldThrowWhenZoneContainsWhitespace() {
+    // given / when / then
+    assertThatThrownBy(() -> MemberId.from("  eu-west  ", 7))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/MemberIdUtil.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/MemberIdUtil.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.util;
 
+import java.util.regex.Pattern;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
@@ -17,24 +18,49 @@ import org.jspecify.annotations.Nullable;
 @NullMarked
 public final class MemberIdUtil {
 
+  private static final Pattern ZONE_PATTERN = Pattern.compile("^[A-Za-z0-9][A-Za-z0-9-]*$");
+  private static final int MAX_ZONE_LENGTH = 63;
+
   private MemberIdUtil() {}
+
+  /**
+   * Validates that {@code zone} is a legal zone name: at most 63 characters, starting with an
+   * alphanumeric character, and containing only alphanumeric characters and hyphens {@code
+   * [A-Za-z0-9-]}. The zone must start with an alphanumeric character.
+   *
+   * @throws IllegalArgumentException if {@code zone} is non-null and violates any constraint
+   */
+  public static @Nullable String validateZone(final @Nullable String zone) {
+    if (zone == null) {
+      return null;
+    }
+    if (zone.length() > MAX_ZONE_LENGTH) {
+      throw new IllegalArgumentException(
+          "Expected zone length to be <= "
+              + MAX_ZONE_LENGTH
+              + ", but got "
+              + zone.length()
+              + " for zone: "
+              + zone);
+    }
+    if (!ZONE_PATTERN.matcher(zone).matches()) {
+      throw new IllegalArgumentException(
+          "Expected zone to start with an alphanumeric character and contain only alphanumeric characters and hyphens [A-Za-z0-9-], but got: "
+              + zone);
+    }
+    return zone;
+  }
 
   /**
    * Returns the canonical string representation of a zone-aware member identifier.
    *
    * <p>When {@code zone} is {@code null} the result is the bare form {@code "$nodeId"}; otherwise
-   * it is {@code "$zone/$nodeId"}. Leading/trailing whitespace is stripped from {@code zone}.
-   *
-   * @throws IllegalArgumentException if {@code zone} is blank
+   * it is {@code "$zone/$nodeId"}. The zone must already be validated (see {@link #validateZone}).
    */
   public static String memberIdString(final @Nullable String zone, final int nodeId) {
     if (zone == null) {
       return Integer.toString(nodeId);
     }
-    final var stripped = zone.strip();
-    if (stripped.isEmpty()) {
-      throw new IllegalArgumentException("Expected zone to be non-empty, but was empty");
-    }
-    return stripped + "/" + nodeId;
+    return zone + "/" + nodeId;
   }
 }


### PR DESCRIPTION
## Description
This PR adds some extra validation to `zone` so that it conforms the following:
- starts with an alphanumeric characters
- contains only alphanumeric characters or `-`
- max allowed length is 63

All the availability zones/ regions from AWS, GCP and azure conforms to these rules, so it's safe to require this.

Moreover, this will allow us to easily sanitize `/` to `_` or to just define the broker id as `$zone_$nodeIdx` directly.

`zone` is validated at startup in `Cluster` and in `Zone` classes in `configuration/`
Added to the Javadoc in `camunda.cluster.zone` the validations applied 

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #54106
