### PR TITLE
test: Batch delete completed process instances via toolbar

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
@@ -62,11 +62,14 @@ class OperateProcessesPage {
     rowIndex?: number,
     cellIndex?: number,
   ) => Locator;
+  readonly deleteButton: Locator;
+  readonly deleteBatchOperationConfirmButton: Locator;
   readonly batchOperationStartedMessage: (
     batchOperationType:
       | 'Resolve Incident'
       | 'Retry'
-      | 'Cancel Process Instance',
+      | 'Cancel Process Instance'
+      | 'Delete Process Instance',
   ) => Locator;
   readonly processCouldNotBeFoundMessage: Locator;
   readonly goToOperationDetailsButton: Locator;
@@ -189,11 +192,16 @@ class OperateProcessesPage {
         .nth(rowIndex)
         .getByRole('cell')
         .nth(cellIndex);
+    this.deleteButton = page.getByTestId('delete-batch-operation');
+    this.deleteBatchOperationConfirmButton = page
+      .getByRole('dialog')
+      .getByRole('button', {name: 'Delete'});
     this.batchOperationStartedMessage = (
       batchOperationType:
         | 'Resolve Incident'
         | 'Retry'
-        | 'Cancel Process Instance',
+        | 'Cancel Process Instance'
+        | 'Delete Process Instance',
     ) =>
       page.getByText(
         `Batch operation \"${batchOperationType}\" has been started`,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/batch_delete_process.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/batch_delete_process.bpmn
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_batch_delete" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.35.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+  <bpmn:process id="batchDeleteProcess" name="Batch Delete Process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="EndEvent_1" />
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="batchDeleteProcess">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="332" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1_di" bpmnElement="Flow_1">
+        <di:waypoint x="218" y="100" />
+        <di:waypoint x="332" y="100" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
@@ -18,6 +18,7 @@ import {captureScreenshot, captureFailureVideo} from '@setup';
 import {navigateToAppHome} from '@pages/UtilitiesPage';
 import {waitForAssertion} from 'utils/waitForAssertion';
 import {sleep} from 'utils/sleep';
+import {jsonHeaders} from 'utils/http';
 
 type ProcessInstance = {
   processInstanceKey: string;
@@ -241,7 +242,7 @@ let deleteTestData: {
 
 const batchDeleteProcessId = `batchDeleteProcess-${runSuffix}`;
 
-test.beforeAll(async () => {
+test.beforeAll(async ({request}) => {
   await deployWithSubstitutions('./resources/batch_delete_process.bpmn', {
     batchDeleteProcess: batchDeleteProcessId,
   });
@@ -254,14 +255,38 @@ test.beforeAll(async () => {
     })),
   };
 
-  // Allow time for all instances to auto-complete
-  await sleep(5000);
+  // Poll until all instances are COMPLETED and indexed in the search backend
+  // before the test runs. Avoids a fixed sleep that is too short on slow runners
+  // and wastes time on fast ones.
+  const instanceKeys = instances.map((i) => i.processInstanceKey.toString());
+  await expect
+    .poll(
+      async () => {
+        const response = await request.post('/v2/process-instances/search', {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              state: 'COMPLETED',
+              processInstanceKey: {$in: instanceKeys},
+            },
+          },
+        });
+        if (response.status() !== 200) {
+          throw new Error(
+            `process-instances/search returned ${response.status()}: ${await response.text()}`,
+          );
+        }
+        const result = await response.json();
+        return result.page?.totalItems ?? 0;
+      },
+      {timeout: 60_000, intervals: [2_000, 5_000]},
+    )
+    .toBe(instances.length);
 });
 
 test.describe('Delete Operations', () => {
-  test.beforeEach(async ({page, loginPage, operateHomePage}) => {
-    await navigateToApp(page, 'operate');
-    await loginPage.login('demo', 'demo');
+  test.beforeEach(async ({page, operateHomePage}) => {
+    await navigateToAppHome(page, 'operate');
     await expect(operateHomePage.operateBanner).toBeVisible();
     await operateHomePage.clickProcessesTab();
   });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
@@ -234,3 +234,98 @@ test.describe('Operations', () => {
     });
   });
 });
+
+let deleteTestData: {
+  instances: ProcessInstance[];
+};
+
+const batchDeleteProcessId = `batchDeleteProcess-${runSuffix}`;
+
+test.beforeAll(async () => {
+  await deployWithSubstitutions('./resources/batch_delete_process.bpmn', {
+    batchDeleteProcess: batchDeleteProcessId,
+  });
+
+  const instances = await createInstances(batchDeleteProcessId, 1, 5);
+  deleteTestData = {
+    instances: instances.map((instance) => ({
+      processInstanceKey: instance.processInstanceKey,
+      bpmnProcessId: batchDeleteProcessId,
+    })),
+  };
+
+  // Allow time for all instances to auto-complete
+  await sleep(5000);
+});
+
+test.describe('Delete Operations', () => {
+  test.beforeEach(async ({page, loginPage, operateHomePage}) => {
+    await navigateToApp(page, 'operate');
+    await loginPage.login('demo', 'demo');
+    await expect(operateHomePage.operateBanner).toBeVisible();
+    await operateHomePage.clickProcessesTab();
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('Delete completed instances in batch', async ({
+    operateProcessesPage,
+    operateFiltersPanelPage,
+    page,
+  }) => {
+    test.slow();
+    const instances = deleteTestData.instances;
+
+    await test.step('Enable finished instances filter and filter by process instance keys', async () => {
+      await operateFiltersPanelPage.clickFinishedInstancesCheckbox();
+      await expect(operateProcessesPage.dataList).toBeVisible();
+      await operateFiltersPanelPage.displayOptionalFilter(
+        'Process Instance Key(s)',
+      );
+      await operateFiltersPanelPage.processInstanceKeysFilter.fill(
+        instances.map((instance) => instance.processInstanceKey).join(','),
+      );
+      await expect(operateProcessesPage.dataList.getByRole('row')).toHaveCount(
+        instances.length,
+      );
+    });
+
+    await test.step('Select all completed instances', async () => {
+      await operateProcessesPage.selectAllRowsCheckbox.click();
+    });
+
+    await test.step('Click Delete batch operation button', async () => {
+      await expect(operateProcessesPage.deleteButton).toBeEnabled();
+      await operateProcessesPage.deleteButton.click();
+    });
+
+    await test.step('Confirm deletion in modal', async () => {
+      await operateProcessesPage.deleteBatchOperationConfirmButton.click();
+    });
+
+    await test.step('Verify batch delete operation started', async () => {
+      await expect(
+        operateProcessesPage.batchOperationStartedMessage(
+          'Delete Process Instance',
+        ),
+      ).toBeVisible({timeout: 60000});
+    });
+
+    await test.step('Verify instances are removed from the list after deletion', async () => {
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(
+            operateProcessesPage.noMatchingInstancesMessage,
+          ).toBeVisible();
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+        maxRetries: 5,
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Description

Adds an end-to-end Operate test that verifies deleting completed process instances in batch. This PR introduces the test BPMN resource, extends the Operate page object with delete batch operation selectors, and validates that completed instances disappear from the list after the delete operation is confirmed.

## checklist

- add a new BPMN test resource for completed-process batch delete scenarios
- extend `OperateProcessesPage` with:
  - delete batch operation button locator
  - delete confirmation modal button locator
  - support for the `Delete Process Instance` batch operation success message
- add a new Playwright E2E test covering:
  - deployment of a dedicated process
  - creation of completed instances
  - filtering finished instances by process instance keys
  - selecting all returned instances
  - triggering and confirming the delete batch operation
  - verifying the batch operation start notification
  - verifying the deleted instances no longer appear in the list

## Test details

The new test:
- deploys a simple `batch_delete_process` workflow
- creates 5 instances and waits for them to complete
- filters Operate to show only those completed instances
- performs batch deletion from the processes view
- checks for the `Delete Process Instance` batch operation started message
- retries with page reloads until the instances are no longer listed


