### PR TITLE
docs: customer documentation for the analytics exporter

### DIFF
--- a/zeebe/exporters/analytics-exporter/README.md
+++ b/zeebe/exporters/analytics-exporter/README.md
@@ -111,12 +111,12 @@ Analytics exporter configured: endpoint=https://analytics.cloud.camunda.io, clus
 All options live under `args`. Defaults are tuned for typical Self-Managed deployments and
 rarely need to be changed.
 
-| Option           | Type     | Description                                                                                                            | Default                              |
-|------------------|----------|------------------------------------------------------------------------------------------------------------------------|--------------------------------------|
-| `endpoint`       | string   | OTLP/HTTP base URL for the analytics endpoint. The OTel SDK appends `/v1/logs` automatically.                          | `https://analytics.cloud.camunda.io` |
-| `push-interval`  | duration | Maximum time between batch pushes, as an [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations).        | `PT5S`                               |
-| `max-queue-size` | int      | Maximum number of log records buffered in memory before new records are dropped.                                       | `2048`                               |
-| `max-batch-size` | int      | Maximum number of records sent in a single OTLP request. Must be less than or equal to `max-queue-size`.               | `512`                                |
+|      Option      |   Type   |                                                   Description                                                   |               Default                |
+|------------------|----------|-----------------------------------------------------------------------------------------------------------------|--------------------------------------|
+| `endpoint`       | string   | OTLP/HTTP base URL for the analytics endpoint. The OTel SDK appends `/v1/logs` automatically.                   | `https://analytics.cloud.camunda.io` |
+| `push-interval`  | duration | Maximum time between batch pushes, as an [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations). | `PT5S`                               |
+| `max-queue-size` | int      | Maximum number of log records buffered in memory before new records are dropped.                                | `2048`                               |
+| `max-batch-size` | int      | Maximum number of records sent in a single OTLP request. Must be less than or equal to `max-queue-size`.        | `512`                                |
 
 ## What data is exported
 
@@ -125,29 +125,29 @@ identified by the `event.name` attribute following the OTel Events semantic conv
 
 ### Event types
 
-| Source record                | Event name                 |
-|------------------------------|----------------------------|
-| `PROCESS_INSTANCE_CREATION`  | `process_instance_created` |
+|        Source record        |         Event name         |
+|-----------------------------|----------------------------|
+| `PROCESS_INSTANCE_CREATION` | `process_instance_created` |
 
 ### Log record attributes
 
 Per-event attributes attached to each log record:
 
-| Attribute                          | Type   | Description                                                |
-|------------------------------------|--------|------------------------------------------------------------|
-| `event.name`                       | string | Event type identifier.                                     |
-| `camunda.bpmn_process_id`          | string | BPMN process ID.                                           |
-| `camunda.process_version`          | long   | Process definition version.                                |
-| `camunda.process_definition_key`   | long   | Process definition key.                                    |
-| `camunda.process_instance_key`     | long   | Process instance key.                                      |
-| `camunda.tenant_id`                | string | Tenant ID, or the default tenant when not multi-tenant.    |
-| `camunda.log.position`             | long   | Log stream position. Used as a deduplication key.          |
+|            Attribute             |  Type  |                       Description                       |
+|----------------------------------|--------|---------------------------------------------------------|
+| `event.name`                     | string | Event type identifier.                                  |
+| `camunda.bpmn_process_id`        | string | BPMN process ID.                                        |
+| `camunda.process_version`        | long   | Process definition version.                             |
+| `camunda.process_definition_key` | long   | Process definition key.                                 |
+| `camunda.process_instance_key`   | long   | Process instance key.                                   |
+| `camunda.tenant_id`              | string | Tenant ID, or the default tenant when not multi-tenant. |
+| `camunda.log.position`           | long   | Log stream position. Used as a deduplication key.       |
 
 ### Resource attributes
 
 Cluster-wide attributes attached to every log record:
 
-| Attribute              | Type   | Description             |
+|       Attribute        |  Type  |       Description       |
 |------------------------|--------|-------------------------|
 | `camunda.cluster.id`   | string | Cluster identifier.     |
 | `camunda.partition.id` | long   | Partition ID.           |

--- a/zeebe/exporters/analytics-exporter/README.md
+++ b/zeebe/exporters/analytics-exporter/README.md
@@ -125,23 +125,50 @@ identified by the `event.name` attribute following the OTel Events semantic conv
 
 ### Event types
 
