### PR TITLE
fix: increase PartitionJoinTest timeout to avoid flakiness on CI

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/PartitionJoinTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/PartitionJoinTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 final class PartitionJoinTest {
-  private static final Duration JOIN_TIMEOUT = Duration.ofSeconds(20);
+  private static final Duration JOIN_TIMEOUT = Duration.ofMinutes(2);
 
   @ParameterizedTest
   @MethodSource("testScenarios")
@@ -50,7 +50,7 @@ final class PartitionJoinTest {
       final var join = runOperation(cluster, scenario.operation());
       assertChangeIsPlanned(join);
       Awaitility.await("Requested change is completed in time")
-          .atMost(Duration.ofSeconds(30))
+          .atMost(JOIN_TIMEOUT)
           .untilAsserted(() -> ClusterActuatorAssert.assertThat(cluster).hasCompletedChanges(join));
       ClusterActuatorAssert.assertThat(cluster).hasAppliedChanges(join);
       // when

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
@@ -472,6 +472,7 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
     final var metadata = unifiedConfig.getCluster().getMetadata();
     metadata.setSyncInitializerDelay(Duration.ofMillis(500));
     metadata.setSyncDelay(Duration.ofMillis(500));
+    metadata.setSyncRequestTimeout(Duration.ofMillis(500));
 
     // Set raft defaults - disable flushing for faster tests
     unifiedConfig.getCluster().getRaft().setFlushEnabled(false);


### PR DESCRIPTION
## Description
JOIN_TIMEOUT was 20s but CI runs with a single actor thread (zb-actors-0) might not be enough time for it to complete all the times. Reduce the metadata.syncTimeout to 500millis to accelerate retries.

I'm not entirely sure this is enough to reduce the flakyness, but let's see how it plays out.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

relates #51938
