### PR TITLE
test: fix MI EL test titles over TestRail automation_id limit + add a PR-time guard

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/package.json
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/package.json
@@ -5,8 +5,9 @@
   "scripts": {
     "test": "playwright test",
     "test:local": "node --env-file=.env ./runTest.js",
-    "lint": "tsc && eslint .",
+    "lint": "tsc && eslint . && npm run check:testrail-ids",
     "lint:fix": "eslint . --fix",
+    "check:testrail-ids": "playwright test --list --reporter=./scripts/check-automation-id-length.ts",
     "responses:regenerate": "assert-json-body extract"
   },
   "devDependencies": {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/scripts/check-automation-id-length.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/scripts/check-automation-id-length.ts
@@ -1,4 +1,11 @@
-/* eslint-disable */
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
 import type {
   FullConfig,
   FullResult,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/scripts/check-automation-id-length.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/scripts/check-automation-id-length.ts
@@ -1,0 +1,79 @@
+/* eslint-disable */
+import type {
+  FullConfig,
+  FullResult,
+  Reporter,
+  Suite,
+  TestCase,
+} from '@playwright/test/reporter';
+
+/**
+ * CI guard for TestRail's `custom_automation_id` 250-byte limit.
+ *
+ * The `Publish test results to TestRail` step in the nightly API/E2E
+ * workflows uses `trcli parse_junit`, which derives each case's
+ * `custom_automation_id` as `"<classname>.<name>"` — exactly
+ * `<spec file path>.<describe chain › test title>` from the Playwright
+ * JUnit reporter. TestRail rejects any value over 250 bytes and aborts
+ * the whole `add_case` batch, so a single over-long test name fails the
+ * entire nightly run (hours after merge, on a step unrelated to whether
+ * the test itself passes).
+ *
+ * This reporter recomputes that id with the same `test.titlePath()` API
+ * the JUnit reporter uses and fails fast at PR time, with an actionable
+ * message, before the test name can ever break the nightly.
+ *
+ * Run via `--list` so no tests actually execute:
+ *   playwright test --list --reporter=./scripts/check-automation-id-length.ts
+ */
+
+// TestRail field limit. trcli auto-truncates the case *title* to this
+// length but intentionally never truncates the automation_id (it is the
+// stable matching key), so we must keep it within budget ourselves.
+const MAX_AUTOMATION_ID_BYTES = 250;
+
+function automationIdFor(test: TestCase): string {
+  // Playwright JUnit reporter: classname = titlePath()[2] (spec file path),
+  // name = titlePath().slice(3).join(' › ') (describe chain + test title).
+  const path = test.titlePath();
+  const classname = path[2] ?? '';
+  const name = path.slice(3).join(' › ');
+  return `${classname}.${name}`;
+}
+
+class AutomationIdLengthReporter implements Reporter {
+  private readonly violations = new Map<string, number>();
+
+  onBegin(_config: FullConfig, suite: Suite): void {
+    for (const test of suite.allTests()) {
+      const id = automationIdFor(test);
+      const bytes = Buffer.byteLength(id, 'utf8');
+      // Dedupe: the same id appears once per project.
+      if (bytes > MAX_AUTOMATION_ID_BYTES && !this.violations.has(id)) {
+        this.violations.set(id, bytes);
+      }
+    }
+  }
+
+  async onEnd(): Promise<{status: FullResult['status']}> {
+    if (this.violations.size === 0) {
+      console.log(
+        `✓ TestRail automation_id check: all test ids are within ${MAX_AUTOMATION_ID_BYTES} bytes.`,
+      );
+      return {status: 'passed'};
+    }
+
+    console.error(
+      `\n✗ TestRail automation_id check failed: ${this.violations.size} test(s) exceed the ${MAX_AUTOMATION_ID_BYTES}-byte limit.\n` +
+        `  trcli would reject these and abort the entire "Publish test results to TestRail" step.\n` +
+        `  Shorten the test title and/or its enclosing describe blocks.\n`,
+    );
+    for (const [id, bytes] of this.violations) {
+      console.error(`  [${bytes} bytes] ${id}`);
+    }
+    console.error('');
+    return {status: 'failed'};
+  }
+}
+
+export default AutomationIdLengthReporter;

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/mi-el-before-all-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/mi-el-before-all-tests.spec.ts
@@ -614,7 +614,7 @@ test.describe.parallel('Multi-Instance Execution Listeners — beforeAll', () =>
         });
       });
 
