### PR TITLE
fix: move GRPC_KEEPALIVE_PERMIT_WITHOUT_CALLS into zeebeGrpcSettings

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/zeebeClient.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/zeebeClient.ts
@@ -24,11 +24,12 @@ const c8 = new Camunda8({
   ZEEBE_REST_ADDRESS: process.env.ZEEBE_REST_ADDRESS,
   ZEEBE_GRPC_ADDRESS:
     process.env.ZEEBE_GRPC_ADDRESS || 'grpc://localhost:26500',
-  // Zeebe server rejects keepalive pings sent without active RPC calls
-  // (permitKeepAliveWithoutCalls=false). Setting this to 0 aligns the client
-  // with the server's expectation and prevents ENHANCE_YOUR_CALM / excess pings errors.
-  // @ts-expect-error -- GRPC_KEEPALIVE_PERMIT_WITHOUT_CALLS is a valid gRPC channel option but not yet typed in the SDK
-  GRPC_KEEPALIVE_PERMIT_WITHOUT_CALLS: 0,
+  zeebeGrpcSettings: {
+    // Zeebe server rejects keepalive pings sent without active RPC calls
+    // (permitKeepAliveWithoutCalls=false). Setting this to 0 aligns the client
+    // with the server's expectation and prevents ENHANCE_YOUR_CALM / excess pings errors.
+    GRPC_KEEPALIVE_PERMIT_WITHOUT_CALLS: 0,
+  },
 });
 
 function generateManyVariables(): Record<string, string> {


### PR DESCRIPTION
## Summary
[Run](https://github.com/camunda/camunda/actions/runs/26514792509/job/78089122613) started and did not end up with failure 


- The gRPC excess-pings fix introduced in #(original PR) was passing `GRPC_KEEPALIVE_PERMIT_WITHOUT_CALLS: 0` at the **top level** of the `Camunda8` constructor options, but the SDK's `GrpcClient.js` reads the value from `config.zeebeGrpcSettings.GRPC_KEEPALIVE_PERMIT_WITHOUT_CALLS`
- lodash `mergeWith` deep-merges the constructor config on top of `CamundaSDKConfiguration`, but a top-level key in the constructor object is NOT propagated into the `zeebeGrpcSettings` subobject — the SDK default of `1` (permit pings without active calls) was never overridden
- As a result, the gRPC channel was still created with `grpc.keepalive_permit_without_calls = 1`, causing the client to send keepalive pings even when no RPCs were active; Zeebe's embedded gateway (`permitKeepAliveWithoutCalls=false`) rejected them with `ENHANCE_YOUR_CALM`, which closed the connection and caused transient test failures
- This PR moves the option inside `zeebeGrpcSettings`, where the SDK actually reads it, so the channel is created with `grpc.keepalive_permit_without_calls = 0`
- The `@ts-expect-error` is no longer needed because the option is now at the correct, typed location

## Test plan

- [ ] Nightly E2E run for `main` completes without "rejected by server because of excess pings" errors in the test output

Failing nightly run that prompted this fix: https://github.com/camunda/camunda/actions/runs/26487468411/job/77997878853

🤖 Generated with [Claude Code](https://claude.com/claude-code)