### PR TITLE
ci: retry docker image pull when starting Camunda in OC test workflows

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-e2e-api-test-branch-on-demand.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-api-test-branch-on-demand.yml
@@ -137,13 +137,35 @@ jobs:
         run: |
           export CAMUNDA_DOCKER_IMAGE="camunda/camunda:${RESOLVED_DOCKER_TAG}"
           echo "Using CAMUNDA_DOCKER_IMAGE=${CAMUNDA_DOCKER_IMAGE}"
-          if [[ "$NON_STANDALONE" == "true" ]]; then
-            echo "Using single services for older branches (8.6/8.7)"
-            DATABASE=elasticsearch docker compose up -d operate tasklist
-          else
-            echo "Using standalone camunda container"
-            DATABASE=elasticsearch docker compose up -d camunda
-          fi
+          # Retry to absorb transient Docker Hub registry timeouts during the
+          # image pull (e.g. "Get https://registry-1.docker.io/v2/: context
+          # deadline exceeded"). docker compose up -d is idempotent, so a retry
+          # simply resumes the pull and starts the container.
+          start_camunda() {
+            if [[ "$NON_STANDALONE" == "true" ]]; then
+              echo "Using single services for older branches (8.6/8.7)"
+              DATABASE=elasticsearch docker compose up -d operate tasklist
+            else
+              echo "Using standalone camunda container"
+              DATABASE=elasticsearch docker compose up -d camunda
+            fi
+          }
+
+          attempts=3
+          for attempt in $(seq 1 "$attempts"); do
+            if start_camunda; then
+              echo "Camunda started on attempt ${attempt}."
+              exit 0
+            fi
+            echo "Attempt ${attempt}/${attempts} to start Camunda failed."
+            if [[ "$attempt" -lt "$attempts" ]]; then
+              echo "Retrying in 15s..."
+              sleep 15
+            fi
+          done
+
+          echo "Failed to start Camunda after ${attempts} attempts."
+          exit 1
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
 
       - name: List running Docker containers

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml
@@ -84,13 +84,35 @@ jobs:
 
       - name: Start Camunda
         run: |
-          if [[ "$NON_STANDALONE" == "true" ]]; then
-            echo "Using single services for older branches (8.6/8.7)"
-            DATABASE=elasticsearch docker compose up -d operate tasklist
-          else
-            echo "Using standalone camunda container"
-            DATABASE=elasticsearch docker compose up -d camunda
-          fi
+          # Retry to absorb transient Docker Hub registry timeouts during the
+          # image pull (e.g. "Get https://registry-1.docker.io/v2/: context
+          # deadline exceeded"). docker compose up -d is idempotent, so a retry
+          # simply resumes the pull and starts the container.
+          start_camunda() {
+            if [[ "$NON_STANDALONE" == "true" ]]; then
+              echo "Using single services for older branches (8.6/8.7)"
+              DATABASE=elasticsearch docker compose up -d operate tasklist
+            else
+              echo "Using standalone camunda container"
+              DATABASE=elasticsearch docker compose up -d camunda
+            fi
+          }
+
+          attempts=3
+          for attempt in $(seq 1 "$attempts"); do
+            if start_camunda; then
+              echo "Camunda started on attempt ${attempt}."
+              exit 0
+            fi
+            echo "Attempt ${attempt}/${attempts} to start Camunda failed."
+            if [[ "$attempt" -lt "$attempts" ]]; then
+              echo "Retrying in 15s..."
+              sleep 15
+            fi
+          done
+
+          echo "Failed to start Camunda after ${attempts} attempts."
+          exit 1
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
 
       - name: List running Docker containers
@@ -450,19 +472,41 @@ jobs:
 
       - name: Start Camunda
         run: |
