### PR TITLE
test: stabilize suspend-twice batch operation test on slow backing stores

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts
@@ -10,7 +10,6 @@ import {test} from '@playwright/test';
 import {deploy} from '../../../../utils/zeebeClient';
 import {
   assertBadRequest,
-  assertConflictRequest,
   assertInvalidState,
   assertNotFoundRequest,
   assertStatusCode,
@@ -66,7 +65,12 @@ test.describe('Suspend & Resume Batch Operation Tests', () => {
   }) => {
     const key =
       await test.step('Create cancelable batch operation', async () => {
-        return createCancellationBatch(request, 3, 'batch_suspension_process');
+        // Use 20 instances so the batch stays ACTIVE long enough for the
+        // suspend command to arrive before the engine finishes it. With only
+        // 3 instances the batch completes (state COMPLETED) before the suspend
+        // takes effect, so the SUSPENDED poll times out — same race the first
+        // test in this file documents and avoids.
+        return createCancellationBatch(request, 20, 'batch_suspension_process');
       });
 
     await test.step('Suspend batch operation once', async () => {


### PR DESCRIPTION
## Problem

The nightly RDBMS/MSSQL run failed on `tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts` →
**"Suspend batch operation twice fails on second request, finally resumes"**:

```
Expected: "SUSPENDED"
Received: "COMPLETED"
Timeout 120000ms exceeded while waiting on the predicate
```

The test created a cancellation batch with only **3 instances**, then polled for the `SUSPENDED` state. With so few instances the engine completes the batch (state `COMPLETED`) before the suspend command takes effect, so `expectBatchState(..., 'SUSPENDED')` times out. This is the exact race the **first** test in the same file already documents and avoids by using 20 instances — it is more likely to manifest on the slower RDBMS/MSSQL backing store.

## Fix

Mirror the working sibling test and create **20 instances** so the batch stays `ACTIVE` long enough for the suspend command to land before completion. Also dropped the unused `assertConflictRequest` import so the file passes the lint gate.

No `skip`/`fixme` introduced; minimal diff scoped to the single failing test.

Nightly run: https://github.com/camunda/camunda/actions/runs/26754610377

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## On-demand verification runs
- https://github.com/camunda/camunda/actions/runs/26754850217
