### PR TITLE
fix: optimize fail to deserialize tags

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/process/ZeebeProcessInstanceDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/process/ZeebeProcessInstanceDataDto.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.BpmnEventType;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -30,6 +31,7 @@ public class ZeebeProcessInstanceDataDto implements ProcessInstanceRecordValue {
   private String elementId;
   private long processInstanceKey;
   private String tenantId;
+  private Set<String> tags;
 
   private final BpmnEventType bpmnEventType;
   private final List<List<Long>> elementInstancePath;
@@ -41,6 +43,7 @@ public class ZeebeProcessInstanceDataDto implements ProcessInstanceRecordValue {
     elementInstancePath = new ArrayList<>();
     processDefinitionPath = new ArrayList<>();
     callingElementPath = new ArrayList<>();
+    tags = new HashSet<>();
   }
 
   @Override
@@ -119,7 +122,7 @@ public class ZeebeProcessInstanceDataDto implements ProcessInstanceRecordValue {
 
   @Override
   public Set<String> getTags() {
-    return Set.of();
+    return tags;
   }
 
   @Override
@@ -166,6 +169,10 @@ public class ZeebeProcessInstanceDataDto implements ProcessInstanceRecordValue {
 
   public void setBpmnProcessId(final String bpmnProcessId) {
     this.bpmnProcessId = bpmnProcessId;
+  }
+
+  public void setTags(final Set<String> tags) {
+    this.tags = tags;
   }
 
   protected boolean canEqual(final Object other) {

--- a/optimize/backend/src/test/java/io/camunda/optimize/dto/zeebe/process/ZeebeProcessInstanceDataDtoTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/dto/zeebe/process/ZeebeProcessInstanceDataDtoTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.dto.zeebe.process;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.optimize.service.util.mapper.ObjectMapperFactory;
+import org.junit.jupiter.api.Test;
+
+class ZeebeProcessInstanceDataDtoTest {
+
+  @Test
+  void shouldDeserializeProcessInstanceRecordWithoutTagsInJson() throws Exception {
+    // given — a record with no tags field at all
+    final String json =
+        """
+        {
+          "position": 1,
+          "partitionId": 3,
+          "intent": "ELEMENT_ACTIVATED",
+          "valueType": "PROCESS_INSTANCE",
+          "recordType": "EVENT",
+          "value": {
+            "bpmnProcessId": "myProcess",
+            "version": 1,
+            "processDefinitionKey": 42,
+            "processInstanceKey": 99,
+            "elementId": "Process_1",
+            "flowScopeKey": -1,
+            "bpmnElementType": "PROCESS",
+            "parentProcessInstanceKey": -1,
+            "parentElementInstanceKey": -1,
+            "tenantId": "<default>"
+          }
+        }
+        """;
+
+    // when
+    final ZeebeProcessInstanceRecordDto record =
+        ObjectMapperFactory.OPTIMIZE_MAPPER.readValue(json, ZeebeProcessInstanceRecordDto.class);
+
+    // then
+    assertThat(record.getValue().getTags()).isEmpty();
+  }
+
+  @Test
+  void shouldDeserializeProcessInstanceRecordWithTags() throws Exception {
+    // given — a document that contains value.tags
+    final String json =
+        """
+        {
+          "position": 1,
+          "partitionId": 3,
+          "intent": "ELEMENT_ACTIVATED",
+          "valueType": "PROCESS_INSTANCE",
+          "recordType": "EVENT",
+          "value": {
+            "bpmnProcessId": "myProcess",
+            "version": 1,
+            "processDefinitionKey": 42,
+            "processInstanceKey": 99,
+            "elementId": "Process_1",
+            "flowScopeKey": -1,
+            "bpmnElementType": "PROCESS",
+            "parentProcessInstanceKey": -1,
+            "parentElementInstanceKey": -1,
+            "tenantId": "<default>",
+            "tags": ["tag1", "tag2"]
+          }
+        }
+        """;
+
+    // when
+    final ZeebeProcessInstanceRecordDto record =
+        ObjectMapperFactory.OPTIMIZE_MAPPER.readValue(json, ZeebeProcessInstanceRecordDto.class);
+
+    // then
+    assertThat(record.getValue().getTags()).containsExactlyInAnyOrder("tag1", "tag2");
+  }
+
+  @Test
+  void shouldDeserializeProcessInstanceRecordWithEmptyTagsAndAllowMutation() throws Exception {
+    // given
+    final String json =
+        """
+        {
+          "position": 1,
+          "partitionId": 3,
+          "intent": "ELEMENT_ACTIVATED",
+          "valueType": "PROCESS_INSTANCE",
+          "recordType": "EVENT",
+          "value": {
+            "bpmnProcessId": "myProcess",
+            "version": 1,
+            "processDefinitionKey": 42,
+            "processInstanceKey": 99,
+            "elementId": "Process_1",
+            "flowScopeKey": -1,
+            "bpmnElementType": "PROCESS",
+            "parentProcessInstanceKey": -1,
+            "parentElementInstanceKey": -1,
+            "tenantId": "<default>",
+            "tags": []
+          }
+        }
+        """;
+
+    // when
+    final ZeebeProcessInstanceRecordDto record =
+        ObjectMapperFactory.OPTIMIZE_MAPPER.readValue(json, ZeebeProcessInstanceRecordDto.class);
+
+    // then — collection must be mutable; Set.of() would throw UnsupportedOperationException here
+    assertThat(record.getValue().getTags()).isEmpty();
+    record.getValue().getTags().add("tag3");
+    assertThat(record.getValue().getTags()).containsExactly("tag3");
+  }
+}


### PR DESCRIPTION
## Description

make `ZeebeProcessInstanceDataDto` tags mutable

add get and set tags as `ZeebeUserTaskDataDto`

## Checklist

<!--- Please delete options that are not relevant. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #54425