-|        Source record        |         Event name         |
-|-----------------------------|----------------------------|
-| `PROCESS_INSTANCE_CREATION` | `process_instance_created` |
+|        Source record        |       Intent        |          Event name          |                                       Notes                                       |
+|-----------------------------|---------------------|------------------------------|-----------------------------------------------------------------------------------|
+| `PROCESS_INSTANCE_CREATION` | `CREATED`           | `process_instance_created`   | Emitted for every new process instance.                                           |
+| `PROCESS_INSTANCE`          | `ELEMENT_ACTIVATED` | `adhoc_subprocess_activated` | Emitted only when the activated element is an ad-hoc sub-process.                 |
+| `USAGE_METRIC`              | `EXPORTED`          | `usage_metric_exported`      | Emitted once per usage metric export interval. Internal reset events are skipped. |
 
-### Log record attributes
+### Common log record attributes
 
-Per-event attributes attached to each log record:
+These attributes are set on every log record:
+
+|         Attribute         |  Type  |                                               Description                                                |
+|---------------------------|--------|----------------------------------------------------------------------------------------------------------|
+| `event.name`              | string | Event type identifier (one of the names in the table above).                                             |
+| `camunda.log.position`    | long   | Log stream position. Used as a deduplication key.                                                        |
+| `camunda.sequence_number` | long   | Monotonic per-partition counter incremented for each emitted event. Used for ordering and gap detection. |
+
+### `process_instance_created` attributes
 
 |            Attribute             |  Type  |                       Description                       |
 |----------------------------------|--------|---------------------------------------------------------|
-| `event.name`                     | string | Event type identifier.                                  |
 | `camunda.bpmn_process_id`        | string | BPMN process ID.                                        |
 | `camunda.process_version`        | long   | Process definition version.                             |
 | `camunda.process_definition_key` | long   | Process definition key.                                 |
 | `camunda.process_instance_key`   | long   | Process instance key.                                   |
 | `camunda.tenant_id`              | string | Tenant ID, or the default tenant when not multi-tenant. |
-| `camunda.log.position`           | long   | Log stream position. Used as a deduplication key.       |
+
+### `adhoc_subprocess_activated` attributes
+
+|            Attribute             |  Type  |                       Description                       |
+|----------------------------------|--------|---------------------------------------------------------|
+| `camunda.bpmn_process_id`        | string | BPMN process ID.                                        |
+| `camunda.process_definition_key` | long   | Process definition key.                                 |
+| `camunda.process_instance_key`   | long   | Process instance key.                                   |
+| `camunda.element_id`             | string | BPMN element ID of the ad-hoc sub-process.              |
+| `camunda.tenant_id`              | string | Tenant ID, or the default tenant when not multi-tenant. |
+
+### `usage_metric_exported` attributes
+
+|               Attribute               |  Type  |                                        Description                                        |
+|---------------------------------------|--------|-------------------------------------------------------------------------------------------|
+| `camunda.usage_metric.event_type`     | string | Metric type: `RPI` (process instances), `EDI` (decision instances), or `TU` (task users). |
+| `camunda.usage_metric.count`          | long   | Total occurrences in the interval. For `TU`, the count of distinct task users.            |
+| `camunda.usage_metric.interval_start` | long   | Interval start timestamp, in epoch milliseconds.                                          |
+| `camunda.usage_metric.interval_end`   | long   | Interval end timestamp, in epoch milliseconds.                                            |
 
 ### Resource attributes
 

--- a/zeebe/exporters/analytics-exporter/README.md
+++ b/zeebe/exporters/analytics-exporter/README.md
@@ -8,17 +8,21 @@ cannot impact broker throughput, and it accepts data loss under failure. It runs
 the partition leader, so no extra high-availability setup is required.
 
 > **Data handling.** The exporter sends process metadata only. It does **not** export
