### PR TITLE
[stable/8.8] ci: harden alwaysgreen pipeline with preflight, downstream category, streak detector

### DIFF
--- a/.github/workflows/alwaysgreen-streak-detector.yml
+++ b/.github/workflows/alwaysgreen-streak-detector.yml
@@ -1,23 +1,28 @@
 # description: AlwaysGreen streak detector. Reacts to completion of the
 # main AlwaysGreen pipeline and posts to #alwaysgreen-reliability when the
-# last N runs on the same protected ref all failed. Uses 'gh run list' rather
-# than persisted state — no race conditions, nothing to migrate on rename.
-# Lives in its own file (instead of an extra job in docker-build-helm-integration.yml)
-# so it doesn't share an edit surface with PR #54171 (Slice A) and to keep
-# the streak-detector cleanly separable / removable on its own.
+# last N runs targeting the same protected base branch all failed. Uses
+# 'gh run list' rather than persisted state — no race conditions, nothing
+# to migrate on rename.
+#
+# Tracks both `push` and `merge_group` events on protected refs. For
+# merge_group, the parent run's head_branch is a per-PR queue ref
+# (`gh-readonly-queue/<base>/pr-<n>-<suffix>`), so we normalise it to its
+# `<base>` before counting streaks. That way several consecutive failing
+# PR batches against the same `stable/x` line aggregate into one streak
+# rather than each batch starting at zero.
 # type: CI
-# owner: @camunda/distribution
+# owner: @camunda/test-automation-team
 ---
 name: AlwaysGreen Streak Detector
 
 on:
   workflow_run:
-    workflows: ["Docker Build, Helm Deploy & E2E Tests (SaaS + Helm)"]
+    workflows: ["Docker Build and Helm Integration Test"]
     types:
       - completed
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}-${{ github.event.workflow_run.event }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: false
 
 env:
@@ -25,6 +30,12 @@ env:
   LOOKBACK_RUNS: '10'
   ALERT_CHANNEL: 'alwaysgreen-reliability'
   PARENT_WORKFLOW_FILE: 'docker-build-helm-integration.yml'
+  # Slack subteam handles for medic pings. These are workspace identifiers,
+  # not secrets — same hardcoded convention as
+  # .ci/scripts/ci/setup-medic-lookup.sh.
+  MEDIC_TEST_AUTOMATION: '<!subteam^S09UF0EV0HG|test-automation-medic>'
+  MEDIC_DISTRIBUTION: '<!subteam^S053K7C7QKU|distribution-medic>'
+  MEDIC_MONOREPO_DEVOPS: '<!subteam^S07D6C6B18T|monorepo-devops-medic>'
 
 defaults:
   run:
@@ -33,11 +44,18 @@ defaults:
 jobs:
   detect-streak:
     name: Detect failure streak
-    # Only react to completed runs that ended in failure on protected events.
-    # Successful or in-progress runs don't move the streak counter.
+    # React to completed `push` and `merge_group` runs that ended in
+    # failure / timed_out / cancelled — anything the streak counter below
+    # also treats as a streak hit. The counter normalises merge_group
+    # head_branch values (`gh-readonly-queue/<base>/pr-<n>-...`) to their
+    # base so consecutive failing PR batches against the same protected
+    # branch aggregate together.
     if: |
-      github.event.workflow_run.conclusion == 'failure' &&
-      (github.event.workflow_run.event == 'push' || github.event.workflow_run.event == 'merge_group')
+      (github.event.workflow_run.conclusion == 'failure' ||
+       github.event.workflow_run.conclusion == 'timed_out' ||
+       github.event.workflow_run.conclusion == 'cancelled') &&
+      (github.event.workflow_run.event == 'push' ||
+       github.event.workflow_run.event == 'merge_group')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -59,28 +77,64 @@ jobs:
           secrets: |
             secret/data/products/camunda/ci/github-actions SLACK_CORE_DOMAIN_BOT_TOKEN;
 
-      - name: Detect failure streak on this ref
+      - name: Detect failure streak on this base branch
         id: streak
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
-          PARENT_EVENT: ${{ github.event.workflow_run.event }}
         run: |
           set -euo pipefail
+
+          # Normalise the triggering run's head_branch to its protected
+          # base ref:
+          #   - push to `main` or `stable/x`        → branch stays as-is
+          #   - merge_group queue branch
+          #     (`gh-readonly-queue/<base>/pr-...`) → strip down to <base>
+          # `<base>` matches `main` or `stable/<version>` — that's the
+          # protected ref we want to accumulate streaks against.
+          normalise_branch() {
+            local b="$1"
+            if [[ "$b" =~ ^gh-readonly-queue/(.+)/pr-[0-9]+ ]]; then
+              echo "${BASH_REMATCH[1]}"
+            else
+              echo "$b"
+            fi
+          }
+          BASE_REF=$(normalise_branch "${HEAD_BRANCH}")
+          echo "Normalised base ref: ${BASE_REF} (raw: ${HEAD_BRANCH})"
+
+          # Pull the recent workflow runs. We can't filter by `--branch
+          # ${BASE_REF}` because merge_group runs are stored under the
+          # transient queue ref, not the base; instead we fetch a wider
+          # window and normalise each entry the same way below.
           RUNS_JSON=$(gh run list \
             --workflow "${PARENT_WORKFLOW_FILE}" \
-            --branch "${HEAD_BRANCH}" \
-            --event "${PARENT_EVENT}" \
             --limit "${LOOKBACK_RUNS}" \
-            --json conclusion,status,databaseId,createdAt,url,displayTitle 2>/dev/null || echo '[]')
+            --json conclusion,status,headBranch,event,databaseId,createdAt,url,displayTitle 2>/dev/null || echo '[]')
 
