### PR TITLE
ci: add nightly orchestration cluster fix agent (initial implementation)

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
@@ -5,7 +5,7 @@
 #              triggers the matching on-demand workflow(s) and patches the PR body with
 #              the run URL(s) for verification.
 # type: CI
-# owner: @camunda/qa-engineering
+# owner: @camunda/test-automation-team
 ---
 name: C8 Orchestration Cluster Nightly Fix Agent
 

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
@@ -145,7 +145,7 @@ jobs:
         run: |
           go install github.com/camunda/workspace-cli/cmd/workspace@latest
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
-          npm install -g @anthropic-ai/claude-code
+          npm install -g @anthropic-ai/claude-code@2.1.156
           claude --version
 
       - name: Compute workspace name
@@ -314,17 +314,15 @@ jobs:
               done
             fi
 
-            # Patch PR body to add the verification links
+            # Patch PR body with the verification links (idempotent: strip any
+            # existing "## On-demand verification runs" section before appending
+            # so re-runs do not accumulate duplicate blocks)
             current_body=$(gh pr view "$pr_number" --repo "$REPO" --json body --jq '.body')
-            verification_block="
-
-          ## On-demand verification runs
-          "
-            [ -n "$e2e_run_url" ] && verification_block+="- E2E: ${e2e_run_url}
-          "
-            [ -n "$api_run_url" ] && verification_block+="- API: ${api_run_url}
-          "
-            new_body="${current_body}${verification_block}"
+            base_body=$(printf '%s' "$current_body" | sed '/^## On-demand verification runs/,$d' | sed 's/[[:space:]]*$//')
+            verification_block=$'\n\n## On-demand verification runs\n'
+            [ -n "$e2e_run_url" ] && verification_block+="- E2E: ${e2e_run_url}"$'\n'
+            [ -n "$api_run_url" ] && verification_block+="- API: ${api_run_url}"$'\n'
+            new_body="${base_body}${verification_block}"
             printf '%s' "$new_body" | gh pr edit "$pr_number" --repo "$REPO" --body-file - || true
           done
 

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
@@ -399,7 +399,7 @@ jobs:
           if-no-files-found: warn
 
       - name: Slack thread reply
-        if: always() && github.event.inputs.slack_thread_ts != ''
+        if: always() && github.event.inputs.slack_thread_ts != '' && github.event.inputs.slack_channel != ''
         env:
           SLACK_BOT_USER_OAUTH_TOKEN: ${{ steps.secrets.outputs.SLACK_BOT_USER_OAUTH_TOKEN }}
           SLACK_THREAD_TS:            ${{ github.event.inputs.slack_thread_ts }}

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
@@ -164,157 +164,34 @@ jobs:
           # Pre-create artifact dirs so Claude does not need to mkdir
           mkdir -p /tmp/nightly-artifacts
 
