### PR TITLE
feat: add ProcessViewAgent metric interpreters

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/view/process/agent/AbstractProcessViewAgentMetricInterpreterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/view/process/agent/AbstractProcessViewAgentMetricInterpreterES.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.es.report.interpreter.view.process.agent;
+
+import co.elastic.clients.elasticsearch._types.Script;
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregate;
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregation;
+import co.elastic.clients.elasticsearch.core.search.ResponseBody;
+import co.elastic.clients.util.Pair;
+import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
+import io.camunda.optimize.service.db.es.report.aggregations.AggregationStrategyES;
+import io.camunda.optimize.service.db.es.report.interpreter.view.process.AbstractProcessViewMultiAggregationInterpreterES;
+import io.camunda.optimize.service.db.report.ExecutionContext;
+import io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan;
+import io.camunda.optimize.service.db.report.result.CompositeCommandResult.ViewMeasure;
+import io.camunda.optimize.service.db.report.result.CompositeCommandResult.ViewResult;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public abstract class AbstractProcessViewAgentMetricInterpreterES
+    extends AbstractProcessViewMultiAggregationInterpreterES {
+
+  @Override
+  public Map<String, Aggregation.Builder.ContainerBuilder> createAggregations(
+      final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context) {
+    final String aggregationFieldName = getAggregationFieldName();
+    final Script aggregationScript = getAggregationScript();
+
+    return getAggregationStrategies(context.getReportData()).stream()
+        .map(
+            strategy ->
+                aggregationFieldName == null
+                    ? strategy.createAggregationBuilder(aggregationScript)
+                    : strategy.createAggregationBuilder(aggregationScript, aggregationFieldName))
+        .collect(Collectors.toMap(Pair::key, Pair::value));
+  }
+
+  @Override
+  public ViewResult retrieveResult(
+      final ResponseBody<?> response,
+      final Map<String, Aggregate> aggs,
+      final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context) {
+    final ViewResult.ViewResultBuilder viewResultBuilder = ViewResult.builder();
+    for (final AggregationStrategyES<?> aggregationStrategy :
+        getAggregationStrategies(context.getReportData())) {
+      viewResultBuilder.viewMeasure(
+          ViewMeasure.builder()
+              .aggregationType(aggregationStrategy.getAggregationType())
+              .value(aggregationStrategy.getValue(aggs))
+              .build());
+    }
+    return viewResultBuilder.build();
+  }
+
+  protected String getAggregationFieldName() {
+    return null;
+  }
+
+  protected Script getAggregationScript() {
+    return null;
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/view/process/agent/AbstractProcessViewAgentMetricInterpreterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/view/process/agent/AbstractProcessViewAgentMetricInterpreterES.java
@@ -31,6 +31,13 @@ public abstract class AbstractProcessViewAgentMetricInterpreterES
     final String aggregationFieldName = getAggregationFieldName();
     final Script aggregationScript = getAggregationScript();
 
+    // A subclass must supply a field name or a script for the metric.
+    if (aggregationFieldName == null && aggregationScript == null) {
+      throw new IllegalStateException(
+          getClass().getSimpleName()
+              + " must override getAggregationFieldName() or getAggregationScript()");
+    }
+
     return getAggregationStrategies(context.getReportData()).stream()
         .map(
             strategy ->

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/view/process/agent/ProcessViewAgentInputTokensInterpreterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/view/process/agent/ProcessViewAgentInputTokensInterpreterES.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.es.report.interpreter.view.process.agent;
+
+import static io.camunda.optimize.service.db.report.plan.process.ProcessView.PROCESS_VIEW_AGENT_INPUT_TOKENS;
+
+import io.camunda.optimize.service.db.report.plan.process.ProcessView;
+import io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex;
+import io.camunda.optimize.service.util.configuration.condition.ElasticSearchCondition;
+import java.util.Set;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+
+@Component
+@Conditional(ElasticSearchCondition.class)
+public class ProcessViewAgentInputTokensInterpreterES
+    extends AbstractProcessViewAgentMetricInterpreterES {
+
+  @Override
+  public Set<ProcessView> getSupportedViews() {
+    return Set.of(PROCESS_VIEW_AGENT_INPUT_TOKENS);
+  }
+
+  @Override
+  protected String getAggregationFieldName() {
+    return ProcessInstanceIndex.AGENT_TOTAL_INPUT_TOKENS;
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/view/process/agent/ProcessViewAgentOutputTokensInterpreterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/view/process/agent/ProcessViewAgentOutputTokensInterpreterES.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.es.report.interpreter.view.process.agent;
+
+import static io.camunda.optimize.service.db.report.plan.process.ProcessView.PROCESS_VIEW_AGENT_OUTPUT_TOKENS;
+
+import io.camunda.optimize.service.db.report.plan.process.ProcessView;
+import io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex;
+import io.camunda.optimize.service.util.configuration.condition.ElasticSearchCondition;
+import java.util.Set;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+
+@Component
+@Conditional(ElasticSearchCondition.class)
+public class ProcessViewAgentOutputTokensInterpreterES
+    extends AbstractProcessViewAgentMetricInterpreterES {
+
+  @Override
+  public Set<ProcessView> getSupportedViews() {
+    return Set.of(PROCESS_VIEW_AGENT_OUTPUT_TOKENS);
+  }
+
+  @Override
+  protected String getAggregationFieldName() {
+    return ProcessInstanceIndex.AGENT_TOTAL_OUTPUT_TOKENS;
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/view/process/agent/ProcessViewAgentToolCallsInterpreterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/view/process/agent/ProcessViewAgentToolCallsInterpreterES.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.es.report.interpreter.view.process.agent;
+
+import static io.camunda.optimize.service.db.report.plan.process.ProcessView.PROCESS_VIEW_AGENT_TOOL_CALLS;
+
+import io.camunda.optimize.service.db.report.plan.process.ProcessView;
+import io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex;
+import io.camunda.optimize.service.util.configuration.condition.ElasticSearchCondition;
+import java.util.Set;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+
+@Component
+@Conditional(ElasticSearchCondition.class)
+public class ProcessViewAgentToolCallsInterpreterES
+    extends AbstractProcessViewAgentMetricInterpreterES {
+
+  @Override
+  public Set<ProcessView> getSupportedViews() {
+    return Set.of(PROCESS_VIEW_AGENT_TOOL_CALLS);
+  }
+
+  @Override
+  protected String getAggregationFieldName() {
+    return ProcessInstanceIndex.AGENT_TOTAL_TOOL_CALLS;
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/view/process/agent/ProcessViewAgentTotalTokensInterpreterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/view/process/agent/ProcessViewAgentTotalTokensInterpreterES.java
@@ -11,8 +11,8 @@ import static io.camunda.optimize.service.db.report.plan.process.ProcessView.PRO
 
 import co.elastic.clients.elasticsearch._types.Script;
 import io.camunda.optimize.service.db.es.writer.ElasticsearchWriterUtil;
+import io.camunda.optimize.service.db.report.interpreter.view.process.agent.AgentMetricScripts;
 import io.camunda.optimize.service.db.report.plan.process.ProcessView;
-import io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex;
 import io.camunda.optimize.service.util.configuration.condition.ElasticSearchCondition;
 import java.util.Set;
 import org.springframework.context.annotation.Conditional;
@@ -23,19 +23,6 @@ import org.springframework.stereotype.Component;
 public class ProcessViewAgentTotalTokensInterpreterES
     extends AbstractProcessViewAgentMetricInterpreterES {
 
-  private static final String TOTAL_TOKENS_SCRIPT =
-      "long inputTokens = doc['"
-          + ProcessInstanceIndex.AGENT_TOTAL_INPUT_TOKENS
-          + "'].empty ? 0L : doc['"
-          + ProcessInstanceIndex.AGENT_TOTAL_INPUT_TOKENS
-          + "'].value;"
-          + "long outputTokens = doc['"
-          + ProcessInstanceIndex.AGENT_TOTAL_OUTPUT_TOKENS
-          + "'].empty ? 0L : doc['"
-          + ProcessInstanceIndex.AGENT_TOTAL_OUTPUT_TOKENS
-          + "'].value;"
-          + "return inputTokens + outputTokens;";
-
   @Override
   public Set<ProcessView> getSupportedViews() {
     return Set.of(PROCESS_VIEW_AGENT_TOTAL_TOKENS);
@@ -43,6 +30,6 @@ public class ProcessViewAgentTotalTokensInterpreterES
 
   @Override
   protected Script getAggregationScript() {
-    return ElasticsearchWriterUtil.createDefaultScript(TOTAL_TOKENS_SCRIPT);
+    return ElasticsearchWriterUtil.createDefaultScript(AgentMetricScripts.TOTAL_TOKENS);
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/view/process/agent/ProcessViewAgentTotalTokensInterpreterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/view/process/agent/ProcessViewAgentTotalTokensInterpreterES.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.es.report.interpreter.view.process.agent;
+
+import static io.camunda.optimize.service.db.report.plan.process.ProcessView.PROCESS_VIEW_AGENT_TOTAL_TOKENS;
+
+import co.elastic.clients.elasticsearch._types.Script;
+import io.camunda.optimize.service.db.es.writer.ElasticsearchWriterUtil;
+import io.camunda.optimize.service.db.report.plan.process.ProcessView;
+import io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex;
+import io.camunda.optimize.service.util.configuration.condition.ElasticSearchCondition;
+import java.util.Set;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+
+@Component
+@Conditional(ElasticSearchCondition.class)
+public class ProcessViewAgentTotalTokensInterpreterES
+    extends AbstractProcessViewAgentMetricInterpreterES {
+
+  private static final String TOTAL_TOKENS_SCRIPT =
+      "long inputTokens = doc['"
+          + ProcessInstanceIndex.AGENT_TOTAL_INPUT_TOKENS
+          + "'].empty ? 0L : doc['"
+          + ProcessInstanceIndex.AGENT_TOTAL_INPUT_TOKENS
+          + "'].value;"
+          + "long outputTokens = doc['"
+          + ProcessInstanceIndex.AGENT_TOTAL_OUTPUT_TOKENS
+          + "'].empty ? 0L : doc['"
+          + ProcessInstanceIndex.AGENT_TOTAL_OUTPUT_TOKENS
+          + "'].value;"
+          + "return inputTokens + outputTokens;";
+
+  @Override
+  public Set<ProcessView> getSupportedViews() {
+    return Set.of(PROCESS_VIEW_AGENT_TOTAL_TOKENS);
+  }
+
+  @Override
+  protected Script getAggregationScript() {
+    return ElasticsearchWriterUtil.createDefaultScript(TOTAL_TOKENS_SCRIPT);
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/view/process/agent/AbstractProcessViewAgentMetricInterpreterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/view/process/agent/AbstractProcessViewAgentMetricInterpreterOS.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.os.report.interpreter.view.process.agent;
+
+import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
+import io.camunda.optimize.service.db.os.report.aggregations.AggregationStrategyOS;
+import io.camunda.optimize.service.db.os.report.interpreter.RawResult;
+import io.camunda.optimize.service.db.os.report.interpreter.view.process.AbstractProcessViewMultiAggregationInterpreterOS;
+import io.camunda.optimize.service.db.report.ExecutionContext;
+import io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan;
+import io.camunda.optimize.service.db.report.result.CompositeCommandResult.ViewMeasure;
+import io.camunda.optimize.service.db.report.result.CompositeCommandResult.ViewResult;
+import io.camunda.optimize.util.types.MapUtil;
+import java.util.Map;
+import org.opensearch.client.opensearch._types.Script;
+import org.opensearch.client.opensearch._types.aggregations.Aggregate;
+import org.opensearch.client.opensearch._types.aggregations.Aggregation;
+import org.opensearch.client.opensearch.core.SearchResponse;
+
+public abstract class AbstractProcessViewAgentMetricInterpreterOS
+    extends AbstractProcessViewMultiAggregationInterpreterOS {
+
+  @Override
+  public Map<String, Aggregation> createAggregations(
+      final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context) {
+    final String aggregationFieldName = getAggregationFieldName();
+    final Script aggregationScript = getAggregationScript();
+
+    return getAggregationStrategies(context.getReportData()).stream()
+        .map(
+            strategy ->
+                aggregationFieldName == null
+                    ? strategy.createAggregation(aggregationScript)
+                    : strategy.createAggregation(aggregationScript, aggregationFieldName))
+        .collect(MapUtil.pairCollector());
+  }
+
+  @Override
+  public ViewResult retrieveResult(
+      final SearchResponse<RawResult> response,
+      final Map<String, Aggregate> aggs,
+      final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context) {
+    final ViewResult.ViewResultBuilder viewResultBuilder = ViewResult.builder();
+    for (final AggregationStrategyOS aggregationStrategy :
+        getAggregationStrategies(context.getReportData())) {
+      viewResultBuilder.viewMeasure(
+          ViewMeasure.builder()
+              .aggregationType(aggregationStrategy.getAggregationType())
+              .value(aggregationStrategy.getValue(aggs))
+              .build());
+    }
+    return viewResultBuilder.build();
+  }
+
+  protected String getAggregationFieldName() {
+    return null;
+  }
+
+  protected Script getAggregationScript() {
+    return null;
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/view/process/agent/AbstractProcessViewAgentMetricInterpreterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/view/process/agent/AbstractProcessViewAgentMetricInterpreterOS.java
@@ -31,6 +31,13 @@ public abstract class AbstractProcessViewAgentMetricInterpreterOS
     final String aggregationFieldName = getAggregationFieldName();
     final Script aggregationScript = getAggregationScript();
 
+    // A subclass must supply a field name or a script for the metric.
+    if (aggregationFieldName == null && aggregationScript == null) {
+      throw new IllegalStateException(
+          getClass().getSimpleName()
+              + " must override getAggregationFieldName() or getAggregationScript()");
+    }
+
     return getAggregationStrategies(context.getReportData()).stream()
         .map(
             strategy ->

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/view/process/agent/ProcessViewAgentInputTokensInterpreterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/view/process/agent/ProcessViewAgentInputTokensInterpreterOS.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.os.report.interpreter.view.process.agent;
+
+import static io.camunda.optimize.service.db.report.plan.process.ProcessView.PROCESS_VIEW_AGENT_INPUT_TOKENS;
+
+import io.camunda.optimize.service.db.report.plan.process.ProcessView;
+import io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex;
+import io.camunda.optimize.service.util.configuration.condition.OpenSearchCondition;
+import java.util.Set;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+
+@Component
+@Conditional(OpenSearchCondition.class)
+public class ProcessViewAgentInputTokensInterpreterOS
+    extends AbstractProcessViewAgentMetricInterpreterOS {
+
+  @Override
+  public Set<ProcessView> getSupportedViews() {
+    return Set.of(PROCESS_VIEW_AGENT_INPUT_TOKENS);
+  }
+
+  @Override
+  protected String getAggregationFieldName() {
+    return ProcessInstanceIndex.AGENT_TOTAL_INPUT_TOKENS;
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/view/process/agent/ProcessViewAgentOutputTokensInterpreterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/view/process/agent/ProcessViewAgentOutputTokensInterpreterOS.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.os.report.interpreter.view.process.agent;
+
+import static io.camunda.optimize.service.db.report.plan.process.ProcessView.PROCESS_VIEW_AGENT_OUTPUT_TOKENS;
+
+import io.camunda.optimize.service.db.report.plan.process.ProcessView;
+import io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex;
+import io.camunda.optimize.service.util.configuration.condition.OpenSearchCondition;
+import java.util.Set;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+
+@Component
+@Conditional(OpenSearchCondition.class)
+public class ProcessViewAgentOutputTokensInterpreterOS
+    extends AbstractProcessViewAgentMetricInterpreterOS {
+
+  @Override
+  public Set<ProcessView> getSupportedViews() {
+    return Set.of(PROCESS_VIEW_AGENT_OUTPUT_TOKENS);
+  }
+
+  @Override
+  protected String getAggregationFieldName() {
+    return ProcessInstanceIndex.AGENT_TOTAL_OUTPUT_TOKENS;
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/view/process/agent/ProcessViewAgentToolCallsInterpreterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/view/process/agent/ProcessViewAgentToolCallsInterpreterOS.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.os.report.interpreter.view.process.agent;
+
+import static io.camunda.optimize.service.db.report.plan.process.ProcessView.PROCESS_VIEW_AGENT_TOOL_CALLS;
+
+import io.camunda.optimize.service.db.report.plan.process.ProcessView;
+import io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex;
+import io.camunda.optimize.service.util.configuration.condition.OpenSearchCondition;
+import java.util.Set;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+
+@Component
+@Conditional(OpenSearchCondition.class)
+public class ProcessViewAgentToolCallsInterpreterOS
+    extends AbstractProcessViewAgentMetricInterpreterOS {
+
+  @Override
+  public Set<ProcessView> getSupportedViews() {
+    return Set.of(PROCESS_VIEW_AGENT_TOOL_CALLS);
+  }
+
+  @Override
+  protected String getAggregationFieldName() {
+    return ProcessInstanceIndex.AGENT_TOTAL_TOOL_CALLS;
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/view/process/agent/ProcessViewAgentTotalTokensInterpreterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/view/process/agent/ProcessViewAgentTotalTokensInterpreterOS.java
@@ -10,8 +10,8 @@ package io.camunda.optimize.service.db.os.report.interpreter.view.process.agent;
 import static io.camunda.optimize.service.db.report.plan.process.ProcessView.PROCESS_VIEW_AGENT_TOTAL_TOKENS;
 
 import io.camunda.optimize.service.db.os.writer.OpenSearchWriterUtil;
+import io.camunda.optimize.service.db.report.interpreter.view.process.agent.AgentMetricScripts;
 import io.camunda.optimize.service.db.report.plan.process.ProcessView;
-import io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex;
 import io.camunda.optimize.service.util.configuration.condition.OpenSearchCondition;
 import java.util.Set;
 import org.opensearch.client.opensearch._types.Script;
@@ -23,19 +23,6 @@ import org.springframework.stereotype.Component;
 public class ProcessViewAgentTotalTokensInterpreterOS
     extends AbstractProcessViewAgentMetricInterpreterOS {
 
-  private static final String TOTAL_TOKENS_SCRIPT =
-      "long inputTokens = doc['"
-          + ProcessInstanceIndex.AGENT_TOTAL_INPUT_TOKENS
-          + "'].empty ? 0L : doc['"
-          + ProcessInstanceIndex.AGENT_TOTAL_INPUT_TOKENS
-          + "'].value;"
-          + "long outputTokens = doc['"
-          + ProcessInstanceIndex.AGENT_TOTAL_OUTPUT_TOKENS
-          + "'].empty ? 0L : doc['"
-          + ProcessInstanceIndex.AGENT_TOTAL_OUTPUT_TOKENS
-          + "'].value;"
-          + "return inputTokens + outputTokens;";
-
   @Override
   public Set<ProcessView> getSupportedViews() {
     return Set.of(PROCESS_VIEW_AGENT_TOTAL_TOKENS);
@@ -43,6 +30,6 @@ public class ProcessViewAgentTotalTokensInterpreterOS
 
   @Override
   protected Script getAggregationScript() {
-    return OpenSearchWriterUtil.createDefaultScript(TOTAL_TOKENS_SCRIPT);
+    return OpenSearchWriterUtil.createDefaultScript(AgentMetricScripts.TOTAL_TOKENS);
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/view/process/agent/ProcessViewAgentTotalTokensInterpreterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/view/process/agent/ProcessViewAgentTotalTokensInterpreterOS.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.os.report.interpreter.view.process.agent;
+
+import static io.camunda.optimize.service.db.report.plan.process.ProcessView.PROCESS_VIEW_AGENT_TOTAL_TOKENS;
+
+import io.camunda.optimize.service.db.os.writer.OpenSearchWriterUtil;
+import io.camunda.optimize.service.db.report.plan.process.ProcessView;
+import io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex;
+import io.camunda.optimize.service.util.configuration.condition.OpenSearchCondition;
+import java.util.Set;
+import org.opensearch.client.opensearch._types.Script;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+
+@Component
+@Conditional(OpenSearchCondition.class)
+public class ProcessViewAgentTotalTokensInterpreterOS
+    extends AbstractProcessViewAgentMetricInterpreterOS {
+
+  private static final String TOTAL_TOKENS_SCRIPT =
+      "long inputTokens = doc['"
+          + ProcessInstanceIndex.AGENT_TOTAL_INPUT_TOKENS
+          + "'].empty ? 0L : doc['"
+          + ProcessInstanceIndex.AGENT_TOTAL_INPUT_TOKENS
+          + "'].value;"
+          + "long outputTokens = doc['"
+          + ProcessInstanceIndex.AGENT_TOTAL_OUTPUT_TOKENS
+          + "'].empty ? 0L : doc['"
+          + ProcessInstanceIndex.AGENT_TOTAL_OUTPUT_TOKENS
+          + "'].value;"
+          + "return inputTokens + outputTokens;";
+
+  @Override
+  public Set<ProcessView> getSupportedViews() {
+    return Set.of(PROCESS_VIEW_AGENT_TOTAL_TOKENS);
+  }
+
+  @Override
+  protected Script getAggregationScript() {
+    return OpenSearchWriterUtil.createDefaultScript(TOTAL_TOKENS_SCRIPT);
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/interpreter/view/process/agent/AgentMetricScripts.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/interpreter/view/process/agent/AgentMetricScripts.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.report.interpreter.view.process.agent;
+
+import io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex;
+
+/**
+ * Painless scripts shared by the Elasticsearch and OpenSearch agent metric interpreters. The script
+ * bodies are database-agnostic (they reference only shared {@link ProcessInstanceIndex} field
+ * constants), so they live here rather than being duplicated per stack — see {@code
+ * AbstractProcessViewRawDataInterpreter} for the same pattern.
+ */
+public final class AgentMetricScripts {
+
+  /**
+   * Total tokens is derived (not a raw Zeebe field): the sum of the input and output token fields.
+   * The {@code .empty} guard handles non-agent docs that lack the fields — the index mapping's
+   * {@code null_value(0L)} only substitutes explicit nulls, not missing fields, so without the
+   * guard the script would throw on such docs.
+   */
+  public static final String TOTAL_TOKENS =
+      "long inputTokens = doc['"
+          + ProcessInstanceIndex.AGENT_TOTAL_INPUT_TOKENS
+          + "'].empty ? 0L : doc['"
+          + ProcessInstanceIndex.AGENT_TOTAL_INPUT_TOKENS
+          + "'].value;"
+          + "long outputTokens = doc['"
+          + ProcessInstanceIndex.AGENT_TOTAL_OUTPUT_TOKENS
+          + "'].empty ? 0L : doc['"
+          + ProcessInstanceIndex.AGENT_TOTAL_OUTPUT_TOKENS
+          + "'].value;"
+          + "return inputTokens + outputTokens;";
+
+  private AgentMetricScripts() {}
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/es/report/interpreter/view/process/agent/AbstractProcessViewAgentMetricInterpreterESTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/es/report/interpreter/view/process/agent/AbstractProcessViewAgentMetricInterpreterESTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.es.report.interpreter.view.process.agent;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.optimize.dto.optimize.query.report.single.configuration.AggregationType;
+import io.camunda.optimize.service.db.report.plan.process.ProcessView;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class AbstractProcessViewAgentMetricInterpreterESTest {
+
+  @Test
+  void createAggregationsThrowsWhenNeitherFieldNorScriptProvided() {
+    final var interpreter = new MissingSourceInterpreterES();
+    final var ctx = AgentInterpreterTestSupport.contextWith(AggregationType.SUM);
+    assertThatThrownBy(() -> interpreter.createAggregations(ctx))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("getAggregationFieldName")
+        .hasMessageContaining("getAggregationScript");
+  }
+
+  /** Subclass that overrides neither hook, exercising the fail-fast guard. */
+  private static final class MissingSourceInterpreterES
+      extends AbstractProcessViewAgentMetricInterpreterES {
+    @Override
+    public Set<ProcessView> getSupportedViews() {
+      return Set.of();
+    }
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/es/report/interpreter/view/process/agent/AgentInterpreterTestSupport.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/es/report/interpreter/view/process/agent/AgentInterpreterTestSupport.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.es.report.interpreter.view.process.agent;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.optimize.dto.optimize.query.report.single.configuration.AggregationDto;
+import io.camunda.optimize.dto.optimize.query.report.single.configuration.AggregationType;
+import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
+import io.camunda.optimize.service.db.report.ExecutionContext;
+import io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan;
+import java.util.Arrays;
+
+final class AgentInterpreterTestSupport {
+
+  private AgentInterpreterTestSupport() {}
+
+  /**
+   * Builds an {@link ExecutionContext} backed by a {@link ProcessReportDataDto} configured with the
+   * given aggregation types. The context is a Mockito mock because the real constructor requires a
+   * fully populated {@code ReportEvaluationContext}, which the agent interpreters do not use — they
+   * only read {@link ExecutionContext#getReportData()}.
+   */
+  static ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> contextWith(
+      final AggregationType... aggregationTypes) {
+    final ProcessReportDataDto reportData = new ProcessReportDataDto();
+    final AggregationDto[] aggregations =
+        Arrays.stream(aggregationTypes).map(AggregationDto::new).toArray(AggregationDto[]::new);
+    reportData.getConfiguration().setAggregationTypes(aggregations);
+    @SuppressWarnings("unchecked")
+    final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> ctx =
+        mock(ExecutionContext.class);
+    when(ctx.getReportData()).thenReturn(reportData);
+    return ctx;
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/es/report/interpreter/view/process/agent/ProcessViewAgentInputTokensInterpreterESTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/es/report/interpreter/view/process/agent/ProcessViewAgentInputTokensInterpreterESTest.java
@@ -9,15 +9,9 @@ package io.camunda.optimize.service.db.es.report.interpreter.view.process.agent;
 
 import static io.camunda.optimize.service.db.report.plan.process.ProcessView.PROCESS_VIEW_AGENT_INPUT_TOKENS;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import co.elastic.clients.elasticsearch._types.aggregations.Aggregate;
-import io.camunda.optimize.dto.optimize.query.report.single.configuration.AggregationDto;
 import io.camunda.optimize.dto.optimize.query.report.single.configuration.AggregationType;
-import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
-import io.camunda.optimize.service.db.report.ExecutionContext;
-import io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan;
 import io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -40,14 +34,14 @@ class ProcessViewAgentInputTokensInterpreterESTest {
 
   @Test
   void createAggregationsWithSumTypeCreatesSumAggregationKey() {
-    final var ctx = contextWithSumAggregation();
+    final var ctx = AgentInterpreterTestSupport.contextWith(AggregationType.SUM);
     final var aggs = interpreter.createAggregations(ctx);
     assertThat(aggs).containsKey("sumAggregation");
   }
 
   @Test
   void retrieveResultHappyPathReturnsMappedValue() {
-    final var ctx = contextWithSumAggregation();
+    final var ctx = AgentInterpreterTestSupport.contextWith(AggregationType.SUM);
     final var aggs = Map.of("sumAggregation", Aggregate.of(a -> a.sum(s -> s.value(42.0))));
     final var result = interpreter.retrieveResult(null, aggs, ctx);
     assertThat(result.getViewMeasures()).hasSize(1);
@@ -56,7 +50,7 @@ class ProcessViewAgentInputTokensInterpreterESTest {
 
   @Test
   void retrieveResultZeroValueReturnsZero() {
-    final var ctx = contextWithSumAggregation();
+    final var ctx = AgentInterpreterTestSupport.contextWith(AggregationType.SUM);
     final var aggs = Map.of("sumAggregation", Aggregate.of(a -> a.sum(s -> s.value(0.0))));
     final var result = interpreter.retrieveResult(null, aggs, ctx);
     assertThat(result.getViewMeasures().get(0).getValue()).isEqualTo(0.0);
@@ -64,28 +58,18 @@ class ProcessViewAgentInputTokensInterpreterESTest {
 
   @Test
   void retrieveResultNanAggregationReturnsNull() {
-    final var ctx = contextWithSumAggregation();
+    final var ctx = AgentInterpreterTestSupport.contextWith(AggregationType.SUM);
     final var aggs = Map.of("sumAggregation", Aggregate.of(a -> a.sum(s -> s.value(Double.NaN))));
     final var result = interpreter.retrieveResult(null, aggs, ctx);
     assertThat(result.getViewMeasures().get(0).getValue()).isNull();
   }
 
   @Test
-  void retrieveResultLargeValueNoOverflow() {
-    final var ctx = contextWithSumAggregation();
+  void retrieveResultLargeValueMapsThroughUnchanged() {
+    final var ctx = AgentInterpreterTestSupport.contextWith(AggregationType.SUM);
     final var largeValue = 200_000_000.0;
     final var aggs = Map.of("sumAggregation", Aggregate.of(a -> a.sum(s -> s.value(largeValue))));
     final var result = interpreter.retrieveResult(null, aggs, ctx);
     assertThat(result.getViewMeasures().get(0).getValue()).isEqualTo(largeValue);
-  }
-
-  private ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> contextWithSumAggregation() {
-    final var reportData = new ProcessReportDataDto();
-    reportData.getConfiguration().setAggregationTypes(new AggregationDto(AggregationType.SUM));
-    @SuppressWarnings("unchecked")
-    final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> ctx =
-        mock(ExecutionContext.class);
-    when(ctx.getReportData()).thenReturn(reportData);
-    return ctx;
   }
 }

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/es/report/interpreter/view/process/agent/ProcessViewAgentInputTokensInterpreterESTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/es/report/interpreter/view/process/agent/ProcessViewAgentInputTokensInterpreterESTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.es.report.interpreter.view.process.agent;
+
+import static io.camunda.optimize.service.db.report.plan.process.ProcessView.PROCESS_VIEW_AGENT_INPUT_TOKENS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregate;
+import io.camunda.optimize.dto.optimize.query.report.single.configuration.AggregationDto;
+import io.camunda.optimize.dto.optimize.query.report.single.configuration.AggregationType;
+import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
+import io.camunda.optimize.service.db.report.ExecutionContext;
+import io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan;
+import io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ProcessViewAgentInputTokensInterpreterESTest {
+
+  private final ProcessViewAgentInputTokensInterpreterES interpreter =
+      new ProcessViewAgentInputTokensInterpreterES();
+
+  @Test
+  void getSupportedViewsReturnsInputTokensView() {
+    assertThat(interpreter.getSupportedViews()).containsExactly(PROCESS_VIEW_AGENT_INPUT_TOKENS);
+  }
+
+  @Test
+  void getAggregationFieldNameReturnsCorrectField() {
+    assertThat(interpreter.getAggregationFieldName())
+        .isEqualTo(ProcessInstanceIndex.AGENT_TOTAL_INPUT_TOKENS);
+  }
+
+  @Test
+  void createAggregationsWithSumTypeCreatesSumAggregationKey() {
+    final var ctx = contextWithSumAggregation();
+    final var aggs = interpreter.createAggregations(ctx);
+    assertThat(aggs).containsKey("sumAggregation");
+  }
+
+  @Test
+  void retrieveResultHappyPathReturnsMappedValue() {
+    final var ctx = contextWithSumAggregation();
+    final var aggs = Map.of("sumAggregation", Aggregate.of(a -> a.sum(s -> s.value(42.0))));
+    final var result = interpreter.retrieveResult(null, aggs, ctx);
+    assertThat(result.getViewMeasures()).hasSize(1);
+    assertThat(result.getViewMeasures().get(0).getValue()).isEqualTo(42.0);
+  }
+
+  @Test
+  void retrieveResultZeroValueReturnsZero() {
+    final var ctx = contextWithSumAggregation();
+    final var aggs = Map.of("sumAggregation", Aggregate.of(a -> a.sum(s -> s.value(0.0))));
+    final var result = interpreter.retrieveResult(null, aggs, ctx);
+    assertThat(result.getViewMeasures().get(0).getValue()).isEqualTo(0.0);
+  }
+
+  @Test
+  void retrieveResultNanAggregationReturnsNull() {
+    final var ctx = contextWithSumAggregation();
+    final var aggs = Map.of("sumAggregation", Aggregate.of(a -> a.sum(s -> s.value(Double.NaN))));
+    final var result = interpreter.retrieveResult(null, aggs, ctx);
+    assertThat(result.getViewMeasures().get(0).getValue()).isNull();
+  }
+
+  @Test
+  void retrieveResultLargeValueNoOverflow() {
+    final var ctx = contextWithSumAggregation();
+    final var largeValue = 200_000_000.0;
+    final var aggs = Map.of("sumAggregation", Aggregate.of(a -> a.sum(s -> s.value(largeValue))));
+    final var result = interpreter.retrieveResult(null, aggs, ctx);
+    assertThat(result.getViewMeasures().get(0).getValue()).isEqualTo(largeValue);
+  }
+
+  private ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> contextWithSumAggregation() {
+    final var reportData = new ProcessReportDataDto();
+    reportData.getConfiguration().setAggregationTypes(new AggregationDto(AggregationType.SUM));
+    @SuppressWarnings("unchecked")
+    final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> ctx =
+        mock(ExecutionContext.class);
+    when(ctx.getReportData()).thenReturn(reportData);
+    return ctx;
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/es/report/interpreter/view/process/agent/ProcessViewAgentOutputTokensInterpreterESTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/es/report/interpreter/view/process/agent/ProcessViewAgentOutputTokensInterpreterESTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.es.report.interpreter.view.process.agent;
+
+import static io.camunda.optimize.service.db.report.plan.process.ProcessView.PROCESS_VIEW_AGENT_OUTPUT_TOKENS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregate;
+import io.camunda.optimize.dto.optimize.query.report.single.configuration.AggregationDto;
+import io.camunda.optimize.dto.optimize.query.report.single.configuration.AggregationType;
+import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
+import io.camunda.optimize.service.db.report.ExecutionContext;
+import io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan;
+import io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ProcessViewAgentOutputTokensInterpreterESTest {
+
+  private final ProcessViewAgentOutputTokensInterpreterES interpreter =
+      new ProcessViewAgentOutputTokensInterpreterES();
+
+  @Test
+  void getSupportedViewsReturnsOutputTokensView() {
+    assertThat(interpreter.getSupportedViews()).containsExactly(PROCESS_VIEW_AGENT_OUTPUT_TOKENS);
+  }
+
+  @Test
+  void getAggregationFieldNameReturnsCorrectField() {
+    assertThat(interpreter.getAggregationFieldName())
+        .isEqualTo(ProcessInstanceIndex.AGENT_TOTAL_OUTPUT_TOKENS);
+  }
+
+  @Test
+  void createAggregationsWithSumTypeCreatesSumAggregationKey() {
+    final var ctx = contextWithSumAggregation();
+    final var aggs = interpreter.createAggregations(ctx);
+    assertThat(aggs).containsKey("sumAggregation");
+  }
+
+  @Test
+  void retrieveResultHappyPathReturnsMappedValue() {
+    final var ctx = contextWithSumAggregation();
+    final var aggs = Map.of("sumAggregation", Aggregate.of(a -> a.sum(s -> s.value(99.0))));
+    final var result = interpreter.retrieveResult(null, aggs, ctx);
+    assertThat(result.getViewMeasures()).hasSize(1);
+    assertThat(result.getViewMeasures().get(0).getValue()).isEqualTo(99.0);
+  }
+
+  @Test
+  void retrieveResultZeroValueReturnsZero() {
+    final var ctx = contextWithSumAggregation();
+    final var aggs = Map.of("sumAggregation", Aggregate.of(a -> a.sum(s -> s.value(0.0))));
+    final var result = interpreter.retrieveResult(null, aggs, ctx);
+    assertThat(result.getViewMeasures().get(0).getValue()).isEqualTo(0.0);
+  }
+
+  @Test
+  void retrieveResultNanAggregationReturnsNull() {
+    final var ctx = contextWithSumAggregation();
+    final var aggs = Map.of("sumAggregation", Aggregate.of(a -> a.sum(s -> s.value(Double.NaN))));
+    final var result = interpreter.retrieveResult(null, aggs, ctx);
+    assertThat(result.getViewMeasures().get(0).getValue()).isNull();
+  }
+
+  @Test
+  void retrieveResultLargeValueNoOverflow() {
+    final var ctx = contextWithSumAggregation();
+    final var largeValue = 200_000_000.0;
+    final var aggs = Map.of("sumAggregation", Aggregate.of(a -> a.sum(s -> s.value(largeValue))));
+    final var result = interpreter.retrieveResult(null, aggs, ctx);
+    assertThat(result.getViewMeasures().get(0).getValue()).isEqualTo(largeValue);
+  }
+
+  private ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> contextWithSumAggregation() {
+    final var reportData = new ProcessReportDataDto();
+    reportData.getConfiguration().setAggregationTypes(new AggregationDto(AggregationType.SUM));
+    @SuppressWarnings("unchecked")
+    final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> ctx =
+        mock(ExecutionContext.class);
+    when(ctx.getReportData()).thenReturn(reportData);
+    return ctx;
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/es/report/interpreter/view/process/agent/ProcessViewAgentToolCallsInterpreterESTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/es/report/interpreter/view/process/agent/ProcessViewAgentToolCallsInterpreterESTest.java
@@ -9,15 +9,9 @@ package io.camunda.optimize.service.db.es.report.interpreter.view.process.agent;
 
 import static io.camunda.optimize.service.db.report.plan.process.ProcessView.PROCESS_VIEW_AGENT_TOOL_CALLS;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import co.elastic.clients.elasticsearch._types.aggregations.Aggregate;
-import io.camunda.optimize.dto.optimize.query.report.single.configuration.AggregationDto;
 import io.camunda.optimize.dto.optimize.query.report.single.configuration.AggregationType;
-import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
-import io.camunda.optimize.service.db.report.ExecutionContext;
-import io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan;
 import io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -40,14 +34,14 @@ class ProcessViewAgentToolCallsInterpreterESTest {
 
   @Test
   void createAggregationsWithSumTypeCreatesSumAggregationKey() {
-    final var ctx = contextWithSumAggregation();
+    final var ctx = AgentInterpreterTestSupport.contextWith(AggregationType.SUM);
     final var aggs = interpreter.createAggregations(ctx);
     assertThat(aggs).containsKey("sumAggregation");
   }
 
   @Test
   void retrieveResultHappyPathReturnsMappedValue() {
-    final var ctx = contextWithSumAggregation();
+    final var ctx = AgentInterpreterTestSupport.contextWith(AggregationType.SUM);
     final var aggs = Map.of("sumAggregation", Aggregate.of(a -> a.sum(s -> s.value(23.0))));
     final var result = interpreter.retrieveResult(null, aggs, ctx);
     assertThat(result.getViewMeasures()).hasSize(1);
@@ -56,7 +50,7 @@ class ProcessViewAgentToolCallsInterpreterESTest {
 
   @Test
   void retrieveResultZeroValueReturnsZero() {
-    final var ctx = contextWithSumAggregation();
+    final var ctx = AgentInterpreterTestSupport.contextWith(AggregationType.SUM);
     final var aggs = Map.of("sumAggregation", Aggregate.of(a -> a.sum(s -> s.value(0.0))));
     final var result = interpreter.retrieveResult(null, aggs, ctx);
     assertThat(result.getViewMeasures().get(0).getValue()).isEqualTo(0.0);
@@ -64,28 +58,18 @@ class ProcessViewAgentToolCallsInterpreterESTest {
 
   @Test
   void retrieveResultNanAggregationReturnsNull() {
-    final var ctx = contextWithSumAggregation();
+    final var ctx = AgentInterpreterTestSupport.contextWith(AggregationType.SUM);
     final var aggs = Map.of("sumAggregation", Aggregate.of(a -> a.sum(s -> s.value(Double.NaN))));
     final var result = interpreter.retrieveResult(null, aggs, ctx);
     assertThat(result.getViewMeasures().get(0).getValue()).isNull();
   }
 
   @Test
-  void retrieveResultLargeValueNoOverflow() {
-    final var ctx = contextWithSumAggregation();
+  void retrieveResultLargeValueMapsThroughUnchanged() {
+    final var ctx = AgentInterpreterTestSupport.contextWith(AggregationType.SUM);
     final var largeValue = 300_000_000.0;
     final var aggs = Map.of("sumAggregation", Aggregate.of(a -> a.sum(s -> s.value(largeValue))));
     final var result = interpreter.retrieveResult(null, aggs, ctx);
     assertThat(result.getViewMeasures().get(0).getValue()).isEqualTo(largeValue);
-  }
-
-  private ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> contextWithSumAggregation() {
-    final var reportData = new ProcessReportDataDto();
-    reportData.getConfiguration().setAggregationTypes(new AggregationDto(AggregationType.SUM));
-    @SuppressWarnings("unchecked")
-    final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> ctx =
-        mock(ExecutionContext.class);
-    when(ctx.getReportData()).thenReturn(reportData);
-    return ctx;
   }
 }

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/es/report/interpreter/view/process/agent/ProcessViewAgentToolCallsInterpreterESTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/es/report/interpreter/view/process/agent/ProcessViewAgentToolCallsInterpreterESTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.es.report.interpreter.view.process.agent;
+
+import static io.camunda.optimize.service.db.report.plan.process.ProcessView.PROCESS_VIEW_AGENT_TOOL_CALLS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregate;
+import io.camunda.optimize.dto.optimize.query.report.single.configuration.AggregationDto;
+import io.camunda.optimize.dto.optimize.query.report.single.configuration.AggregationType;
+import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
+import io.camunda.optimize.service.db.report.ExecutionContext;
+import io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan;
+import io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ProcessViewAgentToolCallsInterpreterESTest {
+
+  private final ProcessViewAgentToolCallsInterpreterES interpreter =
+      new ProcessViewAgentToolCallsInterpreterES();
+
+  @Test
+  void getSupportedViewsReturnsToolCallsView() {
+    assertThat(interpreter.getSupportedViews()).containsExactly(PROCESS_VIEW_AGENT_TOOL_CALLS);
+  }
+
+  @Test
+  void getAggregationFieldNameReturnsCorrectField() {
+    assertThat(interpreter.getAggregationFieldName())
+        .isEqualTo(ProcessInstanceIndex.AGENT_TOTAL_TOOL_CALLS);
+  }
+
+  @Test
+  void createAggregationsWithSumTypeCreatesSumAggregationKey() {
+    final var ctx = contextWithSumAggregation();
+    final var aggs = interpreter.createAggregations(ctx);
+    assertThat(aggs).containsKey("sumAggregation");
+  }
+
+  @Test
+  void retrieveResultHappyPathReturnsMappedValue() {
+    final var ctx = contextWithSumAggregation();
+    final var aggs = Map.of("sumAggregation", Aggregate.of(a -> a.sum(s -> s.value(23.0))));
+    final var result = interpreter.retrieveResult(null, aggs, ctx);
+    assertThat(result.getViewMeasures()).hasSize(1);
+    assertThat(result.getViewMeasures().get(0).getValue()).isEqualTo(23.0);
+  }
+
+  @Test
+  void retrieveResultZeroValueReturnsZero() {
+    final var ctx = contextWithSumAggregation();
+    final var aggs = Map.of("sumAggregation", Aggregate.of(a -> a.sum(s -> s.value(0.0))));
+    final var result = interpreter.retrieveResult(null, aggs, ctx);
+    assertThat(result.getViewMeasures().get(0).getValue()).isEqualTo(0.0);
+  }
+
+  @Test
+  void retrieveResultNanAggregationReturnsNull() {
+    final var ctx = contextWithSumAggregation();
+    final var aggs = Map.of("sumAggregation", Aggregate.of(a -> a.sum(s -> s.value(Double.NaN))));
+    final var result = interpreter.retrieveResult(null, aggs, ctx);
+    assertThat(result.getViewMeasures().get(0).getValue()).isNull();
+  }
+
+  @Test
+  void retrieveResultLargeValueNoOverflow() {
+    final var ctx = contextWithSumAggregation();
+    final var largeValue = 300_000_000.0;
+    final var aggs = Map.of("sumAggregation", Aggregate.of(a -> a.sum(s -> s.value(largeValue))));
+    final var result = interpreter.retrieveResult(null, aggs, ctx);
+    assertThat(result.getViewMeasures().get(0).getValue()).isEqualTo(largeValue);
+  }
+
+  private ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> contextWithSumAggregation() {
+    final var reportData = new ProcessReportDataDto();
+    reportData.getConfiguration().setAggregationTypes(new AggregationDto(AggregationType.SUM));
+    @SuppressWarnings("unchecked")
+    final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> ctx =
+        mock(ExecutionContext.class);
+    when(ctx.getReportData()).thenReturn(reportData);
+    return ctx;
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/es/report/interpreter/view/process/agent/ProcessViewAgentTotalTokensInterpreterESTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/es/report/interpreter/view/process/agent/ProcessViewAgentTotalTokensInterpreterESTest.java
@@ -9,15 +9,9 @@ package io.camunda.optimize.service.db.es.report.interpreter.view.process.agent;
 
 import static io.camunda.optimize.service.db.report.plan.process.ProcessView.PROCESS_VIEW_AGENT_TOTAL_TOKENS;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import co.elastic.clients.elasticsearch._types.aggregations.Aggregate;
-import io.camunda.optimize.dto.optimize.query.report.single.configuration.AggregationDto;
 import io.camunda.optimize.dto.optimize.query.report.single.configuration.AggregationType;
-import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
-import io.camunda.optimize.service.db.report.ExecutionContext;
-import io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan;
 import io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -48,14 +42,14 @@ class ProcessViewAgentTotalTokensInterpreterESTest {
 
   @Test
   void createAggregationsWithSumTypeCreatesSumAggregationKey() {
-    final var ctx = contextWithSumAggregation();
+    final var ctx = AgentInterpreterTestSupport.contextWith(AggregationType.SUM);
     final var aggs = interpreter.createAggregations(ctx);
     assertThat(aggs).containsKey("sumAggregation");
   }
 
   @Test
   void retrieveResultHappyPathReturnsMappedValue() {
-    final var ctx = contextWithSumAggregation();
+    final var ctx = AgentInterpreterTestSupport.contextWith(AggregationType.SUM);
     final var aggs = Map.of("sumAggregation", Aggregate.of(a -> a.sum(s -> s.value(150.0))));
     final var result = interpreter.retrieveResult(null, aggs, ctx);
     assertThat(result.getViewMeasures()).hasSize(1);
@@ -64,7 +58,7 @@ class ProcessViewAgentTotalTokensInterpreterESTest {
 
   @Test
   void retrieveResultZeroValueReturnsZero() {
-    final var ctx = contextWithSumAggregation();
+    final var ctx = AgentInterpreterTestSupport.contextWith(AggregationType.SUM);
     final var aggs = Map.of("sumAggregation", Aggregate.of(a -> a.sum(s -> s.value(0.0))));
     final var result = interpreter.retrieveResult(null, aggs, ctx);
     assertThat(result.getViewMeasures().get(0).getValue()).isEqualTo(0.0);
@@ -72,28 +66,18 @@ class ProcessViewAgentTotalTokensInterpreterESTest {
 
   @Test
   void retrieveResultNanAggregationReturnsNull() {
-    final var ctx = contextWithSumAggregation();
+    final var ctx = AgentInterpreterTestSupport.contextWith(AggregationType.SUM);
     final var aggs = Map.of("sumAggregation", Aggregate.of(a -> a.sum(s -> s.value(Double.NaN))));
     final var result = interpreter.retrieveResult(null, aggs, ctx);
     assertThat(result.getViewMeasures().get(0).getValue()).isNull();
   }
 
   @Test
-  void retrieveResultLargeValueNoOverflow() {
-    final var ctx = contextWithSumAggregation();
+  void retrieveResultLargeValueMapsThroughUnchanged() {
+    final var ctx = AgentInterpreterTestSupport.contextWith(AggregationType.SUM);
     final var largeValue = 400_000_000.0;
     final var aggs = Map.of("sumAggregation", Aggregate.of(a -> a.sum(s -> s.value(largeValue))));
     final var result = interpreter.retrieveResult(null, aggs, ctx);
     assertThat(result.getViewMeasures().get(0).getValue()).isEqualTo(largeValue);
-  }
-
-  private ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> contextWithSumAggregation() {
-    final var reportData = new ProcessReportDataDto();
-    reportData.getConfiguration().setAggregationTypes(new AggregationDto(AggregationType.SUM));
-    @SuppressWarnings("unchecked")
-    final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> ctx =
-        mock(ExecutionContext.class);
-    when(ctx.getReportData()).thenReturn(reportData);
-    return ctx;
   }
 }

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/es/report/interpreter/view/process/agent/ProcessViewAgentTotalTokensInterpreterESTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/es/report/interpreter/view/process/agent/ProcessViewAgentTotalTokensInterpreterESTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.es.report.interpreter.view.process.agent;
+
+import static io.camunda.optimize.service.db.report.plan.process.ProcessView.PROCESS_VIEW_AGENT_TOTAL_TOKENS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregate;
+import io.camunda.optimize.dto.optimize.query.report.single.configuration.AggregationDto;
+import io.camunda.optimize.dto.optimize.query.report.single.configuration.AggregationType;
+import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
+import io.camunda.optimize.service.db.report.ExecutionContext;
+import io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan;
+import io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ProcessViewAgentTotalTokensInterpreterESTest {
+
+  private final ProcessViewAgentTotalTokensInterpreterES interpreter =
+      new ProcessViewAgentTotalTokensInterpreterES();
+
+  @Test
+  void getSupportedViewsReturnsTotalTokensView() {
+    assertThat(interpreter.getSupportedViews()).containsExactly(PROCESS_VIEW_AGENT_TOTAL_TOKENS);
+  }
+
+  @Test
+  void getAggregationScriptReferencesInputTokensField() {
+    final var script = interpreter.getAggregationScript();
+    assertThat(script).isNotNull();
+    assertThat(script.source()).contains(ProcessInstanceIndex.AGENT_TOTAL_INPUT_TOKENS);
+  }
+
+  @Test
+  void getAggregationScriptReferencesOutputTokensField() {
+    final var script = interpreter.getAggregationScript();
+    assertThat(script).isNotNull();
+    assertThat(script.source()).contains(ProcessInstanceIndex.AGENT_TOTAL_OUTPUT_TOKENS);
+  }
+
+  @Test
+  void createAggregationsWithSumTypeCreatesSumAggregationKey() {
+    final var ctx = contextWithSumAggregation();
+    final var aggs = interpreter.createAggregations(ctx);
+    assertThat(aggs).containsKey("sumAggregation");
+  }
+
+  @Test
+  void retrieveResultHappyPathReturnsMappedValue() {
+    final var ctx = contextWithSumAggregation();
+    final var aggs = Map.of("sumAggregation", Aggregate.of(a -> a.sum(s -> s.value(150.0))));
+    final var result = interpreter.retrieveResult(null, aggs, ctx);
+    assertThat(result.getViewMeasures()).hasSize(1);
+    assertThat(result.getViewMeasures().get(0).getValue()).isEqualTo(150.0);
+  }
+
+  @Test
+  void retrieveResultZeroValueReturnsZero() {
+    final var ctx = contextWithSumAggregation();
+    final var aggs = Map.of("sumAggregation", Aggregate.of(a -> a.sum(s -> s.value(0.0))));
+    final var result = interpreter.retrieveResult(null, aggs, ctx);
+    assertThat(result.getViewMeasures().get(0).getValue()).isEqualTo(0.0);
+  }
+
+  @Test
+  void retrieveResultNanAggregationReturnsNull() {
+    final var ctx = contextWithSumAggregation();
+    final var aggs = Map.of("sumAggregation", Aggregate.of(a -> a.sum(s -> s.value(Double.NaN))));
+    final var result = interpreter.retrieveResult(null, aggs, ctx);
+    assertThat(result.getViewMeasures().get(0).getValue()).isNull();
+  }
+
+  @Test
+  void retrieveResultLargeValueNoOverflow() {
+    final var ctx = contextWithSumAggregation();
+    final var largeValue = 400_000_000.0;
+    final var aggs = Map.of("sumAggregation", Aggregate.of(a -> a.sum(s -> s.value(largeValue))));
+    final var result = interpreter.retrieveResult(null, aggs, ctx);
+    assertThat(result.getViewMeasures().get(0).getValue()).isEqualTo(largeValue);
+  }
+
+  private ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> contextWithSumAggregation() {
+    final var reportData = new ProcessReportDataDto();
+    reportData.getConfiguration().setAggregationTypes(new AggregationDto(AggregationType.SUM));
+    @SuppressWarnings("unchecked")
+    final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> ctx =
+        mock(ExecutionContext.class);
+    when(ctx.getReportData()).thenReturn(reportData);
+    return ctx;
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/os/report/interpreter/view/process/agent/AbstractProcessViewAgentMetricInterpreterOSTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/os/report/interpreter/view/process/agent/AbstractProcessViewAgentMetricInterpreterOSTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.os.report.interpreter.view.process.agent;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.optimize.dto.optimize.query.report.single.configuration.AggregationType;
+import io.camunda.optimize.service.db.report.plan.process.ProcessView;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class AbstractProcessViewAgentMetricInterpreterOSTest {
+
+  @Test
+  void createAggregationsThrowsWhenNeitherFieldNorScriptProvided() {
+    final var interpreter = new MissingSourceInterpreterOS();
+    final var ctx = AgentInterpreterTestSupport.contextWith(AggregationType.SUM);
+    assertThatThrownBy(() -> interpreter.createAggregations(ctx))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("getAggregationFieldName")
+        .hasMessageContaining("getAggregationScript");
+  }
+
+  /** Subclass that overrides neither hook, exercising the fail-fast guard. */
+  private static final class MissingSourceInterpreterOS
+      extends AbstractProcessViewAgentMetricInterpreterOS {
+    @Override
+    public Set<ProcessView> getSupportedViews() {
+      return Set.of();
+    }
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/os/report/interpreter/view/process/agent/AgentInterpreterTestSupport.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/os/report/interpreter/view/process/agent/AgentInterpreterTestSupport.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.os.report.interpreter.view.process.agent;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.optimize.dto.optimize.query.report.single.configuration.AggregationDto;
+import io.camunda.optimize.dto.optimize.query.report.single.configuration.AggregationType;
+import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
+import io.camunda.optimize.service.db.report.ExecutionContext;
+import io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan;
+import java.util.Arrays;
+
+final class AgentInterpreterTestSupport {
+
+  private AgentInterpreterTestSupport() {}
+
+  /**
+   * Builds an {@link ExecutionContext} backed by a {@link ProcessReportDataDto} configured with the
+   * given aggregation types. The context is a Mockito mock because the real constructor requires a
+   * fully populated {@code ReportEvaluationContext}, which the agent interpreters do not use — they
+   * only read {@link ExecutionContext#getReportData()}.
+   */
+  static ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> contextWith(
+      final AggregationType... aggregationTypes) {
+    final ProcessReportDataDto reportData = new ProcessReportDataDto();
+    final AggregationDto[] aggregations =
+        Arrays.stream(aggregationTypes).map(AggregationDto::new).toArray(AggregationDto[]::new);
+    reportData.getConfiguration().setAggregationTypes(aggregations);
+    @SuppressWarnings("unchecked")
+    final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> ctx =
+        mock(ExecutionContext.class);
+    when(ctx.getReportData()).thenReturn(reportData);
+    return ctx;
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/os/report/interpreter/view/process/agent/ProcessViewAgentInputTokensInterpreterOSTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/os/report/interpreter/view/process/agent/ProcessViewAgentInputTokensInterpreterOSTest.java
@@ -5,31 +5,31 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.optimize.service.db.es.report.interpreter.view.process.agent;
+package io.camunda.optimize.service.db.os.report.interpreter.view.process.agent;
 
-import static io.camunda.optimize.service.db.report.plan.process.ProcessView.PROCESS_VIEW_AGENT_OUTPUT_TOKENS;
+import static io.camunda.optimize.service.db.report.plan.process.ProcessView.PROCESS_VIEW_AGENT_INPUT_TOKENS;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import co.elastic.clients.elasticsearch._types.aggregations.Aggregate;
 import io.camunda.optimize.dto.optimize.query.report.single.configuration.AggregationType;
 import io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.opensearch.client.opensearch._types.aggregations.Aggregate;
 
-class ProcessViewAgentOutputTokensInterpreterESTest {
+class ProcessViewAgentInputTokensInterpreterOSTest {
 
-  private final ProcessViewAgentOutputTokensInterpreterES interpreter =
-      new ProcessViewAgentOutputTokensInterpreterES();
+  private final ProcessViewAgentInputTokensInterpreterOS interpreter =
+      new ProcessViewAgentInputTokensInterpreterOS();
 
   @Test
-  void getSupportedViewsReturnsOutputTokensView() {
-    assertThat(interpreter.getSupportedViews()).containsExactly(PROCESS_VIEW_AGENT_OUTPUT_TOKENS);
+  void getSupportedViewsReturnsInputTokensView() {
+    assertThat(interpreter.getSupportedViews()).containsExactly(PROCESS_VIEW_AGENT_INPUT_TOKENS);
   }
 
   @Test
   void getAggregationFieldNameReturnsCorrectField() {
     assertThat(interpreter.getAggregationFieldName())
-        .isEqualTo(ProcessInstanceIndex.AGENT_TOTAL_OUTPUT_TOKENS);
+        .isEqualTo(ProcessInstanceIndex.AGENT_TOTAL_INPUT_TOKENS);
   }
 
   @Test
@@ -42,10 +42,10 @@ class ProcessViewAgentOutputTokensInterpreterESTest {
   @Test
   void retrieveResultHappyPathReturnsMappedValue() {
     final var ctx = AgentInterpreterTestSupport.contextWith(AggregationType.SUM);
-    final var aggs = Map.of("sumAggregation", Aggregate.of(a -> a.sum(s -> s.value(99.0))));
+    final var aggs = Map.of("sumAggregation", Aggregate.of(a -> a.sum(s -> s.value(42.0))));
     final var result = interpreter.retrieveResult(null, aggs, ctx);
     assertThat(result.getViewMeasures()).hasSize(1);
-    assertThat(result.getViewMeasures().get(0).getValue()).isEqualTo(99.0);
+    assertThat(result.getViewMeasures().get(0).getValue()).isEqualTo(42.0);
   }
 
   @Test

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/os/report/interpreter/view/process/agent/ProcessViewAgentOutputTokensInterpreterOSTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/os/report/interpreter/view/process/agent/ProcessViewAgentOutputTokensInterpreterOSTest.java
@@ -5,21 +5,21 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.optimize.service.db.es.report.interpreter.view.process.agent;
+package io.camunda.optimize.service.db.os.report.interpreter.view.process.agent;
 
 import static io.camunda.optimize.service.db.report.plan.process.ProcessView.PROCESS_VIEW_AGENT_OUTPUT_TOKENS;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import co.elastic.clients.elasticsearch._types.aggregations.Aggregate;
 import io.camunda.optimize.dto.optimize.query.report.single.configuration.AggregationType;
 import io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.opensearch.client.opensearch._types.aggregations.Aggregate;
 
-class ProcessViewAgentOutputTokensInterpreterESTest {
+class ProcessViewAgentOutputTokensInterpreterOSTest {
 
-  private final ProcessViewAgentOutputTokensInterpreterES interpreter =
-      new ProcessViewAgentOutputTokensInterpreterES();
+  private final ProcessViewAgentOutputTokensInterpreterOS interpreter =
+      new ProcessViewAgentOutputTokensInterpreterOS();
 
   @Test
   void getSupportedViewsReturnsOutputTokensView() {

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/os/report/interpreter/view/process/agent/ProcessViewAgentToolCallsInterpreterOSTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/os/report/interpreter/view/process/agent/ProcessViewAgentToolCallsInterpreterOSTest.java
@@ -5,31 +5,31 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.optimize.service.db.es.report.interpreter.view.process.agent;
+package io.camunda.optimize.service.db.os.report.interpreter.view.process.agent;
 
-import static io.camunda.optimize.service.db.report.plan.process.ProcessView.PROCESS_VIEW_AGENT_OUTPUT_TOKENS;
+import static io.camunda.optimize.service.db.report.plan.process.ProcessView.PROCESS_VIEW_AGENT_TOOL_CALLS;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import co.elastic.clients.elasticsearch._types.aggregations.Aggregate;
 import io.camunda.optimize.dto.optimize.query.report.single.configuration.AggregationType;
 import io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.opensearch.client.opensearch._types.aggregations.Aggregate;
 
-class ProcessViewAgentOutputTokensInterpreterESTest {
+class ProcessViewAgentToolCallsInterpreterOSTest {
 
-  private final ProcessViewAgentOutputTokensInterpreterES interpreter =
-      new ProcessViewAgentOutputTokensInterpreterES();
+  private final ProcessViewAgentToolCallsInterpreterOS interpreter =
+      new ProcessViewAgentToolCallsInterpreterOS();
 
   @Test
-  void getSupportedViewsReturnsOutputTokensView() {
-    assertThat(interpreter.getSupportedViews()).containsExactly(PROCESS_VIEW_AGENT_OUTPUT_TOKENS);
+  void getSupportedViewsReturnsToolCallsView() {
+    assertThat(interpreter.getSupportedViews()).containsExactly(PROCESS_VIEW_AGENT_TOOL_CALLS);
   }
 
   @Test
   void getAggregationFieldNameReturnsCorrectField() {
     assertThat(interpreter.getAggregationFieldName())
-        .isEqualTo(ProcessInstanceIndex.AGENT_TOTAL_OUTPUT_TOKENS);
+        .isEqualTo(ProcessInstanceIndex.AGENT_TOTAL_TOOL_CALLS);
   }
 
   @Test
@@ -42,10 +42,10 @@ class ProcessViewAgentOutputTokensInterpreterESTest {
   @Test
   void retrieveResultHappyPathReturnsMappedValue() {
     final var ctx = AgentInterpreterTestSupport.contextWith(AggregationType.SUM);
-    final var aggs = Map.of("sumAggregation", Aggregate.of(a -> a.sum(s -> s.value(99.0))));
+    final var aggs = Map.of("sumAggregation", Aggregate.of(a -> a.sum(s -> s.value(23.0))));
     final var result = interpreter.retrieveResult(null, aggs, ctx);
     assertThat(result.getViewMeasures()).hasSize(1);
-    assertThat(result.getViewMeasures().get(0).getValue()).isEqualTo(99.0);
+    assertThat(result.getViewMeasures().get(0).getValue()).isEqualTo(23.0);
   }
 
   @Test
@@ -67,7 +67,7 @@ class ProcessViewAgentOutputTokensInterpreterESTest {
   @Test
   void retrieveResultLargeValueMapsThroughUnchanged() {
     final var ctx = AgentInterpreterTestSupport.contextWith(AggregationType.SUM);
-    final var largeValue = 200_000_000.0;
+    final var largeValue = 300_000_000.0;
     final var aggs = Map.of("sumAggregation", Aggregate.of(a -> a.sum(s -> s.value(largeValue))));
     final var result = interpreter.retrieveResult(null, aggs, ctx);
     assertThat(result.getViewMeasures().get(0).getValue()).isEqualTo(largeValue);

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/os/report/interpreter/view/process/agent/ProcessViewAgentTotalTokensInterpreterOSTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/os/report/interpreter/view/process/agent/ProcessViewAgentTotalTokensInterpreterOSTest.java
@@ -5,31 +5,39 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.optimize.service.db.es.report.interpreter.view.process.agent;
+package io.camunda.optimize.service.db.os.report.interpreter.view.process.agent;
 
-import static io.camunda.optimize.service.db.report.plan.process.ProcessView.PROCESS_VIEW_AGENT_OUTPUT_TOKENS;
+import static io.camunda.optimize.service.db.report.plan.process.ProcessView.PROCESS_VIEW_AGENT_TOTAL_TOKENS;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import co.elastic.clients.elasticsearch._types.aggregations.Aggregate;
 import io.camunda.optimize.dto.optimize.query.report.single.configuration.AggregationType;
 import io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.opensearch.client.opensearch._types.aggregations.Aggregate;
 
-class ProcessViewAgentOutputTokensInterpreterESTest {
+class ProcessViewAgentTotalTokensInterpreterOSTest {
 
-  private final ProcessViewAgentOutputTokensInterpreterES interpreter =
-      new ProcessViewAgentOutputTokensInterpreterES();
+  private final ProcessViewAgentTotalTokensInterpreterOS interpreter =
+      new ProcessViewAgentTotalTokensInterpreterOS();
 
   @Test
-  void getSupportedViewsReturnsOutputTokensView() {
-    assertThat(interpreter.getSupportedViews()).containsExactly(PROCESS_VIEW_AGENT_OUTPUT_TOKENS);
+  void getSupportedViewsReturnsTotalTokensView() {
+    assertThat(interpreter.getSupportedViews()).containsExactly(PROCESS_VIEW_AGENT_TOTAL_TOKENS);
   }
 
   @Test
-  void getAggregationFieldNameReturnsCorrectField() {
-    assertThat(interpreter.getAggregationFieldName())
-        .isEqualTo(ProcessInstanceIndex.AGENT_TOTAL_OUTPUT_TOKENS);
+  void getAggregationScriptReferencesInputTokensField() {
+    final var script = interpreter.getAggregationScript();
+    assertThat(script).isNotNull();
+    assertThat(script.inline().source()).contains(ProcessInstanceIndex.AGENT_TOTAL_INPUT_TOKENS);
+  }
+
+  @Test
+  void getAggregationScriptReferencesOutputTokensField() {
+    final var script = interpreter.getAggregationScript();
+    assertThat(script).isNotNull();
+    assertThat(script.inline().source()).contains(ProcessInstanceIndex.AGENT_TOTAL_OUTPUT_TOKENS);
   }
 
   @Test
@@ -42,10 +50,10 @@ class ProcessViewAgentOutputTokensInterpreterESTest {
   @Test
   void retrieveResultHappyPathReturnsMappedValue() {
     final var ctx = AgentInterpreterTestSupport.contextWith(AggregationType.SUM);
-    final var aggs = Map.of("sumAggregation", Aggregate.of(a -> a.sum(s -> s.value(99.0))));
+    final var aggs = Map.of("sumAggregation", Aggregate.of(a -> a.sum(s -> s.value(150.0))));
     final var result = interpreter.retrieveResult(null, aggs, ctx);
     assertThat(result.getViewMeasures()).hasSize(1);
-    assertThat(result.getViewMeasures().get(0).getValue()).isEqualTo(99.0);
+    assertThat(result.getViewMeasures().get(0).getValue()).isEqualTo(150.0);
   }
 
   @Test
@@ -67,7 +75,7 @@ class ProcessViewAgentOutputTokensInterpreterESTest {
   @Test
   void retrieveResultLargeValueMapsThroughUnchanged() {
     final var ctx = AgentInterpreterTestSupport.contextWith(AggregationType.SUM);
-    final var largeValue = 200_000_000.0;
+    final var largeValue = 400_000_000.0;
     final var aggs = Map.of("sumAggregation", Aggregate.of(a -> a.sum(s -> s.value(largeValue))));
     final var result = interpreter.retrieveResult(null, aggs, ctx);
     assertThat(result.getViewMeasures().get(0).getValue()).isEqualTo(largeValue);


### PR DESCRIPTION
related to #54075

## Description
Adds ProcessViewAgent metric interpreters (input/output/total tokens, tool calls) for ES/OS

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #54075
