### PR TITLE
feat: return process name on deployment and create process instance from Java client

### DIFF
--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/processor/DeploymentAnnotationProcessorTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/processor/DeploymentAnnotationProcessorTest.java
@@ -313,6 +313,11 @@ public class DeploymentAnnotationProcessorTest {
       public String getTenantId() {
         return "TestTenantId";
       }
+
+      @Override
+      public String getProcessName() {
+        return "TestProcessName";
+      }
     };
   }
 

--- a/clients/java/src/main/java/io/camunda/client/api/response/Process.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/Process.java
@@ -40,4 +40,9 @@ public interface Process {
    * @return the tenant identifier that owns this process
    */
   String getTenantId();
+
+  /**
+   * @return the name of the process, or {@code null} if it is not defined in BPMN
+   */
+  String getProcessName();
 }

--- a/clients/java/src/main/java/io/camunda/client/api/response/ProcessInstanceEvent.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/ProcessInstanceEvent.java
@@ -43,4 +43,10 @@ public interface ProcessInstanceEvent {
    * @return the business id, or null if not set
    */
   String getBusinessId();
+
+  /**
+   * @return the name of the process which this instance was created for, as defined in the BPMN, or
+   *     an empty string if no name was defined.
+   */
+  String getProcessName();
 }

--- a/clients/java/src/main/java/io/camunda/client/api/response/ProcessInstanceResult.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/ProcessInstanceResult.java
@@ -78,4 +78,10 @@ public interface ProcessInstanceResult {
    * @return the business id, or null if not set
    */
   String getBusinessId();
+
+  /**
+   * @return the name of the process which this instance was created for, as defined in the BPMN, or
+   *     an empty string if no name was defined.
+   */
+  String getProcessName();
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/CreateProcessInstanceResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/CreateProcessInstanceResponseImpl.java
@@ -31,6 +31,7 @@ public final class CreateProcessInstanceResponseImpl implements ProcessInstanceE
   private final String tenantId;
   private final Set<String> tags;
   private final String businessId;
+  private final String processName;
 
   public CreateProcessInstanceResponseImpl(
       final GatewayOuterClass.CreateProcessInstanceResponse response) {
@@ -41,6 +42,7 @@ public final class CreateProcessInstanceResponseImpl implements ProcessInstanceE
     tenantId = response.getTenantId();
     tags = Collections.unmodifiableSet(new HashSet<>(response.getTagsList()));
     businessId = response.hasBusinessId() ? response.getBusinessId() : null;
+    processName = response.hasProcessName() ? response.getProcessName() : "";
   }
 
   public CreateProcessInstanceResponseImpl(final CreateProcessInstanceResult response) {
@@ -54,6 +56,7 @@ public final class CreateProcessInstanceResponseImpl implements ProcessInstanceE
             ? Collections.emptySet()
             : Collections.unmodifiableSet(response.getTags());
     businessId = response.getBusinessId();
+    processName = response.getProcessName() != null ? response.getProcessName() : "";
   }
 
   @Override
@@ -92,6 +95,11 @@ public final class CreateProcessInstanceResponseImpl implements ProcessInstanceE
   }
 
   @Override
+  public String getProcessName() {
+    return processName;
+  }
+
+  @Override
   public String toString() {
     return "CreateProcessInstanceResponseImpl{"
         + "processDefinitionKey="
@@ -108,6 +116,9 @@ public final class CreateProcessInstanceResponseImpl implements ProcessInstanceE
         + '\''
         + ", businessId='"
         + businessId
+        + '\''
+        + ", processName='"
+        + processName
         + '\''
         + '}';
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/CreateProcessInstanceWithResultResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/CreateProcessInstanceWithResultResponseImpl.java
@@ -38,6 +38,7 @@ public final class CreateProcessInstanceWithResultResponseImpl implements Proces
   private Map<String, Object> variablesAsMap;
   private final Set<String> tags;
   private final String businessId;
+  private final String processName;
 
   public CreateProcessInstanceWithResultResponseImpl(
       final JsonMapper jsonMapper, final CreateProcessInstanceResult response) {
@@ -50,6 +51,7 @@ public final class CreateProcessInstanceWithResultResponseImpl implements Proces
     variables = jsonMapper.toJson(response.getVariables());
     tags = response.getTags();
     businessId = response.getBusinessId();
+    processName = response.getProcessName() != null ? response.getProcessName() : "";
   }
 
   public CreateProcessInstanceWithResultResponseImpl(
@@ -63,6 +65,7 @@ public final class CreateProcessInstanceWithResultResponseImpl implements Proces
     tenantId = response.getTenantId();
     tags = Collections.unmodifiableSet(new HashSet<>(response.getTagsList()));
     businessId = response.hasBusinessId() ? response.getBusinessId() : null;
+    processName = response.hasProcessName() ? response.getProcessName() : "";
   }
 
   @Override
@@ -128,6 +131,11 @@ public final class CreateProcessInstanceWithResultResponseImpl implements Proces
   }
 
   @Override