-      test('search returns 200 for all types when start EL fails (FAILED, retries > 0)', async ({
+      test('search returns 200 for all job states when start EL fails', async ({
         request,
       }) => {
         const instance = await createSingleInstance(processId, 1);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/mi-el-before-all-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/mi-el-before-all-tests.spec.ts
@@ -614,7 +614,7 @@ test.describe.parallel('Multi-Instance Execution Listeners — beforeAll', () =>
         });
       });
 
-      test('search returns 200 for all job states when start EL fails', async ({
+      test('jobs search returns 200 after a start EL failure', async ({
         request,
       }) => {
         const instance = await createSingleInstance(processId, 1);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/mi-el-start-end-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/mi-el-start-end-tests.spec.ts
@@ -136,7 +136,7 @@ test.describe
       });
     });
 
-    test('start EL failure with no retries raises EXECUTION_LISTENER_NO_RETRIES incident; /jobs/search returns 200 in FAILED and RETRIES_UPDATED states', async ({
+    test('start EL failure with no retries raises NO_RETRIES incident', async ({
       request,
     }) => {
       const instance = await createSingleInstance(processId, 1, {


### PR DESCRIPTION
## Problem

The nightly **C8 Orchestration Cluster API Tests** workflows (RDBMS and ES) have been failing since 2026-05-29 (e.g. [run 26794380679](https://github.com/camunda/camunda/actions/runs/26794380679)). All tests **pass**, but the `Publish test results to TestRail` step fails:

```
Found 7 test cases not matching any TestRail case.
Error during add_case. Trying to cancel scheduled tasks.
Field :custom_automation_id is too long (250 characters at most).
```

## Root cause

`trcli parse_junit` derives `custom_automation_id` as `"<classname>.<name>"` = `<spec file path>.<describe chain › test title>`. TestRail enforces a **250-byte** limit on that field, and trcli aborts the entire `add_case` batch on the first rejected case — so one over-long test name fails the whole nightly, hours after merge, on a step unrelated to whether the test itself passes.

Confirmed against the trcli 1.14.1 source: it auto-truncates the case *title* to 250 but intentionally **never** truncates the `automation_id` (it is the stable matching key), so there is no trcli/TestRail-side knob — the budget has to be respected in the test names.

Both `nightly-api-tests-rdbms` and `nightly-api-tests-es` hit this because they share TestRail suite `17050`.

## Changes

1. **Fix the over-long titles** in the new MI execution-listener specs:
   - `mi-el-before-all-tests.spec.ts`: `255 → 229` bytes
   - `mi-el-start-end-tests.spec.ts`: `280 → 198` bytes (surfaced by the new guard below; was a latent landmine — it only avoided breaking the nightly because it currently matches an existing case)

   Both old titles also overstated what they assert — they work *around* the FAILED/RETRIES_UPDATED states (per #54238) rather than verifying `/jobs/search` in them — so the new titles describe the actual assertions.

2. **Add a PR-time guard** (`scripts/check-automation-id-length.ts`): a Playwright `--list`-mode reporter that recomputes each id with the same `test.titlePath()` API the JUnit reporter uses and fails with an actionable message if any exceeds 250 bytes. Wired into `npm run lint` (`check:testrail-ids`) so the existing PR-triggered **Lint / C8 E2E Test Suite** job catches it before it can reach a nightly. Runs with `--list`, so no tests execute and no backend is needed.

## Verification
https://github.com/camunda/camunda/actions/runs/26808222886 ✅ Publish results sucsseeded 
- `npm run lint` (tsc + eslint + check) passes on the final tree.
- The guard fails with exit 1 and lists the offending id when a title is too long; passes (exit 0) once within budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)