### PR TITLE
test: add e2e tests for "Cancel" process instance execution listener

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/el-cancel-on-task-invalid.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/el-cancel-on-task-invalid.bpmn
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions
+  xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+  xmlns:modeler="http://camunda.org/schema/modeler/1.0"
+  id="Definitions_el_cancel_on_task_invalid"
+  targetNamespace="http://bpmn.io/schema/bpmn"
+  modeler:executionPlatform="Camunda Cloud"
+  modeler:executionPlatformVersion="8.10.0">
+  <bpmn:process id="el-cancel-on-task-invalid" name="EL Cancel On Task Invalid" isExecutable="true">
+    <bpmn:startEvent id="start" name="Start">
+      <bpmn:outgoing>sf1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="sf1" sourceRef="start" targetRef="task"/>
+    <bpmn:serviceTask id="task" name="Task With Invalid Cancel Listener">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="el-cancel-invalid-main" retries="3"/>
+        <zeebe:executionListeners>
+          <zeebe:executionListener eventType="cancel" type="el-cancel-invalid-on-task" retries="3"/>
+        </zeebe:executionListeners>
+      </bpmn:extensionElements>
+      <bpmn:incoming>sf1</bpmn:incoming>
+      <bpmn:outgoing>sf2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="sf2" sourceRef="task" targetRef="end"/>
+    <bpmn:endEvent id="end" name="End">
+      <bpmn:incoming>sf2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="el-cancel-on-task-invalid">
+      <bpmndi:BPMNShape id="start_di" bpmnElement="start"><dc:Bounds x="150" y="100" width="36" height="36"/></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="task_di" bpmnElement="task"><dc:Bounds x="240" y="78" width="100" height="80"/></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="end_di" bpmnElement="end"><dc:Bounds x="402" y="100" width="36" height="36"/></bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="sf1_di" bpmnElement="sf1"><di:waypoint x="186" y="118"/><di:waypoint x="240" y="118"/></bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="sf2_di" bpmnElement="sf2"><di:waypoint x="340" y="118"/><di:waypoint x="402" y="118"/></bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/el-cancel-process-multi.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/el-cancel-process-multi.bpmn
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions
+  xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+  xmlns:modeler="http://camunda.org/schema/modeler/1.0"
+  id="Definitions_el_cancel_process_multi"
+  targetNamespace="http://bpmn.io/schema/bpmn"
+  modeler:executionPlatform="Camunda Cloud"
+  modeler:executionPlatformVersion="8.10.0">
+  <bpmn:process id="el-cancel-process-multi" name="EL Cancel Process Multi" isExecutable="true">
+    <bpmn:extensionElements>
+      <zeebe:executionListeners>
+        <zeebe:executionListener eventType="cancel" type="el-cancel-listener-first" retries="3"/>
+        <zeebe:executionListener eventType="cancel" type="el-cancel-listener-second" retries="3"/>
+      </zeebe:executionListeners>
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="start" name="Start">
+      <bpmn:outgoing>sf1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="sf1" sourceRef="start" targetRef="task"/>
+    <bpmn:serviceTask id="task" name="Long Running Task">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="el-cancel-main-multi" retries="3"/>
+      </bpmn:extensionElements>
+      <bpmn:incoming>sf1</bpmn:incoming>
+      <bpmn:outgoing>sf2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="sf2" sourceRef="task" targetRef="end"/>
+    <bpmn:endEvent id="end" name="End">
+      <bpmn:incoming>sf2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="el-cancel-process-multi">
+      <bpmndi:BPMNShape id="start_di" bpmnElement="start"><dc:Bounds x="150" y="100" width="36" height="36"/></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="task_di" bpmnElement="task"><dc:Bounds x="240" y="78" width="100" height="80"/></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="end_di" bpmnElement="end"><dc:Bounds x="402" y="100" width="36" height="36"/></bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="sf1_di" bpmnElement="sf1"><di:waypoint x="186" y="118"/><di:waypoint x="240" y="118"/></bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="sf2_di" bpmnElement="sf2"><di:waypoint x="340" y="118"/><di:waypoint x="402" y="118"/></bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/el-cancel-process.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/el-cancel-process.bpmn
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions
+  xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+  xmlns:modeler="http://camunda.org/schema/modeler/1.0"
+  id="Definitions_el_cancel_process"
+  targetNamespace="http://bpmn.io/schema/bpmn"
+  modeler:executionPlatform="Camunda Cloud"
+  modeler:executionPlatformVersion="8.10.0">
+  <bpmn:process id="el-cancel-process" name="EL Cancel Process" isExecutable="true">
+    <bpmn:extensionElements>
+      <zeebe:executionListeners>
+        <zeebe:executionListener eventType="cancel" type="el-cancel-listener" retries="3">
+          <zeebe:taskHeaders>
+            <zeebe:header key="reason" value="user-cancellation"/>
+            <zeebe:header key="audit" value="true"/>
+          </zeebe:taskHeaders>
+        </zeebe:executionListener>
+      </zeebe:executionListeners>
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="start" name="Start">
+      <bpmn:outgoing>sf1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="sf1" sourceRef="start" targetRef="task"/>
+    <bpmn:serviceTask id="task" name="Long Running Task">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="el-cancel-main-task" retries="3"/>
+      </bpmn:extensionElements>
+      <bpmn:incoming>sf1</bpmn:incoming>
+      <bpmn:outgoing>sf2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="sf2" sourceRef="task" targetRef="end"/>
+    <bpmn:endEvent id="end" name="End">
+      <bpmn:incoming>sf2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="el-cancel-process">
+      <bpmndi:BPMNShape id="start_di" bpmnElement="start"><dc:Bounds x="150" y="100" width="36" height="36"/></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="task_di" bpmnElement="task"><dc:Bounds x="240" y="78" width="100" height="80"/></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="end_di" bpmnElement="end"><dc:Bounds x="402" y="100" width="36" height="36"/></bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="sf1_di" bpmnElement="sf1"><di:waypoint x="186" y="118"/><di:waypoint x="240" y="118"/></bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="sf2_di" bpmnElement="sf2"><di:waypoint x="340" y="118"/><di:waypoint x="402" y="118"/></bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/el-cancel-process-instance-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/el-cancel-process-instance-tests.spec.ts
@@ -1,0 +1,311 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect, test} from '@playwright/test';
+import {randomUUID} from 'crypto';
+import {readFileSync} from 'node:fs';
+import {
+  cancelProcessInstance,
+  createSingleInstance,
+  deployWithSubstitutions,
+} from '../../../../utils/zeebeClient';
+import {assertStatusCode, buildUrl, jsonHeaders} from '../../../../utils/http';
+import {extendedAssertionOptions} from '../../../../utils/constants';
+import {
+  activateJobAndGetHeaders,
+  activateJobToObtainAValidJobKey,
+  completeJob,
+  expectJobsByType,
+  expectProcessState,
+} from '@requestHelpers';
+import {searchIncidentByPIK} from '../../../../utils/requestHelpers/incident-requestHelpers';
+
+test.describe.parallel('Cancel Process Instance Execution Listener', () => {
+  test.describe.parallel('Single cancel listener with headers', () => {
+    const suffix = randomUUID().slice(0, 8);
+    const processId = `el-cancel-process-${suffix}`;
+    const cancelListenerType = `el-cancel-listener-${suffix}`;
+    const mainTaskType = `el-cancel-main-task-${suffix}`;
+
+    test.beforeAll(async () => {
+      await deployWithSubstitutions('./resources/el-cancel-process.bpmn', {
+        'el-cancel-process': processId,
+        'el-cancel-listener': cancelListenerType,
+        'el-cancel-main-task': mainTaskType,
+      });
+    });
+
+    test('E2E-CEL-01: cancel listener job is created; instance terminates only after listener completes', async ({
+      request,
+    }) => {
+      const instance = await createSingleInstance(processId, 1);
+      const piKey = String(instance.processInstanceKey);
+
+      try {
+        await expectProcessState(request, piKey, 'ACTIVE');
+        await expectJobsByType(request, piKey, cancelListenerType, 0);
+
+        await cancelProcessInstance(piKey);
+        await expectJobsByType(request, piKey, cancelListenerType, 1);
+
+        const searchRes = await request.post(
+          buildUrl('/process-instances/search'),
+          {
+            headers: jsonHeaders(),
+            data: {filter: {processInstanceKey: piKey}},
+          },
+        );
+        await assertStatusCode(searchRes, 200);
+        const beforeJson = await searchRes.json();
+        expect(beforeJson.items).toHaveLength(1);
+        expect(beforeJson.items[0].state).not.toBe('TERMINATED');
+
+        const jobKey = await activateJobToObtainAValidJobKey(
+          request,
+          cancelListenerType,
+        );
+        await completeJob(request, jobKey);
+
+        await expectProcessState(
+          request,
+          piKey,
+          'TERMINATED',
+          extendedAssertionOptions,
+        );
+      } catch (e) {
+        await cancelProcessInstance(piKey);
+        throw e;
+      }
+    });
+
+    test('E2E-CEL-02: cancel listener job carries the custom headers defined in the BPMN', async ({
+      request,
+    }) => {
+      const instance = await createSingleInstance(processId, 1);
+      const piKey = String(instance.processInstanceKey);
+
+      try {
+        await cancelProcessInstance(piKey);
+        await expectJobsByType(request, piKey, cancelListenerType, 1);
+
+        const job = await activateJobAndGetHeaders(request, cancelListenerType);
+        expect(job.customHeaders).toMatchObject({
+          reason: 'user-cancellation',
+          audit: 'true',
+        });
+
+        await completeJob(request, job.jobKey);
+        await expectProcessState(
+          request,
+          piKey,
+          'TERMINATED',
+          extendedAssertionOptions,
+        );
+      } catch (e) {
+        await cancelProcessInstance(piKey);
+        throw e;
+      }
+    });
+  });
+
+  test.describe.parallel('Multiple cancel listeners', () => {
+    const suffix = randomUUID().slice(0, 8);
+    const processId = `el-cancel-process-multi-${suffix}`;
+    const firstType = `el-cancel-listener-first-${suffix}`;
+    const secondType = `el-cancel-listener-second-${suffix}`;
+    const mainType = `el-cancel-main-multi-${suffix}`;
+
+    test.beforeAll(async () => {
+      await deployWithSubstitutions(
+        './resources/el-cancel-process-multi.bpmn',
+        {
+          'el-cancel-process-multi': processId,
+          'el-cancel-listener-first': firstType,
+          'el-cancel-listener-second': secondType,
+          'el-cancel-main-multi': mainType,
+        },
+      );
+    });
+
+    test('E2E-CEL-03: cancel listeners run sequentially in declaration order; instance terminates only after the last one', async ({
+      request,
+    }) => {
+      const instance = await createSingleInstance(processId, 1);
+      const piKey = String(instance.processInstanceKey);
+
+      try {
+        await cancelProcessInstance(piKey);
+
+        await expectJobsByType(request, piKey, firstType, 1);
+        await expectJobsByType(request, piKey, secondType, 0);
+
+        const firstJob = await activateJobToObtainAValidJobKey(
+          request,
+          firstType,
+        );
+        await completeJob(request, firstJob);
+
+        await expectJobsByType(request, piKey, secondType, 1);
+        const intermediate = await request.post(
+          buildUrl('/process-instances/search'),
+          {
+            headers: jsonHeaders(),
+            data: {filter: {processInstanceKey: piKey}},
+          },
+        );
+        await assertStatusCode(intermediate, 200);
+        const intermediateJson = await intermediate.json();
+        expect(intermediateJson.items).toHaveLength(1);
+        expect(intermediateJson.items[0].state).not.toBe('TERMINATED');
+
+        const secondJob = await activateJobToObtainAValidJobKey(
+          request,
+          secondType,
+        );
+        await completeJob(request, secondJob);
+
+        await expectProcessState(
+          request,
+          piKey,
+          'TERMINATED',
+          extendedAssertionOptions,
+        );
+      } catch (e) {
+        await cancelProcessInstance(piKey);
+        throw e;
+      }
+    });
+  });
+
+  test.describe.parallel('Failure handling', () => {
+    const suffix = randomUUID().slice(0, 8);
+    const processId = `el-cancel-process-neg-${suffix}`;
+    const cancelListenerType = `el-cancel-listener-neg-${suffix}`;
+    const mainTaskType = `el-cancel-main-task-neg-${suffix}`;
+
+    test.beforeAll(async () => {
+      await deployWithSubstitutions('./resources/el-cancel-process.bpmn', {
+        'el-cancel-process': processId,
+        'el-cancel-listener': cancelListenerType,
+        'el-cancel-main-task': mainTaskType,
+      });
+    });
+
+    test('E2E-CEL-04: failed cancel listener with no retries raises EXECUTION_LISTENER_NO_RETRIES incident; stays ACTIVE', async ({
+      request,
+    }) => {
+      const instance = await createSingleInstance(processId, 1);
+      const piKey = String(instance.processInstanceKey);
+
+      try {
+        await cancelProcessInstance(piKey);
+        await expectJobsByType(request, piKey, cancelListenerType, 1);
+
+        const jobKey = await activateJobToObtainAValidJobKey(
+          request,
+          cancelListenerType,
+        );
+        const failRes = await request.post(
+          buildUrl(`/jobs/${jobKey}/failure`),
+          {
+            headers: jsonHeaders(),
+            data: {
+              retries: 0,
+              errorMessage: 'Simulated cancel-listener failure CEL-04',
+            },
+          },
+        );
+        await assertStatusCode(failRes, 204);
+
+        const incidents = await searchIncidentByPIK(request, {
+          processInstanceKey: piKey,
+        });
+        expect(incidents.length).toBeGreaterThanOrEqual(1);
+        expect(incidents[0].errorMessage).toContain(
+          'Simulated cancel-listener failure CEL-04',
+        );
+
+        const incidentDetail = await request.post(
+          buildUrl('/incidents/search'),
+          {
+            headers: jsonHeaders(),
+            data: {filter: {processInstanceKey: piKey}},
+          },
+        );
+        await assertStatusCode(incidentDetail, 200);
+        expect((await incidentDetail.json()).items[0].errorType).toBe(
+          'EXECUTION_LISTENER_NO_RETRIES',
+        );
+
+        await expectProcessState(
+          request,
+          piKey,
+          'ACTIVE',
+          extendedAssertionOptions,
+        );
+
+        const updateRes = await request.patch(buildUrl(`/jobs/${jobKey}`), {
+          headers: jsonHeaders(),
+          data: {changeset: {retries: 1}},
+        });
+        await assertStatusCode(updateRes, 204);
+
+        const resolveRes = await request.post(
+          buildUrl(`/incidents/${incidents[0].incidentKey}/resolution`),
+          {headers: jsonHeaders()},
+        );
+        await assertStatusCode(resolveRes, 204);
+
+        let retriedJobKey = 0;
+        await expect(async () => {
+          retriedJobKey = await activateJobToObtainAValidJobKey(
+            request,
+            cancelListenerType,
+          );
+        }).toPass(extendedAssertionOptions);
+        await completeJob(request, retriedJobKey);
+
+        await expectProcessState(
+          request,
+          piKey,
+          'TERMINATED',
+          extendedAssertionOptions,
+        );
+      } finally {
+        await cancelProcessInstance(piKey);
+      }
+    });
+  });
+
+  test.describe.parallel('Validation', () => {
+    test('E2E-CEL-05: deploying a `cancel` listener on a non-process element is rejected at deploy time', async () => {
+      const filePath = './resources/el-cancel-on-task-invalid.bpmn';
+
+      const xml = readFileSync(filePath, 'utf-8');
+      expect(xml).toContain('eventType="cancel"');
+
+      let caught: Error | undefined;
+      try {
+        await deployWithSubstitutions(filePath, {
+          'el-cancel-on-task-invalid': `el-cancel-on-task-invalid-${randomUUID().slice(0, 8)}`,
+          'el-cancel-invalid-on-task': `el-cancel-invalid-on-task-${randomUUID().slice(0, 8)}`,
+          'el-cancel-invalid-main': `el-cancel-invalid-main-${randomUUID().slice(0, 8)}`,
+        });
+      } catch (e) {
+        caught = e as Error;
+      }
+
+      expect(caught, 'Deployment should have failed validation').toBeDefined();
+      const message = String(
+        (caught as Error & {details?: string}).details ?? caught?.message ?? '',
+      );
+      expect(message).toMatch(/cancel.*execution listener/i);
+      expect(message).toMatch(/only.*supported.*process/i);
+    });
+  });
+});


