### PR TITLE
test: update error message

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-api-tests.spec.ts
@@ -242,7 +242,7 @@ test.describe.parallel('Job API Tests', () => {
 
       await assertBadRequest(
         res,
-        "Unexpected value '123' for enum field 'field'. Use any of the following values: [deadline, deniedReason, elementId, elementInstanceKey, endTime, errorCode, errorMessage, hasFailedWithRetriesLeft, isDenied, jobKey, kind, listenerEventType, processDefinitionId, processDefinitionKey, processInstanceKey, retries, state, tenantId, type, worker]",
+        "Unexpected value '123' for enum field 'field'. Use any of the following values: [deadline, deniedReason, elementId, elementInstanceKey, endTime, errorCode, errorMessage, hasFailedWithRetriesLeft, isDenied, jobKey, kind, listenerEventType, priority, processDefinitionId, processDefinitionKey, processInstanceKey, retries, state, tenantId, type, worker]",
       );
     });
   });


### PR DESCRIPTION
## Description

This PR adjusts error message.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## On demand workflow
[Was green on APIs](https://github.com/camunda/camunda/actions/runs/26632620837)