### PR TITLE
ci: fix flaky test lookup for nested classes

### DIFF
--- a/.ci/scripts/ci/setup-medic-lookup.sh
+++ b/.ci/scripts/ci/setup-medic-lookup.sh
@@ -64,7 +64,9 @@ resolve_test_source_file() {
     # Input: fully qualified test class name, e.g. io.camunda.foo.BarTest
     # Output: prints a single repo-relative path or empty string.
     local fqcn="$1"
-    local rel_test_path="${fqcn//./\/}.java"
+    # Strip nested class suffix (e.g. OuterClass$InnerClass -> OuterClass)
+    local outer_fqcn="${fqcn%%\$*}"
+    local rel_test_path="${outer_fqcn//./\/}.java"
 
     # Find the test file location (first match is good enough)
     local test_file


### PR DESCRIPTION
## Description

Resolve the lookup for cases like `McpServerConfigurationIT$McpServerEnabledWithRestGatewayDisabledIT`

Slack: https://camunda.slack.com/archives/C071KP5BTHB/p1779970439115719?thread_ts=1779953685.557599&cid=C071KP5BTHB

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)) - only needed on `main` for scheduled jobs
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

None
