### PR TITLE
feat: add ProcessGroupByProcessDefinitionKey/Version interpreters

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionKeyInterpreterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionKeyInterpreterES.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.es.report.interpreter.groupby.process;
+
+import static io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy.PROCESS_GROUP_BY_PROCESS_DEFINITION_KEY;
+import static io.camunda.optimize.service.db.report.result.CompositeCommandResult.GroupByResult;
+import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.PROCESS_DEFINITION_KEY;
+
+import co.elastic.clients.elasticsearch._types.SortOrder;
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregation;
+import co.elastic.clients.elasticsearch._types.aggregations.StringTermsAggregate;
+import co.elastic.clients.elasticsearch._types.aggregations.StringTermsBucket;
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch.core.search.ResponseBody;
+import co.elastic.clients.util.NamedValue;
+import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
+import io.camunda.optimize.service.db.es.report.interpreter.distributedby.process.ProcessDistributedByInterpreterFacadeES;
+import io.camunda.optimize.service.db.es.report.interpreter.view.process.ProcessViewInterpreterFacadeES;
+import io.camunda.optimize.service.db.report.ExecutionContext;
+import io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan;
+import io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy;
+import io.camunda.optimize.service.db.report.result.CompositeCommandResult;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import io.camunda.optimize.service.util.configuration.condition.ElasticSearchCondition;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+
+@Component
+@Conditional(ElasticSearchCondition.class)
+public class ProcessGroupByProcessDefinitionKeyInterpreterES
+    extends AbstractProcessGroupByInterpreterES {
+
+  private static final String PROCESS_DEFINITION_KEY_AGGREGATION = "processDefinitionKeyAgg";
+
+  private final ConfigurationService configurationService;
+  private final ProcessDistributedByInterpreterFacadeES distributedByInterpreter;
+  private final ProcessViewInterpreterFacadeES viewInterpreter;
+
+  public ProcessGroupByProcessDefinitionKeyInterpreterES(
+      final ConfigurationService configurationService,
+      final ProcessDistributedByInterpreterFacadeES distributedByInterpreter,
+      final ProcessViewInterpreterFacadeES viewInterpreter) {
+    this.configurationService = configurationService;
+    this.distributedByInterpreter = distributedByInterpreter;
+    this.viewInterpreter = viewInterpreter;
+  }
+
+  @Override
+  public Set<ProcessGroupBy> getSupportedGroupBys() {
+    return Set.of(PROCESS_GROUP_BY_PROCESS_DEFINITION_KEY);
+  }
+
+  @Override
+  public Map<String, Aggregation.Builder.ContainerBuilder> createAggregation(
+      final BoolQuery boolQuery,
+      final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context) {
+    final Aggregation.Builder.ContainerBuilder builder =
+        new Aggregation.Builder()
+            .terms(
+                terms ->
+                    terms
+                        .size(
+                            configurationService
+                                .getElasticSearchConfiguration()
+                                .getAggregationBucketLimit())
+                        .field(PROCESS_DEFINITION_KEY)
+                        .order(NamedValue.of("_key", SortOrder.Asc)));
+    distributedByInterpreter
+        .createAggregations(context, boolQuery)
+        .forEach((key, value) -> builder.aggregations(key, value.build()));
+    return Map.of(PROCESS_DEFINITION_KEY_AGGREGATION, builder);
+  }
+
+  @Override
+  protected void addQueryResult(
+      final CompositeCommandResult compositeCommandResult,
+      final ResponseBody<?> response,
+      final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context) {
+    final StringTermsAggregate processDefinitionKeyAggregation =
+        response.aggregations().get(PROCESS_DEFINITION_KEY_AGGREGATION).sterms();
+    final List<GroupByResult> groupedData = new ArrayList<>();
+    for (final StringTermsBucket processDefinitionKeyBucket :
+        processDefinitionKeyAggregation.buckets().array()) {
+      final String processDefinitionKey = processDefinitionKeyBucket.key().stringValue();
+      final List<CompositeCommandResult.DistributedByResult> distributedByResult =
+          distributedByInterpreter.retrieveResult(
+              response, processDefinitionKeyBucket.aggregations(), context);
+      groupedData.add(GroupByResult.createGroupByResult(processDefinitionKey, distributedByResult));
+    }
+    compositeCommandResult.setGroups(groupedData);
+    compositeCommandResult.setDistributedByKeyOfNumericType(
+        distributedByInterpreter.isKeyOfNumericType(context));
+  }
+
+  @Override
+  public ProcessDistributedByInterpreterFacadeES getDistributedByInterpreter() {
+    return distributedByInterpreter;
+  }
+
+  @Override
+  public ProcessViewInterpreterFacadeES getViewInterpreter() {
+    return viewInterpreter;
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionVersionInterpreterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionVersionInterpreterES.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.es.report.interpreter.groupby.process;
+
+import static io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy.PROCESS_GROUP_BY_PROCESS_DEFINITION_VERSION;
+import static io.camunda.optimize.service.db.report.result.CompositeCommandResult.GroupByResult;
+import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.PROCESS_DEFINITION_VERSION;
+
+import co.elastic.clients.elasticsearch._types.SortOrder;
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregation;
+import co.elastic.clients.elasticsearch._types.aggregations.StringTermsAggregate;
+import co.elastic.clients.elasticsearch._types.aggregations.StringTermsBucket;
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch.core.search.ResponseBody;
+import co.elastic.clients.util.NamedValue;
+import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
+import io.camunda.optimize.service.db.es.report.interpreter.distributedby.process.ProcessDistributedByInterpreterFacadeES;
+import io.camunda.optimize.service.db.es.report.interpreter.view.process.ProcessViewInterpreterFacadeES;
+import io.camunda.optimize.service.db.report.ExecutionContext;
+import io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan;
+import io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy;
+import io.camunda.optimize.service.db.report.result.CompositeCommandResult;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import io.camunda.optimize.service.util.configuration.condition.ElasticSearchCondition;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+
+@Component
+@Conditional(ElasticSearchCondition.class)
+public class ProcessGroupByProcessDefinitionVersionInterpreterES
+    extends AbstractProcessGroupByInterpreterES {
+
+  private static final String PROCESS_DEFINITION_VERSION_AGGREGATION =
+      "processDefinitionVersionAgg";
+
+  private final ConfigurationService configurationService;
+  private final ProcessDistributedByInterpreterFacadeES distributedByInterpreter;
+  private final ProcessViewInterpreterFacadeES viewInterpreter;
+
+  public ProcessGroupByProcessDefinitionVersionInterpreterES(
+      final ConfigurationService configurationService,
+      final ProcessDistributedByInterpreterFacadeES distributedByInterpreter,
+      final ProcessViewInterpreterFacadeES viewInterpreter) {
+    this.configurationService = configurationService;
+    this.distributedByInterpreter = distributedByInterpreter;
+    this.viewInterpreter = viewInterpreter;
+  }
+
+  @Override
+  public Set<ProcessGroupBy> getSupportedGroupBys() {
+    return Set.of(PROCESS_GROUP_BY_PROCESS_DEFINITION_VERSION);
+  }
+
+  @Override
+  public Map<String, Aggregation.Builder.ContainerBuilder> createAggregation(
+      final BoolQuery boolQuery,
+      final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context) {
+    final Aggregation.Builder.ContainerBuilder builder =
+        new Aggregation.Builder()
+            .terms(
+                terms ->
+                    terms
+                        .size(
+                            configurationService
+                                .getElasticSearchConfiguration()
+                                .getAggregationBucketLimit())
+                        .field(PROCESS_DEFINITION_VERSION)
+                        .order(NamedValue.of("_key", SortOrder.Asc)));
+    distributedByInterpreter
+        .createAggregations(context, boolQuery)
+        .forEach((key, value) -> builder.aggregations(key, value.build()));
+    return Map.of(PROCESS_DEFINITION_VERSION_AGGREGATION, builder);
+  }
+
+  @Override
+  protected void addQueryResult(
+      final CompositeCommandResult compositeCommandResult,
+      final ResponseBody<?> response,
+      final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context) {
+    final StringTermsAggregate processDefinitionVersionAggregation =
+        response.aggregations().get(PROCESS_DEFINITION_VERSION_AGGREGATION).sterms();
+    final List<GroupByResult> groupedData = new ArrayList<>();
+    for (final StringTermsBucket processDefinitionVersionBucket :
+        processDefinitionVersionAggregation.buckets().array()) {
+      final String processDefinitionVersion = processDefinitionVersionBucket.key().stringValue();
+      final List<CompositeCommandResult.DistributedByResult> distributedByResult =
+          distributedByInterpreter.retrieveResult(
+              response, processDefinitionVersionBucket.aggregations(), context);
+      groupedData.add(
+          GroupByResult.createGroupByResult(processDefinitionVersion, distributedByResult));
+    }
+    compositeCommandResult.setGroups(groupedData);
+    compositeCommandResult.setGroupByKeyOfNumericType(true);
+    compositeCommandResult.setDistributedByKeyOfNumericType(
+        distributedByInterpreter.isKeyOfNumericType(context));
+  }
+
+  @Override
+  public ProcessDistributedByInterpreterFacadeES getDistributedByInterpreter() {
+    return distributedByInterpreter;
+  }
+
+  @Override
+  public ProcessViewInterpreterFacadeES getViewInterpreter() {
+    return viewInterpreter;
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionKeyInterpreterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionKeyInterpreterOS.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.os.report.interpreter.groupby.process;
+
+import static io.camunda.optimize.service.db.os.client.dsl.AggregationDSL.termAggregation;
+import static io.camunda.optimize.service.db.os.client.dsl.AggregationDSL.withSubaggregations;
+import static io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy.PROCESS_GROUP_BY_PROCESS_DEFINITION_KEY;
+import static io.camunda.optimize.service.db.report.result.CompositeCommandResult.GroupByResult;
+import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.PROCESS_DEFINITION_KEY;
+
+import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
+import io.camunda.optimize.service.db.os.report.interpreter.RawResult;
+import io.camunda.optimize.service.db.os.report.interpreter.distributedby.process.ProcessDistributedByInterpreterFacadeOS;
+import io.camunda.optimize.service.db.os.report.interpreter.view.process.ProcessViewInterpreterFacadeOS;
+import io.camunda.optimize.service.db.report.ExecutionContext;
+import io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan;
+import io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy;
+import io.camunda.optimize.service.db.report.result.CompositeCommandResult;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import io.camunda.optimize.service.util.configuration.condition.OpenSearchCondition;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.opensearch.client.opensearch._types.SortOrder;
+import org.opensearch.client.opensearch._types.aggregations.Aggregation;
+import org.opensearch.client.opensearch._types.aggregations.StringTermsAggregate;
+import org.opensearch.client.opensearch._types.aggregations.StringTermsBucket;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.opensearch.client.opensearch.core.SearchResponse;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+
+@Component
+@Conditional(OpenSearchCondition.class)
+public class ProcessGroupByProcessDefinitionKeyInterpreterOS
+    extends AbstractProcessGroupByInterpreterOS {
+
+  private static final String PROCESS_DEFINITION_KEY_AGGREGATION = "processDefinitionKeyAgg";
+
+  private final ConfigurationService configurationService;
+  private final ProcessDistributedByInterpreterFacadeOS distributedByInterpreter;
+  private final ProcessViewInterpreterFacadeOS viewInterpreter;
+
+  public ProcessGroupByProcessDefinitionKeyInterpreterOS(
+      final ConfigurationService configurationService,
+      final ProcessDistributedByInterpreterFacadeOS distributedByInterpreter,
+      final ProcessViewInterpreterFacadeOS viewInterpreter) {
+    this.configurationService = configurationService;
+    this.distributedByInterpreter = distributedByInterpreter;
+    this.viewInterpreter = viewInterpreter;
+  }
+
+  @Override
+  public Set<ProcessGroupBy> getSupportedGroupBys() {
+    return Set.of(PROCESS_GROUP_BY_PROCESS_DEFINITION_KEY);
+  }
+
+  @Override
+  public Map<String, Aggregation> createAggregation(
+      final Query query,
+      final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context) {
+    final int size = configurationService.getOpenSearchConfiguration().getAggregationBucketLimit();
+    final Map<String, SortOrder> order = Map.of("_key", SortOrder.Asc);
+    final Aggregation processDefinitionKeyAggregation =
+        withSubaggregations(
+            termAggregation(PROCESS_DEFINITION_KEY, size, order),
+            distributedByInterpreter.createAggregations(context, query));
+    return Map.of(PROCESS_DEFINITION_KEY_AGGREGATION, processDefinitionKeyAggregation);
+  }
+
+  @Override
+  protected void addQueryResult(
+      final CompositeCommandResult compositeCommandResult,
+      final SearchResponse<RawResult> response,
+      final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context) {
+    final StringTermsAggregate processDefinitionKeyAggregation =
+        response.aggregations().get(PROCESS_DEFINITION_KEY_AGGREGATION).sterms();
+    final List<GroupByResult> groupedData = new ArrayList<>();
+    for (final StringTermsBucket processDefinitionKeyBucket :
+        processDefinitionKeyAggregation.buckets().array()) {
+      final String processDefinitionKey = processDefinitionKeyBucket.key();
+      final List<CompositeCommandResult.DistributedByResult> distributedByResult =
+          distributedByInterpreter.retrieveResult(
+              response, processDefinitionKeyBucket.aggregations(), context);
+      groupedData.add(GroupByResult.createGroupByResult(processDefinitionKey, distributedByResult));
+    }
+    compositeCommandResult.setGroups(groupedData);
+    compositeCommandResult.setDistributedByKeyOfNumericType(
+        distributedByInterpreter.isKeyOfNumericType(context));
+  }
+
+  @Override
+  public ProcessDistributedByInterpreterFacadeOS getDistributedByInterpreter() {
+    return distributedByInterpreter;
+  }
+
+  @Override
+  public ProcessViewInterpreterFacadeOS getViewInterpreter() {
+    return viewInterpreter;
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionVersionInterpreterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionVersionInterpreterOS.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.os.report.interpreter.groupby.process;
+
+import static io.camunda.optimize.service.db.os.client.dsl.AggregationDSL.termAggregation;
+import static io.camunda.optimize.service.db.os.client.dsl.AggregationDSL.withSubaggregations;
+import static io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy.PROCESS_GROUP_BY_PROCESS_DEFINITION_VERSION;
+import static io.camunda.optimize.service.db.report.result.CompositeCommandResult.GroupByResult;
+import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.PROCESS_DEFINITION_VERSION;
+
+import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
+import io.camunda.optimize.service.db.os.report.interpreter.RawResult;
+import io.camunda.optimize.service.db.os.report.interpreter.distributedby.process.ProcessDistributedByInterpreterFacadeOS;
+import io.camunda.optimize.service.db.os.report.interpreter.view.process.ProcessViewInterpreterFacadeOS;
+import io.camunda.optimize.service.db.report.ExecutionContext;
+import io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan;
+import io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy;
+import io.camunda.optimize.service.db.report.result.CompositeCommandResult;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import io.camunda.optimize.service.util.configuration.condition.OpenSearchCondition;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.opensearch.client.opensearch._types.SortOrder;
+import org.opensearch.client.opensearch._types.aggregations.Aggregation;
+import org.opensearch.client.opensearch._types.aggregations.StringTermsAggregate;
+import org.opensearch.client.opensearch._types.aggregations.StringTermsBucket;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.opensearch.client.opensearch.core.SearchResponse;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+
+@Component
+@Conditional(OpenSearchCondition.class)
+public class ProcessGroupByProcessDefinitionVersionInterpreterOS
+    extends AbstractProcessGroupByInterpreterOS {
+
+  private static final String PROCESS_DEFINITION_VERSION_AGGREGATION =
+      "processDefinitionVersionAgg";
+
+  private final ConfigurationService configurationService;
+  private final ProcessDistributedByInterpreterFacadeOS distributedByInterpreter;
+  private final ProcessViewInterpreterFacadeOS viewInterpreter;
+
+  public ProcessGroupByProcessDefinitionVersionInterpreterOS(
+      final ConfigurationService configurationService,
+      final ProcessDistributedByInterpreterFacadeOS distributedByInterpreter,
+      final ProcessViewInterpreterFacadeOS viewInterpreter) {
+    this.configurationService = configurationService;
+    this.distributedByInterpreter = distributedByInterpreter;
+    this.viewInterpreter = viewInterpreter;
+  }
+
+  @Override
+  public Set<ProcessGroupBy> getSupportedGroupBys() {
+    return Set.of(PROCESS_GROUP_BY_PROCESS_DEFINITION_VERSION);
+  }
+
+  @Override
+  public Map<String, Aggregation> createAggregation(
+      final Query query,
+      final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context) {
+    final int size = configurationService.getOpenSearchConfiguration().getAggregationBucketLimit();
+    final Map<String, SortOrder> order = Map.of("_key", SortOrder.Asc);
+    final Aggregation processDefinitionVersionAggregation =
+        withSubaggregations(
+            termAggregation(PROCESS_DEFINITION_VERSION, size, order),
+            distributedByInterpreter.createAggregations(context, query));
+    return Map.of(PROCESS_DEFINITION_VERSION_AGGREGATION, processDefinitionVersionAggregation);
+  }
+
+  @Override
+  protected void addQueryResult(
+      final CompositeCommandResult compositeCommandResult,
+      final SearchResponse<RawResult> response,
+      final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context) {
+    final StringTermsAggregate processDefinitionVersionAggregation =
+        response.aggregations().get(PROCESS_DEFINITION_VERSION_AGGREGATION).sterms();
+    final List<GroupByResult> groupedData = new ArrayList<>();
+    for (final StringTermsBucket processDefinitionVersionBucket :
+        processDefinitionVersionAggregation.buckets().array()) {
+      final String processDefinitionVersion = processDefinitionVersionBucket.key();
+      final List<CompositeCommandResult.DistributedByResult> distributedByResult =
+          distributedByInterpreter.retrieveResult(
+              response, processDefinitionVersionBucket.aggregations(), context);
+      groupedData.add(
+          GroupByResult.createGroupByResult(processDefinitionVersion, distributedByResult));
+    }
+    compositeCommandResult.setGroups(groupedData);
+    compositeCommandResult.setGroupByKeyOfNumericType(true);
+    compositeCommandResult.setDistributedByKeyOfNumericType(
+        distributedByInterpreter.isKeyOfNumericType(context));
+  }
+
+  @Override
+  public ProcessDistributedByInterpreterFacadeOS getDistributedByInterpreter() {
+    return distributedByInterpreter;
+  }
+
+  @Override
+  public ProcessViewInterpreterFacadeOS getViewInterpreter() {
+    return viewInterpreter;
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionKeyInterpreterESTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionKeyInterpreterESTest.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.es.report.interpreter.groupby.process;
+
+import static io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy.PROCESS_GROUP_BY_PROCESS_DEFINITION_KEY;
+import static io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy.PROCESS_GROUP_BY_PROCESS_DEFINITION_VERSION;
+import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.PROCESS_DEFINITION_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import co.elastic.clients.elasticsearch._types.FieldValue;
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregate;
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregation;
+import co.elastic.clients.elasticsearch._types.aggregations.StringTermsBucket;
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch.core.search.ResponseBody;
+import io.camunda.optimize.dto.optimize.query.report.single.ViewProperty;
+import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
+import io.camunda.optimize.service.db.es.report.interpreter.distributedby.process.ProcessDistributedByInterpreterFacadeES;
+import io.camunda.optimize.service.db.es.report.interpreter.view.process.ProcessViewInterpreterFacadeES;
+import io.camunda.optimize.service.db.report.ExecutionContext;
+import io.camunda.optimize.service.db.report.result.CompositeCommandResult;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import io.camunda.optimize.service.util.configuration.ElasticSearchConfiguration;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ProcessGroupByProcessDefinitionKeyInterpreterESTest {
+
+  @Mock private ConfigurationService configurationService;
+  @Mock private ElasticSearchConfiguration elasticSearchConfiguration;
+  @Mock private ProcessDistributedByInterpreterFacadeES distributedByInterpreter;
+  @Mock private ProcessViewInterpreterFacadeES viewInterpreter;
+
+  @SuppressWarnings("rawtypes")
+  @Mock
+  private ExecutionContext context;
+
+  private ProcessGroupByProcessDefinitionKeyInterpreterES underTest;
+
+  @BeforeEach
+  void setUp() {
+    underTest =
+        new ProcessGroupByProcessDefinitionKeyInterpreterES(
+            configurationService, distributedByInterpreter, viewInterpreter);
+  }
+
+  @Test
+  void shouldReturnOnlyProcessDefinitionKeyConstantFromSupportedGroupBys() {
+    assertThat(underTest.getSupportedGroupBys())
+        .containsExactly(PROCESS_GROUP_BY_PROCESS_DEFINITION_KEY);
+  }
+
+  @Test
+  void shouldNotIncludeVersionConstantInSupportedGroupBys() {
+    assertThat(underTest.getSupportedGroupBys())
+        .doesNotContain(PROCESS_GROUP_BY_PROCESS_DEFINITION_VERSION);
+  }
+
+  @Test
+  void shouldUseTermsAggregationTypeForKeyGroupBy() {
+    when(configurationService.getElasticSearchConfiguration())
+        .thenReturn(elasticSearchConfiguration);
+    when(elasticSearchConfiguration.getAggregationBucketLimit()).thenReturn(10);
+    when(distributedByInterpreter.createAggregations(any(), any())).thenReturn(Map.of());
+
+    final Map<String, Aggregation.Builder.ContainerBuilder> result =
+        underTest.createAggregation(mock(BoolQuery.class), context);
+    final Aggregation aggregation = result.get("processDefinitionKeyAgg").build();
+
+    assertThat(aggregation._kind()).isEqualTo(Aggregation.Kind.Terms);
+  }
+
+  @Test
+  void shouldTargetProcessDefinitionKeyFieldInAggregation() {
+    when(configurationService.getElasticSearchConfiguration())
+        .thenReturn(elasticSearchConfiguration);
+    when(elasticSearchConfiguration.getAggregationBucketLimit()).thenReturn(10);
+    when(distributedByInterpreter.createAggregations(any(), any())).thenReturn(Map.of());
+
+    final Map<String, Aggregation.Builder.ContainerBuilder> result =
+        underTest.createAggregation(mock(BoolQuery.class), context);
+    final Aggregation aggregation = result.get("processDefinitionKeyAgg").build();
+
+    assertThat(aggregation.terms().field()).isEqualTo(PROCESS_DEFINITION_KEY);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void shouldMapMultipleBucketsToGroupByResults() {
+    final Aggregate aggregate =
+        Aggregate.of(
+            a ->
+                a.sterms(
+                    st ->
+                        st.sumOtherDocCount(0L)
+                            .docCountErrorUpperBound(0L)
+                            .buckets(
+                                b ->
+                                    b.array(
+                                        List.of(
+                                            StringTermsBucket.of(
+                                                sb ->
+                                                    sb.key(FieldValue.of("invoice-process"))
+                                                        .docCount(3L)
+                                                        .aggregations(Map.of())),
+                                            StringTermsBucket.of(
+                                                sb ->
+                                                    sb.key(FieldValue.of("order-process"))
+                                                        .docCount(7L)
+                                                        .aggregations(Map.of())),
+                                            StringTermsBucket.of(
+                                                sb ->
+                                                    sb.key(FieldValue.of("payment-process"))
+                                                        .docCount(2L)
+                                                        .aggregations(Map.of())))))));
+    final ResponseBody<?> response = mock(ResponseBody.class);
+    when(response.aggregations()).thenReturn(Map.of("processDefinitionKeyAgg", aggregate));
+    when(distributedByInterpreter.retrieveResult(any(), any(), any())).thenReturn(List.of());
+    when(distributedByInterpreter.isKeyOfNumericType(any())).thenReturn(false);
+
+    final CompositeCommandResult result =
+        new CompositeCommandResult(new ProcessReportDataDto(), ViewProperty.FREQUENCY);
+    underTest.addQueryResult(result, response, context);
+
+    assertThat(result.getGroups())
+        .extracting(CompositeCommandResult.GroupByResult::getKey)
+        .containsExactly("invoice-process", "order-process", "payment-process");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void shouldReturnEmptyGroupsWhenNoBuckets() {
+    final Aggregate aggregate =
+        Aggregate.of(
+            a ->
+                a.sterms(
+                    st ->
+                        st.sumOtherDocCount(0L)
+                            .docCountErrorUpperBound(0L)
+                            .buckets(b -> b.array(List.of()))));
+    final ResponseBody<?> response = mock(ResponseBody.class);
+    when(response.aggregations()).thenReturn(Map.of("processDefinitionKeyAgg", aggregate));
+    when(distributedByInterpreter.isKeyOfNumericType(any())).thenReturn(false);
+
+    final CompositeCommandResult result =
+        new CompositeCommandResult(new ProcessReportDataDto(), ViewProperty.FREQUENCY);
+    underTest.addQueryResult(result, response, context);
+
+    assertThat(result.getGroups()).isEmpty();
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void shouldReturnSingleGroupResultForOneBucket() {
+    final Aggregate aggregate =
+        Aggregate.of(
+            a ->
+                a.sterms(
+                    st ->
+                        st.sumOtherDocCount(0L)
+                            .docCountErrorUpperBound(0L)
+                            .buckets(
+                                b ->
+                                    b.array(
+                                        List.of(
+                                            StringTermsBucket.of(
+                                                sb ->
+                                                    sb.key(FieldValue.of("single-process"))
+                                                        .docCount(1L)
+                                                        .aggregations(Map.of())))))));
+    final ResponseBody<?> response = mock(ResponseBody.class);
+    when(response.aggregations()).thenReturn(Map.of("processDefinitionKeyAgg", aggregate));
+    when(distributedByInterpreter.retrieveResult(any(), any(), any())).thenReturn(List.of());
+    when(distributedByInterpreter.isKeyOfNumericType(any())).thenReturn(false);
+
+    final CompositeCommandResult result =
+        new CompositeCommandResult(new ProcessReportDataDto(), ViewProperty.FREQUENCY);
+    underTest.addQueryResult(result, response, context);
+
+    assertThat(result.getGroups()).hasSize(1);
+    assertThat(result.getGroups().get(0).getKey()).isEqualTo("single-process");
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionVersionInterpreterESTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionVersionInterpreterESTest.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.es.report.interpreter.groupby.process;
+
+import static io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy.PROCESS_GROUP_BY_PROCESS_DEFINITION_KEY;
+import static io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy.PROCESS_GROUP_BY_PROCESS_DEFINITION_VERSION;
+import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.PROCESS_DEFINITION_VERSION;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import co.elastic.clients.elasticsearch._types.FieldValue;
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregate;
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregation;
+import co.elastic.clients.elasticsearch._types.aggregations.StringTermsBucket;
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch.core.search.ResponseBody;
+import io.camunda.optimize.dto.optimize.query.report.single.ViewProperty;
+import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
+import io.camunda.optimize.service.db.es.report.interpreter.distributedby.process.ProcessDistributedByInterpreterFacadeES;
+import io.camunda.optimize.service.db.es.report.interpreter.view.process.ProcessViewInterpreterFacadeES;
+import io.camunda.optimize.service.db.report.ExecutionContext;
+import io.camunda.optimize.service.db.report.result.CompositeCommandResult;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import io.camunda.optimize.service.util.configuration.ElasticSearchConfiguration;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ProcessGroupByProcessDefinitionVersionInterpreterESTest {
+
+  @Mock private ConfigurationService configurationService;
+  @Mock private ElasticSearchConfiguration elasticSearchConfiguration;
+  @Mock private ProcessDistributedByInterpreterFacadeES distributedByInterpreter;
+  @Mock private ProcessViewInterpreterFacadeES viewInterpreter;
+
+  @SuppressWarnings("rawtypes")
+  @Mock
+  private ExecutionContext context;
+
+  private ProcessGroupByProcessDefinitionVersionInterpreterES underTest;
+
+  @BeforeEach
+  void setUp() {
+    underTest =
+        new ProcessGroupByProcessDefinitionVersionInterpreterES(
+            configurationService, distributedByInterpreter, viewInterpreter);
+  }
+
+  @Test
+  void shouldReturnOnlyProcessDefinitionVersionConstantFromSupportedGroupBys() {
+    assertThat(underTest.getSupportedGroupBys())
+        .containsExactly(PROCESS_GROUP_BY_PROCESS_DEFINITION_VERSION);
+  }
+
+  @Test
+  void shouldNotIncludeKeyConstantInSupportedGroupBys() {
+    assertThat(underTest.getSupportedGroupBys())
+        .doesNotContain(PROCESS_GROUP_BY_PROCESS_DEFINITION_KEY);
+  }
+
+  @Test
+  void shouldUseTermsAggregationTypeForVersionGroupBy() {
+    when(configurationService.getElasticSearchConfiguration())
+        .thenReturn(elasticSearchConfiguration);
+    when(elasticSearchConfiguration.getAggregationBucketLimit()).thenReturn(10);
+    when(distributedByInterpreter.createAggregations(any(), any())).thenReturn(Map.of());
+
+    final Map<String, Aggregation.Builder.ContainerBuilder> result =
+        underTest.createAggregation(mock(BoolQuery.class), context);
+    final Aggregation aggregation = result.get("processDefinitionVersionAgg").build();
+
+    assertThat(aggregation._kind()).isEqualTo(Aggregation.Kind.Terms);
+  }
+
+  @Test
+  void shouldTargetProcessDefinitionVersionFieldInAggregation() {
+    when(configurationService.getElasticSearchConfiguration())
+        .thenReturn(elasticSearchConfiguration);
+    when(elasticSearchConfiguration.getAggregationBucketLimit()).thenReturn(10);
+    when(distributedByInterpreter.createAggregations(any(), any())).thenReturn(Map.of());
+
+    final Map<String, Aggregation.Builder.ContainerBuilder> result =
+        underTest.createAggregation(mock(BoolQuery.class), context);
+    final Aggregation aggregation = result.get("processDefinitionVersionAgg").build();
+
+    assertThat(aggregation.terms().field()).isEqualTo(PROCESS_DEFINITION_VERSION);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void shouldMapMultipleBucketsToGroupByResults() {
+    final Aggregate aggregate =
+        Aggregate.of(
+            a ->
+                a.sterms(
+                    st ->
+                        st.sumOtherDocCount(0L)
+                            .docCountErrorUpperBound(0L)
+                            .buckets(
+                                b ->
+                                    b.array(
+                                        List.of(
+                                            StringTermsBucket.of(
+                                                sb ->
+                                                    sb.key(FieldValue.of("1"))
+                                                        .docCount(5L)
+                                                        .aggregations(Map.of())),
+                                            StringTermsBucket.of(
+                                                sb ->
+                                                    sb.key(FieldValue.of("2"))
+                                                        .docCount(3L)
+                                                        .aggregations(Map.of())),
+                                            StringTermsBucket.of(
+                                                sb ->
+                                                    sb.key(FieldValue.of("3"))
+                                                        .docCount(1L)
+                                                        .aggregations(Map.of())))))));
+    final ResponseBody<?> response = mock(ResponseBody.class);
+    when(response.aggregations()).thenReturn(Map.of("processDefinitionVersionAgg", aggregate));
+    when(distributedByInterpreter.retrieveResult(any(), any(), any())).thenReturn(List.of());
+    when(distributedByInterpreter.isKeyOfNumericType(any())).thenReturn(false);
+
+    final CompositeCommandResult result =
+        new CompositeCommandResult(new ProcessReportDataDto(), ViewProperty.FREQUENCY);
+    underTest.addQueryResult(result, response, context);
+
+    assertThat(result.getGroups())
+        .extracting(CompositeCommandResult.GroupByResult::getKey)
+        .containsExactly("1", "2", "3");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void shouldReturnEmptyGroupsWhenNoBuckets() {
+    final Aggregate aggregate =
+        Aggregate.of(
+            a ->
+                a.sterms(
+                    st ->
+                        st.sumOtherDocCount(0L)
+                            .docCountErrorUpperBound(0L)
+                            .buckets(b -> b.array(List.of()))));
+    final ResponseBody<?> response = mock(ResponseBody.class);
+    when(response.aggregations()).thenReturn(Map.of("processDefinitionVersionAgg", aggregate));
+    when(distributedByInterpreter.isKeyOfNumericType(any())).thenReturn(false);
+
+    final CompositeCommandResult result =
+        new CompositeCommandResult(new ProcessReportDataDto(), ViewProperty.FREQUENCY);
+    underTest.addQueryResult(result, response, context);
+
+    assertThat(result.getGroups()).isEmpty();
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void shouldReturnSingleGroupResultForOneBucket() {
+    final Aggregate aggregate =
+        Aggregate.of(
+            a ->
+                a.sterms(
+                    st ->
+                        st.sumOtherDocCount(0L)
+                            .docCountErrorUpperBound(0L)
+                            .buckets(
+                                b ->
+                                    b.array(
+                                        List.of(
+                                            StringTermsBucket.of(
+                                                sb ->
+                                                    sb.key(FieldValue.of("42"))
+                                                        .docCount(1L)
+                                                        .aggregations(Map.of())))))));
+    final ResponseBody<?> response = mock(ResponseBody.class);
+    when(response.aggregations()).thenReturn(Map.of("processDefinitionVersionAgg", aggregate));
+    when(distributedByInterpreter.retrieveResult(any(), any(), any())).thenReturn(List.of());
+    when(distributedByInterpreter.isKeyOfNumericType(any())).thenReturn(false);
+
+    final CompositeCommandResult result =
+        new CompositeCommandResult(new ProcessReportDataDto(), ViewProperty.FREQUENCY);
+    underTest.addQueryResult(result, response, context);
+
+    assertThat(result.getGroups()).hasSize(1);
+    assertThat(result.getGroups().get(0).getKey()).isEqualTo("42");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void shouldSetGroupByKeyOfNumericTypeToTrue() {
+    final Aggregate aggregate =
+        Aggregate.of(
+            a ->
+                a.sterms(
+                    st ->
+                        st.sumOtherDocCount(0L)
+                            .docCountErrorUpperBound(0L)
+                            .buckets(b -> b.array(List.of()))));
+    final ResponseBody<?> response = mock(ResponseBody.class);
+    when(response.aggregations()).thenReturn(Map.of("processDefinitionVersionAgg", aggregate));
+    when(distributedByInterpreter.isKeyOfNumericType(any())).thenReturn(false);
+
+    final CompositeCommandResult result =
+        new CompositeCommandResult(new ProcessReportDataDto(), ViewProperty.FREQUENCY);
+    underTest.addQueryResult(result, response, context);
+
+    assertThat(result.isGroupByKeyOfNumericType()).isTrue();
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionVersionInterpreterESTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionVersionInterpreterESTest.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.optimize.service.db.es.report.interpreter.groupby.process;
 
-import static io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy.PROCESS_GROUP_BY_PROCESS_DEFINITION_KEY;
 import static io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy.PROCESS_GROUP_BY_PROCESS_DEFINITION_VERSION;
 import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.PROCESS_DEFINITION_VERSION;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -16,6 +15,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import co.elastic.clients.elasticsearch._types.FieldValue;
+import co.elastic.clients.elasticsearch._types.SortOrder;
 import co.elastic.clients.elasticsearch._types.aggregations.Aggregate;
 import co.elastic.clients.elasticsearch._types.aggregations.Aggregation;
 import co.elastic.clients.elasticsearch._types.aggregations.StringTermsBucket;
@@ -29,6 +29,7 @@ import io.camunda.optimize.service.db.report.ExecutionContext;
 import io.camunda.optimize.service.db.report.result.CompositeCommandResult;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import io.camunda.optimize.service.util.configuration.ElasticSearchConfiguration;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -65,16 +66,9 @@ class ProcessGroupByProcessDefinitionVersionInterpreterESTest {
   }
 
   @Test
-  void shouldNotIncludeKeyConstantInSupportedGroupBys() {
-    assertThat(underTest.getSupportedGroupBys())
-        .doesNotContain(PROCESS_GROUP_BY_PROCESS_DEFINITION_KEY);
-  }
-
-  @Test
-  void shouldUseTermsAggregationTypeForVersionGroupBy() {
+  void shouldBuildTermsAggregationOnVersionFieldSortedByKeyAscending() {
     when(configurationService.getElasticSearchConfiguration())
         .thenReturn(elasticSearchConfiguration);
-    when(elasticSearchConfiguration.getAggregationBucketLimit()).thenReturn(10);
     when(distributedByInterpreter.createAggregations(any(), any())).thenReturn(Map.of());
 
     final Map<String, Aggregation.Builder.ContainerBuilder> result =
@@ -82,53 +76,22 @@ class ProcessGroupByProcessDefinitionVersionInterpreterESTest {
     final Aggregation aggregation = result.get("processDefinitionVersionAgg").build();
 
     assertThat(aggregation._kind()).isEqualTo(Aggregation.Kind.Terms);
-  }
-
-  @Test
-  void shouldTargetProcessDefinitionVersionFieldInAggregation() {
-    when(configurationService.getElasticSearchConfiguration())
-        .thenReturn(elasticSearchConfiguration);
-    when(elasticSearchConfiguration.getAggregationBucketLimit()).thenReturn(10);
-    when(distributedByInterpreter.createAggregations(any(), any())).thenReturn(Map.of());
-
-    final Map<String, Aggregation.Builder.ContainerBuilder> result =
-        underTest.createAggregation(mock(BoolQuery.class), context);
-    final Aggregation aggregation = result.get("processDefinitionVersionAgg").build();
-
     assertThat(aggregation.terms().field()).isEqualTo(PROCESS_DEFINITION_VERSION);
+    assertThat(aggregation.terms().order())
+        .singleElement()
+        .satisfies(
+            order -> {
+              assertThat(order.name()).isEqualTo("_key");
+              assertThat(order.value()).isEqualTo(SortOrder.Asc);
+            });
   }
 
   @Test
   @SuppressWarnings("unchecked")
   void shouldMapMultipleBucketsToGroupByResults() {
-    final Aggregate aggregate =
-        Aggregate.of(
-            a ->
-                a.sterms(
-                    st ->
-                        st.sumOtherDocCount(0L)
-                            .docCountErrorUpperBound(0L)
-                            .buckets(
-                                b ->
-                                    b.array(
-                                        List.of(
-                                            StringTermsBucket.of(
-                                                sb ->
-                                                    sb.key(FieldValue.of("1"))
-                                                        .docCount(5L)
-                                                        .aggregations(Map.of())),
-                                            StringTermsBucket.of(
-                                                sb ->
-                                                    sb.key(FieldValue.of("2"))
-                                                        .docCount(3L)
-                                                        .aggregations(Map.of())),
-                                            StringTermsBucket.of(
-                                                sb ->
-                                                    sb.key(FieldValue.of("3"))
-                                                        .docCount(1L)
-                                                        .aggregations(Map.of())))))));
     final ResponseBody<?> response = mock(ResponseBody.class);
-    when(response.aggregations()).thenReturn(Map.of("processDefinitionVersionAgg", aggregate));
+    when(response.aggregations())
+        .thenReturn(Map.of("processDefinitionVersionAgg", stringTermsAggregate("1", "2", "3")));
     when(distributedByInterpreter.retrieveResult(any(), any(), any())).thenReturn(List.of());
     when(distributedByInterpreter.isKeyOfNumericType(any())).thenReturn(false);
 
@@ -144,16 +107,9 @@ class ProcessGroupByProcessDefinitionVersionInterpreterESTest {
   @Test
   @SuppressWarnings("unchecked")
   void shouldReturnEmptyGroupsWhenNoBuckets() {
-    final Aggregate aggregate =
-        Aggregate.of(
-            a ->
-                a.sterms(
-                    st ->
-                        st.sumOtherDocCount(0L)
-                            .docCountErrorUpperBound(0L)
-                            .buckets(b -> b.array(List.of()))));
     final ResponseBody<?> response = mock(ResponseBody.class);
-    when(response.aggregations()).thenReturn(Map.of("processDefinitionVersionAgg", aggregate));
+    when(response.aggregations())
+        .thenReturn(Map.of("processDefinitionVersionAgg", stringTermsAggregate()));
     when(distributedByInterpreter.isKeyOfNumericType(any())).thenReturn(false);
 
     final CompositeCommandResult result =
@@ -166,24 +122,9 @@ class ProcessGroupByProcessDefinitionVersionInterpreterESTest {
   @Test
   @SuppressWarnings("unchecked")
   void shouldReturnSingleGroupResultForOneBucket() {
-    final Aggregate aggregate =
-        Aggregate.of(
-            a ->
-                a.sterms(
-                    st ->
-                        st.sumOtherDocCount(0L)
-                            .docCountErrorUpperBound(0L)
-                            .buckets(
-                                b ->
-                                    b.array(
-                                        List.of(
-                                            StringTermsBucket.of(
-                                                sb ->
-                                                    sb.key(FieldValue.of("42"))
-                                                        .docCount(1L)
-                                                        .aggregations(Map.of())))))));
     final ResponseBody<?> response = mock(ResponseBody.class);
-    when(response.aggregations()).thenReturn(Map.of("processDefinitionVersionAgg", aggregate));
+    when(response.aggregations())
+        .thenReturn(Map.of("processDefinitionVersionAgg", stringTermsAggregate("42")));
     when(distributedByInterpreter.retrieveResult(any(), any(), any())).thenReturn(List.of());
     when(distributedByInterpreter.isKeyOfNumericType(any())).thenReturn(false);
 
@@ -198,16 +139,9 @@ class ProcessGroupByProcessDefinitionVersionInterpreterESTest {
   @Test
   @SuppressWarnings("unchecked")
   void shouldSetGroupByKeyOfNumericTypeToTrue() {
-    final Aggregate aggregate =
-        Aggregate.of(
-            a ->
-                a.sterms(
-                    st ->
-                        st.sumOtherDocCount(0L)
-                            .docCountErrorUpperBound(0L)
-                            .buckets(b -> b.array(List.of()))));
     final ResponseBody<?> response = mock(ResponseBody.class);
-    when(response.aggregations()).thenReturn(Map.of("processDefinitionVersionAgg", aggregate));
+    when(response.aggregations())
+        .thenReturn(Map.of("processDefinitionVersionAgg", stringTermsAggregate()));
     when(distributedByInterpreter.isKeyOfNumericType(any())).thenReturn(false);
 
     final CompositeCommandResult result =
@@ -215,5 +149,26 @@ class ProcessGroupByProcessDefinitionVersionInterpreterESTest {
     underTest.addQueryResult(result, response, context);
 
     assertThat(result.isGroupByKeyOfNumericType()).isTrue();
+  }
+
+  private static Aggregate stringTermsAggregate(final String... keys) {
+    return Aggregate.of(
+        a ->
+            a.sterms(
+                st ->
+                    st.sumOtherDocCount(0L)
+                        .docCountErrorUpperBound(0L)
+                        .buckets(
+                            b ->
+                                b.array(
+                                    Arrays.stream(keys)
+                                        .map(
+                                            key ->
+                                                StringTermsBucket.of(
+                                                    sb ->
+                                                        sb.key(FieldValue.of(key))
+                                                            .docCount(1L)
+                                                            .aggregations(Map.of())))
+                                        .toList()))));
   }
 }

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionKeyInterpreterOSTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionKeyInterpreterOSTest.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.optimize.service.db.es.report.interpreter.groupby.process;
+package io.camunda.optimize.service.db.os.report.interpreter.groupby.process;
 
 import static io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy.PROCESS_GROUP_BY_PROCESS_DEFINITION_KEY;
 import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.PROCESS_DEFINITION_KEY;
@@ -14,21 +14,15 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import co.elastic.clients.elasticsearch._types.FieldValue;
-import co.elastic.clients.elasticsearch._types.SortOrder;
-import co.elastic.clients.elasticsearch._types.aggregations.Aggregate;
-import co.elastic.clients.elasticsearch._types.aggregations.Aggregation;
-import co.elastic.clients.elasticsearch._types.aggregations.StringTermsBucket;
-import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
-import co.elastic.clients.elasticsearch.core.search.ResponseBody;
 import io.camunda.optimize.dto.optimize.query.report.single.ViewProperty;
 import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
-import io.camunda.optimize.service.db.es.report.interpreter.distributedby.process.ProcessDistributedByInterpreterFacadeES;
-import io.camunda.optimize.service.db.es.report.interpreter.view.process.ProcessViewInterpreterFacadeES;
+import io.camunda.optimize.service.db.os.report.interpreter.RawResult;
+import io.camunda.optimize.service.db.os.report.interpreter.distributedby.process.ProcessDistributedByInterpreterFacadeOS;
+import io.camunda.optimize.service.db.os.report.interpreter.view.process.ProcessViewInterpreterFacadeOS;
 import io.camunda.optimize.service.db.report.ExecutionContext;
 import io.camunda.optimize.service.db.report.result.CompositeCommandResult;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
-import io.camunda.optimize.service.util.configuration.ElasticSearchConfiguration;
+import io.camunda.optimize.service.util.configuration.OpenSearchConfiguration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -37,25 +31,31 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.client.opensearch._types.SortOrder;
+import org.opensearch.client.opensearch._types.aggregations.Aggregate;
+import org.opensearch.client.opensearch._types.aggregations.Aggregation;
+import org.opensearch.client.opensearch._types.aggregations.StringTermsBucket;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.opensearch.client.opensearch.core.SearchResponse;
 
 @ExtendWith(MockitoExtension.class)
-class ProcessGroupByProcessDefinitionKeyInterpreterESTest {
+class ProcessGroupByProcessDefinitionKeyInterpreterOSTest {
 
   @Mock private ConfigurationService configurationService;
-  @Mock private ElasticSearchConfiguration elasticSearchConfiguration;
-  @Mock private ProcessDistributedByInterpreterFacadeES distributedByInterpreter;
-  @Mock private ProcessViewInterpreterFacadeES viewInterpreter;
+  @Mock private OpenSearchConfiguration openSearchConfiguration;
+  @Mock private ProcessDistributedByInterpreterFacadeOS distributedByInterpreter;
+  @Mock private ProcessViewInterpreterFacadeOS viewInterpreter;
 
   @SuppressWarnings("rawtypes")
   @Mock
   private ExecutionContext context;
 
-  private ProcessGroupByProcessDefinitionKeyInterpreterES underTest;
+  private ProcessGroupByProcessDefinitionKeyInterpreterOS underTest;
 
   @BeforeEach
   void setUp() {
     underTest =
-        new ProcessGroupByProcessDefinitionKeyInterpreterES(
+        new ProcessGroupByProcessDefinitionKeyInterpreterOS(
             configurationService, distributedByInterpreter, viewInterpreter);
   }
 
@@ -67,29 +67,22 @@ class ProcessGroupByProcessDefinitionKeyInterpreterESTest {
 
   @Test
   void shouldBuildTermsAggregationOnKeyFieldSortedByKeyAscending() {
-    when(configurationService.getElasticSearchConfiguration())
-        .thenReturn(elasticSearchConfiguration);
+    when(configurationService.getOpenSearchConfiguration()).thenReturn(openSearchConfiguration);
+    when(openSearchConfiguration.getAggregationBucketLimit()).thenReturn(10);
     when(distributedByInterpreter.createAggregations(any(), any())).thenReturn(Map.of());
 
-    final Map<String, Aggregation.Builder.ContainerBuilder> result =
-        underTest.createAggregation(mock(BoolQuery.class), context);
-    final Aggregation aggregation = result.get("processDefinitionKeyAgg").build();
+    final Map<String, Aggregation> result = underTest.createAggregation(mock(Query.class), context);
+    final Aggregation aggregation = result.get("processDefinitionKeyAgg");
 
     assertThat(aggregation._kind()).isEqualTo(Aggregation.Kind.Terms);
     assertThat(aggregation.terms().field()).isEqualTo(PROCESS_DEFINITION_KEY);
-    assertThat(aggregation.terms().order())
-        .singleElement()
-        .satisfies(
-            order -> {
-              assertThat(order.name()).isEqualTo("_key");
-              assertThat(order.value()).isEqualTo(SortOrder.Asc);
-            });
+    assertThat(aggregation.terms().order()).containsExactly(Map.of("_key", SortOrder.Asc));
   }
 
   @Test
   @SuppressWarnings("unchecked")
   void shouldMapMultipleBucketsToGroupByResults() {
-    final ResponseBody<?> response = mock(ResponseBody.class);
+    final SearchResponse<RawResult> response = mock(SearchResponse.class);
     when(response.aggregations())
         .thenReturn(
             Map.of(
@@ -110,7 +103,7 @@ class ProcessGroupByProcessDefinitionKeyInterpreterESTest {
   @Test
   @SuppressWarnings("unchecked")
   void shouldReturnEmptyGroupsWhenNoBuckets() {
-    final ResponseBody<?> response = mock(ResponseBody.class);
+    final SearchResponse<RawResult> response = mock(SearchResponse.class);
     when(response.aggregations())
         .thenReturn(Map.of("processDefinitionKeyAgg", stringTermsAggregate()));
     when(distributedByInterpreter.isKeyOfNumericType(any())).thenReturn(false);
@@ -125,7 +118,7 @@ class ProcessGroupByProcessDefinitionKeyInterpreterESTest {
   @Test
   @SuppressWarnings("unchecked")
   void shouldReturnSingleGroupResultForOneBucket() {
-    final ResponseBody<?> response = mock(ResponseBody.class);
+    final SearchResponse<RawResult> response = mock(SearchResponse.class);
     when(response.aggregations())
         .thenReturn(Map.of("processDefinitionKeyAgg", stringTermsAggregate("single-process")));
     when(distributedByInterpreter.retrieveResult(any(), any(), any())).thenReturn(List.of());
@@ -154,7 +147,7 @@ class ProcessGroupByProcessDefinitionKeyInterpreterESTest {
                                             key ->
                                                 StringTermsBucket.of(
                                                     sb ->
-                                                        sb.key(FieldValue.of(key))
+                                                        sb.key(key)
                                                             .docCount(1L)
                                                             .aggregations(Map.of())))
                                         .toList()))));

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionVersionInterpreterOSTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionVersionInterpreterOSTest.java
@@ -5,30 +5,24 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.optimize.service.db.es.report.interpreter.groupby.process;
+package io.camunda.optimize.service.db.os.report.interpreter.groupby.process;
 
-import static io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy.PROCESS_GROUP_BY_PROCESS_DEFINITION_KEY;
-import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.PROCESS_DEFINITION_KEY;
+import static io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy.PROCESS_GROUP_BY_PROCESS_DEFINITION_VERSION;
+import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.PROCESS_DEFINITION_VERSION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import co.elastic.clients.elasticsearch._types.FieldValue;
-import co.elastic.clients.elasticsearch._types.SortOrder;
-import co.elastic.clients.elasticsearch._types.aggregations.Aggregate;
-import co.elastic.clients.elasticsearch._types.aggregations.Aggregation;
-import co.elastic.clients.elasticsearch._types.aggregations.StringTermsBucket;
-import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
-import co.elastic.clients.elasticsearch.core.search.ResponseBody;
 import io.camunda.optimize.dto.optimize.query.report.single.ViewProperty;
 import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
-import io.camunda.optimize.service.db.es.report.interpreter.distributedby.process.ProcessDistributedByInterpreterFacadeES;
-import io.camunda.optimize.service.db.es.report.interpreter.view.process.ProcessViewInterpreterFacadeES;
+import io.camunda.optimize.service.db.os.report.interpreter.RawResult;
+import io.camunda.optimize.service.db.os.report.interpreter.distributedby.process.ProcessDistributedByInterpreterFacadeOS;
+import io.camunda.optimize.service.db.os.report.interpreter.view.process.ProcessViewInterpreterFacadeOS;
 import io.camunda.optimize.service.db.report.ExecutionContext;
 import io.camunda.optimize.service.db.report.result.CompositeCommandResult;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
-import io.camunda.optimize.service.util.configuration.ElasticSearchConfiguration;
+import io.camunda.optimize.service.util.configuration.OpenSearchConfiguration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -37,64 +31,60 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.client.opensearch._types.SortOrder;
+import org.opensearch.client.opensearch._types.aggregations.Aggregate;
+import org.opensearch.client.opensearch._types.aggregations.Aggregation;
+import org.opensearch.client.opensearch._types.aggregations.StringTermsBucket;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.opensearch.client.opensearch.core.SearchResponse;
 
 @ExtendWith(MockitoExtension.class)
-class ProcessGroupByProcessDefinitionKeyInterpreterESTest {
+class ProcessGroupByProcessDefinitionVersionInterpreterOSTest {
 
   @Mock private ConfigurationService configurationService;
-  @Mock private ElasticSearchConfiguration elasticSearchConfiguration;
-  @Mock private ProcessDistributedByInterpreterFacadeES distributedByInterpreter;
-  @Mock private ProcessViewInterpreterFacadeES viewInterpreter;
+  @Mock private OpenSearchConfiguration openSearchConfiguration;
+  @Mock private ProcessDistributedByInterpreterFacadeOS distributedByInterpreter;
+  @Mock private ProcessViewInterpreterFacadeOS viewInterpreter;
 
   @SuppressWarnings("rawtypes")
   @Mock
   private ExecutionContext context;
 
-  private ProcessGroupByProcessDefinitionKeyInterpreterES underTest;
+  private ProcessGroupByProcessDefinitionVersionInterpreterOS underTest;
 
   @BeforeEach
   void setUp() {
     underTest =
-        new ProcessGroupByProcessDefinitionKeyInterpreterES(
+        new ProcessGroupByProcessDefinitionVersionInterpreterOS(
             configurationService, distributedByInterpreter, viewInterpreter);
   }
 
   @Test
-  void shouldReturnOnlyProcessDefinitionKeyConstantFromSupportedGroupBys() {
+  void shouldReturnOnlyProcessDefinitionVersionConstantFromSupportedGroupBys() {
     assertThat(underTest.getSupportedGroupBys())
-        .containsExactly(PROCESS_GROUP_BY_PROCESS_DEFINITION_KEY);
+        .containsExactly(PROCESS_GROUP_BY_PROCESS_DEFINITION_VERSION);
   }
 
   @Test
-  void shouldBuildTermsAggregationOnKeyFieldSortedByKeyAscending() {
-    when(configurationService.getElasticSearchConfiguration())
-        .thenReturn(elasticSearchConfiguration);
+  void shouldBuildTermsAggregationOnVersionFieldSortedByKeyAscending() {
+    when(configurationService.getOpenSearchConfiguration()).thenReturn(openSearchConfiguration);
+    when(openSearchConfiguration.getAggregationBucketLimit()).thenReturn(10);
     when(distributedByInterpreter.createAggregations(any(), any())).thenReturn(Map.of());
 
-    final Map<String, Aggregation.Builder.ContainerBuilder> result =
-        underTest.createAggregation(mock(BoolQuery.class), context);
-    final Aggregation aggregation = result.get("processDefinitionKeyAgg").build();
+    final Map<String, Aggregation> result = underTest.createAggregation(mock(Query.class), context);
+    final Aggregation aggregation = result.get("processDefinitionVersionAgg");
 
     assertThat(aggregation._kind()).isEqualTo(Aggregation.Kind.Terms);
-    assertThat(aggregation.terms().field()).isEqualTo(PROCESS_DEFINITION_KEY);
-    assertThat(aggregation.terms().order())
-        .singleElement()
-        .satisfies(
-            order -> {
-              assertThat(order.name()).isEqualTo("_key");
-              assertThat(order.value()).isEqualTo(SortOrder.Asc);
-            });
+    assertThat(aggregation.terms().field()).isEqualTo(PROCESS_DEFINITION_VERSION);
+    assertThat(aggregation.terms().order()).containsExactly(Map.of("_key", SortOrder.Asc));
   }
 
   @Test
   @SuppressWarnings("unchecked")
   void shouldMapMultipleBucketsToGroupByResults() {
-    final ResponseBody<?> response = mock(ResponseBody.class);
+    final SearchResponse<RawResult> response = mock(SearchResponse.class);
     when(response.aggregations())
-        .thenReturn(
-            Map.of(
-                "processDefinitionKeyAgg",
-                stringTermsAggregate("invoice-process", "order-process", "payment-process")));
+        .thenReturn(Map.of("processDefinitionVersionAgg", stringTermsAggregate("1", "2", "3")));
     when(distributedByInterpreter.retrieveResult(any(), any(), any())).thenReturn(List.of());
     when(distributedByInterpreter.isKeyOfNumericType(any())).thenReturn(false);
 
@@ -104,15 +94,15 @@ class ProcessGroupByProcessDefinitionKeyInterpreterESTest {
 
     assertThat(result.getGroups())
         .extracting(CompositeCommandResult.GroupByResult::getKey)
-        .containsExactly("invoice-process", "order-process", "payment-process");
+        .containsExactly("1", "2", "3");
   }
 
   @Test
   @SuppressWarnings("unchecked")
   void shouldReturnEmptyGroupsWhenNoBuckets() {
-    final ResponseBody<?> response = mock(ResponseBody.class);
+    final SearchResponse<RawResult> response = mock(SearchResponse.class);
     when(response.aggregations())
-        .thenReturn(Map.of("processDefinitionKeyAgg", stringTermsAggregate()));
+        .thenReturn(Map.of("processDefinitionVersionAgg", stringTermsAggregate()));
     when(distributedByInterpreter.isKeyOfNumericType(any())).thenReturn(false);
 
     final CompositeCommandResult result =
@@ -125,9 +115,9 @@ class ProcessGroupByProcessDefinitionKeyInterpreterESTest {
   @Test
   @SuppressWarnings("unchecked")
   void shouldReturnSingleGroupResultForOneBucket() {
-    final ResponseBody<?> response = mock(ResponseBody.class);
+    final SearchResponse<RawResult> response = mock(SearchResponse.class);
     when(response.aggregations())
-        .thenReturn(Map.of("processDefinitionKeyAgg", stringTermsAggregate("single-process")));
+        .thenReturn(Map.of("processDefinitionVersionAgg", stringTermsAggregate("42")));
     when(distributedByInterpreter.retrieveResult(any(), any(), any())).thenReturn(List.of());
     when(distributedByInterpreter.isKeyOfNumericType(any())).thenReturn(false);
 
@@ -136,7 +126,22 @@ class ProcessGroupByProcessDefinitionKeyInterpreterESTest {
     underTest.addQueryResult(result, response, context);
 
     assertThat(result.getGroups()).hasSize(1);
-    assertThat(result.getGroups().get(0).getKey()).isEqualTo("single-process");
+    assertThat(result.getGroups().get(0).getKey()).isEqualTo("42");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void shouldSetGroupByKeyOfNumericTypeToTrue() {
+    final SearchResponse<RawResult> response = mock(SearchResponse.class);
+    when(response.aggregations())
+        .thenReturn(Map.of("processDefinitionVersionAgg", stringTermsAggregate()));
+    when(distributedByInterpreter.isKeyOfNumericType(any())).thenReturn(false);
+
+    final CompositeCommandResult result =
+        new CompositeCommandResult(new ProcessReportDataDto(), ViewProperty.FREQUENCY);
+    underTest.addQueryResult(result, response, context);
+
+    assertThat(result.isGroupByKeyOfNumericType()).isTrue();
   }
 
   private static Aggregate stringTermsAggregate(final String... keys) {
@@ -154,7 +159,7 @@ class ProcessGroupByProcessDefinitionKeyInterpreterESTest {
                                             key ->
                                                 StringTermsBucket.of(
                                                     sb ->
-                                                        sb.key(FieldValue.of(key))
+                                                        sb.key(key)
                                                             .docCount(1L)
                                                             .aggregations(Map.of())))
                                         .toList()))));


### PR DESCRIPTION
related to #54074

## Description

Implements the groupBy interpreters needed to evaluate reports grouped by process definition key and version 

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #54074