+  public String getProcessName() {
+    return processName;
+  }
+
+  @Override
   public String toString() {
     return "CreateProcessInstanceWithResultResponseImpl{"
         + "processDefinitionKey="
@@ -150,6 +158,9 @@ public final class CreateProcessInstanceWithResultResponseImpl implements Proces
         + '\''
         + ", businessId='"
         + businessId
+        + '\''
+        + ", processName='"
+        + processName
         + '\''
         + '}';
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/DeploymentEventImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/DeploymentEventImpl.java
@@ -165,7 +165,8 @@ public final class DeploymentEventImpl implements DeploymentEvent {
                         p.getProcessDefinitionId(),
                         p.getProcessDefinitionVersion(),
                         p.getResourceName(),
-                        p.getTenantId())));
+                        p.getTenantId(),
+                        p.getProcessName())));
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/response/ProcessImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/ProcessImpl.java
@@ -26,6 +26,7 @@ public final class ProcessImpl implements Process {
   private final int version;
   private final String resourceName;
   private final String tenantId;
+  private final String processName;
 
   public ProcessImpl(final ProcessMetadata process) {
     this(
@@ -33,7 +34,8 @@ public final class ProcessImpl implements Process {
         process.getBpmnProcessId(),
         process.getVersion(),
         process.getResourceName(),
-        process.getTenantId());
+        process.getTenantId(),
+        process.hasProcessName() ? process.getProcessName() : null);
   }
 
   public ProcessImpl(
@@ -41,12 +43,14 @@ public final class ProcessImpl implements Process {
       final String bpmnProcessId,
       final int version,
       final String resourceName,
-      final String tenantId) {
+      final String tenantId,
+      final String processName) {
     this.processDefinitionKey = processDefinitionKey;
     this.bpmnProcessId = bpmnProcessId;
     this.version = version;
     this.resourceName = resourceName;
     this.tenantId = tenantId;
+    this.processName = processName;
   }
 
   @Override
@@ -75,8 +79,14 @@ public final class ProcessImpl implements Process {
   }
 
   @Override
+  public String getProcessName() {
+    return processName;
+  }
+
+  @Override
   public int hashCode() {
-    return Objects.hash(processDefinitionKey, bpmnProcessId, version, resourceName, tenantId);
+    return Objects.hash(
+        processDefinitionKey, bpmnProcessId, version, resourceName, tenantId, processName);
   }
 
   @Override
@@ -92,7 +102,8 @@ public final class ProcessImpl implements Process {
         && version == process.version
         && Objects.equals(bpmnProcessId, process.bpmnProcessId)
         && Objects.equals(resourceName, process.resourceName)
-        && Objects.equals(tenantId, process.tenantId);
+        && Objects.equals(tenantId, process.tenantId)
+        && Objects.equals(processName, process.processName);
   }
 
   @Override
@@ -110,6 +121,9 @@ public final class ProcessImpl implements Process {
         + '\''
         + ", tenantId='"
         + tenantId
+        + '\''
+        + ", processName='"
+        + processName
         + '\''
         + '}';
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/ProcessDefinitionImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/ProcessDefinitionImpl.java
@@ -89,6 +89,11 @@ public class ProcessDefinitionImpl implements ProcessDefinition, Process {
   }
 
   @Override
+  public String getProcessName() {
+    return name;
+  }
+
+  @Override
   public int hashCode() {
     return Objects.hash(
         processDefinitionKey,

--- a/clients/java/src/test/java/io/camunda/client/process/DeployProcessTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/DeployProcessTest.java
@@ -200,8 +200,9 @@ public final class DeployProcessTest extends ClientTest {
     final long key = 123L;
     final String testTenantId = "test-tenant";
     final String filename = DeployProcessTest.class.getResource(BPMN_1_FILENAME).getPath();
+    final String processName = "TestProcess";
     gatewayService.onDeployProcessRequest(
-        key, deployedProcess(BPMN_1_PROCESS_ID, 12, 423, filename, testTenantId));
+        key, deployedProcess(BPMN_1_PROCESS_ID, 12, 423, filename, testTenantId, processName));
 
     // when
     final DeploymentEvent response =
@@ -210,7 +211,8 @@ public final class DeployProcessTest extends ClientTest {
     // then
     assertThat(response.getKey()).isEqualTo(key);
     assertThat(response.getProcesses())
-        .containsExactly(new ProcessImpl(423, BPMN_1_PROCESS_ID, 12, filename, testTenantId));
+        .containsExactly(
+            new ProcessImpl(423, BPMN_1_PROCESS_ID, 12, filename, testTenantId, processName));
   }
 
   @Test
@@ -219,6 +221,8 @@ public final class DeployProcessTest extends ClientTest {
     final long key = 345L;
     final String filename1 = BPMN_1_FILENAME.substring(1);
     final String filename2 = BPMN_2_FILENAME.substring(1);
+    final String processName1 = null;
+    final String processName2 = null;
     gatewayService.onDeployProcessRequest(
         key,
         deployedProcess(BPMN_1_PROCESS_ID, 1, 1, filename1),
@@ -237,8 +241,10 @@ public final class DeployProcessTest extends ClientTest {
     assertThat(response.getKey()).isEqualTo(key);
     assertThat(response.getProcesses())
         .containsExactly(
-            new ProcessImpl(1, BPMN_1_PROCESS_ID, 1, filename1, DEFAULT_TENANT_IDENTIFIER),
-            new ProcessImpl(2, BPMN_2_PROCESS_ID, 1, filename2, DEFAULT_TENANT_IDENTIFIER));
+            new ProcessImpl(
+                1, BPMN_1_PROCESS_ID, 1, filename1, DEFAULT_TENANT_IDENTIFIER, processName1),
+            new ProcessImpl(
+                2, BPMN_2_PROCESS_ID, 1, filename2, DEFAULT_TENANT_IDENTIFIER, processName2));
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/client/resource/DeployResourceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/resource/DeployResourceTest.java
@@ -220,8 +220,11 @@ public final class DeployResourceTest extends ClientTest {
     final long key = 123L;
     final String tenantId = "test-tenant";
     final String filename = DeployResourceTest.class.getResource(BPMN_1_FILENAME).getPath();
+    final String processName = "TestProcess";
     gatewayService.onDeployResourceRequest(
-        key, tenantId, deployment(deployedProcess(BPMN_1_PROCESS_ID, 12, 423, filename, tenantId)));
+        key,
+        tenantId,
+        deployment(deployedProcess(BPMN_1_PROCESS_ID, 12, 423, filename, tenantId, processName)));
 
     // when
     final DeploymentEvent response =
@@ -236,7 +239,8 @@ public final class DeployResourceTest extends ClientTest {
     assertThat(response.getKey()).isEqualTo(key);
     assertThat(response.getTenantId()).isEqualTo(tenantId);
     assertThat(response.getProcesses())
-        .containsExactly(new ProcessImpl(423, BPMN_1_PROCESS_ID, 12, filename, tenantId));
+        .containsExactly(
+            new ProcessImpl(423, BPMN_1_PROCESS_ID, 12, filename, tenantId, processName));
   }
 
   @Test
@@ -246,11 +250,13 @@ public final class DeployResourceTest extends ClientTest {
     final String tenantId = "test-tenant";
     final String filename1 = BPMN_1_FILENAME.substring(1);
     final String filename2 = BPMN_2_FILENAME.substring(1);
+    final String processName1 = "TestProcess1";
+    final String processName2 = null;
     gatewayService.onDeployResourceRequest(
         key,
         tenantId,
-        deployment(deployedProcess(BPMN_1_PROCESS_ID, 1, 1, filename1, tenantId)),
-        deployment(deployedProcess(BPMN_2_PROCESS_ID, 1, 2, filename2, tenantId)));
+        deployment(deployedProcess(BPMN_1_PROCESS_ID, 1, 1, filename1, tenantId, processName1)),
+        deployment(deployedProcess(BPMN_2_PROCESS_ID, 1, 2, filename2, tenantId, processName2)));
 
     // when
     final DeploymentEvent response =
@@ -266,8 +272,8 @@ public final class DeployResourceTest extends ClientTest {
     assertThat(response.getKey()).isEqualTo(key);
     assertThat(response.getProcesses())
         .containsExactly(
-            new ProcessImpl(1, BPMN_1_PROCESS_ID, 1, filename1, tenantId),
-            new ProcessImpl(2, BPMN_2_PROCESS_ID, 1, filename2, tenantId));
+            new ProcessImpl(1, BPMN_1_PROCESS_ID, 1, filename1, tenantId, processName1),
+            new ProcessImpl(2, BPMN_2_PROCESS_ID, 1, filename2, tenantId, processName2));
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/client/resource/rest/DeployResourceRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/resource/rest/DeployResourceRestTest.java
@@ -215,6 +215,7 @@ public class DeployResourceRestTest extends ClientRestTest {
     final String key = "123";
     final String tenantId = "test-tenant";
     final String filename = DeployResourceTest.class.getResource(BPMN_1_FILENAME).getPath();
+    final String processName = "Demo Process";
     gatewayService.onDeploymentsRequest(
         new DeploymentResult()
             .deploymentKey(key)
@@ -227,7 +228,8 @@ public class DeployResourceRestTest extends ClientRestTest {
                             .processDefinitionVersion(12)
                             .processDefinitionKey("423")
                             .tenantId(tenantId)
-                            .resourceName(filename))));
+                            .resourceName(filename)
+                            .processName(processName))));
 
     // when
     final DeploymentEvent response =
@@ -242,7 +244,8 @@ public class DeployResourceRestTest extends ClientRestTest {
     assertThat(String.valueOf(response.getKey())).isEqualTo(key);
     assertThat(response.getTenantId()).isEqualTo(tenantId);
     assertThat(response.getProcesses())
-        .containsExactly(new ProcessImpl(423, BPMN_1_PROCESS_ID, 12, filename, tenantId));
+        .containsExactly(
+            new ProcessImpl(423, BPMN_1_PROCESS_ID, 12, filename, tenantId, processName));
   }
 
   @Test
@@ -252,6 +255,8 @@ public class DeployResourceRestTest extends ClientRestTest {
     final String tenantId = "test-tenant";
     final String filename1 = BPMN_1_FILENAME.substring(1);
     final String filename2 = BPMN_2_FILENAME.substring(1);
+    final String processName1 = "Demo Process 1";
+    final String processName2 = "Demo Process 2";
     gatewayService.onDeploymentsRequest(
         new DeploymentResult()
             .deploymentKey(key)
@@ -264,6 +269,7 @@ public class DeployResourceRestTest extends ClientRestTest {
                             .processDefinitionVersion(1)
                             .processDefinitionKey("1")
                             .tenantId(tenantId)
+                            .processName(processName1)
                             .resourceName(filename1)))
             .addDeploymentsItem(
                 new DeploymentMetadataResult()
@@ -273,7 +279,8 @@ public class DeployResourceRestTest extends ClientRestTest {
                             .processDefinitionVersion(1)
                             .processDefinitionKey("2")
                             .tenantId(tenantId)
-                            .resourceName(filename2))));
+                            .resourceName(filename2)
+                            .processName(processName2))));
 
     // when
     final DeploymentEvent response =
@@ -289,8 +296,8 @@ public class DeployResourceRestTest extends ClientRestTest {
     assertThat(String.valueOf(response.getKey())).isEqualTo(key);
     assertThat(response.getProcesses())
         .containsExactly(
-            new ProcessImpl(1, BPMN_1_PROCESS_ID, 1, filename1, tenantId),
-            new ProcessImpl(2, BPMN_2_PROCESS_ID, 1, filename2, tenantId));
+            new ProcessImpl(1, BPMN_1_PROCESS_ID, 1, filename1, tenantId, processName1),
+            new ProcessImpl(2, BPMN_2_PROCESS_ID, 1, filename2, tenantId, processName2));
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/client/util/RecordingGatewayService.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RecordingGatewayService.java
@@ -186,12 +186,14 @@ public final class RecordingGatewayService extends GatewayImplBase {
       final int version,
       final long processDefinitionKey,
       final String resourceName) {
+    final String name = "";
     return deployedProcess(
         bpmnProcessId,
         version,
         processDefinitionKey,
         resourceName,
-        CommandWithTenantStep.DEFAULT_TENANT_IDENTIFIER);
+        CommandWithTenantStep.DEFAULT_TENANT_IDENTIFIER,
+        name);
   }
 
   public static ProcessMetadata deployedProcess(
@@ -199,14 +201,19 @@ public final class RecordingGatewayService extends GatewayImplBase {
       final int version,
       final long processDefinitionKey,
       final String resourceName,
-      final String tenantId) {
-    return ProcessMetadata.newBuilder()
-        .setBpmnProcessId(bpmnProcessId)
-        .setVersion(version)
-        .setProcessDefinitionKey(processDefinitionKey)
-        .setResourceName(resourceName)
-        .setTenantId(tenantId)
-        .build();
+      final String tenantId,
+      final String processName) {
+    final ProcessMetadata.Builder builder =
+        ProcessMetadata.newBuilder()
+            .setBpmnProcessId(bpmnProcessId)
+            .setVersion(version)
+            .setProcessDefinitionKey(processDefinitionKey)
+            .setResourceName(resourceName)
+            .setTenantId(tenantId);
+    if (processName != null && !processName.isEmpty()) {
+      builder.setProcessName(processName);
+    }
+    return builder.build();
   }
 
   public static DecisionMetadata deployedDecision(

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
@@ -539,21 +539,25 @@ public final class ResponseMapper {
       final List<ProcessMetadataValue> processesMetadata) {
     return processesMetadata.stream()
         .map(
-            process ->
-                DeploymentMetadataResult.Builder.create()
-                    .processDefinition(
-                        DeploymentProcessResult.Builder.create()
-                            .processDefinitionId(process.getBpmnProcessId())
-                            .processDefinitionVersion(process.getVersion())
-                            .resourceName(process.getResourceName())
-                            .processDefinitionKey(keyToString(process.getProcessDefinitionKey()))
-                            .tenantId(process.getTenantId())
-                            .build())
-                    .decisionDefinition(null)
-                    .decisionRequirements(null)
-                    .form(null)
-                    .resource(null)
-                    .build())
+            process -> {
+              final var processName = process.getProcessName();
+              return DeploymentMetadataResult.Builder.create()
+                  .processDefinition(
+                      DeploymentProcessResult.Builder.create()
+                          .processDefinitionId(process.getBpmnProcessId())
+                          .processDefinitionVersion(process.getVersion())
+                          .resourceName(process.getResourceName())
+                          .processDefinitionKey(keyToString(process.getProcessDefinitionKey()))
+                          .tenantId(process.getTenantId())
+                          .processName(
+                              processName != null && !processName.isEmpty() ? processName : null)
+                          .build())
+                  .decisionDefinition(null)
+                  .decisionRequirements(null)
+                  .form(null)
+                  .resource(null)
+                  .build();
+            })
         .toList();
   }
 
@@ -567,7 +571,8 @@ public final class ResponseMapper {
         brokerResponse.getTenantId(),
         null,
         brokerResponse.getTags(),
-        brokerResponse.getBusinessId());
+        brokerResponse.getBusinessId(),
+        brokerResponse.getProcessName());
   }
 
   public static CreateProcessInstanceResult toCreateProcessInstanceWithResultResponse(
@@ -580,7 +585,8 @@ public final class ResponseMapper {
         brokerResponse.getTenantId(),
         brokerResponse.getVariables(),
         brokerResponse.getTags(),
-        brokerResponse.getBusinessId());
+        brokerResponse.getBusinessId(),
+        brokerResponse.getProcessName());
   }
 
   private static CreateProcessInstanceResult buildCreateProcessInstanceResponse(
@@ -591,7 +597,8 @@ public final class ResponseMapper {
       final String tenantId,
       final @Nullable Map<String, Object> variables,
       final @Nullable Set<String> tags,
-      final String businessId) {
+      final String businessId,
+      final String processName) {
     return CreateProcessInstanceResult.Builder.create()
         .processDefinitionId(bpmnProcessId)
         .processDefinitionKey(keyToString(processDefinitionKey))
@@ -603,6 +610,7 @@ public final class ResponseMapper {
         // defaults to an empty string on the originating record
         // the conversion to null ensures response contract compliance
         .businessId(emptyToNull(businessId))
+        .processName(processName != null ? processName : "")
         .build();
   }
 

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/definition/ZeebeProcessDefinitionDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/definition/ZeebeProcessDefinitionDataDto.java
@@ -24,6 +24,7 @@ public class ZeebeProcessDefinitionDataDto implements ProcessMetadataValue {
   private String bpmnProcessId;
   private String tenantId;
   private String versionTag;
+  private String processName;
 
   public ZeebeProcessDefinitionDataDto() {}
 
@@ -76,6 +77,10 @@ public class ZeebeProcessDefinitionDataDto implements ProcessMetadataValue {
     return this.versionTag;
   }
 
+  public String getProcessName() {
+    return this.processName;
+  }
+
   public void setResource(final byte[] resource) {
     this.resource = resource;
   }
@@ -108,6 +113,10 @@ public class ZeebeProcessDefinitionDataDto implements ProcessMetadataValue {
     this.versionTag = versionTag;
   }
 
+  public void setProcessName(final String processName) {
+    this.processName = processName;
+  }
+
   public String toString() {
     return "ZeebeProcessDefinitionDataDto(resource="
         + java.util.Arrays.toString(this.getResource())
@@ -125,6 +134,8 @@ public class ZeebeProcessDefinitionDataDto implements ProcessMetadataValue {
         + this.getTenantId()
         + ", versionTag="
         + this.getVersionTag()
+        + ", processName="
+        + this.getProcessName()
         + ")";
   }
 
@@ -141,7 +152,8 @@ public class ZeebeProcessDefinitionDataDto implements ProcessMetadataValue {
         && Objects.equals(resourceName, that.resourceName)
         && Objects.equals(bpmnProcessId, that.bpmnProcessId)
         && Objects.equals(tenantId, that.tenantId)
-        && Objects.equals(versionTag, that.versionTag);
+        && Objects.equals(versionTag, that.versionTag)
+        && Objects.equals(processName, that.processName);
   }
 
   @Override
@@ -154,7 +166,8 @@ public class ZeebeProcessDefinitionDataDto implements ProcessMetadataValue {
         resourceName,
         bpmnProcessId,
         tenantId,
-        versionTag);
+        versionTag,
+        processName);
   }
 
   protected boolean canEqual(final Object other) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnProcessResultSenderBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnProcessResultSenderBehavior.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnProcessingException;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
+import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.VariableState;
 import io.camunda.zeebe.engine.state.instance.AwaitProcessInstanceResultMetadata;
@@ -30,12 +31,14 @@ public final class BpmnProcessResultSenderBehavior {
 
   private final ElementInstanceState elementInstanceState;
   private final VariableState variableState;
+  private final ProcessState processState;
   private final TypedResponseWriter responseWriter;
 
   public BpmnProcessResultSenderBehavior(
       final ProcessingState processingState, final TypedResponseWriter responseWriter) {
     elementInstanceState = processingState.getElementInstanceState();
     variableState = processingState.getVariableState();
+    processState = processingState.getProcessState();
     this.responseWriter = responseWriter;
   }
 
@@ -69,6 +72,20 @@ public final class BpmnProcessResultSenderBehavior {
         .setTenantId(context.getTenantId())
         .setTags(context.getTags())
         .setBusinessId(context.getBusinessId());
+
+    final var deployedProcess =
+        processState.getProcessByKeyAndTenant(
+            context.getProcessDefinitionKey(), context.getTenantId());
+    if (deployedProcess != null) {
+      final DirectBuffer processName = deployedProcess.getProcess().getName();
+      if (processName != null) {
+        resultRecord.setProcessName(processName);
+      } else {
+        resultRecord.setProcessName("");
+      }
+    } else {
+      resultRecord.setProcessName("");
+    }
 
     responseWriter.writeResponse(
         context.getProcessInstanceKey(),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
@@ -221,6 +221,7 @@ public final class BpmnResourceTransformer implements DeploymentResourceTransfor
           .setResourceName(deploymentResource.getResourceNameBuffer())
           .setTenantId(tenantId);
       getOptionalVersionTag(process).ifPresent(processMetadata::setVersionTag);
+      getOptionalProcessName(process).ifPresent(processMetadata::setProcessName);
 
       final var isDuplicate =
           isDuplicateOfLatest(deploymentResource, resourceDigest, lastProcess, lastDigest);
@@ -250,6 +251,10 @@ public final class BpmnResourceTransformer implements DeploymentResourceTransfor
   private Optional<String> getOptionalVersionTag(final Process process) {
     return Optional.ofNullable(process.getSingleExtensionElement(ZeebeVersionTag.class))
         .map(ZeebeVersionTag::getValue);
+  }
+
+  private Optional<String> getOptionalProcessName(final Process process) {
+    return Optional.ofNullable(process.getName());
   }
 
   private boolean isDuplicateOfLatest(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateProcessor.java
@@ -112,7 +112,7 @@ public final class ProcessInstanceCreationCreateProcessor
           record.startInstructions(), process, processInstance);
     }
 
-    helper.updateCreationRecord(record, processInstance);
+    helper.updateCreationRecord(record, processInstance, process);
 
     final var entityKey = commandKey < 0 ? keyGenerator.nextKey() : commandKey;
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateWithAwaitingResultProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateWithAwaitingResultProcessor.java
@@ -115,7 +115,7 @@ public final class ProcessInstanceCreationCreateWithAwaitingResultProcessor
           record.startInstructions(), process, processInstance);
     }
 
-    helper.updateCreationRecord(record, processInstance);
+    helper.updateCreationRecord(record, processInstance, process);
 
     final var entityKey = commandKey < 0 ? keyGenerator.nextKey() : commandKey;
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
@@ -229,13 +229,19 @@ public class ProcessInstanceCreationHelper {
   }
 
   public void updateCreationRecord(
-      final ProcessInstanceCreationRecord record, final ProcessInstanceRecord processInstance) {
+      final ProcessInstanceCreationRecord record,
+      final ProcessInstanceRecord processInstance,
+      final DeployedProcess deployedProcess) {
     record
         .setProcessInstanceKey(processInstance.getProcessInstanceKey())
         .setRootProcessInstanceKey(processInstance.getRootProcessInstanceKey())
         .setBpmnProcessId(processInstance.getBpmnProcessId())
         .setVersion(processInstance.getVersion())
         .setProcessDefinitionKey(processInstance.getProcessDefinitionKey());
+    final DirectBuffer processName = deployedProcess.getProcess().getName();
+    if (processName != null) {
+      record.setProcessName(processName);
+    }
   }
 
   public void setVariablesFromDocument(

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
@@ -16,6 +16,8 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.EvaluatedDecisionValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
+import io.camunda.zeebe.protocol.record.value.deployment.ProcessMetadataValue;
 import io.camunda.zeebe.util.SemanticVersion;
 import io.camunda.zeebe.util.VersionUtil;
 import java.io.IOException;
@@ -42,6 +44,8 @@ final class BulkIndexRequest {
           .addMixIn(CommandDistributionRecordValue.class, CommandDistributionMixin.class)
           .addMixIn(EvaluatedDecisionValue.class, EvaluatedDecisionMixin.class)
           .addMixIn(JobRecordValue.class, JobMixin.class)
+          .addMixIn(ProcessMetadataValue.class, ProcessMetadataMixin.class)
+          .addMixIn(ProcessInstanceCreationRecordValue.class, ProcessInstanceCreationMixin.class)
           .enable(Feature.ALLOW_SINGLE_QUOTES);
 
   // The property of the ES record template to store the sequence of the record.
@@ -52,6 +56,7 @@ final class BulkIndexRequest {
       "decisionEvaluationInstanceKey";
   private static final String AUTH_INFO_PROPERTY = "authInfo";
   private static final String PRIORITY_PROPERTY = "priority";
+  private static final String PROCESS_NAME_PROPERTY = "processName";
   private final List<IndexOperation> operations = new ArrayList<>();
   private BulkIndexAction lastIndexedMetadata;
   private int memoryUsageBytes = 0;
@@ -168,4 +173,10 @@ final class BulkIndexRequest {
 
   @JsonIgnoreProperties({PRIORITY_PROPERTY})
   private static final class JobMixin {}
+
+  @JsonIgnoreProperties({PROCESS_NAME_PROPERTY})
+  private static final class ProcessMetadataMixin {}
+
+  @JsonIgnoreProperties({PROCESS_NAME_PROPERTY})
+  private static final class ProcessInstanceCreationMixin {}
 }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-deployment-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-deployment-template.json
@@ -26,6 +26,9 @@
                 "bpmnProcessId": {
                   "type": "keyword"
                 },
+                "processName": {
+                  "type": "keyword"
+                },
                 "version": {
                   "type": "long"
                 },

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-creation-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-creation-template.json
@@ -63,6 +63,9 @@
             "businessId": {
               "type": "keyword"
             },
+            "processName": {
+              "type": "keyword"
+            },
             "elementInstanceKey": {
               "enabled": false
             }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-template.json
@@ -22,6 +22,9 @@
             "bpmnProcessId": {
               "type": "keyword"
             },
+            "processName": {
+              "type": "keyword"
+            },
             "version": {
               "type": "long"
             },

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
@@ -15,8 +15,10 @@ import io.camunda.zeebe.exporter.BulkIndexRequest.IndexOperation;
 import io.camunda.zeebe.exporter.dto.BulkIndexAction;
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.value.decision.DecisionEvaluationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
 import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
 import io.camunda.zeebe.protocol.jackson.ZeebeProtocolModule;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
@@ -436,6 +438,108 @@ final class BulkIndexRequestTest {
           .containsExactly(50);
     }
 
+    @Test
+    void shouldIndexProcessRecordWithoutProcessNameOnPreviousVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.PROCESS,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(newProcessRecord()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("processName"))
+          .describedAs(
+              "Expect that process records are NOT serialized with processName on previous version")
+          .containsExactly(new Object[] {null});
+    }
+
+    @Test
+    void shouldIndexProcessRecordWithProcessNameOnCurrentVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.PROCESS,
+              r -> r.withBrokerVersion(VersionUtil.getVersion()).withValue(newProcessRecord()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("processName"))
+          .describedAs(
+              "Expect that process records are serialized with processName on current version")
+          .containsExactly("My Process");
+    }
+
+    @Test
+    void shouldIndexProcessInstanceCreationRecordWithoutProcessNameOnPreviousVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.PROCESS_INSTANCE_CREATION,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(new ProcessInstanceCreationRecord().setProcessName("My Process")));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("processName"))
+          .describedAs(
+              "Expect that process instance creation records are NOT serialized with processName on previous version")
+          .containsExactly(new Object[] {null});
+    }
+
+    @Test
+    void shouldIndexProcessInstanceCreationRecordWithProcessNameOnCurrentVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.PROCESS_INSTANCE_CREATION,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(new ProcessInstanceCreationRecord().setProcessName("My Process")));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("processName"))
+          .describedAs(
+              "Expect that process instance creation records are serialized with processName on current version")
+          .containsExactly("My Process");
+    }
+
     private Record<?> deserializeSource(final IndexOperation operation) {
       try {
         return MAPPER.readValue(operation.source(), new TypeReference<>() {});
@@ -443,6 +547,17 @@ final class BulkIndexRequestTest {
         throw new UncheckedIOException(
             String.format("Failed to deserialize operation [%s] source", operation.metadata()), e);
       }
+    }
+
+    private static ProcessRecord newProcessRecord() {
+      return new ProcessRecord()
+          .setKey(1L)
+          .setBpmnProcessId("processId")
+          .setVersion(1)
+          .setResourceName("process.bpmn")
+          .setChecksum(BufferUtil.wrapString("checksum"))
+          .setResource(BufferUtil.wrapString("resource"))
+          .setProcessName("My Process");
     }
   }
 }

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
@@ -16,6 +16,8 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.EvaluatedDecisionValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
+import io.camunda.zeebe.protocol.record.value.deployment.ProcessMetadataValue;
 import io.camunda.zeebe.util.SemanticVersion;
 import io.camunda.zeebe.util.VersionUtil;
 import jakarta.json.spi.JsonProvider;
