### PR TITLE
ci: dispatch fix agent for workflow-level failures, remove infra label

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
@@ -260,8 +260,13 @@ jobs:
           diagnosis steps, artifact-download patterns, constraints (NEVER skip/fixme),
           PR conventions, and the /tmp/fix-meta.json schema.
 
-          Failing tests to fix are in /tmp/test_specs.json (may be empty for workflow-level failures).
-          Fix ONLY those entries — ignore other failures visible in artifacts.
+          /tmp/test_specs.json contains the failures to address ($(jq 'length' /tmp/test_specs.json) entries).
+          $(if [ "$test_spec_count" -gt 0 ]; then
+            echo "Fix ONLY the test failures listed in that file — do not address other failures visible in artifacts."
+          else
+            echo "The array is empty: this is a workflow-level failure. Follow the AGENTS.md section above to"
+            echo "inspect the failing run logs, trace the root cause to the owning file, and open a fix PR."
+          fi)
 
           Context (env vars already exported):
             VERSION=${VERSION}  TARGET_REF=${TARGET_REF}  SAFE_VERSION=${SAFE_VERSION}
@@ -490,7 +495,7 @@ jobs:
           elif [ "$category" = "not-determined" ]; then
             icon=":question:"; summary="Could not determine a fix — manual investigation required"
           else
-            icon=":information_source:"; summary="No PR opened — agent could not determine a fix"
+            icon=":information_source:"; summary="No changes required"
           fi
 
           text="${icon} *${VERSION}* fix agent — ${summary}\n<${RUN_URL}|Agent run ↗>"

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
@@ -241,16 +241,26 @@ jobs:
           # patterns, PR rules, and constraints live in AGENTS.md (which Claude must
           # read first). This keeps the per-run prompt small and the source-of-truth
           # for behaviour in a single file the team can update without editing CI.
+
+          # Determine which AGENTS.md section to use based on whether test_specs is empty.
+          # Empty test_specs means a workflow-level failure (no test results produced).
+          test_spec_count=$(jq 'length' /tmp/test_specs.json 2>/dev/null || echo 0)
+          if [ "$test_spec_count" -eq 0 ]; then
+            agents_section="## Workflow-Level Failure Fix Agent"
+          else
+            agents_section="## Nightly Fix Agent"
+          fi
+
           prompt=$(cat <<EOF
           You are the Camunda orchestration-cluster nightly fix agent.
           Workspace: ${ws_dir} (already on branch ${TARGET_REF}).
 
           STEP 0 — read ${ws_dir}/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md,
-          the "## Nightly Fix Agent" section. That file is your full operating manual:
+          the "${agents_section}" section. That file is your full operating manual:
           diagnosis steps, artifact-download patterns, constraints (NEVER skip/fixme),
-          PR conventions ('test:' not 'fix:'), and the /tmp/fix-meta.json schema.
+          PR conventions, and the /tmp/fix-meta.json schema.
 
-          Failing tests to fix are in /tmp/test_specs.json.
+          Failing tests to fix are in /tmp/test_specs.json (may be empty for workflow-level failures).
           Fix ONLY those entries — ignore other failures visible in artifacts.
 
           Context (env vars already exported):
@@ -259,8 +269,11 @@ jobs:
             HAS_E2E=${HAS_E2E}  HAS_API_ES=${HAS_API_ES}  HAS_API_RDBMS=${HAS_API_RDBMS}
             TRIAGE_RUN_URL=${TRIAGE_RUN_URL}  REPO=${REPO}
 
-          Branch name to use: fix/nightly-${VERSION}-<short-slug>.
-          Commit + PR title prefix: 'test:' (NEVER 'fix:' — commitlint rejects it).
+          Branch name to use: fix/nightly-${VERSION}-<short-slug> for test fixes,
+          ci/<short-slug> for workflow-level fixes.
+          Commit + PR title prefix: 'test:' for test-only changes, 'ci:' for workflow-only
+          changes, 'fix:' for other code changes (NEVER 'fix:' for test-only changes —
+          commitlint rejects it).
 
           CRITICAL for /tmp/fix-meta.json: the "branch" field must be the exact
           headRefName of the PR you opened — never null, never omitted. Obtain it
@@ -292,8 +305,12 @@ jobs:
           fi
 
           count=$(jq '.prs | length' /tmp/fix-meta.json)
+          category=$(jq -r '.category // ""' /tmp/fix-meta.json 2>/dev/null || echo "")
           if [ "$count" -eq 0 ]; then
             echo "No PRs were opened — nothing to verify."
+            if [ "$category" = "not-determined" ]; then
+              echo "::warning::Fix agent could not determine a fix (category: not-determined)"
+            fi
             exit 0
           fi
 
@@ -450,7 +467,9 @@ jobs:
         run: |
           set -euo pipefail
           prs_json="[]"
+          category=""
           [ -f /tmp/fix-meta.json ] && prs_json=$(jq -c '.prs // []' /tmp/fix-meta.json 2>/dev/null || echo '[]')
+          [ -f /tmp/fix-meta.json ] && category=$(jq -r '.category // ""' /tmp/fix-meta.json 2>/dev/null || echo "")
           pr_count=$(echo "$prs_json" | jq 'length')
 
           # Check fix-meta.json first — if a PR was opened report it even when
@@ -468,6 +487,8 @@ jobs:
             [ "$JOB_STATUS" = "failure" ] && summary="${summary} _(post-processing failed — see run)_"
           elif [ "$JOB_STATUS" = "failure" ]; then
             icon=":x:"; summary="Agent failed (no fix applied)"
+          elif [ "$category" = "not-determined" ]; then
+            icon=":question:"; summary="Could not determine a fix — manual investigation required"
           else
             icon=":information_source:"; summary="No PR opened — agent could not determine a fix"
           fi

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
@@ -495,7 +495,7 @@ jobs:
           elif [ "$category" = "not-determined" ]; then
             icon=":question:"; summary="Could not determine a fix — manual investigation required"
           else
-            icon=":information_source:"; summary="No changes required"
+            icon=":warning:"; summary="No fix applied — manual investigation required"
           fi
 
           text="${icon} *${VERSION}* fix agent — ${summary}\n<${RUN_URL}|Agent run ↗>"

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -369,17 +369,18 @@ jobs:
           fi
 
           # Merge workflow-level failures as additional dispatch entries (test_specs: [])
-          # Exclude any version already covered by test-failure dispatches or open PRs
+          # Exclude only versions that already have an open failing-test-fix PR.
+          # Do NOT exclude versions already in test-failure dispatches — a version can
+          # have failing tests in one workflow type and a workflow-level crash in another
+          # (e.g. api_es has test failures while api_rdbms crashes before producing results).
           jq --slurpfile run_ids /tmp/run_ids.json \
              --argjson wf_failures "$workflow_failures" \
              --argjson openrefs "$open_pr_versions" \
              --argjson cap "${DAILY_CAP}" '
             . as $test_dispatches |
-            ($test_dispatches | map(.version)) as $covered_versions |
             $wf_failures
             | map(select(
-                (.version as $v | $covered_versions | index($v)) == null
-                and ((.ref as $ref | $openrefs | index($ref)) == null)
+                (.ref as $ref | $openrefs | index($ref)) == null
               ))
             | map(. + {
                 test_specs: [],
@@ -489,7 +490,7 @@ jobs:
               if [ "$test_count" -gt 0 ]; then
                 failing_list="${failing_list}"$'\n'"  :x: <${rurl}|${rtitle}> — ${test_count} test failure(s)"
               else
-                failing_list="${failing_list}"$'\n'"  :x: <${rurl}|${rtitle}> — workflow-level failure (no test results)"
+                failing_list="${failing_list}"$'\n'"  :x: <${rurl}|${rtitle}> — workflow-level failure (no failing tests detected)"
               fi
             done < <(jq -c '.[]' /tmp/failed_runs.json)
           fi

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -319,7 +319,8 @@ jobs:
               has_test_failure=$(echo "$jq_failures_normalized" | jq -r --arg v "$version" --arg t "$test_type" \
                 '[.[] | select(.version == $v and (
                     (.test_type == "e2e"  and $t == "e2e") or
-                    (.test_type == "api"  and ($t == "api_es" or $t == "api_rdbms"))
+                    (.test_type == "api"  and $t == "api_es"    and (.database == "elasticsearch" or .database == null or .database == "")) or
+                    (.test_type == "api"  and $t == "api_rdbms" and (.database != null and .database != "" and .database != "elasticsearch"))
                   ))] | length > 0' 2>/dev/null || echo false)
               if [ "$has_test_failure" = "false" ]; then
                 conclusion=$(gh run view "$run_id" --repo "$REPO" --json conclusion --jq '.conclusion' 2>/dev/null || echo "unknown")
@@ -485,7 +486,8 @@ jobs:
               test_count=$(jq --arg v "$rv" --arg t "$rt" '[.[] | select(
                 .version == $v and (
                   (.test_type == "e2e"  and $t == "e2e") or
-                  (.test_type == "api"  and ($t == "api_es" or $t == "api_rdbms"))
+                  (.test_type == "api"  and $t == "api_es"    and (.database == "elasticsearch" or .database == null or .database == "")) or
+                  (.test_type == "api"  and $t == "api_rdbms" and (.database != null and .database != "" and .database != "elasticsearch"))
                 ))] | length' /tmp/failures_normalized.json 2>/dev/null || echo 0)
               if [ "$test_count" -gt 0 ]; then
                 failing_list="${failing_list}"$'\n'"  :x: <${rurl}|${rtitle}> — ${test_count} test failure(s)"

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -327,16 +327,23 @@ jobs:
                 if [ "$conclusion" = "failure" ]; then
                   ref=$([ "$version" = "main" ] && echo "main" || echo "stable/${version}")
                   workflow_failures=$(echo "$workflow_failures" | jq \
-                    --arg v "$version" --arg ref "$ref" \
-                    '. += [{"version": $v, "ref": $ref}]')
+                    --arg v "$version" --arg ref "$ref" --arg t "$test_type" \
+                    '. += [{"version": $v, "ref": $ref, "test_type": $t}]')
                 fi
               fi
             done < <(jq -r 'to_entries[] | "\(.key)=\(.value)"' /tmp/run_ids.json)
