### PR TITLE
feat: add agentic control plane page with routing and date filter

### DIFF
--- a/optimize/backend/src/main/resources/localization/de.json
+++ b/optimize/backend/src/main/resources/localization/de.json
@@ -2,9 +2,16 @@
   "appName": "Optimize",
   "appFullName": "Camunda Optimize",
   "agenticControlPlane": {
-    "title": "Agentische Steuerungsebene",
-    "description": "Überwachen Sie die Einführung von KI-Agenten, Token-Verbrauch, Verhalten und Zuverlässigkeit über Ihre Prozesse hinweg.",
-    "dateRange": "Zeitraum"
+    "title": "Agentic control plane",
+    "description": "Überwachen Sie die Einführung, das Verhalten und die Zuverlässigkeit von KI-Agenten sowie den Token-Verbrauch prozessübergreifend.",
+    "dateRange": "Zeitraum",
+    "presets": {
+      "last7Days": "Letzte 7 Tage",
+      "last30Days": "Letzte 30 Tage",
+      "last3Months": "Letzte 3 Monate",
+      "last6Months": "Letzte 6 Monate",
+      "last12Months": "Letzte 12 Monate"
+    }
   },
   "navigation": {
     "analysis": "Analyse",

--- a/optimize/backend/src/main/resources/localization/de.json
+++ b/optimize/backend/src/main/resources/localization/de.json
@@ -1,6 +1,11 @@
 {
   "appName": "Optimize",
   "appFullName": "Camunda Optimize",
+  "agenticControlPlane": {
+    "title": "Agentische Steuerungsebene",
+    "description": "Überwachen Sie die Einführung von KI-Agenten, Token-Verbrauch, Verhalten und Zuverlässigkeit über Ihre Prozesse hinweg.",
+    "dateRange": "Zeitraum"
+  },
   "navigation": {
     "analysis": "Analyse",
     "logout": "Abmelden",
@@ -13,6 +18,7 @@
     "appSwitcher": "App Switcher",
     "dashboards": "Dashboards",
     "collections": "Sammlungen",
+    "agenticControlPlane": "Agentische Steuerungsebene",
     "apps": {
       "zeebe": "Zeebe",
       "operate": "Operate",

--- a/optimize/backend/src/main/resources/localization/en.json
+++ b/optimize/backend/src/main/resources/localization/en.json
@@ -4,7 +4,14 @@
   "agenticControlPlane": {
     "title": "Agentic control plane",
     "description": "Monitor AI agent adoption, token spend, behavior, and reliability across your processes.",
-    "dateRange": "Date range"
+    "dateRange": "Date range",
+    "presets": {
+      "last7Days": "Last 7 days",
+      "last30Days": "Last 30 days",
+      "last3Months": "Last 3 months",
+      "last6Months": "Last 6 months",
+      "last12Months": "Last 12 months"
+    }
   },
   "navigation": {
     "analysis": "Analysis",

--- a/optimize/backend/src/main/resources/localization/en.json
+++ b/optimize/backend/src/main/resources/localization/en.json
@@ -1,6 +1,11 @@
 {
   "appName": "Optimize",
   "appFullName": "Camunda Optimize",
+  "agenticControlPlane": {
+    "title": "Agentic control plane",
+    "description": "Monitor AI agent adoption, token spend, behavior, and reliability across your processes.",
+    "dateRange": "Date range"
+  },
   "navigation": {
     "analysis": "Analysis",
     "logout": "Logout",
@@ -13,6 +18,7 @@
     "appSwitcher": "App switcher",
     "dashboards": "Dashboards",
     "collections": "Collections",
+    "agenticControlPlane": "Agentic Control Plane",
     "apps": {
       "zeebe": "Zeebe",
       "operate": "Operate",

--- a/optimize/client/src/App.js
+++ b/optimize/client/src/App.js
@@ -10,6 +10,7 @@ import {HashRouter as Router, Route, Switch, matchPath} from 'react-router-dom';
 import {Button} from '@carbon/react';
 
 import {
+  AgenticControlPlane,
   PrivateRoute,
   Home,
   Collection,
@@ -92,6 +93,11 @@ export default function App({error}) {
                         render={renderEntity}
                       />
                       <PrivateRoute exact path="/collections" component={Home} />
+                      <PrivateRoute
+                        exact
+                        path="/agentic-control-plane"
+                        component={AgenticControlPlane}
+                      />
                       <Route path="/logout" component={Logout} />
                       <PrivateRoute path="*" component={ErrorPage} />
                     </Switch>

--- a/optimize/client/src/components/AgenticControlPlane/AgenticControlPlane.js
+++ b/optimize/client/src/components/AgenticControlPlane/AgenticControlPlane.js
@@ -52,13 +52,8 @@ export function AgenticControlPlane() {
   return (
     <div className="AgenticControlPlane">
       <div className="AgenticControlPlane__header">
-        <h1 className="AgenticControlPlane__title">
-          {t('agenticControlPlane.title') || 'Agentic control plane'}
-        </h1>
-        <p className="AgenticControlPlane__description">
-          {t('agenticControlPlane.description') ||
-            'Monitor AI agent adoption, token spend, behavior, and reliability across your processes.'}
-        </p>
+        <h1 className="AgenticControlPlane__title">{t('agenticControlPlane.title')}</h1>
+        <p className="AgenticControlPlane__description">{t('agenticControlPlane.description')}</p>
       </div>
       <FilterBar preset={preset} onPresetChange={setPreset} />
       <DashboardRenderer loadTile={evaluateReport} tiles={dashboard.tiles} filter={filter} />

--- a/optimize/client/src/components/AgenticControlPlane/AgenticControlPlane.js
+++ b/optimize/client/src/components/AgenticControlPlane/AgenticControlPlane.js
@@ -1,0 +1,67 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useState, useEffect} from 'react';
+
+import {useErrorHandling} from 'hooks';
+import {showError} from 'notifications';
+import {DashboardRenderer, Loading} from 'components';
+import {evaluateReport} from 'services';
+import {t} from 'translation';
+
+import {DATE_PRESETS, FilterBar} from './FilterBar';
+import {loadAgenticDashboard} from './service';
+
+import './AgenticControlPlane.scss';
+
+function presetToFilter(preset) {
+  return {
+    type: 'instanceEndDate',
+    filterLevel: 'instance',
+    data: {
+      type: 'rolling',
+      start: {value: preset.value, unit: preset.unit},
+      end: null,
+      excludeUndefined: false,
+      includeUndefined: false,
+    },
+  };
+}
+
+export function AgenticControlPlane() {
+  const [preset, setPreset] = useState('30d');
+  const [dashboard, setDashboard] = useState(null);
+  const {mightFail} = useErrorHandling();
+
+  useEffect(() => {
+    mightFail(loadAgenticDashboard(), setDashboard, showError);
+  }, [mightFail]);
+
+  const selectedPreset = DATE_PRESETS.find((p) => p.id === preset);
+  const filter = [presetToFilter(selectedPreset)];
+
+  if (!dashboard) {
+    return <Loading />;
+  }
+
+  return (
+    <div className="AgenticControlPlane">
+      <div className="AgenticControlPlane__header">
+        <h1 className="AgenticControlPlane__title">
+          {t('agenticControlPlane.title') || 'Agentic control plane'}
+        </h1>
+        <p className="AgenticControlPlane__description">
+          {t('agenticControlPlane.description') ||
+            'Monitor AI agent adoption, token spend, behavior, and reliability across your processes.'}
+        </p>
+      </div>
+      <FilterBar preset={preset} onPresetChange={setPreset} />
+      <DashboardRenderer loadTile={evaluateReport} tiles={dashboard.tiles} filter={filter} />
+    </div>
+  );
+}

--- a/optimize/client/src/components/AgenticControlPlane/AgenticControlPlane.scss
+++ b/optimize/client/src/components/AgenticControlPlane/AgenticControlPlane.scss
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+.AgenticControlPlane {
+  display: flex;
+  flex-direction: column;
+  padding: 1.5rem 2rem 0;
+
+  &__header {
+    margin-bottom: 1.5rem;
+  }
+
+  &__title {
+    font-size: 1.75rem;
+    font-weight: 600;
+    margin: 0 0 0.5rem;
+  }
+
+  &__description {
+    font-size: 0.875rem;
+    color: var(--cds-text-secondary);
+    margin: 0 0 0.5rem;
+  }
+}

--- a/optimize/client/src/components/AgenticControlPlane/AgenticControlPlane.test.js
+++ b/optimize/client/src/components/AgenticControlPlane/AgenticControlPlane.test.js
@@ -1,0 +1,120 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {runAllEffects} from 'react';
+import {shallow} from 'enzyme';
+
+import {AgenticControlPlane} from './AgenticControlPlane';
+import {loadAgenticDashboard} from './service';
+
+jest.mock('hooks', () => ({
+  useErrorHandling: jest.fn(() => ({
+    mightFail: jest.fn().mockImplementation((data, cb) => cb(data)),
+  })),
+}));
+
+jest.mock('notifications', () => ({showError: jest.fn()}));
+
+jest.mock('services', () => ({
+  ...jest.requireActual('services'),
+  evaluateReport: jest.fn(),
+}));
+
+jest.mock('./service', () => ({
+  loadAgenticDashboard: jest.fn().mockReturnValue({tiles: [], availableFilters: []}),
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  loadAgenticDashboard.mockReturnValue({tiles: [], availableFilters: []});
+});
+
+it('should show a loading state while the dashboard is being fetched', () => {
+  const node = shallow(<AgenticControlPlane />);
+
+  expect(node.find('Loading')).toExist();
+});
+
+it('should load the agentic dashboard on mount', async () => {
+  shallow(<AgenticControlPlane />);
+
+  await runAllEffects();
+
+  expect(loadAgenticDashboard).toHaveBeenCalled();
+});
+
+it('should render the dashboard once tiles are loaded', async () => {
+  const node = shallow(<AgenticControlPlane />);
+
+  await runAllEffects();
+
+  expect(node.find('DashboardRenderer')).toExist();
+  expect(node.find('Loading')).not.toExist();
+});
+
+it('should pass the default Last 30 days filter to DashboardRenderer', async () => {
+  const node = shallow(<AgenticControlPlane />);
+
+  await runAllEffects();
+
+  expect(node.find('DashboardRenderer').prop('filter')).toEqual([
+    {
+      type: 'instanceEndDate',
+      filterLevel: 'instance',
+      data: {
+        type: 'rolling',
+        start: {value: 30, unit: 'days'},
+        end: null,
+        excludeUndefined: false,
+        includeUndefined: false,
+      },
+    },
+  ]);
+});
+
+it('should update the filter when the date preset changes', async () => {
+  const node = shallow(<AgenticControlPlane />);
+
+  await runAllEffects();
+
+  node.find('FilterBar').prop('onPresetChange')('7d');
+
+  expect(node.find('DashboardRenderer').prop('filter')).toEqual([
+    {
+      type: 'instanceEndDate',
+      filterLevel: 'instance',
+      data: {
+        type: 'rolling',
+        start: {value: 7, unit: 'days'},
+        end: null,
+        excludeUndefined: false,
+        includeUndefined: false,
+      },
+    },
+  ]);
+});
+
+it('should render the page header with title and description', async () => {
+  const node = shallow(<AgenticControlPlane />);
+
+  await runAllEffects();
+
+  expect(node.find('.AgenticControlPlane__title')).toExist();
+  expect(node.find('.AgenticControlPlane__description')).toExist();
+});
+
+it('should pass the loaded tiles to DashboardRenderer', async () => {
+  const tiles = [{id: 'report-1', position: {x: 0, y: 0}, dimensions: {width: 4, height: 3}}];
+  loadAgenticDashboard.mockReturnValueOnce({tiles, availableFilters: []});
+
+  const node = shallow(<AgenticControlPlane />);
+
+  await runAllEffects();
+
+  expect(node.find('DashboardRenderer').prop('tiles')).toEqual(tiles);
+});

--- a/optimize/client/src/components/AgenticControlPlane/FilterBar.js
+++ b/optimize/client/src/components/AgenticControlPlane/FilterBar.js
@@ -14,11 +14,11 @@ import {t} from 'translation';
 import './FilterBar.scss';
 
 export const DATE_PRESETS = [
-  {id: '7d', label: 'Last 7 days', value: 7, unit: 'days'},
-  {id: '30d', label: 'Last 30 days', value: 30, unit: 'days'},
-  {id: '3m', label: 'Last 3 months', value: 3, unit: 'months'},
-  {id: '6m', label: 'Last 6 months', value: 6, unit: 'months'},
-  {id: '12m', label: 'Last 12 months', value: 12, unit: 'months'},
+  {id: '7d', translationKey: 'agenticControlPlane.presets.last7Days', value: 7, unit: 'days'},
+  {id: '30d', translationKey: 'agenticControlPlane.presets.last30Days', value: 30, unit: 'days'},
+  {id: '3m', translationKey: 'agenticControlPlane.presets.last3Months', value: 3, unit: 'months'},
+  {id: '6m', translationKey: 'agenticControlPlane.presets.last6Months', value: 6, unit: 'months'},
+  {id: '12m', translationKey: 'agenticControlPlane.presets.last12Months', value: 12, unit: 'months'},
 ];
 
 export function FilterBar({preset, onPresetChange}) {
@@ -27,14 +27,12 @@ export function FilterBar({preset, onPresetChange}) {
   return (
     <div className="FilterBar">
       <div className="FilterBar__dateRange">
-        <span className="FilterBar__label">
-          {t('agenticControlPlane.dateRange') || 'Date range'}
-        </span>
-        <MenuDropdown label={selected.label} size="sm">
+        <span className="FilterBar__label">{t('agenticControlPlane.dateRange')}</span>
+        <MenuDropdown label={t(selected.translationKey)} size="sm">
           {DATE_PRESETS.map((p) => (
             <MenuItemSelectable
               key={p.id}
-              label={p.label}
+              label={t(p.translationKey)}
               selected={p.id === preset}
               onChange={() => onPresetChange(p.id)}
             />

--- a/optimize/client/src/components/AgenticControlPlane/FilterBar.js
+++ b/optimize/client/src/components/AgenticControlPlane/FilterBar.js
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {MenuItemSelectable} from '@carbon/react';
+
+import {MenuDropdown} from 'components';
+import {t} from 'translation';
+
+import './FilterBar.scss';
+
+export const DATE_PRESETS = [
+  {id: '7d', label: 'Last 7 days', value: 7, unit: 'days'},
+  {id: '30d', label: 'Last 30 days', value: 30, unit: 'days'},
+  {id: '3m', label: 'Last 3 months', value: 3, unit: 'months'},
+  {id: '6m', label: 'Last 6 months', value: 6, unit: 'months'},
+  {id: '12m', label: 'Last 12 months', value: 12, unit: 'months'},
+];
+
+export function FilterBar({preset, onPresetChange}) {
+  const selected = DATE_PRESETS.find((p) => p.id === preset);
+
+  return (
+    <div className="FilterBar">
+      <div className="FilterBar__dateRange">
+        <span className="FilterBar__label">
+          {t('agenticControlPlane.dateRange') || 'Date range'}
+        </span>
+        <MenuDropdown label={selected.label} size="sm">
+          {DATE_PRESETS.map((p) => (
+            <MenuItemSelectable
+              key={p.id}
+              label={p.label}
+              selected={p.id === preset}
+              onChange={() => onPresetChange(p.id)}
+            />
+          ))}
+        </MenuDropdown>
+      </div>
+    </div>
+  );
+}

--- a/optimize/client/src/components/AgenticControlPlane/FilterBar.scss
+++ b/optimize/client/src/components/AgenticControlPlane/FilterBar.scss
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+.FilterBar {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  padding: 0.75rem 0;
+  border-top: 1px solid var(--cds-border-subtle);
+  border-bottom: 1px solid var(--cds-border-subtle);
+  margin-bottom: 1rem;
+
+  &__dateRange {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  &__label {
+    font-size: 0.875rem;
+    color: var(--cds-text-secondary);
+    white-space: nowrap;
+  }
+}

--- a/optimize/client/src/components/AgenticControlPlane/FilterBar.test.js
+++ b/optimize/client/src/components/AgenticControlPlane/FilterBar.test.js
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {shallow} from 'enzyme';
+import {MenuItemSelectable} from '@carbon/react';
+
+import {MenuDropdown} from 'components';
+
+import {FilterBar, DATE_PRESETS} from './FilterBar';
+
+const props = {
+  preset: '30d',
+  onPresetChange: jest.fn(),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+it('should render one option for each date preset', () => {
+  const node = shallow(<FilterBar {...props} />);
+
+  expect(node.find(MenuItemSelectable)).toHaveLength(DATE_PRESETS.length);
+});
+
+it('should mark only the active preset as selected', () => {
+  const node = shallow(<FilterBar {...props} preset="7d" />);
+
+  const selectedItems = node.find(MenuItemSelectable).filterWhere((n) => n.prop('selected'));
+  expect(selectedItems).toHaveLength(1);
+  expect(selectedItems.prop('label')).toBe('Last 7 days');
+});
+
+it('should show the active preset label in the dropdown trigger', () => {
+  const node = shallow(<FilterBar {...props} preset="3m" />);
+
+  expect(node.find(MenuDropdown).prop('label')).toBe('Last 3 months');
+});
+
+it('should call onPresetChange with the preset id when an option is selected', () => {
+  const node = shallow(<FilterBar {...props} />);
+
+  node.find(MenuItemSelectable).at(0).prop('onChange')();
+
+  expect(props.onPresetChange).toHaveBeenCalledWith('7d');
+});
+
+it('should default to Last 30 days being selected when preset is 30d', () => {
+  const node = shallow(<FilterBar {...props} preset="30d" />);
+
+  const selectedItem = node.find(MenuItemSelectable).filterWhere((n) => n.prop('selected'));
+  expect(selectedItem.prop('label')).toBe('Last 30 days');
+});

--- a/optimize/client/src/components/AgenticControlPlane/index.js
+++ b/optimize/client/src/components/AgenticControlPlane/index.js
@@ -7,12 +7,3 @@
  */
 
 export {AgenticControlPlane} from './AgenticControlPlane';
-export {Analysis} from './Analysis';
-export {Header} from './Header';
-export {PrivateRoute} from './PrivateRoute';
-export {Dashboard} from './Dashboards';
-export {Report} from './Reports';
-export {Sharing} from './Sharing';
-export {Home, Collection} from './Home';
-export {default as Logout} from './Logout';
-export {Processes, ProcessReport} from './Processes';

--- a/optimize/client/src/components/AgenticControlPlane/service.js
+++ b/optimize/client/src/components/AgenticControlPlane/service.js
@@ -1,0 +1,18 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+// TODO: Replace stub with real API call once AgentDashboardService is ready:
+// import {get} from 'request';
+// export async function loadAgenticDashboard() {
+//   const response = await get('api/dashboard/agentic-control-plane-dashboard');
+//   return response.json();
+// }
+
+export async function loadAgenticDashboard() {
+  return {tiles: [], availableFilters: []};
+}

--- a/optimize/client/src/components/Header/Header.tsx
+++ b/optimize/client/src/components/Header/Header.tsx
@@ -159,9 +159,12 @@ function createNavBarProps(
     },
     {
       key: 'agentic-control-plane',
-      label: (t('navigation.agenticControlPlane') || 'Agentic Control Plane').toString(),
+      label: t('navigation.agenticControlPlane').toString(),
       routeProps: {to: '/agentic-control-plane'},
-      isCurrentPage: isCurrentPage(['/agentic-control-plane'], pathname),
+      isCurrentPage: isCurrentPage(
+        ['/agentic-control-plane', '/agentic-control-plane/*'],
+        pathname,
+      ),
     },
   ];
 

--- a/optimize/client/src/components/Header/Header.tsx
+++ b/optimize/client/src/components/Header/Header.tsx
@@ -157,6 +157,12 @@ function createNavBarProps(
       routeProps: {to: '/analysis'},
       isCurrentPage: isCurrentPage(['/analysis/', '/analysis/*'], pathname),
     },
+    {
+      key: 'agentic-control-plane',
+      label: (t('navigation.agenticControlPlane') || 'Agentic Control Plane').toString(),
+      routeProps: {to: '/agentic-control-plane'},
+      isCurrentPage: isCurrentPage(['/agentic-control-plane'], pathname),
+    },
   ];
 
   const licenseTag: C3NavigationNavBarProps['licenseTag'] = {


### PR DESCRIPTION
## Description

Adds the `/agentic-control-plane` route and a standalone date filter dropdown
as the frontend shell for the Agentic Trust Dashboard (Phase 1, task 1/2).

- New route at `/agentic-control-plane` renders the `AgenticControlPlane` page
  component with a page header and a `DashboardRenderer` wired to a stub service
  (real `AgentDashboardService` API call is commented in `service.js`, ready to
  swap when the backend task lands)
- `FilterBar` component provides 5 `instanceEndDate` rolling presets (Last 7 days,
  Last 30 days [default], Last 3 months, Last 6 months, Last 12 months); changing
  the preset re-triggers all tile evaluate calls via `DashboardRenderer`'s `filter`
  prop
- Nav item added to the top-level header
- Translation keys added to `en.json` and `de.json`
- No changes to existing `Dashboard`, `DashboardView`, or `DashboardRenderer` —
  existing routes and dashboards are unaffected

## Checklist

- [x] Navigate to `/#/agentic-control-plane` — page loads with title and description
- [x] Date range dropdown shows all 5 presets; default is "Last 30 days"
- [x] Change preset to "Last 7 days" — confirm `POST /api/report/{id}/evaluate`
      requests include `"type":"instanceEndDate"` with `"start":{"value":7,"unit":"days"}`
      in the filter body (check DevTools Network tab)
- [x] Navigate to an existing dashboard — confirm no change in behaviour
- [x] `yarn test:ci --testPathPattern="AgenticControlPlane"` passes (12 tests)

## Screenshots
<img width="1796" height="514" alt="Screenshot 2026-05-27 at 5 20 08 PM" src="https://github.com/user-attachments/assets/876f905e-3d65-462a-8606-42d4b669f357" />


## Related issues

closes #53300