-          if [[ "$NON_STANDALONE" == "true" ]]; then
-            echo "Using single services for older branches (8.6/8.7)"
-            DATABASE=elasticsearch docker compose up -d operate tasklist
-          else
-            echo "Using standalone camunda container"
-            if [[ "${{ matrix.tasklist_mode }}" == "v1" ]]; then
-              echo "Starting with Tasklist V1 mode enabled"
-              CAMUNDA_TASKLIST_V2_MODE_ENABLED=false DATABASE=elasticsearch docker compose up -d camunda
+          # Retry to absorb transient Docker Hub registry timeouts during the
+          # image pull (e.g. "Get https://registry-1.docker.io/v2/: context
+          # deadline exceeded"). docker compose up -d is idempotent, so a retry
+          # simply resumes the pull and starts the container.
+          start_camunda() {
+            if [[ "$NON_STANDALONE" == "true" ]]; then
+              echo "Using single services for older branches (8.6/8.7)"
+              DATABASE=elasticsearch docker compose up -d operate tasklist
             else
-              echo "Starting with default Tasklist V2 mode"
-              DATABASE=elasticsearch docker compose up -d camunda
+              echo "Using standalone camunda container"
+              if [[ "${{ matrix.tasklist_mode }}" == "v1" ]]; then
+                echo "Starting with Tasklist V1 mode enabled"
+                CAMUNDA_TASKLIST_V2_MODE_ENABLED=false DATABASE=elasticsearch docker compose up -d camunda
+              else
+                echo "Starting with default Tasklist V2 mode"
+                DATABASE=elasticsearch docker compose up -d camunda
+              fi
             fi
-          fi
+          }
+
+          attempts=3
+          for attempt in $(seq 1 "$attempts"); do
+            if start_camunda; then
+              echo "Camunda started on attempt ${attempt}."
+              exit 0
+            fi
+            echo "Attempt ${attempt}/${attempts} to start Camunda failed."
+            if [[ "$attempt" -lt "$attempts" ]]; then
+              echo "Retrying in 15s..."
+              sleep 15
+            fi
+          done
+
+          echo "Failed to start Camunda after ${attempts} attempts."
+          exit 1
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
 
       - name: List running Docker containers

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
@@ -213,13 +213,35 @@ jobs:
       - name: Start Camunda
         shell: bash
         run: |
-          if [[ "$NON_STANDALONE" == "true" ]]; then
-            echo "Using single services for older branches (8.6/8.7)"
-            DATABASE=elasticsearch docker compose up -d operate tasklist
-          else
-            echo "Using standalone camunda container"
-            DATABASE=elasticsearch docker compose up -d camunda
-          fi
+          # Retry to absorb transient Docker Hub registry timeouts during the
+          # image pull (e.g. "Get https://registry-1.docker.io/v2/: context
+          # deadline exceeded"). docker compose up -d is idempotent, so a retry
+          # simply resumes the pull and starts the container.
+          start_camunda() {
+            if [[ "$NON_STANDALONE" == "true" ]]; then
+              echo "Using single services for older branches (8.6/8.7)"
+              DATABASE=elasticsearch docker compose up -d operate tasklist
+            else
+              echo "Using standalone camunda container"
+              DATABASE=elasticsearch docker compose up -d camunda
+            fi
+          }
+
+          attempts=3
+          for attempt in $(seq 1 "$attempts"); do
+            if start_camunda; then
+              echo "Camunda started on attempt ${attempt}."
+              exit 0
+            fi
+            echo "Attempt ${attempt}/${attempts} to start Camunda failed."
+            if [[ "$attempt" -lt "$attempts" ]]; then
+              echo "Retrying in 15s..."
+              sleep 15
+            fi
+          done
+
+          echo "Failed to start Camunda after ${attempts} attempts."
+          exit 1
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
 
       - name: List running Docker containers
@@ -859,19 +881,41 @@ jobs:
 
       - name: Start Camunda
         run: |
-          if [[ "$NON_STANDALONE" == "true" ]]; then
-            echo "Using separate services for older branches (8.6/8.7)"
-            DATABASE=elasticsearch docker compose up -d zeebe operate tasklist
-          else
-            echo "Using standalone camunda container"
-            if [[ "${{ matrix.tasklist_mode }}" == "v1" ]]; then
-              echo "Starting with Tasklist V1 mode enabled"
-              CAMUNDA_TASKLIST_V2_MODE_ENABLED=false DATABASE=elasticsearch docker compose up -d camunda
+          # Retry to absorb transient Docker Hub registry timeouts during the
+          # image pull (e.g. "Get https://registry-1.docker.io/v2/: context
+          # deadline exceeded"). docker compose up -d is idempotent, so a retry
+          # simply resumes the pull and starts the container.
+          start_camunda() {
+            if [[ "$NON_STANDALONE" == "true" ]]; then
+              echo "Using separate services for older branches (8.6/8.7)"
+              DATABASE=elasticsearch docker compose up -d zeebe operate tasklist
             else
-              echo "Starting with default Tasklist V2 mode"
-              DATABASE=elasticsearch docker compose up -d camunda
+              echo "Using standalone camunda container"
+              if [[ "${{ matrix.tasklist_mode }}" == "v1" ]]; then
+                echo "Starting with Tasklist V1 mode enabled"
+                CAMUNDA_TASKLIST_V2_MODE_ENABLED=false DATABASE=elasticsearch docker compose up -d camunda
+              else
+                echo "Starting with default Tasklist V2 mode"
+                DATABASE=elasticsearch docker compose up -d camunda
+              fi
             fi
-          fi
+          }
+
+          attempts=3
+          for attempt in $(seq 1 "$attempts"); do
+            if start_camunda; then
+              echo "Camunda started on attempt ${attempt}."
+              exit 0
+            fi
+            echo "Attempt ${attempt}/${attempts} to start Camunda failed."
+            if [[ "$attempt" -lt "$attempts" ]]; then
+              echo "Retrying in 15s..."
+              sleep 15
+            fi
+          done
+
+          echo "Failed to start Camunda after ${attempts} attempts."
+          exit 1
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
 
       - name: List running Docker containers

