### PR TITLE
Add wait state Camunda Exporter handlers

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/backup/BackupPriorityConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/backup/BackupPriorityConfiguration.java
@@ -56,6 +56,7 @@ import io.camunda.webapps.schema.descriptors.template.TaskTemplate;
 import io.camunda.webapps.schema.descriptors.template.UsageMetricTUTemplate;
 import io.camunda.webapps.schema.descriptors.template.UsageMetricTemplate;
 import io.camunda.webapps.schema.descriptors.template.VariableTemplate;
+import io.camunda.webapps.schema.descriptors.template.WaitStateTemplate;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -146,7 +147,9 @@ public class BackupPriorityConfiguration {
             new ClusterVariableIndex(indexPrefix, isElasticsearch),
             new DeployedResourceIndex(indexPrefix, isElasticsearch),
             new GlobalListenerIndex(indexPrefix, isElasticsearch),
-            new JobMetricsBatchTemplate(indexPrefix, isElasticsearch));
+            new JobMetricsBatchTemplate(indexPrefix, isElasticsearch),
+            // WAIT STATE
+            new WaitStateTemplate(indexPrefix, isElasticsearch));
 
     LOG.debug("Prio1 are {}", prio1);
     LOG.debug("Prio2 are {}", prio2);

--- a/dist/src/test/java/io/camunda/application/commons/backup/BackupPrioritiesTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/backup/BackupPrioritiesTest.java
@@ -184,7 +184,8 @@ class BackupPrioritiesTest {
             "camunda-cluster-variable-8.9.0_",
             "camunda-job-metrics-batch-8.9.0_",
             "camunda-global-listener-8.9.0_",
-            "camunda-deployed-resource-8.10.0_");
+            "camunda-deployed-resource-8.10.0_",
+            "camunda-wait-state-8.10.0_");
 
     // PRIO 4 dated indices
     assertThat(iterator.next().allIndices())
