### PR TITLE
feat: move agent status into accordion item

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/SectionTitle.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/SectionTitle.tsx
@@ -13,6 +13,7 @@ const TitleWithIcon = styled.span`
   align-items: center;
   font-weight: var(--cds-heading-compact-01-font-weight);
   gap: var(--cds-spacing-03);
+  color: var(--cds-text-primary);
   & > svg {
     color: var(--cds-icon-primary);
   }

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.test.tsx
@@ -50,7 +50,10 @@ describe('<AgentDetails />', () => {
     );
 
     expect(screen.getByText('AI Agent')).toBeInTheDocument();
-    expect(screen.getByText('Status: Calling tools')).toBeInTheDocument();
+    const statusSection = screen.getByTestId('agent-status-section');
+    expect(
+      within(statusSection).getByText('Status: Calling tools'),
+    ).toBeInTheDocument();
   });
 
   it('should render status for THINKING', () => {
@@ -62,7 +65,10 @@ describe('<AgentDetails />', () => {
       />,
     );
 
-    expect(screen.getByText('Status: Thinking')).toBeInTheDocument();
+    const statusSection = screen.getByTestId('agent-status-section');
+    expect(
+      within(statusSection).getByText('Status: Thinking'),
+    ).toBeInTheDocument();
   });
 
   it('should render status for IDLE', () => {
@@ -74,7 +80,8 @@ describe('<AgentDetails />', () => {
       />,
     );
 
-    expect(screen.getByText('Status: Idle')).toBeInTheDocument();
+    const statusSection = screen.getByTestId('agent-status-section');
+    expect(within(statusSection).getByText('Status: Idle')).toBeInTheDocument();
   });
 
   it('should render status for COMPLETED', () => {
@@ -86,7 +93,10 @@ describe('<AgentDetails />', () => {
       />,
     );
 
-    expect(screen.getByText('Status: Completed')).toBeInTheDocument();
+    const statusSection = screen.getByTestId('agent-status-section');
+    expect(
+      within(statusSection).getByText('Status: Completed'),
+    ).toBeInTheDocument();
   });
 
   it('should render status for INITIALIZING', () => {
@@ -98,7 +108,10 @@ describe('<AgentDetails />', () => {
       />,
     );
 
-    expect(screen.getByText('Status: Initializing')).toBeInTheDocument();
+    const statusSection = screen.getByTestId('agent-status-section');
+    expect(
+      within(statusSection).getByText('Status: Initializing'),
+    ).toBeInTheDocument();
   });
 
   it('should render status for TOOL_DISCOVERY', () => {
@@ -110,7 +123,10 @@ describe('<AgentDetails />', () => {
       />,
     );
 
-    expect(screen.getByText('Status: Discovering tools')).toBeInTheDocument();
+    const statusSection = screen.getByTestId('agent-status-section');
+    expect(
+      within(statusSection).getByText('Status: Discovering tools'),
+    ).toBeInTheDocument();
   });
 
   it('should render loading state', () => {
@@ -136,7 +152,9 @@ describe('<AgentDetails />', () => {
     );
 
     expect(screen.getByText('AI Agent')).toBeInTheDocument();
-    expect(screen.getByText('Unable to load agent status')).toBeInTheDocument();
+    expect(
+      screen.getByText('Unable to load agent information.'),
+    ).toBeInTheDocument();
   });
 
   it('should render usage metrics', () => {

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.test.tsx
@@ -139,7 +139,7 @@ describe('<AgentDetails />', () => {
     );
 
     expect(screen.getByText('AI Agent')).toBeInTheDocument();
-    expect(screen.getByText('Loading...')).toBeInTheDocument();
+    expect(screen.getByTestId('agent-details-skeleton')).toBeInTheDocument();
   });
 
   it('should render error state when fetch fails', () => {

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.tsx
@@ -24,9 +24,7 @@ import {
   AgentDetailsContainer,
   AgentHeading,
   Accordion,
-  StatusRow,
-  StatusIconWrapper,
-  StatusLabel,
+  LoadingStatusHint,
   MetricsRow,
   ModelInfo,
   ModelInfoLabel,
@@ -77,9 +75,7 @@ const AgentDetails: React.FC<AgentDetailsProps> = ({
     return (
       <AgentDetailsContainer>
         <AgentHeading>AI Agent</AgentHeading>
-        <StatusRow>
-          <StatusLabel>Loading...</StatusLabel>
-        </StatusRow>
+        <LoadingStatusHint>Loading...</LoadingStatusHint>
       </AgentDetailsContainer>
     );
   }
@@ -88,12 +84,7 @@ const AgentDetails: React.FC<AgentDetailsProps> = ({
     return (
       <AgentDetailsContainer>
         <AgentHeading>AI Agent</AgentHeading>
-        <StatusRow>
-          <StatusIconWrapper>
-            <WarningFilled size={16} />
-          </StatusIconWrapper>
-          <StatusLabel>Unable to load agent status</StatusLabel>
-        </StatusRow>
+        <LoadingStatusHint>Unable to load agent information.</LoadingStatusHint>
       </AgentDetailsContainer>
     );
   }
@@ -105,13 +96,16 @@ const AgentDetails: React.FC<AgentDetailsProps> = ({
   return (
     <AgentDetailsContainer data-testid="agent-details">
       <AgentHeading>AI Agent</AgentHeading>
-      <StatusRow data-testid="agent-status-row">
-        <StatusIconWrapper>
-          <StatusIcon status={agentInstance.status} />
-        </StatusIconWrapper>
-        <StatusLabel>Status: {statusLabel}</StatusLabel>
-      </StatusRow>
       <Accordion align="start">
+        <AccordionItem
+          data-testid="agent-status-section"
+          disabled
+          title={
+            <SectionTitle icon={<StatusIcon status={agentInstance.status} />}>
+              Status: {statusLabel}
+            </SectionTitle>
+          }
+        ></AccordionItem>
         <AccordionItem
           data-testid="agent-usage-section"
           title={

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.tsx
@@ -10,7 +10,7 @@ import type {
   AgentInstance,
   AgentInstanceStatus,
 } from '@camunda/camunda-api-zod-schemas/8.10';
-import {AccordionItem} from '@carbon/react';
+import {Accordion, AccordionItem, AccordionSkeleton} from '@carbon/react';
 import {
   CircleDash,
   WarningFilled,
@@ -23,8 +23,7 @@ import {
 import {
   AgentDetailsContainer,
   AgentHeading,
-  Accordion,
-  LoadingStatusHint,
+  ErrorHint,
   MetricsRow,
   ModelInfo,
   ModelInfoLabel,
@@ -75,7 +74,12 @@ const AgentDetails: React.FC<AgentDetailsProps> = ({
     return (
       <AgentDetailsContainer>
         <AgentHeading>AI Agent</AgentHeading>
-        <LoadingStatusHint>Loading...</LoadingStatusHint>
+        <AccordionSkeleton
+          align="start"
+          count={4}
+          open={false}
+          data-testid="agent-details-skeleton"
+        />
       </AgentDetailsContainer>
     );
   }
@@ -84,7 +88,7 @@ const AgentDetails: React.FC<AgentDetailsProps> = ({
     return (
       <AgentDetailsContainer>
         <AgentHeading>AI Agent</AgentHeading>
-        <LoadingStatusHint>Unable to load agent information.</LoadingStatusHint>
+        <ErrorHint>Unable to load agent information.</ErrorHint>
       </AgentDetailsContainer>
     );
   }

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/styled.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/styled.ts
@@ -6,16 +6,23 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {Accordion as CarbonAccordion} from '@carbon/react';
 import styled from 'styled-components';
 
 const AgentDetailsContainer = styled.div`
   display: flex;
   flex-direction: column;
   gap: var(--cds-spacing-03);
