### PR TITLE
deps: bump openapi-generator-maven-plugin from 7.21.0 to 7.22.0

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -1133,7 +1133,7 @@
       <plugin>
         <groupId>org.openapitools</groupId>
         <artifactId>openapi-generator-maven-plugin</artifactId>
-        <version>7.21.0</version>
+        <version>7.22.0</version>
         <executions>
           <execution>
             <id>backups</id>
@@ -1159,6 +1159,7 @@
               <modelPackage>io.camunda.zeebe.management.cluster</modelPackage>
               <minimalUpdate>true</minimalUpdate>
               <ignoreFileOverride>${project.basedir}/src/main/resources/api/cluster/.openapi-generator-ignore</ignoreFileOverride>
+              <openapiNormalizer>REPLACE_ONE_OF_BY_DISCRIMINATOR_MAPPING=false</openapiNormalizer>
               <configOptions>
                 <hideGenerationTimestamp>true</hideGenerationTimestamp>
               </configOptions>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -2896,7 +2896,7 @@
         <plugin>
           <groupId>org.openapitools</groupId>
           <artifactId>openapi-generator-maven-plugin</artifactId>
-          <version>7.21.0</version>
+          <version>7.22.0</version>
           <configuration>
             <!-- https://github.com/OpenAPITools/openapi-generator/tree/master/modules/openapi-generator-maven-plugin -->
             <!-- https://github.com/OpenAPITools/openapi-generator/blob/master/docs/generators/spring.md -->


### PR DESCRIPTION
## Summary

Bumps `org.openapitools:openapi-generator-maven-plugin` from `7.21.0` to `7.22.0`.

Version 7.22.0 introduced a `REPLACE_ONE_OF_BY_DISCRIMINATOR_MAPPING` normalizer that collapses a `oneOf` schema with a single discriminator mapping entry into its parent class. The `MessageCorrelation` schema in `cluster/components.yaml` uses exactly this pattern:

```yaml
MessageCorrelation:
  oneOf:
    - $ref: "...#/schemas/MessageCorrelationHashMod"
  discriminator:
    propertyName: strategy
    mapping:
      HashMod: "...#/schemas/MessageCorrelationHashMod"
```

Without intervention this would silently drop `MessageCorrelationHashMod` from the generated sources and break compilation across `dist` and the integration tests.

The `oneOf` + discriminator pattern here is intentional design: it allows future correlation strategies to be added as new `oneOf` entries without changing the `MessageCorrelation` schema. Disabling the normalizer on this execution preserves that design and keeps the existing type-safe generated class hierarchy.

## Change

- Bump plugin version in `dist/pom.xml` and `parent/pom.xml`
- Add `<openapiNormalizer>REPLACE_ONE_OF_BY_DISCRIMINATOR_MAPPING=false</openapiNormalizer>` to the `cluster` API generation execution in `dist/pom.xml`

No Java source changes required.