### PR TITLE
feat: Job priority field in Java client

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/JobFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/JobFilter.java
@@ -144,6 +144,24 @@ public interface JobFilter extends SearchRequestFilter {
   JobFilter retries(final Consumer<IntegerProperty> fn);
 
   /**
+   * Filters jobs by the specified priority. Jobs created before 8.10 have no stored priority and
+   * are excluded from results when this filter is applied.
+   *
+   * @param priority the priority of the job
+   * @return the updated filter
+   */
+  JobFilter priority(final Integer priority);
+
+  /**
+   * Filters jobs by the specified priority using {@link IntegerProperty} consumer. Jobs created
+   * before 8.10 have no stored priority and are excluded from results when this filter is applied.
+   *
+   * @param fn the priority {@link IntegerProperty} consumer of the job
+   * @return the updated filter
+   */
+  JobFilter priority(final Consumer<IntegerProperty> fn);
+
+  /**
    * Filters jobs by the specified job key.
    *
    * @param value the key of the job

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/Job.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/Job.java
@@ -37,6 +37,8 @@ public interface Job {
 
   Integer getRetries();
 
+  Integer getPriority();
+
   Boolean isDenied();
 
   String getDeniedReason();

--- a/clients/java/src/main/java/io/camunda/client/api/search/sort/JobSort.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/sort/JobSort.java
@@ -35,6 +35,8 @@ public interface JobSort extends SearchRequestSort<JobSort> {
 
   JobSort retries();
 
+  JobSort priority();
+
   JobSort jobKey();
 
   JobSort type();

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/JobFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/JobFilterImpl.java
@@ -144,6 +144,20 @@ public class JobFilterImpl
   }
 
   @Override
+  public JobFilter priority(final Integer priority) {
+    priority(b -> b.eq(priority));
+    return this;
+  }
+
+  @Override
+  public JobFilter priority(final Consumer<IntegerProperty> fn) {
+    final IntegerProperty property = new IntegerPropertyImpl();
+    fn.accept(property);
+    filter.setPriority(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
   public JobFilter jobKey(final Long value) {
     jobKey(b -> b.eq(value));
     return this;

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/JobImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/JobImpl.java
@@ -34,6 +34,7 @@ public class JobImpl implements Job {
   private final JobKind kind;
   private final ListenerEventType listenerEventType;
   private final Integer retries;
+  private final Integer priority;
   private final Boolean isDenied;
   private final String deniedReason;
   private final Boolean hasFailedWithRetriesLeft;
@@ -60,6 +61,7 @@ public class JobImpl implements Job {
     kind = EnumUtil.convert(item.getKind(), JobKind.class);
     listenerEventType = EnumUtil.convert(item.getListenerEventType(), ListenerEventType.class);
     retries = item.getRetries();
+    priority = item.getPriority();
     isDenied = item.getIsDenied();
     deniedReason = item.getDeniedReason();
     hasFailedWithRetriesLeft = item.getHasFailedWithRetriesLeft();
@@ -112,6 +114,11 @@ public class JobImpl implements Job {
   @Override
   public Integer getRetries() {
     return retries;
+  }
+
+  @Override
+  public Integer getPriority() {
+    return priority;
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/search/sort/JobSortImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/sort/JobSortImpl.java
@@ -61,6 +61,11 @@ public class JobSortImpl extends SearchRequestSortBase<JobSort> implements JobSo
   }
 
   @Override
+  public JobSort priority() {
+    return field("priority");
+  }
+
+  @Override
   public JobSort jobKey() {
     return field("jobKey");
   }

--- a/clients/java/src/test/java/io/camunda/client/job/SearchJobTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/SearchJobTest.java
@@ -88,7 +88,8 @@ public class SearchJobTest extends ClientRestTest {
                     .errorMessage(f11 -> f11.eq("errorMessage"))
                     .hasFailedWithRetriesLeft(true)
                     .isDenied(false)
-                    .retries(f12 -> f12.eq(3)))
+                    .retries(f12 -> f12.eq(3))
+                    .priority(f13 -> f13.gte(5)))
         .send()
         .join();
 
@@ -139,6 +140,19 @@ public class SearchJobTest extends ClientRestTest {
     assertThat(request.getFilter().getIsDenied()).isEqualTo(false);
     assertThat(request.getFilter().getRetries()).isNotNull();
     assertThat(request.getFilter().getRetries().get$Eq()).isEqualTo(3);
+    assertThat(request.getFilter().getPriority()).isNotNull();
+    assertThat(request.getFilter().getPriority().get$Gte()).isEqualTo(5);
+  }
+
+  @Test
+  void shouldSearchJobWithPriorityEqualityFilter() {
+    // when
+    client.newJobSearchRequest().filter(f -> f.priority(50)).send().join();
+
+    // then
+    final JobSearchQuery request = gatewayService.getLastRequest(JobSearchQuery.class);
+    assertThat(request.getFilter().getPriority()).isNotNull();
+    assertThat(request.getFilter().getPriority().get$Eq()).isEqualTo(50);
   }
 
   @ParameterizedTest
@@ -263,7 +277,9 @@ public class SearchJobTest extends ClientRestTest {
                     .isDenied()
                     .asc()
                     .retries()
-                    .desc())
+                    .desc()
+                    .priority()
+                    .asc())
         .send()
         .join();
 
@@ -272,7 +288,7 @@ public class SearchJobTest extends ClientRestTest {
     final List<SearchRequestSort> sorts =
         SearchRequestSortMapper.fromJobSearchQuerySortRequest(
             Objects.requireNonNull(request.getSort()));
-    assertThat(sorts).hasSize(20);
+    assertThat(sorts).hasSize(21);
     assertSort(sorts.get(0), "jobKey", SortOrderEnum.ASC);
     assertSort(sorts.get(1), "type", SortOrderEnum.DESC);
     assertSort(sorts.get(2), "worker", SortOrderEnum.ASC);
@@ -293,5 +309,6 @@ public class SearchJobTest extends ClientRestTest {
     assertSort(sorts.get(17), "hasFailedWithRetriesLeft", SortOrderEnum.DESC);
     assertSort(sorts.get(18), "isDenied", SortOrderEnum.ASC);
     assertSort(sorts.get(19), "retries", SortOrderEnum.DESC);
+    assertSort(sorts.get(20), "priority", SortOrderEnum.ASC);
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/JobSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/JobSearchIT.java
@@ -1054,6 +1054,87 @@ public class JobSearchIT {
   }
 
   @Test
+  void shouldSearchJobsByPriorityEq() {
+    // given
+    final var priority = 30;
+
+    // when
+    final var result =
+        camundaClient
+            .newJobSearchRequest()
+            .filter(f -> f.priority(o -> o.eq(priority)))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.items().getFirst().getType()).isEqualTo("taskABpmn");
+    assertThat(result.items().getFirst().getPriority()).isEqualTo(priority);
+  }
+
+  @Test
+  void shouldSearchJobsByPriorityLte() {
+    // given
+    final var priority = 5;
+
+    // when
+    final var result =
+        camundaClient
+            .newJobSearchRequest()
+            .filter(f -> f.priority(o -> o.lte(priority)))
+            .send()
+            .join();
+
+    assertThat(result.items()).hasSize(5);
+    assertThat(result.items())
+        .allSatisfy(j -> assertThat(j.getPriority()).isLessThanOrEqualTo(priority));
+  }
+
+  @Test
+  void shouldSearchJobsByPriorityGt() {
+    // given
+    final var priority = 20;
+
+    // when
+    final var result =
+        camundaClient
+            .newJobSearchRequest()
+            .filter(f -> f.priority(o -> o.gt(priority)))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).hasSize(2);
+    assertThat(result.items()).allSatisfy(j -> assertThat(j.getPriority()).isGreaterThan(priority));
+  }
+
+  @Test
+  void shouldSortJobsByPriorityAsc() {
+    // given/when
+    final var result =
+        camundaClient.newJobSearchRequest().sort(s -> s.priority().asc()).send().join();
+
+    // then
+    assertThat(result.items().getFirst().getPriority()).isEqualTo(-20);
+    assertThat(result.items().getFirst().getType()).isEqualTo("taskCBpmn");
+    assertThat(result.items().getLast().getPriority()).isEqualTo(50);
+    assertThat(result.items().getLast().getType()).isEqualTo("taskA");
+  }
+
+  @Test
+  void shouldSortJobsByPriorityDesc() {
+    // given/when
+    final var result =
+        camundaClient.newJobSearchRequest().sort(s -> s.priority().desc()).send().join();
+
+    // then
+    assertThat(result.items().getFirst().getPriority()).isEqualTo(50);
+    assertThat(result.items().getFirst().getType()).isEqualTo("taskA");
+    assertThat(result.items().getLast().getPriority()).isEqualTo(-20);
+    assertThat(result.items().getLast().getType()).isEqualTo("taskCBpmn");
+  }
+
+  @Test
   void shouldSearchByFromLimit() {
     // given
     final var allJobs =

--- a/qa/acceptance-tests/src/test/resources/process/job_search_process.bpmn
+++ b/qa/acceptance-tests/src/test/resources/process/job_search_process.bpmn
@@ -11,6 +11,7 @@
     <bpmn:serviceTask id="taskA_activity" name="Task A">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="taskABpmn" />
+        <zeebe:jobPriorityDefinition priority="30" />
         <zeebe:executionListeners>
           <zeebe:executionListener eventType="start" type="taskAExecutionListener" />
           <zeebe:executionListener eventType="end" type="taskAExecutionListener" />
@@ -39,6 +40,7 @@
     <bpmn:serviceTask id="taskC_activity" name="Task C">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="taskCBpmn" />
+        <zeebe:jobPriorityDefinition priority="-20" />
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0na5ala</bpmn:incoming>
       <bpmn:outgoing>Flow_1bi1z5i</bpmn:outgoing>

--- a/qa/acceptance-tests/src/test/resources/process/service_tasks_v1.bpmn
+++ b/qa/acceptance-tests/src/test/resources/process/service_tasks_v1.bpmn
@@ -14,6 +14,7 @@
     <bpmn:serviceTask id="taskA" name="Task A">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="taskA" />
+        <zeebe:jobPriorityDefinition priority="50" />
         <zeebe:ioMapping>
           <zeebe:input source="=a" target="foo" />
           <zeebe:output source="=foo" target="bar" />


### PR DESCRIPTION
## Description

Now that https://github.com/camunda/camunda/issues/53831 is delivered we need to update the Java client so that the `priority` appears:
* in the filters for Job Search
* in the sort-by fields for Job Search
* in the Job Search response

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes https://github.com/camunda/camunda/issues/53833
