### PR TITLE
deps: update MCP SDK to 2.0.0-M3

### DIFF
--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/CamundaMcpServersAutoConfiguration.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/CamundaMcpServersAutoConfiguration.java
@@ -117,6 +117,7 @@ public class CamundaMcpServersAutoConfiguration {
         .capabilities(capabilities)
         .tools(toolSpecifications)
         .immediateExecution(true)
+        .validateToolInputs(false) // covered by bean validation
         .build();
   }
 
@@ -187,6 +188,7 @@ public class CamundaMcpServersAutoConfiguration {
           """)
             .capabilities(capabilities)
             .immediateExecution(true)
+            .validateToolInputs(false) // covered by bean validation
             .build();
 
     RequestHandlerCustomizer.replaceToolHandlers(processesTransport, jsonMapper, toolRepository);

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/schema/CamundaJsonSchemaGenerator.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/schema/CamundaJsonSchemaGenerator.java
@@ -36,7 +36,7 @@ import java.util.Map;
 import java.util.function.Function;
 import org.springframework.ai.mcp.annotation.McpToolParam;
 import org.springframework.ai.mcp.annotation.method.tool.utils.McpSpringAiSchemaModule;
-import org.springframework.lang.Nullable;
+import org.springframework.core.Nullness;
 import org.springframework.util.ConcurrentReferenceHashMap;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.node.ArrayNode;
@@ -206,8 +206,7 @@ public class CamundaJsonSchemaGenerator {
           || schemaAnnotation.required();
     }
 
-    if (parameter.getAnnotation(Nullable.class) != null
-        || parameter.getAnnotation(org.jspecify.annotations.Nullable.class) != null) {
+    if (Nullness.forParameter(parameter) == Nullness.NULLABLE) {
       return false;
     }
 

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/server/RequestHandlerCustomizer.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/server/RequestHandlerCustomizer.java
@@ -54,7 +54,8 @@ public final class RequestHandlerCustomizer {
       final ToolRepository toolRepository) {
     // load tools via repository and wrap in callable to pass exceptions in a non-blocking way
     return (ctx, params) ->
-        Mono.fromCallable(() -> new McpSchema.ListToolsResult(toolRepository.getTools(ctx), null));
+        Mono.fromCallable(
+            () -> McpSchema.ListToolsResult.builder(toolRepository.getTools(ctx)).build());
   }
 
   private static McpStatelessRequestHandler<CallToolResult> toolsCallRequestHandler(

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/tool/CamundaSyncStatelessMcpToolProvider.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/tool/CamundaSyncStatelessMcpToolProvider.java
@@ -133,10 +133,7 @@ public class CamundaSyncStatelessMcpToolProvider extends AbstractMcpToolProvider
     final String inputSchema = jsonSchemaGenerator.generateForMethodInput(mcpToolMethod);
 
     final var toolBuilder =
-        McpSchema.Tool.builder()
-            .name(toolName)
-            .description(toolDescription)
-            .inputSchema(getJsonMapper(), inputSchema);
+        McpSchema.Tool.builder(toolName, getJsonMapper(), inputSchema).description(toolDescription);
 
     if (toolAnnotation.annotations() != null) {
       final var toolAnnotations = toolAnnotation.annotations();

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/processes/ProcessesToolRepository.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/processes/ProcessesToolRepository.java
@@ -24,7 +24,6 @@ import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
-import io.modelcontextprotocol.spec.McpSchema.JsonSchema;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
 import java.util.List;
 import java.util.Map;
@@ -175,11 +174,9 @@ public class ProcessesToolRepository implements ToolRepository {
   private static Tool buildTool(final MessageSubscriptionEntity entity) {
     final var name = buildToolName(entity);
     final var description = buildDescription(entity.toolProperties());
-    return Tool.builder()
-        .name(name)
+    return Tool.builder(name, Map.of("type", "object"))
         .title(entity.toolName())
         .description(description)
-        .inputSchema(new JsonSchema("object", Map.of(), List.of(), false, Map.of(), Map.of()))
         .outputSchema(TOOL_OUTPUT_SCHEMA)
         .build();
   }

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/config/ProcessesMcpServerDynamicToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/config/ProcessesMcpServerDynamicToolsTest.java
@@ -23,7 +23,6 @@ import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.ErrorCodes;
 import io.modelcontextprotocol.spec.McpSchema.JSONRPCResponse.JSONRPCError;
-import io.modelcontextprotocol.spec.McpSchema.JsonSchema;
 import io.modelcontextprotocol.spec.McpSchema.ListToolsResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
@@ -65,11 +64,11 @@ class ProcessesMcpServerDynamicToolsTest extends ProcessesToolsTest {
 
     // when
     final CallToolResult firstCallResult =
-        mcpClient.callTool(CallToolRequest.builder().name("alphaProcess").build());
+        mcpClient.callTool(CallToolRequest.builder("alphaProcess").build());
 
     toolRepository.setTools(List.of(toolSpecification("betaProcess", "started beta process")));
     final CallToolResult secondCallResult =
-        mcpClient.callTool(CallToolRequest.builder().name("betaProcess").build());
+        mcpClient.callTool(CallToolRequest.builder("betaProcess").build());
 
     // then
     assertThat(firstCallResult.isError()).isFalse();
@@ -98,7 +97,7 @@ class ProcessesMcpServerDynamicToolsTest extends ProcessesToolsTest {
     assertThatThrownBy(
             () ->
                 mcpClient.callTool(
-                    CallToolRequest.builder().name(oldTools.tools().getFirst().name()).build()))
+                    CallToolRequest.builder(oldTools.tools().getFirst().name()).build()))
         .isInstanceOfSatisfying(
             McpError.class,
             exception ->
@@ -121,8 +120,7 @@ class ProcessesMcpServerDynamicToolsTest extends ProcessesToolsTest {
                 new ServiceException("Just a test", Status.INVALID_ARGUMENT))));
 
     // when/then
-    assertThatThrownBy(
-            () -> mcpClient.callTool(CallToolRequest.builder().name("alphaProcess").build()))
+    assertThatThrownBy(() -> mcpClient.callTool(CallToolRequest.builder("alphaProcess").build()))
         .isInstanceOfSatisfying(
             McpError.class,
             exception ->
@@ -145,8 +143,7 @@ class ProcessesMcpServerDynamicToolsTest extends ProcessesToolsTest {
                     .build())));
 
     // when/then
-    assertThatThrownBy(
-            () -> mcpClient.callTool(CallToolRequest.builder().name("alphaProcess").build()))
+    assertThatThrownBy(() -> mcpClient.callTool(CallToolRequest.builder("alphaProcess").build()))
         .isInstanceOfSatisfying(
             McpError.class,
             exception ->
@@ -164,11 +161,9 @@ class ProcessesMcpServerDynamicToolsTest extends ProcessesToolsTest {
       final String toolName, final String responseText, final RuntimeException failure) {
     return SyncToolSpecification.builder()
         .tool(
-            Tool.builder()
-                .name(toolName)
+            Tool.builder(toolName, Map.of("type", "object"))
                 .title(toolName)
                 .description("Test process tool " + toolName)
-                .inputSchema(new JsonSchema("object", null, null, false, null, null))
                 .build())
         .callHandler(
             (transportContext, callToolRequest) -> {

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/config/ProcessesMcpServerEmptyToolRepositoryTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/config/ProcessesMcpServerEmptyToolRepositoryTest.java
@@ -42,7 +42,7 @@ class ProcessesMcpServerEmptyToolRepositoryTest extends ProcessesToolsTest {
   @Test
   void shouldCreateMcpErrorForToolFind() {
     // when/then
-    assertThatThrownBy(() -> mcpClient.callTool(CallToolRequest.builder().name("anyTool").build()))
+    assertThatThrownBy(() -> mcpClient.callTool(CallToolRequest.builder("anyTool").build()))
         .isInstanceOfSatisfying(
             McpError.class,
             exception ->

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/config/ProcessesMcpServerFailingToolRepositoryTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/config/ProcessesMcpServerFailingToolRepositoryTest.java
@@ -47,7 +47,7 @@ class ProcessesMcpServerFailingToolRepositoryTest extends ProcessesToolsTest {
   @Test
   void shouldCreateMcpErrorForToolFindException() {
     // when/then
-    assertThatThrownBy(() -> mcpClient.callTool(CallToolRequest.builder().name("anyTool").build()))
+    assertThatThrownBy(() -> mcpClient.callTool(CallToolRequest.builder("anyTool").build()))
         .isInstanceOfSatisfying(
             McpError.class,
             exception ->

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/config/ProcessesMcpServerStaticToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/config/ProcessesMcpServerStaticToolsTest.java
@@ -16,7 +16,6 @@ import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
-import io.modelcontextprotocol.spec.McpSchema.JsonSchema;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
 import java.util.List;
@@ -43,7 +42,7 @@ class ProcessesMcpServerStaticToolsTest extends ProcessesToolsTest {
   void shouldCallStaticallyConfiguredTools() {
     // when
     final CallToolResult result =
-        mcpClient.callTool(CallToolRequest.builder().name("staticProcess").build());
+        mcpClient.callTool(CallToolRequest.builder("staticProcess").build());
 
     // then
     assertThat(result.isError()).isFalse();
@@ -66,11 +65,9 @@ class ProcessesMcpServerStaticToolsTest extends ProcessesToolsTest {
                 "staticProcess",
                 SyncToolSpecification.builder()
                     .tool(
-                        Tool.builder()
-                            .name("staticProcess")
+                        Tool.builder("staticProcess", Map.of("type", "object"))
                             .title("staticProcess")
                             .description("Static fallback process tool")
-                            .inputSchema(new JsonSchema("object", null, null, false, null, null))
                             .build())
                     .callHandler(
                         (context, callToolRequest) ->

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/config/tool/McpToolParamsUnwrappedValidationTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/config/tool/McpToolParamsUnwrappedValidationTest.java
@@ -80,8 +80,7 @@ class McpToolParamsUnwrappedValidationTest extends OperationalToolsTest {
     void shouldDeserializeAndPassWrappedDto() {
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("createTask")
+              CallToolRequest.builder("createTask")
                   .arguments(
                       Map.of("name", "My Task", "priority", 5, "tags", Set.of("urgent", "review")))
                   .build());
@@ -99,8 +98,7 @@ class McpToolParamsUnwrappedValidationTest extends OperationalToolsTest {
     void shouldReturnValidationErrorWithNormalizedPath() {
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("createTask")
+              CallToolRequest.builder("createTask")
                   .arguments(Map.of("name", "", "priority", 1))
                   .build());
 
@@ -119,8 +117,7 @@ class McpToolParamsUnwrappedValidationTest extends OperationalToolsTest {
     void shouldReturnMultipleValidationErrors() {
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("createTask")
+              CallToolRequest.builder("createTask")
                   .arguments(Map.of("name", "", "priority", -1))
                   .build());
 
@@ -140,8 +137,7 @@ class McpToolParamsUnwrappedValidationTest extends OperationalToolsTest {
     void shouldValidateCollectionElements() {
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("createTask")
+              CallToolRequest.builder("createTask")
                   .arguments(Map.of("name", "Valid", "priority", 1, "tags", Set.of("")))
                   .build());
 
@@ -162,7 +158,7 @@ class McpToolParamsUnwrappedValidationTest extends OperationalToolsTest {
     void shouldReturnErrorOnIndividualParamValidation() {
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder().name("getTask").arguments(Map.of("taskKey", -1L)).build());
+              CallToolRequest.builder("getTask").arguments(Map.of("taskKey", -1L)).build());
 
       assertThat(result.isError()).isTrue();
       assertThat(result.structuredContent()).isNull();

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/processes/ProcessesToolRepositoryTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/processes/ProcessesToolRepositoryTest.java
@@ -31,7 +31,6 @@ import io.camunda.zeebe.protocol.impl.record.value.message.MessageCorrelationRec
 import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
-import io.modelcontextprotocol.spec.McpSchema.JsonSchema;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
 import java.util.List;
 import java.util.Map;
@@ -190,12 +189,7 @@ class ProcessesToolRepositoryTest {
           "title": "orderProcess",
           "description": "Core purpose",
           "inputSchema": {
-            "type": "object",
-            "properties": {},
-            "required": [],
-            "additionalProperties":false,
-            "$defs":{},
-            "definitions":{}
+            "type": "object"
           },
           "outputSchema": {
             "type": "object",
@@ -314,7 +308,7 @@ class ProcessesToolRepositoryTest {
           .callHandler()
           .apply(
               transportContext,
-              CallToolRequest.builder().name("deploy_77").arguments(Map.of("foo", "bar")).build());
+              CallToolRequest.builder("deploy_77").arguments(Map.of("foo", "bar")).build());
 
       final var reqCaptor = ArgumentCaptor.forClass(CorrelateMessageRequest.class);
       verify(messageServices).correlateMessage(reqCaptor.capture(), any());
@@ -428,7 +422,7 @@ class ProcessesToolRepositoryTest {
               .callHandler()
               .apply(
                   transportContext,
-                  CallToolRequest.builder().name("myTool_88").arguments(Map.of()).build());
+                  CallToolRequest.builder("myTool_88").arguments(Map.of()).build());
 
       // then
       assertThat(result.isError()).isFalse();
@@ -471,15 +465,13 @@ class ProcessesToolRepositoryTest {
       final var callHandler = tool.get().callHandler();
 
       callHandler.apply(
-          transportContext,
-          CallToolRequest.builder().name("myTool_88").arguments(Map.of()).build());
+          transportContext, CallToolRequest.builder("myTool_88").arguments(Map.of()).build());
       final var firstCaptor = ArgumentCaptor.forClass(CorrelateMessageRequest.class);
       verify(messageServices).correlateMessage(firstCaptor.capture(), any());
 
       // when
       callHandler.apply(
-          transportContext,
-          CallToolRequest.builder().name("myTool_88").arguments(Map.of()).build());
+          transportContext, CallToolRequest.builder("myTool_88").arguments(Map.of()).build());
 
       // then
       final var secondCaptor = ArgumentCaptor.forClass(CorrelateMessageRequest.class);
@@ -502,11 +494,8 @@ class ProcessesToolRepositoryTest {
       mockStaticTool =
           SyncToolSpecification.builder()
               .tool(
-                  Tool.builder()
-                      .name("getProcessInstance")
+                  Tool.builder("getProcessInstance", Map.of("type", "object"))
                       .description("Get process instance by key.")
-                      .inputSchema(
-                          new JsonSchema("object", Map.of(), List.of(), false, Map.of(), Map.of()))
                       .build())
               .callHandler((ctx, req) -> null)
               .build();

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/cluster/ClusterToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/cluster/ClusterToolsTest.java
@@ -59,7 +59,7 @@ class ClusterToolsTest extends OperationalToolsTest {
 
       // when
       final CallToolResult result =
-          mcpClient.callTool(CallToolRequest.builder().name("getClusterStatus").build());
+          mcpClient.callTool(CallToolRequest.builder("getClusterStatus").build());
 
       // then
       assertThat(result.isError()).isFalse();
@@ -81,7 +81,7 @@ class ClusterToolsTest extends OperationalToolsTest {
 
       // when
       final CallToolResult result =
-          mcpClient.callTool(CallToolRequest.builder().name("getClusterStatus").build());
+          mcpClient.callTool(CallToolRequest.builder("getClusterStatus").build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -190,7 +190,7 @@ class ClusterToolsTest extends OperationalToolsTest {
 
       // when
       final CallToolResult result =
-          mcpClient.callTool(CallToolRequest.builder().name("getTopology").build());
+          mcpClient.callTool(CallToolRequest.builder("getTopology").build());
 
       // then
       assertThat(result.isError()).isFalse();
@@ -211,7 +211,7 @@ class ClusterToolsTest extends OperationalToolsTest {
 
       // when
       final CallToolResult result =
-          mcpClient.callTool(CallToolRequest.builder().name("getTopology").build());
+          mcpClient.callTool(CallToolRequest.builder("getTopology").build());
 
       // then
       assertThat(result.isError()).isTrue();

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/incident/IncidentToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/incident/IncidentToolsTest.java
@@ -125,10 +125,7 @@ class IncidentToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("getIncident")
-                  .arguments(Map.of("incidentKey", 5L))
-                  .build());
+              CallToolRequest.builder("getIncident").arguments(Map.of("incidentKey", 5L)).build());
 
       // then
       assertThat(result.isError()).isFalse();
@@ -152,10 +149,7 @@ class IncidentToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("getIncident")
-                  .arguments(Map.of("incidentKey", 5L))
-                  .build());
+              CallToolRequest.builder("getIncident").arguments(Map.of("incidentKey", 5L)).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -174,8 +168,7 @@ class IncidentToolsTest extends OperationalToolsTest {
     void shouldFailGetIncidentByKeyOnMissingKey() {
       // when
       final CallToolResult result =
-          mcpClient.callTool(
-              CallToolRequest.builder().name("getIncident").arguments(Map.of()).build());
+          mcpClient.callTool(CallToolRequest.builder("getIncident").arguments(Map.of()).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -196,8 +189,7 @@ class IncidentToolsTest extends OperationalToolsTest {
       final var arguments = new HashMap<String, Object>();
       arguments.put("incidentKey", null);
       final CallToolResult result =
-          mcpClient.callTool(
-              CallToolRequest.builder().name("getIncident").arguments(arguments).build());
+          mcpClient.callTool(CallToolRequest.builder("getIncident").arguments(arguments).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -217,10 +209,7 @@ class IncidentToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("getIncident")
-                  .arguments(Map.of("incidentKey", -3L))
-                  .build());
+              CallToolRequest.builder("getIncident").arguments(Map.of("incidentKey", -3L)).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -251,8 +240,7 @@ class IncidentToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchIncidents")
+              CallToolRequest.builder("searchIncidents")
                   .arguments(
                       Map.of(
                           "filter",
@@ -284,8 +272,7 @@ class IncidentToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchIncidents")
+              CallToolRequest.builder("searchIncidents")
                   .arguments(
                       Map.of(
                           "filter",
@@ -342,7 +329,7 @@ class IncidentToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder().name("searchIncidents").arguments(Map.of()).build());
+              CallToolRequest.builder("searchIncidents").arguments(Map.of()).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -362,8 +349,7 @@ class IncidentToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchIncidents")
+              CallToolRequest.builder("searchIncidents")
                   .arguments(Map.of("filter", Map.of("processInstanceKey", "abc")))
                   .build());
 
@@ -386,8 +372,7 @@ class IncidentToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchIncidents")
+              CallToolRequest.builder("searchIncidents")
                   .arguments(Map.of("filter", Map.of("creationTime", Map.of("from", "not-a-date"))))
                   .build());
 
@@ -418,8 +403,7 @@ class IncidentToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("resolveIncident")
+              CallToolRequest.builder("resolveIncident")
                   .arguments(Map.of("incidentKey", 5L))
                   .build());
 
@@ -454,8 +438,7 @@ class IncidentToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("resolveIncident")
+              CallToolRequest.builder("resolveIncident")
                   .arguments(Map.of("incidentKey", 5L))
                   .build());
 
@@ -494,8 +477,7 @@ class IncidentToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("resolveIncident")
+              CallToolRequest.builder("resolveIncident")
                   .arguments(Map.of("incidentKey", 5L))
                   .build());
 
@@ -521,7 +503,7 @@ class IncidentToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder().name("resolveIncident").arguments(Map.of()).build());
+              CallToolRequest.builder("resolveIncident").arguments(Map.of()).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -543,7 +525,7 @@ class IncidentToolsTest extends OperationalToolsTest {
       arguments.put("incidentKey", null);
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder().name("resolveIncident").arguments(arguments).build());
+              CallToolRequest.builder("resolveIncident").arguments(arguments).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -563,8 +545,7 @@ class IncidentToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("resolveIncident")
+              CallToolRequest.builder("resolveIncident")
                   .arguments(Map.of("incidentKey", -3L))
                   .build());
 

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/process/definition/ProcessDefinitionToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/process/definition/ProcessDefinitionToolsTest.java
@@ -102,8 +102,7 @@ class ProcessDefinitionToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("getProcessDefinition")
+              CallToolRequest.builder("getProcessDefinition")
                   .arguments(Map.of("processDefinitionKey", 5L))
                   .build());
 
@@ -123,7 +122,7 @@ class ProcessDefinitionToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder().name("getProcessDefinition").arguments(Map.of()).build());
+              CallToolRequest.builder("getProcessDefinition").arguments(Map.of()).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -145,7 +144,7 @@ class ProcessDefinitionToolsTest extends OperationalToolsTest {
       arguments.put("processDefinitionKey", null);
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder().name("getProcessDefinition").arguments(arguments).build());
+              CallToolRequest.builder("getProcessDefinition").arguments(arguments).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -165,8 +164,7 @@ class ProcessDefinitionToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("getProcessDefinition")
+              CallToolRequest.builder("getProcessDefinition")
                   .arguments(Map.of("processDefinitionKey", -3L))
                   .build());
 
@@ -197,8 +195,7 @@ class ProcessDefinitionToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchProcessDefinitions")
+              CallToolRequest.builder("searchProcessDefinitions")
                   .arguments(
                       Map.of(
                           "filter",
@@ -252,10 +249,7 @@ class ProcessDefinitionToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchProcessDefinitions")
-                  .arguments(Map.of())
-                  .build());
+              CallToolRequest.builder("searchProcessDefinitions").arguments(Map.of()).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -278,8 +272,7 @@ class ProcessDefinitionToolsTest extends OperationalToolsTest {
 
       // when (tenantId passed in arguments should be ignored by MCP filter schema)
       mcpClient.callTool(
-          CallToolRequest.builder()
-              .name("searchProcessDefinitions")
+          CallToolRequest.builder("searchProcessDefinitions")
               .arguments(Map.of("filter", Map.of("tenantId", "tenantId")))
               .build());
 
@@ -298,10 +291,7 @@ class ProcessDefinitionToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("getProcessDefinitionXml")
-                  .arguments(Map.of())
-                  .build());
+              CallToolRequest.builder("getProcessDefinitionXml").arguments(Map.of()).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -323,10 +313,7 @@ class ProcessDefinitionToolsTest extends OperationalToolsTest {
       arguments.put("processDefinitionKey", null);
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("getProcessDefinitionXml")
-                  .arguments(arguments)
-                  .build());
+              CallToolRequest.builder("getProcessDefinitionXml").arguments(arguments).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -346,8 +333,7 @@ class ProcessDefinitionToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("getProcessDefinitionXml")
+              CallToolRequest.builder("getProcessDefinitionXml")
                   .arguments(Map.of("processDefinitionKey", -3L))
                   .build());
 
@@ -374,8 +360,7 @@ class ProcessDefinitionToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("getProcessDefinitionXml")
+              CallToolRequest.builder("getProcessDefinitionXml")
                   .arguments(Map.of("processDefinitionKey", 5L))
                   .build());
 
@@ -399,8 +384,7 @@ class ProcessDefinitionToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("getProcessDefinitionXml")
+              CallToolRequest.builder("getProcessDefinitionXml")
                   .arguments(Map.of("processDefinitionKey", 5L))
                   .build());
 

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceToolsTest.java
@@ -134,8 +134,7 @@ class ProcessInstanceToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("getProcessInstance")
+              CallToolRequest.builder("getProcessInstance")
                   .arguments(Map.of("processInstanceKey", 123L))
                   .build());
 
@@ -161,8 +160,7 @@ class ProcessInstanceToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("getProcessInstance")
+              CallToolRequest.builder("getProcessInstance")
                   .arguments(Map.of("processInstanceKey", 123L))
                   .build());
 
@@ -184,7 +182,7 @@ class ProcessInstanceToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder().name("getProcessInstance").arguments(Map.of()).build());
+              CallToolRequest.builder("getProcessInstance").arguments(Map.of()).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -206,7 +204,7 @@ class ProcessInstanceToolsTest extends OperationalToolsTest {
       arguments.put("processInstanceKey", null);
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder().name("getProcessInstance").arguments(arguments).build());
+              CallToolRequest.builder("getProcessInstance").arguments(arguments).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -226,8 +224,7 @@ class ProcessInstanceToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("getProcessInstance")
+              CallToolRequest.builder("getProcessInstance")
                   .arguments(Map.of("processInstanceKey", -3L))
                   .build());
 
@@ -258,8 +255,7 @@ class ProcessInstanceToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchProcessInstances")
+              CallToolRequest.builder("searchProcessInstances")
                   .arguments(
                       Map.of(
                           "filter",
@@ -347,8 +343,7 @@ class ProcessInstanceToolsTest extends OperationalToolsTest {
 
       // when (tenantId passed in arguments should be ignored by MCP filter schema)
       mcpClient.callTool(
-          CallToolRequest.builder()
-              .name("searchProcessInstances")
+          CallToolRequest.builder("searchProcessInstances")
               .arguments(Map.of("filter", Map.of("tenantId", "tenantId")))
               .build());
 
@@ -367,7 +362,7 @@ class ProcessInstanceToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder().name("searchProcessInstances").arguments(Map.of()).build());
+              CallToolRequest.builder("searchProcessInstances").arguments(Map.of()).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -386,8 +381,7 @@ class ProcessInstanceToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchProcessInstances")
+              CallToolRequest.builder("searchProcessInstances")
                   .arguments(Map.of("filter", Map.of("processInstanceKey", "abc")))
                   .build());
 
@@ -410,8 +404,7 @@ class ProcessInstanceToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchProcessInstances")
+              CallToolRequest.builder("searchProcessInstances")
                   .arguments(Map.of("filter", Map.of("startDate", Map.of("from", "not-a-date"))))
                   .build());
 
@@ -434,8 +427,7 @@ class ProcessInstanceToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchProcessInstances")
+              CallToolRequest.builder("searchProcessInstances")
                   .arguments(
                       Map.of(
                           "filter",
@@ -486,8 +478,7 @@ class ProcessInstanceToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("createProcessInstance")
+              CallToolRequest.builder("createProcessInstance")
                   .arguments(
                       Map.of(
                           "processDefinitionKey",
@@ -543,8 +534,7 @@ class ProcessInstanceToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("createProcessInstance")
+              CallToolRequest.builder("createProcessInstance")
                   .arguments(
                       Map.of(
                           "processDefinitionId",
@@ -605,8 +595,7 @@ class ProcessInstanceToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("createProcessInstance")
+              CallToolRequest.builder("createProcessInstance")
                   .arguments(
                       Map.of(
                           "processDefinitionId",
@@ -669,8 +658,7 @@ class ProcessInstanceToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("createProcessInstance")
+              CallToolRequest.builder("createProcessInstance")
                   .arguments(
                       Map.of(
                           "processDefinitionId",
@@ -722,8 +710,7 @@ class ProcessInstanceToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("createProcessInstance")
+              CallToolRequest.builder("createProcessInstance")
                   .arguments(Map.of("processDefinitionId", "invalidProcessId"))
                   .build());
 
@@ -744,7 +731,7 @@ class ProcessInstanceToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder().name("createProcessInstance").arguments(Map.of()).build());
+              CallToolRequest.builder("createProcessInstance").arguments(Map.of()).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -764,8 +751,7 @@ class ProcessInstanceToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("createProcessInstance")
+              CallToolRequest.builder("createProcessInstance")
                   .arguments(
                       Map.of("processDefinitionKey", "123", "processDefinitionId", "testProcessId"))
                   .build());
@@ -804,8 +790,7 @@ class ProcessInstanceToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("createProcessInstance")
+              CallToolRequest.builder("createProcessInstance")
                   .arguments(
                       Map.of(
                           "processDefinitionKey",
@@ -863,8 +848,7 @@ class ProcessInstanceToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("createProcessInstance")
+              CallToolRequest.builder("createProcessInstance")
                   .arguments(
                       Map.of(
                           "processDefinitionId",
@@ -914,8 +898,7 @@ class ProcessInstanceToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("createProcessInstance")
+              CallToolRequest.builder("createProcessInstance")
                   .arguments(Map.of("processDefinitionKey", "123", "tenantId", tenantId))
                   .build());
 
@@ -941,8 +924,7 @@ class ProcessInstanceToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("createProcessInstance")
+              CallToolRequest.builder("createProcessInstance")
                   .arguments(Map.of("processDefinitionKey", "123"))
                   .build());
 
@@ -983,8 +965,7 @@ class ProcessInstanceToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("createProcessInstance")
+              CallToolRequest.builder("createProcessInstance")
                   .arguments(Map.of("processDefinitionKey", "123", "businessId", businessId))
                   .build());
 

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/usertask/UserTaskToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/usertask/UserTaskToolsTest.java
@@ -178,10 +178,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("getUserTask")
-                  .arguments(Map.of("userTaskKey", 5L))
-                  .build());
+              CallToolRequest.builder("getUserTask").arguments(Map.of("userTaskKey", 5L)).build());
 
       // then
       assertThat(result.isError()).isFalse();
@@ -205,10 +202,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("getUserTask")
-                  .arguments(Map.of("userTaskKey", 5L))
-                  .build());
+              CallToolRequest.builder("getUserTask").arguments(Map.of("userTaskKey", 5L)).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -227,8 +221,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
     void shouldFailGetUserTaskByKeyOnMissingKey() {
       // when
       final CallToolResult result =
-          mcpClient.callTool(
-              CallToolRequest.builder().name("getUserTask").arguments(Map.of()).build());
+          mcpClient.callTool(CallToolRequest.builder("getUserTask").arguments(Map.of()).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -249,8 +242,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
       final var arguments = new HashMap<String, Object>();
       arguments.put("userTaskKey", null);
       final CallToolResult result =
-          mcpClient.callTool(
-              CallToolRequest.builder().name("getUserTask").arguments(arguments).build());
+          mcpClient.callTool(CallToolRequest.builder("getUserTask").arguments(arguments).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -270,10 +262,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("getUserTask")
-                  .arguments(Map.of("userTaskKey", -3L))
-                  .build());
+              CallToolRequest.builder("getUserTask").arguments(Map.of("userTaskKey", -3L)).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -301,8 +290,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchUserTasks")
+              CallToolRequest.builder("searchUserTasks")
                   .arguments(
                       Map.of(
                           "filter",
@@ -366,8 +354,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchUserTasks")
+              CallToolRequest.builder("searchUserTasks")
                   .arguments(
                       Map.of(
                           "filter",
@@ -402,8 +389,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchUserTasks")
+              CallToolRequest.builder("searchUserTasks")
                   .arguments(
                       Map.of(
                           "filter",
@@ -435,8 +421,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchUserTasks")
+              CallToolRequest.builder("searchUserTasks")
                   .arguments(
                       Map.of(
                           "filter",
@@ -479,8 +464,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchUserTasks")
+              CallToolRequest.builder("searchUserTasks")
                   .arguments(
                       Map.of(
                           "filter",
@@ -523,8 +507,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
       // when (tenantId, candidateGroup, candidateUser passed in arguments should be ignored by MCP
       // filter schema)
       mcpClient.callTool(
-          CallToolRequest.builder()
-              .name("searchUserTasks")
+          CallToolRequest.builder("searchUserTasks")
               .arguments(
                   Map.of(
                       "filter",
@@ -554,7 +537,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder().name("searchUserTasks").arguments(Map.of()).build());
+              CallToolRequest.builder("searchUserTasks").arguments(Map.of()).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -574,8 +557,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchUserTasks")
+              CallToolRequest.builder("searchUserTasks")
                   .arguments(Map.of("filter", Map.of("processInstanceKey", "abc")))
                   .build());
 
@@ -598,8 +580,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchUserTasks")
+              CallToolRequest.builder("searchUserTasks")
                   .arguments(Map.of("filter", Map.of("creationDate", Map.of("from", "not-a-date"))))
                   .build());
 
@@ -631,8 +612,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("assignUserTask")
+              CallToolRequest.builder("assignUserTask")
                   .arguments(Map.of("userTaskKey", 5L, "assignee", "jane.doe"))
                   .build());
 
@@ -661,8 +641,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("assignUserTask")
+              CallToolRequest.builder("assignUserTask")
                   .arguments(
                       Map.of(
                           "userTaskKey",
@@ -697,8 +676,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("assignUserTask")
+              CallToolRequest.builder("assignUserTask")
                   .arguments(Map.of("userTaskKey", 5L))
                   .build());
 
@@ -729,7 +707,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
 
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder().name("assignUserTask").arguments(arguments).build());
+              CallToolRequest.builder("assignUserTask").arguments(arguments).build());
 
       // then
       assertThat(result.isError()).isFalse();
@@ -756,8 +734,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("assignUserTask")
+              CallToolRequest.builder("assignUserTask")
                   .arguments(Map.of("userTaskKey", 5L, "assignee", "jane.doe"))
                   .build());
 
@@ -779,8 +756,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("assignUserTask")
+              CallToolRequest.builder("assignUserTask")
                   .arguments(Map.of("assignee", "jane.doe"))
                   .build());
 
@@ -805,7 +781,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
       arguments.put("assignee", "jane.doe");
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder().name("assignUserTask").arguments(arguments).build());
+              CallToolRequest.builder("assignUserTask").arguments(arguments).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -825,8 +801,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("assignUserTask")
+              CallToolRequest.builder("assignUserTask")
                   .arguments(Map.of("userTaskKey", -3L, "assignee", "jane.doe"))
                   .build());
 
@@ -857,8 +832,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchUserTaskVariables")
+              CallToolRequest.builder("searchUserTaskVariables")
                   .arguments(
                       Map.of(
                           "userTaskKey",
@@ -903,8 +877,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchUserTaskVariables")
+              CallToolRequest.builder("searchUserTaskVariables")
                   .arguments(Map.of("userTaskKey", 5L, "truncateValues", false))
                   .build());
 
@@ -940,8 +913,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchUserTaskVariables")
+              CallToolRequest.builder("searchUserTaskVariables")
                   .arguments(
                       Map.of(
                           "userTaskKey",
@@ -983,8 +955,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchUserTaskVariables")
+              CallToolRequest.builder("searchUserTaskVariables")
                   .arguments(Map.of("userTaskKey", 5L))
                   .build());
 
@@ -1006,10 +977,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchUserTaskVariables")
-                  .arguments(Map.of())
-                  .build());
+              CallToolRequest.builder("searchUserTaskVariables").arguments(Map.of()).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -1031,10 +999,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
       arguments.put("userTaskKey", null);
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchUserTaskVariables")
-                  .arguments(arguments)
-                  .build());
+              CallToolRequest.builder("searchUserTaskVariables").arguments(arguments).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -1054,8 +1019,7 @@ class UserTaskToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchUserTaskVariables")
+              CallToolRequest.builder("searchUserTaskVariables")
                   .arguments(Map.of("userTaskKey", -3L))
                   .build());
 

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/variable/VariableToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/variable/VariableToolsTest.java
@@ -113,8 +113,7 @@ class VariableToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("getVariable")
+              CallToolRequest.builder("getVariable")
                   .arguments(Map.of("variableKey", 123L))
                   .build());
 
@@ -140,8 +139,7 @@ class VariableToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("getVariable")
+              CallToolRequest.builder("getVariable")
                   .arguments(Map.of("variableKey", 123L))
                   .build());
 
@@ -162,8 +160,7 @@ class VariableToolsTest extends OperationalToolsTest {
     void shouldFailGetVariableByKeyOnMissingKey() {
       // when
       final CallToolResult result =
-          mcpClient.callTool(
-              CallToolRequest.builder().name("getVariable").arguments(Map.of()).build());
+          mcpClient.callTool(CallToolRequest.builder("getVariable").arguments(Map.of()).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -184,8 +181,7 @@ class VariableToolsTest extends OperationalToolsTest {
       final var arguments = new HashMap<String, Object>();
       arguments.put("variableKey", null);
       final CallToolResult result =
-          mcpClient.callTool(
-              CallToolRequest.builder().name("getVariable").arguments(arguments).build());
+          mcpClient.callTool(CallToolRequest.builder("getVariable").arguments(arguments).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -205,10 +201,7 @@ class VariableToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("getVariable")
-                  .arguments(Map.of("variableKey", -3L))
-                  .build());
+              CallToolRequest.builder("getVariable").arguments(Map.of("variableKey", -3L)).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -236,8 +229,7 @@ class VariableToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchVariables")
+              CallToolRequest.builder("searchVariables")
                   .arguments(
                       Map.of(
                           "filter",
@@ -283,8 +275,7 @@ class VariableToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchVariables")
+              CallToolRequest.builder("searchVariables")
                   .arguments(
                       Map.of(
                           "filter",
@@ -351,7 +342,7 @@ class VariableToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder().name("searchVariables").arguments(Map.of()).build());
+              CallToolRequest.builder("searchVariables").arguments(Map.of()).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -370,8 +361,7 @@ class VariableToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchVariables")
+              CallToolRequest.builder("searchVariables")
                   .arguments(Map.of("filter", Map.of("processInstanceKey", "abc")))
                   .build());
 
@@ -393,8 +383,7 @@ class VariableToolsTest extends OperationalToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchVariables")
+              CallToolRequest.builder("searchVariables")
                   .arguments(Map.of("filter", Map.of("variableKey", "abc")))
                   .build());
 

--- a/gateways/gateway-mcp/src/test/resources/schema/tools-schema-snapshot.json
+++ b/gateways/gateway-mcp/src/test/resources/schema/tools-schema-snapshot.json
@@ -5,6 +5,7 @@
       "title": "getClusterStatus",
       "description": "Checks the health status of the cluster by verifying if there's at least one partition with a healthy leader.",
       "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
         "properties": {},
         "required": []
@@ -18,6 +19,7 @@
       "title": "getTopology",
       "description": "Obtains the current topology of the cluster the gateway is part of.",
       "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
         "properties": {},
         "required": []
@@ -31,6 +33,7 @@
       "title": "getIncident",
       "description": "Get incident by key. Note: Results are eventually consistent and may not immediately reflect recent changes.",
       "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
         "properties": {
           "incidentKey": {
@@ -52,6 +55,7 @@
       "title": "resolveIncident",
       "description": "Resolve incident by key. Note: Results are eventually consistent and may not immediately reflect recent changes.",
       "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
         "properties": {
           "incidentKey": {
@@ -71,6 +75,7 @@
       "title": "searchIncidents",
       "description": "Search for incidents. Note: Results are eventually consistent and may not immediately reflect recent changes.",
       "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
         "properties": {
           "filter": {
@@ -214,6 +219,7 @@
       "title": "getProcessDefinition",
       "description": "Get process definition by key. Note: Results are eventually consistent and may not immediately reflect recent changes.",
       "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
         "properties": {
           "processDefinitionKey": {
@@ -235,6 +241,7 @@
       "title": "getProcessDefinitionXml",
       "description": "Get the BPMN XML of a process definition by key. Note: Results are eventually consistent and may not immediately reflect recent changes.",
       "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
         "properties": {
           "processDefinitionKey": {
@@ -256,6 +263,7 @@
       "title": "searchProcessDefinitions",
       "description": "Search for process definitions. Note: Results are eventually consistent and may not immediately reflect recent changes.",
       "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
         "properties": {
           "filter": {
@@ -365,6 +373,7 @@
       "title": "createProcessInstance",
       "description": "Create a new process instance of the given process definition. Either a processDefinitionKey or\na processDefinitionId (with an optional processDefinitionVersion) need to be passed.\n\nWhen using the awaitCompletion flag, the tool will wait for the process instance to complete\nand return its result variables. When using awaitCompletion, always include a unique tag\n`mcp-tool:<uniqueId>` which can be used to search for the started process instance in case\nof timeouts. Processes with wait states, like service tasks, user tasks, or defined listeners,\nare more likely to time out. You can increase the timeout to wait for completion by defining\na longer requestTimeout.",
       "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
         "properties": {
           "awaitCompletion": {
@@ -401,7 +410,7 @@
             "description": "Timeout (in ms) the request waits for the process to complete. By default or when set to 0, the generic request timeout configured in the cluster is applied. "
           },
           "tags": {
-            "description": "List of tags. Tags need to start with a letter; then alphanumerics, `_`, `-`, `:`, or `.`; length \u2264 100.",
+            "description": "List of tags. Tags need to start with a letter; then alphanumerics, `_`, `-`, `:`, or `.`; length ≤ 100.",
             "type": "array",
             "items": {
               "type": "string"
@@ -425,6 +434,7 @@
       "title": "getProcessInstance",
       "description": "Get process instance by key. Note: Results are eventually consistent and may not immediately reflect recent changes.",
       "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
         "properties": {
           "processInstanceKey": {
@@ -446,6 +456,7 @@
       "title": "searchProcessInstances",
       "description": "Search for process instances. Note: Results are eventually consistent and may not immediately reflect recent changes.",
       "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
         "properties": {
           "filter": {
@@ -518,7 +529,7 @@
                 "description": "The process instance state."
               },
               "tags": {
-                "description": "List of tags. Tags need to start with a letter; then alphanumerics, `_`, `-`, `:`, or `.`; length \u2264 100.",
+                "description": "List of tags. Tags need to start with a letter; then alphanumerics, `_`, `-`, `:`, or `.`; length ≤ 100.",
                 "type": "array",
                 "items": {
                   "type": "string"
@@ -623,6 +634,7 @@
       "title": "assignUserTask",
       "description": "Assign or unassign a user task. Provide an assignee to assign the task, or omit/provide null to unassign it.",
       "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
         "properties": {
           "userTaskKey": {
@@ -660,6 +672,7 @@
       "title": "getUserTask",
       "description": "Get user task by key. Note: Results are eventually consistent and may not immediately reflect recent changes.",
       "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
         "properties": {
           "userTaskKey": {
@@ -681,6 +694,7 @@
       "title": "searchUserTaskVariables",
       "description": "Search user task variables based on given criteria. Returns deduplicated variables where the innermost scope wins. The variable value is returned in serialized JSON format. Note: Results are eventually consistent and may not immediately reflect recent changes.",
       "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
         "properties": {
           "userTaskKey": {
@@ -763,6 +777,7 @@
       "title": "searchUserTasks",
       "description": "Search for user tasks. Variable values in filters need to be in serialized JSON format. Example string value: `\\\"myValue\\\"`. Example nested JSON value: `{\\\"myVar\\\":\\\"myValue\\\"}`. Note: Results are eventually consistent and may not immediately reflect recent changes.",
       "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
         "properties": {
           "filter": {
@@ -915,7 +930,7 @@
                 "description": "The user task state."
               },
               "tags": {
-                "description": "List of tags. Tags need to start with a letter; then alphanumerics, `_`, `-`, `:`, or `.`; length \u2264 100.",
+                "description": "List of tags. Tags need to start with a letter; then alphanumerics, `_`, `-`, `:`, or `.`; length ≤ 100.",
                 "type": "array",
                 "items": {
                   "type": "string"
@@ -995,6 +1010,7 @@
       "title": "getVariable",
       "description": "Get variable by key. The variable value is returned in serialized JSON format. Note: Results are eventually consistent and may not immediately reflect recent changes.",
       "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
         "properties": {
           "variableKey": {
@@ -1016,6 +1032,7 @@
       "title": "searchVariables",
       "description": "Search for variables. The variable value is returned in serialized JSON format. Note: Results are eventually consistent and may not immediately reflect recent changes.",
       "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
         "properties": {
           "filter": {

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -116,7 +116,7 @@
     <version.spring-security>7.0.5</version.spring-security>
     <version.spring-boot>4.0.6</version.spring-boot>
     <version.spring-ai>2.0.0-M7</version.spring-ai>
-    <version.mcp-sdk>1.1.3</version.mcp-sdk>
+    <version.mcp-sdk>2.0.0-M3</version.mcp-sdk>
     <version.jsonschema-generator>5.0.0</version.jsonschema-generator>
     <version.tomcat>11.0.22</version.tomcat>
     <version.concurrentunit>0.4.6</version.concurrentunit>

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/mcp/authentication/AuthenticatedMcpServerTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/mcp/authentication/AuthenticatedMcpServerTest.java
@@ -107,7 +107,7 @@ abstract class AuthenticatedMcpServerTest extends McpServerAuthenticationTest {
   private Set<String> searchProcessDefinitionIds(final McpSyncClient client) {
     final CallToolResult result =
         client.callTool(
-            CallToolRequest.builder().name("searchProcessDefinitions").arguments(Map.of()).build());
+            CallToolRequest.builder("searchProcessDefinitions").arguments(Map.of()).build());
     assertThat(result.isError())
         .withFailMessage(
             "Expected successful searchProcessDefinitions response, but got error result: %s",

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/mcp/authentication/McpServerAuthenticationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/mcp/authentication/McpServerAuthenticationTest.java
@@ -95,7 +95,7 @@ abstract class McpServerAuthenticationTest extends McpServerTest {
     try (final McpSyncClient mcpClient =
         createMcpClient("cluster", testInstance(), createMcpClientRequestCustomizer())) {
       final CallToolResult result =
-          mcpClient.callTool(CallToolRequest.builder().name("getClusterStatus").build());
+          mcpClient.callTool(CallToolRequest.builder("getClusterStatus").build());
 
       assertThat(result.isError()).isFalse();
       assertThat(result.content())
@@ -112,7 +112,7 @@ abstract class McpServerAuthenticationTest extends McpServerTest {
     try (final McpSyncClient mcpClient =
         createMcpClient("cluster", testInstance(), createMcpClientRequestCustomizer())) {
       final CallToolResult result =
-          mcpClient.callTool(CallToolRequest.builder().name("getTopology").build());
+          mcpClient.callTool(CallToolRequest.builder("getTopology").build());
 
       assertThat(result.isError()).isFalse();
       assertThat(result.structuredContent()).isNotNull();


### PR DESCRIPTION
## Summary
Updates the MCP Java SDK to `2.0.0-M3` to align with the Spring AI `2.0.0-M7` upgrade pulled in via #53096.

Includes corresponding source/test adjustments for SDK API changes (notably the new `CallToolRequest.builder(name)` overload replacing the deprecated `builder()` + `.name(...)` pattern).