### PR TITLE
feat: 2/4 add agent execution plans and register in GenericProcessExecutionPlanInterpreter

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/interpreter/plan/process/GenericProcessExecutionPlanInterpreter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/interpreter/plan/process/GenericProcessExecutionPlanInterpreter.java
@@ -36,6 +36,19 @@ import static io.camunda.optimize.service.db.report.plan.process.ProcessExecutio
 import static io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan.INCIDENT_DURATION_GROUP_BY_NONE;
 import static io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan.INCIDENT_FREQUENCY_GROUP_BY_FLOW_NODE;
 import static io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan.INCIDENT_FREQUENCY_GROUP_BY_NONE;
+import static io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan.PROCESS_AGENT_INPUT_TOKENS_GROUP_BY_END_DATE;
+import static io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan.PROCESS_AGENT_INPUT_TOKENS_GROUP_BY_NONE;
+import static io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan.PROCESS_AGENT_INPUT_TOKENS_GROUP_BY_START_DATE;
+import static io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan.PROCESS_AGENT_OUTPUT_TOKENS_GROUP_BY_END_DATE;
+import static io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan.PROCESS_AGENT_OUTPUT_TOKENS_GROUP_BY_NONE;
+import static io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan.PROCESS_AGENT_OUTPUT_TOKENS_GROUP_BY_START_DATE;
+import static io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan.PROCESS_AGENT_TOOL_CALLS_GROUP_BY_END_DATE;
+import static io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan.PROCESS_AGENT_TOOL_CALLS_GROUP_BY_NONE;
+import static io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan.PROCESS_AGENT_TOOL_CALLS_GROUP_BY_START_DATE;
+import static io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan.PROCESS_AGENT_TOTAL_TOKENS_GROUP_BY_END_DATE;
+import static io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan.PROCESS_AGENT_TOTAL_TOKENS_GROUP_BY_NONE;
+import static io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan.PROCESS_AGENT_TOTAL_TOKENS_GROUP_BY_PROCESS_DEFINITION_KEY;
+import static io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan.PROCESS_AGENT_TOTAL_TOKENS_GROUP_BY_START_DATE;
 import static io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan.PROCESS_INSTANCE_DURATION_GROUP_BY_END_DATE;
 import static io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan.PROCESS_INSTANCE_DURATION_GROUP_BY_END_DATE_BY_PROCESS;
 import static io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan.PROCESS_INSTANCE_DURATION_GROUP_BY_END_DATE_BY_VARIABLE;
@@ -63,6 +76,7 @@ import static io.camunda.optimize.service.db.report.plan.process.ProcessExecutio
 import static io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan.PROCESS_INSTANCE_FREQUENCY_GROUP_BY_END_DATE_BY_VARIABLE;
 import static io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan.PROCESS_INSTANCE_FREQUENCY_GROUP_BY_NONE;
 import static io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan.PROCESS_INSTANCE_FREQUENCY_GROUP_BY_NONE_BY_PROCESS;
+import static io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan.PROCESS_INSTANCE_FREQUENCY_GROUP_BY_PROCESS_DEFINITION_KEY;
 import static io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan.PROCESS_INSTANCE_FREQUENCY_GROUP_BY_RUNNING_DATE;
 import static io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan.PROCESS_INSTANCE_FREQUENCY_GROUP_BY_RUNNING_DATE_BY_PROCESS;
 import static io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan.PROCESS_INSTANCE_FREQUENCY_GROUP_BY_START_DATE;
@@ -73,6 +87,7 @@ import static io.camunda.optimize.service.db.report.plan.process.ProcessExecutio
 import static io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan.PROCESS_INSTANCE_FREQUENCY_GROUP_BY_VARIABLE_BY_PROCESS;
 import static io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan.PROCESS_INSTANCE_FREQUENCY_GROUP_BY_VARIABLE_BY_START_DATE;
 import static io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan.PROCESS_INSTANCE_PERCENTAGE_GROUP_BY_NONE;
