### PR TITLE
refactor: disable OS load test

### DIFF
--- a/.github/workflows/camunda-weekly-load-tests.yml
+++ b/.github/workflows/camunda-weekly-load-tests.yml
@@ -265,7 +265,7 @@ jobs:
   notify:
     name: Notify on failure
     runs-on: ubuntu-latest
-    needs: [ build-camunda-image, build-load-test-images, setup-rdbms-realistic-load-test, setup-opensearch-realistic-load-test, setup-realistic-test, setup-latency-test, setup-ecs-benchmark ]
+    needs: [ build-camunda-image, build-load-test-images, setup-rdbms-realistic-load-test, setup-realistic-test, setup-latency-test, setup-ecs-benchmark ]
     if: failure()
     timeout-minutes: 5
     permissions: { }

--- a/.github/workflows/camunda-weekly-load-tests.yml
+++ b/.github/workflows/camunda-weekly-load-tests.yml
@@ -186,25 +186,26 @@ jobs:
       secondary-storage-type: 'postgresql'
       scenario: realistic
 
-  setup-opensearch-realistic-load-test:
-    name: OpenSearch realistic load test
-    needs:
-      - test-data
-      - build-camunda-image
-      - build-load-test-images
-    if: |
-      always() &&
-      needs.test-data.result == 'success' &&
-      (needs.build-camunda-image.result == 'success' || needs.build-camunda-image.result == 'skipped') &&
-      (needs.build-load-test-images.result == 'success' || needs.build-load-test-images.result == 'skipped')
-    uses: ./.github/workflows/camunda-load-test.yml
-    secrets: inherit
-    with:
-      name: ${{ needs.test-data.outputs.image-tag }}-opensearch-realistic
-      ttl: ${{ fromJSON(inputs.ttl || '28') }}
-      reuse-tag: ${{ needs.test-data.outputs.image-tag }}
-      secondary-storage-type: 'opensearch'
-      scenario: realistic
+  # Disabled Opensearch load test until https://github.com/camunda/camunda/issues/50527 is resolved
+  # setup-opensearch-realistic-load-test:
+  #   name: OpenSearch realistic load test
+  #   needs:
+  #     - test-data
+  #     - build-camunda-image
+  #     - build-load-test-images
+  #   if: |
+  #     always() &&
+  #     needs.test-data.result == 'success' &&
+  #     (needs.build-camunda-image.result == 'success' || needs.build-camunda-image.result == 'skipped') &&
+  #     (needs.build-load-test-images.result == 'success' || needs.build-load-test-images.result == 'skipped')
+  #   uses: ./.github/workflows/camunda-load-test.yml
+  #   secrets: inherit
+  #   with:
+  #     name: ${{ needs.test-data.outputs.image-tag }}-opensearch-realistic
+  #     ttl: ${{ fromJSON(inputs.ttl || '28') }}
+  #     reuse-tag: ${{ needs.test-data.outputs.image-tag }}
+  #     secondary-storage-type: 'opensearch'
+  #     scenario: realistic
 
   setup-realistic-test:
     name: Realistic load test


### PR DESCRIPTION
## Description

* disable OS load test until https://github.com/camunda/camunda/issues/50527 is resolved
<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

related https://github.com/camunda/camunda/issues/50527 is resolved
