### PR TITLE
ci: downsize FOSSA c8run analysis runner from 16 to 4 cores

### DIFF
--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -29,7 +29,7 @@ jobs:
       # Needed for camunda/infra-global-github-actions/fossa/info
       actions: read
       contents: read
-    runs-on: gcp-core-16-longrunning
+    runs-on: ${{ matrix.project.runner }}
     # Skip analysis on fork PRs as they cannot access FOSSA due to lack of credentials
     if: github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork
     # If you change the job timeout, update the timeout in camunda/infra-global-github-actions/fossa/pr-check accordingly.
@@ -41,12 +41,15 @@ jobs:
         project:
         - name: c8run
           path: ./c8run
+          runner: gcp-core-4-longrunning
         - name: optimize
           path: ./optimize
+          runner: gcp-core-16-longrunning
           maven-config: |
             -DskipQaBuild=true
         - name: single-app
           path: ./
+          runner: gcp-core-16-longrunning
           maven-config: |
             -Dquickly=true
             -DskipQaBuild=true


### PR DESCRIPTION
## Summary

- The `c8run` variant in `check-licenses.yml` ran on `gcp-core-16-longrunning` while only using ~2.3 effective cores (max CPU p95 = 14.1%, max memory p95 = 3.4% across 442 samples)
- Adds a `runner` field to each matrix entry and switches `runs-on` to `${{ matrix.project.runner }}`, so variants can be sized independently
- `c8run` moves to `gcp-core-4-longrunning` (75% fewer cores); `optimize` and `single-app` keep `gcp-core-16-longrunning` (`optimize` needs CPU headroom at 41.5% max, `single-app` is memory-constrained at 81.1%)

The price difference between the two runner types in our region is $0.557676/hr, the `c8run` FOSSA check takes around 1.5 minutes and is projected to ~100k annual executions -> ~1500 USD annual savings.

## Test plan

- [x] Confirm `analyze/c8run` job completes successfully on this PR
- [x] Confirm `analyze/c8run` runtime does not increase meaningfully vs baseline (FOSSA is network-bound, not CPU-bound)
- [x] Confirm `analyze/optimize` and `analyze/single-app` are unaffected

> Runtime is identical to the 1.66-min historical average on the old 16-core runner — confirming that FOSSA analysis is network-bound, not CPU-bound. No regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)