### PR TITLE
Add wait states configuration

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Data.java
+++ b/configuration/src/main/java/io/camunda/configuration/Data.java
@@ -25,6 +25,9 @@ public class Data {
   /** This section allows to configure the audit log setup. */
   @NestedConfigurationProperty private AuditLog auditLog = new AuditLog();
 
+  /** This section allows to configure the wait-states tracking setup. */
+  @NestedConfigurationProperty private WaitStates waitStates = new WaitStates();
+
   /** This section allows to configure the history deletion setup. */
   @NestedConfigurationProperty private HistoryDeletion historyDeletion = new HistoryDeletion();
 
@@ -50,6 +53,14 @@ public class Data {
 
   public void setAuditLog(final AuditLog auditLog) {
     this.auditLog = auditLog;
+  }
+
+  public WaitStates getWaitStates() {
+    return waitStates;
+  }
+
+  public void setWaitStates(final WaitStates waitStates) {
+    this.waitStates = waitStates;
   }
 
   public HistoryDeletion getHistoryDeletion() {

--- a/configuration/src/main/java/io/camunda/configuration/WaitStates.java
+++ b/configuration/src/main/java/io/camunda/configuration/WaitStates.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import io.camunda.zeebe.exporter.common.waitstate.WaitStateConfiguration;
+
+/**
+ * Configuration for wait-state tracking.
+ *
+ * <p>Maps to the {@code camunda.data.wait-states} property namespace. When disabled, no wait-state
+ * rows are written to or deleted from secondary storage.
+ */
+public class WaitStates {
+
+  private boolean enabled = true;
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(final boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  /** Converts this configuration to a {@link WaitStateConfiguration} for the exporters. */
+  public WaitStateConfiguration toConfiguration() {
+    return new WaitStateConfiguration().setEnabled(enabled);
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -943,6 +943,12 @@ public class BrokerBasedPropertiesOverride {
                       database.getBatchOperationItemInsertBlockSize());
                   config.setAuditLog(
                       unifiedConfiguration.getCamunda().getData().getAuditLog().toConfiguration());
+                  config.setWaitState(
+                      unifiedConfiguration
+                          .getCamunda()
+                          .getData()
+                          .getWaitStates()
+                          .toConfiguration());
                   config.setHistoryDeletion(
                       unifiedConfiguration
                           .getCamunda()

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/CamundaExporterConfigurationApplier.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/CamundaExporterConfigurationApplier.java
@@ -225,6 +225,8 @@ public final class CamundaExporterConfigurationApplier {
 
     exporterConfiguration.setAuditLog(
         unifiedConfiguration.getCamunda().getData().getAuditLog().toConfiguration());
+    exporterConfiguration.setWaitState(
+        unifiedConfiguration.getCamunda().getData().getWaitStates().toConfiguration());
     exporterConfiguration.setHistoryDeletion(
         unifiedConfiguration.getCamunda().getData().getHistoryDeletion().toConfiguration());
 

--- a/configuration/src/test/java/io/camunda/configuration/WaitStatesTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/WaitStatesTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import io.camunda.zeebe.broker.exporter.context.ExporterConfiguration;
+import io.camunda.zeebe.exporter.common.waitstate.WaitStateConfiguration;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+class WaitStatesTest {
+
+  @Test
+  void shouldBeEnabledByDefault() {
+    assertThat(new WaitStates().isEnabled()).as("WaitStates should be enabled by default").isTrue();
+  }
+
+  @Test
+  void shouldConvertToWaitStateConfiguration() {
+    // given
+    final WaitStates waitStates = new WaitStates();
+
+    // when
+    final WaitStateConfiguration config = waitStates.toConfiguration();
+
+    // then
+    assertThat(config.isEnabled())
+        .as("WaitStateConfiguration.enabled should match WaitStates.enabled")
+        .isEqualTo(waitStates.isEnabled());
+  }
+
+  @Test
+  void shouldPropagateDisabledToConfiguration() {
+    // given
+    final WaitStates waitStates = new WaitStates();
+    waitStates.setEnabled(false);
+
+    // when
+    final WaitStateConfiguration config = waitStates.toConfiguration();
+
+    // then
+    assertThat(config.isEnabled()).isFalse();
+  }
+
+  @Nested
+  @ActiveProfiles({"broker"})
+  @SpringJUnitConfig({
+    UnifiedConfiguration.class,
+    UnifiedConfigurationHelper.class,
+    BrokerBasedPropertiesOverride.class,
+  })
+  @TestPropertySource(
+      properties = {
+        "camunda.data.secondary-storage.type=rdbms",
+        "camunda.data.wait-states.enabled=false"
+      })
+  class RdbmsExporterTest {
+    @Test
+    void shouldPropagateWaitStatesEnabledToRdbmsExporter(
+        @Autowired final BrokerBasedProperties brokerBasedProperties) {
+      // when
+      final var exporter = brokerBasedProperties.getRdbmsExporter();
+      final var config =
+          ExporterConfiguration.fromArgs(
+              io.camunda.exporter.rdbms.ExporterConfiguration.class, exporter.getArgs());
+
+      // then
+      assertThat(config.getWaitState().isEnabled()).isFalse();
+    }
+  }
+
+  @Nested
+  @ActiveProfiles({"broker"})
+  @SpringJUnitConfig({
+    UnifiedConfiguration.class,
+    UnifiedConfigurationHelper.class,
+    BrokerBasedPropertiesOverride.class,
+  })
+  @TestPropertySource(
+      properties = {
+        "camunda.data.secondary-storage.type=elasticsearch",
+        "camunda.data.wait-states.enabled=false"
+      })
+  class CamundaExporterTest {
+    @Test
+    void shouldPropagateWaitStatesEnabledToCamundaExporter(
+        @Autowired final BrokerBasedProperties brokerBasedProperties) {
+      // when
+      final var exporter = brokerBasedProperties.getCamundaExporter();
+      final var config =
+          ExporterConfiguration.fromArgs(
+              io.camunda.exporter.config.ExporterConfiguration.class, exporter.getArgs());
+
+      // then
+      assertThat(config.getWaitState().isEnabled()).isFalse();
+    }
+  }
+}

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/ClientConfig.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/ClientConfig.java
@@ -15,6 +15,7 @@ import io.camunda.operate.property.OperateProperties;
 import io.camunda.security.spring.CamundaSecurityLibraryProperties;
 import jakarta.servlet.ServletContext;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -33,10 +34,15 @@ public class ClientConfig {
   public boolean resourcePermissionsEnabled;
   public boolean multiTenancyEnabled;
   public String databaseType;
+  public boolean waitStatesEnabled;
   @Autowired private OperateProfileService profileService;
   @Autowired private EnvironmentService environmentService;
   @Autowired private OperateProperties operateProperties;
   @Autowired private CamundaSecurityLibraryProperties cslProperties;
+
+  @Value("${camunda.data.wait-states.enabled:true}")
+  private boolean waitStatesEnabledProperty;
+
   @Autowired private ServletContext context;
 
   public String asJson() {
@@ -53,6 +59,7 @@ public class ClientConfig {
     resourcePermissionsEnabled = cslProperties.getAuthorizations().isEnabled();
     multiTenancyEnabled = cslProperties.getMultiTenancy().isChecksEnabled();
     databaseType = environmentService.getDatabaseType();
+    waitStatesEnabled = waitStatesEnabledProperty;
     try {
       return String.format(
           "window.clientConfig = %s;", new ObjectMapper().writeValueAsString(this));

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/WaitStateConfiguration.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/waitstate/WaitStateConfiguration.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.common.waitstate;
+
+/**
+ * Runtime configuration for wait-state tracking.
+ *
+ * <p>When disabled, no wait-state handlers are registered in either the Camunda or RDBMS exporter,
+ * and no rows are written to or deleted from the wait-state index/table.
+ *
+ * <p>Corresponds to the {@code camunda.data.wait-states.enabled} property (default {@code true}).
+ */
+public final class WaitStateConfiguration {
+
+  private boolean enabled = true;
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public WaitStateConfiguration setEnabled(final boolean enabled) {
+    this.enabled = enabled;
+    return this;
+  }
+
+  @Override
+  public String toString() {
+    return "WaitStateConfiguration{enabled=" + enabled + '}';
+  }
+}

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/waitstate/WaitStateConfigurationTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/waitstate/WaitStateConfigurationTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.common.waitstate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class WaitStateConfigurationTest {
+
+  @Test
+  void shouldBeEnabledByDefault() {
+    assertThat(new WaitStateConfiguration().isEnabled()).isTrue();
+  }
+
+  @Test
+  void shouldAllowDisabling() {
+    // given / when
+    final var config = new WaitStateConfiguration().setEnabled(false);
+
+    // then
+    assertThat(config.isEnabled()).isFalse();
+  }
+
+  @Test
+  void shouldAllowReEnabling() {
+    // given
+    final var config = new WaitStateConfiguration().setEnabled(false);
+
+    // when
+    config.setEnabled(true);
+
+    // then
+    assertThat(config.isEnabled()).isTrue();
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -409,6 +409,10 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
       addAuditLogHandlers(configuration.getAuditLog(), partitionId);
     }
 
+    if (configuration.getWaitState().isEnabled()) {
+      // TODO: call addWaitStateHandlers();
+    }
+
     if (configuration.getBatchOperation().isExportItemsOnCreation()) {
       // only add this handler when the items are exported on creation
       exportHandlers.add(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
@@ -13,6 +13,7 @@ import io.camunda.search.schema.config.RetentionConfiguration;
 import io.camunda.zeebe.exporter.common.auditlog.AuditLogConfiguration;
 import io.camunda.zeebe.exporter.common.extensionproperty.ExtensionPropertyConfiguration;
 import io.camunda.zeebe.exporter.common.historydeletion.HistoryDeletionConfiguration;
+import io.camunda.zeebe.exporter.common.waitstate.WaitStateConfiguration;
 
 public class ExporterConfiguration {
 
@@ -29,6 +30,7 @@ public class ExporterConfiguration {
   private BatchOperationConfiguration batchOperation = new BatchOperationConfiguration();
   private AuditLogConfiguration auditLog = new AuditLogConfiguration();
   private HistoryDeletionConfiguration historyDeletion = new HistoryDeletionConfiguration();
+  private WaitStateConfiguration waitState = new WaitStateConfiguration();
   private boolean createSchema = true;
   private boolean skipVariableWriteWithoutUserTasks = false;
   private ExtensionPropertyConfiguration extensionProperties = new ExtensionPropertyConfiguration();
@@ -39,6 +41,14 @@ public class ExporterConfiguration {
 
   public void setAuditLog(final AuditLogConfiguration auditLog) {
     this.auditLog = auditLog;
+  }
+
+  public WaitStateConfiguration getWaitState() {
+    return waitState;
+  }
+
+  public void setWaitState(final WaitStateConfiguration waitState) {
+    this.waitState = waitState;
   }
 
   public HistoryDeletionConfiguration getHistoryDeletion() {
@@ -191,6 +201,8 @@ public class ExporterConfiguration {
         + auditLog
         + ", historyDeletion="
         + historyDeletion
+        + ", waitState="
+        + waitState
         + ", skipVariableWriteWithoutUserTasks="
         + skipVariableWriteWithoutUserTasks
         + '}';

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/DefaultExporterResourceProviderTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/DefaultExporterResourceProviderTest.java
@@ -156,6 +156,36 @@ public class DefaultExporterResourceProviderTest {
                 handlersExcludingAuditLog.stream().map(ExportHandler::getClass).distinct().count());
   }
 
+  // TODO: enable with #54996
+  //  @Test
+  //  void shouldNotAddWaitStateHandlersWhenDisabled() {
+  //    // given
+  //    final var config = new ExporterConfiguration();
+  //    config.getWaitState().setEnabled(false);
+  //
+  //    final var provider = new DefaultExporterResourceProvider();
+  //    provider.init(
+  //        config,
+  //        mock(ExporterEntityCacheProvider.class),
+  //        new ExporterTestContext(),
+  //        new ExporterMetadata(TestObjectMapper.objectMapper()),
+  //        TestObjectMapper.objectMapper());
+  //
+  //    // when / then
+  //    assertThat(
+  //            provider.getExportHandlers().stream()
+  //                .filter(WaitStateAddHandler.class::isInstance)
+  //                .toList())
+  //        .as("No WaitStateAddHandler should be registered when waitState is disabled")
+  //        .isEmpty();
+  //    assertThat(
+  //            provider.getExportHandlers().stream()
+  //                .filter(WaitStateRemoveHandler.class::isInstance)
+  //                .toList())
+  //        .as("No WaitStateRemoveHandler should be registered when waitState is disabled")
+  //        .isEmpty();
+  //  }
+
   @ParameterizedTest
   @MethodSource("expectedAuditLogTransformers")
   void shouldAddAuditLogHandlersFromAddAuditLogHandlersMethod(
@@ -297,7 +327,7 @@ public class DefaultExporterResourceProviderTest {
       final ExportHandler<?, ?> handler) {
     // For AuditLogHandler, extract RecordValue from the transformer instance, because the handler
     // itself uses generic RecordValue
-    if (handler instanceof AuditLogHandler<?> auditLogHandler) {
+    if (handler instanceof final AuditLogHandler<?> auditLogHandler) {
       return findRecordValueTypeParameterFromClass(auditLogHandler.getTransformer().getClass());
     }
 

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ExporterConfiguration.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ExporterConfiguration.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.exporter.api.ExporterException;
 import io.camunda.zeebe.exporter.common.auditlog.AuditLogConfiguration;
 import io.camunda.zeebe.exporter.common.extensionproperty.ExtensionPropertyConfiguration;
 import io.camunda.zeebe.exporter.common.historydeletion.HistoryDeletionConfiguration;
+import io.camunda.zeebe.exporter.common.waitstate.WaitStateConfiguration;
 import java.time.Duration;
 import java.time.InstantSource;
 import java.util.ArrayList;
@@ -29,6 +30,8 @@ public class ExporterConfiguration {
   // AuditLog
   private AuditLogConfiguration auditLog = new AuditLogConfiguration();
   private HistoryDeletionConfiguration historyDeletion = new HistoryDeletionConfiguration();
+  // WaitState
+  private WaitStateConfiguration waitState = new WaitStateConfiguration();
   private Duration flushInterval = DEFAULT_FLUSH_INTERVAL;
   private int queueSize = RdbmsWriterConfig.DEFAULT_QUEUE_SIZE;
   private int queueMemoryLimit = RdbmsWriterConfig.DEFAULT_QUEUE_MEMORY_LIMIT;
@@ -53,6 +56,14 @@ public class ExporterConfiguration {
 
   public void setAuditLog(final AuditLogConfiguration auditLog) {
     this.auditLog = auditLog;
+  }
+
+  public WaitStateConfiguration getWaitState() {
+    return waitState;
+  }
+
+  public void setWaitState(final WaitStateConfiguration waitState) {
+    this.waitState = waitState;
   }
 
   public HistoryDeletionConfiguration getHistoryDeletion() {

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
@@ -304,7 +304,9 @@ public class RdbmsExporterWrapper implements Exporter {
       registerAuditLogHandlers(rdbmsWriters, builder, config, partitionId);
     }
 
-    registerWaitStateHandlers(rdbmsWriters, builder);
+    if (config.getWaitState().isEnabled()) {
+      registerWaitStateHandlers(rdbmsWriters, builder);
+    }
   }
 
   private void createBatchOperationHandlers(


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Implements the `camunda.data.wait-states.enabled` feature flag from issue #54225. When set to
`false`, wait-state tracking is fully disabled: no handlers are registered in either exporter and
no rows are written to or deleted from secondary storage. The flag defaults to `true`, preserving
the existing behavior for all deployments that don't explicitly configure it.

The flag is also exposed to the Operate frontend via `ClientConfig.waitStatesEnabled` so the UI
can conditionally show or hide wait-state components.

## Changes

### `zeebe/exporter-common`
- **`WaitStateConfiguration`** — runtime config class with a single `boolean enabled = true`
  property and fluent `setEnabled()`. Held inside each exporter's `ExporterConfiguration` and
  checked at handler-registration time. No per-record gating interface needed — the flag is
  all-or-nothing.

### `zeebe/exporters/camunda-exporter` and `zeebe/exporters/rdbms-exporter`
- Both `ExporterConfiguration` classes gain a `waitState` field (`WaitStateConfiguration`,
  default enabled) with `getWaitState()` / `setWaitState()`, mirroring the existing `auditLog`
  field.
- Handler registration is now guarded: `if (config.getWaitState().isEnabled())` wraps
  `addWaitStateHandlers()` (Camunda exporter) and `registerWaitStateHandlers()` (RDBMS exporter).

### `configuration`
- **`WaitStates`** — Spring-bindable config class. Maps `camunda.data.wait-states.enabled`
  (default `true`) and provides `toConfiguration() → WaitStateConfiguration` for the exporters.
  Named `WaitStates` so Spring's kebab-case conversion produces the `wait-states` path, matching
  the property name in the issue exactly.
- **`Data`** — `@NestedConfigurationProperty private WaitStates waitStates` added alongside
  `auditLog`, yielding the full property key `camunda.data.wait-states.enabled`.
- **`BrokerBasedPropertiesOverride`** and **`CamundaExporterConfigurationApplier`** — both call
  `getData().getWaitStates().toConfiguration()` and pass the result to `config.setWaitState()`,
  completing the binding chain from the Spring environment to the handler-registration guard.

### `operate/webapp`
- **`ClientConfig`** — adds `public boolean waitStatesEnabled`, injected via
  `@Value("${camunda.data.wait-states.enabled:true}")`. The default in the `@Value` expression
  ensures Operate continues to work correctly even when the `configuration` module is not on its
  classpath (e.g. in tests or standalone deployments).

## Tests
- **`WaitStateConfigurationTest`** — enabled-by-default and setter toggle.
- **`WaitStatesTest`** — enabled-by-default, `toConfiguration()` propagates the flag, and two
  `@TestPropertySource` Spring integration tests confirm that `camunda.data.wait-states.enabled=false`
  flows end-to-end through the binding chain to both `ExporterConfiguration` instances.
- **`DefaultExporterResourceProviderTest`** — `shouldNotAddWaitStateHandlersWhenDisabled` asserts
  no `WaitStateAddHandler` or `WaitStateRemoveHandler` is registered when the flag is off.

## Notes
- No UI is provided for toggling the flag — it is controlled via environment variables in SaaS and
  SM, as described in the issue.
- The Operate frontend integration (`clientConfig.waitStatesEnabled`) is exposed here but the
  actual UI component gating is left to the Operate FE team as a separate concern.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #54225
