### PR TITLE
docs: add local test setup for analytics exporter

### DIFF
--- a/zeebe/exporters/analytics-exporter/src/test/resources/local-test/README.md
+++ b/zeebe/exporters/analytics-exporter/src/test/resources/local-test/README.md
@@ -1,0 +1,117 @@
+# Analytics Exporter Local Test
+
+Run the analytics exporter locally and see raw log events + pre-aggregated metrics in Grafana.
+
+## 1. Start the observability stack
+
+```bash
+docker compose -f zeebe/exporters/analytics-exporter/src/test/resources/local-test/docker-compose.yaml up -d
+```
+
+This starts:
+| Service | URL | Purpose |
+|---|---|---|
+| OTel Collector | localhost:4318 | Receives OTLP logs + metrics |
+| Prometheus | localhost:9090 | Metric storage |
+| Loki | localhost:3100 | Log storage |
+| Grafana | localhost:3333 | Dashboards (no login) |
+
+## 2. Configure the analytics exporter
+
+### Option A: Environment variables
+
+Add these to your Zeebe / Camunda run configuration:
+
+```
+CAMUNDA_LICENSE_KEY=local-test-license-key
+ZEEBE_BROKER_EXPORTERS_ANALYTICS_CLASSNAME=io.camunda.exporter.analytics.AnalyticsExporter
+ZEEBE_BROKER_EXPORTERS_ANALYTICS_ARGS_ENDPOINT=http://localhost:4318
+ZEEBE_BROKER_EXPORTERS_ANALYTICS_ARGS_PUSHINTERVAL=PT10S
+
+```
+
+### Option B: YAML configuration
+
+Add to your `application.yaml` or pass via `-Dspring.config.additional-location=`:
+
+```yaml
+zeebe:
+  broker:
+    exporters:
+      analytics:
+        className: io.camunda.exporter.analytics.AnalyticsExporter
+        args:
+          endpoint: http://localhost:4318
+          pushInterval: PT10S
+
+camunda:
+  license:
+    key: local-test-license-key
+```
+
+A reference file is provided at `application.yaml` in this directory.
+
+## 3. Generate load
+
+### Shell script (included)
+
+```bash
+# Default: 5 instances/sec for 120 seconds
+./zeebe/exporters/analytics-exporter/src/test/resources/local-test/generate-load.sh
+
+# Custom: 10 instances/sec for 60 seconds
+./zeebe/exporters/analytics-exporter/src/test/resources/local-test/generate-load.sh 10 60
+```
+
+### curl (one-off)
+
+```bash
+# Deploy a process
+curl -X POST http://localhost:8080/v2/deployments \
+  -F "resources=@-;filename=test.bpmn;type=application/xml" <<'BPMN'
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" targetNamespace="http://camunda.org/test">
+  <bpmn:process id="analytics-test" isExecutable="true">
+    <bpmn:startEvent id="start"/><bpmn:endEvent id="end"/>
+    <bpmn:sequenceFlow id="flow" sourceRef="start" targetRef="end"/>
+  </bpmn:process>
+</bpmn:definitions>
+BPMN
+
+# Create instances
+for i in $(seq 1 50); do
+  curl -s -X POST http://localhost:8080/v2/process-instances \
+    -H "Content-Type: application/json" \
+    -d '{"bpmnProcessId":"analytics-test"}'
+done
+```
+
+### Camunda Modeler / Web UI
+
+Deploy any process via Modeler or the web UI at http://localhost:8080 and start instances manually.
+
+## 4. View in Grafana
+
+Open http://localhost:3333 → **Explore**
+
+### Metrics (Prometheus datasource)
+
+|                                 Query                                  |                      What it shows                       |
+|------------------------------------------------------------------------|----------------------------------------------------------|
+| `camunda_process_instance_created_total`                               | Pre-aggregated counter                                   |
+| `sum by (camunda_process_id) (camunda_process_instance_created_total)` | Breakdown by process                                     |
+| `camunda_metric_export_window`                                         | Companion gauge (flush sequence, positions, event times) |
+
+### Logs (Loki datasource)
+
+|                              Query                              |        What it shows         |
+|-----------------------------------------------------------------|------------------------------|
+| `{service_name="camunda-zeebe"}`                                | All raw analytics events     |
+| `{service_name="camunda-zeebe"} \|= "process_instance_created"` | Process instance events only |
+
+## 5. Tear down
+
+```bash
+docker compose -f zeebe/exporters/analytics-exporter/src/test/resources/local-test/docker-compose.yaml down
+```
+

