### PR TITLE
test: wait for state element after reload when polling batch operation status

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
@@ -624,7 +624,9 @@ test.describe('Process Instances Filters', () => {
         },
         onFailure: async () => {
           await page.reload();
+          await expect(operateOperationsDetailsPage.state).toBeVisible();
         },
+        maxRetries: 5,
       });
 
       const batchOperationKey =


### PR DESCRIPTION
## Summary

 ✅ On-demand run with this branch: https://github.com/camunda/camunda/actions/runs/26562821093

- After `page.reload()` in the `onFailure` callback, the next assertion called `getBatchOperationStatus()` before the state element had fully loaded, causing `innerText()` to race against page hydration and consistently return `'Created'` instead of `'Completed'`
- Increased `maxRetries` from 3 to 5 to give more time for batch operations to complete in slower CI environments

## Root cause

The failing assertion loop was:
```typescript
onFailure: async () => {
  await page.reload();
  // ← missing wait for state element here
},
maxRetries: 3,  // ← not enough retries on CI
```

After reload, `getBatchOperationStatus()` → `this.state.innerText()` would read the DOM before the `state` element appeared, getting `'Created'` every time.

## Fix

Added `await expect(operateOperationsDetailsPage.state).toBeVisible()` inside `onFailure` and bumped `maxRetries` to `5`.

## Test plan

- [x] Nightly failure: https://github.com/camunda/camunda/actions/runs/26551300574/job/78213790283 — `processInstancesFilters.spec.ts:247` fails with `Expected: "Completed" / Received: "Created"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)