### PR TITLE
Add rootProcessInstanceKey to AGENT_INSTANCE record

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/response/AgentInstance.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/AgentInstance.java
@@ -50,7 +50,7 @@ public interface AgentInstance {
   long getProcessInstanceKey();
 
   /** Returns the key of the root process instance. */
-  Long getRootProcessInstanceKey();
+  long getRootProcessInstanceKey();
 
   /** Returns the key of the process definition associated with this agent instance. */
   long getProcessDefinitionKey();

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/AgentInstanceImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/AgentInstanceImpl.java
@@ -36,7 +36,7 @@ public class AgentInstanceImpl implements AgentInstance {
   private final List<Tool> tools;
   private final String elementId;
   private final long processInstanceKey;
-  private final Long rootProcessInstanceKey;
+  private final long rootProcessInstanceKey;
   private final long processDefinitionKey;
   private final String processDefinitionId;
   private final int processDefinitionVersion;
@@ -59,7 +59,7 @@ public class AgentInstanceImpl implements AgentInstance {
             : Collections.emptyList();
     elementId = result.getElementId();
     processInstanceKey = Long.parseLong(result.getProcessInstanceKey());
-    rootProcessInstanceKey = ParseUtil.parseLongOrNull(result.getRootProcessInstanceKey());
+    rootProcessInstanceKey = Long.parseLong(result.getRootProcessInstanceKey());
     processDefinitionKey = Long.parseLong(result.getProcessDefinitionKey());
     processDefinitionId = result.getProcessDefinitionId();
     processDefinitionVersion = result.getProcessDefinitionVersion();
@@ -117,7 +117,7 @@ public class AgentInstanceImpl implements AgentInstance {
   }
 
   @Override
-  public Long getRootProcessInstanceKey() {
+  public long getRootProcessInstanceKey() {
     return rootProcessInstanceKey;
   }
 

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -2044,7 +2044,7 @@ public final class SearchQueryResponseMapper {
         .tools(tools)
         .elementId(entity.elementId())
         .processInstanceKey(keyToString(entity.processInstanceKey()))
-        .rootProcessInstanceKey(keyToStringOrNull(entity.rootProcessInstanceKey()))
+        .rootProcessInstanceKey(keyToString(entity.rootProcessInstanceKey()))
         .processDefinitionKey(keyToString(entity.processDefinitionKey()))
         .processDefinitionId(entity.processDefinitionId())
         .processDefinitionVersion(entity.processDefinitionVersion())

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
@@ -17,6 +17,7 @@ import io.camunda.gateway.protocol.model.IncidentErrorTypeEnum;
 import io.camunda.gateway.protocol.model.IncidentStateEnum;
 import io.camunda.gateway.protocol.model.JobListenerEventTypeEnum;
 import io.camunda.gateway.protocol.model.JobSearchQueryResult;
+import io.camunda.search.entities.AgentInstanceEntity;
 import io.camunda.search.entities.AuditLogEntity;
 import io.camunda.search.entities.AuditLogEntity.AuditLogActorType;
 import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
@@ -743,6 +744,38 @@ class SearchQueryResponseMapperTest {
 
     // then
     assertThat(response.getRootProcessInstanceKey()).isNull();
+  }
+
+  @Test
+  void shouldMapRootProcessInstanceKeyForAgentInstance() {
+    // given
+    final var entity =
+        new AgentInstanceEntity(
+            123L, // agentInstanceKey
+            List.of(456L), // elementInstanceKeys
+            AgentInstanceEntity.AgentInstanceStatus.IDLE,
+            new AgentInstanceEntity.AgentInstanceDefinition("gpt-4o", "openai", "You are helpful"),
+            new AgentInstanceEntity.AgentInstanceMetrics(10L, 20L, 1, 2),
+            new AgentInstanceEntity.AgentInstanceLimits(1000L, 5, 6),
+            List.of(
+                new AgentInstanceEntity.AgentInstanceTool("search", "Web search", "searchTask")),
+            "agentElement", // elementId
+            789L, // processInstanceKey
+            999L, // rootProcessInstanceKey
+            321L, // processDefinitionKey
+            "processId", // processDefinitionId
+            1, // processDefinitionVersion
+            "v1", // versionTag
+            "tenant", // tenantId
+            OffsetDateTime.now(), // creationDate
+            OffsetDateTime.now(), // lastUpdatedDate
+            null); // completionDate
+
+    // when
+    final var response = SearchQueryResponseMapper.toAgentInstanceResult(entity);
+
+    // then
+    assertThat(response.getRootProcessInstanceKey()).isEqualTo("999");
   }
 
   @Test

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/agentinstance/ZeebeAgentInstanceDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/agentinstance/ZeebeAgentInstanceDataDto.java
@@ -24,6 +24,7 @@ public class ZeebeAgentInstanceDataDto implements AgentInstanceRecordValue {
   private List<Long> elementInstanceKeys = new ArrayList<>();
   private String elementId;
   private long processInstanceKey;
+  private long rootProcessInstanceKey;
   private String bpmnProcessId;
   private long processDefinitionKey;
   private int processDefinitionVersion;
@@ -83,6 +84,15 @@ public class ZeebeAgentInstanceDataDto implements AgentInstanceRecordValue {
 
   public void setProcessInstanceKey(final long processInstanceKey) {
     this.processInstanceKey = processInstanceKey;
+  }
+
+  @Override
+  public long getRootProcessInstanceKey() {
+    return rootProcessInstanceKey;
+  }
+
+  public void setRootProcessInstanceKey(final long rootProcessInstanceKey) {
+    this.rootProcessInstanceKey = rootProcessInstanceKey;
   }
 
   @Override
@@ -173,6 +183,24 @@ public class ZeebeAgentInstanceDataDto implements AgentInstanceRecordValue {
   }
 
   @Override
+  public int hashCode() {
+    return Objects.hash(
+        agentInstanceKey,
+        elementInstanceKey,
+        elementId,
+        processInstanceKey,
+        rootProcessInstanceKey,
+        bpmnProcessId,
+        processDefinitionKey,
+        processDefinitionVersion,
+        tenantId,
+        status,
+        definition,
+        metrics,
+        tools);
+  }
+
+  @Override
   public boolean equals(final Object o) {
     if (o == null || getClass() != o.getClass()) {
       return false;
@@ -181,6 +209,7 @@ public class ZeebeAgentInstanceDataDto implements AgentInstanceRecordValue {
     return agentInstanceKey == that.agentInstanceKey
         && elementInstanceKey == that.elementInstanceKey
         && processInstanceKey == that.processInstanceKey
+        && rootProcessInstanceKey == that.rootProcessInstanceKey
         && processDefinitionKey == that.processDefinitionKey
         && processDefinitionVersion == that.processDefinitionVersion
         && Objects.equals(elementId, that.elementId)
@@ -193,23 +222,6 @@ public class ZeebeAgentInstanceDataDto implements AgentInstanceRecordValue {
   }
 
   @Override
-  public int hashCode() {
-    return Objects.hash(
-        agentInstanceKey,
-        elementInstanceKey,
-        elementId,
-        processInstanceKey,
-        bpmnProcessId,
-        processDefinitionKey,
-        processDefinitionVersion,
-        tenantId,
-        status,
-        definition,
-        metrics,
-        tools);
-  }
-
-  @Override
   public String toString() {
     return "ZeebeAgentInstanceDataDto(agentInstanceKey="
         + agentInstanceKey
@@ -217,6 +229,8 @@ public class ZeebeAgentInstanceDataDto implements AgentInstanceRecordValue {
         + elementId
         + ", processInstanceKey="
         + processInstanceKey
+        + ", rootProcessInstanceKey="
+        + rootProcessInstanceKey
         + ", bpmnProcessId="
         + bpmnProcessId
         + ", processDefinitionKey="
@@ -243,6 +257,7 @@ public class ZeebeAgentInstanceDataDto implements AgentInstanceRecordValue {
     public static final String elementInstanceKey = "elementInstanceKey";
     public static final String elementId = "elementId";
     public static final String processInstanceKey = "processInstanceKey";
+    public static final String rootProcessInstanceKey = "rootProcessInstanceKey";
     public static final String bpmnProcessId = "bpmnProcessId";
     public static final String processDefinitionKey = "processDefinitionKey";
     public static final String processDefinitionVersion = "processDefinitionVersion";
@@ -289,6 +304,11 @@ public class ZeebeAgentInstanceDataDto implements AgentInstanceRecordValue {
     }
 
     @Override
+    public int hashCode() {
+      return Objects.hash(model, provider, systemPrompt);
+    }
+
+    @Override
     public boolean equals(final Object o) {
       if (o == null || getClass() != o.getClass()) {
         return false;
@@ -297,11 +317,6 @@ public class ZeebeAgentInstanceDataDto implements AgentInstanceRecordValue {
       return Objects.equals(model, that.model)
           && Objects.equals(provider, that.provider)
           && Objects.equals(systemPrompt, that.systemPrompt);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(model, provider, systemPrompt);
     }
 
     @Override
@@ -356,6 +371,11 @@ public class ZeebeAgentInstanceDataDto implements AgentInstanceRecordValue {
     }
 
     @Override
+    public int hashCode() {
+      return Objects.hash(inputTokens, outputTokens, modelCalls, toolCalls);
+    }
+
+    @Override
     public boolean equals(final Object o) {
       if (o == null || getClass() != o.getClass()) {
         return false;
@@ -365,11 +385,6 @@ public class ZeebeAgentInstanceDataDto implements AgentInstanceRecordValue {
           && outputTokens == that.outputTokens
           && modelCalls == that.modelCalls
           && toolCalls == that.toolCalls;
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(inputTokens, outputTokens, modelCalls, toolCalls);
     }
 
     @Override
@@ -422,6 +437,11 @@ public class ZeebeAgentInstanceDataDto implements AgentInstanceRecordValue {
     }
 
     @Override
+    public int hashCode() {
+      return Objects.hash(name, description, elementId);
+    }
+
+    @Override
     public boolean equals(final Object o) {
       if (o == null || getClass() != o.getClass()) {
         return false;
@@ -430,11 +450,6 @@ public class ZeebeAgentInstanceDataDto implements AgentInstanceRecordValue {
       return Objects.equals(name, that.name)
           && Objects.equals(description, that.description)
           && Objects.equals(elementId, that.elementId);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(name, description, elementId);
     }
 
     @Override

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceFetchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceFetchIT.java
@@ -161,7 +161,7 @@ public class AgentInstanceFetchIT {
           softly
               .assertThat(response.getRootProcessInstanceKey())
               .as("rootProcessInstanceKey")
-              .isEqualTo(-1L);
+              .isEqualTo(processInstanceKey1);
           softly
               .assertThat(response.getProcessDefinitionId())
               .as("processDefinitionId")
@@ -218,7 +218,7 @@ public class AgentInstanceFetchIT {
           softly
               .assertThat(response.getRootProcessInstanceKey())
               .as("rootProcessInstanceKey")
-              .isEqualTo(-1L);
+              .isEqualTo(processInstanceKey2);
           softly
               .assertThat(response.getProcessDefinitionId())
               .as("processDefinitionId")

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/AgentInstanceFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/AgentInstanceFixtures.java
@@ -24,12 +24,13 @@ public final class AgentInstanceFixtures extends CommonFixtures {
   public static AgentInstanceDbModel createRandomAgentInstance(
       final Function<Builder, Builder> builderFunction) {
     final var key = nextKey();
+    final var processInstanceKey = nextKey();
     final var builder =
         new Builder()
             .agentInstanceKey(key)
             .elementId("element-" + key)
-            .processInstanceKey(nextKey())
-            .rootProcessInstanceKey(-1L)
+            .processInstanceKey(processInstanceKey)
+            .rootProcessInstanceKey(processInstanceKey)
             .processDefinitionId("process-" + nextStringKey())
             .processDefinitionKey(nextKey())
             .processDefinitionVersion(1)

--- a/search/search-domain/src/main/java/io/camunda/search/entities/AgentInstanceEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/AgentInstanceEntity.java
@@ -25,7 +25,7 @@ public record AgentInstanceEntity(
     List<AgentInstanceTool> tools,
     String elementId,
     Long processInstanceKey,
-    @Nullable Long rootProcessInstanceKey,
+    Long rootProcessInstanceKey,
     Long processDefinitionKey,
     String processDefinitionId,
     Integer processDefinitionVersion,
@@ -44,6 +44,7 @@ public record AgentInstanceEntity(
     Objects.requireNonNull(limits, "limits");
     Objects.requireNonNull(elementId, "elementId");
     Objects.requireNonNull(processInstanceKey, "processInstanceKey");
+    Objects.requireNonNull(rootProcessInstanceKey, "rootProcessInstanceKey");
     Objects.requireNonNull(processDefinitionKey, "processDefinitionKey");
     Objects.requireNonNull(processDefinitionId, "processDefinitionId");
     Objects.requireNonNull(processDefinitionVersion, "processDefinitionVersion");

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
@@ -155,6 +155,7 @@ public final class AgentInstanceCreateProcessor
             .setElementId(elementInstanceValue.getElementId())
             .setBpmnProcessId(elementInstanceValue.getBpmnProcessId())
             .setProcessInstanceKey(elementInstanceValue.getProcessInstanceKey())
+            .setRootProcessInstanceKey(elementInstanceValue.getRootProcessInstanceKey())
             .setProcessDefinitionKey(elementInstanceValue.getProcessDefinitionKey())
             .setProcessDefinitionVersion(elementInstanceValue.getVersion())
             .setVersionTag(deployedProcess == null ? "" : deployedProcess.getVersionTag())

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateTest.java
@@ -34,6 +34,7 @@ public class AgentInstanceCreateTest {
   @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
 
   private static final String PROCESS_ID = "process";
+  private static final String CHILD_PROCESS_ID = "child-process";
   private static final String SERVICE_TASK_ID = "service-task";
   private static final String AD_HOC_SUB_PROCESS_ID = "ad-hoc-subprocess";
 
@@ -125,12 +126,53 @@ public class AgentInstanceCreateTest {
     assertThat(created.getValue().getElementId()).isEqualTo(customElementId);
     assertThat(created.getValue().getBpmnProcessId()).isEqualTo(PROCESS_ID);
     assertThat(created.getValue().getProcessInstanceKey()).isEqualTo(processInstanceKey);
+    assertThat(created.getValue().getRootProcessInstanceKey()).isEqualTo(processInstanceKey);
     assertThat(created.getValue().getProcessDefinitionKey())
         .isEqualTo(processMetadata.getProcessDefinitionKey());
     assertThat(created.getValue().getProcessDefinitionVersion())
         .isEqualTo(processMetadata.getVersion());
     assertThat(created.getValue().getTenantId())
         .isEqualTo(elementInstance.getValue().getTenantId());
+  }
+
+  @Test
+  public void shouldSetRootProcessInstanceKeyToTopLevelParentForCallActivity() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            "parent.bpmn",
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .callActivity("call", c -> c.zeebeProcessId(CHILD_PROCESS_ID))
+                .endEvent()
+                .done())
+        .withXmlResource(
+            "child.bpmn",
+            Bpmn.createExecutableProcess(CHILD_PROCESS_ID)
+                .startEvent()
+                .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType("agent"))
+                .endEvent()
+                .done())
+        .deploy();
+    final var rootProcessInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var childProcessInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withParentProcessInstanceKey(rootProcessInstanceKey)
+            .withElementType(BpmnElementType.PROCESS)
+            .getFirst();
+    final var childServiceTaskInstance = awaitServiceTaskActivated(childProcessInstance.getKey());
+
+    // when
+    final var created =
+        ENGINE.agentInstances().withElementInstanceKey(childServiceTaskInstance.getKey()).create();
+
+    // then
+    assertThat(created.getValue().getProcessInstanceKey()).isEqualTo(childProcessInstance.getKey());
+    assertThat(created.getValue().getRootProcessInstanceKey()).isEqualTo(rootProcessInstanceKey);
+    assertThat(created.getValue().getRootProcessInstanceKey())
+        .isNotEqualTo(childProcessInstance.getKey());
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AgentInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AgentInstanceHandler.java
@@ -90,10 +90,7 @@ public class AgentInstanceHandler
         .setPartitionId(record.getPartitionId())
         .setElementId(value.getElementId())
         .setProcessInstanceKey(value.getProcessInstanceKey())
-        // `value.getRootProcessInstanceKey()` is not yet available in the record, so we set it to
-        // -1 for now. Once it is available, this line should be updated to use the actual value.
-        // tracked by: https://github.com/camunda/camunda/issues/53236
-        .setRootProcessInstanceKey(-1)
+        .setRootProcessInstanceKey(value.getRootProcessInstanceKey())
         .setBpmnProcessId(value.getBpmnProcessId())
         .setProcessDefinitionKey(value.getProcessDefinitionKey())
         .setProcessDefinitionVersion(value.getProcessDefinitionVersion())

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentInstanceHandlerTest.java
@@ -95,6 +95,7 @@ final class AgentInstanceHandlerTest {
     final long elementInstanceKey = 200L;
     final String elementId = "elementId";
     final long processInstanceKey = 300L;
+    final long rootProcessInstanceKey = 250L;
     final String bpmnProcessId = "myProcess";
     final long processDefinitionKey = 400L;
     final int processDefinitionVersion = 2;
@@ -124,6 +125,7 @@ final class AgentInstanceHandlerTest {
             .withElementInstanceKey(elementInstanceKey)
             .withElementId(elementId)
             .withProcessInstanceKey(processInstanceKey)
+            .withRootProcessInstanceKey(rootProcessInstanceKey)
             .withBpmnProcessId(bpmnProcessId)
             .withProcessDefinitionKey(processDefinitionKey)
             .withProcessDefinitionVersion(processDefinitionVersion)
@@ -175,7 +177,7 @@ final class AgentInstanceHandlerTest {
     assertThat(entity.getPartitionId()).isEqualTo(partitionId);
     assertThat(entity.getElementId()).isEqualTo(elementId);
     assertThat(entity.getProcessInstanceKey()).isEqualTo(processInstanceKey);
-    assertThat(entity.getRootProcessInstanceKey()).isEqualTo(-1L);
+    assertThat(entity.getRootProcessInstanceKey()).isEqualTo(rootProcessInstanceKey);
     assertThat(entity.getBpmnProcessId()).isEqualTo(bpmnProcessId);
     assertThat(entity.getProcessDefinitionKey()).isEqualTo(processDefinitionKey);
     assertThat(entity.getProcessDefinitionVersion()).isEqualTo(processDefinitionVersion);
@@ -409,6 +411,7 @@ final class AgentInstanceHandlerTest {
   private AgentInstanceRecordValue buildMinimalRecordValue(final long agentInstanceKey) {
     return ImmutableAgentInstanceRecordValue.builder()
         .withAgentInstanceKey(agentInstanceKey)
+        .withRootProcessInstanceKey(50L)
         .withStatus(io.camunda.zeebe.protocol.record.value.AgentInstanceStatus.IDLE)
         .withDefinition(
             ImmutableAgentInstanceDefinitionValue.builder()

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-agent-instance-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-agent-instance-template.json
@@ -34,6 +34,9 @@
             "processInstanceKey": {
               "type": "long"
             },
+            "rootProcessInstanceKey": {
+              "type": "long"
+            },
             "bpmnProcessId": {
               "type": "keyword"
             },

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-agent-instance-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-agent-instance-template.json
@@ -40,6 +40,9 @@
             "processInstanceKey": {
               "type": "long"
             },
+            "rootProcessInstanceKey": {
+              "type": "long"
+            },
             "bpmnProcessId": {
               "type": "keyword"
             },

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/AgentInstanceExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/AgentInstanceExportHandler.java
@@ -65,9 +65,7 @@ public class AgentInstanceExportHandler implements RdbmsExportHandler<AgentInsta
             .agentInstanceKey(record.getKey())
             .elementId(value.getElementId())
             .processInstanceKey(value.getProcessInstanceKey())
-            // `rootProcessInstanceKey` is not yet available on the record — use -1 sentinel
-            // until https://github.com/camunda/camunda/issues/53236 lands, matching PR-2.
-            .rootProcessInstanceKey(-1L)
+            .rootProcessInstanceKey(value.getRootProcessInstanceKey())
             .processDefinitionId(value.getBpmnProcessId())
             .processDefinitionKey(value.getProcessDefinitionKey())
             .processDefinitionVersion(value.getProcessDefinitionVersion())

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/AgentInstanceExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/AgentInstanceExportHandlerTest.java
@@ -112,7 +112,7 @@ class AgentInstanceExportHandlerTest {
     assertThat(model.agentInstanceKey()).isEqualTo(agentKey);
     assertThat(model.elementId()).isEqualTo("myElement");
     assertThat(model.processInstanceKey()).isEqualTo(100L);
-    assertThat(model.rootProcessInstanceKey()).isEqualTo(-1L);
+    assertThat(model.rootProcessInstanceKey()).isEqualTo(50L);
     assertThat(model.processDefinitionId()).isEqualTo("myProcess");
     assertThat(model.processDefinitionKey()).isEqualTo(200L);
     assertThat(model.processDefinitionVersion()).isEqualTo(3);
@@ -300,6 +300,7 @@ class AgentInstanceExportHandlerTest {
         .withElementInstanceKeys(List.of(200L, 300L))
         .withElementId("myElement")
         .withProcessInstanceKey(100L)
+        .withRootProcessInstanceKey(50L)
         .withBpmnProcessId("myProcess")
         .withProcessDefinitionKey(200L)
         .withProcessDefinitionVersion(3)

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -342,7 +342,6 @@ components:
           description: |
             The key of the root process instance. The root process instance is the top-level
             ancestor in the process instance hierarchy.
-          nullable: true
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
         processDefinitionKey:

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceRecord.java
@@ -31,6 +31,8 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
       new ArrayProperty<>("elementInstanceKeys", LongValue::new);
   private final StringProperty elementIdProp = new StringProperty("elementId", "");
   private final LongProperty processInstanceKeyProp = new LongProperty("processInstanceKey", -1L);
+  private final LongProperty rootProcessInstanceKeyProp =
+      new LongProperty("rootProcessInstanceKey", -1L);
   private final StringProperty bpmnProcessIdProp = new StringProperty("bpmnProcessId", "");
   private final LongProperty processDefinitionKeyProp =
       new LongProperty("processDefinitionKey", -1L);
@@ -53,12 +55,13 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
       new ArrayProperty<>("changedAttributes", StringValue::new);
 
   public AgentInstanceRecord() {
-    super(16);
+    super(17);
     declareProperty(agentInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
         .declareProperty(elementInstanceKeysProp)
         .declareProperty(elementIdProp)
         .declareProperty(processInstanceKeyProp)
+        .declareProperty(rootProcessInstanceKeyProp)
         .declareProperty(bpmnProcessIdProp)
         .declareProperty(processDefinitionKeyProp)
         .declareProperty(processDefinitionVersionProp)
@@ -147,6 +150,16 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
 
   public AgentInstanceRecord setProcessDefinitionKey(final long processDefinitionKey) {
     processDefinitionKeyProp.setValue(processDefinitionKey);
+    return this;
+  }
+
+  @Override
+  public long getRootProcessInstanceKey() {
+    return rootProcessInstanceKeyProp.getValue();
+  }
+
+  public AgentInstanceRecord setRootProcessInstanceKey(final long rootProcessInstanceKey) {
+    rootProcessInstanceKeyProp.setValue(rootProcessInstanceKey);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -4696,6 +4696,7 @@ final class JsonSerializableToJsonTest {
                       .setElementInstanceKeys(List.of(2251799813685248L, 2251799813685249L))
                       .setElementId("invoice-data-extraction-agent")
                       .setProcessInstanceKey(2251799813685248L)
+                      .setRootProcessInstanceKey(2251799813685248L)
                       .setBpmnProcessId("invoice-handling-process")
                       .setProcessDefinitionKey(2251799813685100L)
                       .setProcessDefinitionVersion(3)
@@ -4733,6 +4734,7 @@ final class JsonSerializableToJsonTest {
           "elementInstanceKeys": [2251799813685248, 2251799813685249],
           "elementId": "invoice-data-extraction-agent",
           "processInstanceKey": 2251799813685248,
+          "rootProcessInstanceKey": 2251799813685248,
           "bpmnProcessId": "invoice-handling-process",
           "processDefinitionKey": 2251799813685100,
           "processDefinitionVersion": 3,
@@ -4764,6 +4766,7 @@ final class JsonSerializableToJsonTest {
           "elementInstanceKeys": [],
           "elementId": "",
           "processInstanceKey": -1,
+          "rootProcessInstanceKey": -1,
           "bpmnProcessId": "",
           "processDefinitionKey": -1,
           "processDefinitionVersion": -1,

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceRecordTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceRecordTest.java
@@ -30,6 +30,7 @@ final class AgentInstanceRecordTest {
     assertThat(record.getProcessInstanceKey()).isEqualTo(-1L);
     assertThat(record.getBpmnProcessId()).isEmpty();
     assertThat(record.getProcessDefinitionKey()).isEqualTo(-1L);
+    assertThat(record.getRootProcessInstanceKey()).isEqualTo(-1L);
     assertThat(record.getProcessDefinitionVersion()).isEqualTo(-1);
     assertThat(record.getVersionTag()).isEmpty();
     assertThat(record.getTenantId()).isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
@@ -46,6 +47,7 @@ final class AgentInstanceRecordTest {
             .setProcessInstanceKey(2251799813685248L)
             .setBpmnProcessId("invoice-handling-process")
             .setProcessDefinitionKey(2251799813685100L)
+            .setRootProcessInstanceKey(2251799813685000L)
             .setProcessDefinitionVersion(3)
             .setVersionTag("v1.2")
             .setTenantId("acme");
@@ -61,6 +63,7 @@ final class AgentInstanceRecordTest {
     assertThat(copy.getProcessInstanceKey()).isEqualTo(original.getProcessInstanceKey());
     assertThat(copy.getBpmnProcessId()).isEqualTo(original.getBpmnProcessId());
     assertThat(copy.getProcessDefinitionKey()).isEqualTo(original.getProcessDefinitionKey());
+    assertThat(copy.getRootProcessInstanceKey()).isEqualTo(original.getRootProcessInstanceKey());
     assertThat(copy.getProcessDefinitionVersion())
         .isEqualTo(original.getProcessDefinitionVersion());
     assertThat(copy.getVersionTag()).isEqualTo(original.getVersionTag());

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentInstanceRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentInstanceRecord.golden
@@ -31,6 +31,8 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
       new ArrayProperty<>("elementInstanceKeys", LongValue::new);
   private final StringProperty elementIdProp = new StringProperty("elementId", "");
   private final LongProperty processInstanceKeyProp = new LongProperty("processInstanceKey", -1L);
+  private final LongProperty rootProcessInstanceKeyProp =
+      new LongProperty("rootProcessInstanceKey", -1L);
   private final StringProperty bpmnProcessIdProp = new StringProperty("bpmnProcessId", "");
   private final LongProperty processDefinitionKeyProp =
       new LongProperty("processDefinitionKey", -1L);
@@ -53,12 +55,13 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
       new ArrayProperty<>("changedAttributes", StringValue::new);
 
   public AgentInstanceRecord() {
-    super(16);
+    super(17);
     declareProperty(agentInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
         .declareProperty(elementInstanceKeysProp)
         .declareProperty(elementIdProp)
         .declareProperty(processInstanceKeyProp)
+        .declareProperty(rootProcessInstanceKeyProp)
         .declareProperty(bpmnProcessIdProp)
         .declareProperty(processDefinitionKeyProp)
         .declareProperty(processDefinitionVersionProp)
@@ -147,6 +150,16 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
 
   public AgentInstanceRecord setProcessDefinitionKey(final long processDefinitionKey) {
     processDefinitionKeyProp.setValue(processDefinitionKey);
+    return this;
+  }
+
+  @Override
+  public long getRootProcessInstanceKey() {
+    return rootProcessInstanceKeyProp.getValue();
+  }
+
+  public AgentInstanceRecord setRootProcessInstanceKey(final long rootProcessInstanceKey) {
+    rootProcessInstanceKeyProp.setValue(rootProcessInstanceKey);
     return this;
   }
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentInstanceRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentInstanceRecordValue.java
@@ -52,6 +52,12 @@ public interface AgentInstanceRecordValue extends RecordValue, ProcessInstanceRe
   long getProcessInstanceKey();
 
   /**
+   * @return the key of the root process instance in the hierarchy; for top-level process instances,
+   *     this is equal to {@link #getProcessInstanceKey()}
+   */
+  long getRootProcessInstanceKey();
+
+  /**
    * @return the BPMN process ID of the process definition containing this agent
    */
   String getBpmnProcessId();


### PR DESCRIPTION
## Description

Adds `rootProcessInstanceKey` to the `AGENT_INSTANCE` Zeebe record and wires it through the full data pipeline so the archiver can correctly cascade-delete agent instance documents when a root process instance is cleaned up — including cases where the agent instance was spawned inside a call-activity sub-process.

### Why

The archiver queries secondary storage by `rootProcessInstanceKey` to find all documents belonging to a finished process hierarchy. Without this field on `AGENT_INSTANCE`, agent instances created inside call activities would never be archived, causing storage to grow unboundedly over time.

The field is always set once at creation and never mutated, matching the semantics of the same field on `JOB` and `USER_TASK` records.

### What was done

- Added `getRootProcessInstanceKey()` to `AgentInstanceRecordValue` protocol interface
  and `AgentInstanceRecord` implementation
- Populated the field in `AgentInstanceCreateProcessor`: equals `processInstanceKey`
  when at the root level, or the inherited root key when inside a call activity
- Added the field to Zeebe ES/OS raw record index templates (required due to `dynamic: strict`)
- Mapped the field in both Camunda Exporter and RDBMS Exporter handlers
- Made `rootProcessInstanceKey` non-nullable throughout the AgentInstance stack
  (safe: feature is 8.10-SNAPSHOT only, no production data exists)
- Removed `nullable: true` from the OpenAPI `AgentInstanceResult` schema to align
  the contract with the implementation

### Out of scope

Filtering and sorting by `rootProcessInstanceKey` in the query API will be addressed
either in a dedicated follow-up PR or as part of [#53823](https://github.com/camunda/camunda/issues/53823).

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

Closes #53236