@@ -196,7 +197,9 @@ class BackupPrioritiesTest {
             "camunda-audit-log-8.9.0_*",
             "-camunda-audit-log-8.9.0_",
             "camunda-job-metrics-batch-8.9.0_*",
-            "-camunda-job-metrics-batch-8.9.0_");
+            "-camunda-job-metrics-batch-8.9.0_",
+            "camunda-wait-state-8.10.0_*",
+            "-camunda-wait-state-8.10.0_");
 
     for (final var indexList : indices) {
       assertThat(indexList.allIndices())

--- a/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerIT.java
@@ -1000,6 +1000,7 @@ public class SchemaManagerIT {
         // we verify the names hard coded on purpose
         // to make sure no index will be accidentally dropped, names are changed or added
         .containsExactlyInAnyOrder(
+            newPrefix + "-camunda-wait-state-8.10.0_",
             newPrefix + "-camunda-job-metrics-batch-8.9.0_",
             newPrefix + "-camunda-authorization-8.8.0_",
             newPrefix + "-camunda-cluster-variable-8.9.0_",

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/IndexDescriptors.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/IndexDescriptors.java
@@ -45,6 +45,7 @@ import io.camunda.webapps.schema.descriptors.template.TaskTemplate;
 import io.camunda.webapps.schema.descriptors.template.UsageMetricTUTemplate;
 import io.camunda.webapps.schema.descriptors.template.UsageMetricTemplate;
 import io.camunda.webapps.schema.descriptors.template.VariableTemplate;
+import io.camunda.webapps.schema.descriptors.template.WaitStateTemplate;
 import java.util.Collection;
 import java.util.Map;
 import java.util.function.Function;
@@ -89,6 +90,7 @@ public class IndexDescriptors {
                 new UsageMetricTemplate(indexPrefix, isElasticsearch),
                 new UsageMetricTUTemplate(indexPrefix, isElasticsearch),
                 new AuditLogTemplate(indexPrefix, isElasticsearch),
+                new WaitStateTemplate(indexPrefix, isElasticsearch),
                 new HistoryDeletionIndex(indexPrefix, isElasticsearch),
                 new JobMetricsBatchTemplate(indexPrefix, isElasticsearch),
                 new AuditLogCleanupIndex(indexPrefix, isElasticsearch),

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/WaitStateTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/WaitStateTemplate.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.schema.descriptors.template;
+
+import io.camunda.webapps.schema.descriptors.AbstractTemplateDescriptor;
+import io.camunda.webapps.schema.descriptors.ComponentNames;
+import io.camunda.webapps.schema.descriptors.ProcessInstanceDependant;
+import io.camunda.webapps.schema.descriptors.backup.Prio4Backup;
+import java.util.Optional;
+
+public class WaitStateTemplate extends AbstractTemplateDescriptor
+    implements ProcessInstanceDependant, Prio4Backup {
+
+  public static final String INDEX_NAME = "wait-state";
+  public static final String INDEX_VERSION = "8.10.0";
+
+  public static final String ID = "id";
+  public static final String ROOT_PROCESS_INSTANCE_KEY = "rootProcessInstanceKey";
+  public static final String PROCESS_INSTANCE_KEY = "processInstanceKey";
+  public static final String ELEMENT_INSTANCE_KEY = "elementInstanceKey";
+  public static final String ELEMENT_ID = "elementId";
+  public static final String ELEMENT_TYPE = "elementType";
+  public static final String WAIT_STATE_TYPE = "waitStateType";
+  public static final String DETAILS = "details";
+  public static final String TENANT_ID = "tenantId";
+  public static final String PARTITION_ID = "partitionId";
+
+  public WaitStateTemplate(final String indexPrefix, final boolean isElasticsearch) {
+    super(indexPrefix, isElasticsearch);
+  }
+
+  @Override
+  public String getIndexName() {
+    return INDEX_NAME;
+  }
+
+  @Override
+  public String getVersion() {
+    return INDEX_VERSION;
+  }
+
+  @Override
+  public String getComponentName() {
+    return ComponentNames.CAMUNDA.toString();
+  }
+
+  @Override
+  public Optional<String> getTenantIdField() {
+    return Optional.of(TENANT_ID);
+  }
+}

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/waitstate/WaitStateEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/waitstate/WaitStateEntity.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.schema.entities.waitstate;
+
+import io.camunda.webapps.schema.entities.AbstractExporterEntity;
+import io.camunda.webapps.schema.entities.SinceVersion;
+
+/** Represents a single waiting-state element instance stored in the wait-state index. */
+public class WaitStateEntity extends AbstractExporterEntity<WaitStateEntity> {
+
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private Long rootProcessInstanceKey;
+
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private Long processInstanceKey;
+
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private Long elementInstanceKey;
+
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private String elementId;
+
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private String elementType;
+
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private String waitStateType;
+
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private String details;
+
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private String tenantId;
+
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private Long partitionId;
+
+  public Long getRootProcessInstanceKey() {
+    return rootProcessInstanceKey;
+  }
+
+  public WaitStateEntity setRootProcessInstanceKey(final Long rootProcessInstanceKey) {
+    this.rootProcessInstanceKey = rootProcessInstanceKey;
+    return this;
+  }
+
+  public Long getProcessInstanceKey() {
+    return processInstanceKey;
+  }
+
+  public WaitStateEntity setProcessInstanceKey(final Long processInstanceKey) {
+    this.processInstanceKey = processInstanceKey;
+    return this;
+  }
+
+  public Long getElementInstanceKey() {
+    return elementInstanceKey;
+  }
+
+  public WaitStateEntity setElementInstanceKey(final Long elementInstanceKey) {
+    this.elementInstanceKey = elementInstanceKey;
+    return this;
+  }
+
+  public String getElementId() {
+    return elementId;
+  }
+
+  public WaitStateEntity setElementId(final String elementId) {
+    this.elementId = elementId;
+    return this;
+  }
+
+  public String getElementType() {
+    return elementType;
+  }
+
+  public WaitStateEntity setElementType(final String elementType) {
+    this.elementType = elementType;
+    return this;
+  }
+
+  public String getWaitStateType() {
+    return waitStateType;
+  }
+
+  public WaitStateEntity setWaitStateType(final String waitStateType) {
+    this.waitStateType = waitStateType;
+    return this;
+  }
+
+  public String getDetails() {
+    return details;
+  }
+
+  public WaitStateEntity setDetails(final String details) {
+    this.details = details;
+    return this;
+  }
+
+  public String getTenantId() {
+    return tenantId;
+  }
+
+  public WaitStateEntity setTenantId(final String tenantId) {
+    this.tenantId = tenantId;
+    return this;
+  }
+
+  public Long getPartitionId() {
+    return partitionId;
+  }
+
+  public WaitStateEntity setPartitionId(final Long partitionId) {
+    this.partitionId = partitionId;
+    return this;
+  }
+}

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/template/camunda-wait-state.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/template/camunda-wait-state.json
@@ -1,0 +1,38 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "id": {
+        "type": "keyword"
+      },
+      "rootProcessInstanceKey": {
+        "type": "long"
+      },
+      "processInstanceKey": {
+        "type": "long"
+      },
+      "elementInstanceKey": {
+        "type": "long"
+      },
+      "elementId": {
+        "type": "keyword"
+      },
+      "elementType": {
+        "type": "keyword"
+      },
+      "waitStateType": {
+        "type": "keyword"
+      },
+      "details": {
+        "type": "keyword",
+        "index": false
+      },
+      "tenantId": {
+        "type": "keyword"
+      },
+      "partitionId": {
+        "type": "long"
+      }
+    }
+  }
+}

--- a/webapps-schema/src/main/resources/schema/opensearch/create/template/camunda-wait-state.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/template/camunda-wait-state.json
@@ -1,0 +1,38 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "id": {
+        "type": "keyword"
+      },
+      "rootProcessInstanceKey": {
+        "type": "long"
+      },
+      "processInstanceKey": {
+        "type": "long"
+      },
+      "elementInstanceKey": {
+        "type": "long"
+      },
+      "elementId": {
+        "type": "keyword"
+      },
+      "elementType": {
+        "type": "keyword"
+      },
+      "waitStateType": {
+        "type": "keyword"
+      },
+      "details": {
+        "type": "keyword",
+        "index": false
+      },
+      "tenantId": {
+        "type": "keyword"
+      },
+      "partitionId": {
+        "type": "long"
+      }
+    }
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -96,6 +96,7 @@ import io.camunda.exporter.handlers.operation.OperationFromHistoryDeletionHandle
 import io.camunda.exporter.handlers.operation.OperationFromIncidentHandler;
 import io.camunda.exporter.handlers.operation.OperationFromProcessInstanceHandler;
 import io.camunda.exporter.handlers.operation.OperationFromVariableDocumentHandler;
+import io.camunda.exporter.handlers.waitstate.WaitStateHandlerBuilder;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
@@ -133,6 +134,7 @@ import io.camunda.webapps.schema.descriptors.template.TaskTemplate;
 import io.camunda.webapps.schema.descriptors.template.UsageMetricTUTemplate;
 import io.camunda.webapps.schema.descriptors.template.UsageMetricTemplate;
 import io.camunda.webapps.schema.descriptors.template.VariableTemplate;
+import io.camunda.webapps.schema.descriptors.template.WaitStateTemplate;
 import io.camunda.zeebe.exporter.api.context.Context;
 import io.camunda.zeebe.exporter.common.auditlog.AuditLogConfiguration;
 import io.camunda.zeebe.exporter.common.auditlog.transformers.AuditLogTransformerRegistry;
@@ -140,6 +142,7 @@ import io.camunda.zeebe.exporter.common.cache.ExporterEntityCacheImpl;
 import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
 import io.camunda.zeebe.exporter.common.cache.decisionRequirements.CachedDecisionRequirementsEntity;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
+import io.camunda.zeebe.exporter.common.waitstate.transformers.WaitStateTransformerRegistry;
 import io.camunda.zeebe.util.VisibleForTesting;
 import io.camunda.zeebe.util.cache.CaffeineCacheStatsCounter;
 import java.util.Collection;