+
+  /* Small accordion overrides that apply to both Accordion and AccordionSkeleton. */
+  .cds--accordion__item:first-child {
+    border-block-start: none;
+  }
+  .cds--accordion__content {
+    padding-inline-end: var(--cds-spacing-02);
+  }
 `;
 
-const LoadingStatusHint = styled.span`
+const ErrorHint = styled.span`
   font-size: var(--cds-body-compact-01-font-size);
   line-height: var(--cds-body-compact-01-line-height);
   letter-spacing: var(--cds-body-compact-01-letter-spacing);
@@ -27,15 +34,6 @@ const AgentHeading = styled.h5`
   font-weight: var(--cds-heading-compact-01-font-weight);
   line-height: var(--cds-heading-compact-01-line-height);
   margin: 0;
-`;
-
-const Accordion = styled(CarbonAccordion)`
-  .cds--accordion__item:first-child {
-    border-block-start: none;
-  }
-  .cds--accordion__content {
-    padding-inline-end: var(--cds-spacing-02);
-  }
 `;
 
 const MetricsRow = styled.div`
@@ -59,8 +57,7 @@ const ModelInfoLabel = styled.strong`
 export {
   AgentDetailsContainer,
   AgentHeading,
-  Accordion,
-  LoadingStatusHint,
+  ErrorHint,
   MetricsRow,
   ModelInfo,
   ModelInfoLabel,

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/styled.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/styled.ts
@@ -15,6 +15,13 @@ const AgentDetailsContainer = styled.div`
   gap: var(--cds-spacing-03);
 `;
 
+const LoadingStatusHint = styled.span`
+  font-size: var(--cds-body-compact-01-font-size);
+  line-height: var(--cds-body-compact-01-line-height);
+  letter-spacing: var(--cds-body-compact-01-letter-spacing);
+  color: var(--cds-text-primary);
+`;
+
 const AgentHeading = styled.h5`
   font-size: var(--cds-heading-compact-01-font-size);
   font-weight: var(--cds-heading-compact-01-font-weight);
