### PR TITLE
 fix: load test: remove Operate 1h rollover index configuration 

### DIFF
--- a/load-tests/setup/default/values/camunda-platform-values-defaults.yaml
+++ b/load-tests/setup/default/values/camunda-platform-values-defaults.yaml
@@ -5,7 +5,7 @@
 # The values are optimized for running the load tests with a Camunda cluster on GKE.
 #
 # This is a YAML-formatted file.
-# Per default we run with the Orchestration Cluster, Optimize, Connectors, and Identity 
+# Per default we run with the Orchestration Cluster, Optimize, Connectors, and Identity
 # Keycloak as identity provider with OIDC authentication, but you can easily
 # switch to other configurations by changing the values in this file or by overriding them via the
 # command line when installing the chart.
@@ -262,13 +262,11 @@ orchestration:
         # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
         zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
         zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
-        # Configure index suffix with hour pattern, so we create every hour a new index
-        # such that ILM can clean it up quickly
-        # We need to configure it for the ES exporter AND the CamundaExporter
-        zeebe.broker.exporters.camundaexporter.args.history.elsRolloverDateFormat: "yyyy-MM-dd-HH"
-        zeebe.broker.exporters.camundaexporter.args.history.rolloverInterval: "1h"
+
+        # Camunda Exporter configuration
         zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 300
         zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
+
         # Configure a rate limit for all writes, so that we can visualize flow control metrics.
         zeebe.broker.flowControl.write.enabled: "true"
         zeebe.broker.flowControl.write.limit: 10000


### PR DESCRIPTION
## Description

Cleanup from the @camunda/reliability-testing team Chaos Day from week 22.

* This deviates from our default configuration
* We don't recommend this to our customers
* It can create too many indices inside Elasticsearch
* The original reason is not clearly document


## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