+import static io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan.PROCESS_INSTANCE_PERCENTAGE_GROUP_BY_PROCESS_DEFINITION_VERSION;
 import static io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan.PROCESS_USER_TASK_DURATION_GROUP_BY_ASSIGNEE;
 import static io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan.PROCESS_USER_TASK_DURATION_GROUP_BY_ASSIGNEE_BY_PROCESS;
 import static io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan.PROCESS_USER_TASK_DURATION_GROUP_BY_ASSIGNEE_BY_TASK;
@@ -189,6 +204,8 @@ public interface GenericProcessExecutionPlanInterpreter extends ProcessExecution
         PROCESS_INSTANCE_FREQUENCY_GROUP_BY_VARIABLE_BY_START_DATE,
         PROCESS_INSTANCE_FREQUENCY_GROUP_BY_VARIABLE_BY_PROCESS,
         PROCESS_INSTANCE_FREQUENCY_GROUP_BY_VARIABLE,
+        PROCESS_INSTANCE_FREQUENCY_GROUP_BY_PROCESS_DEFINITION_KEY,
+        PROCESS_INSTANCE_PERCENTAGE_GROUP_BY_PROCESS_DEFINITION_VERSION,
         PROCESS_INSTANCE_PERCENTAGE_GROUP_BY_NONE,
         PROCESS_USER_TASK_DURATION_GROUP_BY_ASSIGNEE,
         PROCESS_USER_TASK_DURATION_GROUP_BY_ASSIGNEE_BY_PROCESS,
@@ -233,6 +250,19 @@ public interface GenericProcessExecutionPlanInterpreter extends ProcessExecution
         PROCESS_USER_TASK_FREQUENCY_GROUP_BY_TASK_BY_CANDIDATE_GROUP,
         PROCESS_USER_TASK_FREQUENCY_GROUP_BY_TASK_BY_PROCESS,
         PROCESS_USER_TASK_FREQUENCY_GROUP_BY_TASK,
-        PROCESS_VARIABLE_GROUP_BY_NONE);
+        PROCESS_VARIABLE_GROUP_BY_NONE,
+        PROCESS_AGENT_INPUT_TOKENS_GROUP_BY_END_DATE,
+        PROCESS_AGENT_INPUT_TOKENS_GROUP_BY_START_DATE,
+        PROCESS_AGENT_INPUT_TOKENS_GROUP_BY_NONE,
+        PROCESS_AGENT_OUTPUT_TOKENS_GROUP_BY_END_DATE,
+        PROCESS_AGENT_OUTPUT_TOKENS_GROUP_BY_START_DATE,
+        PROCESS_AGENT_OUTPUT_TOKENS_GROUP_BY_NONE,
+        PROCESS_AGENT_TOOL_CALLS_GROUP_BY_END_DATE,
+        PROCESS_AGENT_TOOL_CALLS_GROUP_BY_START_DATE,
+        PROCESS_AGENT_TOOL_CALLS_GROUP_BY_NONE,
+        PROCESS_AGENT_TOTAL_TOKENS_GROUP_BY_END_DATE,
+        PROCESS_AGENT_TOTAL_TOKENS_GROUP_BY_START_DATE,
+        PROCESS_AGENT_TOTAL_TOKENS_GROUP_BY_PROCESS_DEFINITION_KEY,
+        PROCESS_AGENT_TOTAL_TOKENS_GROUP_BY_NONE);
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/plan/process/ProcessExecutionPlan.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/plan/process/ProcessExecutionPlan.java
@@ -29,6 +29,8 @@ import static io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy.
 import static io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy.PROCESS_GROUP_BY_FLOW_NODE_START_DATE;
 import static io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy.PROCESS_GROUP_BY_INCIDENT_FLOW_NODE;
 import static io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy.PROCESS_GROUP_BY_NONE;
