### PR TITLE
Add wait state rdbms exporter handlers

### DIFF
--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
@@ -256,4 +256,70 @@
     </createIndex>
   </changeSet>
 
+  <changeSet id="create_wait_state_table" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="${prefix}WAIT_STATE"/>
+      </not>
+    </preConditions>
+    <createTable tableName="${prefix}WAIT_STATE">
+      <column name="WAIT_STATE_KEY" type="BIGINT">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="ROOT_PROCESS_INSTANCE_KEY" type="BIGINT"/>
+      <column name="PROCESS_INSTANCE_KEY" type="BIGINT"/>
+      <column name="ELEMENT_INSTANCE_KEY" type="BIGINT"/>
+      <column name="ELEMENT_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="ELEMENT_TYPE" type="VARCHAR(50)"/>
+      <column name="WAIT_STATE_TYPE" type="VARCHAR(50)"/>
+      <column name="DETAILS" type="CLOB"/>
+      <column name="TENANT_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="PARTITION_ID" type="NUMBER"/>
+    </createTable>
+  </changeSet>
+
+  <changeSet id="create_wait_state_process_instance_key_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_WAIT_STATE_PROCESS_INSTANCE_KEY"
+          tableName="${prefix}WAIT_STATE"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}WAIT_STATE"
+      indexName="${prefix}IDX_WAIT_STATE_PROCESS_INSTANCE_KEY">
+      <column name="PROCESS_INSTANCE_KEY"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_wait_state_element_instance_key_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_WAIT_STATE_ELEMENT_INSTANCE_KEY"
+          tableName="${prefix}WAIT_STATE"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}WAIT_STATE"
+      indexName="${prefix}IDX_WAIT_STATE_ELEMENT_INSTANCE_KEY">
+      <column name="ELEMENT_INSTANCE_KEY"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_wait_state_root_process_instance_key_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_WAIT_STATE_ROOT_PROCESS_INSTANCE_KEY"
+          tableName="${prefix}WAIT_STATE"/>
+      </not>
+    </preConditions>
+    <sql dbms="mysql,mariadb,h2,oracle">
+      CREATE INDEX ${prefix}IDX_WAIT_STATE_ROOT_PROCESS_INSTANCE_KEY
+      ON ${prefix}WAIT_STATE (ROOT_PROCESS_INSTANCE_KEY)
+    </sql>
+    <!-- Since the user task key is sparse, we allow Postgres and MSSQL to exclude null values -->
+    <sql dbms="postgresql,mssql">
+      CREATE INDEX ${prefix}IDX_WAIT_STATE_ROOT_PROCESS_INSTANCE_KEY
+      ON ${prefix}WAIT_STATE (ROOT_PROCESS_INSTANCE_KEY) WHERE ROOT_PROCESS_INSTANCE_KEY IS NOT NULL
+    </sql>
+  </changeSet>
+
 </databaseChangeLog>

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsService.java
@@ -48,6 +48,7 @@ import io.camunda.db.rdbms.read.service.UsageMetricsDbReader;
 import io.camunda.db.rdbms.read.service.UserDbReader;
 import io.camunda.db.rdbms.read.service.UserTaskDbReader;
 import io.camunda.db.rdbms.read.service.VariableDbReader;
+import io.camunda.db.rdbms.read.service.WaitStateDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriterConfig;
 import io.camunda.db.rdbms.write.RdbmsWriterConfig.Builder;
 import io.camunda.db.rdbms.write.RdbmsWriterFactory;
