### PR TITLE
feat: include broker zone in backup storage paths

### DIFF
--- a/zeebe/backup-stores/azure/pom.xml
+++ b/zeebe/backup-stores/azure/pom.xml
@@ -47,6 +47,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-atomix-cluster</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-identity</artifactId>
     </dependency>

--- a/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/FileSetManager.java
+++ b/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/FileSetManager.java
@@ -128,6 +128,7 @@ final class FileSetManager {
   }
 
   private String fileSetPath(final BackupIdentifier id, final String fileSetName) {
-    return PATH_FORMAT.formatted(id.partitionId(), id.checkpointId(), id.nodeId(), fileSetName);
+    return PATH_FORMAT.formatted(
+        id.partitionId(), id.checkpointId(), id.brokerId().id(), fileSetName);
   }
 }

--- a/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/ManifestManager.java
+++ b/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/ManifestManager.java
@@ -199,7 +199,7 @@ public final class ManifestManager {
   Manifest getManifest(final BackupIdentifier id) {
     assureContainerCreated();
     return getManifestWithPath(
-        MANIFEST_PATH_FORMAT.formatted(id.partitionId(), id.checkpointId(), id.nodeId()));
+        MANIFEST_PATH_FORMAT.formatted(id.partitionId(), id.checkpointId(), id.brokerId().id()));
   }
 
   private Manifest getManifestWithPath(final String path) {
@@ -242,7 +242,9 @@ public final class ManifestManager {
 
   private static String manifestIdPath(final BackupIdentifier backupIdentifier) {
     return MANIFEST_PATH_FORMAT.formatted(
-        backupIdentifier.partitionId(), backupIdentifier.checkpointId(), backupIdentifier.nodeId());
+        backupIdentifier.partitionId(),
+        backupIdentifier.checkpointId(),
+        backupIdentifier.brokerId().id());
   }
 
   private boolean filterBlobsByWildcard(
@@ -252,7 +254,7 @@ public final class ManifestManager {
                 MANIFEST_PATH_FORMAT.formatted(
                     wildcard.partitionId().map(Number::toString).orElse("\\d+"),
                     wildcard.checkpointPattern().asRegex(),
-                    wildcard.nodeId().map(Number::toString).orElse("\\d+")))
+                    BackupIdentifierWildcard.memberIdRegex(wildcard)))
             .asMatchPredicate();
     return pattern.test(path);
   }

--- a/zeebe/backup-stores/filesystem/pom.xml
+++ b/zeebe/backup-stores/filesystem/pom.xml
@@ -36,6 +36,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-atomix-cluster</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jdk8</artifactId>
     </dependency>

--- a/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/FileSetManager.java
+++ b/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/FileSetManager.java
@@ -121,7 +121,7 @@ final class FileSetManager {
     return contentsPath
         .resolve(String.valueOf(id.partitionId()))
         .resolve(String.valueOf(id.checkpointId()))
-        .resolve(String.valueOf(id.nodeId()))
+        .resolve(id.brokerId().id())
         .resolve(fileSetName);
   }
 }

--- a/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/ManifestManager.java
+++ b/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/ManifestManager.java
@@ -206,9 +206,7 @@ public final class ManifestManager {
 
   private Path getManifestPath(final BackupIdentifier id) {
     return getManifestPath(
-        String.valueOf(id.partitionId()),
-        String.valueOf(id.checkpointId()),
-        String.valueOf(id.nodeId()));
+        String.valueOf(id.partitionId()), String.valueOf(id.checkpointId()), id.brokerId().id());
   }
 
   private boolean filterBlobsByWildcard(
@@ -218,7 +216,7 @@ public final class ManifestManager {
                 getManifestPath(
                         wildcard.partitionId().map(Number::toString).orElse("\\d+"),
                         wildcard.checkpointPattern().asRegex(),
-                        wildcard.nodeId().map(Number::toString).orElse("\\d+"))
+                        BackupIdentifierWildcard.memberIdRegex(wildcard))
                     .toString())
             .asMatchPredicate();
     return pattern.test(path);

--- a/zeebe/backup-stores/filesystem/src/test/java/io/camunda/zeebe/backup/filesystem/ManifestManagerTest.java
+++ b/zeebe/backup-stores/filesystem/src/test/java/io/camunda/zeebe/backup/filesystem/ManifestManagerTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.backup.filesystem;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.atomix.cluster.BrokerMemberId;
 import io.camunda.zeebe.backup.api.Backup;
 import io.camunda.zeebe.backup.api.BackupIdentifier;
 import io.camunda.zeebe.backup.api.BackupIdentifierWildcard.CheckpointPattern;
