### PR TITLE
test: filter waitForCancelledInstancesToExport by cancelled keys

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/AbstractCCSMIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/AbstractCCSMIT.java
@@ -170,6 +170,17 @@ public abstract class AbstractCCSMIT extends AbstractIT {
             + "."
             + ZeebeProcessInstanceDataDto.Fields.bpmnElementType,
         BpmnElementType.PROCESS.name());
+    // Restrict the count to the cancelled instances we are actually waiting for. Without this
+    // filter, terminal records from any other instance (e.g. instances that completed normally
+    // during the test and were excluded from cancelledKeys) can satisfy the count, letting the
+    // wait return before the exporter has flushed the records for the cancelled instances. The
+    // subsequent cleanup would then race the still-pending flush and leak records into the next
+    // test.
+    terminalQuery.addTermQuery(
+        ZeebeProcessInstanceRecordDto.Fields.value
+            + "."
+            + ZeebeProcessInstanceDataDto.Fields.processInstanceKey,
+        cancelledKeys.stream().map(String::valueOf).toList());
     waitUntilMinimumDataExportedCount(
         cancelledKeys.size(), DatabaseConstants.ZEEBE_PROCESS_INSTANCE_INDEX_NAME, terminalQuery);
   }


### PR DESCRIPTION
## Summary

- Fixes a race in `AbstractCCSMIT` cleanup introduced by **PR #51821** (`Optimize it tests faster`). The race manifests as cascading IT failures, e.g. `"Could not find property for process instance with key: someProcess"`, and was called out on the original PR by Copilot (review comment `r3171209930`) and re-analyzed during **INC-5777**.
- `waitForCancelledInstancesToExport` is supposed to block `@AfterEach` cleanup until every cancelled instance's PROCESS-scope terminal record (`ELEMENT_COMPLETED` / `ELEMENT_TERMINATED`) is visible in the Zeebe process-instance index. The current query filters only on intent + `bpmnElementType=PROCESS` — **not on the cancelled keys** — so any terminal record from any instance satisfies the count. When tests cancel N instances but the index already contains ≥ N unrelated terminal records (e.g. instances that completed normally and were excluded from `cancelledKeys`), the wait returns immediately. The subsequent `deleteZeebeRecordsAndAssertClean` pass then races the still-pending exporter flush. Records that arrive after delete leak into the next test's `importAllZeebeEntitiesFromScratch()`, satisfy setup assertions against stale data, and cause downstream test failures.
- Add a terms-query on `value.processInstanceKey IN cancelledKeys` so the count only reaches `cancelledKeys.size()` when all expected instances are actually visible. The `bpmnElementType=PROCESS` filter already enforces at most one terminal record per instance, so the count remains exact.

## Diff (essence)

```java
terminalQuery.addTermQuery(
    ZeebeProcessInstanceRecordDto.Fields.value
        + "."
        + ZeebeProcessInstanceDataDto.Fields.processInstanceKey,
    cancelledKeys.stream().map(String::valueOf).toList());
```

## Why this is correct

- `ZeebeExtension#cancelAllStartedInstances()` returns only keys that were actually still running, so the set is the precise list of cancellations awaiting export.
- `bpmnElementType=PROCESS` already restricts to one terminal record per instance, so `count == cancelledKeys.size()` iff every expected key has been exported.
- The query change keeps the same Awaitility / wait helper plumbing; only the filter widens.

## Why a wait + key filter and not a different design

- A broader cleanup change (e.g. index-deletion in `@AfterEach`, or per-test broker restart) would undo the speed-up the original PR was added to deliver.
- A coarser wait (e.g. wait for ALL terminal records) is unsound across tests that intentionally leave some instances completed.
- Keying the wait is the minimum-invasive fix that restores the original invariant (cleanup runs only after the exporter is caught up).

## Test plan

- [ ] Re-run the Optimize ITs (`mvn verify -P ccsm-it -Ddatabase.type=elasticsearch -f optimize/pom.xml -pl backend -am`) locally / in CI and confirm no `Could not find property for process instance with key: …` failures.
- [ ] Loop the previously flaky `ZeebeProcessInstanceImportIT`, `ZeebeVariableCreationImportIT`, `ZeebeVariableUpdateImportIT`, `ZeebeIncidentImportIT`, `ZeebeProcessDefinitionImportIT` for N iterations — expect no stale-record leakage.
- [ ] Cross-check on the OpenSearch IT job after docker-log-dump PR (#54242) lands so the only remaining failure signal is real test breakage.

## Related

- Incident: INC-5777
- Original PR: #51821 (`Optimize it tests faster`)
- Copilot review comment on the race: https://github.com/camunda/camunda/pull/51821/changes#r3171209930

🤖 Generated with [Claude Code](https://claude.com/claude-code)