@@ -49,6 +51,8 @@ final class BulkIndexRequest {
           .addMixIn(CommandDistributionRecordValue.class, CommandDistributionMixin.class)
           .addMixIn(EvaluatedDecisionValue.class, EvaluatedDecisionMixin.class)
           .addMixIn(JobRecordValue.class, JobMixin.class)
+          .addMixIn(ProcessMetadataValue.class, ProcessMetadataMixin.class)
+          .addMixIn(ProcessInstanceCreationRecordValue.class, ProcessInstanceCreationMixin.class)
           .enable(Feature.ALLOW_SINGLE_QUOTES);
 
   // The property of the ES record template to store the sequence of the record.
@@ -59,6 +63,7 @@ final class BulkIndexRequest {
       "decisionEvaluationInstanceKey";
   private static final String AUTH_INFO_PROPERTY = "authInfo";
   private static final String PRIORITY_PROPERTY = "priority";
+  private static final String PROCESS_NAME_PROPERTY = "processName";
 
   private final List<BulkOperation> operations = new ArrayList<>();
 
@@ -191,4 +196,10 @@ final class BulkIndexRequest {
 
   @JsonIgnoreProperties({PRIORITY_PROPERTY})
   private static final class JobMixin {}
+
+  @JsonIgnoreProperties({PROCESS_NAME_PROPERTY})
+  private static final class ProcessMetadataMixin {}
+
+  @JsonIgnoreProperties({PROCESS_NAME_PROPERTY})
+  private static final class ProcessInstanceCreationMixin {}
 }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-deployment-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-deployment-template.json
@@ -55,6 +55,9 @@
                 },
                 "versionTag": {
                   "type": "keyword"
+                },
+                "processName": {
+                  "type": "keyword"
                 }
               }
             },

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-instance-creation-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-instance-creation-template.json
@@ -69,6 +69,9 @@
             "businessId": {
               "type": "keyword"
             },
