### PR TITLE
test: stabilize suspend-batch-twice API test on fast RDBMS backends

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts
@@ -66,7 +66,12 @@ test.describe('Suspend & Resume Batch Operation Tests', () => {
   }) => {
     const key =
       await test.step('Create cancelable batch operation', async () => {
-        return createCancellationBatch(request, 3, 'batch_suspension_process');
+        // Use 20 instances so the batch takes long enough to process that the
+        // suspend command can arrive while the batch is still ACTIVE. With only
+        // 3 instances the engine finishes the batch (COMPLETED) before the
+        // suspend takes effect, so it never reaches SUSPENDED (same race as the
+        // first suspend test — not an indexing lag).
+        return createCancellationBatch(request, 20, 'batch_suspension_process');
       });
 
     await test.step('Suspend batch operation once', async () => {


### PR DESCRIPTION
## Problem

The nightly API run (RDBMS / MSSQL 2025 backend) failed:

```
tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts
› Suspend batch operation twice fails on second request, finally resumes

Expected: "SUSPENDED"
Received: "COMPLETED"
Timeout 120000ms exceeded while waiting on the predicate
```

## Root cause

The test created a cancellation batch with only **3 instances**. On fast backing
stores (MSSQL/RDBMS) the engine processes and finishes the batch (`COMPLETED`)
before the suspend command takes effect, so the batch never reaches `SUSPENDED`
and `expectBatchState(..., 'SUSPENDED')` times out.

This is the exact race the **first** suspend test in the same file already
documents and works around by using 20 instances.

## Fix

Bump the instance count from 3 → 20 (with the same explanatory comment as the
first test) so the batch stays `ACTIVE` long enough for the suspend to land while
it is still processing. No skip/fixme; minimal diff.

Nightly run: https://github.com/camunda/camunda/actions/runs/26745870849

🤖 Generated with [Claude Code](https://claude.com/claude-code)