### PR TITLE
ci: make TestRail result publishing non-blocking in C8 OC nightly tests

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-reusable-api-tests.yml
+++ b/.github/workflows/c8-orchestration-cluster-reusable-api-tests.yml
@@ -201,6 +201,7 @@ jobs:
 
       - name: Publish test results to TestRail
         if: always()
+        continue-on-error: true
         shell: bash
         env:
           TESTRAIL_HOST: "https://camunda.testrail.com/"

--- a/.github/workflows/c8-orchestration-cluster-reusable-e2e-tests.yml
+++ b/.github/workflows/c8-orchestration-cluster-reusable-e2e-tests.yml
@@ -226,6 +226,7 @@ jobs:
 
       - name: Publish test results to TestRail
         if: always()
+        continue-on-error: true
         shell: bash
         env:
           TESTRAIL_HOST: "https://camunda.testrail.com/"

--- a/.github/workflows/c8-orchestration-cluster-reusable-rdbms-api-tests.yml
+++ b/.github/workflows/c8-orchestration-cluster-reusable-rdbms-api-tests.yml
@@ -369,6 +369,7 @@ jobs:
 
       - name: Publish test results to TestRail
         if: always()
+        continue-on-error: true
         shell: bash
         env:
           TESTRAIL_HOST: "https://camunda.testrail.com/"


### PR DESCRIPTION
## Root cause

The C8 Orchestration Cluster **main – API Tests (RDBMS)** nightly run
([26794380679](https://github.com/camunda/camunda/actions/runs/26794380679))
failed on **every** database matrix job (Postgres 15–18, MySQL 8.4, MariaDB
10.11–11.8, MSSQL 2022/2025, Oracle 21c/26ai). In every job the **only**
failing step was `Publish test results to TestRail` — the actual API tests all
passed. The `trcli` invocation exited non-zero with:

```
Found 10 test cases not matching any TestRail case.
Error during add_case. Trying to cancel scheduled tasks.
##[error]Process completed with exit code 1.
```

The TestRail publish step had `if: always()` but **no** `continue-on-error`, so
a server-side TestRail reporting failure (`add_case`) failed the whole job even
though the tests it was reporting on succeeded. Publishing results to an
external reporting system is a reporting side-effect, not a validation gate, and
must not fail CI.

The same latent defect exists in the ES API and E2E reusable workflows (identical
TestRail step without `continue-on-error`), so the fix is applied to all three.

> Note: the **API Tests (ES)** nightly
> ([26794234759](https://github.com/camunda/camunda/actions/runs/26794234759))
> failed for an unrelated, transient infra reason — a Docker Hub registry
> timeout in `Start Camunda` (`Get "https://registry-1.docker.io/v2/": context
> deadline exceeded`). That is not addressed here as it is not a code/workflow
> defect.

## Fix

Add `continue-on-error: true` to the `Publish test results to TestRail` step in
the three reusable nightly workflows:

- `c8-orchestration-cluster-reusable-rdbms-api-tests.yml`
- `c8-orchestration-cluster-reusable-api-tests.yml`
- `c8-orchestration-cluster-reusable-e2e-tests.yml`

TestRail flakiness will no longer mark an otherwise-green nightly run as failed.

## Failing runs

- API Tests (RDBMS): https://github.com/camunda/camunda/actions/runs/26794380679
- API Tests (ES): https://github.com/camunda/camunda/actions/runs/26794234759 (unrelated infra)
- Triage run: https://github.com/camunda/camunda/actions/runs/26814077483

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## On-demand verification runs
- https://github.com/camunda/camunda/actions/runs/26814361363
