### PR TITLE
fix(agent-instance): validate positive keys to return 400 instead of 503

### DIFF
--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidator.java
@@ -11,6 +11,7 @@ import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESS
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_INVALID_ATTRIBUTE_VALUE;
 import static io.camunda.gateway.mapping.http.validator.RequestValidator.validate;
 import static io.camunda.gateway.mapping.http.validator.RequestValidator.validateKeyFormat;
+import static io.camunda.gateway.mapping.http.validator.RequestValidator.validatePositiveKeyFormat;
 
 import io.camunda.gateway.protocol.model.AgentInstanceCreationRequest;
 import io.camunda.gateway.protocol.model.AgentInstanceUpdateRequest;
@@ -36,7 +37,8 @@ public class AgentInstanceRequestValidator {
           if (request.getElementInstanceKey() == null) {
             violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("elementInstanceKey"));
           } else {
-            validateKeyFormat(request.getElementInstanceKey(), "elementInstanceKey", violations);
+            validatePositiveKeyFormat(
+                request.getElementInstanceKey(), "elementInstanceKey", violations);
           }
 
           if (request.getDefinition() == null) {
@@ -74,7 +76,7 @@ public class AgentInstanceRequestValidator {
         () -> {
           final List<String> violations = new ArrayList<>();
 
-          validateKeyFormat(agentInstanceKey, "agentInstanceKey", violations);
+          validatePositiveKeyFormat(agentInstanceKey, "agentInstanceKey", violations);
 
           if (request.getElementInstanceKey() == null) {
             violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("elementInstanceKey"));

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/RequestValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/RequestValidator.java
@@ -132,6 +132,19 @@ public final class RequestValidator {
     }
   }
 
+  public static void validatePositiveKeyFormat(
+      final @Nullable String keyValue, final String fieldName, final List<String> violations) {
+    if (keyValue != null && tryParseLong(keyValue).isEmpty()) {
+      violations.add(ERROR_MESSAGE_INVALID_KEY_FORMAT.formatted(fieldName, keyValue));
+    } else if (keyValue != null) {
+      final var parsedKey = tryParseLong(keyValue).orElse(null);
+      if (parsedKey != null && parsedKey <= 0) {
+        violations.add(
+            ERROR_MESSAGE_INVALID_KEY_FORMAT.formatted(fieldName, keyValue + " (must be > 0)"));
+      }
+    }
+  }
+
   /**
    * Validates that a {@code decisionEvaluationInstanceKey} matches the expected format produced by
    * the engine: {@code <decisionEvaluationKey>-<index>} where both parts are non-negative integers


### PR DESCRIPTION
## Issue
#54315 - Agent instance endpoints return 503 instead of 400 for invalid keys

## Problem
POST /v2/agent-instances and PATCH /v2/agent-instances/{agentInstanceKey} 
with zero or negative key values return HTTP 503 (Service Unavailable) instead 
of HTTP 400 (Bad Request).

The requests reach the broker without validation, which tries to route based 
on a non-existent partition and throws PartitionNotFoundException, 
mapped to 503 by ErrorMapper.

## Solution
Added validatePositiveKeyFormat() to RequestValidator and applied it to 
AgentInstanceRequestValidator for both endpoints.

### Changes
- Add `validatePositiveKeyFormat()` method to RequestValidator
  - Validates that key is a number and > 0
  - Returns INVALID_ARGUMENT (400) for violation
- Update `AgentInstanceRequestValidator.validateCreateRequest()` 
  - Use validatePositiveKeyFormat for elementInstanceKey
- Update `AgentInstanceRequestValidator.validateUpdateRequest()` 
  - Use validatePositiveKeyFormat for agentInstanceKey
- Add 4 parametrized test cases covering:
  - POST with elementInstanceKey = "0"
  - POST with elementInstanceKey = "-1"
  - PATCH with agentInstanceKey = 0 (path parameter)
  - PATCH with agentInstanceKey = -1 (path parameter)

## Testing
All existing tests pass. New test cases verify:
- Zero keys rejected with 400 and correct error message
- Negative keys rejected with 400 and correct error message
- Validation happens at gateway layer, not at broker

## Related
Closes #54315