--- a/zeebe/exporters/analytics-exporter/src/test/resources/local-test/application.yaml
+++ b/zeebe/exporters/analytics-exporter/src/test/resources/local-test/application.yaml
@@ -1,0 +1,12 @@
+zeebe:
+  broker:
+    exporters:
+      analytics:
+        className: io.camunda.exporter.analytics.AnalyticsExporter
+        args:
+          endpoint: http://localhost:4318
+          pushInterval: PT10S
+
+camunda:
+  license:
+    key: local-test-license-key

--- a/zeebe/exporters/analytics-exporter/src/test/resources/local-test/docker-compose.yaml
+++ b/zeebe/exporters/analytics-exporter/src/test/resources/local-test/docker-compose.yaml
@@ -1,0 +1,56 @@
+services:
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:latest
+    ports:
+      - "4318:4318"
+    volumes:
+      - ./otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml
+    depends_on:
+      - prometheus
+      - loki
+
+  prometheus:
+    image: prom/prometheus:latest
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yaml:/etc/prometheus/prometheus.yml
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --web.enable-remote-write-receiver
+      - --enable-feature=native-histograms
+
+  loki:
+    image: grafana/loki:latest
+    ports:
+      - "3100:3100"
+
+  grafana:
+    image: grafana/grafana:latest
+    ports:
+      - "3333:3000"
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+    volumes:
+      - ./grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
+    depends_on:
+      - prometheus
+      - loki
+
+  # Optional: uncomment to run Camunda in Docker instead of from IntelliJ.
+  # Uses the docker network — endpoint is otel-collector:4318 (not localhost).
+  #
+  # camunda:
+  #   image: camunda/camunda:SNAPSHOT
+  #   ports:
+  #     - "8080:8080"
+  #     - "26500:26500"
+  #   environment:
+  #     - CAMUNDA_LICENSE_KEY=local-test-license-key
+  #     - ZEEBE_BROKER_EXPORTERS_ANALYTICS_CLASSNAME=io.camunda.exporter.analytics.AnalyticsExporter
+  #     - ZEEBE_BROKER_EXPORTERS_ANALYTICS_ARGS_ENDPOINT=http://otel-collector:4318
+  #     - ZEEBE_BROKER_EXPORTERS_ANALYTICS_ARGS_PUSHINTERVAL=PT10S
+  #   depends_on:
+  #     - otel-collector

