### PR TITLE
feat: support S3-compatible endpoints in AWS document store

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Document.java
+++ b/configuration/src/main/java/io/camunda/configuration/Document.java
@@ -135,6 +135,7 @@ public class Document {
     private String endpoint;
     private Boolean forcePathStyle;
     private Boolean chunkedEncodingEnabled;
+    private Boolean supportLegacyMd5;
 
     public String getBucketName() {
       return bucketName;
@@ -190,6 +191,14 @@ public class Document {
 
     public void setChunkedEncodingEnabled(final Boolean chunkedEncodingEnabled) {
       this.chunkedEncodingEnabled = chunkedEncodingEnabled;
+    }
+
+    public Boolean getSupportLegacyMd5() {
+      return supportLegacyMd5;
+    }
+
+    public void setSupportLegacyMd5(final Boolean supportLegacyMd5) {
+      this.supportLegacyMd5 = supportLegacyMd5;
     }
   }
 

--- a/configuration/src/main/java/io/camunda/configuration/Document.java
+++ b/configuration/src/main/java/io/camunda/configuration/Document.java
@@ -132,6 +132,9 @@ public class Document {
     private String bucketPath;
     private String region;
     private Long bucketTtl;
+    private String endpoint;
+    private Boolean forcePathStyle;
+    private Boolean chunkedEncodingEnabled;
 
     public String getBucketName() {
       return bucketName;
@@ -163,6 +166,30 @@ public class Document {
 
     public void setBucketTtl(final Long bucketTtl) {
       this.bucketTtl = bucketTtl;
+    }
+
+    public String getEndpoint() {
+      return endpoint;
+    }
+
+    public void setEndpoint(final String endpoint) {
+      this.endpoint = endpoint;
+    }
+
+    public Boolean getForcePathStyle() {
+      return forcePathStyle;
+    }
+
+    public void setForcePathStyle(final Boolean forcePathStyle) {
+      this.forcePathStyle = forcePathStyle;
+    }
+
+    public Boolean getChunkedEncodingEnabled() {
+      return chunkedEncodingEnabled;
+    }
+
+    public void setChunkedEncodingEnabled(final Boolean chunkedEncodingEnabled) {
+      this.chunkedEncodingEnabled = chunkedEncodingEnabled;
     }
   }
 

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/DocumentStoreLocation.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/DocumentStoreLocation.java
@@ -29,7 +29,11 @@ record DocumentStoreLocation(String provider, List<String> coordinates) {
    */
   static DocumentStoreLocation aws(final AwsStore store) {
     return new DocumentStoreLocation(
-        "aws", List.of(normalize(store.getBucketName()), normalize(store.getBucketPath())));
+        "aws",
+        List.of(
+            normalize(store.getBucketName()),
+            normalize(store.getBucketPath()),
+            normalize(store.getEndpoint())));
   }
 
   static DocumentStoreLocation gcp(final GcpStore store) {

--- a/dist/src/main/java/io/camunda/application/commons/document/CamundaDocumentStoreConfigurationLoader.java
+++ b/dist/src/main/java/io/camunda/application/commons/document/CamundaDocumentStoreConfigurationLoader.java
@@ -90,7 +90,12 @@ public final class CamundaDocumentStoreConfigurationLoader
     putResolved(properties, AWS, storeId, "bucket-ttl", "BUCKET_TTL", store.getBucketTtl());
     putResolved(properties, AWS, storeId, "endpoint", "ENDPOINT", store.getEndpoint());
     putResolved(
-        properties, AWS, storeId, "force-path-style", "FORCE_PATH_STYLE", store.getForcePathStyle());
+        properties,
+        AWS,
+        storeId,
+        "force-path-style",
+        "FORCE_PATH_STYLE",
+        store.getForcePathStyle());
     putResolved(
         properties,
         AWS,
@@ -98,7 +103,7 @@ public final class CamundaDocumentStoreConfigurationLoader
         "chunked-encoding-enabled",
         "CHUNKED_ENCODING_ENABLED",
         store.getChunkedEncodingEnabled());
-     putResolved(
+    putResolved(
         properties,
         AWS,
         storeId,

--- a/dist/src/main/java/io/camunda/application/commons/document/CamundaDocumentStoreConfigurationLoader.java
+++ b/dist/src/main/java/io/camunda/application/commons/document/CamundaDocumentStoreConfigurationLoader.java
@@ -98,6 +98,13 @@ public final class CamundaDocumentStoreConfigurationLoader
         "chunked-encoding-enabled",
         "CHUNKED_ENCODING_ENABLED",
         store.getChunkedEncodingEnabled());
+     putResolved(
+        properties,
+        AWS,
+        storeId,
+        "support-legacy-md5",
+        "SUPPORT_LEGACY_MD5",
+        store.getSupportLegacyMd5());
     return toRecord(storeId, AwsDocumentStoreProvider.class, properties);
   }
 

--- a/dist/src/main/java/io/camunda/application/commons/document/CamundaDocumentStoreConfigurationLoader.java
+++ b/dist/src/main/java/io/camunda/application/commons/document/CamundaDocumentStoreConfigurationLoader.java
@@ -88,6 +88,16 @@ public final class CamundaDocumentStoreConfigurationLoader
     putResolved(properties, AWS, storeId, "bucket-path", "BUCKET_PATH", store.getBucketPath());
     putResolved(properties, AWS, storeId, "region", "REGION", store.getRegion());
     putResolved(properties, AWS, storeId, "bucket-ttl", "BUCKET_TTL", store.getBucketTtl());
+    putResolved(properties, AWS, storeId, "endpoint", "ENDPOINT", store.getEndpoint());
+    putResolved(
+        properties, AWS, storeId, "force-path-style", "FORCE_PATH_STYLE", store.getForcePathStyle());
+    putResolved(
+        properties,
+        AWS,
+        storeId,
+        "chunked-encoding-enabled",
+        "CHUNKED_ENCODING_ENABLED",
+        store.getChunkedEncodingEnabled());
     return toRecord(storeId, AwsDocumentStoreProvider.class, properties);
   }
 

--- a/document/store/src/main/java/io/camunda/document/store/InputStreamHashCalculator.java
+++ b/document/store/src/main/java/io/camunda/document/store/InputStreamHashCalculator.java
@@ -9,6 +9,8 @@ package io.camunda.document.store;
 
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.util.HexFormat;
@@ -30,6 +32,16 @@ public class InputStreamHashCalculator {
   public static String streamAndCalculateHash(final InputStream inputStream) throws Exception {
     return streamAndCalculateHash(
         inputStream, stream -> stream.transferTo(OutputStream.nullOutputStream()));
+  }
+
+  public static String spoolToFileAndCalculateHash(final InputStream inputStream, final Path target)
+      throws Exception {
+    final MessageDigest md = MessageDigest.getInstance(MessageDigestAlgorithms.SHA_256);
+    try (final DigestInputStream digestStream = new DigestInputStream(inputStream, md);
+        final OutputStream out = Files.newOutputStream(target)) {
+      digestStream.transferTo(out);
+    }
+    return HexFormat.of().formatHex(md.digest());
   }
 
   @FunctionalInterface

--- a/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStore.java
+++ b/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStore.java
@@ -20,6 +20,9 @@ import io.camunda.document.api.DocumentReference;
 import io.camunda.document.api.DocumentStore;
 import io.camunda.document.store.InputStreamHashCalculator;
 import io.camunda.zeebe.util.Either;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -38,6 +41,8 @@ import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.http.HttpStatusCode;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
+import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
@@ -75,13 +80,32 @@ public class AwsDocumentStore implements DocumentStore {
   private final S3Presigner preSigner;
   private final Long defaultTTL;
   private final String bucketPath;
+  private final boolean requiresBuffering;
 
   public AwsDocumentStore(
       final String bucketName,
       final Long defaultTTL,
       final String bucketPath,
       final ExecutorService executor) {
-    this(bucketName, defaultTTL, bucketPath, S3Client.create(), executor, S3Presigner.create());
+    this(bucketName, defaultTTL, bucketPath, executor, null, null, null);
+  }
+
+  public AwsDocumentStore(
+      final String bucketName,
+      final Long defaultTTL,
+      final String bucketPath,
+      final ExecutorService executor,
+      final URI endpointOverride,
+      final Boolean forcePathStyle,
+      final Boolean chunkedEncodingEnabled) {
+    this(
+        bucketName,
+        defaultTTL,
+        bucketPath,
+        buildClient(endpointOverride, forcePathStyle, chunkedEncodingEnabled),
+        executor,
+        buildPresigner(endpointOverride, forcePathStyle, chunkedEncodingEnabled),
+        Boolean.FALSE.equals(chunkedEncodingEnabled));
   }
 
   public AwsDocumentStore(
@@ -91,12 +115,69 @@ public class AwsDocumentStore implements DocumentStore {
       final S3Client client,
       final ExecutorService executor,
       final S3Presigner preSigner) {
+    this(bucketName, defaultTTL, bucketPath, client, executor, preSigner, false);
+  }
+
+  AwsDocumentStore(
+      final String bucketName,
+      final Long defaultTTL,
+      final String bucketPath,
+      final S3Client client,
+      final ExecutorService executor,
+      final S3Presigner preSigner,
+      final boolean requiresBuffering) {
     this.bucketName = bucketName;
     this.defaultTTL = defaultTTL;
     this.bucketPath = bucketPath;
     this.client = client;
     this.executor = executor;
     this.preSigner = preSigner;
+    this.requiresBuffering = requiresBuffering;
+  }
+
+  private static S3Client buildClient(
+      final URI endpointOverride,
+      final Boolean forcePathStyle,
+      final Boolean chunkedEncodingEnabled) {
+    if (endpointOverride == null && forcePathStyle == null && chunkedEncodingEnabled == null) {
+      return S3Client.create();
+    }
+    final S3ClientBuilder builder = S3Client.builder();
+    if (endpointOverride != null) {
+      builder.endpointOverride(endpointOverride);
+    }
+    builder.serviceConfiguration(
+        buildS3Configuration(endpointOverride, forcePathStyle, chunkedEncodingEnabled));
+    return builder.build();
+  }
+
+  private static S3Presigner buildPresigner(
+      final URI endpointOverride,
+      final Boolean forcePathStyle,
+      final Boolean chunkedEncodingEnabled) {
+    if (endpointOverride == null && forcePathStyle == null && chunkedEncodingEnabled == null) {
+      return S3Presigner.create();
+    }
+    final S3Presigner.Builder builder = S3Presigner.builder();
+    if (endpointOverride != null) {
+      builder.endpointOverride(endpointOverride);
+    }
+    builder.serviceConfiguration(
+        buildS3Configuration(endpointOverride, forcePathStyle, chunkedEncodingEnabled));
+    return builder.build();
+  }
+
+  private static S3Configuration buildS3Configuration(
+      final URI endpointOverride,
+      final Boolean forcePathStyle,
+      final Boolean chunkedEncodingEnabled) {
+    final boolean usePathStyle = forcePathStyle != null ? forcePathStyle : endpointOverride != null;
+    final S3Configuration.Builder s3config =
+        S3Configuration.builder().pathStyleAccessEnabled(usePathStyle);
+    if (chunkedEncodingEnabled != null) {
+      s3config.chunkedEncodingEnabled(chunkedEncodingEnabled);
+    }
+    return s3config.build();
   }
 
   @Override
@@ -289,38 +370,12 @@ public class AwsDocumentStore implements DocumentStore {
       final DocumentCreationRequest request, final String documentId) {
     final String fileName = resolveFileName(request.metadata(), documentId);
 
-    final var putObjectRequest =
-        PutObjectRequest.builder()
-            .key(resolveKey(documentId))
-            .bucket(bucketName)
-            .metadata(toS3MetaData(request.metadata(), fileName, ""))
-            .tagging(generateExpiryTag(request.metadata().expiresAt()))
-            .contentType(request.metadata().contentType())
-            .build();
-
     final String hash;
     try {
       hash =
-          InputStreamHashCalculator.streamAndCalculateHash(
-              request.contentInputStream(),
-              stream ->
-                  client.putObject(
-                      putObjectRequest,
-                      RequestBody.fromInputStream(stream, request.metadata().size())));
-
-      final var copyObjectRequest =
-          CopyObjectRequest.builder()
-              .sourceKey(resolveKey(documentId))
-              .destinationKey(resolveKey(documentId))
-              .sourceBucket(bucketName)
-              .destinationBucket(bucketName)
-              .metadata(toS3MetaData(request.metadata(), fileName, hash))
-              .metadataDirective(MetadataDirective.REPLACE)
-              .tagging(generateExpiryTag(request.metadata().expiresAt()))
-              .contentType(request.metadata().contentType())
-              .build();
-
-      client.copyObject(copyObjectRequest);
+          requiresBuffering
+              ? uploadBuffered(request, documentId, fileName)
+              : uploadStreaming(request, documentId, fileName);
     } catch (final Exception e) {
       return Either.left(new UnknownDocumentError(e));
     }
@@ -335,6 +390,75 @@ public class AwsDocumentStore implements DocumentStore {
             request.metadata().processInstanceKey(),
             request.metadata().customProperties());
     return Either.right(new DocumentReference(documentId, hash, updatedMetadata));
+  }
+
+  private String uploadStreaming(
+      final DocumentCreationRequest request, final String documentId, final String fileName)
+      throws Exception {
+    final var putObjectRequest =
+        PutObjectRequest.builder()
+            .key(resolveKey(documentId))
+            .bucket(bucketName)
+            .metadata(toS3MetaData(request.metadata(), fileName, ""))
+            .tagging(generateExpiryTag(request.metadata().expiresAt()))
+            .contentType(request.metadata().contentType())
+            .build();
+
+    final String hash =
+        InputStreamHashCalculator.streamAndCalculateHash(
+            request.contentInputStream(),
+            stream ->
+                client.putObject(
+                    putObjectRequest,
+                    RequestBody.fromInputStream(stream, request.metadata().size())));
+
+    final var copyObjectRequest =
+        CopyObjectRequest.builder()
+            .sourceKey(resolveKey(documentId))
+            .destinationKey(resolveKey(documentId))
+            .sourceBucket(bucketName)
+            .destinationBucket(bucketName)
+            .metadata(toS3MetaData(request.metadata(), fileName, hash))
+            .metadataDirective(MetadataDirective.REPLACE)
+            .tagging(generateExpiryTag(request.metadata().expiresAt()))
+            .contentType(request.metadata().contentType())
+            .build();
+
+    client.copyObject(copyObjectRequest);
+    return hash;
+  }
+
+  /**
+   * Uploads the document by spooling the request body to a temp file before invoking S3.
+   *
+   * @implNote S3-compatible backends that disable chunked encoding force the SDK to compute the
+   *     payload SHA-256 before sending, and then re-read the stream to send the body. HTTP request
+   *     streams aren't markable, so we spool to a temp file once (computing the hash on the way
+   *     through) and upload directly with the hash already in the metadata — which also lets us
+   *     skip the metadata-replacing copy that the streaming path performs.
+   */
+  private String uploadBuffered(
+      final DocumentCreationRequest request, final String documentId, final String fileName)
+      throws Exception {
+    final Path temp = Files.createTempFile("camunda-document-upload-", ".bin");
+    try {
+      final String hash =
+          InputStreamHashCalculator.spoolToFileAndCalculateHash(request.contentInputStream(), temp);
+
+      final var putObjectRequest =
+          PutObjectRequest.builder()
+              .key(resolveKey(documentId))
+              .bucket(bucketName)
+              .metadata(toS3MetaData(request.metadata(), fileName, hash))
+              .tagging(generateExpiryTag(request.metadata().expiresAt()))
+              .contentType(request.metadata().contentType())
+              .build();
+
+      client.putObject(putObjectRequest, RequestBody.fromFile(temp));
+      return hash;
+    } finally {
+      Files.deleteIfExists(temp);
+    }
   }
 
   private Map<String, String> toS3MetaData(

--- a/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStore.java
+++ b/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStore.java
@@ -492,6 +492,9 @@ public class AwsDocumentStore implements DocumentStore {
   }
 
   private OffsetDateTime resolveEffectiveExpiry(final OffsetDateTime requestedExpiry) {
+    if (defaultTTL == null) {
+      return requestedExpiry;
+    }
     final OffsetDateTime maxExpiry = OffsetDateTime.now().plus(Duration.ofDays(defaultTTL));
     if (requestedExpiry == null || requestedExpiry.isEqual(maxExpiry)) {
       return null;

--- a/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStore.java
+++ b/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStore.java
@@ -54,8 +54,6 @@ import software.amazon.awssdk.services.s3.model.MetadataDirective;
 import software.amazon.awssdk.services.s3.model.NoSuchBucketException;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Exception;
-import software.amazon.awssdk.services.s3.model.Tag;
-import software.amazon.awssdk.services.s3.model.Tagging;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
@@ -68,8 +66,6 @@ public class AwsDocumentStore implements DocumentStore {
   public static final String SIZE_METADATA_KEY = "size";
   public static final String CONTENT_TYPE_METADATA_KEY = "content-type";
   private static final Logger LOGGER = LoggerFactory.getLogger(AwsDocumentStore.class);
-  private static final Tag NO_AUTO_DELETE_TAG =
-      Tag.builder().key("NoAutoDelete").value("true").build();
 
   private static final String METADATA_PROCESS_DEFINITION_ID = "camunda.processDefinitionId";
   private static final String METADATA_PROCESS_INSTANCE_KEY = "camunda.processInstanceKey";
@@ -369,13 +365,14 @@ public class AwsDocumentStore implements DocumentStore {
   private Either<DocumentError, DocumentReference> uploadDocument(
       final DocumentCreationRequest request, final String documentId) {
     final String fileName = resolveFileName(request.metadata(), documentId);
+    final OffsetDateTime effectiveExpiry = resolveEffectiveExpiry(request.metadata().expiresAt());
 
     final String hash;
     try {
       hash =
           requiresBuffering
-              ? uploadBuffered(request, documentId, fileName)
-              : uploadStreaming(request, documentId, fileName);
+              ? uploadBuffered(request, documentId, fileName, effectiveExpiry)
+              : uploadStreaming(request, documentId, fileName, effectiveExpiry);
     } catch (final Exception e) {
       return Either.left(new UnknownDocumentError(e));
     }
@@ -384,7 +381,7 @@ public class AwsDocumentStore implements DocumentStore {
         new DocumentMetadataModel(
             request.metadata().contentType(),
             resolveFileName(request.metadata(), documentId),
-            request.metadata().expiresAt(),
+            effectiveExpiry,
             request.metadata().size(),
             request.metadata().processDefinitionId(),
             request.metadata().processInstanceKey(),
@@ -393,14 +390,16 @@ public class AwsDocumentStore implements DocumentStore {
   }
 
   private String uploadStreaming(
-      final DocumentCreationRequest request, final String documentId, final String fileName)
+      final DocumentCreationRequest request,
+      final String documentId,
+      final String fileName,
+      final OffsetDateTime effectiveExpiry)
       throws Exception {
     final var putObjectRequest =
         PutObjectRequest.builder()
             .key(resolveKey(documentId))
             .bucket(bucketName)
-            .metadata(toS3MetaData(request.metadata(), fileName, ""))
-            .tagging(generateExpiryTag(request.metadata().expiresAt()))
+            .metadata(toS3MetaData(request.metadata(), fileName, "", effectiveExpiry))
             .contentType(request.metadata().contentType())
             .build();
 
@@ -418,9 +417,8 @@ public class AwsDocumentStore implements DocumentStore {
             .destinationKey(resolveKey(documentId))
             .sourceBucket(bucketName)
             .destinationBucket(bucketName)
-            .metadata(toS3MetaData(request.metadata(), fileName, hash))
+            .metadata(toS3MetaData(request.metadata(), fileName, hash, effectiveExpiry))
             .metadataDirective(MetadataDirective.REPLACE)
-            .tagging(generateExpiryTag(request.metadata().expiresAt()))
             .contentType(request.metadata().contentType())
             .build();
 
@@ -438,7 +436,10 @@ public class AwsDocumentStore implements DocumentStore {
    *     skip the metadata-replacing copy that the streaming path performs.
    */
   private String uploadBuffered(
-      final DocumentCreationRequest request, final String documentId, final String fileName)
+      final DocumentCreationRequest request,
+      final String documentId,
+      final String fileName,
+      final OffsetDateTime effectiveExpiry)
       throws Exception {
     final Path temp = Files.createTempFile("camunda-document-upload-", ".bin");
     try {
@@ -449,8 +450,7 @@ public class AwsDocumentStore implements DocumentStore {
           PutObjectRequest.builder()
               .key(resolveKey(documentId))
               .bucket(bucketName)
-              .metadata(toS3MetaData(request.metadata(), fileName, hash))
-              .tagging(generateExpiryTag(request.metadata().expiresAt()))
+              .metadata(toS3MetaData(request.metadata(), fileName, hash, effectiveExpiry))
               .contentType(request.metadata().contentType())
               .build();
 
@@ -462,7 +462,10 @@ public class AwsDocumentStore implements DocumentStore {
   }
 
   private Map<String, String> toS3MetaData(
-      final DocumentMetadataModel metadata, final String fileName, final String contentHash) {
+      final DocumentMetadataModel metadata,
+      final String fileName,
+      final String contentHash,
+      final OffsetDateTime effectiveExpiry) {
     if (metadata == null) {
       return Collections.emptyMap();
     }
@@ -472,7 +475,7 @@ public class AwsDocumentStore implements DocumentStore {
     putIfPresent(CONTENT_TYPE_METADATA_KEY, metadata.contentType(), metadataMap);
     putIfPresent(SIZE_METADATA_KEY, metadata.size(), metadataMap);
     putIfPresent(FILENAME_METADATA_KEY, fileName, metadataMap);
-    putIfPresent(EXPIRES_AT_METADATA_KEY, metadata.expiresAt(), metadataMap);
+    putIfPresent(EXPIRES_AT_METADATA_KEY, effectiveExpiry, metadataMap);
 
     metadataMap.put(CONTENT_HASH_METADATA_KEY, contentHash);
 
@@ -488,6 +491,17 @@ public class AwsDocumentStore implements DocumentStore {
     return metadataMap;
   }
 
+  private OffsetDateTime resolveEffectiveExpiry(final OffsetDateTime requestedExpiry) {
+    final OffsetDateTime maxExpiry = OffsetDateTime.now().plus(Duration.ofDays(defaultTTL));
+    if (requestedExpiry == null || requestedExpiry.isEqual(maxExpiry)) {
+      return null;
+    }
+    if (requestedExpiry.isAfter(maxExpiry)) {
+      return maxExpiry;
+    }
+    return requestedExpiry;
+  }
+
   private <T> void putIfPresent(
       final String key, final T value, final Map<String, String> metadataMap) {
     if (value != null) {
@@ -501,20 +515,6 @@ public class AwsDocumentStore implements DocumentStore {
       return new DocumentNotFound(documentId);
     }
     return new UnknownDocumentError(e);
-  }
-
-  private Tagging generateExpiryTag(final OffsetDateTime expiryDate) {
-    final boolean isExpiryDateBeyondBucketTTL =
-        expiryDate != null
-            && defaultTTL != null
-            && expiryDate.isAfter(OffsetDateTime.now().plus(Duration.ofDays(defaultTTL)));
-
-    return Tagging.builder()
-        .tagSet(
-            isExpiryDateBeyondBucketTTL
-                ? Collections.singletonList(NO_AUTO_DELETE_TAG)
-                : Collections.emptyList())
-        .build();
   }
 
   private String resolveKey(final String documentId) {

--- a/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStore.java
+++ b/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStore.java
@@ -20,6 +20,7 @@ import io.camunda.document.api.DocumentReference;
 import io.camunda.document.api.DocumentStore;
 import io.camunda.document.store.InputStreamHashCalculator;
 import io.camunda.zeebe.util.Either;
+import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -485,7 +486,11 @@ public class AwsDocumentStore implements DocumentStore {
       client.putObject(putObjectRequest, RequestBody.fromFile(temp));
       return hash;
     } finally {
-      Files.deleteIfExists(temp);
+      try {
+        Files.deleteIfExists(temp);
+      } catch (final IOException e) {
+        LOGGER.warn("Failed to delete temp file {}", temp, e);
+      }
     }
   }
 

--- a/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStore.java
+++ b/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStore.java
@@ -40,6 +40,7 @@ import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.http.HttpStatusCode;
+import software.amazon.awssdk.services.s3.LegacyMd5Plugin;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
 import software.amazon.awssdk.services.s3.S3Configuration;
@@ -98,7 +99,27 @@ public class AwsDocumentStore implements DocumentStore {
         bucketName,
         defaultTTL,
         bucketPath,
-        buildClient(endpointOverride, forcePathStyle, chunkedEncodingEnabled),
+        executor,
+        endpointOverride,
+        forcePathStyle,
+        chunkedEncodingEnabled,
+        null);
+  }
+
+  public AwsDocumentStore(
+      final String bucketName,
+      final Long defaultTTL,
+      final String bucketPath,
+      final ExecutorService executor,
+      final URI endpointOverride,
+      final Boolean forcePathStyle,
+      final Boolean chunkedEncodingEnabled,
+      final Boolean supportLegacyMd5) {
+    this(
+        bucketName,
+        defaultTTL,
+        bucketPath,
+        buildClient(endpointOverride, forcePathStyle, chunkedEncodingEnabled, supportLegacyMd5),
         executor,
         buildPresigner(endpointOverride, forcePathStyle, chunkedEncodingEnabled),
         Boolean.FALSE.equals(chunkedEncodingEnabled));
@@ -134,13 +155,20 @@ public class AwsDocumentStore implements DocumentStore {
   private static S3Client buildClient(
       final URI endpointOverride,
       final Boolean forcePathStyle,
-      final Boolean chunkedEncodingEnabled) {
-    if (endpointOverride == null && forcePathStyle == null && chunkedEncodingEnabled == null) {
+      final Boolean chunkedEncodingEnabled,
+      final Boolean supportLegacyMd5) {
+    if (endpointOverride == null
+        && forcePathStyle == null
+        && chunkedEncodingEnabled == null
+        && !Boolean.TRUE.equals(supportLegacyMd5)) {
       return S3Client.create();
     }
     final S3ClientBuilder builder = S3Client.builder();
     if (endpointOverride != null) {
       builder.endpointOverride(endpointOverride);
+    }
+    if (Boolean.TRUE.equals(supportLegacyMd5)) {
+      builder.addPlugin(LegacyMd5Plugin.create());
     }
     builder.serviceConfiguration(
         buildS3Configuration(endpointOverride, forcePathStyle, chunkedEncodingEnabled));

--- a/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStore.java
+++ b/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStore.java
@@ -520,13 +520,10 @@ public class AwsDocumentStore implements DocumentStore {
   }
 
   private OffsetDateTime resolveEffectiveExpiry(final OffsetDateTime requestedExpiry) {
-    if (defaultTTL == null) {
+    if (defaultTTL == null || requestedExpiry == null) {
       return requestedExpiry;
     }
     final OffsetDateTime maxExpiry = OffsetDateTime.now().plus(Duration.ofDays(defaultTTL));
-    if (requestedExpiry == null || requestedExpiry.isEqual(maxExpiry)) {
-      return null;
-    }
     if (requestedExpiry.isAfter(maxExpiry)) {
       return maxExpiry;
     }

--- a/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStoreFactory.java
+++ b/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStoreFactory.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.document.store.aws;
 
+import java.net.URI;
 import java.util.concurrent.ExecutorService;
 
 public class AwsDocumentStoreFactory {
@@ -16,5 +17,23 @@ public class AwsDocumentStoreFactory {
       final String bucketPath,
       final ExecutorService executor) {
     return new AwsDocumentStore(bucketName, defaultTTL, bucketPath, executor);
+  }
+
+  public static AwsDocumentStore create(
+      final String bucketName,
+      final Long defaultTTL,
+      final String bucketPath,
+      final ExecutorService executor,
+      final URI endpointOverride,
+      final Boolean forcePathStyle,
+      final Boolean chunkedEncodingEnabled) {
+    return new AwsDocumentStore(
+        bucketName,
+        defaultTTL,
+        bucketPath,
+        executor,
+        endpointOverride,
+        forcePathStyle,
+        chunkedEncodingEnabled);
   }
 }

--- a/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStoreFactory.java
+++ b/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStoreFactory.java
@@ -27,6 +27,20 @@ public class AwsDocumentStoreFactory {
       final URI endpointOverride,
       final Boolean forcePathStyle,
       final Boolean chunkedEncodingEnabled) {
+    return create(
+        bucketName, defaultTTL, bucketPath, executor, endpointOverride, forcePathStyle,
+        chunkedEncodingEnabled, null);
+  }
+
+  public static AwsDocumentStore create(
+      final String bucketName,
+      final Long defaultTTL,
+      final String bucketPath,
+      final ExecutorService executor,
+      final URI endpointOverride,
+      final Boolean forcePathStyle,
+      final Boolean chunkedEncodingEnabled,
+      final Boolean supportLegacyMd5) {
     return new AwsDocumentStore(
         bucketName,
         defaultTTL,
@@ -34,6 +48,7 @@ public class AwsDocumentStoreFactory {
         executor,
         endpointOverride,
         forcePathStyle,
-        chunkedEncodingEnabled);
+        chunkedEncodingEnabled,
+        supportLegacyMd5);
   }
 }

--- a/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStoreFactory.java
+++ b/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStoreFactory.java
@@ -28,8 +28,14 @@ public class AwsDocumentStoreFactory {
       final Boolean forcePathStyle,
       final Boolean chunkedEncodingEnabled) {
     return create(
-        bucketName, defaultTTL, bucketPath, executor, endpointOverride, forcePathStyle,
-        chunkedEncodingEnabled, null);
+        bucketName,
+        defaultTTL,
+        bucketPath,
+        executor,
+        endpointOverride,
+        forcePathStyle,
+        chunkedEncodingEnabled,
+        null);
   }
 
   public static AwsDocumentStore create(

--- a/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStoreProvider.java
+++ b/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStoreProvider.java
@@ -10,6 +10,8 @@ package io.camunda.document.store.aws;
 import io.camunda.document.api.DocumentStore;
 import io.camunda.document.api.DocumentStoreConfiguration.DocumentStoreConfigurationRecord;
 import io.camunda.document.api.DocumentStoreProvider;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
@@ -25,6 +27,9 @@ public class AwsDocumentStoreProvider implements DocumentStoreProvider {
   private static final String BUCKET_NAME_PROPERTY = "BUCKET";
   private static final String BUCKET_TTL = "BUCKET_TTL";
   private static final String BUCKET_PATH = "BUCKET_PATH";
+  private static final String ENDPOINT = "ENDPOINT";
+  private static final String FORCE_PATH_STYLE = "FORCE_PATH_STYLE";
+  private static final String CHUNKED_ENCODING_ENABLED = "CHUNKED_ENCODING_ENABLED";
 
   @Override
   public DocumentStore createDocumentStore(
@@ -41,7 +46,13 @@ public class AwsDocumentStoreProvider implements DocumentStoreProvider {
                             + "'"));
 
     return AwsDocumentStoreFactory.create(
-        bucketName, getDefaultTTL(configuration), getBucketPath(configuration), executorService);
+        bucketName,
+        getDefaultTTL(configuration),
+        getBucketPath(configuration),
+        executorService,
+        getEndpoint(configuration),
+        getForcePathStyle(configuration),
+        getChunkedEncodingEnabled(configuration));
   }
 
   private static Long getDefaultTTL(final DocumentStoreConfigurationRecord configuration) {
@@ -81,5 +92,35 @@ public class AwsDocumentStoreProvider implements DocumentStoreProvider {
     }
 
     return bucketPath;
+  }
+
+  private static URI getEndpoint(final DocumentStoreConfigurationRecord configuration) {
+    final String endpoint = configuration.properties().get(ENDPOINT);
+    if (endpoint == null || endpoint.isBlank()) {
+      return null;
+    }
+    try {
+      return new URI(endpoint);
+    } catch (final URISyntaxException e) {
+      throw new IllegalArgumentException(
+          "Failed to configure document store with id '"
+              + configuration.id()
+              + "': '"
+              + ENDPOINT
+              + "' is not a valid URI: "
+              + endpoint,
+          e);
+    }
+  }
+
+  private static Boolean getForcePathStyle(final DocumentStoreConfigurationRecord configuration) {
+    final String value = configuration.properties().get(FORCE_PATH_STYLE);
+    return value == null ? null : Boolean.parseBoolean(value);
+  }
+
+  private static Boolean getChunkedEncodingEnabled(
+      final DocumentStoreConfigurationRecord configuration) {
+    final String value = configuration.properties().get(CHUNKED_ENCODING_ENABLED);
+    return value == null ? null : Boolean.parseBoolean(value);
   }
 }

--- a/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStoreProvider.java
+++ b/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStoreProvider.java
@@ -126,8 +126,7 @@ public class AwsDocumentStoreProvider implements DocumentStoreProvider {
     return value == null ? null : Boolean.parseBoolean(value);
   }
 
-  private static Boolean getSupportLegacyMd5(
-      final DocumentStoreConfigurationRecord configuration) {
+  private static Boolean getSupportLegacyMd5(final DocumentStoreConfigurationRecord configuration) {
     final String value = configuration.properties().get(SUPPORT_LEGACY_MD5);
     return value == null ? null : Boolean.parseBoolean(value);
   }

--- a/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStoreProvider.java
+++ b/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStoreProvider.java
@@ -30,6 +30,7 @@ public class AwsDocumentStoreProvider implements DocumentStoreProvider {
   private static final String ENDPOINT = "ENDPOINT";
   private static final String FORCE_PATH_STYLE = "FORCE_PATH_STYLE";
   private static final String CHUNKED_ENCODING_ENABLED = "CHUNKED_ENCODING_ENABLED";
+  private static final String SUPPORT_LEGACY_MD5 = "SUPPORT_LEGACY_MD5";
 
   @Override
   public DocumentStore createDocumentStore(
@@ -52,7 +53,8 @@ public class AwsDocumentStoreProvider implements DocumentStoreProvider {
         executorService,
         getEndpoint(configuration),
         getForcePathStyle(configuration),
-        getChunkedEncodingEnabled(configuration));
+        getChunkedEncodingEnabled(configuration),
+        getSupportLegacyMd5(configuration));
   }
 
   private static Long getDefaultTTL(final DocumentStoreConfigurationRecord configuration) {
@@ -121,6 +123,12 @@ public class AwsDocumentStoreProvider implements DocumentStoreProvider {
   private static Boolean getChunkedEncodingEnabled(
       final DocumentStoreConfigurationRecord configuration) {
     final String value = configuration.properties().get(CHUNKED_ENCODING_ENABLED);
+    return value == null ? null : Boolean.parseBoolean(value);
+  }
+
+  private static Boolean getSupportLegacyMd5(
+      final DocumentStoreConfigurationRecord configuration) {
+    final String value = configuration.properties().get(SUPPORT_LEGACY_MD5);
     return value == null ? null : Boolean.parseBoolean(value);
   }
 }

--- a/document/store/src/test/java/io/camunda/document/store/InputStreamHashCalculatorTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/InputStreamHashCalculatorTest.java
@@ -10,7 +10,11 @@ package io.camunda.document.store;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayInputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -41,5 +45,21 @@ public class InputStreamHashCalculatorTest {
         Arguments.of(
             "last test I promise",
             "763e43816c8efe27f0021050a897a3749ecb49a0720f502c11f2ec407a9e378e"));
+  }
+
+  @Test
+  void shouldSpoolToFileAndReturnHashMatchingFileContents(@TempDir final Path tempDir)
+      throws Exception {
+    // given
+    final byte[] payload = "Hello, World".getBytes();
+    final var stream = new ByteArrayInputStream(payload);
+    final Path target = tempDir.resolve("spooled.bin");
+
+    // when
+    final String hash = InputStreamHashCalculator.spoolToFileAndCalculateHash(stream, target);
+
+    // then
+    assertThat(Files.readAllBytes(target)).isEqualTo(payload);
+    assertThat(hash).isEqualTo("03675ac53ff9cd1535ccc7dfcdfa2c458c5218371f418dc136f2d19ac1fbe8a5");
   }
 }

--- a/document/store/src/test/java/io/camunda/document/store/aws/AwsDocumentStoreProviderTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/aws/AwsDocumentStoreProviderTest.java
@@ -16,9 +16,11 @@ import static org.mockito.Mockito.mockStatic;
 
 import io.camunda.document.api.DocumentStore;
 import io.camunda.document.api.DocumentStoreConfiguration.DocumentStoreConfigurationRecord;
+import java.net.URI;
 import java.util.HashMap;
 import java.util.concurrent.Executors;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 public class AwsDocumentStoreProviderTest {
 
@@ -32,7 +34,16 @@ public class AwsDocumentStoreProviderTest {
 
       // this mock is used to bypass the auto config of S3Client.create()
       mockedFactory
-          .when(() -> AwsDocumentStoreFactory.create(eq(bucketName), eq(bucketTtl), eq(""), any()))
+          .when(
+              () ->
+                  AwsDocumentStoreFactory.create(
+                      eq(bucketName),
+                      eq(bucketTtl),
+                      eq(""),
+                      any(),
+                      eq((URI) null),
+                      eq((Boolean) null),
+                      eq((Boolean) null)))
           .thenReturn(mockDocumentStore);
 
       final DocumentStoreConfigurationRecord configuration =
@@ -121,5 +132,123 @@ public class AwsDocumentStoreProviderTest {
     assertThat(ex.getMessage())
         .isEqualTo(
             "Failed to configure document store with id 'aws': 'BUCKET_PATH is invalid. Must not contain \\ character'");
+  }
+
+  @Test
+  public void shouldPassS3CompatibleOptionsWhenEndpointSet() {
+    try (final var mockedFactory = mockStatic(AwsDocumentStoreFactory.class)) {
+      // given
+      final AwsDocumentStore mockDocumentStore = mock(AwsDocumentStore.class);
+      final ArgumentCaptor<URI> endpointCaptor = ArgumentCaptor.forClass(URI.class);
+      final ArgumentCaptor<Boolean> pathStyleCaptor = ArgumentCaptor.forClass(Boolean.class);
+      mockedFactory
+          .when(
+              () ->
+                  AwsDocumentStoreFactory.create(
+                      any(),
+                      any(),
+                      any(),
+                      any(),
+                      endpointCaptor.capture(),
+                      pathStyleCaptor.capture(),
+                      any()))
+          .thenReturn(mockDocumentStore);
+
+      final DocumentStoreConfigurationRecord configuration =
+          new DocumentStoreConfigurationRecord(
+              "aws", AwsDocumentStoreProvider.class, new HashMap<>());
+      configuration.properties().put("BUCKET", "bucket");
+      configuration.properties().put("ENDPOINT", "http://minio.local:9000");
+
+      // when
+      new AwsDocumentStoreProvider()
+          .createDocumentStore(configuration, Executors.newSingleThreadExecutor());
+
+      // then
+      assertThat(endpointCaptor.getValue()).isEqualTo(URI.create("http://minio.local:9000"));
+      assertThat(pathStyleCaptor.getValue()).isNull();
+    }
+  }
+
+  @Test
+  public void shouldRespectExplicitForcePathStyleFalse() {
+    try (final var mockedFactory = mockStatic(AwsDocumentStoreFactory.class)) {
+      // given
+      final AwsDocumentStore mockDocumentStore = mock(AwsDocumentStore.class);
+      final ArgumentCaptor<Boolean> pathStyleCaptor = ArgumentCaptor.forClass(Boolean.class);
+      mockedFactory
+          .when(
+              () ->
+                  AwsDocumentStoreFactory.create(
+                      any(), any(), any(), any(), any(), pathStyleCaptor.capture(), any()))
+          .thenReturn(mockDocumentStore);
+
+      final DocumentStoreConfigurationRecord configuration =
+          new DocumentStoreConfigurationRecord(
+              "aws", AwsDocumentStoreProvider.class, new HashMap<>());
+      configuration.properties().put("BUCKET", "bucket");
+      configuration.properties().put("ENDPOINT", "http://minio.local:9000");
+      configuration.properties().put("FORCE_PATH_STYLE", "false");
+
+      // when
+      new AwsDocumentStoreProvider()
+          .createDocumentStore(configuration, Executors.newSingleThreadExecutor());
+
+      // then
+      assertThat(pathStyleCaptor.getValue()).isFalse();
+    }
+  }
+
+  @Test
+  public void shouldThrowIfEndpointIsNotAValidUri() {
+    // given
+    final DocumentStoreConfigurationRecord configuration =
+        new DocumentStoreConfigurationRecord(
+            "aws", AwsDocumentStoreProvider.class, new HashMap<>());
+    configuration.properties().put("BUCKET", "bucket");
+    configuration.properties().put("ENDPOINT", "not a uri");
+
+    final AwsDocumentStoreProvider provider = new AwsDocumentStoreProvider();
+
+    // when / then
+    final var ex =
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(
+                () ->
+                    provider.createDocumentStore(
+                        configuration, Executors.newSingleThreadExecutor()))
+            .actual();
+    assertThat(ex.getMessage())
+        .startsWith(
+            "Failed to configure document store with id 'aws': 'ENDPOINT' is not a valid URI");
+  }
+
+  @Test
+  public void shouldRespectExplicitChunkedEncodingDisabled() {
+    try (final var mockedFactory = mockStatic(AwsDocumentStoreFactory.class)) {
+      // given
+      final AwsDocumentStore mockDocumentStore = mock(AwsDocumentStore.class);
+      final ArgumentCaptor<Boolean> chunkedCaptor = ArgumentCaptor.forClass(Boolean.class);
+      mockedFactory
+          .when(
+              () ->
+                  AwsDocumentStoreFactory.create(
+                      any(), any(), any(), any(), any(), any(), chunkedCaptor.capture()))
+          .thenReturn(mockDocumentStore);
+
+      final DocumentStoreConfigurationRecord configuration =
+          new DocumentStoreConfigurationRecord(
+              "aws", AwsDocumentStoreProvider.class, new HashMap<>());
+      configuration.properties().put("BUCKET", "bucket");
+      configuration.properties().put("ENDPOINT", "http://garage.local:3900");
+      configuration.properties().put("CHUNKED_ENCODING_ENABLED", "false");
+
+      // when
+      new AwsDocumentStoreProvider()
+          .createDocumentStore(configuration, Executors.newSingleThreadExecutor());
+
+      // then
+      assertThat(chunkedCaptor.getValue()).isFalse();
+    }
   }
 }

--- a/document/store/src/test/java/io/camunda/document/store/aws/AwsDocumentStoreProviderTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/aws/AwsDocumentStoreProviderTest.java
@@ -43,6 +43,7 @@ public class AwsDocumentStoreProviderTest {
                       any(),
                       eq((URI) null),
                       eq((Boolean) null),
+                      eq((Boolean) null),
                       eq((Boolean) null)))
           .thenReturn(mockDocumentStore);
 
@@ -151,6 +152,7 @@ public class AwsDocumentStoreProviderTest {
                       any(),
                       endpointCaptor.capture(),
                       pathStyleCaptor.capture(),
+                      any(),
                       any()))
           .thenReturn(mockDocumentStore);
 
@@ -180,7 +182,7 @@ public class AwsDocumentStoreProviderTest {
           .when(
               () ->
                   AwsDocumentStoreFactory.create(
-                      any(), any(), any(), any(), any(), pathStyleCaptor.capture(), any()))
+                      any(), any(), any(), any(), any(), pathStyleCaptor.capture(), any(), any()))
           .thenReturn(mockDocumentStore);
 
       final DocumentStoreConfigurationRecord configuration =
@@ -233,7 +235,7 @@ public class AwsDocumentStoreProviderTest {
           .when(
               () ->
                   AwsDocumentStoreFactory.create(
-                      any(), any(), any(), any(), any(), any(), chunkedCaptor.capture()))
+                      any(), any(), any(), any(), any(), any(), chunkedCaptor.capture(), any()))
           .thenReturn(mockDocumentStore);
 
       final DocumentStoreConfigurationRecord configuration =

--- a/document/store/src/test/java/io/camunda/document/store/aws/AwsDocumentStoreTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/aws/AwsDocumentStoreTest.java
@@ -470,4 +470,57 @@ class AwsDocumentStoreTest {
     final var request = requestCaptor.getValue();
     assertThat(request.bucket()).isEqualTo(BUCKET_NAME);
   }
+
+  @Test
+  void createDocumentInBufferedModeShouldPutHashInMetadataAndSkipCopy() {
+    // given
+    final var bufferedStore =
+        new AwsDocumentStore(
+            BUCKET_NAME,
+            BUCKET_TTL,
+            BUCKET_PATH,
+            s3Client,
+            Executors.newSingleThreadExecutor(),
+            preSigner,
+            true);
+
+    final var documentId = "buffered-document-id";
+    final var content = "buffered-content".getBytes();
+    final var inputStream = new ByteArrayInputStream(content);
+
+    final var metadata =
+        new DocumentMetadataModel(
+            "text/plain",
+            "buffered.txt",
+            null,
+            (long) content.length,
+            null,
+            null,
+            Collections.emptyMap());
+
+    when(s3Client.headObject(any(HeadObjectRequest.class)))
+        .thenThrow(S3Exception.builder().statusCode(HttpStatusCode.NOT_FOUND).build());
+    when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+        .thenReturn(mock(PutObjectResponse.class));
+
+    final var request = new DocumentCreationRequest(documentId, inputStream, metadata);
+
+    // when
+    final var result = bufferedStore.createDocument(request).join();
+
+    // then
+    assertThat(result.isRight()).isTrue();
+    assertThat(result.get().documentId()).isEqualTo(documentId);
+
+    // and — the buffered path embeds the hash directly in the put's metadata, so the
+    // metadata-replacing copy that the streaming path performs is unnecessary.
+    final var putRequestCaptor = ArgumentCaptor.forClass(PutObjectRequest.class);
+    verify(s3Client).putObject(putRequestCaptor.capture(), any(RequestBody.class));
+    final var putRequest = putRequestCaptor.getValue();
+    assertThat(putRequest.key()).isEqualTo(BUCKET_PATH + documentId);
+    assertThat(putRequest.bucket()).isEqualTo(BUCKET_NAME);
+    assertThat(putRequest.metadata().get("content-hash"))
+        .isEqualTo("78636f5cf96b5a61fc7147b4ee4c2e503ee1a3463128978fb02f6d33bcfcea59");
+    verify(s3Client, never()).copyObject(any(CopyObjectRequest.class));
+  }
 }

--- a/document/store/src/test/java/io/camunda/document/store/aws/AwsDocumentStoreTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/aws/AwsDocumentStoreTest.java
@@ -9,6 +9,7 @@ package io.camunda.document.store.aws;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.within;
 import static org.mockito.Mockito.*;
 
 import io.camunda.document.api.*;
@@ -25,6 +26,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.Executors;
@@ -146,12 +148,13 @@ class AwsDocumentStoreTest {
   }
 
   @Test
-  void createDocumentShouldApplyTagIfDocumentExpiryGreaterThanTTL() {
+  void createDocumentShouldCapExpiryIfDocumentExpiryGreaterThanTTL() {
     // given
     final var documentId = "existing-document-id";
     final var inputStream = new ByteArrayInputStream(new byte[0]);
     final ArgumentCaptor<PutObjectRequest> putObjectRequestCaptor = ArgumentCaptor.captor();
-    final var expiryTime = OffsetDateTime.now().plus(Duration.ofDays(60));
+    final var now = OffsetDateTime.now();
+    final var expiryTime = now.plus(Duration.ofDays(60));
     final var metadata =
         new DocumentMetadataModel(
             "application/text",
@@ -172,7 +175,43 @@ class AwsDocumentStoreTest {
 
     // then
     verify(s3Client).putObject(putObjectRequestCaptor.capture(), any(RequestBody.class));
-    assertThat(putObjectRequestCaptor.getValue().tagging()).isEqualTo("NoAutoDelete=true");
+    // OffsetDateTime.now() in production and in the test are captured at different instants;
+    // string equality would fail on sub-millisecond differences, so we compare with tolerance.
+    final var storedExpiry =
+        OffsetDateTime.parse(putObjectRequestCaptor.getValue().metadata().get("expires-at"));
+    assertThat(storedExpiry)
+        .isCloseTo(now.plus(Duration.ofDays(BUCKET_TTL)), within(1, ChronoUnit.SECONDS));
+  }
+
+  @Test
+  void createDocumentShouldSetExpiryIfDocumentExpirySmallerThanTTL() {
+    // given
+    final var documentId = "existing-document-id";
+    final var inputStream = new ByteArrayInputStream(new byte[0]);
+    final ArgumentCaptor<PutObjectRequest> putObjectRequestCaptor = ArgumentCaptor.captor();
+    final var expiryTime = OffsetDateTime.now().plus(Duration.ofDays(10));
+    final var metadata =
+        new DocumentMetadataModel(
+            "application/text",
+            "given-test-document.jpeg",
+            expiryTime,
+            10000L,
+            null,
+            null,
+            Collections.emptyMap());
+
+    final var request = new DocumentCreationRequest(documentId, inputStream, metadata);
+
+    when(s3Client.headObject(any(HeadObjectRequest.class)))
+        .thenThrow(S3Exception.builder().statusCode(HttpStatusCode.NOT_FOUND).build());
+
+    // when
+    documentStore.createDocument(request).join();
+
+    // then
+    verify(s3Client).putObject(putObjectRequestCaptor.capture(), any(RequestBody.class));
+    assertThat(putObjectRequestCaptor.getValue().metadata().get("expires-at"))
+        .isEqualTo(expiryTime.toString());
   }
 
   @Test

--- a/qa/acceptance-tests/pom.xml
+++ b/qa/acceptance-tests/pom.xml
@@ -196,6 +196,18 @@
     </dependency>
 
     <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>aws-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>auth</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.jeasy</groupId>
       <artifactId>easy-random-core</artifactId>
       <scope>test</scope>

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/document/DocumentStoreS3CompatibleIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/document/DocumentStoreS3CompatibleIT.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.document;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.DocumentReferenceResponse;
+import io.camunda.qa.util.cluster.TestCamundaApplication;
+import io.camunda.qa.util.multidb.MultiDbConfigurator;
+import io.camunda.security.api.model.config.AuthenticationMethod;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+import org.agrona.CloseHelper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.localstack.LocalStackContainer;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+
+/**
+ * Verifies that Camunda Document Handling can be pointed at a self-hosted S3-compatible backend via
+ * the {@code DOCUMENT_STORE_AWS_*} configuration properties.
+ *
+ * <p>Exercises both upload paths of {@link io.camunda.document.store.aws.AwsDocumentStore}: the
+ * default streaming path (chunked encoding enabled, used by real AWS) and the buffered temp-file
+ * path (chunked encoding disabled, required by some S3-compatible backends).
+ *
+ * <p>Assertions are made directly against the backend so a regression in the wiring that silently
+ * sends documents to the wrong place would be caught.
+ */
+@Testcontainers
+@ZeebeIntegration
+final class DocumentStoreS3CompatibleIT {
+
+  private static final String INDEX_PREFIX = "doc-s3-compat-it";
+
+  @Container
+  private static final LocalStackContainer LOCALSTACK =
+      new LocalStackContainer(DockerImageName.parse("localstack/localstack:4.10"))
+          .withServices("s3");
+
+  @Container
+  private static final GenericContainer<?> ELASTICSEARCH =
+      TestSearchContainers.createDefaultElasticsearchContainer()
+          .withStartupTimeout(Duration.ofMinutes(5));
+
+  private static S3Client s3AdminClient;
+
+  @TestZeebe(autoStart = false)
+  private TestCamundaApplication testCamundaApplication;
+
+  private CamundaClient camundaClient;
+  private String bucketName;
+  private final Set<String> setSystemProperties = new HashSet<>();
+
+  @BeforeAll
+  static void setupAdminClient() {
+    s3AdminClient =
+        S3Client.builder()
+            .endpointOverride(LOCALSTACK.getEndpoint())
+            .region(Region.of(LOCALSTACK.getRegion()))
+            .credentialsProvider(
+                StaticCredentialsProvider.create(
+                    AwsBasicCredentials.create(
+                        LOCALSTACK.getAccessKey(), LOCALSTACK.getSecretKey())))
+            .serviceConfiguration(S3Configuration.builder().pathStyleAccessEnabled(true).build())
+            .build();
+  }
+
+  @AfterEach
+  void cleanup() {
+    setSystemProperties.forEach(System::clearProperty);
+    setSystemProperties.clear();
+    CloseHelper.quietCloseAll(camundaClient);
+    camundaClient = null;
+  }
+
+  @Test
+  void shouldStoreDocumentInBackendWithChunkedEncodingDefault() {
+    // given
+    startCamundaWith(null);
+    final byte[] payload = "hello".getBytes(StandardCharsets.UTF_8);
+
+    // when
+    final var ref = uploadDocument(payload);
+
+    // then
+    final var head = s3AdminClient.headObject(b -> b.bucket(bucketName).key(ref.getDocumentId()));
+    assertThat(head.contentLength()).isEqualTo((long) payload.length);
+  }
+
+  @Test
+  void shouldStoreDocumentInBackendWithChunkedEncodingDisabled() {
+    // given
+    startCamundaWith(false);
+    final byte[] payload = "hello".getBytes(StandardCharsets.UTF_8);
+
+    // when
+    final var ref = uploadDocument(payload);
+
+    // then
+    final var head = s3AdminClient.headObject(b -> b.bucket(bucketName).key(ref.getDocumentId()));
+    assertThat(head.contentLength()).isEqualTo((long) payload.length);
+  }
+
+  @Test
+  void shouldFetchDocumentContentFromBackend() throws Exception {
+    // given
+    startCamundaWith(null);
+    final byte[] payload = "fetch me".getBytes(StandardCharsets.UTF_8);
+    final var ref = uploadDocument(payload);
+
+    // when
+    final byte[] fetched;
+    try (final var stream =
+        camundaClient
+            .newDocumentContentGetRequest(ref.getDocumentId())
+            .contentHash(ref.getContentHash())
+            .send()
+            .join()) {
+      fetched = stream.readAllBytes();
+    }
+
+    // then
+    assertThat(fetched).isEqualTo(payload);
+  }
+
+  @Test
+  void shouldCreatePresignedLinkThatServesTheDocument() throws Exception {
+    // given
+    startCamundaWith(null);
+    final byte[] payload = "link me".getBytes(StandardCharsets.UTF_8);
+    final var ref = uploadDocument(payload);
+
+    // when
+    final var link =
+        camundaClient
+            .newCreateDocumentLinkCommand(ref.getDocumentId())
+            .contentHash(ref.getContentHash())
+            .timeToLive(Duration.ofMinutes(1))
+            .send()
+            .join();
+
+    // then — the presigned URL points at the configured S3 endpoint, not real AWS
+    final URI linkUri = URI.create(link.getUrl());
+    final URI endpoint = LOCALSTACK.getEndpoint();
+    assertThat(linkUri.getHost()).isEqualTo(endpoint.getHost());
+    assertThat(linkUri.getPort()).isEqualTo(endpoint.getPort());
+
+    // and — following the link returns the original document content
+    try (final var httpClient = HttpClient.newHttpClient()) {
+      final var response =
+          httpClient.send(
+              HttpRequest.newBuilder(linkUri).GET().build(), BodyHandlers.ofByteArray());
+      assertThat(response.statusCode()).isEqualTo(200);
+      assertThat(response.body()).isEqualTo(payload);
+    }
+  }
+
+  @Test
+  void shouldDeleteDocumentFromBackend() {
+    // given
+    startCamundaWith(null);
+    final var ref = uploadDocument("delete me".getBytes(StandardCharsets.UTF_8));
+    // sanity: the object is in the bucket before delete
+    s3AdminClient.headObject(b -> b.bucket(bucketName).key(ref.getDocumentId()));
+
+    // when
+    camundaClient.newDeleteDocumentCommand(ref.getDocumentId()).send().join();
+
+    // then — the object is no longer in the bucket
+    assertThatThrownBy(
+            () -> s3AdminClient.headObject(b -> b.bucket(bucketName).key(ref.getDocumentId())))
+        .isInstanceOf(NoSuchKeyException.class);
+  }
+
+  private DocumentReferenceResponse uploadDocument(final byte[] payload) {
+    return camundaClient
+        .newCreateDocumentCommand()
+        .content(payload)
+        .contentType("text/plain")
+        .fileName("hello.txt")
+        .send()
+        .join();
+  }
+
+  private void startCamundaWith(final Boolean chunkedEncodingEnabled) {
+    bucketName = "documents-" + UUID.randomUUID().toString().substring(0, 8);
+    s3AdminClient.createBucket(b -> b.bucket(bucketName));
+
+    setSystemProperty("DOCUMENT_DEFAULT_STORE_ID", "aws");
+    setSystemProperty(
+        "DOCUMENT_STORE_AWS_CLASS", "io.camunda.document.store.aws.AwsDocumentStoreProvider");
+    setSystemProperty("DOCUMENT_STORE_AWS_BUCKET", bucketName);
+    setSystemProperty("DOCUMENT_STORE_AWS_ENDPOINT", LOCALSTACK.getEndpoint().toString());
+    if (chunkedEncodingEnabled != null) {
+      setSystemProperty(
+          "DOCUMENT_STORE_AWS_CHUNKED_ENCODING_ENABLED", chunkedEncodingEnabled.toString());
+    }
+    setSystemProperty("aws.accessKeyId", LOCALSTACK.getAccessKey());
+    setSystemProperty("aws.secretAccessKey", LOCALSTACK.getSecretKey());
+    setSystemProperty("aws.region", LOCALSTACK.getRegion());
+
+    testCamundaApplication =
+        new TestCamundaApplication()
+            .withAuthenticationMethod(AuthenticationMethod.BASIC)
+            .withUnauthenticatedAccess();
+    new MultiDbConfigurator(testCamundaApplication)
+        .configureElasticsearchSupportIncludingOldExporter(
+            "http://" + ELASTICSEARCH.getHost() + ":" + ELASTICSEARCH.getFirstMappedPort(),
+            INDEX_PREFIX);
+    testCamundaApplication.start().awaitCompleteTopology();
+
+    camundaClient = testCamundaApplication.newClientBuilder().build();
+  }
+
+  private void setSystemProperty(final String key, final String value) {
+    System.setProperty(key, value);
+    setSystemProperties.add(key);
+  }
+}


### PR DESCRIPTION
Adds ENDPOINT, FORCE_PATH_STYLE, CHUNKED_ENCODING_ENABLED config properties to AwsDocumentStoreProvider, threaded through to S3Client and S3Presigner via S3Configuration. When none of the new properties are set, behavior is byte-identical to the prior code path.

## Description

https://github.com/camunda/product-hub/issues/3507

Allows users to specify endpoint for Aws Document Handling, so rather than the real S3 a self-hosted S3-compatible document store can be used. 

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
