### PR TITLE
fix: Archivnerless Batch Op Item Ordinal

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -100,7 +100,6 @@ import io.camunda.exporter.store.IndexLocatorProvider;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
-import io.camunda.webapps.schema.descriptors.ProcessInstanceDependant;
 import io.camunda.webapps.schema.descriptors.index.AuditLogCleanupIndex;
 import io.camunda.webapps.schema.descriptors.index.AuthorizationIndex;
 import io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex;
@@ -145,7 +144,6 @@ import io.camunda.zeebe.util.VisibleForTesting;
 import io.camunda.zeebe.util.cache.CaffeineCacheStatsCounter;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
@@ -425,27 +423,7 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
             indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName(),
             ErrorHandlers.IGNORE_DOCUMENT_DOES_NOT_EXIST);
 
-    final Set<String> ordinalBasedIndexes = new HashSet<>();
-    final var listViewName = indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName();
-    ordinalBasedIndexes.add(listViewName);
-
-    // TODO tmp exempt batch operation items from ordinal indexes - we will need to update
-    // BatchOperationUpdateTask and HistoryDeletionJob to handle ordinal suffixes if we want to use
-    // ordinal indexes for operations
-    final var operationIndexName =
-        indexDescriptors.get(OperationTemplate.class).getFullQualifiedName();
-    final var nonOrdinalIndexes = Set.of(operationIndexName);
-    for (final var indexDescriptor : indexDescriptors.templates()) {
-      final var indexName = indexDescriptor.getFullQualifiedName();
-      if (nonOrdinalIndexes.contains(indexName)) {
-        continue;
-      }
-      if (indexDescriptor instanceof ProcessInstanceDependant) {
-        ordinalBasedIndexes.add(indexName);
-      }
-    }
-
-    indexLocatorProvider = new FakeOrdinalIndexLocatorProvider(ordinalBasedIndexes);
+    indexLocatorProvider = new FakeOrdinalIndexLocatorProvider();
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ExportHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ExportHandler.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.handlers;
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.store.IndexLocator;
+import io.camunda.exporter.store.IndexLocatorProvider;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
@@ -59,6 +60,11 @@ public interface ExportHandler<T extends ExporterEntity<T>, R extends RecordValu
    * @return the new entity
    */
   T createNewEntity(String id);
