### PR TITLE
[Backport stable/8.9] deps: update MCP SDK to 2.0.0-M3

### DIFF
--- a/dist/src/main/resources/application.properties
+++ b/dist/src/main/resources/application.properties
@@ -90,7 +90,9 @@ spring.autoconfigure.exclude=\
   org.springframework.boot.security.autoconfigure.web.servlet.ServletWebSecurityAutoConfiguration, \
   org.springframework.boot.security.autoconfigure.actuate.web.servlet.ManagementWebSecurityAutoConfiguration, \
   org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration, \
-  org.springframework.boot.jdbc.autoconfigure.DataSourceTransactionManagerAutoConfiguration
+  org.springframework.boot.jdbc.autoconfigure.DataSourceTransactionManagerAutoConfiguration, \
+  org.springframework.ai.mcp.server.common.autoconfigure.McpServerStatelessAutoConfiguration, \
+  org.springframework.ai.mcp.server.webmvc.autoconfigure.McpServerStatelessWebMvcAutoConfiguration
 
 # Spring metrics configuration
 management.metrics.distribution.percentiles-histogram.http.server.requests=true

--- a/dist/src/main/resources/mcp/mcp-gateway.yaml
+++ b/dist/src/main/resources/mcp/mcp-gateway.yaml
@@ -3,33 +3,7 @@ spring:
     mcp:
       server:
         enabled: true
-        name: Camunda 8 Orchestration API MCP Server
-        version: '${project.version}'
-        instructions: |
-          This server exposes APIs of a Camunda 8 Orchestration Cluster. All operations are
-          scoped to the permissions of the authenticated user.
-
-          Most tools return eventually consistent data. Recently written data may not appear
-          immediately in subsequent reads.
-
-          Process instances, incidents, and user tasks are related. A process instance can have
-          active incidents and user tasks. Use the process instance key to correlate across
-          domains. To understand the structure of a process, retrieve its BPMN XML.
-
-          When starting a process instance with awaitCompletion, a timeout does NOT mean the
-          process failed — the instance was created and continues running. Tag each instance
-          (e.g. "mcp-tool:<operation>-<timestamp>") so you can find it later. Poll the instance
-          state: if COMPLETED, retrieve result variables; if it has an incident, investigate
-          using the process instance key. Variables can be retrieved at any time, including
-          while the instance is still running.
         type: sync
         protocol: stateless
         annotation-scanner:
           enabled: true
-        streamable-http:
-          mcp-endpoint: /mcp/cluster
-        capabilities:
-          completion: false
-          prompt: true
-          resource: true
-          tool: true

--- a/dist/src/test/java/io/camunda/application/commons/mcp/McpGatewayConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/mcp/McpGatewayConfigurationTest.java
@@ -52,6 +52,9 @@ class McpGatewayConfigurationTest {
     // mock JsonMapper used in MCP observation convention
     mockBeans.add(JsonMapper.class);
 
+    // mock qualified JsonMapper dependency used in MCP transports
+    runner = runner.withBean("mcpServerJsonMapper", JsonMapper.class, () -> mock(JsonMapper.class));
+
     for (final Class<?> mockedBean : mockBeans) {
       runner = addMockedBean(runner, mockedBean);
     }

--- a/gateways/gateway-mcp/pom.xml
+++ b/gateways/gateway-mcp/pom.xml
@@ -78,6 +78,10 @@
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
+      <artifactId>spring-webmvc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
       <artifactId>spring-aop</artifactId>
     </dependency>
 
@@ -99,18 +103,22 @@
       <artifactId>spring-ai-mcp-annotations</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.ai</groupId>
+      <artifactId>mcp-spring-webmvc</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.modelcontextprotocol.sdk</groupId>
       <artifactId>mcp-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.modelcontextprotocol.sdk</groupId>
+      <artifactId>mcp-json-jackson3</artifactId>
     </dependency>
 
     <!-- Various dependencies -->
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.jspecify</groupId>
-      <artifactId>jspecify</artifactId>
     </dependency>
 
     <dependency>

--- a/gateways/gateway-mcp/pom.xml
+++ b/gateways/gateway-mcp/pom.xml
@@ -58,6 +58,13 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-validation</artifactId>
+      <exclusions>
+        <!-- pulls in log4j-to-slf4j, which conflicts with log4j-slf4j2-impl on the classpath -->
+        <exclusion>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/CamundaMcpServersAutoConfiguration.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/CamundaMcpServersAutoConfiguration.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.gateway.mcp.config;
+
+import io.camunda.gateway.mcp.ConditionalOnMcpGatewayEnabled;
+import io.camunda.gateway.mcp.config.tool.CamundaMcpTool;
+import io.camunda.zeebe.util.VersionUtil;
+import io.modelcontextprotocol.json.jackson3.JacksonMcpJsonMapper;
+import io.modelcontextprotocol.server.McpServer;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.server.McpStatelessSyncServer;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpStatelessServerTransport;
+import java.util.List;
+import org.springframework.ai.mcp.server.webmvc.transport.WebMvcStatelessServerTransport;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.servlet.function.RouterFunction;
+import org.springframework.web.servlet.function.ServerResponse;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * Configuration for the cluster MCP server instance with its own transport.
+ *
+ * <p>This configuration creates the MCP server programmatically:
+ *
+ * <ul>
+ *   <li>{@code /mcp/cluster} - Static tools from {@link CamundaMcpTool} annotated methods
+ * </ul>
+ *
+ * <p>Replaces the Spring AI MCP stateless server autoconfiguration to give us full control over
+ * server construction (server info, instructions, capabilities, immediate execution).
+ */
+@AutoConfiguration
+@ConditionalOnMcpGatewayEnabled
+public class CamundaMcpServersAutoConfiguration {
+
+  /**
+   * Transport provider for the cluster MCP server at {@code /mcp/cluster}.
+   *
+   * <p>Handles MCP protocol messages for cluster-wide operations and general Camunda API access.
+   *
+   * <p>The MCP JsonMapper is provided by Spring AI auto-configuration. We tie into that to reuse
+   * what Spring AI is using for tool schema definitions.
+   *
+   * @param jsonMapper the JSON mapper to use for MCP message serialization and deserialization
+   */
+  @Bean(name = "clusterTransportProvider")
+  public WebMvcStatelessServerTransport clusterTransportProvider(
+      @Qualifier("mcpServerJsonMapper") final JsonMapper jsonMapper) {
+    return WebMvcStatelessServerTransport.builder()
+        .jsonMapper(new JacksonMcpJsonMapper(jsonMapper))
+        .messageEndpoint("/mcp/cluster")
+        .build();
+  }
+
+  /**
+   * Router function for the cluster MCP server to tie in with the web server stack.
+   *
+   * @param clusterTransportProvider the associated transport provider
+   */
+  @Bean
+  public RouterFunction<ServerResponse> clusterRouterFunction(
+      @Qualifier("clusterTransportProvider")
+          final WebMvcStatelessServerTransport clusterTransportProvider) {
+    return clusterTransportProvider.getRouterFunction();
+  }
+
+  /**
+   * MCP server for general cluster-wide operations.
+   *
+   * <p>Provides static tools defined via {@link CamundaMcpTool} annotations.
+   */
+  @Bean
+  public McpStatelessSyncServer clusterMcpServer(
+      @Qualifier("clusterTransportProvider") final McpStatelessServerTransport clusterTransport,
+      @Qualifier("clusterMcpToolSpecifications")
+          final List<SyncToolSpecification> toolSpecifications) {
+
+    final var capabilities =
+        McpSchema.ServerCapabilities.builder()
+            .tools(false)
+            .resources(false, false)
+            .prompts(false)
+            .build();
+
+    return McpServer.sync(clusterTransport)
+        .serverInfo("Camunda 8 Orchestration API MCP Server", VersionUtil.getVersion())
+        .instructions(
+            """
+          This server exposes APIs of a Camunda 8 Orchestration Cluster. All operations are
+          scoped to the permissions of the authenticated user.
+
+          Most tools return eventually consistent data. Recently written data may not appear
+          immediately in subsequent reads.
+
+          Process instances, incidents, and user tasks are related. A process instance can have
+          active incidents and user tasks. Use the process instance key to correlate across
+          domains. To understand the structure of a process, retrieve its BPMN XML.
+
+          When starting a process instance with awaitCompletion, a timeout does NOT mean the
+          process failed — the instance was created and continues running. Tag each instance
+          (e.g. "mcp-tool:<operation>-<timestamp>") so you can find it later. Poll the instance
+          state: if COMPLETED, retrieve result variables; if it has an incident, investigate
+          using the process instance key. Variables can be retrieved at any time, including
+          while the instance is still running.
+          """)
+        .capabilities(capabilities)
+        .tools(toolSpecifications)
+        .immediateExecution(true)
+        .build();
+  }
+}

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/CamundaMcpServersAutoConfiguration.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/CamundaMcpServersAutoConfiguration.java
@@ -114,6 +114,7 @@ public class CamundaMcpServersAutoConfiguration {
         .capabilities(capabilities)
         .tools(toolSpecifications)
         .immediateExecution(true)
+        .validateToolInputs(false) // covered by bean validation
         .build();
   }
 }

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/CamundaMcpToolSpecificationsAutoConfiguration.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/CamundaMcpToolSpecificationsAutoConfiguration.java
@@ -42,7 +42,7 @@ public class CamundaMcpToolSpecificationsAutoConfiguration {
     return new CamundaJsonSchemaGenerator(JsonParser.getJsonMapper());
   }
 
