### PR TITLE
[stable/8.8] ci: emit AlwaysGreen context artifacts only for failures

### DIFF
--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - run: echo "Workflow conditions met, proceeding with build"
       - name: Emit AlwaysGreen failure context
-        if: always()
+        if: ${{ always() && (failure() || cancelled()) }}
         run: |
           CONTEXT_FILE="${RUNNER_TEMP}/alwaysgreen-context-${{ github.job }}.json"
           OWNER_TEAM="none"
@@ -94,7 +94,7 @@ jobs:
             echo "- owner_team: ${OWNER_TEAM}"
           } >> "$GITHUB_STEP_SUMMARY"
       - name: Upload AlwaysGreen failure context artifact
-        if: always()
+        if: ${{ always() && (failure() || cancelled()) }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: alwaysgreen-failure-context-${{ github.job }}
@@ -132,7 +132,7 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
       - name: Emit AlwaysGreen failure context
-        if: always()
+        if: ${{ always() && (failure() || cancelled()) }}
         run: |
           CONTEXT_FILE="${RUNNER_TEMP}/alwaysgreen-context-${{ github.job }}.json"
           OWNER_TEAM="none"
@@ -150,7 +150,7 @@ jobs:
             --arg status "${{ job.status }}" \
             '{stage:$stage,failure_category:$failure_category,owner_team:$owner_team,escalation_team:$escalation_team,run_url:$run_url,status:$status}' > "$CONTEXT_FILE"
       - name: Upload AlwaysGreen failure context artifact
-        if: always()
+        if: ${{ always() && (failure() || cancelled()) }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: alwaysgreen-failure-context-${{ github.job }}
@@ -187,7 +187,7 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
       - name: Emit AlwaysGreen failure context
-        if: always()
+        if: ${{ always() && (failure() || cancelled()) }}
         run: |
           CONTEXT_FILE="${RUNNER_TEMP}/alwaysgreen-context-${{ github.job }}.json"
           OWNER_TEAM="none"
@@ -205,7 +205,7 @@ jobs:
             --arg status "${{ job.status }}" \
             '{stage:$stage,failure_category:$failure_category,owner_team:$owner_team,escalation_team:$escalation_team,run_url:$run_url,status:$status}' > "$CONTEXT_FILE"
       - name: Upload AlwaysGreen failure context artifact
-        if: always()
+        if: ${{ always() && (failure() || cancelled()) }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: alwaysgreen-failure-context-${{ github.job }}
@@ -243,7 +243,7 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
       - name: Emit AlwaysGreen failure context
-        if: always()
+        if: ${{ always() && (failure() || cancelled()) }}
         run: |
           CONTEXT_FILE="${RUNNER_TEMP}/alwaysgreen-context-${{ github.job }}.json"
           OWNER_TEAM="none"
@@ -261,7 +261,7 @@ jobs:
             --arg status "${{ job.status }}" \
             '{stage:$stage,failure_category:$failure_category,owner_team:$owner_team,escalation_team:$escalation_team,run_url:$run_url,status:$status}' > "$CONTEXT_FILE"
       - name: Upload AlwaysGreen failure context artifact
-        if: always()
+        if: ${{ always() && (failure() || cancelled()) }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: alwaysgreen-failure-context-${{ github.job }}
@@ -393,7 +393,7 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
       - name: Emit AlwaysGreen failure context
-        if: always()
+        if: ${{ always() && (failure() || cancelled()) }}
         run: |
           CONTEXT_FILE="${RUNNER_TEMP}/alwaysgreen-context-${{ github.job }}.json"
           OWNER_TEAM="none"
@@ -411,7 +411,7 @@ jobs:
             --arg status "${{ job.status }}" \
             '{stage:$stage,failure_category:$failure_category,owner_team:$owner_team,escalation_team:$escalation_team,run_url:$run_url,status:$status}' > "$CONTEXT_FILE"
       - name: Upload AlwaysGreen failure context artifact
-        if: always()
+        if: ${{ always() && (failure() || cancelled()) }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: alwaysgreen-failure-context-${{ github.job }}
@@ -440,7 +440,7 @@ jobs:
           IDENTIFIER="${IDENTIFIER:0:40}"
           echo "identifier=${IDENTIFIER}" >> "$GITHUB_OUTPUT"
       - name: Emit AlwaysGreen failure context
-        if: always()
+        if: ${{ always() && (failure() || cancelled()) }}
         run: |
           CONTEXT_FILE="${RUNNER_TEMP}/alwaysgreen-context-${{ github.job }}.json"
           OWNER_TEAM="none"
@@ -458,7 +458,7 @@ jobs:
             --arg status "${{ job.status }}" \
             '{stage:$stage,failure_category:$failure_category,owner_team:$owner_team,escalation_team:$escalation_team,run_url:$run_url,status:$status}' > "$CONTEXT_FILE"
       - name: Upload AlwaysGreen failure context artifact
-        if: always()
+        if: ${{ always() && (failure() || cancelled()) }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: alwaysgreen-failure-context-${{ github.job }}
@@ -550,7 +550,7 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
       - name: Emit AlwaysGreen failure context
-        if: always()
+        if: ${{ always() && (needs.helm-deploy.result == 'failure' || needs.helm-deploy.result == 'cancelled') }}
         run: |
           CONTEXT_FILE="${RUNNER_TEMP}/alwaysgreen-context-${{ github.job }}.json"
           OWNER_TEAM="none"
@@ -569,7 +569,7 @@ jobs:
             --arg upstream_result "${{ needs.helm-deploy.result }}" \
             '{stage:$stage,failure_category:$failure_category,owner_team:$owner_team,escalation_team:$escalation_team,run_url:$run_url,status:$status,upstream_result:$upstream_result}' > "$CONTEXT_FILE"
       - name: Upload AlwaysGreen failure context artifact
-        if: always()
+        if: ${{ always() && (needs.helm-deploy.result == 'failure' || needs.helm-deploy.result == 'cancelled') }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: alwaysgreen-failure-context-${{ github.job }}
@@ -773,7 +773,7 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
       - name: Emit AlwaysGreen failure context
-        if: always()
+        if: ${{ always() && (failure() || cancelled()) }}
         run: |
           CONTEXT_FILE="${RUNNER_TEMP}/alwaysgreen-context-${{ github.job }}.json"
           OWNER_TEAM="none"
@@ -799,7 +799,7 @@ jobs:
             --arg downstream_conclusion "${{ steps.wait-downstream.outputs.downstream_conclusion }}" \
             '{stage:$stage,failure_category:$failure_category,owner_team:$owner_team,escalation_team:$escalation_team,run_url:$run_url,status:$status,downstream_conclusion:$downstream_conclusion}' > "$CONTEXT_FILE"
       - name: Upload AlwaysGreen failure context artifact
-        if: always()
+        if: ${{ always() && (failure() || cancelled()) }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: alwaysgreen-failure-context-${{ github.job }}

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -781,7 +781,7 @@ jobs:
 
           if [[ "${{ job.status }}" == "failure" || "${{ job.status }}" == "cancelled" ]]; then
             if [[ "${{ steps.wait-downstream.outputs.downstream_conclusion }}" == "failure" ]]; then
-              OWNER_TEAM="@camunda/qa-engineering"
+              OWNER_TEAM="@camunda/test-automation-team"
               FAILURE_CATEGORY="saas_e2e"
             else
               OWNER_TEAM="@camunda/monorepo-devops-team"


### PR DESCRIPTION
Backport follow-up fix for AlwaysGreen context artifact selection.

This change updates .github/workflows/docker-build-helm-integration.yml so AlwaysGreen failure-context artifacts are emitted/uploaded only when a stage actually failed (or when helm-deploy upstream failed for the observer job).

Why:
- Success-stage artifacts with failure_category=none (e.g. should-run) can be selected ahead of real failing-stage context, producing incorrect routing and messaging.
- This preserves correct routing such as saas_e2e -> @camunda/qa-engineering.

Mainline change: https://github.com/camunda/camunda/pull/54171