+            "processName": {
+              "type": "keyword"
+            },
             "elementInstanceKey": {
               "enabled": false
             }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-template.json
@@ -28,6 +28,9 @@
             "bpmnProcessId": {
               "type": "keyword"
             },
+            "processName": {
+              "type": "keyword"
+            },
             "version": {
               "type": "long"
             },

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
@@ -14,8 +14,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.zeebe.exporter.opensearch.dto.BulkIndexAction;
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.value.decision.DecisionEvaluationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
 import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
 import io.camunda.zeebe.protocol.jackson.ZeebeProtocolModule;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
@@ -446,6 +448,102 @@ final class BulkIndexRequestTest {
           .isEqualTo(50);
     }
 
+    @Test
+    void shouldIndexProcessRecordWithoutProcessNameOnPreviousVersion() throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.PROCESS,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(newProcessRecord()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value.get("processName"))
+          .describedAs(
+              "Expect that process records are NOT serialized with processName on previous version")
+          .isNull();
+    }
+
+    @Test
+    void shouldIndexProcessRecordWithProcessNameOnCurrentVersion() throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.PROCESS,
+              r -> r.withBrokerVersion(VersionUtil.getVersion()).withValue(newProcessRecord()));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value.get("processName"))
+          .describedAs(
+              "Expect that process records are serialized with processName on current version")
+          .isEqualTo("My Process");
+    }
+
+    @Test
+    void shouldIndexProcessInstanceCreationRecordWithoutProcessNameOnPreviousVersion()
+        throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.PROCESS_INSTANCE_CREATION,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(new ProcessInstanceCreationRecord().setProcessName("My Process")));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value.get("processName"))
+          .describedAs(
+              "Expect that process instance creation records are NOT serialized with processName on previous version")
+          .isNull();
+    }
+
+    @Test
+    void shouldIndexProcessInstanceCreationRecordWithProcessNameOnCurrentVersion()
+        throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.PROCESS_INSTANCE_CREATION,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(new ProcessInstanceCreationRecord().setProcessName("My Process")));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value.get("processName"))
+          .describedAs(
+              "Expect that process instance creation records are serialized with processName on current version")
+          .isEqualTo("My Process");
+    }
+
     private static Map<String, Object> getDocumentAsMap(final BulkOperation operation)
         throws IOException {
       return MAPPER.readValue(
@@ -456,6 +554,17 @@ final class BulkIndexRequestTest {
         throws IOException {
       final Map<String, Object> doc = getDocumentAsMap(request.bulkOperations().getFirst());
       return (Map<String, Object>) doc.get("value");
+    }
+
+    private static ProcessRecord newProcessRecord() {
+      return new ProcessRecord()
+          .setKey(1L)
+          .setBpmnProcessId("processId")
+          .setVersion(1)
+          .setResourceName("process.bpmn")
+          .setChecksum(BufferUtil.wrapString("checksum"))
+          .setResource(BufferUtil.wrapString("resource"))
+          .setProcessName("My Process");
     }
   }
 }

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
@@ -86,14 +86,20 @@ public final class ResponseMapper {
     brokerResponse
         .processesMetadata()
         .forEach(
-            process ->
-                responseBuilder
-                    .addProcessesBuilder()
-                    .setBpmnProcessId(bufferAsString(process.getBpmnProcessIdBuffer()))
-                    .setVersion(process.getVersion())
-                    .setProcessDefinitionKey(process.getKey())
-                    .setTenantId(process.getTenantId())
-                    .setResourceName(bufferAsString(process.getResourceNameBuffer())));
+            process -> {
+              final var builder =
+                  responseBuilder
+                      .addProcessesBuilder()
+                      .setBpmnProcessId(bufferAsString(process.getBpmnProcessIdBuffer()))
+                      .setVersion(process.getVersion())
+                      .setProcessDefinitionKey(process.getKey())
+                      .setTenantId(process.getTenantId())
+                      .setResourceName(bufferAsString(process.getResourceNameBuffer()));
+              final var processName = process.getProcessName();
+              if (processName != null && !processName.isEmpty()) {
+                builder.setProcessName(processName);
+              }
+            });
 
     return responseBuilder.build();
   }