--- a/.github/workflows/c8-orchestration-cluster-forward-compatibility-tests.yml
+++ b/.github/workflows/c8-orchestration-cluster-forward-compatibility-tests.yml
@@ -151,7 +151,22 @@ jobs:
       - name: Pull server Docker image
         run: |
           echo "Pulling image: ${{ matrix.server_image }}"
-          docker pull ${{ matrix.server_image }}
+          # Retry to absorb transient Docker Hub registry timeouts
+          # (e.g. "Get https://registry-1.docker.io/v2/: context deadline exceeded").
+          attempts=3
+          for attempt in $(seq 1 "$attempts"); do
+            if docker pull "${{ matrix.server_image }}"; then
+              echo "Image pulled on attempt ${attempt}."
+              exit 0
+            fi
+            echo "Attempt ${attempt}/${attempts} to pull image failed."
+            if [[ "$attempt" -lt "$attempts" ]]; then
+              echo "Retrying in 15s..."
+              sleep 15
+            fi
+          done
+          echo "Failed to pull image after ${attempts} attempts."
+          exit 1
 
       - name: Start Camunda
         run: CAMUNDA_DOCKER_IMAGE=${{ matrix.server_image }} DATABASE=elasticsearch docker compose up -d camunda

--- a/.github/workflows/c8-orchestration-cluster-request-validation-nightly.yml
+++ b/.github/workflows/c8-orchestration-cluster-request-validation-nightly.yml
@@ -29,7 +29,24 @@ jobs:
       - name: Start Camunda
         run: |
           echo "Starting Camunda with unified architecture"
-          DATABASE=elasticsearch docker compose up -d camunda
+          # Retry to absorb transient Docker Hub registry timeouts during the
+          # image pull (e.g. "Get https://registry-1.docker.io/v2/: context
+          # deadline exceeded"). docker compose up -d is idempotent, so a retry
+          # simply resumes the pull and starts the container.
+          attempts=3
+          for attempt in $(seq 1 "$attempts"); do
+            if DATABASE=elasticsearch docker compose up -d camunda; then
+              echo "Camunda started on attempt ${attempt}."
+              exit 0
+            fi
+            echo "Attempt ${attempt}/${attempts} to start Camunda failed."
+            if [[ "$attempt" -lt "$attempts" ]]; then
+              echo "Retrying in 15s..."
+              sleep 15
+            fi
+          done
+          echo "Failed to start Camunda after ${attempts} attempts."
+          exit 1
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
 
       - name: List running Docker containers

--- a/.github/workflows/c8-orchestration-cluster-reusable-api-tests.yml
+++ b/.github/workflows/c8-orchestration-cluster-reusable-api-tests.yml
@@ -40,13 +40,35 @@ jobs:
       - name: Start Camunda
         shell: bash
         run: |
-          if [[ "${{ inputs.branch }}" == "stable/8.7" ]]; then
-            echo "Using single services for stable/8.7"
-            DATABASE=elasticsearch docker compose up -d operate tasklist
-          else
-            echo "Using standalone camunda container"
-            DATABASE=elasticsearch docker compose up -d camunda
-          fi
+          # Retry to absorb transient Docker Hub registry timeouts during the
+          # image pull (e.g. "Get https://registry-1.docker.io/v2/: context
+          # deadline exceeded"). docker compose up -d is idempotent, so a retry
+          # simply resumes the pull and starts the container.
+          start_camunda() {
+            if [[ "${{ inputs.branch }}" == "stable/8.7" ]]; then
+              echo "Using single services for stable/8.7"
+              DATABASE=elasticsearch docker compose up -d operate tasklist
+            else
+              echo "Using standalone camunda container"
+              DATABASE=elasticsearch docker compose up -d camunda
+            fi
+          }
+
+          attempts=3
+          for attempt in $(seq 1 "$attempts"); do
+            if start_camunda; then
+              echo "Camunda started on attempt ${attempt}."
+              exit 0
+            fi
+            echo "Attempt ${attempt}/${attempts} to start Camunda failed."
+            if [[ "$attempt" -lt "$attempts" ]]; then
+              echo "Retrying in 15s..."
+              sleep 15
+            fi
+          done
+
+          echo "Failed to start Camunda after ${attempts} attempts."
+          exit 1
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
 
       - name: List running Docker containers