@@ -31,23 +38,6 @@ const Accordion = styled(CarbonAccordion)`
   }
 `;
 
-const StatusRow = styled.div`
-  display: flex;
-  align-items: center;
-  gap: var(--cds-spacing-03);
-  padding: var(--cds-spacing-03) 0;
-`;
-
-const StatusIconWrapper = styled.span`
-  display: flex;
-  align-items: center;
-  color: var(--cds-icon-primary);
-`;
-
-const StatusLabel = styled.span`
-  font-size: var(--cds-body-compact-01-font-size);
-`;
-
 const MetricsRow = styled.div`
   display: flex;
   gap: var(--cds-spacing-05);
@@ -57,12 +47,12 @@ const MetricsRow = styled.div`
 const ModelInfo = styled.p`
   font-size: var(--cds-body-compact-01-font-size);
   line-height: var(--cds-body-compact-01-line-height);
-  letter-spacing: var(--cds-label-01-letter-spacing);
+  letter-spacing: var(--cds-body-compact-01-letter-spacing);
   color: var(--cds-text-secondary);
 `;
 
 const ModelInfoLabel = styled.strong`
-  font-weight: 600;
+  font-weight: var(--cds-heading-compact-01-font-weight);
   color: var(--cds-text-primary);
 `;
 
@@ -70,9 +60,7 @@ export {
   AgentDetailsContainer,
   AgentHeading,
   Accordion,
-  StatusRow,
-  StatusIconWrapper,
-  StatusLabel,
+  LoadingStatusHint,
   MetricsRow,
   ModelInfo,
   ModelInfoLabel,


### PR DESCRIPTION
## Description

This PR moves the agent instance status into an accordion item:
- The accordion is disabled, and will be enabled with #52969.
- Simplified the custom styles (`Status***` stylings removed) 

## Related issues

closes #53481
