### PR TITLE
feat: add Zeebe agent instance data model

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/ZeebeRecordDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/ZeebeRecordDto.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.optimize.dto.zeebe;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.protocol.record.Agent;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
@@ -111,6 +112,7 @@ public abstract class ZeebeRecordDto<VALUE extends RecordValue, INTENT extends I
     return null;
   }
 
+  @JsonIgnore
   @Override
   public int getRecordVersion() {
     throw new UnsupportedOperationException("Operation not supported");

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/agentinstance/ZeebeAgentInstanceDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/agentinstance/ZeebeAgentInstanceDataDto.java
@@ -1,0 +1,445 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.dto.zeebe.agentinstance;
+
+import static io.camunda.optimize.service.util.importing.ZeebeConstants.ZEEBE_DEFAULT_TENANT_ID;
+
+import io.camunda.zeebe.protocol.record.value.AgentInstanceRecordValue;
+import io.camunda.zeebe.protocol.record.value.AgentInstanceRecordValue.AgentInstanceToolValue;
+import io.camunda.zeebe.protocol.record.value.AgentInstanceStatus;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import org.apache.commons.lang3.StringUtils;
+
+public class ZeebeAgentInstanceDataDto implements AgentInstanceRecordValue {
+
+  private long agentInstanceKey;
+  private long elementInstanceKey;
+  private List<Long> elementInstanceKeys = new ArrayList<>();
+  private String elementId;
+  private long processInstanceKey;
+  private String bpmnProcessId;
+  private long processDefinitionKey;
+  private int processDefinitionVersion;
+  private String tenantId;
+  private AgentInstanceStatus status;
+  private AgentDefinitionValueDto definition = new AgentDefinitionValueDto();
+  private AgentMetricsValueDto metrics = new AgentMetricsValueDto();
+  private List<AgentToolValueDto> tools = new ArrayList<>();
+
+  public ZeebeAgentInstanceDataDto() {}
+
+  @Override
+  public String toJson() {
+    throw new UnsupportedOperationException("Operation not supported");
+  }
+
+  @Override
+  public long getAgentInstanceKey() {
+    return agentInstanceKey;
+  }
+
+  public void setAgentInstanceKey(final long agentInstanceKey) {
+    this.agentInstanceKey = agentInstanceKey;
+  }
+
+  @Override
+  public long getElementInstanceKey() {
+    return elementInstanceKey;
+  }
+
+  public void setElementInstanceKey(final long elementInstanceKey) {
+    this.elementInstanceKey = elementInstanceKey;
+  }
+
+  @Override
+  public List<Long> getElementInstanceKeys() {
+    return elementInstanceKeys;
+  }
+
+  public void setElementInstanceKeys(final List<Long> elementInstanceKeys) {
+    this.elementInstanceKeys = elementInstanceKeys;
+  }
+
+  @Override
+  public String getElementId() {
+    return elementId;
+  }
+
+  public void setElementId(final String elementId) {
+    this.elementId = elementId;
+  }
+
+  @Override
+  public long getProcessInstanceKey() {
+    return processInstanceKey;
+  }
+
+  public void setProcessInstanceKey(final long processInstanceKey) {
+    this.processInstanceKey = processInstanceKey;
+  }
+
+  @Override
+  public String getBpmnProcessId() {
+    return bpmnProcessId;
+  }
+
+  public void setBpmnProcessId(final String bpmnProcessId) {
+    this.bpmnProcessId = bpmnProcessId;
+  }
+
+  @Override
+  public long getProcessDefinitionKey() {
+    return processDefinitionKey;
+  }
+
+  public void setProcessDefinitionKey(final long processDefinitionKey) {
+    this.processDefinitionKey = processDefinitionKey;
+  }
+
+  @Override
+  public int getProcessDefinitionVersion() {
+    return processDefinitionVersion;
+  }
+
+  public void setProcessDefinitionVersion(final int processDefinitionVersion) {
+    this.processDefinitionVersion = processDefinitionVersion;
+  }
+
+  @Override
+  public String getVersionTag() {
+    return null;
+  }
+
+  @Override
+  public String getTenantId() {
+    return StringUtils.isEmpty(tenantId) ? ZEEBE_DEFAULT_TENANT_ID : tenantId;
+  }
+
+  public void setTenantId(final String tenantId) {
+    this.tenantId = tenantId;
+  }
+
+  @Override
+  public AgentInstanceStatus getStatus() {
+    return status;
+  }
+
+  public void setStatus(final AgentInstanceStatus status) {
+    this.status = status;
+  }
+
+  @Override
+  public AgentDefinitionValueDto getDefinition() {
+    return definition;
+  }
+
+  public void setDefinition(final AgentDefinitionValueDto definition) {
+    this.definition = definition;
+  }
+
+  @Override
+  public AgentInstanceLimitsValue getLimits() {
+    return null;
+  }
+
+  @Override
+  public AgentMetricsValueDto getMetrics() {
+    return metrics;
+  }
+
+  public void setMetrics(final AgentMetricsValueDto metrics) {
+    this.metrics = metrics;
+  }
+
+  @Override
+  public List<AgentInstanceToolValue> getTools() {
+    return new ArrayList<>(tools);
+  }
+
+  public void setTools(final List<AgentToolValueDto> tools) {
+    this.tools = tools;
+  }
+
+  @Override
+  public List<String> getChangedAttributes() {
+    return List.of();
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ZeebeAgentInstanceDataDto that = (ZeebeAgentInstanceDataDto) o;
+    return agentInstanceKey == that.agentInstanceKey
+        && elementInstanceKey == that.elementInstanceKey
+        && processInstanceKey == that.processInstanceKey
+        && processDefinitionKey == that.processDefinitionKey
+        && processDefinitionVersion == that.processDefinitionVersion
+        && Objects.equals(elementId, that.elementId)
+        && Objects.equals(bpmnProcessId, that.bpmnProcessId)
+        && Objects.equals(tenantId, that.tenantId)
+        && Objects.equals(status, that.status)
+        && Objects.equals(definition, that.definition)
+        && Objects.equals(metrics, that.metrics)
+        && Objects.equals(tools, that.tools);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        agentInstanceKey,
+        elementInstanceKey,
+        elementId,
+        processInstanceKey,
+        bpmnProcessId,
+        processDefinitionKey,
+        processDefinitionVersion,
+        tenantId,
+        status,
+        definition,
+        metrics,
+        tools);
+  }
+
+  @Override
+  public String toString() {
+    return "ZeebeAgentInstanceDataDto(agentInstanceKey="
+        + agentInstanceKey
+        + ", elementId="
+        + elementId
+        + ", processInstanceKey="
+        + processInstanceKey
+        + ", bpmnProcessId="
+        + bpmnProcessId
+        + ", processDefinitionKey="
+        + processDefinitionKey
+        + ", processDefinitionVersion="
+        + processDefinitionVersion
+        + ", tenantId="
+        + tenantId
+        + ", status="
+        + status
+        + ", definition="
+        + definition
+        + ", metrics="
+        + metrics
+        + ", tools="
+        + tools
+        + ")";
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
+  public static final class Fields {
+
+    public static final String agentInstanceKey = "agentInstanceKey";
+    public static final String elementInstanceKey = "elementInstanceKey";
+    public static final String elementId = "elementId";
+    public static final String processInstanceKey = "processInstanceKey";
+    public static final String bpmnProcessId = "bpmnProcessId";
+    public static final String processDefinitionKey = "processDefinitionKey";
+    public static final String processDefinitionVersion = "processDefinitionVersion";
+    public static final String tenantId = "tenantId";
+    public static final String status = "status";
+    public static final String definition = "definition";
+    public static final String metrics = "metrics";
+    public static final String tools = "tools";
+  }
+
+  public static class AgentDefinitionValueDto implements AgentInstanceDefinitionValue {
+
+    private String model = "";
+    private String provider = "";
+    private String systemPrompt = "";
+
+    public AgentDefinitionValueDto() {}
+
+    @Override
+    public String getModel() {
+      return model;
+    }
+
+    public void setModel(final String model) {
+      this.model = model;
+    }
+
+    @Override
+    public String getProvider() {
+      return provider;
+    }
+
+    public void setProvider(final String provider) {
+      this.provider = provider;
+    }
+
+    @Override
+    public String getSystemPrompt() {
+      return systemPrompt;
+    }
+
+    public void setSystemPrompt(final String systemPrompt) {
+      this.systemPrompt = systemPrompt;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final AgentDefinitionValueDto that = (AgentDefinitionValueDto) o;
+      return Objects.equals(model, that.model)
+          && Objects.equals(provider, that.provider)
+          && Objects.equals(systemPrompt, that.systemPrompt);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(model, provider, systemPrompt);
+    }
+
+    @Override
+    public String toString() {
+      return "AgentDefinitionValueDto(model=" + model + ", provider=" + provider + ")";
+    }
+  }
+
+  public static class AgentMetricsValueDto implements AgentInstanceMetricsValue {
+
+    private long inputTokens;
+    private long outputTokens;
+    private int modelCalls;
+    private int toolCalls;
+
+    public AgentMetricsValueDto() {}
+
+    @Override
+    public long getInputTokens() {
+      return inputTokens;
+    }
+
+    public void setInputTokens(final long inputTokens) {
+      this.inputTokens = inputTokens;
+    }
+
+    @Override
+    public long getOutputTokens() {
+      return outputTokens;
+    }
+
+    public void setOutputTokens(final long outputTokens) {
+      this.outputTokens = outputTokens;
+    }
+
+    @Override
+    public int getModelCalls() {
+      return modelCalls;
+    }
+
+    public void setModelCalls(final int modelCalls) {
+      this.modelCalls = modelCalls;
+    }
+
+    @Override
+    public int getToolCalls() {
+      return toolCalls;
+    }
+
+    public void setToolCalls(final int toolCalls) {
+      this.toolCalls = toolCalls;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final AgentMetricsValueDto that = (AgentMetricsValueDto) o;
+      return inputTokens == that.inputTokens
+          && outputTokens == that.outputTokens
+          && modelCalls == that.modelCalls
+          && toolCalls == that.toolCalls;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(inputTokens, outputTokens, modelCalls, toolCalls);
+    }
+
+    @Override
+    public String toString() {
+      return "AgentMetricsValueDto(inputTokens="
+          + inputTokens
+          + ", outputTokens="
+          + outputTokens
+          + ", modelCalls="
+          + modelCalls
+          + ", toolCalls="
+          + toolCalls
+          + ")";
+    }
+  }
+
+  public static class AgentToolValueDto implements AgentInstanceToolValue {
+
+    private String name;
+    private String description;
+    private String elementId;
+
+    public AgentToolValueDto() {}
+
+    @Override
+    public String getName() {
+      return name;
+    }
+
+    public void setName(final String name) {
+      this.name = name;
+    }
+
+    @Override
+    public String getDescription() {
+      return description;
+    }
+
+    public void setDescription(final String description) {
+      this.description = description;
+    }
+
+    @Override
+    public String getElementId() {
+      return elementId;
+    }
+
+    public void setElementId(final String elementId) {
+      this.elementId = elementId;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final AgentToolValueDto that = (AgentToolValueDto) o;
+      return Objects.equals(name, that.name)
+          && Objects.equals(description, that.description)
+          && Objects.equals(elementId, that.elementId);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(name, description, elementId);
+    }
+
+    @Override
+    public String toString() {
+      return "AgentToolValueDto(name=" + name + ", description=" + description + ")";
+    }
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/agentinstance/ZeebeAgentInstanceRecordDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/agentinstance/ZeebeAgentInstanceRecordDto.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.dto.zeebe.agentinstance;
+
+import io.camunda.optimize.dto.zeebe.ZeebeRecordDto;
+import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
+import java.util.Objects;
+
+public class ZeebeAgentInstanceRecordDto
+    extends ZeebeRecordDto<ZeebeAgentInstanceDataDto, AgentInstanceIntent> {
+
+  @Override
+  protected boolean canEqual(final Object other) {
+    return other instanceof ZeebeAgentInstanceRecordDto;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getClass(), super.hashCode());
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    return super.equals(o);
+  }
+}

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/ProcessInstanceDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/ProcessInstanceDto.java
@@ -12,6 +12,7 @@ import static io.camunda.optimize.service.util.importing.ZeebeConstants.FLOW_NOD
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.optimize.dto.optimize.datasource.DataSourceDto;
 import io.camunda.optimize.dto.optimize.persistence.incident.IncidentDto;
+import io.camunda.optimize.dto.optimize.query.process.AgentInstanceDto;
 import io.camunda.optimize.dto.optimize.query.process.FlowNodeInstanceDto;
 import io.camunda.optimize.dto.optimize.query.variable.SimpleProcessVariableDto;
 import java.time.OffsetDateTime;
@@ -60,6 +61,12 @@ public class ProcessInstanceDto implements OptimizeDto {
   private List<FlowNodeInstanceDto> flowNodeInstances = new ArrayList<>();
   private List<SimpleProcessVariableDto> variables = new ArrayList<>();
   private List<IncidentDto> incidents = new ArrayList<>();
+  private List<AgentInstanceDto> agentInstances = new ArrayList<>();
+  private Long agentTotalInputTokens;
+  private Long agentTotalOutputTokens;
+  private Long agentTotalModelCalls;
+  private Long agentTotalToolCalls;
+  private Long agentTotalTokens;
   private DataSourceDto dataSource;
   private String tenantId;
 
@@ -121,6 +128,16 @@ public class ProcessInstanceDto implements OptimizeDto {
     } else {
       incidents = defaultIncidents();
     }
+    if (b.agentInstancesSet) {
+      agentInstances = b.agentInstancesValue;
+    } else {
+      agentInstances = defaultAgentInstances();
+    }
+    agentTotalInputTokens = b.agentTotalInputTokens;
+    agentTotalOutputTokens = b.agentTotalOutputTokens;
+    agentTotalModelCalls = b.agentTotalModelCalls;
+    agentTotalToolCalls = b.agentTotalToolCalls;
+    agentTotalTokens = b.agentTotalTokens;
     dataSource = b.dataSource;
     tenantId = b.tenantId;
   }
@@ -228,6 +245,54 @@ public class ProcessInstanceDto implements OptimizeDto {
     this.incidents = incidents;
   }
 
+  public List<AgentInstanceDto> getAgentInstances() {
+    return agentInstances;
+  }
+
+  public void setAgentInstances(final List<AgentInstanceDto> agentInstances) {
+    this.agentInstances = agentInstances;
+  }
+
+  public Long getAgentTotalInputTokens() {
+    return agentTotalInputTokens;
+  }
+
+  public void setAgentTotalInputTokens(final Long agentTotalInputTokens) {
+    this.agentTotalInputTokens = agentTotalInputTokens;
+  }
+
+  public Long getAgentTotalOutputTokens() {
+    return agentTotalOutputTokens;
+  }
+
+  public void setAgentTotalOutputTokens(final Long agentTotalOutputTokens) {
+    this.agentTotalOutputTokens = agentTotalOutputTokens;
+  }
+
+  public Long getAgentTotalModelCalls() {
+    return agentTotalModelCalls;
+  }
+
+  public void setAgentTotalModelCalls(final Long agentTotalModelCalls) {
+    this.agentTotalModelCalls = agentTotalModelCalls;
+  }
+
+  public Long getAgentTotalToolCalls() {
+    return agentTotalToolCalls;
+  }
+
+  public void setAgentTotalToolCalls(final Long agentTotalToolCalls) {
+    this.agentTotalToolCalls = agentTotalToolCalls;
+  }
+
+  public Long getAgentTotalTokens() {
+    return agentTotalTokens;
+  }
+
+  public void setAgentTotalTokens(final Long agentTotalTokens) {
+    this.agentTotalTokens = agentTotalTokens;
+  }
+
   public DataSourceDto getDataSource() {
     return dataSource;
   }
@@ -263,6 +328,12 @@ public class ProcessInstanceDto implements OptimizeDto {
         flowNodeInstances,
         variables,
         incidents,
+        agentInstances,
+        agentTotalInputTokens,
+        agentTotalOutputTokens,
+        agentTotalModelCalls,
+        agentTotalToolCalls,
+        agentTotalTokens,
         dataSource,
         tenantId);
   }
@@ -288,6 +359,12 @@ public class ProcessInstanceDto implements OptimizeDto {
         && Objects.equals(flowNodeInstances, that.flowNodeInstances)
         && Objects.equals(variables, that.variables)
         && Objects.equals(incidents, that.incidents)
+        && Objects.equals(agentInstances, that.agentInstances)
+        && Objects.equals(agentTotalInputTokens, that.agentTotalInputTokens)
+        && Objects.equals(agentTotalOutputTokens, that.agentTotalOutputTokens)
+        && Objects.equals(agentTotalModelCalls, that.agentTotalModelCalls)
+        && Objects.equals(agentTotalToolCalls, that.agentTotalToolCalls)
+        && Objects.equals(agentTotalTokens, that.agentTotalTokens)
         && Objects.equals(dataSource, that.dataSource)
         && Objects.equals(tenantId, that.tenantId);
   }
@@ -318,6 +395,18 @@ public class ProcessInstanceDto implements OptimizeDto {
         + getVariables()
         + ", incidents="
         + getIncidents()
+        + ", agentInstances="
+        + getAgentInstances()
+        + ", agentTotalInputTokens="
+        + getAgentTotalInputTokens()
+        + ", agentTotalOutputTokens="
+        + getAgentTotalOutputTokens()
+        + ", agentTotalModelCalls="
+        + getAgentTotalModelCalls()
+        + ", agentTotalToolCalls="
+        + getAgentTotalToolCalls()
+        + ", agentTotalTokens="
+        + getAgentTotalTokens()
         + ", dataSource="
         + getDataSource()
         + ", tenantId="
@@ -334,6 +423,10 @@ public class ProcessInstanceDto implements OptimizeDto {
   }
 
   private static List<IncidentDto> defaultIncidents() {
+    return new ArrayList<>();
+  }
+
+  private static List<AgentInstanceDto> defaultAgentInstances() {
     return new ArrayList<>();
   }
 
@@ -356,6 +449,12 @@ public class ProcessInstanceDto implements OptimizeDto {
     public static final String flowNodeInstances = "flowNodeInstances";
     public static final String variables = "variables";
     public static final String incidents = "incidents";
+    public static final String agentInstances = "agentInstances";
+    public static final String agentTotalInputTokens = "agentTotalInputTokens";
+    public static final String agentTotalOutputTokens = "agentTotalOutputTokens";
+    public static final String agentTotalModelCalls = "agentTotalModelCalls";
+    public static final String agentTotalToolCalls = "agentTotalToolCalls";
+    public static final String agentTotalTokens = "agentTotalTokens";
     public static final String dataSource = "dataSource";
     public static final String tenantId = "tenantId";
   }
@@ -378,6 +477,13 @@ public class ProcessInstanceDto implements OptimizeDto {
     private boolean variablesSet;
     private List<IncidentDto> incidentsValue;
     private boolean incidentsSet;
+    private List<AgentInstanceDto> agentInstancesValue;
+    private boolean agentInstancesSet;
+    private Long agentTotalInputTokens;
+    private Long agentTotalOutputTokens;
+    private Long agentTotalModelCalls;
+    private Long agentTotalToolCalls;
+    private Long agentTotalTokens;
     private DataSourceDto dataSource;
     private String tenantId;
 
@@ -441,6 +547,37 @@ public class ProcessInstanceDto implements OptimizeDto {
     public B incidents(final List<IncidentDto> incidents) {
       incidentsValue = incidents;
       incidentsSet = true;
+      return self();
+    }
+
+    public B agentInstances(final List<AgentInstanceDto> agentInstances) {
+      agentInstancesValue = agentInstances;
+      agentInstancesSet = true;
+      return self();
+    }
+
+    public B agentTotalInputTokens(final Long agentTotalInputTokens) {
+      this.agentTotalInputTokens = agentTotalInputTokens;
+      return self();
+    }
+
+    public B agentTotalOutputTokens(final Long agentTotalOutputTokens) {
+      this.agentTotalOutputTokens = agentTotalOutputTokens;
+      return self();
+    }
+
+    public B agentTotalModelCalls(final Long agentTotalModelCalls) {
+      this.agentTotalModelCalls = agentTotalModelCalls;
+      return self();
+    }
+
+    public B agentTotalToolCalls(final Long agentTotalToolCalls) {
+      this.agentTotalToolCalls = agentTotalToolCalls;
+      return self();
+    }
+
+    public B agentTotalTokens(final Long agentTotalTokens) {
+      this.agentTotalTokens = agentTotalTokens;
       return self();
     }
 

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/process/AgentInstanceDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/process/AgentInstanceDto.java
@@ -1,0 +1,383 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.dto.optimize.query.process;
+
+import io.camunda.optimize.dto.optimize.OptimizeDto;
+import java.io.Serializable;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class AgentInstanceDto implements Serializable, OptimizeDto {
+
+  private String agentInstanceId;
+  private String flowNodeId;
+  private String flowNodeInstanceId;
+  private String status;
+  private OffsetDateTime startDate;
+  private OffsetDateTime endDate;
+  private OffsetDateTime lastUpdatedDate;
+  private Long totalDurationInMs;
+  private List<String> flowNodeInstanceIds = new ArrayList<>();
+  private AgentDefinitionDto definition = new AgentDefinitionDto();
+  private AgentMetricsDto metrics = new AgentMetricsDto();
+  private List<AgentToolDto> tools = new ArrayList<>();
+
+  public AgentInstanceDto() {}
+
+  public String getAgentInstanceId() {
+    return agentInstanceId;
+  }
+
+  public void setAgentInstanceId(final String agentInstanceId) {
+    this.agentInstanceId = agentInstanceId;
+  }
+
+  public String getFlowNodeId() {
+    return flowNodeId;
+  }
+
+  public void setFlowNodeId(final String flowNodeId) {
+    this.flowNodeId = flowNodeId;
+  }
+
+  public String getFlowNodeInstanceId() {
+    return flowNodeInstanceId;
+  }
+
+  public void setFlowNodeInstanceId(final String flowNodeInstanceId) {
+    this.flowNodeInstanceId = flowNodeInstanceId;
+  }
+
+  public String getStatus() {
+    return status;
+  }
+
+  public void setStatus(final String status) {
+    this.status = status;
+  }
+
+  public OffsetDateTime getStartDate() {
+    return startDate;
+  }
+
+  public void setStartDate(final OffsetDateTime startDate) {
+    this.startDate = startDate;
+  }
+
+  public OffsetDateTime getEndDate() {
+    return endDate;
+  }
+
+  public void setEndDate(final OffsetDateTime endDate) {
+    this.endDate = endDate;
+  }
+
+  public OffsetDateTime getLastUpdatedDate() {
+    return lastUpdatedDate;
+  }
+
+  public void setLastUpdatedDate(final OffsetDateTime lastUpdatedDate) {
+    this.lastUpdatedDate = lastUpdatedDate;
+  }
+
+  public Long getTotalDurationInMs() {
+    return totalDurationInMs;
+  }
+
+  public void setTotalDurationInMs(final Long totalDurationInMs) {
+    this.totalDurationInMs = totalDurationInMs;
+  }
+
+  public List<String> getFlowNodeInstanceIds() {
+    return flowNodeInstanceIds;
+  }
+
+  public void setFlowNodeInstanceIds(final List<String> flowNodeInstanceIds) {
+    this.flowNodeInstanceIds = flowNodeInstanceIds;
+  }
+
+  public AgentDefinitionDto getDefinition() {
+    return definition;
+  }
+
+  public void setDefinition(final AgentDefinitionDto definition) {
+    this.definition = definition;
+  }
+
+  public AgentMetricsDto getMetrics() {
+    return metrics;
+  }
+
+  public void setMetrics(final AgentMetricsDto metrics) {
+    this.metrics = metrics;
+  }
+
+  public List<AgentToolDto> getTools() {
+    return tools;
+  }
+
+  public void setTools(final List<AgentToolDto> tools) {
+    this.tools = tools;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final AgentInstanceDto that = (AgentInstanceDto) o;
+    return Objects.equals(agentInstanceId, that.agentInstanceId)
+        && Objects.equals(flowNodeId, that.flowNodeId)
+        && Objects.equals(flowNodeInstanceId, that.flowNodeInstanceId)
+        && Objects.equals(flowNodeInstanceIds, that.flowNodeInstanceIds)
+        && Objects.equals(status, that.status)
+        && Objects.equals(startDate, that.startDate)
+        && Objects.equals(endDate, that.endDate)
+        && Objects.equals(lastUpdatedDate, that.lastUpdatedDate)
+        && Objects.equals(totalDurationInMs, that.totalDurationInMs)
+        && Objects.equals(definition, that.definition)
+        && Objects.equals(metrics, that.metrics)
+        && Objects.equals(tools, that.tools);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        agentInstanceId,
+        flowNodeId,
+        flowNodeInstanceId,
+        status,
+        startDate,
+        endDate,
+        lastUpdatedDate,
+        totalDurationInMs,
+        flowNodeInstanceIds,
+        definition,
+        metrics,
+        tools);
+  }
+
+  @Override
+  public String toString() {
+    return "AgentInstanceDto(agentInstanceId="
+        + agentInstanceId
+        + ", flowNodeId="
+        + flowNodeId
+        + ", flowNodeInstanceId="
+        + flowNodeInstanceId
+        + ", status="
+        + status
+        + ", startDate="
+        + startDate
+        + ", endDate="
+        + endDate
+        + ", lastUpdatedDate="
+        + lastUpdatedDate
+        + ", totalDurationInMs="
+        + totalDurationInMs
+        + ", flowNodeInstanceIds="
+        + flowNodeInstanceIds
+        + ", definition="
+        + definition
+        + ", metrics="
+        + metrics
+        + ", tools="
+        + tools
+        + ")";
+  }
+
+  @SuppressWarnings("checkstyle:ConstantName")
+  public static final class Fields {
+
+    public static final String agentInstanceId = "agentInstanceId";
+    public static final String flowNodeId = "flowNodeId";
+    public static final String flowNodeInstanceId = "flowNodeInstanceId";
+    public static final String status = "status";
+    public static final String startDate = "startDate";
+    public static final String endDate = "endDate";
+    public static final String lastUpdatedDate = "lastUpdatedDate";
+    public static final String totalDurationInMs = "totalDurationInMs";
+    public static final String flowNodeInstanceIds = "flowNodeInstanceIds";
+    public static final String definition = "definition";
+    public static final String metrics = "metrics";
+    public static final String tools = "tools";
+  }
+
+  public static class AgentMetricsDto implements Serializable {
+
+    private long inputTokens;
+    private long outputTokens;
+    private long modelCalls;
+    private long toolCalls;
+
+    public AgentMetricsDto() {}
+
+    public long getInputTokens() {
+      return inputTokens;
+    }
+
+    public void setInputTokens(final long inputTokens) {
+      this.inputTokens = inputTokens;
+    }
+
+    public long getOutputTokens() {
+      return outputTokens;
+    }
+
+    public void setOutputTokens(final long outputTokens) {
+      this.outputTokens = outputTokens;
+    }
+
+    public long getModelCalls() {
+      return modelCalls;
+    }
+
+    public void setModelCalls(final long modelCalls) {
+      this.modelCalls = modelCalls;
+    }
+
+    public long getToolCalls() {
+      return toolCalls;
+    }
+
+    public void setToolCalls(final long toolCalls) {
+      this.toolCalls = toolCalls;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final AgentMetricsDto that = (AgentMetricsDto) o;
+      return inputTokens == that.inputTokens
+          && outputTokens == that.outputTokens
+          && modelCalls == that.modelCalls
+          && toolCalls == that.toolCalls;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(inputTokens, outputTokens, modelCalls, toolCalls);
+    }
+
+    @Override
+    public String toString() {
+      return "AgentMetricsDto(inputTokens="
+          + inputTokens
+          + ", outputTokens="
+          + outputTokens
+          + ", modelCalls="
+          + modelCalls
+          + ", toolCalls="
+          + toolCalls
+          + ")";
+    }
+
+    @SuppressWarnings("checkstyle:ConstantName")
+    public static final class Fields {
+
+      public static final String inputTokens = "inputTokens";
+      public static final String outputTokens = "outputTokens";
+      public static final String modelCalls = "modelCalls";
+      public static final String toolCalls = "toolCalls";
+    }
+  }
+
+  public static class AgentToolDto implements Serializable {
+
+    private String name;
+
+    public AgentToolDto() {}
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(final String name) {
+      this.name = name;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final AgentToolDto that = (AgentToolDto) o;
+      return Objects.equals(name, that.name);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(name);
+    }
+
+    @Override
+    public String toString() {
+      return "AgentToolDto(name=" + name + ")";
+    }
+
+    @SuppressWarnings("checkstyle:ConstantName")
+    public static final class Fields {
+
+      public static final String name = "name";
+    }
+  }
+
+  public static class AgentDefinitionDto implements Serializable {
+
+    private String model;
+    private String provider;
+
+    public AgentDefinitionDto() {}
+
+    public String getModel() {
+      return model;
+    }
+
+    public void setModel(final String model) {
+      this.model = model;
+    }
+
+    public String getProvider() {
+      return provider;
+    }
+
+    public void setProvider(final String provider) {
+      this.provider = provider;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final AgentDefinitionDto that = (AgentDefinitionDto) o;
+      return Objects.equals(model, that.model) && Objects.equals(provider, that.provider);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(model, provider);
+    }
+
+    @Override
+    public String toString() {
+      return "AgentDefinitionDto(model=" + model + ", provider=" + provider + ")";
+    }
+
+    @SuppressWarnings("checkstyle:ConstantName")
+    public static final class Fields {
+
+      public static final String model = "model";
+      public static final String provider = "provider";
+    }
+  }
+}

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/DatabaseConstants.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/DatabaseConstants.java
@@ -55,6 +55,7 @@ public final class DatabaseConstants {
   public static final String ZEEBE_VARIABLE_INDEX_NAME = "variable";
   public static final String ZEEBE_INCIDENT_INDEX_NAME = "incident";
   public static final String ZEEBE_USER_TASK_INDEX_NAME = "user-task";
+  public static final String ZEEBE_AGENT_INSTANCE_INDEX_NAME = "agent-instance";
   public static final String VARIABLE_UPDATE_INSTANCE_INDEX_NAME = "variable-update-instance";
   public static final String BUSINESS_KEY_INDEX_NAME = "business-key";
   public static final String SETTINGS_INDEX_NAME = "settings";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/ProcessInstanceIndex.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/ProcessInstanceIndex.java
@@ -17,13 +17,14 @@ import io.camunda.optimize.dto.optimize.ProcessInstanceDto;
 import io.camunda.optimize.dto.optimize.persistence.AssigneeOperationDto;
 import io.camunda.optimize.dto.optimize.persistence.CandidateGroupOperationDto;
 import io.camunda.optimize.dto.optimize.persistence.incident.IncidentDto;
+import io.camunda.optimize.dto.optimize.query.process.AgentInstanceDto;
 import io.camunda.optimize.dto.optimize.query.process.FlowNodeInstanceDto;
 import io.camunda.optimize.dto.optimize.query.variable.SimpleProcessVariableDto;
 import java.util.Locale;
 
 public abstract class ProcessInstanceIndex<TBuilder> extends AbstractInstanceIndex<TBuilder> {
 
-  public static final int VERSION = 8;
+  public static final int VERSION = 9;
 
   public static final String START_DATE = ProcessInstanceDto.Fields.startDate;
   public static final String END_DATE = ProcessInstanceDto.Fields.endDate;
@@ -84,6 +85,50 @@ public abstract class ProcessInstanceIndex<TBuilder> extends AbstractInstanceInd
       CandidateGroupOperationDto.Fields.operationType;
   public static final String CANDIDATE_GROUP_OPERATION_TIMESTAMP =
       CandidateGroupOperationDto.Fields.timestamp;
+
+  // Agent Instance Fields
+  public static final String AGENT_INSTANCES = ProcessInstanceDto.Fields.agentInstances;
+  public static final String AGENT_TOTAL_INPUT_TOKENS =
+      ProcessInstanceDto.Fields.agentTotalInputTokens;
+  public static final String AGENT_TOTAL_OUTPUT_TOKENS =
+      ProcessInstanceDto.Fields.agentTotalOutputTokens;
+  public static final String AGENT_TOTAL_MODEL_CALLS =
+      ProcessInstanceDto.Fields.agentTotalModelCalls;
+  public static final String AGENT_TOTAL_TOOL_CALLS = ProcessInstanceDto.Fields.agentTotalToolCalls;
+  public static final String AGENT_TOTAL_TOKENS = ProcessInstanceDto.Fields.agentTotalTokens;
+
+  public static final String AGENT_INSTANCE_ID = AgentInstanceDto.Fields.agentInstanceId;
+  public static final String AGENT_INSTANCE_FLOW_NODE_ID = AgentInstanceDto.Fields.flowNodeId;
+  public static final String AGENT_INSTANCE_FLOW_NODE_INSTANCE_ID =
+      AgentInstanceDto.Fields.flowNodeInstanceId;
+  public static final String AGENT_INSTANCE_STATUS = AgentInstanceDto.Fields.status;
+  public static final String AGENT_INSTANCE_START_DATE = AgentInstanceDto.Fields.startDate;
+  public static final String AGENT_INSTANCE_END_DATE = AgentInstanceDto.Fields.endDate;
+  public static final String AGENT_INSTANCE_LAST_UPDATED_DATE =
+      AgentInstanceDto.Fields.lastUpdatedDate;
+  public static final String AGENT_INSTANCE_TOTAL_DURATION =
+      AgentInstanceDto.Fields.totalDurationInMs;
+  public static final String AGENT_INSTANCE_FLOW_NODE_INSTANCE_IDS =
+      AgentInstanceDto.Fields.flowNodeInstanceIds;
+  public static final String AGENT_INSTANCE_DEFINITION = AgentInstanceDto.Fields.definition;
+  public static final String AGENT_INSTANCE_DEFINITION_MODEL =
+      AgentInstanceDto.Fields.definition + "." + AgentInstanceDto.AgentDefinitionDto.Fields.model;
+  public static final String AGENT_INSTANCE_DEFINITION_PROVIDER =
+      AgentInstanceDto.Fields.definition
+          + "."
+          + AgentInstanceDto.AgentDefinitionDto.Fields.provider;
+  public static final String AGENT_INSTANCE_METRICS = AgentInstanceDto.Fields.metrics;
+  public static final String AGENT_INSTANCE_METRICS_INPUT_TOKENS =
+      AgentInstanceDto.Fields.metrics + "." + AgentInstanceDto.AgentMetricsDto.Fields.inputTokens;
+  public static final String AGENT_INSTANCE_METRICS_OUTPUT_TOKENS =
+      AgentInstanceDto.Fields.metrics + "." + AgentInstanceDto.AgentMetricsDto.Fields.outputTokens;
+  public static final String AGENT_INSTANCE_METRICS_MODEL_CALLS =
+      AgentInstanceDto.Fields.metrics + "." + AgentInstanceDto.AgentMetricsDto.Fields.modelCalls;
+  public static final String AGENT_INSTANCE_METRICS_TOOL_CALLS =
+      AgentInstanceDto.Fields.metrics + "." + AgentInstanceDto.AgentMetricsDto.Fields.toolCalls;
+  public static final String AGENT_INSTANCE_TOOLS = AgentInstanceDto.Fields.tools;
+  public static final String AGENT_INSTANCE_TOOL_NAME =
+      AgentInstanceDto.Fields.tools + "." + AgentInstanceDto.AgentToolDto.Fields.name;
 
   // Variable Fields
   public static final String VARIABLES = ProcessInstanceDto.Fields.variables;
@@ -267,7 +312,76 @@ public abstract class ProcessInstanceIndex<TBuilder> extends AbstractInstanceInd
                             .properties(INCIDENT_STATUS, np -> np.keyword(k -> k))
                             .properties(INCIDENT_DEFINITION_KEY, np -> np.keyword(k -> k))
                             .properties(INCIDENT_DEFINITION_VERSION, np -> np.keyword(k -> k))
-                            .properties(INCIDENT_TENANT_ID, np -> np.keyword(k -> k))));
+                            .properties(INCIDENT_TENANT_ID, np -> np.keyword(k -> k))))
+        .properties(AGENT_TOTAL_INPUT_TOKENS, p -> p.long_(k -> k.nullValue(0L)))
+        .properties(AGENT_TOTAL_OUTPUT_TOKENS, p -> p.long_(k -> k.nullValue(0L)))
+        .properties(AGENT_TOTAL_MODEL_CALLS, p -> p.long_(k -> k.nullValue(0L)))
+        .properties(AGENT_TOTAL_TOOL_CALLS, p -> p.long_(k -> k.nullValue(0L)))
+        .properties(AGENT_TOTAL_TOKENS, p -> p.long_(k -> k.nullValue(0L)))
+        .properties(
+            AGENT_INSTANCES,
+            p ->
+                p.nested(
+                    k ->
+                        k.properties(AGENT_INSTANCE_ID, pp -> pp.keyword(kk -> kk))
+                            .properties(AGENT_INSTANCE_FLOW_NODE_ID, pp -> pp.keyword(kk -> kk))
+                            .properties(
+                                AGENT_INSTANCE_FLOW_NODE_INSTANCE_ID, pp -> pp.keyword(kk -> kk))
+                            .properties(
+                                AGENT_INSTANCE_FLOW_NODE_INSTANCE_IDS, pp -> pp.keyword(kk -> kk))
+                            .properties(AGENT_INSTANCE_STATUS, pp -> pp.keyword(kk -> kk))
+                            .properties(
+                                AGENT_INSTANCE_START_DATE,
+                                pp -> pp.date(kk -> kk.format(OPTIMIZE_DATE_FORMAT)))
+                            .properties(
+                                AGENT_INSTANCE_END_DATE,
+                                pp -> pp.date(kk -> kk.format(OPTIMIZE_DATE_FORMAT)))
+                            .properties(
+                                AGENT_INSTANCE_LAST_UPDATED_DATE,
+                                pp -> pp.date(kk -> kk.format(OPTIMIZE_DATE_FORMAT)))
+                            .properties(AGENT_INSTANCE_TOTAL_DURATION, pp -> pp.long_(kk -> kk))
+                            .properties(
+                                AGENT_INSTANCE_DEFINITION,
+                                pp ->
+                                    pp.object(
+                                        kk ->
+                                            kk.properties(
+                                                    AgentInstanceDto.AgentDefinitionDto.Fields
+                                                        .model,
+                                                    p2 -> p2.keyword(k2 -> k2))
+                                                .properties(
+                                                    AgentInstanceDto.AgentDefinitionDto.Fields
+                                                        .provider,
+                                                    p2 -> p2.keyword(k2 -> k2))))
+                            .properties(
+                                AGENT_INSTANCE_METRICS,
+                                pp ->
+                                    pp.object(
+                                        kk ->
+                                            kk.properties(
+                                                    AgentInstanceDto.AgentMetricsDto.Fields
+                                                        .inputTokens,
+                                                    p2 -> p2.long_(k2 -> k2))
+                                                .properties(
+                                                    AgentInstanceDto.AgentMetricsDto.Fields
+                                                        .outputTokens,
+                                                    p2 -> p2.long_(k2 -> k2))
+                                                .properties(
+                                                    AgentInstanceDto.AgentMetricsDto.Fields
+                                                        .modelCalls,
+                                                    p2 -> p2.long_(k2 -> k2))
+                                                .properties(
+                                                    AgentInstanceDto.AgentMetricsDto.Fields
+                                                        .toolCalls,
+                                                    p2 -> p2.long_(k2 -> k2))))
+                            .properties(
+                                AGENT_INSTANCE_TOOLS,
+                                pp ->
+                                    pp.nested(
+                                        kk ->
+                                            kk.properties(
+                                                AgentInstanceDto.AgentToolDto.Fields.name,
+                                                p2 -> p2.keyword(k2 -> k2))))));
   }
 
   protected String getIndexPrefix() {

--- a/optimize/util/optimize-commons/src/test/java/io/camunda/optimize/service/db/schema/index/ProcessInstanceIndexMappingTest.java
+++ b/optimize/util/optimize-commons/src/test/java/io/camunda/optimize/service/db/schema/index/ProcessInstanceIndexMappingTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.schema.index;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import co.elastic.clients.elasticsearch._types.mapping.Property;
+import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
+import io.camunda.optimize.service.db.es.schema.index.ProcessInstanceIndexES;
+import org.junit.jupiter.api.Test;
+
+class ProcessInstanceIndexMappingTest {
+
+  @Test
+  void shouldMapAgentInstancesAsNested() {
+    // given
+    final ProcessInstanceIndexES index = new ProcessInstanceIndexES("test");
+
+    // when
+    final TypeMapping mapping = index.addProperties(new TypeMapping.Builder()).build();
+
+    // then
+    final Property agentInstancesProperty =
+        mapping.properties().get(ProcessInstanceIndex.AGENT_INSTANCES);
+    assertThat(agentInstancesProperty).isNotNull();
+    assertThat(agentInstancesProperty._kind())
+        .as("agentInstances must be nested, not object — wrong type silently breaks aggregations")
+        .isEqualTo(Property.Kind.Nested);
+  }
+
+  @Test
+  void shouldHaveVersionNine() {
+    assertThat(ProcessInstanceIndex.VERSION).isEqualTo(9);
+  }
+}


### PR DESCRIPTION
## Description

  Introduces the foundational data model and Elasticsearch schema for importing AI agent execution data from Zeebe into Optimize.

  Agent instances are stored as nested objects within ProcessInstance documents to enable analytics on agent performance, token usage, tool usage, and migration patterns.

  What's Changed

   - New DTOs: ZeebeAgentInstanceDataDto and ZeebeAgentInstanceRecordDto to deserialize AGENT_INSTANCE records from Zeebe. Uses concrete DTO types (AgentMetricsValueDto, AgentDefinitionValueDto,
  AgentToolValueDto) for Jackson deserialization.
   - Domain Model: AgentInstanceDto
   - ProcessInstance Extension:
     - Added agentInstances list (nested)
     - Added 5 aggregate fields: agentTotalInputTokens, agentTotalOutputTokens, agentTotalTokens, agentTotalModelCalls, agentTotalToolCalls
   - ES Mapping:
   - 24 nested fields for agent instance properties (identity, lifecycle, metrics, definition, tools, elementInstanceKeys)
   - Nested mapping for tools to support per-tool aggregations
   - 5 top-level aggregate fields in ProcessInstanceIndex
   - Tests: ProcessInstanceIndexMappingTest validates all new fields appear in ES mapping with correct types

closes https://github.com/camunda/camunda/issues/54067