-  @Bean
+  @Bean(name = "clusterMcpToolSpecifications")
   public List<SyncToolSpecification> mcpGatewayToolSpecifications(
       final CamundaMcpToolAnnotatedBeans annotatedBeans,
       final CamundaJsonSchemaGenerator jsonSchemaGenerator) {

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/schema/CamundaJsonSchemaGenerator.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/schema/CamundaJsonSchemaGenerator.java
@@ -36,7 +36,7 @@ import java.util.Map;
 import java.util.function.Function;
 import org.springframework.ai.mcp.annotation.McpToolParam;
 import org.springframework.ai.mcp.annotation.method.tool.utils.McpSpringAiSchemaModule;
-import org.springframework.lang.Nullable;
+import org.springframework.core.Nullness;
 import org.springframework.util.ConcurrentReferenceHashMap;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.node.ArrayNode;
@@ -206,8 +206,7 @@ public class CamundaJsonSchemaGenerator {
           || schemaAnnotation.required();
     }
 
-    if (parameter.getAnnotation(Nullable.class) != null
-        || parameter.getAnnotation(org.jspecify.annotations.Nullable.class) != null) {
+    if (Nullness.forParameter(parameter) == Nullness.NULLABLE) {
       return false;
     }
 

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/tool/CamundaSyncStatelessMcpToolProvider.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/tool/CamundaSyncStatelessMcpToolProvider.java
@@ -114,10 +114,7 @@ public class CamundaSyncStatelessMcpToolProvider extends AbstractMcpToolProvider
     final String inputSchema = jsonSchemaGenerator.generateForMethodInput(mcpToolMethod);
 
     final var toolBuilder =
-        McpSchema.Tool.builder()
-            .name(toolName)
-            .description(toolDescription)
-            .inputSchema(getJsonMapper(), inputSchema);
+        McpSchema.Tool.builder(toolName, getJsonMapper(), inputSchema).description(toolDescription);
 
     if (toolAnnotation.annotations() != null) {
       final var toolAnnotations = toolAnnotation.annotations();

--- a/gateways/gateway-mcp/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/gateways/gateway-mcp/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,2 +1,3 @@
+io.camunda.gateway.mcp.config.CamundaMcpServersAutoConfiguration
 io.camunda.gateway.mcp.config.CamundaMcpToolScannerAutoConfiguration
 io.camunda.gateway.mcp.config.CamundaMcpToolSpecificationsAutoConfiguration

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/config/tool/McpToolParamsUnwrappedValidationTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/config/tool/McpToolParamsUnwrappedValidationTest.java
@@ -80,8 +80,7 @@ class McpToolParamsUnwrappedValidationTest extends ToolsTest {
     void shouldDeserializeAndPassWrappedDto() {
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("createTask")
+              CallToolRequest.builder("createTask")
                   .arguments(
                       Map.of("name", "My Task", "priority", 5, "tags", Set.of("urgent", "review")))
                   .build());
@@ -99,8 +98,7 @@ class McpToolParamsUnwrappedValidationTest extends ToolsTest {
     void shouldReturnValidationErrorWithNormalizedPath() {
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("createTask")
+              CallToolRequest.builder("createTask")
                   .arguments(Map.of("name", "", "priority", 1))
                   .build());
 
@@ -119,8 +117,7 @@ class McpToolParamsUnwrappedValidationTest extends ToolsTest {
     void shouldReturnMultipleValidationErrors() {
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("createTask")
+              CallToolRequest.builder("createTask")
                   .arguments(Map.of("name", "", "priority", -1))
                   .build());
 
@@ -140,8 +137,7 @@ class McpToolParamsUnwrappedValidationTest extends ToolsTest {
     void shouldValidateCollectionElements() {
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("createTask")
+              CallToolRequest.builder("createTask")
                   .arguments(Map.of("name", "Valid", "priority", 1, "tags", Set.of("")))
                   .build());
 
@@ -162,7 +158,7 @@ class McpToolParamsUnwrappedValidationTest extends ToolsTest {
     void shouldReturnErrorOnIndividualParamValidation() {
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder().name("getTask").arguments(Map.of("taskKey", -1L)).build());
+              CallToolRequest.builder("getTask").arguments(Map.of("taskKey", -1L)).build());
 
       assertThat(result.isError()).isTrue();
       assertThat(result.structuredContent()).isNull();

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/cluster/ClusterToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/cluster/ClusterToolsTest.java
@@ -59,7 +59,7 @@ class ClusterToolsTest extends ToolsTest {
 
       // when
       final CallToolResult result =
-          mcpClient.callTool(CallToolRequest.builder().name("getClusterStatus").build());
+          mcpClient.callTool(CallToolRequest.builder("getClusterStatus").build());
 
       // then
       assertThat(result.isError()).isFalse();
@@ -81,7 +81,7 @@ class ClusterToolsTest extends ToolsTest {
 
       // when
       final CallToolResult result =
-          mcpClient.callTool(CallToolRequest.builder().name("getClusterStatus").build());
+          mcpClient.callTool(CallToolRequest.builder("getClusterStatus").build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -178,7 +178,7 @@ class ClusterToolsTest extends ToolsTest {
 
       // when
       final CallToolResult result =
-          mcpClient.callTool(CallToolRequest.builder().name("getTopology").build());
+          mcpClient.callTool(CallToolRequest.builder("getTopology").build());
 
       // then
       assertThat(result.isError()).isFalse();
@@ -199,7 +199,7 @@ class ClusterToolsTest extends ToolsTest {
 
       // when
       final CallToolResult result =
-          mcpClient.callTool(CallToolRequest.builder().name("getTopology").build());
+          mcpClient.callTool(CallToolRequest.builder("getTopology").build());
 
       // then
       assertThat(result.isError()).isTrue();

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/incident/IncidentToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/incident/IncidentToolsTest.java
@@ -125,10 +125,7 @@ class IncidentToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("getIncident")
-                  .arguments(Map.of("incidentKey", 5L))
-                  .build());
+              CallToolRequest.builder("getIncident").arguments(Map.of("incidentKey", 5L)).build());
 
       // then
       assertThat(result.isError()).isFalse();
@@ -152,10 +149,7 @@ class IncidentToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("getIncident")
-                  .arguments(Map.of("incidentKey", 5L))
-                  .build());
+              CallToolRequest.builder("getIncident").arguments(Map.of("incidentKey", 5L)).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -174,8 +168,7 @@ class IncidentToolsTest extends ToolsTest {
     void shouldFailGetIncidentByKeyOnMissingKey() {
       // when
       final CallToolResult result =
-          mcpClient.callTool(
-              CallToolRequest.builder().name("getIncident").arguments(Map.of()).build());
+          mcpClient.callTool(CallToolRequest.builder("getIncident").arguments(Map.of()).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -196,8 +189,7 @@ class IncidentToolsTest extends ToolsTest {
       final var arguments = new HashMap<String, Object>();
       arguments.put("incidentKey", null);
       final CallToolResult result =
-          mcpClient.callTool(
-              CallToolRequest.builder().name("getIncident").arguments(arguments).build());
+          mcpClient.callTool(CallToolRequest.builder("getIncident").arguments(arguments).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -217,10 +209,7 @@ class IncidentToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("getIncident")
-                  .arguments(Map.of("incidentKey", -3L))
-                  .build());
+              CallToolRequest.builder("getIncident").arguments(Map.of("incidentKey", -3L)).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -251,8 +240,7 @@ class IncidentToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchIncidents")
+              CallToolRequest.builder("searchIncidents")
                   .arguments(
                       Map.of(
                           "filter",
@@ -284,8 +272,7 @@ class IncidentToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchIncidents")
+              CallToolRequest.builder("searchIncidents")
                   .arguments(
                       Map.of(
                           "filter",
@@ -342,7 +329,7 @@ class IncidentToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder().name("searchIncidents").arguments(Map.of()).build());
+              CallToolRequest.builder("searchIncidents").arguments(Map.of()).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -362,8 +349,7 @@ class IncidentToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchIncidents")
+              CallToolRequest.builder("searchIncidents")
                   .arguments(Map.of("filter", Map.of("processInstanceKey", "abc")))
                   .build());
 
@@ -386,8 +372,7 @@ class IncidentToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchIncidents")
+              CallToolRequest.builder("searchIncidents")
                   .arguments(Map.of("filter", Map.of("creationTime", Map.of("from", "not-a-date"))))
                   .build());
 
@@ -418,8 +403,7 @@ class IncidentToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("resolveIncident")
+              CallToolRequest.builder("resolveIncident")
                   .arguments(Map.of("incidentKey", 5L))
                   .build());
 
@@ -454,8 +438,7 @@ class IncidentToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("resolveIncident")
+              CallToolRequest.builder("resolveIncident")
                   .arguments(Map.of("incidentKey", 5L))
                   .build());
 
@@ -494,8 +477,7 @@ class IncidentToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("resolveIncident")
+              CallToolRequest.builder("resolveIncident")
                   .arguments(Map.of("incidentKey", 5L))
                   .build());
 
@@ -521,7 +503,7 @@ class IncidentToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder().name("resolveIncident").arguments(Map.of()).build());
+              CallToolRequest.builder("resolveIncident").arguments(Map.of()).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -543,7 +525,7 @@ class IncidentToolsTest extends ToolsTest {
       arguments.put("incidentKey", null);
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder().name("resolveIncident").arguments(arguments).build());
+              CallToolRequest.builder("resolveIncident").arguments(arguments).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -563,8 +545,7 @@ class IncidentToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("resolveIncident")
+              CallToolRequest.builder("resolveIncident")
                   .arguments(Map.of("incidentKey", -3L))
                   .build());
 

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/process/definition/ProcessDefinitionToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/process/definition/ProcessDefinitionToolsTest.java
@@ -102,8 +102,7 @@ class ProcessDefinitionToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("getProcessDefinition")
+              CallToolRequest.builder("getProcessDefinition")
                   .arguments(Map.of("processDefinitionKey", 5L))
                   .build());
 
@@ -123,7 +122,7 @@ class ProcessDefinitionToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder().name("getProcessDefinition").arguments(Map.of()).build());
+              CallToolRequest.builder("getProcessDefinition").arguments(Map.of()).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -145,7 +144,7 @@ class ProcessDefinitionToolsTest extends ToolsTest {
       arguments.put("processDefinitionKey", null);
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder().name("getProcessDefinition").arguments(arguments).build());
+              CallToolRequest.builder("getProcessDefinition").arguments(arguments).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -165,8 +164,7 @@ class ProcessDefinitionToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("getProcessDefinition")
+              CallToolRequest.builder("getProcessDefinition")
                   .arguments(Map.of("processDefinitionKey", -3L))
                   .build());
 
@@ -197,8 +195,7 @@ class ProcessDefinitionToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchProcessDefinitions")
+              CallToolRequest.builder("searchProcessDefinitions")
                   .arguments(
                       Map.of(
                           "filter",
@@ -252,10 +249,7 @@ class ProcessDefinitionToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchProcessDefinitions")
-                  .arguments(Map.of())
-                  .build());
+              CallToolRequest.builder("searchProcessDefinitions").arguments(Map.of()).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -278,8 +272,7 @@ class ProcessDefinitionToolsTest extends ToolsTest {
 
       // when (tenantId passed in arguments should be ignored by MCP filter schema)
       mcpClient.callTool(
-          CallToolRequest.builder()
-              .name("searchProcessDefinitions")
+          CallToolRequest.builder("searchProcessDefinitions")
               .arguments(Map.of("filter", Map.of("tenantId", "tenantId")))
               .build());
 
@@ -298,10 +291,7 @@ class ProcessDefinitionToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("getProcessDefinitionXml")
-                  .arguments(Map.of())
-                  .build());
+              CallToolRequest.builder("getProcessDefinitionXml").arguments(Map.of()).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -323,10 +313,7 @@ class ProcessDefinitionToolsTest extends ToolsTest {
       arguments.put("processDefinitionKey", null);
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("getProcessDefinitionXml")
-                  .arguments(arguments)
-                  .build());
+              CallToolRequest.builder("getProcessDefinitionXml").arguments(arguments).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -346,8 +333,7 @@ class ProcessDefinitionToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("getProcessDefinitionXml")
+              CallToolRequest.builder("getProcessDefinitionXml")
                   .arguments(Map.of("processDefinitionKey", -3L))
                   .build());
 
@@ -374,8 +360,7 @@ class ProcessDefinitionToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("getProcessDefinitionXml")
+              CallToolRequest.builder("getProcessDefinitionXml")
                   .arguments(Map.of("processDefinitionKey", 5L))
                   .build());
 
@@ -399,8 +384,7 @@ class ProcessDefinitionToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("getProcessDefinitionXml")
+              CallToolRequest.builder("getProcessDefinitionXml")
                   .arguments(Map.of("processDefinitionKey", 5L))
                   .build());
 

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceToolsTest.java
@@ -134,8 +134,7 @@ class ProcessInstanceToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("getProcessInstance")
+              CallToolRequest.builder("getProcessInstance")
                   .arguments(Map.of("processInstanceKey", 123L))
                   .build());
 
@@ -161,8 +160,7 @@ class ProcessInstanceToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("getProcessInstance")
+              CallToolRequest.builder("getProcessInstance")
                   .arguments(Map.of("processInstanceKey", 123L))
                   .build());
 
@@ -184,7 +182,7 @@ class ProcessInstanceToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder().name("getProcessInstance").arguments(Map.of()).build());
+              CallToolRequest.builder("getProcessInstance").arguments(Map.of()).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -206,7 +204,7 @@ class ProcessInstanceToolsTest extends ToolsTest {
       arguments.put("processInstanceKey", null);
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder().name("getProcessInstance").arguments(arguments).build());
+              CallToolRequest.builder("getProcessInstance").arguments(arguments).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -226,8 +224,7 @@ class ProcessInstanceToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("getProcessInstance")
+              CallToolRequest.builder("getProcessInstance")
                   .arguments(Map.of("processInstanceKey", -3L))
                   .build());
 
