### PR TITLE
feat: extract secret references from IO mappings for activated jobs

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableFlowNode.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableFlowNode.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 public class ExecutableFlowNode extends AbstractFlowElement {
 
@@ -21,6 +22,15 @@ public class ExecutableFlowNode extends AbstractFlowElement {
 
   private Optional<Expression> inputMappings = Optional.empty();
   private Optional<Expression> outputMappings = Optional.empty();
+
+  /**
+   * Secret references statically declared in this node's input mappings, indexed by the
+   * JSON-pointer path (e.g. {@code /authentication/token}) of the variable they produce. The value
+   * is the set of {@code camunda.secrets.*} references found at that path. Computed at deploy time
+   * so the gateway can resolve them without re-parsing variables. Empty when no input mapping
+   * references a secret.
+   */
+  private Map<String, Set<String>> inputSecretReferences = Map.of();
 
   private final List<ExecutionListener> executionListeners = new ArrayList<>();
 
@@ -58,6 +68,14 @@ public class ExecutableFlowNode extends AbstractFlowElement {
 
   public void setOutputMappings(final Expression outputMappings) {
     this.outputMappings = Optional.of(outputMappings);
+  }
+
+  public Map<String, Set<String>> getInputSecretReferences() {
+    return inputSecretReferences;
+  }
+
+  public void setInputSecretReferences(final Map<String, Set<String>> inputSecretReferences) {
+    this.inputSecretReferences = inputSecretReferences;
   }
 
   public List<ExecutionListener> getBeforeAllExecutionListeners() {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/FlowNodeTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/FlowNodeTransformer.java
@@ -17,11 +17,24 @@ import io.camunda.zeebe.engine.processing.deployment.model.transformer.zeebe.Exe
 import io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants;
 import io.camunda.zeebe.model.bpmn.instance.FlowNode;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListeners;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeInput;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeIoMapping;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.regex.MatchResult;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 public final class FlowNodeTransformer implements ModelElementTransformer<FlowNode> {
+
+  /** Matches a {@code camunda.secrets.<name>} reference anywhere within a mapping source. */
+  private static final Pattern SECRET_REFERENCE =
+      Pattern.compile("camunda\\.secrets\\.[A-Za-z0-9_-]+");
 
   private final VariableMappingTransformer variableMappingTransformer =
       new VariableMappingTransformer();
@@ -80,12 +93,49 @@ public final class FlowNodeTransformer implements ModelElementTransformer<FlowNo
         .ifPresent(flowNode::setInputMappings);
 
     ioMapping
+        .map(ZeebeIoMapping::getInputs)
+        .map(FlowNodeTransformer::extractInputSecretReferences)
+        .filter(refs -> !refs.isEmpty())
+        .ifPresent(flowNode::setInputSecretReferences);
+
+    ioMapping
         .map(ZeebeIoMapping::getOutputs)
         .filter(mappings -> !mappings.isEmpty())
         .map(
             mappings ->
                 variableMappingTransformer.transformOutputMappings(mappings, expressionLanguage))
         .ifPresent(flowNode::setOutputMappings);
+  }
+
+  /**
+   * Scans each input mapping source for {@code camunda.secrets.*} references and indexes them by
+   * the JSON-pointer path of the variable they produce. The path is derived from the mapping
+   * target: {@code authentication.token} becomes {@code /authentication/token}. Only statically
+   * modeled references are captured — this is what makes resolution safe against injection via
+   * untrusted process variables.
+   */
+  private static Map<String, Set<String>> extractInputSecretReferences(
+      final Collection<ZeebeInput> inputs) {
+    final Map<String, Set<String>> secretReferences = new HashMap<>();
+    for (final ZeebeInput input : inputs) {
+      final String source = input.getSource();
+      final String target = input.getTarget();
+      if (source == null || target == null) {
+        continue;
+      }
+      final Set<String> references =
+          SECRET_REFERENCE
+              .matcher(source)
+              .results()
+              .map(MatchResult::group)
+              .collect(Collectors.toCollection(LinkedHashSet::new));
+      if (references.isEmpty()) {
+        continue;
+      }
+      final String path = "/" + target.replace('.', '/');
+      secretReferences.computeIfAbsent(path, k -> new LinkedHashSet<>()).addAll(references);
+    }
+    return secretReferences;
   }
 
   private void transformExecutionListeners(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobVariablesCollector.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobVariablesCollector.java
@@ -7,7 +7,9 @@
  */
 package io.camunda.zeebe.engine.processing.job;
 
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowNode;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
+import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.UserTaskState;
 import io.camunda.zeebe.engine.state.immutable.VariableState;
@@ -25,11 +27,13 @@ public class JobVariablesCollector {
   private final VariableState variableState;
   private final UserTaskState userTaskState;
   private final ElementInstanceState elementInstanceState;
+  private final ProcessState processState;
 
   public JobVariablesCollector(final ProcessingState processingState) {
     variableState = processingState.getVariableState();
     userTaskState = processingState.getUserTaskState();
     elementInstanceState = processingState.getElementInstanceState();
+    processState = processingState.getProcessState();
   }
 
   public void setJobVariables(
@@ -60,6 +64,27 @@ public class JobVariablesCollector {
         };
 
     jobRecord.setVariables(jobVariables);
+    setJobSecretPaths(jobRecord);
+  }
+
+  /**
+   * Attaches the statically modeled secret references of the activated element to the job, so the
+   * gateway can resolve them in the job's variables before returning them to the client. References
+   * come from the process definition (input mappings), never from runtime variable values — which
+   * is what prevents secret resolution from being triggered by injected, untrusted input.
+   */
+  private void setJobSecretPaths(final JobRecord jobRecord) {
+    final var process =
+        processState.getProcessByKeyAndTenant(
+            jobRecord.getProcessDefinitionKey(), jobRecord.getTenantId());
+    if (process == null) {
+      return;
+    }
+    final var element = process.getProcess().getElementById(jobRecord.getElementId());
+    if (element instanceof final ExecutableFlowNode flowNode
+        && !flowNode.getInputSecretReferences().isEmpty()) {
+      jobRecord.setSecretPaths(flowNode.getInputSecretReferences());
+    }
   }
 
   private Map<String, Object> getTaskVariables(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/IoMappingSecretReferenceTransformerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/IoMappingSecretReferenceTransformerTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.transformer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import io.camunda.zeebe.el.ExpressionLanguage;
+import io.camunda.zeebe.el.ExpressionLanguageFactory;
+import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableJobWorkerTask;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableProcess;
+import io.camunda.zeebe.engine.processing.deployment.model.transformation.BpmnTransformer;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.ServiceTaskBuilder;
+import java.time.InstantSource;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+
+class IoMappingSecretReferenceTransformerTest {
+
+  private static final String TASK_ID = "service-task";
+
+  private final ExpressionLanguage expressionLanguage =
+      ExpressionLanguageFactory.createExpressionLanguage(
+          new ZeebeFeelEngineClock(InstantSource.system()));
+  private final BpmnTransformer transformer = new BpmnTransformer(expressionLanguage);
+
+  private ExecutableJobWorkerTask transformServiceTask(
+      final Consumer<ServiceTaskBuilder> modifier) {
+    final BpmnModelInstance model =
+        Bpmn.createExecutableProcess()
+            .startEvent()
+            .serviceTask(TASK_ID, b -> modifier.accept(b.zeebeJobType("test")))
+            .done();
+    final List<ExecutableProcess> processes = transformer.transformDefinitions(model);
+    return processes.get(0).getElementById(TASK_ID, ExecutableJobWorkerTask.class);
+  }
+
+  @Test
+  void shouldExtractSecretReferenceFromInputMapping() {
+    // when
+    final var task =
+        transformServiceTask(
+            b -> b.zeebeInputExpression("camunda.secrets.TOKEN", "authentication.token"));
+
+    // then
+    assertThat(task.getInputSecretReferences())
+        .containsOnly(entry("/authentication/token", Set.of("camunda.secrets.TOKEN")));
+  }
+
+  @Test
+  void shouldExtractEmbeddedSecretReference() {
+    // when — a static string with the reference embedded, e.g. "Bearer camunda.secrets.MY_TOKEN"
+    final var task =
+        transformServiceTask(
+            b -> b.zeebeInput("Bearer camunda.secrets.MY_TOKEN", "authentication.header"));
+
+    // then
+    assertThat(task.getInputSecretReferences())
+        .containsOnly(entry("/authentication/header", Set.of("camunda.secrets.MY_TOKEN")));
+  }
+
+  @Test
+  void shouldExtractMultipleReferencesFromSingleMapping() {
+    // when
+    final var task =
+        transformServiceTask(
+            b -> b.zeebeInputExpression("camunda.secrets.A + camunda.secrets.B", "combined"));
+
+    // then
+    assertThat(task.getInputSecretReferences()).containsOnlyKeys("/combined");
+    assertThat(task.getInputSecretReferences().get("/combined"))
+        .containsExactlyInAnyOrder("camunda.secrets.A", "camunda.secrets.B");
+  }
+
+  @Test
+  void shouldIndexReferencesByVariablePath() {
+    // when — two mappings building the same top-level variable at different nested paths
+    final var task =
+        transformServiceTask(
+            b ->
+                b.zeebeInputExpression("camunda.secrets.X", "auth.token")
+                    .zeebeInputExpression("camunda.secrets.Y", "auth.url"));
+
+    // then
+    assertThat(task.getInputSecretReferences())
+        .containsOnly(
+            entry("/auth/token", Set.of("camunda.secrets.X")),
+            entry("/auth/url", Set.of("camunda.secrets.Y")));
+  }
+
+  @Test
+  void shouldNotExtractWhenNoSecretReference() {
+    // when
+    final var task = transformServiceTask(b -> b.zeebeInputExpression("someVariable", "target"));
+
+    // then
+    assertThat(task.getInputSecretReferences()).isEmpty();
+  }
+
+  @Test
+  void shouldHaveNoSecretReferencesWithoutInputMappings() {
+    // when
+    final var task = transformServiceTask(b -> {});
+
+    // then
+    assertThat(task.getInputSecretReferences()).isEmpty();
+  }
+}

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/MsgPackConverter.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/MsgPackConverter.java
@@ -60,6 +60,8 @@ public final class MsgPackConverter {
       new TypeReference<>() {};
   private static final TypeReference<HashMap<String, Set<Long>>> SET_LONG_MAP_TYPE_REFERENCE =
       new TypeReference<>() {};
+  private static final TypeReference<HashMap<String, Set<String>>> SET_STRING_MAP_TYPE_REFERENCE =
+      new TypeReference<>() {};
   private static final TypeReference<HashMap<PermissionType, Set<AuthorizationScope>>>
       PERMISSION_MAP_TYPE_REFERENCE = new TypeReference<>() {};
 
@@ -190,6 +192,10 @@ public final class MsgPackConverter {
 
   public static Map<String, Set<Long>> convertToSetLongMap(final DirectBuffer buffer) {
     return convertToMap(SET_LONG_MAP_TYPE_REFERENCE, buffer);
+  }
+
+  public static Map<String, Set<String>> convertToSetStringMap(final DirectBuffer buffer) {
+    return convertToMap(SET_STRING_MAP_TYPE_REFERENCE, buffer);
   }
 
   public static Map<PermissionType, Set<AuthorizationScope>> convertToPermissionMap(

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
@@ -30,6 +30,7 @@ import io.camunda.zeebe.protocol.record.value.JobListenerEventType;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -58,6 +59,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   private static final String TYPE = "type";
   private static final String CUSTOM_HEADERS = "customHeaders";
   private static final String VARIABLES = "variables";
+  private static final String SECRET_PATHS = "secretPaths";
   private static final String ERROR_MESSAGE = "errorMessage";
   // Static StringValue keys to avoid memory waste
   private static final StringValue TYPE_KEY = new StringValue(TYPE);
@@ -69,6 +71,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   private static final StringValue RECURRING_TIME_KEY = new StringValue("recurringTime");
   private static final StringValue CUSTOM_HEADERS_KEY = new StringValue(CUSTOM_HEADERS);
   private static final StringValue VARIABLES_KEY = new StringValue(VARIABLES);
+  private static final StringValue SECRET_PATHS_KEY = new StringValue(SECRET_PATHS);
   private static final StringValue ERROR_MESSAGE_KEY = new StringValue(ERROR_MESSAGE);
   private static final StringValue ERROR_CODE_KEY = new StringValue("errorCode");
   private static final StringValue PROCESS_DEFINITION_VERSION_KEY =
@@ -99,6 +102,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   private final PackedProperty customHeadersProp =
       new PackedProperty(CUSTOM_HEADERS_KEY, NO_HEADERS);
   private final DocumentProperty variableProp = new DocumentProperty(VARIABLES_KEY);
+  private final DocumentProperty secretPathsProp = new DocumentProperty(SECRET_PATHS_KEY);
   private final StringProperty errorMessageProp =
       new StringProperty(ERROR_MESSAGE_KEY, EMPTY_STRING);
   private final StringProperty errorCodeProp = new StringProperty(ERROR_CODE_KEY, EMPTY_STRING);
@@ -134,7 +138,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   private final IntegerProperty priorityProp = new IntegerProperty(PRIORITY_KEY, 0);
 
   public JobRecord() {
-    super(25);
+    super(26);
     declareProperty(deadlineProp)
         .declareProperty(timeoutProp)
         .declareProperty(workerProp)
@@ -144,6 +148,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
         .declareProperty(typeProp)
         .declareProperty(customHeadersProp)
         .declareProperty(variableProp)
+        .declareProperty(secretPathsProp)
         .declareProperty(errorMessageProp)
         .declareProperty(errorCodeProp)
         .declareProperty(bpmnProcessIdProp)
@@ -505,6 +510,26 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   @JsonIgnore
   public DirectBuffer getVariablesBuffer() {
     return variableProp.getValue();
+  }
+
+  /**
+   * Secret references carried with this job, indexed by the JSON-pointer path of the variable that
+   * holds them (e.g. {@code /authentication/token -> [camunda.secrets.TOKEN]}). Populated at job
+   * activation from the statically modeled input mappings; the gateway resolves these before
+   * returning the job to the client.
+   */
+  public Map<String, Set<String>> getSecretPaths() {
+    return MsgPackConverter.convertToSetStringMap(secretPathsProp.getValue());
+  }
+
+  public JobRecord setSecretPaths(final Map<String, ? extends Collection<String>> secretPaths) {
+    secretPathsProp.setValue(BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(secretPaths)));
+    return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getSecretPathsBuffer() {
+    return secretPathsProp.getValue();
   }
 
   @JsonIgnore

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -867,6 +867,7 @@ final class JsonSerializableToJsonTest {
                       "variables": {
                         "foo": "bar"
                       },
+                      "secretPaths": {},
                       "retries": 3,
                       "priority": 0,
                       "jobKind": "BPMN_ELEMENT",
@@ -1053,6 +1054,7 @@ final class JsonSerializableToJsonTest {
                   "variables": {
                     "foo": "bar"
                   },
+                  "secretPaths": {},
                   "retries": 12,
                   "priority": 42,
                   "jobKind": "BPMN_ELEMENT",
@@ -1130,6 +1132,7 @@ final class JsonSerializableToJsonTest {
                   "processInstanceKey": -1,
                   "elementInstanceKey": -1,
                   "variables": {},
+                  "secretPaths": {},
                   "worker": "",
                   "retries": -1,
                   "priority": 0,
@@ -1191,6 +1194,7 @@ final class JsonSerializableToJsonTest {
                   "variables": {
                     "foo": null
                   },
+                  "secretPaths": {},
                   "deadline": -1,
                   "timeout": -1,
                   "worker": "",


### PR DESCRIPTION
Detect statically modeled camunda.secrets.* references in a flow node's input mappings at deploy time and index them by the JSON-pointer path of the variable they produce. At job activation these references are attached to the job record (new secretPaths field) so the gateway can later resolve them in the job's variables.

References are taken only from the process definition (input mappings), never from runtime variable values. This is what keeps secret resolution safe against injection: an attacker feeding "camunda.secrets.X" through an untrusted process variable produces no allow-listed path and is ignored.

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
