### PR TITLE
feat: load-test: add info metric to the load test client starter

### DIFF
--- a/load-tests/load-tester/Makefile
+++ b/load-tests/load-tester/Makefile
@@ -1,0 +1,35 @@
+MVNW = ../../mvnw -pl .
+
+all: build test
+
+.PHONY: build
+build:
+	$(MVNW) clean package -DskipTests -DskipChecks
+
+.PHONY: clean
+clean:
+	$(MVNW) -am clean
+
+.PHONY: test
+test:
+	$(MVNW) -am clean test -DskipChecks
+
+.PHONY: check
+check:
+	$(MVNW) -am package
+
+.PHONY: starter
+starter: build
+	java -jar target/camunda-load-tester-*-exec.jar --spring.profiles.active=starter
+
+.PHONY: worker
+worker: build
+	java -jar target/camunda-load-tester-*-exec.jar --spring.profiles.active=worker
+
+.PHONY: docker-starter
+docker-starter:
+	$(MVNW) jib:build -Pstarter
+
+.PHONY: docker-worker
+docker-worker:
+	$(MVNW) jib:build -Pworker

--- a/load-tests/load-tester/pom.xml
+++ b/load-tests/load-tester/pom.xml
@@ -317,6 +317,16 @@
         <configuration>
           <mainClass>io.camunda.zeebe.LoadTesterApplication</mainClass>
         </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+            <configuration>
+              <classifier>exec</classifier>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/metrics/ProcessInstanceStartMeter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/metrics/ProcessInstanceStartMeter.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.metrics;
 
-import io.camunda.zeebe.metrics.StarterLatencyMetricsDoc.StarterMetricKeyNames;
+import io.camunda.zeebe.metrics.StarterMetricsDoc.StarterMetricKeyNames;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.util.micrometer.MicrometerUtil;
 import io.micrometer.core.instrument.MeterRegistry;

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/metrics/StarterLatencyMetricsDoc.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/metrics/StarterLatencyMetricsDoc.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.metrics;
 
+import io.camunda.zeebe.metrics.StarterMetricsDoc.StarterMetricKeyNames;
 import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
 import io.micrometer.common.docs.KeyName;
 import io.micrometer.core.instrument.Meter.Type;
