### PR TITLE
test: add script to regenerate MCP tools schema snapshot from running cluster

### DIFF
--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/ToolsSchemaRegressionTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/ToolsSchemaRegressionTest.java
@@ -47,8 +47,16 @@ import tools.jackson.databind.node.ObjectNode;
  * <p>This test compares the current tool schema output against a stored snapshot to catch any
  * unintended schema changes during migration (e.g., from @McpTool to @CamundaMcpTool).
  *
- * <p>To update the snapshot after intentional changes, manually update the file at:
- * src/test/resources/schema/tools-schema-snapshot.json
+ * <p>To update the snapshot after intentional changes, start a local Camunda cluster with the MCP
+ * gateway enabled and run (from the repository root):
+ *
+ * <pre>
+ * ./gateways/gateway-mcp/src/test/resources/schema/update-tools-schema-snapshot.sh \
+ *   &gt; gateways/gateway-mcp/src/test/resources/schema/tools-schema-snapshot.json
+ * </pre>
+ *
+ * <p>The script fetches the live {@code tools/list} response from {@code /mcp/cluster}, so the
+ * snapshot reflects what the running server actually serves rather than the partial test context.
  */
 @ContextConfiguration(
     classes = {
@@ -102,23 +110,20 @@ class ToolsSchemaRegressionTest extends OperationalToolsTest {
                             "Tool '"
                                 + toolName
                                 + "' is present but not in snapshot. "
-                                + "If intentional, add it to: src/test/resources/"
-                                + SNAPSHOT_PATH);
+                                + "If intentional, regenerate the snapshot — see class javadoc.");
                       }
                       if (actual == null) {
                         throw new AssertionError(
                             "Tool '"
                                 + toolName
                                 + "' is in snapshot but missing from current tools. "
-                                + "If intentional, remove it from: src/test/resources/"
-                                + SNAPSHOT_PATH);
+                                + "If intentional, regenerate the snapshot — see class javadoc.");
                       }
 
                       JSONAssert.assertEquals(
                           "Schema mismatch for tool '"
                               + toolName
-                              + "'. If intentional, update: src/test/resources/"
-                              + SNAPSHOT_PATH,
+                              + "'. If intentional, regenerate the snapshot — see class javadoc.",
                           OBJECT_MAPPER.writeValueAsString(expected),
                           OBJECT_MAPPER.writeValueAsString(actual),
                           JSONCompareMode.STRICT);

--- a/gateways/gateway-mcp/src/test/resources/schema/update-tools-schema-snapshot.sh
+++ b/gateways/gateway-mcp/src/test/resources/schema/update-tools-schema-snapshot.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# Fetches the current MCP tools schema from a running local Camunda cluster
+# and prints it to STDOUT in the snapshot format expected by
+# ToolsSchemaRegressionTest.
+#
+# Prerequisites:
+#   - A local Camunda cluster running with the MCP gateway enabled, serving
+#     the cluster MCP server at http://localhost:8080/mcp/cluster (override
+#     via the CAMUNDA_MCP_ENDPOINT env var).
+#   - The cluster is reachable without authentication (run locally with auth
+#     disabled).
+#   - curl and jq on PATH.
+#
+# Usage (from the repository root):
+#   ./gateways/gateway-mcp/src/test/resources/schema/update-tools-schema-snapshot.sh \
+#     > gateways/gateway-mcp/src/test/resources/schema/tools-schema-snapshot.json
+#
+# Or from the gateway-mcp module directory:
+#   ./src/test/resources/schema/update-tools-schema-snapshot.sh \
+#     > src/test/resources/schema/tools-schema-snapshot.json
+
+set -euo pipefail
+
+ENDPOINT="${CAMUNDA_MCP_ENDPOINT:-http://localhost:8080/mcp/cluster}"
+
+if ! curl -sS --max-time 5 -o /dev/null "$ENDPOINT" 2>/dev/null; then
+  echo "ERROR: Cannot reach MCP endpoint at $ENDPOINT" >&2
+  echo "Make sure a local Camunda cluster is running with the MCP gateway enabled." >&2
+  exit 1
+fi
+
+curl -fsS -X POST "$ENDPOINT" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  --data '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' \
+  | jq '{tools: .result.tools}'


### PR DESCRIPTION
## Summary

- Add `gateways/gateway-mcp/src/test/resources/schema/update-tools-schema-snapshot.sh` to regenerate `tools-schema-snapshot.json` by POSTing a `tools/list` JSON-RPC request to a local cluster's `/mcp/cluster` endpoint and piping through `jq`.
- Update `ToolsSchemaRegressionTest` javadoc and failure messages to point at the script instead of "manually update the file".

## Why

Updating the snapshot previously required spinning up a cluster, calling `tools/list` from an MCP client (e.g. Postman), copying the response JSON out, extracting the `tools` array, and reformatting — all undocumented. The script collapses that into a single command + redirect.