### PR TITLE
[stable/8.7] ci: emit AlwaysGreen failure-context artifacts per job

### DIFF
--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -92,6 +92,39 @@ jobs:
             echo "group=${{ github.workflow }}-${{ github.ref }}" >> "$GITHUB_OUTPUT"
           fi
       - run: echo "Workflow conditions met, proceeding with build"
+      - name: Emit AlwaysGreen failure context
+        if: always()
+        run: |
+          CONTEXT_FILE="${RUNNER_TEMP}/alwaysgreen-context-${{ github.job }}.json"
+          OWNER_TEAM="none"
+          FAILURE_CATEGORY="none"
+          if [[ "${{ job.status }}" == "failure" || "${{ job.status }}" == "cancelled" ]]; then
+            OWNER_TEAM="Monorepo DevOps Medic"
+            FAILURE_CATEGORY="orchestration_should_run"
+          fi
+          jq -n \
+            --arg stage "${{ github.job }}" \
+            --arg failure_category "$FAILURE_CATEGORY" \
+            --arg owner_team "$OWNER_TEAM" \
+            --arg escalation_team "$OWNER_TEAM" \
+            --arg run_url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --arg status "${{ job.status }}" \
+            '{stage:$stage,failure_category:$failure_category,owner_team:$owner_team,escalation_team:$escalation_team,run_url:$run_url,status:$status}' > "$CONTEXT_FILE"
+          {
+            echo "### AlwaysGreen Failure Context"
+            echo ""
+            echo "- stage: ${{ github.job }}"
+            echo "- status: ${{ job.status }}"
+            echo "- failure_category: ${FAILURE_CATEGORY}"
+            echo "- owner_team: ${OWNER_TEAM}"
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload AlwaysGreen failure context artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: alwaysgreen-failure-context-${{ github.job }}
+          path: ${{ runner.temp }}/alwaysgreen-context-${{ github.job }}.json
+          retention-days: 5
   # Parallel frontend builds
   build-operate-frontend:
     name: Build Operate Frontend
@@ -125,6 +158,31 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+      - name: Emit AlwaysGreen failure context
+        if: always()
+        run: |
+          CONTEXT_FILE="${RUNNER_TEMP}/alwaysgreen-context-${{ github.job }}.json"
+          OWNER_TEAM="none"
+          FAILURE_CATEGORY="none"
+          if [[ "${{ job.status }}" == "failure" || "${{ job.status }}" == "cancelled" ]]; then
+            OWNER_TEAM="Monorepo DevOps Medic"
+            FAILURE_CATEGORY="orchestration_frontend_build"
+          fi
+          jq -n \
+            --arg stage "${{ github.job }}" \
+            --arg failure_category "$FAILURE_CATEGORY" \
+            --arg owner_team "$OWNER_TEAM" \
+            --arg escalation_team "$OWNER_TEAM" \
+            --arg run_url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --arg status "${{ job.status }}" \
+            '{stage:$stage,failure_category:$failure_category,owner_team:$owner_team,escalation_team:$escalation_team,run_url:$run_url,status:$status}' > "$CONTEXT_FILE"
+      - name: Upload AlwaysGreen failure context artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: alwaysgreen-failure-context-${{ github.job }}
+          path: ${{ runner.temp }}/alwaysgreen-context-${{ github.job }}.json
+          retention-days: 5
   build-tasklist-frontend:
     name: Build Tasklist Frontend
     needs: should-run
@@ -157,6 +215,31 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+      - name: Emit AlwaysGreen failure context
+        if: always()
+        run: |
+          CONTEXT_FILE="${RUNNER_TEMP}/alwaysgreen-context-${{ github.job }}.json"
+          OWNER_TEAM="none"
+          FAILURE_CATEGORY="none"
+          if [[ "${{ job.status }}" == "failure" || "${{ job.status }}" == "cancelled" ]]; then
+            OWNER_TEAM="Monorepo DevOps Medic"
+            FAILURE_CATEGORY="orchestration_frontend_build"
+          fi
+          jq -n \
+            --arg stage "${{ github.job }}" \
+            --arg failure_category "$FAILURE_CATEGORY" \
+            --arg owner_team "$OWNER_TEAM" \
+            --arg escalation_team "$OWNER_TEAM" \
+            --arg run_url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --arg status "${{ job.status }}" \
+            '{stage:$stage,failure_category:$failure_category,owner_team:$owner_team,escalation_team:$escalation_team,run_url:$run_url,status:$status}' > "$CONTEXT_FILE"
+      - name: Upload AlwaysGreen failure context artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: alwaysgreen-failure-context-${{ github.job }}
+          path: ${{ runner.temp }}/alwaysgreen-context-${{ github.job }}.json
+          retention-days: 5
   build-identity-frontend:
     name: Build Identity Frontend
     needs: should-run
@@ -189,6 +272,31 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+      - name: Emit AlwaysGreen failure context
+        if: always()
+        run: |
+          CONTEXT_FILE="${RUNNER_TEMP}/alwaysgreen-context-${{ github.job }}.json"
+          OWNER_TEAM="none"
+          FAILURE_CATEGORY="none"
+          if [[ "${{ job.status }}" == "failure" || "${{ job.status }}" == "cancelled" ]]; then
+            OWNER_TEAM="Monorepo DevOps Medic"
+            FAILURE_CATEGORY="orchestration_frontend_build"
+          fi
+          jq -n \
+            --arg stage "${{ github.job }}" \
+            --arg failure_category "$FAILURE_CATEGORY" \
+            --arg owner_team "$OWNER_TEAM" \
+            --arg escalation_team "$OWNER_TEAM" \
+            --arg run_url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --arg status "${{ job.status }}" \
+            '{stage:$stage,failure_category:$failure_category,owner_team:$owner_team,escalation_team:$escalation_team,run_url:$run_url,status:$status}' > "$CONTEXT_FILE"
+      - name: Upload AlwaysGreen failure context artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: alwaysgreen-failure-context-${{ github.job }}
+          path: ${{ runner.temp }}/alwaysgreen-context-${{ github.job }}.json
+          retention-days: 5
 
   # Main build job - waits for all frontends to complete
   build-and-push-images:
@@ -348,6 +456,31 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+      - name: Emit AlwaysGreen failure context
+        if: always()
+        run: |
+          CONTEXT_FILE="${RUNNER_TEMP}/alwaysgreen-context-${{ github.job }}.json"
+          OWNER_TEAM="none"
+          FAILURE_CATEGORY="none"
+          if [[ "${{ job.status }}" == "failure" || "${{ job.status }}" == "cancelled" ]]; then
+            OWNER_TEAM="Monorepo DevOps Medic"
+            FAILURE_CATEGORY="orchestration_build_and_push"
+          fi
+          jq -n \
+            --arg stage "${{ github.job }}" \
+            --arg failure_category "$FAILURE_CATEGORY" \
+            --arg owner_team "$OWNER_TEAM" \
+            --arg escalation_team "$OWNER_TEAM" \
+            --arg run_url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --arg status "${{ job.status }}" \
+            '{stage:$stage,failure_category:$failure_category,owner_team:$owner_team,escalation_team:$escalation_team,run_url:$run_url,status:$status}' > "$CONTEXT_FILE"
+      - name: Upload AlwaysGreen failure context artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: alwaysgreen-failure-context-${{ github.job }}
+          path: ${{ runner.temp }}/alwaysgreen-context-${{ github.job }}.json
+          retention-days: 5
 
   format-identifier:
     name: Format Identifier
@@ -373,6 +506,31 @@ jobs:
           # Truncate to max 40 chars if needed (k8s namespace limit)
           IDENTIFIER="${IDENTIFIER:0:40}"
           echo "identifier=${IDENTIFIER}" >> "$GITHUB_OUTPUT"
+      - name: Emit AlwaysGreen failure context
+        if: always()
+        run: |
+          CONTEXT_FILE="${RUNNER_TEMP}/alwaysgreen-context-${{ github.job }}.json"
+          OWNER_TEAM="none"
+          FAILURE_CATEGORY="none"
+          if [[ "${{ job.status }}" == "failure" || "${{ job.status }}" == "cancelled" ]]; then
+            OWNER_TEAM="Monorepo DevOps Medic"
+            FAILURE_CATEGORY="orchestration_identifier"
+          fi
+          jq -n \
+            --arg stage "${{ github.job }}" \
+            --arg failure_category "$FAILURE_CATEGORY" \
+            --arg owner_team "$OWNER_TEAM" \
+            --arg escalation_team "$OWNER_TEAM" \
+            --arg run_url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --arg status "${{ job.status }}" \
+            '{stage:$stage,failure_category:$failure_category,owner_team:$owner_team,escalation_team:$escalation_team,run_url:$run_url,status:$status}' > "$CONTEXT_FILE"
+      - name: Upload AlwaysGreen failure context artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: alwaysgreen-failure-context-${{ github.job }}
+          path: ${{ runner.temp }}/alwaysgreen-context-${{ github.job }}.json
+          retention-days: 5
 
   helm-deploy:
     name: Helm chart Integration Tests
@@ -478,6 +636,31 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+      - name: Emit AlwaysGreen failure context
+        if: always()
+        run: |
+          CONTEXT_FILE="${RUNNER_TEMP}/alwaysgreen-context-${{ github.job }}.json"
+          OWNER_TEAM="none"
+          FAILURE_CATEGORY="none"
+          if [[ "${{ needs.helm-deploy.result }}" == "failure" || "${{ needs.helm-deploy.result }}" == "cancelled" ]]; then
+            OWNER_TEAM="Distribution Team Medic"
+            FAILURE_CATEGORY="helm_install_or_it"
+          fi
+          jq -n \
+            --arg stage "${{ github.job }}" \
+            --arg failure_category "$FAILURE_CATEGORY" \
+            --arg owner_team "$OWNER_TEAM" \
+            --arg escalation_team "$OWNER_TEAM" \
+            --arg run_url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --arg status "${{ needs.helm-deploy.result }}" \
+            '{stage:$stage,failure_category:$failure_category,owner_team:$owner_team,escalation_team:$escalation_team,run_url:$run_url,status:$status}' > "$CONTEXT_FILE"
+      - name: Upload AlwaysGreen failure context artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: alwaysgreen-failure-context-${{ github.job }}
+          path: ${{ runner.temp }}/alwaysgreen-context-${{ github.job }}.json
+          retention-days: 5
 
   trigger-saas-e2e:
     name: Trigger SaaS E2E tests
@@ -608,9 +791,11 @@ jobs:
 
             if [[ "$STATUS" == "completed" ]]; then
               if [[ "$CONCLUSION" == "success" ]]; then
+                echo "downstream_conclusion=success" >> "$GITHUB_OUTPUT"
                 echo "Downstream workflow succeeded!"
                 exit 0
               else
+                echo "downstream_conclusion=${CONCLUSION}" >> "$GITHUB_OUTPUT"
                 echo "Downstream workflow failed: $CONCLUSION"
                 exit 1
               fi
@@ -619,6 +804,7 @@ jobs:
             sleep 30
           done
 
+          echo "downstream_conclusion=timeout" >> "$GITHUB_OUTPUT"
           echo "Timed out waiting for downstream workflow to complete."
           exit 1
 
@@ -675,3 +861,36 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+      - name: Emit AlwaysGreen failure context
+        if: always()
+        run: |
+          CONTEXT_FILE="${RUNNER_TEMP}/alwaysgreen-context-${{ github.job }}.json"
+          OWNER_TEAM="none"
+          FAILURE_CATEGORY="none"
+
+          if [[ "${{ job.status }}" == "failure" || "${{ job.status }}" == "cancelled" ]]; then
+            if [[ "${{ steps.wait-downstream.outputs.downstream_conclusion }}" == "failure" ]]; then
+              OWNER_TEAM="Test Automation Team Medic"
+              FAILURE_CATEGORY="saas_e2e"
+            else
+              OWNER_TEAM="Monorepo DevOps Medic"
+              FAILURE_CATEGORY="orchestration_dispatch_or_wait"
+            fi
+          fi
+
+          jq -n \
+            --arg stage "${{ github.job }}" \
+            --arg failure_category "$FAILURE_CATEGORY" \
+            --arg owner_team "$OWNER_TEAM" \
+            --arg escalation_team "$OWNER_TEAM" \
+            --arg run_url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --arg status "${{ job.status }}" \
+            --arg downstream_conclusion "${{ steps.wait-downstream.outputs.downstream_conclusion }}" \
+            '{stage:$stage,failure_category:$failure_category,owner_team:$owner_team,escalation_team:$escalation_team,run_url:$run_url,status:$status,downstream_conclusion:$downstream_conclusion}' > "$CONTEXT_FILE"
+      - name: Upload AlwaysGreen failure context artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: alwaysgreen-failure-context-${{ github.job }}
+          path: ${{ runner.temp }}/alwaysgreen-context-${{ github.job }}.json
+          retention-days: 5

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -99,7 +99,7 @@ jobs:
           OWNER_TEAM="none"
           FAILURE_CATEGORY="none"
           if [[ "${{ job.status }}" == "failure" || "${{ job.status }}" == "cancelled" ]]; then
-            OWNER_TEAM="Monorepo DevOps Medic"
+            OWNER_TEAM="@camunda/monorepo-devops-team"
             FAILURE_CATEGORY="orchestration_should_run"
           fi
           jq -n \
@@ -165,7 +165,7 @@ jobs:
           OWNER_TEAM="none"
           FAILURE_CATEGORY="none"
           if [[ "${{ job.status }}" == "failure" || "${{ job.status }}" == "cancelled" ]]; then
-            OWNER_TEAM="Monorepo DevOps Medic"
+            OWNER_TEAM="@camunda/monorepo-devops-team"
             FAILURE_CATEGORY="orchestration_frontend_build"
           fi
           jq -n \
@@ -222,7 +222,7 @@ jobs:
           OWNER_TEAM="none"
           FAILURE_CATEGORY="none"
           if [[ "${{ job.status }}" == "failure" || "${{ job.status }}" == "cancelled" ]]; then
-            OWNER_TEAM="Monorepo DevOps Medic"
+            OWNER_TEAM="@camunda/monorepo-devops-team"
             FAILURE_CATEGORY="orchestration_frontend_build"
           fi
           jq -n \
@@ -279,7 +279,7 @@ jobs:
           OWNER_TEAM="none"
           FAILURE_CATEGORY="none"
           if [[ "${{ job.status }}" == "failure" || "${{ job.status }}" == "cancelled" ]]; then
-            OWNER_TEAM="Monorepo DevOps Medic"
+            OWNER_TEAM="@camunda/monorepo-devops-team"
             FAILURE_CATEGORY="orchestration_frontend_build"
           fi
           jq -n \
@@ -463,7 +463,7 @@ jobs:
           OWNER_TEAM="none"
           FAILURE_CATEGORY="none"
           if [[ "${{ job.status }}" == "failure" || "${{ job.status }}" == "cancelled" ]]; then
-            OWNER_TEAM="Monorepo DevOps Medic"
+            OWNER_TEAM="@camunda/monorepo-devops-team"
             FAILURE_CATEGORY="orchestration_build_and_push"
           fi
           jq -n \
@@ -513,7 +513,7 @@ jobs:
           OWNER_TEAM="none"
           FAILURE_CATEGORY="none"
           if [[ "${{ job.status }}" == "failure" || "${{ job.status }}" == "cancelled" ]]; then
-            OWNER_TEAM="Monorepo DevOps Medic"
+            OWNER_TEAM="@camunda/monorepo-devops-team"
             FAILURE_CATEGORY="orchestration_identifier"
           fi
           jq -n \
@@ -643,7 +643,7 @@ jobs:
           OWNER_TEAM="none"
           FAILURE_CATEGORY="none"
           if [[ "${{ needs.helm-deploy.result }}" == "failure" || "${{ needs.helm-deploy.result }}" == "cancelled" ]]; then
-            OWNER_TEAM="Distribution Team Medic"
+            OWNER_TEAM="@camunda/distribution"
             FAILURE_CATEGORY="helm_install_or_it"
           fi
           jq -n \
@@ -652,8 +652,9 @@ jobs:
             --arg owner_team "$OWNER_TEAM" \
             --arg escalation_team "$OWNER_TEAM" \
             --arg run_url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-            --arg status "${{ needs.helm-deploy.result }}" \
-            '{stage:$stage,failure_category:$failure_category,owner_team:$owner_team,escalation_team:$escalation_team,run_url:$run_url,status:$status}' > "$CONTEXT_FILE"
+            --arg status "${{ job.status }}" \
+            --arg upstream_result "${{ needs.helm-deploy.result }}" \
+            '{stage:$stage,failure_category:$failure_category,owner_team:$owner_team,escalation_team:$escalation_team,run_url:$run_url,status:$status,upstream_result:$upstream_result}' > "$CONTEXT_FILE"
       - name: Upload AlwaysGreen failure context artifact
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -870,10 +871,10 @@ jobs:
 
           if [[ "${{ job.status }}" == "failure" || "${{ job.status }}" == "cancelled" ]]; then
             if [[ "${{ steps.wait-downstream.outputs.downstream_conclusion }}" == "failure" ]]; then
-              OWNER_TEAM="Test Automation Team Medic"
+              OWNER_TEAM="@camunda/qa-engineering"
               FAILURE_CATEGORY="saas_e2e"
             else
-              OWNER_TEAM="Monorepo DevOps Medic"
+              OWNER_TEAM="@camunda/monorepo-devops-team"
               FAILURE_CATEGORY="orchestration_dispatch_or_wait"
             fi
           fi


### PR DESCRIPTION
Backport of #54171 to `stable/8.7`.

Includes:
- Per-job AlwaysGreen failure-context JSON artifact emission/upload
- Owner routing fields emitted as GitHub team handles (e.g. `@camunda/monorepo-devops-team`) for deterministic routing in the current AlwaysGreen setup
- `downstream_conclusion` propagation for SaaS trigger/wait routing
- `helm-deploy-status` payload fix (`status=job.status`, plus `upstream_result`)

This is part of the 2-PR plan rollout where Slice A is applied consistently across main and stable branches.