### PR TITLE
[CPT] test: Reduce CPT compatibility tests

### DIFF
--- a/.github/workflows/camunda-process-test-compatibility-trigger.yml
+++ b/.github/workflows/camunda-process-test-compatibility-trigger.yml
@@ -1,6 +1,6 @@
 # description: trigger workflow to run the camunda-process-test-compatibility.yml workflow on a schedule
 # type: CI
-# owner: @camunda/camunda-ex
+# owner: @camunda/c8-testing
 name: CPT Compatibility Tests - Trigger
 
 on:
@@ -22,8 +22,10 @@ jobs:
         include:
           - branch: stable/8.8
             camunda_image_version: 8.9-SNAPSHOT
+            connectors_image_version: 8.9-SNAPSHOT
           - branch: stable/8.9
             camunda_image_version: 8.10-SNAPSHOT
+            connectors_image_version: 8.10-SNAPSHOT
     steps:
       - name: Trigger CPT compatibility tests
         env:
@@ -33,4 +35,5 @@ jobs:
             --ref ${{ matrix.branch }} \
             -f branch=${{ matrix.branch }} \
             -f camunda_image_version=${{ matrix.camunda_image_version }} \
+            -f connectors_image_version=${{ matrix.connectors_image_version }} \
             --repo ${{ github.repository }}

--- a/.github/workflows/camunda-process-test-compatibility-trigger.yml
+++ b/.github/workflows/camunda-process-test-compatibility-trigger.yml
@@ -7,52 +7,30 @@ on:
   schedule:
     # Run daily at 02:00 UTC
     - cron: "0 2 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: write
 
 jobs:
-  trigger-stable-8-8:
+  trigger:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - branch: stable/8.8
+            camunda_image_version: 8.9-SNAPSHOT
+          - branch: stable/8.9
+            camunda_image_version: 8.10-SNAPSHOT
     steps:
-      - name: Trigger CPT compatibility tests on stable/8.8
+      - name: Trigger CPT compatibility tests
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh workflow run .github/workflows/camunda-process-test-compatibility.yml \
-            --ref stable/8.8 \
+            --ref ${{ matrix.branch }} \
+            -f branch=${{ matrix.branch }} \
+            -f camunda_image_version=${{ matrix.camunda_image_version }} \
             --repo ${{ github.repository }}
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          sparse-checkout: .github
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          build_status: ${{ job.status }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-
-  trigger-stable-8-9:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Trigger CPT compatibility tests on stable/8.9
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh workflow run .github/workflows/camunda-process-test-compatibility.yml \
-            --ref stable/8.9 \
-            --repo ${{ github.repository }}
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          sparse-checkout: .github
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          build_status: ${{ job.status }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/camunda-process-test-compatibility-trigger.yml
+++ b/.github/workflows/camunda-process-test-compatibility-trigger.yml
@@ -37,3 +37,17 @@ jobs:
             -f camunda_image_version=${{ matrix.camunda_image_version }} \
             -f connectors_image_version=${{ matrix.connectors_image_version }} \
             --repo ${{ github.repository }}
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          job_name: trigger-cpt-compatibility-tests (branch=${{ matrix.branch }}, runtime=${{ matrix.camunda_image_version }})
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/camunda-process-test-compatibility.yml
+++ b/.github/workflows/camunda-process-test-compatibility.yml
@@ -107,7 +107,7 @@ jobs:
         if: always()
         uses: ./.github/actions/collect-test-artifacts
         with:
-          name: 'cpt compatibility tests - branch ${{ inputs.branch }} server ${{ inputs.camunda_image_version }}'
+          name: 'cpt compatibility tests - cpt version ${{ steps.cpt-version.outputs.version }} camunda version ${{ inputs.camunda_image_version }}'
 
       - name: Observe build status
         if: always()

--- a/.github/workflows/camunda-process-test-compatibility.yml
+++ b/.github/workflows/camunda-process-test-compatibility.yml
@@ -20,7 +20,7 @@ on:
         type: boolean
         default: false
 
-permissions: {}
+permissions: { }
 
 defaults:
   run:
@@ -39,7 +39,6 @@ jobs:
       actions: read
     outputs:
       matrix: ${{ steps.create-matrix.outputs.matrix }}
-      is-main: ${{ steps.branch-info.outputs.is-main }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -73,195 +72,34 @@ jobs:
           echo "pom-version=$POM_VERSION" >> "$GITHUB_OUTPUT"
           echo "Current pom.xml version: $POM_VERSION"
 
-      - name: Get versions from git tags
-        id: get-versions
+      - name: Prepare simple test matrix
+        id: prepare-matrix-info
         run: |
-          # Get all version tags (format: 8.x.y)
-          ALL_TAGS=$(git tag -l '[0-9]*.[0-9]*.[0-9]*' | sort -V)
+          # For stable branches, test current snapshot against next minor version
+          POM_VERSION="${{ steps.pom-version.outputs.pom-version }}"
+          echo "Current pom version: $POM_VERSION"
+          echo "pom-snapshot=$POM_VERSION" >> "$GITHUB_OUTPUT"
 
-          STABLE_VERSION="${{ steps.branch-info.outputs.stable-version }}"
-          IS_MAIN="${{ steps.branch-info.outputs.is-main }}"
-
-          if [[ "$IS_MAIN" == "true" ]]; then
-            # On main, use only the snapshot version from pom as the tag
-            FILTERED_TAGS=""
+          # Extract major.minor from version (e.g., 8.8.2-SNAPSHOT -> 8.8)
+          if [[ "$POM_VERSION" =~ ^([0-9]+)\.([0-9]+) ]]; then
+            MAJOR="${BASH_REMATCH[1]}"
+            MINOR="${BASH_REMATCH[2]}"
+            NEXT_MINOR=$((MINOR + 1))
+            NEXT_MINOR_SNAPSHOT="${MAJOR}.${NEXT_MINOR}-SNAPSHOT"
+            echo "Next minor version snapshot: $NEXT_MINOR_SNAPSHOT"
+            echo "next-minor-snapshot=$NEXT_MINOR_SNAPSHOT" >> "$GITHUB_OUTPUT"
           else
-            # Filter tags >= stable version (e.g., >= 8.8.0)
-            FILTERED_TAGS=""
-            SKIPPED_COUNT=0
-            FILTERED_COUNT=0
-            for tag in $ALL_TAGS; do
-              # Skip alpha/beta/rc releases (format: 8.x.x-alpha1, 8.x.x-rc1)
-              if [[ "$tag" =~ -alpha|-beta|-rc ]]; then
-                SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
-                continue
-              fi
-
-              # Extract major.minor from tag
-              if [[ "$tag" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
-                TAG_MAJOR="${BASH_REMATCH[1]}"
-                TAG_MINOR="${BASH_REMATCH[2]}"
-
-                # Compare versions
-                IFS='.' read -r STABLE_MAJOR STABLE_MINOR <<< "$STABLE_VERSION"
-
-                if (( TAG_MAJOR > STABLE_MAJOR )) || \
-                   (( TAG_MAJOR == STABLE_MAJOR && TAG_MINOR >= STABLE_MINOR )); then
-                  FILTERED_TAGS+="$tag"$'\n'
-                  FILTERED_COUNT=$((FILTERED_COUNT + 1))
-                fi
-              fi
-            done
+            echo "ERROR: Could not parse version from $POM_VERSION"
+            exit 1
           fi
-
-          # Save filtered tags
-          echo "$FILTERED_TAGS" > /tmp/filtered_tags.txt
-          FILTERED_COUNT=$(echo "$FILTERED_TAGS" | grep -c -v '^$' || echo "0")
-          echo "Filtered tags:"
-          cat /tmp/filtered_tags.txt
-
-      - name: Create version lists
-        id: create-lists
-        run: |
-          FILTERED_TAGS=$(grep -v '^$' /tmp/filtered_tags.txt || true)
-          IS_MAIN="${{ steps.branch-info.outputs.is-main }}"
-
-          STABLE_VERSION="${{ steps.branch-info.outputs.stable-version }}"
-
-          if [[ "$IS_MAIN" == "true" ]]; then
-            NEXT_SNAPSHOT="SNAPSHOT"
-          elif [[ -n "$STABLE_VERSION" ]]; then
-            IFS='.' read -r STABLE_MAJOR STABLE_MINOR <<< "$STABLE_VERSION"
-            NEXT_MINOR=$((STABLE_MINOR + 1))
-            if echo "$FILTERED_TAGS" | grep -q "^${STABLE_MAJOR}\\.${NEXT_MINOR}\\."; then
-              NEXT_SNAPSHOT="${STABLE_MAJOR}.${NEXT_MINOR}-SNAPSHOT"
-            else
-              NEXT_SNAPSHOT="SNAPSHOT"
-            fi
-          else
-            NEXT_SNAPSHOT="SNAPSHOT"
-          fi
-
-          echo "next-snapshot=$NEXT_SNAPSHOT" >> "$GITHUB_OUTPUT"
-
-          # Create CLIENT_LIST: on stable branches, only same-minor versions (no snapshot)
-          CLIENT_LIST=""
-          CLIENT_COUNT=0
-          if [[ -n "$FILTERED_TAGS" ]]; then
-            for tag in $FILTERED_TAGS; do
-              if [[ -n "$STABLE_VERSION" ]]; then
-                # On stable branches, only include tags matching the stable major and minor
-                if [[ "$tag" =~ ^([0-9]+)\.([0-9]+)\. ]]; then
-                  TAG_MAJOR="${BASH_REMATCH[1]}"
-                  TAG_MINOR="${BASH_REMATCH[2]}"
-                  if (( TAG_MAJOR != STABLE_MAJOR || TAG_MINOR != STABLE_MINOR )); then
-                    continue
-                  fi
-                fi
-              fi
-              CLIENT_LIST+="$tag"$'\n'
-              CLIENT_COUNT=$((CLIENT_COUNT + 1))
-            done
-          fi
-
-          if [[ "$IS_MAIN" == "true" ]]; then
-            # On main, the only client is the pom version
-            CLIENT_LIST="${{ steps.pom-version.outputs.pom-version }}"$'\n'
-          elif (( CLIENT_COUNT == 0 )); then
-            # On stable branches with no GA tags yet, use the pom SNAPSHOT version
-            CLIENT_LIST="${{ steps.pom-version.outputs.pom-version }}"$'\n'
-            echo "No GA tags found for stable version $STABLE_VERSION - using pom SNAPSHOT as client"
-          fi
-
-          echo "$CLIENT_LIST" > /tmp/client_list.txt
-          echo "CLIENT_LIST:"
-          cat /tmp/client_list.txt
-
-          # Create SERVER_LIST: versions from next minor onwards + snapshot (if not on main)
-          SERVER_LIST=""
-          STABLE_VERSION="${{ steps.branch-info.outputs.stable-version }}"
-
-          if [[ -n "$STABLE_VERSION" ]]; then
-            # Parse stable version to get next minor
-            IFS='.' read -r STABLE_MAJOR STABLE_MINOR <<< "$STABLE_VERSION"
-            NEXT_MINOR=$((STABLE_MINOR + 1))
-
-            SERVER_COUNT=0
-            if [[ -n "$FILTERED_TAGS" ]]; then
-              for tag in $FILTERED_TAGS; do
-                if [[ "$tag" =~ ^([0-9]+)\.([0-9]+)\. ]]; then
-                  TAG_MAJOR="${BASH_REMATCH[1]}"
-                  TAG_MINOR="${BASH_REMATCH[2]}"
-
-                  if (( TAG_MAJOR > STABLE_MAJOR )) || \
-                     (( TAG_MAJOR == STABLE_MAJOR && TAG_MINOR >= NEXT_MINOR )); then
-                    SERVER_LIST+="$tag"$'\n'
-                    SERVER_COUNT=$((SERVER_COUNT + 1))
-                  fi
-                fi
-              done
-            fi
-          else
-            # On main, SERVER_LIST uses SNAPSHOT
-            SERVER_LIST="SNAPSHOT"$'\n'
-          fi
-
-          if [[ "$IS_MAIN" != "true" ]]; then
-            SERVER_LIST+="$NEXT_SNAPSHOT"$'\n'
-          fi
-
-          echo "$SERVER_LIST" > /tmp/server_list.txt
-          echo "SERVER_LIST:"
-          cat /tmp/server_list.txt
-
-      - name: Restore tested combinations from previous run
-        id: restore-tested
-        if: inputs.skip_cache != true
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          mkdir -p /tmp/cpt-compatibility-state
-
-          # Find the most recent tested-combinations artifact for this branch
-          ARTIFACT_NAME="cpt-tested-combinations-${{ github.ref_name }}"
-          ARTIFACT_NAME="${ARTIFACT_NAME//\//-}"  # Replace / with - for artifact naming
-
-          # Query for the artifact directly by name across recent runs
-          if ! ARTIFACT_URL=$(gh api "repos/${{ github.repository }}/actions/artifacts?name=${ARTIFACT_NAME}&per_page=1" \
-            --jq '.artifacts[0].archive_download_url // empty' 2>&1); then
-            echo "::warning::Failed to query artifacts API: $ARTIFACT_URL"
-            ARTIFACT_URL=""
-          fi
-
-          if [[ -n "$ARTIFACT_URL" ]]; then
-            echo "Found previous tested-combinations artifact, downloading..."
-            if ! gh api "$ARTIFACT_URL" > /tmp/artifact.zip 2>&1; then
-              echo "::warning::Failed to download artifact from $ARTIFACT_URL"
-              touch /tmp/cpt-compatibility-state/tested-combinations.txt
-            elif ! unzip -q /tmp/artifact.zip -d /tmp/cpt-compatibility-state; then
-              echo "::warning::Downloaded file is not a valid zip archive - starting fresh"
-              touch /tmp/cpt-compatibility-state/tested-combinations.txt
-            else
-              echo "Loaded $(wc -l < /tmp/cpt-compatibility-state/tested-combinations.txt) previously tested combinations"
-            fi
-          else
-            echo "No previous test history found - starting fresh"
-            touch /tmp/cpt-compatibility-state/tested-combinations.txt
-          fi
-
-      - name: Load tested combinations
-        id: load-tested
-        if: inputs.skip_cache == true
-        run: |
-          mkdir -p /tmp/cpt-compatibility-state
-          touch /tmp/cpt-compatibility-state/tested-combinations.txt
-          echo "Skipping cache - will test all combinations"
 
       - name: Create version matrix
         id: create-matrix
         run: |
           CLIENT_VERSION="${{ inputs.cpt_version }}"
           SERVER_VERSION="${{ inputs.runtime_version }}"
+          POM_SNAPSHOT="${{ steps.prepare-matrix-info.outputs.pom-snapshot }}"
+          NEXT_MINOR_SNAPSHOT="${{ steps.prepare-matrix-info.outputs.next-minor-snapshot }}"
 
           # Normalize x.y.0-SNAPSHOT to x.y-SNAPSHOT (Docker tag format)
           CLIENT_VERSION="${CLIENT_VERSION/%.0-SNAPSHOT/-SNAPSHOT}"
@@ -272,59 +110,16 @@ jobs:
             MATRIX_JSON=$(jq -nc --arg client "$CLIENT_VERSION" --arg server "$SERVER_VERSION" '{"include": [{"client": $client, "server": $server}]}')
             echo "matrix=$MATRIX_JSON" >> "$GITHUB_OUTPUT"
           elif [[ -n "$CLIENT_VERSION" ]]; then
-            echo "Manual trigger: Testing client version $CLIENT_VERSION against all servers"
-            SERVER_LIST=$(grep -v '^$' /tmp/server_list.txt)
-            MATRIX_ITEMS="[]"
-            for server in $SERVER_LIST; do
-              MATRIX_ITEMS=$(echo "$MATRIX_ITEMS" | jq -c '. += [{"client": "'"$CLIENT_VERSION"'", "server": "'"$server"'"}]')
-            done
-            MATRIX_JSON=$(jq -nc --argjson items "$MATRIX_ITEMS" '{"include": $items}')
+            echo "Manual trigger: Testing client version $CLIENT_VERSION against next minor snapshot ($NEXT_MINOR_SNAPSHOT)"
+            MATRIX_JSON=$(jq -nc --arg client "$CLIENT_VERSION" --arg server "$NEXT_MINOR_SNAPSHOT" '{"include": [{"client": $client, "server": $server}]}')
             echo "matrix=$MATRIX_JSON" >> "$GITHUB_OUTPUT"
           elif [[ -n "$SERVER_VERSION" ]]; then
-            echo "Manual trigger: Testing server version $SERVER_VERSION with all clients"
-            CLIENT_LIST=$(grep -v '^$' /tmp/client_list.txt)
-            MATRIX_ITEMS="[]"
-            for client in $CLIENT_LIST; do
-              MATRIX_ITEMS=$(echo "$MATRIX_ITEMS" | jq -c '. += [{"client": "'"$client"'", "server": "'"$SERVER_VERSION"'"}]')
-            done
-            MATRIX_JSON=$(jq -nc --argjson items "$MATRIX_ITEMS" '{"include": $items}')
+            echo "Manual trigger: Testing server version $SERVER_VERSION with current snapshot client ($POM_SNAPSHOT)"
+            MATRIX_JSON=$(jq -nc --arg client "$POM_SNAPSHOT" --arg server "$SERVER_VERSION" '{"include": [{"client": $client, "server": $server}]}')
             echo "matrix=$MATRIX_JSON" >> "$GITHUB_OUTPUT"
           else
-            CLIENT_LIST=$(grep -v '^$' /tmp/client_list.txt)
-            SERVER_LIST=$(grep -v '^$' /tmp/server_list.txt)
-            SKIP_CACHE="${{ inputs.skip_cache }}"
-
-            MATRIX_ITEMS="[]"
-            ADDED_COUNT=0
-            SKIPPED_COUNT=0
-
-            for client in $CLIENT_LIST; do
-              for server in $SERVER_LIST; do
-                COMBO="$client-$server"
-
-                # Skip SNAPSHOT client vs SNAPSHOT server - not a compatibility test (except on main)
-                if [[ "${{ steps.branch-info.outputs.is-main }}" != "true" && "$client" =~ SNAPSHOT && "$server" =~ SNAPSHOT ]]; then
-                  SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
-                  continue
-                fi
-
-                # Skip if combination already tested (unless skip_cache is true or server is snapshot)
-                if [[ "$SKIP_CACHE" != "true" ]]; then
-                  if grep -q "^$COMBO$" /tmp/cpt-compatibility-state/tested-combinations.txt 2>/dev/null; then
-                    if [[ "$server" != *"-SNAPSHOT" ]]; then
-                      SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
-                      continue
-                    fi
-                  fi
-                fi
-
-                MATRIX_ITEMS=$(echo "$MATRIX_ITEMS" | jq -c '. += [{"client": "'"$client"'", "server": "'"$server"'"}]')
-                ADDED_COUNT=$((ADDED_COUNT + 1))
-              done
-            done
-
-            echo "Matrix contains $ADDED_COUNT combinations (skipped $SKIPPED_COUNT already tested)"
-            MATRIX_JSON=$(jq -nc --argjson items "$MATRIX_ITEMS" '{"include": $items}')
+            echo "Scheduled run: Testing CPT $POM_SNAPSHOT against Camunda $NEXT_MINOR_SNAPSHOT"
+            MATRIX_JSON=$(jq -nc --arg client "$POM_SNAPSHOT" --arg server "$NEXT_MINOR_SNAPSHOT" '{"include": [{"client": $client, "server": $server}]}')
             echo "matrix=$MATRIX_JSON" >> "$GITHUB_OUTPUT"
             echo "Generated matrix:"
             echo "$MATRIX_JSON" | jq '.'
@@ -342,7 +137,7 @@ jobs:
   run-cpt-tests:
     name: Test CPT ${{ matrix.client }} -> Runtime ${{ matrix.server }}
     needs: prepare-versions
-    if: needs.prepare-versions.outputs.matrix != '{"include":[]}'
+    if: needs.prepare-versions.result == 'success' && needs.prepare-versions.outputs.matrix != '{"include":[]}'
     runs-on: ubuntu-latest
     timeout-minutes: 120
     permissions:
@@ -512,20 +307,6 @@ jobs:
             -DfailIfNoTests=false
             ${{ steps.api-version.outputs.extra-props }}
 
-      - name: Record tested combination
-        if: success() && !contains(matrix.client, 'SNAPSHOT') && !contains(matrix.server, 'SNAPSHOT')
-        run: |
-          mkdir -p cpt-test-results
-          echo "${{ matrix.client }}-${{ matrix.server }}" >> cpt-test-results/tested.txt
-
-      - name: Upload tested combinations
-        if: success() && !contains(matrix.client, 'SNAPSHOT') && !contains(matrix.server, 'SNAPSHOT')
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: tested-combo-${{ matrix.client }}-${{ matrix.server }}
-          path: cpt-test-results/tested.txt
-          retention-days: 30
-
       - name: Upload test artifacts
         if: always()
         uses: ./.github/actions/collect-test-artifacts
@@ -543,97 +324,13 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
-  save-tested-combinations:
-    name: Save Tested Combinations
-    needs: [prepare-versions, run-cpt-tests]
-    if: always() && needs.prepare-versions.result == 'success'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      contents: read
-      actions: read
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Restore previous tested combinations
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          mkdir -p /tmp/cpt-compatibility-state
-
-          ARTIFACT_NAME="cpt-tested-combinations-${GITHUB_REF_NAME//\//-}"
-
-          if ! ARTIFACT_URL=$(gh api "repos/${{ github.repository }}/actions/artifacts?name=${ARTIFACT_NAME}&per_page=1" \
-            --jq '.artifacts[0].archive_download_url // empty' 2>&1); then
-            echo "::warning::Failed to query artifacts API: $ARTIFACT_URL"
-            ARTIFACT_URL=""
-          fi
-
-          if [[ -n "$ARTIFACT_URL" ]]; then
-            if ! gh api "$ARTIFACT_URL" > /tmp/artifact.zip 2>&1; then
-              echo "::warning::Failed to download artifact from $ARTIFACT_URL"
-              touch /tmp/cpt-compatibility-state/tested-combinations.txt
-            elif ! unzip -q /tmp/artifact.zip -d /tmp/cpt-compatibility-state; then
-              echo "::warning::Downloaded file is not a valid zip archive"
-              touch /tmp/cpt-compatibility-state/tested-combinations.txt
-            else
-              echo "Restored $(wc -l < /tmp/cpt-compatibility-state/tested-combinations.txt) previously tested combinations"
-            fi
-          else
-            touch /tmp/cpt-compatibility-state/tested-combinations.txt
-          fi
-
-      - name: Download all tested combinations from this run
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          pattern: tested-combo-*
-          path: cpt-test-results
-          merge-multiple: true
-
-      - name: Merge tested combinations
-        run: |
-          # Merge new results with existing
-          if [[ -d cpt-test-results ]]; then
-            cat cpt-test-results/*.txt >> /tmp/cpt-compatibility-state/tested-combinations.txt 2>/dev/null || true
-          fi
-
-          # Remove duplicates and sort
-          sort -u /tmp/cpt-compatibility-state/tested-combinations.txt -o /tmp/cpt-compatibility-state/tested-combinations.txt
-
-          echo "Total tested combinations: $(wc -l < /tmp/cpt-compatibility-state/tested-combinations.txt)"
-          cat /tmp/cpt-compatibility-state/tested-combinations.txt
-
-      - name: Determine artifact name
-        id: artifact-name
-        run: |
-          NAME="cpt-tested-combinations-${GITHUB_REF_NAME//\//-}"
-          echo "name=$NAME" >> "$GITHUB_OUTPUT"
-
-      - name: Save tested combinations artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: ${{ steps.artifact-name.outputs.name }}
-          path: /tmp/cpt-compatibility-state/tested-combinations.txt
-          retention-days: 90
-          overwrite: true
-
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          build_status: ${{ job.status }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-
   notify-failure:
     name: Notify on failure
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [prepare-versions, run-cpt-tests]
+    needs: [ prepare-versions, run-cpt-tests ]
     if: always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
-    permissions: {}
+    permissions: { }
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Import Secrets
@@ -654,24 +351,24 @@ jobs:
           webhook: ${{ steps.secrets.outputs.SLACK_CAMUNDA_EX_CI_WEBHOOK }}
           webhook-type: incoming-webhook
           payload: |
-           {
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": ":alarm: *Camunda Process Test Compatibility Tests Failed*"
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Branch: `${{ github.ref_name }}`\nPlease check: https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}"
-                  }
-                }
-              ]
-            }
+            {
+               "blocks": [
+                 {
+                   "type": "section",
+                   "text": {
+                     "type": "mrkdwn",
+                     "text": ":alarm: *Camunda Process Test Compatibility Tests Failed*"
+                   }
+                 },
+                 {
+                   "type": "section",
+                   "text": {
+                     "type": "mrkdwn",
+                     "text": "Branch: `${{ github.ref_name }}`\nPlease check: https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}"
+                   }
+                 }
+               ]
+             }
 
       - name: Observe build status
         if: always()

--- a/.github/workflows/camunda-process-test-compatibility.yml
+++ b/.github/workflows/camunda-process-test-compatibility.yml
@@ -153,14 +153,14 @@ jobs:
                    "type": "section",
                    "text": {
                      "type": "mrkdwn",
-                     "text": ":alarm: *Camunda Process Test Compatibility Tests Failed*"
+                     "text": ":alarm: *Camunda Process Test (CPT) Compatibility Tests Failed*"
                    }
                  },
                  {
                    "type": "section",
                    "text": {
                      "type": "mrkdwn",
-                     "text": "Branch: `${{ github.ref_name }}`\nPlease check: https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}"
+                     "text": "Branch: `${{ github.ref_name }}`\nCamunda image: `${{ inputs.camunda_image_version }}`\nConnectors image: `${{ inputs.connectors_image_version }}`\nPlease check: https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}"
                    }
                  }
                ]

--- a/.github/workflows/camunda-process-test-compatibility.yml
+++ b/.github/workflows/camunda-process-test-compatibility.yml
@@ -15,6 +15,11 @@ on:
         required: false
         default: 'SNAPSHOT'
         type: string
+      connectors_image_version:
+        description: 'Connectors Docker image version (e.g., 8.9-SNAPSHOT).'
+        required: false
+        default: 'SNAPSHOT'
+        type: string
 
 permissions: {}
 
@@ -52,105 +57,6 @@ jobs:
           CPT_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
           echo "version=$CPT_VERSION" >> "$GITHUB_OUTPUT"
           echo "Resolved CPT version: $CPT_VERSION"
-
-      - name: Resolve connectors Docker image version
-        id: connectors-version
-        # Connectors-bundle Docker images don't have a 1:1 version match with Camunda
-        # (e.g. Camunda 8.8.11 may exist but connectors-bundle only goes up to 8.8.7).
-        # Resolution strategy:
-        #   0. SNAPSHOT server  → use SNAPSHOT connectors
-        #   1. Exact match      → use connectors-bundle:<server-version> if the tag exists
-        #   2. Latest patch     → find the highest connectors-bundle:<major.minor.x> tag
-        #   3. Fallback         → use SNAPSHOT connectors
-        run: |
-          SERVER_VERSION="${{ inputs.camunda_image_version }}"
-
-          # If server is SNAPSHOT, use SNAPSHOT for connectors too
-          if [[ "$SERVER_VERSION" == "SNAPSHOT" || "$SERVER_VERSION" == *"-SNAPSHOT" ]]; then
-            echo "version=SNAPSHOT" >> "$GITHUB_OUTPUT"
-            echo "Connectors version: SNAPSHOT (matching SNAPSHOT server)"
-            exit 0
-          fi
-
-          # Check if the exact version exists for connectors-bundle
-          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" --retry 3 --retry-delay 5 --max-time 10 \
-            "https://hub.docker.com/v2/repositories/camunda/connectors-bundle/tags/${SERVER_VERSION}")
-
-          if [[ "$HTTP_STATUS" == "200" ]]; then
-            echo "version=$SERVER_VERSION" >> "$GITHUB_OUTPUT"
-            echo "Connectors version: $SERVER_VERSION (exact match found)"
-            exit 0
-          elif [[ "$HTTP_STATUS" != "404" ]]; then
-            echo "::warning::Docker Hub returned unexpected status $HTTP_STATUS when checking connectors-bundle:${SERVER_VERSION}, falling back to SNAPSHOT"
-            echo "version=SNAPSHOT" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "No exact connectors-bundle tag for $SERVER_VERSION (404), finding latest matching major.minor..."
-
-          # Extract major.minor from server version
-          if [[ "$SERVER_VERSION" =~ ^([0-9]+\.[0-9]+)\. ]]; then
-            MAJOR_MINOR="${BASH_REMATCH[1]}"
-          else
-            echo "::warning::Cannot parse server version $SERVER_VERSION, falling back to SNAPSHOT"
-            echo "version=SNAPSHOT" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Query Docker Hub for the latest connectors-bundle tag with the same major.minor,
-          # paginating through all results to handle versions with many patch releases
-          LATEST_TAG=$(python3 -c "
-          import json, re, sys, urllib.request, urllib.error
-
-          major_minor = '${MAJOR_MINOR}'
-          prefix = major_minor + '.'
-          base_url = 'https://hub.docker.com/v2/repositories/camunda/connectors-bundle/tags/'
-          url = base_url + '?page_size=100&ordering=-name'
-          tags = []
-          pages_fetched = 0
-          max_pages = 10  # safety limit
-
-          while url and pages_fetched < max_pages:
-              pages_fetched += 1
-              try:
-                  req = urllib.request.Request(url, headers={'Accept': 'application/json'})
-                  with urllib.request.urlopen(req, timeout=15) as resp:
-                      data = json.loads(resp.read().decode())
-              except (urllib.error.URLError, json.JSONDecodeError, ValueError) as e:
-                  print(f'ERROR: failed to fetch tags (page {pages_fetched}): {e}', file=sys.stderr)
-                  sys.exit(1)
-
-              if 'results' not in data:
-                  print('ERROR: unexpected response structure, missing results key', file=sys.stderr)
-                  sys.exit(1)
-
-              for r in data['results']:
-                  name = r.get('name', '')
-                  if name.startswith(prefix) and re.match(r'^[0-9]+\.[0-9]+\.[0-9]+$', name):
-                      parts = name.split('.')
-                      tags.append((int(parts[0]), int(parts[1]), int(parts[2]), name))
-
-              # If we already found tags and the next page would be for older versions,
-              # we can stop early since results are ordered by name descending
-              url = data.get('next')
-              if tags and url:
-                  # Check if last result on this page is already below our major.minor
-                  last_name = data['results'][-1].get('name', '') if data['results'] else ''
-                  if last_name and not last_name.startswith(major_minor[0]):
-                      break
-
-          if tags:
-              tags.sort(reverse=True)
-              print(tags[0][3])
-          ") || true
-
-          if [[ -n "$LATEST_TAG" ]]; then
-            echo "version=$LATEST_TAG" >> "$GITHUB_OUTPUT"
-            echo "Connectors version: $LATEST_TAG (latest for $MAJOR_MINOR.x)"
-          else
-            echo "::warning::No connectors-bundle tag found for $MAJOR_MINOR.x, falling back to SNAPSHOT"
-            echo "version=SNAPSHOT" >> "$GITHUB_OUTPUT"
-          fi
 
       - name: Install zeebe-parent only
         uses: ./.github/actions/run-maven
@@ -191,7 +97,7 @@ jobs:
             -f testing/pom.xml
             -DskipUTs
             -Dio.camunda.process.test.camundaDockerImageVersion=${{ inputs.camunda_image_version }}
-            -Dio.camunda.process.test.connectorsDockerImageVersion=${{ steps.connectors-version.outputs.version }}
+            -Dio.camunda.process.test.connectorsDockerImageVersion=${{ inputs.connectors_image_version }}
             -Dfailsafe.rerunFailingTestsCount=${{ env.FLAKY_TEST_RERUN_COUNT }}
             -Dsurefire.rerunFailingTestsCount=${{ env.FLAKY_TEST_RERUN_COUNT }}
             -DfailIfNoTests=false

--- a/.github/workflows/camunda-process-test-compatibility.yml
+++ b/.github/workflows/camunda-process-test-compatibility.yml
@@ -4,9 +4,6 @@
 name: Camunda Process Test Compatibility Tests
 
 on:
-  schedule:
-    # Runs at 02:00 every day https://crontab.guru/#0_2_*_*_*
-    - cron: '0 2 * * *'
   workflow_dispatch:
     inputs:
       cpt_version:

--- a/.github/workflows/camunda-process-test-compatibility.yml
+++ b/.github/workflows/camunda-process-test-compatibility.yml
@@ -1,26 +1,22 @@
-# description: Daily compatibility tests for Camunda Process Test across runtime versions
+# description: Compatibility tests for Camunda Process Test against a selected Camunda image
 # type: CI
-# owner: @camunda/camunda-ex
+# owner: @camunda/c8-testing
 name: Camunda Process Test Compatibility Tests
 
 on:
   workflow_dispatch:
     inputs:
-      cpt_version:
-        description: 'CPT version to test (e.g., 8.8.0 or 8.9-SNAPSHOT). Leave empty to test all versions.'
-        required: false
+      branch:
+        description: 'Branch to check out for CPT tests (e.g., stable/8.8)'
+        required: true
         type: string
-      runtime_version:
-        description: 'Runtime version to test (e.g., 8.8.0 or 8.9-SNAPSHOT). Leave empty to test all versions.'
+      camunda_image_version:
+        description: 'Camunda Docker image version (e.g., 8.9-SNAPSHOT).'
         required: false
+        default: 'SNAPSHOT'
         type: string
-      skip_cache:
-        description: 'Skip version cache and retest all combinations'
-        required: false
-        type: boolean
-        default: false
 
-permissions: { }
+permissions: {}
 
 defaults:
   run:
@@ -30,132 +26,18 @@ env:
   FLAKY_TEST_RERUN_COUNT: '3'
 
 jobs:
-  prepare-versions:
-    name: Prepare Version Matrix
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      contents: read
-      actions: read
-    outputs:
-      matrix: ${{ steps.create-matrix.outputs.matrix }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0  # Fetch all history for git tags
-
-      - name: Get branch information
-        id: branch-info
-        run: |
-          BRANCH_NAME="${GITHUB_REF#refs/heads/}"
-          echo "branch-name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
-
-          if [[ "$BRANCH_NAME" == "main" ]]; then
-            echo "is-main=true" >> "$GITHUB_OUTPUT"
-            echo "stable-version=" >> "$GITHUB_OUTPUT"
-          else
-            echo "is-main=false" >> "$GITHUB_OUTPUT"
-            # Extract version from stable/8.x branch name
-            if [[ "$BRANCH_NAME" =~ ^stable/([0-9]+\.[0-9]+)$ ]]; then
-              STABLE_VERSION="${BASH_REMATCH[1]}"
-              echo "stable-version=$STABLE_VERSION" >> "$GITHUB_OUTPUT"
-            else
-              echo "WARN: No main or stable branch detected"
-            fi
-          fi
-
-      - name: Get current version from pom.xml
-        id: pom-version
-        run: |
-          # Extract version from root pom.xml
-          POM_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
-          echo "pom-version=$POM_VERSION" >> "$GITHUB_OUTPUT"
-          echo "Current pom.xml version: $POM_VERSION"
-
-      - name: Prepare simple test matrix
-        id: prepare-matrix-info
-        run: |
-          # For stable branches, test current snapshot against next minor version
-          POM_VERSION="${{ steps.pom-version.outputs.pom-version }}"
-          echo "Current pom version: $POM_VERSION"
-          echo "pom-snapshot=$POM_VERSION" >> "$GITHUB_OUTPUT"
-
-          # Extract major.minor from version (e.g., 8.8.2-SNAPSHOT -> 8.8)
-          if [[ "$POM_VERSION" =~ ^([0-9]+)\.([0-9]+) ]]; then
-            MAJOR="${BASH_REMATCH[1]}"
-            MINOR="${BASH_REMATCH[2]}"
-            NEXT_MINOR=$((MINOR + 1))
-            NEXT_MINOR_SNAPSHOT="${MAJOR}.${NEXT_MINOR}-SNAPSHOT"
-            echo "Next minor version snapshot: $NEXT_MINOR_SNAPSHOT"
-            echo "next-minor-snapshot=$NEXT_MINOR_SNAPSHOT" >> "$GITHUB_OUTPUT"
-          else
-            echo "ERROR: Could not parse version from $POM_VERSION"
-            exit 1
-          fi
-
-      - name: Create version matrix
-        id: create-matrix
-        run: |
-          CLIENT_VERSION="${{ inputs.cpt_version }}"
-          SERVER_VERSION="${{ inputs.runtime_version }}"
-          POM_SNAPSHOT="${{ steps.prepare-matrix-info.outputs.pom-snapshot }}"
-          NEXT_MINOR_SNAPSHOT="${{ steps.prepare-matrix-info.outputs.next-minor-snapshot }}"
-
-          # Normalize x.y.0-SNAPSHOT to x.y-SNAPSHOT (Docker tag format)
-          CLIENT_VERSION="${CLIENT_VERSION/%.0-SNAPSHOT/-SNAPSHOT}"
-          SERVER_VERSION="${SERVER_VERSION/%.0-SNAPSHOT/-SNAPSHOT}"
-
-          if [[ -n "$CLIENT_VERSION" ]] && [[ -n "$SERVER_VERSION" ]]; then
-            echo "Manual trigger: Testing specific versions - Client: $CLIENT_VERSION, Server: $SERVER_VERSION"
-            MATRIX_JSON=$(jq -nc --arg client "$CLIENT_VERSION" --arg server "$SERVER_VERSION" '{"include": [{"client": $client, "server": $server}]}')
-            echo "matrix=$MATRIX_JSON" >> "$GITHUB_OUTPUT"
-          elif [[ -n "$CLIENT_VERSION" ]]; then
-            echo "Manual trigger: Testing client version $CLIENT_VERSION against next minor snapshot ($NEXT_MINOR_SNAPSHOT)"
-            MATRIX_JSON=$(jq -nc --arg client "$CLIENT_VERSION" --arg server "$NEXT_MINOR_SNAPSHOT" '{"include": [{"client": $client, "server": $server}]}')
-            echo "matrix=$MATRIX_JSON" >> "$GITHUB_OUTPUT"
-          elif [[ -n "$SERVER_VERSION" ]]; then
-            echo "Manual trigger: Testing server version $SERVER_VERSION with current snapshot client ($POM_SNAPSHOT)"
-            MATRIX_JSON=$(jq -nc --arg client "$POM_SNAPSHOT" --arg server "$SERVER_VERSION" '{"include": [{"client": $client, "server": $server}]}')
-            echo "matrix=$MATRIX_JSON" >> "$GITHUB_OUTPUT"
-          else
-            echo "Scheduled run: Testing CPT $POM_SNAPSHOT against Camunda $NEXT_MINOR_SNAPSHOT"
-            MATRIX_JSON=$(jq -nc --arg client "$POM_SNAPSHOT" --arg server "$NEXT_MINOR_SNAPSHOT" '{"include": [{"client": $client, "server": $server}]}')
-            echo "matrix=$MATRIX_JSON" >> "$GITHUB_OUTPUT"
-            echo "Generated matrix:"
-            echo "$MATRIX_JSON" | jq '.'
-          fi
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          build_status: ${{ job.status }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-
   run-cpt-tests:
-    name: Test CPT ${{ matrix.client }} -> Runtime ${{ matrix.server }}
-    needs: prepare-versions
-    if: needs.prepare-versions.result == 'success' && needs.prepare-versions.outputs.matrix != '{"include":[]}'
+    name: Test CPT (${{ inputs.branch }}) -> Runtime ${{ inputs.camunda_image_version }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
     permissions:
       contents: read
       id-token: write
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.prepare-versions.outputs.matrix) }}
     steps:
-      - name: Checkout Camunda (main for SNAPSHOT)
-        if: endsWith(matrix.client, '-SNAPSHOT')
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Checkout Camunda
-        if: ${{ !endsWith(matrix.client, '-SNAPSHOT') }}
+      - name: Checkout Camunda branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ matrix.client }}
+          ref: ${{ inputs.branch }}
 
       - uses: ./.github/actions/setup-build
         with:
@@ -163,6 +45,13 @@ jobs:
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+
+      - name: Resolve CPT version from pom.xml
+        id: cpt-version
+        run: |
+          CPT_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "version=$CPT_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Resolved CPT version: $CPT_VERSION"
 
       - name: Resolve connectors Docker image version
         id: connectors-version
@@ -174,7 +63,7 @@ jobs:
         #   2. Latest patch     → find the highest connectors-bundle:<major.minor.x> tag
         #   3. Fallback         → use SNAPSHOT connectors
         run: |
-          SERVER_VERSION="${{ matrix.server }}"
+          SERVER_VERSION="${{ inputs.camunda_image_version }}"
 
           # If server is SNAPSHOT, use SNAPSHOT for connectors too
           if [[ "$SERVER_VERSION" == "SNAPSHOT" || "$SERVER_VERSION" == *"-SNAPSHOT" ]]; then
@@ -277,7 +166,8 @@ jobs:
       - name: Determine Docker API version override
         id: api-version
         run: |
-          CLIENT_VERSION="${{ matrix.client }}"
+          CLIENT_VERSION="${{ steps.cpt-version.outputs.version }}"
+          CLIENT_VERSION="${CLIENT_VERSION/%.0-SNAPSHOT/-SNAPSHOT}"
           EXTRA_PROPS=""
           # For CPT versions < 8.8.5, we need to pin the API version
           if [[ "$CLIENT_VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
@@ -300,7 +190,7 @@ jobs:
             verify
             -f testing/pom.xml
             -DskipUTs
-            -Dio.camunda.process.test.camundaDockerImageVersion=${{ matrix.server }}
+            -Dio.camunda.process.test.camundaDockerImageVersion=${{ inputs.camunda_image_version }}
             -Dio.camunda.process.test.connectorsDockerImageVersion=${{ steps.connectors-version.outputs.version }}
             -Dfailsafe.rerunFailingTestsCount=${{ env.FLAKY_TEST_RERUN_COUNT }}
             -Dsurefire.rerunFailingTestsCount=${{ env.FLAKY_TEST_RERUN_COUNT }}
@@ -311,7 +201,7 @@ jobs:
         if: always()
         uses: ./.github/actions/collect-test-artifacts
         with:
-          name: 'cpt compatibility tests - client ${{ matrix.client }} server ${{ matrix.server }}'
+          name: 'cpt compatibility tests - branch ${{ inputs.branch }} server ${{ inputs.camunda_image_version }}'
 
       - name: Observe build status
         if: always()
@@ -319,7 +209,7 @@ jobs:
         uses: ./.github/actions/observe-build-status
         with:
           build_status: ${{ job.status }}
-          job_name: run-cpt-tests (cpt=${{ matrix.client }}, runtime=${{ matrix.server }})
+          job_name: run-cpt-tests (branch=${{ inputs.branch }}, runtime=${{ inputs.camunda_image_version }})
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
@@ -328,7 +218,7 @@ jobs:
     name: Notify on failure
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [ prepare-versions, run-cpt-tests ]
+    needs: [run-cpt-tests]
     if: always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
     permissions: { }
     steps:

--- a/.github/workflows/camunda-process-test-compatibility.yml
+++ b/.github/workflows/camunda-process-test-compatibility.yml
@@ -44,6 +44,17 @@ jobs:
         with:
           ref: ${{ inputs.branch }}
 
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          job_name: run-cpt-tests (branch=${{ inputs.branch }}, runtime=${{ inputs.camunda_image_version }})
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+
       - uses: ./.github/actions/setup-build
         with:
           dockerhub-readonly: true

--- a/testing/CONTRIBUTING.md
+++ b/testing/CONTRIBUTING.md
@@ -138,6 +138,24 @@ We select the Docker image using the Maven properties
 `io.camunda.process.test.camundaDockerImageVersion` in the properties file
 `camunda-container-runtime-version.properties`.
 
+## CI compatibility tests
+
+We run CPT compatibility test in CI to ensure forward-compatibility between Camunda runtime images
+and CPT.
+
+Workflow resources:
+
+- Main workflow: `.github/workflows/camunda-process-test-compatibility.yml`
+- Daily trigger workflow: `.github/workflows/camunda-process-test-compatibility-trigger.yml`
+
+Parameters:
+
+- `branch` (for example: `stable/8.8`)
+- `camunda_image_version` (for example: `8.9-SNAPSHOT`)
+- `connectors_image_version` (for example: `8.9-SNAPSHOT`)
+
+We trigger the workflow daily for the stable branches and report test failures to a Slack channel.
+
 ## Guide for common contributions
 
 If you're new and want to contribute to the project, check out the following step-by-step guides for


### PR DESCRIPTION
## Description

Reduce the CPT compatibility tests to save resources and make them more meaningful. 

- Don't run on `main` branch because the regular CI build covers the tests (CPT: `SNAPSHOT` with Camunda: `SNAPSHOT`)
- Run only the CPT SNAPSHOT version with the next minor Camunda SNAPSHOT image (CPT: `stable/8.8` with Camunda: `8.9-SNAPSHOT` and Connectors `8.9-SNAPSHOT`)
- Pass the branch, the Camunda image, and Connectors image as parameters

Before:
- For `main`: CPT: `8.10.0-SNAPSHOT` with Camunda `SNAPSHOT` (https://github.com/camunda/camunda/actions/runs/26733243435/job/78781533875)
- For `stable/8.8`: CPT `8.8.0` .. `8.8.24` with Camunda: `8.9.0` .. `8.9.4` and `8.9-SNAPSHOT`
 (https://github.com/camunda/camunda/actions/runs/26733117959)
 
After:
- For `stable/8.8`: CPT `8.8.25-SNAPSHOT` with Camunda: `8.9-SNAPSHOT`

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
