### PR TITLE
test: add advanced filter operator tests for user task search API

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-search-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-search-api-tests.spec.ts
@@ -215,7 +215,7 @@ test.describe.parallel('Search User Task Tests', () => {
       expect(json.items.length).toBeGreaterThan(0);
       processDefinitionId = json.items[0].processDefinitionId;
       // Use a suffix of the ID so the pattern genuinely exercises the * wildcard
-      idSuffix = processDefinitionId.slice(-15);
+      idSuffix = processDefinitionId.slice(-10);
     }).toPass(defaultAssertionOptions);
 
     await expect(async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-search-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-search-api-tests.spec.ts
@@ -172,7 +172,7 @@ test.describe.parallel('Search User Task Tests', () => {
         data: {
           filter: {
             processDefinitionKey: {
-              $in: [processDefinitionKey],
+              $in: [processDefinitionKey, '9999999999999'],
             },
           },
         },
@@ -200,6 +200,7 @@ test.describe.parallel('Search User Task Tests', () => {
     request,
   }) => {
     let processDefinitionId = '';
+    let idSuffix = '';
 
     await expect(async () => {
       const res = await request.post(buildUrl('/user-tasks/search'), {
@@ -213,6 +214,8 @@ test.describe.parallel('Search User Task Tests', () => {
       const json = await res.json();
       expect(json.items.length).toBeGreaterThan(0);
       processDefinitionId = json.items[0].processDefinitionId;
+      // Use a suffix of the ID so the pattern genuinely exercises the * wildcard
+      idSuffix = processDefinitionId.slice(-15);
     }).toPass(defaultAssertionOptions);
 
     await expect(async () => {
@@ -221,7 +224,7 @@ test.describe.parallel('Search User Task Tests', () => {
         data: {
           filter: {
             processDefinitionId: {
-              $like: `*${processDefinitionId}*`,
+              $like: `*${idSuffix}`,
             },
           },
         },
@@ -237,9 +240,8 @@ test.describe.parallel('Search User Task Tests', () => {
       );
       expect(json.page.totalItems).toBeGreaterThanOrEqual(3);
       expect(
-        json.items.every(
-          (item: {processDefinitionId: string}) =>
-            item.processDefinitionId === processDefinitionId,
+        json.items.every((item: {processDefinitionId: string}) =>
+          item.processDefinitionId.endsWith(idSuffix),
         ),
       ).toBe(true);
     }).toPass(defaultAssertionOptions);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-search-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-search-api-tests.spec.ts
@@ -146,4 +146,136 @@ test.describe.parallel('Search User Task Tests', () => {
       expect(json.items).toHaveLength(0);
     }).toPass(defaultAssertionOptions);
   });
+
+  test('Search user task - filter by processDefinitionKey with $in operator', async ({
+    request,
+  }) => {
+    let processDefinitionKey = '';
+
+    await expect(async () => {
+      const res = await request.post(buildUrl('/user-tasks/search'), {
+        headers: jsonHeaders(),
+        data: {
+          filter: {
+            processInstanceKey: state['processInstanceKey'],
+          },
+        },
+      });
+      const json = await res.json();
+      expect(json.items.length).toBeGreaterThan(0);
+      processDefinitionKey = String(json.items[0].processDefinitionKey);
+    }).toPass(defaultAssertionOptions);
+
+    await expect(async () => {
+      const res = await request.post(buildUrl('/user-tasks/search'), {
+        headers: jsonHeaders(),
+        data: {
+          filter: {
+            processDefinitionKey: {
+              $in: [processDefinitionKey],
+            },
+          },
+        },
+      });
+      const json = await res.json();
+      validateResponseShape(
+        {
+          path: '/user-tasks/search',
+          method: 'POST',
+          status: '200',
+        },
+        json,
+      );
+      expect(json.page.totalItems).toBeGreaterThanOrEqual(3);
+      expect(
+        json.items.every(
+          (item: {processDefinitionKey: number | string}) =>
+            String(item.processDefinitionKey) === processDefinitionKey,
+        ),
+      ).toBe(true);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search user task - filter by processDefinitionId with $like operator', async ({
+    request,
+  }) => {
+    let processDefinitionId = '';
+
+    await expect(async () => {
+      const res = await request.post(buildUrl('/user-tasks/search'), {
+        headers: jsonHeaders(),
+        data: {
+          filter: {
+            processInstanceKey: state['processInstanceKey'],
+          },
+        },
+      });
+      const json = await res.json();
+      expect(json.items.length).toBeGreaterThan(0);
+      processDefinitionId = json.items[0].processDefinitionId;
+    }).toPass(defaultAssertionOptions);
+
+    await expect(async () => {
+      const res = await request.post(buildUrl('/user-tasks/search'), {
+        headers: jsonHeaders(),
+        data: {
+          filter: {
+            processDefinitionId: {
+              $like: `*${processDefinitionId}*`,
+            },
+          },
+        },
+      });
+      const json = await res.json();
+      validateResponseShape(
+        {
+          path: '/user-tasks/search',
+          method: 'POST',
+          status: '200',
+        },
+        json,
+      );
+      expect(json.page.totalItems).toBeGreaterThanOrEqual(3);
+      expect(
+        json.items.every(
+          (item: {processDefinitionId: string}) =>
+            item.processDefinitionId === processDefinitionId,
+        ),
+      ).toBe(true);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search user task - filter by processInstanceKey with $exists operator', async ({
+    request,
+  }) => {
+    await expect(async () => {
+      const res = await request.post(buildUrl('/user-tasks/search'), {
+        headers: jsonHeaders(),
+        data: {
+          filter: {
+            processInstanceKey: {
+              $exists: true,
+            },
+          },
+        },
+      });
+      const json = await res.json();
+      validateResponseShape(
+        {
+          path: '/user-tasks/search',
+          method: 'POST',
+          status: '200',
+        },
+        json,
+      );
+      expect(json.page.totalItems).toBeGreaterThan(0);
+      expect(
+        json.items.every(
+          (item: {processInstanceKey: number | null | undefined}) =>
+            item.processInstanceKey !== null &&
+            item.processInstanceKey !== undefined,
+        ),
+      ).toBe(true);
+    }).toPass(defaultAssertionOptions);
+  });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-search-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-search-api-tests.spec.ts
@@ -199,7 +199,6 @@ test.describe.parallel('Search User Task Tests', () => {
   test('Search user task - filter by processDefinitionId with $like operator', async ({
     request,
   }) => {
-    let processDefinitionId = '';
     let idSuffix = '';
 
     await expect(async () => {
@@ -213,9 +212,8 @@ test.describe.parallel('Search User Task Tests', () => {
       });
       const json = await res.json();
       expect(json.items.length).toBeGreaterThan(0);
-      processDefinitionId = json.items[0].processDefinitionId;
       // Use a suffix of the ID so the pattern genuinely exercises the * wildcard
-      idSuffix = processDefinitionId.slice(-10);
+      idSuffix = json.items[0].processDefinitionId.slice(-10);
     }).toPass(defaultAssertionOptions);
 
     await expect(async () => {


### PR DESCRIPTION
Add E2E tests covering $in, $like, and $exists:true filter operators on processDefinitionKey, processDefinitionId, and processInstanceKey fields of the user task search endpoint (/v2/user-tasks/search). Each operator is tested in an isolated test case to ensure clear failure attribution and independent retries.


## Description

Three new test cases added to \`user-task-search-api-tests.spec.ts\`, each covering one filter operator in isolation:

- **\`\$in\`** on \`processDefinitionKey\` — verifies that all returned tasks belong to the specified process definition
- **\`\$like\`** on \`processDefinitionId\` — verifies wildcard matching with \`*\` syntax returns the expected tasks
- **\`\$exists: true\`** on \`processInstanceKey\` — verifies that tasks with a \`processInstanceKey\` are returned correctly

Tests were run locally against a self-managed Camunda instance — all 3 pass ✅

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

Relates to #50122,  https://github.com/camunda/product-hub/issues/3579 and https://github.com/camunda/camunda/issues/51868