@@ -258,8 +255,7 @@ class ProcessInstanceToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchProcessInstances")
+              CallToolRequest.builder("searchProcessInstances")
                   .arguments(
                       Map.of(
                           "filter",
@@ -347,8 +343,7 @@ class ProcessInstanceToolsTest extends ToolsTest {
 
       // when (tenantId passed in arguments should be ignored by MCP filter schema)
       mcpClient.callTool(
-          CallToolRequest.builder()
-              .name("searchProcessInstances")
+          CallToolRequest.builder("searchProcessInstances")
               .arguments(Map.of("filter", Map.of("tenantId", "tenantId")))
               .build());
 
@@ -367,7 +362,7 @@ class ProcessInstanceToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder().name("searchProcessInstances").arguments(Map.of()).build());
+              CallToolRequest.builder("searchProcessInstances").arguments(Map.of()).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -386,8 +381,7 @@ class ProcessInstanceToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchProcessInstances")
+              CallToolRequest.builder("searchProcessInstances")
                   .arguments(Map.of("filter", Map.of("processInstanceKey", "abc")))
                   .build());
 
@@ -410,8 +404,7 @@ class ProcessInstanceToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchProcessInstances")
+              CallToolRequest.builder("searchProcessInstances")
                   .arguments(Map.of("filter", Map.of("startDate", Map.of("from", "not-a-date"))))
                   .build());
 
