### PR TITLE
feat: add document list content modal to Operate variables

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentList/DocumentListModal.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentList/DocumentListModal.tsx
@@ -1,0 +1,92 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Modal} from '@carbon/react';
+import type {StateProps} from 'modules/components/ModalStateManager';
+import {
+  toHumanReadableBytes,
+  type DocumentInfo,
+} from '../DocumentValueCell/parseDocumentVariable';
+import {middleTruncate} from '../DocumentValueCell/middleTruncate';
+import {PreviewDocumentButton} from '../DocumentPreview/PreviewDocumentButton';
+import {DownloadDocumentButton} from '../DownloadDocumentButton';
+import {
+  DocumentList,
+  DocumentListItem,
+  DocumentInfo as DocumentInfoBlock,
+  DocumentFileName,
+  DocumentSize,
+  TruncationNotice,
+} from './styled';
+
+type Props = {
+  documents: DocumentInfo[];
+  isLowerBound: boolean;
+  variableName: string;
+};
+
+const DocumentListModal: React.FC<StateProps & Props> = ({
+  open,
+  setOpen,
+  documents,
+  isLowerBound,
+  variableName,
+}) => {
+  const count = documents.length;
+  const prefix = isLowerBound ? `${count}+` : `${count}`;
+  const suffix = count !== 1 ? 'documents' : 'document';
+
+  return (
+    <Modal
+      open={open}
+      onRequestClose={() => setOpen(false)}
+      modalHeading={`${prefix} ${suffix} in ${variableName}`}
+      size="md"
+      passiveModal
+    >
+      <DocumentList>
+        {documents.map((document, index) => (
+          <DocumentListItem
+            aria-labelledby={`document-item-${index}`}
+            key={index}
+          >
+            <DocumentInfoBlock>
+              <DocumentFileName
+                id={`document-item-${index}`}
+                title={document.fileName}
+              >
+                {middleTruncate(document.fileName)}
+              </DocumentFileName>
+              {document.size !== undefined && (
+                <DocumentSize>
+                  {toHumanReadableBytes(document.size)}
+                </DocumentSize>
+              )}
+            </DocumentInfoBlock>
+            <PreviewDocumentButton
+              document={document}
+              variableName={variableName}
+            />
+            <DownloadDocumentButton
+              fileName={document.fileName}
+              documentLink={document.link}
+              variableName={variableName}
+            />
+          </DocumentListItem>
+        ))}
+      </DocumentList>
+      {isLowerBound && (
+        <TruncationNotice>
+          More documents may exist for this variable.
+        </TruncationNotice>
+      )}
+    </Modal>
+  );
+};
+
+export {DocumentListModal};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentList/ViewDocumentListButton.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentList/ViewDocumentListButton.test.tsx
@@ -1,0 +1,183 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {render, screen, within} from 'modules/testing-library';
+import {ViewDocumentListButton} from './ViewDocumentListButton';
+import type {DocumentInfo} from '../DocumentValueCell/parseDocumentVariable';
+
+const documents: DocumentInfo[] = [
+  {
+    link: '/v2/documents/1',
+    fileName: 'photo.png',
+    type: 'image',
+    size: 1024,
+  },
+  {
+    link: '/v2/documents/2',
+    fileName: 'report.pdf',
+    type: 'unknown',
+    size: 2048,
+  },
+  {
+    link: '/v2/documents/3',
+    fileName: 'notes.txt',
+    type: 'unknown',
+    size: undefined,
+  },
+];
+
+describe('<ViewDocumentListButton />', () => {
+  it('should render a launcher button with the correct aria-label', () => {
+    render(
+      <ViewDocumentListButton
+        documents={documents}
+        isLowerBound={false}
+        variableName="files"
+      />,
+    );
+
+    expect(
+      screen.getByLabelText('View documents for variable files'),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('should open the modal with the count heading when clicked', async () => {
+    const {user} = render(
+      <ViewDocumentListButton
+        documents={documents}
+        isLowerBound={false}
+        variableName="files"
+      />,
+    );
+
+    await user.click(
+      screen.getByLabelText('View documents for variable files'),
+    );
+
+    const dialog = within(screen.getByRole('dialog'));
+    expect(
+      dialog.getByRole('heading', {name: '3 documents in files'}),
+    ).toBeInTheDocument();
+  });
+
+  it('should show a list row for each document with filename and size', async () => {
+    const {user} = render(
+      <ViewDocumentListButton
+        documents={documents}
+        isLowerBound={false}
+        variableName="files"
+      />,
+    );
+
+    await user.click(
+      screen.getByLabelText('View documents for variable files'),
+    );
+
+    const dialog = within(screen.getByRole('dialog'));
+    const photoItem = dialog.getByRole('listitem', {name: 'photo.png'});
+    expect(photoItem).toBeInTheDocument();
+    expect(photoItem).toHaveTextContent('1 KiB');
+    const reportItem = dialog.getByRole('listitem', {name: 'report.pdf'});
+    expect(reportItem).toBeInTheDocument();
+    expect(reportItem).toHaveTextContent('2 KiB');
+    const notesItem = dialog.getByRole('listitem', {name: 'notes.txt'});
+    expect(notesItem).toBeInTheDocument();
+  });
+
+  it('should render preview and download buttons per document row', async () => {
+    const {user} = render(
+      <ViewDocumentListButton
+        documents={documents}
+        isLowerBound={false}
+        variableName="files"
+      />,
+    );
+
+    await user.click(
+      screen.getByLabelText('View documents for variable files'),
+    );
+
+    const dialog = within(screen.getByRole('dialog'));
+    expect(
+      dialog.getAllByLabelText('Preview document for variable files'),
+    ).toHaveLength(3);
+    expect(
+      dialog.getAllByLabelText('Download document for variable files'),
+    ).toHaveLength(3);
+  });
+
+  it('should show truncation notices when isLowerBound is true', async () => {
+    const {user} = render(
+      <ViewDocumentListButton
+        documents={documents}
+        isLowerBound
+        variableName="files"
+      />,
+    );
+
+    await user.click(
+      screen.getByLabelText('View documents for variable files'),
+    );
+
+    const dialog = within(screen.getByRole('dialog'));
+    expect(
+      dialog.getByRole('heading', {name: '3+ documents in files'}),
+    ).toBeInTheDocument();
+    expect(
+      dialog.getByText('More documents may exist for this variable.'),
+    ).toBeInTheDocument();
+  });
+
+  it('should not show a truncation notice when isLowerBound is false', async () => {
+    const {user} = render(
+      <ViewDocumentListButton
+        documents={documents}
+        isLowerBound={false}
+        variableName="files"
+      />,
+    );
+
+    await user.click(
+      screen.getByLabelText('View documents for variable files'),
+    );
+
+    const dialog = within(screen.getByRole('dialog'));
+    expect(
+      dialog.queryByText('More documents may exist for this variable.'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should middle-truncate long file names inside the list', async () => {
+    const longFileName = 'a'.repeat(40) + 'original-middle' + 'z'.repeat(40);
+    const {user} = render(
+      <ViewDocumentListButton
+        documents={[
+          {
+            link: '/v2/documents/long',
+            fileName: longFileName,
+            type: 'unknown',
+            size: 1024,
+          },
+        ]}
+        isLowerBound={false}
+        variableName="files"
+      />,
+    );
+
+    await user.click(
+      screen.getByLabelText('View documents for variable files'),
+    );
+
+    const dialog = within(screen.getByRole('dialog'));
+    const fileNameEl = dialog.getByTitle(longFileName);
+    expect(fileNameEl.textContent).toContain('\u2026');
+    expect(fileNameEl.textContent).not.toContain('original-middle');
+    expect(fileNameEl.textContent).not.toBe(longFileName);
+  });
+});

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentList/ViewDocumentListButton.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentList/ViewDocumentListButton.tsx
@@ -10,19 +10,19 @@ import {Button} from '@carbon/react';
 import {View} from '@carbon/react/icons';
 import {ModalStateManager} from 'modules/components/ModalStateManager';
 import type {DocumentInfo} from '../DocumentValueCell/parseDocumentVariable';
-import {DocumentPreviewModal} from './DocumentPreviewModal';
+import {DocumentListModal} from './DocumentListModal';
 
 type Props = {
-  document: DocumentInfo;
+  documents: DocumentInfo[];
+  isLowerBound: boolean;
   variableName: string;
 };
 
-const PreviewDocumentButton: React.FC<Props> = ({document, variableName}) => {
-  const tooltipText =
-    document.type !== 'unknown'
-      ? 'Preview'
-      : 'Preview not available for this document type';
-
+const ViewDocumentListButton: React.FC<Props> = ({
+  documents,
+  isLowerBound,
+  variableName,
+}) => {
   return (
     <ModalStateManager
       renderLauncher={({setOpen}) => (
@@ -31,25 +31,25 @@ const PreviewDocumentButton: React.FC<Props> = ({document, variableName}) => {
           size="sm"
           hasIconOnly
           renderIcon={View}
-          iconDescription={tooltipText}
+          iconDescription="View documents"
           tooltipPosition="top"
-          // @ts-expect-error - Solves rendering issues in `DocumentListModal`. Not exposed through TS but used at runtime.
-          autoAlign={true}
-          aria-label={`Preview document for variable ${variableName}`}
-          disabled={document.type === 'unknown'}
+          tooltipAlignment="end"
+          aria-label={`View documents for variable ${variableName}`}
           onClick={() => setOpen(true)}
         />
       )}
     >
       {({open, setOpen}) => (
-        <DocumentPreviewModal
+        <DocumentListModal
           open={open}
           setOpen={setOpen}
-          document={document}
+          documents={documents}
+          isLowerBound={isLowerBound}
+          variableName={variableName}
         />
       )}
     </ModalStateManager>
   );
 };
 
-export {PreviewDocumentButton};
+export {ViewDocumentListButton};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentList/styled.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentList/styled.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import styled from 'styled-components';
+
+const DocumentList = styled.ul`
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+`;
+
+const DocumentListItem = styled.li`
+  display: flex;
+  align-items: center;
+  gap: var(--cds-spacing-03);
+  padding: var(--cds-spacing-04) 0;
+  border-bottom: 1px solid var(--cds-border-subtle-01);
+
+  &:last-child {
+    border-bottom: none;
+  }
+`;
+
+const DocumentInfo = styled.div`
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--cds-spacing-01);
+`;
+
+const DocumentFileName = styled.span`
+  font-size: var(--cds-body-short-01-font-size);
+  font-weight: var(--cds-body-short-01-font-weight);
+  line-height: var(--cds-body-short-01-line-height);
+  letter-spacing: var(--cds-body-short-01-letter-spacing);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+const DocumentSize = styled.span`
+  font-size: var(--cds-caption-01-font-size);
+  font-weight: var(--cds-caption-01-font-weight);
+  line-height: var(--cds-caption-01-line-height);
+  letter-spacing: var(--cds-caption-01-letter-spacing);
+  color: var(--cds-text-secondary);
+`;
+
+const TruncationNotice = styled.p`
+  /* Without !important, the modal sets a padding due to higher specificity,
+  which causes the text to be off-center. */
+  padding-inline: 0 !important;
+  color: var(--cds-text-secondary);
+  text-align: center;
+`;
+
+export {
+  DocumentList,
+  DocumentListItem,
+  DocumentInfo,
+  DocumentFileName,
+  DocumentSize,
+  TruncationNotice,
+};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/index.tsx
@@ -11,6 +11,7 @@ import {
   toHumanReadableBytes,
   type DocumentParseResult,
 } from './parseDocumentVariable';
+import {middleTruncate} from './middleTruncate';
 import {
   DocumentCellContainer,
   DocumentIcon,
@@ -23,16 +24,6 @@ type Props = {
   result: DocumentParseResult;
 };
 
-const TRUNCATION_LIMIT = 60;
-
-function middleTruncate(text: string, limit: number): string {
-  if (text.length <= limit) {
-    return text;
-  }
-  const half = Math.floor((limit - 1) / 2);
-  return text.slice(0, half) + '\u2026' + text.slice(text.length - half);
-}
-
 const DocumentValueCell: React.FC<Props> = ({result}) => {
   if (result.type === 'single') {
     const {fileName, size} = result.document;
@@ -42,7 +33,7 @@ const DocumentValueCell: React.FC<Props> = ({result}) => {
           <Document size={16} />
         </DocumentIcon>
         <DocumentFileName title={fileName}>
-          {middleTruncate(fileName, TRUNCATION_LIMIT)}
+          {middleTruncate(fileName)}
         </DocumentFileName>
         {size !== undefined && (
           <DocumentSize>{toHumanReadableBytes(size)}</DocumentSize>

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/middleTruncate.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/middleTruncate.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+const TRUNCATION_LIMIT = 60;
+
+function middleTruncate(
+  text: string,
+  limit: number = TRUNCATION_LIMIT,
+): string {
+  if (text.length <= limit) {
+    return text;
+  }
+  const half = Math.floor((limit - 1) / 2);
+  return text.slice(0, half) + '…' + text.slice(text.length - half);
+}
+
+export {middleTruncate, TRUNCATION_LIMIT};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DownloadDocumentButton/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DownloadDocumentButton/index.tsx
@@ -33,6 +33,8 @@ const DownloadDocumentButton: React.FC<Props> = ({
       iconDescription="Download"
       tooltipPosition="top"
       tooltipAlignment="end"
+      // @ts-expect-error - Solves rendering issues in `DocumentListModal`. Not exposed through TS but used at runtime.
+      autoAlign={true}
       aria-label={`Download document for variable ${variableName}`}
     />
   );

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/VariablesTable.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/VariablesTable.tsx
@@ -28,6 +28,7 @@ import {VariableValueCell} from './VariableValueCell';
 import {parseDocumentVariable} from './DocumentValueCell/parseDocumentVariable';
 import {DownloadDocumentButton} from './DownloadDocumentButton';
 import {PreviewDocumentButton} from './DocumentPreview/PreviewDocumentButton';
+import {ViewDocumentListButton} from './DocumentList/ViewDocumentListButton';
 
 type Props = {
   scopeId: string | null;
@@ -135,6 +136,13 @@ const VariablesTable: React.FC<Props> = ({
                             variableName={name}
                           />
                         </>
+                      )}
+                      {documentResult.type === 'list' && (
+                        <ViewDocumentListButton
+                          documents={documentResult.documents}
+                          isLowerBound={documentResult.isLowerBound}
+                          variableName={name}
+                        />
                       )}
                     </>
                   );

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/documentVariable.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/documentVariable.test.tsx
@@ -196,7 +196,7 @@ describe('VariablesTab document variables', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('should not render a document-related buttons for regular variables', async () => {
+  it('should not render document-related buttons for regular variables', async () => {
     mockSearchVariables().withSuccess(searchResult([createVariable()]));
 
     render(<VariablesTab />, {wrapper: getWrapper()});

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/documentVariable.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/documentVariable.test.tsx
@@ -155,7 +155,48 @@ describe('VariablesTab document variables', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('should not render a download button for regular variables', async () => {
+  it('should render a view documents button for variables with multiple documents', async () => {
+    mockSearchVariables().withSuccess(
+      searchResult([
+        createVariable({
+          name: 'myDocumentList',
+          value: JSON.stringify([
+            makeDocumentRef({documentId: 'doc-1'}),
+            makeDocumentRef({documentId: 'doc-2'}),
+          ]),
+        }),
+      ]),
+    );
+
+    render(<VariablesTab />, {wrapper: getWrapper()});
+    await screen.findByTestId('variables-list');
+
+    const variableRow = within(screen.getByTestId('variable-myDocumentList'));
+    expect(
+      variableRow.getByLabelText('View documents for variable myDocumentList'),
+    ).toBeInTheDocument();
+  });
+
+  it('should not render a view documents button for single-document variables', async () => {
+    mockSearchVariables().withSuccess(
+      searchResult([
+        createVariable({
+          name: 'myDocument',
+          value: JSON.stringify(makeDocumentRef()),
+        }),
+      ]),
+    );
+
+    render(<VariablesTab />, {wrapper: getWrapper()});
+    await screen.findByTestId('variables-list');
+
+    const variableRow = within(screen.getByTestId('variable-myDocument'));
+    expect(
+      variableRow.queryByLabelText(/view documents for variable/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should not render a document-related buttons for regular variables', async () => {
     mockSearchVariables().withSuccess(searchResult([createVariable()]));
 
     render(<VariablesTab />, {wrapper: getWrapper()});
@@ -164,6 +205,12 @@ describe('VariablesTab document variables', () => {
     const variableRow = within(screen.getByTestId('variable-testVariableName'));
     expect(
       variableRow.queryByLabelText(/download document for variable/i),
+    ).not.toBeInTheDocument();
+    expect(
+      variableRow.queryByLabelText(/view documents for variable/i),
+    ).not.toBeInTheDocument();
+    expect(
+      variableRow.queryByLabelText(/preview document for variable/i),
     ).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Description

This PR adds a new modal that displays the content of variable's document lists. If the document list is truncated, a hint about more documents is shown at the bottom of the list.

## Related issues

closes #52915
