### PR TITLE
ci: switch OpenAPI linter to @camunda8/spectral-cli

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -636,6 +636,7 @@
       "description": "Disable release cooldown for trusted first-party and bpmn-io ecosystem packages.",
       "matchPackageNames": [
         "@camunda{/,}**",
+        "@camunda8{/,}**",
         "@bpmn-io{/,}**",
         "bpmn-js",
         "bpmn-js-disable-collapsed-subprocess",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1772,14 +1772,8 @@ jobs:
     timeout-minutes: 10
     permissions: {}  # GITHUB_TOKEN unused in this job
     env:
-      # renovate: datasource=npm depName=@stoplight/spectral-cli
-      SPECTRAL_VERSION: '6.16.0'
-      # Pin the transitive @stoplight/spectral-rulesets to avoid a nimma
-      # null-deref triggered by the duplicated-entry-in-enum rule in
-      # spectral-rulesets >= 1.22.3 against null example values in the spec.
-      # Revisit once nimma releases past 0.7.2 or spectral-rulesets ships a fix.
-      # renovate: datasource=npm depName=@stoplight/spectral-rulesets
-      SPECTRAL_RULESETS_VERSION: '1.22.2'
+      # renovate: datasource=npm depName=@camunda8/spectral-cli packageName=@camunda8/spectral-cli
+      SPECTRAL_VERSION: '6.16.1'
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -1789,10 +1783,14 @@ jobs:
         with:
           node-version: 24
       - name: Install Spectral CLI
-        run: |
-          npm install -g \
-            "@stoplight/spectral-cli@${SPECTRAL_VERSION}" \
-            "@stoplight/spectral-rulesets@${SPECTRAL_RULESETS_VERSION}"
+        # We use our own maintained fork of Spectral CLI (@camunda8/spectral-cli)
+        # to fix upstream issues that are unresolved in @stoplight/spectral-cli:
+        # - nimma null-dereference crash on certain JSONPath expressions
+        # - Unicode regex false positives in pattern validation
+        # - unrecognized-format warnings without ignoreUnknownFormat support
+        # See: https://github.com/camunda/camunda/issues/54071
+        # Fork: https://github.com/camunda/camunda-spectral
+        run: npm install -g "@camunda8/spectral-cli@${SPECTRAL_VERSION}"
         shell: bash
       - name: Run OpenAPI Linter (Structural pass)
         # Spectral provides comprehensive OpenAPI validation including:

--- a/docs/rest-api-endpoint-guidelines.md
+++ b/docs/rest-api-endpoint-guidelines.md
@@ -1207,7 +1207,7 @@ TenantId:
 
 ```bash
 # Install (one-time)
-npm install -g @stoplight/spectral-cli
+npm install -g @camunda8/spectral-cli
 
 # From the repository root, run BOTH passes:
 

--- a/zeebe/gateway-protocol/.spectral.yaml
+++ b/zeebe/gateway-protocol/.spectral.yaml
@@ -2,6 +2,7 @@
 # Replaces Vacuum for comprehensive OpenAPI linting and validation
 description: Recommended ruleset with additional customizations.
 extends: [[spectral:oas, recommended]]
+ignoreUnknownFormat: true
 functions:
   - verifyKeyTypesPaths
   - verifyKeyTypesSchemas
@@ -19,16 +20,14 @@ rules:
   # Tag validation
   operation-tag-defined: error
 
-  # Schema example validation rules.
-  # Downgraded from error → warn because Spectral does not support Unicode regex
-  # (\p{L}, \p{N}) in pattern validation. Our identifier schemas use Unicode-aware
-  # patterns (e.g. ProcessDefinitionId, DecisionDefinitionId, Tag), which causes
-  # false-positive failures on all example values.
-  # Upstream issue: https://github.com/stoplightio/spectral/issues/2419
-  # Upstream fix:   https://github.com/stoplightio/spectral/pull/2809
-  # TODO: Restore to error once Spectral ships the unicodeRegExp option.
+  # Schema example validation — @camunda8/spectral-cli supports unicodeRegExp,
+  # so false-positive pattern failures are resolved.
+  # oas3-valid-schema-example remains at warn because ScopeKey uses oneOf with
+  # structurally identical branches (ProcessInstanceKey, ElementInstanceKey),
+  # causing "must match exactly one schema in oneOf" on any ScopeKey example.
+  # Changing oneOf→anyOf would fix the warning but breaks Java code generation.
   oas3-valid-schema-example: warn
-  oas3-valid-media-example: warn
+  oas3-valid-media-example: error
 
   # Custom validation rules migrated from Vacuum
   no-period-in-summary:

--- a/zeebe/gateway-protocol/OPENAPI_VALIDATION.md
+++ b/zeebe/gateway-protocol/OPENAPI_VALIDATION.md
@@ -28,7 +28,7 @@ We use [Spectral CLI](https://docs.stoplight.io/docs/spectral/) to validate the 
 
 ```bash
 # Install Spectral CLI (if not already installed)
-npm install -g @stoplight/spectral-cli
+npm install -g @camunda8/spectral-cli
 
 # Run validation from the repository root
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/decision-definitions.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/decision-definitions.yaml
@@ -151,7 +151,7 @@ paths:
               By decision definition ID:
                 summary: Evaluate the decision by decisionDefinitionId.
                 value:
-                  decisionDefinitionId: 1234-5678
+                  decisionDefinitionId: my-decision
                   variables: {}
       responses:
         "200":

--- a/zeebe/gateway-protocol/src/main/proto/v2/system.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/system.yaml
@@ -123,7 +123,7 @@ paths:
                       canLogout: true
                       isLoginDelegated: false
                     cloud:
-                      stage: null
+                      stage: "prod"
         "401":
           $ref: 'common-responses.yaml#/components/responses/Unauthorized'
         "500":
@@ -303,6 +303,7 @@ components:
       properties:
         stage:
           description: The cloud deployment stage.
+          type: string
           nullable: true
           allOf:
             - $ref: '#/components/schemas/CloudStage'


### PR DESCRIPTION
## Description

Switch the `openapi-lint` CI job from upstream `@stoplight/spectral-cli` + pinned `@stoplight/spectral-rulesets` to the Camunda fork [`@camunda8/spectral-cli`](https://www.npmjs.com/package/@camunda8/spectral-cli).

The fork is a single pre-bundled package (no transitive dependency on `@stoplight/spectral-rulesets`) that fixes three upstream issues:

1. **nimma null-deref** — the `duplicated-entry-in-enum` rule crashes on `null` example values. The fork adds null guards to the JSONPath filter.
2. **Unicode regex false positives** — Ajv rejects valid Unicode patterns (e.g. `\p{L}`) because `unicodeRegExp` defaults to `false`. The fork integrates [PR #2809](https://github.com/stoplightio/spectral/pull/2809) and defaults `unicodeRegExp` to `true`.
3. **`ignoreUnknownFormat` at ruleset level** — allows rulesets to suppress `unrecognized-format` warnings without requiring CLI flags.

Fork repo: https://github.com/camunda/camunda-spectral

## Changes

### CI workflow (`.github/workflows/ci.yml`)
- Replace `@stoplight/spectral-cli@6.16.0` + `@stoplight/spectral-rulesets@1.22.2` with `@camunda8/spectral-cli@6.16.1`
- Simplify install step to a single `npm install -g` call
- Remove the `spectral-rulesets` pinning workaround comment

### Spectral ruleset (`.spectral.yaml`)
- Add `ignoreUnknownFormat: true` to suppress `unrecognized-format` warnings on YAML partials (eliminates 43 warnings on the file-level pass)
- Promote `oas3-valid-media-example` from `warn` to `error` (all media example issues are now fixed)
- Keep `oas3-valid-schema-example` at `warn` — ScopeKey uses `oneOf` with structurally identical branches (`ProcessInstanceKey`, `ElementInstanceKey`), causing "must match exactly one schema in oneOf" on any ScopeKey example. Changing `oneOf` to `anyOf` would fix the warning but breaks Java code generation. 4 warnings remain from this.
- Remove the `TODO` comment about restoring severity (no longer needed for media examples)

### OpenAPI spec fixes
- `decision-definitions.yaml`: Fix example `decisionDefinitionId` from `1234-5678` (starts with digit, violates `^[\p{L}_]...` pattern) to `my-decision`
- `system.yaml`: Add `type: string` to nullable `stage` property (Spectral requires `type` alongside `nullable`), change example from `null` to `"prod"`

### What was NOT changed (and why)
- `keys.yaml` ScopeKey `oneOf` — left as-is because changing to `anyOf` alters the generated Java classes and breaks the build (confirmed by CI failure on earlier push)
- `process-instances.yaml` `ancestorElementInstanceKey` `oneOf` — same reason; changing to `allOf` breaks codegen

Closes #54071