### PR TITLE
test: add zeebe-qa-util to unit tests list and fix test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -467,7 +467,7 @@ jobs:
           BACKUP="':zeebe-backup',':zeebe-backup-store-azure',':zeebe-backup-store-common',':zeebe-backup-store-filesystem',':zeebe-backup-store-gcs',':zeebe-backup-store-s3',':zeebe-backup-testkit'"
 
           # Zeebe modules owned by @camunda/zeebe-distributed-platform
-          DISTRIBUTED="':zeebe-atomix-cluster',':zeebe-atomix-utils',':zeebe-broker',':zeebe-broker-client',':zeebe-cluster-config',':dynamic-node-id-provider',':zeebe-journal',':zeebe-logstreams',':zeebe-restore',':zeebe-scheduler',':zeebe-snapshots',':zeebe-stream-platform',':zeebe-transport'"
+          DISTRIBUTED="':zeebe-atomix-cluster',':zeebe-atomix-utils',':zeebe-broker',':zeebe-broker-client',':zeebe-cluster-config',':dynamic-node-id-provider',':zeebe-journal',':zeebe-logstreams',':zeebe-restore',':zeebe-scheduler',':zeebe-snapshots',':zeebe-stream-platform',':zeebe-transport',':zeebe-qa-util'"
 
           # Zeebe modules owned by @camunda/camundaex
           CLIENT="':camunda-client-java'"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -467,7 +467,7 @@ jobs:
           BACKUP="':zeebe-backup',':zeebe-backup-store-azure',':zeebe-backup-store-common',':zeebe-backup-store-filesystem',':zeebe-backup-store-gcs',':zeebe-backup-store-s3',':zeebe-backup-testkit'"
 
           # Zeebe modules owned by @camunda/zeebe-distributed-platform
-          DISTRIBUTED="':zeebe-atomix-cluster',':zeebe-atomix-utils',':zeebe-broker',':zeebe-broker-client',':zeebe-cluster-config',':dynamic-node-id-provider',':zeebe-journal',':zeebe-logstreams',':zeebe-restore',':zeebe-scheduler',':zeebe-snapshots',':zeebe-stream-platform',':zeebe-transport',':zeebe-qa-util'"
+          DISTRIBUTED="':zeebe-atomix-cluster',':zeebe-atomix-utils',':zeebe-broker',':zeebe-broker-client',':zeebe-cluster-config',':dynamic-node-id-provider',':zeebe-journal',':zeebe-logstreams',':zeebe-restore',':zeebe-scheduler',':zeebe-snapshots',':zeebe-stream-platform',':zeebe-transport'"
 
           # Zeebe modules owned by @camunda/camundaex
           CLIENT="':camunda-client-java'"
@@ -481,7 +481,9 @@ jobs:
           # ============================================================================
 
           # IT Distributed = DISTRIBUTED + BACKUP (all distributed platform modules)
-          IT_DISTRIBUTED="${DISTRIBUTED},${BACKUP}"
+          # zeebe-qa-util is excluded from DISTRIBUTED (skipQaBuild=true skips zeebe/qa/ in UT jobs)
+          # but must run its ITs, so it is added here explicitly
+          IT_DISTRIBUTED="${DISTRIBUTED},${BACKUP},':zeebe-qa-util'"
 
           # IT Exporter = EXPORTER (direct reuse)
           IT_EXPORTER="$EXPORTER"

--- a/zeebe/qa/util/src/test/java/io/camunda/zeebe/qa/util/junit/ZeebeIntegrationExtensionTest.java
+++ b/zeebe/qa/util/src/test/java/io/camunda/zeebe/qa/util/junit/ZeebeIntegrationExtensionTest.java
@@ -59,9 +59,9 @@ final class ZeebeIntegrationExtensionTest {
     final var brokerB0 = CLUSTER.brokers().get(MemberId.from("zoneB", 0));
 
     // then
-    assertWorkingDirectory(brokerA0, "broker-zoneA-0");
-    assertWorkingDirectory(brokerA1, "broker-zoneA-1");
-    assertWorkingDirectory(brokerB0, "broker-zoneB-0");
+    assertWorkingDirectory(brokerA0, "broker-zoneA_0");
+    assertWorkingDirectory(brokerA1, "broker-zoneA_1");
+    assertWorkingDirectory(brokerB0, "broker-zoneB_0");
   }
 
   @Test
@@ -71,9 +71,9 @@ final class ZeebeIntegrationExtensionTest {
 
     // then
     assertThat(workingDirectory).isNotNull().exists().isDirectory();
-    assertThat(workingDirectory.getFileName()).hasToString("broker-zoneA-1");
+    assertThat(workingDirectory.getFileName()).hasToString("broker-zoneA_1");
     assertThat(workingDirectory.getParent().getFileName().toString())
-        .startsWith("junit-broker-zoneA-1");
+        .startsWith("junit-broker-zoneA_1");
   }
 
   private static void assertWorkingDirectory(


### PR DESCRIPTION
## Description

With PR #54152 I forgot to change the test in `ZeebeIntegrationExtensionTest`. this test is run as IT, which was not included in the ci job.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues
