### PR TITLE
ci: prevent docker log dump from failing optimize IT jobs

### DIFF
--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -135,6 +135,7 @@ jobs:
       - name: Docker log dump
         uses: ./.github/actions/docker-logs
         if: always()
+        continue-on-error: true
         with:
           archive_name: integration-tests-elasticsearch-${{ matrix.includedGroups }}-docker
 
@@ -227,6 +228,7 @@ jobs:
       - name: Docker log dump
         uses: ./.github/actions/docker-logs
         if: always()
+        continue-on-error: true
         with:
           archive_name: integration-tests-opensearch-${{ matrix.includedGroups }}-docker
 
@@ -479,6 +481,7 @@ jobs:
       - name: Docker log dump
         uses: ./.github/actions/docker-logs
         if: always()
+        continue-on-error: true
         with:
           archive_name: optimize-e2e-smoke-docker-logs
 


### PR DESCRIPTION
## Summary

- `optimize-it-elasticsearch/ccsm-test` and `optimize-it-opensearch/ccsm-test` jobs fail when the **Docker log dump** step (`jwalton/gh-docker-logs@v2.2.2`) exits non-zero, even though all tests pass. The failure kicks unrelated PRs out of the merge queue and triggered **INC-5777**.
- The action emits `docker logs --tail true <id>` (string `"all"` is coerced to boolean `true` in `src/main.ts:36` → interpolated as literal `true` in `src/lib.ts:70`). The CLI tolerates this for most containers, but `testcontainers` Ryuk removes containers immediately after the Maven JVM exits the **Verify integration** step. Any container removed between the action's `docker ps -a` enumeration and its `docker logs <id>` read causes the step to error.
- Log collection is forensics. A failed dump must not fail the gating CI job. Mark the step `continue-on-error: true` at the three optimize call sites in `ci-optimize.yml`.

## Why this is the right fix now

- Stops the merge-queue churn immediately without touching test code or the third-party action.
- No change to test semantics; tests already passed in every observed failure.
- Symmetric with how other forensics steps treat `if: always()` collectors elsewhere in the repo.

## Why not fix the action itself

- The bug lives in `jwalton/gh-docker-logs`; a proper fix needs an upstream PR or a swap to an inline `docker logs` loop. Both are larger changes that should follow this hotfix, not block it. Follow-up tracked separately.

## Statistics gathered while diagnosing

- 50 most recent `ci.yml` runs on `main`: OS IT 22 pass / 0 fail, ES IT 20 pass / 1 fail / 2 cancelled.
- 20 most recent `failure` merge_group runs: OS IT 4 fail / 14 pass, ES IT 0 fail / 17 pass.
- Failure is flaky; race window with Ryuk teardown widens with container count (OS stack runs 4 containers vs ES 3 due to `opensearch-fixsysctl-1`).

## Files changed

- `.github/workflows/ci-optimize.yml` — three `Docker log dump` steps gain `continue-on-error: true`.

## Test plan

- [ ] Re-run a previously failing OS IT job; expect the docker log dump artifact to still upload when containers are available and the step to be marked non-fatal otherwise.
- [ ] Confirm merge queue runs that previously failed now stay green when only the docker log dump errored.
- [ ] Visually verify the `integration-tests-*-docker` artifact is still attached to passing runs.

## Follow-ups (separate work)

1. Race in `AbstractCCSMIT#waitForCancelledInstancesToExport` — addressed in companion PR (branch `fabiopaini/inc-5777-optimize-it-cleanup-race`).
2. Open issue / PR against `jwalton/gh-docker-logs` for the `--tail true` bug, or replace the composite action with an inline loop.
3. Apply the same `continue-on-error: true` treatment to the other `./.github/actions/docker-logs` callers (`operate-e2e-tests.yml`, `optimize-ci-data-upgrade-nightly.yml`, `optimize-e2e-tests-sm-nightly.yml`, `optimize-release-optimize-c8-only.yml`) so the bug stays harmless wherever it surfaces.

## Related

- Incident: INC-5777 (merged INC-5783)
- Triggering change: PR #53666 (`CI: Integrate optimize-ci-core-features into unified CI`)
- Underlying race source: PR #51821 (`Optimize it tests faster`)


🤖 Generated with [Claude Code](https://claude.com/claude-code)