-> process variables, payloads, message bodies, or any other potentially sensitive data. For
-> the company-wide policy on what telemetry Camunda collects and how privacy is protected,
-> see [data collection](https://docs.camunda.io/docs/reference/data-collection/data-collection/).
+> process variables, payloads, message bodies, or any other potentially sensitive data.
 
 ## Enable the exporter
 
-To enable the exporter, add an `analytics` block to your broker configuration. To disable
-it, remove the block. On Camunda 8.10 and later, the exporter ships with Zeebe and no
-`jarPath` is required. On 8.9 and earlier, you must install the standalone JAR (see
-[Install on older clusters](#install-on-older-clusters-standalone-jar)) and reference it
-via `jarPath`.
+The analytics exporter is disabled by default. To enable it, add an `analytics` exporter
+declaration to your broker configuration; to disable it again, remove the declaration.
+The configuration can be provided via YAML or as environment variables — both styles are
+shown below.
+
+The exact shape of the configuration depends on your Camunda version:
+
+- **8.10 and later:** the exporter ships with Zeebe; you only need to declare it.
+- **8.9 and earlier:** the exporter is not shipped, so you must install the
+  [standalone JAR](#install-on-older-clusters-standalone-jar) and reference it via
+  `jarPath`.
 
 ### Prerequisites
 

--- a/zeebe/exporters/analytics-exporter/README.md
+++ b/zeebe/exporters/analytics-exporter/README.md
@@ -1,55 +1,60 @@
 # Camunda Analytics Exporter
 
-Zeebe exporter that ships product analytics events to a Camunda analytics endpoint via
-OTLP/HTTP. Designed for Self-Managed and SaaS deployments.
+Zeebe exporter that ships product analytics events to a Camunda analytics endpoint over
+OTLP/HTTP. It is opt-in, default-off, and intended for Camunda 8 Self-Managed deployments.
 
-## Design Principles
+The exporter is **analytics-grade**, not billing- or audit-grade: it is designed so it
+cannot impact broker throughput, and it accepts data loss under failure. It runs only on
+the partition leader, so no extra high-availability setup is required.
 
-### Fire-and-forget
+> **Data handling.** The exporter sends process metadata only. It does **not** export
+> process variables, payloads, message bodies, or any other potentially sensitive data. For
+> the company-wide policy on what telemetry Camunda collects and how privacy is protected,
+> see [data collection](https://docs.camunda.io/docs/reference/data-collection/data-collection/).
 
-The exporter **never impacts broker throughput**. Every record's position is updated eagerly
-and unconditionally — before any analytics processing happens. If the analytics pipeline is
-slow, saturated, or completely down, the broker keeps running at full speed.
+## Enable the exporter
 
-### Analytics-grade delivery
+To enable the exporter, add an `analytics` block to your broker configuration. To disable
+it, remove the block. On Camunda 8.10 and later, the exporter ships with Zeebe and no
+`jarPath` is required. On 8.9 and earlier, you must install the standalone JAR (see
+[Install on older clusters](#install-on-older-clusters-standalone-jar)) and reference it
+via `jarPath`.
 
-Data loss is accepted. Events may be dropped under any of these conditions:
+### Prerequisites
 
-- The OTel batch queue is full (back-pressure from a slow or unreachable endpoint)
-- The broker crashes or restarts (in-memory queue is lost)
-- The OTLP endpoint returns errors (no persistent retry, no disk buffering)
+The exporter requires a Camunda license key and a cluster ID.
 
-This is a deliberate trade-off: analytics data is approximate, not exact. Consumer-side
-de-duplication is expected (using `camunda.cluster.id` + `camunda.partition.id` +
-`camunda.log.position` as composite key).
+- **Camunda 8.10 and later:** both values are resolved automatically from the broker
+  context. No additional setup is needed.
+- **Camunda 8.9 and earlier:** the broker does not expose the license key or cluster ID
+  through the context API. Provide them via environment variables on every broker:
+  - `CAMUNDA_LICENSE_KEY` — the Camunda license key.
+  - `ZEEBE_BROKER_CLUSTER_CLUSTERID` — the cluster identifier.
 
-### Zero backpressure
+  Without these variables, the exporter fails to start on 8.9 and earlier.
 
-The OTel SDK's `BatchLogRecordProcessor` runs on a background thread with a bounded queue.
-When the queue fills, new records are silently dropped — the `export()` method on the Zeebe
-actor thread never blocks, never waits, never retries synchronously.
+### YAML configuration
 
-### Record filter
+Two configuration styles are supported.
 
-The exporter sets a `RecordFilter` that accepts only event records for registered handler
-types, originating from the local partition. See `AnalyticsRecordFilter` Javadoc for the
-filtering layers and the rationale behind partition-based deduplication.
+**Unified configuration (Camunda 8.9 and later, recommended):**
 
-## What it exports
+```yaml
+camunda:
+  data:
+    exporters:
+      analytics:
+        class-name: io.camunda.exporter.analytics.AnalyticsExporter
+        # jar-path is required on 8.9 only; omit on 8.10+
+        jar-path: /usr/local/zeebe/exporters/camunda-analytics-exporter.jar
+        args:
+          endpoint: https://analytics.cloud.camunda.io
+          push-interval: PT5S
+          max-queue-size: 2048
+          max-batch-size: 512
+```
 
-Events follow the [OTel Events semantic convention](https://opentelemetry.io/docs/specs/semconv/general/events/) —
-identified by the `event.name` attribute. See handler classes in `handler/` and
-`AnalyticsAttributes` for the specific events and their attributes.
-
-### OTel resource attributes
-
-|       Attribute        |  Type  |                 Description                  |
-|------------------------|--------|----------------------------------------------|
-| `camunda.cluster.id`   | string | Cluster identifier (from broker Context API) |
-| `camunda.partition.id` | long   | Partition ID                                 |
-| `service.name`         | string | Always `camunda-zeebe`                       |
-
-## Configuration
+**Legacy configuration (Camunda 8.8 and earlier):**
 
 ```yaml
 zeebe:
@@ -57,19 +62,156 @@ zeebe:
     exporters:
       analytics:
         className: io.camunda.exporter.analytics.AnalyticsExporter
+        jarPath: /usr/local/zeebe/exporters/camunda-analytics-exporter.jar
         args:
-          endpoint: "https://analytics.cloud.camunda.io"
-          pushInterval: "PT5S"
+          endpoint: https://analytics.cloud.camunda.io
+          pushInterval: PT5S
           maxQueueSize: 2048
           maxBatchSize: 512
 ```
 
-|    Property    |               Default                |                      Description                      |
-|----------------|--------------------------------------|-------------------------------------------------------|
-| `endpoint`     | `https://analytics.cloud.camunda.io` | OTLP/HTTP base URL. The SDK appends `/v1/logs`.       |
-| `pushInterval` | `PT5S`                               | Batch push interval (ISO 8601 duration).              |
-| `maxQueueSize` | `2048`                               | Maximum log records queued in-memory before dropping. |
-| `maxBatchSize` | `512`                                | Maximum records per export batch.                     |
+### Environment variables
+
+The same settings can be provided via environment variables.
+
+**Unified (8.9+):** `CAMUNDA_DATA_EXPORTERS_ANALYTICS_*`
+
+```sh
+CAMUNDA_DATA_EXPORTERS_ANALYTICS_CLASSNAME=io.camunda.exporter.analytics.AnalyticsExporter
+# JARPATH is required on 8.9 only; omit on 8.10+
+CAMUNDA_DATA_EXPORTERS_ANALYTICS_JARPATH=/usr/local/zeebe/exporters/camunda-analytics-exporter.jar
+CAMUNDA_DATA_EXPORTERS_ANALYTICS_ARGS_ENDPOINT=https://analytics.cloud.camunda.io
+CAMUNDA_DATA_EXPORTERS_ANALYTICS_ARGS_PUSHINTERVAL=PT5S
+CAMUNDA_DATA_EXPORTERS_ANALYTICS_ARGS_MAXQUEUESIZE=2048
+CAMUNDA_DATA_EXPORTERS_ANALYTICS_ARGS_MAXBATCHSIZE=512
+```
+
+**Legacy (8.8 and earlier):** `ZEEBE_BROKER_EXPORTERS_ANALYTICS_*`
+
+```sh
+ZEEBE_BROKER_EXPORTERS_ANALYTICS_CLASSNAME=io.camunda.exporter.analytics.AnalyticsExporter
+ZEEBE_BROKER_EXPORTERS_ANALYTICS_JARPATH=/usr/local/zeebe/exporters/camunda-analytics-exporter.jar
+ZEEBE_BROKER_EXPORTERS_ANALYTICS_ARGS_ENDPOINT=https://analytics.cloud.camunda.io
+ZEEBE_BROKER_EXPORTERS_ANALYTICS_ARGS_PUSHINTERVAL=PT5S
+ZEEBE_BROKER_EXPORTERS_ANALYTICS_ARGS_MAXQUEUESIZE=2048
+ZEEBE_BROKER_EXPORTERS_ANALYTICS_ARGS_MAXBATCHSIZE=512
+```
+
+### Verify the exporter is running
+
+On broker startup, look for the following log line — it confirms the exporter loaded with
+the expected endpoint, cluster ID, and partition ID:
+
+```
+Analytics exporter configured: endpoint=https://analytics.cloud.camunda.io, clusterId=<cluster-id>, partitionId=<partition-id>
+```
+
+## Configuration reference
+
+All options live under `args`. Defaults are tuned for typical Self-Managed deployments and
+rarely need to be changed.
+
+| Option           | Type     | Description                                                                                                            | Default                              |
+|------------------|----------|------------------------------------------------------------------------------------------------------------------------|--------------------------------------|
+| `endpoint`       | string   | OTLP/HTTP base URL for the analytics endpoint. The OTel SDK appends `/v1/logs` automatically.                          | `https://analytics.cloud.camunda.io` |
+| `push-interval`  | duration | Maximum time between batch pushes, as an [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations).        | `PT5S`                               |
+| `max-queue-size` | int      | Maximum number of log records buffered in memory before new records are dropped.                                       | `2048`                               |
+| `max-batch-size` | int      | Maximum number of records sent in a single OTLP request. Must be less than or equal to `max-queue-size`.               | `512`                                |
+
+## What data is exported
+
+Each supported record is emitted as an [OpenTelemetry log record](https://opentelemetry.io/docs/specs/semconv/general/events/),
+identified by the `event.name` attribute following the OTel Events semantic convention.
+
+### Event types
+
+| Source record                | Event name                 |
+|------------------------------|----------------------------|
+| `PROCESS_INSTANCE_CREATION`  | `process_instance_created` |
+
+### Log record attributes
+
+Per-event attributes attached to each log record:
+
+| Attribute                          | Type   | Description                                                |
+|------------------------------------|--------|------------------------------------------------------------|
+| `event.name`                       | string | Event type identifier.                                     |
+| `camunda.bpmn_process_id`          | string | BPMN process ID.                                           |
+| `camunda.process_version`          | long   | Process definition version.                                |
+| `camunda.process_definition_key`   | long   | Process definition key.                                    |
+| `camunda.process_instance_key`     | long   | Process instance key.                                      |
+| `camunda.tenant_id`                | string | Tenant ID, or the default tenant when not multi-tenant.    |
+| `camunda.log.position`             | long   | Log stream position. Used as a deduplication key.          |
+
+### Resource attributes
+
+Cluster-wide attributes attached to every log record:
+
+| Attribute              | Type   | Description             |
+|------------------------|--------|-------------------------|
+| `camunda.cluster.id`   | string | Cluster identifier.     |
+| `camunda.partition.id` | long   | Partition ID.           |
+| `service.name`         | string | Always `camunda-zeebe`. |
+
+The exporter does **not** include process variables, payloads, message contents, job
+variables, or any other end-user data. Only the process metadata listed above is exported.
+
+## Failure behavior
+
+The exporter is fire-and-forget: under any failure mode, broker throughput is unaffected
+and analytics records may be dropped silently. Specifically, events can be lost when:
+
+- **The in-memory queue is full.** When `max-queue-size` is reached — typically because
+  the endpoint is slow or unreachable — new records are dropped on the broker thread
+  without retry.
+- **The broker crashes or restarts.** The in-memory queue is not persisted, so any records
+  buffered at the time of the crash are lost.
+- **The OTLP endpoint returns an error.** The exporter does not retry persistently and
+  does not buffer to disk; the affected batch is dropped.
+
+Because each event carries `camunda.cluster.id`, `camunda.partition.id`, and
+`camunda.log.position`, downstream consumers can deduplicate events using the combination
+of these attributes as a composite key.
+
+## Known limitations
+
+- **Analytics-grade only.** No exactly-once delivery, no reconciliation, no client-side
+  gap filling. Use the exporter for product analytics and trends, not for billing, audit,
+  or any workflow that requires complete data.
+- **No PII.** Only process metadata is exported. Process variables, message payloads, and
+  other potentially sensitive fields are never sent.
+- **Fixed event set.** The exporter emits a small, hardcoded set of event types. There is
+  no runtime configuration to add, remove, or filter event types.
+- **Camunda endpoint only.** The exporter is intended for use with the Camunda analytics
+  endpoint. While the `endpoint` option accepts any OTLP/HTTP URL, redirecting to a
+  custom backend is not a supported deployment pattern.
+
+## Install on older clusters (standalone JAR)
+
+For clusters that do not ship the exporter as part of their distribution, a standalone
+JAR will be provided. Drop the JAR onto the broker classpath (for example, into
+`/usr/local/zeebe/exporters/`), point the exporter configuration at it with `jarPath`,
+and provide the `CAMUNDA_LICENSE_KEY` and `ZEEBE_BROKER_CLUSTER_CLUSTERID` environment
+variables described in [Prerequisites](#prerequisites).
+
+## How it works
+
+The exporter consumes records from the Zeebe log stream, filters for a small set of event
+types, converts each matching record into an OpenTelemetry log record, and pushes it to
+the configured OTLP/HTTP endpoint. Three design choices keep the broker fast and
+predictable:
+
+- **Fire-and-forget, non-blocking pipeline.** Every record's position is acknowledged
+  eagerly and unconditionally, before any analytics processing happens. A background
+  thread batches and pushes records through the OTel SDK's `BatchLogRecordProcessor`; when
+  the in-memory queue fills, new records are silently dropped instead of back-pressuring
+  the broker.
+- **Partition-aware filtering.** Each event is emitted by exactly one partition — the one
+  that originally produced it — so events are not duplicated across a multi-partition
+  cluster. See `AnalyticsRecordFilter` for the filtering layers and the rationale behind
+  partition-based deduplication.
+- **Leader-only execution.** The exporter runs on the partition leader only, so no extra
+  high-availability setup or cross-replica coordination is needed.
 
 ## Architecture
 
@@ -94,7 +236,7 @@ See source Javadocs for component details. Key files:
 ./mvnw verify -pl zeebe/exporters/analytics-exporter -DskipTests=false -Dquickly
 ```
 
-## Local Development
+## Local development
 
 Start a local OTel Collector with debug output:
 
@@ -116,12 +258,12 @@ the OTLP transport — same Resource and SDK construction as production.
 
 ### SDK pipeline tests (`OtelSdkManagerTest`)
 
-Tests OTel pipeline contract: non-blocking when queue is full, unreachable endpoint handling,
-event delivery, flush-on-shutdown, failure recovery, and post-shutdown safety.
+Tests OTel pipeline contract: non-blocking when queue is full, unreachable endpoint
+handling, event delivery, flush-on-shutdown, failure recovery, and post-shutdown safety.
 
 ### Integration tests (`AnalyticsExporterOtelIT`)
 
 End-to-end tests using a real OTel Collector in Docker (Testcontainers). No mocking, no
 overrides — uses the default `AnalyticsExporter` constructor with the production
-`BatchLogRecordProcessor` and real OTLP/HTTP transport. Tests event delivery with attribute
-verification and batching behavior.
+`BatchLogRecordProcessor` and real OTLP/HTTP transport. Tests event delivery with
+attribute verification and batching behavior.

--- a/zeebe/exporters/analytics-exporter/README.md
+++ b/zeebe/exporters/analytics-exporter/README.md
@@ -28,12 +28,31 @@ The exact shape of the configuration depends on your Camunda version:
 
 The exporter requires a Camunda license key and a cluster ID.
 
+**License key.** The exporter authenticates to the Camunda analytics endpoint using your
+Camunda 8 Self-Managed license key. The raw key is never sent over the network — it is
+hashed into a fingerprint (sent as the `x-camunda-fingerprint` header) and used as the
+HMAC secret for signing each batch of events. This is the same license key you already
+use to run Camunda 8 Self-Managed; if you do not have it, contact your Camunda account
+team or open a support ticket.
+
+**Cluster ID.** The cluster ID identifies which cluster a given event came from. It is
+attached to every event as the `camunda.cluster.id` resource attribute and is part of the
+deduplication key used by the analytics backend (`camunda.cluster.id` +
+`camunda.partition.id` + `camunda.log.position`). The value should be stable per cluster —
+changing it makes existing events look like they come from a different cluster. Any
+unique string works; many operators use a UUID or an environment-derived name (for
+example, `prod-eu-1`).
+
+How the exporter obtains these values depends on your Camunda version:
+
 - **Camunda 8.10 and later:** both values are resolved automatically from the broker
   context. No additional setup is needed.
 - **Camunda 8.9 and earlier:** the broker does not expose the license key or cluster ID
   through the context API. Provide them via environment variables on every broker:
   - `CAMUNDA_LICENSE_KEY` — the Camunda license key.
-  - `ZEEBE_BROKER_CLUSTER_CLUSTERID` — the cluster identifier.
+  - `ZEEBE_BROKER_CLUSTER_CLUSTERID` — the cluster identifier. This is the broker's
+    standard cluster-ID setting (`zeebe.broker.cluster.clusterId`); if it is already
+    configured on the broker, the analytics exporter picks it up automatically.
 
   Without these variables, the exporter fails to start on 8.9 and earlier.
 

--- a/zeebe/exporters/analytics-exporter/README.md
+++ b/zeebe/exporters/analytics-exporter/README.md
@@ -39,14 +39,13 @@ team or open a support ticket.
 attached to every event as the `camunda.cluster.id` resource attribute and is part of the
 deduplication key used by the analytics backend (`camunda.cluster.id` +
 `camunda.partition.id` + `camunda.log.position`). The value should be stable per cluster —
-changing it makes existing events look like they come from a different cluster. Any
-unique string works; many operators use a UUID or an environment-derived name (for
-example, `prod-eu-1`).
+changing it makes existing events look like they come from a different cluster.
 
 How the exporter obtains these values depends on your Camunda version:
 
-- **Camunda 8.10 and later:** both values are resolved automatically from the broker
-  context. No additional setup is needed.
+- **Camunda 8.10 and later:** [cluster id](https://docs.camunda.io/docs/next/self-managed/components/orchestration-cluster/core-settings/configuration/properties/#cluster)
+  and [license key](https://docs.camunda.io/docs/next/self-managed/components/orchestration-cluster/core-settings/configuration/properties/#licensing)
+  values are resolved automatically from the broker context. No additional setup is needed.
 - **Camunda 8.9 and earlier:** the broker does not expose the license key or cluster ID
   through the context API. Provide them via environment variables on every broker:
   - `CAMUNDA_LICENSE_KEY` — the Camunda license key.
@@ -146,6 +145,9 @@ rarely need to be changed.
 Each supported record is emitted as an [OpenTelemetry log record](https://opentelemetry.io/docs/specs/semconv/general/events/),
 identified by the `event.name` attribute following the OTel Events semantic convention.
 
+The exporter does **not** include process variables, payloads, message contents, job
+variables, or any other end-user data.
+
 ### Event types
 
 |        Source record        |       Intent        |          Event name          |                                       Notes                                       |
@@ -164,35 +166,6 @@ These attributes are set on every log record:
 | `camunda.log.position`    | long   | Log stream position. Used as a deduplication key.                                                        |
 | `camunda.sequence_number` | long   | Monotonic per-partition counter incremented for each emitted event. Used for ordering and gap detection. |
 
-### `process_instance_created` attributes
-
-|            Attribute             |  Type  |                       Description                       |
-|----------------------------------|--------|---------------------------------------------------------|
-| `camunda.bpmn_process_id`        | string | BPMN process ID.                                        |
-| `camunda.process_version`        | long   | Process definition version.                             |
-| `camunda.process_definition_key` | long   | Process definition key.                                 |
-| `camunda.process_instance_key`   | long   | Process instance key.                                   |
-| `camunda.tenant_id`              | string | Tenant ID, or the default tenant when not multi-tenant. |
-
-### `adhoc_subprocess_activated` attributes
-
-|            Attribute             |  Type  |                       Description                       |
-|----------------------------------|--------|---------------------------------------------------------|
-| `camunda.bpmn_process_id`        | string | BPMN process ID.                                        |
-| `camunda.process_definition_key` | long   | Process definition key.                                 |
-| `camunda.process_instance_key`   | long   | Process instance key.                                   |
-| `camunda.element_id`             | string | BPMN element ID of the ad-hoc sub-process.              |
-| `camunda.tenant_id`              | string | Tenant ID, or the default tenant when not multi-tenant. |
-
-### `usage_metric_exported` attributes
-
-|               Attribute               |  Type  |                                        Description                                        |
-|---------------------------------------|--------|-------------------------------------------------------------------------------------------|
-| `camunda.usage_metric.event_type`     | string | Metric type: `RPI` (process instances), `EDI` (decision instances), or `TU` (task users). |
-| `camunda.usage_metric.count`          | long   | Total occurrences in the interval. For `TU`, the count of distinct task users.            |
-| `camunda.usage_metric.interval_start` | long   | Interval start timestamp, in epoch milliseconds.                                          |
-| `camunda.usage_metric.interval_end`   | long   | Interval end timestamp, in epoch milliseconds.                                            |
-
 ### Resource attributes
 
 Cluster-wide attributes attached to every log record:
@@ -202,9 +175,6 @@ Cluster-wide attributes attached to every log record:
 | `camunda.cluster.id`   | string | Cluster identifier.     |
 | `camunda.partition.id` | long   | Partition ID.           |
 | `service.name`         | string | Always `camunda-zeebe`. |
-
-The exporter does **not** include process variables, payloads, message contents, job
-variables, or any other end-user data. Only the process metadata listed above is exported.
 
 ## Failure behavior
 
@@ -217,7 +187,7 @@ and analytics records may be dropped silently. Specifically, events can be lost 
 - **The broker crashes or restarts.** The in-memory queue is not persisted, so any records
   buffered at the time of the crash are lost.
 - **The OTLP endpoint returns an error.** The exporter does not retry persistently and
-  does not buffer to disk; the affected batch is dropped.
+  does not buffer to disk; the affected events are dropped.
 
 Because each event carries `camunda.cluster.id`, `camunda.partition.id`, and
 `camunda.log.position`, downstream consumers can deduplicate events using the combination
@@ -232,9 +202,6 @@ of these attributes as a composite key.
   other potentially sensitive fields are never sent.
 - **Fixed event set.** The exporter emits a small, hardcoded set of event types. There is
   no runtime configuration to add, remove, or filter event types.
-- **Camunda endpoint only.** The exporter is intended for use with the Camunda analytics
-  endpoint. While the `endpoint` option accepts any OTLP/HTTP URL, redirecting to a
-  custom backend is not a supported deployment pattern.
 
 ## Install on older clusters (standalone JAR)
 
@@ -243,6 +210,9 @@ JAR will be provided. Drop the JAR onto the broker classpath (for example, into
 `/usr/local/zeebe/exporters/`), point the exporter configuration at it with `jarPath`,
 and provide the `CAMUNDA_LICENSE_KEY` and `ZEEBE_BROKER_CLUSTER_CLUSTERID` environment
 variables described in [Prerequisites](#prerequisites).
+
+For the general procedure for adding custom exporters to a broker, see
+[installing Zeebe exporters](https://docs.camunda.io/docs/next/self-managed/components/orchestration-cluster/zeebe/exporters/install-zeebe-exporters/).
 
 ## How it works
 

--- a/zeebe/exporters/analytics-exporter/README.md
+++ b/zeebe/exporters/analytics-exporter/README.md
@@ -228,11 +228,12 @@ types, converts each matching record into an OpenTelemetry log record, and pushe
 the configured OTLP/HTTP endpoint. Three design choices keep the broker fast and
 predictable:
 
-- **Fire-and-forget, non-blocking pipeline.** Every record's position is acknowledged
-  eagerly and unconditionally, before any analytics processing happens. A background
-  thread batches and pushes records through the OTel SDK's `BatchLogRecordProcessor`; when
-  the in-memory queue fills, new records are silently dropped instead of back-pressuring
-  the broker.
+- **Fire-and-forget, non-blocking pipeline.** A background thread batches and pushes
+  records through the OTel SDK's `BatchLogRecordProcessor`; when the in-memory queue
+  fills, new records are silently dropped instead of back-pressuring the broker. After
+  invoking the handler, the broker unconditionally acknowledges the record's position —
+  handler exceptions are caught and swallowed — so neither a failing handler nor a
+  saturated queue can stall the broker.
 - **Partition-aware filtering.** Each event is emitted by exactly one partition — the one
   that originally produced it — so events are not duplicated across a multi-partition
   cluster. See `AnalyticsRecordFilter` for the filtering layers and the rationale behind


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Rewrites the analytics exporter README into customer-facing operator documentation, per the acceptance criteria in #52389. It now covers enable/disable (with version-specific `jarPath` guidance for 8.10+ vs 8.9 and earlier), the full configuration reference, what data is exported (event types, log record attributes, resource attributes), failure behavior, and known limitations. There's also a placeholder note about the standalone JAR distribution for older clusters — we can fill in the actual coordinates once those are settled.

The original engineering sections (Architecture, Building, Local development, Testing) are kept below the operator content so the file still works as a module README.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #52389