### PR TITLE
feat: load full variable in document-list modal

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentList/DocumentListModal.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentList/DocumentListModal.tsx
@@ -6,9 +6,12 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import {useMemo} from 'react';
 import {Modal} from '@carbon/react';
 import type {StateProps} from 'modules/components/ModalStateManager';
+import {useVariable} from 'modules/queries/variables/useVariable';
 import {
+  parseDocumentVariable,
   toHumanReadableBytes,
   type DocumentInfo,
 } from '../DocumentValueCell/parseDocumentVariable';
@@ -27,6 +30,7 @@ import {
 type Props = {
   documents: DocumentInfo[];
   isLowerBound: boolean;
+  variableKey: string;
   variableName: string;
 };
 
@@ -35,10 +39,29 @@ const DocumentListModal: React.FC<StateProps & Props> = ({
   setOpen,
   documents,
   isLowerBound,
+  variableKey,
   variableName,
 }) => {
-  const count = documents.length;
-  const prefix = isLowerBound ? `${count}+` : `${count}`;
+  const {data, isSuccess, isError, isLoading} = useVariable(variableKey, {
+    enabled: open && isLowerBound,
+  });
+
+  const resolvedDocuments = useMemo(() => {
+    if (data?.value === undefined) {
+      return documents;
+    }
+
+    const result = parseDocumentVariable(data.value, false);
+    if (result === null) {
+      return documents;
+    }
+
+    return result.type === 'list' ? result.documents : [result.document];
+  }, [data?.value, documents]);
+
+  const isFullyLoaded = !isLowerBound || isSuccess;
+  const count = resolvedDocuments.length;
+  const prefix = isFullyLoaded ? `${count}` : `${count}+`;
   const suffix = count !== 1 ? 'documents' : 'document';
 
   return (
@@ -50,7 +73,7 @@ const DocumentListModal: React.FC<StateProps & Props> = ({
       passiveModal
     >
       <DocumentList>
-        {documents.map((document, index) => (
+        {resolvedDocuments.map((document, index) => (
           <DocumentListItem
             aria-labelledby={`document-item-${index}`}
             key={index}
@@ -80,9 +103,16 @@ const DocumentListModal: React.FC<StateProps & Props> = ({
           </DocumentListItem>
         ))}
       </DocumentList>
-      {isLowerBound && (
+      {isLoading && (
         <TruncationNotice>
-          More documents may exist for this variable.
+          Loading the full variable value... More documents may exist for this
+          variable.
+        </TruncationNotice>
+      )}
+      {isError && (
+        <TruncationNotice>
+          Failed to load the full variable value. More documents may exist for
+          this variable.
         </TruncationNotice>
       )}
     </Modal>

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentList/ViewDocumentListButton.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentList/ViewDocumentListButton.test.tsx
@@ -6,11 +6,17 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import {QueryClientProvider} from '@tanstack/react-query';
 import {render, screen, within} from 'modules/testing-library';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {mockGetVariable} from 'modules/mocks/api/v2/variables/getVariable';
+import {createVariable} from 'modules/testUtils';
 import {ViewDocumentListButton} from './ViewDocumentListButton';
 import type {DocumentInfo} from '../DocumentValueCell/parseDocumentVariable';
 
-const documents: DocumentInfo[] = [
+const VARIABLE_KEY = 'variable-key-123';
+
+const preparsedDocuments: DocumentInfo[] = [
   {
     link: '/v2/documents/1',
     fileName: 'photo.png',
@@ -31,14 +37,45 @@ const documents: DocumentInfo[] = [
   },
 ];
 
+const buildDocumentReference = (
+  documentId: string,
+  fileName: string,
+  contentType: string,
+  size: number,
+) => ({
+  'camunda.document.type': 'camunda',
+  documentId,
+  contentHash: `hash-${documentId}`,
+  metadata: {fileName, contentType, size},
+});
+
+const fullVariableValue = JSON.stringify([
+  buildDocumentReference('1', 'photo.png', 'image/png', 1024),
+  buildDocumentReference('2', 'report.pdf', 'application/pdf', 2048),
+  buildDocumentReference('3', 'notes.json', 'application/json', 256),
+  buildDocumentReference('4', 'extra-1.png', 'image/png', 512),
+  buildDocumentReference('5', 'extra-2.txt', 'text/plain', 4096),
+]);
+
+const createWrapper = () => {
+  const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => (
+    <QueryClientProvider client={getMockQueryClient()}>
+      {children}
+    </QueryClientProvider>
+  );
+  return Wrapper;
+};
+
 describe('<ViewDocumentListButton />', () => {
   it('should render a launcher button with the correct aria-label', () => {
     render(
       <ViewDocumentListButton
-        documents={documents}
+        documents={preparsedDocuments}
         isLowerBound={false}
+        variableKey={VARIABLE_KEY}
         variableName="files"
       />,
+      {wrapper: createWrapper()},
     );
 
     expect(
@@ -47,13 +84,15 @@ describe('<ViewDocumentListButton />', () => {
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 
-  it('should open the modal with the count heading when clicked', async () => {
+  it('should open the modal and not fetch the full variable when isLowerBound is false', async () => {
     const {user} = render(
       <ViewDocumentListButton
-        documents={documents}
+        documents={preparsedDocuments}
         isLowerBound={false}
+        variableKey={VARIABLE_KEY}
         variableName="files"
       />,
+      {wrapper: createWrapper()},
     );
 
     await user.click(
@@ -64,15 +103,23 @@ describe('<ViewDocumentListButton />', () => {
     expect(
       dialog.getByRole('heading', {name: '3 documents in files'}),
     ).toBeInTheDocument();
+    expect(
+      dialog.queryByText(/Loading the full variable value.../),
+    ).not.toBeInTheDocument();
+    expect(
+      dialog.queryByText(/Failed to load the full variable value/),
+    ).not.toBeInTheDocument();
   });
 
   it('should show a list row for each document with filename and size', async () => {
     const {user} = render(
       <ViewDocumentListButton
-        documents={documents}
+        documents={preparsedDocuments}
         isLowerBound={false}
+        variableKey={VARIABLE_KEY}
         variableName="files"
       />,
+      {wrapper: createWrapper()},
     );
 
     await user.click(
@@ -93,10 +140,12 @@ describe('<ViewDocumentListButton />', () => {
   it('should render preview and download buttons per document row', async () => {
     const {user} = render(
       <ViewDocumentListButton
-        documents={documents}
+        documents={preparsedDocuments}
         isLowerBound={false}
+        variableKey={VARIABLE_KEY}
         variableName="files"
       />,
+      {wrapper: createWrapper()},
     );
 
     await user.click(
@@ -112,13 +161,19 @@ describe('<ViewDocumentListButton />', () => {
     ).toHaveLength(3);
   });
 
-  it('should show truncation notices when isLowerBound is true', async () => {
+  it('should show the truncated document list first, then replace it with the full list once loaded', async () => {
+    mockGetVariable().withDelay(
+      createVariable({variableKey: VARIABLE_KEY, value: fullVariableValue}),
+    );
+
     const {user} = render(
       <ViewDocumentListButton
-        documents={documents}
+        documents={preparsedDocuments}
         isLowerBound
+        variableKey={VARIABLE_KEY}
         variableName="files"
       />,
+      {wrapper: createWrapper()},
     );
 
     await user.click(
@@ -126,21 +181,50 @@ describe('<ViewDocumentListButton />', () => {
     );
 
     const dialog = within(screen.getByRole('dialog'));
+    // Full variable is still loading...
     expect(
       dialog.getByRole('heading', {name: '3+ documents in files'}),
     ).toBeInTheDocument();
+    expect(dialog.getAllByRole('listitem')).toHaveLength(3);
     expect(
-      dialog.getByText('More documents may exist for this variable.'),
+      dialog.getByText(
+        'Loading the full variable value... More documents may exist for this variable.',
+      ),
     ).toBeInTheDocument();
+    expect(
+      dialog.queryByText(/Failed to load the full variable value/),
+    ).not.toBeInTheDocument();
+
+    // ...full variable is loaded
+    expect(
+      await dialog.findByRole('heading', {name: '5 documents in files'}),
+    ).toBeInTheDocument();
+    expect(dialog.getAllByRole('listitem')).toHaveLength(5);
+    expect(
+      dialog.getByRole('listitem', {name: 'extra-1.png'}),
+    ).toBeInTheDocument();
+    expect(
+      dialog.getByRole('listitem', {name: 'extra-2.txt'}),
+    ).toBeInTheDocument();
+    expect(
+      dialog.queryByText(/Loading the full variable value.../),
+    ).not.toBeInTheDocument();
+    expect(
+      dialog.queryByText(/Failed to load the full variable value/),
+    ).not.toBeInTheDocument();
   });
 
-  it('should not show a truncation notice when isLowerBound is false', async () => {
+  it('should keep the truncated document list and show an error notice when loading the full value fails', async () => {
+    mockGetVariable().withServerError();
+
     const {user} = render(
       <ViewDocumentListButton
-        documents={documents}
-        isLowerBound={false}
+        documents={preparsedDocuments}
+        isLowerBound
+        variableKey={VARIABLE_KEY}
         variableName="files"
       />,
+      {wrapper: createWrapper()},
     );
 
     await user.click(
@@ -149,7 +233,16 @@ describe('<ViewDocumentListButton />', () => {
 
     const dialog = within(screen.getByRole('dialog'));
     expect(
-      dialog.queryByText('More documents may exist for this variable.'),
+      await dialog.findByText(
+        'Failed to load the full variable value. More documents may exist for this variable.',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      dialog.getByRole('heading', {name: '3+ documents in files'}),
+    ).toBeInTheDocument();
+    expect(dialog.getAllByRole('listitem')).toHaveLength(3);
+    expect(
+      dialog.queryByText(/Loading the full variable value.../),
     ).not.toBeInTheDocument();
   });
 
@@ -166,8 +259,10 @@ describe('<ViewDocumentListButton />', () => {
           },
         ]}
         isLowerBound={false}
+        variableKey={VARIABLE_KEY}
         variableName="files"
       />,
+      {wrapper: createWrapper()},
     );
 
     await user.click(

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentList/ViewDocumentListButton.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentList/ViewDocumentListButton.tsx
@@ -15,12 +15,14 @@ import {DocumentListModal} from './DocumentListModal';
 type Props = {
   documents: DocumentInfo[];
   isLowerBound: boolean;
+  variableKey: string;
   variableName: string;
 };
 
 const ViewDocumentListButton: React.FC<Props> = ({
   documents,
   isLowerBound,
+  variableKey,
   variableName,
 }) => {
   return (
@@ -45,6 +47,7 @@ const ViewDocumentListButton: React.FC<Props> = ({
           setOpen={setOpen}
           documents={documents}
           isLowerBound={isLowerBound}
+          variableKey={variableKey}
           variableName={variableName}
         />
       )}

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/VariablesTable.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/VariablesTable.tsx
@@ -141,6 +141,7 @@ const VariablesTable: React.FC<Props> = ({
                         <ViewDocumentListButton
                           documents={documentResult.documents}
                           isLowerBound={documentResult.isLowerBound}
+                          variableKey={variableKey}
                           variableName={name}
                         />
                       )}


### PR DESCRIPTION
## Description

This PR follows up on the initial document-list modal PR #54200. It enhances the document-list modal with the ability to load the full variable and display **all** documents.

- Full variable is only loaded when the `isLowerBound` is set, i.e. the document list is truncated.
- While the variable loads the truncated document list is shown with a loading hint at the bottom.
- When loading fails, the truncated document list is shown with an error hint at the bottom.
- => Already parsed document list is not thrown away, but used as a graceful fallback for the loading and error states instead.

## Related issues

closes #54296