+import static io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy.PROCESS_GROUP_BY_PROCESS_DEFINITION_KEY;
+import static io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy.PROCESS_GROUP_BY_PROCESS_DEFINITION_VERSION;
 import static io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy.PROCESS_GROUP_BY_PROCESS_INSTANCE_END_DATE;
 import static io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy.PROCESS_GROUP_BY_PROCESS_INSTANCE_RUNNING_DATE;
 import static io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy.PROCESS_GROUP_BY_PROCESS_INSTANCE_START_DATE;
@@ -38,6 +40,10 @@ import static io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy.
 import static io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy.PROCESS_GROUP_BY_USER_TASK_START_DATE;
 import static io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy.PROCESS_GROUP_BY_VARIABLE;
 import static io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy.PROCESS_INCIDENT_GROUP_BY_NONE;
+import static io.camunda.optimize.service.db.report.plan.process.ProcessView.PROCESS_VIEW_AGENT_INPUT_TOKENS;
+import static io.camunda.optimize.service.db.report.plan.process.ProcessView.PROCESS_VIEW_AGENT_OUTPUT_TOKENS;
+import static io.camunda.optimize.service.db.report.plan.process.ProcessView.PROCESS_VIEW_AGENT_TOOL_CALLS;
+import static io.camunda.optimize.service.db.report.plan.process.ProcessView.PROCESS_VIEW_AGENT_TOTAL_TOKENS;
 import static io.camunda.optimize.service.db.report.plan.process.ProcessView.PROCESS_VIEW_FLOW_NODE_DURATION;
 import static io.camunda.optimize.service.db.report.plan.process.ProcessView.PROCESS_VIEW_FLOW_NODE_FREQUENCY;
 import static io.camunda.optimize.service.db.report.plan.process.ProcessView.PROCESS_VIEW_INCIDENT_DURATION;