@@ -141,7 +142,8 @@ public enum StarterLatencyMetricsDoc implements ExtendedMeterDocumentation {
 
   /** The latency of read benchmark queries executed against the Camunda cluster. */
   READ_BENCHMARK {
-    private static final KeyName[] KEY_NAMES = new KeyName[] {StarterMetricKeyNames.QUERY_NAME};
+    private static final KeyName[] KEY_NAMES =
+        new KeyName[] {StarterLatencyMetricKeyNames.QUERY_NAME};
 
     private static final Duration[] BUCKETS = {
       Duration.ofMillis(10),
@@ -188,16 +190,7 @@ public enum StarterLatencyMetricsDoc implements ExtendedMeterDocumentation {
     }
   };
 
-  public enum StarterMetricKeyNames implements KeyName {
-
-    /** The ID of the partition associated to the metric */
-    PARTITION {
-      @Override
-      public String asString() {
-        return "partition";
-      }
-    },
-
+  public enum StarterLatencyMetricKeyNames implements KeyName {
     /** The name of the query being benchmarked */
     QUERY_NAME {
       @Override

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/metrics/StarterMetricsDoc.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/metrics/StarterMetricsDoc.java
@@ -8,9 +8,45 @@
 package io.camunda.zeebe.metrics;
 
 import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
+import io.micrometer.common.docs.KeyName;
 import io.micrometer.core.instrument.Meter.Type;
 
 public enum StarterMetricsDoc implements ExtendedMeterDocumentation {
+
+  /**
+   * An "info"-style metric: a gauge constantly set to 1 whose tags carry static configuration — the
+   * {@code name} (load-tester component, e.g. "starter"), the {@code process_id} (BPMN process id
+   * loaded by the starter) and the {@code nb_threads} (number of starter threads). Lets dashboards
+   * surface how a load test is configured, e.g. {@code avg(client_info) by (process_id)}.
+   */
+  CLIENT_INFO {
+    private static final KeyName[] KEY_NAMES =
+        new KeyName[] {
+          StarterMetricKeyNames.NAME,
+          StarterMetricKeyNames.PROCESS_ID,
+          StarterMetricKeyNames.NB_THREADS
+        };
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return KEY_NAMES;
+    }
+
+    @Override
+    public String getDescription() {
+      return "The information about the client.";
+    }
+
+    @Override
+    public String getName() {
+      return "client.info";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.GAUGE;
+    }
+  },
 
   /**
    * Total number of process instance start requests submitted by the starter. Incremented before
@@ -58,5 +94,40 @@ public enum StarterMetricsDoc implements ExtendedMeterDocumentation {
     public Type getType() {
       return Type.GAUGE;
     }
+  };
+
+  public enum StarterMetricKeyNames implements KeyName {
+
+    /** The name of the load-tester component emitting the metric */
+    NAME {
+      @Override
+      public String asString() {
+        return "name";
+      }
+    },
+
+    /** The number of threads configured in the starter */
+    NB_THREADS {
+      @Override
+      public String asString() {
+        return "nb_threads";
+      }
+    },
+
+    /** The ID of the partition associated to the metric */
+    PARTITION {
+      @Override
+      public String asString() {
+        return "partition";
+      }
+    },
+
+    /** The BPMN process id loaded by the starter */
+    PROCESS_ID {
+      @Override
+      public String asString() {
+        return "process_id";
+      }
+    },
   }
 }

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/read/DataReadMeter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/read/DataReadMeter.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.read;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.zeebe.metrics.StarterLatencyMetricsDoc;
-import io.camunda.zeebe.metrics.StarterLatencyMetricsDoc.StarterMetricKeyNames;
+import io.camunda.zeebe.metrics.StarterLatencyMetricsDoc.StarterLatencyMetricKeyNames;
 import io.camunda.zeebe.util.micrometer.MicrometerUtil;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
@@ -54,7 +54,7 @@ public class DataReadMeter implements AutoCloseable {
     for (final ReadQuery query : queries) {
       final Timer timer =
           MicrometerUtil.buildTimer(StarterLatencyMetricsDoc.READ_BENCHMARK)
-              .tag(StarterMetricKeyNames.QUERY_NAME.asString(), query.name())
+              .tag(StarterLatencyMetricKeyNames.QUERY_NAME.asString(), query.name())
               .register(registry);
 
       final ScheduledFuture<?> task =

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/starter/Starter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/starter/Starter.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.metrics.ConnectionMonitor;
 import io.camunda.zeebe.metrics.ProcessInstanceStartMeter;
 import io.camunda.zeebe.metrics.StarterLatencyMetricsDoc;
 import io.camunda.zeebe.metrics.StarterMetricsDoc;
+import io.camunda.zeebe.metrics.StarterMetricsDoc.StarterMetricKeyNames;
 import io.camunda.zeebe.optimize.OptimizeReportEvaluator;
 import io.camunda.zeebe.optimize.OptimizeReportEvaluatorFactory;
 import io.camunda.zeebe.read.DataReadMeter;
@@ -113,6 +114,17 @@ public class Starter implements CommandLineRunner {
     this.connectionMonitor = connectionMonitor;
     this.webClientBuilder = webClientBuilder;
     this.objectMapper = objectMapper;
+
+    // Expose the client information early: these are only static values which are not supposed to
+    // be affected by the current state of the client (whether it successfully connects to the
+    // brokers, etc.)
+    // Having these infos early could help to investigate the client faster.
+    Gauge.builder(StarterMetricsDoc.CLIENT_INFO.getName(), () -> 1)
+        .description(StarterMetricsDoc.CLIENT_INFO.getDescription())
+        .tag(StarterMetricKeyNames.NAME.asString(), "starter")
+        .tag(StarterMetricKeyNames.PROCESS_ID.asString(), starterCfg.getProcessId())
+        .tag(StarterMetricKeyNames.NB_THREADS.asString(), String.valueOf(starterCfg.getThreads()))
+        .register(registry);
   }
 
   @Override

--- a/load-tests/load-tester/src/test/java/io/camunda/zeebe/metrics/StarterMetricsDocTest.java
+++ b/load-tests/load-tester/src/test/java/io/camunda/zeebe/metrics/StarterMetricsDocTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.metrics.StarterMetricsDoc.StarterMetricKeyNames;
+import io.micrometer.core.instrument.Meter.Type;
+import org.junit.jupiter.api.Test;
+
+class StarterMetricsDocTest {
+
+  @Test
+  void shouldDefineClientInfoGauge() {
+    // given
+    final var metric = StarterMetricsDoc.CLIENT_INFO;
+
+    // when / then
+    assertThat(metric.getName()).isEqualTo("client.info");
+    assertThat(metric.getType()).isEqualTo(Type.GAUGE);
+    assertThat(metric.getDescription()).isEqualTo("The information about the client.");
+    assertThat(metric.getKeyNames())
+        .containsExactly(
+            StarterMetricKeyNames.NAME,
+            StarterMetricKeyNames.PROCESS_ID,
+            StarterMetricKeyNames.NB_THREADS);
+  }
+}

--- a/load-tests/load-tester/src/test/java/io/camunda/zeebe/read/DataReadMeterTest.java
+++ b/load-tests/load-tester/src/test/java/io/camunda/zeebe/read/DataReadMeterTest.java
@@ -16,7 +16,7 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.zeebe.metrics.StarterLatencyMetricsDoc;
-import io.camunda.zeebe.metrics.StarterLatencyMetricsDoc.StarterMetricKeyNames;
+import io.camunda.zeebe.metrics.StarterLatencyMetricsDoc.StarterLatencyMetricKeyNames;
 import io.camunda.zeebe.read.DataReadMeter.ReadQuery;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -69,7 +69,7 @@ final class DataReadMeterTest {
                 assertThat(
                         meterRegistry
                             .get(StarterLatencyMetricsDoc.READ_BENCHMARK.getName())
-                            .tag(StarterMetricKeyNames.QUERY_NAME.asString(), "readSuccess")
+                            .tag(StarterLatencyMetricKeyNames.QUERY_NAME.asString(), "readSuccess")
                             .timer()
                             .count())
                     .isGreaterThanOrEqualTo(1));
@@ -77,7 +77,7 @@ final class DataReadMeterTest {
     final Timer timer =
         meterRegistry
             .get(StarterLatencyMetricsDoc.READ_BENCHMARK.getName())
-            .tag(StarterMetricKeyNames.QUERY_NAME.asString(), "readSuccess")
+            .tag(StarterLatencyMetricKeyNames.QUERY_NAME.asString(), "readSuccess")
             .timer();
 
     assertThat(timer.totalTime(TimeUnit.NANOSECONDS)).isPositive();

--- a/load-tests/load-tester/src/test/java/io/camunda/zeebe/starter/StarterTest.java
+++ b/load-tests/load-tester/src/test/java/io/camunda/zeebe/starter/StarterTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.starter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.client.CamundaClient;
+import io.camunda.zeebe.config.LoadTesterProperties;
+import io.camunda.zeebe.config.StarterProperties;
+import io.camunda.zeebe.metrics.ConnectionMonitor;
+import io.camunda.zeebe.metrics.StarterMetricsDoc;
+import io.camunda.zeebe.metrics.StarterMetricsDoc.StarterMetricKeyNames;
+import io.camunda.zeebe.util.PayloadReader;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+
+class StarterTest {
+
+  @Test
+  void shouldReportGaugeTagsFromProperties() {
+    // given
+    final var starterProperties = new StarterProperties();
+    starterProperties.setProcessId("foobar");
+    starterProperties.setThreads(2);
+    final var properties = new LoadTesterProperties();
+    properties.setStarter(starterProperties);
+
+    final var registry = new SimpleMeterRegistry();
+
+    // when
+    new Starter(
+        mock(CamundaClient.class),
+        properties,
+        registry,
+        mock(PayloadReader.class),
+        mock(ConnectionMonitor.class),
+        mock(WebClient.Builder.class),
+        new ObjectMapper());
+
+    // then
+    final var gauge = registry.find(StarterMetricsDoc.CLIENT_INFO.getName()).gauge();
+
+    assertThat(gauge).describedAs("client.info gauge should be registered").isNotNull();
+    assertThat(gauge.value()).describedAs("client.info gauge value should be 1").isEqualTo(1.0);
+    assertThat(gauge.getId().getTags())
+        .describedAs("client.info gauge tags should reflect the starter configuration")
+        .containsExactlyInAnyOrder(
+            Tag.of(StarterMetricKeyNames.NAME.asString(), "starter"),
+            Tag.of(StarterMetricKeyNames.PROCESS_ID.asString(), "foobar"),
+            Tag.of(StarterMetricKeyNames.NB_THREADS.asString(), "2"));
+  }
+}


### PR DESCRIPTION
## Description

This will allow us to visualize from Grafana how the clients have been configured and be able to more easily see if the scenario currently running is the expected one.

We can display that in a widget using:

```
avg(client_info{namespace=~"${namespace}"} == 1) by (process_id)
```

[Cf. Grafana](https://dashboard.benchmark.camunda.cloud/goto/bfnx5cx7meh34c?orgId=1)

like this:
<img width="1009" height="728" alt="image" src="https://github.com/user-attachments/assets/66930e3c-21f2-4fd9-a216-61d8f229ad48" />

See https://www.robustperception.io/why-info-style-metrics-have-a-value-of-1/ for some information about "info" metrics.

I also added a small Makefile to help building/testing/running the load tester application from the CLI ; I can remove it if it's inappropriate.


## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

* https://camunda.slack.com/archives/C0B03ER9LNB/p1780388347597939