--- a/zeebe/exporters/analytics-exporter/src/test/resources/local-test/generate-load.sh
+++ b/zeebe/exporters/analytics-exporter/src/test/resources/local-test/generate-load.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Deploys 2 processes and creates instances in a loop.
+# Usage: ./generate-load.sh [instances-per-second] [duration-seconds]
+# Defaults: 5 instances/sec for 120 seconds
+
+set -euo pipefail
+
+API="http://localhost:8080/v2"
+RATE="${1:-5}"
+DURATION="${2:-120}"
+
+if [ "$RATE" -le 0 ] 2>/dev/null; then
+  echo "Error: rate must be a positive integer" >&2
+  exit 1
+fi
+
+SLEEP=$(awk "BEGIN {printf \"%.3f\", 1/$RATE}")
+
+echo "Waiting for Zeebe to be ready..."
+until curl -sf "$API/../v1/topology" > /dev/null 2>&1; do sleep 1; done
+
+echo "Deploying processes..."
+
+for PROCESS_ID in order-process payment-flow; do
+  curl -sf --retry 3 --retry-connrefused -X POST "$API/deployments" \
+    -F "resources=@-;filename=$PROCESS_ID.bpmn;type=application/xml" <<BPMN
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" targetNamespace="http://camunda.org/test">
+  <bpmn:process id="$PROCESS_ID" isExecutable="true">
+    <bpmn:startEvent id="start"/><bpmn:endEvent id="end"/>
+    <bpmn:sequenceFlow id="flow" sourceRef="start" targetRef="end"/>
+  </bpmn:process>
+</bpmn:definitions>
+BPMN
+  echo "  Deployed $PROCESS_ID"
+done
+
+PROCESSES=("order-process" "payment-flow")
+COUNT=0
+START=$(date +%s)
+
+echo ""
+echo "Creating ~$RATE instances/sec for ${DURATION}s..."
+echo "Grafana: http://localhost:3333  Prometheus: http://localhost:9090"
+echo ""
+
+while true; do
+  ELAPSED=$(( $(date +%s) - START ))
+  if [ "$ELAPSED" -ge "$DURATION" ]; then break; fi
+
+  PROCESS="${PROCESSES[$((COUNT % ${#PROCESSES[@]}))]}"
+  curl -sf -X POST "$API/process-instances" \
+    -H "Content-Type: application/json" \
+    -d "{\"bpmnProcessId\":\"$PROCESS\"}" > /dev/null
+
+  COUNT=$((COUNT + 1))
+  if [ $((COUNT % 50)) -eq 0 ]; then
+    echo "  $COUNT instances (${ELAPSED}s)"
+  fi
+
+  sleep "$SLEEP"
+done
+
+echo ""
+echo "Done — created $COUNT instances in ${DURATION}s"
+echo "Wait ~10s for the next metric flush, then check Grafana."

--- a/zeebe/exporters/analytics-exporter/src/test/resources/local-test/grafana-datasources.yaml
+++ b/zeebe/exporters/analytics-exporter/src/test/resources/local-test/grafana-datasources.yaml
@@ -1,0 +1,11 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100

--- a/zeebe/exporters/analytics-exporter/src/test/resources/local-test/otel-collector-config.yaml
+++ b/zeebe/exporters/analytics-exporter/src/test/resources/local-test/otel-collector-config.yaml
@@ -1,0 +1,26 @@
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  deltatocumulative:
+
+exporters:
+  debug:
+    verbosity: detailed
+  prometheusremotewrite:
+    endpoint: http://prometheus:9090/api/v1/write
+  otlphttp/loki:
+    endpoint: http://loki:3100/otlp
+
+service:
+  pipelines:
+    logs:
+      receivers: [otlp]
+      exporters: [debug, otlphttp/loki]
+    metrics:
+      receivers: [otlp]
+      processors: [deltatocumulative]
+      exporters: [debug, prometheusremotewrite]

--- a/zeebe/exporters/analytics-exporter/src/test/resources/local-test/prometheus.yaml
+++ b/zeebe/exporters/analytics-exporter/src/test/resources/local-test/prometheus.yaml
@@ -1,0 +1,2 @@
+global:
+  scrape_interval: 5s


### PR DESCRIPTION
## Summary

Local dev setup for testing the analytics exporter end-to-end with real observability tools.

**What's included:**
- Docker Compose stack: OTel Collector → Prometheus (metrics) + Loki (logs) + Grafana (dashboards)
- `generate-load.sh` — deploys 2 processes, creates instances at configurable rate
- `README.md` — step-by-step instructions
- `application.yaml` — Zeebe config with analytics exporter enabled

**How to use:**
```bash
# Start the stack
docker compose -f zeebe/exporters/analytics-exporter/src/test/resources/local-test/docker-compose.yaml up -d

# Run Zeebe from IntelliJ with the env vars from the README

# Generate load
./zeebe/exporters/analytics-exporter/src/test/resources/local-test/generate-load.sh

# Open Grafana at http://localhost:3333
```

Related: #52386, #54281

🤖 Generated with [Claude Code](https://claude.com/claude-code)