@@ -166,6 +169,7 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
   private ExporterEntityCacheImpl<String, CachedFormEntity> formCache;
   private ExporterEntityCacheImpl<Long, CachedProcessEntity> processCache;
   private ExporterEntityCacheImpl<Long, CachedDecisionRequirementsEntity> decisionRequirementsCache;
+  private ObjectMapper objectMapper;
 
   @Override
   public void init(
@@ -174,6 +178,7 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
       final Context context,
       final ExporterMetadata exporterMetadata,
       final ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
     final var globalPrefix = configuration.getConnect().getIndexPrefix();
     final var isElasticsearch =
         ConnectionTypes.isElasticSearch(configuration.getConnect().getType());
@@ -410,7 +415,7 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
     }
 
     if (configuration.getWaitState().isEnabled()) {
-      // TODO: call addWaitStateHandlers();
+      addWaitStateHandlers();
     }
 
     if (configuration.getBatchOperation().isExportItemsOnCreation()) {
@@ -513,6 +518,14 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
   @Override
   public ExporterEntityCacheImpl<String, CachedFormEntity> getFormCache() {
     return formCache;
+  }
+
+  private void addWaitStateHandlers() {
+    final var indexName = indexDescriptors.get(WaitStateTemplate.class).getFullQualifiedName();
+    final var waitStateHandlerBuilder = WaitStateHandlerBuilder.of(indexName, objectMapper);
+    WaitStateTransformerRegistry.createAllTransformers()
+        .forEach(waitStateHandlerBuilder::addTransformer);
+    exportHandlers.addAll(waitStateHandlerBuilder.build());
   }
 
   private void addAuditLogHandlers(final AuditLogConfiguration auditLog, final int partitionId) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/waitstate/WaitStateAddHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/waitstate/WaitStateAddHandler.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers.waitstate;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.handlers.ExportHandler;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.entities.waitstate.WaitStateEntity;
+import io.camunda.zeebe.exporter.common.waitstate.WaitStateDetails;
+import io.camunda.zeebe.exporter.common.waitstate.WaitStateTransformer;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.value.WaitStateRelated;
+import io.camunda.zeebe.util.VisibleForTesting;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Writes a {@link WaitStateEntity} to the wait-state index when a process element enters a waiting
+ * state. The document is upserted using the stable entity key (e.g. jobKey, userTaskKey) as the
+ * document id, so re-entering the same wait state overwrites the previous entry.
+ *
+ * @param <R> the record value type handled by the injected transformer
+ */
+public class WaitStateAddHandler<R extends RecordValue & WaitStateRelated>
+    implements ExportHandler<WaitStateEntity, R> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(WaitStateAddHandler.class);
+
+  private final String indexName;
+  private final WaitStateTransformer<R> transformer;
+  private final ObjectMapper objectMapper;
+
+  public WaitStateAddHandler(
+      final String indexName,
+      final WaitStateTransformer<R> transformer,
+      final ObjectMapper objectMapper) {
+    this.indexName = indexName;
+    this.transformer = transformer;
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public ValueType getHandledValueType() {
+    return transformer.config().valueType();
+  }
+
+  @Override
+  public Class<WaitStateEntity> getEntityType() {
+    return WaitStateEntity.class;
+  }
+
+  @Override
+  public boolean handlesRecord(final Record<R> record) {
+    return transformer.triggersAdd(record);
+  }
+
+  @Override
+  public List<String> generateIds(final Record<R> record) {
+    return List.of(String.valueOf(record.getKey()));
+  }
+
+  @Override
+  public WaitStateEntity createNewEntity(final String id) {
+    return new WaitStateEntity().setId(id);
+  }
+
+  @Override
+  public void updateEntity(final Record<R> record, final WaitStateEntity entity) {
+    final var entry = transformer.transform(record);
+
+    entity
+        .setRootProcessInstanceKey(entry.getRootProcessInstanceKey())
+        .setProcessInstanceKey(entry.getProcessInstanceKey())
+        .setElementInstanceKey(entry.getElementInstanceKey())
+        .setElementId(entry.getElementId())
+        .setElementType(entry.getElementType() != null ? entry.getElementType().name() : null)
+        .setWaitStateType(entry.getWaitStateType() != null ? entry.getWaitStateType().name() : null)
+        .setDetails(serializeDetails(entry.getDetails()))
+        .setTenantId(entry.getTenantId())
+        .setPartitionId(entry.getPartitionId());
+  }
+
+  @Override
+  public void flush(final WaitStateEntity entity, final BatchRequest batchRequest)
+      throws PersistenceException {
+    batchRequest.add(indexName, entity);
+  }
+
+  @Override
+  public String getIndexName() {
+    return indexName;
+  }
+
+  @VisibleForTesting
+  public WaitStateTransformer<R> getTransformer() {
+    return transformer;
+  }
+
+  private String serializeDetails(final WaitStateDetails details) {
+    if (details == null) {
+      return null;
+    }
+    try {
+      return objectMapper.writeValueAsString(details);
+    } catch (final JsonProcessingException e) {
+      LOG.error("Failed to serialize wait state details: {}", e.getMessage(), e);
+      return null;
+    }
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/waitstate/WaitStateHandlerBuilder.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/waitstate/WaitStateHandlerBuilder.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers.waitstate;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.exporter.handlers.ExportHandler;
+import io.camunda.webapps.schema.entities.waitstate.WaitStateEntity;
+import io.camunda.zeebe.exporter.common.waitstate.WaitStateTransformer;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.value.WaitStateRelated;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Builds matched pairs of {@link WaitStateAddHandler} and {@link WaitStateRemoveHandler} from a set
+ * of {@link WaitStateTransformer}s, so that handler registration stays concise and DRY.
+ *
+ * <p>Usage:
+ *
+ * <pre>{@code
+ * WaitStateHandlerBuilder.of(indexName, objectMapper)
+ *     .addTransformer(new JobBasedWaitStateTransformer())
+ *     .build();
+ * }</pre>
+ */
+public final class WaitStateHandlerBuilder {
+
+  private final String indexName;
+  private final ObjectMapper objectMapper;
+  private final Set<ExportHandler<WaitStateEntity, ?>> handlers = new HashSet<>();
+
+  private WaitStateHandlerBuilder(final String indexName, final ObjectMapper objectMapper) {
+    this.indexName = indexName;
+    this.objectMapper = objectMapper;
+  }
+
+  public static WaitStateHandlerBuilder of(
+      final String indexName, final ObjectMapper objectMapper) {
+    return new WaitStateHandlerBuilder(indexName, objectMapper);
+  }
+
+  public <R extends RecordValue & WaitStateRelated> WaitStateHandlerBuilder addTransformer(
+      final WaitStateTransformer<R> transformer) {
+    handlers.add(new WaitStateAddHandler<>(indexName, transformer, objectMapper));
+    handlers.add(new WaitStateRemoveHandler<>(indexName, transformer));
+    return this;
+  }
+
+  public Set<ExportHandler<WaitStateEntity, ?>> build() {
+    return new HashSet<>(handlers);
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/waitstate/WaitStateRemoveHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/waitstate/WaitStateRemoveHandler.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers.waitstate;
+
+import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.handlers.ExportHandler;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.entities.waitstate.WaitStateEntity;
+import io.camunda.zeebe.exporter.common.waitstate.WaitStateTransformer;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.value.WaitStateRelated;
+import io.camunda.zeebe.util.VisibleForTesting;
+import java.util.List;
+
+/**
+ * Deletes a {@link WaitStateEntity} from the wait-state index when a process element leaves its
+ * waiting state (e.g. job completed, user task completed). The document is identified by the same
+ * stable entity key used during insertion.
+ *
+ * @param <R> the record value type handled by the injected transformer
+ */
+public class WaitStateRemoveHandler<R extends RecordValue & WaitStateRelated>
+    implements ExportHandler<WaitStateEntity, R> {
+
+  private final String indexName;
+  private final WaitStateTransformer<R> transformer;
+
+  public WaitStateRemoveHandler(final String indexName, final WaitStateTransformer<R> transformer) {
+    this.indexName = indexName;
+    this.transformer = transformer;
+  }
+
+  @Override
+  public ValueType getHandledValueType() {
+    return transformer.config().valueType();
+  }
+
+  @Override
+  public Class<WaitStateEntity> getEntityType() {
+    return WaitStateEntity.class;
+  }
+
+  @Override
+  public boolean handlesRecord(final Record<R> record) {
+    return transformer.triggersRemoval(record);
+  }
+
+  @Override
+  public List<String> generateIds(final Record<R> record) {
+    return List.of(String.valueOf(record.getKey()));
+  }
+
+  @Override
+  public WaitStateEntity createNewEntity(final String id) {
+    return new WaitStateEntity().setId(id);
+  }
+
+  @Override
+  public void updateEntity(final Record<R> record, final WaitStateEntity entity) {
+    // no-op: only the id is needed to issue the delete
+  }
+
+  @Override
+  public void flush(final WaitStateEntity entity, final BatchRequest batchRequest)
+      throws PersistenceException {
+    batchRequest.delete(indexName, entity.getId());
+  }
+
+  @Override
+  public String getIndexName() {
+    return indexName;
+  }
+
+  @VisibleForTesting
+  public WaitStateTransformer<R> getTransformer() {
+    return transformer;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/DefaultExporterResourceProviderTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/DefaultExporterResourceProviderTest.java
@@ -17,12 +17,15 @@ import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.handlers.AuditLogHandler;
 import io.camunda.exporter.handlers.ExportHandler;
 import io.camunda.exporter.handlers.batchoperation.BatchOperationChunkCreatedItemHandler;
+import io.camunda.exporter.handlers.waitstate.WaitStateAddHandler;
+import io.camunda.exporter.handlers.waitstate.WaitStateRemoveHandler;
 import io.camunda.search.test.utils.TestObjectMapper;
 import io.camunda.webapps.schema.descriptors.ComponentNames;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import io.camunda.zeebe.exporter.common.auditlog.transformers.AuditLogTransformer;
 import io.camunda.zeebe.exporter.common.auditlog.transformers.AuditLogTransformerRegistry;
+import io.camunda.zeebe.exporter.common.waitstate.transformers.WaitStateTransformerRegistry;
 import io.camunda.zeebe.exporter.test.ExporterTestContext;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -144,47 +147,94 @@ public class DefaultExporterResourceProviderTest {
         TestObjectMapper.objectMapper());
 
     // then
-    // AuditLogHandlers are excluded because they by design have multiple instances
-    final var handlersExcludingAuditLog =
+    // AuditLogHandlers and WaitState handlers are excluded because they by design have multiple
+    // instances (one per transformer)
+    final var handlersExcludingMultiInstance =
         provider.getExportHandlers().stream()
             .filter(handler -> !(handler instanceof AuditLogHandler))
+            .filter(handler -> !(handler instanceof WaitStateAddHandler))
+            .filter(handler -> !(handler instanceof WaitStateRemoveHandler))
             .toList();
 
-    assertThat(handlersExcludingAuditLog)
+    assertThat(handlersExcludingMultiInstance)
         .hasSize(
             (int)
-                handlersExcludingAuditLog.stream().map(ExportHandler::getClass).distinct().count());
+                handlersExcludingMultiInstance.stream()
+                    .map(ExportHandler::getClass)
+                    .distinct()
+                    .count());
   }
 
-  // TODO: enable with #54996
-  //  @Test
-  //  void shouldNotAddWaitStateHandlersWhenDisabled() {
-  //    // given
-  //    final var config = new ExporterConfiguration();
-  //    config.getWaitState().setEnabled(false);
-  //
-  //    final var provider = new DefaultExporterResourceProvider();
-  //    provider.init(
-  //        config,
-  //        mock(ExporterEntityCacheProvider.class),
-  //        new ExporterTestContext(),
-  //        new ExporterMetadata(TestObjectMapper.objectMapper()),
-  //        TestObjectMapper.objectMapper());
-  //
-  //    // when / then
-  //    assertThat(
-  //            provider.getExportHandlers().stream()
-  //                .filter(WaitStateAddHandler.class::isInstance)
-  //                .toList())
-  //        .as("No WaitStateAddHandler should be registered when waitState is disabled")
-  //        .isEmpty();
-  //    assertThat(
-  //            provider.getExportHandlers().stream()
-  //                .filter(WaitStateRemoveHandler.class::isInstance)
-  //                .toList())
-  //        .as("No WaitStateRemoveHandler should be registered when waitState is disabled")
-  //        .isEmpty();
-  //  }
+  @Test
+  void shouldAddWaitStateHandlersFromAddWaitStateHandlersMethod() {
+    // given
+    final var config = new ExporterConfiguration();
+    final var provider = new DefaultExporterResourceProvider();
+    provider.init(
+        config,
+        mock(ExporterEntityCacheProvider.class),
+        new ExporterTestContext(),
+        new ExporterMetadata(TestObjectMapper.objectMapper()),
+        TestObjectMapper.objectMapper());
+
+    // when
+    final var waitStateAddHandlers =
+        provider.getExportHandlers().stream()
+            .filter(WaitStateAddHandler.class::isInstance)
+            .map(h -> (WaitStateAddHandler<?>) h)
+            .toList();
+
+    // then — one WaitStateAddHandler per registered transformer, each with the correct ValueType
+    final Map<String, ValueType> expectedTransformers =
+        WaitStateTransformerRegistry.createAllTransformers().stream()
+            .collect(
+                Collectors.toMap(
+                    t -> t.getClass().getName(), transformer -> transformer.config().valueType()));
+
+    assertThat(
+            waitStateAddHandlers.stream()
+                .collect(
+                    Collectors.toMap(
+                        h -> h.getTransformer().getClass().getName(),
+                        ExportHandler::getHandledValueType)))
+        .containsExactlyInAnyOrderEntriesOf(expectedTransformers);
+
+    assertThat(waitStateAddHandlers)
+        .as(
+            "Should have exactly "
+                + expectedTransformers.size()
+                + " WaitStateAddHandler instances added by addWaitStateHandlers method")
+        .hasSize(expectedTransformers.size());
+  }
+
+  @Test
+  void shouldNotAddWaitStateHandlersWhenDisabled() {
+    // given
+    final var config = new ExporterConfiguration();
+    config.getWaitState().setEnabled(false);
+
+    final var provider = new DefaultExporterResourceProvider();
+    provider.init(
+        config,
+        mock(ExporterEntityCacheProvider.class),
+        new ExporterTestContext(),
+        new ExporterMetadata(TestObjectMapper.objectMapper()),
+        TestObjectMapper.objectMapper());
+
+    // when / then
+    assertThat(
+            provider.getExportHandlers().stream()
+                .filter(WaitStateAddHandler.class::isInstance)
+                .toList())
+        .as("No WaitStateAddHandler should be registered when waitState is disabled")
+        .isEmpty();
+    assertThat(
+            provider.getExportHandlers().stream()
+                .filter(WaitStateRemoveHandler.class::isInstance)
+                .toList())
+        .as("No WaitStateRemoveHandler should be registered when waitState is disabled")
+        .isEmpty();
+  }
 
   @ParameterizedTest
   @MethodSource("expectedAuditLogTransformers")
@@ -329,6 +379,15 @@ public class DefaultExporterResourceProviderTest {
     // itself uses generic RecordValue
     if (handler instanceof final AuditLogHandler<?> auditLogHandler) {
       return findRecordValueTypeParameterFromClass(auditLogHandler.getTransformer().getClass());
+    }
+
+    // For WaitState handlers, extract RecordValue from the transformer instance for the same reason
+    if (handler instanceof final WaitStateAddHandler<?> waitStateAddHandler) {
+      return findRecordValueTypeParameterFromClass(waitStateAddHandler.getTransformer().getClass());
+    }
+    if (handler instanceof final WaitStateRemoveHandler<?> waitStateRemoveHandler) {
+      return findRecordValueTypeParameterFromClass(
+          waitStateRemoveHandler.getTransformer().getClass());
     }
 
     // For regular handlers, extract from class hierarchy

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/waitstate/JobWaitStateHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/waitstate/JobWaitStateHandlerTest.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers.waitstate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.entities.waitstate.WaitStateEntity;
+import io.camunda.zeebe.exporter.common.waitstate.WaitStateEntry.WaitStateType;
+import io.camunda.zeebe.exporter.common.waitstate.transformers.JobBasedWaitStateTransformer;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ImmutableJobRecordValue;
+import io.camunda.zeebe.protocol.record.value.JobKind;
+import io.camunda.zeebe.protocol.record.value.JobListenerEventType;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end integration test for the job wait-state handler pair produced by {@link
+ * WaitStateHandlerBuilder} with {@link JobBasedWaitStateTransformer}.
+ *
+ * <p>Validates the full lifecycle: a {@code JOB.CREATED} event writes the wait-state entry, and a
+ * subsequent {@code JOB.COMPLETED} or {@code JOB.CANCELED} event removes it using the same stable
+ * document id (the jobKey).
+ */
+class JobWaitStateHandlerTest {
+
+  private static final String INDEX_NAME = "test-wait-state";
+  private static final long JOB_KEY = 999L;
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  private WaitStateAddHandler<JobRecordValue> addHandler;
+  private WaitStateRemoveHandler<JobRecordValue> removeHandler;
+
+  @BeforeEach
+  @SuppressWarnings("unchecked")
+  void setUp() {
+    final var handlers =
+        WaitStateHandlerBuilder.of(INDEX_NAME, objectMapper)
+            .addTransformer(new JobBasedWaitStateTransformer())
+            .build();
+
+    addHandler =
+        (WaitStateAddHandler<JobRecordValue>)
+            handlers.stream()
+                .filter(h -> h instanceof WaitStateAddHandler)
+                .findFirst()
+                .orElseThrow();
+    removeHandler =
+        (WaitStateRemoveHandler<JobRecordValue>)
+            handlers.stream()
+                .filter(h -> h instanceof WaitStateRemoveHandler)
+                .findFirst()
+                .orElseThrow();
+  }
+
+  @Test
+  void shouldAddHandlerHandleCreatedAndRemoveHandlerNotHandle() {
+    // given
+    final var created = jobRecord(JobIntent.CREATED);
+    final var completed = jobRecord(JobIntent.COMPLETED);
+
+    // when / then
+    assertThat(addHandler.handlesRecord(created)).isTrue();
+    assertThat(addHandler.handlesRecord(completed)).isFalse();
+    assertThat(removeHandler.handlesRecord(created)).isFalse();
+    assertThat(removeHandler.handlesRecord(completed)).isTrue();
+  }
+
+  @Test
+  void shouldBothHandlersUseTheSameDocumentId() {
+    // given
+    final var created = jobRecord(JobIntent.CREATED);
+    final var completed = jobRecord(JobIntent.COMPLETED);
+
+    // when
+    final var addIds = addHandler.generateIds(created);
+    final var removeIds = removeHandler.generateIds(completed);
+
+    // then — same stable document id (jobKey) used for write and delete
+    assertThat(addIds).containsExactly(String.valueOf(JOB_KEY));
+    assertThat(removeIds).containsExactly(String.valueOf(JOB_KEY));
+  }
+
+  @Test
+  void shouldWriteFullyPopulatedEntityOnJobCreated() throws Exception {
+    // given
+    final var jobValue =
+        ImmutableJobRecordValue.builder()
+            .from(factory.generateObject(JobRecordValue.class))
+            .withType("payment-service")
+            .withJobKind(JobKind.BPMN_ELEMENT)
+            .withJobListenerEventType(JobListenerEventType.UNSPECIFIED)
+            .withRetries(3)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId("task-payment")
+            .withElementInstanceKey(300L)
+            .withProcessInstanceKey(200L)
+            .withRootProcessInstanceKey(100L)
+            .withTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+            .build();
+    final var record =
+        cast(
+            factory.generateRecord(
+                ValueType.JOB,
+                r ->
+                    r.withKey(JOB_KEY)
+                        .withRecordType(RecordType.EVENT)
+                        .withIntent(JobIntent.CREATED)
+                        .withValue(jobValue)));
+    final var entity = addHandler.createNewEntity(String.valueOf(JOB_KEY));
+
+    // when
+    addHandler.updateEntity(record, entity);
+
+    // then
+    assertThat(entity.getRootProcessInstanceKey()).isEqualTo(100L);
+    assertThat(entity.getProcessInstanceKey()).isEqualTo(200L);
+    assertThat(entity.getElementInstanceKey()).isEqualTo(300L);
+    assertThat(entity.getElementId()).isEqualTo("task-payment");
+    assertThat(entity.getElementType()).isEqualTo(BpmnElementType.SERVICE_TASK.name());
+    assertThat(entity.getWaitStateType()).isEqualTo(WaitStateType.JOB.name());
+    assertThat(entity.getTenantId()).isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+
+    // then — details serialised as JSON with all fields
+    final var details = objectMapper.readTree(entity.getDetails());
+    assertThat(details.get("jobKey").longValue()).isEqualTo(JOB_KEY);
+    assertThat(details.get("jobType").textValue()).isEqualTo("payment-service");
+    assertThat(details.get("jobKind").textValue()).isEqualTo(JobKind.BPMN_ELEMENT.name());
+    assertThat(details.get("listenerEventType").textValue())
+        .isEqualTo(JobListenerEventType.UNSPECIFIED.name());
+    assertThat(details.get("retries").intValue()).isEqualTo(3);
+  }
+
+  @Test
+  void shouldFlushAddEntityToIndex() throws PersistenceException {
+    // given
+    final var entity = new WaitStateEntity().setId(String.valueOf(JOB_KEY));
+    final var batchRequest = mock(BatchRequest.class);
+
+    // when
+    addHandler.flush(entity, batchRequest);
+
+    // then
+    verify(batchRequest).add(eq(INDEX_NAME), eq(entity));
+  }
+
+  @Test
+  void shouldFlushRemoveDeleteFromIndexBySameId() throws PersistenceException {
+    // given
+    final var entity = new WaitStateEntity().setId(String.valueOf(JOB_KEY));
+    final var batchRequest = mock(BatchRequest.class);
+
+    // when
+    removeHandler.flush(entity, batchRequest);
+
+    // then
+    verify(batchRequest).delete(INDEX_NAME, String.valueOf(JOB_KEY));
+  }
+
+  @Test
+  void shouldRemoveHandlerAlsoHandleCanceledEvent() {
+    // given
+    final var canceled = jobRecord(JobIntent.CANCELED);
+
+    // when / then
+    assertThat(removeHandler.handlesRecord(canceled)).isTrue();
+    assertThat(addHandler.handlesRecord(canceled)).isFalse();
+  }
+
+  @Test
+  void shouldBuilderProduceExactlyTwoHandlers() {
+    final var handlers =
+        WaitStateHandlerBuilder.of(INDEX_NAME, objectMapper)
+            .addTransformer(new JobBasedWaitStateTransformer())
+            .build();
+
+    assertThat(handlers).hasSize(2);
+    assertThat(handlers.stream().filter(h -> h instanceof WaitStateAddHandler).count())
+        .isEqualTo(1);
+    assertThat(handlers.stream().filter(h -> h instanceof WaitStateRemoveHandler).count())
+        .isEqualTo(1);
+  }
+
+  @SuppressWarnings("unchecked")
+  private Record<JobRecordValue> jobRecord(final JobIntent intent) {
+    return (Record<JobRecordValue>)
+        (Record<? extends RecordValue>)
+            factory.generateRecord(
+                ValueType.JOB,
+                r -> r.withKey(JOB_KEY).withRecordType(RecordType.EVENT).withIntent(intent));
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Record<JobRecordValue> cast(final Record<? extends RecordValue> record) {
+    return (Record<JobRecordValue>) record;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/waitstate/WaitStateHandlerBuilderTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/waitstate/WaitStateHandlerBuilderTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers.waitstate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.zeebe.exporter.common.waitstate.transformers.JobBasedWaitStateTransformer;
+import org.junit.jupiter.api.Test;
+
+class WaitStateHandlerBuilderTest {
+
+  private static final String INDEX_NAME = "test-wait-state";
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Test
+  void shouldProduceAddAndRemoveHandlerForEachTransformer() {
+    // when
+    final var handlers =
+        WaitStateHandlerBuilder.of(INDEX_NAME, objectMapper)
+            .addTransformer(new JobBasedWaitStateTransformer())
+            .build();
+
+    // then — one add + one remove
+    assertThat(handlers).hasSize(2);
+    assertThat(handlers).hasAtLeastOneElementOfType(WaitStateAddHandler.class);
+    assertThat(handlers).hasAtLeastOneElementOfType(WaitStateRemoveHandler.class);
+  }
+
+  @Test
+  void shouldProduceFourHandlersForTwoTransformers() {
+    // when
+    final var handlers =
+        WaitStateHandlerBuilder.of(INDEX_NAME, objectMapper)
+            .addTransformer(new JobBasedWaitStateTransformer())
+            .addTransformer(new JobBasedWaitStateTransformer())
+            .build();
+
+    // then — two transformers → four handlers
+    assertThat(handlers).hasSize(4);
+  }
+
+  @Test
+  void shouldReturnEmptySetWhenNoTransformersAdded() {
+    // when
+    final var handlers = WaitStateHandlerBuilder.of(INDEX_NAME, objectMapper).build();
+
+    // then
+    assertThat(handlers).isEmpty();
+  }
+
+  @Test
+  void shouldSetCorrectIndexNameOnHandlers() {
+    // when
+    final var handlers =
+        WaitStateHandlerBuilder.of(INDEX_NAME, objectMapper)
+            .addTransformer(new JobBasedWaitStateTransformer())
+            .build();
+
+    // then
+    handlers.forEach(h -> assertThat(h.getIndexName()).isEqualTo(INDEX_NAME));
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AbstractProcessInstanceArchiverJobIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AbstractProcessInstanceArchiverJobIT.java
@@ -29,6 +29,7 @@ import io.camunda.webapps.schema.descriptors.template.SequenceFlowTemplate;
 import io.camunda.webapps.schema.descriptors.template.SnapshotTaskVariableTemplate;
 import io.camunda.webapps.schema.descriptors.template.TaskTemplate;
 import io.camunda.webapps.schema.descriptors.template.VariableTemplate;
+import io.camunda.webapps.schema.descriptors.template.WaitStateTemplate;
 import io.camunda.webapps.schema.entities.CorrelatedMessageSubscriptionEntity;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.webapps.schema.entities.JobEntity;
@@ -47,6 +48,7 @@ import io.camunda.webapps.schema.entities.operation.OperationEntity;
 import io.camunda.webapps.schema.entities.post.PostImporterQueueEntity;
 import io.camunda.webapps.schema.entities.usertask.SnapshotTaskVariableEntity;
 import io.camunda.webapps.schema.entities.usertask.TaskEntity;
+import io.camunda.webapps.schema.entities.waitstate.WaitStateEntity;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
@@ -500,6 +502,9 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
             resourceProvider.getIndexTemplateDescriptor(AuditLogTemplate.class),
             List.of(auditLogEntity(processInstance))),
         new DependentEntities(
+            resourceProvider.getIndexTemplateDescriptor(WaitStateTemplate.class),
+            List.of(waitStateEntity(processInstance))),
+        new DependentEntities(
             resourceProvider.getIndexTemplateDescriptor(TaskTemplate.class),
             List.of(taskEntity(processInstance))),
         new DependentEntities(
@@ -635,6 +640,13 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
 
   private AuditLogEntity auditLogEntity(final ProcessInstanceForListViewEntity processInstance) {
     final AuditLogEntity entity = create(AuditLogEntity::new);
+    entity.setProcessInstanceKey(processInstance.getKey());
+    entity.setRootProcessInstanceKey(processInstance.getKey());
+    return entity;
+  }
+
+  private WaitStateEntity waitStateEntity(final ProcessInstanceForListViewEntity processInstance) {
+    final WaitStateEntity entity = create(WaitStateEntity::new);
     entity.setProcessInstanceKey(processInstance.getKey());
     entity.setRootProcessInstanceKey(processInstance.getKey());
     return entity;

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
@@ -1091,13 +1091,13 @@ final class ElasticsearchArchiverRepositoryIT {
         .untilAsserted(
             () ->
                 verify(
-                        indicesClientSpy, times(21) // number of index templates
+                        indicesClientSpy, times(22) // number of index templates
                         )
                     .putSettings(captor.capture()));
 
     final var putIndicesSettingsRequests = captor.getAllValues();
     assertThat(putIndicesSettingsRequests)
-        .hasSize(21)
+        .hasSize(22)
         .allSatisfy(
             request -> {
               assertThat(request.index()).hasSize(1);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
@@ -1189,7 +1189,7 @@ final class OpenSearchArchiverRepositoryIT {
                 verify(
                         genericClientSpy,
                         times(
-                            42) // number of index templates * 2 (for change policy requests and add
+                            44) // number of index templates * 2 (for change policy requests and add
                         // policy requests)
                         )
                     .executeAsync(captor.capture()));
@@ -1197,7 +1197,7 @@ final class OpenSearchArchiverRepositoryIT {
     final var putIndicesSettingsRequests = captor.getAllValues();
     assertThat(putIndicesSettingsRequests)
         .filteredOn(req -> req.getEndpoint().contains("_ism/add"))
-        .hasSize(21)
+        .hasSize(22)
         .allSatisfy(
             request -> {
               final var indexPattern =

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJobTest.java
@@ -21,6 +21,7 @@ import io.camunda.webapps.schema.descriptors.template.AuditLogTemplate;
 import io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.descriptors.template.SequenceFlowTemplate;
+import io.camunda.webapps.schema.descriptors.template.WaitStateTemplate;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
 import java.util.Map;
@@ -45,6 +46,7 @@ final class ProcessInstanceArchiverJobTest extends ArchiverJobRecordingMetricsAb
       new DecisionInstanceTemplate("", true);
   private final SequenceFlowTemplate sequenceFlowTemplate = new SequenceFlowTemplate("", true);
   private final AuditLogTemplate auditLogTemplate = new AuditLogTemplate("", true);
+  private final WaitStateTemplate waitStateTemplate = new WaitStateTemplate("", true);
 
   private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
   private final CamundaExporterMetrics metrics = new CamundaExporterMetrics(meterRegistry);
@@ -54,7 +56,8 @@ final class ProcessInstanceArchiverJobTest extends ArchiverJobRecordingMetricsAb
           historyConfiguration,
           repository,
           processInstanceTemplate,
-          List.of(decisionInstanceTemplate, sequenceFlowTemplate, auditLogTemplate),
+          List.of(
+              decisionInstanceTemplate, sequenceFlowTemplate, auditLogTemplate, waitStateTemplate),
           metrics,
           LOGGER,
           executor);
@@ -138,6 +141,11 @@ final class ProcessInstanceArchiverJobTest extends ArchiverJobRecordingMetricsAb
                 Map.of(auditLogTemplate.getProcessInstanceDependantField(), List.of("1", "2", "3")),
                 executor),
             new DocumentMove(
+                waitStateTemplate.getFullQualifiedName(),
+                waitStateTemplate.getFullQualifiedName() + "2024-01-01",
+                Map.of(WaitStateTemplate.PROCESS_INSTANCE_KEY, List.of("1", "2", "3")),
+                executor),
+            new DocumentMove(
                 decisionInstanceTemplate.getFullQualifiedName(),
                 decisionInstanceTemplate.getFullQualifiedName() + "2024-01-01",
                 Map.of(
@@ -173,6 +181,7 @@ final class ProcessInstanceArchiverJobTest extends ArchiverJobRecordingMetricsAb
         .map(DocumentMove::sourceIndexName)
         .containsExactly(
             auditLogTemplate.getFullQualifiedName(),
+            waitStateTemplate.getFullQualifiedName(),
             decisionInstanceTemplate.getFullQualifiedName(),
             sequenceFlowTemplate.getFullQualifiedName(),
             processInstanceTemplate.getFullQualifiedName());


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Implements the Camunda exporter handling code for waiting states (issue #53996), building on the
common scaffolding introduced in #53994. When a process element enters or leaves a waiting state,
the exporter now writes to or deletes from a dedicated `wait-state` index in Elasticsearch/OpenSearch.

## Changes

### `webapps-schema`
- **`WaitStateEntity`** — document POJO for the wait-state index. Fields mirror the `WaitStateEntry`
  from `exporter-common`: process/element identity fields, `elementType` and `waitStateType` stored
  as keyword strings, and a `details` field that holds wait-state-specific attributes serialised as
  a JSON blob.
- **`WaitStateTemplate`** — index template descriptor (`camunda` component, version `8.10.0`).
  Registered alongside all other templates in `IndexDescriptors`.
- **`camunda-wait-state.json`** (ES + OS) — `dynamic: strict` mapping. All identity fields are
  `long`/`keyword`. The `details` field is `keyword` with `index: false` — it is stored but not
  searchable directly, keeping the schema stable as the details structure evolves per wait-state type.

### `zeebe/exporter-common`
- **`WaitStateDetails`** — marker interface for typed wait-state detail objects. Keeps serialisation
  concerns out of the common layer; each backend exporter decides how to serialise the concrete type.
- **`JobWaitStateDetails`** — record carrying the job-specific fields: `jobKey`, `jobType`,
  `jobKind`, `listenerEventType`, `retries`. Replaces the untyped `Map<String, Object>` previously
  used in `WaitStateEntry.details`, giving consumers direct field access and type safety.
- **`WaitStateTransformerRegistry`** — single source of truth for all wait-state transformers,
  mirroring `AuditLogTransformerRegistry`.

### `zeebe/exporters/camunda-exporter`
- **`WaitStateAddHandler<R>`** — writes a `WaitStateEntity` on add-intent records
  (`batchRequest.add`). Calls the injected `WaitStateTransformer` to extract the entry, maps it to
  the entity, and serialises the `WaitStateDetails` object to JSON using Jackson.
- **`WaitStateRemoveHandler<R>`** — deletes the document on remove-intent records
  (`batchRequest.delete`). Only the document id (stable entity key, e.g. jobKey) is needed.
- **`WaitStateHandlerBuilder`** — produces a matched add + remove handler pair for each
  `WaitStateTransformer` registered, keeping the wiring in `DefaultExporterResourceProvider`
  concise.
- **`DefaultExporterResourceProvider`** — calls `addWaitStateHandlers()` unconditionally for all
  partitions, currently registering `JobBasedWaitStateTransformer`. Additional transformers
  (user tasks, messages, timers, etc.) plug in via `WaitStateTransformerRegistry`.
- **`DefaultExporterResourceProviderTest`** — extended with
  `shouldAddWaitStateHandlersFromAddWaitStateHandlersMethod`, mirroring the existing audit-log
  registration test. The single-instance handler check is updated to exclude wait-state handlers,
  which are designed to have one instance per transformer.

The document ID is the stable Zeebe entity key (jobKey, userTaskKey, etc.), consistent across the
full lifecycle — the same key appears on both the creation event (add) and the
completion/cancellation event (remove).

## Out of scope

Additional wait-state transformers (user tasks, message subscriptions, timers, signals) and their
corresponding `WaitStateDetails` implementations are left for follow-up issues. The foundation is
pluggable: each new transformer requires only an `addTransformer(...)` call in the registry and a
new `WaitStateDetails` record.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #53996
related to #48548