@@ -72,6 +73,7 @@ public class RdbmsService {
   private final ProcessInstanceDbReader processInstanceReader;
   private final VariableDbReader variableReader;
   private final ClusterVariableDbReader clusterVariableDbReader;
+  private final WaitStateDbReader waitStateReader;
   private final RoleDbReader roleReader;
   private final RoleMemberDbReader roleMemberReader;
   private final TenantDbReader tenantReader;
@@ -120,6 +122,7 @@ public class RdbmsService {
       final ProcessInstanceDbReader processInstanceReader,
       final VariableDbReader variableReader,
       final ClusterVariableDbReader clusterVariableDbReader,
+      final WaitStateDbReader waitStateReader,
       final RoleDbReader roleReader,
       final RoleMemberDbReader roleMemberReader,
       final TenantDbReader tenantReader,
@@ -167,6 +170,7 @@ public class RdbmsService {
     this.tenantReader = tenantReader;
     this.variableReader = variableReader;
     this.clusterVariableDbReader = clusterVariableDbReader;
+    this.waitStateReader = waitStateReader;
     this.roleReader = roleReader;
     this.tenantMemberReader = tenantMemberReader;
     this.userReader = userReader;
@@ -255,6 +259,10 @@ public class RdbmsService {
 
   public ClusterVariableDbReader getClusterVariableReader() {
     return clusterVariableDbReader;
+  }
+
+  public WaitStateDbReader getWaitStateReader() {
+    return waitStateReader;
   }
 
   public RoleDbReader getRoleReader() {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsTableNames.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsTableNames.java
@@ -68,6 +68,7 @@ public final class RdbmsTableNames {
           "USER_TASK",
           "USER_",
           "VARIABLE",
+          "WAIT_STATE",
           "WEB_SESSION",
           "RDBMS_SCHEMA_VERSION");
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/WaitStateDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/WaitStateDbReader.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.service;
+
+import io.camunda.db.rdbms.sql.WaitStateMapper;
+import io.camunda.db.rdbms.write.domain.WaitStateDbModel;
+import java.util.Optional;
+
+/**
+ * Reads wait-state rows by key.
+ *
+ * <p>Only key-based lookup is provided; the searchable read layer for waiting states is built
+ * separately on top of the wait-state index.
+ */
+public class WaitStateDbReader {
+
+  private final WaitStateMapper waitStateMapper;
+
+  public WaitStateDbReader(final WaitStateMapper waitStateMapper) {
+    this.waitStateMapper = waitStateMapper;
+  }
+
+  public Optional<WaitStateDbModel> findOne(final long waitStateKey) {
+    return Optional.ofNullable(waitStateMapper.findOne(waitStateKey));
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/WaitStateMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/WaitStateMapper.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.sql;
+
+import io.camunda.db.rdbms.write.domain.WaitStateDbModel;
+
+public interface WaitStateMapper {
+
+  void insert(WaitStateDbModel waitState);
+
+  void delete(Long waitStateKey);
+
+  WaitStateDbModel findOne(Long waitStateKey);
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsMapperBundle.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsMapperBundle.java
@@ -31,6 +31,7 @@ import io.camunda.db.rdbms.sql.UsageMetricMapper;
 import io.camunda.db.rdbms.sql.UsageMetricTUMapper;
 import io.camunda.db.rdbms.sql.UserTaskMapper;
 import io.camunda.db.rdbms.sql.VariableMapper;
+import io.camunda.db.rdbms.sql.WaitStateMapper;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 
@@ -59,7 +60,8 @@ public record RdbmsMapperBundle(
     CorrelatedMessageSubscriptionMapper correlatedMessageSubscriptionMapper,
     ClusterVariableMapper clusterVariableMapper,
     HistoryDeletionMapper historyDeletionMapper,
-    AgentInstanceMapper agentInstanceMapper) {
+    AgentInstanceMapper agentInstanceMapper,
+    WaitStateMapper waitStateMapper) {
 
   public static RdbmsMapperBundle from(
       final SqlSessionFactory sqlSessionFactory,
@@ -90,6 +92,7 @@ public record RdbmsMapperBundle(
         sqlSession.getMapper(CorrelatedMessageSubscriptionMapper.class),
         sqlSession.getMapper(ClusterVariableMapper.class),
         sqlSession.getMapper(HistoryDeletionMapper.class),
-        sqlSession.getMapper(AgentInstanceMapper.class));
+        sqlSession.getMapper(AgentInstanceMapper.class),
+        sqlSession.getMapper(WaitStateMapper.class));
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterFactory.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterFactory.java
@@ -73,6 +73,7 @@ public class RdbmsWriterFactory {
         bundle.correlatedMessageSubscriptionMapper(),
         bundle.clusterVariableMapper(),
         bundle.historyDeletionMapper(),
-        bundle.agentInstanceMapper());
+        bundle.agentInstanceMapper(),
+        bundle.waitStateMapper());
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriters.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriters.java
@@ -30,6 +30,7 @@ import io.camunda.db.rdbms.sql.UsageMetricMapper;
 import io.camunda.db.rdbms.sql.UsageMetricTUMapper;
 import io.camunda.db.rdbms.sql.UserTaskMapper;
 import io.camunda.db.rdbms.sql.VariableMapper;
+import io.camunda.db.rdbms.sql.WaitStateMapper;
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.service.AgentInstanceWriter;
 import io.camunda.db.rdbms.write.service.AuditLogWriter;
@@ -65,6 +66,7 @@ import io.camunda.db.rdbms.write.service.UsageMetricWriter;
 import io.camunda.db.rdbms.write.service.UserTaskWriter;
 import io.camunda.db.rdbms.write.service.UserWriter;
 import io.camunda.db.rdbms.write.service.VariableWriter;
+import io.camunda.db.rdbms.write.service.WaitStateWriter;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -107,7 +109,8 @@ public class RdbmsWriters {
       final CorrelatedMessageSubscriptionMapper correlatedMessageSubscriptionMapper,
       final ClusterVariableMapper clusterVariableMapper,
       final HistoryDeletionMapper historyDeletionMapper,
-      final AgentInstanceMapper agentInstanceMapper) {
+      final AgentInstanceMapper agentInstanceMapper,
+      final WaitStateMapper waitStateMapper) {
     this.executionQueue = executionQueue;
     this.exporterPositionService = exporterPositionService;
     this.vendorDatabaseProperties = vendorDatabaseProperties;
@@ -184,6 +187,7 @@ public class RdbmsWriters {
     writers.put(
         AgentInstanceWriter.class,
         new AgentInstanceWriter(executionQueue, agentInstanceMapper, vendorDatabaseProperties));
+    writers.put(WaitStateWriter.class, new WaitStateWriter(executionQueue));
   }
 
   public AuthorizationWriter getAuthorizationWriter() {
@@ -192,6 +196,10 @@ public class RdbmsWriters {
 
   public AuditLogWriter getAuditLogWriter() {
     return getWriter(AuditLogWriter.class);
+  }
+
+  public WaitStateWriter getWaitStateWriter() {
+    return getWriter(WaitStateWriter.class);
   }
 
   public DecisionDefinitionWriter getDecisionDefinitionWriter() {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/WaitStateDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/WaitStateDbModel.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write.domain;
+
+import io.camunda.util.ObjectBuilder;
+
+/**
+ * Persistent representation of a single waiting-state element instance.
+ *
+ * <p>The {@code details} field holds the wait-state-specific attributes already serialized to JSON
+ * (stored as a CLOB). It is intentionally kept as an opaque string here so it can be deserialized
+ * into the matching {@code WaitStateDetails} type when read back, based on {@code waitStateType}.
+ */
+public record WaitStateDbModel(
+    Long waitStateKey,
+    Long rootProcessInstanceKey,
+    Long processInstanceKey,
+    Long elementInstanceKey,
+    String elementId,
+    String elementType,
+    String waitStateType,
+    String details,
+    String tenantId,
+    Integer partitionId) {
+
+  public static class Builder implements ObjectBuilder<WaitStateDbModel> {
+
+    private Long waitStateKey;
+    private Long rootProcessInstanceKey;
+    private Long processInstanceKey;
+    private Long elementInstanceKey;
+    private String elementId;
+    private String elementType;
+    private String waitStateType;
+    private String details;
+    private String tenantId;
+    private Integer partitionId;
+
+    public Builder waitStateKey(final Long waitStateKey) {
+      this.waitStateKey = waitStateKey;
+      return this;
+    }
+
+    public Builder rootProcessInstanceKey(final Long rootProcessInstanceKey) {
+      this.rootProcessInstanceKey = rootProcessInstanceKey;
+      return this;
+    }
+
+    public Builder processInstanceKey(final Long processInstanceKey) {
+      this.processInstanceKey = processInstanceKey;
+      return this;
+    }
+
+    public Builder elementInstanceKey(final Long elementInstanceKey) {
+      this.elementInstanceKey = elementInstanceKey;
+      return this;
+    }
+
+    public Builder elementId(final String elementId) {
+      this.elementId = elementId;
+      return this;
+    }
+
+    public Builder elementType(final String elementType) {
+      this.elementType = elementType;
+      return this;
+    }
+
+    public Builder waitStateType(final String waitStateType) {
+      this.waitStateType = waitStateType;
+      return this;
+    }
+
+    public Builder details(final String details) {
+      this.details = details;
+      return this;
+    }
+
+    public Builder tenantId(final String tenantId) {
+      this.tenantId = tenantId;
+      return this;
+    }
+
+    public Builder partitionId(final Integer partitionId) {
+      this.partitionId = partitionId;
+      return this;
+    }
+
+    @Override
+    public WaitStateDbModel build() {
+      return new WaitStateDbModel(
+          waitStateKey,
+          rootProcessInstanceKey,
+          processInstanceKey,
+          elementInstanceKey,
+          elementId,
+          elementType,
+          waitStateType,
+          details,
+          tenantId,
+          partitionId);
+    }
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/ContextType.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/ContextType.java
@@ -37,6 +37,7 @@ public enum ContextType {
   USER(false),
   USER_TASK(true),
   VARIABLE(false),
+  WAIT_STATE(false),
   CLUSTER_VARIABLE(false),
   // for global listeners, event types are updated through delete+insert, so order needs to be
   // preserved

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/WaitStateWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/WaitStateWriter.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write.service;
+
+import io.camunda.db.rdbms.write.domain.WaitStateDbModel;
+import io.camunda.db.rdbms.write.queue.ContextType;
+import io.camunda.db.rdbms.write.queue.ExecutionQueue;
+import io.camunda.db.rdbms.write.queue.QueueItem;
+import io.camunda.db.rdbms.write.queue.WriteStatementType;
+
+public class WaitStateWriter implements RdbmsWriter {
+
+  private final ExecutionQueue executionQueue;
+
+  public WaitStateWriter(final ExecutionQueue executionQueue) {
+    this.executionQueue = executionQueue;
+  }
+
+  public void create(final WaitStateDbModel waitState) {
+    executionQueue.executeInQueue(
+        new QueueItem(
+            ContextType.WAIT_STATE,
+            WriteStatementType.INSERT,
+            waitState.waitStateKey(),
+            "io.camunda.db.rdbms.sql.WaitStateMapper.insert",
+            waitState));
+  }
+
+  public void delete(final long waitStateKey) {
+    executionQueue.executeInQueue(
+        new QueueItem(
+            ContextType.WAIT_STATE,
+            WriteStatementType.DELETE,
+            waitStateKey,
+            "io.camunda.db.rdbms.sql.WaitStateMapper.delete",
+            waitStateKey));
+  }
+}

--- a/db/rdbms/src/main/resources/mapper/WaitStateMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/WaitStateMapper.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Camunda License 1.0. You may not use this file
+  ~ except in compliance with the Camunda License 1.0.
+  -->
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="io.camunda.db.rdbms.sql.WaitStateMapper">
+
+  <resultMap id="waitStateResultMap" type="io.camunda.db.rdbms.write.domain.WaitStateDbModel">
+    <constructor>
+      <idArg column="WAIT_STATE_KEY" javaType="java.lang.Long"/>
+      <arg column="ROOT_PROCESS_INSTANCE_KEY" javaType="java.lang.Long"/>
+      <arg column="PROCESS_INSTANCE_KEY" javaType="java.lang.Long"/>
+      <arg column="ELEMENT_INSTANCE_KEY" javaType="java.lang.Long"/>
+      <arg column="ELEMENT_ID" javaType="java.lang.String"/>
+      <arg column="ELEMENT_TYPE" javaType="java.lang.String"/>
+      <arg column="WAIT_STATE_TYPE" javaType="java.lang.String"/>
+      <arg column="DETAILS" javaType="java.lang.String"/>
+      <arg column="TENANT_ID" javaType="java.lang.String"/>
+      <arg column="PARTITION_ID" javaType="java.lang.Integer"/>
+    </constructor>
+  </resultMap>
+
+  <select id="findOne" parameterType="java.lang.Long"
+    resultMap="io.camunda.db.rdbms.sql.WaitStateMapper.waitStateResultMap">
+    SELECT WAIT_STATE_KEY, ROOT_PROCESS_INSTANCE_KEY, PROCESS_INSTANCE_KEY, ELEMENT_INSTANCE_KEY,
+           ELEMENT_ID, ELEMENT_TYPE, WAIT_STATE_TYPE, DETAILS, TENANT_ID, PARTITION_ID
+    FROM ${prefix}WAIT_STATE
+    WHERE WAIT_STATE_KEY = #{waitStateKey}
+  </select>
+
+  <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.WaitStateDbModel">
+    INSERT INTO ${prefix}WAIT_STATE (WAIT_STATE_KEY, ROOT_PROCESS_INSTANCE_KEY, PROCESS_INSTANCE_KEY,
+                                     ELEMENT_INSTANCE_KEY, ELEMENT_ID, ELEMENT_TYPE, WAIT_STATE_TYPE,
+                                     DETAILS, TENANT_ID, PARTITION_ID)
+    VALUES (#{waitStateKey}, #{rootProcessInstanceKey}, #{processInstanceKey},
+            #{elementInstanceKey}, #{elementId}, #{elementType}, #{waitStateType},
+            #{details, jdbcType=CLOB}, #{tenantId}, #{partitionId})
+  </insert>
+
+  <delete id="delete" parameterType="java.lang.Long">
+    DELETE
+    FROM ${prefix}WAIT_STATE
+    WHERE WAIT_STATE_KEY = #{waitStateKey}
+  </delete>
+
+</mapper>

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/RdbmsWriterFactoryTenantRoutingTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/RdbmsWriterFactoryTenantRoutingTest.java
@@ -35,6 +35,7 @@ import io.camunda.db.rdbms.sql.UsageMetricMapper;
 import io.camunda.db.rdbms.sql.UsageMetricTUMapper;
 import io.camunda.db.rdbms.sql.UserTaskMapper;
 import io.camunda.db.rdbms.sql.VariableMapper;
+import io.camunda.db.rdbms.sql.WaitStateMapper;
 import io.camunda.db.rdbms.write.queue.TransactionRunner;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.Map;
@@ -114,6 +115,7 @@ class RdbmsWriterFactoryTenantRoutingTest {
         mock(CorrelatedMessageSubscriptionMapper.class),
         mock(ClusterVariableMapper.class),
         mock(HistoryDeletionMapper.class),
-        mock(AgentInstanceMapper.class));
+        mock(AgentInstanceMapper.class),
+        mock(WaitStateMapper.class));
   }
 }

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/MyBatisConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/MyBatisConfiguration.java
@@ -49,6 +49,7 @@ import io.camunda.db.rdbms.sql.UsageMetricTUMapper;
 import io.camunda.db.rdbms.sql.UserMapper;
 import io.camunda.db.rdbms.sql.UserTaskMapper;
 import io.camunda.db.rdbms.sql.VariableMapper;
+import io.camunda.db.rdbms.sql.WaitStateMapper;
 import io.camunda.db.rdbms.write.RdbmsMapperBundle;
 import io.camunda.zeebe.util.VersionUtil;
 import java.io.IOException;
@@ -417,6 +418,12 @@ public class MyBatisConfiguration {
   public MapperFactoryBean<DeployedResourceMapper> resourceMapper(
       final SqlSessionFactory sqlSessionFactory) {
     return createMapperFactoryBean(sqlSessionFactory, DeployedResourceMapper.class);
+  }
+
+  @Bean
+  public MapperFactoryBean<WaitStateMapper> waitStateMapper(
+      final SqlSessionFactory sqlSessionFactory) {
+    return createMapperFactoryBean(sqlSessionFactory, WaitStateMapper.class);
   }
 
   private <T> MapperFactoryBean<T> createMapperFactoryBean(

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
@@ -57,6 +57,7 @@ import io.camunda.db.rdbms.read.service.UsageMetricsDbReader;
 import io.camunda.db.rdbms.read.service.UserDbReader;
 import io.camunda.db.rdbms.read.service.UserTaskDbReader;
 import io.camunda.db.rdbms.read.service.VariableDbReader;
+import io.camunda.db.rdbms.read.service.WaitStateDbReader;
 import io.camunda.db.rdbms.sql.AgentInstanceMapper;
 import io.camunda.db.rdbms.sql.AuditLogMapper;
 import io.camunda.db.rdbms.sql.AuthorizationMapper;
@@ -90,6 +91,7 @@ import io.camunda.db.rdbms.sql.UsageMetricTUMapper;
 import io.camunda.db.rdbms.sql.UserMapper;
 import io.camunda.db.rdbms.sql.UserTaskMapper;
 import io.camunda.db.rdbms.sql.VariableMapper;
+import io.camunda.db.rdbms.sql.WaitStateMapper;
 import io.camunda.db.rdbms.write.RdbmsMapperBundle;
 import io.camunda.db.rdbms.write.RdbmsWriterFactory;
 import io.camunda.db.rdbms.write.queue.TransactionRunner;
@@ -139,6 +141,11 @@ public class RdbmsConfiguration {
   public ClusterVariableDbReader clusterVariableRdbmsReader(
       final ClusterVariableMapper clusterVariableMapper, final RdbmsReaderConfig readerConfig) {
     return new ClusterVariableDbReader(clusterVariableMapper, readerConfig);
+  }
+
+  @Bean
+  public WaitStateDbReader waitStateRdbmsReader(final WaitStateMapper waitStateMapper) {
+    return new WaitStateDbReader(waitStateMapper);
   }
 
   @Bean
@@ -443,6 +450,7 @@ public class RdbmsConfiguration {
       final AgentInstanceDbReader agentInstanceDbReader,
       final VariableDbReader variableReader,
       final ClusterVariableDbReader clusterVariableDbReader,
+      final WaitStateDbReader waitStateReader,
       final AuditLogDbReader auditLogReader,
       final AuthorizationDbReader authorizationReader,
       final DecisionDefinitionDbReader decisionDefinitionReader,
@@ -500,6 +508,7 @@ public class RdbmsConfiguration {
         processInstanceReader,
         variableReader,
         clusterVariableDbReader,
+        waitStateReader,
         roleReader,
         roleMemberReader,
         tenantReader,

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/waitstate/WaitStateIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/waitstate/WaitStateIT.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.waitstate;
+
+import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextKey;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.write.RdbmsWriters;
+import io.camunda.db.rdbms.write.domain.WaitStateDbModel;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Tag("rdbms")
+@ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
+public class WaitStateIT {
+
+  public static final int PARTITION_ID = 0;
+
+  @TestTemplate
+  public void shouldInsertAndFindWaitStateByKey(final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final var model = createRandomized(nextKey());
+
+    // when
+    rdbmsWriters.getWaitStateWriter().create(model);
+    rdbmsWriters.flush();
+
+    // then
+    final var found = rdbmsService.getWaitStateReader().findOne(model.waitStateKey()).orElse(null);
+    assertThat(found).isNotNull();
+    assertThat(found.waitStateKey()).isEqualTo(model.waitStateKey());
+    assertThat(found.rootProcessInstanceKey()).isEqualTo(model.rootProcessInstanceKey());
+    assertThat(found.processInstanceKey()).isEqualTo(model.processInstanceKey());
+    assertThat(found.elementInstanceKey()).isEqualTo(model.elementInstanceKey());
+    assertThat(found.elementId()).isEqualTo(model.elementId());
+    assertThat(found.elementType()).isEqualTo(model.elementType());
+    assertThat(found.waitStateType()).isEqualTo(model.waitStateType());
+    assertThat(found.details()).isEqualTo(model.details());
+    assertThat(found.tenantId()).isEqualTo(model.tenantId());
+    assertThat(found.partitionId()).isEqualTo(PARTITION_ID);
+  }
+
+  @TestTemplate
+  public void shouldDeleteWaitStateByKey(final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final var model = createRandomized(nextKey());
+    rdbmsWriters.getWaitStateWriter().create(model);
+    rdbmsWriters.flush();
+    assertThat(rdbmsService.getWaitStateReader().findOne(model.waitStateKey())).isPresent();
+
+    // when
+    rdbmsWriters.getWaitStateWriter().delete(model.waitStateKey());
+    rdbmsWriters.flush();
+
+    // then
+    assertThat(rdbmsService.getWaitStateReader().findOne(model.waitStateKey())).isEmpty();
+  }
+
+  private static WaitStateDbModel createRandomized(final long waitStateKey) {
+    return new WaitStateDbModel.Builder()
+        .waitStateKey(waitStateKey)
+        .rootProcessInstanceKey(nextKey())
+        .processInstanceKey(nextKey())
+        .elementInstanceKey(nextKey())
+        .elementId("task-" + waitStateKey)
+        .elementType(BpmnElementType.SERVICE_TASK.name())
+        .waitStateType("JOB")
+        .details("{\"jobKey\":" + waitStateKey + ",\"jobType\":\"payment\",\"retries\":3}")
+        .tenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+        .partitionId(PARTITION_ID)
+        .build();
+  }
+}

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/WaitStateDetails.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/WaitStateDetails.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.common.waitstate;
+
+/**
+ * Marker interface for wait-state-specific detail objects.
+ *
+ * <p>Each concrete implementation carries the fields relevant to one wait-state type (e.g. {@code
+ * JobWaitStateDetails} for job-based waits). Backend exporters are responsible for serialising the
+ * details into their respective storage format.
+ */
+public interface WaitStateDetails {}

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/WaitStateEntry.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/WaitStateEntry.java
@@ -11,15 +11,15 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.WaitStateRelated;
-import java.util.Map;
 
 /**
  * Represents a single waiting-state entry exported from the engine.
  *
  * <p>A waiting state captures a process element that is currently paused, awaiting an external
  * signal to continue (a job worker, message correlation, user task completion, timer firing, etc.).
- * The {@link #details} map carries wait-state-specific attributes (e.g. job type, message name, due
- * date) and is serialized by each backend exporter according to its own schema.
+ * The {@link #details} field carries a {@link WaitStateDetails} implementation whose concrete type
+ * is specific to the wait-state kind (e.g. {@code JobWaitStateDetails}). Backend exporters are
+ * responsible for serialising it into their respective storage format.
  *
  * <p>Instances are built via {@link #of(Record)} and then enriched by a {@link
  * WaitStateTransformer} which sets the remaining fields.
@@ -32,7 +32,7 @@ public class WaitStateEntry {
   private String elementId;
   private BpmnElementType elementType;
   private WaitStateType waitStateType;
-  private Map<String, Object> details;
+  private WaitStateDetails details;
   private String tenantId;
   private long partitionId;
 
@@ -90,11 +90,11 @@ public class WaitStateEntry {
     return this;
   }
 
-  public Map<String, Object> getDetails() {
+  public WaitStateDetails getDetails() {
     return details;
   }
 
-  public WaitStateEntry setDetails(final Map<String, Object> details) {
+  public WaitStateEntry setDetails(final WaitStateDetails details) {
     this.details = details;
     return this;
   }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/transformers/JobBasedWaitStateTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/transformers/JobBasedWaitStateTransformer.java
@@ -14,16 +14,8 @@ import io.camunda.zeebe.exporter.common.waitstate.WaitStateTransformer;
 import io.camunda.zeebe.exporter.common.waitstate.WaitStateTransformerConfig;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
-import java.util.HashMap;
-import java.util.Map;
 
 public class JobBasedWaitStateTransformer implements WaitStateTransformer<JobRecordValue> {
-
-  public static final String DETAIL_JOB_KEY = "jobKey";
-  public static final String DETAIL_JOB_TYPE = "jobType";
-  public static final String DETAIL_JOB_KIND = "jobKind";
-  public static final String DETAIL_LISTENER_EVENT_TYPE = "listenerEventType";
-  public static final String DETAIL_RETRIES = "retries";
 
   @Override
   public WaitStateTransformerConfig config() {
@@ -33,14 +25,14 @@ public class JobBasedWaitStateTransformer implements WaitStateTransformer<JobRec
   @Override
   public void extract(final Record<JobRecordValue> record, final WaitStateEntry entry) {
     final JobRecordValue value = record.getValue();
-
-    final Map<String, Object> details = new HashMap<>();
-    details.put(DETAIL_JOB_KEY, record.getKey());
-    details.put(DETAIL_JOB_TYPE, value.getType());
-    details.put(DETAIL_JOB_KIND, value.getJobKind().name());
-    details.put(DETAIL_LISTENER_EVENT_TYPE, value.getJobListenerEventType().name());
-    details.put(DETAIL_RETRIES, value.getRetries());
-
-    entry.setElementType(value.getElementType()).setDetails(details);
+    entry
+        .setElementType(value.getElementType())
+        .setDetails(
+            new JobWaitStateDetails(
+                record.getKey(),
+                value.getType(),
+                value.getJobKind(),
+                value.getJobListenerEventType(),
+                value.getRetries()));
   }
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/transformers/JobWaitStateDetails.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/transformers/JobWaitStateDetails.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.common.waitstate.transformers;
+
+import io.camunda.zeebe.exporter.common.waitstate.WaitStateDetails;
+import io.camunda.zeebe.protocol.record.value.JobKind;
+import io.camunda.zeebe.protocol.record.value.JobListenerEventType;
+
+/**
+ * Wait-state details for job-based element waits (service tasks, send tasks, script tasks,
+ * business-rule tasks).
+ */
+public record JobWaitStateDetails(
+    long jobKey,
+    String jobType,
+    JobKind jobKind,
+    JobListenerEventType listenerEventType,
+    int retries)
+    implements WaitStateDetails {}

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/transformers/WaitStateTransformerRegistry.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/transformers/WaitStateTransformerRegistry.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.common.waitstate.transformers;
+
+import io.camunda.zeebe.exporter.common.waitstate.WaitStateTransformer;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+public final class WaitStateTransformerRegistry {
+
+  private WaitStateTransformerRegistry() {}
+
+  /**
+   * Returns suppliers for transformers that run on all partitions. Suppliers are used to create
+   * fresh instances when needed.
+   *
+   * @return list of transformer suppliers for all partitions
+   */
+  public static List<Supplier<WaitStateTransformer<?>>>
+      getAllPartitionWaitStateTransformerSuppliers() {
+    return List.of(JobBasedWaitStateTransformer::new);
+  }
+
+  /**
+   * Creates new instances of all transformers. This is useful for tests that need to verify all
+   * transformers are properly configured.
+   *
+   * @return list of all new transformer instances
+   */
+  public static List<WaitStateTransformer<?>> createAllTransformers() {
+    return getAllPartitionWaitStateTransformerSuppliers().stream()
+        .map(Supplier::get)
+        .collect(Collectors.toList());
+  }
+}

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/waitstate/WaitStateEntryTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/waitstate/WaitStateEntryTest.java
@@ -10,16 +10,18 @@ package io.camunda.zeebe.exporter.common.waitstate;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.exporter.common.waitstate.WaitStateEntry.WaitStateType;
+import io.camunda.zeebe.exporter.common.waitstate.transformers.JobWaitStateDetails;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.ImmutableJobRecordValue;
+import io.camunda.zeebe.protocol.record.value.JobKind;
+import io.camunda.zeebe.protocol.record.value.JobListenerEventType;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
-import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class WaitStateEntryTest {
@@ -27,7 +29,9 @@ class WaitStateEntryTest {
   @Test
   void shouldExposeAllFieldsViaAccessors() {
     // given
-    final Map<String, Object> details = Map.of("jobType", "payment", "retries", 3);
+    final var details =
+        new JobWaitStateDetails(
+            42L, "payment", JobKind.BPMN_ELEMENT, JobListenerEventType.UNSPECIFIED, 3);
     final var entry =
         new WaitStateEntry()
             .setRootProcessInstanceKey(100L)
@@ -53,18 +57,18 @@ class WaitStateEntryTest {
   }
 
   @Test
-  void shouldAcceptDefaultTenantAndEmptyDetails() {
+  void shouldAcceptDefaultTenantWithNullDetails() {
     // given / when
     final var entry =
         new WaitStateEntry()
             .setElementType(BpmnElementType.USER_TASK)
             .setWaitStateType(WaitStateType.USER_TASK)
-            .setDetails(Map.of())
+            .setDetails(null)
             .setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
     // then
     assertThat(entry.getTenantId()).isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
-    assertThat(entry.getDetails()).isEmpty();
+    assertThat(entry.getDetails()).isNull();
   }
 
   @Test

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/waitstate/WaitStateTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/waitstate/WaitStateTransformerTest.java
@@ -18,7 +18,6 @@ import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
-import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class WaitStateTransformerTest {
@@ -46,7 +45,7 @@ class WaitStateTransformerTest {
               .setElementId("job-element")
               .setElementType(BpmnElementType.SERVICE_TASK)
               .setWaitStateType(WaitStateType.JOB)
-              .setDetails(Map.of())
+              .setDetails(null)
               .setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
               .setPartitionId(record.getPartitionId());
         }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/waitstate/transformers/JobBasedWaitStateTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/waitstate/transformers/JobBasedWaitStateTransformerTest.java
@@ -7,11 +7,6 @@
  */
 package io.camunda.zeebe.exporter.common.waitstate.transformers;
 
-import static io.camunda.zeebe.exporter.common.waitstate.transformers.JobBasedWaitStateTransformer.DETAIL_JOB_KEY;
-import static io.camunda.zeebe.exporter.common.waitstate.transformers.JobBasedWaitStateTransformer.DETAIL_JOB_KIND;
-import static io.camunda.zeebe.exporter.common.waitstate.transformers.JobBasedWaitStateTransformer.DETAIL_JOB_TYPE;
-import static io.camunda.zeebe.exporter.common.waitstate.transformers.JobBasedWaitStateTransformer.DETAIL_LISTENER_EVENT_TYPE;
-import static io.camunda.zeebe.exporter.common.waitstate.transformers.JobBasedWaitStateTransformer.DETAIL_RETRIES;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.exporter.common.waitstate.WaitStateEntry.WaitStateType;
@@ -76,12 +71,13 @@ class JobBasedWaitStateTransformerTest {
     assertThat(entry.getElementType()).isEqualTo(BpmnElementType.SERVICE_TASK);
 
     // then — job-specific details
-    assertThat(entry.getDetails())
-        .containsEntry(DETAIL_JOB_KEY, 999L)
-        .containsEntry(DETAIL_JOB_TYPE, "payment-service")
-        .containsEntry(DETAIL_JOB_KIND, JobKind.BPMN_ELEMENT.name())
-        .containsEntry(DETAIL_LISTENER_EVENT_TYPE, JobListenerEventType.UNSPECIFIED.name())
-        .containsEntry(DETAIL_RETRIES, 3);
+    assertThat(entry.getDetails()).isInstanceOf(JobWaitStateDetails.class);
+    final var details = (JobWaitStateDetails) entry.getDetails();
+    assertThat(details.jobKey()).isEqualTo(999L);
+    assertThat(details.jobType()).isEqualTo("payment-service");
+    assertThat(details.jobKind()).isEqualTo(JobKind.BPMN_ELEMENT);
+    assertThat(details.listenerEventType()).isEqualTo(JobListenerEventType.UNSPECIFIED);
+    assertThat(details.retries()).isEqualTo(3);
   }
 
   @Test

--- a/zeebe/exporters/rdbms-exporter/pom.xml
+++ b/zeebe/exporters/rdbms-exporter/pom.xml
@@ -90,6 +90,16 @@
       <artifactId>micrometer-core</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+
     <!-- testing -->
     <dependency>
       <groupId>io.camunda</groupId>

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.rdbms;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.db.rdbms.RdbmsSchemaManagerRegistry;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
@@ -59,6 +60,8 @@ import io.camunda.exporter.rdbms.handlers.batchoperation.ProcessInstanceCancella
 import io.camunda.exporter.rdbms.handlers.batchoperation.ProcessInstanceHistoryDeletionBatchOperationExportHandler;
 import io.camunda.exporter.rdbms.handlers.batchoperation.ProcessInstanceMigrationBatchOperationExportHandler;
 import io.camunda.exporter.rdbms.handlers.batchoperation.ProcessInstanceModificationBatchOperationExportHandler;
+import io.camunda.exporter.rdbms.handlers.waitstate.WaitStateAddHandler;
+import io.camunda.exporter.rdbms.handlers.waitstate.WaitStateRemoveHandler;
 import io.camunda.exporter.rdbms.replication.LsnReplicationControllerFactory;
 import io.camunda.exporter.rdbms.replication.ReplicationControllerFactory;
 import io.camunda.search.entities.BatchOperationType;
@@ -67,6 +70,7 @@ import io.camunda.zeebe.exporter.api.context.Context;
 import io.camunda.zeebe.exporter.api.context.Controller;
 import io.camunda.zeebe.exporter.common.auditlog.transformers.AuditLogTransformer;
 import io.camunda.zeebe.exporter.common.auditlog.transformers.AuditLogTransformerRegistry;
+import io.camunda.zeebe.exporter.common.waitstate.transformers.WaitStateTransformerRegistry;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.util.VisibleForTesting;
@@ -299,6 +303,8 @@ public class RdbmsExporterWrapper implements Exporter {
     if (config.getAuditLog().isEnabled()) {
       registerAuditLogHandlers(rdbmsWriters, builder, config, partitionId);
     }
+
+    registerWaitStateHandlers(rdbmsWriters, builder);
   }
 
   private void createBatchOperationHandlers(
@@ -374,5 +380,21 @@ public class RdbmsExporterWrapper implements Exporter {
                     vendorDatabaseProperties,
                     transformer,
                     config.getAuditLog())));
+  }
+
+  private void registerWaitStateHandlers(final RdbmsWriters rdbmsWriters, final Builder builder) {
+    final var waitStateWriter = rdbmsWriters.getWaitStateWriter();
+    final var objectMapper = new ObjectMapper();
+
+    WaitStateTransformerRegistry.createAllTransformers()
+        .forEach(
+            transformer -> {
+              builder.withHandler(
+                  transformer.config().valueType(),
+                  new WaitStateAddHandler<>(waitStateWriter, transformer, objectMapper));
+              builder.withHandler(
+                  transformer.config().valueType(),
+                  new WaitStateRemoveHandler<>(waitStateWriter, transformer));
+            });
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/waitstate/WaitStateAddHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/waitstate/WaitStateAddHandler.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.handlers.waitstate;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.db.rdbms.write.domain.WaitStateDbModel;
+import io.camunda.db.rdbms.write.service.WaitStateWriter;
+import io.camunda.exporter.rdbms.RdbmsExportHandler;
+import io.camunda.zeebe.exporter.common.waitstate.WaitStateDetails;
+import io.camunda.zeebe.exporter.common.waitstate.WaitStateEntry;
+import io.camunda.zeebe.exporter.common.waitstate.WaitStateTransformer;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.value.WaitStateRelated;
+import io.camunda.zeebe.util.VisibleForTesting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Inserts a {@link WaitStateDbModel} when a process element enters a waiting state. The row is
+ * keyed by the stable entity key (e.g. jobKey, userTaskKey).
+ *
+ * @param <R> the record value type handled by the injected transformer
+ */
+public class WaitStateAddHandler<R extends RecordValue & WaitStateRelated>
+    implements RdbmsExportHandler<R> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(WaitStateAddHandler.class);
+
+  private final WaitStateWriter waitStateWriter;
+  private final WaitStateTransformer<R> transformer;
+  private final ObjectMapper objectMapper;
+
+  public WaitStateAddHandler(
+      final WaitStateWriter waitStateWriter,
+      final WaitStateTransformer<R> transformer,
+      final ObjectMapper objectMapper) {
+    this.waitStateWriter = waitStateWriter;
+    this.transformer = transformer;
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public boolean canExport(final Record<R> record) {
+    return transformer.triggersAdd(record);
+  }
+
+  @Override
+  public void export(final Record<R> record) {
+    final var entry = transformer.transform(record);
+    waitStateWriter.create(map(record, entry));
+  }
+
+  @VisibleForTesting
+  public WaitStateTransformer<R> getTransformer() {
+    return transformer;
+  }
+
+  private WaitStateDbModel map(final Record<R> record, final WaitStateEntry entry) {
+    return new WaitStateDbModel.Builder()
+        .waitStateKey(record.getKey())
+        .rootProcessInstanceKey(entry.getRootProcessInstanceKey())
+        .processInstanceKey(entry.getProcessInstanceKey())
+        .elementInstanceKey(entry.getElementInstanceKey())
+        .elementId(entry.getElementId())
+        .elementType(entry.getElementType() != null ? entry.getElementType().name() : null)
+        .waitStateType(entry.getWaitStateType() != null ? entry.getWaitStateType().name() : null)
+        .details(serializeDetails(entry.getDetails()))
+        .tenantId(entry.getTenantId())
+        .partitionId(record.getPartitionId())
+        .build();
+  }
+
+  private String serializeDetails(final WaitStateDetails details) {
+    if (details == null) {
+      return null;
+    }
+    try {
+      return objectMapper.writeValueAsString(details);
+    } catch (final JsonProcessingException e) {
+      LOG.error("Failed to serialize wait state details: {}", e.getMessage(), e);
+      return null;
+    }
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/waitstate/WaitStateRemoveHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/waitstate/WaitStateRemoveHandler.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.handlers.waitstate;
+
+import io.camunda.db.rdbms.write.service.WaitStateWriter;
+import io.camunda.exporter.rdbms.RdbmsExportHandler;
+import io.camunda.zeebe.exporter.common.waitstate.WaitStateTransformer;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.value.WaitStateRelated;
+import io.camunda.zeebe.util.VisibleForTesting;
+
+/**
+ * Deletes a wait-state row when a process element leaves its waiting state (e.g. job completed,
+ * user task completed). The row is identified by the same stable entity key used on insertion.
+ *
+ * @param <R> the record value type handled by the injected transformer
+ */
+public class WaitStateRemoveHandler<R extends RecordValue & WaitStateRelated>
+    implements RdbmsExportHandler<R> {
+
+  private final WaitStateWriter waitStateWriter;
+  private final WaitStateTransformer<R> transformer;
+
+  public WaitStateRemoveHandler(
+      final WaitStateWriter waitStateWriter, final WaitStateTransformer<R> transformer) {
+    this.waitStateWriter = waitStateWriter;
+    this.transformer = transformer;
+  }
+
+  @Override
+  public boolean canExport(final Record<R> record) {
+    return transformer.triggersRemoval(record);
+  }
+
+  @Override
+  public void export(final Record<R> record) {
+    waitStateWriter.delete(record.getKey());
+  }
+
+  @VisibleForTesting
+  public WaitStateTransformer<R> getTransformer() {
+    return transformer;
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/waitstate/WaitStateAddHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/waitstate/WaitStateAddHandlerTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.handlers.waitstate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.db.rdbms.write.domain.WaitStateDbModel;
+import io.camunda.db.rdbms.write.service.WaitStateWriter;
+import io.camunda.zeebe.exporter.common.waitstate.WaitStateEntry.WaitStateType;
+import io.camunda.zeebe.exporter.common.waitstate.transformers.JobBasedWaitStateTransformer;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ImmutableJobRecordValue;
+import io.camunda.zeebe.protocol.record.value.JobKind;
+import io.camunda.zeebe.protocol.record.value.JobListenerEventType;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class WaitStateAddHandlerTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Mock private WaitStateWriter waitStateWriter;
+  @Captor private ArgumentCaptor<WaitStateDbModel> modelCaptor;
+
+  private WaitStateAddHandler<JobRecordValue> handler;
+
+  @BeforeEach
+  void setUp() {
+    handler =
+        new WaitStateAddHandler<>(
+            waitStateWriter, new JobBasedWaitStateTransformer(), objectMapper);
+  }
+
+  @Test
+  void shouldExportJobCreatedRecord() {
+    // given
+    final Record<JobRecordValue> record =
+        factory.generateRecord(
+            ValueType.JOB, r -> r.withRecordType(RecordType.EVENT).withIntent(JobIntent.CREATED));
+
+    // when / then
+    assertThat(handler.canExport(record)).isTrue();
+  }
+
+  @Test
+  void shouldNotExportJobCompletedRecord() {
+    // given
+    final Record<JobRecordValue> record =
+        factory.generateRecord(
+            ValueType.JOB, r -> r.withRecordType(RecordType.EVENT).withIntent(JobIntent.COMPLETED));
+
+    // when / then
+    assertThat(handler.canExport(record)).isFalse();
+  }
+
+  @Test
+  void shouldInsertWaitStateRowOnExport() {
+    // given
+    final JobRecordValue value =
+        ImmutableJobRecordValue.builder()
+            .from(factory.generateObject(JobRecordValue.class))
+            .withType("payment-service")
+            .withJobKind(JobKind.BPMN_ELEMENT)
+            .withJobListenerEventType(JobListenerEventType.UNSPECIFIED)
+            .withRetries(3)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId("task-payment")
+            .withElementInstanceKey(300L)
+            .withProcessInstanceKey(200L)
+            .withRootProcessInstanceKey(100L)
+            .withTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+            .build();
+    final Record<JobRecordValue> record =
+        factory.generateRecord(
+            ValueType.JOB,
+            r ->
+                r.withKey(999L)
+                    .withRecordType(RecordType.EVENT)
+                    .withIntent(JobIntent.CREATED)
+                    .withValue(value));
+
+    // when
+    handler.export(record);
+
+    // then
+    verify(waitStateWriter).create(modelCaptor.capture());
+    final WaitStateDbModel model = modelCaptor.getValue();
+    assertThat(model.waitStateKey()).isEqualTo(999L);
+    assertThat(model.rootProcessInstanceKey()).isEqualTo(100L);
+    assertThat(model.processInstanceKey()).isEqualTo(200L);
+    assertThat(model.elementInstanceKey()).isEqualTo(300L);
+    assertThat(model.elementId()).isEqualTo("task-payment");
+    assertThat(model.elementType()).isEqualTo(BpmnElementType.SERVICE_TASK.name());
+    assertThat(model.waitStateType()).isEqualTo(WaitStateType.JOB.name());
+    assertThat(model.tenantId()).isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+    assertThat(model.partitionId()).isEqualTo(record.getPartitionId());
+    assertThat(model.details())
+        .contains("\"jobType\":\"payment-service\"")
+        .contains("\"jobKind\":\"BPMN_ELEMENT\"")
+        .contains("\"retries\":3");
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/waitstate/WaitStateRemoveHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/waitstate/WaitStateRemoveHandlerTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.handlers.waitstate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.db.rdbms.write.service.WaitStateWriter;
+import io.camunda.zeebe.exporter.common.waitstate.transformers.JobBasedWaitStateTransformer;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class WaitStateRemoveHandlerTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+
+  @Mock private WaitStateWriter waitStateWriter;
+
+  private WaitStateRemoveHandler<JobRecordValue> handler;
+
+  @BeforeEach
+  void setUp() {
+    handler = new WaitStateRemoveHandler<>(waitStateWriter, new JobBasedWaitStateTransformer());
+  }
+
+  @Test
+  void shouldExportJobCompletedRecord() {
+    // given
+    final Record<JobRecordValue> record =
+        factory.generateRecord(
+            ValueType.JOB, r -> r.withRecordType(RecordType.EVENT).withIntent(JobIntent.COMPLETED));
+
+    // when / then
+    assertThat(handler.canExport(record)).isTrue();
+  }
+
+  @Test
+  void shouldExportJobCanceledRecord() {
+    // given
+    final Record<JobRecordValue> record =
+        factory.generateRecord(
+            ValueType.JOB, r -> r.withRecordType(RecordType.EVENT).withIntent(JobIntent.CANCELED));
+
+    // when / then
+    assertThat(handler.canExport(record)).isTrue();
+  }
+
+  @Test
+  void shouldNotExportJobCreatedRecord() {
+    // given
+    final Record<JobRecordValue> record =
+        factory.generateRecord(
+            ValueType.JOB, r -> r.withRecordType(RecordType.EVENT).withIntent(JobIntent.CREATED));
+
+    // when / then
+    assertThat(handler.canExport(record)).isFalse();
+  }
+
+  @Test
+  void shouldDeleteByRecordKeyOnExport() {
+    // given
+    final Record<JobRecordValue> record =
+        factory.generateRecord(
+            ValueType.JOB,
+            r -> r.withKey(777L).withRecordType(RecordType.EVENT).withIntent(JobIntent.COMPLETED));
+
+    // when
+    handler.export(record);
+
+    // then
+    verify(waitStateWriter).delete(777L);
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Implements RDBMS exporter wait-state handlers for issue #53997, completing
the secondary-storage pipeline for waiting-state element instances alongside
the Elasticsearch/OpenSearch implementation from #53996. When a process element
enters a waiting state the exporter persists a row; when it leaves, the row
is deleted.

All shared extraction logic (`WaitStateEntry`, `WaitStateDetails`,
`JobWaitStateDetails`, `WaitStateTransformer`, `WaitStateTransformerConfig`,
`WaitStateTransformerRegistry`, `JobBasedWaitStateTransformer`) is reused
directly from `exporter-common` with no changes.

## Changes

### `db/rdbms-schema`
- **`8.10.0.xml`** — new `WAIT_STATE` table changeset: `WAIT_STATE_KEY BIGINT PK`,
  all process/element identity columns, `ELEMENT_TYPE`/`WAIT_STATE_TYPE VARCHAR(50)`,
  `DETAILS CLOB` (opaque JSON blob), `TENANT_ID`, `PARTITION_ID`. Indexes on
  `PROCESS_INSTANCE_KEY`, `ELEMENT_INSTANCE_KEY`, and `ROOT_PROCESS_INSTANCE_KEY`.

### `db/rdbms`
- **`WaitStateDbModel`** — record + builder; `details` typed as `String`
  (pre-serialized JSON) so each backend decides how to serialize/deserialize
  based on `waitStateType`.
- **`WaitStateMapper`** (+`WaitStateMapper.xml`) — `insert`, `delete(key)`,
  `findOne(key)`. No search queries — those belong to the future search layer.
- **`WaitStateWriter`** — `create` / `delete(key)` via `ExecutionQueue` under
  new `ContextType.WAIT_STATE` (`preserveOrder=false`).
- **`WaitStateDbReader`** — minimal `findOne(key) → Optional<WaitStateDbModel>`;
  exposed via `RdbmsService.getWaitStateReader()` for integration test verification.
- **Wiring** — `WaitStateMapper` registered in `MyBatisConfiguration` and
  `RdbmsMapperBundle`; `WaitStateWriter` instantiated in `RdbmsWriters`;
  `WaitStateDbReader` wired into `RdbmsService` and `RdbmsConfiguration`.

### `zeebe/exporters/rdbms-exporter`
- **`WaitStateAddHandler<R>`** — `canExport = triggersAdd`; calls
  `transformer.transform()`, maps the resulting `WaitStateEntry` to a
  `WaitStateDbModel` (Jackson-serializing the typed `WaitStateDetails`),
  and delegates to `WaitStateWriter.create()`.
- **`WaitStateRemoveHandler<R>`** — `canExport = triggersRemoval`; calls
  `WaitStateWriter.delete(record.getKey())` — no data extraction needed.
- **`RdbmsExporterWrapper.registerWaitStateHandlers()`** — iterates
  `WaitStateTransformerRegistry` and registers both an add and a remove handler
  per transformer under the transformer's `ValueType`. Unconditional for all
  partitions, mirroring audit-log handler registration.

## Tests
- **`WaitStateAddHandlerTest`** — routing (JOB.CREATED → handled, JOB.COMPLETED → not
  handled), full entity mapping including JSON details content.
- **`WaitStateRemoveHandlerTest`** — routing (COMPLETED/CANCELED → handled, CREATED →
  not), delete-by-key delegation.
- **`WaitStateIT`** — full persistence round-trip against H2 (all DB vendors in CI):
  insert via writer → flush → findOne asserts all fields → delete → findOne returns
  empty.

## Notes
- The `details` CLOB is intentionally stored opaque — deserialization by `waitStateType`
  is a read/search-layer concern, out of scope for this PR.
- No `WaitStateHandlerBuilder` equivalent — the RDBMS registration idiom requires
  `(ValueType, handler)` pairs via `builder.withHandler()`, so both handlers are
  registered inline in `registerWaitStateHandlers()`, consistent with the existing
  audit-log pattern.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #53997
related to #48548
