### PR TITLE
docs: add note on PATCH nullable field

### DIFF
--- a/docs/rest-api-endpoint-guidelines.md
+++ b/docs/rest-api-endpoint-guidelines.md
@@ -1785,3 +1785,4 @@ MySchema:
 | CI OpenAPI lint job          | `.github/workflows/ci.yml` (job: `openapi-lint`)                                                                                                                              |
 | Slack channel                | [`#top-c8-cluster-api-governance`](https://camunda.slack.com/archives/C0A154VV8DB)                                                                                            |
 | API team (reviewers)         | `@camunda/c8-api-team`                                                                                                                                                        |
+

--- a/docs/rest-api-endpoint-guidelines.md
+++ b/docs/rest-api-endpoint-guidelines.md
@@ -273,7 +273,7 @@ For how the `required` / `nullable` flags propagate from the spec down through t
 
 On request schemas, the `nullable` property is **not** used to express optionality. Request schema fields are optional by default, and must be added to the `required` array if they are not optional and must be set by the client. If a request field can be omitted by the client, **do not** mark it as `nullable: true` - simply omit it from the `required` array. The Jackson deserialiser will produce an object with `null` for request fields that are not sent by the client. In Java, not present and `null` are the same thing. In JSON, `null` is an explicit value, distinct from "not present". Both JSON `null` and "not present" deserialise to `null` in Java. Marking an *optional* request schema field as `nullable: true` does not make it optional (its omission from `required` does that). It generates ternary client types in languages such as JavaScript and Python, where "not present" (JS `undefined` / Python `Unset`) are *distinct* from present and explicitly null (JS `null` / Python `None`).
 
-You are reaching for `T | undefined` in JS, and `T | Unset` in Python. Just leave it out of the required array. Marking it `nullable: true` will create `T | undefined | null` in JS and `T | Unset | None` in Python.
+You are probably reaching for `T | undefined` in JS, and `T | Unset` in Python. Just leave it out of the required array. Marking it `nullable: true` will create `T | undefined | null` in JS and `T | Unset | None` in Python.
 
 The exception to this is a PATCH operation where sending an explicit `null` is semantically meaningful: it erases any previous set value.
 

--- a/docs/rest-api-endpoint-guidelines.md
+++ b/docs/rest-api-endpoint-guidelines.md
@@ -275,6 +275,8 @@ On request schemas, the `nullable` property is **not** used to express optionali
 
 You are reaching for `T | undefined` in JS, and `T | Unset` in Python. Just leave it out of the required array. Marking it `nullable: true` will create `T | undefined | null` in JS and `T | Unset | None` in Python.
 
+The exception to this is a PATCH operation where sending an explicit `null` is semantically meaningful: it erases any previous set value.
+
 ### 2.5 Eventually consistent annotation (`x-eventually-consistent`)
 
 Every operation **should** declare `x-eventually-consistent` explicitly:
@@ -1783,4 +1785,3 @@ MySchema:
 | CI OpenAPI lint job          | `.github/workflows/ci.yml` (job: `openapi-lint`)                                                                                                                              |
 | Slack channel                | [`#top-c8-cluster-api-governance`](https://camunda.slack.com/archives/C0A154VV8DB)                                                                                            |
 | API team (reviewers)         | `@camunda/c8-api-team`                                                                                                                                                        |
-


### PR DESCRIPTION
## Description

Add note on valid use of `nullable: true` in PATCH operation.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
