### PR TITLE
test: fix task completion retry not re-clicking complete button

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskDetailsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskDetailsPage.ts
@@ -147,7 +147,7 @@ class TaskDetailsPage {
           (await this.completeTaskButton.isVisible()) &&
           (await this.completeTaskButton.isEnabled())
         ) {
-          await this.completeTaskButton.click();
+          await this.completeTaskButton.click({timeout: 60000});
         }
       },
     });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskDetailsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskDetailsPage.ts
@@ -147,7 +147,7 @@ class TaskDetailsPage {
           (await this.completeTaskButton.isVisible()) &&
           (await this.completeTaskButton.isEnabled())
         ) {
-          await expect(this.completeTaskButton).toBeVisible({timeout: 60000});
+          await this.completeTaskButton.click();
         }
       },
     });


### PR DESCRIPTION
## Summary

- The `onFailure` handler in `TaskDetailsPage.clickCompleteTaskButton` reloads the page and detects that the Complete Task button is still present (task was never submitted), but then only waits for the button to be visible instead of clicking it
- On retry, the assertion checks for the "Task completed" banner — which never appears because the task was never actually re-submitted
- Fix: replace the no-op `toBeVisible` wait with `click()` so retries actually re-submit the completion

## Failing nightly run

https://github.com/camunda/camunda/actions/runs/26548429774/job/78205272738

Failed test: `complete zeebe and job worker tasks` in `tasklist/task-details.spec.ts`

## On-demand verification run

✅ https://github.com/camunda/camunda/actions/runs/26562915996

## Test plan

- [ ] On-demand run on fix branch passes
- [ ] Nightly run on stable/8.7 passes after this fix lands