### PR TITLE
ci: drop redundant process-resources step in validate-pom-metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,10 +232,9 @@ jobs:
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-      - name: Bootstrap reactor modules
+      - name: Bootstrap reactor and generate flattened POMs
+        # quickly=false default → flatten.skip=false → flatten-maven-plugin runs during `process-resources` of `install`.
         run: ./mvnw clean install -B -T1C --no-snapshot-updates -DskipChecks=true -DskipTests=true -PskipFrontendBuild
-      - name: Generate flattened POMs
-        run: ./mvnw -B -T1C --no-snapshot-updates -DskipChecks=true -Dcheckstyle.skip=true -DskipTests=true -Dquickly=false -PskipFrontendBuild process-resources
       - name: Validate flattened POM metadata
         uses: ./.github/actions/validate-pom-metadata
       - name: Observe build status


### PR DESCRIPTION
## Summary

- Removes the second `mvnw … process-resources` step from the `validate-pom-metadata` job in `ci.yml`.
- The preceding `mvnw clean install` already runs `process-resources` with `quickly=false` default → `flatten.skip=false`, so the flatten-maven-plugin runs and flattened POMs (`.flattened-pom.xml`) are already on disk when the `validate-pom-metadata` action consumes them.
- The deleted step re-ran `process-resources` over the whole reactor, regenerating the same files — pure duplication.

## Why this is safe

`parent/pom.xml`:

```xml
<quickly>false</quickly>
<flatten.skip>${quickly}</flatten.skip>
```

The first step omits `-Dquickly` ⇒ `quickly` defaults to `false` ⇒ `flatten.skip=false` ⇒ flatten plugin binds to `process-resources` and runs during `install`. The deleted step explicitly set `-Dquickly=false` and called `process-resources` — same result, second time.

`-Dcheckstyle.skip=true` in the deleted step was already covered by `-DskipChecks=true` in the first step (parent POM: `<skipChecks>${quickly}</skipChecks>` plus the explicit `-DskipChecks=true` flag).

## Scope

- File touched: `.github/workflows/ci.yml` only (one job).
- Job touched: `validate-pom-metadata` only.
- No new triggers, conditions, permissions, runners, matrix entries, or inputs.
- Retention-days work is **not** in this PR. `ci.yml` on `main` has no `upload-artifact` calls. The implementation plan now mandates per-artifact retention investigation any time a workflow file with existing `upload-artifact` is touched (see plan, "📐 Implementation Rules").

## Validation

- `actionlint .github/workflows/ci.yml` — clean for the changed region. Unrelated pre-existing warnings about self-hosted runner labels (`gcp-*`, `ubuntu-slim`) not introduced here.
- `conftest test --rego-version v0 --policy .github .github/workflows/ci.yml` — 33/34 pass, 1 pre-existing warning about jobs missing `print-metadata` (also affects other jobs unrelated to this change).
- Spotless not run: no Java/POM/Kotlin files touched.
- Tier 3 per `.claude/skills/act-testing` rubric: pure step deletion inside one existing job, no surface change. Local `act` infeasible (job requires Vault secrets + full Maven reactor).

## Test plan

- [x] CI run on this PR triggers `validate-pom-metadata` (PR touches `ci.yml`, which matches the filter).
- [x] `validate-pom-metadata` job passes.
- [x] Job log shows exactly one `mvnw` invocation (`Bootstrap reactor and generate flattened POMs`) and the `Validate flattened POM metadata` action passes — i.e., the flattened POMs are present after the single step.
- [x] Compare job duration to last 9 successful runs on `main`. Expected ~30–90 s reduction.

## Measured impact (initial CI run)

| | Duration |
|--|----------|
| `Lint / Flattened POM Metadata` on this PR ([run 26752259177](https://github.com/camunda/camunda/actions/runs/26752259177/job/78843033657)) | **5m 29s** |
| Last 9 successful runs on `main` — min | 5m 25s |
| Last 9 successful runs on `main` — max | 7m 32s |
| Last 9 successful runs on `main` — mean | ~6m 42s |

- **Saving vs main mean:** ~1m 13s (~18% reduction).
- PR run matches the main min within 4 s; faster than 8 of 9 baseline runs.
- Single-run sample — baseline spread is ~2 min, so a multi-run sample would tighten the estimate. Direction matches the plan's predicted ~30–90 s reduction (at the high end of the range).

## Rollback

Revert this single commit — no other workflow files affected, no consumers downstream.

## Plan reference

PR 1 of the phased rollout for #52693 — see the [implementation plan comment](https://github.com/camunda/camunda/issues/52693#issuecomment-4592125469) for full PR breakdown, dependencies, and expected savings per step. Scope confirmed against `origin/main`.

## Related

- Parent issue: #52693
