### PR TITLE
test: stabilize JobWorker task open in zeebe/job-worker tasklist test

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
@@ -191,8 +191,22 @@ test.describe('task details page', () => {
     await expect(taskDetailsPage.taskCompletedBanner).toBeVisible();
 
     await taskPanelPage.openTask('JobWorker_user_task');
-    await expect(taskDetailsPage.completeTaskButton).toBeDisabled({
-      timeout: 60000,
+    // After the Zeebe task is completed it drops out of the "All open tasks"
+    // list, and the resulting reflow can deselect the just-clicked JobWorker
+    // task — leaving the details panel on "Pick a task to work on" with a stale
+    // (enabled) Complete Task button from the previous panel still mounted.
+    // Re-open the task until its details actually load (Assign to me visible for
+    // the unassigned task), then assert the Complete Task button is disabled.
+    await waitForAssertion({
+      assertion: async () => {
+        await expect(taskDetailsPage.assignToMeButton).toBeVisible({
+          timeout: 60000,
+        });
+        await expect(taskDetailsPage.completeTaskButton).toBeDisabled();
+      },
+      onFailure: async () => {
+        await taskPanelPage.openTask('JobWorker_user_task');
+      },
     });
     await taskDetailsPage.clickAssignToMeButton();
     await expect(taskDetailsPage.completeTaskButton).toBeEnabled();


### PR DESCRIPTION
## Description

Fixes a nightly E2E failure in `tasklist/task-details.spec.ts` →
**complete zeebe and job worker tasks @v1-only** (V1 Tasklist, chromium).

### Root cause

The `zeebe_and_job_worker_process` runs a Zeebe (native) user task assigned to
`demo` and a job-worker user task (unassigned) in parallel. The test completes
the Zeebe task, then opens `JobWorker_user_task` and asserts its **Complete
Task** button is disabled (unassigned).

After the Zeebe task is completed it drops out of the **All open tasks** list.
The resulting list reflow can deselect the just-clicked JobWorker task, leaving
the details panel on **"Pick a task to work on"** while a stale, enabled
Complete Task button from the previous (completed) panel is still mounted. The
bare `toBeDisabled({timeout: 60000})` assertion polled that stale button and
failed on **both** retries — the failure screenshots show the JobWorker card
selected but the details panel empty.

### Fix

Re-open the JobWorker task until its details actually load — anchored on the
**Assign to me** button being visible for the unassigned task — before
asserting the Complete Task button is disabled. This reuses the file's existing
`waitForAssertion` re-open pattern and still surfaces a genuine product bug (it
fails after retries if an unassigned task truly shows an enabled Complete
button).

Test-only change; no product or page-object code touched.

### Reference

Nightly run: https://github.com/camunda/camunda/actions/runs/26792886778

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## On-demand verification runs
- https://github.com/camunda/camunda/actions/runs/26800756260 ✅  (will check Docker failure in another PR)