@@ -607,7 +613,75 @@ public enum ProcessExecutionPlan implements ExecutionPlan {
       MAP),
 
   PROCESS_VARIABLE_GROUP_BY_NONE(
-      PROCESS_VIEW_VARIABLE, PROCESS_GROUP_BY_NONE, PROCESS_DISTRIBUTED_BY_NONE, NUMBER);
+      PROCESS_VIEW_VARIABLE, PROCESS_GROUP_BY_NONE, PROCESS_DISTRIBUTED_BY_NONE, NUMBER),
+
+  PROCESS_INSTANCE_FREQUENCY_GROUP_BY_PROCESS_DEFINITION_KEY(
+      PROCESS_VIEW_INSTANCE_FREQUENCY,
+      PROCESS_GROUP_BY_PROCESS_DEFINITION_KEY,
+      PROCESS_DISTRIBUTED_BY_NONE,
+      MAP),
+  PROCESS_INSTANCE_PERCENTAGE_GROUP_BY_PROCESS_DEFINITION_VERSION(
+      PROCESS_VIEW_INSTANCE_PERCENTAGE,
+      PROCESS_GROUP_BY_PROCESS_DEFINITION_VERSION,
+      PROCESS_DISTRIBUTED_BY_NONE,
+      MAP),
+
+  PROCESS_AGENT_INPUT_TOKENS_GROUP_BY_END_DATE(
+      PROCESS_VIEW_AGENT_INPUT_TOKENS,
+      PROCESS_GROUP_BY_PROCESS_INSTANCE_END_DATE,
+      PROCESS_DISTRIBUTED_BY_NONE,
+      MAP),
+  PROCESS_AGENT_INPUT_TOKENS_GROUP_BY_START_DATE(
+      PROCESS_VIEW_AGENT_INPUT_TOKENS,
+      PROCESS_GROUP_BY_PROCESS_INSTANCE_START_DATE,
+      PROCESS_DISTRIBUTED_BY_NONE,
+      MAP),
+  PROCESS_AGENT_INPUT_TOKENS_GROUP_BY_NONE(
+      PROCESS_VIEW_AGENT_INPUT_TOKENS, PROCESS_GROUP_BY_NONE, PROCESS_DISTRIBUTED_BY_NONE, NUMBER),
+
+  PROCESS_AGENT_OUTPUT_TOKENS_GROUP_BY_END_DATE(
+      PROCESS_VIEW_AGENT_OUTPUT_TOKENS,
+      PROCESS_GROUP_BY_PROCESS_INSTANCE_END_DATE,
+      PROCESS_DISTRIBUTED_BY_NONE,
+      MAP),
+  PROCESS_AGENT_OUTPUT_TOKENS_GROUP_BY_START_DATE(
+      PROCESS_VIEW_AGENT_OUTPUT_TOKENS,
+      PROCESS_GROUP_BY_PROCESS_INSTANCE_START_DATE,
+      PROCESS_DISTRIBUTED_BY_NONE,
+      MAP),
+  PROCESS_AGENT_OUTPUT_TOKENS_GROUP_BY_NONE(
+      PROCESS_VIEW_AGENT_OUTPUT_TOKENS, PROCESS_GROUP_BY_NONE, PROCESS_DISTRIBUTED_BY_NONE, NUMBER),
+
+  PROCESS_AGENT_TOOL_CALLS_GROUP_BY_END_DATE(
+      PROCESS_VIEW_AGENT_TOOL_CALLS,
+      PROCESS_GROUP_BY_PROCESS_INSTANCE_END_DATE,
+      PROCESS_DISTRIBUTED_BY_NONE,
+      MAP),
+  PROCESS_AGENT_TOOL_CALLS_GROUP_BY_START_DATE(
+      PROCESS_VIEW_AGENT_TOOL_CALLS,
+      PROCESS_GROUP_BY_PROCESS_INSTANCE_START_DATE,
+      PROCESS_DISTRIBUTED_BY_NONE,
+      MAP),
+  PROCESS_AGENT_TOOL_CALLS_GROUP_BY_NONE(
+      PROCESS_VIEW_AGENT_TOOL_CALLS, PROCESS_GROUP_BY_NONE, PROCESS_DISTRIBUTED_BY_NONE, NUMBER),
+
+  PROCESS_AGENT_TOTAL_TOKENS_GROUP_BY_END_DATE(
+      PROCESS_VIEW_AGENT_TOTAL_TOKENS,
+      PROCESS_GROUP_BY_PROCESS_INSTANCE_END_DATE,
+      PROCESS_DISTRIBUTED_BY_NONE,
+      MAP),
+  PROCESS_AGENT_TOTAL_TOKENS_GROUP_BY_START_DATE(
+      PROCESS_VIEW_AGENT_TOTAL_TOKENS,
+      PROCESS_GROUP_BY_PROCESS_INSTANCE_START_DATE,
+      PROCESS_DISTRIBUTED_BY_NONE,
+      MAP),
+  PROCESS_AGENT_TOTAL_TOKENS_GROUP_BY_PROCESS_DEFINITION_KEY(
+      PROCESS_VIEW_AGENT_TOTAL_TOKENS,
+      PROCESS_GROUP_BY_PROCESS_DEFINITION_KEY,
+      PROCESS_DISTRIBUTED_BY_NONE,
+      MAP),
+  PROCESS_AGENT_TOTAL_TOKENS_GROUP_BY_NONE(
+      PROCESS_VIEW_AGENT_TOTAL_TOKENS, PROCESS_GROUP_BY_NONE, PROCESS_DISTRIBUTED_BY_NONE, NUMBER);
 
   private final ProcessView view;
   private final ProcessGroupBy groupBy;

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/plan/process/ProcessGroupBy.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/plan/process/ProcessGroupBy.java
@@ -13,6 +13,8 @@ import io.camunda.optimize.dto.optimize.query.report.single.process.group.Durati
 import io.camunda.optimize.dto.optimize.query.report.single.process.group.EndDateGroupByDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.group.FlowNodesGroupByDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.group.NoneGroupByDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.group.ProcessDefinitionKeyGroupByDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.group.ProcessDefinitionVersionGroupByDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.group.ProcessGroupByDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.group.RunningDateGroupByDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.group.StartDateGroupByDto;