-          prompt=$(cat <<'EOF_PROMPT'
-          You are a Camunda QA engineer fixing failing nightly tests in the camunda/camunda
-          monorepo. Working directory: the current repo checkout (already on the correct
-          target branch). Test suite path: qa/c8-orchestration-cluster-e2e-test-suite/.
+          # The prompt is deliberately terse: all diagnosis steps, artifact-download
+          # patterns, PR rules, and constraints live in AGENTS.md (which Claude must
+          # read first). This keeps the per-run prompt small and the source-of-truth
+          # for behaviour in a single file the team can update without editing CI.
+          claude --dangerously-skip-permissions -p "$(cat <<EOF
+          You are the Camunda orchestration-cluster nightly fix agent. The repo is
+          already on the correct target branch (${TARGET_REF}).
 
-          Read qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md (its "## Nightly Fix Agent"
-          section) for diagnosis steps and HARD CONSTRAINTS before doing anything else.
+          STEP 0 — read qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md, the
+          "## Nightly Fix Agent" section. That file is your full operating manual:
+          diagnosis steps, artifact-download patterns, constraints (NEVER skip/fixme),
+          PR conventions ('test:' not 'fix:'), and the /tmp/fix-meta.json schema.
 
-          ## HARD RULES — no exceptions
-          - NEVER use test.skip(), test.fixme(), test.only, or any skip/pending variant.
-            If you cannot write a code fix, write {"prs":[]} to /tmp/fix-meta.json and stop.
-          - Fix ONLY the tests listed in /tmp/test_specs.json. Ignore any additional failures
-            visible in the downloaded artifacts — they are handled by separate agents.
-          - Minimal diff. No refactoring, no dependency bumps, no unrelated edits.
-          - Lint before commit: cd qa/c8-orchestration-cluster-e2e-test-suite &&
-            npx prettier --write <changed-files> && npx eslint <changed-files> --fix.
-            Fix any remaining eslint errors before committing.
+          Failing tests to fix are in /tmp/test_specs.json.
+          Fix ONLY those entries — ignore other failures visible in artifacts.
 
-          ## Step 1 — Download nightly artifacts
+          Context (env vars already exported):
+            VERSION=${VERSION}  TARGET_REF=${TARGET_REF}  SAFE_VERSION=${SAFE_VERSION}
+            E2E_RUN_ID=${E2E_RUN_ID}  API_ES_RUN_ID=${API_ES_RUN_ID}  API_RDBMS_RUN_ID=${API_RDBMS_RUN_ID}
+            HAS_E2E=${HAS_E2E}  HAS_API_ES=${HAS_API_ES}  HAS_API_RDBMS=${HAS_API_RDBMS}
+            TRIAGE_RUN_URL=${TRIAGE_RUN_URL}  REPO=${REPO}
 
-          Read /tmp/test_specs.json — each entry has:
-            file         : path relative to qa/c8-orchestration-cluster-e2e-test-suite/
-            test_name    : the test("...") title
-            error        : first line of the failure from json-report results.json
-            test_type    : "e2e" or "api"
-            tasklist_mode: "v1" or "v2" (E2E only)
-            database     : RDBMS database name (API only, e.g. "Postgres 17") or "elasticsearch"
+          Branch name to use: fix/nightly-${VERSION}-<short-slug>.
+          Commit + PR title prefix: 'test:' (NEVER 'fix:' — commitlint rejects it).
 
-          Environment:
-            VERSION          = the camunda version (8.7 / 8.8 / 8.9 / main)
-            SAFE_VERSION     = "stable-${VERSION}" for stable branches, "main" for main
-            E2E_RUN_ID       = run ID for the failing E2E nightly (empty if no E2E failed)
-            API_ES_RUN_ID    = run ID for the failing API ES nightly
-            API_RDBMS_RUN_ID = run ID for the failing API RDBMS nightly (8.9 / main only)
-            HAS_E2E, HAS_API_ES, HAS_API_RDBMS : "true" / "false" flags
-
-          Download exactly what is needed:
-
-            if [ "$HAS_E2E" = "true" ] && [ -n "$E2E_RUN_ID" ]; then
-              for mode in v1 v2; do
-                # Skip absent modes: 8.7 has no v2, main has no v1
-                gh run download "$E2E_RUN_ID" --repo "$REPO" \
-                  --pattern "json-report-nightly-e2e-${SAFE_VERSION}-${mode}" \
-                  --dir "/tmp/nightly-artifacts/e2e-${mode}" 2>/dev/null || true
-                gh run download "$E2E_RUN_ID" --repo "$REPO" \
-                  --pattern "html-report-nightly-e2e-${SAFE_VERSION}-${mode}" \
-                  --dir "/tmp/nightly-artifacts/e2e-${mode}-html" 2>/dev/null || true
-              done
-            fi
-
-            if [ "$HAS_API_ES" = "true" ] && [ -n "$API_ES_RUN_ID" ]; then
-              gh run download "$API_ES_RUN_ID" --repo "$REPO" \
-                --pattern "json-report-nightly-api-${SAFE_VERSION}" \
-                --dir /tmp/nightly-artifacts/api-es 2>/dev/null || true
-            fi
-
-            if [ "$HAS_API_RDBMS" = "true" ] && [ -n "$API_RDBMS_RUN_ID" ]; then
-              # Only download artifacts for databases that actually have failing tests
-              jq -r '[.[] | select(.test_type == "api" and .database != null
-                       and .database != "" and .database != "elasticsearch")
-                       | .database] | unique[]' /tmp/test_specs.json | while read -r db; do
-                gh run download "$API_RDBMS_RUN_ID" --repo "$REPO" \
-                  --pattern "json-report-nightly-api-rdbms-${SAFE_VERSION}-${db}" \
-                  --dir "/tmp/nightly-artifacts/api-rdbms" 2>/dev/null || true
-              done
-            fi
-
-          ## Step 2 — Diagnose each failing test
-
-          For each entry in /tmp/test_specs.json:
-
-          1. Read the test file at qa/c8-orchestration-cluster-e2e-test-suite/<file>.
-             Read any imported page objects / helpers.
-          2. For E2E entries: open the matching screenshot under
-             /tmp/nightly-artifacts/e2e-<mode>-html/.../data/<image>.png — you can read PNG
-             images directly. Cross-reference with the error message and the test code.
-          3. For API entries: read the JSON report under /tmp/nightly-artifacts/api-es/results.json
-             (or api-rdbms/). Look at the full error message + stack trace + any response body.
-          4. Form a hypothesis. Match it to a specific assertion / action in the test or page
-             object. If the failure is clearly a product bug (not a test bug) and no test-side
-             fix is reasonable, write {"prs":[]} to /tmp/fix-meta.json and stop. Do not skip.
-
-          ## Step 3 — Apply the fix and open the PR
-
-          1. Determine a short slug describing the fix (e.g. "operate-process-name-wait",
-             "tasklist-task-assignment-flake").
-          2. Create branch: git checkout -b "fix/nightly-${VERSION}-<slug>"
-          3. Edit files under qa/c8-orchestration-cluster-e2e-test-suite/ only.
-          4. Run lint (see HARD RULES) on changed files. Fix any eslint errors.
-          5. Stage + commit (Conventional Commits, no scope — commitlint enforces scope-empty):
-               git add <files>
-               git commit -m "test: fix nightly ${VERSION} failures (<slug>)"
-          6. Push: git push -u origin "fix/nightly-${VERSION}-<slug>"
-          7. Check for existing open PRs first:
-               gh pr list --repo "$REPO" --search "nightly is:open label:failing-test-fix" \
-                          --json number,title,baseRefName
-             If an open PR exists targeting the same base branch (${TARGET_REF}) for the same
-             root cause, COMMENT on it instead of opening a new one, and add its number to
-             /tmp/fix-meta.json.
-          8. Open a draft PR (note: title type is "test:" per camunda/camunda commitlint rules
-             — do NOT use "fix:" for test-only changes):
-               gh pr create --repo "$REPO" --draft \
-                 --base "${TARGET_REF}" \
-                 --head "fix/nightly-${VERSION}-<slug>" \
-                 --label "failing-test-fix" \
-                 --title "test: fix nightly ${VERSION} failures (<slug>)" \
-                 --body "$(cat <<'PRBODY'
-          ## Summary
-          Bot-opened fix for failing tests detected by the nightly triage agent.
-
-          **Version:** ${VERSION} (target: \`${TARGET_REF}\`)
-          **Triage run:** ${TRIAGE_RUN_URL}
-          **Failing nightly runs:**
-          - E2E: <link if applicable>
-          - API ES: <link if applicable>
-          - API RDBMS: <link if applicable>
-
-          ## Root cause analysis
-          <Claude's diagnosis>
-
-          ## Tests fixed
-          <bulleted list from test_specs>
-
-          ## Verification
-          On-demand runs will be linked here automatically by the workflow.
-
-          ---
-          Generated by the nightly fix agent. Review carefully — this is a bot fix.
-          PRBODY
+          When done (or if no fix is possible), write /tmp/fix-meta.json and stop.
+          EOF
           )"
-
-          ## Step 4 — Write the result manifest
-
-          Write /tmp/fix-meta.json with this shape:
-            {"prs": [{"number": 1234, "owner": "camunda", "repo": "camunda",
-                      "branch": "fix/nightly-${VERSION}-<slug>",
-                      "has_e2e": <bool>, "has_api": <bool>}]}
-          Multiple PRs: one object per PR. {"prs": []} if no PR was opened.
-
-          STOP after writing the file. Do not run any further commands.
-          EOF_PROMPT
-          )
-
-          # Substitute environment variables into the prompt at the heredoc level (the
-          # outer heredoc was quoted with 'EOF_PROMPT' to preserve $-references in the
-          # Bash snippets — but we need a small set of variables resolved upfront for
-          # the PR body template). Easier: write the prompt with envsubst on a narrow allowlist.
-          export VERSION TARGET_REF TRIAGE_RUN_URL REPO
-          prompt_resolved=$(printf '%s' "$prompt" | envsubst '$VERSION $TARGET_REF $TRIAGE_RUN_URL $REPO')
-
-          claude -p "$prompt_resolved" --dangerously-skip-permissions
 
       - name: Trigger on-demand verification runs and patch PR body
         if: always()

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
@@ -139,10 +139,44 @@ jobs:
             --description "Bot-opened fix PR for failing nightly orchestration cluster tests" \
             2>/dev/null || true
 
-      - name: Install Claude Code CLI
+      - name: Install workspace-cli and Claude Code CLI
+        env:
+          GOPRIVATE: github.com/camunda/*
         run: |
+          go install github.com/camunda/workspace-cli/cmd/workspace@latest
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
           npm install -g @anthropic-ai/claude-code
           claude --version
+
+      - name: Compute workspace name
+        id: ws
+        env:
+          VERSION: ${{ github.event.inputs.version }}
+        run: |
+          name="fix-oc-${VERSION}-$(date -u +%Y%m%d-%H%M)-${GITHUB_RUN_ID}"
+          echo "name=${name}" >> "$GITHUB_OUTPUT"
+
+      - name: Stage workspace manifest
+        run: |
+          mkdir -p "$HOME/.workspace-templates"
+          cp qa/c8-orchestration-cluster-e2e-test-suite/workspace-templates/camunda-orchestration-cluster-nightly.yaml \
+             "$HOME/.workspace-templates/camunda-orchestration-cluster-nightly.yaml"
+          cp qa/c8-orchestration-cluster-e2e-test-suite/workspace-templates/camunda-orchestration-cluster-nightly.guidance.md \
+             "$HOME/.workspace-templates/camunda-orchestration-cluster-nightly.guidance.md"
+
+      - name: Create workspace
+        run: |
+          workspace create "${{ steps.ws.outputs.name }}" \
+            --manifest camunda-orchestration-cluster-nightly
+
+      - name: Switch workspace to target branch
+        env:
+          TARGET_REF:     ${{ steps.target.outputs.ref }}
+          WORKSPACE_NAME: ${{ steps.ws.outputs.name }}
+        run: |
+          ws_dir="$HOME/workspaces/${WORKSPACE_NAME}/camunda"
+          git -C "$ws_dir" fetch --depth 1 origin "${TARGET_REF}"
+          git -C "$ws_dir" checkout "${TARGET_REF}"
 
       - name: Determine which artifact downloads + on-demand verifications are needed
         id: scope
@@ -174,8 +208,10 @@ jobs:
           HAS_API_ES:          ${{ steps.scope.outputs.has_api_es }}
           HAS_API_RDBMS:       ${{ steps.scope.outputs.has_api_rdbms }}
           REPO:                ${{ github.repository }}
+          WORKSPACE_NAME:      ${{ steps.ws.outputs.name }}
         run: |
           set -euo pipefail
+          ws_dir="$HOME/workspaces/${WORKSPACE_NAME}/camunda"
 
           # Pre-create artifact dirs so Claude does not need to mkdir
           mkdir -p /tmp/nightly-artifacts
@@ -184,12 +220,12 @@ jobs:
           # patterns, PR rules, and constraints live in AGENTS.md (which Claude must
           # read first). This keeps the per-run prompt small and the source-of-truth
           # for behaviour in a single file the team can update without editing CI.
-          claude --dangerously-skip-permissions -p "$(cat <<EOF
-          You are the Camunda orchestration-cluster nightly fix agent. The repo is
-          already on the correct target branch (${TARGET_REF}).
+          prompt=$(cat <<EOF
+          You are the Camunda orchestration-cluster nightly fix agent.
+          Workspace: ${ws_dir} (already on branch ${TARGET_REF}).
 
-          STEP 0 — read qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md, the
-          "## Nightly Fix Agent" section. That file is your full operating manual:
+          STEP 0 — read ${ws_dir}/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md,
+          the "## Nightly Fix Agent" section. That file is your full operating manual:
           diagnosis steps, artifact-download patterns, constraints (NEVER skip/fixme),
           PR conventions ('test:' not 'fix:'), and the /tmp/fix-meta.json schema.
 
@@ -207,7 +243,10 @@ jobs:
 
           When done (or if no fix is possible), write /tmp/fix-meta.json and stop.
           EOF
-          )"
+          )
+
+          cd "${ws_dir}"
+          claude -p "$prompt" --dangerously-skip-permissions
 
       - name: Trigger on-demand verification runs and patch PR body
         if: always()

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
@@ -61,9 +61,13 @@ jobs:
     steps:
       - name: Resolve target branch
         id: target
+        env:
+          # Read workflow_dispatch input through env to avoid template injection
+          # (zizmor: template-injection — github.event.inputs.* is attacker-controllable)
+          INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
           set -euo pipefail
-          version="${{ github.event.inputs.version }}"
+          version="$INPUT_VERSION"
           case "$version" in
             main)
               {
@@ -88,12 +92,18 @@ jobs:
         with:
           ref: ${{ steps.target.outputs.ref }}
           fetch-depth: 1
+          # We re-configure git with the bot PAT below; no need to keep the
+          # short-lived GITHUB_TOKEN around in .git/config (zizmor: artipacked).
+          persist-credentials: false
 
       - name: Write test_specs to file
+        env:
+          # Read the (potentially large + arbitrary) JSON input through env to
+          # avoid template injection (zizmor: template-injection).
+          INPUT_TEST_SPECS: ${{ github.event.inputs.test_specs }}
         run: |
-          cat > /tmp/test_specs.json <<'ENDOFSPECS'
-          ${{ github.event.inputs.test_specs }}
-          ENDOFSPECS
+          set -euo pipefail
+          printf '%s' "$INPUT_TEST_SPECS" > /tmp/test_specs.json
           echo "test_specs entries: $(jq 'length' /tmp/test_specs.json)"
           jq '.[0:3]' /tmp/test_specs.json || true
 

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
@@ -87,11 +87,15 @@ jobs:
               ;;
           esac
 
-      - name: Checkout target branch
+      - name: Checkout main for workflow tooling
         uses: actions/checkout@v4
         with:
-          ref: ${{ steps.target.outputs.ref }}
           fetch-depth: 1
+          # Intentionally NOT pinning to the target stable branch.
+          # The workspace manifest and guidance files live on main (introduced
+          # by this PR) and are absent from stable branches. workspace-cli
+          # handles cloning + switching to the correct stable branch inside
+          # ws_dir; nothing in the runner workspace needs the stable tree.
           # We re-configure git with the bot PAT below; no need to keep the
           # short-lived GITHUB_TOKEN around in .git/config (zizmor: artipacked).
           persist-credentials: false

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
@@ -162,11 +162,13 @@ jobs:
 
       - name: Stage workspace manifest
         run: |
+          set -euo pipefail
           mkdir -p "$HOME/.workspace-templates"
-          cp qa/c8-orchestration-cluster-e2e-test-suite/workspace-templates/camunda-orchestration-cluster-nightly.yaml \
-             "$HOME/.workspace-templates/camunda-orchestration-cluster-nightly.yaml"
-          cp qa/c8-orchestration-cluster-e2e-test-suite/workspace-templates/camunda-orchestration-cluster-nightly.guidance.md \
-             "$HOME/.workspace-templates/camunda-orchestration-cluster-nightly.guidance.md"
+          git fetch --depth 1 origin main
+          git show origin/main:qa/c8-orchestration-cluster-e2e-test-suite/workspace-templates/camunda-orchestration-cluster-nightly.yaml \
+            > "$HOME/.workspace-templates/camunda-orchestration-cluster-nightly.yaml"
+          git show origin/main:qa/c8-orchestration-cluster-e2e-test-suite/workspace-templates/camunda-orchestration-cluster-nightly.guidance.md \
+            > "$HOME/.workspace-templates/camunda-orchestration-cluster-nightly.guidance.md"
 
       - name: Create workspace
         run: |

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
@@ -66,12 +66,16 @@ jobs:
           version="${{ github.event.inputs.version }}"
           case "$version" in
             main)
-              echo "ref=main"             >> "$GITHUB_OUTPUT"
-              echo "safe_version=main"    >> "$GITHUB_OUTPUT"
+              {
+                echo "ref=main"
+                echo "safe_version=main"
+              } >> "$GITHUB_OUTPUT"
               ;;
             8.7|8.8|8.9)
-              echo "ref=stable/${version}"          >> "$GITHUB_OUTPUT"
-              echo "safe_version=stable-${version}" >> "$GITHUB_OUTPUT"
+              {
+                echo "ref=stable/${version}"
+                echo "safe_version=stable-${version}"
+              } >> "$GITHUB_OUTPUT"
               ;;
             *)
               echo "::error::Unsupported version: $version (must be 8.7, 8.8, 8.9, or main)"
@@ -138,10 +142,12 @@ jobs:
           has_api=$(jq '[.[] | select(.test_type == "api")] | length > 0' /tmp/test_specs.json)
           has_api_es=$(jq '[.[] | select(.test_type == "api" and (.database == null or .database == "" or .database == "elasticsearch"))] | length > 0' /tmp/test_specs.json)
           has_api_rdbms=$(jq '[.[] | select(.test_type == "api" and .database != null and .database != "" and .database != "elasticsearch")] | length > 0' /tmp/test_specs.json)
-          echo "has_e2e=$has_e2e"             >> "$GITHUB_OUTPUT"
-          echo "has_api=$has_api"             >> "$GITHUB_OUTPUT"
-          echo "has_api_es=$has_api_es"       >> "$GITHUB_OUTPUT"
-          echo "has_api_rdbms=$has_api_rdbms" >> "$GITHUB_OUTPUT"
+          {
+            echo "has_e2e=$has_e2e"
+            echo "has_api=$has_api"
+            echo "has_api_es=$has_api_es"
+            echo "has_api_rdbms=$has_api_rdbms"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Run Claude Code fix agent
         env:
@@ -227,7 +233,7 @@ jobs:
               gh workflow run c8-orchestration-cluster-e2e-tests-on-demand.yml \
                 --repo "$REPO" -f branch="$branch"
               # Poll up to 90s for the new run to appear
-              for i in $(seq 1 18); do
+              for _ in $(seq 1 18); do
                 sleep 5
                 run_id=$(gh run list \
                   --workflow c8-orchestration-cluster-e2e-tests-on-demand.yml \
@@ -245,7 +251,7 @@ jobs:
               echo "Triggering API on-demand run for branch $branch..."
               gh workflow run c8-orchestration-cluster-e2e-api-test-branch-on-demand.yml \
                 --repo "$REPO" -f branch="$branch"
-              for i in $(seq 1 18); do
+              for _ in $(seq 1 18); do
                 sleep 5
                 run_id=$(gh run list \
                   --workflow c8-orchestration-cluster-e2e-api-test-branch-on-demand.yml \

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
@@ -143,7 +143,7 @@ jobs:
         env:
           GOPRIVATE: github.com/camunda/*
         run: |
-          go install github.com/camunda/workspace-cli/cmd/workspace@latest
+          go install github.com/camunda/workspace-cli/cmd/workspace@0d062533bd9da7e29be8974d3c34f8788fd4ef6c
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
           npm install -g @anthropic-ai/claude-code@2.1.156
           claude --version

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
@@ -146,7 +146,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: ">=1.23.1"
+          go-version: '>=1.23.1'
           cache: false
 
       - name: Install workspace-cli and Claude Code CLI

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
@@ -292,7 +292,7 @@ jobs:
             if [ "$pr_has_e2e" = "true" ]; then
               echo "Triggering E2E on-demand run for branch $branch..."
               gh workflow run c8-orchestration-cluster-e2e-tests-on-demand.yml \
-                --repo "$REPO" -f branch="$branch"
+                --repo "$REPO" --ref "$branch" -f branch="$branch"
               # Poll up to 90s for the new run to appear
               for _ in $(seq 1 18); do
                 sleep 5
@@ -311,7 +311,7 @@ jobs:
             if [ "$pr_has_api" = "true" ]; then
               echo "Triggering API on-demand run for branch $branch..."
               gh workflow run c8-orchestration-cluster-e2e-api-test-branch-on-demand.yml \
-                --repo "$REPO" -f branch="$branch"
+                --repo "$REPO" --ref "$branch" -f branch="$branch"
               for _ in $(seq 1 18); do
                 sleep 5
                 run_id=$(gh run list \
@@ -422,7 +422,7 @@ jobs:
           if [ "$JOB_STATUS" = "failure" ]; then
             icon=":x:"; summary="Agent failed (no fix applied)"
           elif [ "$pr_count" -eq 0 ]; then
-            icon=":skipping:"; summary="No PR opened — agent could not determine a fix"
+            icon=":information_source:"; summary="No PR opened — agent could not determine a fix"
           else
             icon=":white_check_mark:"
             pr_links=$(echo "$prs_json" | jq -r \

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
@@ -1,0 +1,459 @@
+# description: Triage-driven fix agent for C8 Orchestration Cluster nightly E2E/API failures.
+#              Dispatched per version by c8-orchestration-cluster-e2e-nightly-triage.yml.
+#              Uses Claude Code CLI to read failing tests + screenshots, apply a minimal fix,
+#              and open a draft PR against stable/<version> (or main). After the PR is open,
+#              triggers the matching on-demand workflow(s) and patches the PR body with
+#              the run URL(s) for verification.
+# type: CI
+# owner: @camunda/qa-engineering
+---
+name: C8 Orchestration Cluster Nightly Fix Agent
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Camunda version (8.7, 8.8, 8.9, or main)'
+        required: true
+      test_specs:
+        description: 'JSON array of {file, test_name, error, test_type, tasklist_mode?, database?}'
+        required: true
+      e2e_run_id:
+        description: 'Run ID of the failing E2E nightly (empty if E2E did not fail)'
+        required: false
+        default: ''
+      api_es_run_id:
+        description: 'Run ID of the failing API ES nightly (empty if API ES did not fail)'
+        required: false
+        default: ''
+      api_rdbms_run_id:
+        description: 'Run ID of the failing API RDBMS nightly (empty / N/A for 8.7, 8.8)'
+        required: false
+        default: ''
+      triage_run_url:
+        description: 'URL of the triage run that dispatched this (for PR body)'
+        required: false
+        default: ''
+      slack_thread_ts:
+        description: 'Slack thread ts to reply to (posted by triage)'
+        required: false
+        default: ''
+      slack_channel:
+        description: 'Slack channel ID for thread reply'
+        required: false
+        default: ''
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
+  actions: write
+  pull-requests: write
+
+jobs:
+  fix:
+    name: Fix nightly failures (${{ github.event.inputs.version }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Resolve target branch
+        id: target
+        run: |
+          set -euo pipefail
+          version="${{ github.event.inputs.version }}"
+          case "$version" in
+            main)
+              echo "ref=main"             >> "$GITHUB_OUTPUT"
+              echo "safe_version=main"    >> "$GITHUB_OUTPUT"
+              ;;
+            8.7|8.8|8.9)
+              echo "ref=stable/${version}"          >> "$GITHUB_OUTPUT"
+              echo "safe_version=stable-${version}" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "::error::Unsupported version: $version (must be 8.7, 8.8, 8.9, or main)"
+              exit 1
+              ;;
+          esac
+
+      - name: Checkout target branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.target.outputs.ref }}
+          fetch-depth: 1
+
+      - name: Write test_specs to file
+        run: |
+          cat > /tmp/test_specs.json <<'ENDOFSPECS'
+          ${{ github.event.inputs.test_specs }}
+          ENDOFSPECS
+          echo "test_specs entries: $(jq 'length' /tmp/test_specs.json)"
+          jq '.[0:3]' /tmp/test_specs.json || true
+
+      - name: Import Vault secrets
+        id: secrets
+        uses: hashicorp/vault-action@d1720f055e0635fd932a1d2a48f87a666a57906c
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/qa/ci/common GH_TOKEN ;
+            secret/data/products/qa/ci/common CLAUDE_API_KEY | ANTHROPIC_API_KEY ;
+            secret/data/products/qa/ci/common SLACK_BOT_USER_OAUTH_TOKEN ;
+
+      - name: Configure git with bot PAT
+        env:
+          TOKEN: ${{ steps.secrets.outputs.GH_TOKEN }}
+        run: |
+          git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "https://github.com/"
+          git config --global user.name  "Nightly Fix Agent"
+          git config --global user.email "nightly-fix-agent@camunda.com"
+
+      - name: Ensure failing-test-fix label exists
+        env:
+          GH_TOKEN: ${{ steps.secrets.outputs.GH_TOKEN }}
+        run: |
+          gh label create "failing-test-fix" \
+            --repo "${{ github.repository }}" \
+            --color "FF4444" \
+            --description "Bot-opened fix PR for failing nightly orchestration cluster tests" \
+            2>/dev/null || true
+
+      - name: Install Claude Code CLI
+        run: |
+          npm install -g @anthropic-ai/claude-code
+          claude --version
+
+      - name: Determine which artifact downloads + on-demand verifications are needed
+        id: scope
+        run: |
+          set -euo pipefail
+          has_e2e=$(jq '[.[] | select(.test_type == "e2e")] | length > 0' /tmp/test_specs.json)
+          has_api=$(jq '[.[] | select(.test_type == "api")] | length > 0' /tmp/test_specs.json)
+          has_api_es=$(jq '[.[] | select(.test_type == "api" and (.database == null or .database == "" or .database == "elasticsearch"))] | length > 0' /tmp/test_specs.json)
+          has_api_rdbms=$(jq '[.[] | select(.test_type == "api" and .database != null and .database != "" and .database != "elasticsearch")] | length > 0' /tmp/test_specs.json)
+          echo "has_e2e=$has_e2e"             >> "$GITHUB_OUTPUT"
+          echo "has_api=$has_api"             >> "$GITHUB_OUTPUT"
+          echo "has_api_es=$has_api_es"       >> "$GITHUB_OUTPUT"
+          echo "has_api_rdbms=$has_api_rdbms" >> "$GITHUB_OUTPUT"
+
+      - name: Run Claude Code fix agent
+        env:
+          ANTHROPIC_API_KEY:   ${{ steps.secrets.outputs.ANTHROPIC_API_KEY }}
+          GH_TOKEN:            ${{ steps.secrets.outputs.GH_TOKEN }}
+          VERSION:             ${{ github.event.inputs.version }}
+          TARGET_REF:          ${{ steps.target.outputs.ref }}
+          SAFE_VERSION:        ${{ steps.target.outputs.safe_version }}
+          E2E_RUN_ID:          ${{ github.event.inputs.e2e_run_id }}
+          API_ES_RUN_ID:       ${{ github.event.inputs.api_es_run_id }}
+          API_RDBMS_RUN_ID:    ${{ github.event.inputs.api_rdbms_run_id }}
+          TRIAGE_RUN_URL:      ${{ github.event.inputs.triage_run_url }}
+          HAS_E2E:             ${{ steps.scope.outputs.has_e2e }}
+          HAS_API_ES:          ${{ steps.scope.outputs.has_api_es }}
+          HAS_API_RDBMS:       ${{ steps.scope.outputs.has_api_rdbms }}
+          REPO:                ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Pre-create artifact dirs so Claude does not need to mkdir
+          mkdir -p /tmp/nightly-artifacts
+
+          prompt=$(cat <<'EOF_PROMPT'
+          You are a Camunda QA engineer fixing failing nightly tests in the camunda/camunda
+          monorepo. Working directory: the current repo checkout (already on the correct
+          target branch). Test suite path: qa/c8-orchestration-cluster-e2e-test-suite/.
+
+          Read qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md (its "## Nightly Fix Agent"
+          section) for diagnosis steps and HARD CONSTRAINTS before doing anything else.
+
+          ## HARD RULES — no exceptions
+          - NEVER use test.skip(), test.fixme(), test.only, or any skip/pending variant.
+            If you cannot write a code fix, write {"prs":[]} to /tmp/fix-meta.json and stop.
+          - Fix ONLY the tests listed in /tmp/test_specs.json. Ignore any additional failures
+            visible in the downloaded artifacts — they are handled by separate agents.
+          - Minimal diff. No refactoring, no dependency bumps, no unrelated edits.
+          - Lint before commit: cd qa/c8-orchestration-cluster-e2e-test-suite &&
+            npx prettier --write <changed-files> && npx eslint <changed-files> --fix.
+            Fix any remaining eslint errors before committing.
+
+          ## Step 1 — Download nightly artifacts
+
+          Read /tmp/test_specs.json — each entry has:
+            file         : path relative to qa/c8-orchestration-cluster-e2e-test-suite/
+            test_name    : the test("...") title
+            error        : first line of the failure from json-report results.json
+            test_type    : "e2e" or "api"
+            tasklist_mode: "v1" or "v2" (E2E only)
+            database     : RDBMS database name (API only, e.g. "Postgres 17") or "elasticsearch"
+
+          Environment:
+            VERSION          = the camunda version (8.7 / 8.8 / 8.9 / main)
+            SAFE_VERSION     = "stable-${VERSION}" for stable branches, "main" for main
+            E2E_RUN_ID       = run ID for the failing E2E nightly (empty if no E2E failed)
+            API_ES_RUN_ID    = run ID for the failing API ES nightly
+            API_RDBMS_RUN_ID = run ID for the failing API RDBMS nightly (8.9 / main only)
+            HAS_E2E, HAS_API_ES, HAS_API_RDBMS : "true" / "false" flags
+
+          Download exactly what is needed:
+
+            if [ "$HAS_E2E" = "true" ] && [ -n "$E2E_RUN_ID" ]; then
+              for mode in v1 v2; do
+                # Skip absent modes: 8.7 has no v2, main has no v1
+                gh run download "$E2E_RUN_ID" --repo "$REPO" \
+                  --pattern "json-report-nightly-e2e-${SAFE_VERSION}-${mode}" \
+                  --dir "/tmp/nightly-artifacts/e2e-${mode}" 2>/dev/null || true
+                gh run download "$E2E_RUN_ID" --repo "$REPO" \
+                  --pattern "html-report-nightly-e2e-${SAFE_VERSION}-${mode}" \
+                  --dir "/tmp/nightly-artifacts/e2e-${mode}-html" 2>/dev/null || true
+              done
+            fi
+
+            if [ "$HAS_API_ES" = "true" ] && [ -n "$API_ES_RUN_ID" ]; then
+              gh run download "$API_ES_RUN_ID" --repo "$REPO" \
+                --pattern "json-report-nightly-api-${SAFE_VERSION}" \
+                --dir /tmp/nightly-artifacts/api-es 2>/dev/null || true
+            fi
+
+            if [ "$HAS_API_RDBMS" = "true" ] && [ -n "$API_RDBMS_RUN_ID" ]; then
+              # Only download artifacts for databases that actually have failing tests
+              jq -r '[.[] | select(.test_type == "api" and .database != null
+                       and .database != "" and .database != "elasticsearch")
+                       | .database] | unique[]' /tmp/test_specs.json | while read -r db; do
+                gh run download "$API_RDBMS_RUN_ID" --repo "$REPO" \
+                  --pattern "json-report-nightly-api-rdbms-${SAFE_VERSION}-${db}" \
+                  --dir "/tmp/nightly-artifacts/api-rdbms" 2>/dev/null || true
+              done
+            fi
+
+          ## Step 2 — Diagnose each failing test
+
+          For each entry in /tmp/test_specs.json:
+
+          1. Read the test file at qa/c8-orchestration-cluster-e2e-test-suite/<file>.
+             Read any imported page objects / helpers.
+          2. For E2E entries: open the matching screenshot under
+             /tmp/nightly-artifacts/e2e-<mode>-html/.../data/<image>.png — you can read PNG
+             images directly. Cross-reference with the error message and the test code.
+          3. For API entries: read the JSON report under /tmp/nightly-artifacts/api-es/results.json
+             (or api-rdbms/). Look at the full error message + stack trace + any response body.
+          4. Form a hypothesis. Match it to a specific assertion / action in the test or page
+             object. If the failure is clearly a product bug (not a test bug) and no test-side
+             fix is reasonable, write {"prs":[]} to /tmp/fix-meta.json and stop. Do not skip.
+
+          ## Step 3 — Apply the fix and open the PR
+
+          1. Determine a short slug describing the fix (e.g. "operate-process-name-wait",
+             "tasklist-task-assignment-flake").
+          2. Create branch: git checkout -b "fix/nightly-${VERSION}-<slug>"
+          3. Edit files under qa/c8-orchestration-cluster-e2e-test-suite/ only.
+          4. Run lint (see HARD RULES) on changed files. Fix any eslint errors.
+          5. Stage + commit (Conventional Commits, no scope — commitlint enforces scope-empty):
+               git add <files>
+               git commit -m "test: fix nightly ${VERSION} failures (<slug>)"
+          6. Push: git push -u origin "fix/nightly-${VERSION}-<slug>"
+          7. Check for existing open PRs first:
+               gh pr list --repo "$REPO" --search "nightly is:open label:failing-test-fix" \
+                          --json number,title,baseRefName
+             If an open PR exists targeting the same base branch (${TARGET_REF}) for the same
+             root cause, COMMENT on it instead of opening a new one, and add its number to
+             /tmp/fix-meta.json.
+          8. Open a draft PR (note: title type is "test:" per camunda/camunda commitlint rules
+             — do NOT use "fix:" for test-only changes):
+               gh pr create --repo "$REPO" --draft \
+                 --base "${TARGET_REF}" \
+                 --head "fix/nightly-${VERSION}-<slug>" \
+                 --label "failing-test-fix" \
+                 --title "test: fix nightly ${VERSION} failures (<slug>)" \
+                 --body "$(cat <<'PRBODY'
+          ## Summary
+          Bot-opened fix for failing tests detected by the nightly triage agent.
+
+          **Version:** ${VERSION} (target: \`${TARGET_REF}\`)
+          **Triage run:** ${TRIAGE_RUN_URL}
+          **Failing nightly runs:**
+          - E2E: <link if applicable>
+          - API ES: <link if applicable>
+          - API RDBMS: <link if applicable>
+
+          ## Root cause analysis
+          <Claude's diagnosis>
+
+          ## Tests fixed
+          <bulleted list from test_specs>
+
+          ## Verification
+          On-demand runs will be linked here automatically by the workflow.
+
+          ---
+          Generated by the nightly fix agent. Review carefully — this is a bot fix.
+          PRBODY
+          )"
+
+          ## Step 4 — Write the result manifest
+
+          Write /tmp/fix-meta.json with this shape:
+            {"prs": [{"number": 1234, "owner": "camunda", "repo": "camunda",
+                      "branch": "fix/nightly-${VERSION}-<slug>",
+                      "has_e2e": <bool>, "has_api": <bool>}]}
+          Multiple PRs: one object per PR. {"prs": []} if no PR was opened.
+
+          STOP after writing the file. Do not run any further commands.
+          EOF_PROMPT
+          )
+
+          # Substitute environment variables into the prompt at the heredoc level (the
+          # outer heredoc was quoted with 'EOF_PROMPT' to preserve $-references in the
+          # Bash snippets — but we need a small set of variables resolved upfront for
+          # the PR body template). Easier: write the prompt with envsubst on a narrow allowlist.
+          export VERSION TARGET_REF TRIAGE_RUN_URL REPO
+          prompt_resolved=$(printf '%s' "$prompt" | envsubst '$VERSION $TARGET_REF $TRIAGE_RUN_URL $REPO')
+
+          claude -p "$prompt_resolved" --dangerously-skip-permissions
+
+      - name: Trigger on-demand verification runs and patch PR body
+        if: always()
+        env:
+          GH_TOKEN: ${{ steps.secrets.outputs.GH_TOKEN }}
+          REPO:     ${{ github.repository }}
+          HAS_E2E:  ${{ steps.scope.outputs.has_e2e }}
+          HAS_API:  ${{ steps.scope.outputs.has_api }}
+        run: |
+          set -euo pipefail
+          if [ ! -f /tmp/fix-meta.json ]; then
+            echo "No fix-meta.json produced — nothing to verify."
+            exit 0
+          fi
+
+          count=$(jq '.prs | length' /tmp/fix-meta.json)
+          if [ "$count" -eq 0 ]; then
+            echo "No PRs were opened — nothing to verify."
+            exit 0
+          fi
+
+          jq -c '.prs[]' /tmp/fix-meta.json | while read -r pr_obj; do
+            pr_number=$(echo "$pr_obj" | jq -r '.number')
+            branch=$(echo    "$pr_obj" | jq -r '.branch')
+            pr_has_e2e=$(echo "$pr_obj" | jq -r '.has_e2e // false')
+            pr_has_api=$(echo "$pr_obj" | jq -r '.has_api // false')
+
+            e2e_run_url=""
+            api_run_url=""
+
+            if [ "$pr_has_e2e" = "true" ]; then
+              echo "Triggering E2E on-demand run for branch $branch..."
+              gh workflow run c8-orchestration-cluster-e2e-tests-on-demand.yml \
+                --repo "$REPO" -f branch="$branch"
+              # Poll up to 90s for the new run to appear
+              for i in $(seq 1 18); do
+                sleep 5
+                run_id=$(gh run list \
+                  --workflow c8-orchestration-cluster-e2e-tests-on-demand.yml \
+                  --repo "$REPO" --branch "$branch" --limit 1 \
+                  --json databaseId,createdAt --jq '.[0].databaseId' || echo "")
+                if [ -n "$run_id" ] && [ "$run_id" != "null" ]; then
+                  e2e_run_url="https://github.com/${REPO}/actions/runs/${run_id}"
+                  echo "E2E on-demand run: $e2e_run_url"
+                  break
+                fi
+              done
+            fi
+
+            if [ "$pr_has_api" = "true" ]; then
+              echo "Triggering API on-demand run for branch $branch..."
+              gh workflow run c8-orchestration-cluster-e2e-api-test-branch-on-demand.yml \
+                --repo "$REPO" -f branch="$branch"
+              for i in $(seq 1 18); do
+                sleep 5
+                run_id=$(gh run list \
+                  --workflow c8-orchestration-cluster-e2e-api-test-branch-on-demand.yml \
+                  --repo "$REPO" --branch "$branch" --limit 1 \
+                  --json databaseId,createdAt --jq '.[0].databaseId' || echo "")
+                if [ -n "$run_id" ] && [ "$run_id" != "null" ]; then
+                  api_run_url="https://github.com/${REPO}/actions/runs/${run_id}"
+                  echo "API on-demand run: $api_run_url"
+                  break
+                fi
+              done
+            fi
+
+            # Patch PR body to add the verification links
+            current_body=$(gh pr view "$pr_number" --repo "$REPO" --json body --jq '.body')
+            verification_block="
+
+          ## On-demand verification runs
+          "
+            [ -n "$e2e_run_url" ] && verification_block+="- E2E: ${e2e_run_url}
+          "
+            [ -n "$api_run_url" ] && verification_block+="- API: ${api_run_url}
+          "
+            new_body="${current_body}${verification_block}"
+            printf '%s' "$new_body" | gh pr edit "$pr_number" --repo "$REPO" --body-file - || true
+          done
+
+      - name: Re-label PRs (idempotent)
+        if: always()
+        env:
+          GH_TOKEN: ${{ steps.secrets.outputs.GH_TOKEN }}
+          REPO:     ${{ github.repository }}
+        run: |
+          if [ -f /tmp/fix-meta.json ]; then
+            jq -r '.prs[]?.number // empty' /tmp/fix-meta.json | while read -r pr_num; do
+              gh pr edit "$pr_num" --repo "$REPO" --add-label "failing-test-fix" 2>/dev/null || true
+            done
+          fi
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-fix-${{ github.event.inputs.version }}-${{ github.run_id }}
+          path: |
+            /tmp/test_specs.json
+            /tmp/fix-meta.json
+          retention-days: 14
+          if-no-files-found: warn
+
+      - name: Slack thread reply
+        if: always() && github.event.inputs.slack_thread_ts != ''
+        env:
+          SLACK_BOT_USER_OAUTH_TOKEN: ${{ steps.secrets.outputs.SLACK_BOT_USER_OAUTH_TOKEN }}
+          SLACK_THREAD_TS:            ${{ github.event.inputs.slack_thread_ts }}
+          SLACK_CHANNEL:              ${{ github.event.inputs.slack_channel }}
+          VERSION:                    ${{ github.event.inputs.version }}
+          RUN_URL:                    ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          JOB_STATUS:                 ${{ job.status }}
+        run: |
+          set -euo pipefail
+          prs_json="[]"
+          [ -f /tmp/fix-meta.json ] && prs_json=$(jq -c '.prs // []' /tmp/fix-meta.json)
+          pr_count=$(echo "$prs_json" | jq 'length')
+
+          if [ "$JOB_STATUS" = "failure" ]; then
+            icon=":x:"; summary="Agent failed (no fix applied)"
+          elif [ "$pr_count" -eq 0 ]; then
+            icon=":skipping:"; summary="No PR opened — agent could not determine a fix"
+          else
+            icon=":white_check_mark:"
+            pr_links=$(echo "$prs_json" | jq -r \
+              '.[] | "<https://github.com/\(.owner)/\(.repo)/pull/\(.number)|PR #\(.number)>"' \
+              | tr '\n' '  ')
+            summary="PR(s) opened: ${pr_links}"
+          fi
+
+          text="${icon} *${VERSION}* fix agent — ${summary}\n<${RUN_URL}|Agent run ↗>"
+          payload=$(jq -nc \
+            --arg channel    "$SLACK_CHANNEL" \
+            --arg thread_ts  "$SLACK_THREAD_TS" \
+            --arg text       "$text" \
+            '{channel: $channel, thread_ts: $thread_ts, text: $text, mrkdwn: true}')
+
+          curl -sS -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer ${SLACK_BOT_USER_OAUTH_TOKEN}" \
+            -H 'Content-Type: application/json; charset=utf-8' \
+            -d "$payload" | jq '.' || true

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
@@ -301,6 +301,49 @@ jobs:
             done
           fi
 
+      - name: Write job summary
+        if: always()
+        env:
+          VERSION:        ${{ github.event.inputs.version }}
+          TARGET_REF:     ${{ steps.target.outputs.ref }}
+          TRIAGE_RUN_URL: ${{ github.event.inputs.triage_run_url }}
+          REPO:           ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## Fix Agent — ${VERSION} (\`${TARGET_REF}\`)"
+            echo ""
+
+            if [ ! -f /tmp/fix-meta.json ]; then
+              echo ":x: **Agent did not produce \`/tmp/fix-meta.json\`** — see agent logs above."
+            else
+              pr_count=$(jq '.prs | length' /tmp/fix-meta.json)
+              if [ "$pr_count" -eq 0 ]; then
+                echo ":warning: **No PRs opened** — agent could not determine a safe fix."
+                echo ""
+                echo "Check the agent log above for the root-cause analysis."
+              else
+                echo "### PRs opened"
+                echo ""
+                jq -r --arg repo "$REPO" \
+                  '.prs[] | "- [PR #\(.number)](https://github.com/\($repo)/pull/\(.number)) — `\(.branch)`"' \
+                  /tmp/fix-meta.json
+                echo ""
+                echo "### Tests covered"
+                echo ""
+                echo "| PR | E2E | API |"
+                echo "|----|-----|-----|"
+                jq -r '.prs[] | "| #\(.number) | \(if .has_e2e then ":white_check_mark:" else ":heavy_minus_sign:" end) | \(if .has_api then ":white_check_mark:" else ":heavy_minus_sign:" end) |"' \
+                  /tmp/fix-meta.json
+              fi
+            fi
+
+            if [ -n "${TRIAGE_RUN_URL:-}" ]; then
+              echo ""
+              echo "**Triage run:** [↗](${TRIAGE_RUN_URL})"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Upload artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
@@ -143,6 +143,12 @@ jobs:
             --description "Bot-opened fix PR for failing nightly orchestration cluster tests" \
             2>/dev/null || true
 
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: ">=1.23.1"
+          cache: false
+
       - name: Install workspace-cli and Claude Code CLI
         env:
           GOPRIVATE: github.com/camunda/*

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -300,6 +300,47 @@ jobs:
             echo "EOF_DISPATCH"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Write job summary
+        if: always()
+        run: |
+          set -euo pipefail
+          {
+            echo "## C8 Orchestration Cluster Nightly Triage"
+            echo ""
+
+            # Failures per version
+            count=$(jq 'length' /tmp/failures_normalized.json 2>/dev/null || echo 0)
+            if [ "$count" -gt 0 ]; then
+              echo "### Failures found"
+              echo ""
+              echo "| Version | Count | Test types |"
+              echo "|---------|-------|------------|"
+              jq -r '
+                group_by(.version)[]
+                | (.[0].version) as $v
+                | (length) as $n
+                | ([.[].test_type] | unique | join(", ")) as $types
+                | "| \($v) | \($n) | \($types) |"
+              ' /tmp/failures_normalized.json
+              echo ""
+            else
+              echo "> No failures found — all nightly runs passed or no runs exist yet."
+              echo ""
+            fi
+
+            # Dispatch decisions
+            dispatches=$(jq 'length' /tmp/dispatches.json 2>/dev/null || echo 0)
+            if [ "$dispatches" -gt 0 ]; then
+              echo "### Fix agents dispatched"
+              echo ""
+              echo "| Version | Branch | Tests |"
+              echo "|---------|--------|-------|"
+              jq -r '.[] | "| \(.version) | `\(.ref)` | \(.test_specs | length) |"' /tmp/dispatches.json
+            else
+              echo "> No fix agents dispatched (no failures, daily cap reached, or open PRs already exist)."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Upload triage artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -11,7 +11,7 @@ name: C8 Orchestration Cluster Nightly Triage
 
 on:
   schedule:
-    - cron: '0 4 * * *'   # 04:00 UTC — after all nightlies finish (00:00–01:45 starts)
+    - cron: '0 4 * * 1-5' # 04:00 UTC Mon–Fri — after all nightlies finish (00:00–01:45 starts)
                           # and before close-stale-fix-prs.yml runs at 05:00 UTC.
   workflow_dispatch:
     inputs:

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -153,17 +153,18 @@ jobs:
               # List the per-database artifact names from the run
               gh api "repos/${REPO}/actions/runs/${run_id}/artifacts" --paginate \
                 --jq '.artifacts[].name' > /tmp/rdbms_artifact_names.txt
+              rdbms_prefix="json-report-nightly-api-rdbms-${safe_version}-"
               while read -r artifact_name; do
-                # Strip the "json-report-nightly-api-rdbms-${safe_version}-" prefix to extract db name
-                db_name="${artifact_name#json-report-nightly-api-rdbms-${safe_version}-}"
+                # Strip the prefix to extract db name; quoted to avoid pattern expansion
+                db_name="${artifact_name#"${rdbms_prefix}"}"
                 [ "$db_name" = "$artifact_name" ] && continue   # didn't match prefix → not an rdbms report
                 patterns+=("${artifact_name}|${db_name}")
               done < /tmp/rdbms_artifact_names.txt
             fi
 
-            # Download each artifact and extract failures
-            for entry in "${patterns[@]}"; do
-              IFS='|' read -r artifact_name dim <<< "$entry"
+            # Download each artifact and extract failures (inner loop var differs from outer)
+            for pattern_entry in "${patterns[@]}"; do
+              IFS='|' read -r artifact_name dim <<< "$pattern_entry"
               tmp_dir=$(mktemp -d)
               if ! gh run download "$run_id" --repo "$REPO" \
                     --pattern "$artifact_name" --dir "$tmp_dir" 2>/dev/null; then

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -122,7 +122,7 @@ jobs:
 
             # Find the latest run
             run_info=$(gh run list --workflow "$workflow_file" --repo "$REPO" \
-                        --limit 1 --json databaseId,conclusion,createdAt,event 2>/dev/null \
+                        --status completed --limit 1 --json databaseId,conclusion,createdAt,event 2>/dev/null \
                         | jq -c '.[0] // empty')
             if [ -z "$run_info" ] || [ "$run_info" = "null" ]; then
               echo "  no recent runs — skipping"

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -120,7 +120,7 @@ jobs:
               safe_version="stable-${version}"
             fi
 
-            # Find the latest run
+            # Find the latest completed run
             run_info=$(gh run list --workflow "$workflow_file" --repo "$REPO" \
                         --status completed --limit 1 --json databaseId,conclusion,createdAt,event 2>/dev/null \
                         | jq -c '.[0] // empty')

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -380,10 +380,13 @@ jobs:
 
       - name: Dispatch one fix-agent run per version
         env:
-          GH_TOKEN:        ${{ steps.secrets.outputs.GH_TOKEN }}
-          REPO:            ${{ github.repository }}
-          DISPATCHES_JSON: ${{ needs.triage.outputs.dispatches }}
-          TRIAGE_RUN_URL:  ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GH_TOKEN:            ${{ steps.secrets.outputs.GH_TOKEN }}
+          REPO:                ${{ github.repository }}
+          DISPATCHES_JSON:     ${{ needs.triage.outputs.dispatches }}
+          TRIAGE_RUN_URL:      ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          # schedule always runs on the default branch so ref_name == main;
+          # workflow_dispatch from a feature branch uses that branch, enabling PR-time testing.
+          FIX_WORKFLOW_REF:    ${{ github.ref_name }}
         run: |
           set -euo pipefail
 
@@ -394,10 +397,10 @@ jobs:
             api_es=$(echo "$d" | jq -r '.api_es_run_id')
             api_rdbms=$(echo "$d" | jq -r '.api_rdbms_run_id')
 
-            echo "Dispatching fix agent: version=$version  failures=$(echo "$specs" | jq 'length')"
+            echo "Dispatching fix agent: version=$version  failures=$(echo "$specs" | jq 'length')  ref=${FIX_WORKFLOW_REF}"
 
             gh workflow run c8-orchestration-cluster-e2e-nightly-fix.yml \
-              --repo "$REPO" --ref main \
+              --repo "$REPO" --ref "${FIX_WORKFLOW_REF}" \
               -f version="$version" \
               -f test_specs="$specs" \
               -f e2e_run_id="$e2e" \

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -234,7 +234,7 @@ jobs:
           #   - Strip leading 'qa/c8-orchestration-cluster-e2e-test-suite/' prefix so the
           #     value is a path relative to the test suite root (e.g. 'tests/operate/foo.spec.ts')
           # Filter out:
-          #   - tests/identity/* entries for version 8.7 (8.7 has no identity dir)
+          #   - tests/identity/* entries for all stable branches (identity tests only exist on main)
           #   - empty/malformed file fields
 
           # Path normalization + error truncation. Errors are truncated to 600 chars
@@ -253,7 +253,7 @@ jobs:
               | select(.file | test("\\.spec\\.[jt]s$"))
             )
             | map(select(
-                (.version != "8.7") or (.file | test("^tests/identity/") | not)
+                (.version == "main") or (.file | test("^tests/identity/") | not)
               ))
           ' /tmp/all_failures.jsonl > /tmp/failures_normalized.json
 

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -231,8 +231,8 @@ jobs:
 
           # Normalize file paths:
           #   - Strip absolute prefixes (anything before 'qa/c8-orchestration-cluster-e2e-test-suite/')
-          #   - Strip leading 'qa/c8-orchestration-cluster-e2e-test-suite/' or 'tests/' prefix so the
-          #     value is a path relative to the test suite root (the fix agent prepends the suite path)
+          #   - Strip leading 'qa/c8-orchestration-cluster-e2e-test-suite/' prefix so the
+          #     value is a path relative to the test suite root (e.g. 'tests/operate/foo.spec.ts')
           # Filter out:
           #   - identity/* entries for version 8.7 (8.7 has no identity dir)
           #   - empty/malformed file fields
@@ -271,7 +271,7 @@ jobs:
              --argjson openrefs "$open_pr_versions" \
              --argjson cap "${DAILY_CAP}" '
             # group failures by version
-            group_by(.version)
+            sort_by(.version) | group_by(.version)
             | map({
                 version: .[0].version,
                 test_specs: map(del(.version)),
@@ -316,7 +316,7 @@ jobs:
               echo "| Version | Count | Test types |"
               echo "|---------|-------|------------|"
               jq -r '
-                group_by(.version)[]
+                sort_by(.version) | group_by(.version)[]
                 | (.[0].version) as $v
                 | (length) as $n
                 | ([.[].test_type] | unique | join(", ")) as $types
@@ -361,7 +361,7 @@ jobs:
               n=$(echo "$line"       | jq -r '.count')
               types=$(echo "$line"   | jq -r '.types')
               text="${text}"$'\n'"• \`${version}\` — ${n} failed test(s) (${types})"
-            done < <(jq -c 'group_by(.version)[] | {version: .[0].version, count: length, types: ([.[].test_type] | unique | join(", "))}' \
+            done < <(jq -c 'sort_by(.version) | group_by(.version)[] | {version: .[0].version, count: length, types: ([.[].test_type] | unique | join(", "))}' \
                       /tmp/failures_normalized.json)
             dispatches=$(jq 'length' /tmp/dispatches.json 2>/dev/null || echo 0)
             if [ "$dispatches" -gt 0 ]; then

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -282,6 +282,9 @@ jobs:
                 api_es_run_id:    ($run_ids[0][(.version + "/api_es")]    // ""),
                 api_rdbms_run_id: ($run_ids[0][(.version + "/api_rdbms")] // "")
               })
+            # cap failures per version to 20 so the workflow_dispatch input
+            # stays well under the 64KB limit even with many nightly failures
+            | map(.test_specs |= .[0:20])
             # cap dispatch count
             | .[0:$cap]
           ' /tmp/failures_normalized.json > /tmp/dispatches.json
@@ -370,7 +373,7 @@ jobs:
           fi
           text="${text}"$'\n\n'"<${RUN_URL}|Triage run ↗>"
 
-          payload=$(jq -nc --arg channel '#c8-orchestration-cluster-e2e-test-results' --arg text "$text" \
+          payload=$(jq -nc --arg channel 'c8-orchestration-cluster-e2e-test-results' --arg text "$text" \
             '{channel: $channel, text: $text, mrkdwn: true}')
           response=$(curl -sS -X POST https://slack.com/api/chat.postMessage \
             -H "Authorization: Bearer ${SLACK_BOT_USER_OAUTH_TOKEN}" \

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -343,6 +343,9 @@ jobs:
           REPO:            ${{ github.repository }}
           DISPATCHES_JSON: ${{ needs.triage.outputs.dispatches }}
           TRIAGE_RUN_URL:  ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          # On pull_request events use the PR branch so the fix workflow is found there too;
+          # on schedule/workflow_dispatch github.head_ref is empty so we fall back to main.
+          FIX_WORKFLOW_REF: ${{ github.head_ref || 'main' }}
         run: |
           set -euo pipefail
 
@@ -353,10 +356,10 @@ jobs:
             api_es=$(echo "$d" | jq -r '.api_es_run_id')
             api_rdbms=$(echo "$d" | jq -r '.api_rdbms_run_id')
 
-            echo "Dispatching fix agent: version=$version  failures=$(echo "$specs" | jq 'length')"
+            echo "Dispatching fix agent: version=$version  failures=$(echo "$specs" | jq 'length')  ref=${FIX_WORKFLOW_REF}"
 
             gh workflow run c8-orchestration-cluster-e2e-nightly-fix.yml \
-              --repo "$REPO" --ref main \
+              --repo "$REPO" --ref "${FIX_WORKFLOW_REF}" \
               -f version="$version" \
               -f test_specs="$specs" \
               -f e2e_run_id="$e2e" \

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -357,7 +357,7 @@ jobs:
   dispatch:
     name: Dispatch fix agents
     needs: triage
-    if: ${{ github.event.inputs.dispatch != 'false' && needs.triage.outputs.dispatches != '[]' && needs.triage.outputs.dispatches != '' }}
+    if: ${{ github.event_name != 'pull_request' && github.event.inputs.dispatch != 'false' && needs.triage.outputs.dispatches != '[]' && needs.triage.outputs.dispatches != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -384,9 +384,6 @@ jobs:
           REPO:            ${{ github.repository }}
           DISPATCHES_JSON: ${{ needs.triage.outputs.dispatches }}
           TRIAGE_RUN_URL:  ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          # On pull_request events use the PR branch so the fix workflow is found there too;
-          # on schedule/workflow_dispatch github.head_ref is empty so we fall back to main.
-          FIX_WORKFLOW_REF: ${{ github.head_ref || 'main' }}
         run: |
           set -euo pipefail
 
@@ -397,10 +394,10 @@ jobs:
             api_es=$(echo "$d" | jq -r '.api_es_run_id')
             api_rdbms=$(echo "$d" | jq -r '.api_rdbms_run_id')
 
-            echo "Dispatching fix agent: version=$version  failures=$(echo "$specs" | jq 'length')  ref=${FIX_WORKFLOW_REF}"
+            echo "Dispatching fix agent: version=$version  failures=$(echo "$specs" | jq 'length')"
 
             gh workflow run c8-orchestration-cluster-e2e-nightly-fix.yml \
-              --repo "$REPO" --ref "${FIX_WORKFLOW_REF}" \
+              --repo "$REPO" --ref main \
               -f version="$version" \
               -f test_specs="$specs" \
               -f e2e_run_id="$e2e" \

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -82,7 +82,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Allowlist of nightly workflows to scan. Each entry: workflow file | version | test_type | tasklist_mode (optional)
+          # Allowlist of nightly workflows to scan. Each entry: workflow file | version | test_type
           # test_type ∈ {e2e, api_es, api_rdbms}.
           declare -a SCOPE=(
             "c8-orchestration-cluster-nightly-8.7-e2e.yml|8.7|e2e"

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -50,7 +50,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     outputs:
-      dispatches: ${{ steps.group.outputs.dispatches }}
+      dispatches:    ${{ steps.group.outputs.dispatches }}
+      slack_ts:      ${{ steps.slack.outputs.ts }}
+      slack_channel: ${{ steps.slack.outputs.channel }}
 
     steps:
       - name: Import Vault secrets
@@ -339,6 +341,51 @@ jobs:
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Post Slack triage summary
+        id: slack
+        if: always()
+        env:
+          SLACK_BOT_USER_OAUTH_TOKEN: ${{ steps.secrets.outputs.SLACK_BOT_USER_OAUTH_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          date_str=$(date -u +%Y-%m-%d)
+          text=":mag: *C8 Orchestration Cluster Nightly Triage — ${date_str}*"$'\n'
+
+          count=$(jq 'length' /tmp/failures_normalized.json 2>/dev/null || echo 0)
+          if [ "$count" -gt 0 ]; then
+            text="${text}"$'\n'"*Failed tests by version:*"
+            while IFS= read -r line; do
+              version=$(echo "$line" | jq -r '.version')
+              n=$(echo "$line"       | jq -r '.count')
+              types=$(echo "$line"   | jq -r '.types')
+              text="${text}"$'\n'"• \`${version}\` — ${n} failed test(s) (${types})"
+            done < <(jq -c 'group_by(.version)[] | {version: .[0].version, count: length, types: ([.[].test_type] | unique | join(", "))}' \
+                      /tmp/failures_normalized.json)
+            dispatches=$(jq 'length' /tmp/dispatches.json 2>/dev/null || echo 0)
+            if [ "$dispatches" -gt 0 ]; then
+              text="${text}"$'\n\n'":hourglass_flowing_sand: Dispatching fix agents..."
+            else
+              text="${text}"$'\n\n'":information_source: No fix agents dispatched (open PRs already cover all failing versions)."
+            fi
+          else
+            text="${text}"$'\n'":white_check_mark: No failures found — all nightly runs passed."
+          fi
+          text="${text}"$'\n\n'"<${RUN_URL}|Triage run ↗>"
+
+          payload=$(jq -nc --arg channel '#c8-orchestration-cluster-e2e-test-results' --arg text "$text" \
+            '{channel: $channel, text: $text, mrkdwn: true}')
+          response=$(curl -sS -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer ${SLACK_BOT_USER_OAUTH_TOKEN}" \
+            -H 'Content-Type: application/json; charset=utf-8' \
+            -d "$payload")
+          echo "$response" | jq '.'
+          ts=$(echo "$response"      | jq -r '.ts      // ""')
+          channel=$(echo "$response" | jq -r '.channel // ""')
+          echo "ts=${ts}"           >> "$GITHUB_OUTPUT"
+          echo "channel=${channel}" >> "$GITHUB_OUTPUT"
+
       - name: Upload triage artifacts
         if: always()
         uses: actions/upload-artifact@v4
@@ -382,6 +429,8 @@ jobs:
           REPO:            ${{ github.repository }}
           DISPATCHES_JSON: ${{ needs.triage.outputs.dispatches }}
           TRIAGE_RUN_URL:  ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SLACK_THREAD_TS: ${{ needs.triage.outputs.slack_ts }}
+          SLACK_CHANNEL:   ${{ needs.triage.outputs.slack_channel }}
         run: |
           set -euo pipefail
 
@@ -401,5 +450,7 @@ jobs:
               -f e2e_run_id="$e2e" \
               -f api_es_run_id="$api_es" \
               -f api_rdbms_run_id="$api_rdbms" \
-              -f triage_run_url="$TRIAGE_RUN_URL"
+              -f triage_run_url="$TRIAGE_RUN_URL" \
+              -f slack_thread_ts="$SLACK_THREAD_TS" \
+              -f slack_channel="$SLACK_CHANNEL"
           done

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -5,7 +5,7 @@
 #              one fix-agent run per version. Skips dispatch when an open failing-test-fix
 #              PR already exists for the same base branch.
 # type: CI
-# owner: @camunda/qa-engineering
+# owner: @camunda/test-automation-team
 ---
 name: C8 Orchestration Cluster Nightly Triage
 

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -234,7 +234,7 @@ jobs:
           #   - Strip leading 'qa/c8-orchestration-cluster-e2e-test-suite/' prefix so the
           #     value is a path relative to the test suite root (e.g. 'tests/operate/foo.spec.ts')
           # Filter out:
-          #   - identity/* entries for version 8.7 (8.7 has no identity dir)
+          #   - tests/identity/* entries for version 8.7 (8.7 has no identity dir)
           #   - empty/malformed file fields
 
           # Path normalization + error truncation. Errors are truncated to 600 chars
@@ -253,7 +253,7 @@ jobs:
               | select(.file | test("\\.spec\\.[jt]s$"))
             )
             | map(select(
-                (.version != "8.7") or (.file | test("^identity/") | not)
+                (.version != "8.7") or (.file | test("^tests/identity/") | not)
               ))
           ' /tmp/all_failures.jsonl > /tmp/failures_normalized.json
 

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -376,10 +376,11 @@ jobs:
 
           payload=$(jq -nc --arg channel 'c8-orchestration-cluster-e2e-test-results' --arg text "$text" \
             '{channel: $channel, text: $text, mrkdwn: true}')
+          # Slack post is non-critical — a transient failure must not block dispatch.
           response=$(curl -sS -X POST https://slack.com/api/chat.postMessage \
             -H "Authorization: Bearer ${SLACK_BOT_USER_OAUTH_TOKEN}" \
             -H 'Content-Type: application/json; charset=utf-8' \
-            -d "$payload")
+            -d "$payload" || echo '{}')
           echo "$response" | jq '.'
           ts=$(echo "$response"      | jq -r '.ts      // ""')
           channel=$(echo "$response" | jq -r '.channel // ""')

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -342,6 +342,7 @@ jobs:
 
       - name: Post Slack triage summary
         id: slack
+        continue-on-error: true
         if: always()
         env:
           SLACK_BOT_USER_OAUTH_TOKEN: ${{ steps.secrets.outputs.SLACK_BOT_USER_OAUTH_TOKEN }}

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -1,0 +1,359 @@
+# description: Discovery + classification + dispatch for C8 Orchestration Cluster nightly
+#              E2E and API test failures. Scans the latest run of each in-scope nightly
+#              workflow for every supported version (8.7 / 8.8 / 8.9 / main), extracts
+#              failing tests from json-report artifacts, groups by version, and dispatches
+#              one fix-agent run per version. Skips dispatch when an open failing-test-fix
+#              PR already exists for the same base branch.
+# type: CI
+# owner: @camunda/qa-engineering
+---
+name: C8 Orchestration Cluster Nightly Triage
+
+on:
+  schedule:
+    - cron: '0 4 * * *'   # 04:00 UTC — after all nightlies finish (00:00–01:45 starts)
+                          # and before close-stale-fix-prs.yml runs at 05:00 UTC.
+  workflow_dispatch:
+    inputs:
+      dispatch:
+        description: 'Dispatch fix agents for grouped failures'
+        type: boolean
+        default: true
+        required: false
+      daily_cap:
+        description: 'Max fix-agent dispatches this run (default: 4 — one per supported version)'
+        default: '4'
+        required: false
+      include_main:
+        description: 'Include main in triage scope (set false to limit to stable branches)'
+        type: boolean
+        default: true
+        required: false
+
+permissions:
+  contents: read
+  actions: write
+  pull-requests: read
+
+concurrency:
+  group: triage-orchestration-cluster-nightly
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    outputs:
+      dispatches: ${{ steps.group.outputs.dispatches }}
+
+    steps:
+      - name: Import Vault secrets
+        id: secrets
+        uses: hashicorp/vault-action@d1720f055e0635fd932a1d2a48f87a666a57906c
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/qa/ci/common GH_TOKEN ;
+            secret/data/products/qa/ci/common SLACK_BOT_USER_OAUTH_TOKEN ;
+
+      - name: Show tool versions
+        run: |
+          jq --version
+          gh --version
+
+      - name: Scan nightly workflows and extract failures
+        id: scan
+        env:
+          GH_TOKEN: ${{ steps.secrets.outputs.GH_TOKEN }}
+          REPO:     ${{ github.repository }}
+          INCLUDE_MAIN: ${{ github.event.inputs.include_main || 'true' }}
+        run: |
+          set -euo pipefail
+
+          # Allowlist of nightly workflows to scan. Each entry: workflow file | version | test_type | tasklist_mode (optional)
+          # test_type ∈ {e2e, api_es, api_rdbms}.
+          declare -a SCOPE=(
+            "c8-orchestration-cluster-nightly-8.7-e2e.yml|8.7|e2e"
+            "c8-orchestration-cluster-nightly-8.7-api-es.yml|8.7|api_es"
+            "c8-orchestration-cluster-nightly-8.8-e2e.yml|8.8|e2e"
+            "c8-orchestration-cluster-nightly-8.8-api-es.yml|8.8|api_es"
+            "c8-orchestration-cluster-nightly-8.9-e2e.yml|8.9|e2e"
+            "c8-orchestration-cluster-nightly-8.9-api-es.yml|8.9|api_es"
+            "c8-orchestration-cluster-nightly-8.9-api-rdbms.yml|8.9|api_rdbms"
+          )
+          if [ "$INCLUDE_MAIN" = "true" ]; then
+            SCOPE+=(
+              "c8-orchestration-cluster-nightly-main-e2e.yml|main|e2e"
+              "c8-orchestration-cluster-nightly-main-api-es.yml|main|api_es"
+              "c8-orchestration-cluster-nightly-main-api-rdbms.yml|main|api_rdbms"
+            )
+          fi
+
+          # Working files
+          all_failures=/tmp/all_failures.jsonl
+          run_ids_map=/tmp/run_ids.json
+          : > "$all_failures"
+          echo '{}' > "$run_ids_map"
+
+          for entry in "${SCOPE[@]}"; do
+            IFS='|' read -r workflow_file version test_type <<< "$entry"
+            echo ""
+            echo "──────────────────────────────────────────────────────────────"
+            echo "Scanning ${workflow_file} (version=${version}, type=${test_type})"
+
+            # safe_version follows artifact naming: stable-8.x or main
+            if [ "$version" = "main" ]; then
+              safe_version="main"
+            else
+              safe_version="stable-${version}"
+            fi
+
+            # Find the latest run
+            run_info=$(gh run list --workflow "$workflow_file" --repo "$REPO" \
+                        --limit 1 --json databaseId,conclusion,createdAt,event 2>/dev/null \
+                        | jq -c '.[0] // empty')
+            if [ -z "$run_info" ] || [ "$run_info" = "null" ]; then
+              echo "  no recent runs — skipping"
+              continue
+            fi
+            run_id=$(echo "$run_info" | jq -r '.databaseId')
+            conclusion=$(echo "$run_info" | jq -r '.conclusion')
+            created=$(echo "$run_info" | jq -r '.createdAt')
+            echo "  latest run: $run_id  conclusion=$conclusion  created=$created"
+
+            # Record the run ID per (version, test_type) so dispatch step can pass them through
+            jq --arg v "$version" --arg t "$test_type" --arg r "$run_id" \
+               '. + {($v + "/" + $t): $r}' "$run_ids_map" > "${run_ids_map}.tmp"
+            mv "${run_ids_map}.tmp" "$run_ids_map"
+
+            # Only continue extracting failures when conclusion is failure
+            if [ "$conclusion" != "failure" ]; then
+              echo "  not failed — no failures to extract"
+              continue
+            fi
+
+            # Build the list of json-report artifact patterns to download
+            declare -a patterns=()
+            if [ "$test_type" = "e2e" ]; then
+              # Each version has different modes; just attempt both — gh will silently miss
+              for mode in v1 v2; do
+                patterns+=("json-report-nightly-e2e-${safe_version}-${mode}|${mode}")
+              done
+            elif [ "$test_type" = "api_es" ]; then
+              patterns+=("json-report-nightly-api-${safe_version}|elasticsearch")
+            elif [ "$test_type" = "api_rdbms" ]; then
+              # List the per-database artifact names from the run
+              gh api "repos/${REPO}/actions/runs/${run_id}/artifacts" --paginate \
+                --jq '.artifacts[].name' > /tmp/rdbms_artifact_names.txt
+              while read -r artifact_name; do
+                # Strip the "json-report-nightly-api-rdbms-${safe_version}-" prefix to extract db name
+                db_name="${artifact_name#json-report-nightly-api-rdbms-${safe_version}-}"
+                [ "$db_name" = "$artifact_name" ] && continue   # didn't match prefix → not an rdbms report
+                patterns+=("${artifact_name}|${db_name}")
+              done < /tmp/rdbms_artifact_names.txt
+            fi
+
+            # Download each artifact and extract failures
+            for entry in "${patterns[@]}"; do
+              IFS='|' read -r artifact_name dim <<< "$entry"
+              tmp_dir=$(mktemp -d)
+              if ! gh run download "$run_id" --repo "$REPO" \
+                    --pattern "$artifact_name" --dir "$tmp_dir" 2>/dev/null; then
+                rm -rf "$tmp_dir"
+                continue
+              fi
+              results=$(find "$tmp_dir" -name 'results.json' -type f | head -1)
+              if [ -z "$results" ]; then
+                rm -rf "$tmp_dir"
+                continue
+              fi
+              # Extract failing specs. tasklist_mode is non-null only for e2e; database for api.
+              if [ "$test_type" = "e2e" ]; then
+                jq -c --arg v "$version" --arg mode "$dim" '
+                  [.. | objects | select(.specs?) | .specs[]]
+                  | map(select(.ok == false))
+                  | .[] | {
+                      version: $v,
+                      file: .file,
+                      test_name: .title,
+                      error: (.tests[0].results[-1].error.message // "unknown error"),
+                      test_type: "e2e",
+                      tasklist_mode: $mode
+                    }' "$results" >> "$all_failures" || true
+              else
+                # API tests (ES or RDBMS): set database from dim
+                jq -c --arg v "$version" --arg db "$dim" '
+                  [.. | objects | select(.specs?) | .specs[]]
+                  | map(select(.ok == false))
+                  | .[] | {
+                      version: $v,
+                      file: .file,
+                      test_name: .title,
+                      error: (.tests[0].results[-1].error.message // "unknown error"),
+                      test_type: "api",
+                      database: $db
+                    }' "$results" >> "$all_failures" || true
+              fi
+              rm -rf "$tmp_dir"
+            done
+          done
+
+          echo ""
+          echo "──────────────────────────────────────────────────────────────"
+          echo "Total failure records collected: $(wc -l < $all_failures || echo 0)"
+          # First few entries for visibility
+          head -3 "$all_failures" || true
+
+          # Expose run_ids_map for the next step
+          cp "$run_ids_map" /tmp/run_ids.json
+
+      - name: Normalize, filter and group by version
+        id: group
+        env:
+          GH_TOKEN: ${{ steps.secrets.outputs.GH_TOKEN }}
+          REPO:     ${{ github.repository }}
+          DAILY_CAP: ${{ github.event.inputs.daily_cap || '4' }}
+        run: |
+          set -euo pipefail
+
+          [ ! -s /tmp/all_failures.jsonl ] && { echo "No failures."; echo "dispatches=[]" >> "$GITHUB_OUTPUT"; exit 0; }
+
+          # Normalize file paths:
+          #   - Strip absolute prefixes (anything before 'qa/c8-orchestration-cluster-e2e-test-suite/')
+          #   - Strip leading 'qa/c8-orchestration-cluster-e2e-test-suite/' or 'tests/' prefix so the
+          #     value is a path relative to the test suite root (the fix agent prepends the suite path)
+          # Filter out:
+          #   - identity/* entries for version 8.7 (8.7 has no identity dir)
+          #   - empty/malformed file fields
+
+          # Path normalization + error truncation. Errors are truncated to 600 chars
+          # because workflow_dispatch inputs cap at ~64KB total payload — long stack
+          # traces from many failures would otherwise overflow.
+          jq -s '
+            map(
+              .file as $f
+              | .file = (
+                  $f
+                  | sub("^.*/qa/c8-orchestration-cluster-e2e-test-suite/"; "")
+                  | sub("^qa/c8-orchestration-cluster-e2e-test-suite/"; "")
+                )
+              | .error = ((.error // "unknown error")[0:600])
+              | select(.file != null and .file != "")
+              | select(.file | test("\\.spec\\.[jt]s$"))
+            )
+            | map(select(
+                (.version != "8.7") or (.file | test("^identity/") | not)
+              ))
+          ' /tmp/all_failures.jsonl > /tmp/failures_normalized.json
+
+          echo "After normalization + filtering: $(jq 'length' /tmp/failures_normalized.json)"
+
+          # Determine which versions have open failing-test-fix PRs (dedup)
+          open_pr_versions=$(gh pr list --repo "$REPO" \
+            --search "label:failing-test-fix is:open" \
+            --json baseRefName --jq '[.[].baseRefName] | unique' 2>/dev/null || echo '[]')
+          echo "Open failing-test-fix PR base refs: $open_pr_versions"
+
+          # Build dispatch payloads, one per version
+          # version → {test_specs, e2e_run_id, api_es_run_id, api_rdbms_run_id}
+          jq --slurpfile run_ids /tmp/run_ids.json \
+             --argjson openrefs "$open_pr_versions" \
+             --argjson cap "${DAILY_CAP}" '
+            # group failures by version
+            group_by(.version)
+            | map({
+                version: .[0].version,
+                test_specs: map(del(.version)),
+                ref: (if .[0].version == "main" then "main" else ("stable/" + .[0].version) end)
+              })
+            | map(select(.test_specs | length > 0))
+            # dedup against open PRs
+            | map(select((.ref as $ref | $openrefs | index($ref)) == null))
+            # attach run IDs
+            | map(. + {
+                e2e_run_id:       ($run_ids[0][(.version + "/e2e")]       // ""),
+                api_es_run_id:    ($run_ids[0][(.version + "/api_es")]    // ""),
+                api_rdbms_run_id: ($run_ids[0][(.version + "/api_rdbms")] // "")
+              })
+            # cap dispatch count
+            | .[0:$cap]
+          ' /tmp/failures_normalized.json > /tmp/dispatches.json
+
+          echo "Dispatches planned: $(jq 'length' /tmp/dispatches.json)"
+          jq '[.[] | {version, count: (.test_specs | length), e2e_run_id, api_es_run_id, api_rdbms_run_id}]' /tmp/dispatches.json || true
+
+          # Emit as compact single-line output
+          {
+            echo "dispatches<<EOF_DISPATCH"
+            jq -c '.' /tmp/dispatches.json
+            echo "EOF_DISPATCH"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Upload triage artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-triage-${{ github.run_id }}
+          path: |
+            /tmp/all_failures.jsonl
+            /tmp/failures_normalized.json
+            /tmp/dispatches.json
+            /tmp/run_ids.json
+          retention-days: 14
+          if-no-files-found: warn
+
+  dispatch:
+    name: Dispatch fix agents
+    needs: triage
+    if: ${{ github.event.inputs.dispatch != 'false' && needs.triage.outputs.dispatches != '[]' && needs.triage.outputs.dispatches != '' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Import Vault secrets
+        id: secrets
+        uses: hashicorp/vault-action@d1720f055e0635fd932a1d2a48f87a666a57906c
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/qa/ci/common GH_TOKEN ;
+
+      - name: Dispatch one fix-agent run per version
+        env:
+          GH_TOKEN:        ${{ steps.secrets.outputs.GH_TOKEN }}
+          REPO:            ${{ github.repository }}
+          DISPATCHES_JSON: ${{ needs.triage.outputs.dispatches }}
+          TRIAGE_RUN_URL:  ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          echo "$DISPATCHES_JSON" | jq -c '.[]' | while read -r d; do
+            version=$(echo "$d" | jq -r '.version')
+            specs=$(echo "$d" | jq -c '.test_specs')
+            e2e=$(echo "$d"   | jq -r '.e2e_run_id')
+            api_es=$(echo "$d" | jq -r '.api_es_run_id')
+            api_rdbms=$(echo "$d" | jq -r '.api_rdbms_run_id')
+
+            echo "Dispatching fix agent: version=$version  failures=$(echo "$specs" | jq 'length')"
+
+            gh workflow run c8-orchestration-cluster-e2e-nightly-fix.yml \
+              --repo "$REPO" --ref main \
+              -f version="$version" \
+              -f test_specs="$specs" \
+              -f e2e_run_id="$e2e" \
+              -f api_es_run_id="$api_es" \
+              -f api_rdbms_run_id="$api_rdbms" \
+              -f triage_run_url="$TRIAGE_RUN_URL"
+          done

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -234,7 +234,6 @@ jobs:
           #   - Strip leading 'qa/c8-orchestration-cluster-e2e-test-suite/' prefix so the
           #     value is a path relative to the test suite root (e.g. 'tests/operate/foo.spec.ts')
           # Filter out:
-          #   - tests/identity/* entries for all stable branches (identity tests only exist on main)
           #   - empty/malformed file fields
 
           # Path normalization + error truncation. Errors are truncated to 600 chars
@@ -252,9 +251,6 @@ jobs:
               | select(.file != null and .file != "")
               | select(.file | test("\\.spec\\.[jt]s$"))
             )
-            | map(select(
-                (.version == "main") or (.file | test("^tests/identity/") | not)
-              ))
           ' /tmp/all_failures.jsonl > /tmp/failures_normalized.json
 
           echo "After normalization + filtering: $(jq 'length' /tmp/failures_normalized.json)"

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -217,8 +217,6 @@ jobs:
           # First few entries for visibility
           head -3 "$all_failures" || true
 
-          # Expose run_ids_map for the next step
-          cp "$run_ids_map" /tmp/run_ids.json
 
       - name: Normalize, filter and group by version
         id: group

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -10,8 +10,6 @@
 name: C8 Orchestration Cluster Nightly Triage
 
 on:
-  pull_request:
-    types: [opened, edited, synchronize]  # Triggers on PR open, new commits on PR and when the PR description is edited
   schedule:
     - cron: '0 4 * * *'   # 04:00 UTC — after all nightlies finish (00:00–01:45 starts)
                           # and before close-stale-fix-prs.yml runs at 05:00 UTC.
@@ -357,7 +355,7 @@ jobs:
   dispatch:
     name: Dispatch fix agents
     needs: triage
-    if: ${{ github.event_name != 'pull_request' && github.event.inputs.dispatch != 'false' && needs.triage.outputs.dispatches != '[]' && needs.triage.outputs.dispatches != '' }}
+    if: ${{ github.event.inputs.dispatch != 'false' && needs.triage.outputs.dispatches != '[]' && needs.triage.outputs.dispatches != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -380,13 +378,10 @@ jobs:
 
       - name: Dispatch one fix-agent run per version
         env:
-          GH_TOKEN:            ${{ steps.secrets.outputs.GH_TOKEN }}
-          REPO:                ${{ github.repository }}
-          DISPATCHES_JSON:     ${{ needs.triage.outputs.dispatches }}
-          TRIAGE_RUN_URL:      ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          # schedule always runs on the default branch so ref_name == main;
-          # workflow_dispatch from a feature branch uses that branch, enabling PR-time testing.
-          FIX_WORKFLOW_REF:    ${{ github.ref_name }}
+          GH_TOKEN:        ${{ steps.secrets.outputs.GH_TOKEN }}
+          REPO:            ${{ github.repository }}
+          DISPATCHES_JSON: ${{ needs.triage.outputs.dispatches }}
+          TRIAGE_RUN_URL:  ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
 
@@ -397,10 +392,10 @@ jobs:
             api_es=$(echo "$d" | jq -r '.api_es_run_id')
             api_rdbms=$(echo "$d" | jq -r '.api_rdbms_run_id')
 
-            echo "Dispatching fix agent: version=$version  failures=$(echo "$specs" | jq 'length')  ref=${FIX_WORKFLOW_REF}"
+            echo "Dispatching fix agent: version=$version  failures=$(echo "$specs" | jq 'length')"
 
             gh workflow run c8-orchestration-cluster-e2e-nightly-fix.yml \
-              --repo "$REPO" --ref "${FIX_WORKFLOW_REF}" \
+              --repo "$REPO" --ref main \
               -f version="$version" \
               -f test_specs="$specs" \
               -f e2e_run_id="$e2e" \

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -270,7 +270,7 @@ jobs:
             sort_by(.version) | group_by(.version)
             | map({
                 version: .[0].version,
-                test_specs: map(del(.version)),
+                test_specs: (map(del(.version)) | .[0:50]),
                 ref: (if .[0].version == "main" then "main" else ("stable/" + .[0].version) end)
               })
             | map(select(.test_specs | length > 0))

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -30,9 +30,11 @@ on:
         default: true
         required: false
 
+# Minimal at workflow level. Triage job only needs to read; dispatch job
+# bumps actions: write to trigger the fix workflow (zizmor: excessive-permissions).
 permissions:
   contents: read
-  actions: write
+  actions: read
   pull-requests: read
 
 concurrency:
@@ -317,6 +319,10 @@ jobs:
     if: ${{ github.event.inputs.dispatch != 'false' && needs.triage.outputs.dispatches != '[]' && needs.triage.outputs.dispatches != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      actions: write   # required to dispatch the fix workflow
+      pull-requests: read
 
     steps:
       - name: Import Vault secrets

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -10,6 +10,8 @@
 name: C8 Orchestration Cluster Nightly Triage
 
 on:
+  pull_request:
+    types: [opened, edited, synchronize]  # Triggers on PR open, new commits on PR and when the PR description is edited
   schedule:
     - cron: '0 4 * * *'   # 04:00 UTC — after all nightlies finish (00:00–01:45 starts)
                           # and before close-stale-fix-prs.yml runs at 05:00 UTC.

--- a/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
@@ -406,26 +406,35 @@ If a minimal test-side fix exists, apply it.
    Touch page objects when the selector itself is wrong; touch utilities
    only when multiple tests share the same root cause.
 4. Lint changed files:
+
    ```bash
    cd qa/c8-orchestration-cluster-e2e-test-suite
    npx prettier --write <changed-files>
    npx eslint <changed-files> --fix
    ```
+
    Fix any remaining eslint errors before committing.
+
 5. Commit with `test:` (NOT `fix:` — see above on Conventional Commits):
    `git commit -m "test: <one-line description> (nightly ${VERSION})"`
+
 6. Push: `git push -u origin fix/nightly-${VERSION}-<slug>`
+
 7. Check for existing open PRs before opening a new one:
+
    ```bash
    gh pr list --repo camunda/camunda \
      --search "nightly is:open label:failing-test-fix" \
      --json number,title,baseRefName,headRefName
    ```
+
    If an open PR targets the same `stable/<version>` for the same root
    cause: comment on it with your additional diagnosis; do not open a
    second PR.
+
 8. Open a draft PR targeting the same base branch you are on, label
    `failing-test-fix`. Body must include:
+
    - Root cause analysis
    - List of fixed tests (file + name)
    - Link to the failing nightly run(s)

--- a/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
@@ -280,3 +280,150 @@ test: add operate batch cancel assertion for RDBMS
 fix: retry flaky identity role assignment check
 ```
 
+## Nightly Fix Agent
+
+This section is read automatically by the Claude Code agent dispatched from
+`c8-orchestration-cluster-e2e-nightly-triage.yml`. It defines the agent's
+diagnosis steps and operating constraints.
+
+### Context the agent receives
+
+The triage workflow writes `/tmp/test_specs.json` before invoking the agent.
+Each entry is one failing test:
+
+```json
+{
+  "file": "tests/operate/processInstancesFilters.spec.ts",
+  "test_name": "Filter process instances by parent key, date range, and error message",
+  "error": "TimeoutError: locator.click: Timeout 10000ms exceeded.\n  - waiting for getByRole('menuitem', { name: 'Operation Id' })\n",
+  "test_type": "e2e",
+  "tasklist_mode": "v2"
+}
+```
+
+For API entries, `test_type` is `"api"` and `tasklist_mode` is absent;
+`database` is set (`"elasticsearch"` for ES nightlies, e.g. `"Postgres 17"`
+for RDBMS).
+
+`file` is **relative to this test suite** (`qa/c8-orchestration-cluster-e2e-test-suite/`).
+To read the test code, open
+`qa/c8-orchestration-cluster-e2e-test-suite/<file>`.
+
+The agent is also given the failing nightly run IDs via env vars:
+`E2E_RUN_ID`, `API_ES_RUN_ID`, `API_RDBMS_RUN_ID`. Empty string means that
+test type did not fail (or does not exist for this version).
+
+### Diagnosis steps
+
+**Step 1 — Download nightly artifacts.** Run the download block from the
+workflow prompt. Resulting layout:
+
+```
+/tmp/nightly-artifacts/
+  e2e-v1/        json-report-nightly-e2e-<safe_version>-v1/results.json
+  e2e-v1-html/   html-report-nightly-e2e-<safe_version>-v1/...   ← contains screenshots
+  e2e-v2/        json-report-nightly-e2e-<safe_version>-v2/results.json
+  e2e-v2-html/   html-report-nightly-e2e-<safe_version>-v2/...
+  api-es/        json-report-nightly-api-<safe_version>/results.json
+  api-rdbms/     json-report-nightly-api-rdbms-<safe_version>-<db>/results.json
+```
+
+Screenshots from Playwright's HTML report live under
+`html-report/.../data/*.png`. You can read PNGs directly — use them as the
+primary signal for E2E diagnosis.
+
+**Step 2 — Read the test file.** Open
+`qa/c8-orchestration-cluster-e2e-test-suite/<file>` from the test spec.
+Read any imported page objects under
+`qa/c8-orchestration-cluster-e2e-test-suite/pages/` and helpers under
+`qa/c8-orchestration-cluster-e2e-test-suite/utils/`.
+
+**Step 3 — Form a hypothesis.** Match the screenshot and/or error message to
+a specific assertion or action. Typical patterns:
+
+- **Element not found within timeout** — the previous step did not finish
+  rendering. Add a `expect(...).toBeVisible()` or `waitFor({state: 'visible'})`
+  before the click. Do NOT use `page.waitForTimeout()` — it is banned.
+- **Stale element / re-render race** — wrap the action in a retry helper if
+  one exists in `utils/`, or split into smaller steps.
+- **Auth / cookie state lost between describes** — check `beforeEach` for a
+  missing `context.clearCookies()` or login step.
+- **API response shape change** — only a test-side fix is in scope if the
+  test was asserting on a field that legitimately moved/renamed. If the
+  endpoint regressed, this is a product bug — see Step 4.
+
+**Step 4 — Decide: fix or stop.**
+
+If the failure is **clearly a product bug** (e.g., a 500 from the server, a
+panel that never renders despite correct backend response, an authorization
+regression) and no test-side change is reasonable: write `{"prs":[]}` to
+`/tmp/fix-meta.json` and stop. Do not open a PR. Do not skip the test.
+
+If a minimal test-side fix exists, apply it.
+
+### Apply the fix
+
+1. The repo is already on the correct target branch (`stable/<version>` or
+   `main`). Verify with `git status`.
+2. Create a fix branch:
+   `git checkout -b fix/nightly-${VERSION}-<short-slug>`
+3. Edit files under `qa/c8-orchestration-cluster-e2e-test-suite/` only.
+   Touch page objects when the selector itself is wrong; touch utilities
+   only when multiple tests share the same root cause.
+4. Lint changed files:
+   ```bash
+   cd qa/c8-orchestration-cluster-e2e-test-suite
+   npx prettier --write <changed-files>
+   npx eslint <changed-files> --fix
+   ```
+   Fix any remaining eslint errors before committing.
+5. Commit with `test:` (NOT `fix:` — see above on Conventional Commits):
+   `git commit -m "test: <one-line description> (nightly ${VERSION})"`
+6. Push: `git push -u origin fix/nightly-${VERSION}-<slug>`
+7. Check for existing open PRs before opening a new one:
+   ```bash
+   gh pr list --repo camunda/camunda \
+     --search "nightly is:open label:failing-test-fix" \
+     --json number,title,baseRefName,headRefName
+   ```
+   If an open PR targets the same `stable/<version>` for the same root
+   cause: comment on it with your additional diagnosis; do not open a
+   second PR.
+8. Open a draft PR targeting the same base branch you are on, label
+   `failing-test-fix`. Body must include:
+   - Root cause analysis
+   - List of fixed tests (file + name)
+   - Link to the failing nightly run(s)
+   - Link to the triage run
+
+### Constraints
+
+- **Allowed tools:** `gh`, `git`, `grep`, `rg`, `cat`, `find`, `jq`, `sed`, `awk`, `unzip`, `npx prettier`, `npx eslint`.
+- **Forbidden:** `make`, `mvn`, `./mvnw`, `docker`, `kubectl`, `helm`, `npm install`, `npm run build`, `npm run test`, `npx playwright test`. The fix agent does **not** execute tests — it fixes from artifact evidence only. Verification is delegated to the on-demand workflows triggered by the calling workflow.
+- **NO skipping — EVER:** `test.skip()`, `test.fixme()`, `test.only`, and all pending variants are banned. There are no exceptions, not even for confirmed product bugs. If you cannot fix in code, write `{"prs":[]}` and stop.
+- **Minimal diff:** no refactoring, no dependency bumps, no unrelated edits, no formatting sweeps on untouched files.
+- **PR title type must be `test:`** — commitlint rejects `fix:` for test-only changes (see Commit / PR Conventions above).
+- **One PR per version** — a single PR may fix multiple tests on the same `stable/<version>` branch, including a mix of API and E2E failures, but never crosses branch boundaries.
+
+### Result manifest
+
+Always write `/tmp/fix-meta.json` before stopping:
+
+```json
+{
+  "prs": [
+    {
+      "number": 1234,
+      "owner": "camunda",
+      "repo": "camunda",
+      "branch": "fix/nightly-8.9-operate-filter-wait",
+      "has_e2e": true,
+      "has_api": false
+    }
+  ]
+}
+```
+
+Use `{"prs": []}` if no PR was opened (regardless of reason). The calling
+workflow uses `has_e2e` and `has_api` to decide which on-demand verification
+workflows to trigger.

--- a/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
@@ -315,8 +315,43 @@ test type did not fail (or does not exist for this version).
 
 ### Diagnosis steps
 
-**Step 1 — Download nightly artifacts.** Run the download block from the
-workflow prompt. Resulting layout:
+**Step 1 — Download nightly artifacts.** Run this block as-is (env vars are
+already exported by the calling workflow):
+
+```bash
+mkdir -p /tmp/nightly-artifacts
+
+if [ "$HAS_E2E" = "true" ] && [ -n "$E2E_RUN_ID" ]; then
+  for mode in v1 v2; do
+    # 8.7 has no v2, main has no v1 — gh silently no-ops on missing patterns
+    gh run download "$E2E_RUN_ID" --repo "$REPO" \
+      --pattern "json-report-nightly-e2e-${SAFE_VERSION}-${mode}" \
+      --dir "/tmp/nightly-artifacts/e2e-${mode}" 2>/dev/null || true
+    gh run download "$E2E_RUN_ID" --repo "$REPO" \
+      --pattern "html-report-nightly-e2e-${SAFE_VERSION}-${mode}" \
+      --dir "/tmp/nightly-artifacts/e2e-${mode}-html" 2>/dev/null || true
+  done
+fi
+
+if [ "$HAS_API_ES" = "true" ] && [ -n "$API_ES_RUN_ID" ]; then
+  gh run download "$API_ES_RUN_ID" --repo "$REPO" \
+    --pattern "json-report-nightly-api-${SAFE_VERSION}" \
+    --dir /tmp/nightly-artifacts/api-es 2>/dev/null || true
+fi
+
+if [ "$HAS_API_RDBMS" = "true" ] && [ -n "$API_RDBMS_RUN_ID" ]; then
+  # Only download the DB-specific artifacts that have failing tests
+  jq -r '[.[] | select(.test_type == "api" and .database != null
+           and .database != "" and .database != "elasticsearch")
+           | .database] | unique[]' /tmp/test_specs.json | while read -r db; do
+    gh run download "$API_RDBMS_RUN_ID" --repo "$REPO" \
+      --pattern "json-report-nightly-api-rdbms-${SAFE_VERSION}-${db}" \
+      --dir "/tmp/nightly-artifacts/api-rdbms" 2>/dev/null || true
+  done
+fi
+```
+
+Resulting layout:
 
 ```
 /tmp/nightly-artifacts/

--- a/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
@@ -424,7 +424,7 @@ If a minimal test-side fix exists, apply it.
 
    ```bash
    gh pr list --repo camunda/camunda \
-     --search "nightly is:open label:failing-test-fix" \
+     --search "is:open label:failing-test-fix" \
      --json number,title,baseRefName,headRefName
    ```
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/workspace-templates/camunda-orchestration-cluster-nightly.guidance.md
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/workspace-templates/camunda-orchestration-cluster-nightly.guidance.md
@@ -46,3 +46,4 @@ and follow the **"## Nightly Fix Agent"** section exactly. That section contains
 - Commit type must be `test:` — commitlint rejects `fix:` for test-only changes
 - Run `npx prettier --write <files>` + `npx eslint <files> --ext .ts` before committing
 - If no safe fix exists, write `{"prs":[]}` to `/tmp/fix-meta.json` and stop
+

--- a/qa/c8-orchestration-cluster-e2e-test-suite/workspace-templates/camunda-orchestration-cluster-nightly.guidance.md
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/workspace-templates/camunda-orchestration-cluster-nightly.guidance.md
@@ -44,6 +44,6 @@ and follow the **"## Nightly Fix Agent"** section exactly. That section contains
 - Fix ONLY the tests listed in `/tmp/test_specs.json`
 - NEVER use `test.skip()`, `test.fixme()`, or any skip/pending variant
 - Commit type must be `test:` — commitlint rejects `fix:` for test-only changes
-- Run `npx prettier --write <files>` + `npx eslint <files> --ext .ts` before committing
+- Run `npx prettier --write <files>` + `npx eslint <files> --fix` before committing
 - If no safe fix exists, write `{"prs":[]}` to `/tmp/fix-meta.json` and stop
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/workspace-templates/camunda-orchestration-cluster-nightly.guidance.md
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/workspace-templates/camunda-orchestration-cluster-nightly.guidance.md
@@ -1,0 +1,48 @@
+# C8 Orchestration Cluster Nightly — Workspace Guidance
+
+## Role
+
+You are a Camunda QA engineer fixing failing nightly E2E and API tests for the C8
+orchestration cluster. Your job is to read the failing test artifacts, identify the
+root cause, apply a minimal targeted fix, and open a draft PR against the correct
+stable branch (or `main`). You operate exclusively within `camunda/camunda` at
+`qa/c8-orchestration-cluster-e2e-test-suite/`.
+
+## Repository
+
+- **`{{.WorkspacePath}}/camunda/`** — The Camunda 8 monorepo. The test suite lives at
+  `qa/c8-orchestration-cluster-e2e-test-suite/`. Tests are Playwright + TypeScript.
+  API tests live under `tests/api/`, E2E UI tests under `tests/operate/`,
+  `tests/tasklist/`, `tests/identity/`, etc. Page objects are in `pages/`.
+  The suite is version-segregated by branch (`main`, `stable/8.9`, `stable/8.8`,
+  `stable/8.7`) — always work in the branch already checked out in this workspace.
+
+## Operating manual
+
+Read `{{.WorkspacePath}}/camunda/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md`
+and follow the **"## Nightly Fix Agent"** section exactly. That section contains:
+- Artifact download commands
+- Diagnosis steps (screenshots, JSON reports)
+- Constraints (NEVER skip/fixme, minimal diff, lint before commit)
+- PR conventions (`test:` type, not `fix:`)
+- Result manifest schema (`/tmp/fix-meta.json`)
+
+## Key paths
+
+```
+{{.WorkspacePath}}/camunda/
+  qa/c8-orchestration-cluster-e2e-test-suite/
+    tests/          # Playwright specs
+    pages/          # Page Object Model classes
+    utils/          # Helpers (waitForAssertion, zeebeClient, etc.)
+    fixtures.ts     # Playwright fixture definitions
+    AGENTS.md       # YOUR OPERATING MANUAL — read this first
+```
+
+## Constraints
+
+- Fix ONLY the tests listed in `/tmp/test_specs.json`
+- NEVER use `test.skip()`, `test.fixme()`, or any skip/pending variant
+- Commit type must be `test:` — commitlint rejects `fix:` for test-only changes
+- Run `npx prettier --write <files>` + `npx eslint <files> --ext .ts` before committing
+- If no safe fix exists, write `{"prs":[]}` to `/tmp/fix-meta.json` and stop

--- a/qa/c8-orchestration-cluster-e2e-test-suite/workspace-templates/camunda-orchestration-cluster-nightly.yaml
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/workspace-templates/camunda-orchestration-cluster-nightly.yaml
@@ -1,0 +1,20 @@
+name: camunda-orchestration-cluster-nightly
+description: "Nightly fix-agent workspace for C8 orchestration cluster E2E and API tests"
+purpose: |
+  You are a Camunda QA engineer fixing failing nightly E2E and API tests
+  in qa/c8-orchestration-cluster-e2e-test-suite/ inside camunda/camunda.
+  Read qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md — the
+  "## Nightly Fix Agent" section — for diagnosis steps and constraints before
+  doing anything else.
+
+repos:
+  - url: https://github.com/camunda/camunda.git
+    path: camunda
+    default_branch: main
+
+# Derive workspace AGENTS.md from the repo's own AGENTS.md at create time.
+# Refresh with:
+#   workspace templates derive-guidance camunda-orchestration-cluster-nightly --ai claude --force
+derive:
+  agents_from: AGENTS.md
+  ai_guidance: camunda-orchestration-cluster-nightly.guidance.md


### PR DESCRIPTION
## Summary

Adds a triage + fix agent pair for failing C8 orchestration cluster nightly tests (E2E and API across 8.7, 8.8, 8.9, and main), modeled on the existing fix agent in `camunda/c8-cross-component-e2e-tests`.

## Files

- `.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml` — runs daily at 04:00 UTC . Scans the latest run of every in-scope nightly workflow (10 workflows total), extracts failing specs from `json-report` artifacts, normalizes file paths, dedups against open `failing-test-fix` PRs, and dispatches one fix-agent run per version.
- `.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml` — `workflow_dispatch`-only. Checks out `main` for workflow tooling, downloads json + html artifacts (HTML for E2E screenshots), runs Claude Code CLI to fix tests, opens a draft PR with the `test:` Conventional Commit type, then triggers the matching on-demand workflows and patches the PR body with verification run URLs.
- `qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md` — agent operating instructions. Most importantly: the absolute ban on `test.skip()` / `test.fixme()`, and the `test:` vs `fix:` PR title rule (commitlint rejects `fix:` on test-only changes).

## Design notes

**Why two workflows?** Triage is scheduled, read-only, and runs in a tight time window. The fix agent is dispatchable, has elevated permissions (push, PR), and runs per-version in parallel. Separation mirrors the cross-component pattern.

**Why one PR per version?** Each `stable/8.x` is a separate branch with its own copy of the test suite. A cross-version PR is impossible — the bases differ. API and E2E failures for the same version go into one PR.

**Verification.** After opening the PR, the fix agent triggers:
- `c8-orchestration-cluster-e2e-tests-on-demand.yml` if any E2E test was fixed
- `c8-orchestration-cluster-e2e-api-test-branch-on-demand.yml` if any API test was fixed

Both run URLs are patched into the PR body for reviewers.

**Secrets.** All from `secret/data/products/qa/ci/common`:
- `GH_TOKEN` — for git push and `gh pr create` (currently maintainer's PAT; will swap to a dedicated bot token when infra provisions it)
- `CLAUDE_API_KEY` — mapped to `ANTHROPIC_API_KEY` for Claude Code CLI
- `SLACK_BOT_USER_OAUTH_TOKEN` — for thread replies when dispatched from triage

## Scope in / out

**In scope** — 10 nightly workflows:
- 8.7: e2e, api-es
- 8.8: e2e, api-es
- 8.9: e2e, api-es, api-rdbms
- main: e2e, api-es, api-rdbms

**Out of scope** (intentional):
- `c8-orchestration-cluster-forward-compatibility-tests.yml` (cross-version)
- `c8-orchestration-cluster-request-validation-nightly.yml` (no artifacts)
- 8.6 and earlier
- Java unit/integration tests

## Validation plan

1. Merge this PR (workflows take effect on `main`).
2. Manually dispatch the triage workflow with `dispatch: false` to verify scanning + grouping without dispatching fix agents.
3. Pick a known failing nightly, manually dispatch the fix agent with hand-crafted `test_specs` to validate the fix loop end-to-end.
4. Enable the schedule by leaving the cron in place — it fires the next 04:00 UTC.

## Open items

- Branch protection on `stable/8.x` — the bot needs to be able to open draft PRs. Will verify after merge.
- Slack channel routing for triage notifications — not wired yet (the fix agent supports it via inputs; triage doesn't post a digest yet).
- After running for ~1 week, review false-positive / false-negative rates and tune the prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
