### PR TITLE
pg/backport-gcs-improvements

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Gcs.java
+++ b/configuration/src/main/java/io/camunda/configuration/Gcs.java
@@ -50,6 +50,9 @@ public class Gcs {
    */
   private GcsBackupStoreAuth auth = GcsBackupStoreAuth.AUTO;
 
+  /** Maximum number of concurrent file transfers (uploads and downloads) using virtual threads. */
+  private int maxConcurrentTransfers = 8;
+
   /** Size of the buffer (in bytes) used when uploading files to GCS. */
   private int bufferSize = 2 * 1024 * 1024;
 
@@ -103,6 +106,14 @@ public class Gcs {
 
   public void setAuth(final GcsBackupStoreAuth auth) {
     this.auth = auth;
+  }
+
+  public int getMaxConcurrentTransfers() {
+    return maxConcurrentTransfers;
+  }
+
+  public void setMaxConcurrentTransfers(final int maxConcurrentTransfers) {
+    this.maxConcurrentTransfers = maxConcurrentTransfers;
   }
 
   public int getBufferSize() {

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -373,6 +373,7 @@ public class BrokerBasedPropertiesOverride {
     gcsBackupStoreConfig.setBasePath(gcs.getBasePath());
     gcsBackupStoreConfig.setHost(gcs.getHost());
     gcsBackupStoreConfig.setAuth(GcsBackupStoreAuth.valueOf(gcs.getAuth().name()));
+    gcsBackupStoreConfig.setMaxConcurrentTransfers(gcs.getMaxConcurrentTransfers());
     gcsBackupStoreConfig.setBufferSize(gcs.getBufferSize());
 
     override.getData().getBackup().setGcs(gcsBackupStoreConfig);

--- a/configuration/src/test/java/io/camunda/configuration/DataBackupGcsTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/DataBackupGcsTest.java
@@ -62,6 +62,11 @@ public class DataBackupGcsTest {
       assertThat(brokerCfg.getData().getBackup().getGcs().getAuth())
           .isEqualTo(GcsBackupStoreAuth.NONE);
     }
+
+    @Test
+    void shouldUseDefaultMaxConcurrentUploads() {
+      assertThat(brokerCfg.getData().getBackup().getGcs().getMaxConcurrentTransfers()).isEqualTo(8);
+    }
   }
 
   @Nested
@@ -163,6 +168,26 @@ public class DataBackupGcsTest {
     @Test
     void shouldSetBufferSize() {
       assertThat(brokerCfg.getData().getBackup().getGcs().getBufferSize()).isEqualTo(4194304);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.data.backup.gcs.bucket-name=test-bucket",
+        "camunda.data.backup.gcs.max-concurrent-transfers=100",
+      })
+  class WithCustomMaxConcurrentTransfers {
+    final BrokerBasedProperties brokerCfg;
+
+    WithCustomMaxConcurrentTransfers(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetMaxConcurrentTransfers() {
+      assertThat(brokerCfg.getData().getBackup().getGcs().getMaxConcurrentTransfers())
+          .isEqualTo(100);
     }
   }
 }

--- a/zeebe/backup-stores/gcs/pom.xml
+++ b/zeebe/backup-stores/gcs/pom.xml
@@ -134,6 +134,13 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/zeebe/backup-stores/gcs/pom.xml
+++ b/zeebe/backup-stores/gcs/pom.xml
@@ -141,7 +141,6 @@
       <scope>test</scope>
     </dependency>
 
-
     <dependency>
       <groupId>net.jqwik</groupId>
       <artifactId>jqwik</artifactId>
@@ -168,6 +167,9 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <configuration>
+          <usedDependencies>
+            <dependency>net.jqwik:jqwik</dependency>
+          </usedDependencies>
           <ignoredUnusedDeclaredDependencies>
             <!-- Will be used soon and is already useful for bringing in dependencies on auto-generated google api libraries -->
             <ignoredUnusedDeclaredDependency>com.google.cloud:google-cloud-storage</ignoredUnusedDeclaredDependency>

--- a/zeebe/backup-stores/gcs/pom.xml
+++ b/zeebe/backup-stores/gcs/pom.xml
@@ -156,6 +156,7 @@
             -->
             <ignoredUsedUndeclaredDependency>com.google.auth:*</ignoredUsedUndeclaredDependency>
             <ignoredUsedUndeclaredDependency>com.google.apis:*</ignoredUsedUndeclaredDependency>
+            <ignoredUsedUndeclaredDependency>com.google.api:*</ignoredUsedUndeclaredDependency>
           </ignoredUsedUndeclaredDependencies>
         </configuration>
       </plugin>

--- a/zeebe/backup-stores/gcs/pom.xml
+++ b/zeebe/backup-stores/gcs/pom.xml
@@ -141,6 +141,25 @@
       <scope>test</scope>
     </dependency>
 
+
+    <dependency>
+      <groupId>net.jqwik</groupId>
+      <artifactId>jqwik</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>net.jqwik</groupId>
+      <artifactId>jqwik-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <!--  Ensure non-jqwik junit5 tests can be run -->
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/zeebe/backup-stores/gcs/pom.xml
+++ b/zeebe/backup-stores/gcs/pom.xml
@@ -136,12 +136,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-junit-jupiter</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>net.jqwik</groupId>
       <artifactId>jqwik</artifactId>
       <scope>test</scope>

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/FileSetManager.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/FileSetManager.java
@@ -21,9 +21,18 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Semaphore;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 final class FileSetManager {
+
+  public static final String SNAPSHOT_FILESET_NAME = "snapshot";
+  public static final String SEGMENTS_FILESET_NAME = "segments";
+
   /**
    * The path format consists of the following elements:
    *
@@ -41,41 +50,95 @@ final class FileSetManager {
   private final Storage client;
   private final BucketInfo bucketInfo;
   private final String basePath;
+  private final ExecutorService executor;
+  private final Semaphore concurrencyLimit;
   private final int bufferSize;
 
   FileSetManager(
       final Storage client,
       final BucketInfo bucketInfo,
       final String basePath,
+      final ExecutorService executor,
+      final int maxConcurrentOperations,
       final int bufferSize) {
     this.client = client;
     this.bucketInfo = bucketInfo;
     this.basePath = basePath;
+    this.executor = executor;
+    concurrencyLimit = new Semaphore(maxConcurrentOperations);
     this.bufferSize = bufferSize;
   }
 
+  /**
+   * Uploads files in parallel using virtual threads. Uses an InputStream-based approach to prevent
+   * the GCS client from reading the file twice (once for CRC32C checksum, once for upload) which
+   * could cause checksum mismatches if the file is modified during upload.
+   *
+   * <p>Concurrency is limited by a semaphore to avoid resource exhaustion.
+   *
+   * @see <a href="https://github.com/camunda/camunda/issues/45636">#45636</a>
+   */
   void save(final BackupIdentifier id, final String fileSetName, final NamedFileSet fileSet) {
-    for (final var namedFile : fileSet.namedFiles().entrySet()) {
-      final var fileName = namedFile.getKey();
-      final var filePath = namedFile.getValue();
-      // Use InputStream instead of Path to prevent the GCS client from reading the file
-      // twice (once for CRC32C checksum, once for upload). Log segments may be modified
-      // during upload, causing checksum mismatches.
-      // See https://github.com/camunda/camunda/issues/45636
-      try (final var inputStream = Files.newInputStream(filePath)) {
-        final int effectiveBufferSize = Math.clamp(Files.size(filePath), 1, bufferSize);
-        client.createFrom(
-            blobInfo(id, fileSetName, fileName),
-            inputStream,
-            effectiveBufferSize,
-            BlobWriteOption.doesNotExist());
-      } catch (final IOException e) {
-        throw new UncheckedIOException(e);
-      }
+    final var uploadFutures =
+        fileSet.namedFiles().entrySet().stream()
+            .map(
+                namedFile ->
+                    schedule(
+                        () -> {
+                          uploadFile(id, fileSetName, namedFile.getKey(), namedFile.getValue());
+                          return null;
+                        }))
+            .toList();
+
+    // Wait for all uploads to complete
+    CompletableFuture.allOf(uploadFutures.toArray(new CompletableFuture[0])).join();
+  }
+
+  /**
+   * Schedules a task to be executed asynchronously using virtual threads, respecting the
+   * concurrency limit imposed by the semaphore.
+   */
+  private <T> CompletableFuture<T> schedule(final Supplier<T> task) {
+    final var result = new CompletableFuture<T>();
+    executor.execute(
+        () -> {
+          try {
+            concurrencyLimit.acquire();
+            result.complete(task.get());
+          } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            result.completeExceptionally(e);
+          } catch (final Exception e) {
+            result.completeExceptionally(e);
+          } finally {
+            concurrencyLimit.release();
+          }
+        });
+    return result;
+  }
+
+  private void uploadFile(
+      final BackupIdentifier id,
+      final String fileSetName,
+      final String fileName,
+      final Path filePath) {
+    // Use InputStream instead of Path to prevent the GCS client from reading the file
+    // twice (once for CRC32C checksum, once for upload). Log segments may be modified
+    // during upload, causing checksum mismatches.
+    // See https://github.com/camunda/camunda/issues/45636
+    try (final var inputStream = Files.newInputStream(filePath)) {
+      final int effectiveBufferSize = Math.clamp(Files.size(filePath), 1, bufferSize);
+      client.createFrom(
+          blobInfo(id, fileSetName, fileName),
+          inputStream,
+          effectiveBufferSize,
+          BlobWriteOption.doesNotExist());
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
     }
   }
 
-  public void delete(final BackupIdentifier id, final String fileSetName) {
+  void delete(final BackupIdentifier id, final String fileSetName) {
     for (final var blob :
         client
             .list(bucketInfo.getName(), BlobListOption.prefix(fileSetPath(id, fileSetName)))
@@ -84,22 +147,43 @@ final class FileSetManager {
     }
   }
 
-  public NamedFileSet restore(
+  /**
+   * Downloads files in parallel using virtual threads. Concurrency is limited by the same semaphore
+   * used for uploads to avoid resource exhaustion.
+   */
+  NamedFileSet restore(
       final BackupIdentifier id,
       final String filesetName,
       final FileSet fileSet,
       final Path targetFolder) {
-    final var pathByName =
+    final var downloadFutures =
         fileSet.files().stream()
-            .collect(Collectors.toMap(NamedFile::name, (f) -> targetFolder.resolve(f.name())));
+            .collect(
+                Collectors.toMap(
+                    NamedFile::name,
+                    namedFile ->
+                        schedule(
+                            () -> downloadFile(id, filesetName, namedFile.name(), targetFolder))));
 
-    for (final var entry : pathByName.entrySet()) {
-      final var fileName = entry.getKey();
-      final var filePath = entry.getValue();
-      client.downloadTo(blobInfo(id, filesetName, fileName).getBlobId(), filePath);
-    }
+    // Wait for all downloads to complete
+    CompletableFuture.allOf(downloadFutures.values().toArray(new CompletableFuture[0])).join();
+
+    // Collect results
+    final var pathByName =
+        downloadFutures.entrySet().stream()
+            .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().join()));
 
     return new NamedFileSetImpl(pathByName);
+  }
+
+  private Path downloadFile(
+      final BackupIdentifier id,
+      final String filesetName,
+      final String fileName,
+      final Path targetFolder) {
+    final var filePath = targetFolder.resolve(fileName);
+    client.downloadTo(blobInfo(id, filesetName, fileName).getBlobId(), filePath);
+    return filePath;
   }
 
   private String fileSetPath(final BackupIdentifier id, final String fileSetName) {

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupConfig.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupConfig.java
@@ -14,15 +14,21 @@ import io.camunda.zeebe.backup.gcs.GcsConnectionConfig.Authentication.Auto;
 import io.camunda.zeebe.backup.gcs.GcsConnectionConfig.Authentication.None;
 
 public record GcsBackupConfig(
-    String bucketName, String basePath, GcsConnectionConfig connection, int bufferSize) {
+    String bucketName,
+    String basePath,
+    GcsConnectionConfig connection,
+    int maxConcurrentTransfers,
+    int bufferSize) {
   public GcsBackupConfig(
       final String bucketName,
       final String basePath,
       final GcsConnectionConfig connection,
+      final int maxConcurrentTransfers,
       final int bufferSize) {
     this.bucketName = requireBucketName(bucketName);
     this.basePath = sanitizeBasePath(basePath);
     this.connection = requireNonNull(connection);
+    this.maxConcurrentTransfers = maxConcurrentTransfers;
     if (bufferSize <= 0) {
       throw new ConfigurationException("Expected bufferSize to be > 0, but got " + bufferSize);
     }
@@ -70,6 +76,9 @@ public record GcsBackupConfig(
     // 2MiB matches the default used by the GCS library's Path-based upload
     private int bufferSize = 2 * 1024 * 1024;
 
+    /** Default parallelism for file transfers (uploads and downloads) using virtual threads */
+    private int maxConcurrentTransfers = 50;
+
     public Builder withBucketName(final String bucketName) {
       this.bucketName = bucketName;
       return this;
@@ -82,6 +91,11 @@ public record GcsBackupConfig(
 
     public Builder withHost(final String host) {
       this.host = host;
+      return this;
+    }
+
+    public Builder withMaxConcurrentTransfers(final int maxConcurrentTransfers) {
+      this.maxConcurrentTransfers = maxConcurrentTransfers;
       return this;
     }
 
@@ -103,7 +117,11 @@ public record GcsBackupConfig(
 
     public GcsBackupConfig build() {
       return new GcsBackupConfig(
-          bucketName, basePath, new GcsConnectionConfig(host, auth), bufferSize);
+          bucketName,
+          basePath,
+          new GcsConnectionConfig(host, auth),
+          maxConcurrentTransfers,
+          bufferSize);
     }
   }
 }

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
@@ -31,7 +31,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.event.Level;
 
 public final class GcsBackupStore implements BackupStore {
   public static final String ERROR_MSG_BACKUP_NOT_FOUND =
@@ -40,46 +39,81 @@ public final class GcsBackupStore implements BackupStore {
       "Expected to restore from completed backup with id '%s', but was in state '%s'";
   public static final String ERROR_VALIDATION_FAILED =
       "Invalid configuration for GcsBackupStore: %s";
-  public static final String SNAPSHOT_FILESET_NAME = "snapshot";
-  public static final String SEGMENTS_FILESET_NAME = "segments";
   private static final Logger LOG = LoggerFactory.getLogger(GcsBackupStore.class);
   private final ExecutorService executor;
   private final ManifestManager manifestManager;
   private final FileSetManager fileSetManager;
   private final Storage client;
+  private final GcsBackupConfig config;
 
   GcsBackupStore(final GcsBackupConfig config) {
     this(config, buildClient(config));
   }
 
   GcsBackupStore(final GcsBackupConfig config, final Storage client) {
+    this.config = config;
     final var bucketInfo = BucketInfo.of(config.bucketName());
     final var basePath = Optional.ofNullable(config.basePath()).map(s -> s + "/").orElse("");
     this.client = client;
-    executor = Executors.newWorkStealingPool(4);
+    executor = Executors.newVirtualThreadPerTaskExecutor();
     manifestManager = new ManifestManager(client, bucketInfo, basePath);
-    fileSetManager = new FileSetManager(client, bucketInfo, basePath, config.bufferSize());
+    fileSetManager =
+        new FileSetManager(
+            client,
+            bucketInfo,
+            basePath,
+            executor,
+            config.maxConcurrentTransfers(),
+            config.bufferSize());
   }
 
   public static BackupStore of(final GcsBackupConfig config) {
-    return new GcsBackupStore(config).logging(LOG, Level.INFO);
+    return new GcsBackupStore(config);
   }
 
   @Override
   public CompletableFuture<Void> save(final Backup backup) {
-    return CompletableFuture.runAsync(
-        () -> {
-          final var persistedManifest = manifestManager.createInitialManifest(backup);
-          try {
-            fileSetManager.save(backup.id(), SNAPSHOT_FILESET_NAME, backup.snapshot());
-            fileSetManager.save(backup.id(), SEGMENTS_FILESET_NAME, backup.segments());
-            manifestManager.completeManifest(persistedManifest);
-          } catch (final Exception e) {
-            manifestManager.markAsFailed(persistedManifest.manifest(), e.getMessage());
-            throw e;
-          }
-        },
-        executor);
+    return CompletableFuture.supplyAsync(
+            () -> manifestManager.createInitialManifest(backup), executor)
+        .thenComposeAsync(
+            persistedManifest -> {
+              final var snapshotFuture =
+                  CompletableFuture.runAsync(
+                      () ->
+                          fileSetManager.save(
+                              backup.id(), FileSetManager.SNAPSHOT_FILESET_NAME, backup.snapshot()),
+                      executor);
+              final var segmentsFuture =
+                  CompletableFuture.runAsync(
+                      () ->
+                          fileSetManager.save(
+                              backup.id(), FileSetManager.SEGMENTS_FILESET_NAME, backup.segments()),
+                      executor);
+
+              return CompletableFuture.allOf(snapshotFuture, segmentsFuture)
+                  .handleAsync(
+                      (ignored, error) -> {
+                        if (error != null) {
+                          manifestManager.markAsFailed(
+                              persistedManifest.manifest(), error.getMessage());
+                          throw new GcsBackupStoreException.UploadException(
+                              "Failed to save backup contents", error);
+                        }
+                        return persistedManifest;
+                      },
+                      executor);
+            },
+            executor)
+        .thenAcceptAsync(
+            persistedManifest -> {
+              try {
+                manifestManager.completeManifest(persistedManifest);
+              } catch (final Exception e) {
+                manifestManager.markAsFailed(persistedManifest.manifest(), e.getMessage());
+                throw e;
+              }
+            },
+            executor);
   }
 
   @Override
@@ -107,8 +141,8 @@ public final class GcsBackupStore implements BackupStore {
     return CompletableFuture.runAsync(
         () -> {
           manifestManager.deleteManifest(id);
-          fileSetManager.delete(id, SNAPSHOT_FILESET_NAME);
-          fileSetManager.delete(id, SEGMENTS_FILESET_NAME);
+          fileSetManager.delete(id, FileSetManager.SNAPSHOT_FILESET_NAME);
+          fileSetManager.delete(id, FileSetManager.SEGMENTS_FILESET_NAME);
         },
         executor);
   }
@@ -127,13 +161,30 @@ public final class GcsBackupStore implements BackupStore {
                     ERROR_MSG_BACKUP_WRONG_STATE_TO_RESTORE.formatted(id, manifest.statusCode()));
             case COMPLETED -> {
               final var completed = manifest.asCompleted();
-              final var snapshot =
-                  fileSetManager.restore(
-                      id, SNAPSHOT_FILESET_NAME, completed.snapshot(), targetFolder);
-              final var segments =
-                  fileSetManager.restore(
-                      id, SEGMENTS_FILESET_NAME, completed.segments(), targetFolder);
-              yield new BackupImpl(id, manifest.descriptor(), snapshot, segments);
+              final var snapshotFuture =
+                  CompletableFuture.supplyAsync(
+                      () ->
+                          fileSetManager.restore(
+                              id,
+                              FileSetManager.SNAPSHOT_FILESET_NAME,
+                              completed.snapshot(),
+                              targetFolder),
+                      executor);
+              final var segmentsFuture =
+                  CompletableFuture.supplyAsync(
+                      () ->
+                          fileSetManager.restore(
+                              id,
+                              FileSetManager.SEGMENTS_FILESET_NAME,
+                              completed.segments(),
+                              targetFolder),
+                      executor);
+
+              // Wait for both to complete
+              CompletableFuture.allOf(snapshotFuture, segmentsFuture).join();
+
+              yield new BackupImpl(
+                  id, manifest.descriptor(), snapshotFuture.join(), segmentsFuture.join());
             }
           };
         },

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
@@ -130,15 +130,17 @@ public final class GcsBackupStore implements BackupStore {
   @Override
   public CompletableFuture<Collection<BackupStatus>> list(final BackupIdentifierWildcard wildcard) {
     return CompletableFuture.supplyAsync(
-        () -> manifestManager.listManifests(wildcard).stream().map(Manifest::toStatus).toList(),
-        executor);
+        () -> manifestManager.listBackupStatuses(wildcard), executor);
   }
 
   @Override
   public CompletableFuture<Void> delete(final BackupIdentifier id) {
     return CompletableFuture.runAsync(
         () -> {
-          manifestManager.deleteManifest(id);
+          final var manifest = manifestManager.getManifest(id);
+          if (manifest != null) {
+            manifestManager.deleteManifest(manifest);
+          }
           fileSetManager.delete(id, FileSetManager.SNAPSHOT_FILESET_NAME);
           fileSetManager.delete(id, FileSetManager.SEGMENTS_FILESET_NAME);
         },

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
@@ -56,7 +56,7 @@ public final class GcsBackupStore implements BackupStore {
     final var basePath = Optional.ofNullable(config.basePath()).map(s -> s + "/").orElse("");
     this.client = client;
     executor = Executors.newVirtualThreadPerTaskExecutor();
-    manifestManager = new ManifestManager(client, bucketInfo, basePath);
+    manifestManager = new ManifestManager(client, bucketInfo, basePath, executor);
     fileSetManager =
         new FileSetManager(
             client,

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
@@ -44,14 +44,12 @@ public final class GcsBackupStore implements BackupStore {
   private final ManifestManager manifestManager;
   private final FileSetManager fileSetManager;
   private final Storage client;
-  private final GcsBackupConfig config;
 
   GcsBackupStore(final GcsBackupConfig config) {
     this(config, buildClient(config));
   }
 
   GcsBackupStore(final GcsBackupConfig config, final Storage client) {
-    this.config = config;
     final var bucketInfo = BucketInfo.of(config.bucketName());
     final var basePath = Optional.ofNullable(config.basePath()).map(s -> s + "/").orElse("");
     this.client = client;
@@ -192,6 +190,17 @@ public final class GcsBackupStore implements BackupStore {
   }
 
   @Override
+  public CompletableFuture<BackupStatusCode> markFailed(
+      final BackupIdentifier id, final String failureReason) {
+    return CompletableFuture.supplyAsync(
+        () -> {
+          manifestManager.markAsFailed(id, failureReason);
+          return BackupStatusCode.FAILED;
+        },
+        executor);
+  }
+
+  @Override
   public CompletableFuture<Void> closeAsync() {
     return CompletableFuture.runAsync(
         () -> {
@@ -206,17 +215,6 @@ public final class GcsBackupStore implements BackupStore {
             throw new RuntimeException(e);
           }
         });
-  }
-
-  @Override
-  public CompletableFuture<BackupStatusCode> markFailed(
-      final BackupIdentifier id, final String failureReason) {
-    return CompletableFuture.supplyAsync(
-        () -> {
-          manifestManager.markAsFailed(id, failureReason);
-          return BackupStatusCode.FAILED;
-        },
-        executor);
   }
 
   public static Storage buildClient(final GcsBackupConfig config) {

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStoreException.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStoreException.java
@@ -32,4 +32,10 @@ public abstract class GcsBackupStoreException extends RuntimeException {
       }
     }
   }
+
+  public static class UploadException extends GcsBackupStoreException {
+    public UploadException(final String message, final Throwable cause) {
+      super(message, cause);
+    }
+  }
 }

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/ManifestManager.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/ManifestManager.java
@@ -15,7 +15,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.google.cloud.storage.Blob;
-import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.Storage;
@@ -186,36 +185,36 @@ public final class ManifestManager {
   public Collection<Manifest> listManifests(final BackupIdentifierWildcard wildcard) {
     final var blobFilter = filterBlobsByWildcard(wildcard);
     LOG.debug("Searching for matching blobs for wildcard {}", wildcard);
-
-    final var matchingBlobIds = new ArrayList<BlobId>();
-    for (final var blob :
+    final var listing =
         client
             .list(bucketInfo.getName(), BlobListOption.prefix(wildcardPrefix(wildcard)))
-            .iterateAll()) {
-      if (blobFilter.test(blob)) {
-        matchingBlobIds.add(blob.getBlobId());
+            .iterateAll();
+    final var manifestFutures = new ArrayList<CompletableFuture<Manifest>>();
+    for (final var blob : listing) {
+      if (!blobFilter.test(blob)) {
+        continue;
       }
+      final var future =
+          CompletableFuture.supplyAsync(
+              () -> {
+                try {
+                  return MAPPER.readValue(client.readAllBytes(blob.getBlobId()), Manifest.class);
+                } catch (final IOException e) {
+                  throw new UncheckedIOException(e);
+                }
+              },
+              executor);
+      manifestFutures.add(future);
     }
 
-    LOG.trace("Found {} matching blobs for wildcard {}", matchingBlobIds.size(), wildcard);
-    final var futures =
-        matchingBlobIds.stream()
-            .map(
-                blobId ->
-                    CompletableFuture.supplyAsync(
-                        () -> {
-                          try {
-                            return MAPPER.readValue(client.readAllBytes(blobId), Manifest.class);
-                          } catch (final IOException e) {
-                            throw new UncheckedIOException(e);
-                          }
-                        },
-                        executor));
+    CompletableFuture.allOf(manifestFutures.toArray(CompletableFuture[]::new)).join();
+    LOG.debug(
+        "Found {} matching manifestFutures for wildcard {}", manifestFutures.size(), wildcard);
 
-    final var filtered =
-        futures.map(CompletableFuture::join).filter(m -> wildcard.matches(m.id())).toList();
-    LOG.debug("Found {} matching manifests for wildcard {}", filtered.size(), wildcard);
-    return filtered;
+    return manifestFutures.stream()
+        .map(CompletableFuture::join)
+        .filter(manifest -> wildcard.matches(manifest.id()))
+        .toList();
   }
 
   public void deleteManifest(final BackupIdentifier id) {

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/ManifestManager.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/ManifestManager.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.Storage;
@@ -29,12 +30,14 @@ import io.camunda.zeebe.backup.common.Manifest;
 import io.camunda.zeebe.backup.common.Manifest.InProgressManifest;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Spliterator;
-import java.util.Spliterators;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
-import java.util.stream.StreamSupport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class ManifestManager {
 
@@ -49,6 +52,7 @@ public final class ManifestManager {
           .disable(WRITE_DATES_AS_TIMESTAMPS)
           .setSerializationInclusion(Include.NON_ABSENT);
   public static final int PRECONDITION_FAILED = 412;
+  private static final Logger LOG = LoggerFactory.getLogger(ManifestManager.class);
 
   /**
    * Format for path to all manifests.
@@ -78,11 +82,17 @@ public final class ManifestManager {
   private final BucketInfo bucketInfo;
   private final Storage client;
   private final String basePath;
+  private final ExecutorService executor;
 
-  ManifestManager(final Storage client, final BucketInfo bucketInfo, final String basePath) {
+  ManifestManager(
+      final Storage client,
+      final BucketInfo bucketInfo,
+      final String basePath,
+      final ExecutorService executor) {
     this.bucketInfo = bucketInfo;
     this.client = client;
     this.basePath = basePath;
+    this.executor = executor;
   }
 
   PersistedManifest createInitialManifest(final Backup backup) {
@@ -174,26 +184,38 @@ public final class ManifestManager {
   }
 
   public Collection<Manifest> listManifests(final BackupIdentifierWildcard wildcard) {
-    final var spliterator =
-        Spliterators.spliteratorUnknownSize(
-            client
-                .list(bucketInfo.getName(), BlobListOption.prefix(wildcardPrefix(wildcard)))
-                .iterateAll()
-                .iterator(),
-            Spliterator.IMMUTABLE);
-    return StreamSupport.stream(spliterator, false)
-        .filter(filterBlobsByWildcard(wildcard))
-        .parallel()
-        .map(Blob::getContent)
-        .map(
-            content -> {
-              try {
-                return MAPPER.readValue(content, Manifest.class);
-              } catch (final IOException e) {
-                throw new RuntimeException(e);
-              }
-            })
-        .toList();
+    final var blobFilter = filterBlobsByWildcard(wildcard);
+    LOG.debug("Searching for matching blobs for wildcard {}", wildcard);
+
+    final var matchingBlobIds = new ArrayList<BlobId>();
+    for (final var blob :
+        client
+            .list(bucketInfo.getName(), BlobListOption.prefix(wildcardPrefix(wildcard)))
+            .iterateAll()) {
+      if (blobFilter.test(blob)) {
+        matchingBlobIds.add(blob.getBlobId());
+      }
+    }
+
+    LOG.trace("Found {} matching blobs for wildcard {}", matchingBlobIds.size(), wildcard);
+    final var futures =
+        matchingBlobIds.stream()
+            .map(
+                blobId ->
+                    CompletableFuture.supplyAsync(
+                        () -> {
+                          try {
+                            return MAPPER.readValue(client.readAllBytes(blobId), Manifest.class);
+                          } catch (final IOException e) {
+                            throw new UncheckedIOException(e);
+                          }
+                        },
+                        executor));
+
+    final var filtered =
+        futures.map(CompletableFuture::join).filter(m -> wildcard.matches(m.id())).toList();
+    LOG.debug("Found {} matching manifests for wildcard {}", filtered.size(), wildcard);
+    return filtered;
   }
 
   public void deleteManifest(final BackupIdentifier id) {

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/ManifestManager.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/ManifestManager.java
@@ -204,18 +204,7 @@ public final class ManifestManager {
         statusFutures.add(CompletableFuture.completedFuture(fromMetadata.get()));
       } else {
         // Fallback: download the manifest for blobs without metadata
-        statusFutures.add(
-            CompletableFuture.supplyAsync(
-                () -> {
-                  try {
-                    final var manifest =
-                        MAPPER.readValue(client.readAllBytes(blob.getBlobId()), Manifest.class);
-                    return Manifest.toStatus(manifest);
-                  } catch (final IOException e) {
-                    throw new UncheckedIOException(e);
-                  }
-                },
-                executor));
+        statusFutures.add(downloadManifestStatus(blob));
       }
     }
 
@@ -226,6 +215,20 @@ public final class ManifestManager {
         .map(CompletableFuture::join)
         .filter(status -> wildcard.matches(status.id()))
         .toList();
+  }
+
+  private CompletableFuture<BackupStatus> downloadManifestStatus(final Blob blob) {
+    return CompletableFuture.supplyAsync(
+        () -> {
+          try {
+            final var manifest =
+                MAPPER.readValue(client.readAllBytes(blob.getBlobId()), Manifest.class);
+            return Manifest.toStatus(manifest);
+          } catch (final IOException e) {
+            throw new UncheckedIOException(e);
+          }
+        },
+        executor);
   }
 
   public void deleteManifest(final Manifest manifest) {

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/ManifestManager.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/ManifestManager.java
@@ -24,6 +24,7 @@ import com.google.cloud.storage.StorageException;
 import io.camunda.zeebe.backup.api.Backup;
 import io.camunda.zeebe.backup.api.BackupIdentifier;
 import io.camunda.zeebe.backup.api.BackupIdentifierWildcard;
+import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.common.BackupStoreException.UnexpectedManifestState;
 import io.camunda.zeebe.backup.common.Manifest;
 import io.camunda.zeebe.backup.common.Manifest.InProgressManifest;
@@ -95,14 +96,12 @@ public final class ManifestManager {
   }
 
   PersistedManifest createInitialManifest(final Backup backup) {
-    final var manifestBlobInfo = manifestBlobInfo(backup.id());
     final var manifest = Manifest.createInProgress(backup);
+    final var blobInfo = manifestBlobInfoWithMetadata(backup.id(), manifest);
     try {
       final var blob =
           client.create(
-              manifestBlobInfo,
-              MAPPER.writeValueAsBytes(manifest),
-              BlobTargetOption.doesNotExist());
+              blobInfo, MAPPER.writeValueAsBytes(manifest), BlobTargetOption.doesNotExist());
       return new PersistedManifest(blob.getGeneration(), manifest);
     } catch (final StorageException e) {
       if (e.getCode() == PRECONDITION_FAILED) { // blob must already exist
@@ -119,7 +118,7 @@ public final class ManifestManager {
     final var completed = persistedManifest.manifest().complete();
     try {
       client.create(
-          manifestBlobInfo(completed.id()),
+          manifestBlobInfoWithMetadata(completed.id(), completed),
           MAPPER.writeValueAsBytes(completed),
           BlobTargetOption.generationMatch(generation));
     } catch (final StorageException e) {
@@ -147,11 +146,11 @@ public final class ManifestManager {
   }
 
   void markAsFailed(final BackupIdentifier id, final String failureReason) {
-    final var blobInfo = manifestBlobInfo(id);
-    final var blob = client.get(blobInfo.getBlobId());
+    final var blob = client.get(manifestBlobInfo(id).getBlobId());
     try {
       if (blob == null) {
         final var failed = Manifest.createFailed(id);
+        final var blobInfo = manifestBlobInfoWithMetadata(id, failed);
         client.create(blobInfo, MAPPER.writeValueAsBytes(failed), BlobTargetOption.doesNotExist());
       } else {
         final var existingManifest = MAPPER.readValue(blob.getContent(), Manifest.class);
@@ -175,50 +174,63 @@ public final class ManifestManager {
     if (existingManifest != updatedManifest) {
       try {
         client.create(
-            manifestBlobInfo(existingManifest.id()), MAPPER.writeValueAsBytes(updatedManifest));
+            manifestBlobInfoWithMetadata(existingManifest.id(), updatedManifest),
+            MAPPER.writeValueAsBytes(updatedManifest));
       } catch (final JsonProcessingException e) {
         throw new RuntimeException(e);
       }
     }
   }
 
-  public Collection<Manifest> listManifests(final BackupIdentifierWildcard wildcard) {
+  /**
+   * Lists backup statuses by reading status information directly from blob custom metadata,
+   * avoiding the need to download each manifest's content. Falls back to downloading the manifest
+   * for blobs that don't have metadata (written by older versions).
+   */
+  public Collection<BackupStatus> listBackupStatuses(final BackupIdentifierWildcard wildcard) {
     final var blobFilter = filterBlobsByWildcard(wildcard);
-    LOG.debug("Searching for matching blobs for wildcard {}", wildcard);
+    LOG.debug("Listing backup statuses for wildcard {}", wildcard);
     final var listing =
         client
             .list(bucketInfo.getName(), BlobListOption.prefix(wildcardPrefix(wildcard)))
             .iterateAll();
-    final var manifestFutures = new ArrayList<CompletableFuture<Manifest>>();
+    final var statusFutures = new ArrayList<CompletableFuture<BackupStatus>>();
     for (final var blob : listing) {
       if (!blobFilter.test(blob)) {
         continue;
       }
-      final var future =
-          CompletableFuture.supplyAsync(
-              () -> {
-                try {
-                  return MAPPER.readValue(client.readAllBytes(blob.getBlobId()), Manifest.class);
-                } catch (final IOException e) {
-                  throw new UncheckedIOException(e);
-                }
-              },
-              executor);
-      manifestFutures.add(future);
+      final var fromMetadata = ManifestMetadata.toBackupStatus(blob, basePath, MANIFEST_BLOB_NAME);
+      if (fromMetadata.isPresent()) {
+        statusFutures.add(CompletableFuture.completedFuture(fromMetadata.get()));
+      } else {
+        // Fallback: download the manifest for blobs without metadata
+        statusFutures.add(
+            CompletableFuture.supplyAsync(
+                () -> {
+                  try {
+                    final var manifest =
+                        MAPPER.readValue(client.readAllBytes(blob.getBlobId()), Manifest.class);
+                    return Manifest.toStatus(manifest);
+                  } catch (final IOException e) {
+                    throw new UncheckedIOException(e);
+                  }
+                },
+                executor));
+      }
     }
 
-    CompletableFuture.allOf(manifestFutures.toArray(CompletableFuture[]::new)).join();
-    LOG.debug(
-        "Found {} matching manifestFutures for wildcard {}", manifestFutures.size(), wildcard);
+    CompletableFuture.allOf(statusFutures.toArray(CompletableFuture[]::new)).join();
+    LOG.debug("Found {} matching backup statuses for wildcard {}", statusFutures.size(), wildcard);
 
-    return manifestFutures.stream()
+    return statusFutures.stream()
         .map(CompletableFuture::join)
-        .filter(manifest -> wildcard.matches(manifest.id()))
+        .filter(status -> wildcard.matches(status.id()))
         .toList();
   }
 
-  public void deleteManifest(final BackupIdentifier id) {
-    client.delete(manifestBlobInfo(id).getBlobId());
+  public void deleteManifest(final Manifest manifest) {
+    final var blobInfo = manifestBlobInfo(manifest.id());
+    client.delete(blobInfo.getBlobId());
   }
 
   private BlobInfo manifestBlobInfo(final BackupIdentifier id) {
@@ -226,6 +238,17 @@ public final class ManifestManager {
         MANIFEST_PATH_FORMAT.formatted(
             basePath, id.partitionId(), id.checkpointId(), id.nodeId(), MANIFEST_BLOB_NAME);
     return BlobInfo.newBuilder(bucketInfo, blobName).setContentType("application/json").build();
+  }
+
+  private BlobInfo manifestBlobInfoWithMetadata(
+      final BackupIdentifier id, final Manifest manifest) {
+    final var blobName =
+        MANIFEST_PATH_FORMAT.formatted(
+            basePath, id.partitionId(), id.checkpointId(), id.nodeId(), MANIFEST_BLOB_NAME);
+    return BlobInfo.newBuilder(bucketInfo, blobName)
+        .setContentType("application/json")
+        .setMetadata(ManifestMetadata.fromManifest(manifest))
+        .build();
   }
 
   /**

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/ManifestMetadata.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/ManifestMetadata.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.gcs;
+
+import com.google.cloud.storage.Blob;
+import io.camunda.zeebe.backup.api.BackupDescriptor;
+import io.camunda.zeebe.backup.api.BackupIdentifier;
+import io.camunda.zeebe.backup.api.BackupStatus;
+import io.camunda.zeebe.backup.api.BackupStatusCode;
+import io.camunda.zeebe.backup.common.BackupDescriptorImpl;
+import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
+import io.camunda.zeebe.backup.common.BackupStatusImpl;
+import io.camunda.zeebe.backup.common.Manifest;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Converts backup manifest information to and from GCS blob custom metadata. This allows listing
+ * backup statuses without downloading the manifest content, eliminating one GET request per backup.
+ */
+final class ManifestMetadata {
+
+  static final String STATUS_CODE = "status-code";
+  static final String FAILURE_REASON = "failure-reason";
+  static final String CREATED_AT = "created-at";
+  static final String MODIFIED_AT = "modified-at";
+  static final String SNAPSHOT_ID = "snapshot-id";
+  static final String CHECKPOINT_POSITION = "checkpoint-position";
+  static final String NUMBER_OF_PARTITIONS = "number-of-partitions";
+  static final String BROKER_VERSION = "broker-version";
+
+  private ManifestMetadata() {}
+
+  static Map<String, String> fromManifest(final Manifest manifest) {
+    final var metadata = new HashMap<String, String>();
+    metadata.put(STATUS_CODE, manifest.statusCode().name());
+
+    if (manifest.createdAt() != null) {
+      metadata.put(CREATED_AT, manifest.createdAt().toString());
+    }
+    if (manifest.modifiedAt() != null) {
+      metadata.put(MODIFIED_AT, manifest.modifiedAt().toString());
+    }
+
+    if (manifest.statusCode() == Manifest.StatusCode.FAILED) {
+      final var failureReason = manifest.asFailed().failureReason();
+      if (failureReason != null) {
+        metadata.put(FAILURE_REASON, failureReason);
+      }
+    }
+
+    final var descriptor = manifest.descriptor();
+    if (descriptor != null) {
+      descriptor.snapshotId().ifPresent(id -> metadata.put(SNAPSHOT_ID, id));
+      metadata.put(CHECKPOINT_POSITION, Long.toString(descriptor.checkpointPosition()));
+      metadata.put(NUMBER_OF_PARTITIONS, Integer.toString(descriptor.numberOfPartitions()));
+      metadata.put(BROKER_VERSION, descriptor.brokerVersion());
+    }
+
+    return metadata;
+  }
+
+  /**
+   * Reconstructs a {@link BackupStatus} from the GCS blob's custom metadata and path. The blob path
+   * encodes the backup identifier (partitionId/checkpointId/nodeId).
+   *
+   * @return the backup status, or empty if the blob has no status metadata (e.g. written by an
+   *     older version)
+   */
+  static Optional<BackupStatus> toBackupStatus(
+      final Blob blob, final String basePath, final String manifestBlobName) {
+    final var metadata = blob.getMetadata();
+    if (metadata == null || !metadata.containsKey(STATUS_CODE)) {
+      return Optional.empty();
+    }
+
+    final var id = parseIdentifierFromPath(blob.getName(), basePath, manifestBlobName);
+    final var statusCode = BackupStatusCode.valueOf(metadata.get(STATUS_CODE));
+    final var failureReason = Optional.ofNullable(metadata.get(FAILURE_REASON));
+    final var created = Optional.ofNullable(metadata.get(CREATED_AT)).map(Instant::parse);
+    final var modified = Optional.ofNullable(metadata.get(MODIFIED_AT)).map(Instant::parse);
+    final var descriptor = parseDescriptor(metadata);
+
+    return Optional.of(
+        new BackupStatusImpl(id, descriptor, statusCode, failureReason, created, modified));
+  }
+
+  private static BackupIdentifier parseIdentifierFromPath(
+      final String blobName, final String basePath, final String manifestBlobName) {
+    // Path format: {basePath}manifests/{partitionId}/{checkpointId}/{nodeId}/manifest.json
+    final var manifestsPrefix = basePath + "manifests/";
+    final var relativePath =
+        blobName.substring(manifestsPrefix.length(), blobName.length() - manifestBlobName.length());
+    // relativePath is now: {partitionId}/{checkpointId}/{nodeId}/
+    final var parts = relativePath.split("/");
+    return new BackupIdentifierImpl(
+        Integer.parseInt(parts[2]), Integer.parseInt(parts[0]), Long.parseLong(parts[1]));
+  }
+
+  private static Optional<BackupDescriptor> parseDescriptor(final Map<String, String> metadata) {
+    final var checkpointPositionStr = metadata.get(CHECKPOINT_POSITION);
+    if (checkpointPositionStr == null) {
+      return Optional.empty();
+    }
+
+    return Optional.of(
+        new BackupDescriptorImpl(
+            Optional.ofNullable(metadata.get(SNAPSHOT_ID)),
+            Long.parseLong(checkpointPositionStr),
+            Integer.parseInt(metadata.get(NUMBER_OF_PARTITIONS)),
+            metadata.get(BROKER_VERSION)));
+  }
+}

--- a/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/FileSetManagerTest.java
+++ b/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/FileSetManagerTest.java
@@ -26,12 +26,15 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executors;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 final class FileSetManagerTest {
   private static final int BUFFER_SIZE = 2 * 1024 * 1024;
+  private static final int MAX_CONCURRENT = 50;
 
   private static final byte[] FILE_CONTENT = new byte[1024];
 
@@ -39,12 +42,21 @@ final class FileSetManagerTest {
     Arrays.fill(FILE_CONTENT, 0, 1024, (byte) 1);
   }
 
+  private static FileSetManager newManager(final Storage client) {
+    return new FileSetManager(
+        client,
+        BucketInfo.of("bucket"),
+        "basePath",
+        Executors.newVirtualThreadPerTaskExecutor(),
+        MAX_CONCURRENT,
+        BUFFER_SIZE);
+  }
+
   @Test
   void shouldSaveFileSet(@TempDir final Path tempDir) throws IOException {
     // given
     final var mockClient = mock(Storage.class);
-    final var manager =
-        new FileSetManager(mockClient, BucketInfo.of("bucket"), "basePath", BUFFER_SIZE);
+    final var manager = newManager(mockClient);
     final var backupIdentifier = new BackupIdentifierImpl(1, 2, 3);
     final var file1 = Files.createFile(tempDir.resolve("file1"));
     final var file2 = Files.createFile(tempDir.resolve("file2"));
@@ -52,9 +64,9 @@ final class FileSetManagerTest {
         new NamedFileSetImpl(Map.of("snapshotFile1", file1, "snapshotFile2", file2));
 
     // when
-    manager.save(backupIdentifier, "filesetName", namedFileSet);
+    manager.save(backupIdentifier, FileSetManager.SNAPSHOT_FILESET_NAME, namedFileSet);
 
-    // then
+    // then - snapshots are uploaded in parallel using the executor
     verify(mockClient, times(2)).createFrom(any(), any(InputStream.class), anyInt(), any());
   }
 
@@ -62,8 +74,7 @@ final class FileSetManagerTest {
   void shouldThrowExceptionOnSaveFileSet(@TempDir final Path tempDir) throws IOException {
     // given
     final var mockClient = mock(Storage.class);
-    final var manager =
-        new FileSetManager(mockClient, BucketInfo.of("bucket"), "basePath", BUFFER_SIZE);
+    final var manager = newManager(mockClient);
     final var backupIdentifier = new BackupIdentifierImpl(1, 2, 3);
     final var file1 = Files.createFile(tempDir.resolve("file1"));
     final var file2 = Files.createFile(tempDir.resolve("file2"));
@@ -72,9 +83,52 @@ final class FileSetManagerTest {
     when(mockClient.createFrom(any(), any(InputStream.class), anyInt(), any()))
         .thenThrow(new StorageException(412, "expected"));
 
-    // when throw
-    Assertions.assertThatThrownBy(() -> manager.save(backupIdentifier, "filesetName", namedFileSet))
-        .isInstanceOf(StorageException.class)
+    // when throw - parallel execution wraps exception in CompletionException
+    Assertions.assertThatThrownBy(
+            () ->
+                manager.save(backupIdentifier, FileSetManager.SNAPSHOT_FILESET_NAME, namedFileSet))
+        .isInstanceOf(CompletionException.class)
+        .hasCauseInstanceOf(StorageException.class)
+        .hasMessageContaining("expected");
+  }
+
+  @Test
+  void shouldSaveSegmentFilesInParallel(@TempDir final Path tempDir) throws IOException {
+    // given
+    final var mockClient = mock(Storage.class);
+    final var manager = newManager(mockClient);
+    final var backupIdentifier = new BackupIdentifierImpl(1, 2, 3);
+    final var file1 = Files.createFile(tempDir.resolve("file1"));
+    final var file2 = Files.createFile(tempDir.resolve("file2"));
+    final var namedFileSet =
+        new NamedFileSetImpl(Map.of("segmentFile1", file1, "segmentFile2", file2));
+
+    // when
+    manager.save(backupIdentifier, FileSetManager.SEGMENTS_FILESET_NAME, namedFileSet);
+
+    // then - segments are uploaded in parallel using the executor
+    verify(mockClient, times(2)).createFrom(any(), any(InputStream.class), anyInt(), any());
+  }
+
+  @Test
+  void shouldThrowExceptionOnSaveSegments(@TempDir final Path tempDir) throws IOException {
+    // given
+    final var mockClient = mock(Storage.class);
+    final var manager = newManager(mockClient);
+    final var backupIdentifier = new BackupIdentifierImpl(1, 2, 3);
+    final var file1 = Files.createFile(tempDir.resolve("file1"));
+    final var file2 = Files.createFile(tempDir.resolve("file2"));
+    final var namedFileSet =
+        new NamedFileSetImpl(Map.of("segmentFile1", file1, "segmentFile2", file2));
+    when(mockClient.createFrom(any(), any(InputStream.class), anyInt(), any()))
+        .thenThrow(new StorageException(412, "expected"));
+
+    // when throw - parallel execution wraps exception in CompletionException
+    Assertions.assertThatThrownBy(
+            () ->
+                manager.save(backupIdentifier, FileSetManager.SEGMENTS_FILESET_NAME, namedFileSet))
+        .isInstanceOf(CompletionException.class)
+        .hasCauseInstanceOf(StorageException.class)
         .hasMessageContaining("expected");
   }
 
@@ -82,8 +136,7 @@ final class FileSetManagerTest {
   void shouldUseFileSizeAsBufferSize(@TempDir final Path tempDir) throws IOException {
     // given
     final var mockClient = mock(Storage.class);
-    final var manager =
-        new FileSetManager(mockClient, BucketInfo.of("bucket"), "basePath", BUFFER_SIZE);
+    final var manager = newManager(mockClient);
     final var backupIdentifier = new BackupIdentifierImpl(1, 2, 3);
     final var file1 = Files.createFile(tempDir.resolve("file1"));
     final var file2 = Files.createFile(tempDir.resolve("file2"));
@@ -93,7 +146,7 @@ final class FileSetManagerTest {
     Files.write(file2, FILE_CONTENT);
 
     // when
-    manager.save(backupIdentifier, "snapshot", namedFileSet);
+    manager.save(backupIdentifier, FileSetManager.SNAPSHOT_FILESET_NAME, namedFileSet);
 
     // then - the file size is used as the upload buffer size
     verify(mockClient, times(2)).createFrom(any(), any(InputStream.class), eq(1024), any());
@@ -104,8 +157,7 @@ final class FileSetManagerTest {
   void shouldDeleteFileSet() {
     // given
     final var mockClient = mock(Storage.class);
-    final var manager =
-        new FileSetManager(mockClient, BucketInfo.of("bucket"), "basePath", BUFFER_SIZE);
+    final var manager = newManager(mockClient);
     final var backupIdentifier = new BackupIdentifierImpl(1, 2, 3);
 
     final var mockBlob = mock(Blob.class);
@@ -124,8 +176,7 @@ final class FileSetManagerTest {
   void shouldThrowExceptionOnDeleteFileSetWhenListThrows() {
     // given
     final var mockClient = mock(Storage.class);
-    final var manager =
-        new FileSetManager(mockClient, BucketInfo.of("bucket"), "basePath", BUFFER_SIZE);
+    final var manager = newManager(mockClient);
     final var backupIdentifier = new BackupIdentifierImpl(1, 2, 3);
     when(mockClient.list(eq("bucket"), any())).thenThrow(new StorageException(412, "expected"));
 
@@ -140,8 +191,7 @@ final class FileSetManagerTest {
   void shouldThrowExceptionOnDeleteFileSetWhenBlobDeleteThrows() {
     // given
     final var mockClient = mock(Storage.class);
-    final var manager =
-        new FileSetManager(mockClient, BucketInfo.of("bucket"), "basePath", BUFFER_SIZE);
+    final var manager = newManager(mockClient);
     final var backupIdentifier = new BackupIdentifierImpl(1, 2, 3);
 
     final Blob mockBlob = mock(Blob.class);
@@ -160,8 +210,7 @@ final class FileSetManagerTest {
   void shouldRestoreFileSet() {
     // given
     final var mockClient = mock(Storage.class);
-    final var manager =
-        new FileSetManager(mockClient, BucketInfo.of("bucket"), "basePath", BUFFER_SIZE);
+    final var manager = newManager(mockClient);
     final var backupIdentifier = new BackupIdentifierImpl(1, 2, 3);
     final var fileSet =
         new FileSet(List.of(new NamedFile("snapshotFile"), new NamedFile("snapshotFile2")));
@@ -185,8 +234,7 @@ final class FileSetManagerTest {
   void shouldThrowRestoreFileSetWhenDownloadToFails() {
     // given
     final var mockClient = mock(Storage.class);
-    final var manager =
-        new FileSetManager(mockClient, BucketInfo.of("bucket"), "basePath", BUFFER_SIZE);
+    final var manager = newManager(mockClient);
     final var backupIdentifier = new BackupIdentifierImpl(1, 2, 3);
     final var fileSet =
         new FileSet(List.of(new NamedFile("snapshotFile"), new NamedFile("snapshotFile2")));
@@ -195,9 +243,10 @@ final class FileSetManagerTest {
         .when(mockClient)
         .downloadTo(any(), any(Path.class));
 
-    // when - then throw
+    // when - then throw; parallel execution wraps exception in CompletionException
     assertThatThrownBy(() -> manager.restore(backupIdentifier, "filesetName", fileSet, restorePath))
-        .isInstanceOf(StorageException.class)
+        .isInstanceOf(CompletionException.class)
+        .hasCauseInstanceOf(StorageException.class)
         .hasMessageContaining("expected");
   }
 }

--- a/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ManifestManagerTest.java
+++ b/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ManifestManagerTest.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.Executors;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -33,7 +34,9 @@ final class ManifestManagerTest {
   void shouldCreateInitialManifest() {
     // given
     final var client = Mockito.mock(Storage.class);
-    final var manager = new ManifestManager(client, BucketInfo.of("bucket"), "basePath");
+    final var manager =
+        new ManifestManager(
+            client, BucketInfo.of("bucket"), "basePath", Executors.newSingleThreadExecutor());
     final var backup =
         new BackupImpl(
             new BackupIdentifierImpl(1, 2, 3),
@@ -64,7 +67,9 @@ final class ManifestManagerTest {
   void shouldCompleteManifest() throws IOException {
     // given
     final var client = Mockito.mock(Storage.class);
-    final var manager = new ManifestManager(client, BucketInfo.of("bucket"), "basePath");
+    final var manager =
+        new ManifestManager(
+            client, BucketInfo.of("bucket"), "basePath", Executors.newSingleThreadExecutor());
     final var backup =
         new BackupImpl(
             new BackupIdentifierImpl(1, 2, 3),
@@ -104,7 +109,9 @@ final class ManifestManagerTest {
   void shouldThrowWhenManifestAlreadyExists() {
     // given
     final var client = Mockito.mock(Storage.class);
-    final var manager = new ManifestManager(client, BucketInfo.of("bucket"), "basePath");
+    final var manager =
+        new ManifestManager(
+            client, BucketInfo.of("bucket"), "basePath", Executors.newSingleThreadExecutor());
     final var backup =
         new BackupImpl(
             new BackupIdentifierImpl(1, 2, 3),
@@ -127,7 +134,9 @@ final class ManifestManagerTest {
   void shouldThrowWhenUnexpectedStorageExceptionOccurs() {
     // given
     final var client = Mockito.mock(Storage.class);
-    final var manager = new ManifestManager(client, BucketInfo.of("bucket"), "basePath");
+    final var manager =
+        new ManifestManager(
+            client, BucketInfo.of("bucket"), "basePath", Executors.newSingleThreadExecutor());
     final var backup =
         new BackupImpl(
             new BackupIdentifierImpl(1, 2, 3),
@@ -150,7 +159,9 @@ final class ManifestManagerTest {
   void shouldThrowWhenManifestChangedBeforeCompletion() {
     // given
     final var client = Mockito.mock(Storage.class);
-    final var manager = new ManifestManager(client, BucketInfo.of("bucket"), "basePath");
+    final var manager =
+        new ManifestManager(
+            client, BucketInfo.of("bucket"), "basePath", Executors.newSingleThreadExecutor());
     final var backup =
         new BackupImpl(
             new BackupIdentifierImpl(1, 2, 3),
@@ -182,7 +193,9 @@ final class ManifestManagerTest {
   void shouldThrowWhenCompletingManifestThrowsUnexpectedStorageException() {
     // given
     final var client = Mockito.mock(Storage.class);
-    final var manager = new ManifestManager(client, BucketInfo.of("bucket"), "basePath");
+    final var manager =
+        new ManifestManager(
+            client, BucketInfo.of("bucket"), "basePath", Executors.newSingleThreadExecutor());
     final var backup =
         new BackupImpl(
             new BackupIdentifierImpl(1, 2, 3),

--- a/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ManifestMetadataPropertyTest.java
+++ b/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ManifestMetadataPropertyTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.gcs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.cloud.storage.Blob;
+import io.camunda.zeebe.backup.common.BackupDescriptorImpl;
+import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
+import io.camunda.zeebe.backup.common.BackupImpl;
+import io.camunda.zeebe.backup.common.Manifest;
+import io.camunda.zeebe.backup.common.NamedFileSetImpl;
+import java.util.Map;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Combinators;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+import org.mockito.Mockito;
+
+final class ManifestMetadataPropertyTest {
+
+  private static final String BASE_PATH = "base/";
+  private static final String MANIFEST_BLOB_NAME = "manifest.json";
+
+  @Property(tries = 100)
+  void shouldRoundTripAnyManifest(@ForAll("manifests") final Manifest manifest) {
+    // given
+    final var expectedStatus = Manifest.toStatus(manifest);
+    final var id = manifest.id();
+    final var blobName =
+        BASE_PATH
+            + "manifests/"
+            + id.partitionId()
+            + "/"
+            + id.checkpointId()
+            + "/"
+            + id.nodeId()
+            + "/"
+            + MANIFEST_BLOB_NAME;
+
+    // when
+    final var metadata = ManifestMetadata.fromManifest(manifest);
+    final var blob = Mockito.mock(Blob.class);
+    Mockito.when(blob.getName()).thenReturn(blobName);
+    Mockito.when(blob.getMetadata()).thenReturn(metadata);
+    final var result = ManifestMetadata.toBackupStatus(blob, BASE_PATH, MANIFEST_BLOB_NAME);
+
+    // then
+    assertThat(result).isPresent();
+    final var status = result.get();
+    assertThat(status.statusCode()).isEqualTo(expectedStatus.statusCode());
+    assertThat(status.id().nodeId()).isEqualTo(id.nodeId());
+    assertThat(status.id().partitionId()).isEqualTo(id.partitionId());
+    assertThat(status.id().checkpointId()).isEqualTo(id.checkpointId());
+    assertThat(status.failureReason()).isEqualTo(expectedStatus.failureReason());
+    assertThat(status.created()).isEqualTo(expectedStatus.created());
+    assertThat(status.lastModified()).isEqualTo(expectedStatus.lastModified());
+
+    if (expectedStatus.descriptor().isPresent()) {
+      assertThat(status.descriptor()).isPresent();
+      final var desc = status.descriptor().get();
+      final var expectedDesc = expectedStatus.descriptor().get();
+      assertThat(desc.snapshotId()).isEqualTo(expectedDesc.snapshotId());
+      assertThat(desc.checkpointPosition()).isEqualTo(expectedDesc.checkpointPosition());
+      assertThat(desc.numberOfPartitions()).isEqualTo(expectedDesc.numberOfPartitions());
+      assertThat(desc.brokerVersion()).isEqualTo(expectedDesc.brokerVersion());
+    } else {
+      assertThat(status.descriptor()).isEmpty();
+    }
+  }
+
+  @Provide
+  Arbitrary<Manifest> manifests() {
+    return backups()
+        .flatMap(
+            backup -> {
+              final var inProgress = Manifest.createInProgress(backup);
+              return Arbitraries.of("IN_PROGRESS", "COMPLETED", "FAILED")
+                  .map(
+                      state ->
+                          switch (state) {
+                            case "IN_PROGRESS" -> inProgress;
+                            case "COMPLETED" -> inProgress.complete();
+                            case "FAILED" -> inProgress.fail("test failure reason");
+                            default -> throw new IllegalStateException();
+                          });
+            });
+  }
+
+  Arbitrary<BackupImpl> backups() {
+    return Combinators.combine(identifiers(), descriptors())
+        .as(
+            (id, descriptor) ->
+                new BackupImpl(
+                    id,
+                    descriptor,
+                    new NamedFileSetImpl(Map.of()),
+                    new NamedFileSetImpl(Map.of())));
+  }
+
+  Arbitrary<BackupIdentifierImpl> identifiers() {
+    return Combinators.combine(
+            Arbitraries.integers().between(0, 100),
+            Arbitraries.integers().between(1, 64),
+            Arbitraries.longs().between(1L, 1_000_000L))
+        .as(BackupIdentifierImpl::new);
+  }
+
+  Arbitrary<BackupDescriptorImpl> descriptors() {
+    return Combinators.combine(
+            Arbitraries.strings().alpha().ofMinLength(1).ofMaxLength(10).optional(),
+            Arbitraries.longs().between(0L, 1_000_000L),
+            Arbitraries.integers().between(1, 32),
+            Arbitraries.strings().alpha().numeric().ofMinLength(1).ofMaxLength(20))
+        .as(
+            (snapshotId, checkpointPos, partitions, version) ->
+                new BackupDescriptorImpl(snapshotId, checkpointPos, partitions, version));
+  }
+}

--- a/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ManifestMetadataTest.java
+++ b/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ManifestMetadataTest.java
@@ -1,0 +1,460 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.gcs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.cloud.storage.Blob;
+import io.camunda.zeebe.backup.api.BackupStatusCode;
+import io.camunda.zeebe.backup.common.BackupDescriptorImpl;
+import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
+import io.camunda.zeebe.backup.common.BackupImpl;
+import io.camunda.zeebe.backup.common.Manifest;
+import io.camunda.zeebe.backup.common.NamedFileSetImpl;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+final class ManifestMetadataTest {
+
+  private static final String BASE_PATH = "my-prefix/";
+  private static final String MANIFEST_BLOB_NAME = "manifest.json";
+
+  private static BackupImpl createBackup(
+      final int nodeId, final int partitionId, final long checkpointId) {
+    return new BackupImpl(
+        new BackupIdentifierImpl(nodeId, partitionId, checkpointId),
+        new BackupDescriptorImpl(Optional.of("snap-1"), 500L, 3, "8.5.0"),
+        new NamedFileSetImpl(Map.of("file1", Path.of("f1"))),
+        new NamedFileSetImpl(Map.of("seg1", Path.of("s1"))));
+  }
+
+  private static BackupImpl createBackupWithMinimalDescriptor(
+      final int nodeId, final int partitionId, final long checkpointId) {
+    return new BackupImpl(
+        new BackupIdentifierImpl(nodeId, partitionId, checkpointId),
+        new BackupDescriptorImpl(Optional.empty(), 500L, 3, "8.5.0"),
+        new NamedFileSetImpl(Map.of()),
+        new NamedFileSetImpl(Map.of()));
+  }
+
+  private static String blobPath(final int partitionId, final long checkpointId, final int nodeId) {
+    return BASE_PATH
+        + "manifests/"
+        + partitionId
+        + "/"
+        + checkpointId
+        + "/"
+        + nodeId
+        + "/"
+        + MANIFEST_BLOB_NAME;
+  }
+
+  private static Blob mockBlob(final String name, final Map<String, String> metadata) {
+    final var blob = Mockito.mock(Blob.class);
+    Mockito.when(blob.getName()).thenReturn(name);
+    Mockito.when(blob.getMetadata()).thenReturn(metadata);
+    return blob;
+  }
+
+  @Nested
+  class FromManifest {
+
+    @Test
+    void shouldIncludeStatusCodeForInProgressManifest() {
+      // given
+      final var manifest = Manifest.createInProgress(createBackup(1, 2, 3));
+
+      // when
+      final var metadata = ManifestMetadata.fromManifest(manifest);
+
+      // then
+      assertThat(metadata).containsEntry(ManifestMetadata.STATUS_CODE, "IN_PROGRESS");
+    }
+
+    @Test
+    void shouldIncludeStatusCodeForCompletedManifest() {
+      // given
+      final var manifest = Manifest.createInProgress(createBackup(1, 2, 3)).complete();
+
+      // when
+      final var metadata = ManifestMetadata.fromManifest(manifest);
+
+      // then
+      assertThat(metadata).containsEntry(ManifestMetadata.STATUS_CODE, "COMPLETED");
+    }
+
+    @Test
+    void shouldIncludeFailureReasonForFailedManifest() {
+      // given
+      final var manifest = Manifest.createInProgress(createBackup(1, 2, 3)).fail("disk full");
+
+      // when
+      final var metadata = ManifestMetadata.fromManifest(manifest);
+
+      // then
+      assertThat(metadata)
+          .containsEntry(ManifestMetadata.STATUS_CODE, "FAILED")
+          .containsEntry(ManifestMetadata.FAILURE_REASON, "disk full");
+    }
+
+    @Test
+    void shouldIncludeAllDescriptorFields() {
+      // given
+      final var manifest = Manifest.createInProgress(createBackup(1, 2, 3));
+
+      // when
+      final var metadata = ManifestMetadata.fromManifest(manifest);
+
+      // then
+      assertThat(metadata)
+          .containsEntry(ManifestMetadata.SNAPSHOT_ID, "snap-1")
+          .containsEntry(ManifestMetadata.CHECKPOINT_POSITION, "500")
+          .containsEntry(ManifestMetadata.NUMBER_OF_PARTITIONS, "3")
+          .containsEntry(ManifestMetadata.BROKER_VERSION, "8.5.0");
+    }
+
+    @Test
+    void shouldOmitOptionalDescriptorFieldsWhenAbsent() {
+      // given
+      final var manifest = Manifest.createInProgress(createBackupWithMinimalDescriptor(1, 2, 3));
+
+      // when
+      final var metadata = ManifestMetadata.fromManifest(manifest);
+
+      // then
+      assertThat(metadata)
+          .doesNotContainKey(ManifestMetadata.SNAPSHOT_ID)
+          .containsEntry(ManifestMetadata.CHECKPOINT_POSITION, "500")
+          .containsEntry(ManifestMetadata.NUMBER_OF_PARTITIONS, "3");
+    }
+
+    @Test
+    void shouldIncludeCreatedAndModifiedTimestamps() {
+      // given
+      final var manifest = Manifest.createInProgress(createBackup(1, 2, 3));
+
+      // when
+      final var metadata = ManifestMetadata.fromManifest(manifest);
+
+      // then
+      assertThat(metadata)
+          .containsKey(ManifestMetadata.CREATED_AT)
+          .containsKey(ManifestMetadata.MODIFIED_AT);
+      assertThat(Instant.parse(metadata.get(ManifestMetadata.CREATED_AT))).isNotNull();
+      assertThat(Instant.parse(metadata.get(ManifestMetadata.MODIFIED_AT))).isNotNull();
+    }
+
+    @Test
+    void shouldNotIncludeFailureReasonForNonFailedManifest() {
+      // given
+      final var manifest = Manifest.createInProgress(createBackup(1, 2, 3)).complete();
+
+      // when
+      final var metadata = ManifestMetadata.fromManifest(manifest);
+
+      // then
+      assertThat(metadata).doesNotContainKey(ManifestMetadata.FAILURE_REASON);
+    }
+
+    @Test
+    void shouldOmitDescriptorFieldsWhenDescriptorIsNull() {
+      // given
+      final var manifest = Manifest.createFailed(new BackupIdentifierImpl(1, 2, 3));
+
+      // when
+      final var metadata = ManifestMetadata.fromManifest(manifest);
+
+      // then
+      assertThat(metadata)
+          .containsEntry(ManifestMetadata.STATUS_CODE, "FAILED")
+          .doesNotContainKey(ManifestMetadata.CHECKPOINT_POSITION)
+          .doesNotContainKey(ManifestMetadata.BROKER_VERSION);
+    }
+  }
+
+  @Nested
+  class ToBackupStatus {
+
+    @Test
+    void shouldReturnEmptyWhenMetadataIsNull() {
+      // given
+      final var blob = mockBlob(blobPath(2, 3, 1), null);
+
+      // when
+      final var result = ManifestMetadata.toBackupStatus(blob, BASE_PATH, MANIFEST_BLOB_NAME);
+
+      // then
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    void shouldReturnEmptyWhenStatusCodeIsMissing() {
+      // given
+      final var blob = mockBlob(blobPath(2, 3, 1), Map.of("some-key", "some-value"));
+
+      // when
+      final var result = ManifestMetadata.toBackupStatus(blob, BASE_PATH, MANIFEST_BLOB_NAME);
+
+      // then
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    void shouldParseCompletedStatusAndIdentifier() {
+      // given
+      final var metadata =
+          Map.of(
+              ManifestMetadata.STATUS_CODE, "COMPLETED",
+              ManifestMetadata.CHECKPOINT_POSITION, "500",
+              ManifestMetadata.NUMBER_OF_PARTITIONS, "3",
+              ManifestMetadata.BROKER_VERSION, "8.5.0");
+      final var blob = mockBlob(blobPath(2, 3, 1), metadata);
+
+      // when
+      final var result = ManifestMetadata.toBackupStatus(blob, BASE_PATH, MANIFEST_BLOB_NAME);
+
+      // then
+      assertThat(result).isPresent();
+      final var status = result.get();
+      assertThat(status.statusCode()).isEqualTo(BackupStatusCode.COMPLETED);
+      assertThat(status.id().partitionId()).isEqualTo(2);
+      assertThat(status.id().checkpointId()).isEqualTo(3L);
+      assertThat(status.id().nodeId()).isEqualTo(1);
+    }
+
+    @Test
+    void shouldParseFailedStatusWithReason() {
+      // given
+      final var metadata =
+          Map.of(
+              ManifestMetadata.STATUS_CODE, "FAILED",
+              ManifestMetadata.FAILURE_REASON, "disk full");
+      final var blob = mockBlob(blobPath(2, 3, 1), metadata);
+
+      // when
+      final var result = ManifestMetadata.toBackupStatus(blob, BASE_PATH, MANIFEST_BLOB_NAME);
+
+      // then
+      assertThat(result).isPresent();
+      final var status = result.get();
+      assertThat(status.statusCode()).isEqualTo(BackupStatusCode.FAILED);
+      assertThat(status.failureReason()).isEqualTo(Optional.of("disk full"));
+    }
+
+    @Test
+    void shouldParseCreatedAndModifiedTimestamps() {
+      // given
+      final var createdAt = Instant.parse("2025-01-15T10:00:00Z");
+      final var modifiedAt = Instant.parse("2025-01-15T11:00:00Z");
+      final var metadata =
+          Map.of(
+              ManifestMetadata.STATUS_CODE, "COMPLETED",
+              ManifestMetadata.CREATED_AT, createdAt.toString(),
+              ManifestMetadata.MODIFIED_AT, modifiedAt.toString());
+      final var blob = mockBlob(blobPath(2, 3, 1), metadata);
+
+      // when
+      final var result = ManifestMetadata.toBackupStatus(blob, BASE_PATH, MANIFEST_BLOB_NAME);
+
+      // then
+      assertThat(result).isPresent();
+      assertThat(result.get().created()).isEqualTo(Optional.of(createdAt));
+      assertThat(result.get().lastModified()).isEqualTo(Optional.of(modifiedAt));
+    }
+
+    @Test
+    void shouldReturnEmptyDescriptorWhenCheckpointPositionIsMissing() {
+      // given
+      final var metadata = Map.of(ManifestMetadata.STATUS_CODE, "IN_PROGRESS");
+      final var blob = mockBlob(blobPath(2, 3, 1), metadata);
+
+      // when
+      final var result = ManifestMetadata.toBackupStatus(blob, BASE_PATH, MANIFEST_BLOB_NAME);
+
+      // then
+      assertThat(result).isPresent();
+      assertThat(result.get().descriptor()).isEmpty();
+    }
+
+    @Test
+    void shouldParseFullDescriptor() {
+      // given
+      final var metadata =
+          Map.of(
+              ManifestMetadata.STATUS_CODE, "COMPLETED",
+              ManifestMetadata.SNAPSHOT_ID, "snap-1",
+              ManifestMetadata.CHECKPOINT_POSITION, "500",
+              ManifestMetadata.NUMBER_OF_PARTITIONS, "3",
+              ManifestMetadata.BROKER_VERSION, "8.5.0");
+      final var blob = mockBlob(blobPath(2, 3, 1), metadata);
+
+      // when
+      final var result = ManifestMetadata.toBackupStatus(blob, BASE_PATH, MANIFEST_BLOB_NAME);
+
+      // then
+      assertThat(result).isPresent();
+      final var descriptor = result.get().descriptor();
+      assertThat(descriptor).isPresent();
+      assertThat(descriptor.get().snapshotId()).isEqualTo(Optional.of("snap-1"));
+      assertThat(descriptor.get().checkpointPosition()).isEqualTo(500L);
+      assertThat(descriptor.get().numberOfPartitions()).isEqualTo(3);
+      assertThat(descriptor.get().brokerVersion()).isEqualTo("8.5.0");
+    }
+  }
+
+  @Nested
+  class PathParsing {
+
+    @Test
+    void shouldParseIdentifierFromPathWithBasePath() {
+      // given
+      final var metadata = Map.of(ManifestMetadata.STATUS_CODE, "COMPLETED");
+      final var blob = mockBlob("my-prefix/manifests/4/1000/2/manifest.json", metadata);
+
+      // when
+      final var result = ManifestMetadata.toBackupStatus(blob, "my-prefix/", MANIFEST_BLOB_NAME);
+
+      // then
+      assertThat(result).isPresent();
+      assertThat(result.get().id().partitionId()).isEqualTo(4);
+      assertThat(result.get().id().checkpointId()).isEqualTo(1000L);
+      assertThat(result.get().id().nodeId()).isEqualTo(2);
+    }
+
+    @Test
+    void shouldParseIdentifierFromPathWithoutBasePath() {
+      // given
+      final var metadata = Map.of(ManifestMetadata.STATUS_CODE, "COMPLETED");
+      final var blob = mockBlob("manifests/1/99/0/manifest.json", metadata);
+
+      // when
+      final var result = ManifestMetadata.toBackupStatus(blob, "", MANIFEST_BLOB_NAME);
+
+      // then
+      assertThat(result).isPresent();
+      assertThat(result.get().id().partitionId()).isEqualTo(1);
+      assertThat(result.get().id().checkpointId()).isEqualTo(99L);
+      assertThat(result.get().id().nodeId()).isEqualTo(0);
+    }
+
+    @Test
+    void shouldParseIdentifierWithLargeValues() {
+      // given
+      final var metadata = Map.of(ManifestMetadata.STATUS_CODE, "IN_PROGRESS");
+      final var blob = mockBlob(BASE_PATH + "manifests/100/9999999999/50/manifest.json", metadata);
+
+      // when
+      final var result = ManifestMetadata.toBackupStatus(blob, BASE_PATH, MANIFEST_BLOB_NAME);
+
+      // then
+      assertThat(result).isPresent();
+      assertThat(result.get().id().partitionId()).isEqualTo(100);
+      assertThat(result.get().id().checkpointId()).isEqualTo(9999999999L);
+      assertThat(result.get().id().nodeId()).isEqualTo(50);
+    }
+  }
+
+  @Nested
+  class RoundTrip {
+
+    @Test
+    void shouldRoundTripCompletedManifest() {
+      // given
+      final var manifest = Manifest.createInProgress(createBackup(1, 2, 3)).complete();
+      final var expectedStatus = Manifest.toStatus(manifest);
+
+      // when
+      final var metadata = ManifestMetadata.fromManifest(manifest);
+      final var blob = mockBlob(blobPath(2, 3, 1), metadata);
+      final var result = ManifestMetadata.toBackupStatus(blob, BASE_PATH, MANIFEST_BLOB_NAME);
+
+      // then
+      assertThat(result).isPresent();
+      final var status = result.get();
+      assertThat(status.statusCode()).isEqualTo(expectedStatus.statusCode());
+      assertThat(status.id().nodeId()).isEqualTo(expectedStatus.id().nodeId());
+      assertThat(status.id().partitionId()).isEqualTo(expectedStatus.id().partitionId());
+      assertThat(status.id().checkpointId()).isEqualTo(expectedStatus.id().checkpointId());
+      assertThat(status.failureReason()).isEqualTo(expectedStatus.failureReason());
+      assertThat(status.created()).isEqualTo(expectedStatus.created());
+      assertThat(status.lastModified()).isEqualTo(expectedStatus.lastModified());
+      assertThat(status.descriptor()).isPresent();
+      final var desc = status.descriptor().get();
+      final var expectedDesc = expectedStatus.descriptor().get();
+      assertThat(desc.snapshotId()).isEqualTo(expectedDesc.snapshotId());
+      assertThat(desc.checkpointPosition()).isEqualTo(expectedDesc.checkpointPosition());
+      assertThat(desc.numberOfPartitions()).isEqualTo(expectedDesc.numberOfPartitions());
+      assertThat(desc.brokerVersion()).isEqualTo(expectedDesc.brokerVersion());
+    }
+
+    @Test
+    void shouldRoundTripInProgressManifest() {
+      // given
+      final var manifest = Manifest.createInProgress(createBackup(5, 10, 42));
+      final var expectedStatus = Manifest.toStatus(manifest);
+
+      // when
+      final var metadata = ManifestMetadata.fromManifest(manifest);
+      final var blob = mockBlob(blobPath(10, 42, 5), metadata);
+      final var result = ManifestMetadata.toBackupStatus(blob, BASE_PATH, MANIFEST_BLOB_NAME);
+
+      // then
+      assertThat(result).isPresent();
+      final var status = result.get();
+      assertThat(status.statusCode()).isEqualTo(BackupStatusCode.IN_PROGRESS);
+      assertThat(status.id().nodeId()).isEqualTo(expectedStatus.id().nodeId());
+      assertThat(status.id().partitionId()).isEqualTo(expectedStatus.id().partitionId());
+      assertThat(status.id().checkpointId()).isEqualTo(expectedStatus.id().checkpointId());
+      assertThat(status.descriptor()).isPresent();
+    }
+
+    @Test
+    void shouldRoundTripFailedManifestWithReason() {
+      // given
+      final var manifest = Manifest.createInProgress(createBackup(0, 1, 7)).fail("out of space");
+      final var expectedStatus = Manifest.toStatus(manifest);
+
+      // when
+      final var metadata = ManifestMetadata.fromManifest(manifest);
+      final var blob = mockBlob(blobPath(1, 7, 0), metadata);
+      final var result = ManifestMetadata.toBackupStatus(blob, BASE_PATH, MANIFEST_BLOB_NAME);
+
+      // then
+      assertThat(result).isPresent();
+      final var status = result.get();
+      assertThat(status.statusCode()).isEqualTo(BackupStatusCode.FAILED);
+      assertThat(status.failureReason()).isEqualTo(Optional.of("out of space"));
+      assertThat(status.created()).isEqualTo(expectedStatus.created());
+      assertThat(status.lastModified()).isEqualTo(expectedStatus.lastModified());
+    }
+
+    @Test
+    void shouldRoundTripManifestWithMinimalDescriptor() {
+      // given
+      final var manifest =
+          Manifest.createInProgress(createBackupWithMinimalDescriptor(1, 2, 3)).complete();
+
+      // when
+      final var metadata = ManifestMetadata.fromManifest(manifest);
+      final var blob = mockBlob(blobPath(2, 3, 1), metadata);
+      final var result = ManifestMetadata.toBackupStatus(blob, BASE_PATH, MANIFEST_BLOB_NAME);
+
+      // then
+      assertThat(result).isPresent();
+      final var descriptor = result.get().descriptor();
+      assertThat(descriptor).isPresent();
+      assertThat(descriptor.get().snapshotId()).isEmpty();
+      assertThat(descriptor.get().checkpointPosition()).isEqualTo(500L);
+    }
+  }
+}

--- a/zeebe/backup-stores/testkit/src/main/java/io/camunda/zeebe/backup/testkit/ListingBackups.java
+++ b/zeebe/backup-stores/testkit/src/main/java/io/camunda/zeebe/backup/testkit/ListingBackups.java
@@ -9,10 +9,13 @@ package io.camunda.zeebe.backup.testkit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.backup.api.Backup;
 import io.camunda.zeebe.backup.api.BackupIdentifierWildcard.CheckpointPattern;
 import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.api.BackupStore;
+import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
 import io.camunda.zeebe.backup.common.BackupIdentifierWildcardImpl;
+import io.camunda.zeebe.backup.common.BackupImpl;
 import io.camunda.zeebe.backup.testkit.support.TestBackupProvider;
 import io.camunda.zeebe.backup.testkit.support.WildcardBackupProvider;
 import io.camunda.zeebe.backup.testkit.support.WildcardBackupProvider.WildcardTestParameter;
@@ -21,6 +24,7 @@ import java.io.UncheckedIOException;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -71,5 +75,48 @@ public interface ListingBackups {
     assertThat(result)
         .map(BackupStatus::id)
         .containsExactlyInAnyOrderElementsOf(parameter.expectedIds());
+  }
+
+  @Test
+  default void canListManyBackups() throws IOException {
+    // given
+    final int backupCount = 2_000;
+    final var ids =
+        IntStream.rangeClosed(1, backupCount)
+            .mapToObj(i -> new BackupIdentifierImpl(1, 1, i))
+            .toList();
+    final var backupTemplate = getBackup(ids.getFirst());
+
+    CompletableFuture.allOf(
+            ids.stream()
+                .map(
+                    id ->
+                        getStore()
+                            .save(
+                                new BackupImpl(
+                                    id,
+                                    backupTemplate.descriptor(),
+                                    backupTemplate.snapshot(),
+                                    backupTemplate.segments())))
+                .toArray(CompletableFuture[]::new))
+        .join();
+
+    // when
+    final var status =
+        getStore()
+            .list(
+                new BackupIdentifierWildcardImpl(
+                    Optional.empty(), Optional.of(1), CheckpointPattern.any()));
+
+    // then
+    assertThat(status)
+        // Deliberately a lower timeout than the default response timeout of 15 seconds.
+        // If this is not enough, we might need to improve the implementation.
+        .succeedsWithin(Duration.ofSeconds(10))
+        .satisfies(statuses -> assertThat(statuses).hasSize(backupCount));
+  }
+
+  default Backup getBackup(final BackupIdentifierImpl id) throws IOException {
+    return new TestBackupProvider().minimalBackupWithId(id);
   }
 }

--- a/zeebe/backup-stores/testkit/src/main/java/io/camunda/zeebe/backup/testkit/ListingBackups.java
+++ b/zeebe/backup-stores/testkit/src/main/java/io/camunda/zeebe/backup/testkit/ListingBackups.java
@@ -24,6 +24,7 @@ import java.io.UncheckedIOException;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Semaphore;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
@@ -81,6 +82,7 @@ public interface ListingBackups {
   default void canListManyBackups() throws IOException {
     // given
     final int backupCount = 2_000;
+    final var semaphore = new Semaphore(200);
     final var ids =
         IntStream.rangeClosed(1, backupCount)
             .mapToObj(i -> new BackupIdentifierImpl(1, 1, i))
@@ -90,14 +92,17 @@ public interface ListingBackups {
     CompletableFuture.allOf(
             ids.stream()
                 .map(
-                    id ->
-                        getStore()
-                            .save(
-                                new BackupImpl(
-                                    id,
-                                    backupTemplate.descriptor(),
-                                    backupTemplate.snapshot(),
-                                    backupTemplate.segments())))
+                    id -> {
+                      semaphore.acquireUninterruptibly();
+                      return getStore()
+                          .save(
+                              new BackupImpl(
+                                  id,
+                                  backupTemplate.descriptor(),
+                                  backupTemplate.snapshot(),
+                                  backupTemplate.segments()))
+                          .whenComplete((v, e) -> semaphore.release());
+                    })
                 .toArray(CompletableFuture[]::new))
         .join();
 

--- a/zeebe/backup-stores/testkit/src/main/java/io/camunda/zeebe/backup/testkit/SavingBackup.java
+++ b/zeebe/backup-stores/testkit/src/main/java/io/camunda/zeebe/backup/testkit/SavingBackup.java
@@ -60,7 +60,9 @@ public interface SavingBackup {
         .failsWithin(Duration.ofMinutes(1))
         .withThrowableOfType(Throwable.class)
         .withRootCauseInstanceOf(getFileNotFoundExceptionClass())
-        .withMessageContaining(deletedFile.toString());
+        .havingRootCause()
+        .withMessageContaining(deletedFile.toString())
+        .isInstanceOf(getFileNotFoundExceptionClass());
   }
 
   @ParameterizedTest

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/GcsBackupStoreConfig.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/GcsBackupStoreConfig.java
@@ -20,6 +20,9 @@ public class GcsBackupStoreConfig implements ConfigurationEntry {
   /** Size of the buffer (in bytes) used when uploading files to GCS. */
   private int bufferSize = 2 * 1024 * 1024;
 
+  /** Default maximum concurrent transfers (uploads and downloads) */
+  private int maxConcurrentTransfers = 8;
+
   public String getBucketName() {
     return bucketName;
   }
@@ -60,13 +63,22 @@ public class GcsBackupStoreConfig implements ConfigurationEntry {
     this.bufferSize = bufferSize;
   }
 
-  public static GcsBackupConfig toStoreConfig(GcsBackupStoreConfig config) {
+  public int getMaxConcurrentTransfers() {
+    return maxConcurrentTransfers;
+  }
+
+  public void setMaxConcurrentTransfers(final int maxConcurrentTransfers) {
+    this.maxConcurrentTransfers = maxConcurrentTransfers;
+  }
+
+  public static GcsBackupConfig toStoreConfig(final GcsBackupStoreConfig config) {
     final var storeConfig =
         new GcsBackupConfig.Builder()
             .withBucketName(config.getBucketName())
             .withBasePath(config.getBasePath())
             .withHost(config.getHost())
-            .withBufferSize(config.getBufferSize());
+            .withBufferSize(config.getBufferSize())
+            .withMaxConcurrentTransfers(config.getMaxConcurrentTransfers());
     final var authenticated =
         switch (config.getAuth()) {
           case NONE -> storeConfig.withoutAuthentication();
@@ -77,7 +89,7 @@ public class GcsBackupStoreConfig implements ConfigurationEntry {
 
   @Override
   public int hashCode() {
-    return Objects.hash(bucketName, basePath, host, auth, bufferSize);
+    return Objects.hash(bucketName, basePath, host, auth, bufferSize, maxConcurrentTransfers);
   }
 
   @Override
@@ -93,7 +105,8 @@ public class GcsBackupStoreConfig implements ConfigurationEntry {
         && Objects.equals(basePath, that.basePath)
         && Objects.equals(host, that.host)
         && auth == that.auth
-        && bufferSize == that.bufferSize;
+        && bufferSize == that.bufferSize
+        && maxConcurrentTransfers == that.maxConcurrentTransfers;
   }
 
   @Override
@@ -112,6 +125,8 @@ public class GcsBackupStoreConfig implements ConfigurationEntry {
         + auth
         + ", bufferSize="
         + bufferSize
+        + ", maxConcurrentTransfers="
+        + maxConcurrentTransfers
         + '}';
   }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Backports improvements done in GCS Backup store from `main`:
- https://github.com/camunda/camunda/pull/45784
- https://github.com/camunda/camunda/pull/48023
- https://github.com/camunda/camunda/pull/48309

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
