### PR TITLE
[Backport stable/8.7] fix: user task migration prevents target task listeners from being invoked

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -313,6 +313,7 @@ public class ProcessInstanceMigrationMigrateProcessor
           elementInstance.getUserTaskKey(),
           UserTaskIntent.MIGRATED,
           userTask
+              .copy()
               .setProcessDefinitionKey(targetProcessDefinition.getKey())
               .setProcessDefinitionVersion(targetProcessDefinition.getVersion())
               .setBpmnProcessId(targetProcessDefinition.getBpmnProcessId())

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateUserTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateUserTaskTest.java
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.builder.AbstractUserTaskBuilder;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
@@ -483,6 +484,60 @@ public class MigrateUserTaskTest {
         .hasProcessDefinitionKey(targetProcessDefinitionKey)
         .hasBpmnProcessId(targetProcessId)
         .hasVersion(1)
+        .hasElementId("B");
+  }
+
+  @Test
+  public void shouldPersistTargetProcessDefinitionFieldsInUserTaskStateAfterMigration() {
+    // given
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .userTask("A", AbstractUserTaskBuilder::zeebeUserTask)
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .userTask("B", AbstractUserTaskBuilder::zeebeUserTask)
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+    RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("A", "B")
+        .migrate();
+
+    ENGINE.userTask().ofInstance(processInstanceKey).withCandidateUsers("user").update();
+
+    // then: UPDATED event reads from persisted state — verifies migration correctly stored target
+    // fields
+    assertThat(
+            RecordingExporter.userTaskRecords(UserTaskIntent.UPDATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that process definition fields are updated to target after migration")
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .hasBpmnProcessId(targetProcessId)
         .hasElementId("B");
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessingComposite.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessingComposite.java
@@ -243,6 +243,27 @@ public class StreamProcessingComposite implements CommandWriter {
   }
 
   @Override
+  public long writeCommand(
+      final long key,
+      final int requestStreamId,
+      final long requestId,
+      final Intent intent,
+      final UnifiedRecordValue recordValue,
+      final String... authorizedTenants) {
+    final var writer =
+        streams
+            .newRecord(getLogName(partitionId))
+            .recordType(RecordType.COMMAND)
+            .key(key)
+            .requestStreamId(requestStreamId)
+            .requestId(requestId)
+            .intent(intent)
+            .authorizations(authorizedTenants)
+            .event(recordValue);
+    return writeActor.submit(writer::write).join();
+  }
+
+  @Override
   public long writeCommandOnPartition(
       final int partitionId, final UnaryOperator<FluentLogWriter> builder) {
     final var writer =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
@@ -260,6 +260,18 @@ public final class StreamProcessorRule implements TestRule, CommandWriter {
   }
 
   @Override
+  public long writeCommand(
+      final long key,
+      final int requestStreamId,
+      final long requestId,
+      final Intent intent,
+      final UnifiedRecordValue recordValue,
+      final String... authorizedTenants) {
+    return streamProcessingComposite.writeCommand(
+        key, requestStreamId, requestId, intent, recordValue, authorizedTenants);
+  }
+
+  @Override
   public long writeCommandOnPartition(
       final int partitionId, final UnaryOperator<FluentLogWriter> builder) {
     return streamProcessingComposite.writeCommandOnPartition(partitionId, builder);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/CommandWriter.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/CommandWriter.java
@@ -40,6 +40,14 @@ public interface CommandWriter {
       final UnifiedRecordValue value,
       String... authorizedTenants);
 
+  long writeCommand(
+      final long key,
+      final int requestStreamId,
+      final long requestId,
+      final Intent intent,
+      final UnifiedRecordValue recordValue,
+      final String... authorizedTenants);
+
   long writeCommandOnPartition(int partitionId, final UnaryOperator<FluentLogWriter> builder);
 
   long writeCommandOnPartition(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/UserTaskClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/UserTaskClient.java
@@ -67,6 +67,15 @@ public final class UserTaskClient {
     return this;
   }
 
+  public UserTaskClient withCandidateUsers(final String... candidateUsers) {
+    return withCandidateUsersList(List.of(candidateUsers));
+  }
+
+  public UserTaskClient withCandidateUsersList(final List<String> candidateUsers) {
+    userTaskRecord.setCandidateUsersList(candidateUsers).setCandidateUsersChanged();
+    return this;
+  }
+
   public UserTaskClient withAssignee(final String assignee) {
     userTaskRecord.setAssignee(assignee);
     return this;
@@ -165,6 +174,72 @@ public final class UserTaskClient {
       return DEFAULT_PARTITION_ID;
     }
     return partitionId;
+  }
+
+  /**
+   * Sends an {@link UserTaskIntent#UPDATE} command for the user task with the specified attribute
+   * values.
+   *
+   * <p>This method uses the attributes set through the {@code with<AttributeName>()} methods to
+   * construct the {@link UserTaskRecord} with the appropriate changed attributes. Only explicitly
+   * set attributes will be included in the {@code changedAttributes} list, ensuring precise control
+   * over which properties are updated.
+   *
+   * <p>Example 1: Update specific attributes
+   *
+   * <pre>{@code
+   * final var candidateGroups = List.of("elves", "dwarves");
+   * userTaskClient
+   *     .ofInstance(processInstanceKey)
+   *     .withCandidateGroupsList(candidateGroups)
+   *     .withCandidateUsers("legolas", "thorin")
+   *     .withDueDate("2023-03-02T15:35+02:00")
+   *     .withPriority(99)
+   *     .update();
+   * }</pre>
+   *
+   * This example constructs and sends an {@link UserTaskIntent#UPDATE} command that updates the
+   * following attributes: {@code candidateGroupsList}, {@code candidateUsersList}, {@code dueDate},
+   * and {@code priority}. These attribute names will be included in the {@code changedAttributes}
+   * list.
+   *
+   * <p>Example 2: Reset all updatable attributes to their default values
+   *
+   * <pre>{@code
+   * userTaskClient
+   *     .ofInstance(processInstanceKey)
+   *     .withAllAttributesChanged()
+   *     .update();
+   * }</pre>
+   *
+   * This example sends an {@link UserTaskIntent#UPDATE} command with all updatable attributes
+   * marked as changed, resulting in all such attributes being reset to their default values.
+   *
+   * <p>Example 3: Trigger update transition without updating any attributes
+   *
+   * <pre>{@code
+   * userTaskClient
+   *     .ofInstance(processInstanceKey)
+   *     .update();
+   * }</pre>
+   *
+   * In this example, the {@link UserTaskIntent#UPDATE} command is sent with an empty {@code
+   * changedAttributes} list. This triggers the update transition, including the execution of
+   * configured {@code updating} listeners, by without updating any user task properties.
+   *
+   * @return the {@link UserTaskIntent#UPDATING} record.
+   */
+  public Record<UserTaskRecordValue> update() {
+    final long userTaskKey = findUserTaskKey();
+    final long position =
+        writer.writeCommand(
+            userTaskKey,
+            DEFAULT_REQUEST_STREAM_ID,
+            DEFAULT_REQUEST_ID,
+            UserTaskIntent.UPDATE,
+            userTaskRecord.setUserTaskKey(userTaskKey),
+            authorizedTenantIds.toArray(new String[0]));
+    return expectation.apply(position);
   }
 
   public Record<UserTaskRecordValue> update(

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
@@ -131,6 +131,13 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
     priorityProp.setValue(record.getPriority());
   }
 
+  /** Returns a full copy of the record. */
+  public UserTaskRecord copy() {
+    final UserTaskRecord copy = new UserTaskRecord();
+    copy.copyFrom(this);
+    return copy;
+  }
+
   public void wrapChangedAttributes(
       final UserTaskRecord record, final boolean includeTrackingProperties) {
     record.getChangedAttributesProp().stream()


### PR DESCRIPTION
## Description

Backport of https://github.com/camunda/camunda/pull/53822

## Related issues

relates #53122