@@ -434,8 +427,7 @@ class ProcessInstanceToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchProcessInstances")
+              CallToolRequest.builder("searchProcessInstances")
                   .arguments(
                       Map.of(
                           "filter",
@@ -486,8 +478,7 @@ class ProcessInstanceToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("createProcessInstance")
+              CallToolRequest.builder("createProcessInstance")
                   .arguments(
                       Map.of(
                           "processDefinitionKey",
@@ -543,8 +534,7 @@ class ProcessInstanceToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("createProcessInstance")
+              CallToolRequest.builder("createProcessInstance")
                   .arguments(
                       Map.of(
                           "processDefinitionId",
@@ -605,8 +595,7 @@ class ProcessInstanceToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("createProcessInstance")
+              CallToolRequest.builder("createProcessInstance")
                   .arguments(
                       Map.of(
                           "processDefinitionId",
@@ -669,8 +658,7 @@ class ProcessInstanceToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("createProcessInstance")
+              CallToolRequest.builder("createProcessInstance")
                   .arguments(
                       Map.of(
                           "processDefinitionId",
@@ -722,8 +710,7 @@ class ProcessInstanceToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("createProcessInstance")
+              CallToolRequest.builder("createProcessInstance")
                   .arguments(Map.of("processDefinitionId", "invalidProcessId"))
                   .build());
 
@@ -744,7 +731,7 @@ class ProcessInstanceToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder().name("createProcessInstance").arguments(Map.of()).build());
+              CallToolRequest.builder("createProcessInstance").arguments(Map.of()).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -764,8 +751,7 @@ class ProcessInstanceToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("createProcessInstance")
+              CallToolRequest.builder("createProcessInstance")
                   .arguments(
                       Map.of("processDefinitionKey", "123", "processDefinitionId", "testProcessId"))
                   .build());
@@ -804,8 +790,7 @@ class ProcessInstanceToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("createProcessInstance")
+              CallToolRequest.builder("createProcessInstance")
                   .arguments(
                       Map.of(
                           "processDefinitionKey",
@@ -863,8 +848,7 @@ class ProcessInstanceToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("createProcessInstance")
+              CallToolRequest.builder("createProcessInstance")
                   .arguments(
                       Map.of(
                           "processDefinitionId",
@@ -914,8 +898,7 @@ class ProcessInstanceToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("createProcessInstance")
+              CallToolRequest.builder("createProcessInstance")
                   .arguments(Map.of("processDefinitionKey", "123", "tenantId", tenantId))
                   .build());
 
@@ -941,8 +924,7 @@ class ProcessInstanceToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("createProcessInstance")
+              CallToolRequest.builder("createProcessInstance")
                   .arguments(Map.of("processDefinitionKey", "123"))
                   .build());
 
@@ -983,8 +965,7 @@ class ProcessInstanceToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("createProcessInstance")
+              CallToolRequest.builder("createProcessInstance")
                   .arguments(Map.of("processDefinitionKey", "123", "businessId", businessId))
                   .build());
 

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/usertask/UserTaskToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/usertask/UserTaskToolsTest.java
@@ -178,10 +178,7 @@ class UserTaskToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("getUserTask")
-                  .arguments(Map.of("userTaskKey", 5L))
-                  .build());
+              CallToolRequest.builder("getUserTask").arguments(Map.of("userTaskKey", 5L)).build());
 
       // then
       assertThat(result.isError()).isFalse();
@@ -205,10 +202,7 @@ class UserTaskToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("getUserTask")
-                  .arguments(Map.of("userTaskKey", 5L))
-                  .build());
+              CallToolRequest.builder("getUserTask").arguments(Map.of("userTaskKey", 5L)).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -227,8 +221,7 @@ class UserTaskToolsTest extends ToolsTest {
     void shouldFailGetUserTaskByKeyOnMissingKey() {
       // when
       final CallToolResult result =
-          mcpClient.callTool(
-              CallToolRequest.builder().name("getUserTask").arguments(Map.of()).build());
+          mcpClient.callTool(CallToolRequest.builder("getUserTask").arguments(Map.of()).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -249,8 +242,7 @@ class UserTaskToolsTest extends ToolsTest {
       final var arguments = new HashMap<String, Object>();
       arguments.put("userTaskKey", null);
       final CallToolResult result =
-          mcpClient.callTool(
-              CallToolRequest.builder().name("getUserTask").arguments(arguments).build());
+          mcpClient.callTool(CallToolRequest.builder("getUserTask").arguments(arguments).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -270,10 +262,7 @@ class UserTaskToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("getUserTask")
-                  .arguments(Map.of("userTaskKey", -3L))
-                  .build());
+              CallToolRequest.builder("getUserTask").arguments(Map.of("userTaskKey", -3L)).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -301,8 +290,7 @@ class UserTaskToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchUserTasks")
+              CallToolRequest.builder("searchUserTasks")
                   .arguments(
                       Map.of(
                           "filter",
@@ -366,8 +354,7 @@ class UserTaskToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchUserTasks")
+              CallToolRequest.builder("searchUserTasks")
                   .arguments(
                       Map.of(
                           "filter",
@@ -402,8 +389,7 @@ class UserTaskToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchUserTasks")
+              CallToolRequest.builder("searchUserTasks")
                   .arguments(
                       Map.of(
                           "filter",
@@ -435,8 +421,7 @@ class UserTaskToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchUserTasks")
+              CallToolRequest.builder("searchUserTasks")
                   .arguments(
                       Map.of(
                           "filter",
@@ -479,8 +464,7 @@ class UserTaskToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchUserTasks")
+              CallToolRequest.builder("searchUserTasks")
                   .arguments(
                       Map.of(
                           "filter",
@@ -523,8 +507,7 @@ class UserTaskToolsTest extends ToolsTest {
       // when (tenantId, candidateGroup, candidateUser passed in arguments should be ignored by MCP
       // filter schema)
       mcpClient.callTool(
-          CallToolRequest.builder()
-              .name("searchUserTasks")
+          CallToolRequest.builder("searchUserTasks")
               .arguments(
                   Map.of(
                       "filter",
@@ -554,7 +537,7 @@ class UserTaskToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder().name("searchUserTasks").arguments(Map.of()).build());
+              CallToolRequest.builder("searchUserTasks").arguments(Map.of()).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -574,8 +557,7 @@ class UserTaskToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchUserTasks")
+              CallToolRequest.builder("searchUserTasks")
                   .arguments(Map.of("filter", Map.of("processInstanceKey", "abc")))
                   .build());
 
@@ -598,8 +580,7 @@ class UserTaskToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchUserTasks")
+              CallToolRequest.builder("searchUserTasks")
                   .arguments(Map.of("filter", Map.of("creationDate", Map.of("from", "not-a-date"))))
                   .build());
 
@@ -631,8 +612,7 @@ class UserTaskToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("assignUserTask")
+              CallToolRequest.builder("assignUserTask")
                   .arguments(Map.of("userTaskKey", 5L, "assignee", "jane.doe"))
                   .build());
 
@@ -661,8 +641,7 @@ class UserTaskToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("assignUserTask")
+              CallToolRequest.builder("assignUserTask")
                   .arguments(
                       Map.of(
                           "userTaskKey",
@@ -697,8 +676,7 @@ class UserTaskToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("assignUserTask")
+              CallToolRequest.builder("assignUserTask")
                   .arguments(Map.of("userTaskKey", 5L))
                   .build());
 
@@ -729,7 +707,7 @@ class UserTaskToolsTest extends ToolsTest {
 
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder().name("assignUserTask").arguments(arguments).build());
+              CallToolRequest.builder("assignUserTask").arguments(arguments).build());
 
       // then
       assertThat(result.isError()).isFalse();
@@ -756,8 +734,7 @@ class UserTaskToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("assignUserTask")
+              CallToolRequest.builder("assignUserTask")
                   .arguments(Map.of("userTaskKey", 5L, "assignee", "jane.doe"))
                   .build());
 
@@ -779,8 +756,7 @@ class UserTaskToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("assignUserTask")
+              CallToolRequest.builder("assignUserTask")
                   .arguments(Map.of("assignee", "jane.doe"))
                   .build());
 
@@ -805,7 +781,7 @@ class UserTaskToolsTest extends ToolsTest {
       arguments.put("assignee", "jane.doe");
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder().name("assignUserTask").arguments(arguments).build());
+              CallToolRequest.builder("assignUserTask").arguments(arguments).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -825,8 +801,7 @@ class UserTaskToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("assignUserTask")
+              CallToolRequest.builder("assignUserTask")
                   .arguments(Map.of("userTaskKey", -3L, "assignee", "jane.doe"))
                   .build());
 
@@ -857,8 +832,7 @@ class UserTaskToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchUserTaskVariables")
+              CallToolRequest.builder("searchUserTaskVariables")
                   .arguments(
                       Map.of(
                           "userTaskKey",
@@ -903,8 +877,7 @@ class UserTaskToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchUserTaskVariables")
+              CallToolRequest.builder("searchUserTaskVariables")
                   .arguments(Map.of("userTaskKey", 5L, "truncateValues", false))
                   .build());
 
@@ -940,8 +913,7 @@ class UserTaskToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchUserTaskVariables")
+              CallToolRequest.builder("searchUserTaskVariables")
                   .arguments(
                       Map.of(
                           "userTaskKey",
@@ -983,8 +955,7 @@ class UserTaskToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchUserTaskVariables")
+              CallToolRequest.builder("searchUserTaskVariables")
                   .arguments(Map.of("userTaskKey", 5L))
                   .build());
 
@@ -1006,10 +977,7 @@ class UserTaskToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchUserTaskVariables")
-                  .arguments(Map.of())
-                  .build());
+              CallToolRequest.builder("searchUserTaskVariables").arguments(Map.of()).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -1031,10 +999,7 @@ class UserTaskToolsTest extends ToolsTest {
       arguments.put("userTaskKey", null);
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchUserTaskVariables")
-                  .arguments(arguments)
-                  .build());
+              CallToolRequest.builder("searchUserTaskVariables").arguments(arguments).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -1054,8 +1019,7 @@ class UserTaskToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchUserTaskVariables")
+              CallToolRequest.builder("searchUserTaskVariables")
                   .arguments(Map.of("userTaskKey", -3L))
                   .build());
 

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/variable/VariableToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/variable/VariableToolsTest.java
@@ -113,8 +113,7 @@ class VariableToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("getVariable")
+              CallToolRequest.builder("getVariable")
                   .arguments(Map.of("variableKey", 123L))
                   .build());
 
@@ -140,8 +139,7 @@ class VariableToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("getVariable")
+              CallToolRequest.builder("getVariable")
                   .arguments(Map.of("variableKey", 123L))
                   .build());
 
@@ -162,8 +160,7 @@ class VariableToolsTest extends ToolsTest {
     void shouldFailGetVariableByKeyOnMissingKey() {
       // when
       final CallToolResult result =
-          mcpClient.callTool(
-              CallToolRequest.builder().name("getVariable").arguments(Map.of()).build());
+          mcpClient.callTool(CallToolRequest.builder("getVariable").arguments(Map.of()).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -184,8 +181,7 @@ class VariableToolsTest extends ToolsTest {
       final var arguments = new HashMap<String, Object>();
       arguments.put("variableKey", null);
       final CallToolResult result =
-          mcpClient.callTool(
-              CallToolRequest.builder().name("getVariable").arguments(arguments).build());
+          mcpClient.callTool(CallToolRequest.builder("getVariable").arguments(arguments).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -205,10 +201,7 @@ class VariableToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("getVariable")
-                  .arguments(Map.of("variableKey", -3L))
-                  .build());
+              CallToolRequest.builder("getVariable").arguments(Map.of("variableKey", -3L)).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -236,8 +229,7 @@ class VariableToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchVariables")
+              CallToolRequest.builder("searchVariables")
                   .arguments(
                       Map.of(
                           "filter",
@@ -283,8 +275,7 @@ class VariableToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchVariables")
+              CallToolRequest.builder("searchVariables")
                   .arguments(
                       Map.of(
                           "filter",
@@ -351,7 +342,7 @@ class VariableToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder().name("searchVariables").arguments(Map.of()).build());
+              CallToolRequest.builder("searchVariables").arguments(Map.of()).build());
 
       // then
       assertThat(result.isError()).isTrue();
@@ -370,8 +361,7 @@ class VariableToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchVariables")
+              CallToolRequest.builder("searchVariables")
                   .arguments(Map.of("filter", Map.of("processInstanceKey", "abc")))
                   .build());
 
@@ -393,8 +383,7 @@ class VariableToolsTest extends ToolsTest {
       // when
       final CallToolResult result =
           mcpClient.callTool(
-              CallToolRequest.builder()
-                  .name("searchVariables")
+              CallToolRequest.builder("searchVariables")
                   .arguments(Map.of("filter", Map.of("variableKey", "abc")))
                   .build());
 

--- a/gateways/gateway-mcp/src/test/resources/application.yaml
+++ b/gateways/gateway-mcp/src/test/resources/application.yaml
@@ -3,20 +3,14 @@ spring:
     mcp:
       server:
         enabled: true
-        name: Camunda 8 Orchestration API Test MCP Server
-        version: '${project.version}'
         type: sync
         protocol: stateless
         annotation-scanner:
           enabled: true
-        streamable-http:
-          mcp-endpoint: /mcp/cluster
-        capabilities:
-          completion: false
-          prompt: false
-          resource: false
-          tool: true
-
+  autoconfigure:
+    exclude:
+      - org.springframework.ai.mcp.server.common.autoconfigure.McpServerStatelessAutoConfiguration
+      - org.springframework.ai.mcp.server.webmvc.autoconfigure.McpServerStatelessWebMvcAutoConfiguration
 camunda:
   mcp:
     enabled: true

--- a/gateways/gateway-mcp/src/test/resources/schema/tools-schema-snapshot.json
+++ b/gateways/gateway-mcp/src/test/resources/schema/tools-schema-snapshot.json
@@ -5,6 +5,7 @@
       "title": "getClusterStatus",
       "description": "Checks the health status of the cluster by verifying if there's at least one partition with a healthy leader.",
       "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
         "properties": {},
         "required": []
@@ -18,6 +19,7 @@
       "title": "getTopology",
       "description": "Obtains the current topology of the cluster the gateway is part of.",
       "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
         "properties": {},
         "required": []
@@ -31,6 +33,7 @@
       "title": "getIncident",
       "description": "Get incident by key. Note: Results are eventually consistent and may not immediately reflect recent changes.",
       "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
         "properties": {
           "incidentKey": {
@@ -52,6 +55,7 @@
       "title": "resolveIncident",
       "description": "Resolve incident by key. Note: Results are eventually consistent and may not immediately reflect recent changes.",
       "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
         "properties": {
           "incidentKey": {
@@ -71,6 +75,7 @@
       "title": "searchIncidents",
       "description": "Search for incidents. Note: Results are eventually consistent and may not immediately reflect recent changes.",
       "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
         "properties": {
           "filter": {
@@ -214,6 +219,7 @@
       "title": "getProcessDefinition",
       "description": "Get process definition by key. Note: Results are eventually consistent and may not immediately reflect recent changes.",
       "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
         "properties": {
           "processDefinitionKey": {
@@ -235,6 +241,7 @@
       "title": "getProcessDefinitionXml",
       "description": "Get the BPMN XML of a process definition by key. Note: Results are eventually consistent and may not immediately reflect recent changes.",
       "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
         "properties": {
           "processDefinitionKey": {
@@ -256,6 +263,7 @@
       "title": "searchProcessDefinitions",
       "description": "Search for process definitions. Note: Results are eventually consistent and may not immediately reflect recent changes.",
       "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
         "properties": {
           "filter": {
@@ -365,6 +373,7 @@
       "title": "createProcessInstance",
       "description": "Create a new process instance of the given process definition. Either a processDefinitionKey or\na processDefinitionId (with an optional processDefinitionVersion) need to be passed.\n\nWhen using the awaitCompletion flag, the tool will wait for the process instance to complete\nand return its result variables. When using awaitCompletion, always include a unique tag\n`mcp-tool:<uniqueId>` which can be used to search for the started process instance in case\nof timeouts. Processes with wait states, like service tasks, user tasks, or defined listeners,\nare more likely to time out. You can increase the timeout to wait for completion by defining\na longer requestTimeout.",
       "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
         "properties": {
           "awaitCompletion": {
@@ -401,7 +410,7 @@
             "description": "Timeout (in ms) the request waits for the process to complete. By default or when set to 0, the generic request timeout configured in the cluster is applied. "
           },
           "tags": {
-            "description": "List of tags. Tags need to start with a letter; then alphanumerics, `_`, `-`, `:`, or `.`; length \u2264 100.",
+            "description": "List of tags. Tags need to start with a letter; then alphanumerics, `_`, `-`, `:`, or `.`; length ≤ 100.",
             "type": "array",
             "items": {
               "type": "string"
@@ -425,6 +434,7 @@
       "title": "getProcessInstance",
       "description": "Get process instance by key. Note: Results are eventually consistent and may not immediately reflect recent changes.",
       "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
         "properties": {
           "processInstanceKey": {
@@ -446,6 +456,7 @@
       "title": "searchProcessInstances",
       "description": "Search for process instances. Note: Results are eventually consistent and may not immediately reflect recent changes.",
       "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
         "properties": {
           "filter": {
@@ -518,7 +529,7 @@
                 "description": "The process instance state."
               },
               "tags": {
-                "description": "List of tags. Tags need to start with a letter; then alphanumerics, `_`, `-`, `:`, or `.`; length \u2264 100.",
+                "description": "List of tags. Tags need to start with a letter; then alphanumerics, `_`, `-`, `:`, or `.`; length ≤ 100.",
                 "type": "array",
                 "items": {
                   "type": "string"
@@ -623,6 +634,7 @@
       "title": "assignUserTask",
       "description": "Assign or unassign a user task. Provide an assignee to assign the task, or omit/provide null to unassign it.",
       "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
         "properties": {
           "userTaskKey": {
@@ -660,6 +672,7 @@
       "title": "getUserTask",
       "description": "Get user task by key. Note: Results are eventually consistent and may not immediately reflect recent changes.",
       "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
         "properties": {
           "userTaskKey": {
@@ -681,6 +694,7 @@
       "title": "searchUserTaskVariables",
       "description": "Search user task variables based on given criteria. Returns deduplicated variables where the innermost scope wins. The variable value is returned in serialized JSON format. Note: Results are eventually consistent and may not immediately reflect recent changes.",
       "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
         "properties": {
           "userTaskKey": {
@@ -763,6 +777,7 @@
       "title": "searchUserTasks",
       "description": "Search for user tasks. Variable values in filters need to be in serialized JSON format. Example string value: `\\\"myValue\\\"`. Example nested JSON value: `{\\\"myVar\\\":\\\"myValue\\\"}`. Note: Results are eventually consistent and may not immediately reflect recent changes.",
       "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
         "properties": {
           "filter": {
@@ -915,7 +930,7 @@
                 "description": "The user task state."
               },
               "tags": {
-                "description": "List of tags. Tags need to start with a letter; then alphanumerics, `_`, `-`, `:`, or `.`; length \u2264 100.",
+                "description": "List of tags. Tags need to start with a letter; then alphanumerics, `_`, `-`, `:`, or `.`; length ≤ 100.",
                 "type": "array",
                 "items": {
                   "type": "string"
@@ -995,6 +1010,7 @@
       "title": "getVariable",
       "description": "Get variable by key. The variable value is returned in serialized JSON format. Note: Results are eventually consistent and may not immediately reflect recent changes.",
       "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
         "properties": {
           "variableKey": {
@@ -1016,6 +1032,7 @@
       "title": "searchVariables",
       "description": "Search for variables. The variable value is returned in serialized JSON format. Note: Results are eventually consistent and may not immediately reflect recent changes.",
       "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
         "properties": {
           "filter": {

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -112,7 +112,7 @@
     <spring-security.version>${version.spring-security}</spring-security.version>
     <version.spring-boot>4.0.6</version.spring-boot>
     <version.spring-ai>2.0.0-M7</version.spring-ai>
-    <version.mcp-sdk>1.1.3</version.mcp-sdk>
+    <version.mcp-sdk>2.0.0-M3</version.mcp-sdk>
     <version.jsonschema-generator>5.0.0</version.jsonschema-generator>
     <version.tomcat>11.0.22</version.tomcat>
     <version.concurrentunit>0.4.6</version.concurrentunit>

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/mcp/authentication/AuthenticatedMcpServerTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/mcp/authentication/AuthenticatedMcpServerTest.java
@@ -101,7 +101,7 @@ abstract class AuthenticatedMcpServerTest extends McpServerAuthenticationTest {
   private Set<String> searchProcessDefinitionIds(final McpSyncClient client) {
     final CallToolResult result =
         client.callTool(
-            CallToolRequest.builder().name("searchProcessDefinitions").arguments(Map.of()).build());
+            CallToolRequest.builder("searchProcessDefinitions").arguments(Map.of()).build());
     assertThat(result.isError())
         .withFailMessage(
             "Expected successful searchProcessDefinitions response, but got error result: %s",

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/mcp/authentication/McpServerAuthenticationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/mcp/authentication/McpServerAuthenticationTest.java
@@ -69,7 +69,7 @@ abstract class McpServerAuthenticationTest extends McpServerTest {
   @Test
   void fetchesClusterStatus() {
     final CallToolResult result =
-        mcpClient.callTool(CallToolRequest.builder().name("getClusterStatus").build());
+        mcpClient.callTool(CallToolRequest.builder("getClusterStatus").build());
 
     assertThat(result.isError()).isFalse();
     assertThat(result.content())
@@ -82,7 +82,7 @@ abstract class McpServerAuthenticationTest extends McpServerTest {
   @Test
   void fetchesTopology() {
     final CallToolResult result =
-        mcpClient.callTool(CallToolRequest.builder().name("getTopology").build());
+        mcpClient.callTool(CallToolRequest.builder("getTopology").build());
 
     assertThat(result.isError()).isFalse();
     assertThat(result.structuredContent()).isNotNull();


### PR DESCRIPTION
Backport of #54155 → `stable/8.9`

## Summary
Updates the MCP Java SDK to `2.0.0-M3` to align with the Spring AI `2.0.0-M7` upgrade pulled in via https://github.com/camunda/camunda/pull/53042.

Includes corresponding source/test adjustments for SDK API changes (notably the new `CallToolRequest.builder(name)` overload replacing the deprecated `builder()` + `.name(...)` pattern).

## Additional partial backport of #49082

Backporting the SDK-level input-validation disable from #54155 requires a customizer hook on the MCP sync server builder, which Spring AI 2.0.0-M7 does not expose for stateless servers. To unblock it, this PR also partially backports #49082 — only the `cluster` half, as `stable/8.9` does not have the `/mcp/processes` server — so the gateway builds the `McpStatelessSyncServer` itself instead of relying on Spring AI's autoconfiguration. With the server built in our own autoconfig, `validateToolInputs(false)` can be applied directly.

The backported class adopts the post-rename name `CamundaMcpServersAutoConfiguration` (introduced in follow-up refactors on `main`) so future backports stay in lockstep.