### PR TITLE
test: do not await for healthy topology to speed up test

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ScaleUpPartitionsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ScaleUpPartitionsTest.java
@@ -79,7 +79,8 @@ public class ScaleUpPartitionsTest {
   private ClusterActuator clusterActuator;
   private BackupActuator backupActuator;
 
-  @TestZeebe private final TestCluster cluster;
+  @TestZeebe(awaitCompleteTopology = false)
+  private final TestCluster cluster;
 
   ScaleUpPartitionsTest(@TempDir final Path backupPath) {
     cluster =


### PR DESCRIPTION
## Description

Experimental change to see if skipping topology makes the test more reliable.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

relates #51932