### PR DESCRIPTION
## Description

Adds end-to-end automation coverage for the **"Cancel" process instance execution listener** feature ([product-hub #2768](https://github.com/camunda/product-hub/issues/2768)).

The new `cancel` event type for `<zeebe:executionListener>` can only be defined on the `<bpmn:process>` element. When a running instance is cancelled (via `CancelProcessInstance`), the engine creates a job for each registered cancel listener and only finalises the termination once every listener job has completed. A listener job that fails with no retries raises an `EXECUTION_LISTENER_NO_RETRIES` incident and the instance is held in the terminating phase until the incident is resolved.

## Test cases implemented

| ID | Scenario |
|----|----------|
| **E2E-CEL-01** | Single cancel listener job is created on `CancelProcessInstance`; the instance does **not** reach `TERMINATED` until the listener job completes. |
| **E2E-CEL-02** | Cancel listener job carries the `<zeebe:taskHeaders>` (`reason=user-cancellation`, `audit=true`) defined in the BPMN. |
| **E2E-CEL-03** | Multiple cancel listeners on the same `<bpmn:process>` execute **sequentially in declaration order**; instance terminates only after the last one completes. |
| **E2E-CEL-04** | Cancel listener that fails with `retries=0` raises an `EXECUTION_LISTENER_NO_RETRIES` incident; instance stays `ACTIVE`. Afterwards the test recovers cleanly: update retries → resolve incident → complete retried job → instance reaches `TERMINATED` (mirrors the recovery pattern in `mi-el-before-all-tests.spec.ts`, prevents suite pollution). |
| **E2E-CEL-05** | Validation: deploying a `<zeebe:executionListener eventType="cancel">` on a non-process element (service task) is rejected at deploy time with a clear error message. |

## Files added

- `qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/el-cancel-process-instance-tests.spec.ts` — Playwright spec containing the five test cases above
- `qa/c8-orchestration-cluster-e2e-test-suite/resources/el-cancel-process.bpmn` — process with one cancel listener (with custom task headers)
- `qa/c8-orchestration-cluster-e2e-test-suite/resources/el-cancel-process-multi.bpmn` — process with two sequential cancel listeners
- `qa/c8-orchestration-cluster-e2e-test-suite/resources/el-cancel-on-task-invalid.bpmn` — invalid BPMN (cancel listener placed on a service task) used by the validation test

## Pattern alignment

All tests follow the existing conventions used by sibling EL specs in the same folder (`el-header-*`, `mi-el-*`):

- per-suffix process/job IDs via `randomUUID().slice(0, 8)` + `deployWithSubstitutions` → safe to run in parallel with the rest of `api-tests`
- only depends on helpers already exported from `utils/requestHelpers/` (`expectJobsByType`, `activateJobToObtainAValidJobKey`, `activateJobAndGetHeaders`, `completeJob`, `expectProcessState`, `searchIncidentByPIK`)
- failure path uses the same job-retry-update + incident-resolution recovery sequence as `mi-el-before-all-tests.spec.ts`
- no inline `//` comments — only the mandatory license header
- no edits to shared helpers, fixtures, or any existing spec file

## How to run locally

```bash
cd qa/c8-orchestration-cluster-e2e-test-suite
npx playwright test --project=api-tests tests/api/v2/job/el-cancel-process-instance-tests.spec.ts
```

## Validation

- `npx tsc --noEmit -p tsconfig.json` — clean
- `npm run lint` — no new errors or warnings introduced (only pre-existing repo warnings remain)
- Static-analysis only at this point. The on-demand workflow (`c8-orchestration-cluster-e2e-tests-on-demand.yml`) still needs to be run against this branch before review per `AGENTS.md`.

## TestRail

Test cases E2E-CEL-01..05 to be imported into the [TestRail test case suite](https://camunda.testrail.com/index.php?/suites/view/17050); link will be added here once IDs are assigned.

## Backport

This is a new feature on `main` only — no backport required unless `cancel` execution listeners are backported to a `stable/8.x` branch.
