### PR TITLE
feat: spectral rule requiring security declaration on every operation

### DIFF
--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -300,6 +300,9 @@ runs:
           - 'zeebe/gateway-protocol/src/main/proto/v2/**'
           - 'zeebe/gateway-protocol/vacuum-ruleset.yaml'
           - 'zeebe/gateway-protocol/vacuum-ignores.yaml'
+          - 'zeebe/gateway-protocol/.spectral.yaml'
+          - 'zeebe/gateway-protocol/spectral-functions/**'
+          - 'zeebe/gateway-protocol/spectral-tests/**'
           - '.github/scripts/x-added-in-version-check/**'
           - '.github/workflows/verify-x-added-in-version-annotations.yml'
 

--- a/zeebe/gateway-protocol/.spectral.yaml
+++ b/zeebe/gateway-protocol/.spectral.yaml
@@ -315,7 +315,7 @@ rules:
   # Every operation must declare its security modes (camunda/camunda#54268).
   # See verifySecurityDeclared.js for the accepted shapes — either
   # `security: []` for publicly unauthenticated endpoints, or a list of the
-  # conditionally-enforced schemes (`BearerAuth`, `basicAuth`) with empty
+  # conditionally-enforced schemes (`bearerAuth`, `basicAuth`) with empty
   # scopes. The conditional-enforcement metadata on the schemes themselves is
   # set in rest-api.yaml (camunda/camunda#53708).
   require-security-declared:

--- a/zeebe/gateway-protocol/.spectral.yaml
+++ b/zeebe/gateway-protocol/.spectral.yaml
@@ -13,6 +13,7 @@ functions:
   - verifyAddedInVersion
   - verifySemanticKindsRegistered
   - verifyNoAmbiguousIdentifierProperty
+  - verifySecurityDeclared
 functionsDir: ./spectral-functions
 rules:
   # Tag validation
@@ -310,3 +311,17 @@ rules:
     message: "{{error}}"
     then:
       function: verifyNoAmbiguousIdentifierProperty
+
+  # Every operation must declare its security modes (camunda/camunda#54268).
+  # See verifySecurityDeclared.js for the accepted shapes — either
+  # `security: []` for publicly unauthenticated endpoints, or a list of the
+  # conditionally-enforced schemes (`BearerAuth`, `basicAuth`) with empty
+  # scopes. The conditional-enforcement metadata on the schemes themselves is
+  # set in rest-api.yaml (camunda/camunda#53708).
+  require-security-declared:
+    description: "Every operation must declare a `security:` block."
+    severity: error
+    given: $.paths[*][*]
+    message: "{{error}}"
+    then:
+      function: verifySecurityDeclared

--- a/zeebe/gateway-protocol/spectral-functions/verifySecurityDeclared.js
+++ b/zeebe/gateway-protocol/spectral-functions/verifySecurityDeclared.js
@@ -13,10 +13,10 @@
 //      /license).
 //
 //   2. A list whose entries each select one of the two conditionally-enforced
-//      security schemes (`BearerAuth`, `basicAuth`) with empty scopes:
+//      security schemes (`bearerAuth`, `basicAuth`) with empty scopes:
 //
 //        security:
-//          - BearerAuth: []
+//          - bearerAuth: []
 //          - basicAuth: []
 //
 //      Each entry must reference exactly one scheme. Schemes other than the
@@ -28,7 +28,7 @@
 // delete).
 
 const HTTP_METHODS = new Set(['get', 'post', 'put', 'patch', 'delete']);
-const ALLOWED_SCHEMES = new Set(['BearerAuth', 'basicAuth']);
+const ALLOWED_SCHEMES = new Set(['bearerAuth', 'basicAuth']);
 
 module.exports = (input, _opts, context) => {
   const errors = [];
@@ -54,7 +54,7 @@ module.exports = (input, _opts, context) => {
         `Operation ${location} is missing \`security:\`. Every operation must ` +
         `declare its security modes — either \`security: []\` for a publicly ` +
         `unauthenticated endpoint, or a list of conditionally-enforced schemes ` +
-        `(\`BearerAuth\` and/or \`basicAuth\`).`,
+        `(\`bearerAuth\` and/or \`basicAuth\`).`,
       path: [...context.path],
     });
     return errors;
