### PR TITLE
Optimize improvements for IT local run

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/AbstractCCSMIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/AbstractCCSMIT.java
@@ -143,6 +143,9 @@ public abstract class AbstractCCSMIT extends AbstractIT {
     final Set<Long> cancelledKeys = zeebeExtension.cancelAllStartedInstances();
     waitForCancelledInstancesToExport(cancelledKeys);
     deleteZeebeRecordsAndAssertClean(zeebeExtension.getZeebeRecordPrefix());
+    // Clean up Optimize's imported data to ensure complete test isolation
+    databaseIntegrationTestExtension.deleteAllOptimizeData();
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
   }
 
   /**

--- a/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/DatabaseIntegrationTestExtension.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/DatabaseIntegrationTestExtension.java
@@ -114,6 +114,10 @@ public class DatabaseIntegrationTestExtension implements BeforeEachCallback, Aft
     return getAllDocumentsOfIndexAs(PROCESS_INSTANCE_MULTI_ALIAS, ProcessInstanceDto.class);
   }
 
+  public void deleteAllOptimizeData() {
+    databaseTestService.deleteAllOptimizeData();
+  }
+
   public void deleteAllZeebeRecordsForPrefix(final String zeebeRecordPrefix) {
     databaseTestService.deleteAllZeebeRecordsForPrefix(zeebeRecordPrefix);
   }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/es/OptimizeElasticsearchClient.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/es/OptimizeElasticsearchClient.java
@@ -1014,21 +1014,30 @@ public class OptimizeElasticsearchClient extends DatabaseClient {
 
   @Override
   public void reloadConfiguration(final ApplicationContext context) {
+    // Close both the transport and restClient before creating new ones. Attempt both closes even
+    // if one fails to avoid leaking file descriptors in the error path.
     try {
       esWithTransportOptions()._transport().close();
-      final ConfigurationService configurationService = context.getBean(ConfigurationService.class);
-      esClient =
-          ElasticsearchClientBuilder.build(
-              configurationService, objectMapper, new PluginRepository());
-      restClient =
-          ElasticsearchClientBuilder.restClient(configurationService, new PluginRepository());
-      indexNameService = context.getBean(OptimizeIndexNameService.class);
-      transportOptionsProvider = new TransportOptionsProvider(configurationService);
-      elasticsearchAsyncClient =
-          new ElasticsearchAsyncClient(esClient._transport(), esClient._transportOptions());
     } catch (final IOException e) {
       throw new RuntimeException(e);
+    } finally {
+      try {
+        restClient.close();
+      } catch (final IOException e) {
+        LOG.warn("Failed to close old RestClient during configuration reload", e);
+      }
     }
+
+    final ConfigurationService configurationService = context.getBean(ConfigurationService.class);
+    esClient =
+        ElasticsearchClientBuilder.build(
+            configurationService, objectMapper, new PluginRepository());
+    restClient =
+        ElasticsearchClientBuilder.restClient(configurationService, new PluginRepository());
+    indexNameService = context.getBean(OptimizeIndexNameService.class);
+    transportOptionsProvider = new TransportOptionsProvider(configurationService);
+    elasticsearchAsyncClient =
+        new ElasticsearchAsyncClient(esClient._transport(), esClient._transportOptions());
   }
 
   public final <T> SearchResponse<T> searchWithoutPrefixing(


### PR DESCRIPTION
## Description

Optimize integration tests were experiencing several stability issues:

1. **File descriptor exhaustion**: `OptimizeElasticsearchClient.reloadConfiguration()` created new `RestClient` instances without closing old ones, leaking file descriptors (selectors/pipes) across test restarts. After a few test classes, tests would fail with "Too many open files".

2. **Cross-test data contamination**: Optimize's imported data (process instances, incidents, user tasks) persisted across test methods. Only Zeebe export records were cleaned up in `@AfterEach`, causing tests to fail when expecting a single process instance but finding multiple from previous test methods.

   Example failure:
   ```
   ZeebeIncidentImportIT.importZeebeIncidentData_importResolvedIncidentInDifferentBatches
   Error: Could not find property for process instance with key: someProcess
   ```
   
   The test expected `.singleElement()` but `getAllProcessInstances()` returned instances from both current and previous tests.

## Solution

### 1. Fix resource leaks
- Modified `OptimizeElasticsearchClient.reloadConfiguration()` to properly close the existing `RestClient` before creating a new one
- Prevents file descriptor exhaustion across test restarts

### 2. Ensure complete test isolation
- Added `databaseIntegrationTestExtension.deleteAllOptimizeData()` to `AbstractCCSMIT.after()`
- Exposes `deleteAllOptimizeData()` in `DatabaseIntegrationTestExtension` to enable cleanup
- Now both Zeebe records AND Optimize imported data are deleted between each test method

## Changes
  
- `optimize/backend/src/main/java/io/camunda/optimize/service/db/es/OptimizeElasticsearchClient.java`
  - Close existing `RestClient` before replacing in `reloadConfiguration()`
  
- `optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/DatabaseIntegrationTestExtension.java`
  - Add public `deleteAllOptimizeData()` method
  
- `optimize/backend/src/it/java/io/camunda/optimize/AbstractCCSMIT.java`
  - Call `deleteAllOptimizeData()` in `@AfterEach` cleanup

## Related issues

closes https://github.com/camunda/camunda/issues/54066
