### PR TITLE
feat: add priority field to job activation API response (gRPC and REST)

### DIFF
--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
@@ -234,6 +234,7 @@ public final class ResponseMapper {
             rootProcessInstanceKey > 0 ? keyToString(rootProcessInstanceKey) : null)
         .tags(job.getTags())
         .userTask(toUserTaskProperties(job))
+        .priority(job.getPriority())
         .build();
   }
 

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/rest/ResponseMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/rest/ResponseMapperTest.java
@@ -122,6 +122,41 @@ class ResponseMapperTest {
               });
     }
 
+    @Test
+    void shouldMapPriorityToActivatedJobResult() {
+      // given
+      final JobRecord jobRecord =
+          new JobRecord()
+              .setJobKind(JobKind.BPMN_ELEMENT)
+              .setType("test-type")
+              .setBpmnProcessId("procId")
+              .setElementId("elementId")
+              .setProcessInstanceKey(456L)
+              .setProcessDefinitionVersion(1)
+              .setProcessDefinitionKey(123L)
+              .setElementInstanceKey(555L)
+              .setWorker("worker")
+              .setRetries(3)
+              .setDeadline(0L)
+              .setPriority(80)
+              .setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+
+      final byte[] emptyVariables = MsgPackConverter.convertToMsgPack(Collections.emptyMap());
+      jobRecord.setVariables(new UnsafeBuffer(emptyVariables));
+
+      final JobBatchRecord batchRecord = buildJobBatchRecord(jobRecord);
+      final JobActivationResponse activationResponse =
+          new JobActivationResponse(123L, batchRecord, 1024 * 1024L);
+
+      // when
+      final var result = ResponseMapper.toActivateJobsResponse(activationResponse);
+
+      // then
+      assertThat(result.getActivateJobsResponse().getJobs())
+          .singleElement()
+          .satisfies(job -> assertThat(job.getPriority()).isEqualTo(80));
+    }
+
     static Stream<ActivatedJobWithUserTaskPropsCase> activatedJobWithUserTaskPropsCases() {
       return Stream.of(
           new ActivatedJobWithUserTaskPropsCase(
@@ -283,6 +318,7 @@ class ResponseMapperTest {
           .setElementInstanceKey(jobRecord.getElementInstanceKey())
           .setWorker(jobRecord.getWorker())
           .setRetries(jobRecord.getRetries())
+          .setPriority(jobRecord.getPriority())
           .setDeadline(jobRecord.getDeadline())
           .setTenantId(jobRecord.getTenantId());
 
@@ -323,6 +359,7 @@ class ResponseMapperTest {
           .setElementInstanceKey(jobRecord.getElementInstanceKey())
           .setWorker(jobRecord.getWorker())
           .setRetries(jobRecord.getRetries())
+          .setPriority(jobRecord.getPriority())
           .setDeadline(jobRecord.getDeadline())
           .setTenantId(jobRecord.getTenantId())
           .setRootProcessInstanceKey(jobRecord.getRootProcessInstanceKey());

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
@@ -390,6 +390,7 @@ public final class ResponseMapper {
             .setCustomHeaders(bufferAsJson(job.getCustomHeadersBuffer()))
             .setWorker(bufferAsString(job.getWorkerBuffer()))
             .setRetries(job.getRetries())
+            .setPriority(job.getPriority())
             .setDeadline(job.getDeadline())
             .setVariables(bufferAsJson(job.getVariablesBuffer()))
             .setTenantId(job.getTenantId())

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/ResponseMapperTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/ResponseMapperTest.java
@@ -174,6 +174,20 @@ class ResponseMapperTest {
       assertThat(result.getKind().name()).isEqualTo(jobKind.name());
     }
 
+    @Test
+    void shouldMapPriorityToActivatedJob() {
+      // given
+      final JobRecord jobRecord = mockJobRecord(JobKind.BPMN_ELEMENT, Map.of());
+      when(jobRecord.getPriority()).thenReturn(80);
+      final var activatedJob = mockActivatedJob(jobRecord);
+
+      // when
+      final var result = ResponseMapper.toActivatedJob(activatedJob);
+
+      // then
+      assertThat(result.getPriority()).isEqualTo(80);
+    }
+
     @ParameterizedTest
     @EnumSource(JobListenerEventType.class)
     void shouldMapActivatedJobWithListenerEventType(final JobListenerEventType listenerEventType) {

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsPriorityTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsPriorityTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.gateway.Gateway;
+import io.camunda.zeebe.gateway.RequestMapper;
+import io.camunda.zeebe.gateway.ResponseMapper;
+import io.camunda.zeebe.gateway.api.job.ActivateJobsStub;
+import io.camunda.zeebe.gateway.api.util.StubbedBrokerClient;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerActivateJobsRequest;
+import io.camunda.zeebe.gateway.metrics.LongPollingMetrics;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsResponse;
+import io.camunda.zeebe.scheduler.Actor;
+import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerExtension;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.util.unit.DataSize;
+
+final class LongPollingActivateJobsPriorityTest {
+
+  private static final String TYPE = "test";
+  private static final long LONG_POLLING_TIMEOUT = 5000;
+  private static final int MAX_JOBS_TO_ACTIVATE = 1;
+  private static final long MAX_MESSAGE_SIZE = DataSize.ofMegabytes(4).toBytes();
+
+  @RegisterExtension
+  final ControlledActorSchedulerExtension actorScheduler = new ControlledActorSchedulerExtension();
+
+  private final StubbedBrokerClient brokerClient = new StubbedBrokerClient();
+  private LongPollingActivateJobsHandler<ActivateJobsResponse> handler;
+  private ActivateJobsStub activateJobsStub;
+
+  @BeforeEach
+  void setUp() {
+    handler =
+        LongPollingActivateJobsHandler.<ActivateJobsResponse>newBuilder()
+            .setBrokerClient(brokerClient)
+            .setMaxMessageSize(MAX_MESSAGE_SIZE)
+            .setLongPollingTimeout(LONG_POLLING_TIMEOUT)
+            .setProbeTimeoutMillis(20000)
+            .setMinEmptyResponses(3)
+            .setActivationResultMapper(ResponseMapper::toActivateJobsResponse)
+            .setResourceExhaustedExceptionProvider(Gateway.RESOURCE_EXHAUSTED_EXCEPTION_PROVIDER)
+            .setRequestCanceledExceptionProvider(Gateway.REQUEST_CANCELED_EXCEPTION_PROVIDER)
+            .setMetrics(LongPollingMetrics.noop())
+            .build();
+    submitHandlerActor(handler);
+
+    activateJobsStub = new ActivateJobsStub();
+    activateJobsStub.registerWith(brokerClient);
+    activateJobsStub.addAvailableJobs(TYPE, 0);
+  }
+
+  @Test
+  void shouldIncludePriorityWhenJobImmediatelyActivated() {
+    // given
+    activateJobsStub.addAvailableJobs(TYPE, 1);
+    final var responseRef = new AtomicReference<ActivateJobsResponse>();
+
+    // when
+    handler.activateJobs(
+        buildBrokerRequest(MAX_JOBS_TO_ACTIVATE),
+        buildObserver(responseRef),
+        ignored -> {},
+        LONG_POLLING_TIMEOUT);
+    actorScheduler.workUntilDone();
+
+    // then
+    assertThat(responseRef.get()).as("expected a response to be received").isNotNull();
+    assertThat(responseRef.get().getJobsList())
+        .singleElement()
+        .satisfies(
+            job ->
+                assertThat(job.getPriority())
+                    .as("activated job priority should match stub value")
+                    .isEqualTo(ActivateJobsStub.PRIORITY));
+  }
+
+  @Test
+  void shouldIncludePriorityInAllJobsWhenBatchIsActivated() {
+    // given
+    final int batchSize = 3;
+    final var responseRef = new AtomicReference<ActivateJobsResponse>();
+    final var request =
+        new InflightActivateJobsRequest<>(
+            1L, buildBrokerRequest(batchSize), buildObserver(responseRef), LONG_POLLING_TIMEOUT);
+
+    // park the request
+    handler.internalActivateJobsRetry(request);
+    actorScheduler.workUntilDone();
+
+    // when
+    activateJobsStub.addAvailableJobs(TYPE, batchSize);
+    brokerClient.notifyJobsAvailable(TYPE);
+    actorScheduler.workUntilDone();
+
+    // then
+    assertThat(responseRef.get()).as("expected a response to be received").isNotNull();
+    assertThat(responseRef.get().getJobsList())
+        .hasSize(batchSize)
+        .allSatisfy(
+            job ->
+                assertThat(job.getPriority())
+                    .as("activated job priority should match stub value")
+                    .isEqualTo(ActivateJobsStub.PRIORITY));
+  }
+
+  private BrokerActivateJobsRequest buildBrokerRequest(final int maxJobs) {
+    final var grpcRequest =
+        ActivateJobsRequest.newBuilder()
+            .setType(TYPE)
+            .setMaxJobsToActivate(maxJobs)
+            .setRequestTimeout(LONG_POLLING_TIMEOUT)
+            .build();
+    return RequestMapper.toActivateJobsRequest(grpcRequest);
+  }
+
+  private ResponseObserver<ActivateJobsResponse> buildObserver(
+      final AtomicReference<ActivateJobsResponse> responseRef) {
+    return new ResponseObserver<>() {
+      @Override
+      public void onCompleted() {}
+
+      @Override
+      public void onNext(final ActivateJobsResponse response) {
+        responseRef.set(response);
+      }
+
+      @Override
+      public boolean isCancelled() {
+        return false;
+      }
+
+      @Override
+      public void onError(final Throwable t) {
+        throw new AssertionError("Unexpected error in activate jobs observer", t);
+      }
+    };
+  }
+
+  private void submitHandlerActor(final LongPollingActivateJobsHandler<ActivateJobsResponse> h) {
+    final var ready = new CompletableFuture<Void>();
+    final var actor =
+        Actor.newActor()
+            .name("TestHandler")
+            .actorStartedHandler(h.andThen(ignored -> ready.complete(null)))
+            .build();
+    actorScheduler.submitActor(actor);
+    actorScheduler.workUntilDone();
+    ready.join();
+  }
+}

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -125,6 +125,8 @@ message ActivatedJob {
   ListenerEventType listenerEventType = 17;
   // the list of tags
   repeated string tags = 18;
+  // the priority of the job; higher values indicate higher priority
+  int32 priority = 19;
 }
 
 message UserTaskProperties {

--- a/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
@@ -377,6 +377,7 @@ components:
         - rootProcessInstanceKey
         - tags
         - userTask
+        - priority
       properties:
         type:
           description: The type of the job (should match what was requested).
@@ -459,6 +460,12 @@ components:
           nullable: true
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
+        priority:
+          description: >
+            The priority of the job. Higher values indicate higher priority.
+            Jobs created before 8.10 have no stored priority; the API returns 0 for such jobs.
+          type: integer
+          format: int32
       x-properties-added-in-version:
         - propertyName: kind
           addedInVersion: "8.8"
@@ -470,6 +477,8 @@ components:
           addedInVersion: "8.8"
         - propertyName: rootProcessInstanceKey
           addedInVersion: "8.9"
+        - propertyName: priority
+          addedInVersion: "8.10"
 
     UserTaskProperties:
       required:

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerRoundRobinTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerRoundRobinTest.java
@@ -129,7 +129,8 @@ public class JobControllerRoundRobinTest extends RestControllerTest {
               "kind": "BPMN_ELEMENT",
               "listenerEventType": "UNSPECIFIED",
               "rootProcessInstanceKey": null,
-              "userTask": null
+              "userTask": null,
+              "priority": 80
             },
             {
               "jobKey": "%d",
@@ -156,7 +157,8 @@ public class JobControllerRoundRobinTest extends RestControllerTest {
               "kind": "BPMN_ELEMENT",
               "listenerEventType": "UNSPECIFIED",
               "rootProcessInstanceKey": null,
-              "userTask": null
+              "userTask": null,
+              "priority": 80
             }
           ]
         }"""

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/job/ActivateJobsStub.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/job/ActivateJobsStub.java
@@ -30,6 +30,7 @@ public class ActivateJobsStub
   public static final long JOB_BATCH_KEY = 123;
   public static final int RETRIES = 12;
   public static final long DEADLINE = 123123123L;
+  public static final int PRIORITY = 80;
 
   public static final long PROCESS_INSTANCE_KEY = 123L;
   public static final String BPMN_PROCESS_ID = "stubProcess";
@@ -138,6 +139,7 @@ public class ActivateJobsStub
               job.setType(type)
                   .setWorker(worker)
                   .setRetries(RETRIES)
+                  .setPriority(PRIORITY)
                   .setDeadline(DEADLINE)
                   .setCustomHeaders(CUSTOM_HEADERS_MSGPACK)
                   .setVariables(VARIABLES_MSGPACK)


### PR DESCRIPTION
## Description

Exposes the job `priority` field in job activation API responses (gRPC and REST)

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes https://github.com/camunda/camunda/issues/53834
