### PR TITLE
refactor: add jspecify annotations to zeebe/dynamic-node-id-provider

### DIFF
--- a/zeebe/dynamic-node-id-provider/pom.xml
+++ b/zeebe/dynamic-node-id-provider/pom.xml
@@ -75,6 +75,10 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+    </dependency>
 
     <!--  TEST   -->
     <dependency>

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProvider.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProvider.java
@@ -29,6 +29,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,7 +39,7 @@ public class RepositoryNodeIdProvider implements NodeIdProvider, AutoCloseable {
 
   private final NodeIdRepository nodeIdRepository;
   private final InstantSource clock;
-  private volatile StoredLease.Initialized currentLease;
+  private volatile StoredLease.@Nullable Initialized currentLease;
   private final Duration leaseDuration;
   private final Duration readinessCheckTimeout;
   private final Duration expiredLeaseThreshold;
@@ -47,7 +48,7 @@ public class RepositoryNodeIdProvider implements NodeIdProvider, AutoCloseable {
   private final ScheduledExecutorService executor;
   private final ExponentialBackoffRetryDelay backoff;
   private final Duration renewalDelay;
-  private ScheduledFuture<?> renewalTask;
+  private @Nullable ScheduledFuture<?> renewalTask;
   private final AtomicBoolean shutdownInitiated = new AtomicBoolean(false);
   private VersionMappings knownVersionMappings = VersionMappings.empty();
   private final CompletableFuture<Boolean> previousNodeGracefullyShutdown =
@@ -105,7 +106,13 @@ public class RepositoryNodeIdProvider implements NodeIdProvider, AutoCloseable {
 
   @Override
   public NodeInstance currentNodeInstance() {
-    return getCurrentLease().lease().nodeInstance();
+    final var lease = getCurrentLease();
+    if (lease == null) {
+      throw new IllegalStateException(
+          "Current lease is not available; the provider may not be initialized yet, "
+              + "the lease may have been lost, or shutdown may be in progress");
+    }
+    return lease.lease().nodeInstance();
   }
 
   /**
@@ -156,9 +163,14 @@ public class RepositoryNodeIdProvider implements NodeIdProvider, AutoCloseable {
       return;
     }
 
+    final var lease = currentLease;
+    if (lease == null) {
+      throw new IllegalStateException("Current lease is null during readiness check");
+    }
+
     new RepositoryNodeIdProviderReadinessChecker(
             clusterSize,
-            currentLease.node(),
+            lease.node(),
             nodeIdRepository,
             Duration.ofSeconds(5),
             readinessCheckTimeout)
@@ -181,7 +193,7 @@ public class RepositoryNodeIdProvider implements NodeIdProvider, AutoCloseable {
             this::renew, renewalDelay.toMillis(), renewalDelay.toMillis(), TimeUnit.MILLISECONDS);
   }
 
-  public Initialized getCurrentLease() {
+  public @Nullable Initialized getCurrentLease() {
     return currentLease;
   }
 
@@ -256,7 +268,7 @@ public class RepositoryNodeIdProvider implements NodeIdProvider, AutoCloseable {
     backoff.reset();
   }
 
-  private StoredLease tryAcquireLeaseForNode(final int nodeId) {
+  private @Nullable StoredLease tryAcquireLeaseForNode(final int nodeId) {
     try {
       final var storedLease = nodeIdRepository.getLease(nodeId);
       currentLease = tryAcquireInitialLease(storedLease);
@@ -267,8 +279,9 @@ public class RepositoryNodeIdProvider implements NodeIdProvider, AutoCloseable {
     }
   }
 
-  private boolean wasGracefullyShutdown(final StoredLease storedLease) {
+  private boolean wasGracefullyShutdown(final @Nullable StoredLease storedLease) {
     return switch (storedLease) {
+      case null -> true;
       case final StoredLease.Uninitialized u -> true;
       case final StoredLease.Initialized initialized ->
           initialized.lease().isExpiredBeyondThreshold(clock.instant(), expiredLeaseThreshold);
@@ -310,7 +323,7 @@ public class RepositoryNodeIdProvider implements NodeIdProvider, AutoCloseable {
     return currentCount;
   }
 
-  private StoredLease.Initialized tryAcquireInitialLease(final StoredLease lease) {
+  private StoredLease.@Nullable Initialized tryAcquireInitialLease(final StoredLease lease) {
     try {
       final var newLease = lease.acquireInitialLease(taskId, clock, leaseDuration);
       return newLease.map(value -> nodeIdRepository.acquire(value, lease.eTag())).orElse(null);

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/fs/DirectoryInitializationInfo.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/fs/DirectoryInitializationInfo.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.dynamic.nodeid.fs;
 
 import io.camunda.zeebe.dynamic.nodeid.Version;
+import org.jspecify.annotations.Nullable;
 
 /**
  * @param initializedAt epoch in milliseconds when the directory was initialized
@@ -16,7 +17,7 @@ import io.camunda.zeebe.dynamic.nodeid.Version;
  *     the first initialization
  */
 public record DirectoryInitializationInfo(
-    long initializedAt, Version version, Version initializedFrom) {
+    long initializedAt, Version version, @Nullable Version initializedFrom) {
   public DirectoryInitializationInfo {
     if (initializedAt < 0L) {
       throw new IllegalArgumentException("initializedAt cannot be negative");
@@ -27,7 +28,7 @@ public record DirectoryInitializationInfo(
   }
 
   static DirectoryInitializationInfo copiedFrom(
-      final Version currentVersion, final Version copiedFromVersion) {
+      final Version currentVersion, final @Nullable Version copiedFromVersion) {
     return new DirectoryInitializationInfo(
         System.currentTimeMillis(), currentVersion, copiedFromVersion);
   }

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/fs/VersionedDirectoryLayout.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/fs/VersionedDirectoryLayout.java
@@ -18,6 +18,7 @@ import java.nio.file.StandardOpenOption;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -116,8 +117,8 @@ public final class VersionedDirectoryLayout {
     }
   }
 
-  public void initializeDirectory(final Version currentVersion, final Version copiedFromVersion)
-      throws IOException {
+  public void initializeDirectory(
+      final Version currentVersion, final @Nullable Version copiedFromVersion) throws IOException {
     final var initInfo = DirectoryInitializationInfo.copiedFrom(currentVersion, copiedFromVersion);
 
     final var bytes = objectMapper.writeValueAsBytes(initInfo);

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/fs/package-info.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/fs/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+@NullMarked
+package io.camunda.zeebe.dynamic.nodeid.fs;
+
+import org.jspecify.annotations.NullMarked;

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/package-info.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+@NullMarked
+package io.camunda.zeebe.dynamic.nodeid;
+
+import org.jspecify.annotations.NullMarked;

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/Metadata.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/Metadata.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.dynamic.nodeid.Version;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import org.jspecify.annotations.Nullable;
 
 public record Metadata(Optional<String> task, Version version, boolean acquirable) {
   // KEYS MUST BE LOWERCASE
@@ -54,7 +55,7 @@ public record Metadata(Optional<String> task, Version version, boolean acquirabl
         ACQUIRABLE_KEY, Boolean.toString(acquirable));
   }
 
-  public static Metadata fromMap(final Map<String, String> map) {
+  public static @Nullable Metadata fromMap(final Map<String, String> map) {
     if (map.isEmpty()) {
       return null;
     }

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/NodeIdRepository.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/NodeIdRepository.java
@@ -15,6 +15,7 @@ import java.time.Duration;
 import java.time.InstantSource;
 import java.util.Objects;
 import java.util.Optional;
+import org.jspecify.annotations.Nullable;
 
 public interface NodeIdRepository extends AutoCloseable {
 
@@ -70,16 +71,18 @@ public interface NodeIdRepository extends AutoCloseable {
    * Update the restore status in the repository
    *
    * @param restoreStatus the new restore status
-   * @param etag the etag of the current restore status in the repository
+   * @param etag the ETag of the current restore status in the repository, or null or empty if no
+   *     status exists yet; null or empty causes the status to be created only if it does not
+   *     already exist
    */
-  void updateRestoreStatus(StoredRestoreStatus.RestoreStatus restoreStatus, String etag);
+  void updateRestoreStatus(StoredRestoreStatus.RestoreStatus restoreStatus, @Nullable String etag);
 
   /**
    * Get the current restore status from the repository
    *
    * @return the current restore status, or null if none exists
    */
-  StoredRestoreStatus getRestoreStatus(final String restoreId);
+  @Nullable StoredRestoreStatus getRestoreStatus(final String restoreId);
 
   /**
    * Get the count of available leases in the repository. This can be used to refresh the available
@@ -153,9 +156,12 @@ public interface NodeIdRepository extends AutoCloseable {
     }
 
     static StoredLease of(
-        final int nodeId, final Lease lease, final Metadata metadata, final String eTag) {
+        final int nodeId,
+        final @Nullable Lease lease,
+        final @Nullable Metadata metadata,
+        final String eTag) {
       if (eTag == null || eTag.isEmpty()) {
-        throw new IllegalArgumentException("eTag cannot be null or empty:" + eTag);
+        throw new IllegalArgumentException("eTag cannot be null or empty: " + eTag);
       }
       if (metadata != null && !metadata.acquirable()) {
         return new StoredLease.Unusable(new NodeInstance(nodeId, metadata.version()), eTag);
@@ -165,6 +171,9 @@ public interface NodeIdRepository extends AutoCloseable {
             Optional.ofNullable(metadata).map(Metadata::version).orElse(Version.zero());
         return new StoredLease.Uninitialized(new NodeInstance(nodeId, version), eTag);
       } else {
+        if (metadata == null) {
+          throw new IllegalArgumentException("metadata cannot be null when lease is initialized");
+        }
         return new StoredLease.Initialized(metadata, lease, eTag);
       }
     }

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/package-info.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+@NullMarked
+package io.camunda.zeebe.dynamic.nodeid.repository;
+
+import org.jspecify.annotations.NullMarked;

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepository.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/S3NodeIdRepository.java
@@ -22,6 +22,7 @@ import java.time.InstantSource;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.stream.IntStream;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
@@ -168,7 +169,7 @@ public class S3NodeIdRepository implements NodeIdRepository {
   }
 
   @Override
-  public void updateRestoreStatus(final RestoreStatus restoreStatus, final String etag) {
+  public void updateRestoreStatus(final RestoreStatus restoreStatus, final @Nullable String etag) {
     final PutObjectRequest.Builder putRequestBuilder =
         PutObjectRequest.builder()
             .bucket(config.bucketName)
@@ -196,7 +197,7 @@ public class S3NodeIdRepository implements NodeIdRepository {
   }
 
   @Override
-  public StoredRestoreStatus getRestoreStatus(final String restoreId) {
+  public @Nullable StoredRestoreStatus getRestoreStatus(final String restoreId) {
     final var request =
         GetObjectRequest.builder()
             .bucket(config.bucketName)

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/package-info.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/repository/s3/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+@NullMarked
+package io.camunda.zeebe.dynamic.nodeid.repository.s3;
+
+import org.jspecify.annotations.NullMarked;


### PR DESCRIPTION

## Description

Add @NullMarked package-info.java files to all packages and resolve all NullAway compilation errors by annotating nullable fields and method parameters with @Nullable where appropriate.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #53253