@@ -31,6 +33,8 @@ public enum ProcessGroupBy {
   PROCESS_GROUP_BY_PROCESS_INSTANCE_END_DATE(new EndDateGroupByDto()),
   PROCESS_GROUP_BY_PROCESS_INSTANCE_RUNNING_DATE(new RunningDateGroupByDto()),
   PROCESS_GROUP_BY_PROCESS_INSTANCE_START_DATE(new StartDateGroupByDto()),
+  PROCESS_GROUP_BY_PROCESS_DEFINITION_KEY(new ProcessDefinitionKeyGroupByDto()),
+  PROCESS_GROUP_BY_PROCESS_DEFINITION_VERSION(new ProcessDefinitionVersionGroupByDto()),
   PROCESS_GROUP_BY_NONE(new NoneGroupByDto()),
   PROCESS_INCIDENT_GROUP_BY_NONE(new NoneGroupByDto()),
   PROCESS_GROUP_BY_USER_TASK(new UserTasksGroupByDto()),

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/plan/process/ProcessView.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/plan/process/ProcessView.java
@@ -9,7 +9,12 @@ package io.camunda.optimize.service.db.report.plan.process;
 
 import static io.camunda.optimize.dto.optimize.query.report.single.ViewProperty.DURATION;
 import static io.camunda.optimize.dto.optimize.query.report.single.ViewProperty.FREQUENCY;
+import static io.camunda.optimize.dto.optimize.query.report.single.ViewProperty.INPUT_TOKENS;
+import static io.camunda.optimize.dto.optimize.query.report.single.ViewProperty.OUTPUT_TOKENS;
 import static io.camunda.optimize.dto.optimize.query.report.single.ViewProperty.PERCENTAGE;
+import static io.camunda.optimize.dto.optimize.query.report.single.ViewProperty.TOOL_CALLS;
+import static io.camunda.optimize.dto.optimize.query.report.single.ViewProperty.TOTAL_TOKENS;
+import static io.camunda.optimize.dto.optimize.query.report.single.process.view.ProcessViewEntity.AGENT_INSTANCE;
 import static io.camunda.optimize.dto.optimize.query.report.single.process.view.ProcessViewEntity.FLOW_NODE;
 import static io.camunda.optimize.dto.optimize.query.report.single.process.view.ProcessViewEntity.INCIDENT;
 import static io.camunda.optimize.dto.optimize.query.report.single.process.view.ProcessViewEntity.PROCESS_INSTANCE;
@@ -34,7 +39,11 @@ public enum ProcessView {
   PROCESS_VIEW_VARIABLE(
       new ProcessViewDto(ProcessViewEntity.VARIABLE, ViewProperty.variable(null, null))),
   PROCESS_VIEW_USER_TASK_FREQUENCY(new ProcessViewDto(USER_TASK, FREQUENCY)),
-  PROCESS_VIEW_USER_TASK_DURATION(new ProcessViewDto(USER_TASK, DURATION));
+  PROCESS_VIEW_USER_TASK_DURATION(new ProcessViewDto(USER_TASK, DURATION)),
+  PROCESS_VIEW_AGENT_INPUT_TOKENS(new ProcessViewDto(AGENT_INSTANCE, INPUT_TOKENS)),
+  PROCESS_VIEW_AGENT_OUTPUT_TOKENS(new ProcessViewDto(AGENT_INSTANCE, OUTPUT_TOKENS)),
+  PROCESS_VIEW_AGENT_TOOL_CALLS(new ProcessViewDto(AGENT_INSTANCE, TOOL_CALLS)),
+  PROCESS_VIEW_AGENT_TOTAL_TOKENS(new ProcessViewDto(AGENT_INSTANCE, TOTAL_TOKENS));
 
   private final ProcessViewDto processViewDto;
   private final ProcessPartDto processPartDto;

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/ReportConstants.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/ReportConstants.java
@@ -27,10 +27,8 @@ public final class ReportConstants {
   public static final String VIEW_RAW_DATA_PROPERTY = "rawData";
   public static final String VIEW_INPUT_TOKENS_PROPERTY = "inputTokens";
   public static final String VIEW_OUTPUT_TOKENS_PROPERTY = "outputTokens";
-  public static final String VIEW_MODEL_CALLS_PROPERTY = "modelCalls";
   public static final String VIEW_TOOL_CALLS_PROPERTY = "toolCalls";
   public static final String VIEW_TOTAL_TOKENS_PROPERTY = "totalTokens";
-  public static final String VIEW_AVG_TOKENS_PER_CALL_PROPERTY = "avgTokensPerCall";
 
   public static final String GROUP_BY_FLOW_NODES_TYPE = "flowNodes";
   public static final String GROUP_BY_USER_TASKS_TYPE = "userTasks";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/ViewProperty.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/ViewProperty.java
@@ -7,11 +7,9 @@
  */
 package io.camunda.optimize.dto.optimize.query.report.single;
 
-import static io.camunda.optimize.dto.optimize.ReportConstants.VIEW_AVG_TOKENS_PER_CALL_PROPERTY;
 import static io.camunda.optimize.dto.optimize.ReportConstants.VIEW_DURATION_PROPERTY;
 import static io.camunda.optimize.dto.optimize.ReportConstants.VIEW_FREQUENCY_PROPERTY;
 import static io.camunda.optimize.dto.optimize.ReportConstants.VIEW_INPUT_TOKENS_PROPERTY;
-import static io.camunda.optimize.dto.optimize.ReportConstants.VIEW_MODEL_CALLS_PROPERTY;
 import static io.camunda.optimize.dto.optimize.ReportConstants.VIEW_OUTPUT_TOKENS_PROPERTY;
 import static io.camunda.optimize.dto.optimize.ReportConstants.VIEW_PERCENTAGE_PROPERTY;
 import static io.camunda.optimize.dto.optimize.ReportConstants.VIEW_RAW_DATA_PROPERTY;
@@ -38,11 +36,8 @@ public class ViewProperty implements Combinable {
   public static final ViewProperty RAW_DATA = new ViewProperty(VIEW_RAW_DATA_PROPERTY);
   public static final ViewProperty INPUT_TOKENS = new ViewProperty(VIEW_INPUT_TOKENS_PROPERTY);
   public static final ViewProperty OUTPUT_TOKENS = new ViewProperty(VIEW_OUTPUT_TOKENS_PROPERTY);
-  public static final ViewProperty MODEL_CALLS = new ViewProperty(VIEW_MODEL_CALLS_PROPERTY);
   public static final ViewProperty TOOL_CALLS = new ViewProperty(VIEW_TOOL_CALLS_PROPERTY);
   public static final ViewProperty TOTAL_TOKENS = new ViewProperty(VIEW_TOTAL_TOKENS_PROPERTY);
-  public static final ViewProperty AVG_TOKENS_PER_CALL =
-      new ViewProperty(VIEW_AVG_TOKENS_PER_CALL_PROPERTY);
   private final TypedViewPropertyDto viewPropertyDto;
 
   @JsonCreator


### PR DESCRIPTION
related to #54073

## Description

Second of 4 PRs for task s-engine-plans. Adds all agent execution plan enum entries and registers them so the report engine can evaluate agent reports without throwing UnsupportedOperationException.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #54073
