### PR TITLE
feat: pin Camunda Platform Helm Chart version for load tests

### DIFF
--- a/load-tests/setup/newLoadTest.sh
+++ b/load-tests/setup/newLoadTest.sh
@@ -256,8 +256,12 @@ helm repo add camunda-load-tests https://camunda.github.io/camunda-load-tests-he
 helm repo add opensearch https://opensearch-project.github.io/helm-charts/ --force-update
 helm repo update
 
-# Clone Platform Helm so we can run the latest chart
-git clone --depth 1 --branch main --single-branch https://github.com/camunda/camunda-platform-helm.git
+# Clone Camunda Platform Helm so we can run the latest chart
+# TODO: 347642d30179479f8ab8a2f00b2d979be05f5a8c is the latest commit before the removal of the
+# embedded Bitnami Helm Chart.
+# We should remove the checkout of this specific revision once we have a solution to replace these
+# removed dependencies.
+git clone --depth 1 --revision 347642d30179479f8ab8a2f00b2d979be05f5a8c --single-branch https://github.com/camunda/camunda-platform-helm.git
 
 # Make deps
 helm dependency build "camunda-platform-helm/charts/$helm_chart"


### PR DESCRIPTION
## Description

This should prevent all our deployments from breaking up once https://github.com/camunda/camunda-platform-helm/pull/6146 has been merged.

Closes: https://github.com/camunda/camunda/issues/54144

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

* https://github.com/camunda/camunda/issues/54144
* https://github.com/camunda/camunda/issues/50947
* https://github.com/camunda/camunda-platform-helm/pull/6146
