### PR TITLE
feat: warn users that contains filter searches only truncated variable values

### DIFF
--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterModal.test.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterModal.test.tsx
@@ -532,4 +532,38 @@ describe('<VariableFilterModal />', () => {
         expect(input).not.toBeVisible();
       });
   });
+
+  it('should show truncation warning when contains operator is selected', async () => {
+    const {user} = render(<VariableFilterModal />, {wrapper: getWrapper()});
+
+    await user.click(screen.getByRole('combobox', {name: 'Operator'}));
+    await user.click(screen.getByText('contains'));
+
+    expect(
+      screen.getByText(
+        '"contains" searches only the first ~8 000 characters of a variable value. Matches in longer values may not be returned.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('should hide truncation warning when operator is changed away from contains', async () => {
+    const {user} = render(<VariableFilterModal />, {wrapper: getWrapper()});
+
+    await user.click(screen.getByRole('combobox', {name: 'Operator'}));
+    await user.click(screen.getByText('contains'));
+    expect(
+      screen.getByText(
+        '"contains" searches only the first ~8 000 characters of a variable value. Matches in longer values may not be returned.',
+      ),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole('combobox', {name: 'Operator'}));
+    await user.click(screen.getByText('equals'));
+
+    expect(
+      screen.queryByText(
+        '"contains" searches only the first ~8 000 characters of a variable value. Matches in longer values may not be returned.',
+      ),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterModal.test.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterModal.test.tsx
@@ -546,6 +546,35 @@ describe('<VariableFilterModal />', () => {
     ).toBeInTheDocument();
   });
 
+  it('should show truncation warning when one of multiple conditions uses contains', async () => {
+    variableFilterStore.setConditions([
+      {name: 'status', operator: 'equals', value: '"active"'},
+    ]);
+    const {user} = render(<VariableFilterModal />, {wrapper: getWrapper()});
+
+    await user.click(screen.getByRole('button', {name: 'Add condition'}));
+    const operatorDropdowns = screen.getAllByRole('combobox', {name: 'Operator'});
+    await user.click(operatorDropdowns[1]!);
+    await user.click(screen.getByText('contains'));
+
+    expect(
+      screen.getByText(
+        '"contains" searches only the first ~8 000 characters of a variable value. Matches in longer values may not be returned.',
+      ),
+    ).toBeInTheDocument();
+
+    const deleteButtons = screen.getAllByRole('button', {
+      name: 'Remove condition',
+    });
+    await user.click(deleteButtons[1]!);
+
+    expect(
+      screen.queryByText(
+        '"contains" searches only the first ~8 000 characters of a variable value. Matches in longer values may not be returned.',
+      ),
+    ).not.toBeInTheDocument();
+  });
+
   it('should hide truncation warning when operator is changed away from contains', async () => {
     const {user} = render(<VariableFilterModal />, {wrapper: getWrapper()});
 

--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterModal.test.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterModal.test.tsx
@@ -553,7 +553,9 @@ describe('<VariableFilterModal />', () => {
     const {user} = render(<VariableFilterModal />, {wrapper: getWrapper()});
 
     await user.click(screen.getByRole('button', {name: 'Add condition'}));
-    const operatorDropdowns = screen.getAllByRole('combobox', {name: 'Operator'});
+    const operatorDropdowns = screen.getAllByRole('combobox', {
+      name: 'Operator',
+    });
     await user.click(operatorDropdowns[1]!);
     await user.click(screen.getByText('contains'));
 

--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterModal.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterModal.tsx
@@ -9,7 +9,7 @@
 import {lazy, Suspense, useEffect, useRef, useState} from 'react';
 import {Button, InlineNotification, Modal, Stack} from '@carbon/react';
 import {Add} from '@carbon/react/icons';
-import {Field, Form} from 'react-final-form';
+import {Field, Form, FormSpy} from 'react-final-form';
 import {FieldArray} from 'react-final-form-arrays';
 import arrayMutators from 'final-form-arrays';
 import {useNavigate, useLocation} from 'react-router-dom';
@@ -244,6 +244,22 @@ const VariableFilterModal: React.FC = observer(() => {
                     Define one or more conditions to filter process instances by
                     variable values. All conditions are combined with AND logic.
                   </Description>
+                  <FormSpy subscription={{values: true}}>
+                    {({values}) => {
+                      const hasContains = (
+                        values as FormValues
+                      ).conditions?.some((c) => c.operator === 'contains');
+                      return hasContains ? (
+                        <InlineNotification
+                          kind="warning"
+                          lowContrast
+                          hideCloseButton
+                          subtitle='"contains" searches only the first ~8 000 characters of a variable value. Matches in longer values may not be returned.'
+                          role="status"
+                        />
+                      ) : null;
+                    }}
+                  </FormSpy>
                   <FieldArray<DraftCondition> name="conditions">
                     {({fields}) => (
                       <>

--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterModal.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterModal.tsx
@@ -244,19 +244,6 @@ const VariableFilterModal: React.FC = observer(() => {
                     Define one or more conditions to filter process instances by
                     variable values. All conditions are combined with AND logic.
                   </Description>
-                  {form
-                    .getState()
-                    .values?.conditions?.some(
-                      (c) => c.operator === 'contains',
-                    ) && (
-                    <InlineNotification
-                      kind="warning"
-                      lowContrast
-                      hideCloseButton
-                      subtitle='"contains" searches only the first ~8 000 characters of a variable value. Matches in longer values may not be returned.'
-                      role="status"
-                    />
-                  )}
                   <FieldArray<DraftCondition> name="conditions">
                     {({fields}) => (
                       <>
@@ -284,6 +271,19 @@ const VariableFilterModal: React.FC = observer(() => {
                             ))}
                           </Stack>
                         </ConditionRowsScroll>
+                        {form
+                          .getState()
+                          .values?.conditions?.some(
+                            (c) => c.operator === 'contains',
+                          ) && (
+                          <InlineNotification
+                            kind="warning"
+                            lowContrast
+                            hideCloseButton
+                            subtitle='"contains" searches only the first ~8 000 characters of a variable value. Matches in longer values may not be returned.'
+                            role="status"
+                          />
+                        )}
                         {(fields.length ?? 0) >= SOFT_WARNING_THRESHOLD && (
                           <InlineNotification
                             kind="info"

--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterModal.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterModal.tsx
@@ -246,7 +246,7 @@ const VariableFilterModal: React.FC = observer(() => {
                   </Description>
                   {form
                     .getState()
-                    .values.conditions?.some(
+                    .values?.conditions?.some(
                       (c) => c.operator === 'contains',
                     ) && (
                     <InlineNotification

--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterModal.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterModal.tsx
@@ -9,7 +9,7 @@
 import {lazy, Suspense, useEffect, useRef, useState} from 'react';
 import {Button, InlineNotification, Modal, Stack} from '@carbon/react';
 import {Add} from '@carbon/react/icons';
-import {Field, Form, FormSpy} from 'react-final-form';
+import {Field, Form} from 'react-final-form';
 import {FieldArray} from 'react-final-form-arrays';
 import arrayMutators from 'final-form-arrays';
 import {useNavigate, useLocation} from 'react-router-dom';
@@ -244,22 +244,19 @@ const VariableFilterModal: React.FC = observer(() => {
                     Define one or more conditions to filter process instances by
                     variable values. All conditions are combined with AND logic.
                   </Description>
-                  <FormSpy subscription={{values: true}}>
-                    {({values}) => {
-                      const hasContains = (
-                        values as FormValues
-                      ).conditions?.some((c) => c.operator === 'contains');
-                      return hasContains ? (
-                        <InlineNotification
-                          kind="warning"
-                          lowContrast
-                          hideCloseButton
-                          subtitle='"contains" searches only the first ~8 000 characters of a variable value. Matches in longer values may not be returned.'
-                          role="status"
-                        />
-                      ) : null;
-                    }}
-                  </FormSpy>
+                  {form
+                    .getState()
+                    .values.conditions?.some(
+                      (c) => c.operator === 'contains',
+                    ) && (
+                    <InlineNotification
+                      kind="warning"
+                      lowContrast
+                      hideCloseButton
+                      subtitle='"contains" searches only the first ~8 000 characters of a variable value. Matches in longer values may not be returned.'
+                      role="status"
+                    />
+                  )}
                   <FieldArray<DraftCondition> name="conditions">
                     {({fields}) => (
                       <>


### PR DESCRIPTION
## Description

- Adds an inline warning banner in the variable filter modal whenever any condition row uses the `contains` operator
- The banner appears reactively (via `FormSpy`) and disappears as soon as all `contains` rows are switched to another operator
- No backend query logic is changed

## Why

Variable values longer than ~8 000 characters are stored **truncated** in Elasticsearch (`variableSizeThreshold = 8 191` chars, configured in `application-elasticsearch.yaml`). The `contains` filter runs a wildcard query against this truncated `varValue` field in `operate-list-view`. If the search term falls past the truncation boundary, the filter silently returns zero results — a false negative with no user-visible signal.

This was verified by injecting synthetic Elasticsearch documents that mirror exactly what `VariableHandler.java` and `ListViewVariableFromVariableHandler.java` write for a long variable, then confirming the wildcard query returns 0 hits for a term past position 8 191.

Closes #51812
