### PR TITLE
feat: add DelayReplicationController to delay exporter position ackno…

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/RdbmsAsyncReplication.java
+++ b/configuration/src/main/java/io/camunda/configuration/RdbmsAsyncReplication.java
@@ -8,23 +8,33 @@
 package io.camunda.configuration;
 
 import io.camunda.exporter.rdbms.ExporterConfiguration.ReplicationConfiguration;
+import io.camunda.exporter.rdbms.ExporterConfiguration.ReplicationConfiguration.ReplicationType;
 import java.time.Duration;
 
 public class RdbmsAsyncReplication {
 
-  private boolean enabled = ReplicationConfiguration.DEFAULT_ENABLED;
+  private ReplicationType type = ReplicationConfiguration.DEFAULT_TYPE;
   private Duration pollingInterval = ReplicationConfiguration.DEFAULT_POLLING_INTERVAL;
   private int minSyncReplicas = ReplicationConfiguration.DEFAULT_MIN_SYNC_REPLICAS;
   private Duration maxLag = ReplicationConfiguration.DEFAULT_MAX_LAG;
   private boolean pauseOnMaxLagExceeded =
       ReplicationConfiguration.DEFAULT_PAUSE_ON_MAX_LAG_EXCEEDED;
+  private Duration delay = ReplicationConfiguration.DEFAULT_DELAY;
 
-  public boolean isEnabled() {
-    return enabled;
+  public ReplicationType getType() {
+    return type;
   }
 
-  public void setEnabled(final boolean enabled) {
-    this.enabled = enabled;
+  public void setType(final ReplicationType type) {
+    this.type = type;
+  }
+
+  public Duration getDelay() {
+    return delay;
+  }
+
+  public void setDelay(final Duration delay) {
+    this.delay = delay;
   }
 
   public Duration getPollingInterval() {

--- a/configuration/src/main/java/io/camunda/configuration/RdbmsAsyncReplication.java
+++ b/configuration/src/main/java/io/camunda/configuration/RdbmsAsyncReplication.java
@@ -13,13 +13,22 @@ import java.time.Duration;
 
 public class RdbmsAsyncReplication {
 
-  private ReplicationType type = ReplicationConfiguration.DEFAULT_TYPE;
+  private boolean enabled = ReplicationConfiguration.DEFAULT_ENABLED;
+  private ReplicationType type;
   private Duration pollingInterval = ReplicationConfiguration.DEFAULT_POLLING_INTERVAL;
   private int minSyncReplicas = ReplicationConfiguration.DEFAULT_MIN_SYNC_REPLICAS;
   private Duration maxLag = ReplicationConfiguration.DEFAULT_MAX_LAG;
   private boolean pauseOnMaxLagExceeded =
       ReplicationConfiguration.DEFAULT_PAUSE_ON_MAX_LAG_EXCEEDED;
-  private Duration delay = ReplicationConfiguration.DEFAULT_DELAY;
+  private Duration delay;
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(final boolean enabled) {
+    this.enabled = enabled;
+  }
 
   public ReplicationType getType() {
     return type;

--- a/configuration/src/main/java/io/camunda/configuration/RdbmsAsyncReplication.java
+++ b/configuration/src/main/java/io/camunda/configuration/RdbmsAsyncReplication.java
@@ -21,6 +21,8 @@ public class RdbmsAsyncReplication {
   private boolean pauseOnMaxLagExceeded =
       ReplicationConfiguration.DEFAULT_PAUSE_ON_MAX_LAG_EXCEEDED;
   private Duration delay;
+  private Duration queueDebounceTime = ReplicationConfiguration.DEFAULT_QUEUE_DEBOUNCE_TIME;
+  private int queueCapacity = ReplicationConfiguration.DEFAULT_QUEUE_CAPACITY;
 
   public boolean isEnabled() {
     return enabled;
@@ -44,6 +46,22 @@ public class RdbmsAsyncReplication {
 
   public void setDelay(final Duration delay) {
     this.delay = delay;
+  }
+
+  public Duration getQueueDebounceTime() {
+    return queueDebounceTime;
+  }
+
+  public void setQueueDebounceTime(final Duration queueDebounceTime) {
+    this.queueDebounceTime = queueDebounceTime;
+  }
+
+  public int getQueueCapacity() {
+    return queueCapacity;
+  }
+
+  public void setQueueCapacity(final int queueCapacity) {
+    this.queueCapacity = queueCapacity;
   }
 
   public Duration getPollingInterval() {

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -1040,6 +1040,8 @@ public class BrokerBasedPropertiesOverride {
       if (asyncReplication.getDelay() != null) {
         config.getAsyncReplication().setDelay(asyncReplication.getDelay());
       }
+      config.getAsyncReplication().setQueueDebounceTime(asyncReplication.getQueueDebounceTime());
+      config.getAsyncReplication().setQueueCapacity(asyncReplication.getQueueCapacity());
     }
 
     applyRdbmsExtensionPropertyConfiguration(

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -1028,12 +1028,18 @@ public class BrokerBasedPropertiesOverride {
     if (database.getAsyncReplication() != null) {
       final var asyncReplication = database.getAsyncReplication();
       config.getAsyncReplication().setEnabled(asyncReplication.isEnabled());
+      if (asyncReplication.getType() != null) {
+        config.getAsyncReplication().setType(asyncReplication.getType());
+      }
       config.getAsyncReplication().setPollingInterval(asyncReplication.getPollingInterval());
       config.getAsyncReplication().setMinSyncReplicas(asyncReplication.getMinSyncReplicas());
       config.getAsyncReplication().setMaxLag(asyncReplication.getMaxLag());
       config
           .getAsyncReplication()
           .setPauseOnMaxLagExceeded(asyncReplication.isPauseOnMaxLagExceeded());
+      if (asyncReplication.getDelay() != null) {
+        config.getAsyncReplication().setDelay(asyncReplication.getDelay());
+      }
     }
 
     applyRdbmsExtensionPropertyConfiguration(

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageRdbmsTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageRdbmsTest.java
@@ -118,7 +118,7 @@ public class SecondaryStorageRdbmsTest {
         "camunda.data.secondary-storage.rdbms.exportBatchOperationItemsOnCreation=false",
         "camunda.data.secondary-storage.rdbms.batchOperationItemInsertBlockSize=1234",
         "camunda.data.secondary-storage.rdbms.insert-batching.max-audit-log-insert-batch-size=50",
-        "camunda.data.secondary-storage.rdbms.async-replication.enabled=true",
+        "camunda.data.secondary-storage.rdbms.async-replication.type=LOG_SEQ",
         "camunda.data.secondary-storage.rdbms.async-replication.polling-interval="
             + ASYNC_REPLICATION_POLLING_INTERVAL,
         "camunda.data.secondary-storage.rdbms.async-replication.min-sync-replicas=2",
@@ -206,7 +206,8 @@ public class SecondaryStorageRdbmsTest {
       assertThat(exporterConfiguration.getBatchOperationItemInsertBlockSize()).isEqualTo(1234);
       assertThat(exporterConfiguration.getInsertBatching().getMaxAuditLogInsertBatchSize())
           .isEqualTo(50);
-      assertThat(exporterConfiguration.getAsyncReplication().isEnabled()).isTrue();
+      assertThat(exporterConfiguration.getAsyncReplication().getType())
+          .isEqualTo(ExporterConfiguration.ReplicationConfiguration.ReplicationType.LOG_SEQ);
       assertThat(exporterConfiguration.getAsyncReplication().getPollingInterval())
           .isEqualTo(Duration.parse(ASYNC_REPLICATION_POLLING_INTERVAL));
       assertThat(exporterConfiguration.getAsyncReplication().getMinSyncReplicas()).isEqualTo(2);

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageRdbmsTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageRdbmsTest.java
@@ -74,6 +74,8 @@ public class SecondaryStorageRdbmsTest {
   private static final String HISTORY_USAGE_METRICS_TTL = "PT1H";
   private static final String ASYNC_REPLICATION_POLLING_INTERVAL = "PT30S";
   private static final String ASYNC_REPLICATION_MAX_LAG = "PT5M";
+  private static final String ASYNC_REPLICATION_QUEUE_DEBOUNCE_TIME = "PT0.25S";
+  private static final int ASYNC_REPLICATION_QUEUE_CAPACITY = 4096;
 
   private static final int MAX_PROCESS_CACHE_SIZE = 4711;
   private static final int MAX_BATCH_OPERATIONS_CACHE_SIZE = 4711;
@@ -126,6 +128,10 @@ public class SecondaryStorageRdbmsTest {
         "camunda.data.secondary-storage.rdbms.async-replication.max-lag="
             + ASYNC_REPLICATION_MAX_LAG,
         "camunda.data.secondary-storage.rdbms.async-replication.pause-on-max-lag-exceeded=true",
+        "camunda.data.secondary-storage.rdbms.async-replication.queue-debounce-time="
+            + ASYNC_REPLICATION_QUEUE_DEBOUNCE_TIME,
+        "camunda.data.secondary-storage.rdbms.async-replication.queue-capacity="
+            + ASYNC_REPLICATION_QUEUE_CAPACITY,
         "camunda.data.secondary-storage.rdbms.max-varchar-field-length=200",
       })
   class WithOnlyUnifiedConfigSet {
@@ -216,6 +222,10 @@ public class SecondaryStorageRdbmsTest {
       assertThat(exporterConfiguration.getAsyncReplication().getMaxLag())
           .isEqualTo(Duration.parse(ASYNC_REPLICATION_MAX_LAG));
       assertThat(exporterConfiguration.getAsyncReplication().isPauseOnMaxLagExceeded()).isTrue();
+      assertThat(exporterConfiguration.getAsyncReplication().getQueueDebounceTime())
+          .isEqualTo(Duration.parse(ASYNC_REPLICATION_QUEUE_DEBOUNCE_TIME));
+      assertThat(exporterConfiguration.getAsyncReplication().getQueueCapacity())
+          .isEqualTo(ASYNC_REPLICATION_QUEUE_CAPACITY);
     }
 
     @Test

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageRdbmsTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageRdbmsTest.java
@@ -118,6 +118,7 @@ public class SecondaryStorageRdbmsTest {
         "camunda.data.secondary-storage.rdbms.exportBatchOperationItemsOnCreation=false",
         "camunda.data.secondary-storage.rdbms.batchOperationItemInsertBlockSize=1234",
         "camunda.data.secondary-storage.rdbms.insert-batching.max-audit-log-insert-batch-size=50",
+        "camunda.data.secondary-storage.rdbms.async-replication.enabled=true",
         "camunda.data.secondary-storage.rdbms.async-replication.type=LOG_SEQ",
         "camunda.data.secondary-storage.rdbms.async-replication.polling-interval="
             + ASYNC_REPLICATION_POLLING_INTERVAL,
@@ -206,6 +207,7 @@ public class SecondaryStorageRdbmsTest {
       assertThat(exporterConfiguration.getBatchOperationItemInsertBlockSize()).isEqualTo(1234);
       assertThat(exporterConfiguration.getInsertBatching().getMaxAuditLogInsertBatchSize())
           .isEqualTo(50);
+      assertThat(exporterConfiguration.getAsyncReplication().isEnabled()).isTrue();
       assertThat(exporterConfiguration.getAsyncReplication().getType())
           .isEqualTo(ExporterConfiguration.ReplicationConfiguration.ReplicationType.LOG_SEQ);
       assertThat(exporterConfiguration.getAsyncReplication().getPollingInterval())

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
@@ -188,6 +188,8 @@ data.secondary-storage.rdbms.async-replication.max-lag
 data.secondary-storage.rdbms.async-replication.min-sync-replicas
 data.secondary-storage.rdbms.async-replication.pause-on-max-lag-exceeded
 data.secondary-storage.rdbms.async-replication.polling-interval
+data.secondary-storage.rdbms.async-replication.queue-capacity
+data.secondary-storage.rdbms.async-replication.queue-debounce-time
 data.secondary-storage.rdbms.async-replication.type
 data.secondary-storage.rdbms.auto-ddl
 data.secondary-storage.rdbms.batch-operation-cache

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
@@ -182,11 +182,13 @@ data.secondary-storage.opensearch.url
 data.secondary-storage.opensearch.urls
 data.secondary-storage.opensearch.username
 data.secondary-storage.opensearch.variable-size-threshold
+data.secondary-storage.rdbms.async-replication.delay
 data.secondary-storage.rdbms.async-replication.enabled
 data.secondary-storage.rdbms.async-replication.max-lag
 data.secondary-storage.rdbms.async-replication.min-sync-replicas
 data.secondary-storage.rdbms.async-replication.pause-on-max-lag-exceeded
 data.secondary-storage.rdbms.async-replication.polling-interval
+data.secondary-storage.rdbms.async-replication.type
 data.secondary-storage.rdbms.auto-ddl
 data.secondary-storage.rdbms.batch-operation-cache
 data.secondary-storage.rdbms.batch-operation-item-insert-block-size

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/asyncreplication/DelayReplicationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/asyncreplication/DelayReplicationIT.java
@@ -20,7 +20,6 @@ import io.camunda.zeebe.broker.exporter.stream.ExporterMetricsDoc;
 import io.micrometer.core.instrument.Measurement;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
-import java.util.Map;
 import java.util.Objects;
 import org.assertj.core.data.Offset;
 import org.awaitility.Awaitility;
@@ -69,23 +68,15 @@ public class DelayReplicationIT {
                 "jdbc:h2:mem:delay-replication-test;DB_CLOSE_DELAY=-1;MODE=PostgreSQL")
             .withProperty("camunda.data.secondary-storage.rdbms.username", "sa")
             .withProperty("camunda.data.secondary-storage.rdbms.password", "")
-            .withExporter(
-                "rdbms",
-                cfg -> {
-                  cfg.setClassName("io.camunda.db.rdbms.exporter.RdbmsExporter");
-                  cfg.setArgs(
-                      Map.of(
-                          "flushInterval",
-                          "PT0.5S",
-                          "asyncReplication",
-                          Map.of(
-                              "enabled",
-                              true,
-                              "type",
-                              "DELAY",
-                              "delay",
-                              REPLICATION_DELAY.toString())));
-                })
+            .withProperty("camunda.data.secondary-storage.rdbms.flush-interval", "PT0.5S")
+            .withProperty("camunda.data.secondary-storage.rdbms.async-replication.enabled", "true")
+            .withProperty("camunda.data.secondary-storage.rdbms.async-replication.type", "DELAY")
+            .withProperty(
+                "camunda.data.secondary-storage.rdbms.async-replication.delay",
+                REPLICATION_DELAY.toString())
+            .withProperty(
+                "camunda.data.secondary-storage.rdbms.async-replication.queue-debounce-time",
+                Duration.ZERO.toString())
             .withBasicAuth();
 
     testInstance.start();
@@ -121,10 +112,18 @@ public class DelayReplicationIT {
                 assertThat(getCurrentExporterPosition())
                     .isGreaterThan(baselineAcknowledgedPosition));
 
+    Awaitility.await()
+        .during(Duration.ofSeconds(30))
+        .atMost(Duration.ofSeconds(35))
+        .untilAsserted(
+            () ->
+                assertThat(getCurrentAcknowledgedExporterPosition())
+                    .isEqualTo(baselineAcknowledgedPosition));
+
     // then - the delay has not elapsed yet: acknowledged position must not have advanced
     // (REPLICATION_DELAY is PT1M; this assertion runs within a few seconds of the flush)
     assertThat(getCurrentAcknowledgedExporterPosition())
-        .isLessThanOrEqualTo(baselineAcknowledgedPosition + 5L);
+        .isLessThanOrEqualTo(baselineAcknowledgedPosition);
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/asyncreplication/DelayReplicationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/asyncreplication/DelayReplicationIT.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.asyncreplication;
+
+import static io.camunda.it.util.TestHelper.deployResource;
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.Iterables;
+import io.camunda.client.CamundaClient;
+import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
+import io.camunda.qa.util.cluster.TestCamundaApplication;
+import io.camunda.zeebe.broker.exporter.stream.ExporterMetricsDoc;
+import io.micrometer.core.instrument.Measurement;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Objects;
+import org.assertj.core.data.Offset;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.TestMethodOrder;
+
+/**
+ * Integration test for {@link io.camunda.exporter.rdbms.replication.DelayReplicationController}.
+ *
+ * <p>Verifies that exported positions are withheld from acknowledgment until the configured delay
+ * elapses, and that they are acknowledged afterwards. Uses H2 in-memory database (vendor-agnostic)
+ * — no replication cluster is required.
+ *
+ * <p>Tagged {@code dl-nightly} because the 1-minute delay makes it too slow for regular CI.
+ */
+@Tag("dl-nightly")
+@TestInstance(Lifecycle.PER_CLASS)
+@TestMethodOrder(OrderAnnotation.class)
+public class DelayReplicationIT {
+
+  /**
+   * Minimum delay that keeps the "not yet acknowledged" assertion safe even on slow CI runners.
+   * Must be long enough that the assertion in {@code shouldNotAcknowledgeBeforeDelayExpires}
+   * completes well before the first {@code checkDue} fires.
+   */
+  private static final Duration REPLICATION_DELAY = Duration.ofMinutes(1);
+
+  @AutoClose TestCamundaApplication testInstance;
+  @AutoClose CamundaClient camundaClient;
+  MeterRegistry meterRegistry;
+
+  @BeforeAll
+  void beforeAll() {
+    testInstance =
+        new TestCamundaApplication()
+            .withSecondaryStorageType(SecondaryStorageType.rdbms)
+            .withProperty(
+                "camunda.data.secondary-storage.rdbms.url",
+                "jdbc:h2:mem:delay-replication-test;DB_CLOSE_DELAY=-1;MODE=PostgreSQL")
+            .withProperty("camunda.data.secondary-storage.rdbms.username", "sa")
+            .withProperty("camunda.data.secondary-storage.rdbms.password", "")
+            .withExporter(
+                "rdbms",
+                cfg -> {
+                  cfg.setClassName("io.camunda.db.rdbms.exporter.RdbmsExporter");
+                  cfg.setArgs(
+                      Map.of(
+                          "flushInterval",
+                          "PT0.5S",
+                          "asyncReplication",
+                          Map.of(
+                              "enabled",
+                              true,
+                              "type",
+                              "DELAY",
+                              "delay",
+                              REPLICATION_DELAY.toString())));
+                })
+            .withBasicAuth();
+
+    testInstance.start();
+    camundaClient = testInstance.newClientBuilder().build();
+    meterRegistry = testInstance.bean(MeterRegistry.class);
+
+    Objects.requireNonNull(meterRegistry);
+    Objects.requireNonNull(camundaClient);
+
+    deployResource(camundaClient, "process/service_tasks_v1.bpmn");
+    waitForProcessesToBeDeployed(camundaClient, 1);
+
+    // drain any startup traffic before recording baselines
+    exporterAcknowledgedAll();
+  }
+
+  @Test
+  @Order(1)
+  void shouldNotAcknowledgeBeforeDelayExpires() {
+    // given - snapshot positions before generating new traffic
+    final long baselineAcknowledgedPosition = getCurrentAcknowledgedExporterPosition();
+
+    // when - create export traffic
+    for (int i = 0; i < 5; i++) {
+      startProcessInstance(camundaClient, "service_tasks_v1", "{\"xyz\":\"foo\"}");
+    }
+
+    // wait for the exporter to flush the new records to secondary storage
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(
+            () ->
+                assertThat(getCurrentExporterPosition())
+                    .isGreaterThan(baselineAcknowledgedPosition));
+
+    // then - the delay has not elapsed yet: acknowledged position must not have advanced
+    // (REPLICATION_DELAY is PT1M; this assertion runs within a few seconds of the flush)
+    assertThat(getCurrentAcknowledgedExporterPosition())
+        .isLessThanOrEqualTo(baselineAcknowledgedPosition + 5L);
+  }
+
+  @Test
+  @Order(2)
+  void shouldAcknowledgeAfterDelayExpires() {
+    // given - unacknowledged positions remain from @Order(1)
+    final long acknowledgedBefore = getCurrentAcknowledgedExporterPosition();
+
+    // then - after the configured delay elapses, positions are eventually acknowledged
+    // Allow 2x the delay plus buffer to account for CI jitter and rescheduling lag
+    Awaitility.await()
+        .atMost(REPLICATION_DELAY.multipliedBy(2).plus(Duration.ofSeconds(30)))
+        .untilAsserted(
+            () ->
+                assertThat(getCurrentAcknowledgedExporterPosition())
+                    .isGreaterThan(acknowledgedBefore));
+
+    // and the exporter fully catches up
+    exporterAcknowledgedAll();
+  }
+
+  private void exporterAcknowledgedAll() {
+    Awaitility.await()
+        .ignoreExceptions()
+        .atMost(REPLICATION_DELAY.plus(Duration.ofSeconds(30)))
+        .untilAsserted(
+            () ->
+                assertThat(getCurrentExporterPosition())
+                    .isCloseTo(getCurrentAcknowledgedExporterPosition(), Offset.offset(5L)));
+  }
+
+  private long getCurrentExporterPosition() {
+    return getMeterLong(ExporterMetricsDoc.LAST_EXPORTED_POSITION.getName());
+  }
+
+  private long getCurrentAcknowledgedExporterPosition() {
+    return getMeterLong(ExporterMetricsDoc.LAST_UPDATED_EXPORTED_POSITION.getName());
+  }
+
+  private long getMeterLong(final String name) {
+    final var meters =
+        meterRegistry.get(name).tag("exporter", "rdbms").tag("partition", "1").meter().measure();
+    final Measurement first = Iterables.getFirst(meters, null);
+    if (first == null) {
+      return 0;
+    }
+    return (long) first.getValue();
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/CamundaRdbmsInvocationContextProviderExtension.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/CamundaRdbmsInvocationContextProviderExtension.java
@@ -43,11 +43,7 @@ public class CamundaRdbmsInvocationContextProviderExtension
             .withUnifiedConfig(
                 c -> {
                   final var rdbms = c.getData().getSecondaryStorage().getRdbms();
-                  rdbms
-                      .getAsyncReplication()
-                      .setType(
-                          io.camunda.exporter.rdbms.ExporterConfiguration.ReplicationConfiguration
-                              .ReplicationType.LOG_SEQ);
+                  rdbms.getAsyncReplication().setEnabled(true);
                   rdbms.getAsyncReplication().setMinSyncReplicas(1);
                 })
             .withDatabaseContainer(new PostgresReplicationClusterContainer()));

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/CamundaRdbmsInvocationContextProviderExtension.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/CamundaRdbmsInvocationContextProviderExtension.java
@@ -43,7 +43,11 @@ public class CamundaRdbmsInvocationContextProviderExtension
             .withUnifiedConfig(
                 c -> {
                   final var rdbms = c.getData().getSecondaryStorage().getRdbms();
-                  rdbms.getAsyncReplication().setEnabled(true);
+                  rdbms
+                      .getAsyncReplication()
+                      .setType(
+                          io.camunda.exporter.rdbms.ExporterConfiguration.ReplicationConfiguration
+                              .ReplicationType.LOG_SEQ);
                   rdbms.getAsyncReplication().setMinSyncReplicas(1);
                 })
             .withDatabaseContainer(new PostgresReplicationClusterContainer()));

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ExporterConfiguration.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ExporterConfiguration.java
@@ -618,19 +618,28 @@ public class ExporterConfiguration {
   }
 
   public static class ReplicationConfiguration {
-    public static final ReplicationType DEFAULT_TYPE = ReplicationType.NONE;
+    public static final boolean DEFAULT_ENABLED = false;
+    public static final ReplicationType DEFAULT_TYPE = ReplicationType.LOG_SEQ;
     public static final Duration DEFAULT_POLLING_INTERVAL = Duration.ofSeconds(15);
     public static final Duration DEFAULT_MAX_LAG = Duration.ofMinutes(15);
     public static final int DEFAULT_MIN_SYNC_REPLICAS = 1;
     public static final boolean DEFAULT_PAUSE_ON_MAX_LAG_EXCEEDED = false;
-    public static final Duration DEFAULT_DELAY = Duration.ofMinutes(15);
 
+    private boolean enabled = DEFAULT_ENABLED;
     private ReplicationType type = DEFAULT_TYPE;
     private Duration pollingInterval = DEFAULT_POLLING_INTERVAL;
     private int minSyncReplicas = DEFAULT_MIN_SYNC_REPLICAS;
     private Duration maxLag = DEFAULT_MAX_LAG;
     private boolean pauseOnMaxLagExceeded = DEFAULT_PAUSE_ON_MAX_LAG_EXCEEDED;
-    private Duration delay = DEFAULT_DELAY;
+    private Duration delay;
+
+    public boolean isEnabled() {
+      return enabled;
+    }
+
+    public void setEnabled(final boolean enabled) {
+      this.enabled = enabled;
+    }
 
     public ReplicationType getType() {
       return type;
@@ -682,7 +691,8 @@ public class ExporterConfiguration {
 
     public List<String> validate() {
       final List<String> errors = new ArrayList<>();
-      if (type == ReplicationType.LOG_SEQ
+      if (enabled
+          && type == ReplicationType.LOG_SEQ
           && (pollingInterval.isNegative() || pollingInterval.isZero())) {
         errors.add(
             String.format(
@@ -694,12 +704,14 @@ public class ExporterConfiguration {
             String.format(
                 "asyncReplication.minSyncReplicas must be greater 0 but was %d", minSyncReplicas));
       }
-      if (type == ReplicationType.LOG_SEQ && (maxLag.isNegative() || maxLag.isZero())) {
+      if (enabled && type == ReplicationType.LOG_SEQ && (maxLag.isNegative() || maxLag.isZero())) {
         errors.add(
             String.format(
                 "asyncReplication.maxLag must be a positive duration but was %s", maxLag));
       }
-      if (type == ReplicationType.DELAY && (delay.isNegative() || delay.isZero())) {
+      if (enabled
+          && type == ReplicationType.DELAY
+          && (delay == null || delay.isNegative() || delay.isZero())) {
         errors.add(
             String.format("asyncReplication.delay must be a positive duration but was %s", delay));
       }
@@ -707,7 +719,6 @@ public class ExporterConfiguration {
     }
 
     public enum ReplicationType {
-      NONE,
       LOG_SEQ,
       DELAY
     }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ExporterConfiguration.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ExporterConfiguration.java
@@ -271,7 +271,7 @@ public class ExporterConfiguration {
 
   private static void checkPositiveDuration(
       final Duration duration, final String name, final List<String> errors) {
-    if (duration.isNegative() || duration.isZero()) {
+    if (duration == null || duration.isNegative() || duration.isZero()) {
       errors.add(String.format("%s must be a positive duration but was %s", name, duration));
     }
   }
@@ -624,6 +624,8 @@ public class ExporterConfiguration {
     public static final Duration DEFAULT_MAX_LAG = Duration.ofMinutes(15);
     public static final int DEFAULT_MIN_SYNC_REPLICAS = 1;
     public static final boolean DEFAULT_PAUSE_ON_MAX_LAG_EXCEEDED = false;
+    public static final int DEFAULT_QUEUE_CAPACITY = 8192;
+    public static final Duration DEFAULT_QUEUE_DEBOUNCE_TIME = Duration.ofSeconds(5);
 
     private boolean enabled = DEFAULT_ENABLED;
     private ReplicationType type = DEFAULT_TYPE;
@@ -632,6 +634,8 @@ public class ExporterConfiguration {
     private Duration maxLag = DEFAULT_MAX_LAG;
     private boolean pauseOnMaxLagExceeded = DEFAULT_PAUSE_ON_MAX_LAG_EXCEEDED;
     private Duration delay;
+    private Duration queueDebounceTime = DEFAULT_QUEUE_DEBOUNCE_TIME;
+    private int queueCapacity = DEFAULT_QUEUE_CAPACITY;
 
     public boolean isEnabled() {
       return enabled;
@@ -689,33 +693,55 @@ public class ExporterConfiguration {
       this.delay = delay;
     }
 
+    public Duration getQueueDebounceTime() {
+      return queueDebounceTime;
+    }
+
+    public void setQueueDebounceTime(final Duration queueDebounceTime) {
+      this.queueDebounceTime = queueDebounceTime;
+    }
+
+    public int getQueueCapacity() {
+      return queueCapacity;
+    }
+
+    public void setQueueCapacity(final int queueCapacity) {
+      this.queueCapacity = queueCapacity;
+    }
+
     public List<String> validate() {
       final List<String> errors = new ArrayList<>();
-      if (enabled
-          && type == ReplicationType.LOG_SEQ
-          && (pollingInterval.isNegative() || pollingInterval.isZero())) {
-        errors.add(
-            String.format(
-                "asyncReplication.pollingInterval must be a positive duration but was %s",
-                pollingInterval));
+
+      if (!enabled) {
+        return errors;
       }
+
       if (minSyncReplicas <= 0) {
         errors.add(
             String.format(
                 "asyncReplication.minSyncReplicas must be greater 0 but was %d", minSyncReplicas));
       }
-      if (enabled && type == ReplicationType.LOG_SEQ && (maxLag.isNegative() || maxLag.isZero())) {
-        errors.add(
-            String.format(
-                "asyncReplication.maxLag must be a positive duration but was %s", maxLag));
-      }
-      if (enabled
-          && type == ReplicationType.DELAY
-          && (delay == null || delay.isNegative() || delay.isZero())) {
-        errors.add(
-            String.format("asyncReplication.delay must be a positive duration but was %s", delay));
+
+      if (type == ReplicationType.LOG_SEQ) {
+        checkPositiveDuration(pollingInterval, "asyncReplication.pollingInterval", errors);
+        checkPositiveDuration(maxLag, "asyncReplication.maxLag", errors);
+      } else if (type == ReplicationType.DELAY) {
+        checkPositiveDuration(delay, "asyncReplication.delay", errors);
+        checkNonNegativeDuration(queueDebounceTime, "asyncReplication.queueDebounceTime", errors);
+        if (queueCapacity <= 0) {
+          errors.add(
+              String.format(
+                  "asyncReplication.queueCapacity must be greater 0 but was %d", queueCapacity));
+        }
       }
       return errors;
+    }
+
+    private static void checkNonNegativeDuration(
+        final Duration duration, final String name, final List<String> errors) {
+      if (duration == null || duration.isNegative()) {
+        errors.add(String.format("%s must be a non-negative duration but was %s", name, duration));
+      }
     }
 
     public enum ReplicationType {

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ExporterConfiguration.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ExporterConfiguration.java
@@ -618,24 +618,26 @@ public class ExporterConfiguration {
   }
 
   public static class ReplicationConfiguration {
-    public static final boolean DEFAULT_ENABLED = false;
+    public static final ReplicationType DEFAULT_TYPE = ReplicationType.NONE;
     public static final Duration DEFAULT_POLLING_INTERVAL = Duration.ofSeconds(15);
     public static final Duration DEFAULT_MAX_LAG = Duration.ofMinutes(15);
     public static final int DEFAULT_MIN_SYNC_REPLICAS = 1;
     public static final boolean DEFAULT_PAUSE_ON_MAX_LAG_EXCEEDED = false;
+    public static final Duration DEFAULT_DELAY = Duration.ofMinutes(15);
 
-    private boolean enabled = DEFAULT_ENABLED;
+    private ReplicationType type = DEFAULT_TYPE;
     private Duration pollingInterval = DEFAULT_POLLING_INTERVAL;
     private int minSyncReplicas = DEFAULT_MIN_SYNC_REPLICAS;
     private Duration maxLag = DEFAULT_MAX_LAG;
     private boolean pauseOnMaxLagExceeded = DEFAULT_PAUSE_ON_MAX_LAG_EXCEEDED;
+    private Duration delay = DEFAULT_DELAY;
 
-    public boolean isEnabled() {
-      return enabled;
+    public ReplicationType getType() {
+      return type;
     }
 
-    public void setEnabled(final boolean enabled) {
-      this.enabled = enabled;
+    public void setType(final ReplicationType type) {
+      this.type = type;
     }
 
     public Duration getPollingInterval() {
@@ -670,9 +672,18 @@ public class ExporterConfiguration {
       this.pauseOnMaxLagExceeded = pauseOnMaxLagExceeded;
     }
 
+    public Duration getDelay() {
+      return delay;
+    }
+
+    public void setDelay(final Duration delay) {
+      this.delay = delay;
+    }
+
     public List<String> validate() {
       final List<String> errors = new ArrayList<>();
-      if (enabled && (pollingInterval.isNegative() || pollingInterval.isZero())) {
+      if (type == ReplicationType.LOG_SEQ
+          && (pollingInterval.isNegative() || pollingInterval.isZero())) {
         errors.add(
             String.format(
                 "asyncReplication.pollingInterval must be a positive duration but was %s",
@@ -683,12 +694,22 @@ public class ExporterConfiguration {
             String.format(
                 "asyncReplication.minSyncReplicas must be greater 0 but was %d", minSyncReplicas));
       }
-      if (enabled && (maxLag.isNegative() || maxLag.isZero())) {
+      if (type == ReplicationType.LOG_SEQ && (maxLag.isNegative() || maxLag.isZero())) {
         errors.add(
             String.format(
                 "asyncReplication.maxLag must be a positive duration but was %s", maxLag));
       }
+      if (type == ReplicationType.DELAY && (delay.isNegative() || delay.isZero())) {
+        errors.add(
+            String.format("asyncReplication.delay must be a positive duration but was %s", delay));
+      }
       return errors;
+    }
+
+    public enum ReplicationType {
+      NONE,
+      LOG_SEQ,
+      DELAY
     }
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
@@ -171,6 +171,9 @@ public class RdbmsExporterWrapper implements Exporter {
               new DelayReplicationControllerFactory(
                   config.getAsyncReplication(), partitionId, context.clock()));
       case NONE -> builder.replicationControllerFactory(ReplicationControllerFactory.noop());
+      default ->
+          throw new IllegalArgumentException(
+              "Unknown replication type: " + config.getAsyncReplication().getType());
     }
 
     createHandlers(partitionId, rdbmsWriters, builder, config, historyCleanupService);

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
@@ -63,6 +63,7 @@ import io.camunda.exporter.rdbms.handlers.batchoperation.ProcessInstanceMigratio
 import io.camunda.exporter.rdbms.handlers.batchoperation.ProcessInstanceModificationBatchOperationExportHandler;
 import io.camunda.exporter.rdbms.handlers.waitstate.WaitStateAddUpdateHandler;
 import io.camunda.exporter.rdbms.handlers.waitstate.WaitStateRemoveHandler;
+import io.camunda.exporter.rdbms.replication.DelayReplicationControllerFactory;
 import io.camunda.exporter.rdbms.replication.LsnReplicationControllerFactory;
 import io.camunda.exporter.rdbms.replication.ReplicationControllerFactory;
 import io.camunda.search.entities.BatchOperationType;
@@ -153,18 +154,23 @@ public class RdbmsExporterWrapper implements Exporter {
                 config.getHistoryDeletion().getDependentRowLimit()),
             context.clock());
     builder.historyDeletionService(historyDeletionService);
-    if (config.getAsyncReplication().isEnabled()) {
-      final ReplicationLogStatusProvider replicationLogStatusProvider =
-          rdbmsService.getReplicationLogStatusProvider();
-      builder.replicationControllerFactory(
-          new LsnReplicationControllerFactory(
-              replicationLogStatusProvider,
-              config.getAsyncReplication(),
-              partitionId,
-              context.clock(),
-              rdbmsWriters.getMetrics()));
-    } else {
-      builder.replicationControllerFactory(ReplicationControllerFactory.noop());
+    switch (config.getAsyncReplication().getType()) {
+      case LOG_SEQ -> {
+        final ReplicationLogStatusProvider replicationLogStatusProvider =
+            rdbmsService.getReplicationLogStatusProvider();
+        builder.replicationControllerFactory(
+            new LsnReplicationControllerFactory(
+                replicationLogStatusProvider,
+                config.getAsyncReplication(),
+                partitionId,
+                context.clock(),
+                rdbmsWriters.getMetrics()));
+      }
+      case DELAY ->
+          builder.replicationControllerFactory(
+              new DelayReplicationControllerFactory(
+                  config.getAsyncReplication(), partitionId, context.clock()));
+      case NONE -> builder.replicationControllerFactory(ReplicationControllerFactory.noop());
     }
 
     createHandlers(partitionId, rdbmsWriters, builder, config, historyCleanupService);

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
@@ -154,26 +154,29 @@ public class RdbmsExporterWrapper implements Exporter {
                 config.getHistoryDeletion().getDependentRowLimit()),
             context.clock());
     builder.historyDeletionService(historyDeletionService);
-    switch (config.getAsyncReplication().getType()) {
-      case LOG_SEQ -> {
-        final ReplicationLogStatusProvider replicationLogStatusProvider =
-            rdbmsService.getReplicationLogStatusProvider();
-        builder.replicationControllerFactory(
-            new LsnReplicationControllerFactory(
-                replicationLogStatusProvider,
-                config.getAsyncReplication(),
-                partitionId,
-                context.clock(),
-                rdbmsWriters.getMetrics()));
-      }
-      case DELAY ->
+    if (!config.getAsyncReplication().isEnabled()) {
+      builder.replicationControllerFactory(ReplicationControllerFactory.noop());
+    } else {
+      switch (config.getAsyncReplication().getType()) {
+        case LOG_SEQ -> {
+          final ReplicationLogStatusProvider replicationLogStatusProvider =
+              rdbmsService.getReplicationLogStatusProvider();
           builder.replicationControllerFactory(
-              new DelayReplicationControllerFactory(
-                  config.getAsyncReplication(), partitionId, context.clock()));
-      case NONE -> builder.replicationControllerFactory(ReplicationControllerFactory.noop());
-      default ->
-          throw new IllegalArgumentException(
-              "Unknown replication type: " + config.getAsyncReplication().getType());
+              new LsnReplicationControllerFactory(
+                  replicationLogStatusProvider,
+                  config.getAsyncReplication(),
+                  partitionId,
+                  context.clock(),
+                  rdbmsWriters.getMetrics()));
+        }
+        case DELAY ->
+            builder.replicationControllerFactory(
+                new DelayReplicationControllerFactory(
+                    config.getAsyncReplication(), partitionId, context.clock()));
+        default ->
+            throw new IllegalArgumentException(
+                "Unknown replication type: " + config.getAsyncReplication().getType());
+      }
     }
 
     createHandlers(partitionId, rdbmsWriters, builder, config, historyCleanupService);

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/replication/DelayReplicationController.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/replication/DelayReplicationController.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.replication;
+
+import io.camunda.zeebe.exporter.api.context.Controller;
+import io.camunda.zeebe.exporter.api.context.ScheduledTask;
+import java.time.Duration;
+import java.time.InstantSource;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Delays acknowledgment of flushed exporter positions by a fixed duration. On each flush, the
+ * position is queued with its release time ({@code now + delay}). A periodic check drains expired
+ * entries and acknowledges the highest expired position to the broker controller.
+ *
+ * <p>On close, pending entries are discarded without acknowledgment. This is intentional: it is
+ * safer to re-export from the last committed position on restart than to acknowledge too early and
+ * risk data loss after a failover.
+ */
+public class DelayReplicationController implements ReplicationController {
+
+  public static final int DEFAULT_QUEUE_CAPACITY = 8192;
+
+  private static final Logger LOG = LoggerFactory.getLogger(DelayReplicationController.class);
+
+  private final Controller controller;
+  private final Duration delay;
+  private final InstantSource clock;
+  private final int partitionId;
+  private final BlockingQueue<DelayedEntry> pendingEntries;
+
+  private volatile ScheduledTask checkTask;
+
+  public DelayReplicationController(
+      final Controller controller,
+      final Duration delay,
+      final InstantSource clock,
+      final int partitionId) {
+    this.controller = controller;
+    this.delay = delay;
+    this.clock = clock;
+    this.partitionId = partitionId;
+    pendingEntries = new ArrayBlockingQueue<>(DEFAULT_QUEUE_CAPACITY);
+    checkTask = controller.scheduleCancellableTask(delay, this::checkDue);
+  }
+
+  @Override
+  public void onFlush(final long exporterPosition) {
+    final long releaseTimeMs = clock.millis() + delay.toMillis();
+    if (!pendingEntries.offer(new DelayedEntry(exporterPosition, releaseTimeMs))) {
+      LOG.warn(
+          "[RDBMS Exporter P{}] Delay replication queue is full, dropping entry (position={})",
+          partitionId,
+          exporterPosition);
+    }
+  }
+
+  void checkDue() {
+    final long now = clock.millis();
+    long highestExpired = Long.MIN_VALUE;
+
+    DelayedEntry entry;
+    while ((entry = pendingEntries.peek()) != null) {
+      if (entry.releaseTimeMs() > now) {
+        break;
+      }
+      highestExpired = entry.position();
+      pendingEntries.poll();
+    }
+
+    if (highestExpired != Long.MIN_VALUE) {
+      LOG.debug(
+          "[RDBMS Exporter P{}] Acknowledging delayed position {}", partitionId, highestExpired);
+      controller.updateLastExportedRecordPosition(highestExpired);
+    }
+
+    // if null, controller was closed during check
+    if (checkTask != null) {
+      checkTask = controller.scheduleCancellableTask(delay, this::checkDue);
+    }
+  }
+
+  @Override
+  public void close() {
+    final ScheduledTask task = checkTask;
+    checkTask = null;
+    if (task != null) {
+      task.cancel();
+    }
+    // Pending entries are intentionally discarded: the exporter will re-export from the last
+    // acknowledged position on restart, which is safer than acknowledging too early.
+  }
+
+  record DelayedEntry(long position, long releaseTimeMs) {}
+}

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/replication/DelayReplicationController.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/replication/DelayReplicationController.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.rdbms.replication;
 
+import io.camunda.exporter.rdbms.ExporterConfiguration.ReplicationConfiguration;
 import io.camunda.zeebe.exporter.api.context.Controller;
 import io.camunda.zeebe.exporter.api.context.ScheduledTask;
 import java.time.Duration;
@@ -27,56 +28,66 @@ import org.slf4j.LoggerFactory;
  */
 public class DelayReplicationController implements ReplicationController {
 
-  // Minimum queue size used as a floor regardless of delay length.
-  public static final int DEFAULT_QUEUE_CAPACITY = 8192;
-
-  // Conservative upper bound on flushes per second used to size the queue for longer delays.
-  // The queue is a last resort; dropping entries is safe (watermark semantics), but sizing
-  // generously avoids spurious drops for delays up to ~12 h at realistic flush rates.
-  static final int ESTIMATED_MAX_FLUSHES_PER_SECOND = 5;
-
   private static final Logger LOG = LoggerFactory.getLogger(DelayReplicationController.class);
-
+  final BlockingQueue<DelayedEntry> pendingEntries;
   private final Controller controller;
   private final Duration delay;
+  private final long queueDebounceMillis;
   private final InstantSource clock;
   private final int partitionId;
-  private final BlockingQueue<DelayedEntry> pendingEntries;
+  private long lastAdded = Long.MIN_VALUE;
 
   private volatile ScheduledTask checkTask;
 
   public DelayReplicationController(
       final Controller controller,
-      final Duration delay,
+      final ReplicationConfiguration config,
       final InstantSource clock,
       final int partitionId) {
     this.controller = controller;
-    this.delay = delay;
+    delay = config.getDelay();
+    queueDebounceMillis = config.getQueueDebounceTime().toMillis();
     this.clock = clock;
     this.partitionId = partitionId;
-    pendingEntries = new ArrayBlockingQueue<>(queueCapacityFor(delay));
+    pendingEntries = new ArrayBlockingQueue<>(config.getQueueCapacity());
     checkTask = controller.scheduleCancellableTask(delay, this::checkDue);
   }
 
   @Override
   public void onFlush(final long exporterPosition) {
-    final long releaseTimeMs = clock.millis() + delay.toMillis();
+    final long now = clock.millis();
+    final long releaseTimeMs = now + delay.toMillis();
+
+    if (queueDebounceMillis > 0
+        && !pendingEntries.isEmpty()
+        && now - lastAdded < queueDebounceMillis) {
+      LOG.debug(
+          "[RDBMS Exporter P{}] Debouncing flush (position={}), last added {} ms ago",
+          partitionId,
+          exporterPosition,
+          now - lastAdded);
+      return;
+    }
+
     if (!pendingEntries.offer(new DelayedEntry(exporterPosition, releaseTimeMs))) {
       LOG.warn(
           "[RDBMS Exporter P{}] Delay replication queue is full, dropping entry (position={})",
           partitionId,
           exporterPosition);
+    } else {
+      lastAdded = now;
     }
   }
 
+  /**
+   * We have no way of checking if the replication is in sync (that's why we use this configured
+   * delay), so we simply assume it to not stop exporting.
+   *
+   * @return true
+   */
   @Override
   public boolean isReplicationInSync() {
-    final DelayedEntry head = pendingEntries.peek();
-    if (head == null) {
-      return true;
-    }
-    // Returns false when the head entry is overdue (checkDue is behind schedule)
-    return clock.millis() <= head.releaseTimeMs();
+    return true;
   }
 
   void checkDue() {
@@ -111,11 +122,6 @@ public class DelayReplicationController implements ReplicationController {
       }
       checkTask = controller.scheduleCancellableTask(nextDelay, this::checkDue);
     }
-  }
-
-  static int queueCapacityFor(final Duration delay) {
-    final long computed = delay.toSeconds() * ESTIMATED_MAX_FLUSHES_PER_SECOND;
-    return (int) Math.max(DEFAULT_QUEUE_CAPACITY, Math.min(computed, Integer.MAX_VALUE));
   }
 
   @Override

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/replication/DelayReplicationController.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/replication/DelayReplicationController.java
@@ -27,7 +27,13 @@ import org.slf4j.LoggerFactory;
  */
 public class DelayReplicationController implements ReplicationController {
 
+  // Minimum queue size used as a floor regardless of delay length.
   public static final int DEFAULT_QUEUE_CAPACITY = 8192;
+
+  // Conservative upper bound on flushes per second used to size the queue for longer delays.
+  // The queue is a last resort; dropping entries is safe (watermark semantics), but sizing
+  // generously avoids spurious drops for delays up to ~12 h at realistic flush rates.
+  static final int ESTIMATED_MAX_FLUSHES_PER_SECOND = 5;
 
   private static final Logger LOG = LoggerFactory.getLogger(DelayReplicationController.class);
 
@@ -48,7 +54,7 @@ public class DelayReplicationController implements ReplicationController {
     this.delay = delay;
     this.clock = clock;
     this.partitionId = partitionId;
-    pendingEntries = new ArrayBlockingQueue<>(DEFAULT_QUEUE_CAPACITY);
+    pendingEntries = new ArrayBlockingQueue<>(queueCapacityFor(delay));
     checkTask = controller.scheduleCancellableTask(delay, this::checkDue);
   }
 
@@ -105,6 +111,11 @@ public class DelayReplicationController implements ReplicationController {
       }
       checkTask = controller.scheduleCancellableTask(nextDelay, this::checkDue);
     }
+  }
+
+  static int queueCapacityFor(final Duration delay) {
+    final long computed = delay.toSeconds() * ESTIMATED_MAX_FLUSHES_PER_SECOND;
+    return (int) Math.max(DEFAULT_QUEUE_CAPACITY, Math.min(computed, Integer.MAX_VALUE));
   }
 
   @Override

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/replication/DelayReplicationController.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/replication/DelayReplicationController.java
@@ -63,6 +63,16 @@ public class DelayReplicationController implements ReplicationController {
     }
   }
 
+  @Override
+  public boolean isReplicationInSync() {
+    final DelayedEntry head = pendingEntries.peek();
+    if (head == null) {
+      return true;
+    }
+    // Returns false when the head entry is overdue (checkDue is behind schedule)
+    return clock.millis() <= head.releaseTimeMs();
+  }
+
   void checkDue() {
     final long now = clock.millis();
     long highestExpired = Long.MIN_VALUE;
@@ -84,7 +94,16 @@ public class DelayReplicationController implements ReplicationController {
 
     // if null, controller was closed during check
     if (checkTask != null) {
-      checkTask = controller.scheduleCancellableTask(delay, this::checkDue);
+      // Reschedule based on next due entry to avoid adding an extra full delay
+      final DelayedEntry nextHead = pendingEntries.peek();
+      final Duration nextDelay;
+      if (nextHead == null) {
+        nextDelay = delay;
+      } else {
+        final long remainingMs = nextHead.releaseTimeMs() - clock.millis();
+        nextDelay = Duration.ofMillis(Math.max(1, remainingMs));
+      }
+      checkTask = controller.scheduleCancellableTask(nextDelay, this::checkDue);
     }
   }
 

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/replication/DelayReplicationControllerFactory.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/replication/DelayReplicationControllerFactory.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.replication;
+
+import io.camunda.exporter.rdbms.ExporterConfiguration.ReplicationConfiguration;
+import io.camunda.zeebe.exporter.api.context.Controller;
+import java.time.InstantSource;
+
+public class DelayReplicationControllerFactory implements ReplicationControllerFactory {
+
+  private final ReplicationConfiguration config;
+  private final int partitionId;
+  private final InstantSource clock;
+
+  public DelayReplicationControllerFactory(
+      final ReplicationConfiguration config, final int partitionId, final InstantSource clock) {
+    this.config = config;
+    this.partitionId = partitionId;
+    this.clock = clock;
+  }
+
+  @Override
+  public ReplicationController createReplicationController(final Controller controller) {
+    return new DelayReplicationController(controller, config.getDelay(), clock, partitionId);
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/replication/DelayReplicationControllerFactory.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/replication/DelayReplicationControllerFactory.java
@@ -26,6 +26,6 @@ public class DelayReplicationControllerFactory implements ReplicationControllerF
 
   @Override
   public ReplicationController createReplicationController(final Controller controller) {
-    return new DelayReplicationController(controller, config.getDelay(), clock, partitionId);
+    return new DelayReplicationController(controller, config, clock, partitionId);
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/replication/NoopReplicationController.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/replication/NoopReplicationController.java
@@ -23,6 +23,11 @@ public class NoopReplicationController implements ReplicationController {
   }
 
   @Override
+  public boolean isReplicationInSync() {
+    return true;
+  }
+
+  @Override
   public void close() throws Exception {
     // noop
   }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/replication/ReplicationController.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/replication/ReplicationController.java
@@ -16,7 +16,5 @@ public interface ReplicationController extends AutoCloseable {
    *
    * @return if the replication is in sync
    */
-  default boolean isReplicationInSync() {
-    return true;
-  }
+  boolean isReplicationInSync();
 }

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/ExporterConfigurationTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/ExporterConfigurationTest.java
@@ -499,6 +499,7 @@ class ExporterConfigurationTest {
     // given
     final ExporterConfiguration configuration = new ExporterConfiguration();
     final ReplicationConfiguration replication = new ReplicationConfiguration();
+    replication.setEnabled(true);
     replication.setType(ReplicationType.LOG_SEQ);
     replication.setPollingInterval(Duration.ofSeconds(10));
     replication.setMinSyncReplicas(1);
@@ -516,6 +517,7 @@ class ExporterConfigurationTest {
     // given
     final ExporterConfiguration configuration = new ExporterConfiguration();
     final ReplicationConfiguration replication = new ReplicationConfiguration();
+    replication.setEnabled(true);
     replication.setType(ReplicationType.DELAY);
     replication.setDelay(Duration.ofMinutes(10));
     configuration.setAsyncReplication(replication);
@@ -527,11 +529,11 @@ class ExporterConfigurationTest {
   }
 
   @Test
-  public void shouldNotFailWhenReplicationNoneWithCompletelyWrongConfig() {
+  public void shouldNotFailWhenReplicationDisabledWithCompletelyWrongConfig() {
     // given - completely invalid configuration, but replication is disabled
     final ExporterConfiguration configuration = new ExporterConfiguration();
     final ReplicationConfiguration replication = new ReplicationConfiguration();
-    replication.setType(ReplicationType.NONE);
+    replication.setEnabled(false);
     replication.setPollingInterval(Duration.ofMillis(-1000));
     replication.setMaxLag(Duration.ofMillis(-1000));
     configuration.setAsyncReplication(replication);
@@ -539,7 +541,7 @@ class ExporterConfigurationTest {
     // when
     configuration.validate();
 
-    // then - no error, pollingInterval and maxLag are only validated for LOG_SEQ type
+    // then - no error, pollingInterval and maxLag are only validated when enabled
   }
 
   @ParameterizedTest
@@ -561,6 +563,7 @@ class ExporterConfigurationTest {
         Arguments.of(
             (Consumer<ReplicationConfiguration>)
                 r -> {
+                  r.setEnabled(true);
                   r.setType(ReplicationType.LOG_SEQ);
                   r.setPollingInterval(Duration.ofMillis(-1000));
                 },
@@ -568,6 +571,7 @@ class ExporterConfigurationTest {
         Arguments.of(
             (Consumer<ReplicationConfiguration>)
                 r -> {
+                  r.setEnabled(true);
                   r.setType(ReplicationType.LOG_SEQ);
                   r.setPollingInterval(Duration.ZERO);
                 },
@@ -581,6 +585,7 @@ class ExporterConfigurationTest {
         Arguments.of(
             (Consumer<ReplicationConfiguration>)
                 r -> {
+                  r.setEnabled(true);
                   r.setType(ReplicationType.LOG_SEQ);
                   r.setMaxLag(Duration.ofMillis(-1000));
                 },
@@ -588,6 +593,7 @@ class ExporterConfigurationTest {
         Arguments.of(
             (Consumer<ReplicationConfiguration>)
                 r -> {
+                  r.setEnabled(true);
                   r.setType(ReplicationType.LOG_SEQ);
                   r.setMaxLag(Duration.ZERO);
                 },
@@ -595,6 +601,7 @@ class ExporterConfigurationTest {
         Arguments.of(
             (Consumer<ReplicationConfiguration>)
                 r -> {
+                  r.setEnabled(true);
                   r.setType(ReplicationType.DELAY);
                   r.setDelay(Duration.ofMillis(-1000));
                 },
@@ -602,6 +609,7 @@ class ExporterConfigurationTest {
         Arguments.of(
             (Consumer<ReplicationConfiguration>)
                 r -> {
+                  r.setEnabled(true);
                   r.setType(ReplicationType.DELAY);
                   r.setDelay(Duration.ZERO);
                 },

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/ExporterConfigurationTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/ExporterConfigurationTest.java
@@ -520,6 +520,8 @@ class ExporterConfigurationTest {
     replication.setEnabled(true);
     replication.setType(ReplicationType.DELAY);
     replication.setDelay(Duration.ofMinutes(10));
+    replication.setQueueDebounceTime(Duration.ZERO);
+    replication.setQueueCapacity(10);
     configuration.setAsyncReplication(replication);
 
     // when
@@ -577,10 +579,18 @@ class ExporterConfigurationTest {
                 },
             "asyncReplication.pollingInterval must be a positive duration"),
         Arguments.of(
-            (Consumer<ReplicationConfiguration>) r -> r.setMinSyncReplicas(-1),
+            (Consumer<ReplicationConfiguration>)
+                r -> {
+                  r.setEnabled(true);
+                  r.setMinSyncReplicas(-1);
+                },
             "asyncReplication.minSyncReplicas must be greater 0"),
         Arguments.of(
-            (Consumer<ReplicationConfiguration>) r -> r.setMinSyncReplicas(0),
+            (Consumer<ReplicationConfiguration>)
+                r -> {
+                  r.setEnabled(true);
+                  r.setMinSyncReplicas(0);
+                },
             "asyncReplication.minSyncReplicas must be greater 0"),
         Arguments.of(
             (Consumer<ReplicationConfiguration>)
@@ -613,6 +623,42 @@ class ExporterConfigurationTest {
                   r.setType(ReplicationType.DELAY);
                   r.setDelay(Duration.ZERO);
                 },
-            "asyncReplication.delay must be a positive duration"));
+            "asyncReplication.delay must be a positive duration"),
+        Arguments.of(
+            (Consumer<ReplicationConfiguration>)
+                r -> {
+                  r.setEnabled(true);
+                  r.setType(ReplicationType.DELAY);
+                  r.setDelay(Duration.ofMinutes(10));
+                  r.setQueueDebounceTime(Duration.ofMillis(-1));
+                },
+            "asyncReplication.queueDebounceTime must be a non-negative duration"),
+        Arguments.of(
+            (Consumer<ReplicationConfiguration>)
+                r -> {
+                  r.setEnabled(true);
+                  r.setType(ReplicationType.DELAY);
+                  r.setDelay(Duration.ofMinutes(10));
+                  r.setQueueDebounceTime(null);
+                },
+            "asyncReplication.queueDebounceTime must be a non-negative duration"),
+        Arguments.of(
+            (Consumer<ReplicationConfiguration>)
+                r -> {
+                  r.setEnabled(true);
+                  r.setType(ReplicationType.DELAY);
+                  r.setDelay(Duration.ofMinutes(10));
+                  r.setQueueCapacity(0);
+                },
+            "asyncReplication.queueCapacity must be greater 0"),
+        Arguments.of(
+            (Consumer<ReplicationConfiguration>)
+                r -> {
+                  r.setEnabled(true);
+                  r.setType(ReplicationType.DELAY);
+                  r.setDelay(Duration.ofMinutes(10));
+                  r.setQueueCapacity(-1);
+                },
+            "asyncReplication.queueCapacity must be greater 0"));
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/ExporterConfigurationTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/ExporterConfigurationTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.exporter.rdbms.ExporterConfiguration.ReplicationConfiguration;
+import io.camunda.exporter.rdbms.ExporterConfiguration.ReplicationConfiguration.ReplicationType;
 import java.time.Duration;
 import java.time.InstantSource;
 import java.util.function.Consumer;
@@ -494,11 +495,11 @@ class ExporterConfigurationTest {
   // ReplicationConfiguration tests
 
   @Test
-  public void shouldBeOkWithEnabledReplicationAndValidConfig() {
+  public void shouldBeOkWithLogSeqReplicationAndValidConfig() {
     // given
     final ExporterConfiguration configuration = new ExporterConfiguration();
     final ReplicationConfiguration replication = new ReplicationConfiguration();
-    replication.setEnabled(true);
+    replication.setType(ReplicationType.LOG_SEQ);
     replication.setPollingInterval(Duration.ofSeconds(10));
     replication.setMinSyncReplicas(1);
     replication.setMaxLag(Duration.ofMinutes(5));
@@ -511,11 +512,26 @@ class ExporterConfigurationTest {
   }
 
   @Test
-  public void shouldNotFailWhenReplicationDisabledWithCompletelyWrongConfig() {
+  public void shouldBeOkWithDelayReplicationAndValidConfig() {
+    // given
+    final ExporterConfiguration configuration = new ExporterConfiguration();
+    final ReplicationConfiguration replication = new ReplicationConfiguration();
+    replication.setType(ReplicationType.DELAY);
+    replication.setDelay(Duration.ofMinutes(10));
+    configuration.setAsyncReplication(replication);
+
+    // when
+    configuration.validate();
+
+    // then - no error
+  }
+
+  @Test
+  public void shouldNotFailWhenReplicationNoneWithCompletelyWrongConfig() {
     // given - completely invalid configuration, but replication is disabled
     final ExporterConfiguration configuration = new ExporterConfiguration();
     final ReplicationConfiguration replication = new ReplicationConfiguration();
-    replication.setEnabled(false);
+    replication.setType(ReplicationType.NONE);
     replication.setPollingInterval(Duration.ofMillis(-1000));
     replication.setMaxLag(Duration.ofMillis(-1000));
     configuration.setAsyncReplication(replication);
@@ -523,7 +539,7 @@ class ExporterConfigurationTest {
     // when
     configuration.validate();
 
-    // then - no error, pollingInterval and maxLag are only validated when replication is enabled
+    // then - no error, pollingInterval and maxLag are only validated for LOG_SEQ type
   }
 
   @ParameterizedTest
@@ -545,14 +561,14 @@ class ExporterConfigurationTest {
         Arguments.of(
             (Consumer<ReplicationConfiguration>)
                 r -> {
-                  r.setEnabled(true);
+                  r.setType(ReplicationType.LOG_SEQ);
                   r.setPollingInterval(Duration.ofMillis(-1000));
                 },
             "asyncReplication.pollingInterval must be a positive duration"),
         Arguments.of(
             (Consumer<ReplicationConfiguration>)
                 r -> {
-                  r.setEnabled(true);
+                  r.setType(ReplicationType.LOG_SEQ);
                   r.setPollingInterval(Duration.ZERO);
                 },
             "asyncReplication.pollingInterval must be a positive duration"),
@@ -565,16 +581,30 @@ class ExporterConfigurationTest {
         Arguments.of(
             (Consumer<ReplicationConfiguration>)
                 r -> {
-                  r.setEnabled(true);
+                  r.setType(ReplicationType.LOG_SEQ);
                   r.setMaxLag(Duration.ofMillis(-1000));
                 },
             "asyncReplication.maxLag must be a positive duration"),
         Arguments.of(
             (Consumer<ReplicationConfiguration>)
                 r -> {
-                  r.setEnabled(true);
+                  r.setType(ReplicationType.LOG_SEQ);
                   r.setMaxLag(Duration.ZERO);
                 },
-            "asyncReplication.maxLag must be a positive duration"));
+            "asyncReplication.maxLag must be a positive duration"),
+        Arguments.of(
+            (Consumer<ReplicationConfiguration>)
+                r -> {
+                  r.setType(ReplicationType.DELAY);
+                  r.setDelay(Duration.ofMillis(-1000));
+                },
+            "asyncReplication.delay must be a positive duration"),
+        Arguments.of(
+            (Consumer<ReplicationConfiguration>)
+                r -> {
+                  r.setType(ReplicationType.DELAY);
+                  r.setDelay(Duration.ZERO);
+                },
+            "asyncReplication.delay must be a positive duration"));
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/replication/DelayReplicationControllerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/replication/DelayReplicationControllerTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.replication;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.exporter.api.context.Controller;
+import io.camunda.zeebe.exporter.api.context.ScheduledTask;
+import java.time.Duration;
+import java.time.InstantSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class DelayReplicationControllerTest {
+
+  private static final int PARTITION_ID = 1;
+  private static final Duration DELAY = Duration.ofSeconds(30);
+
+  private Controller controller;
+  private InstantSource clock;
+  private ScheduledTask scheduledTask;
+
+  @BeforeEach
+  void setUp() {
+    controller = mock(Controller.class);
+    clock = mock(InstantSource.class);
+    scheduledTask = mock(ScheduledTask.class);
+
+    when(clock.millis()).thenReturn(0L);
+    when(controller.scheduleCancellableTask(any(), any())).thenReturn(scheduledTask);
+  }
+
+  private DelayReplicationController createController() {
+    return new DelayReplicationController(controller, DELAY, clock, PARTITION_ID);
+  }
+
+  @Test
+  void shouldScheduleCheckTaskOnConstruct() {
+    // when
+    createController();
+
+    // then
+    verify(controller, times(1)).scheduleCancellableTask(eq(DELAY), any());
+  }
+
+  @Test
+  void shouldNotAcknowledgeBeforeDelayExpires() {
+    // given
+    final var replicationController = createController();
+    when(clock.millis()).thenReturn(0L);
+    replicationController.onFlush(100L);
+
+    // when - check before delay has elapsed
+    when(clock.millis()).thenReturn(DELAY.toMillis() - 1);
+    replicationController.checkDue();
+
+    // then
+    verify(controller, never()).updateLastExportedRecordPosition(100L);
+  }
+
+  @Test
+  void shouldAcknowledgeAfterDelayExpires() {
+    // given
+    final var replicationController = createController();
+    when(clock.millis()).thenReturn(0L);
+    replicationController.onFlush(100L);
+
+    // when - check exactly at delay boundary
+    when(clock.millis()).thenReturn(DELAY.toMillis());
+    replicationController.checkDue();
+
+    // then
+    verify(controller).updateLastExportedRecordPosition(100L);
+  }
+
+  @Test
+  void shouldAcknowledgeOnlyExpiredEntries() {
+    // given - two flushes: first at t=0 (expires at t=delay), second at t=delay-1 (not yet expired)
+    final var replicationController = createController();
+    when(clock.millis()).thenReturn(0L);
+    replicationController.onFlush(100L);
+    when(clock.millis()).thenReturn(DELAY.toMillis() - 1);
+    replicationController.onFlush(200L);
+
+    // when - check at exactly t=delay; only the first entry has expired
+    when(clock.millis()).thenReturn(DELAY.toMillis());
+    replicationController.checkDue();
+
+    // then - only position 100 acknowledged
+    verify(controller).updateLastExportedRecordPosition(100L);
+    verify(controller, never()).updateLastExportedRecordPosition(200L);
+  }
+
+  @Test
+  void shouldAcknowledgeHighestExpiredPosition() {
+    // given - three entries all enqueued at t=0, all expire at t=delay
+    final var replicationController = createController();
+    when(clock.millis()).thenReturn(0L);
+    replicationController.onFlush(100L);
+    replicationController.onFlush(200L);
+    replicationController.onFlush(300L);
+
+    // when - all entries have expired
+    when(clock.millis()).thenReturn(DELAY.toMillis());
+    replicationController.checkDue();
+
+    // then - only the last (highest) position is acknowledged in the final call
+    verify(controller).updateLastExportedRecordPosition(300L);
+    verify(controller, never()).updateLastExportedRecordPosition(100L);
+    verify(controller, never()).updateLastExportedRecordPosition(200L);
+  }
+
+  @Test
+  void shouldNotAcknowledgeOnClose() throws Exception {
+    // given - a flush is pending
+    final var replicationController = createController();
+    when(clock.millis()).thenReturn(0L);
+    replicationController.onFlush(100L);
+
+    // when - close before delay expires
+    replicationController.close();
+
+    // then - position was never acknowledged (safe: will re-export from last committed position)
+    verify(controller, never()).updateLastExportedRecordPosition(any(Long.class));
+  }
+
+  @Test
+  void shouldRescheduleAfterCheck() {
+    // given
+    final var replicationController = createController();
+
+    // when
+    replicationController.checkDue();
+
+    // then - one schedule on construction + one after checkDue
+    verify(controller, times(2)).scheduleCancellableTask(eq(DELAY), any());
+  }
+
+  @Test
+  void shouldCancelTaskAfterClose() throws Exception {
+    // given
+    final var replicationController = createController();
+
+    // when
+    replicationController.close();
+
+    // then
+    verify(scheduledTask).cancel();
+  }
+
+  @Test
+  void shouldNotRescheduleAfterCloseduringCheck() throws Exception {
+    // given - close is called; checkTask is set to null
+    final var replicationController = createController();
+    replicationController.close(); // sets checkTask to null
+
+    // when - simulate checkDue running after close set task to null
+    replicationController.checkDue();
+
+    // then - only the initial schedule from the constructor; checkDue must not add another one
+    verify(controller, times(1)).scheduleCancellableTask(eq(DELAY), any());
+  }
+
+  @Test
+  void shouldDropEntryOnFullQueue() {
+    // given - fill the queue to capacity
+    final var replicationController = createController();
+    when(clock.millis()).thenReturn(0L);
+    for (int i = 0; i < DelayReplicationController.DEFAULT_QUEUE_CAPACITY; i++) {
+      replicationController.onFlush(i);
+    }
+
+    // when - one more flush that should be silently dropped
+    replicationController.onFlush(DelayReplicationController.DEFAULT_QUEUE_CAPACITY + 1L);
+
+    // then - no exception, controller is still in sync
+    assertThat(replicationController.isReplicationInSync()).isTrue();
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/replication/DelayReplicationControllerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/replication/DelayReplicationControllerTest.java
@@ -212,4 +212,27 @@ class DelayReplicationControllerTest {
     // then
     assertThat(replicationController.isReplicationInSync()).isTrue();
   }
+
+  @Test
+  void shouldUseDefaultCapacityForShortDelays() {
+    // given - a delay shorter than what 5 flushes/sec over DEFAULT_QUEUE_CAPACITY would require
+    final var shortDelay = Duration.ofSeconds(1);
+
+    // then - floor kicks in
+    assertThat(DelayReplicationController.queueCapacityFor(shortDelay))
+        .isEqualTo(DelayReplicationController.DEFAULT_QUEUE_CAPACITY);
+  }
+
+  @Test
+  void shouldScaleCapacityWithDelay() {
+    // given - a 12-hour delay (realistic upper bound for this controller)
+    final var twelveHours = Duration.ofHours(12);
+
+    // then - capacity exceeds default and fits 5 flushes/sec for the full delay
+    final int capacity = DelayReplicationController.queueCapacityFor(twelveHours);
+    assertThat(capacity).isGreaterThan(DelayReplicationController.DEFAULT_QUEUE_CAPACITY);
+    assertThat(capacity)
+        .isEqualTo(
+            (int) (twelveHours.toSeconds() * DelayReplicationController.ESTIMATED_MAX_FLUSHES_PER_SECOND));
+  }
 }

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/replication/DelayReplicationControllerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/replication/DelayReplicationControllerTest.java
@@ -233,6 +233,8 @@ class DelayReplicationControllerTest {
     assertThat(capacity).isGreaterThan(DelayReplicationController.DEFAULT_QUEUE_CAPACITY);
     assertThat(capacity)
         .isEqualTo(
-            (int) (twelveHours.toSeconds() * DelayReplicationController.ESTIMATED_MAX_FLUSHES_PER_SECOND));
+            (int)
+                (twelveHours.toSeconds()
+                    * DelayReplicationController.ESTIMATED_MAX_FLUSHES_PER_SECOND));
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/replication/DelayReplicationControllerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/replication/DelayReplicationControllerTest.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.rdbms.replication;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -133,7 +134,7 @@ class DelayReplicationControllerTest {
     replicationController.close();
 
     // then - position was never acknowledged (safe: will re-export from last committed position)
-    verify(controller, never()).updateLastExportedRecordPosition(any(Long.class));
+    verify(controller, never()).updateLastExportedRecordPosition(anyLong());
   }
 
   @Test
@@ -161,7 +162,7 @@ class DelayReplicationControllerTest {
   }
 
   @Test
-  void shouldNotRescheduleAfterCloseduringCheck() throws Exception {
+  void shouldNotRescheduleAfterCloseDuringCheck() throws Exception {
     // given - close is called; checkTask is set to null
     final var replicationController = createController();
     replicationController.close(); // sets checkTask to null
@@ -182,10 +183,33 @@ class DelayReplicationControllerTest {
       replicationController.onFlush(i);
     }
 
-    // when - one more flush that should be silently dropped
-    replicationController.onFlush(DelayReplicationController.DEFAULT_QUEUE_CAPACITY + 1L);
+    // when - one more flush that should be silently dropped (first entry that overflows capacity)
+    replicationController.onFlush(DelayReplicationController.DEFAULT_QUEUE_CAPACITY);
 
     // then - no exception, controller is still in sync
+    assertThat(replicationController.isReplicationInSync()).isTrue();
+  }
+
+  @Test
+  void shouldReturnOutOfSyncWhenHeadEntryIsOverdue() {
+    // given - a flush was queued, delay has now passed without checkDue running
+    final var replicationController = createController();
+    when(clock.millis()).thenReturn(0L);
+    replicationController.onFlush(100L);
+
+    // when - delay has elapsed but checkDue has not run yet
+    when(clock.millis()).thenReturn(DELAY.toMillis() + 1);
+
+    // then - head entry is overdue; signal out of sync to pause the exporter
+    assertThat(replicationController.isReplicationInSync()).isFalse();
+  }
+
+  @Test
+  void shouldReturnInSyncWhenQueueIsEmpty() {
+    // given - no pending flushes
+    final var replicationController = createController();
+
+    // then
     assertThat(replicationController.isReplicationInSync()).isTrue();
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/replication/DelayReplicationControllerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/replication/DelayReplicationControllerTest.java
@@ -17,10 +17,12 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.exporter.rdbms.ExporterConfiguration.ReplicationConfiguration;
 import io.camunda.zeebe.exporter.api.context.Controller;
 import io.camunda.zeebe.exporter.api.context.ScheduledTask;
 import java.time.Duration;
 import java.time.InstantSource;
+import java.util.stream.LongStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -28,6 +30,8 @@ class DelayReplicationControllerTest {
 
   private static final int PARTITION_ID = 1;
   private static final Duration DELAY = Duration.ofSeconds(30);
+  private static final int QUEUE_CAPACITY = 10;
+  private static final Duration QUEUE_DEBOUNCE_TIME = Duration.ZERO;
 
   private Controller controller;
   private InstantSource clock;
@@ -44,7 +48,17 @@ class DelayReplicationControllerTest {
   }
 
   private DelayReplicationController createController() {
-    return new DelayReplicationController(controller, DELAY, clock, PARTITION_ID);
+    return createController(QUEUE_DEBOUNCE_TIME, QUEUE_CAPACITY);
+  }
+
+  private DelayReplicationController createController(
+      final Duration queueDebounceTime, final int queueCapacity) {
+    final ReplicationConfiguration config = new ReplicationConfiguration();
+    config.setDelay(DELAY);
+    config.setQueueDebounceTime(queueDebounceTime);
+    config.setQueueCapacity(queueCapacity);
+
+    return new DelayReplicationController(controller, config, clock, PARTITION_ID);
   }
 
   @Test
@@ -124,7 +138,53 @@ class DelayReplicationControllerTest {
   }
 
   @Test
-  void shouldNotAcknowledgeOnClose() throws Exception {
+  void shouldDebounceFlushesWithinConfiguredWindow() {
+    // given
+    final var replicationController = createController(Duration.ofMillis(5), QUEUE_CAPACITY);
+    when(clock.millis()).thenReturn(0L);
+    replicationController.onFlush(100L);
+    when(clock.millis()).thenReturn(4L);
+    replicationController.onFlush(200L);
+
+    // then
+    assertThat(replicationController.pendingEntries)
+        .containsExactly(new DelayReplicationController.DelayedEntry(100L, DELAY.toMillis()));
+  }
+
+  @Test
+  void shouldOfferEveryFlushWhenQueueDebounceTimeIsZero() {
+    // given
+    final var replicationController = createController(Duration.ZERO, QUEUE_CAPACITY);
+    when(clock.millis()).thenReturn(0L);
+
+    // when
+    replicationController.onFlush(100L);
+    replicationController.onFlush(200L);
+
+    // then
+    assertThat(replicationController.pendingEntries)
+        .containsExactly(
+            new DelayReplicationController.DelayedEntry(100L, DELAY.toMillis()),
+            new DelayReplicationController.DelayedEntry(200L, DELAY.toMillis()));
+  }
+
+  @Test
+  void shouldUseConfiguredQueueCapacity() {
+    // given
+    final var replicationController = createController(QUEUE_DEBOUNCE_TIME, 1);
+    when(clock.millis()).thenReturn(0L);
+
+    // when
+    replicationController.onFlush(100L);
+    replicationController.onFlush(200L);
+
+    // then
+    assertThat(replicationController.pendingEntries)
+        .containsExactly(new DelayReplicationController.DelayedEntry(100L, DELAY.toMillis()));
+  }
+
+  @Test
+  void shouldNotAcknowledgeOnClose() {
     // given - a flush is pending
     final var replicationController = createController();
     when(clock.millis()).thenReturn(0L);
@@ -150,7 +210,7 @@ class DelayReplicationControllerTest {
   }
 
   @Test
-  void shouldCancelTaskAfterClose() throws Exception {
+  void shouldCancelTaskAfterClose() {
     // given
     final var replicationController = createController();
 
@@ -162,7 +222,7 @@ class DelayReplicationControllerTest {
   }
 
   @Test
-  void shouldNotRescheduleAfterCloseDuringCheck() throws Exception {
+  void shouldNotRescheduleAfterCloseDuringCheck() {
     // given - close is called; checkTask is set to null
     final var replicationController = createController();
     replicationController.close(); // sets checkTask to null
@@ -179,62 +239,20 @@ class DelayReplicationControllerTest {
     // given - fill the queue to capacity
     final var replicationController = createController();
     when(clock.millis()).thenReturn(0L);
-    for (int i = 0; i < DelayReplicationController.DEFAULT_QUEUE_CAPACITY; i++) {
+    for (int i = 0; i < QUEUE_CAPACITY; i++) {
       replicationController.onFlush(i);
     }
 
     // when - one more flush that should be silently dropped (first entry that overflows capacity)
-    replicationController.onFlush(DelayReplicationController.DEFAULT_QUEUE_CAPACITY);
-
-    // then - no exception, controller is still in sync
-    assertThat(replicationController.isReplicationInSync()).isTrue();
-  }
-
-  @Test
-  void shouldReturnOutOfSyncWhenHeadEntryIsOverdue() {
-    // given - a flush was queued, delay has now passed without checkDue running
-    final var replicationController = createController();
-    when(clock.millis()).thenReturn(0L);
-    replicationController.onFlush(100L);
-
-    // when - delay has elapsed but checkDue has not run yet
-    when(clock.millis()).thenReturn(DELAY.toMillis() + 1);
-
-    // then - head entry is overdue; signal out of sync to pause the exporter
-    assertThat(replicationController.isReplicationInSync()).isFalse();
-  }
-
-  @Test
-  void shouldReturnInSyncWhenQueueIsEmpty() {
-    // given - no pending flushes
-    final var replicationController = createController();
+    replicationController.onFlush(42L);
 
     // then
-    assertThat(replicationController.isReplicationInSync()).isTrue();
-  }
-
-  @Test
-  void shouldUseDefaultCapacityForShortDelays() {
-    // given - a delay shorter than what 5 flushes/sec over DEFAULT_QUEUE_CAPACITY would require
-    final var shortDelay = Duration.ofSeconds(1);
-
-    // then - floor kicks in
-    assertThat(DelayReplicationController.queueCapacityFor(shortDelay))
-        .isEqualTo(DelayReplicationController.DEFAULT_QUEUE_CAPACITY);
-  }
-
-  @Test
-  void shouldScaleCapacityWithDelay() {
-    // given - a 12-hour delay (realistic upper bound for this controller)
-    final var twelveHours = Duration.ofHours(12);
-
-    // then - capacity exceeds default and fits 5 flushes/sec for the full delay
-    final int capacity = DelayReplicationController.queueCapacityFor(twelveHours);
-    assertThat(capacity).isGreaterThan(DelayReplicationController.DEFAULT_QUEUE_CAPACITY);
-    assertThat(capacity)
-        .isEqualTo(
-            (int)
-                (twelveHours.toSeconds()
-                    * DelayReplicationController.ESTIMATED_MAX_FLUSHES_PER_SECOND));
+    assertThat(replicationController.pendingEntries)
+        .containsExactlyElementsOf(
+            LongStream.range(0, QUEUE_CAPACITY)
+                .mapToObj(
+                    position ->
+                        new DelayReplicationController.DelayedEntry(position, DELAY.toMillis()))
+                .toList());
   }
 }


### PR DESCRIPTION
…wledgment

Implements issue #51589. Operators can now configure a fixed delay before flushed RDBMS exporter positions are acknowledged to the Zeebe broker, giving replicas time to catch up without requiring LSN-based polling.

Replaces the boolean `asyncReplication.enabled` field with an enum `asyncReplication.type` (NONE / LSN / TIME_DELAY) so the replication strategy is expressed as a single value. NONE is the default (backward compatible). DELAY uses a configurable `asyncReplication.delay` duration (default PT15M) and never acknowledges pending positions on close, which is intentional: re-exporting from the last committed position is safer than acknowledging too early after a failover.

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
