### PR TITLE
Fix starter readiness up

### DIFF
--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/starter/Starter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/starter/Starter.java
@@ -140,18 +140,32 @@ public class Starter implements CommandLineRunner {
     final ScheduledFuture<?> scheduledTask =
         scheduleProcessInstanceCreation(executorService, countDownLatch);
 
-    try {
-      countDownLatch.await();
-    } catch (final InterruptedException e) {
-      LOG.error("Awaiting of count down latch was interrupted.", e);
-    }
-
-    runFinished.set(1);
-    LOG.info(
-        "Starter finished. Total process instance start requests submitted: {}",
-        processInstancesStartedCounter == null ? 0 : (long) processInstancesStartedCounter.count());
-    scheduledTask.cancel(true);
-    shutdown();
+    // Returning from this CommandLineRunner lets Spring publish ApplicationReadyEvent, which sets
+    // ReadinessState.ACCEPTING_TRAFFIC (health UP). Broker connect + deploy above are finite and
+    // stay on this thread so readiness only flips once the starter can actually create instances
+    // (mirrors Worker's @PostConstruct). The creation loop keeps running on executorService; this
+    // watcher awaits the stop signal (duration-limit) and finalizes.
+    final Thread watcher =
+        new Thread(
+            () -> {
+              try {
+                countDownLatch.await();
+              } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
+              }
+              runFinished.set(1);
+              LOG.info(
+                  "Starter finished. Total process instance start requests submitted: {}",
+                  processInstancesStartedCounter == null
+                      ? 0
+                      : (long) processInstancesStartedCounter.count());
+              scheduledTask.cancel(true);
+              shutdown();
+            },
+            "starter-completion-watcher");
+    watcher.setDaemon(true);
+    watcher.start();
   }
 
   @PreDestroy

--- a/load-tests/load-tester/src/test/java/io/camunda/zeebe/it/StarterDurationLimitIT.java
+++ b/load-tests/load-tester/src/test/java/io/camunda/zeebe/it/StarterDurationLimitIT.java
@@ -8,11 +8,13 @@
 package io.camunda.zeebe.it;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 import io.camunda.process.test.impl.containers.CamundaContainer;
 import io.camunda.zeebe.LoadTesterApplication;
 import io.camunda.zeebe.metrics.StarterMetricsDoc;
 import io.micrometer.core.instrument.MeterRegistry;
+import java.time.Duration;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,9 +27,10 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 /**
  * Verifies the starter loop self-terminates when {@code duration-limit} elapses, leaving {@code
- * starter.run.finished} at 1. Spring startup blocks on the {@code CommandLineRunner}, so the test
- * body runs after the starter exits — no Awaitility. Excludes the {@code worker} profile to avoid
- * the known {@code @SpringBootTest} hang.
+ * starter.run.finished} at 1. The {@code CommandLineRunner} returns once the broker is connected
+ * and the process deployed (so the creation loop runs in the background while context startup
+ * completes), so the test body polls with Awaitility until the loop finishes. Excludes the {@code
+ * worker} profile to avoid the known {@code @SpringBootTest} hang.
  */
 @Testcontainers
 @SpringBootTest(
@@ -56,19 +59,25 @@ class StarterDurationLimitIT {
 
   @Test
   void shouldStopAfterDurationLimit() {
-    // given — starter has already run (CommandLineRunner blocks context startup for
-    //         duration-limit=3s) and exited via the timed continuation condition.
+    // given — the starter is creating instances in the background; the CommandLineRunner returned
+    //         once connected + deployed, so we poll until the duration-limit (3s) elapses.
 
-    // then — the run-finished gauge should be 1, proving the loop exited cleanly via the
+    // then — the run-finished gauge should reach 1, proving the loop exited cleanly via the
     //        deadline (not via cancellation or an error path).
-    final var runFinishedGauge =
-        meterRegistry.find(StarterMetricsDoc.RUN_FINISHED.getName()).gauge();
-    assertThat(runFinishedGauge)
-        .describedAs("starter.run.finished gauge should be registered")
-        .isNotNull();
-    assertThat(runFinishedGauge.value())
-        .describedAs("gauge should be 1 after the duration-limit elapsed")
-        .isEqualTo(1.0);
+    await()
+        .atMost(Duration.ofSeconds(30))
+        .pollInterval(Duration.ofMillis(500))
+        .untilAsserted(
+            () -> {
+              final var runFinishedGauge =
+                  meterRegistry.find(StarterMetricsDoc.RUN_FINISHED.getName()).gauge();
+              assertThat(runFinishedGauge)
+                  .describedAs("starter.run.finished gauge should be registered")
+                  .isNotNull();
+              assertThat(runFinishedGauge.value())
+                  .describedAs("gauge should be 1 after the duration-limit elapsed")
+                  .isEqualTo(1.0);
+            });
 
     // and — at least one start request was submitted, ruling out an immediate stop.
     final var counter =

--- a/load-tests/load-tester/src/test/java/io/camunda/zeebe/it/StarterWorkerIT.java
+++ b/load-tests/load-tester/src/test/java/io/camunda/zeebe/it/StarterWorkerIT.java
@@ -67,9 +67,9 @@ class StarterWorkerIT {
 
   @Test
   void shouldStartInstancesAndCompleteThem() {
-    // given — the starter has already run (CommandLineRunner blocks context startup for
-    //         duration-limit=5s) and produced ~5 instances of the "benchmark" process.
-    //         The worker is also active and subscribed to "benchmark-task".
+    // given — the starter creates ~5 instances of the "benchmark" process in the background
+    //         (its CommandLineRunner returns once connected + deployed) over the duration-limit
+    //         window of 5s. The worker is also active and subscribed to "benchmark-task".
 
     // then — at least one instance should be queryable via REST and in COMPLETED state.
     //        Awaitility handles the async gap between "starter stopped" and "worker drained queue".
@@ -105,14 +105,21 @@ class StarterWorkerIT {
         .describedAs("counter should reflect the number of submitted start requests (>0)")
         .isGreaterThan(0.0);
 
-    // and — the run-finished gauge should have flipped to 1 once the duration limit elapsed.
-    final var runFinishedGauge =
-        meterRegistry.find(StarterMetricsDoc.RUN_FINISHED.getName()).gauge();
-    assertThat(runFinishedGauge)
-        .describedAs("starter.run.finished gauge should be registered")
-        .isNotNull();
-    assertThat(runFinishedGauge.value())
-        .describedAs("gauge should be 1 after the starter finished its creation loop")
-        .isEqualTo(1.0);
+    // and — the run-finished gauge should flip to 1 once the duration limit elapses. The starter
+    //        runs in the background, so poll until the creation loop finishes.
+    await()
+        .atMost(Duration.ofSeconds(30))
+        .pollInterval(Duration.ofMillis(500))
+        .untilAsserted(
+            () -> {
+              final var runFinishedGauge =
+                  meterRegistry.find(StarterMetricsDoc.RUN_FINISHED.getName()).gauge();
+              assertThat(runFinishedGauge)
+                  .describedAs("starter.run.finished gauge should be registered")
+                  .isNotNull();
+              assertThat(runFinishedGauge.value())
+                  .describedAs("gauge should be 1 after the starter finished its creation loop")
+                  .isEqualTo(1.0);
+            });
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