@@ -119,7 +119,7 @@ module.exports = (input, _opts, context) => {
         message:
           `Operation ${location} \`security[${i}]\` references unknown scheme ` +
           `\`${schemeName}\`. Only the conditionally-enforced schemes ` +
-          `\`BearerAuth\` and \`basicAuth\` are accepted.`,
+          `\`bearerAuth\` and \`basicAuth\` are accepted.`,
         path: [...entryPath, schemeName],
       });
       continue;
@@ -131,7 +131,7 @@ module.exports = (input, _opts, context) => {
       errors.push({
         message:
           `Operation ${location} \`security[${i}].${schemeName}\` must be an array ` +
-          `(scopes). For \`BearerAuth\`/\`basicAuth\`, this array must be empty.`,
+          `(scopes). For \`bearerAuth\`/\`basicAuth\`, this array must be empty.`,
         path: [...entryPath, schemeName],
       });
       continue;
@@ -141,7 +141,7 @@ module.exports = (input, _opts, context) => {
       errors.push({
         message:
           `Operation ${location} \`security[${i}].${schemeName}\` must declare an ` +
-          `empty scopes array — \`BearerAuth\` and \`basicAuth\` do not use OAuth ` +
+          `empty scopes array — \`bearerAuth\` and \`basicAuth\` do not use OAuth ` +
           `scopes.`,
         path: [...entryPath, schemeName],
       });

--- a/zeebe/gateway-protocol/spectral-functions/verifySecurityDeclared.js
+++ b/zeebe/gateway-protocol/spectral-functions/verifySecurityDeclared.js
@@ -1,0 +1,165 @@
+// Spectral custom function to verify that every operation declares its
+// security modes. See https://github.com/camunda/camunda/issues/54268.
+//
+// The Camunda 8 REST API enforces auth at runtime via `SecurityPathAdapter`
+// when started in secured mode (see PR #53708). To keep the spec in sync
+// with that enforcement and to let downstream tools (camunda/api-test-generator)
+// reason about which endpoints expect 401 responses in which deployment modes,
+// every operation must declare a `security:` block. The accepted shapes are:
+//
+//   1. `security: []`
+//      Explicit empty array — overrides the global enforcement, marking the
+//      endpoint as publicly unauthenticated (e.g. /status, /setup/user,
+//      /license).
+//
+//   2. A list whose entries each select one of the two conditionally-enforced
+//      security schemes (`BearerAuth`, `basicAuth`) with empty scopes:
+//
+//        security:
+//          - BearerAuth: []
+//          - basicAuth: []
+//
+//      Each entry must reference exactly one scheme. Schemes other than the
+//      two conditionally-enforced ones are not accepted by this rule. Empty
+//      objects (`- {}`), duplicate entries, and non-empty scope arrays are
+//      rejected.
+//
+// Applied to each operation object under paths (get, post, put, patch,
+// delete).
+
+const HTTP_METHODS = new Set(['get', 'post', 'put', 'patch', 'delete']);
+const ALLOWED_SCHEMES = new Set(['BearerAuth', 'basicAuth']);
+
+module.exports = (input, _opts, context) => {
+  const errors = [];
+
+  if (!context.path || context.path.length < 3) {
+    return errors;
+  }
+
+  const pathString = context.path[1];
+  const method = context.path[2];
+
+  if (!HTTP_METHODS.has(method)) {
+    return errors;
+  }
+
+  const operationId = input.operationId || '?';
+  const location = `"${operationId}" (${method.toUpperCase()} ${pathString})`;
+  const security = input.security;
+
+  if (security === undefined) {
+    errors.push({
+      message:
+        `Operation ${location} is missing \`security:\`. Every operation must ` +
+        `declare its security modes — either \`security: []\` for a publicly ` +
+        `unauthenticated endpoint, or a list of conditionally-enforced schemes ` +
+        `(\`BearerAuth\` and/or \`basicAuth\`).`,
+      path: [...context.path],
+    });
+    return errors;
+  }
+
+  if (!Array.isArray(security)) {
+    errors.push({
+      message: `Operation ${location} \`security\` must be an array.`,
+      path: [...context.path, 'security'],
+    });
+    return errors;
+  }
+
+  // `security: []` (explicit public) is valid; nothing more to check.
+  if (security.length === 0) {
+    return errors;
+  }
+
+  const seenSchemes = new Set();
+
+  for (let i = 0; i < security.length; i++) {
+    const entry = security[i];
+    const entryPath = [...context.path, 'security', i];
+
+    if (entry === null || typeof entry !== 'object' || Array.isArray(entry)) {
+      errors.push({
+        message:
+          `Operation ${location} \`security[${i}]\` must be an object mapping a ` +
+          `scheme name to a scopes array.`,
+        path: entryPath,
+      });
+      continue;
+    }
+
+    const schemeNames = Object.keys(entry);
+
+    if (schemeNames.length === 0) {
+      errors.push({
+        message:
+          `Operation ${location} \`security[${i}]\` is an empty object. Each entry ` +
+          `must reference exactly one security scheme.`,
+        path: entryPath,
+      });
+      continue;
+    }
+
+    if (schemeNames.length > 1) {
+      errors.push({
+        message:
+          `Operation ${location} \`security[${i}]\` declares multiple schemes ` +
+          `(${schemeNames.join(', ')}) in a single entry (AND semantics). Use ` +
+          `separate list entries to express OR semantics — one scheme per entry.`,
+        path: entryPath,
+      });
+      continue;
+    }
+
+    const schemeName = schemeNames[0];
+
+    if (!ALLOWED_SCHEMES.has(schemeName)) {
+      errors.push({
+        message:
+          `Operation ${location} \`security[${i}]\` references unknown scheme ` +
+          `\`${schemeName}\`. Only the conditionally-enforced schemes ` +
+          `\`BearerAuth\` and \`basicAuth\` are accepted.`,
+        path: [...entryPath, schemeName],
+      });
+      continue;
+    }
+
+    const scopes = entry[schemeName];
+
+    if (!Array.isArray(scopes)) {
+      errors.push({
+        message:
+          `Operation ${location} \`security[${i}].${schemeName}\` must be an array ` +
+          `(scopes). For \`BearerAuth\`/\`basicAuth\`, this array must be empty.`,
+        path: [...entryPath, schemeName],
+      });
+      continue;
+    }
+
+    if (scopes.length !== 0) {
+      errors.push({
+        message:
+          `Operation ${location} \`security[${i}].${schemeName}\` must declare an ` +
+          `empty scopes array — \`BearerAuth\` and \`basicAuth\` do not use OAuth ` +
+          `scopes.`,
+        path: [...entryPath, schemeName],
+      });
+      continue;
+    }
+
+    if (seenSchemes.has(schemeName)) {
+      errors.push({
+        message:
+          `Operation ${location} \`security\` declares scheme \`${schemeName}\` ` +
+          `more than once.`,
+        path: [...entryPath, schemeName],
+      });
+      continue;
+    }
+
+    seenSchemes.add(schemeName);
+  }
+
+  return errors;
+};

--- a/zeebe/gateway-protocol/spectral-tests/fixtures/security-declared/rest-api.yaml
+++ b/zeebe/gateway-protocol/spectral-tests/fixtures/security-declared/rest-api.yaml
@@ -1,7 +1,7 @@
 # Entry point for require-security-declared rule tests.
 # Mirrors the real spec structure: paths $ref to a domain file, and the
 # securitySchemes are declared at the top level so $ref resolution can see
-# both BearerAuth and basicAuth.
+# both bearerAuth and basicAuth.
 openapi: "3.0.3"
 info:
   title: Test Fixture — require-security-declared
@@ -50,7 +50,7 @@ paths:
 
 components:
   securitySchemes:
-    BearerAuth:
+    bearerAuth:
       type: http
       scheme: bearer
       bearerFormat: JWT

--- a/zeebe/gateway-protocol/spectral-tests/fixtures/security-declared/rest-api.yaml
+++ b/zeebe/gateway-protocol/spectral-tests/fixtures/security-declared/rest-api.yaml
@@ -1,0 +1,59 @@
+# Entry point for require-security-declared rule tests.
+# Mirrors the real spec structure: paths $ref to a domain file, and the
+# securitySchemes are declared at the top level so $ref resolution can see
+# both BearerAuth and basicAuth.
+openapi: "3.0.3"
+info:
+  title: Test Fixture — require-security-declared
+  version: "1.0"
+tags:
+  - name: Test
+
+paths:
+  # ── Valid cases ────────────────────────────────────────────────
+  /valid/both-schemes:
+    $ref: 'things.yaml#/paths/~1valid~1both-schemes'
+
+  /valid/bearer-only:
+    $ref: 'things.yaml#/paths/~1valid~1bearer-only'
+
+  /valid/basic-only:
+    $ref: 'things.yaml#/paths/~1valid~1basic-only'
+
+  /valid/public:
+    $ref: 'things.yaml#/paths/~1valid~1public'
+
+  # ── Invalid cases ──────────────────────────────────────────────
+  /invalid/missing-security:
+    $ref: 'things.yaml#/paths/~1invalid~1missing-security'
+
+  /invalid/unknown-scheme:
+    $ref: 'things.yaml#/paths/~1invalid~1unknown-scheme'
+
+  /invalid/non-empty-scopes:
+    $ref: 'things.yaml#/paths/~1invalid~1non-empty-scopes'
+
+  /invalid/empty-entry:
+    $ref: 'things.yaml#/paths/~1invalid~1empty-entry'
+
+  /invalid/multi-scheme-entry:
+    $ref: 'things.yaml#/paths/~1invalid~1multi-scheme-entry'
+
+  /invalid/duplicate-scheme:
+    $ref: 'things.yaml#/paths/~1invalid~1duplicate-scheme'
+
+  /invalid/not-an-array:
+    $ref: 'things.yaml#/paths/~1invalid~1not-an-array'
+
+  /invalid/scopes-not-an-array:
+    $ref: 'things.yaml#/paths/~1invalid~1scopes-not-an-array'
+
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+    basicAuth:
+      type: http
+      scheme: basic

--- a/zeebe/gateway-protocol/spectral-tests/fixtures/security-declared/things.yaml
+++ b/zeebe/gateway-protocol/spectral-tests/fixtures/security-declared/things.yaml
@@ -1,0 +1,176 @@
+# Domain file for require-security-declared rule test fixture.
+openapi: "3.0.3"
+info:
+  title: Things domain (test fixture)
+  version: "1.0"
+tags:
+  - name: Test
+
+paths:
+  # ── Valid: both conditionally-enforced schemes (OR) ───────────
+  /valid/both-schemes:
+    get:
+      operationId: getValidBoth
+      summary: Both schemes declared
+      description: Canonical OR-pattern across BearerAuth and basicAuth.
+      x-added-in-version: "8.8"
+      tags: [Test]
+      security:
+        - BearerAuth: []
+        - basicAuth: []
+      responses:
+        '200':
+          description: OK
+
+  # ── Valid: BearerAuth only (e.g. getAuthentication today) ─────
+  /valid/bearer-only:
+    get:
+      operationId: getValidBearerOnly
+      summary: BearerAuth only
+      description: Single-scheme operation.
+      x-added-in-version: "8.8"
+      tags: [Test]
+      security:
+        - BearerAuth: []
+      responses:
+        '200':
+          description: OK
+
+  # ── Valid: basicAuth only ─────────────────────────────────────
+  /valid/basic-only:
+    get:
+      operationId: getValidBasicOnly
+      summary: basicAuth only
+      description: Single-scheme operation.
+      x-added-in-version: "8.8"
+      tags: [Test]
+      security:
+        - basicAuth: []
+      responses:
+        '200':
+          description: OK
+
+  # ── Valid: explicit public ────────────────────────────────────
+  /valid/public:
+    get:
+      operationId: getValidPublic
+      summary: Explicit public
+      description: Empty security overrides the global enforcement.
+      x-added-in-version: "8.8"
+      tags: [Test]
+      security: []
+      responses:
+        '200':
+          description: OK
+
+  # ── Invalid: missing security block ───────────────────────────
+  /invalid/missing-security:
+    get:
+      operationId: getInvalidMissingSecurity
+      summary: Missing security
+      description: No security block declared.
+      x-added-in-version: "8.8"
+      tags: [Test]
+      responses:
+        '200':
+          description: OK
+
+  # ── Invalid: references an unknown scheme ─────────────────────
+  /invalid/unknown-scheme:
+    get:
+      operationId: getInvalidUnknownScheme
+      summary: Unknown scheme
+      description: Uses a scheme name that is not BearerAuth or basicAuth.
+      x-added-in-version: "8.8"
+      tags: [Test]
+      security:
+        - OAuth2: []
+      responses:
+        '200':
+          description: OK
+
+  # ── Invalid: non-empty scopes array ───────────────────────────
+  /invalid/non-empty-scopes:
+    get:
+      operationId: getInvalidNonEmptyScopes
+      summary: Non-empty scopes
+      description: BearerAuth/basicAuth do not use OAuth scopes.
+      x-added-in-version: "8.8"
+      tags: [Test]
+      security:
+        - BearerAuth: [read:thing]
+      responses:
+        '200':
+          description: OK
+
+  # ── Invalid: empty entry ──────────────────────────────────────
+  /invalid/empty-entry:
+    get:
+      operationId: getInvalidEmptyEntry
+      summary: Empty entry
+      description: An entry with no scheme name.
+      x-added-in-version: "8.8"
+      tags: [Test]
+      security:
+        - {}
+      responses:
+        '200':
+          description: OK
+
+  # ── Invalid: multiple schemes in a single entry (AND) ─────────
+  /invalid/multi-scheme-entry:
+    get:
+      operationId: getInvalidMultiSchemeEntry
+      summary: Multiple schemes in one entry
+      description: AND-semantics is not allowed; use separate list entries.
+      x-added-in-version: "8.8"
+      tags: [Test]
+      security:
+        - BearerAuth: []
+          basicAuth: []
+      responses:
+        '200':
+          description: OK
+
+  # ── Invalid: duplicate scheme in separate entries ─────────────
+  /invalid/duplicate-scheme:
+    get:
+      operationId: getInvalidDuplicateScheme
+      summary: Duplicate scheme entries
+      description: Same scheme listed twice.
+      x-added-in-version: "8.8"
+      tags: [Test]
+      security:
+        - BearerAuth: []
+        - BearerAuth: []
+      responses:
+        '200':
+          description: OK
+
+  # ── Invalid: security is not an array ─────────────────────────
+  /invalid/not-an-array:
+    get:
+      operationId: getInvalidNotAnArray
+      summary: Security is an object
+      description: Security must be an array.
+      x-added-in-version: "8.8"
+      tags: [Test]
+      security:
+        BearerAuth: []
+      responses:
+        '200':
+          description: OK
+
+  # ── Invalid: scopes value is not an array ─────────────────────
+  /invalid/scopes-not-an-array:
+    get:
+      operationId: getInvalidScopesNotAnArray
+      summary: Scopes is a string
+      description: Scopes value must be an array.
+      x-added-in-version: "8.8"
+      tags: [Test]
+      security:
+        - BearerAuth: "not-an-array"
+      responses:
+        '200':
+          description: OK

--- a/zeebe/gateway-protocol/spectral-tests/fixtures/security-declared/things.yaml
+++ b/zeebe/gateway-protocol/spectral-tests/fixtures/security-declared/things.yaml
@@ -12,26 +12,26 @@ paths:
     get:
       operationId: getValidBoth
       summary: Both schemes declared
-      description: Canonical OR-pattern across BearerAuth and basicAuth.
+      description: Canonical OR-pattern across bearerAuth and basicAuth.
       x-added-in-version: "8.8"
       tags: [Test]
       security:
-        - BearerAuth: []
+        - bearerAuth: []
         - basicAuth: []
       responses:
         '200':
           description: OK
 
-  # ── Valid: BearerAuth only (e.g. getAuthentication today) ─────
+  # ── Valid: bearerAuth only (e.g. getAuthentication today) ─────
   /valid/bearer-only:
     get:
       operationId: getValidBearerOnly
-      summary: BearerAuth only
+      summary: bearerAuth only
       description: Single-scheme operation.
       x-added-in-version: "8.8"
       tags: [Test]
       security:
-        - BearerAuth: []
+        - bearerAuth: []
       responses:
         '200':
           description: OK
@@ -80,7 +80,7 @@ paths:
     get:
       operationId: getInvalidUnknownScheme
       summary: Unknown scheme
-      description: Uses a scheme name that is not BearerAuth or basicAuth.
+      description: Uses a scheme name that is not bearerAuth or basicAuth.
       x-added-in-version: "8.8"
       tags: [Test]
       security:
@@ -94,11 +94,11 @@ paths:
     get:
       operationId: getInvalidNonEmptyScopes
       summary: Non-empty scopes
-      description: BearerAuth/basicAuth do not use OAuth scopes.
+      description: bearerAuth/basicAuth do not use OAuth scopes.
       x-added-in-version: "8.8"
       tags: [Test]
       security:
-        - BearerAuth: [read:thing]
+        - bearerAuth: [read:thing]
       responses:
         '200':
           description: OK
@@ -126,7 +126,7 @@ paths:
       x-added-in-version: "8.8"
       tags: [Test]
       security:
-        - BearerAuth: []
+        - bearerAuth: []
           basicAuth: []
       responses:
         '200':
@@ -141,8 +141,8 @@ paths:
       x-added-in-version: "8.8"
       tags: [Test]
       security:
-        - BearerAuth: []
-        - BearerAuth: []
+        - bearerAuth: []
+        - bearerAuth: []
       responses:
         '200':
           description: OK
@@ -156,7 +156,7 @@ paths:
       x-added-in-version: "8.8"
       tags: [Test]
       security:
-        BearerAuth: []
+        bearerAuth: []
       responses:
         '200':
           description: OK
@@ -170,7 +170,7 @@ paths:
       x-added-in-version: "8.8"
       tags: [Test]
       security:
-        - BearerAuth: "not-an-array"
+        - bearerAuth: "not-an-array"
       responses:
         '200':
           description: OK

--- a/zeebe/gateway-protocol/spectral-tests/verifySecurityDeclared.test.js
+++ b/zeebe/gateway-protocol/spectral-tests/verifySecurityDeclared.test.js
@@ -21,11 +21,11 @@ describe('verifySecurityDeclared', () => {
   // ── Valid cases (should produce zero violations) ─────────────────
 
   describe('valid: operation declares accepted security shapes', () => {
-    it('produces no violations for both schemes (BearerAuth + basicAuth)', () => {
+    it('produces no violations for both schemes (bearerAuth + basicAuth)', () => {
       assert.equal(violationsFor('getValidBoth').length, 0);
     });
 
-    it('produces no violations for BearerAuth only', () => {
+    it('produces no violations for bearerAuth only', () => {
       assert.equal(violationsFor('getValidBearerOnly').length, 0);
     });
 
@@ -49,7 +49,7 @@ describe('verifySecurityDeclared', () => {
   });
 
   describe('invalid: unknown scheme reference', () => {
-    it('flags operation referencing scheme other than BearerAuth/basicAuth', () => {
+    it('flags operation referencing scheme other than bearerAuth/basicAuth', () => {
       const v = violationsFor('getInvalidUnknownScheme');
       assert.equal(v.length, 1);
       assert.match(v[0].message, /unknown scheme `OAuth2`/);
@@ -57,7 +57,7 @@ describe('verifySecurityDeclared', () => {
   });
 
   describe('invalid: non-empty scopes', () => {
-    it('flags BearerAuth/basicAuth entry with scope values', () => {
+    it('flags bearerAuth/basicAuth entry with scope values', () => {
       const v = violationsFor('getInvalidNonEmptyScopes');
       assert.equal(v.length, 1);
       assert.match(v[0].message, /empty scopes array/);

--- a/zeebe/gateway-protocol/spectral-tests/verifySecurityDeclared.test.js
+++ b/zeebe/gateway-protocol/spectral-tests/verifySecurityDeclared.test.js
@@ -1,0 +1,112 @@
+'use strict';
+
+const { describe, it, before } = require('node:test');
+const assert = require('node:assert/strict');
+const { lintFixture, filterByRule } = require('./helpers');
+
+const RULE = 'require-security-declared';
+const FIXTURE = 'security-declared';
+
+describe('verifySecurityDeclared', () => {
+  let violations;
+
+  before(() => {
+    const allResults = lintFixture(FIXTURE);
+    violations = filterByRule(allResults, RULE);
+  });
+
+  const violationsFor = (operationId) =>
+    violations.filter((v) => v.message.includes(`"${operationId}"`));
+
+  // ── Valid cases (should produce zero violations) ─────────────────
+
+  describe('valid: operation declares accepted security shapes', () => {
+    it('produces no violations for both schemes (BearerAuth + basicAuth)', () => {
+      assert.equal(violationsFor('getValidBoth').length, 0);
+    });
+
+    it('produces no violations for BearerAuth only', () => {
+      assert.equal(violationsFor('getValidBearerOnly').length, 0);
+    });
+
+    it('produces no violations for basicAuth only', () => {
+      assert.equal(violationsFor('getValidBasicOnly').length, 0);
+    });
+
+    it('produces no violations for explicit public (security: [])', () => {
+      assert.equal(violationsFor('getValidPublic').length, 0);
+    });
+  });
+
+  // ── Invalid cases ────────────────────────────────────────────────
+
+  describe('invalid: missing security block', () => {
+    it('flags operation with no security field', () => {
+      const v = violationsFor('getInvalidMissingSecurity');
+      assert.equal(v.length, 1);
+      assert.match(v[0].message, /missing `security:`/);
+    });
+  });
+
+  describe('invalid: unknown scheme reference', () => {
+    it('flags operation referencing scheme other than BearerAuth/basicAuth', () => {
+      const v = violationsFor('getInvalidUnknownScheme');
+      assert.equal(v.length, 1);
+      assert.match(v[0].message, /unknown scheme `OAuth2`/);
+    });
+  });
+
+  describe('invalid: non-empty scopes', () => {
+    it('flags BearerAuth/basicAuth entry with scope values', () => {
+      const v = violationsFor('getInvalidNonEmptyScopes');
+      assert.equal(v.length, 1);
+      assert.match(v[0].message, /empty scopes array/);
+    });
+  });
+
+  describe('invalid: empty entry', () => {
+    it('flags an entry with no scheme name (- {})', () => {
+      const v = violationsFor('getInvalidEmptyEntry');
+      assert.equal(v.length, 1);
+      assert.match(v[0].message, /empty object/);
+    });
+  });
+
+  describe('invalid: multiple schemes ANDed in one entry', () => {
+    it('flags an entry containing more than one scheme', () => {
+      const v = violationsFor('getInvalidMultiSchemeEntry');
+      assert.equal(v.length, 1);
+      assert.match(v[0].message, /multiple schemes/);
+    });
+  });
+
+  describe('invalid: duplicate scheme entries', () => {
+    it('flags a scheme that appears more than once', () => {
+      const v = violationsFor('getInvalidDuplicateScheme');
+      assert.equal(v.length, 1);
+      assert.match(v[0].message, /more than once/);
+    });
+  });
+
+  describe('invalid: security is not an array', () => {
+    it('flags an object value for security', () => {
+      const v = violationsFor('getInvalidNotAnArray');
+      assert.equal(v.length, 1);
+      assert.match(v[0].message, /must be an array/);
+    });
+  });
+
+  describe('invalid: scopes value is not an array', () => {
+    it('flags a non-array scopes value', () => {
+      const v = violationsFor('getInvalidScopesNotAnArray');
+      assert.equal(v.length, 1);
+      assert.match(v[0].message, /must be an array \(scopes\)/);
+    });
+  });
+
+  describe('total count', () => {
+    it('produces exactly one violation per invalid operation (8 total)', () => {
+      assert.equal(violations.length, 8);
+    });
+  });
+});

--- a/zeebe/gateway-protocol/spectral-tests/verifySemanticKindsRegistered.test.js
+++ b/zeebe/gateway-protocol/spectral-tests/verifySemanticKindsRegistered.test.js
@@ -26,7 +26,13 @@ describe('verifySemanticKindsRegistered + schema rules', () => {
 
   describe('valid: well-formed annotations matched to registry', () => {
     it('produces no violations for createWidget (single-key entity establish)', () => {
-      const v = allResults.filter((e) => e.message.includes('createWidget'));
+      const v = allResults.filter(
+        (e) =>
+          e.message.includes('createWidget') &&
+          (e.code === SHAPE_RULE ||
+            e.code === REQUIRES_SHAPE_RULE ||
+            e.code === REGISTRY_RULE),
+      );
       assert.equal(v.length, 0);
     });
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/authentication.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/authentication.yaml
@@ -97,3 +97,5 @@ components:
         canLogout:
           description: Flag for understanding if the user is able to perform logout.
           type: boolean
+
+# triggers openapi-lint for #54270 verification; reverted before merge

--- a/zeebe/gateway-protocol/src/main/proto/v2/authentication.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/authentication.yaml
@@ -97,5 +97,3 @@ components:
         canLogout:
           description: Flag for understanding if the user is able to perform logout.
           type: boolean
-
-# triggers openapi-lint for #54270 verification; reverted before merge


### PR DESCRIPTION
## Description

MERGE AFTER https://github.com/camunda/camunda/pull/53708.

Adds a Spectral rule (`require-security-declared`) that enforces every operation in the OCA spec under `zeebe/gateway-protocol/src/main/proto/v2/` declares a `security:` block. Pairs with #53708 (which adds the security blocks themselves to 189 operations).

## Accepted shapes

- `security: []` — explicit public (overrides the global enforcement; used by `GET /status`, `POST /setup/user`, `GET /license`)
- One or more entries selecting the conditionally-enforced schemes (`BearerAuth`, `basicAuth`) with empty scopes:
  ```yaml
  security:
    - BearerAuth: []
    - basicAuth: []
  ```

## Rejected shapes (each fixture-covered)

- Missing `security:` field
- `security:` is not an array
- Unknown scheme names (anything other than `BearerAuth`/`basicAuth`)
- Non-empty scopes arrays (these schemes don't use OAuth scopes)
- Empty entries (`- {}`)
- Multiple schemes in a single entry (AND-semantics; must be OR via separate list entries)
- Duplicate scheme entries
- Non-array scopes values

## Implementation

- `zeebe/gateway-protocol/spectral-functions/verifySecurityDeclared.js` — custom function, modelled on the existing `verifyAddedInVersion.js`
- `zeebe/gateway-protocol/.spectral.yaml` — registers the function and the rule (severity: error, given `$.paths[*][*]`)
- Runs in the existing `openapi-lint` job in `.github/workflows/ci.yml` — no new CI job needed

## CI path-filter fix

Extends the `openapi-change` filter in `.github/actions/paths-filter/action.yml` so the `openapi-lint` job is also triggered by changes to:

- `zeebe/gateway-protocol/.spectral.yaml`
- `zeebe/gateway-protocol/spectral-functions/**`
- `zeebe/gateway-protocol/spectral-tests/**`

Previously only edits to the v2 yaml files under `src/main/proto/v2/**` would trigger lint, so rule-only changes (like this PR's) would have been silently unvalidated. This also ensures the new rule is exercised end-to-end on this PR against the real spec.

## Tests

13 fixture-based unit tests under `spectral-tests/verifySecurityDeclared.test.js` (4 valid shapes + 8 rejection cases + total count). All 164 tests across the spectral-tests suite pass.

Side-fix: `verifySemanticKindsRegistered.test.js`'s `createWidget` valid-case assertion was filtering by message-substring only, not by rule code like its sibling assertions. Narrowed it to match the existing pattern so the addition of a new rule cannot incidentally fail it.

## Verification

Ran `spectral lint` against the current real spec: rule produces 190 `missing security:` findings, matching the gap that #53708 closes. After #53708 merges, the rule passes.

End-to-end CI verification: the `openapi-lint` job on this PR ran and failed with the expected `require-security-declared` annotations on the real spec (confirming the rule fires correctly).

## Landing order

The rule will fail CI until #53708 merges. Intended order:
1. Merge #53708 (adds the security blocks)
2. Merge this PR (enforces them going forward)

Closes #54268

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
