### PR TITLE
fix: flakiness in `McpServerEnabledWithRestGatewayDisabledIT`

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/mcp/McpServerConfigurationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/mcp/McpServerConfigurationIT.java
@@ -16,7 +16,7 @@ import io.camunda.qa.util.cluster.TestCamundaApplication;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.modelcontextprotocol.client.McpSyncClient;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -58,13 +58,15 @@ public class McpServerConfigurationIT {
     void setUp() {
       if (!TEST_INSTANCE.isStarted()) {
         TEST_INSTANCE.start();
-        final var grpcClient = TEST_INSTANCE.newClientBuilder().preferRestOverGrpc(false).build();
-        TEST_INSTANCE.awaitCompleteTopology(TEST_INSTANCE.unifiedConfig(), grpcClient);
+        try (final var grpcClient =
+            TEST_INSTANCE.newClientBuilder().preferRestOverGrpc(false).build()) {
+          TEST_INSTANCE.awaitCompleteTopology(TEST_INSTANCE.unifiedConfig(), grpcClient);
+        }
       }
     }
 
-    @AfterEach
-    void tearDown() {
+    @AfterAll
+    static void tearDown() {
       TEST_INSTANCE.stop();
     }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/mcp/McpServerConfigurationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/mcp/McpServerConfigurationIT.java
@@ -16,8 +16,6 @@ import io.camunda.qa.util.cluster.TestCamundaApplication;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.modelcontextprotocol.client.McpSyncClient;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -48,27 +46,11 @@ public class McpServerConfigurationIT {
   @MultiDbTest
   class McpServerEnabledWithRestGatewayDisabledIT {
 
-    @MultiDbTestApplication(managedLifecycle = false)
+    @MultiDbTestApplication
     static final TestCamundaApplication TEST_INSTANCE =
         new TestCamundaApplication()
             .withProperty("camunda.mcp.enabled", true)
             .withProperty("camunda.rest.enabled", false);
-
-    @BeforeEach
-    void setUp() {
-      if (!TEST_INSTANCE.isStarted()) {
-        TEST_INSTANCE.start();
-        try (final var grpcClient =
-            TEST_INSTANCE.newClientBuilder().preferRestOverGrpc(false).build()) {
-          TEST_INSTANCE.awaitCompleteTopology(TEST_INSTANCE.unifiedConfig(), grpcClient);
-        }
-      }
-    }
-
-    @AfterAll
-    static void tearDown() {
-      TEST_INSTANCE.stop();
-    }
 
     @ParameterizedTest
     @MethodSource("io.camunda.it.mcp.McpServerTest#mcpServersToTest")

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestGateway.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestGateway.java
@@ -148,13 +148,21 @@ public interface TestGateway<T extends TestGateway<T>> extends TestApplication<T
       final int replicationFactor,
       final Duration timeout,
       final CamundaClient client) {
+    // when the REST API is disabled, topology cannot be queried over REST, so force the request
+    // over gRPC regardless of the client's default communication API.
+    final boolean restDisabled = !property("camunda.rest.enabled", Boolean.class, true);
     Awaitility.await("until cluster topology is complete")
         .atMost(timeout)
         .ignoreExceptions()
         .untilAsserted(
-            () ->
-                TopologyAssert.assertThat(client.newTopologyRequest().send().join())
-                    .isComplete(clusterSize, partitionCount, replicationFactor));
+            () -> {
+              final var request = client.newTopologyRequest();
+              if (restDisabled) {
+                request.useGrpc();
+              }
+              TopologyAssert.assertThat(request.send().join())
+                  .isComplete(clusterSize, partitionCount, replicationFactor);
+            });
     return self();
   }
 


### PR DESCRIPTION
### Description

This pull request refactors how the test infrastructure handles REST and gRPC communication in the MCP server acceptance tests, simplifying lifecycle management and ensuring correct protocol usage when REST is disabled.

**Test lifecycle and configuration simplification:**

* The `@BeforeEach` and `@AfterEach` methods for manually starting and stopping the `TestCamundaApplication` instance have been removed, and the `@MultiDbTestApplication` annotation now manages the application lifecycle automatically. This reduces boilerplate and potential for errors in test setup and teardown.
* The `managedLifecycle = false` parameter was removed from the `@MultiDbTestApplication` annotation, reverting to the default managed lifecycle.

**Protocol selection improvements:**

* In `TestGateway.awaitCompleteTopology`, the code now detects if the REST API is disabled and, in that case, forces topology requests over gRPC, regardless of the client's default protocol. This ensures tests work correctly when REST is not available.

### Links

[slack discussion](https://camunda.slack.com/archives/C071KP5BTHB/p1779953685557599)