### PR TITLE
test: add ES 9.4 to test matrix (drop 9.2, keep 9.3)

### DIFF
--- a/.ci/db-versions.yml
+++ b/.ci/db-versions.yml
@@ -18,8 +18,8 @@ elasticsearch:
   es8:
     - &saas "8.19.15"
   es9:
-    - "9.2.0"
     - "9.3.0"
+    - "9.4.0"
   saas: *saas
 
 opensearch:


### PR DESCRIPTION
Adds Elasticsearch 9.4.0 and drops 9.2.0 from `.ci/db-versions.yml`. Per the support policy of testing the latest two ES minors, the matrix now covers 9.3 and 9.4.

ES 9.5 is not yet released and will be added in a follow-up (at which point 9.3 will be dropped).

Closes #52444.