### PR TITLE
test: stabilize suspend-twice batch operation test on RDBMS

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts
@@ -10,7 +10,6 @@ import {test} from '@playwright/test';
 import {deploy} from '../../../../utils/zeebeClient';
 import {
   assertBadRequest,
-  assertConflictRequest,
   assertInvalidState,
   assertNotFoundRequest,
   assertStatusCode,
@@ -66,7 +65,12 @@ test.describe('Suspend & Resume Batch Operation Tests', () => {
   }) => {
     const key =
       await test.step('Create cancelable batch operation', async () => {
-        return createCancellationBatch(request, 3, 'batch_suspension_process');
+        // Use 20 instances so the batch stays ACTIVE long enough for the
+        // suspend command to take effect before the engine finishes it. With
+        // only 3 instances the batch can reach COMPLETED before the suspend is
+        // applied, so the poll for SUSPENDED never succeeds (same race the
+        // first suspend test guards against — not an indexing lag).
+        return createCancellationBatch(request, 20, 'batch_suspension_process');
       });
 
     await test.step('Suspend batch operation once', async () => {


### PR DESCRIPTION
## Problem

[Successful run](https://github.com/camunda/camunda/actions/runs/26756729464) ✅ 

The API test **"Suspend batch operation twice fails on second request, finally resumes"** (`tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts`) failed in the nightly run on the **RDBMS / MSSQL 2025** backing store:

```
expect(received).toBe(expected)
Expected: "SUSPENDED"
Received: "COMPLETED"
Timeout 120000ms exceeded while waiting on the predicate
```

## Root cause

The test created a cancellation batch with only **3 instances**. On slower backing stores the engine can finish the batch before the suspend command is applied — the batch reaches `COMPLETED`, so the poll for `SUSPENDED` (`expectBatchState`) never succeeds and times out after 120s.

This is the exact race the **first** suspend test (`Suspend active batch operation returns 204 ...`) already guards against — its comment documents the same finding and it uses 20 instances. This second test was never updated.

## Fix

- Bump the batch from **3 → 20 instances** so it stays `ACTIVE` long enough for the suspend to take effect, matching the sibling test. Added an explanatory comment.
- Removed the now-unused `assertConflictRequest` import (pre-existing lint error in the file).

No `skip`/`fixme` introduced. `prettier` + `eslint` run clean (only the pre-existing, documented bug-43097 skip warning remains).


