### PR TITLE
feat: implement Zeebe agent instance import pipeline

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebePositionBasedImportIndexIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebePositionBasedImportIndexIT.java
@@ -62,7 +62,7 @@ public class ZeebePositionBasedImportIndexIT extends AbstractCCSMIT {
 
     // then
     assertThat(positionBasedHandlers)
-        .hasSize(10)
+        .hasSize(12)
         .allSatisfy(
             handler -> {
               assertThat(handler.getPersistedPositionOfLastEntity()).isZero();

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/agentinstance/ZeebeAgentInstanceDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/agentinstance/ZeebeAgentInstanceDataDto.java
@@ -60,7 +60,7 @@ public class ZeebeAgentInstanceDataDto implements AgentInstanceRecordValue {
 
   @Override
   public List<Long> getElementInstanceKeys() {
-    return elementInstanceKeys;
+    return elementInstanceKeys != null ? elementInstanceKeys : List.of();
   }
 
   public void setElementInstanceKeys(final List<Long> elementInstanceKeys) {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/script/ZeebeProcessInstanceScriptFactory.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/script/ZeebeProcessInstanceScriptFactory.java
@@ -17,7 +17,8 @@ public interface ZeebeProcessInstanceScriptFactory {
   static String createProcessInstanceUpdateScript() {
     return createUpdateProcessInstancePropertiesScript()
         + createUpdateFlowNodeInstancesScript()
-        + createUpdateIncidentsScript();
+        + createUpdateIncidentsScript()
+        + createUpdateAgentInstancesScript();
   }
 
   private static String createUpdateProcessInstancePropertiesScript() {
@@ -154,6 +155,59 @@ public interface ZeebeProcessInstanceScriptFactory {
                 })
                 .collect(Collectors.toList());
           """;
+  }
+
+  private static String createUpdateAgentInstancesScript() {
+    return """
+      if (existingInstance.agentInstances == null) {
+        existingInstance.agentInstances = new ArrayList();
+      }
+      if (params.instance.agentInstances != null && !params.instance.agentInstances.isEmpty()) {
+        def agentsById = existingInstance.agentInstances.stream()
+          .collect(Collectors.toMap(a -> a.agentInstanceId, a -> a, (a1, a2) -> a1));
+        def dateFormatter = new SimpleDateFormat(params.dateFormatPattern);
+        for (def newAgent : params.instance.agentInstances) {
+          def existingAgent = agentsById.get(newAgent.agentInstanceId);
+          if (existingAgent != null) {
+            if (existingAgent.startDate == null && newAgent.startDate != null) { existingAgent.startDate = newAgent.startDate; }
+            if (newAgent.endDate != null) { existingAgent.endDate = newAgent.endDate; }
+            if (existingAgent.startDate != null && existingAgent.endDate != null) {
+              existingAgent.totalDurationInMs = dateFormatter.parse(existingAgent.endDate).getTime() -
+                dateFormatter.parse(existingAgent.startDate).getTime();
+            }
+            boolean isTerminal = existingAgent.status != null && existingAgent.status.equals('COMPLETED');
+            long existingTs = existingAgent.lastUpdatedDate != null ?
+              dateFormatter.parse(existingAgent.lastUpdatedDate).getTime() : 0L;
+            long newTs = newAgent.lastUpdatedDate != null ?
+              dateFormatter.parse(newAgent.lastUpdatedDate).getTime() : Long.MAX_VALUE;
+            if (!isTerminal && newTs >= existingTs) {
+              if (newAgent.status != null) { existingAgent.status = newAgent.status; }
+              if (newAgent.lastUpdatedDate != null) { existingAgent.lastUpdatedDate = newAgent.lastUpdatedDate; }
+              if (newAgent.metrics != null) { existingAgent.metrics = newAgent.metrics; }
+              if (newAgent.tools != null && !newAgent.tools.isEmpty()) { existingAgent.tools = newAgent.tools; }
+            }
+            if (existingAgent.definition == null && newAgent.definition != null) { existingAgent.definition = newAgent.definition; }
+          } else {
+            agentsById.put(newAgent.agentInstanceId, newAgent);
+          }
+        }
+        existingInstance.agentInstances = agentsById.values();
+        long totalInput = 0; long totalOutput = 0; long totalModel = 0; long totalTool = 0;
+        for (def a : existingInstance.agentInstances) {
+          if (a.metrics != null) {
+            if (a.metrics.inputTokens != null) { totalInput += a.metrics.inputTokens; }
+            if (a.metrics.outputTokens != null) { totalOutput += a.metrics.outputTokens; }
+            if (a.metrics.modelCalls != null) { totalModel += a.metrics.modelCalls; }
+            if (a.metrics.toolCalls != null) { totalTool += a.metrics.toolCalls; }
+          }
+        }
+        existingInstance.agentTotalInputTokens = totalInput;
+        existingInstance.agentTotalOutputTokens = totalOutput;
+        existingInstance.agentTotalModelCalls = totalModel;
+        existingInstance.agentTotalToolCalls = totalTool;
+        existingInstance.agentTotalTokens = totalInput + totalOutput;
+      }
+      """;
   }
 
   private static String createUpdatePropertyIfNotNullScript(

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/importing/ImportIndexHandlerRegistry.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/importing/ImportIndexHandlerRegistry.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.service.importing;
 
 import io.camunda.optimize.service.importing.ingested.handler.ExternalVariableUpdateImportIndexHandler;
 import io.camunda.optimize.service.importing.ingested.handler.IngestedImportIndexHandlerProvider;
+import io.camunda.optimize.service.importing.zeebe.handler.ZeebeAgentInstanceImportIndexHandler;
 import io.camunda.optimize.service.importing.zeebe.handler.ZeebeImportIndexHandlerProvider;
 import io.camunda.optimize.service.importing.zeebe.handler.ZeebeIncidentImportIndexHandler;
 import io.camunda.optimize.service.importing.zeebe.handler.ZeebeProcessDefinitionImportIndexHandler;
@@ -76,6 +77,11 @@ public class ImportIndexHandlerRegistry {
   public ZeebeUserTaskImportIndexHandler getZeebeUserTaskImportIndexHandler(
       final Integer partitionId) {
     return getZeebeImportIndexHandler(partitionId, ZeebeUserTaskImportIndexHandler.class);
+  }
+
+  public ZeebeAgentInstanceImportIndexHandler getZeebeAgentInstanceImportIndexHandler(
+      final Integer partitionId) {
+    return getZeebeImportIndexHandler(partitionId, ZeebeAgentInstanceImportIndexHandler.class);
   }
 
   public ExternalVariableUpdateImportIndexHandler getExternalVariableUpdateImportIndexHandler() {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/importing/engine/service/zeebe/ZeebeAgentInstanceImportService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/importing/engine/service/zeebe/ZeebeAgentInstanceImportService.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.importing.engine.service.zeebe;
+
+import static io.camunda.optimize.service.db.DatabaseConstants.ZEEBE_AGENT_INSTANCE_INDEX_NAME;
+
+import io.camunda.optimize.dto.optimize.ProcessInstanceDto;
+import io.camunda.optimize.dto.optimize.query.process.AgentInstanceDto;
+import io.camunda.optimize.dto.zeebe.agentinstance.ZeebeAgentInstanceDataDto;
+import io.camunda.optimize.dto.zeebe.agentinstance.ZeebeAgentInstanceRecordDto;
+import io.camunda.optimize.service.db.DatabaseClient;
+import io.camunda.optimize.service.db.reader.ProcessDefinitionReader;
+import io.camunda.optimize.service.db.writer.ProcessInstanceWriter;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.AgentInstanceStatus;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+
+public class ZeebeAgentInstanceImportService
+    extends ZeebeProcessInstanceSubEntityImportService<ZeebeAgentInstanceRecordDto> {
+
+  private static final Set<AgentInstanceIntent> INTENTS_TO_IMPORT =
+      Set.of(
+          AgentInstanceIntent.CREATED, AgentInstanceIntent.UPDATED, AgentInstanceIntent.COMPLETED);
+  private static final Logger LOG =
+      org.slf4j.LoggerFactory.getLogger(ZeebeAgentInstanceImportService.class);
+
+  public ZeebeAgentInstanceImportService(
+      final ConfigurationService configurationService,
+      final ProcessInstanceWriter processInstanceWriter,
+      final int partitionId,
+      final ProcessDefinitionReader processDefinitionReader,
+      final DatabaseClient databaseClient) {
+    super(
+        configurationService,
+        processInstanceWriter,
+        partitionId,
+        processDefinitionReader,
+        databaseClient,
+        ZEEBE_AGENT_INSTANCE_INDEX_NAME);
+  }
+
+  @Override
+  protected List<ProcessInstanceDto> filterAndMapZeebeRecordsToOptimizeEntities(
+      final List<ZeebeAgentInstanceRecordDto> zeebeRecords) {
+    final List<ProcessInstanceDto> optimizeDtos =
+        zeebeRecords.stream()
+            .filter(zeebeRecord -> INTENTS_TO_IMPORT.contains(zeebeRecord.getIntent()))
+            .collect(
+                Collectors.groupingBy(
+                    zeebeRecord -> zeebeRecord.getValue().getProcessInstanceKey()))
+            .values()
+            .stream()
+            .map(this::createProcessInstanceForData)
+            .toList();
+    LOG.debug(
+        "Processing {} fetched zeebe agent instance records, of which {} are relevant to Optimize and will be imported.",
+        zeebeRecords.size(),
+        optimizeDtos.size());
+    return optimizeDtos;
+  }
+
+  private ProcessInstanceDto createProcessInstanceForData(
+      final List<ZeebeAgentInstanceRecordDto> recordsForInstance) {
+    final ZeebeAgentInstanceDataDto firstRecordValue = recordsForInstance.getFirst().getValue();
+    final ProcessInstanceDto instanceToAdd =
+        createSkeletonProcessInstance(
+            firstRecordValue.getBpmnProcessId(),
+            firstRecordValue.getProcessInstanceKey(),
+            firstRecordValue.getProcessDefinitionKey(),
+            firstRecordValue.getTenantId());
+    return updateAgentInstances(instanceToAdd, recordsForInstance);
+  }
+
+  private ProcessInstanceDto updateAgentInstances(
+      final ProcessInstanceDto instanceToAdd,
+      final List<ZeebeAgentInstanceRecordDto> recordsForInstance) {
+    final Map<Long, AgentInstanceDto> agentsByKey = new HashMap<>();
+    recordsForInstance.stream()
+        .sorted(
+            Comparator.comparingLong(ZeebeAgentInstanceRecordDto::getTimestamp)
+                .thenComparingLong(ZeebeAgentInstanceRecordDto::getPosition))
+        .forEach(
+            record -> {
+              final long agentKey = record.getKey();
+              final AgentInstanceDto agentDto =
+                  agentsByKey.getOrDefault(agentKey, createSkeletonAgentInstance(record));
+              final OffsetDateTime recordDate = dateForTimestamp(record.getTimestamp());
+
+              updateEveryIntent(agentDto, record, recordDate);
+              updateFirstIntent(agentDto, record, recordDate);
+              updateTerminalIntent(agentDto, record, recordDate);
+
+              agentsByKey.put(agentKey, agentDto);
+            });
+
+    final List<AgentInstanceDto> agentInstances = new ArrayList<>(agentsByKey.values());
+    instanceToAdd.setAgentInstances(agentInstances);
+    computeAggregateMetrics(instanceToAdd, agentInstances);
+    return instanceToAdd;
+  }
+
+  private AgentInstanceDto createSkeletonAgentInstance(final ZeebeAgentInstanceRecordDto record) {
+    final ZeebeAgentInstanceDataDto data = record.getValue();
+    final AgentInstanceDto dto = new AgentInstanceDto();
+    dto.setAgentInstanceId(String.valueOf(record.getKey()));
+    dto.setFlowNodeId(data.getElementId());
+    dto.setFlowNodeInstanceId(String.valueOf(data.getElementInstanceKey()));
+    dto.setFlowNodeInstanceIds(
+        data.getElementInstanceKeys().stream().map(String::valueOf).collect(Collectors.toList()));
+    return dto;
+  }
+
+  private void mapDefinition(
+      final AgentInstanceDto agentDto, final ZeebeAgentInstanceDataDto data) {
+    final AgentInstanceDto.AgentDefinitionDto definitionDto =
+        new AgentInstanceDto.AgentDefinitionDto();
+    definitionDto.setModel(data.getDefinition().getModel());
+    definitionDto.setProvider(data.getDefinition().getProvider());
+    agentDto.setDefinition(definitionDto);
+  }
+
+  private void mapMetrics(final AgentInstanceDto agentDto, final ZeebeAgentInstanceDataDto data) {
+    final ZeebeAgentInstanceDataDto.AgentMetricsValueDto zeebeMetrics = data.getMetrics();
+    if (zeebeMetrics != null) {
+      final AgentInstanceDto.AgentMetricsDto metrics = new AgentInstanceDto.AgentMetricsDto();
+      metrics.setInputTokens(zeebeMetrics.getInputTokens());
+      metrics.setOutputTokens(zeebeMetrics.getOutputTokens());
+      metrics.setModelCalls(zeebeMetrics.getModelCalls());
+      metrics.setToolCalls(zeebeMetrics.getToolCalls());
+      agentDto.setMetrics(metrics);
+    }
+  }
+
+  private void mapTools(final AgentInstanceDto agentDto, final ZeebeAgentInstanceDataDto data) {
+    if (data.getTools() == null || data.getTools().isEmpty()) {
+      return;
+    }
+    final List<AgentInstanceDto.AgentToolDto> tools =
+        data.getTools().stream()
+            .map(
+                zeebeTool -> {
+                  final AgentInstanceDto.AgentToolDto toolDto = new AgentInstanceDto.AgentToolDto();
+                  toolDto.setName(zeebeTool.getName());
+                  return toolDto;
+                })
+            .toList();
+    agentDto.setTools(tools);
+  }
+
+  // Seeds parent aggregates for the initial insert. On upserts the painless merge script
+  // (ZeebeProcessInstanceScriptFactory#createUpdateAgentInstancesScript) recomputes these from
+  // the merged agentInstances list, overwriting this value — so this path only matters when no
+  // existing doc is present.
+  private void computeAggregateMetrics(
+      final ProcessInstanceDto instance, final List<AgentInstanceDto> agentInstances) {
+    long totalInputTokens = 0;
+    long totalOutputTokens = 0;
+    long totalModelCalls = 0;
+    long totalToolCalls = 0;
+    for (final AgentInstanceDto agent : agentInstances) {
+      final AgentInstanceDto.AgentMetricsDto m = agent.getMetrics();
+      if (m != null) {
+        totalInputTokens += m.getInputTokens();
+        totalOutputTokens += m.getOutputTokens();
+        totalModelCalls += m.getModelCalls();
+        totalToolCalls += m.getToolCalls();
+      }
+    }
+    instance.setAgentTotalInputTokens(totalInputTokens);
+    instance.setAgentTotalOutputTokens(totalOutputTokens);
+    instance.setAgentTotalModelCalls(totalModelCalls);
+    instance.setAgentTotalToolCalls(totalToolCalls);
+    instance.setAgentTotalTokens(totalInputTokens + totalOutputTokens);
+  }
+
+  private void updateEveryIntent(
+      final AgentInstanceDto agentDto,
+      final ZeebeAgentInstanceRecordDto record,
+      final OffsetDateTime recordDate) {
+    final AgentInstanceStatus status = record.getValue().getStatus();
+    if (status != null) {
+      agentDto.setStatus(status.name());
+    }
+    agentDto.setLastUpdatedDate(recordDate);
+    mapMetrics(agentDto, record.getValue());
+    mapTools(agentDto, record.getValue());
+  }
+
+  private void updateFirstIntent(
+      final AgentInstanceDto agentDto,
+      final ZeebeAgentInstanceRecordDto record,
+      final OffsetDateTime recordDate) {
+    if (record.getIntent() == AgentInstanceIntent.CREATED) {
+      agentDto.setStartDate(recordDate);
+      mapDefinition(agentDto, record.getValue());
+    }
+  }
+
+  private void updateTerminalIntent(
+      final AgentInstanceDto agentDto,
+      final ZeebeAgentInstanceRecordDto record,
+      final OffsetDateTime recordDate) {
+    if (record.getIntent() == AgentInstanceIntent.COMPLETED) {
+      agentDto.setEndDate(recordDate);
+      if (agentDto.getStartDate() != null) {
+        agentDto.setTotalDurationInMs(
+            recordDate.toInstant().toEpochMilli()
+                - agentDto.getStartDate().toInstant().toEpochMilli());
+      }
+    }
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/importing/engine/service/zeebe/ZeebeIncidentImportService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/importing/engine/service/zeebe/ZeebeIncidentImportService.java
@@ -20,9 +20,6 @@ import io.camunda.optimize.service.db.reader.ProcessDefinitionReader;
 import io.camunda.optimize.service.db.writer.ProcessInstanceWriter;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
-import java.time.Instant;
-import java.time.OffsetDateTime;
-import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -99,10 +96,10 @@ public class ZeebeIncidentImportService
           if (incident.getIntent() == IncidentIntent.CREATED
               && incidentForKey.getIncidentStatus() != IncidentStatus.RESOLVED) {
             incidentForKey.setIncidentStatus(IncidentStatus.OPEN);
-            incidentForKey.setCreateTime(dateForTimestamp(incident));
+            incidentForKey.setCreateTime(dateForTimestamp(incident.getTimestamp()));
           } else if (incident.getIntent() == IncidentIntent.RESOLVED) {
             incidentForKey.setIncidentStatus(IncidentStatus.RESOLVED);
-            incidentForKey.setEndTime(dateForTimestamp(incident));
+            incidentForKey.setEndTime(dateForTimestamp(incident.getTimestamp()));
           }
           updateDurationIfMissing(incidentForKey);
           incidentsByRecordKey.put(recordKey, incidentForKey);
@@ -130,10 +127,5 @@ public class ZeebeIncidentImportService
     incidentDto.setIncidentMessage(incidentDataDto.getErrorMessage());
     incidentDto.setTenantId(incidentDataDto.getTenantId());
     return incidentDto;
-  }
-
-  private OffsetDateTime dateForTimestamp(final ZeebeIncidentRecordDto zeebeRecord) {
-    return OffsetDateTime.ofInstant(
-        Instant.ofEpochMilli(zeebeRecord.getTimestamp()), ZoneId.systemDefault());
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/importing/engine/service/zeebe/ZeebeProcessInstanceSubEntityImportService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/importing/engine/service/zeebe/ZeebeProcessInstanceSubEntityImportService.java
@@ -17,6 +17,9 @@ import io.camunda.optimize.service.importing.DatabaseImportJobExecutor;
 import io.camunda.optimize.service.importing.engine.service.ImportService;
 import io.camunda.optimize.service.importing.job.ProcessInstanceDatabaseImportJob;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import org.slf4j.Logger;
 
@@ -117,5 +120,16 @@ public abstract class ZeebeProcessInstanceSubEntityImportService<T> implements I
             databaseClient);
     processInstanceImportJob.setEntitiesToImport(processInstanceDtos);
     return processInstanceImportJob;
+  }
+
+  /**
+   * Converts a Zeebe record timestamp (epoch milliseconds) to an {@link OffsetDateTime} in the
+   * system default time zone.
+   *
+   * @param timestamp the Zeebe record timestamp in milliseconds since epoch
+   * @return the corresponding {@link OffsetDateTime}
+   */
+  protected OffsetDateTime dateForTimestamp(final long timestamp) {
+    return OffsetDateTime.ofInstant(Instant.ofEpochMilli(timestamp), ZoneId.systemDefault());
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/importing/zeebe/db/ZeebeAgentInstanceFetcher.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/importing/zeebe/db/ZeebeAgentInstanceFetcher.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.importing.zeebe.db;
+
+import io.camunda.optimize.dto.zeebe.agentinstance.ZeebeAgentInstanceRecordDto;
+import io.camunda.optimize.service.importing.page.PositionBasedImportPage;
+import java.util.List;
+
+public interface ZeebeAgentInstanceFetcher extends ZeebeFetcher {
+
+  List<ZeebeAgentInstanceRecordDto> getZeebeRecordsForPrefixAndPartitionFrom(
+      PositionBasedImportPage positionBasedImportPage);
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/importing/zeebe/fetcher/es/ZeebeAgentInstanceFetcherES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/importing/zeebe/fetcher/es/ZeebeAgentInstanceFetcherES.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.importing.zeebe.fetcher.es;
+
+import static io.camunda.optimize.service.db.DatabaseConstants.ZEEBE_AGENT_INSTANCE_INDEX_NAME;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.optimize.dto.zeebe.agentinstance.ZeebeAgentInstanceRecordDto;
+import io.camunda.optimize.service.db.es.OptimizeElasticsearchClient;
+import io.camunda.optimize.service.importing.zeebe.db.ZeebeAgentInstanceFetcher;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import io.camunda.optimize.service.util.configuration.condition.ElasticSearchCondition;
+import org.slf4j.Logger;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+@Component
+@Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+@Conditional(ElasticSearchCondition.class)
+public class ZeebeAgentInstanceFetcherES
+    extends AbstractZeebeRecordFetcherES<ZeebeAgentInstanceRecordDto>
+    implements ZeebeAgentInstanceFetcher {
+
+  private static final Logger LOG =
+      org.slf4j.LoggerFactory.getLogger(ZeebeAgentInstanceFetcherES.class);
+
+  public ZeebeAgentInstanceFetcherES(
+      final int partitionId,
+      final OptimizeElasticsearchClient esClient,
+      final ObjectMapper objectMapper,
+      final ConfigurationService configurationService) {
+    super(partitionId, esClient, objectMapper, configurationService);
+  }
+
+  @Override
+  protected String getBaseIndexName() {
+    return ZEEBE_AGENT_INSTANCE_INDEX_NAME;
+  }
+
+  @Override
+  protected Class<ZeebeAgentInstanceRecordDto> getRecordDtoClass() {
+    return ZeebeAgentInstanceRecordDto.class;
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/importing/zeebe/fetcher/os/ZeebeAgentInstanceFetcherOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/importing/zeebe/fetcher/os/ZeebeAgentInstanceFetcherOS.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.importing.zeebe.fetcher.os;
+
+import static io.camunda.optimize.service.db.DatabaseConstants.ZEEBE_AGENT_INSTANCE_INDEX_NAME;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.optimize.dto.zeebe.agentinstance.ZeebeAgentInstanceRecordDto;
+import io.camunda.optimize.service.db.os.OptimizeOpenSearchClient;
+import io.camunda.optimize.service.importing.zeebe.db.ZeebeAgentInstanceFetcher;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import io.camunda.optimize.service.util.configuration.condition.OpenSearchCondition;
+import org.slf4j.Logger;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+@Component
+@Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+@Conditional(OpenSearchCondition.class)
+public class ZeebeAgentInstanceFetcherOS
+    extends AbstractZeebeRecordFetcherOS<ZeebeAgentInstanceRecordDto>
+    implements ZeebeAgentInstanceFetcher {
+
+  private static final Logger LOG =
+      org.slf4j.LoggerFactory.getLogger(ZeebeAgentInstanceFetcherOS.class);
+
+  public ZeebeAgentInstanceFetcherOS(
+      final int partitionId,
+      final OptimizeOpenSearchClient osClient,
+      final ObjectMapper objectMapper,
+      final ConfigurationService configurationService) {
+    super(partitionId, osClient, objectMapper, configurationService);
+  }
+
+  @Override
+  protected String getBaseIndexName() {
+    return ZEEBE_AGENT_INSTANCE_INDEX_NAME;
+  }
+
+  @Override
+  protected Class<ZeebeAgentInstanceRecordDto> getRecordDtoClass() {
+    return ZeebeAgentInstanceRecordDto.class;
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/importing/zeebe/handler/ZeebeAgentInstanceImportIndexHandler.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/importing/zeebe/handler/ZeebeAgentInstanceImportIndexHandler.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.importing.zeebe.handler;
+
+import io.camunda.optimize.dto.optimize.datasource.ZeebeDataSourceDto;
+import io.camunda.optimize.service.importing.PositionBasedImportIndexHandler;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+@Component
+@Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+public class ZeebeAgentInstanceImportIndexHandler extends PositionBasedImportIndexHandler {
+
+  private static final String ZEEBE_AGENT_INSTANCE_IMPORT_INDEX_DOC_ID =
+      "zeebeAgentInstanceImportIndex";
+
+  public ZeebeAgentInstanceImportIndexHandler(final ZeebeDataSourceDto dataSourceDto) {
+    this.dataSource = dataSourceDto;
+  }
+
+  @Override
+  protected String getDatabaseDocID() {
+    return ZEEBE_AGENT_INSTANCE_IMPORT_INDEX_DOC_ID;
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/importing/zeebe/mediator/ZeebeAgentInstanceImportMediator.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/importing/zeebe/mediator/ZeebeAgentInstanceImportMediator.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.importing.zeebe.mediator;
+
+import static io.camunda.optimize.MetricEnum.NEW_PAGE_FETCH_TIME_METRIC;
+import static io.camunda.zeebe.protocol.record.ValueType.AGENT_INSTANCE;
+
+import io.camunda.optimize.OptimizeMetrics;
+import io.camunda.optimize.dto.zeebe.agentinstance.ZeebeAgentInstanceRecordDto;
+import io.camunda.optimize.service.importing.PositionBasedImportMediator;
+import io.camunda.optimize.service.importing.engine.mediator.MediatorRank;
+import io.camunda.optimize.service.importing.engine.service.zeebe.ZeebeAgentInstanceImportService;
+import io.camunda.optimize.service.importing.zeebe.db.ZeebeAgentInstanceFetcher;
+import io.camunda.optimize.service.importing.zeebe.handler.ZeebeAgentInstanceImportIndexHandler;
+import io.camunda.optimize.service.util.BackoffCalculator;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import java.util.List;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+@Component
+@Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+public class ZeebeAgentInstanceImportMediator
+    extends PositionBasedImportMediator<
+        ZeebeAgentInstanceImportIndexHandler, ZeebeAgentInstanceRecordDto> {
+
+  private final ZeebeAgentInstanceFetcher zeebeAgentInstanceFetcher;
+
+  public ZeebeAgentInstanceImportMediator(
+      final ZeebeAgentInstanceImportIndexHandler importIndexHandler,
+      final ZeebeAgentInstanceFetcher zeebeAgentInstanceFetcher,
+      final ZeebeAgentInstanceImportService importService,
+      final ConfigurationService configurationService,
+      final BackoffCalculator idleBackoffCalculator) {
+    this.importIndexHandler = importIndexHandler;
+    this.zeebeAgentInstanceFetcher = zeebeAgentInstanceFetcher;
+    this.importService = importService;
+    this.configurationService = configurationService;
+    this.idleBackoffCalculator = idleBackoffCalculator;
+  }
+
+  @Override
+  public MediatorRank getRank() {
+    return MediatorRank.INSTANCE_SUB_ENTITIES;
+  }
+
+  @Override
+  protected boolean importNextPage(final Runnable importCompleteCallback) {
+    return importNextPagePositionBased(getAgentInstances(), importCompleteCallback);
+  }
+
+  @Override
+  protected String getRecordType() {
+    return AGENT_INSTANCE.name();
+  }
+
+  @Override
+  protected Integer getPartitionId() {
+    return zeebeAgentInstanceFetcher.getPartitionId();
+  }
+
+  private List<ZeebeAgentInstanceRecordDto> getAgentInstances() {
+    return OptimizeMetrics.getTimer(NEW_PAGE_FETCH_TIME_METRIC, getRecordType(), getPartitionId())
+        .record(
+            () ->
+                zeebeAgentInstanceFetcher.getZeebeRecordsForPrefixAndPartitionFrom(
+                    importIndexHandler.getNextPage()));
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/importing/zeebe/mediator/factory/ZeebeAgentInstanceImportMediatorFactory.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/importing/zeebe/mediator/factory/ZeebeAgentInstanceImportMediatorFactory.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.importing.zeebe.mediator.factory;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.optimize.dto.optimize.datasource.ZeebeDataSourceDto;
+import io.camunda.optimize.service.db.DatabaseClient;
+import io.camunda.optimize.service.db.reader.ProcessDefinitionReader;
+import io.camunda.optimize.service.db.writer.ProcessInstanceWriter;
+import io.camunda.optimize.service.importing.ImportIndexHandlerRegistry;
+import io.camunda.optimize.service.importing.ImportMediator;
+import io.camunda.optimize.service.importing.engine.service.zeebe.ZeebeAgentInstanceImportService;
+import io.camunda.optimize.service.importing.zeebe.db.ZeebeAgentInstanceFetcher;
+import io.camunda.optimize.service.importing.zeebe.mediator.ZeebeAgentInstanceImportMediator;
+import io.camunda.optimize.service.util.BackoffCalculator;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import java.util.Collections;
+import java.util.List;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ZeebeAgentInstanceImportMediatorFactory extends AbstractZeebeImportMediatorFactory {
+
+  private final ProcessInstanceWriter zeebeProcessInstanceWriter;
+  private final ProcessDefinitionReader processDefinitionReader;
+
+  public ZeebeAgentInstanceImportMediatorFactory(
+      final BeanFactory beanFactory,
+      final ImportIndexHandlerRegistry importIndexHandlerRegistry,
+      final ConfigurationService configurationService,
+      final ProcessInstanceWriter zeebeProcessInstanceWriter,
+      final ProcessDefinitionReader processDefinitionReader,
+      final ObjectMapper objectMapper,
+      final DatabaseClient databaseClient) {
+    super(
+        beanFactory,
+        importIndexHandlerRegistry,
+        configurationService,
+        objectMapper,
+        databaseClient);
+    this.zeebeProcessInstanceWriter = zeebeProcessInstanceWriter;
+    this.processDefinitionReader = processDefinitionReader;
+  }
+
+  @Override
+  public List<ImportMediator> createMediators(final ZeebeDataSourceDto zeebeDataSourceDto) {
+    return Collections.singletonList(
+        new ZeebeAgentInstanceImportMediator(
+            importIndexHandlerRegistry.getZeebeAgentInstanceImportIndexHandler(
+                zeebeDataSourceDto.getPartitionId()),
+            beanFactory.getBean(
+                ZeebeAgentInstanceFetcher.class,
+                zeebeDataSourceDto.getPartitionId(),
+                databaseClient,
+                objectMapper,
+                configurationService),
+            new ZeebeAgentInstanceImportService(
+                configurationService,
+                zeebeProcessInstanceWriter,
+                zeebeDataSourceDto.getPartitionId(),
+                processDefinitionReader,
+                databaseClient),
+            configurationService,
+            new BackoffCalculator(configurationService)));
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/importing/engine/service/zeebe/ZeebeAgentInstanceImportServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/importing/engine/service/zeebe/ZeebeAgentInstanceImportServiceTest.java
@@ -1,0 +1,664 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.importing.engine.service.zeebe;
+
+import static io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent.COMPLETED;
+import static io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent.CREATED;
+import static io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent.UPDATED;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import io.camunda.optimize.dto.optimize.ProcessInstanceDto;
+import io.camunda.optimize.dto.optimize.query.process.AgentInstanceDto;
+import io.camunda.optimize.dto.zeebe.agentinstance.ZeebeAgentInstanceDataDto;
+import io.camunda.optimize.dto.zeebe.agentinstance.ZeebeAgentInstanceDataDto.AgentMetricsValueDto;
+import io.camunda.optimize.dto.zeebe.agentinstance.ZeebeAgentInstanceDataDto.AgentToolValueDto;
+import io.camunda.optimize.dto.zeebe.agentinstance.ZeebeAgentInstanceRecordDto;
+import io.camunda.optimize.service.db.DatabaseClient;
+import io.camunda.optimize.service.db.reader.ProcessDefinitionReader;
+import io.camunda.optimize.service.db.writer.ProcessInstanceWriter;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.AgentInstanceStatus;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ZeebeAgentInstanceImportServiceTest {
+
+  private static final long PROCESS_INSTANCE_KEY = 100L;
+  private static final long AGENT_KEY = 200L;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private ConfigurationService configurationService;
+
+  @Mock private ProcessInstanceWriter processInstanceWriter;
+  @Mock private ProcessDefinitionReader processDefinitionReader;
+  @Mock private DatabaseClient databaseClient;
+
+  private ZeebeAgentInstanceImportService underTest;
+
+  @BeforeEach
+  void setUp() {
+    when(configurationService.getJobExecutorQueueSize()).thenReturn(10);
+    when(configurationService.getJobExecutorThreadCount()).thenReturn(1);
+    underTest =
+        new ZeebeAgentInstanceImportService(
+            configurationService,
+            processInstanceWriter,
+            1,
+            processDefinitionReader,
+            databaseClient);
+  }
+
+  @Test
+  void shouldGroupRecordsByProcessInstanceKey() {
+    // given
+    final List<ZeebeAgentInstanceRecordDto> records =
+        List.of(
+            record(
+                AGENT_KEY, 1000L, PROCESS_INSTANCE_KEY, AgentInstanceStatus.INITIALIZING, CREATED),
+            record(
+                AGENT_KEY + 1,
+                1000L,
+                PROCESS_INSTANCE_KEY + 1,
+                AgentInstanceStatus.INITIALIZING,
+                CREATED));
+
+    // when
+    final List<ProcessInstanceDto> result =
+        underTest.filterAndMapZeebeRecordsToOptimizeEntities(records);
+
+    // then
+    assertThat(result)
+        .as("Each distinct processInstanceKey produces one ProcessInstanceDto")
+        .hasSize(2)
+        .extracting(ProcessInstanceDto::getProcessInstanceId)
+        .containsExactlyInAnyOrder(
+            String.valueOf(PROCESS_INSTANCE_KEY), String.valueOf(PROCESS_INSTANCE_KEY + 1));
+  }
+
+  @Test
+  void shouldFilterOutCommandsAndOnlyImportEvents() {
+    // given: Mix of commands (CREATE, UPDATE, COMPLETE) and events (CREATED, UPDATED, COMPLETED)
+    final List<ZeebeAgentInstanceRecordDto> records =
+        List.of(
+            record(
+                AGENT_KEY,
+                1000L,
+                PROCESS_INSTANCE_KEY,
+                AgentInstanceStatus.INITIALIZING,
+                AgentInstanceIntent.CREATE), // ← Command (should be filtered out)
+            record(
+                AGENT_KEY, 1100L, PROCESS_INSTANCE_KEY, AgentInstanceStatus.INITIALIZING, CREATED),
+            record(
+                AGENT_KEY,
+                2000L,
+                PROCESS_INSTANCE_KEY,
+                AgentInstanceStatus.THINKING,
+                AgentInstanceIntent.UPDATE), // ← Command (should be filtered out)
+            record(AGENT_KEY, 2100L, PROCESS_INSTANCE_KEY, AgentInstanceStatus.THINKING, UPDATED),
+            record(
+                AGENT_KEY,
+                3000L,
+                PROCESS_INSTANCE_KEY,
+                AgentInstanceStatus.COMPLETED,
+                AgentInstanceIntent.COMPLETE), // ← Command (should be filtered out)
+            record(
+                AGENT_KEY, 3100L, PROCESS_INSTANCE_KEY, AgentInstanceStatus.COMPLETED, COMPLETED));
+
+    // when
+    final List<ProcessInstanceDto> result =
+        underTest.filterAndMapZeebeRecordsToOptimizeEntities(records);
+
+    // then: Only 1 process instance with 1 agent instance built from 3 events (commands filtered)
+    assertThat(result).hasSize(1);
+    final AgentInstanceDto agent = singleAgent(result);
+    assertThat(agent.getStatus()).isEqualTo("COMPLETED");
+    // If commands were included, we'd have 6 records processed instead of 3
+  }
+
+  @Test
+  void shouldSetAgentSkeletonFieldsFromRecord() {
+    // given
+    final ZeebeAgentInstanceDataDto data = baseData(PROCESS_INSTANCE_KEY);
+    data.setElementId("agent-element");
+    data.setProcessDefinitionVersion(3);
+
+    // when
+    final List<ProcessInstanceDto> result =
+        underTest.filterAndMapZeebeRecordsToOptimizeEntities(
+            List.of(record(AGENT_KEY, 1000L, data, AgentInstanceStatus.INITIALIZING, CREATED)));
+
+    // then
+    final AgentInstanceDto agent = singleAgent(result);
+    assertThat(agent.getAgentInstanceId()).isEqualTo(String.valueOf(AGENT_KEY));
+    assertThat(agent.getFlowNodeId()).isEqualTo("agent-element");
+  }
+
+  @Test
+  void shouldSetDefinitionOnlyFromFirstRecord() {
+    // given — CREATED carries the real model; UPDATED carries a different (wrong) model
+    final ZeebeAgentInstanceDataDto createdData = baseData(PROCESS_INSTANCE_KEY);
+    createdData.setDefinition(definition("gpt-4o", "openai"));
+
+    final ZeebeAgentInstanceDataDto updatedData = baseData(PROCESS_INSTANCE_KEY);
+    updatedData.setDefinition(definition("should-not-overwrite", "wrong"));
+    updatedData.setStatus(AgentInstanceStatus.THINKING);
+
+    // when
+    final List<ProcessInstanceDto> result =
+        underTest.filterAndMapZeebeRecordsToOptimizeEntities(
+            List.of(
+                record(AGENT_KEY, 1000L, createdData, AgentInstanceStatus.INITIALIZING, CREATED),
+                record(AGENT_KEY, 2000L, updatedData, AgentInstanceStatus.THINKING, UPDATED)));
+
+    // then
+    final AgentInstanceDto agent = singleAgent(result);
+    assertThat(agent.getDefinition().getModel()).isEqualTo("gpt-4o");
+    assertThat(agent.getDefinition().getProvider()).isEqualTo("openai");
+  }
+
+  @Test
+  void shouldUpdateStatusToLatestRecord() {
+    // given
+    // when
+    final List<ProcessInstanceDto> result =
+        underTest.filterAndMapZeebeRecordsToOptimizeEntities(
+            List.of(
+                record(
+                    AGENT_KEY,
+                    1000L,
+                    PROCESS_INSTANCE_KEY,
+                    AgentInstanceStatus.INITIALIZING,
+                    CREATED),
+                record(
+                    AGENT_KEY, 2000L, PROCESS_INSTANCE_KEY, AgentInstanceStatus.THINKING, UPDATED),
+                record(
+                    AGENT_KEY,
+                    3000L,
+                    PROCESS_INSTANCE_KEY,
+                    AgentInstanceStatus.COMPLETED,
+                    COMPLETED)));
+
+    // then
+    assertThat(singleAgent(result).getStatus()).isEqualTo(AgentInstanceStatus.COMPLETED.name());
+  }
+
+  @Test
+  void shouldUpdateMetricsToLatestRecord() {
+    // given
+    final ZeebeAgentInstanceDataDto updatedData = baseData(PROCESS_INSTANCE_KEY);
+    updatedData.setMetrics(metrics(512, 148, 1, 1));
+
+    // when
+    final List<ProcessInstanceDto> result =
+        underTest.filterAndMapZeebeRecordsToOptimizeEntities(
+            List.of(
+                record(
+                    AGENT_KEY,
+                    1000L,
+                    PROCESS_INSTANCE_KEY,
+                    AgentInstanceStatus.INITIALIZING,
+                    CREATED),
+                record(AGENT_KEY, 2000L, updatedData, AgentInstanceStatus.THINKING, UPDATED)));
+
+    // then
+    final AgentInstanceDto.AgentMetricsDto m = singleAgent(result).getMetrics();
+    assertThat(m.getInputTokens()).isEqualTo(512L);
+    assertThat(m.getOutputTokens()).isEqualTo(148L);
+    assertThat(m.getModelCalls()).isEqualTo(1L);
+    assertThat(m.getToolCalls()).isEqualTo(1L);
+  }
+
+  @Test
+  void shouldReplaceToolsWithLatestRecord() {
+    // given
+    final ZeebeAgentInstanceDataDto updatedData = baseData(PROCESS_INSTANCE_KEY);
+    updatedData.setTools(List.of(tool("tool-a"), tool("tool-b")));
+
+    // when
+    final List<ProcessInstanceDto> result =
+        underTest.filterAndMapZeebeRecordsToOptimizeEntities(
+            List.of(
+                record(
+                    AGENT_KEY,
+                    1000L,
+                    PROCESS_INSTANCE_KEY,
+                    AgentInstanceStatus.INITIALIZING,
+                    CREATED),
+                record(AGENT_KEY, 2000L, updatedData, AgentInstanceStatus.THINKING, UPDATED)));
+
+    // then
+    assertThat(singleAgent(result).getTools())
+        .extracting(AgentInstanceDto.AgentToolDto::getName)
+        .containsExactlyInAnyOrder("tool-a", "tool-b");
+  }
+
+  @Test
+  void shouldSetStartDateFromFirstRecord() {
+    // given — CREATED + UPDATED; startDate must come from the CREATED record
+    // when
+    final List<ProcessInstanceDto> result =
+        underTest.filterAndMapZeebeRecordsToOptimizeEntities(
+            List.of(
+                record(
+                    AGENT_KEY,
+                    1000L,
+                    PROCESS_INSTANCE_KEY,
+                    AgentInstanceStatus.INITIALIZING,
+                    CREATED),
+                record(
+                    AGENT_KEY,
+                    2000L,
+                    PROCESS_INSTANCE_KEY,
+                    AgentInstanceStatus.THINKING,
+                    UPDATED)));
+
+    // then
+    final AgentInstanceDto agent = singleAgent(result);
+    assertThat(agent.getStartDate()).isNotNull();
+    assertThat(agent.getLastUpdatedDate()).isNotNull();
+  }
+
+  @Test
+  void shouldSetEndDateAndDurationOnCompleted() {
+    // given
+    // when
+    final List<ProcessInstanceDto> result =
+        underTest.filterAndMapZeebeRecordsToOptimizeEntities(
+            List.of(
+                record(
+                    AGENT_KEY,
+                    1000L,
+                    PROCESS_INSTANCE_KEY,
+                    AgentInstanceStatus.INITIALIZING,
+                    CREATED),
+                record(
+                    AGENT_KEY,
+                    4000L,
+                    PROCESS_INSTANCE_KEY,
+                    AgentInstanceStatus.COMPLETED,
+                    COMPLETED)));
+
+    // then
+    final AgentInstanceDto agent = singleAgent(result);
+    assertThat(agent.getEndDate()).isNotNull();
+    assertThat(agent.getTotalDurationInMs())
+        .as("Duration must be completedEpoch - createdEpoch")
+        .isEqualTo(3000L);
+  }
+
+  @Test
+  void shouldNotSetEndDateForNonTerminalIntents() {
+    // given
+    // when
+    final List<ProcessInstanceDto> result =
+        underTest.filterAndMapZeebeRecordsToOptimizeEntities(
+            List.of(
+                record(
+                    AGENT_KEY,
+                    1000L,
+                    PROCESS_INSTANCE_KEY,
+                    AgentInstanceStatus.INITIALIZING,
+                    CREATED),
+                record(
+                    AGENT_KEY,
+                    2000L,
+                    PROCESS_INSTANCE_KEY,
+                    AgentInstanceStatus.THINKING,
+                    UPDATED)));
+
+    // then
+    final AgentInstanceDto agent = singleAgent(result);
+    assertThat(agent.getEndDate()).isNull();
+    assertThat(agent.getTotalDurationInMs()).isNull();
+  }
+
+  @Test
+  void shouldAccumulateAggregateMetricsAcrossMultipleAgents() {
+    // given — two distinct agents in the same process instance, each with metrics
+    final long agent2Key = AGENT_KEY + 1;
+    final ZeebeAgentInstanceDataDto data1 = baseData(PROCESS_INSTANCE_KEY);
+    data1.setMetrics(metrics(100, 50, 2, 3));
+    final ZeebeAgentInstanceDataDto data2 = baseData(PROCESS_INSTANCE_KEY);
+    data2.setMetrics(metrics(200, 75, 4, 6));
+
+    // when
+    final List<ProcessInstanceDto> result =
+        underTest.filterAndMapZeebeRecordsToOptimizeEntities(
+            List.of(
+                record(AGENT_KEY, 1000L, data1, AgentInstanceStatus.THINKING, CREATED),
+                record(agent2Key, 1000L, data2, AgentInstanceStatus.THINKING, CREATED)));
+
+    // then
+    final ProcessInstanceDto instance = result.getFirst();
+    assertThat(instance.getAgentTotalInputTokens()).isEqualTo(300L);
+    assertThat(instance.getAgentTotalOutputTokens()).isEqualTo(125L);
+    assertThat(instance.getAgentTotalModelCalls()).isEqualTo(6L);
+    assertThat(instance.getAgentTotalToolCalls()).isEqualTo(9L);
+  }
+
+  @Test
+  void shouldComputeAgentTotalTokensAsInputPlusOutput() {
+    // given
+    final ZeebeAgentInstanceDataDto data = baseData(PROCESS_INSTANCE_KEY);
+    data.setMetrics(metrics(300, 125, 0, 0));
+
+    // when
+    final List<ProcessInstanceDto> result =
+        underTest.filterAndMapZeebeRecordsToOptimizeEntities(
+            List.of(record(AGENT_KEY, 1000L, data, AgentInstanceStatus.THINKING, CREATED)));
+
+    // then
+    assertThat(result.getFirst().getAgentTotalTokens()).isEqualTo(425L);
+  }
+
+  @Test
+  void shouldProcessAllIntentsWithoutFiltering() {
+    // given — CREATED, UPDATED, and COMPLETED records for the same agent
+    // when
+    final List<ProcessInstanceDto> result =
+        underTest.filterAndMapZeebeRecordsToOptimizeEntities(
+            List.of(
+                record(
+                    AGENT_KEY,
+                    1000L,
+                    PROCESS_INSTANCE_KEY,
+                    AgentInstanceStatus.INITIALIZING,
+                    CREATED),
+                record(
+                    AGENT_KEY, 2000L, PROCESS_INSTANCE_KEY, AgentInstanceStatus.THINKING, UPDATED),
+                record(
+                    AGENT_KEY,
+                    3000L,
+                    PROCESS_INSTANCE_KEY,
+                    AgentInstanceStatus.COMPLETED,
+                    COMPLETED)));
+
+    // then — all three records were processed into one consolidated agent instance
+    assertThat(result).hasSize(1);
+    assertThat(singleAgent(result).getStatus()).isEqualTo(AgentInstanceStatus.COMPLETED.name());
+    assertThat(singleAgent(result).getTotalDurationInMs()).isEqualTo(2000L);
+  }
+
+  @Test
+  void shouldSortRecordsByTimestampBeforeProcessing() {
+    // given — records arrive out of order (COMPLETED before CREATED in the list)
+    // when
+    final List<ProcessInstanceDto> result =
+        underTest.filterAndMapZeebeRecordsToOptimizeEntities(
+            List.of(
+                record(
+                    AGENT_KEY,
+                    3000L,
+                    PROCESS_INSTANCE_KEY,
+                    AgentInstanceStatus.COMPLETED,
+                    COMPLETED),
+                record(
+                    AGENT_KEY,
+                    1000L,
+                    PROCESS_INSTANCE_KEY,
+                    AgentInstanceStatus.INITIALIZING,
+                    CREATED)));
+
+    // then — sort ensures CREATED is processed before COMPLETED so duration can be computed
+    final AgentInstanceDto agent = singleAgent(result);
+    assertThat(agent.getStartDate())
+        .as("startDate must be set from the CREATED record")
+        .isNotNull();
+    assertThat(agent.getTotalDurationInMs())
+        .as("duration must be computed even when input list is unordered, because sort runs first")
+        .isEqualTo(2000L);
+  }
+
+  @Test
+  void shouldMapToolNamesFromRecord() {
+    // given
+    final ZeebeAgentInstanceDataDto data = baseData(PROCESS_INSTANCE_KEY);
+    data.setTools(List.of(tool("MCP_slack___post_message"), tool("extract_line_items")));
+
+    // when
+    final List<ProcessInstanceDto> result =
+        underTest.filterAndMapZeebeRecordsToOptimizeEntities(
+            List.of(record(AGENT_KEY, 1000L, data, AgentInstanceStatus.TOOL_CALLING, UPDATED)));
+
+    // then
+    assertThat(singleAgent(result).getTools())
+        .extracting(AgentInstanceDto.AgentToolDto::getName)
+        .containsExactlyInAnyOrder("MCP_slack___post_message", "extract_line_items");
+  }
+
+  // --- helpers ---
+
+  private AgentInstanceDto singleAgent(final List<ProcessInstanceDto> result) {
+    assertThat(result).hasSize(1);
+    assertThat(result.getFirst().getAgentInstances()).hasSize(1);
+    return result.getFirst().getAgentInstances().getFirst();
+  }
+
+  private ZeebeAgentInstanceRecordDto record(
+      final long key,
+      final long timestamp,
+      final long processInstanceKey,
+      final AgentInstanceStatus status,
+      final AgentInstanceIntent intent) {
+    final ZeebeAgentInstanceDataDto data = baseData(processInstanceKey);
+    return record(key, timestamp, data, status, intent);
+  }
+
+  private ZeebeAgentInstanceRecordDto record(
+      final long key,
+      final long timestamp,
+      final ZeebeAgentInstanceDataDto data,
+      final AgentInstanceStatus status,
+      final AgentInstanceIntent intent) {
+    data.setStatus(status);
+    final ZeebeAgentInstanceRecordDto dto = new ZeebeAgentInstanceRecordDto();
+    dto.setKey(key);
+    dto.setTimestamp(timestamp);
+    dto.setIntent(intent);
+    dto.setValue(data);
+    return dto;
+  }
+
+  private ZeebeAgentInstanceDataDto baseData(final long processInstanceKey) {
+    final ZeebeAgentInstanceDataDto data = new ZeebeAgentInstanceDataDto();
+    data.setProcessInstanceKey(processInstanceKey);
+    data.setProcessDefinitionKey(999L);
+    data.setBpmnProcessId("testProcess");
+    data.setTenantId("<default>");
+    data.setElementId("agent-task");
+    data.setProcessDefinitionVersion(1);
+    data.setDefinition(definition("gpt-4o", "openai"));
+    return data;
+  }
+
+  private ZeebeAgentInstanceDataDto.AgentDefinitionValueDto definition(
+      final String model, final String provider) {
+    final ZeebeAgentInstanceDataDto.AgentDefinitionValueDto def =
+        new ZeebeAgentInstanceDataDto.AgentDefinitionValueDto();
+    def.setModel(model);
+    def.setProvider(provider);
+    return def;
+  }
+
+  private AgentMetricsValueDto metrics(
+      final long inputTokens, final long outputTokens, final int modelCalls, final int toolCalls) {
+    final AgentMetricsValueDto m = new AgentMetricsValueDto();
+    m.setInputTokens(inputTokens);
+    m.setOutputTokens(outputTokens);
+    m.setModelCalls(modelCalls);
+    m.setToolCalls(toolCalls);
+    return m;
+  }
+
+  private AgentToolValueDto tool(final String name) {
+    final AgentToolValueDto t = new AgentToolValueDto();
+    t.setName(name);
+    return t;
+  }
+
+  @Test
+  void shouldHandleNullMetricsWhenComputingAggregates() {
+    // given: two agents, one with null metrics
+    final ZeebeAgentInstanceDataDto dataWithoutMetrics = baseData(PROCESS_INSTANCE_KEY);
+    dataWithoutMetrics.setMetrics(null);
+
+    final ZeebeAgentInstanceDataDto dataWithMetrics = baseData(PROCESS_INSTANCE_KEY);
+    dataWithMetrics.setMetrics(metrics(100, 200, 1, 2));
+
+    final var recordsWithNullMetrics =
+        List.of(
+            record(AGENT_KEY, 1000L, dataWithoutMetrics, AgentInstanceStatus.INITIALIZING, CREATED),
+            record(AGENT_KEY, 2000L, dataWithoutMetrics, AgentInstanceStatus.COMPLETED, COMPLETED),
+            record(
+                AGENT_KEY + 1, 1500L, dataWithMetrics, AgentInstanceStatus.INITIALIZING, CREATED),
+            record(
+                AGENT_KEY + 1, 2500L, dataWithMetrics, AgentInstanceStatus.COMPLETED, COMPLETED));
+
+    // when
+    final List<ProcessInstanceDto> result =
+        underTest.filterAndMapZeebeRecordsToOptimizeEntities(recordsWithNullMetrics);
+
+    // then: aggregates only count the agent with metrics
+    assertThat(result)
+        .hasSize(1)
+        .first()
+        .satisfies(
+            aggregates -> {
+              assertThat(aggregates.getAgentTotalInputTokens()).isEqualTo(100);
+              assertThat(aggregates.getAgentTotalOutputTokens()).isEqualTo(200);
+              assertThat(aggregates.getAgentTotalTokens()).isEqualTo(300);
+              assertThat(aggregates.getAgentTotalModelCalls()).isEqualTo(1);
+              assertThat(aggregates.getAgentTotalToolCalls()).isEqualTo(2);
+            });
+  }
+
+  @Test
+  void shouldPreservePriorStatusWhenLaterRecordHasNullStatus() {
+    // given — second record has null status (malformed); first carries a real status
+    final ZeebeAgentInstanceDataDto dataWithNullStatus = baseData(PROCESS_INSTANCE_KEY);
+    final ZeebeAgentInstanceRecordDto firstRecord =
+        record(AGENT_KEY, 1000L, PROCESS_INSTANCE_KEY, AgentInstanceStatus.THINKING, UPDATED);
+    final ZeebeAgentInstanceRecordDto recordWithNullStatus =
+        record(AGENT_KEY, 2000L, dataWithNullStatus, null, UPDATED);
+
+    // when
+    final List<ProcessInstanceDto> result =
+        underTest.filterAndMapZeebeRecordsToOptimizeEntities(
+            List.of(firstRecord, recordWithNullStatus));
+
+    // then — no NPE; prior status preserved
+    assertThat(singleAgent(result).getStatus()).isEqualTo(AgentInstanceStatus.THINKING.name());
+  }
+
+  @Test
+  void shouldHandleNullElementInstanceKeys() {
+    // given — record where elementInstanceKeys was deserialized as null
+    final ZeebeAgentInstanceDataDto data = baseData(PROCESS_INSTANCE_KEY);
+    data.setElementInstanceKeys(null);
+
+    // when
+    final List<ProcessInstanceDto> result =
+        underTest.filterAndMapZeebeRecordsToOptimizeEntities(
+            List.of(record(AGENT_KEY, 1000L, data, AgentInstanceStatus.INITIALIZING, CREATED)));
+
+    // then — no NPE; flowNodeInstanceIds is empty
+    assertThat(singleAgent(result).getFlowNodeInstanceIds()).isEmpty();
+  }
+
+  @Test
+  void shouldKeepPriorToolsWhenLaterRecordHasEmptyTools() {
+    // given — first record has tools; second carries an empty tools list
+    final ZeebeAgentInstanceDataDto firstData = baseData(PROCESS_INSTANCE_KEY);
+    firstData.setTools(List.of(tool("tool-a"), tool("tool-b")));
+
+    final ZeebeAgentInstanceDataDto laterData = baseData(PROCESS_INSTANCE_KEY);
+    laterData.setTools(List.of());
+
+    // when
+    final List<ProcessInstanceDto> result =
+        underTest.filterAndMapZeebeRecordsToOptimizeEntities(
+            List.of(
+                record(AGENT_KEY, 1000L, firstData, AgentInstanceStatus.TOOL_DISCOVERY, CREATED),
+                record(AGENT_KEY, 2000L, laterData, AgentInstanceStatus.THINKING, UPDATED)));
+
+    // then — tools from the first record are preserved (latest-non-empty-wins)
+    assertThat(singleAgent(result).getTools())
+        .extracting(AgentInstanceDto.AgentToolDto::getName)
+        .containsExactlyInAnyOrder("tool-a", "tool-b");
+  }
+
+  @Test
+  void shouldNotSetStartDateOrDefinitionWhenBatchHasNoCreatedRecord() {
+    // given — only UPDATED records, no CREATED (e.g. CREATED imported in a prior batch)
+    final ZeebeAgentInstanceDataDto updatedData = baseData(PROCESS_INSTANCE_KEY);
+    updatedData.setDefinition(definition("should-not-be-mapped", "wrong"));
+
+    // when
+    final List<ProcessInstanceDto> result =
+        underTest.filterAndMapZeebeRecordsToOptimizeEntities(
+            List.of(
+                record(AGENT_KEY, 1000L, updatedData, AgentInstanceStatus.THINKING, UPDATED),
+                record(AGENT_KEY, 2000L, updatedData, AgentInstanceStatus.THINKING, UPDATED)));
+
+    // then — startDate and definition stay null/default; only CREATED-bearing batches seed them
+    final AgentInstanceDto agent = singleAgent(result);
+    assertThat(agent.getStartDate())
+        .as("startDate must only be seeded by a CREATED record")
+        .isNull();
+    assertThat(agent.getDefinition().getModel())
+        .as("definition must only be mapped from a CREATED record")
+        .isNull();
+    assertThat(agent.getLastUpdatedDate()).isNotNull();
+    assertThat(agent.getStatus()).isEqualTo(AgentInstanceStatus.THINKING.name());
+  }
+
+  @Test
+  void shouldMergeRecordsWithDuplicateAgentKeysIntoSingleAgentInstance() {
+    // given — three records, all share the same agent key but different timestamps and intents
+    // when
+    final List<ProcessInstanceDto> result =
+        underTest.filterAndMapZeebeRecordsToOptimizeEntities(
+            List.of(
+                record(
+                    AGENT_KEY,
+                    1000L,
+                    PROCESS_INSTANCE_KEY,
+                    AgentInstanceStatus.INITIALIZING,
+                    CREATED),
+                record(
+                    AGENT_KEY, 2000L, PROCESS_INSTANCE_KEY, AgentInstanceStatus.THINKING, UPDATED),
+                record(
+                    AGENT_KEY,
+                    3000L,
+                    PROCESS_INSTANCE_KEY,
+                    AgentInstanceStatus.COMPLETED,
+                    COMPLETED)));
+
+    // then — single AgentInstanceDto consolidates all three records
+    assertThat(result).hasSize(1);
+    assertThat(result.getFirst().getAgentInstances())
+        .hasSize(1)
+        .first()
+        .satisfies(
+            agent -> {
+              assertThat(agent.getAgentInstanceId()).isEqualTo(String.valueOf(AGENT_KEY));
+              assertThat(agent.getStatus()).isEqualTo(AgentInstanceStatus.COMPLETED.name());
+              assertThat(agent.getStartDate()).isNotNull();
+              assertThat(agent.getEndDate()).isNotNull();
+              assertThat(agent.getTotalDurationInMs()).isEqualTo(2000L);
+            });
+  }
+}


### PR DESCRIPTION
Adds the full position-based import pipeline that reads AGENT_INSTANCE records from the Zeebe exporter ES index and merges them into the ProcessInstance documents.

- ZeebeAgentInstanceFetcher / ES + OS impls: position-based fetcher reading from the Zeebe exporter index, filtered to AGENT_INSTANCE record type.
- ZeebeAgentInstanceImportIndexHandler: tracks the last-seen position across restarts so imports resume from where they left off.
- ZeebeAgentInstanceImportMediator: orchestrates page-by-page import using the standard PositionBasedImportMediator pattern.
- ZeebeAgentInstanceImportMediatorFactory: Spring factory wiring the mediator into the import scheduler.
- ImportIndexHandlerRegistry: registered the new handler so it is persisted and restored with all other Zeebe position handlers.
- ZeebeProcessInstanceScriptFactory: added Painless upsert script that merges individual agent instance events into the nested list, protects terminal statuses from being overwritten by later events, and recomputes duration when the end event arrives after the start.
- ZeebeAgentInstanceImportService: maps raw Zeebe records to AgentInstanceDto and delegates to ProcessInstanceWriter for upsert.
- ZeebeAgentInstanceImportServiceTest: unit tests covering metrics accumulation, out-of-order event arrival, and process-level totals.

## Related issues

closes https://github.com/camunda/camunda/issues/53927