--- a/.github/workflows/c8-orchestration-cluster-reusable-e2e-tests.yml
+++ b/.github/workflows/c8-orchestration-cluster-reusable-e2e-tests.yml
@@ -43,19 +43,41 @@ jobs:
 
       - name: Start Camunda
         run: |
-          if [[ "${{ inputs.branch }}" == "stable/8.7" ]]; then
-            echo "Using single services for Camunda 8.7"
-            DATABASE=elasticsearch docker compose up -d operate tasklist
-          else
-            echo "Using standalone camunda container"
-            if [[ "${{ inputs.tasklist_mode }}" == "v1" ]]; then
-              echo "Starting with Tasklist V1 mode enabled"
-              CAMUNDA_TASKLIST_V2_MODE_ENABLED=false DATABASE=elasticsearch docker compose up -d camunda
+          # Retry to absorb transient Docker Hub registry timeouts during the
+          # image pull (e.g. "Get https://registry-1.docker.io/v2/: context
+          # deadline exceeded"). docker compose up -d is idempotent, so a retry
+          # simply resumes the pull and starts the container.
+          start_camunda() {
+            if [[ "${{ inputs.branch }}" == "stable/8.7" ]]; then
+              echo "Using single services for Camunda 8.7"
+              DATABASE=elasticsearch docker compose up -d operate tasklist
             else
-              echo "Starting with default Tasklist V2 mode"
-              DATABASE=elasticsearch docker compose up -d camunda
+              echo "Using standalone camunda container"
+              if [[ "${{ inputs.tasklist_mode }}" == "v1" ]]; then
+                echo "Starting with Tasklist V1 mode enabled"
+                CAMUNDA_TASKLIST_V2_MODE_ENABLED=false DATABASE=elasticsearch docker compose up -d camunda
+              else
+                echo "Starting with default Tasklist V2 mode"
+                DATABASE=elasticsearch docker compose up -d camunda
+              fi
             fi
-          fi
+          }
+
+          attempts=3
+          for attempt in $(seq 1 "$attempts"); do
+            if start_camunda; then
+              echo "Camunda started on attempt ${attempt}."
+              exit 0
+            fi
+            echo "Attempt ${attempt}/${attempts} to start Camunda failed."
+            if [[ "$attempt" -lt "$attempts" ]]; then
+              echo "Retrying in 15s..."
+              sleep 15
+            fi
+          done
+
+          echo "Failed to start Camunda after ${attempts} attempts."
+          exit 1
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
 
       - name: List running Docker containers


### PR DESCRIPTION
## Problem

The C8 Orchestration Cluster nightly **API Tests (ES)** run [failed](https://github.com/camunda/camunda/actions/runs/26794234759/job/78987082303) at the **Start Camunda** step with a transient Docker Hub registry timeout:

```
camunda Error Get "https://registry-1.docker.io/v2/": context deadline exceeded
Error response from daemon: Get "https://registry-1.docker.io/v2/": context deadline exceeded
```

The Elasticsearch image pulled fine; the `camunda/camunda:SNAPSHOT` pull timed out. A single registry hiccup fails the whole unattended nightly run even though the pull would almost certainly have succeeded on retry. This is an infrastructure flake, not a code defect.

## Change

Wrap the image pull in the OC test workflows' `Start Camunda` (and the forward-compatibility `Pull server Docker image`) steps in a **3-attempt retry loop with a 15s backoff**. `docker compose up -d` is idempotent, so a retry simply resumes the interrupted pull and starts the container.

Applied to all docker-pull-based start steps across the OC test workflows:
- `c8-orchestration-cluster-reusable-api-tests.yml` (the failing one)
- `c8-orchestration-cluster-reusable-e2e-tests.yml`
- `c8-orchestration-cluster-request-validation-nightly.yml`
- `c8-orchestration-cluster-forward-compatibility-tests.yml`
- `c8-orchestration-cluster-e2e-tests-on-demand.yml`
- `c8-orchestration-cluster-e2e-tests-release.yml`
- `c8-orchestration-cluster-e2e-api-test-branch-on-demand.yml`

The local-binary "Start Camunda with H2/RDBMS" steps are untouched — they don't pull images.

## Validation

- `actionlint` — clean (the two `gcp-perf-core-16-default` runner-label warnings are pre-existing and unrelated to these edits)
- `conftest` policy check — 238/238 passed across all 7 workflows
- Retry loop logic validated in isolation (immediate success, recovery on retry, exhaustion → exit 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)