### PR TITLE
fix: load test: always configure Elasticsearch for Optimize without overriding secondary storage

### DIFF
--- a/load-tests/setup/default/Makefile
+++ b/load-tests/setup/default/Makefile
@@ -67,6 +67,12 @@ ifneq ($(enable_optimize),true)
 	ifneq ($(filter $(secondary_storage),postgresql mysql mariadb mssql oracle),)
 		platform_values += --set elasticsearch.enabled=false
 	endif
+else
+	# Optimize needs specifically Elasticsearch (independently from the
+	# secondary storage configuration).
+	ifneq ($(secondary_storage),elasticsearch)
+		platform_values += -f camunda-platform-values-optimize-elasticsearch.yaml
+	endif
 endif
 
 # Platform values with stable configuration

--- a/load-tests/setup/default/values/camunda-platform-values-optimize-elasticsearch.yaml
+++ b/load-tests/setup/default/values/camunda-platform-values-optimize-elasticsearch.yaml
@@ -1,14 +1,13 @@
 # Elasticsearch values for Camunda Platform Chart.
 # https://github.com/camunda/camunda-platform-helm
 #
-# This configures Elasticsearch when it's used for Optimize AND as the Camunda secondary storage.
+# This configures Elasticsearch when it's used fr Optimize, but NOT as the Camunda secondary storage.
+# storage.
 #
-# If you want to configure Elasticsearch only for Optimize and use another
-# secondary storage option for Camunda, see
-# the "camunda-platform-values-optimize-elasticsearch.yaml" file.
-# If you make changes to this file or the
-# "camunda-platform-values-optimize-elasticsearch.yaml" file, make sure to keep
-# the other file in sync (minus the secondary storage-only options).
+# For the Elasticsearch as secondary storage configuration, see the
+# "camunda-platform-values-elasticsearch.yaml" file.
+# If you make changes to this file or the "camunda-platform-values-elasticsearch.yaml" file, make
+# sure to keep the other file in sync (minus the secondary storage-only options).
 
 ########################################################################################
 ################################################### Global cluster configuration
@@ -22,16 +21,6 @@ global:
       # If you change the "elasticsearch.fullnameOverride" value, make sure to
       # update this host value accordingly.
       host: elastic
-
-########################################################################################
-################################################### Orchestration cluster configuration
-########################################################################################
-orchestration:
-  # We need to explicitly set the secondary storage type to ELS
-  # THIS GETS OVERRIDDEN IN THE OTHER VALUES FILES, e.g. for OpenSearch and RDBMS
-  data:
-    secondaryStorage:
-      type: elasticsearch
 
 ########################################################################################
 ################################################### Elasticsearch cluster configuration

--- a/load-tests/setup/newLoadTest.sh
+++ b/load-tests/setup/newLoadTest.sh
@@ -195,6 +195,12 @@ case "$secondaryStorage" in
     ;;
 esac
 
+if [[ "$enable_optimize" == "true" ]]; then
+  # Optimize needs specifically Elasticsearch (independently from the secondary
+  # storage configuration).
+  cp -v default/values/camunda-platform-values-optimize-elasticsearch.yaml "$namespace/"
+fi
+
 cd "$namespace"
 
 # Bake values into the rendered Makefile. The deadline lives only in


### PR DESCRIPTION
## Description

Elasticsearch is a required dependency for Optimize, and its usage is independent from whether the secondary storage is Elasticsearch or something else.

When creating a cluster with a RDBMS like PostgreSQL as the secondary storage option, we still need Elasticsearch as the database for Optimize.

This PR updates the load-test setup to add Elasticsearch for Optimize without overriding `orchestration.data.secondaryStorage` for non-Elasticsearch setups. It does so by using a dedicated values file for Optimize's Elasticsearch dependency instead of reusing the Elasticsearch secondary-storage values file.

The comments specifically call out that both files should be kept in sync. This will also be refactored soon anyway, when we move away from the Elasticsearch Bitnami Helm Charts.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

* https://camunda.slack.com/archives/C0A22S6M4TF/p1779901038110709