### PR TITLE
ci: remove deploy-load-test-images job from zeebe-ci

### DIFF
--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -435,54 +435,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           user_description: "team-distributed-systems"
 
-  # Dynamically generate the concurrency group for load test image deployment
-  utils-get-concurrency-group-for-load-test:
-    uses: ./.github/workflows/generate-concurrency-group.yml
-    secrets: inherit
-    permissions:
-      contents: read
-    with:
-      base_group_name: deploy-load-test-images
-
-  deploy-load-test-images:
-    name: Deploy load test images
-    timeout-minutes: 5
-    needs: [ test-summary, utils-get-snapshot-docker-tag, utils-get-concurrency-group-for-load-test ]
-    runs-on: ubuntu-latest
-    if: github.repository == 'camunda/camunda' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/'))
-    concurrency:
-      group: ${{ needs.utils-get-concurrency-group-for-load-test.outputs.concurrency_group_name }}
-      cancel-in-progress: false
-    permissions:
-      contents: 'read'
-    env:
-      IMAGE_REPOSITORY: registry.camunda.cloud/team-zeebe
-      IMAGE_TAG: ${{ needs.utils-get-snapshot-docker-tag.outputs.snapshot_tag != '' && needs.utils-get-snapshot-docker-tag.outputs.snapshot_tag || needs.utils-get-snapshot-docker-tag.outputs.version_tag }}
-    steps:
-      - uses: camunda/infra-global-github-actions/start-build-monitor@main
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: ./.github/actions/setup-build
-        with:
-          dockerhub-readonly: true
-          harbor: true
-          vault-address: ${{ secrets.VAULT_ADDR }}
-          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
-          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-          minimus: true
-      - run: ./mvnw -B -D skipTests -D skipChecks -pl load-tests/load-tester -am package
-      - name: Build Starter Image
-        run: ./mvnw -pl load-tests/load-tester jib:build -P starter -D image="${{ env.IMAGE_REPOSITORY }}/starter:${{ env.IMAGE_TAG }}"
-      - name: Build Worker Image
-        run: ./mvnw -pl load-tests/load-tester jib:build -P worker -D image="${{ env.IMAGE_REPOSITORY }}/worker:${{ env.IMAGE_TAG }}"
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          build_status: ${{ job.status }}
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
   deploy-snyk-projects:
     name: Deploy Snyk development projects
     needs: [ test-summary ]


### PR DESCRIPTION
## Description
This pull request removes the workflow steps related to dynamically generating a concurrency group and deploying load test images from the `.github/workflows/zeebe-ci.yml` file. The main impact is that the CI pipeline will no longer build or deploy load test images as part of this workflow.

**Removed load test image deployment workflow:**

* Deleted the `utils-get-concurrency-group-for-load-test` job, which generated a concurrency group for load test image deployment.
* Removed the `deploy-load-test-images` job, including all steps for building and pushing the starter and worker Docker images for load tests.

This was working earlier might need to see what has changed in last 3 weeks: [8.7-SNAPSHOT](https://registry.camunda.cloud/harbor/projects/12/repositories/starter/artifacts-tab/artifacts/sha256:bdf7a9212cf81c99a37890a9c075e84661e9cbc8a09f3a1cb0dac1a1c84629a6?sbomDigest=)

## Checklist

<!--- Please delete options that are not relevant. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [x] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #[Thread](https://camunda.slack.com/archives/C071KP5BTHB/p1779952559131369)