+
+  default IndexLocator createIndexLocator(
+      final IndexLocatorProvider indexLocatorProvider, final Record<R> record, final String id) {
+    return indexLocatorProvider.createIndexLocator(record);
+  }
 
   /**
    * Updates the entity from the given record

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedHandler.java
@@ -61,7 +61,11 @@ public class BatchOperationChunkCreatedHandler
 
   @Override
   public List<String> generateIds(final Record<BatchOperationChunkRecordValue> record) {
-    return List.of(generateId(record.getValue()));
+    // Use a composite ID with a static suffix (batchOperationKey:chunk) so that all chunks for the
+    // same batch operation share a single cached entity in the ExporterBatchWriter, while still
+    // being separate from BatchOperationCreatedHandler (which uses just the batchOperationKey).
+    // This avoids double-counting of operationsTotalCount without inflating the batch size.
+    return List.of(record.getValue().getBatchOperationKey() + ":chunk");
   }
 
   @Override
@@ -100,13 +104,5 @@ public class BatchOperationChunkCreatedHandler
   @Override
   public String getIndexName() {
     return indexName;
-  }
-
-  public static String generateId(final BatchOperationChunkRecordValue chunk) {
-    // Use a composite ID with a static suffix (batchOperationKey:chunk) so that all chunks for the
-    // same batch operation share a single cached entity in the ExporterBatchWriter, while still
-    // being separate from BatchOperationCreatedHandler (which uses just the batchOperationKey).
-    // This avoids double-counting of operationsTotalCount without inflating the batch size.
-    return chunk.getBatchOperationKey() + ":chunk";
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedItemHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedItemHandler.java
@@ -12,6 +12,7 @@ import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.handlers.ExportHandler;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.store.IndexLocator;
+import io.camunda.exporter.store.IndexLocatorProvider;
 import io.camunda.webapps.schema.entities.operation.OperationEntity;
 import io.camunda.webapps.schema.entities.operation.OperationState;
 import io.camunda.webapps.schema.entities.operation.OperationType;
@@ -72,6 +73,19 @@ public class BatchOperationChunkCreatedItemHandler
   @Override
   public OperationEntity createNewEntity(final String id) {
     return new OperationEntity().setId(id);
+  }
+
+  @Override
+  public IndexLocator createIndexLocator(
+      final IndexLocatorProvider indexLocatorProvider,
+      final Record<BatchOperationChunkRecordValue> record,
+      final String id) {
+    final var item =
+        record.getValue().getItems().stream()
+            .filter(i -> i.getItemKey() == extractItemKey(id))
+            .findFirst()
+            .orElseThrow();
+    return indexLocatorProvider.createIndexLocator(item);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromChunkItemHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromChunkItemHandler.java
@@ -11,6 +11,7 @@ import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.handlers.ExportHandler;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.store.IndexLocator;
+import io.camunda.exporter.store.IndexLocatorProvider;
 import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -56,6 +57,19 @@ public class ListViewFromChunkItemHandler
   @Override
   public ProcessInstanceForListViewEntity createNewEntity(final String id) {
     return new ProcessInstanceForListViewEntity().setId(id);
+  }
+
+  @Override
+  public IndexLocator createIndexLocator(
+      final IndexLocatorProvider indexLocatorProvider,
+      final Record<BatchOperationChunkRecordValue> record,
+      final String id) {
+    final var item =
+        record.getValue().getItems().stream()
+            .filter(i -> i.getProcessInstanceKey() == Long.parseLong(id.split(":")[0]))
+            .findFirst()
+            .orElseThrow();
+    return indexLocatorProvider.createIndexLocator(item);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/DefaultIndexLocatorProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/DefaultIndexLocatorProvider.java
@@ -8,10 +8,16 @@
 package io.camunda.exporter.store;
 
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.OrdinalKeyBased;
 
 public class DefaultIndexLocatorProvider implements IndexLocatorProvider {
   @Override
   public IndexLocator createIndexLocator(final Record<?> record) {
+    return DefaultIndexLocator.INSTANCE;
+  }
+
+  @Override
+  public IndexLocator createIndexLocator(final OrdinalKeyBased ordinalKeyBased) {
     return DefaultIndexLocator.INSTANCE;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ExporterBatchWriter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ExporterBatchWriter.java
@@ -97,7 +97,7 @@ public final class ExporterBatchWriter {
 
   private CachedEntity createCachedEntity(
       final Record<?> record, final ExportHandler handler, final String id, final long length) {
-    final var indexLocator = indexLocatorProvider.createIndexLocator(record);
+    final IndexLocator indexLocator = handler.createIndexLocator(indexLocatorProvider, record, id);
     return new CachedEntity(handler.createNewEntity(id), indexLocator, length);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/FakeOrdinalIndexLocatorProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/FakeOrdinalIndexLocatorProvider.java
@@ -8,25 +8,17 @@
 package io.camunda.exporter.store;
 
 import com.google.common.base.Strings;
-import io.camunda.exporter.handlers.batchoperation.BatchOperationChunkCreatedHandler;
-import io.camunda.exporter.handlers.batchoperation.BatchOperationChunkCreatedItemHandler;
-import io.camunda.exporter.handlers.batchoperation.listview.ListViewFromChunkItemHandler;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.value.AuditLogProcessInstanceRelated;
-import io.camunda.zeebe.protocol.record.value.BatchOperationChunkRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationChunkRecordValue.BatchOperationItemValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationRelated;
 import io.camunda.zeebe.protocol.record.value.OrdinalKeyBased;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRelated;
-import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,27 +29,15 @@ public class FakeOrdinalIndexLocatorProvider implements IndexLocatorProvider {
   // aim for roughly 1 hours worth at 300 PI/s (across 3 partitions)
   private static final long IDS_PER_ORDINAL =
       100 * 60 * 60 * APPROX_IDS_BETWEEN_ROOT_PROCESS_INSTANCES;
-  private final Set<String> ordinalBasedIndexes;
   private final NoopIndexLocator noopIndexLocator = new NoopIndexLocator();
   private final Map<Integer, String> ordinalSuffixes = new ConcurrentHashMap<>();
 
-  public FakeOrdinalIndexLocatorProvider(final Set<String> ordinalBasedIndexes) {
-    this.ordinalBasedIndexes = ordinalBasedIndexes;
-  }
+  public FakeOrdinalIndexLocatorProvider() {}
 
   @Override
   public IndexLocator createIndexLocator(final Record<?> record) {
-    if (record.getValue() instanceof final BatchOperationChunkRecordValue chunks) {
-      final var ordinalsByKey = extractOrdinalsByKey(chunks);
-      final var suffixesByKey =
-          ordinalsByKey.entrySet().stream()
-              .collect(
-                  Collectors.toMap(
-                      Map.Entry::getKey, e -> getOrCreateOrdinalSuffix("ord", e.getValue())));
-      return new MultiSuffixOrdinalIndexLocator(suffixesByKey);
-    } else if (record.getValue() instanceof final OrdinalKeyBased ordinalKeyBased) {
-      final var suffix = getOrCreateOrdinalSuffix("ord", ordinalKeyBased.getOrdinalKey());
-      return new SingleSuffixOrdinalIndexLocator(suffix);
+    if (record.getValue() instanceof final OrdinalKeyBased ordinalKeyBased) {
+      return createIndexLocator(ordinalKeyBased);
     }
 
     final long ordinalBaseKey = getOrdinalBaseKey(record.getValue());
@@ -85,21 +65,10 @@ public class FakeOrdinalIndexLocatorProvider implements IndexLocatorProvider {
     return noopIndexLocator;
   }
 
-  private Map<String, Integer> extractOrdinalsByKey(final BatchOperationChunkRecordValue chunks) {
-    // TODO this is not a great approach. In the future we will want to handlers to deal with this
-    // themselves.
-    final Map<String, Integer> idsToPIs = new HashMap<>();
-    idsToPIs.put(String.valueOf(chunks.getBatchOperationKey()), chunks.getOrdinalKey());
-    idsToPIs.put(BatchOperationChunkCreatedHandler.generateId(chunks), chunks.getOrdinalKey());
-    for (final var item : chunks.getItems()) {
-      final var ordinal = item.getOrdinalKey();
-      idsToPIs.put(
-          BatchOperationChunkCreatedItemHandler.generateId(
-              chunks.getBatchOperationKey(), item.getItemKey()),
-          ordinal);
-      idsToPIs.put(ListViewFromChunkItemHandler.generateId(chunks, item), ordinal);
-    }
-    return idsToPIs;
+  @Override
+  public IndexLocator createIndexLocator(final OrdinalKeyBased ordinalKeyBased) {
+    final var suffix = getOrCreateOrdinalSuffix("ord", ordinalKeyBased.getOrdinalKey());
+    return new SingleSuffixOrdinalIndexLocator(suffix);
   }
 
   private long getOrdinalBaseKey(final RecordValue recordValue) {
@@ -142,7 +111,7 @@ public class FakeOrdinalIndexLocatorProvider implements IndexLocatorProvider {
     }
   }
 
-  class SingleSuffixOrdinalIndexLocator implements IndexLocator {
+  static class SingleSuffixOrdinalIndexLocator implements IndexLocator {
     private final String suffix;
 
     public SingleSuffixOrdinalIndexLocator(final String suffix) {
@@ -151,26 +120,7 @@ public class FakeOrdinalIndexLocatorProvider implements IndexLocatorProvider {
 
     @Override
     public String getIndexLocation(final ExporterEntity<?> entity, final String baseIndexName) {
-      if (!ordinalBasedIndexes.contains(baseIndexName)) {
-        return baseIndexName;
-      }
       return baseIndexName + suffix;
-    }
-  }
-
-  class MultiSuffixOrdinalIndexLocator implements IndexLocator {
-    private final Map<String, String> suffixesById;
-
-    public MultiSuffixOrdinalIndexLocator(final Map<String, String> suffixesById) {
-      this.suffixesById = suffixesById;
-    }
-
-    @Override
-    public String getIndexLocation(final ExporterEntity<?> entity, final String baseIndexName) {
-      if (!ordinalBasedIndexes.contains(baseIndexName)) {
-        return baseIndexName;
-      }
-      return baseIndexName + Objects.requireNonNull(suffixesById.get(entity.getId()));
     }
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/IndexLocatorProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/IndexLocatorProvider.java
@@ -8,7 +8,10 @@
 package io.camunda.exporter.store;
 
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.OrdinalKeyBased;
 
 public interface IndexLocatorProvider {
   IndexLocator createIndexLocator(Record<?> record);
+
+  IndexLocator createIndexLocator(OrdinalKeyBased ordinalKeyBased);
 }


### PR DESCRIPTION


## Description

This removes the FakeOrdinalLocator tracking ordinal by ID and instead resolves the locator at the time of processing batch chunk items.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
