### PR TITLE
fix: fix failing integration tests in operate for 8.7

### DIFF
--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/ListenerReaderIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/ListenerReaderIT.java
@@ -17,9 +17,11 @@ import io.camunda.operate.entities.JobEntity;
 import io.camunda.operate.entities.ListenerEventType;
 import io.camunda.operate.entities.ListenerState;
 import io.camunda.operate.entities.ListenerType;
+import io.camunda.operate.entities.listview.ProcessInstanceForListViewEntity;
 import io.camunda.operate.schema.templates.JobTemplate;
 import io.camunda.operate.util.j5templates.MockMvcManager;
 import io.camunda.operate.util.j5templates.OperateSearchAbstractIT;
+import io.camunda.operate.webapp.elasticsearch.reader.ProcessInstanceReader;
 import io.camunda.operate.webapp.rest.ProcessInstanceRestService;
 import io.camunda.operate.webapp.rest.dto.ListenerDto;
 import io.camunda.operate.webapp.rest.dto.ListenerRequestDto;
@@ -34,12 +36,14 @@ import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MvcResult;
 
 public class ListenerReaderIT extends OperateSearchAbstractIT {
 
   @Autowired MockMvcManager mockMvcManager;
   @Autowired JobTemplate jobTemplate;
+  @MockBean ProcessInstanceReader processInstanceReader;
   @Autowired private UserService userService;
   private String jobIndexName;
   private final ObjectMapper objectMapper = new ObjectMapper();
@@ -55,6 +59,8 @@ public class ListenerReaderIT extends OperateSearchAbstractIT {
   @Test
   public void testListenerReader() throws Exception {
     Mockito.when(userService.getCurrentUser()).thenReturn(new UserDto().setUserId(DEFAULT_USER));
+    Mockito.when(processInstanceReader.getProcessInstanceByKey(Mockito.any()))
+        .thenReturn(new ProcessInstanceForListViewEntity().setBpmnProcessId("genericid"));
 
     final ListenerRequestDto request =
         new ListenerRequestDto().setPageSize(20).setFlowNodeId("test_task");
@@ -104,6 +110,8 @@ public class ListenerReaderIT extends OperateSearchAbstractIT {
   @Test
   public void testListenerReaderPaging() throws Exception {
     Mockito.when(userService.getCurrentUser()).thenReturn(new UserDto().setUserId(DEFAULT_USER));
+    Mockito.when(processInstanceReader.getProcessInstanceByKey(Mockito.any()))
+        .thenReturn(new ProcessInstanceForListViewEntity().setBpmnProcessId("genericid"));
 
     final ListenerRequestDto request1 =
         new ListenerRequestDto().setPageSize(3).setFlowNodeId("test_task");

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/AuthorizationIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/AuthorizationIT.java
@@ -18,8 +18,10 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.operate.entities.BatchOperationEntity;
 import io.camunda.operate.entities.OperationType;
+import io.camunda.operate.entities.listview.ProcessInstanceForListViewEntity;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.util.TestApplication;
+import io.camunda.operate.webapp.elasticsearch.reader.ProcessInstanceReader;
 import io.camunda.operate.webapp.rest.ProcessInstanceRestService;
 import io.camunda.operate.webapp.rest.dto.UserDto;
 import io.camunda.operate.webapp.rest.dto.listview.ListViewQueryDto;
@@ -50,6 +52,8 @@ public class AuthorizationIT {
   protected static final String USER = "calculon";
 
   @MockBean private UserService<? extends Authentication> userService;
+
+  @MockBean private ProcessInstanceReader processInstanceReader;
 
   @MockBean private BatchOperationWriter batchOperationWriter;
 
@@ -97,6 +101,8 @@ public class AuthorizationIT {
   public void testWritePermissionsForSingleOperation() {
     // given
     userHasPermission(Permission.WRITE);
+    when(processInstanceReader.getProcessInstanceByKey(23L))
+        .thenReturn(new ProcessInstanceForListViewEntity().setBpmnProcessId("23"));
     when(batchOperationWriter.scheduleSingleOperation(anyLong(), any()))
         .thenReturn(new BatchOperationEntity());
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Fix failing Operate integration tests.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #53958