-            # Deduplicate workflow_failures by version (keep unique versions)
-            workflow_failures=$(echo "$workflow_failures" | jq 'unique_by(.version)')
+            # Group workflow_failures by version, collecting all failing run types per version.
+            # Storing failing_types lets the dispatch attach only the run IDs that actually
+            # had workflow-level failures, avoiding spurious run IDs in the agent context.
+            workflow_failures=$(echo "$workflow_failures" | jq '
+              group_by(.version) | map({
+                version: .[0].version,
+                ref: .[0].ref,
+                failing_types: [.[].test_type]
+              })')
           fi
 
-          echo "Workflow-level failures (no test results): $(echo "$workflow_failures" | jq 'length')"
+          echo "Workflow-level failures (no failing tests extracted): $(echo "$workflow_failures" | jq 'length')"
 
           # Build dispatch payloads from test failures
           if [ -s /tmp/failures_normalized.json ]; then
@@ -385,11 +392,13 @@ jobs:
               ))
             | map(. + {
                 test_specs: [],
-                e2e_run_id:       ($run_ids[0][(.version + "/e2e")]       // ""),
-                api_es_run_id:    ($run_ids[0][(.version + "/api_es")]    // ""),
-                api_rdbms_run_id: ($run_ids[0][(.version + "/api_rdbms")] // "")
+                e2e_run_id:       (if (.failing_types | index("e2e"))       != null then ($run_ids[0][(.version + "/e2e")]       // "") else "" end),
+                api_es_run_id:    (if (.failing_types | index("api_es"))    != null then ($run_ids[0][(.version + "/api_es")]    // "") else "" end),
+                api_rdbms_run_id: (if (.failing_types | index("api_rdbms")) != null then ($run_ids[0][(.version + "/api_rdbms")] // "") else "" end)
               })
-            | ($test_dispatches + .) | .[0:$cap]
+            # workflow-level dispatches get their own cap so test-failure dispatches
+            # cannot crowd them out when the daily cap is already full
+            | ($test_dispatches + .[0:$cap])
           ' /tmp/dispatches_test.json > /tmp/dispatches.json
 
           echo "Dispatches planned: $(jq 'length' /tmp/dispatches.json)"

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -254,7 +254,15 @@ jobs:
             exit 1
           fi
 
-          [ ! -s /tmp/all_failures.jsonl ] && { echo "No failures."; echo "dispatches=[]" >> "$GITHUB_OUTPUT"; exit 0; }
+          # Even when there are no test failures, we still need to dispatch for runs that
+          # failed at the workflow level (no test results produced). Check if any failed
+          # runs exist before bailing early.
+          failed_run_count=$(jq 'length' /tmp/failed_runs.json 2>/dev/null || echo 0)
+          if [ ! -s /tmp/all_failures.jsonl ] && [ "$failed_run_count" -eq 0 ]; then
+            echo "No failures."
+            echo "dispatches=[]" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
           # Normalize file paths:
           #   - Strip absolute prefixes (anything before 'qa/c8-orchestration-cluster-e2e-test-suite/')
@@ -288,33 +296,95 @@ jobs:
             --json baseRefName --jq '[.[].baseRefName] | unique' 2>/dev/null || echo '[]')
           echo "Open failing-test-fix PR base refs: $open_pr_versions"
 
-          # Build dispatch payloads, one per version
-          # version → {test_specs, e2e_run_id, api_es_run_id, api_rdbms_run_id}
+          # Build dispatch payloads, one per version.
+          # Sources:
+          #   1. Versions with test failures (from failures_normalized.json)
+          #   2. Versions with workflow-level failures (failed run but no test failures)
+          #      → dispatched with test_specs: [] so the fix agent inspects the workflow logs
+
+          # Build a set of versions that have test failures
+          jq_failures_normalized=$([ -s /tmp/failures_normalized.json ] && cat /tmp/failures_normalized.json || echo '[]')
+
+          # Build a JSON array of workflow-level-only failed versions
+          # (failed run exists but no test failures extracted for that version/type)
+          workflow_failures='[]'
+          if [ -f /tmp/run_ids.json ]; then
+            while IFS='=' read -r key run_id; do
+              version=$(echo "$key" | cut -d/ -f1)
+              test_type=$(echo "$key" | cut -d/ -f2)
+              has_test_failure=$(echo "$jq_failures_normalized" | jq -r --arg v "$version" --arg t "$test_type" \
+                '[.[] | select(.version == $v and (
+                    (.test_type == "e2e"  and $t == "e2e") or
+                    (.test_type == "api"  and ($t == "api_es" or $t == "api_rdbms"))
+                  ))] | length > 0' 2>/dev/null || echo false)
+              if [ "$has_test_failure" = "false" ]; then
+                conclusion=$(gh run view "$run_id" --repo "$REPO" --json conclusion --jq '.conclusion' 2>/dev/null || echo "unknown")
+                if [ "$conclusion" = "failure" ]; then
+                  ref=$([ "$version" = "main" ] && echo "main" || echo "stable/${version}")
+                  workflow_failures=$(echo "$workflow_failures" | jq \
+                    --arg v "$version" --arg ref "$ref" \
+                    '. += [{"version": $v, "ref": $ref}]')
+                fi
+              fi
+            done < <(jq -r 'to_entries[] | "\(.key)=\(.value)"' /tmp/run_ids.json)
+            # Deduplicate workflow_failures by version (keep unique versions)
+            workflow_failures=$(echo "$workflow_failures" | jq 'unique_by(.version)')
+          fi
+
+          echo "Workflow-level failures (no test results): $(echo "$workflow_failures" | jq 'length')"
+
+          # Build dispatch payloads from test failures
+          if [ -s /tmp/failures_normalized.json ]; then
+            jq --slurpfile run_ids /tmp/run_ids.json \
+               --argjson openrefs "$open_pr_versions" \
+               --argjson cap "${DAILY_CAP}" '
+              # group failures by version
+              sort_by(.version) | group_by(.version)
+              | map({
+                  version: .[0].version,
+                  test_specs: (map(del(.version)) | .[0:50]),
+                  ref: (if .[0].version == "main" then "main" else ("stable/" + .[0].version) end)
+                })
+              | map(select(.test_specs | length > 0))
+              # dedup against open PRs
+              | map(select((.ref as $ref | $openrefs | index($ref)) == null))
+              # attach run IDs
+              | map(. + {
+                  e2e_run_id:       ($run_ids[0][(.version + "/e2e")]       // ""),
+                  api_es_run_id:    ($run_ids[0][(.version + "/api_es")]    // ""),
+                  api_rdbms_run_id: ($run_ids[0][(.version + "/api_rdbms")] // "")
+                })
+              # cap failures per version to 20 so the workflow_dispatch input
+              # stays well under the 64KB limit even with many nightly failures
+              | map(.test_specs |= .[0:20])
+              # cap dispatch count
+              | .[0:$cap]
+            ' /tmp/failures_normalized.json > /tmp/dispatches_test.json
+          else
+            echo '[]' > /tmp/dispatches_test.json
+          fi
+
+          # Merge workflow-level failures as additional dispatch entries (test_specs: [])
+          # Exclude any version already covered by test-failure dispatches or open PRs
           jq --slurpfile run_ids /tmp/run_ids.json \
+             --argjson wf_failures "$workflow_failures" \
              --argjson openrefs "$open_pr_versions" \
              --argjson cap "${DAILY_CAP}" '
-            # group failures by version
-            sort_by(.version) | group_by(.version)
-            | map({
-                version: .[0].version,
-                test_specs: (map(del(.version)) | .[0:50]),
-                ref: (if .[0].version == "main" then "main" else ("stable/" + .[0].version) end)
-              })
-            | map(select(.test_specs | length > 0))
-            # dedup against open PRs
-            | map(select((.ref as $ref | $openrefs | index($ref)) == null))
-            # attach run IDs
+            . as $test_dispatches |
+            ($test_dispatches | map(.version)) as $covered_versions |
+            $wf_failures
+            | map(select(
+                (.version as $v | $covered_versions | index($v)) == null
+                and ((.ref as $ref | $openrefs | index($ref)) == null)
+              ))
             | map(. + {
+                test_specs: [],
                 e2e_run_id:       ($run_ids[0][(.version + "/e2e")]       // ""),
                 api_es_run_id:    ($run_ids[0][(.version + "/api_es")]    // ""),
                 api_rdbms_run_id: ($run_ids[0][(.version + "/api_rdbms")] // "")
               })
-            # cap failures per version to 20 so the workflow_dispatch input
-            # stays well under the 64KB limit even with many nightly failures
-            | map(.test_specs |= .[0:20])
-            # cap dispatch count
-            | .[0:$cap]
-          ' /tmp/failures_normalized.json > /tmp/dispatches.json
+            | ($test_dispatches + .) | .[0:$cap]
+          ' /tmp/dispatches_test.json > /tmp/dispatches.json
 
           echo "Dispatches planned: $(jq 'length' /tmp/dispatches.json)"
           jq '[.[] | {version, count: (.test_specs | length), e2e_run_id, api_es_run_id, api_rdbms_run_id}]' /tmp/dispatches.json || true
@@ -354,39 +424,7 @@ jobs:
               echo ""
             fi
 
-            # Infra failures: runs marked failure but no test failures extracted
-            if [ -f /tmp/run_ids.json ]; then
-              infra_failures=""
-              while IFS='=' read -r key run_id; do
-                version=$(echo "$key" | cut -d/ -f1)
-                test_type=$(echo "$key" | cut -d/ -f2)
-                # Check if this version/type combo had test failures
-                has_test_failure=$(jq -r --arg v "$version" --arg t "$test_type" \
-                  '[.[] | select(.version == $v and .test_type == $t)] | length > 0' \
-                  /tmp/failures_normalized.json 2>/dev/null || echo false)
-                if [ "$has_test_failure" = "false" ]; then
-                  # Check the actual conclusion from run_ids
-                  conclusion=$(gh run view "$run_id" --repo "$REPO" --json conclusion --jq '.conclusion' 2>/dev/null || echo "unknown")
-                  if [ "$conclusion" = "failure" ]; then
-                    row="| ${version} | ${test_type} | [${run_id}](https://github.com/${REPO}/actions/runs/${run_id}) |"
-                    infra_failures="${infra_failures:+${infra_failures}$'\n'}${row}"
-                  fi
-                fi
-              done < <(jq -r 'to_entries[] | "\(.key)=\(.value)"' /tmp/run_ids.json)
-
-              if [ -n "$infra_failures" ]; then
-                echo "### Infrastructure failures (no test failures — workflow/setup issue)"
-                echo ""
-                echo "> These runs failed but all tests passed. Likely a post-test step (e.g. TestRail upload) failed."
-                echo ""
-                echo "| Version | Type | Run |"
-                echo "|---------|------|-----|"
-                echo "$infra_failures"
-                echo ""
-              fi
-            fi
-
-            if [ "$count" -eq 0 ] && [ -z "${infra_failures:-}" ]; then
+            if [ "$count" -eq 0 ] && [ "$(jq 'length' /tmp/dispatches.json 2>/dev/null || echo 0)" -eq 0 ]; then
               echo "> All nightly runs passed or no runs exist yet."
               echo ""
             fi
@@ -447,7 +485,7 @@ jobs:
               if [ "$test_count" -gt 0 ]; then
                 failing_list="${failing_list}"$'\n'"  :x: <${rurl}|${rtitle}> — ${test_count} test failure(s)"
               else
-                failing_list="${failing_list}"$'\n'"  :x: <${rurl}|${rtitle}> — infra failure"
+                failing_list="${failing_list}"$'\n'"  :x: <${rurl}|${rtitle}> — workflow-level failure (no test results)"
               fi
             done < <(jq -c '.[]' /tmp/failed_runs.json)
           fi

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -34,6 +34,10 @@ on:
         type: boolean
         default: false
         required: false
+      slack_channel:
+        description: 'Slack channel to post to (default: c8-orchestration-cluster-e2e-test-results; override for testing)'
+        required: false
+        default: ''
 
 # Minimal at workflow level. Triage job only needs to read; dispatch job
 # bumps actions: write to trigger the fix workflow (zizmor: excessive-permissions).
@@ -507,7 +511,9 @@ jobs:
           fi
           text="${base_text}"$'\n\n'"${dispatch_status}"$'\n\n'"<${RUN_URL}|Triage run ↗>"
 
-          payload=$(jq -nc --arg channel 'c8-orchestration-cluster-e2e-test-results' --arg text "$text" \
+          target_channel="${{ github.event.inputs.slack_channel }}"
+          target_channel="${target_channel:-c8-orchestration-cluster-e2e-test-results}"
+          payload=$(jq -nc --arg channel "$target_channel" --arg text "$text" \
             '{channel: $channel, text: $text, mrkdwn: true}')
           response=$(curl -sS -X POST https://slack.com/api/chat.postMessage \
             -H "Authorization: Bearer ${SLACK_BOT_USER_OAUTH_TOKEN}" \

--- a/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
@@ -499,3 +499,67 @@ on-demand verification run is triggered: `c8-orchestration-cluster-e2e-tests-on-
 no verification run is triggered and the fix is never validated automatically.**
 
 Use `{"prs": []}` if no PR was opened (regardless of reason).
+
+## Workflow-Level Failure Fix Agent
+
+This section is read automatically by the fix agent when `/tmp/test_specs.json` is an empty array — meaning the nightly run failed before any test results were produced, or failed in a post-test step (e.g. artifact upload, TestRail sync, build step).
+
+The run IDs are available as env vars: `E2E_RUN_ID`, `API_ES_RUN_ID`, `API_RDBMS_RUN_ID` (any may be `""` if that workflow type did not run). `TRIAGE_RUN_URL` contains the triage run URL for cross-linking.
+
+### Diagnosis steps
+
+**Step 1 — Identify which run(s) failed and which step(s) caused the failure:**
+
+```bash
+for run_id in $E2E_RUN_ID $API_ES_RUN_ID $API_RDBMS_RUN_ID; do
+  [ -z "$run_id" ] && continue
+  echo "=== Run $run_id ==="
+  gh run view "$run_id" --repo camunda/camunda --json jobs \
+    --jq '.jobs[] | select(.conclusion == "failure") | {
+      job: .name,
+      failed_steps: [.steps[] | select(.conclusion == "failure") | .name]
+    }'
+done
+```
+
+**Step 2 — Fetch the failing step logs for each failed job:**
+
+```bash
+gh run view <run_id> --repo camunda/camunda --log-failed 2>/dev/null | head -300
+```
+
+Read the error output carefully — the root cause is almost always visible in the first 300 lines of the failure log.
+
+**Step 3 — Identify the root cause and locate the relevant file(s) in camunda/camunda:**
+
+- Failed step name contains `Start Camunda` or `docker` → Docker image pull issue — look at the reusable workflow that was used and add a retry loop if absent (see existing retry pattern in `c8-orchestration-cluster-reusable-api-tests.yml`)
+- Failed step name contains `TestRail` → examine the error message; fix the root cause (e.g. a test case title that is too long for the `custom_automation_id` field, a trcli version issue, an auth problem)
+- Failed step name contains `Build` or `mvn` or `Maven` → examine the Maven error; fix the compilation or dependency issue in the relevant module
+- Failed step name is something else → read the log and trace it to the workflow YAML or the script it invokes; fix whatever is broken
+
+**Step 4 — Apply the fix:**
+
+You have full access to the entire `camunda/camunda` repository. The fix may land in:
+- A reusable workflow YAML under `.github/workflows/`
+- A test file under `qa/c8-orchestration-cluster-e2e-test-suite/`
+- A configuration file under `qa/c8-orchestration-cluster-e2e-test-suite/config/`
+- A script anywhere in the repo
+
+Keep the diff minimal. Fix exactly what is broken — do not refactor or clean up surrounding code.
+
+**Step 5 — Open a PR:**
+
+Use PR type `ci:` if only workflow files changed, `fix:` if test or application code changed. Cross-link `TRIAGE_RUN_URL` in the PR body.
+
+Write the result to `/tmp/fix-meta.json`:
+```json
+{"prs": [{"number": 123, "owner": "camunda", "repo": "camunda", "branch": "ci/...", "has_e2e": false, "has_api": false}], "category": "workflow-fix"}
+```
+
+### Constraints
+
+- **No error suppression**: do NOT add `continue-on-error: true` or `|| true` to hide a failing step. Fix the root cause.
+- **No skipping**: same no-skip rule as the Nightly Fix Agent.
+- **"Not determined" is a last resort**: only write `{"prs": [], "category": "not-determined"}` to `/tmp/fix-meta.json` if you have read the logs, identified the failing step, traced it to the relevant code, and genuinely cannot write a correct fix. This should be extremely rare because the full repository is accessible.
+- **Allowed tools**: `gh`, `git`, `grep`, `rg`, `cat`, `find`, `jq`, `sed`, `awk`, `unzip`
+- **Forbidden**: `make`, `helm`, `kubectl`, `npm run build`, `go test`, any deploy command

--- a/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
@@ -577,7 +577,10 @@ Realistically that is limited to: the runner host itself died (out of memory or 
 ### Constraints
 
 - **Never recommend re-running the workflow as the outcome** — if flakiness is the cause, the resilience goes into the file, not into a human instruction.
-- **No `continue-on-error: true` and no `|| true`** — never suppress a failing step. Fix the root cause so the step legitimately passes or surfaces a real test result.
+- **`continue-on-error: true` is absolutely forbidden — with no exceptions and no rationalisations.** This includes post-test reporting steps (TestRail, artifact upload, Slack notification). The reasoning "it is only reporting, not a gate" is exactly the rationalisation that must be rejected: if a post-test step fails, that failure is a defect in our code or configuration that deserves a real fix. `continue-on-error` silences the failure rather than fixing it, which means the same bug runs again tomorrow and the day after.
+  - **TestRail `add_case` failure** → the step fails because something in *our* code caused trcli to error (e.g. a test case title whose derived `custom_automation_id` exceeds 250 characters). Find the offending test title in the spec files and shorten it. That is the fix.
+  - **TestRail auth / network failure** → add a retry around the trcli call, or fix the credential configuration. Do not silence.
+  - **Any other post-test step** → find what our code does wrong and fix it. If you genuinely cannot find any code fix after thorough investigation, write `not-determined` — but `continue-on-error` is never a valid alternative.
 - **No skipping** — same absolute no-skip / no-fixme rule as the Nightly Fix Agent.
 - **`.github/workflows/` is always in scope** — the repo "Ask first" constraint applies to application libraries (`webapps-common/`, `webapp/client/`, `security/`), not to CI workflow files.
 - **Minimal diff** — fix only what is broken; no refactoring, no dependency bumps, no unrelated edits.

--- a/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
@@ -561,7 +561,7 @@ Make the **minimal** change that addresses the cause. Do not refactor surroundin
 
 > **Illustration of the loop (not a lookup row):** Suppose step 1 reports the failed step is `Start Camunda` and step 2 shows `context deadline exceeded` pulling an image. Step 3 greps the workflows, finds the step in a reusable workflow, and sees it runs `docker compose up` once. Step 4 classifies this as "depends on something flaky/external" → the fix is to wrap the pull in a retry-with-backoff loop *in that workflow file* so a transient registry blip no longer fails the run. You would reach the same shape of answer for a flaky `npm ci`, a flaky artifact download, or a flaky DB container start — by running the same loop, not by recognising "Docker".
 
-**5 — Open a PR.** Use `ci:` if only `.github/workflows/` changed; `fix:` if test or application code changed. Cross-link `TRIAGE_RUN_URL` in the PR body.
+**5 — Open a PR.** Use `ci:` if only `.github/workflows/` files changed; `test:` if only test files changed; `fix:` if application code changed. Never use `fix:` for test-only changes — commitlint rejects it. Cross-link `TRIAGE_RUN_URL` in the PR body.
 
 Write to `/tmp/fix-meta.json`:
 ```json

--- a/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
@@ -564,6 +564,7 @@ Make the **minimal** change that addresses the cause. Do not refactor surroundin
 **5 — Open a PR.** Use `ci:` if only `.github/workflows/` files changed; `test:` if only test files changed; `fix:` if application code changed. Never use `fix:` for test-only changes — commitlint rejects it. Cross-link `TRIAGE_RUN_URL` in the PR body.
 
 Write to `/tmp/fix-meta.json`:
+
 ```json
 {"prs": [{"number": 123, "owner": "camunda", "repo": "camunda", "branch": "ci/...", "has_e2e": false, "has_api": false}], "category": "workflow-fix"}
 ```
@@ -586,3 +587,4 @@ Realistically that is limited to: the runner host itself died (out of memory or 
 - **Minimal diff** — fix only what is broken; no refactoring, no dependency bumps, no unrelated edits.
 - **Allowed tools**: `gh`, `git`, `grep`, `rg`, `cat`, `find`, `jq`, `sed`, `awk`, `unzip`
 - **Forbidden**: `make`, `helm`, `kubectl`, `npm run build`, `go test`, any deploy command
+

--- a/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
@@ -502,13 +502,19 @@ Use `{"prs": []}` if no PR was opened (regardless of reason).
 
 ## Workflow-Level Failure Fix Agent
 
-This section is read automatically by the fix agent when `/tmp/test_specs.json` is an empty array — meaning the nightly run failed before any test results were produced, or failed in a post-test step (e.g. artifact upload, TestRail sync, build step).
+This section is read by the fix agent when `/tmp/test_specs.json` contains an empty array — the nightly run failed before producing any test results, or failed in a post-test step.
 
-The run IDs are available as env vars: `E2E_RUN_ID`, `API_ES_RUN_ID`, `API_RDBMS_RUN_ID` (any may be `""` if that workflow type did not run). `TRIAGE_RUN_URL` contains the triage run URL for cross-linking.
+The run IDs are in env vars: `E2E_RUN_ID`, `API_ES_RUN_ID`, `API_RDBMS_RUN_ID` (any may be `""`). `TRIAGE_RUN_URL` is the triage run URL for cross-linking.
+
+### Core principle
+
+**"Transient" is never a reason to produce no output.** Every failure pattern that can be made less likely to recur through a code or config change must result in a PR. The goal is resilience — if Docker times out, add retry; if a test name breaks TestRail, shorten the name. Only write `{"prs": [], "category": "not-determined"}` when you have read the logs, identified the failing step, and there is genuinely no code or config change that would address it (e.g. the GitHub Actions runner ran out of disk, a third-party service was fully down with nothing on our side to change).
+
+`.github/workflows/` files are always in scope. The "Ask first" constraint in the repo AGENTS.md applies to application libraries (`webapps-common/`, `webapp/client/`, `security/`), not to CI workflow files.
 
 ### Diagnosis steps
 
-**Step 1 — Identify which run(s) failed and which step(s) caused the failure:**
+**Step 1 — Identify which step(s) failed in each run:**
 
 ```bash
 for run_id in $E2E_RUN_ID $API_ES_RUN_ID $API_RDBMS_RUN_ID; do
@@ -522,44 +528,62 @@ for run_id in $E2E_RUN_ID $API_ES_RUN_ID $API_RDBMS_RUN_ID; do
 done
 ```
 
-**Step 2 — Fetch the failing step logs for each failed job:**
+**Step 2 — Read the failure logs:**
 
 ```bash
 gh run view <run_id> --repo camunda/camunda --log-failed 2>/dev/null | head -300
 ```
 
-Read the error output carefully — the root cause is almost always visible in the first 300 lines of the failure log.
+The root cause is almost always visible in the first 300 lines.
 
-**Step 3 — Identify the root cause and locate the relevant file(s) in camunda/camunda:**
+**Step 3 — Apply the fix. Known patterns:**
 
-- Failed step name contains `Start Camunda` or `docker` → Docker image pull issue — look at the reusable workflow that was used and add a retry loop if absent (see existing retry pattern in `c8-orchestration-cluster-reusable-api-tests.yml`)
-- Failed step name contains `TestRail` → examine the error message; fix the root cause (e.g. a test case title that is too long for the `custom_automation_id` field, a trcli version issue, an auth problem)
-- Failed step name contains `Build` or `mvn` or `Maven` → examine the Maven error; fix the compilation or dependency issue in the relevant module
-- Failed step name is something else → read the log and trace it to the workflow YAML or the script it invokes; fix whatever is broken
+**Docker pull timeout** (`context deadline exceeded` or `i/o timeout` pulling from `registry-1.docker.io`):
 
-**Step 4 — Apply the fix:**
+- The fix is a retry loop. First check whether the failing reusable workflow already has one:
+  ```bash
+  gh api repos/camunda/camunda/contents/.github/workflows/<reusable-workflow>.yml \
+    --jq '.content' | base64 -d | grep -A5 "attempts\|retry\|Retry"
+  ```
+- If no retry exists, add the same 3-attempt/15s-sleep pattern already present in `c8-orchestration-cluster-reusable-api-tests.yml`. Copy it exactly — do not invent a different pattern.
+- If retry already exists (3 attempts), look deeper: check whether the image tag being pulled is a SNAPSHOT that may have been garbage-collected, or whether the compose file references a service that does not exist.
+- This is NOT a transient event to ignore — it is a missing resilience measure. Add the retry.
 
-You have full access to the entire `camunda/camunda` repository. The fix may land in:
-- A reusable workflow YAML under `.github/workflows/`
-- A test file under `qa/c8-orchestration-cluster-e2e-test-suite/`
-- A configuration file under `qa/c8-orchestration-cluster-e2e-test-suite/config/`
-- A script anywhere in the repo
+**TestRail `custom_automation_id` too long** (`Field :custom_automation_id is too long (250 characters at most)`):
 
-Keep the diff minimal. Fix exactly what is broken — do not refactor or clean up surrounding code.
+- Find the test(s) with names exceeding 250 characters. The automation ID is derived from the test title. Run:
+  ```bash
+  grep -r "test\|it\|describe" qa/c8-orchestration-cluster-e2e-test-suite/tests/ \
+    | grep -v ".snap\|node_modules" \
+    | awk -F'"' '{print length($2), $2}' | sort -rn | head -20
+  ```
+- Shorten the offending test title(s) in the spec file so the full path stays under 250 characters.
+- Do NOT add `continue-on-error: true` to the TestRail step. Fix the data.
 
-**Step 5 — Open a PR:**
+**TestRail other errors** (auth failure, API down, rate limit):
 
-Use PR type `ci:` if only workflow files changed, `fix:` if test or application code changed. Cross-link `TRIAGE_RUN_URL` in the PR body.
+- Read the exact trcli error. If it is a configuration problem (wrong key, wrong suite ID), fix the workflow input. If it is a genuine third-party outage with nothing to change on our side, this is a valid `not-determined` case — but confirm the service was actually down before concluding that.
 
-Write the result to `/tmp/fix-meta.json`:
+**Maven build failure** (`BUILD FAILURE` in the log):
+
+- Read the compiler or test error. Fix the compilation or dependency issue in the relevant module. Scope the change to the affected module only.
+
+**Other failures** — read the log, identify the failing script or command, trace it to the file in the repo that owns it, fix it there.
+
+**Step 4 — Open a PR:**
+
+Use `ci:` if only `.github/workflows/` files changed; `fix:` if test or application code changed. Cross-link `TRIAGE_RUN_URL` in the PR body.
+
+Write to `/tmp/fix-meta.json`:
 ```json
 {"prs": [{"number": 123, "owner": "camunda", "repo": "camunda", "branch": "ci/...", "has_e2e": false, "has_api": false}], "category": "workflow-fix"}
 ```
 
 ### Constraints
 
-- **No error suppression**: do NOT add `continue-on-error: true` or `|| true` to hide a failing step. Fix the root cause.
-- **No skipping**: same no-skip rule as the Nightly Fix Agent.
-- **"Not determined" is a last resort**: only write `{"prs": [], "category": "not-determined"}` to `/tmp/fix-meta.json` if you have read the logs, identified the failing step, traced it to the relevant code, and genuinely cannot write a correct fix. This should be extremely rare because the full repository is accessible.
+- **No `continue-on-error: true`** — never suppress a failing step. Fix the root cause.
+- **No skipping** — same absolute no-skip/no-fixme rule as the Nightly Fix Agent.
+- **`.github/workflows/` is always in scope** — do not treat these as "Ask first" territory.
+- **"Transient" ≠ "no fix"** — if a retry, a name change, or a config tweak would prevent recurrence, make that change.
 - **Allowed tools**: `gh`, `git`, `grep`, `rg`, `cat`, `find`, `jq`, `sed`, `awk`, `unzip`
 - **Forbidden**: `make`, `helm`, `kubectl`, `npm run build`, `go test`, any deploy command

--- a/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
@@ -502,19 +502,21 @@ Use `{"prs": []}` if no PR was opened (regardless of reason).
 
 ## Workflow-Level Failure Fix Agent
 
-This section is read by the fix agent when `/tmp/test_specs.json` contains an empty array — the nightly run failed before producing any test results, or failed in a post-test step.
+This section is read by the fix agent when `/tmp/test_specs.json` contains an empty array — the nightly run failed without producing test results, or failed in a non-test step.
 
 The run IDs are in env vars: `E2E_RUN_ID`, `API_ES_RUN_ID`, `API_RDBMS_RUN_ID` (any may be `""`). `TRIAGE_RUN_URL` is the triage run URL for cross-linking.
 
-### Core principle
+### Mental model
 
-**"Transient" is never a reason to produce no output.** Every failure pattern that can be made less likely to recur through a code or config change must result in a PR. The goal is resilience — if Docker times out, add retry; if a test name breaks TestRail, shorten the name. Only write `{"prs": [], "category": "not-determined"}` when you have read the logs, identified the failing step, and there is genuinely no code or config change that would address it (e.g. the GitHub Actions runner ran out of disk, a third-party service was fully down with nothing on our side to change).
+A CI run is a chain of steps. Every step runs a command defined by a file in **this** repo — a workflow YAML, a shell script, a config file, a compose file, or a test. A failure means one of those files produced behaviour that ended the run.
 
-`.github/workflows/` files are always in scope. The "Ask first" constraint in the repo AGENTS.md applies to application libraries (`webapps-common/`, `webapp/client/`, `security/`), not to CI workflow files.
+Your job is to find that file and change it so the run reaches a **correct conclusion**: either it passes, or it fails for a real product reason that surfaces as a *test result* — never as a workflow crash, and never with a "please re-run" recommendation.
 
-### Diagnosis steps
+There is no catalogue of known failures to match against. Any step or any job can fail for any reason. You diagnose from first principles every time, using the full repository, which is entirely accessible to you.
 
-**Step 1 — Identify which step(s) failed in each run:**
+### The loop
+
+**1 — Enumerate every failed job and its failed step(s):**
 
 ```bash
 for run_id in $E2E_RUN_ID $API_ES_RUN_ID $API_RDBMS_RUN_ID; do
@@ -528,62 +530,56 @@ for run_id in $E2E_RUN_ID $API_ES_RUN_ID $API_RDBMS_RUN_ID; do
 done
 ```
 
-**Step 2 — Read the failure logs:**
+**2 — Read the failing step's logs to get the exact error:**
 
 ```bash
 gh run view <run_id> --repo camunda/camunda --log-failed 2>/dev/null | head -300
 ```
 
-The root cause is almost always visible in the first 300 lines.
+The root cause is almost always visible in the first 300 lines. Read the actual error text — do not assume.
 
-**Step 3 — Apply the fix. Known patterns:**
+**3 — Locate the file that owns the failing step.** The step `name` from step 1 is a literal key in a workflow YAML. Find it, then follow it to the real source:
 
-**Docker pull timeout** (`context deadline exceeded` or `i/o timeout` pulling from `registry-1.docker.io`):
+```bash
+# Find which workflow defines the failed step
+grep -rn "<failed step name>" .github/workflows/
 
-- The fix is a retry loop. First check whether the failing reusable workflow already has one:
-  ```bash
-  gh api repos/camunda/camunda/contents/.github/workflows/<reusable-workflow>.yml \
-    --jq '.content' | base64 -d | grep -A5 "attempts\|retry\|Retry"
-  ```
-- If no retry exists, add the same 3-attempt/15s-sleep pattern already present in `c8-orchestration-cluster-reusable-api-tests.yml`. Copy it exactly — do not invent a different pattern.
-- If retry already exists (3 attempts), look deeper: check whether the image tag being pulled is a SNAPSHOT that may have been garbage-collected, or whether the compose file references a service that does not exist.
-- This is NOT a transient event to ignore — it is a missing resilience measure. Add the retry.
+# If the step runs a script, open the script. If it runs a command,
+# find the config that command reads (compose file, package.json script,
+# trcli invocation, mvn goal, etc.) and open that.
+```
 
-**TestRail `custom_automation_id` too long** (`Field :custom_automation_id is too long (250 characters at most)`):
+Keep following until you reach the concrete file whose contents determine whether that step passes — the YAML, the script, the config, the compose file, or the test.
 
-- Find the test(s) with names exceeding 250 characters. The automation ID is derived from the test title. Run:
-  ```bash
-  grep -r "test\|it\|describe" qa/c8-orchestration-cluster-e2e-test-suite/tests/ \
-    | grep -v ".snap\|node_modules" \
-    | awk -F'"' '{print length($2), $2}' | sort -rn | head -20
-  ```
-- Shorten the offending test title(s) in the spec file so the full path stays under 250 characters.
-- Do NOT add `continue-on-error: true` to the TestRail step. Fix the data.
+**4 — Classify the true cause, then fix it in that file.** Every failure is one of three kinds, and each has a definite fix shape:
 
-**TestRail other errors** (auth failure, API down, rate limit):
+- **The step's own logic is wrong** — a bug in the workflow, script, config, compose file, or test. Fix the logic.
+- **The step depends on something flaky or external** — a registry, a network call, a remote API, a download. Encode resilience *in the file*: add a retry with backoff, pin or cache the dependency, or turn a cryptic crash into a clear, actionable failure. Recommending a human re-run is **not** a fix — the resilience must live in the repo so the next run survives the same blip on its own.
+- **A real product or test defect crashed the run instead of being reported** — the run died before the test framework could record the failure. Fix it so the defect surfaces as a normal test result, never as a workflow-level crash.
 
-- Read the exact trcli error. If it is a configuration problem (wrong key, wrong suite ID), fix the workflow input. If it is a genuine third-party outage with nothing to change on our side, this is a valid `not-determined` case — but confirm the service was actually down before concluding that.
+Make the **minimal** change that addresses the cause. Do not refactor surrounding code, suppress the error, or widen the scope.
 
-**Maven build failure** (`BUILD FAILURE` in the log):
+> **Illustration of the loop (not a lookup row):** Suppose step 1 reports the failed step is `Start Camunda` and step 2 shows `context deadline exceeded` pulling an image. Step 3 greps the workflows, finds the step in a reusable workflow, and sees it runs `docker compose up` once. Step 4 classifies this as "depends on something flaky/external" → the fix is to wrap the pull in a retry-with-backoff loop *in that workflow file* so a transient registry blip no longer fails the run. You would reach the same shape of answer for a flaky `npm ci`, a flaky artifact download, or a flaky DB container start — by running the same loop, not by recognising "Docker".
 
-- Read the compiler or test error. Fix the compilation or dependency issue in the relevant module. Scope the change to the affected module only.
-
-**Other failures** — read the log, identify the failing script or command, trace it to the file in the repo that owns it, fix it there.
-
-**Step 4 — Open a PR:**
-
-Use `ci:` if only `.github/workflows/` files changed; `fix:` if test or application code changed. Cross-link `TRIAGE_RUN_URL` in the PR body.
+**5 — Open a PR.** Use `ci:` if only `.github/workflows/` changed; `fix:` if test or application code changed. Cross-link `TRIAGE_RUN_URL` in the PR body.
 
 Write to `/tmp/fix-meta.json`:
 ```json
 {"prs": [{"number": 123, "owner": "camunda", "repo": "camunda", "branch": "ci/...", "has_e2e": false, "has_api": false}], "category": "workflow-fix"}
 ```
 
+### When — and only when — you cannot fix
+
+`{"prs": [], "category": "not-determined"}` is a last resort, expected to be extremely rare because the whole repo is in scope. To use it you must be able to state all three: the failed step, the file that owns it, and a concrete reason why **no edit to that file or anything it touches** could change the outcome.
+
+Realistically that is limited to: the runner host itself died (out of memory or disk on the GitHub Actions runner), or a fully-down external service with no surface in our code to add a retry or fallback against. Note that even most "external service was down" cases have a fix — adding backoff so a brief outage no longer fails the run — so reach for `not-determined` only after confirming there is genuinely nothing in the repo to change.
+
 ### Constraints
 
-- **No `continue-on-error: true`** — never suppress a failing step. Fix the root cause.
-- **No skipping** — same absolute no-skip/no-fixme rule as the Nightly Fix Agent.
-- **`.github/workflows/` is always in scope** — do not treat these as "Ask first" territory.
-- **"Transient" ≠ "no fix"** — if a retry, a name change, or a config tweak would prevent recurrence, make that change.
+- **Never recommend re-running the workflow as the outcome** — if flakiness is the cause, the resilience goes into the file, not into a human instruction.
+- **No `continue-on-error: true` and no `|| true`** — never suppress a failing step. Fix the root cause so the step legitimately passes or surfaces a real test result.
+- **No skipping** — same absolute no-skip / no-fixme rule as the Nightly Fix Agent.
+- **`.github/workflows/` is always in scope** — the repo "Ask first" constraint applies to application libraries (`webapps-common/`, `webapp/client/`, `security/`), not to CI workflow files.
+- **Minimal diff** — fix only what is broken; no refactoring, no dependency bumps, no unrelated edits.
 - **Allowed tools**: `gh`, `git`, `grep`, `rg`, `cat`, `find`, `jq`, `sed`, `awk`, `unzip`
 - **Forbidden**: `make`, `helm`, `kubectl`, `npm run build`, `go test`, any deploy command


### PR DESCRIPTION
## Summary

- Removes the static \"infra failure\" label from nightly triage
- Fix agent is now dispatched for **all** nightly failures, including workflow-level failures (no test results produced)
- When `test_specs` is empty the agent reads the new `## Workflow-Level Failure Fix Agent` section in AGENTS.md: inspect the failing step/job logs, trace to the relevant file in the repo, open a fix PR
- If the agent truly cannot determine a fix it writes `not-determined` — but this should be rare since the full repo is accessible
- No `continue-on-error` or error-suppression added

## What triggered this

Three recent nightly runs were silently labelled "infra failure" with no agent dispatched:
- [26793804429](https://github.com/camunda/camunda/actions/runs/26793804429) — Docker Hub timeout in E2E workflow (no retry)
- [26794234759](https://github.com/camunda/camunda/actions/runs/26794234759) — Docker Hub timeout in API workflow (pre-retry-fix commit)
- [26794380679](https://github.com/camunda/camunda/actions/runs/26794380679) — TestRail `custom_automation_id` too long in RDBMS workflow

With this change the fix agent would have been dispatched for all three and could have opened fix PRs automatically.

## Changes

### `qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md`
Added new `## Workflow-Level Failure Fix Agent` section with diagnosis steps for workflow-level failures: inspect failing step logs, identify root cause, locate and fix the relevant file, open a PR. "Not determined" is explicitly a last resort.

### `.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml`
- Triage now also dispatches for runs that failed without producing test results (workflow-level failures), sending `test_specs: []`
- Removed the "infra failure" table from the job summary (these runs now appear as dispatches)
- Changed Slack message label from "infra failure" to "workflow-level failure (no test results)"

### `.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml`
- Added `test_spec_count` check: routes agent to `## Workflow-Level Failure Fix Agent` section when `test_specs` is empty, `## Nightly Fix Agent` when non-empty
- Added handling for `"category": "not-determined"` in fix-meta.json result: posts a distinct Slack message ("Could not determine a fix — manual investigation required") instead of silently logging nothing

## Test plan
- [ ] Trigger the triage workflow manually against a run that has no json-report artifacts — confirm fix agent is dispatched with empty `test_specs`
- [ ] Confirm the fix agent reads the new AGENTS.md section and inspects the failing step logs
- [ ] Verify no `continue-on-error` was added to any step