@@ -155,7 +156,7 @@ class ManifestManagerTest {
             6),
         Arguments.of(
             new BackupIdentifierWildcardImpl(
-                Optional.of(1337), Optional.empty(), CheckpointPattern.any()),
+                Optional.of(BrokerMemberId.from(1337)), Optional.empty(), CheckpointPattern.any()),
             4),
         Arguments.of(
             new BackupIdentifierWildcardImpl(
@@ -163,7 +164,7 @@ class ManifestManagerTest {
             3),
         Arguments.of(
             new BackupIdentifierWildcardImpl(
-                Optional.of(1337), Optional.of(0), CheckpointPattern.of(42L)),
+                Optional.of(BrokerMemberId.from(1337)), Optional.of(0), CheckpointPattern.of(42L)),
             1));
   }
 

--- a/zeebe/backup-stores/gcs/pom.xml
+++ b/zeebe/backup-stores/gcs/pom.xml
@@ -89,6 +89,11 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>zeebe-atomix-cluster</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>zeebe-backup-testkit</artifactId>
       <classifier>tests</classifier>
       <type>test-jar</type>

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/FileSetManager.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/FileSetManager.java
@@ -184,7 +184,7 @@ final class FileSetManager {
 
   private String fileSetPath(final BackupIdentifier id, final String fileSetName) {
     return PATH_FORMAT.formatted(
-        basePath, id.partitionId(), id.checkpointId(), id.nodeId(), fileSetName);
+        basePath, id.partitionId(), id.checkpointId(), id.brokerId().id(), fileSetName);
   }
 
   private BlobInfo blobInfo(

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/ManifestManager.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/ManifestManager.java
@@ -72,7 +72,7 @@ public final class ManifestManager {
    *   <li>{@code "manifests"}
    *   <li>{@code partitionId}
    *   <li>{@code checkpointId}
-   *   <li>{@code nodeId}
+   *   <li>{@code memberId}
    *   <li>{@code "manifest.json"}
    * </ul>
    */
@@ -261,7 +261,7 @@ public final class ManifestManager {
   private BlobInfo manifestBlobInfo(final BackupIdentifier id) {
     final var blobName =
         MANIFEST_PATH_FORMAT.formatted(
-            basePath, id.partitionId(), id.checkpointId(), id.nodeId(), MANIFEST_BLOB_NAME);
+            basePath, id.partitionId(), id.checkpointId(), id.brokerId().id(), MANIFEST_BLOB_NAME);
     return BlobInfo.newBuilder(bucketInfo, blobName).setContentType("application/json").build();
   }
 
@@ -269,7 +269,7 @@ public final class ManifestManager {
       final BackupIdentifier id, final Manifest manifest) {
     final var blobName =
         MANIFEST_PATH_FORMAT.formatted(
-            basePath, id.partitionId(), id.checkpointId(), id.nodeId(), MANIFEST_BLOB_NAME);
+            basePath, id.partitionId(), id.checkpointId(), id.brokerId().id(), MANIFEST_BLOB_NAME);
     return BlobInfo.newBuilder(bucketInfo, blobName)
         .setContentType("application/json")
         .setMetadata(ManifestMetadata.fromManifest(manifest))
@@ -293,7 +293,7 @@ public final class ManifestManager {
                     Pattern.quote(basePath),
                     wildcard.partitionId().map(Number::toString).orElse("\\d+"),
                     wildcard.checkpointPattern().asRegex(),
-                    wildcard.nodeId().map(Number::toString).orElse("\\d+"),
+                    BackupIdentifierWildcard.memberIdRegex(wildcard),
                     Pattern.quote(MANIFEST_BLOB_NAME)))
             .asMatchPredicate();
     return (blob -> pattern.test(blob.getName()));

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/ManifestMetadata.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/ManifestMetadata.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.backup.gcs;
 
 import com.google.cloud.storage.Blob;
+import io.atomix.cluster.BrokerMemberId;
 import io.camunda.zeebe.backup.api.BackupDescriptor;
 import io.camunda.zeebe.backup.api.BackupIdentifier;
 import io.camunda.zeebe.backup.api.BackupStatus;
@@ -89,7 +90,7 @@ final class ManifestMetadata {
 
   /**
    * Reconstructs a {@link BackupStatus} from the GCS blob's custom metadata and path. The blob path
-   * encodes the backup identifier (partitionId/checkpointId/nodeId).
+   * encodes the backup identifier (partitionId/checkpointId/memberId).
    *
    * @return the backup status, or empty if the blob has no status metadata (e.g. written by an
    *     older version)
@@ -117,17 +118,18 @@ final class ManifestMetadata {
       final String basePath,
       final String manifestBlobName,
       final Map<String, String> metadata) {
-    // Path format: {basePath}manifests/{partitionId}/{checkpointId}/{nodeId}/manifest.json
+    // Path format: {basePath}manifests/{partitionId}/{checkpointId}/{memberId}/manifest.json
+    // where {memberId} is "zone_nodeId" for zone-aware clusters or bare "nodeId" otherwise.
     final var manifestsPrefix = basePath + "manifests/";
     final var relativePath =
         blobName.substring(manifestsPrefix.length(), blobName.length() - manifestBlobName.length());
-    // relativePath is now: {partitionId}/{checkpointId}/{nodeId}/
+    // relativePath is now: {partitionId}/{checkpointId}/{memberId}/
     final var parts = relativePath.split("/");
+    final var memberId = BrokerMemberId.from(parts[2]);
+    // Fall back to metadata zone for blobs written before zone was encoded in the path segment.
+    final var zone = memberId.zone() != null ? memberId.zone() : metadata.get(ZONE);
     return new BackupIdentifierImpl(
-        Integer.parseInt(parts[2]),
-        metadata.get(ZONE),
-        Integer.parseInt(parts[0]),
-        Long.parseLong(parts[1]));
+        memberId.nodeIdx(), zone, Integer.parseInt(parts[0]), Long.parseLong(parts[1]));
   }
 
   private static Optional<BackupDescriptor> parseDescriptor(final Map<String, String> metadata) {

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/ManifestMetadata.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/ManifestMetadata.java
@@ -126,8 +126,7 @@ final class ManifestMetadata {
     // relativePath is now: {partitionId}/{checkpointId}/{memberId}/
     final var parts = relativePath.split("/");
     final var memberId = BrokerMemberId.from(parts[2]);
-    // Fall back to metadata zone for blobs written before zone was encoded in the path segment.
-    final var zone = memberId.zone() != null ? memberId.zone() : metadata.get(ZONE);
+    final var zone = memberId.zone();
     return new BackupIdentifierImpl(
         memberId.nodeIdx(), zone, Integer.parseInt(parts[0]), Long.parseLong(parts[1]));
   }

--- a/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ManifestMetadataTest.java
+++ b/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ManifestMetadataTest.java
@@ -286,26 +286,6 @@ final class ManifestMetadataTest {
     }
 
     @Test
-    void shouldParseZoneFromMetadata() {
-      // given
-      final var metadata =
-          Map.of(
-              ManifestMetadata.STATUS_CODE, "COMPLETED",
-              ManifestMetadata.CHECKPOINT_POSITION, "500",
-              ManifestMetadata.NUMBER_OF_PARTITIONS, "3",
-              ManifestMetadata.BROKER_VERSION, "8.5.0",
-              ManifestMetadata.ZONE, "zone-a");
-      final var blob = mockBlob(blobPath(2, 3, 1), metadata);
-
-      // when
-      final var result = ManifestMetadata.toBackupStatus(blob, BASE_PATH, MANIFEST_BLOB_NAME);
-
-      // then
-      assertThat(result).isPresent();
-      assertThat(result.orElseThrow().id().zone()).isEqualTo("zone-a");
-    }
-
-    @Test
     void shouldParseFailedStatusWithReason() {
       // given
       final var metadata =

--- a/zeebe/backup-stores/s3/pom.xml
+++ b/zeebe/backup-stores/s3/pom.xml
@@ -107,6 +107,11 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>zeebe-atomix-cluster</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>zeebe-backup-testkit</artifactId>
       <classifier>tests</classifier>
       <type>test-jar</type>

--- a/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
+++ b/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
@@ -33,6 +33,7 @@ import io.camunda.zeebe.backup.s3.manifest.Manifest;
 import io.camunda.zeebe.backup.s3.manifest.NoBackupManifest;
 import io.camunda.zeebe.backup.s3.manifest.ValidBackupManifest;
 import io.camunda.zeebe.backup.s3.util.AsyncAggregatingSubscriber;
+import io.camunda.zeebe.util.MemberIdUtil;
 import io.camunda.zeebe.util.SemanticVersion;
 import java.io.IOException;
 import java.net.URI;
@@ -111,7 +112,8 @@ public final class S3BackupStore implements BackupStore {
     final var basePath = config.basePath();
     final var basePrefix = basePath.map(base -> base + "/").map(Pattern::quote).orElse("");
     final var identifierSuffix =
-        "(?:manifests/)?(?<partitionId>\\d+)/(?<checkpointId>\\d+)/(?<memberId>(?:[A-Za-z0-9-]+_)?\\d+).*";
+        "(?:manifests/)?(?<partitionId>\\d+)/(?<checkpointId>\\d+)/(?<memberId>(%s)).*"
+            .formatted(MemberIdUtil.regexPattern());
     backupIdentifierPattern = Pattern.compile("^" + basePrefix + identifierSuffix);
   }
 

--- a/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
+++ b/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.atomix.cluster.BrokerMemberId;
 import io.camunda.zeebe.backup.api.Backup;
 import io.camunda.zeebe.backup.api.BackupDescriptor;
 import io.camunda.zeebe.backup.api.BackupIdentifier;
@@ -67,7 +68,8 @@ import software.amazon.awssdk.services.s3.model.S3Object;
  * {@link BackupStore} for S3. Stores all backups in a given bucket.
  *
  * <p>All created object keys are prefixed by the {@link BackupIdentifier}, with the following
- * scheme: {@code basePath/partitionId/checkpointId/nodeId}.
+ * scheme: {@code basePath/partitionId/checkpointId/memberId}, where {@code memberId} is {@code
+ * zone_nodeId} for zone-aware clusters or just {@code nodeId} for single-zone clusters.
  *
  * <p>Each backup contains:
  *
@@ -109,7 +111,7 @@ public final class S3BackupStore implements BackupStore {
     final var basePath = config.basePath();
     final var basePrefix = basePath.map(base -> base + "/").map(Pattern::quote).orElse("");
     final var identifierSuffix =
-        "(?:manifests/)?(?<partitionId>\\d+)/(?<checkpointId>\\d+)/(?<nodeId>\\d+).*";
+        "(?:manifests/)?(?<partitionId>\\d+)/(?<checkpointId>\\d+)/(?<memberId>(?:[A-Za-z0-9-]+_)?\\d+).*";
     backupIdentifierPattern = Pattern.compile("^" + basePrefix + identifierSuffix);
   }
 
@@ -121,11 +123,13 @@ public final class S3BackupStore implements BackupStore {
     final var matcher = backupIdentifierPattern.matcher(key);
     if (matcher.matches()) {
       try {
-        final var nodeId = Integer.parseInt(matcher.group("nodeId"));
+        final var memberId = BrokerMemberId.from(matcher.group("memberId"));
         final var partitionId = Integer.parseInt(matcher.group("partitionId"));
         final var checkpointId = Long.parseLong(matcher.group("checkpointId"));
-        return Optional.of(new BackupIdentifierImpl(nodeId, partitionId, checkpointId));
-      } catch (final NumberFormatException e) {
+        return Optional.of(
+            new BackupIdentifierImpl(
+                memberId.nodeIdx(), memberId.zone(), partitionId, checkpointId));
+      } catch (final IllegalArgumentException e) {
         LOG.warn("Tried interpreting key {} as a BackupIdentifier but failed", key, e);
       }
     }
@@ -172,21 +176,22 @@ public final class S3BackupStore implements BackupStore {
   /** Backwards compatible object path for backups generated prior to 8.9 */
   public String legacyObjectPrefix(final BackupIdentifier id) {
     final var base = config.basePath();
-    return base.map(
-            s -> "%s/%s/%s/%s/".formatted(s, id.partitionId(), id.checkpointId(), id.nodeId()))
-        .orElseGet(() -> "%s/%s/%s/".formatted(id.partitionId(), id.checkpointId(), id.nodeId()));
+    final var brokerId = id.brokerId().id();
+    return base.map(s -> "%s/%s/%s/%s/".formatted(s, id.partitionId(), id.checkpointId(), brokerId))
+        .orElseGet(() -> "%s/%s/%s/".formatted(id.partitionId(), id.checkpointId(), brokerId));
   }
 
   public String objectPrefix(final BackupIdentifier id, final Directory directory) {
     final var base = config.basePath();
+    final var brokerId = id.brokerId().id();
     return base.map(
             s ->
                 "%s/%s/%s/%s/%s/"
-                    .formatted(s, directory.name, id.partitionId(), id.checkpointId(), id.nodeId()))
+                    .formatted(s, directory.name, id.partitionId(), id.checkpointId(), brokerId))
         .orElseGet(
             () ->
                 "%s/%s/%s/%s/"
-                    .formatted(directory.name, id.partitionId(), id.checkpointId(), id.nodeId()));
+                    .formatted(directory.name, id.partitionId(), id.checkpointId(), brokerId));
   }
 
   public static void validateConfig(final S3BackupConfig config) {

--- a/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/S3BackupStoreTests.java
+++ b/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/S3BackupStoreTests.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.backup.s3;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.atomix.cluster.BrokerMemberId;
 import io.camunda.zeebe.backup.api.Backup;
 import io.camunda.zeebe.backup.api.BackupIdentifierWildcard.CheckpointPattern;
 import io.camunda.zeebe.backup.api.BackupStatus;
@@ -299,7 +300,8 @@ public interface S3BackupStoreTests extends BackupStoreTestKit {
 
     // when
     final var pattern =
-        new BackupIdentifierWildcardImpl(Optional.of(1), Optional.of(2), CheckpointPattern.any());
+        new BackupIdentifierWildcardImpl(
+            Optional.of(BrokerMemberId.from(1)), Optional.of(2), CheckpointPattern.any());
     final var listedBackups = getStore().list(pattern).join();
 
     // then

--- a/zeebe/backup-stores/testkit/pom.xml
+++ b/zeebe/backup-stores/testkit/pom.xml
@@ -35,6 +35,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-atomix-cluster</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/zeebe/backup-stores/testkit/src/test/java/io/camunda/zeebe/backup/testkit/QueryingBackupStatus.java
+++ b/zeebe/backup-stores/testkit/src/test/java/io/camunda/zeebe/backup/testkit/QueryingBackupStatus.java
@@ -12,6 +12,8 @@ import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.api.BackupStatusCode;
 import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
+import io.camunda.zeebe.backup.testkit.support.TestBackupProvider;
+import java.io.IOException;
 import java.time.Duration;
 import java.util.Optional;
 import org.assertj.core.api.Assertions;
@@ -63,6 +65,21 @@ public interface QueryingBackupStatus {
   default void statusIsDoesNotExistForNonExistingBackup() {
     // when
     final var result = getStore().getStatus(new BackupIdentifierImpl(1, 1, 15));
+    // then
+    Assertions.assertThat(result)
+        .succeedsWithin(Duration.ofSeconds(10))
+        .returns(BackupStatusCode.DOES_NOT_EXIST, Assertions.from(BackupStatus::statusCode));
+  }
+
+  @Test
+  default void shouldNotReturnBackupFromDifferentZoneWithSameNodeIdx() throws IOException {
+    // given
+    final var zoneAId = new BackupIdentifierImpl(1, "zone-a", 1, 1);
+    getStore().save(TestBackupProvider.minimalBackupWithId(zoneAId)).join();
+
+    // when
+    final var result = getStore().getStatus(new BackupIdentifierImpl(1, "zone-b", 1, 1));
+
     // then
     Assertions.assertThat(result)
         .succeedsWithin(Duration.ofSeconds(10))

--- a/zeebe/backup-stores/testkit/src/test/java/io/camunda/zeebe/backup/testkit/support/WildcardBackupProvider.java
+++ b/zeebe/backup-stores/testkit/src/test/java/io/camunda/zeebe/backup/testkit/support/WildcardBackupProvider.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.backup.testkit.support;
 
+import io.atomix.cluster.BrokerMemberId;
 import io.camunda.zeebe.backup.api.BackupIdentifierWildcard;
 import io.camunda.zeebe.backup.api.BackupIdentifierWildcard.CheckpointPattern;
 import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
@@ -41,7 +42,9 @@ public class WildcardBackupProvider implements ArgumentsProvider {
                 "Backups of arbitrary partitions",
                 new WildcardTestParameter(
                     new BackupIdentifierWildcardImpl(
-                        Optional.of(1), Optional.empty(), CheckpointPattern.of(1L)),
+                        Optional.of(BrokerMemberId.from(1)),
+                        Optional.empty(),
+                        CheckpointPattern.of(1L)),
                     List.of(
                         new BackupIdentifierImpl(1, 1, 1),
                         new BackupIdentifierImpl(1, 2, 1),
@@ -53,7 +56,9 @@ public class WildcardBackupProvider implements ArgumentsProvider {
                 "Backups of arbitrary checkpoints",
                 new WildcardTestParameter(
                     new BackupIdentifierWildcardImpl(
-                        Optional.of(1), Optional.of(1), CheckpointPattern.any()),
+                        Optional.of(BrokerMemberId.from(1)),
+                        Optional.of(1),
+                        CheckpointPattern.any()),
                     List.of(
                         new BackupIdentifierImpl(1, 1, 1),
                         new BackupIdentifierImpl(1, 1, 2),
@@ -65,7 +70,9 @@ public class WildcardBackupProvider implements ArgumentsProvider {
                 "Backups matching checkpoint prefix",
                 new WildcardTestParameter(
                     new BackupIdentifierWildcardImpl(
-                        Optional.of(1), Optional.of(1), CheckpointPattern.of("10*")),
+                        Optional.of(BrokerMemberId.from(1)),
+                        Optional.of(1),
+                        CheckpointPattern.of("10*")),
                     List.of(
                         new BackupIdentifierImpl(1, 1, 10),
                         new BackupIdentifierImpl(1, 1, 100),
@@ -80,7 +87,9 @@ public class WildcardBackupProvider implements ArgumentsProvider {
                 "Backups of arbitrary partitions and checkpoints",
                 new WildcardTestParameter(
                     new BackupIdentifierWildcardImpl(
-                        Optional.of(1), Optional.empty(), CheckpointPattern.any()),
+                        Optional.of(BrokerMemberId.from(1)),
+                        Optional.empty(),
+                        CheckpointPattern.any()),
                     List.of(
                         new BackupIdentifierImpl(1, 1, 3),
                         new BackupIdentifierImpl(1, 2, 2),

--- a/zeebe/backup-stores/testkit/src/test/java/io/camunda/zeebe/backup/testkit/support/WildcardBackupProvider.java
+++ b/zeebe/backup-stores/testkit/src/test/java/io/camunda/zeebe/backup/testkit/support/WildcardBackupProvider.java
@@ -130,7 +130,21 @@ public class WildcardBackupProvider implements ArgumentsProvider {
                         new BackupIdentifierImpl(1, 1, 1),
                         new BackupIdentifierImpl(2, 2, 2),
                         new BackupIdentifierImpl(3, 3, 3)),
-                    List.of()))));
+                    List.of()))),
+        Arguments.of(
+            Named.of(
+                "Backups of same nodeIdx in different zones are zone-isolated",
+                new WildcardTestParameter(
+                    new BackupIdentifierWildcardImpl(
+                        Optional.of(BrokerMemberId.from("zone-a", 1)),
+                        Optional.empty(),
+                        CheckpointPattern.any()),
+                    List.of(
+                        new BackupIdentifierImpl(1, "zone-a", 1, 1),
+                        new BackupIdentifierImpl(1, "zone-a", 1, 2)),
+                    List.of(
+                        new BackupIdentifierImpl(1, "zone-b", 1, 1),
+                        new BackupIdentifierImpl(1, null, 1, 1))))));
   }
 
   public record WildcardTestParameter(

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupIdentifier.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupIdentifier.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.backup.api;
 
+import io.atomix.cluster.BrokerMemberId;
 import org.jspecify.annotations.Nullable;
 
 /** Uniquely identifies a backup stored in the BackupStore. */
@@ -32,4 +33,11 @@ public interface BackupIdentifier {
    * @return id of the checkpoint included in the backup
    */
   long checkpointId();
+
+  /**
+   * @return the broker member identifier combining zone and nodeId, for use in backup storage paths
+   */
+  default BrokerMemberId brokerId() {
+    return BrokerMemberId.from(zone(), nodeId());
+  }
 }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupIdentifierWildcard.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupIdentifierWildcard.java
@@ -7,8 +7,11 @@
  */
 package io.camunda.zeebe.backup.api;
 
+import io.atomix.cluster.BrokerMemberId;
 import io.camunda.zeebe.backup.api.BackupIdentifierWildcard.CheckpointPattern.Exact;
+import io.camunda.zeebe.util.MemberIdUtil;
 import java.util.Optional;
+import java.util.regex.Pattern;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
@@ -19,9 +22,9 @@ import org.jspecify.annotations.Nullable;
 @NullMarked
 public interface BackupIdentifierWildcard {
   /**
-   * @return id of the broker which took this backup.
+   * @return the broker that took this backup, or empty to match any broker
    */
-  Optional<Integer> nodeId();
+  Optional<BrokerMemberId> brokerId();
 
   /**
    * @return id of the partition of which the backup is taken
@@ -42,7 +45,7 @@ public interface BackupIdentifierWildcard {
 
   /**
    * Tries to build the longest possible prefix based on the given wildcard. The prefix is
-   * constructed as follows: {@code ${partitionId}/${checkpointId}/${nodeId}}. If a field is not
+   * constructed as follows: {@code ${partitionId}/${checkpointId}/${brokerId}}. If a field is not
    * present or is a non-exact match, all following fields are omitted. For example, if the
    * checkpoint id should match a {@link CheckpointPattern.Prefix prefix}, the returned prefix is
    * {@code ${partitionId}/${checkpointPattern.Prefix}}. If none of the fields are present, an empty
@@ -59,12 +62,21 @@ public interface BackupIdentifierWildcard {
 
     if (wildcard.checkpointPattern() instanceof Exact) {
       prefix.append("/");
-      // Checkpoint pattern is exact so we can include node id if present
-      if (wildcard.nodeId().isPresent()) {
-        prefix.append(wildcard.nodeId().get());
-      }
+      wildcard.brokerId().ifPresent(id -> prefix.append(id.id()));
     }
     return prefix.toString();
+  }
+
+  /**
+   * Returns a regex that matches the broker member path segment for the given wildcard. When
+   * brokerId is present, returns the exact encoded segment. Otherwise returns a pattern that
+   * matches the full set of possible forms (both zoned and zone-less).
+   */
+  static String memberIdRegex(final BackupIdentifierWildcard wildcard) {
+    return wildcard
+        .brokerId()
+        .map(id -> Pattern.quote(id.id()))
+        .orElse(MemberIdUtil.regexPattern());
   }
 
   sealed interface CheckpointPattern {

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/common/BackupIdentifierWildcardImpl.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/common/BackupIdentifierWildcardImpl.java
@@ -7,18 +7,21 @@
  */
 package io.camunda.zeebe.backup.common;
 
+import io.atomix.cluster.BrokerMemberId;
 import io.camunda.zeebe.backup.api.BackupIdentifier;
 import io.camunda.zeebe.backup.api.BackupIdentifierWildcard;
 import java.util.Optional;
 import java.util.StringJoiner;
 
 public record BackupIdentifierWildcardImpl(
-    Optional<Integer> nodeId, Optional<Integer> partitionId, CheckpointPattern checkpointPattern)
+    Optional<BrokerMemberId> brokerId,
+    Optional<Integer> partitionId,
+    CheckpointPattern checkpointPattern)
     implements BackupIdentifierWildcard {
 
   @Override
   public boolean matches(final BackupIdentifier id) {
-    return (nodeId.isEmpty() || nodeId.get().equals(id.nodeId()))
+    return (brokerId.isEmpty() || brokerId.get().equals(id.brokerId()))
         && (partitionId.isEmpty() || partitionId.get().equals(id.partitionId()))
         && checkpointPattern.matches(id.checkpointId());
   }
@@ -26,7 +29,7 @@ public record BackupIdentifierWildcardImpl(
   @Override
   public String toString() {
     final var result = new StringJoiner(", ", "Wildcard{", "}");
-    nodeId.ifPresent(id -> result.add("nodeId=" + id));
+    brokerId.ifPresent(id -> result.add("brokerId=" + id));
     partitionId.ifPresent(id -> result.add("partitionId=" + id));
     result.add("checkpointPattern=" + checkpointPattern);
     return result.toString();

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/api/BackupIdentifierWildcardTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/api/BackupIdentifierWildcardTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.backup.api;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.atomix.cluster.BrokerMemberId;
 import io.camunda.zeebe.backup.api.BackupIdentifierWildcard.CheckpointPattern;
 import io.camunda.zeebe.backup.api.BackupIdentifierWildcard.CheckpointPattern.Any;
 import io.camunda.zeebe.backup.api.BackupIdentifierWildcard.CheckpointPattern.Exact;
@@ -48,23 +49,51 @@ class BackupIdentifierWildcardTest {
   }
 
   @Test
-  void shouldBuildPrefixWithPartitionIdAndExactCheckpointAndNodeId() {
+  void shouldIncludeBrokerIdInPrefixWhenPresent() {
     // given
     final var wildcard =
-        new BackupIdentifierWildcardImpl(Optional.of(1), Optional.of(2), new Exact(100));
+        new BackupIdentifierWildcardImpl(
+            Optional.of(BrokerMemberId.from("zone-a", 1)), Optional.of(2), new Exact(100));
 
     // when
     final var prefix = BackupIdentifierWildcard.asPrefix(wildcard);
 
     // then
-    assertThat(prefix).isEqualTo("2/100/1");
+    assertThat(prefix).isEqualTo("2/100/zone-a_1");
+  }
+
+  @Test
+  void shouldIncludeBareNodeIdInPrefixForZonelessBroker() {
+    // given
+    final var wildcard =
+        new BackupIdentifierWildcardImpl(
+            Optional.of(BrokerMemberId.from(null, 5)), Optional.of(2), new Exact(100));
+
+    // when
+    final var prefix = BackupIdentifierWildcard.asPrefix(wildcard);
+
+    // then
+    assertThat(prefix).isEqualTo("2/100/5");
+  }
+
+  @Test
+  void shouldOmitBrokerIdFromPrefixWhenAbsent() {
+    // given — broker-agnostic wildcard: matches any broker
+    final var wildcard =
+        new BackupIdentifierWildcardImpl(Optional.empty(), Optional.of(2), new Exact(100));
+
+    // when
+    final var prefix = BackupIdentifierWildcard.asPrefix(wildcard);
+
+    // then
+    assertThat(prefix).isEqualTo("2/100/");
   }
 
   @Test
   void shouldBuildPrefixWithPartitionIdAndCheckpointPrefix() {
     // given
     final var wildcard =
-        new BackupIdentifierWildcardImpl(Optional.of(1), Optional.of(2), new Prefix("10"));
+        new BackupIdentifierWildcardImpl(Optional.empty(), Optional.of(2), new Prefix("10"));
 
     // when
     final var prefix = BackupIdentifierWildcard.asPrefix(wildcard);
@@ -77,7 +106,7 @@ class BackupIdentifierWildcardTest {
   void shouldReturnEmptyPrefixWhenNoPartitionId() {
     // given
     final var wildcard =
-        new BackupIdentifierWildcardImpl(Optional.of(1), Optional.empty(), new Prefix("10"));
+        new BackupIdentifierWildcardImpl(Optional.empty(), Optional.empty(), new Prefix("10"));
 
     // when
     final var prefix = BackupIdentifierWildcard.asPrefix(wildcard);
@@ -90,7 +119,7 @@ class BackupIdentifierWildcardTest {
   void shouldBuildPrefixWithAnyCheckpoint() {
     // given
     final var wildcard =
-        new BackupIdentifierWildcardImpl(Optional.of(1), Optional.of(2), new Any());
+        new BackupIdentifierWildcardImpl(Optional.empty(), Optional.of(2), new Any());
 
     // when
     final var prefix = BackupIdentifierWildcard.asPrefix(wildcard);

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/MemberIdUtil.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/MemberIdUtil.java
@@ -20,7 +20,7 @@ public final class MemberIdUtil {
 
   private static final Pattern ZONE_PATTERN = Pattern.compile("^[A-Za-z0-9][A-Za-z0-9-]*$");
   private static final Pattern MEMBER_ID_PATTERN =
-      Pattern.compile("(?:[A-Za-z0-9][A-Za-z0-9-]+_)?\\d+");
+      Pattern.compile("(?:[A-Za-z0-9][A-Za-z0-9-]*_)?\\d+");
   private static final int MAX_ZONE_LENGTH = 63;
 
   private MemberIdUtil() {}

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/MemberIdUtil.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/MemberIdUtil.java
@@ -19,6 +19,8 @@ import org.jspecify.annotations.Nullable;
 public final class MemberIdUtil {
 
   private static final Pattern ZONE_PATTERN = Pattern.compile("^[A-Za-z0-9][A-Za-z0-9-]*$");
+  private static final Pattern MEMBER_ID_PATTERN =
+      Pattern.compile("(?:[A-Za-z0-9][A-Za-z0-9-]+_)?\\d+");
   private static final int MAX_ZONE_LENGTH = 63;
 
   private MemberIdUtil() {}
@@ -67,5 +69,13 @@ public final class MemberIdUtil {
       return Integer.toString(nodeId);
     }
     return zone + "_" + nodeId;
+  }
+
+  public static Pattern regex() {
+    return MEMBER_ID_PATTERN;
+  }
+
+  public static String regexPattern() {
+    return regex().pattern();
   }
 }

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/MemberIdUtilTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/MemberIdUtilTest.java
@@ -39,17 +39,12 @@ public class MemberIdUtilTest {
     // given / when / then
     assertThatThrownBy(() -> MemberIdUtil.validateZone(zone))
         .isInstanceOf(IllegalArgumentException.class);
-
-    assertThat(MemberIdUtil.regex().matcher(zone).matches()).isFalse();
   }
 
   @ParameterizedTest
   @MethodSource("illegalZones")
   void shouldThrowWhenZoneIsIllegalRegex(final String zone) {
     // given / when / then
-    assertThatThrownBy(() -> MemberIdUtil.validateZone(zone))
-        .isInstanceOf(IllegalArgumentException.class);
-
     assertThat(MemberIdUtil.regex().matcher(zone).matches()).isFalse();
   }
 

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/MemberIdUtilTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/MemberIdUtilTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.util;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class MemberIdUtilTest {
+
+  static Stream<Named<String>> illegalZones() {
+    return Stream.of(
+        Named.of("empty", ""),
+        Named.of("blank", "   "),
+        Named.of("contains underscore", "zone_a"),
+        Named.of("contains slash", "zone/a"),
+        Named.of("contains dot", "zone.a"),
+        Named.of("starts with hyphen", "-zone"),
+        Named.of("exceeds max length", "a".repeat(64)),
+        Named.of("contains whitespace", "  eu-west  "));
+  }
+
+  static Stream<Named<String>> validMemberIds() {
+    return Stream.of(Named.of("zoned", "us-east1_2"), Named.of("zoned", "2"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("illegalZones")
+  void shouldThrowWhenZoneIsIllegalValidatingZone(final String zone) {
+    // given / when / then
+    assertThatThrownBy(() -> MemberIdUtil.validateZone(zone))
+        .isInstanceOf(IllegalArgumentException.class);
+
+    assertThat(MemberIdUtil.regex().matcher(zone).matches()).isFalse();
+  }
+
+  @ParameterizedTest
+  @MethodSource("illegalZones")
+  void shouldThrowWhenZoneIsIllegalRegex(final String zone) {
+    // given / when / then
+    assertThatThrownBy(() -> MemberIdUtil.validateZone(zone))
+        .isInstanceOf(IllegalArgumentException.class);
+
+    assertThat(MemberIdUtil.regex().matcher(zone).matches()).isFalse();
+  }
+
+  @ParameterizedTest
+  @MethodSource("validMemberIds")
+  void shouldMatchMemberIdWithRegex(final String memberId) {
+    final var matcher = MemberIdUtil.regex().matcher(memberId);
+    assertThat(matcher.matches()).isTrue();
+  }
+}

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/MemberIdUtilTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/MemberIdUtilTest.java
@@ -30,7 +30,12 @@ public class MemberIdUtilTest {
   }
 
   static Stream<Named<String>> validMemberIds() {
-    return Stream.of(Named.of("zoned", "us-east1_2"), Named.of("zoned", "2"));
+    return Stream.of(
+        Named.of("zoned", "us-east1_2"),
+        Named.of("zoned 1 letter", "a_2"),
+        Named.of("zoned 1 number", "1_2"),
+        Named.of("zoned w/ 63 chars", "b".repeat(63) + "_2"),
+        Named.of("without zone", "2"));
   }
 
   @ParameterizedTest


### PR DESCRIPTION
Zone-aware brokers now encode their identity as "zone_nodeId" instead of a "bare" integer nodeId.
Zone-less clusters continue to write bare integer segments ("1"), so existing backups remain readable without migration.

BackupIdentifier gains a default memberId() accessor that returns the BrokerMemberId for the backup path. BackupIdentifierWildcard gains a zone() method and a memberIdRegex() helper used by all store implementations when building listing/filter patterns. All four backup stores (S3, GCS, Azure, Filesystem) now route path construction through BrokerMemberId.toPathSegment().

GCS ManifestMetadata falls back to the stored metadata zone for blobs written before zone was encoded in the path segment (backward compat for the intermediate format introduced in the prior commit on this branch).

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #52809