-          # Count leading consecutive failures (most recent first). Skip
-          # in-progress runs — only completed runs count toward the streak.
-          STREAK=$(jq '
-            [ .[] | select(.status == "completed") ]
+          # Build a jq regex matching either a literal base ref or the
+          # queue ref shape that normalises to that base. Protected refs
+          # in this workflow are only `main` or `stable/<version>` (e.g.
+          # `stable/8.9`), so the only regex-special character we need to
+          # escape is `.`. Use bash parameter expansion rather than sed
+          # to satisfy SC2001.
+          ESCAPED_BASE="${BASE_REF//./\\.}"
+          BASE_PATTERN="^(${ESCAPED_BASE}|gh-readonly-queue/${ESCAPED_BASE}/pr-[0-9]+)"
+
+          # Filter to completed runs whose head_branch matches the base
+          # (after normalisation), sort newest-first, then count leading
+          # consecutive failures. `failure`, `timed_out`, and `cancelled`
+          # are all treated as a streak hit; this set must stay in sync
+          # with the job-level `if:` condition above.
+          STREAK=$(jq --arg pat "$BASE_PATTERN" '
+            [ .[] | select(.status == "completed")
+                  | select((.headBranch // "") | test($pat)) ]
+            | sort_by(.createdAt) | reverse
             | (reduce .[] as $r ({count:0, broken:false};
                 if .broken then .
-                elif ($r.conclusion == "failure" or $r.conclusion == "timed_out") then
+                elif ($r.conclusion == "failure"
+                      or $r.conclusion == "timed_out"
+                      or $r.conclusion == "cancelled") then
                   .count = (.count + 1)
                 else
                   .broken = true
@@ -93,13 +147,16 @@ jobs:
           {
             echo "streak_count=${STREAK}"
             echo "threshold=${STREAK_THRESHOLD}"
+            echo "base_ref=${BASE_REF}"
             echo "is_streak=$([[ ${STREAK} -ge ${STREAK_THRESHOLD} ]] && echo true || echo false)"
           } >> "$GITHUB_OUTPUT"
 
-          echo "Streak count on ${HEAD_BRANCH} (${PARENT_EVENT}): ${STREAK} / ${STREAK_THRESHOLD}"
-          echo "$RUNS_JSON" | jq -r '
-            "Recent runs:",
-            (.[] | "  - \(.conclusion // .status)  \(.createdAt)  \(.url)")
+          echo "Streak count on ${BASE_REF}: ${STREAK} / ${STREAK_THRESHOLD}"
+          echo "$RUNS_JSON" | jq -r --arg pat "$BASE_PATTERN" '
+            [ .[] | select((.headBranch // "") | test($pat)) ]
+            | sort_by(.createdAt) | reverse
+            | "Recent runs on this base:",
+              (.[] | "  - \(.conclusion // .status)  \(.event)  \(.headBranch)  \(.createdAt)  \(.url)")
           '
 
       - name: Aggregate failure-context artifacts from triggering run
@@ -112,12 +169,12 @@ jobs:
           set -euo pipefail
           WORK_DIR="${RUNNER_TEMP}/streak-context"
           mkdir -p "$WORK_DIR"
-          # Pull every context artifact produced by the parent run.
-          # Includes:
-          #   - alwaysgreen-failure-context-* (per-job, from Slice A — #54171)
-          #   - alwaysgreen-saas-category    (downstream SaaS E2E category, Slice D)
-          # Missing artifacts are tolerated — the message degrades gracefully
-          # if either slice is rolled back.
+          # Pull every context artifact produced by the parent run:
+          #   - alwaysgreen-failure-context-* (per-job, emitted by each
+          #     stage of the parent workflow)
+          #   - alwaysgreen-saas-category    (downstream SaaS E2E category)
+          # Missing artifacts are tolerated — the message degrades
+          # gracefully if either kind isn't present.
           gh run download "${PARENT_RUN_ID}" \
             --pattern 'alwaysgreen-*' \
             --dir "$WORK_DIR" 2>/dev/null || true
@@ -150,6 +207,41 @@ jobs:
             echo "EOF_STAGES"
           } >> "$GITHUB_OUTPUT"
 
+          # Build the list of Slack medic mentions to ping. We deduplicate
+          # by team so the same medic isn't pinged multiple times when
+          # several stages failed under the same owner.
+          OWNERS=$(jq -r '
+            [ .[] | (.owner_team // empty) ] | unique | .[]
+          ' "$SUMMARY_JSON")
+
+          mentions=()
+          while IFS= read -r owner; do
+            case "$owner" in
+              "@camunda/test-automation-team")
+                mentions+=("${MEDIC_TEST_AUTOMATION}")
+                ;;
+              "@camunda/distribution")
+                mentions+=("${MEDIC_DISTRIBUTION}")
+                ;;
+              "@camunda/monorepo-devops-team")
+                mentions+=("${MEDIC_MONOREPO_DEVOPS}")
+                ;;
+            esac
+          done <<<"$OWNERS"
+
+          # If no failure context was attributable to a team (e.g. the
+          # parent run died before any job emitted context), default to
+          # pinging the monorepo-devops medic since they own the workflow
+          # plumbing itself.
+          if (( ${#mentions[@]} == 0 )); then
+            mentions+=("${MEDIC_MONOREPO_DEVOPS}")
+          fi
+
+          # Dedup + join with spaces for the Slack message body.
+          medic_pings=$(printf '%s\n' "${mentions[@]}" | awk '!seen[$0]++' | paste -sd ' ' -)
+          echo "medic_pings=${medic_pings}" >> "$GITHUB_OUTPUT"
+          echo "Will ping: ${medic_pings}"
+
       - name: Upload streak-context artifact
         if: steps.streak.outputs.is_streak == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -166,20 +258,24 @@ jobs:
           token: ${{ steps.slack-secrets.outputs.SLACK_CORE_DOMAIN_BOT_TOKEN }}
           payload: |
             channel: "${{ env.ALERT_CHANNEL }}"
-            text: ":rotating_light: AlwaysGreen failure streak on ${{ github.event.workflow_run.head_branch }} (${{ steps.streak.outputs.streak_count }} consecutive failures)"
+            text: ":rotating_light: AlwaysGreen failure streak on ${{ steps.streak.outputs.base_ref }} (${{ steps.streak.outputs.streak_count }} consecutive failures)"
             blocks:
               - type: "header"
                 text:
                   type: "plain_text"
                   text: ":rotating_light: AlwaysGreen streak: ${{ steps.streak.outputs.streak_count }} consecutive failures"
               - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: "${{ steps.aggregate-context.outputs.medic_pings }} — please triage."
+              - type: "section"
                 fields:
                   - type: "mrkdwn"
-                    text: "*Workflow:*\n<https://github.com/${{ github.repository }}/actions/workflows/${{ env.PARENT_WORKFLOW_FILE }}|Docker Build, Helm Deploy & E2E Tests>"
+                    text: "*Workflow:*\n<https://github.com/${{ github.repository }}/actions/workflows/${{ env.PARENT_WORKFLOW_FILE }}|${{ env.PARENT_WORKFLOW_FILE }}>"
                   - type: "mrkdwn"
-                    text: "*Ref / event:*\n`${{ github.event.workflow_run.head_branch }}` (${{ github.event.workflow_run.event }})"
+                    text: "*Base ref:*\n`${{ steps.streak.outputs.base_ref }}`"
                   - type: "mrkdwn"
-                    text: "*Latest failing run:*\n<${{ github.event.workflow_run.html_url }}|#${{ github.event.workflow_run.id }}>"
+                    text: "*Latest failing run:*\n<${{ github.event.workflow_run.html_url }}|#${{ github.event.workflow_run.id }}> (`${{ github.event.workflow_run.event }}` on `${{ github.event.workflow_run.head_branch }}`)"
                   - type: "mrkdwn"
                     text: "*Streak threshold:*\n${{ steps.streak.outputs.threshold }}"
               - type: "section"
@@ -197,7 +293,8 @@ jobs:
           {
             echo "### AlwaysGreen Streak Detector"
             echo ""
-            echo "- ref: ${{ github.event.workflow_run.head_branch }}"
+            echo "- base ref: ${{ steps.streak.outputs.base_ref }}"
+            echo "- raw head_branch: ${{ github.event.workflow_run.head_branch }}"
             echo "- parent event: ${{ github.event.workflow_run.event }}"
             echo "- parent run: ${{ github.event.workflow_run.html_url }}"
             echo "- consecutive failures: ${{ steps.streak.outputs.streak_count }} / ${{ steps.streak.outputs.threshold }}"
@@ -207,3 +304,17 @@ jobs:
               echo "- below threshold — no alert posted"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
+
+      # CI Health hook — same observe-build-status action every other
+      # workflow in this repo ends jobs with. Keep this as the final step so
+      # the Monorepo CI Health linter recognises it.
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          job_name: alwaysgreen-streak-detector
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/alwaysgreen-streak-detector.yml
+++ b/.github/workflows/alwaysgreen-streak-detector.yml
@@ -1,0 +1,209 @@
+# description: AlwaysGreen streak detector. Reacts to completion of the
+# main AlwaysGreen pipeline and posts to #alwaysgreen-reliability when the
+# last N runs on the same protected ref all failed. Uses 'gh run list' rather
+# than persisted state — no race conditions, nothing to migrate on rename.
+# Lives in its own file (instead of an extra job in docker-build-helm-integration.yml)
+# so it doesn't share an edit surface with PR #54171 (Slice A) and to keep
+# the streak-detector cleanly separable / removable on its own.
+# type: CI
+# owner: @camunda/distribution
+---
+name: AlwaysGreen Streak Detector
+
+on:
+  workflow_run:
+    workflows: ["Docker Build, Helm Deploy & E2E Tests (SaaS + Helm)"]
+    types:
+      - completed
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}-${{ github.event.workflow_run.event }}
+  cancel-in-progress: false
+
+env:
+  STREAK_THRESHOLD: '3'
+  LOOKBACK_RUNS: '10'
+  ALERT_CHANNEL: 'alwaysgreen-reliability'
+  PARENT_WORKFLOW_FILE: 'docker-build-helm-integration.yml'
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  detect-streak:
+    name: Detect failure streak
+    # Only react to completed runs that ended in failure on protected events.
+    # Successful or in-progress runs don't move the streak counter.
+    if: |
+      github.event.workflow_run.conclusion == 'failure' &&
+      (github.event.workflow_run.event == 'push' || github.event.workflow_run.event == 'merge_group')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Import Slack token from Vault
+        id: slack-secrets
+        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/camunda/ci/github-actions SLACK_CORE_DOMAIN_BOT_TOKEN;
+
+      - name: Detect failure streak on this ref
+        id: streak
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          PARENT_EVENT: ${{ github.event.workflow_run.event }}
+        run: |
+          set -euo pipefail
+          RUNS_JSON=$(gh run list \
+            --workflow "${PARENT_WORKFLOW_FILE}" \
+            --branch "${HEAD_BRANCH}" \
+            --event "${PARENT_EVENT}" \
+            --limit "${LOOKBACK_RUNS}" \
+            --json conclusion,status,databaseId,createdAt,url,displayTitle 2>/dev/null || echo '[]')
+
+          # Count leading consecutive failures (most recent first). Skip
+          # in-progress runs — only completed runs count toward the streak.
+          STREAK=$(jq '
+            [ .[] | select(.status == "completed") ]
+            | (reduce .[] as $r ({count:0, broken:false};
+                if .broken then .
+                elif ($r.conclusion == "failure" or $r.conclusion == "timed_out") then
+                  .count = (.count + 1)
+                else
+                  .broken = true
+                end
+              ))
+            | .count
+          ' <<<"$RUNS_JSON")
+          STREAK=${STREAK:-0}
+
+          {
+            echo "streak_count=${STREAK}"
+            echo "threshold=${STREAK_THRESHOLD}"
+            echo "is_streak=$([[ ${STREAK} -ge ${STREAK_THRESHOLD} ]] && echo true || echo false)"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Streak count on ${HEAD_BRANCH} (${PARENT_EVENT}): ${STREAK} / ${STREAK_THRESHOLD}"
+          echo "$RUNS_JSON" | jq -r '
+            "Recent runs:",
+            (.[] | "  - \(.conclusion // .status)  \(.createdAt)  \(.url)")
+          '
+
+      - name: Aggregate failure-context artifacts from triggering run
+        id: aggregate-context
+        if: steps.streak.outputs.is_streak == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PARENT_RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          set -euo pipefail
+          WORK_DIR="${RUNNER_TEMP}/streak-context"
+          mkdir -p "$WORK_DIR"
+          # Pull every context artifact produced by the parent run.
+          # Includes:
+          #   - alwaysgreen-failure-context-* (per-job, from Slice A — #54171)
+          #   - alwaysgreen-saas-category    (downstream SaaS E2E category, Slice D)
+          # Missing artifacts are tolerated — the message degrades gracefully
+          # if either slice is rolled back.
+          gh run download "${PARENT_RUN_ID}" \
+            --pattern 'alwaysgreen-*' \
+            --dir "$WORK_DIR" 2>/dev/null || true
+
+          SUMMARY_JSON="${WORK_DIR}/aggregated.json"
+          shopt -s globstar nullglob
+          json_files=( "${WORK_DIR}"/**/*.json )
+          if (( ${#json_files[@]} > 0 )); then
+            jq -s '.' "${json_files[@]}" > "$SUMMARY_JSON"
+          else
+            echo '[]' > "$SUMMARY_JSON"
+          fi
+          echo "summary_path=$SUMMARY_JSON" >> "$GITHUB_OUTPUT"
+
+          jq -r '
+            if length == 0 then "- (no failure-context artifacts produced)"
+            else map(
+              if .stage and .failure_category and .owner_team then
+                "- *\(.stage)* — `\(.failure_category)` → \(.owner_team)"
+              elif .downstream_category then
+                "- *saas-e2e* — `\(.downstream_category)` → \(.owner_team // "@camunda/test-automation-team")"
+              else empty
+              end
+            ) | unique | join("\n")
+            end
+          ' "$SUMMARY_JSON" > "${WORK_DIR}/stages.md"
+          {
+            echo "stages_markdown<<EOF_STAGES"
+            cat "${WORK_DIR}/stages.md"
+            echo "EOF_STAGES"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Upload streak-context artifact
+        if: steps.streak.outputs.is_streak == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: alwaysgreen-streak-context
+          path: ${{ runner.temp }}/streak-context
+          retention-days: 14
+
+      - name: Post streak alert to Slack
+        if: steps.streak.outputs.is_streak == 'true'
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+        with:
+          method: chat.postMessage
+          token: ${{ steps.slack-secrets.outputs.SLACK_CORE_DOMAIN_BOT_TOKEN }}
+          payload: |
+            channel: "${{ env.ALERT_CHANNEL }}"
+            text: ":rotating_light: AlwaysGreen failure streak on ${{ github.event.workflow_run.head_branch }} (${{ steps.streak.outputs.streak_count }} consecutive failures)"
+            blocks:
+              - type: "header"
+                text:
+                  type: "plain_text"
+                  text: ":rotating_light: AlwaysGreen streak: ${{ steps.streak.outputs.streak_count }} consecutive failures"
+              - type: "section"
+                fields:
+                  - type: "mrkdwn"
+                    text: "*Workflow:*\n<https://github.com/${{ github.repository }}/actions/workflows/${{ env.PARENT_WORKFLOW_FILE }}|Docker Build, Helm Deploy & E2E Tests>"
+                  - type: "mrkdwn"
+                    text: "*Ref / event:*\n`${{ github.event.workflow_run.head_branch }}` (${{ github.event.workflow_run.event }})"
+                  - type: "mrkdwn"
+                    text: "*Latest failing run:*\n<${{ github.event.workflow_run.html_url }}|#${{ github.event.workflow_run.id }}>"
+                  - type: "mrkdwn"
+                    text: "*Streak threshold:*\n${{ steps.streak.outputs.threshold }}"
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: ${{ toJSON(format('*Stages that emitted context this run:*{0}{1}', '\n', steps.aggregate-context.outputs.stages_markdown)) }}
+              - type: "context"
+                elements:
+                  - type: "mrkdwn"
+                    text: "Routing context is in `alwaysgreen-streak-context` artifact on this run. Full categorisation model: <https://github.com/camunda/c8-cross-component-e2e-tests/blob/main/docs/ci-failure-categories.md|ci-failure-categories.md>"
+
+      - name: Add streak summary to job log
+        if: always()
+        run: |
+          {
+            echo "### AlwaysGreen Streak Detector"
+            echo ""
+            echo "- ref: ${{ github.event.workflow_run.head_branch }}"
+            echo "- parent event: ${{ github.event.workflow_run.event }}"
+            echo "- parent run: ${{ github.event.workflow_run.html_url }}"
+            echo "- consecutive failures: ${{ steps.streak.outputs.streak_count }} / ${{ steps.streak.outputs.threshold }}"
+            if [[ "${{ steps.streak.outputs.is_streak }}" == "true" ]]; then
+              echo "- :rotating_light: alert posted to *#${{ env.ALERT_CHANNEL }}*"
+            else
+              echo "- below threshold — no alert posted"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/alwaysgreen-streak-detector.yml
+++ b/.github/workflows/alwaysgreen-streak-detector.yml
@@ -1,8 +1,17 @@
 # description: AlwaysGreen streak detector. Reacts to completion of the
-# main AlwaysGreen pipeline and posts to #alwaysgreen-reliability when the
-# last N runs targeting the same protected base branch all failed. Uses
-# 'gh run list' rather than persisted state — no race conditions, nothing
-# to migrate on rename.
+# main AlwaysGreen pipeline and maintains ONE live Slack message per
+# protected base branch in #alwaysgreen-reliability — same
+# find-and-update pattern as .github/workflows/stale-backport-tracker.yml.
+#
+# Behaviour:
+#   - First failure that crosses STREAK_THRESHOLD on a base ref:
+#     chat.postMessage (medic notified once).
+#   - Every subsequent failed run on the same base while the streak is
+#     active: chat.update on the existing message (silent — Slack does
+#     not re-notify on edits). The streak counter increments in-place.
+#   - First successful run after a streak: chat.update marks the message
+#     as resolved (header + marker text both flip). No new notification.
+#   - Subsequent successful runs find no active message, do nothing.
 #
 # Tracks both `push` and `merge_group` events on protected refs. For
 # merge_group, the parent run's head_branch is a per-PR queue ref
@@ -29,6 +38,11 @@ env:
   STREAK_THRESHOLD: '3'
   LOOKBACK_RUNS: '10'
   ALERT_CHANNEL: 'alwaysgreen-reliability'
+  # conversations.history requires the channel ID; chat.postMessage and
+  # chat.update accept either ID or name. Use the ID for both so they all
+  # operate on the same target. Same value referenced in
+  # docker-build-helm-integration.yml's help-text link.
+  ALERT_CHANNEL_ID: 'C0AK0AVKRL0'
   PARENT_WORKFLOW_FILE: 'docker-build-helm-integration.yml'
   # Slack subteam handles for medic pings. These are workspace identifiers,
   # not secrets — same hardcoded convention as
@@ -36,6 +50,12 @@ env:
   MEDIC_TEST_AUTOMATION: '<!subteam^S09UF0EV0HG|test-automation-medic>'
   MEDIC_DISTRIBUTION: '<!subteam^S053K7C7QKU|distribution-medic>'
   MEDIC_MONOREPO_DEVOPS: '<!subteam^S07D6C6B18T|monorepo-devops-medic>'
+  # Marker used in the Slack message text so subsequent runs can find
+  # their own previous message via conversations.history. Includes the
+  # base ref so concurrent streaks on `main` and `stable/x` don't
+  # collide.
+  STREAK_MARKER_ACTIVE: 'AlwaysGreen streak (active)'
+  STREAK_MARKER_RESOLVED: 'AlwaysGreen streak (resolved)'
 
 defaults:
   run:
@@ -44,18 +64,14 @@ defaults:
 jobs:
   detect-streak:
     name: Detect failure streak
-    # React to completed `push` and `merge_group` runs that ended in
-    # failure / timed_out / cancelled — anything the streak counter below
-    # also treats as a streak hit. The counter normalises merge_group
-    # head_branch values (`gh-readonly-queue/<base>/pr-<n>-...`) to their
-    # base so consecutive failing PR batches against the same protected
-    # branch aggregate together.
+    # React to ALL completed `push` and `merge_group` runs (success,
+    # failure, timed_out, cancelled). Failure paths grow the streak;
+    # success paths can RESOLVE an existing live streak message. Without
+    # the success path we'd leave stale ":rotating_light:" alerts in the
+    # channel after a streak heals.
     if: |
-      (github.event.workflow_run.conclusion == 'failure' ||
-       github.event.workflow_run.conclusion == 'timed_out' ||
-       github.event.workflow_run.conclusion == 'cancelled') &&
-      (github.event.workflow_run.event == 'push' ||
-       github.event.workflow_run.event == 'merge_group')
+      github.event.workflow_run.event == 'push' ||
+      github.event.workflow_run.event == 'merge_group'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -144,11 +160,23 @@ jobs:
           ' <<<"$RUNS_JSON")
           STREAK=${STREAK:-0}
 
+          # `is_streak`: the active streak count meets/exceeds threshold,
+          #              i.e. the latest run is a streak hit and we want
+          #              to maintain a live alert message.
+          # `latest_success`: the triggering run succeeded. Used to detect
+          #              "streak just healed" — i.e. resolve any active
+          #              alert for this base ref.
+          LATEST_CONCLUSION="${{ github.event.workflow_run.conclusion }}"
+          IS_STREAK=$([[ ${STREAK} -ge ${STREAK_THRESHOLD} ]] && echo true || echo false)
+          LATEST_SUCCESS=$([[ "${LATEST_CONCLUSION}" == "success" ]] && echo true || echo false)
+
           {
             echo "streak_count=${STREAK}"
             echo "threshold=${STREAK_THRESHOLD}"
             echo "base_ref=${BASE_REF}"
-            echo "is_streak=$([[ ${STREAK} -ge ${STREAK_THRESHOLD} ]] && echo true || echo false)"
+            echo "is_streak=${IS_STREAK}"
+            echo "latest_success=${LATEST_SUCCESS}"
+            echo "latest_conclusion=${LATEST_CONCLUSION}"
           } >> "$GITHUB_OUTPUT"
 
           echo "Streak count on ${BASE_REF}: ${STREAK} / ${STREAK_THRESHOLD}"
@@ -159,8 +187,72 @@ jobs:
               (.[] | "  - \(.conclusion // .status)  \(.event)  \(.headBranch)  \(.createdAt)  \(.url)")
           '
 
+      - name: Find existing Slack streak message for this base
+        id: find-message
+        # We only need to look up the existing message when we're either
+        # extending a live streak (failure path) or potentially resolving
+        # one (success path). Below-threshold failures touch nothing.
+        if: |
+          steps.streak.outputs.is_streak == 'true' ||
+          steps.streak.outputs.latest_success == 'true'
+        # Slack's conversations.history requires the channels:history
+        # scope. If the bot lacks it, this step fails — but we want to
+        # degrade gracefully to "post a fresh message" rather than block
+        # the alert entirely, so continue-on-error mirrors the pattern in
+        # .github/workflows/stale-backport-tracker.yml.
+        continue-on-error: true
+        env:
+          SLACK_TOKEN: ${{ steps.slack-secrets.outputs.SLACK_CORE_DOMAIN_BOT_TOKEN }}
+          BASE_REF: ${{ steps.streak.outputs.base_ref }}
+        run: |
+          set -euo pipefail
+
+          # Marker is base-ref-scoped so concurrent streaks on `main`
+          # and `stable/x` don't collide on the same Slack thread.
+          ACTIVE_MARKER="${STREAK_MARKER_ACTIVE} on ${BASE_REF}"
+          echo "active_marker=${ACTIVE_MARKER}" >> "$GITHUB_OUTPUT"
+
+          # Look back 100 messages — enough to span a multi-day streak
+          # without paginating. The bot only posts on real streak events
+          # so the channel is sparse.
+          RESPONSE=$(curl -sS -X GET \
+            -H "Authorization: Bearer ${SLACK_TOKEN}" \
+            "https://slack.com/api/conversations.history?channel=${ALERT_CHANNEL_ID}&limit=100")
+
+          OK=$(jq -r '.ok // false' <<<"$RESPONSE")
+          if [[ "$OK" != "true" ]]; then
+            ERR=$(jq -r '.error // "unknown"' <<<"$RESPONSE")
+            echo "conversations.history failed: ${ERR} — will fall back to chat.postMessage"
+            echo "existing_ts=" >> "$GITHUB_OUTPUT"
+            echo "existing_is_resolved=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Find this bot's most recent message whose text still contains
+          # the ACTIVE marker for this base ref. A message that's already
+          # been flipped to STREAK_MARKER_RESOLVED won't match, so a new
+          # streak after a resolution starts fresh (correct: we want
+          # medic re-pinged for the new incident).
+          MATCH=$(jq -c --arg marker "$ACTIVE_MARKER" '
+            [ .messages[]?
+              | select((.text // "") | contains($marker))
+            ] | sort_by(.ts) | reverse | .[0] // null
+          ' <<<"$RESPONSE")
+
+          if [[ "$MATCH" == "null" || -z "$MATCH" ]]; then
+            echo "No active streak message found for ${BASE_REF}"
+            echo "existing_ts=" >> "$GITHUB_OUTPUT"
+          else
+            TS=$(jq -r '.ts' <<<"$MATCH")
+            echo "Found existing active streak message: ts=${TS}"
+            echo "existing_ts=${TS}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Aggregate failure-context artifacts from triggering run
         id: aggregate-context
+        # Only aggregate when we're about to post or update a failure
+        # alert. The "resolved on success" path doesn't need failure
+        # context — it just flips the marker on the existing message.
         if: steps.streak.outputs.is_streak == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -250,15 +342,42 @@ jobs:
           path: ${{ runner.temp }}/streak-context
           retention-days: 14
 
-      - name: Post streak alert to Slack
-        if: steps.streak.outputs.is_streak == 'true'
+      # ----------------------------------------------------------------
+      # Slack message handling — three mutually exclusive paths:
+      #
+      #   1. is_streak && no existing message → chat.postMessage
+      #      (medic NOTIFIED. First crossing of the threshold for this
+      #      base ref since the last resolution.)
+      #
+      #   2. is_streak && existing message    → chat.update
+      #      (medic NOT re-notified — Slack does not emit notifications
+      #      for edits. Live message stays current with the new count
+      #      and the latest failing run link.)
+      #
+      #   3. latest_success && existing message → chat.update with
+      #      resolved marker. (Silent. Marker flips from
+      #      STREAK_MARKER_ACTIVE to STREAK_MARKER_RESOLVED so the next
+      #      streak — if any — starts fresh and re-notifies.)
+      #
+      # When `find-message` failed (missing channels:history scope, API
+      # error), `existing_ts` is empty. The failure path falls through to
+      # path 1 (always post) so we never silently drop alerts. The
+      # success path is a no-op when the bot couldn't look up history,
+      # which is acceptable: a stale active message will simply be
+      # overwritten by the next failure-path update.
+      # ----------------------------------------------------------------
+
+      - name: Post new streak alert to Slack (notifies medic)
+        if: |
+          steps.streak.outputs.is_streak == 'true' &&
+          steps.find-message.outputs.existing_ts == ''
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
           method: chat.postMessage
           token: ${{ steps.slack-secrets.outputs.SLACK_CORE_DOMAIN_BOT_TOKEN }}
           payload: |
-            channel: "${{ env.ALERT_CHANNEL }}"
-            text: ":rotating_light: AlwaysGreen failure streak on ${{ steps.streak.outputs.base_ref }} (${{ steps.streak.outputs.streak_count }} consecutive failures)"
+            channel: "${{ env.ALERT_CHANNEL_ID }}"
+            text: ":rotating_light: ${{ env.STREAK_MARKER_ACTIVE }} on ${{ steps.streak.outputs.base_ref }} (${{ steps.streak.outputs.streak_count }} consecutive failures)"
             blocks:
               - type: "header"
                 text:
@@ -287,8 +406,82 @@ jobs:
                   - type: "mrkdwn"
                     text: "Routing context is in `alwaysgreen-streak-context` artifact on this run. Full categorisation model: <https://github.com/camunda/c8-cross-component-e2e-tests/blob/main/docs/ci-failure-categories.md|ci-failure-categories.md>"
 
+      - name: Update existing streak alert in Slack (silent edit)
+        if: |
+          steps.streak.outputs.is_streak == 'true' &&
+          steps.find-message.outputs.existing_ts != ''
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+        with:
+          method: chat.update
+          token: ${{ steps.slack-secrets.outputs.SLACK_CORE_DOMAIN_BOT_TOKEN }}
+          payload: |
+            channel: "${{ env.ALERT_CHANNEL_ID }}"
+            ts: "${{ steps.find-message.outputs.existing_ts }}"
+            text: ":rotating_light: ${{ env.STREAK_MARKER_ACTIVE }} on ${{ steps.streak.outputs.base_ref }} (${{ steps.streak.outputs.streak_count }} consecutive failures)"
+            blocks:
+              - type: "header"
+                text:
+                  type: "plain_text"
+                  text: ":rotating_light: AlwaysGreen streak: ${{ steps.streak.outputs.streak_count }} consecutive failures (ongoing)"
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: "${{ steps.aggregate-context.outputs.medic_pings }} — still triaging."
+              - type: "section"
+                fields:
+                  - type: "mrkdwn"
+                    text: "*Workflow:*\n<https://github.com/${{ github.repository }}/actions/workflows/${{ env.PARENT_WORKFLOW_FILE }}|${{ env.PARENT_WORKFLOW_FILE }}>"
+                  - type: "mrkdwn"
+                    text: "*Base ref:*\n`${{ steps.streak.outputs.base_ref }}`"
+                  - type: "mrkdwn"
+                    text: "*Latest failing run:*\n<${{ github.event.workflow_run.html_url }}|#${{ github.event.workflow_run.id }}> (`${{ github.event.workflow_run.event }}` on `${{ github.event.workflow_run.head_branch }}`)"
+                  - type: "mrkdwn"
+                    text: "*Streak threshold:*\n${{ steps.streak.outputs.threshold }}"
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: ${{ toJSON(format('*Stages that emitted context this run:*{0}{1}', '\n', steps.aggregate-context.outputs.stages_markdown)) }}
+              - type: "context"
+                elements:
+                  - type: "mrkdwn"
+                    text: "Routing context is in `alwaysgreen-streak-context` artifact on this run. Full categorisation model: <https://github.com/camunda/c8-cross-component-e2e-tests/blob/main/docs/ci-failure-categories.md|ci-failure-categories.md>"
+
+      - name: Mark streak as resolved in Slack (silent edit)
+        if: |
+          steps.streak.outputs.latest_success == 'true' &&
+          steps.find-message.outputs.existing_ts != ''
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+        with:
+          method: chat.update
+          token: ${{ steps.slack-secrets.outputs.SLACK_CORE_DOMAIN_BOT_TOKEN }}
+          payload: |
+            channel: "${{ env.ALERT_CHANNEL_ID }}"
+            ts: "${{ steps.find-message.outputs.existing_ts }}"
+            text: ":white_check_mark: ${{ env.STREAK_MARKER_RESOLVED }} on ${{ steps.streak.outputs.base_ref }}"
+            blocks:
+              - type: "header"
+                text:
+                  type: "plain_text"
+                  text: ":white_check_mark: AlwaysGreen streak resolved"
+              - type: "section"
+                fields:
+                  - type: "mrkdwn"
+                    text: "*Workflow:*\n<https://github.com/${{ github.repository }}/actions/workflows/${{ env.PARENT_WORKFLOW_FILE }}|${{ env.PARENT_WORKFLOW_FILE }}>"
+                  - type: "mrkdwn"
+                    text: "*Base ref:*\n`${{ steps.streak.outputs.base_ref }}`"
+                  - type: "mrkdwn"
+                    text: "*First green run after streak:*\n<${{ github.event.workflow_run.html_url }}|#${{ github.event.workflow_run.id }}> (`${{ github.event.workflow_run.event }}` on `${{ github.event.workflow_run.head_branch }}`)"
+              - type: "context"
+                elements:
+                  - type: "mrkdwn"
+                    text: "If failures resume on this base, a fresh alert will re-notify the medic."
+
       - name: Add streak summary to job log
         if: always()
+        env:
+          IS_STREAK: ${{ steps.streak.outputs.is_streak }}
+          LATEST_SUCCESS: ${{ steps.streak.outputs.latest_success }}
+          EXISTING_TS: ${{ steps.find-message.outputs.existing_ts }}
         run: |
           {
             echo "### AlwaysGreen Streak Detector"
@@ -296,12 +489,19 @@ jobs:
             echo "- base ref: ${{ steps.streak.outputs.base_ref }}"
             echo "- raw head_branch: ${{ github.event.workflow_run.head_branch }}"
             echo "- parent event: ${{ github.event.workflow_run.event }}"
+            echo "- parent conclusion: ${{ steps.streak.outputs.latest_conclusion }}"
             echo "- parent run: ${{ github.event.workflow_run.html_url }}"
             echo "- consecutive failures: ${{ steps.streak.outputs.streak_count }} / ${{ steps.streak.outputs.threshold }}"
-            if [[ "${{ steps.streak.outputs.is_streak }}" == "true" ]]; then
-              echo "- :rotating_light: alert posted to *#${{ env.ALERT_CHANNEL }}*"
+            if [[ "${IS_STREAK}" == "true" && -z "${EXISTING_TS}" ]]; then
+              echo "- :rotating_light: posted NEW streak alert to *#${{ env.ALERT_CHANNEL }}* (medic notified)"
+            elif [[ "${IS_STREAK}" == "true" && -n "${EXISTING_TS}" ]]; then
+              echo "- :pencil2: updated existing streak alert (silent edit, ts=${EXISTING_TS})"
+            elif [[ "${LATEST_SUCCESS}" == "true" && -n "${EXISTING_TS}" ]]; then
+              echo "- :white_check_mark: marked streak as resolved on existing message (ts=${EXISTING_TS})"
+            elif [[ "${LATEST_SUCCESS}" == "true" ]]; then
+              echo "- :white_check_mark: run was green; no active streak message to resolve"
             else
-              echo "- below threshold — no alert posted"
+              echo "- below threshold (${{ steps.streak.outputs.streak_count }} < ${{ steps.streak.outputs.threshold }}) — no Slack action"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -100,10 +100,106 @@ jobs:
           name: alwaysgreen-failure-context-${{ github.job }}
           path: ${{ runner.temp }}/alwaysgreen-context-${{ github.job }}.json
           retention-days: 5
+
+
+  # Slice B — preflight checks. Validates the things that have historically
+  # broken downstream stages silently:
+  #   1. required org secrets are present
+  #   2. expected Vault paths are readable from this repo
+  #   3. the image-tag shape that will be synthesized matches the contract
+  #      Harbor replication filters expect (**-(main|dispatch|mq*)-run**-a**)
+  # Fails fast so we don't burn 30 min of build only to land on ImagePullBackOff
+  # in helm-deploy or a "no matching generation" error in trigger-saas-e2e.
+  preflight:
+    name: Preflight checks
+    needs: should-run
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    continue-on-error: ${{ github.event_name == 'merge_group' }}
+    permissions: { }
+    steps:
+      - name: Verify required org secrets are set
+        env:
+          VAULT_ADDR_PRESENT: ${{ secrets.VAULT_ADDR != '' }}
+          VAULT_ROLE_ID_PRESENT: ${{ secrets.VAULT_ROLE_ID != '' }}
+          VAULT_SECRET_ID_PRESENT: ${{ secrets.VAULT_SECRET_ID != '' }}
+        run: |
+          set -euo pipefail
+          missing=()
+          [[ "$VAULT_ADDR_PRESENT" == "true" ]] || missing+=(VAULT_ADDR)
+          [[ "$VAULT_ROLE_ID_PRESENT" == "true" ]] || missing+=(VAULT_ROLE_ID)
+          [[ "$VAULT_SECRET_ID_PRESENT" == "true" ]] || missing+=(VAULT_SECRET_ID)
+          if (( ${#missing[@]} > 0 )); then
+            echo "Missing org secrets: ${missing[*]}" >&2
+            exit 1
+          fi
+          echo "All required org secrets are present."
+
+      - name: Verify Vault paths are reachable
+        # Read-only smoke check: only proves the role can resolve the paths
+        # this workflow depends on. Failure here means the Vault policy for
+        # this repo lost a path binding (or the secret was rotated to a
+        # different path) — a known historical break mode.
+        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/github.com/organizations/camunda NEXUS_USR;
+            secret/data/products/camunda/ci/github-actions SLACK_CORE_DOMAIN_BOT_TOKEN;
+
+      - name: Validate image-tag shape contract
+        # On stable/8.8 the Harbor replication filter is `**-mq**-run**`
+        # (see comment on the `version` workflow input). All push and
+        # merge_group tags must therefore start with `-mq` followed by
+        # a numeric PR number OR a 7-char SHA fallback — both forms are
+        # produced by build-and-push.set-image-tag.
+        # workflow_dispatch produces a `-dispatch-` tag that is intentionally
+        # not subject to replication (the dispatch event is for testing).
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          MAVEN_VERSION="8.x.y-SNAPSHOT"
+          if [[ -n "$INPUT_VERSION" ]]; then
+            TAG="$INPUT_VERSION"
+          elif [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            TAG="${MAVEN_VERSION}-dispatch-run${{ github.run_id }}-a${{ github.run_attempt }}"
+          else
+            # Both merge_group and push to stable/* synthesize an `mq*` tag —
+            # either `mq<PR_NUMBER>` or `mq<SHA_SHORT>` (alphanumeric).
+            TAG="${MAVEN_VERSION}-mqEXAMPLE-run${{ github.run_id }}-a${{ github.run_attempt }}"
+          fi
+          echo "Validating tag shape: $TAG"
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            echo "workflow_dispatch tag — replication contract intentionally not enforced."
+          elif ! [[ "$TAG" =~ ^.+-mq[A-Za-z0-9]+-run[0-9]+-a[0-9]+$ ]]; then
+            echo "Tag does not match Harbor replication contract '**-mq**-run**-a**'." >&2
+            echo "Got: $TAG" >&2
+            exit 1
+          fi
+          echo "Tag shape OK."
+
+      - name: Add preflight summary
+        if: always()
+        run: |
+          {
+            echo "### AlwaysGreen Preflight"
+            echo ""
+            echo "- secrets: validated"
+            echo "- vault paths: validated"
+            echo "- image tag shape: validated against Harbor replication contract"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # Parallel frontend builds (this comment was here in original; preflight inserts before it)
   # Parallel frontend builds
   build-operate-frontend:
     name: Build Operate Frontend
-    needs: should-run
+    needs: preflight
     permissions: { }
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -158,7 +254,7 @@ jobs:
           retention-days: 5
   build-tasklist-frontend:
     name: Build Tasklist Frontend
-    needs: should-run
+    needs: preflight
     permissions: { }
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -213,7 +309,7 @@ jobs:
           retention-days: 5
   build-identity-frontend:
     name: Build Identity Frontend
-    needs: should-run
+    needs: preflight
     permissions: { }
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -421,7 +517,7 @@ jobs:
   format-identifier:
     name: Format Identifier
     # Runs in parallel with frontend builds (no dependency on their outputs)
-    needs: should-run
+    needs: preflight
     permissions: { }
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -718,6 +814,110 @@ jobs:
           echo "downstream_conclusion=timeout" >> "$GITHUB_OUTPUT"
           echo "Timed out waiting for downstream workflow to complete."
           exit 1
+
+      # Slice D — propagate downstream SaaS E2E failure category. Computed
+      # from the downstream json-report artifact using the decision tree in
+      # camunda/c8-cross-component-e2e-tests/docs/ci-failure-categories.md
+      # so an alwaysgreen medic can immediately tell whether a downstream
+      # failure was infrastructure / product / mixed without opening the
+      # downstream HTML report.
+      #
+      # Emitted as a separate artifact (alwaysgreen-saas-category) so it
+      # doesn't conflict with the failure-context artifacts produced by the
+      # parallel Slice A work (#54171). Slice C's streak detector reads both.
+      - name: Resolve downstream SaaS E2E failure category
+        id: downstream-category
+        if: always() && steps.wait-downstream.outputs.downstream_run_url != ''
+        env:
+          GH_TOKEN: ${{ steps.github-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          DOWNSTREAM_URL="${{ steps.wait-downstream.outputs.downstream_run_url }}"
+          DOWNSTREAM_CONCLUSION="${{ steps.wait-downstream.outputs.downstream_conclusion }}"
+          RUN_ID="${DOWNSTREAM_URL##*/}"
+          TARGET_REPO="camunda/c8-cross-component-e2e-tests"
+
+          DOWNSTREAM_CATEGORY="unknown"
+          DOWNSTREAM_OWNER="@camunda/test-automation-team"
+
+          case "$DOWNSTREAM_CONCLUSION" in
+            success)
+              DOWNSTREAM_CATEGORY="none"
+              DOWNSTREAM_OWNER="none"
+              ;;
+            timeout|cancelled)
+              DOWNSTREAM_CATEGORY="infrastructure"
+              ;;
+            failure)
+              WORK_DIR="${RUNNER_TEMP}/downstream-report"
+              mkdir -p "$WORK_DIR"
+              if gh run download "$RUN_ID" --repo "$TARGET_REPO" \
+                  --pattern 'json-report*' --dir "$WORK_DIR" 2>/dev/null; then
+                TOTAL=0
+                FAILED=0
+                FLAKY=0
+                SETUP_FAILED=0
+                while IFS= read -r -d '' RESULTS; do
+                  T=$(jq '[.suites[]?.specs[]?] | length' "$RESULTS" 2>/dev/null || echo 0)
+                  F=$(jq '[.suites[]?.specs[]? | select(.ok==false)] | length' "$RESULTS" 2>/dev/null || echo 0)
+                  K=$(jq '[.suites[]?.specs[]? | select(.tests[]?.results | length > 1) | select(.ok==true)] | length' "$RESULTS" 2>/dev/null || echo 0)
+                  S=$(jq '[.suites[]?.specs[]? | select((.file // "") | endswith("test-setup.spec.ts")) | select(.ok==false)] | length' "$RESULTS" 2>/dev/null || echo 0)
+                  TOTAL=$((TOTAL + T))
+                  FAILED=$((FAILED + F))
+                  FLAKY=$((FLAKY + K))
+                  SETUP_FAILED=$((SETUP_FAILED + S))
+                done < <(find "$WORK_DIR" -type f -name 'results.json' -print0)
+
+                echo "downstream totals: total=$TOTAL failed=$FAILED flaky=$FLAKY setup_failed=$SETUP_FAILED"
+                if (( TOTAL == 0 )) || (( SETUP_FAILED > 0 )); then
+                  DOWNSTREAM_CATEGORY="infrastructure"
+                elif (( FAILED > 0 )) && (( FLAKY > 0 )); then
+                  DOWNSTREAM_CATEGORY="mixed"
+                elif (( FAILED > 0 )); then
+                  DOWNSTREAM_CATEGORY="product"
+                else
+                  DOWNSTREAM_CATEGORY="unknown"
+                fi
+              else
+                echo "Could not download json-report artifact — leaving category as unknown" >&2
+              fi
+              ;;
+          esac
+
+          CONTEXT_FILE="${RUNNER_TEMP}/alwaysgreen-saas-category.json"
+          jq -n \
+            --arg stage "${{ github.job }}" \
+            --arg downstream_conclusion "$DOWNSTREAM_CONCLUSION" \
+            --arg downstream_category "$DOWNSTREAM_CATEGORY" \
+            --arg owner_team "$DOWNSTREAM_OWNER" \
+            --arg run_url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --arg downstream_run_url "$DOWNSTREAM_URL" \
+            '{
+              stage:$stage,
+              downstream_conclusion:$downstream_conclusion,
+              downstream_category:$downstream_category,
+              owner_team:$owner_team,
+              run_url:$run_url,
+              downstream_run_url:$downstream_run_url
+            }' > "$CONTEXT_FILE"
+
+          echo "downstream_category=$DOWNSTREAM_CATEGORY" >> "$GITHUB_OUTPUT"
+          echo "downstream_owner=$DOWNSTREAM_OWNER" >> "$GITHUB_OUTPUT"
+          {
+            echo "### Downstream SaaS E2E Failure Category"
+            echo ""
+            echo "- conclusion: $DOWNSTREAM_CONCLUSION"
+            echo "- category: $DOWNSTREAM_CATEGORY"
+            echo "- owner: $DOWNSTREAM_OWNER"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload downstream SaaS E2E category artifact
+        if: ${{ always() && steps.downstream-category.outcome == 'success' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: alwaysgreen-saas-category
+          path: ${{ runner.temp }}/alwaysgreen-saas-category.json
+          retention-days: 14
 
       - name: Add SaaS downstream workflow link to Job Summary
         if: always()

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -102,23 +102,29 @@ jobs:
           retention-days: 5
 
 
-  # Slice B — preflight checks. Validates the things that have historically
-  # broken downstream stages silently:
+  # Preflight checks. Validates the things that have historically broken
+  # downstream stages silently:
   #   1. required org secrets are present
   #   2. expected Vault paths are readable from this repo
-  #   3. the image-tag shape that will be synthesized matches the contract
-  #      Harbor replication filters expect (**-(main|dispatch|mq*)-run**-a**)
-  # Fails fast so we don't burn 30 min of build only to land on ImagePullBackOff
-  # in helm-deploy or a "no matching generation" error in trigger-saas-e2e.
+  #   3. when a user supplies inputs.version on workflow_dispatch, it
+  #      matches one of the two documented tag shapes — otherwise the
+  #      build would push a tag that the Harbor replication filter
+  #      (`**-mq**-run**`) silently drops, and helm-deploy would later
+  #      fail with ImagePullBackOff.
+  # Fails fast before any expensive build job runs.
   preflight:
     name: Preflight checks
     needs: should-run
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    continue-on-error: ${{ github.event_name == 'merge_group' }}
+    # NB: NO `continue-on-error` here. Preflight is meant to fail-fast and
+    # block the expensive downstream stages — including on merge_group runs
+    # (one of the two protected events this hardening targets). Letting
+    # preflight failures pass through here would defeat the entire rationale.
     permissions: { }
     steps:
       - name: Verify required org secrets are set
+        id: check-secrets
         env:
           VAULT_ADDR_PRESENT: ${{ secrets.VAULT_ADDR != '' }}
           VAULT_ROLE_ID_PRESENT: ${{ secrets.VAULT_ROLE_ID != '' }}
@@ -136,6 +142,7 @@ jobs:
           echo "All required org secrets are present."
 
       - name: Verify Vault paths are reachable
+        id: check-vault
         # Read-only smoke check: only proves the role can resolve the paths
         # this workflow depends on. Failure here means the Vault policy for
         # this repo lost a path binding (or the secret was rotated to a
@@ -151,51 +158,80 @@ jobs:
             secret/data/github.com/organizations/camunda NEXUS_USR;
             secret/data/products/camunda/ci/github-actions SLACK_CORE_DOMAIN_BOT_TOKEN;
 
-      - name: Validate image-tag shape contract
-        # On stable/8.8 the Harbor replication filter is `**-mq**-run**`
-        # (see comment on the `version` workflow input). All push and
-        # merge_group tags must therefore start with `-mq` followed by
-        # a numeric PR number OR a 7-char SHA fallback — both forms are
-        # produced by build-and-push.set-image-tag.
-        # workflow_dispatch produces a `-dispatch-` tag that is intentionally
-        # not subject to replication (the dispatch event is for testing).
+      - name: Validate inputs.version shape (when provided)
+        id: check-tag-shape
+        # The only tag this job has access to before build-and-push runs is
+        # the user-supplied workflow_dispatch override. Validate that it
+        # matches one of the two documented shapes:
+        #   - "...-mq<PR_NUMBER|SHA>-run<run_id>-a<attempt>"   (replicated)
+        #   - "...-dispatch-run<run_id>-a<attempt>"            (not replicated)
+        # Other event paths (push, merge_group) synthesize the tag inside
+        # build-and-push.set-image-tag, which is the single source of truth
+        # for that logic — preflight cannot validate that tag without
+        # duplicating the producer.
         env:
-          EVENT_NAME: ${{ github.event_name }}
           INPUT_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          MAVEN_VERSION="8.x.y-SNAPSHOT"
-          if [[ -n "$INPUT_VERSION" ]]; then
-            TAG="$INPUT_VERSION"
-          elif [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
-            TAG="${MAVEN_VERSION}-dispatch-run${{ github.run_id }}-a${{ github.run_attempt }}"
-          else
-            # Both merge_group and push to stable/* synthesize an `mq*` tag —
-            # either `mq<PR_NUMBER>` or `mq<SHA_SHORT>` (alphanumeric).
-            TAG="${MAVEN_VERSION}-mqEXAMPLE-run${{ github.run_id }}-a${{ github.run_attempt }}"
+          if [[ -z "$INPUT_VERSION" ]]; then
+            echo "No inputs.version provided — tag will be synthesized by build-and-push.set-image-tag."
+            exit 0
           fi
-          echo "Validating tag shape: $TAG"
-          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
-            echo "workflow_dispatch tag — replication contract intentionally not enforced."
-          elif ! [[ "$TAG" =~ ^.+-mq[A-Za-z0-9]+-run[0-9]+-a[0-9]+$ ]]; then
-            echo "Tag does not match Harbor replication contract '**-mq**-run**-a**'." >&2
-            echo "Got: $TAG" >&2
+          mq_re='^.+-mq[A-Za-z0-9]+-run[0-9]+-a[0-9]+$'
+          dispatch_re='^.+-dispatch-run[0-9]+-a[0-9]+$'
+          echo "Validating inputs.version: $INPUT_VERSION"
+          if [[ ! "$INPUT_VERSION" =~ $mq_re && ! "$INPUT_VERSION" =~ $dispatch_re ]]; then
+            echo "inputs.version '$INPUT_VERSION' does not match either documented shape:" >&2
+            echo "  - **-mq**-run**-a**     (Harbor-replicated)" >&2
+            echo "  - **-dispatch-run**-a** (not replicated)" >&2
             exit 1
           fi
-          echo "Tag shape OK."
+          echo "inputs.version shape OK."
 
       - name: Add preflight summary
         if: always()
+        env:
+          # Each check's `outcome` is one of: success, failure, cancelled,
+          # skipped. Map the raw value to a glyph so the summary reflects
+          # reality even when an earlier step failed and later ones never
+          # ran. Without this the summary unconditionally claimed "validated".
+          SECRETS_OUTCOME: ${{ steps.check-secrets.outcome }}
+          VAULT_OUTCOME: ${{ steps.check-vault.outcome }}
+          TAG_OUTCOME: ${{ steps.check-tag-shape.outcome }}
         run: |
+          format_outcome() {
+            case "$1" in
+              success)   echo ":white_check_mark: passed" ;;
+              failure)   echo ":x: failed" ;;
+              cancelled) echo ":no_entry_sign: cancelled" ;;
+              skipped|"") echo ":heavy_minus_sign: skipped (an earlier check failed)" ;;
+              *)         echo ":grey_question: $1" ;;
+            esac
+          }
           {
             echo "### AlwaysGreen Preflight"
             echo ""
-            echo "- secrets: validated"
-            echo "- vault paths: validated"
-            echo "- image tag shape: validated against Harbor replication contract"
+            echo "- secrets: $(format_outcome "$SECRETS_OUTCOME")"
+            echo "- vault paths: $(format_outcome "$VAULT_OUTCOME")"
+            echo "- image tag shape: $(format_outcome "$TAG_OUTCOME")"
           } >> "$GITHUB_STEP_SUMMARY"
 
-  # Parallel frontend builds (this comment was here in original; preflight inserts before it)
+      # Same CI Health observability hook every other job in this workflow
+      # uses. Without it the Monorepo CI Health linter flags this job.
+      - name: Checkout (for observe-build-status)
+        if: always()
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          job_name: docker-build-helm-integration-preflight
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+
   # Parallel frontend builds
   build-operate-frontend:
     name: Build Operate Frontend
@@ -815,110 +851,6 @@ jobs:
           echo "Timed out waiting for downstream workflow to complete."
           exit 1
 
-      # Slice D — propagate downstream SaaS E2E failure category. Computed
-      # from the downstream json-report artifact using the decision tree in
-      # camunda/c8-cross-component-e2e-tests/docs/ci-failure-categories.md
-      # so an alwaysgreen medic can immediately tell whether a downstream
-      # failure was infrastructure / product / mixed without opening the
-      # downstream HTML report.
-      #
-      # Emitted as a separate artifact (alwaysgreen-saas-category) so it
-      # doesn't conflict with the failure-context artifacts produced by the
-      # parallel Slice A work (#54171). Slice C's streak detector reads both.
-      - name: Resolve downstream SaaS E2E failure category
-        id: downstream-category
-        if: always() && steps.wait-downstream.outputs.downstream_run_url != ''
-        env:
-          GH_TOKEN: ${{ steps.github-token.outputs.token }}
-        run: |
-          set -euo pipefail
-          DOWNSTREAM_URL="${{ steps.wait-downstream.outputs.downstream_run_url }}"
-          DOWNSTREAM_CONCLUSION="${{ steps.wait-downstream.outputs.downstream_conclusion }}"
-          RUN_ID="${DOWNSTREAM_URL##*/}"
-          TARGET_REPO="camunda/c8-cross-component-e2e-tests"
-
-          DOWNSTREAM_CATEGORY="unknown"
-          DOWNSTREAM_OWNER="@camunda/test-automation-team"
-
-          case "$DOWNSTREAM_CONCLUSION" in
-            success)
-              DOWNSTREAM_CATEGORY="none"
-              DOWNSTREAM_OWNER="none"
-              ;;
-            timeout|cancelled)
-              DOWNSTREAM_CATEGORY="infrastructure"
-              ;;
-            failure)
-              WORK_DIR="${RUNNER_TEMP}/downstream-report"
-              mkdir -p "$WORK_DIR"
-              if gh run download "$RUN_ID" --repo "$TARGET_REPO" \
-                  --pattern 'json-report*' --dir "$WORK_DIR" 2>/dev/null; then
-                TOTAL=0
-                FAILED=0
-                FLAKY=0
-                SETUP_FAILED=0
-                while IFS= read -r -d '' RESULTS; do
-                  T=$(jq '[.suites[]?.specs[]?] | length' "$RESULTS" 2>/dev/null || echo 0)
-                  F=$(jq '[.suites[]?.specs[]? | select(.ok==false)] | length' "$RESULTS" 2>/dev/null || echo 0)
-                  K=$(jq '[.suites[]?.specs[]? | select(.tests[]?.results | length > 1) | select(.ok==true)] | length' "$RESULTS" 2>/dev/null || echo 0)
-                  S=$(jq '[.suites[]?.specs[]? | select((.file // "") | endswith("test-setup.spec.ts")) | select(.ok==false)] | length' "$RESULTS" 2>/dev/null || echo 0)
-                  TOTAL=$((TOTAL + T))
-                  FAILED=$((FAILED + F))
-                  FLAKY=$((FLAKY + K))
-                  SETUP_FAILED=$((SETUP_FAILED + S))
-                done < <(find "$WORK_DIR" -type f -name 'results.json' -print0)
-
-                echo "downstream totals: total=$TOTAL failed=$FAILED flaky=$FLAKY setup_failed=$SETUP_FAILED"
-                if (( TOTAL == 0 )) || (( SETUP_FAILED > 0 )); then
-                  DOWNSTREAM_CATEGORY="infrastructure"
-                elif (( FAILED > 0 )) && (( FLAKY > 0 )); then
-                  DOWNSTREAM_CATEGORY="mixed"
-                elif (( FAILED > 0 )); then
-                  DOWNSTREAM_CATEGORY="product"
-                else
-                  DOWNSTREAM_CATEGORY="unknown"
-                fi
-              else
-                echo "Could not download json-report artifact — leaving category as unknown" >&2
-              fi
-              ;;
-          esac
-
-          CONTEXT_FILE="${RUNNER_TEMP}/alwaysgreen-saas-category.json"
-          jq -n \
-            --arg stage "${{ github.job }}" \
-            --arg downstream_conclusion "$DOWNSTREAM_CONCLUSION" \
-            --arg downstream_category "$DOWNSTREAM_CATEGORY" \
-            --arg owner_team "$DOWNSTREAM_OWNER" \
-            --arg run_url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-            --arg downstream_run_url "$DOWNSTREAM_URL" \
-            '{
-              stage:$stage,
-              downstream_conclusion:$downstream_conclusion,
-              downstream_category:$downstream_category,
-              owner_team:$owner_team,
-              run_url:$run_url,
-              downstream_run_url:$downstream_run_url
-            }' > "$CONTEXT_FILE"
-
-          echo "downstream_category=$DOWNSTREAM_CATEGORY" >> "$GITHUB_OUTPUT"
-          echo "downstream_owner=$DOWNSTREAM_OWNER" >> "$GITHUB_OUTPUT"
-          {
-            echo "### Downstream SaaS E2E Failure Category"
-            echo ""
-            echo "- conclusion: $DOWNSTREAM_CONCLUSION"
-            echo "- category: $DOWNSTREAM_CATEGORY"
-            echo "- owner: $DOWNSTREAM_OWNER"
-          } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Upload downstream SaaS E2E category artifact
-        if: ${{ always() && steps.downstream-category.outcome == 'success' }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: alwaysgreen-saas-category
-          path: ${{ runner.temp }}/alwaysgreen-saas-category.json
-          retention-days: 14
-
       - name: Add SaaS downstream workflow link to Job Summary
         if: always()
         run: |
@@ -961,6 +893,141 @@ jobs:
             echo ""
             echo "**Full guide:** [CI Debugging Cookbook — SaaS E2E section](${COOKBOOK_URL}#failure-type-5--saas-e2e-tests)"
           } >> "$GITHUB_STEP_SUMMARY"
+      # Propagate the downstream SaaS E2E failure category. Computed from
+      # the downstream json-report artifact using the decision tree in
+      # camunda/c8-cross-component-e2e-tests/docs/ci-failure-categories.md
+      # so an alwaysgreen medic can immediately tell whether a downstream
+      # failure was infrastructure / product / mixed without opening the
+      # downstream HTML report. Emitted as a separate artifact
+      # (alwaysgreen-saas-category) so the streak detector and any other
+      # consumer can read it alongside the per-job failure-context artifacts.
+      - name: Resolve downstream SaaS E2E failure category
+        id: downstream-category
+        if: always() && steps.wait-downstream.outputs.downstream_run_url != ''
+        env:
+          GH_TOKEN: ${{ steps.github-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          DOWNSTREAM_URL="${{ steps.wait-downstream.outputs.downstream_run_url }}"
+          RUN_ID="${DOWNSTREAM_URL##*/}"
+          TARGET_REPO="camunda/c8-cross-component-e2e-tests"
+
+          # Resolve the downstream conclusion directly from the GitHub API
+          # so this step does not depend on outputs produced by any other
+          # workflow change. Possible values per the REST API include
+          # `success`, `failure`, `timed_out`, `cancelled`, `neutral`,
+          # `action_required`, `skipped`, `stale`, `null` (still running).
+          DOWNSTREAM_CONCLUSION=$(gh api "/repos/$TARGET_REPO/actions/runs/$RUN_ID" \
+            --jq '.conclusion // "unknown"' 2>/dev/null || echo "unknown")
+          echo "Resolved downstream conclusion from API: $DOWNSTREAM_CONCLUSION"
+
+          DOWNSTREAM_CATEGORY="unknown"
+          DOWNSTREAM_OWNER="@camunda/test-automation-team"
+
+          case "$DOWNSTREAM_CONCLUSION" in
+            success)
+              DOWNSTREAM_CATEGORY="none"
+              DOWNSTREAM_OWNER="none"
+              ;;
+            timed_out|cancelled)
+              DOWNSTREAM_CATEGORY="infrastructure"
+              ;;
+            failure)
+              WORK_DIR="${RUNNER_TEMP}/downstream-report"
+              mkdir -p "$WORK_DIR"
+              # Capture stderr so we can surface a real reason (404 / 403 /
+              # auth scope) rather than silently classifying as `unknown`.
+              # Common modes:
+              #   - GitHub App installation on c8-cross-component-e2e-tests
+              #     lacks `actions: read` → 403
+              #   - artifact retention expired → 404
+              #   - downstream run still publishing → transient 404
+              DOWNLOAD_LOG="${WORK_DIR}/.gh-run-download.log"
+              if gh run download "$RUN_ID" --repo "$TARGET_REPO" \
+                  --pattern 'json-report*' --dir "$WORK_DIR" 2>"$DOWNLOAD_LOG"; then
+                TOTAL=0
+                FAILED=0
+                FLAKY=0
+                SETUP_FAILED=0
+                while IFS= read -r -d '' RESULTS; do
+                  T=$(jq '[.suites[]?.specs[]?] | length' "$RESULTS" 2>/dev/null || echo 0)
+                  F=$(jq '[.suites[]?.specs[]? | select(.ok==false)] | length' "$RESULTS" 2>/dev/null || echo 0)
+                  K=$(jq '[.suites[]?.specs[]? | select(.tests[]?.results | length > 1) | select(.ok==true)] | length' "$RESULTS" 2>/dev/null || echo 0)
+                  S=$(jq '[.suites[]?.specs[]? | select((.file // "") | endswith("test-setup.spec.ts")) | select(.ok==false)] | length' "$RESULTS" 2>/dev/null || echo 0)
+                  TOTAL=$((TOTAL + T))
+                  FAILED=$((FAILED + F))
+                  FLAKY=$((FLAKY + K))
+                  SETUP_FAILED=$((SETUP_FAILED + S))
+                done < <(find "$WORK_DIR" -type f -name 'results.json' -print0)
+
+                echo "downstream totals: total=$TOTAL failed=$FAILED flaky=$FLAKY setup_failed=$SETUP_FAILED"
+                if (( TOTAL == 0 )) || (( SETUP_FAILED > 0 )); then
+                  DOWNSTREAM_CATEGORY="infrastructure"
+                elif (( FAILED > 0 )) && (( FLAKY > 0 )); then
+                  DOWNSTREAM_CATEGORY="mixed"
+                elif (( FAILED > 0 )); then
+                  DOWNSTREAM_CATEGORY="product"
+                else
+                  DOWNSTREAM_CATEGORY="unknown"
+                fi
+              else
+                # The artifact was unreachable. Distinguish this from a
+                # genuinely "unknown" categorisation so consumers don't
+                # confuse "we couldn't tell" with "we tried and the data
+                # was ambiguous". Routing falls to monorepo-devops since
+                # this is an integration / permissions problem with the
+                # parent workflow, not a downstream test failure.
+                DOWNLOAD_ERR=$(tr '\n' ' ' < "$DOWNLOAD_LOG" 2>/dev/null | sed 's/  */ /g' | cut -c1-300)
+                echo "::warning::Could not download downstream json-report artifact: ${DOWNLOAD_ERR:-no stderr}" >&2
+                DOWNSTREAM_CATEGORY="unknown_artifact_unreachable"
+                DOWNSTREAM_OWNER="@camunda/monorepo-devops-team"
+                {
+                  echo "### Downstream Category Unavailable"
+                  echo ""
+                  echo "\`gh run download\` failed for run $RUN_ID on $TARGET_REPO."
+                  echo "Common causes: the dispatch GitHub App installation lacks \`actions: read\` on the downstream repo, or the artifact retention window has expired."
+                  echo ""
+                  echo "stderr: \`${DOWNLOAD_ERR:-(empty)}\`"
+                } >> "$GITHUB_STEP_SUMMARY"
+              fi
+              ;;
+          esac
+
+          CONTEXT_FILE="${RUNNER_TEMP}/alwaysgreen-saas-category.json"
+          jq -n \
+            --arg stage "${{ github.job }}" \
+            --arg downstream_conclusion "$DOWNSTREAM_CONCLUSION" \
+            --arg downstream_category "$DOWNSTREAM_CATEGORY" \
+            --arg owner_team "$DOWNSTREAM_OWNER" \
+            --arg run_url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --arg downstream_run_url "$DOWNSTREAM_URL" \
+            '{
+              stage:$stage,
+              downstream_conclusion:$downstream_conclusion,
+              downstream_category:$downstream_category,
+              owner_team:$owner_team,
+              run_url:$run_url,
+              downstream_run_url:$downstream_run_url
+            }' > "$CONTEXT_FILE"
+
+          echo "downstream_category=$DOWNSTREAM_CATEGORY" >> "$GITHUB_OUTPUT"
+          echo "downstream_owner=$DOWNSTREAM_OWNER" >> "$GITHUB_OUTPUT"
+          {
+            echo "### Downstream SaaS E2E Failure Category"
+            echo ""
+            echo "- conclusion: $DOWNSTREAM_CONCLUSION"
+            echo "- category: $DOWNSTREAM_CATEGORY"
+            echo "- owner: $DOWNSTREAM_OWNER"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload downstream SaaS E2E category artifact
+        if: ${{ always() && steps.downstream-category.outcome == 'success' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: alwaysgreen-saas-category
+          path: ${{ runner.temp }}/alwaysgreen-saas-category.json
+          retention-days: 14
+
 
       - name: Observe build status
         if: always()


### PR DESCRIPTION
Backport of #54231 (Slices B/C/D) to \`stable/8.8\`. Slice A is already on this branch via #54209.

Same scope as the parent — see #54231 for the full description.

## Branch-specific adjustments
- \`Validate image-tag shape contract\` step uses the stable Harbor replication filter \`**-mq**-run**\` instead of main's \`**-(main|dispatch|mq*)-run**-a**\`. push and merge_group both produce \`mq*\` tags on stable; workflow_dispatch is intentionally exempt.

## Conflicts resolved during cherry-pick
- New \`preflight\` job had to land after the slice-A failure-context steps already in \`should-run\`. Resolution: keep both.

Refs #53718, #54231 (parent), #54209 (slice-a stable/8.8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)