### PR TITLE
Return 400 instead of 503 for zero/negative keys on agent-instance endpoints

### DIFF
--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidator.java
@@ -11,6 +11,7 @@ import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESS
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_INVALID_ATTRIBUTE_VALUE;
 import static io.camunda.gateway.mapping.http.validator.RequestValidator.validate;
 import static io.camunda.gateway.mapping.http.validator.RequestValidator.validateKeyFormat;
+import static io.camunda.gateway.mapping.http.validator.RequestValidator.validatePositiveKeyFormat;
 
 import io.camunda.gateway.protocol.model.AgentInstanceCreationRequest;
 import io.camunda.gateway.protocol.model.AgentInstanceUpdateRequest;
@@ -36,7 +37,8 @@ public class AgentInstanceRequestValidator {
           if (request.getElementInstanceKey() == null) {
             violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("elementInstanceKey"));
           } else {
-            validateKeyFormat(request.getElementInstanceKey(), "elementInstanceKey", violations);
+            validatePositiveKeyFormat(
+                request.getElementInstanceKey(), "elementInstanceKey", violations);
           }
 
           if (request.getDefinition() == null) {

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidator.java
@@ -76,7 +76,7 @@ public class AgentInstanceRequestValidator {
         () -> {
           final List<String> violations = new ArrayList<>();
 
-          validateKeyFormat(agentInstanceKey, "agentInstanceKey", violations);
+          validatePositiveKeyFormat(agentInstanceKey, "agentInstanceKey", violations);
 
           if (request.getElementInstanceKey() == null) {
             violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("elementInstanceKey"));

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/RequestValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/RequestValidator.java
@@ -133,6 +133,30 @@ public final class RequestValidator {
   }
 
   /**
+   * Validates that a string-encoded key can be parsed as a valid Long and is positive (> 0).
+   *
+   * <p>Use this variant when the key is also used for partition routing (e.g. as an element
+   * instance key or agent instance key), because keys ≤ 0 always decode to non-existent partition
+   * IDs and would cause a misleading 503 UNAVAILABLE instead of a clear 400 INVALID_ARGUMENT.
+   *
+   * @param keyValue the string value to validate
+   * @param fieldName the name of the field for error messaging
+   * @param violations the list to add validation errors to
+   */
+  public static void validatePositiveKeyFormat(
+      final @Nullable String keyValue, final String fieldName, final List<String> violations) {
+    if (keyValue == null) {
+      return;
+    }
+    final var parsed = tryParseLong(keyValue);
+    if (parsed.isEmpty()) {
+      violations.add(ERROR_MESSAGE_INVALID_KEY_FORMAT.formatted(fieldName, keyValue));
+    } else if (parsed.get() < 1) {
+      violations.add(ERROR_MESSAGE_INVALID_ATTRIBUTE_VALUE.formatted(fieldName, keyValue, "> 0"));
+    }
+  }
+
+  /**
    * Validates that a {@code decisionEvaluationInstanceKey} matches the expected format produced by
    * the engine: {@code <decisionEvaluationKey>-<index>} where both parts are non-negative integers
    * (e.g. {@code "2251799813684367-1"}).

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
@@ -540,14 +540,14 @@ class AgentInstanceControllerTest extends RestControllerTest {
 
   @ParameterizedTest(name = "[{index}] {0}")
   @MethodSource("invalidUpdateRequests")
-  void shouldRejectInvalidUpdateRequest(final String requestBody, final String expectedDetail) {
+  void shouldRejectInvalidUpdateRequest(final UpdateRequest update, final String expectedDetail) {
     // when / then
     webClient
         .patch()
-        .uri(AGENT_INSTANCES_URL + "/%d".formatted(AGENT_INSTANCE_KEY))
+        .uri(AGENT_INSTANCES_URL + "/%d".formatted(update.agentInstanceKey()))
         .accept(MediaType.APPLICATION_JSON)
         .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(requestBody)
+        .bodyValue(update.requestBody())
         .exchange()
         .expectStatus()
         .isBadRequest()
@@ -564,7 +564,7 @@ class AgentInstanceControllerTest extends RestControllerTest {
               "instance": "/v2/agent-instances/%d"
             }
             """
-                .formatted(expectedDetail, AGENT_INSTANCE_KEY),
+                .formatted(expectedDetail, update.agentInstanceKey()),
             JsonCompareMode.STRICT);
 
     verifyNoInteractions(agentInstanceServices);
@@ -575,91 +575,131 @@ class AgentInstanceControllerTest extends RestControllerTest {
         Arguments.of(
             named(
                 "missing elementInstanceKey",
-                """
-                { "status": "THINKING" }
-                """),
+                new UpdateRequest(
+                    AGENT_INSTANCE_KEY,
+                    """
+                    { "status": "THINKING" }
+                    """)),
             "No elementInstanceKey provided."),
         Arguments.of(
             named(
                 "null elementInstanceKey",
-                """
-                { "elementInstanceKey": null, "status": "THINKING" }
-                """),
+                new UpdateRequest(
+                    AGENT_INSTANCE_KEY,
+                    """
+                    { "elementInstanceKey": null, "status": "THINKING" }
+                    """)),
             "No elementInstanceKey provided."),
         Arguments.of(
             named(
                 "non-numeric elementInstanceKey",
-                """
-                { "elementInstanceKey": "not-a-number", "status": "THINKING" }
-                """),
+                new UpdateRequest(
+                    AGENT_INSTANCE_KEY,
+                    """
+                    { "elementInstanceKey": "not-a-number", "status": "THINKING" }
+                    """)),
             "The provided elementInstanceKey 'not-a-number' is not a valid key."
                 + " Expected a numeric value."
                 + " Did you pass an entity id instead of an entity key?."),
         Arguments.of(
             named(
                 "negative inputTokens delta",
-                """
-                { "elementInstanceKey": "%d", "metrics": { "inputTokens": -1 } }
-                """
-                    .formatted(ELEMENT_INSTANCE_KEY)),
+                new UpdateRequest(
+                    AGENT_INSTANCE_KEY,
+                    """
+                    { "elementInstanceKey": "%d", "metrics": { "inputTokens": -1 } }
+                    """
+                        .formatted(ELEMENT_INSTANCE_KEY))),
             "The value for metrics.inputTokens is '-1' but must be >= 0."),
         Arguments.of(
             named(
                 "negative outputTokens delta",
-                """
-                { "elementInstanceKey": "%d", "metrics": { "outputTokens": -5 } }
-                """
-                    .formatted(ELEMENT_INSTANCE_KEY)),
+                new UpdateRequest(
+                    AGENT_INSTANCE_KEY,
+                    """
+                    { "elementInstanceKey": "%d", "metrics": { "outputTokens": -5 } }
+                    """
+                        .formatted(ELEMENT_INSTANCE_KEY))),
             "The value for metrics.outputTokens is '-5' but must be >= 0."),
         Arguments.of(
             named(
                 "negative modelCalls delta",
-                """
-                { "elementInstanceKey": "%d", "metrics": { "modelCalls": -1 } }
-                """
-                    .formatted(ELEMENT_INSTANCE_KEY)),
+                new UpdateRequest(
+                    AGENT_INSTANCE_KEY,
+                    """
+                    { "elementInstanceKey": "%d", "metrics": { "modelCalls": -1 } }
+                    """
+                        .formatted(ELEMENT_INSTANCE_KEY))),
             "The value for metrics.modelCalls is '-1' but must be >= 0."),
         Arguments.of(
             named(
                 "negative toolCalls delta",
-                """
-                { "elementInstanceKey": "%d", "metrics": { "toolCalls": -2 } }
-                """
-                    .formatted(ELEMENT_INSTANCE_KEY)),
+                new UpdateRequest(
+                    AGENT_INSTANCE_KEY,
+                    """
+                    { "elementInstanceKey": "%d", "metrics": { "toolCalls": -2 } }
+                    """
+                        .formatted(ELEMENT_INSTANCE_KEY))),
             "The value for metrics.toolCalls is '-2' but must be >= 0."),
         Arguments.of(
             named(
                 "tool without name",
-                """
-                {
-                  "elementInstanceKey": "%d",
-                  "tools": [{ "description": "Search database" }]
-                }
-                """
-                    .formatted(ELEMENT_INSTANCE_KEY)),
+                new UpdateRequest(
+                    AGENT_INSTANCE_KEY,
+                    """
+                    {
+                      "elementInstanceKey": "%d",
+                      "tools": [{ "description": "Search database" }]
+                    }
+                    """
+                        .formatted(ELEMENT_INSTANCE_KEY))),
             "No tools[0].name provided."),
         Arguments.of(
             named(
                 "tool with blank name",
-                """
-                {
-                  "elementInstanceKey": "%d",
-                  "tools": [{ "name": "" }]
-                }
-                """
-                    .formatted(ELEMENT_INSTANCE_KEY)),
+                new UpdateRequest(
+                    AGENT_INSTANCE_KEY,
+                    """
+                    {
+                      "elementInstanceKey": "%d",
+                      "tools": [{ "name": "" }]
+                    }
+                    """
+                        .formatted(ELEMENT_INSTANCE_KEY))),
             "No tools[0].name provided."),
         Arguments.of(
             named(
                 "tool with null name",
-                """
-                {
-                  "elementInstanceKey": "%d",
-                  "tools": [{ "name": null }]
-                }
-                """
-                    .formatted(ELEMENT_INSTANCE_KEY)),
-            "No tools[0].name provided."));
+                new UpdateRequest(
+                    AGENT_INSTANCE_KEY,
+                    """
+                    {
+                      "elementInstanceKey": "%d",
+                      "tools": [{ "name": null }]
+                    }
+                    """
+                        .formatted(ELEMENT_INSTANCE_KEY))),
+            "No tools[0].name provided."),
+        Arguments.of(
+            named(
+                "zero agentInstanceKey",
+                new UpdateRequest(
+                    0,
+                    """
+                    { "elementInstanceKey": "%d", "status": "IDLE" }
+                    """
+                        .formatted(ELEMENT_INSTANCE_KEY))),
+            "The value for agentInstanceKey is '0' but must be > 0."),
+        Arguments.of(
+            named(
+                "negative agentInstanceKey",
+                new UpdateRequest(
+                    -1,
+                    """
+                    { "elementInstanceKey": "%d", "status": "IDLE" }
+                    """
+                        .formatted(ELEMENT_INSTANCE_KEY))),
+            "The value for agentInstanceKey is '-1' but must be > 0."));
   }
 
   @Test
@@ -683,4 +723,6 @@ class AgentInstanceControllerTest extends RestControllerTest {
         .expectStatus()
         .is5xxServerError();
   }
+
+  private record UpdateRequest(long agentInstanceKey, String requestBody) {}
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
@@ -229,6 +229,34 @@ class AgentInstanceControllerTest extends RestControllerTest {
                 + " Did you pass an entity id instead of an entity key?."),
         Arguments.of(
             named(
+                "zero elementInstanceKey",
+                """
+                {
+                  "elementInstanceKey": "0",
+                  "definition": {
+                    "model": "gpt-4o",
+                    "provider": "openai",
+                    "systemPrompt": "prompt"
+                  }
+                }
+                """),
+            "The value for elementInstanceKey is '0' but must be > 0."),
+        Arguments.of(
+            named(
+                "negative elementInstanceKey",
+                """
+                {
+                  "elementInstanceKey": "-1",
+                  "definition": {
+                    "model": "gpt-4o",
+                    "provider": "openai",
+                    "systemPrompt": "prompt"
+                  }
+                }
+                """),
+            "The value for elementInstanceKey is '-1' but must be > 0."),
+        Arguments.of(
+            named(
                 "missing definition",
                 """
                 {


### PR DESCRIPTION
## Description

### Bug

`POST /v2/agent-instances` and `PATCH /v2/agent-instances/{agentInstanceKey}` return **503 (UNAVAILABLE)** instead of **400 (INVALID_ARGUMENT)** when a zero or negative value is supplied for `elementInstanceKey` / `agentInstanceKey`.

### Root cause

Zeebe encodes the partition ID in the top 13 bits of every key:

```
Protocol.decodePartitionId(key) = (int)(key >> 51)
```

Values ≤ 0 decode to partition 0 or a negative partition, neither of which exists in the cluster. The chain is:

1. **POST** – [`BrokerCreateAgentInstanceRequest` L26](https://github.com/camunda/camunda/blob/f13148ead3abbfea283f8a344531e3ce3fa274c6/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCreateAgentInstanceRequest.java#L26) calls `Protocol.decodePartitionId(elementInstanceKey)`
2. **PATCH** – [`BrokerUpdateAgentInstanceRequest` L27](https://github.com/camunda/camunda/blob/f13148ead3abbfea283f8a344531e3ce3fa274c6/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerUpdateAgentInstanceRequest.java#L27) calls `Protocol.decodePartitionId(agentInstanceKey)`
3. [`BrokerRequestManager` L224–225](https://github.com/camunda/camunda/blob/f13148ead3abbfea283f8a344531e3ce3fa274c6/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerRequestManager.java#L124-L127) checks the topology — partition 0 / negative partition is not in the topology → throws `PartitionNotFoundException`
4. [`ErrorMapper` L163–166](https://github.com/camunda/camunda/blob/f13148ead3abbfea283f8a344531e3ce3fa274c6/service/src/main/java/io/camunda/service/exception/ErrorMapper.java#L163-L166) catches `PartitionNotFoundException` and maps it to `UNAVAILABLE` → HTTP **503**

Both keys reached the broker without being range-validated in
[`AgentInstanceRequestValidator`](https://github.com/camunda/camunda/blob/f13148ead3abbfea283f8a344531e3ce3fa274c6/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidator.java):
- POST used [`validateKeyFormat` for `elementInstanceKey` (L39)](https://github.com/camunda/camunda/blob/f13148ead3abbfea283f8a344531e3ce3fa274c6/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidator.java#L39) — only checked parseability, not range
- PATCH used [`validateKeyFormat` for `agentInstanceKey` (L77)](https://github.com/camunda/camunda/blob/f13148ead3abbfea283f8a344531e3ce3fa274c6/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidator.java#L77) — same issue

### Fix

Added `validatePositiveKeyFormat` to `RequestValidator` — a variant of the existing `validateKeyFormat` that additionally rejects values < 1 with a descriptive `INVALID_ARGUMENT` error:

> _The value for elementInstanceKey is '0' but must be > 0._

- `validateCreateRequest` now uses `validatePositiveKeyFormat` for `elementInstanceKey`
- `validateUpdateRequest` now uses `validatePositiveKeyFormat` for `agentInstanceKey`

Note: `elementInstanceKey` in the PATCH request body is **not** range-checked — it is not used for partition routing in the update flow.

### Tests

`AgentInstanceControllerTest` (parametrised `shouldRejectInvalidCreateRequest` / `shouldRejectInvalidUpdateRequest`) gained four new cases:

| Endpoint | Input | Expected code| Expected message|
|---|---|---|---|
| POST | `elementInstanceKey: "0"` | 400 | `The value for elementInstanceKey is '0' but must be > 0.` |
| POST | `elementInstanceKey: "-1"` | 400 | `The value for elementInstanceKey is '-1' but must be > 0.` |
| PATCH | path `agentInstanceKey = 0` | 400 | `The value for agentInstanceKey is '0' but must be > 0.` |
| PATCH | path `agentInstanceKey = -1` | 400 | `The value for agentInstanceKey is '-1' but must be > 0.` |

The PATCH test was also refactored to carry `agentInstanceKey` in an `UpdateRequest` record alongside the request body, so each case can independently vary both the path parameter and the body.

### Related: #54092

Issue [#54092](https://github.com/camunda/camunda/issues/54092) shares the same root cause — random / unknown keys that happen to decode to a valid-but-unreachable partition also return 503. However, that scenario requires deeper investigation to evaluate solutions without introducing backward-compatibility problems. It is intentionally **out of scope** for this PR.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #54049