### PR TITLE
test: enable prometheus metrics for opensearch

### DIFF
--- a/load-tests/setup/default/values/camunda-platform-values-opensearch.yaml
+++ b/load-tests/setup/default/values/camunda-platform-values-opensearch.yaml
@@ -56,11 +56,23 @@ config:
     # Disable deprecation logging to avoid filling up the logs with warnings about deprecated features that we might be using in our tests
     logger.org.opensearch.deprecation: "OFF"
 
+plugins:
+  enabled: true
+  installList:
+    # version needs to match the OpenSearch version - see https://github.com/opensearch-project/opensearch-prometheus-exporter/blob/main/COMPATIBILITY.md
+    - "https://github.com/opensearch-project/opensearch-prometheus-exporter/releases/download/2.19.0.0/prometheus-exporter-2.19.0.0.zip"
+
 extraEnvs:
   - name: OPENSEARCH_INITIAL_ADMIN_PASSWORD
     value: "yourStrongPassword123!"
 
 opensearchJavaOpts: "-Xms3g -Xmx3g"
+
+serviceMonitor:
+  enabled: true
+  interval: 30s
+  labels:
+    release: monitoring
 
 sysctlInit:
   enabled: true


### PR DESCRIPTION
so we can get insights into how it behaves under load, compared to elasticsearch.

I have run this to confirm I can see metrics in Prometheus:

https://monitor.benchmark.camunda.cloud/query?g0.expr=opensearch_indices_doc_deleted_number&g0.show_tree=0&g0.tab=table&g0.range_input=2h&g0.res_type=auto&g0.res_density=medium&g0.display_mode=lines&g0.show_exemplars=0

and Grafana:
 https://dashboard.benchmark.camunda.cloud/d/jopcrqf/data-layer-benchmarking-es-shards-replicas-etc

## Related issues

refs #54331