@@ -105,14 +111,20 @@ public final class ResponseMapper {
 
     brokerResponse.processesMetadata().stream()
         .map(
-            process ->
-                ProcessMetadata.newBuilder()
-                    .setBpmnProcessId(process.getBpmnProcessId())
-                    .setVersion(process.getVersion())
-                    .setProcessDefinitionKey(process.getKey())
-                    .setResourceName(process.getResourceName())
-                    .setTenantId(process.getTenantId())
-                    .build())
+            process -> {
+              final var builder =
+                  ProcessMetadata.newBuilder()
+                      .setBpmnProcessId(process.getBpmnProcessId())
+                      .setVersion(process.getVersion())
+                      .setProcessDefinitionKey(process.getKey())
+                      .setResourceName(process.getResourceName())
+                      .setTenantId(process.getTenantId());
+              final var processName = process.getProcessName();
+              if (processName != null && !processName.isEmpty()) {
+                builder.setProcessName(processName);
+              }
+              return builder.build();
+            })
         .forEach(process -> responseBuilder.addDeploymentsBuilder().setProcess(process));
 
     brokerResponse.decisionsMetadata().stream()
@@ -198,6 +210,7 @@ public final class ResponseMapper {
             .setVersion(brokerResponse.getVersion())
             .setTenantId(brokerResponse.getTenantId())
             .setProcessInstanceKey(brokerResponse.getProcessInstanceKey())
+            .setProcessName(brokerResponse.getProcessName())
             .addAllTags(brokerResponse.getTags());
     if (brokerResponse.hasBusinessId()) {
       builder.setBusinessId(brokerResponse.getBusinessId());
@@ -209,16 +222,23 @@ public final class ResponseMapper {
 
   public static CreateProcessInstanceWithResultResponse toCreateProcessInstanceWithResultResponse(
       final long key, final ProcessInstanceResultRecord brokerResponse) {
-    return CreateProcessInstanceWithResultResponse.newBuilder()
-        .setProcessDefinitionKey(brokerResponse.getProcessDefinitionKey())
-        .setBpmnProcessId(bufferAsString(brokerResponse.getBpmnProcessIdBuffer()))
-        .setVersion(brokerResponse.getVersion())
-        .setTenantId(brokerResponse.getTenantId())
-        .setProcessInstanceKey(brokerResponse.getProcessInstanceKey())
-        .setVariables(bufferAsJson(brokerResponse.getVariablesBuffer()))
-        .addAllTags(brokerResponse.getTags())
-        .setBusinessId(brokerResponse.getBusinessId())
-        .build();
+    final var builder =
+        CreateProcessInstanceWithResultResponse.newBuilder()
+            .setProcessDefinitionKey(brokerResponse.getProcessDefinitionKey())
+            .setBpmnProcessId(bufferAsString(brokerResponse.getBpmnProcessIdBuffer()))
+            .setVersion(brokerResponse.getVersion())
+            .setTenantId(brokerResponse.getTenantId())
+            .setProcessInstanceKey(brokerResponse.getProcessInstanceKey())
+            .setVariables(bufferAsJson(brokerResponse.getVariablesBuffer()))
+            .setProcessName(brokerResponse.getProcessName())
+            .addAllTags(brokerResponse.getTags());
+    final var businessId = brokerResponse.getBusinessId();
+    if (businessId != null && !businessId.isEmpty()) {
+      builder.setBusinessId(businessId);
+    } else {
+      builder.clearBusinessId();
+    }
+    return builder.build();
   }
 
   public static EvaluateDecisionResponse toEvaluateDecisionResponse(

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -325,6 +325,9 @@ message CreateProcessInstanceResponse {
   repeated string tags = 6;
   // the business id of the created process instance
   optional string businessId = 7;
+  // the name of the process which this instance was created for, as defined in the BPMN;
+  // empty if not defined
+  optional string process_name = 8;
 }
 
 message CreateProcessInstanceWithResultRequest {
@@ -358,6 +361,9 @@ message CreateProcessInstanceWithResultResponse {
   repeated string tags = 7;
   // the business id of the created process instance
   optional string businessId = 8;
+  // the name of the process which this instance was created for, as defined in the BPMN;
+  // empty if not defined
+  optional string process_name = 9;
 }
 
 message EvaluateDecisionRequest {
@@ -540,6 +546,8 @@ message ProcessMetadata {
   string resourceName = 4;
   // the tenant id of the deployed process
   string tenantId = 5;
+  // the process name as defined in BPMN; not set if not defined
+  optional string process_name = 6;
 }
 
 message DecisionMetadata {

--- a/zeebe/gateway-protocol/src/main/proto/v2/deployments.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/deployments.yaml
@@ -340,6 +340,7 @@ components:
         - resourceName
         - processDefinitionKey
         - tenantId
+        - processName
       properties:
         processDefinitionId:
           allOf:
@@ -354,6 +355,10 @@ components:
         resourceName:
           type: string
           description: The resource name from which this process was parsed.
+        processName:
+          type: string
+          nullable: true
+          description: The name of the process.
         tenantId:
           description: The tenant ID of the deployed process.
           allOf:
@@ -362,6 +367,9 @@ components:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessDefinitionKey'
           description: The assigned key, which acts as a unique identifier for this process.
+      x-properties-added-in-version:
+        - propertyName: processName
+          addedInVersion: "8.10"
 
     DeploymentDecisionResult:
       description: A deployed decision.

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
@@ -967,6 +967,7 @@ components:
         - processInstanceKey
         - tags
         - businessId
+        - processName
       type: object
       properties:
         processDefinitionId:
@@ -1009,11 +1010,19 @@ components:
           description: Business id as provided on creation.
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/BusinessId'
+        processName:
+          type: string
+          description: |
+            The name of the process which this instance was created for, as defined in the BPMN.
+            Returns an empty string if no name was defined in the BPMN.
+          example: My Process
       x-properties-added-in-version:
         - propertyName: tags
           addedInVersion: "8.8"
         - propertyName: businessId
           addedInVersion: "8.9"
+        - propertyName: processName
+          addedInVersion: "8.10"
 
     ProcessInstanceSearchQuerySortRequest:
       type: object

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
@@ -83,7 +83,8 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
              "tenantId":"tenantId",
              "variables":{},
              "tags":[],
-             "businessId": null
+             "businessId": null,
+             "processName": ""
           }""";
   static final String PROCESS_INSTANCES_START_URL = "/v2/process-instances";
   static final String CANCEL_PROCESS_URL = PROCESS_INSTANCES_START_URL + "/%s/cancellation";
@@ -182,7 +183,8 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
               "tenantId":"<default>",
               "variables":{},
               "tags":[],
-              "businessId": null
+              "businessId": null,
+              "processName": ""
             }""";
 
     // when / then
@@ -336,7 +338,8 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
               "tenantId":"<default>",
               "variables":{},
               "tags":[],
-              "businessId":"order-12345"
+              "businessId":"order-12345",
+              "processName": ""
             }""";
 
     // when / then
@@ -802,7 +805,8 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
                 "tenantId":"<default>",
                 "variables":{},
                 "tags":[],
-                "businessId":"order-12345"
+                "businessId":"order-12345",
+                "processName": ""
             }""",
             JsonCompareMode.STRICT);
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ResourceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ResourceControllerTest.java
@@ -84,6 +84,7 @@ public class ResourceControllerTest extends RestControllerTest {
         .processesMetadata()
         .add()
         .setResourceName(filename)
+        .setProcessName("processName")
         .setBpmnProcessId("processId")
         .setDeploymentKey(123L)
         .setVersion(1)
@@ -125,6 +126,7 @@ public class ResourceControllerTest extends RestControllerTest {
                              "processDefinitionVersion":1,
                              "processDefinitionKey":"123456",
                              "resourceName":"process.bpmn",
+                             "processName":"processName",
                              "tenantId":"<default>"
                           },
                           "decisionDefinition": null,
@@ -152,6 +154,7 @@ public class ResourceControllerTest extends RestControllerTest {
         .processesMetadata()
         .add()
         .setResourceName(filename)
+        .setProcessName("processName")
         .setBpmnProcessId("processId")
         .setDeploymentKey(123L)
         .setVersion(1)
@@ -193,6 +196,7 @@ public class ResourceControllerTest extends RestControllerTest {
                              "processDefinitionVersion":1,
                              "processDefinitionKey":"123456",
                              "resourceName":"process.bpmn",
+                             "processName":"processName",
                              "tenantId":"<default>"
                           },
                           "decisionDefinition": null,
@@ -222,6 +226,7 @@ public class ResourceControllerTest extends RestControllerTest {
         .processesMetadata()
         .add()
         .setResourceName(filename)
+        .setProcessName("processName")
         .setBpmnProcessId("processId")
         .setDeploymentKey(123L)
         .setVersion(1)
@@ -265,6 +270,7 @@ public class ResourceControllerTest extends RestControllerTest {
                              "processDefinitionVersion":1,
                              "processDefinitionKey":"123456",
                              "resourceName":"process.bpmn",
+                             "processName":"processName",
                              "tenantId":"tenantId"
                           },
                           "decisionDefinition": null,
@@ -295,6 +301,7 @@ public class ResourceControllerTest extends RestControllerTest {
         .processesMetadata()
         .add()
         .setResourceName(filename)
+        .setProcessName("processName")
         .setBpmnProcessId("processId")
         .setDeploymentKey(123L)
         .setVersion(1)
@@ -304,6 +311,7 @@ public class ResourceControllerTest extends RestControllerTest {
         .processesMetadata()
         .add()
         .setResourceName(secondFilename)
+        .setProcessName("secondProcessName")
         .setBpmnProcessId("secondProcessId")
         .setDeploymentKey(456L)
         .setVersion(1)
@@ -362,6 +370,7 @@ public class ResourceControllerTest extends RestControllerTest {
                              "processDefinitionVersion":1,
                              "processDefinitionKey":"123456",
                              "resourceName":"process.bpmn",
+                             "processName":"processName",
                              "tenantId":"<default>"
                           },
                           "decisionDefinition": null,
@@ -375,6 +384,7 @@ public class ResourceControllerTest extends RestControllerTest {
                              "processDefinitionVersion":1,
                              "processDefinitionKey":"7890123",
                              "resourceName":"second.bpmn",
+                             "processName":"secondProcessName",
                              "tenantId":"<default>"
                           },
                           "decisionDefinition": null,

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/data/repository/ProcessMetadata.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/data/repository/ProcessMetadata.java
@@ -19,13 +19,15 @@ public class ProcessMetadata extends UnpackedObject {
   private final IntegerProperty versionProp = new IntegerProperty("version", -1);
   private final StringProperty bpmnProcessIdProp = new StringProperty("bpmnProcessId");
   private final StringProperty resourceNameProp = new StringProperty("resourceName");
+  private final StringProperty processNameProp = new StringProperty("processName", "");
 
   public ProcessMetadata() {
-    super(4);
+    super(5);
     declareProperty(processDefinitionKeyProp)
         .declareProperty(versionProp)
         .declareProperty(bpmnProcessIdProp)
-        .declareProperty(resourceNameProp);
+        .declareProperty(resourceNameProp)
+        .declareProperty(processNameProp);
   }
 
   public long getProcessDefinitionKey() {
@@ -71,6 +73,20 @@ public class ProcessMetadata extends UnpackedObject {
 
   public ProcessMetadata setResourceName(final String resourceName) {
     resourceNameProp.setValue(resourceName);
+    return this;
+  }
+
+  public DirectBuffer getProcessName() {
+    return processNameProp.getValue();
+  }
+
+  public ProcessMetadata setProcessName(final DirectBuffer name) {
+    processNameProp.setValue(name);
+    return this;
+  }
+
+  public ProcessMetadata setProcessName(final String name) {
+    processNameProp.setValue(name);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ProcessMetadata.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ProcessMetadata.java
@@ -34,6 +34,7 @@ public final class ProcessMetadata extends UnifiedRecordValue implements Process
   private final LongProperty keyProp = new LongProperty(PROCESS_DEFINITION_KEY_KEY);
   private final StringProperty resourceNameProp = new StringProperty("resourceName");
   private final BinaryProperty checksumProp = new BinaryProperty("checksum");
+  private final StringProperty processNameProp = new StringProperty("processName", "");
 
   // should be set to true if the process was already deployed - property should not be exported
   private final BooleanProperty isDuplicateProp = new BooleanProperty("isDuplicate", false);
@@ -43,7 +44,7 @@ public final class ProcessMetadata extends UnifiedRecordValue implements Process
   private final StringProperty versionTagProp = new StringProperty("versionTag", "");
 
   public ProcessMetadata() {
-    super(9);
+    super(10);
     declareProperty(bpmnProcessIdProp)
         .declareProperty(versionProp)
         .declareProperty(keyProp)
@@ -52,7 +53,8 @@ public final class ProcessMetadata extends UnifiedRecordValue implements Process
         .declareProperty(isDuplicateProp)
         .declareProperty(tenantIdProp)
         .declareProperty(deploymentKeyProp)
-        .declareProperty(versionTagProp);
+        .declareProperty(versionTagProp)
+        .declareProperty(processNameProp);
   }
 
   @Override
@@ -86,6 +88,11 @@ public final class ProcessMetadata extends UnifiedRecordValue implements Process
   }
 
   @Override
+  public String getProcessName() {
+    return bufferAsString(processNameProp.getValue());
+  }
+
+  @Override
   public byte[] getChecksum() {
     return BufferUtil.bufferAsArray(checksumProp.getValue());
   }
@@ -112,6 +119,16 @@ public final class ProcessMetadata extends UnifiedRecordValue implements Process
 
   public ProcessMetadata setDeploymentKey(final long deploymentKey) {
     deploymentKeyProp.setValue(deploymentKey);
+    return this;
+  }
+
+  public ProcessMetadata setProcessName(final String name) {
+    processNameProp.setValue(name);
+    return this;
+  }
+
+  public ProcessMetadata setProcessName(final DirectBuffer name) {
+    processNameProp.setValue(name);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ProcessRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ProcessRecord.java
@@ -34,9 +34,10 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   private final LongProperty deploymentKeyProp = new LongProperty("deploymentKey", -1);
   private final StringProperty versionTagProp = new StringProperty("versionTag", "");
+  private final StringProperty processNameProp = new StringProperty("processName", "");
 
   public ProcessRecord() {
-    super(9);
+    super(10);
     declareProperty(bpmnProcessIdProp)
         .declareProperty(versionProp)
         .declareProperty(keyProp)
@@ -45,7 +46,8 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
         .declareProperty(resourceProp)
         .declareProperty(tenantIdProp)
         .declareProperty(deploymentKeyProp)
-        .declareProperty(versionTagProp);
+        .declareProperty(versionTagProp)
+        .declareProperty(processNameProp);
   }
 
   public ProcessRecord wrap(final ProcessMetadata metadata, final byte[] resource) {
@@ -58,6 +60,7 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
     tenantIdProp.setValue(metadata.getTenantId());
     deploymentKeyProp.setValue(metadata.getDeploymentKey());
     versionTagProp.setValue(metadata.getVersionTag());
+    processNameProp.setValue(metadata.getProcessName());
     return this;
   }
 
@@ -92,6 +95,11 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
   }
 
   @Override
+  public String getProcessName() {
+    return BufferUtil.bufferAsString(processNameProp.getValue());
+  }
+
+  @Override
   public byte[] getChecksum() {
     return BufferUtil.bufferAsArray(checksumProp.getValue());
   }
@@ -113,6 +121,16 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
 
   public ProcessRecord setChecksum(final DirectBuffer checksumBuffer) {
     checksumProp.setValue(checksumBuffer);
+    return this;
+  }
+
+  public ProcessRecord setProcessName(final String name) {
+    processNameProp.setValue(name);
+    return this;
+  }
+
+  public ProcessRecord setProcessName(final DirectBuffer name) {
+    processNameProp.setValue(name);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceCreationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceCreationRecord.java
@@ -48,6 +48,7 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
   private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
       new StringValue("rootProcessInstanceKey");
   private static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
+  private static final StringValue PROCESS_NAME_KEY = new StringValue("processName");
 
   private final StringProperty bpmnProcessIdProperty = new StringProperty(BPMN_PROCESS_ID_KEY, "");
   private final LongProperty processDefinitionKeyProperty =
@@ -72,9 +73,10 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
   private final LongProperty rootProcessInstanceKeyProperty =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1);
   private final StringProperty businessIdProperty = new StringProperty(BUSINESS_ID_KEY, "");
+  private final StringProperty processNameProperty = new StringProperty(PROCESS_NAME_KEY, "");
 
   public ProcessInstanceCreationRecord() {
-    super(12);
+    super(13);
     declareProperty(bpmnProcessIdProperty)
         .declareProperty(processDefinitionKeyProperty)
         .declareProperty(processInstanceKeyProperty)
@@ -86,7 +88,8 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
         .declareProperty(tenantIdProperty)
         .declareProperty(tagsProperty)
         .declareProperty(rootProcessInstanceKeyProperty)
-        .declareProperty(businessIdProperty);
+        .declareProperty(businessIdProperty)
+        .declareProperty(processNameProperty);
   }
 
   @Override
@@ -177,6 +180,21 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
 
   public ProcessInstanceCreationRecord setBusinessId(final DirectBuffer businessId) {
     businessIdProperty.setValue(businessId);
+    return this;
+  }
+
+  @Override
+  public String getProcessName() {
+    return bufferAsString(processNameProperty.getValue());
+  }
+
+  public ProcessInstanceCreationRecord setProcessName(final String processName) {
+    processNameProperty.setValue(processName);
+    return this;
+  }
+
+  public ProcessInstanceCreationRecord setProcessName(final DirectBuffer processName) {
+    processNameProperty.setValue(processName);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceResultRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceResultRecord.java
@@ -40,6 +40,7 @@ public final class ProcessInstanceResultRecord extends UnifiedRecordValue
   public static final StringValue PROCESS_INSTANCE_KEY_KEY = new StringValue("processInstanceKey");
   public static final StringValue TAGS_KEY = new StringValue("tags");
   public static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
+  public static final StringValue PROCESS_NAME_KEY = new StringValue("processName");
 
   private final StringProperty bpmnProcessIdProperty = new StringProperty(BPMN_PROCESS_ID_KEY, "");
   private final LongProperty processDefinitionKeyProperty =
@@ -53,9 +54,10 @@ public final class ProcessInstanceResultRecord extends UnifiedRecordValue
   private final ArrayProperty<StringValue> tagsProperty =
       new ArrayProperty<>(TAGS_KEY, StringValue::new);
   private final StringProperty businessIdProperty = new StringProperty(BUSINESS_ID_KEY, "");
+  private final StringProperty processNameProperty = new StringProperty(PROCESS_NAME_KEY, "");
 
   public ProcessInstanceResultRecord() {
-    super(8);
+    super(9);
     declareProperty(bpmnProcessIdProperty)
         .declareProperty(processDefinitionKeyProperty)
         .declareProperty(processInstanceKeyProperty)
@@ -63,7 +65,8 @@ public final class ProcessInstanceResultRecord extends UnifiedRecordValue
         .declareProperty(tenantIdProperty)
         .declareProperty(variablesProperty)
         .declareProperty(tagsProperty)
-        .declareProperty(businessIdProperty);
+        .declareProperty(businessIdProperty)
+        .declareProperty(processNameProperty);
   }
 
   @Override
@@ -134,6 +137,21 @@ public final class ProcessInstanceResultRecord extends UnifiedRecordValue
 
   public ProcessInstanceResultRecord setBusinessId(final DirectBuffer businessId) {
     businessIdProperty.setValue(businessId);
+    return this;
+  }
+
+  @Override
+  public String getProcessName() {
+    return bufferAsString(processNameProperty.getValue());
+  }
+
+  public ProcessInstanceResultRecord setProcessName(final String processName) {
+    processNameProperty.setValue(processName);
+    return this;
+  }
+
+  public ProcessInstanceResultRecord setProcessName(final DirectBuffer processName) {
+    processNameProperty.setValue(processName);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -213,6 +213,7 @@ final class JsonSerializableToJsonTest {
                   .batchOperationReference(5678);
 
               final String resourceName = "resource";
+              final String processName = "Test Process";
               final DirectBuffer resource = wrapString("contents");
               final String bpmnProcessId = "testProcess";
               final long processDefinitionKey = 123;
@@ -231,6 +232,7 @@ final class JsonSerializableToJsonTest {
                   .setBpmnProcessId(wrapString(bpmnProcessId))
                   .setKey(processDefinitionKey)
                   .setResourceName(wrapString(resourceName))
+                  .setProcessName(wrapString(processName))
                   .setVersion(processVersion)
                   .setChecksum(checksum);
 
@@ -270,6 +272,7 @@ final class JsonSerializableToJsonTest {
                         "version": 12,
                         "bpmnProcessId": "testProcess",
                         "resourceName": "resource",
+                        "processName": "Test Process",
                         "checksum": "Y2hlY2tzdW0=",
                         "processDefinitionKey": 123,
                         "duplicate": false,
@@ -361,6 +364,7 @@ final class JsonSerializableToJsonTest {
               final DirectBuffer checksum = wrapString("checksum");
               final long deploymentKey = 1234;
               final String versionTag = "v1.0";
+              final String processName = "Test Process";
               final DeploymentRecord record = new DeploymentRecord();
               record
                   .setDeploymentKey(deploymentKey)
@@ -374,6 +378,7 @@ final class JsonSerializableToJsonTest {
                   .setBpmnProcessId(wrapString(bpmnProcessId))
                   .setKey(processDefinitionKey)
                   .setResourceName(wrapString(resourceName))
+                  .setProcessName(wrapString(processName))
                   .setVersion(processVersion)
                   .setChecksum(checksum)
                   .setDuplicate(true)
@@ -432,6 +437,7 @@ final class JsonSerializableToJsonTest {
                       "version": 12,
                       "processDefinitionKey": 123,
                       "resourceName": "resource",
+                      "processName": "Test Process",
                       "duplicate": true,
                       "tenantId": "<default>",
                       "deploymentKey": 1234,
@@ -563,6 +569,7 @@ final class JsonSerializableToJsonTest {
                   "resource": "Y29udGVudHM=",
                   "checksum": "Y2hlY2tzdW0=",
                   "bpmnProcessId": "testProcess",
+                  "processName": "",
                   "version": 12,
                   "processDefinitionKey": 123,
                   "resourceName": "resource",
@@ -602,6 +609,7 @@ final class JsonSerializableToJsonTest {
                   "resource": "Y29udGVudHM=",
                   "checksum": "Y2hlY2tzdW0=",
                   "bpmnProcessId": "testProcess",
+                  "processName": "",
                   "version": 12,
                   "processDefinitionKey": 123,
                   "resourceName": "resource",
@@ -1754,7 +1762,8 @@ final class JsonSerializableToJsonTest {
                   .setProcessInstanceKey(instanceKey)
                   .setTags(Set.of("tag1", "tag2"))
                   .setRootProcessInstanceKey(rootProcessInstanceKey)
-                  .setBusinessId(businessId);
+                  .setBusinessId(businessId)
+                  .setProcessName("Test Process");
             },
         """
                 {
@@ -1776,6 +1785,7 @@ final class JsonSerializableToJsonTest {
                   "tags": ["tag1", "tag2"],
                   "rootProcessInstanceKey": 3,
                   "businessId": "business-id-456",
+                  "processName": "Test Process",
                   "elementInstanceKey": -1
                 }
                 """
@@ -1802,6 +1812,7 @@ final class JsonSerializableToJsonTest {
                   "tags": [],
                   "rootProcessInstanceKey": -1,
                   "businessId": "",
+                  "processName": "",
                   "elementInstanceKey": -1
                 }
                 """
@@ -2733,6 +2744,70 @@ final class JsonSerializableToJsonTest {
                       "bpmnProcessId": "my_first_process",
                       "resourceName": "my_first_bpmn.bpmn",
                       "checksum": "c2hhMQ==",
+                      "processName": "",
+                      "duplicate": false,
+                      "tenantId": "<default>",
+                      "deploymentKey": -1,
+                      "versionTag": ""
+                    }],
+                    "decisionsMetadata": [],
+                    "decisionRequirementsMetadata": [],
+                    "formMetadata": [],
+                    "resourceMetadata":[],
+                    "tenantId": "<default>",
+                    "deploymentKey": -1
+                  },
+                  "authInfo":{"format":"UNKNOWN","claims":{"claim-a": "foo"},"authData":""}
+                }
+                """
+      },
+      {
+        "CommandDistributionRecord with Process Name",
+        (Supplier<UnifiedRecordValue>)
+            () -> {
+              final var deploymentRecord = new DeploymentRecord();
+              deploymentRecord
+                  .resources()
+                  .add()
+                  .setResourceName("my_first_bpmn.bpmn")
+                  .setResource(wrapString("This is the contents of the BPMN"));
+              deploymentRecord
+                  .processesMetadata()
+                  .add()
+                  .setKey(123)
+                  .setVersion(1)
+                  .setBpmnProcessId("my_first_process")
+                  .setResourceName("my_first_bpmn.bpmn")
+                  .setProcessName("Test Process")
+                  .setChecksum(wrapString("sha1"));
+
+              return new CommandDistributionRecord()
+                  .setPartitionId(1)
+                  .setQueueId("totally-random-queue-id")
+                  .setValueType(ValueType.DEPLOYMENT)
+                  .setIntent(DeploymentIntent.CREATE)
+                  .setCommandValue(deploymentRecord)
+                  .setAuthInfo(new AuthInfo().setClaims(Map.of("claim-a", "foo")));
+            },
+        """
+                {
+                  "startTime": -1,
+                  "partitionId": 1,
+                  "queueId": "totally-random-queue-id",
+                  "valueType": "DEPLOYMENT",
+                  "intent": "CREATE",
+                  "commandValue": {
+                    "resources": [{
+                      "resource": "VGhpcyBpcyB0aGUgY29udGVudHMgb2YgdGhlIEJQTU4=",
+                      "resourceName": "my_first_bpmn.bpmn"
+                    }],
+                    "processesMetadata": [{
+                      "processDefinitionKey": 123,
+                      "version": 1,
+                      "bpmnProcessId": "my_first_process",
+                      "resourceName": "my_first_bpmn.bpmn",
+                      "checksum": "c2hhMQ==",
+                      "processName": "Test Process",
                       "duplicate": false,
                       "tenantId": "<default>",
                       "deploymentKey": -1,
@@ -4770,6 +4845,53 @@ final class JsonSerializableToJsonTest {
           "changedAttributes": []
         }
         """
+      },
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      //////////////////////////////////// ProcessRecord with Process Name ////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "ProcessRecord with Process Name",
+        (Supplier<UnifiedRecordValue>)
+            () -> {
+              final String resourceName = "resource";
+              final String processName = "Test Process";
+              final DirectBuffer resource = wrapString("contents");
+              final String bpmnProcessId = "testProcess";
+              final long processDefinitionKey = 123;
+              final int processVersion = 12;
+              final DirectBuffer checksum = wrapString("checksum");
+              final long deploymentKey = 1234;
+              final String versionTag = "v1.0";
+
+              final ProcessRecord record = new ProcessRecord();
+              record
+                  .setResourceName(wrapString(resourceName))
+                  .setResource(resource)
+                  .setBpmnProcessId(wrapString(bpmnProcessId))
+                  .setKey(processDefinitionKey)
+                  .setProcessName(wrapString(processName))
+                  .setVersion(processVersion)
+                  .setChecksum(checksum)
+                  .setDeploymentKey(deploymentKey)
+                  .setVersionTag(versionTag);
+
+              return record;
+            },
+        """
+                {
+                  "resourceName": "resource",
+                  "resource": "Y29udGVudHM=",
+                  "checksum": "Y2hlY2tzdW0=",
+                  "bpmnProcessId": "testProcess",
+                  "version": 12,
+                  "processDefinitionKey": 123,
+                  "processName": "Test Process",
+                  "duplicate": false,
+                  "tenantId": "<default>",
+                  "deploymentKey": 1234,
+                  "versionTag": "v1.0"
+                }
+                """
       }
     };
   }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceCreationRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceCreationRecord.golden
@@ -48,6 +48,7 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
   private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
       new StringValue("rootProcessInstanceKey");
   private static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
+  private static final StringValue PROCESS_NAME_KEY = new StringValue("processName");
 
   private final StringProperty bpmnProcessIdProperty = new StringProperty(BPMN_PROCESS_ID_KEY, "");
   private final LongProperty processDefinitionKeyProperty =
@@ -72,9 +73,10 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
   private final LongProperty rootProcessInstanceKeyProperty =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1);
   private final StringProperty businessIdProperty = new StringProperty(BUSINESS_ID_KEY, "");
+  private final StringProperty processNameProperty = new StringProperty(PROCESS_NAME_KEY, "");
 
   public ProcessInstanceCreationRecord() {
-    super(12);
+    super(13);
     declareProperty(bpmnProcessIdProperty)
         .declareProperty(processDefinitionKeyProperty)
         .declareProperty(processInstanceKeyProperty)
@@ -86,7 +88,8 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
         .declareProperty(tenantIdProperty)
         .declareProperty(tagsProperty)
         .declareProperty(rootProcessInstanceKeyProperty)
-        .declareProperty(businessIdProperty);
+        .declareProperty(businessIdProperty)
+        .declareProperty(processNameProperty);
   }
 
   @Override

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceResultRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceResultRecord.golden
@@ -40,6 +40,7 @@ public final class ProcessInstanceResultRecord extends UnifiedRecordValue
   public static final StringValue PROCESS_INSTANCE_KEY_KEY = new StringValue("processInstanceKey");
   public static final StringValue TAGS_KEY = new StringValue("tags");
   public static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
+  public static final StringValue PROCESS_NAME_KEY = new StringValue("processName");
 
   private final StringProperty bpmnProcessIdProperty = new StringProperty(BPMN_PROCESS_ID_KEY, "");
   private final LongProperty processDefinitionKeyProperty =
@@ -53,9 +54,10 @@ public final class ProcessInstanceResultRecord extends UnifiedRecordValue
   private final ArrayProperty<StringValue> tagsProperty =
       new ArrayProperty<>(TAGS_KEY, StringValue::new);
   private final StringProperty businessIdProperty = new StringProperty(BUSINESS_ID_KEY, "");
+  private final StringProperty processNameProperty = new StringProperty(PROCESS_NAME_KEY, "");
 
   public ProcessInstanceResultRecord() {
-    super(8);
+    super(9);
     declareProperty(bpmnProcessIdProperty)
         .declareProperty(processDefinitionKeyProperty)
         .declareProperty(processInstanceKeyProperty)
@@ -63,7 +65,8 @@ public final class ProcessInstanceResultRecord extends UnifiedRecordValue
         .declareProperty(tenantIdProperty)
         .declareProperty(variablesProperty)
         .declareProperty(tagsProperty)
-        .declareProperty(businessIdProperty);
+        .declareProperty(businessIdProperty)
+        .declareProperty(processNameProperty);
   }
 
   @Override

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessMetadata.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessMetadata.golden
@@ -34,6 +34,7 @@ public final class ProcessMetadata extends UnifiedRecordValue implements Process
   private final LongProperty keyProp = new LongProperty(PROCESS_DEFINITION_KEY_KEY);
   private final StringProperty resourceNameProp = new StringProperty("resourceName");
   private final BinaryProperty checksumProp = new BinaryProperty("checksum");
+  private final StringProperty processNameProp = new StringProperty("processName", "");
 
   // should be set to true if the process was already deployed - property should not be exported
   private final BooleanProperty isDuplicateProp = new BooleanProperty("isDuplicate", false);
@@ -43,7 +44,7 @@ public final class ProcessMetadata extends UnifiedRecordValue implements Process
   private final StringProperty versionTagProp = new StringProperty("versionTag", "");
 
   public ProcessMetadata() {
-    super(9);
+    super(10);
     declareProperty(bpmnProcessIdProp)
         .declareProperty(versionProp)
         .declareProperty(keyProp)
@@ -52,7 +53,8 @@ public final class ProcessMetadata extends UnifiedRecordValue implements Process
         .declareProperty(isDuplicateProp)
         .declareProperty(tenantIdProp)
         .declareProperty(deploymentKeyProp)
-        .declareProperty(versionTagProp);
+        .declareProperty(versionTagProp)
+        .declareProperty(processNameProp);
   }
 
   @Override
@@ -86,6 +88,11 @@ public final class ProcessMetadata extends UnifiedRecordValue implements Process
   }
 
   @Override
+  public String getProcessName() {
+    return bufferAsString(processNameProp.getValue());
+  }
+
+  @Override
   public byte[] getChecksum() {
     return BufferUtil.bufferAsArray(checksumProp.getValue());
   }
@@ -112,6 +119,16 @@ public final class ProcessMetadata extends UnifiedRecordValue implements Process
 
   public ProcessMetadata setDeploymentKey(final long deploymentKey) {
     deploymentKeyProp.setValue(deploymentKey);
+    return this;
+  }
+
+  public ProcessMetadata setProcessName(final String name) {
+    processNameProp.setValue(name);
+    return this;
+  }
+
+  public ProcessMetadata setProcessName(final DirectBuffer name) {
+    processNameProp.setValue(name);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessRecord.golden
@@ -34,9 +34,10 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   private final LongProperty deploymentKeyProp = new LongProperty("deploymentKey", -1);
   private final StringProperty versionTagProp = new StringProperty("versionTag", "");
+  private final StringProperty processNameProp = new StringProperty("processName", "");
 
   public ProcessRecord() {
-    super(9);
+    super(10);
     declareProperty(bpmnProcessIdProp)
         .declareProperty(versionProp)
         .declareProperty(keyProp)
@@ -45,7 +46,8 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
         .declareProperty(resourceProp)
         .declareProperty(tenantIdProp)
         .declareProperty(deploymentKeyProp)
-        .declareProperty(versionTagProp);
+        .declareProperty(versionTagProp)
+        .declareProperty(processNameProp);
   }
 
   public ProcessRecord wrap(final ProcessMetadata metadata, final byte[] resource) {
@@ -58,6 +60,7 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
     tenantIdProp.setValue(metadata.getTenantId());
     deploymentKeyProp.setValue(metadata.getDeploymentKey());
     versionTagProp.setValue(metadata.getVersionTag());
+    processNameProp.setValue(metadata.getProcessName());
     return this;
   }
 
@@ -89,6 +92,11 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
   @Override
   public String getResourceName() {
     return BufferUtil.bufferAsString(resourceNameProp.getValue());
+  }
+
+  @Override
+  public String getProcessName() {
+    return BufferUtil.bufferAsString(processNameProp.getValue());
   }
 
   @Override
@@ -138,6 +146,16 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
 
   public ProcessRecord setBpmnProcessId(final DirectBuffer bpmnProcessId) {
     bpmnProcessIdProp.setValue(bpmnProcessId);
+    return this;
+  }
+
+  public ProcessRecord setProcessName(final String name) {
+    processNameProp.setValue(name);
+    return this;
+  }
+
+  public ProcessRecord setProcessName(final DirectBuffer name) {
+    processNameProp.setValue(name);
     return this;
   }
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceCreationRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceCreationRecordValue.java
@@ -81,6 +81,15 @@ public interface ProcessInstanceCreationRecordValue
    */
   String getBusinessId();
 
+  /**
+   * Returns the name of the process which this instance was created for, as defined in the BPMN
+   * model. May be empty if no name was defined in the BPMN.
+   *
+   * @return the process name, or an empty string if not defined
+   * @since 8.10
+   */
+  String getProcessName();
+
   @Value.Immutable
   @ImmutableProtocol(builder = ImmutableProcessInstanceCreationStartInstructionValue.Builder.class)
   interface ProcessInstanceCreationStartInstructionValue {

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceResultRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceResultRecordValue.java
@@ -65,4 +65,13 @@ public interface ProcessInstanceResultRecordValue
    * @since 8.9
    */
   String getBusinessId();
+
+  /**
+   * Returns the name of the process which this instance was created for, as defined in the BPMN
+   * model. May be empty if no name was defined in the BPMN.
+   *
+   * @return the process name, or an empty string if not defined
+   * @since 8.10
+   */
+  String getProcessName();
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/deployment/ProcessMetadataValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/deployment/ProcessMetadataValue.java
@@ -50,6 +50,11 @@ public interface ProcessMetadataValue extends RecordValue, TenantOwned {
   String getResourceName();
 
   /**
+   * @return the BPMN process name, or an empty string if none is set
+   */
+  String getProcessName();
+
+  /**
    * @return the checksum of the process (MD5)
    */
   byte[] getChecksum();


### PR DESCRIPTION
## Description

Returns the process name from the Java client in two flows:

1. **Deployment response** — `DeploymentEvent.getProcesses().get(0).getProcessName()` now returns the BPMN process name (in addition to bpmn process id, version, key, etc.).
2. **Create process instance response** — `ProcessInstanceEvent.getProcessName()` and `ProcessInstanceResult.getProcessName()` now return the process name for both `createProcessInstance` and `createProcessInstance(...).withResult()`.

Changes span:
- Record protocol (`ProcessRecord`, `ProcessMetadata`, `ProcessInstanceCreationRecord`, `ProcessInstanceResultRecord`) with backward-compatible MsgPack defaults (`""`).
- Engine processors and `BpmnProcessResultSenderBehavior` resolve the name from `DeployedProcess`/`ProcessState`.
- gRPC `gateway.proto` adds `optional string process_name` to deployment, create-instance, and create-instance-with-result responses.
- REST OpenAPI exposes `processName` on the corresponding response schemas with `x-properties-added-in-version: "8.10"`.
- Java client interfaces gain `getProcessName()`; impls populate via `hasProcessName()` (gRPC) or default `""` (REST).
- Optimize `ProcessMetadata` DTO mirrors the addition.
- Golden files and `JsonSerializableToJsonTest` updated; `EventAppliersTest.NoChangesTest` passes.

## Related issues

closes #47173

## Credit

This work continues the original contribution from @zHd4 in #48192. The commit retains @zHd4 as the author. This PR was raised as a new branch in `camunda/camunda` (rather than updating the original PR) because the original was opened from a fork and the scope was extended to also include CreateProcessInstance, requiring additional review. Thank you @zHd4 for the original implementation.

## Definition of Done

<!-- Please check the items that apply, before submitting your pull request. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/camunda/compare/stable/8.7...main?expand=1&template=backport_template.md&title=[Backport%20stable/8.7])
the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`)
to this PR.

Testing:
* [x] There are unit/integration tests that verify all parts of the code change that matters.
* [x] The behavior is tested manually.
* [ ] The change has been verified by a QA run.
* [ ] The impact of the changes is verified by a benchmark.

Documentation:
* [x] The documentation is updated (e.g. Javadoc, REST API, OpenAPI, gRPC).
* [ ] If the change is large or important, the [migration guide](https://github.com/camunda/camunda-docs/blob/main/versioned_docs/version-8.7/guides/update-guide/introduction.md) is updated.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.

* [ ] Issue created for: _Documentation team_

Please refer to our [review guidelines](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#review-guidelines).
