### PR TITLE
ci: set DATABASE in E2E print-logs step so diagnostics aren't masked

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-reusable-e2e-tests.yml
+++ b/.github/workflows/c8-orchestration-cluster-reusable-e2e-tests.yml
@@ -131,6 +131,12 @@ jobs:
       - name: Print Docker logs before failing
         if: failure()
         run: |
+          # DATABASE must be set so docker compose can resolve the ${DATABASE}
+          # references in the compose file (depends_on / env_file). Without it
+          # every `docker compose logs` call aborts with "service \"camunda\"
+          # depends on undefined service \"\": invalid compose project",
+          # masking the container logs needed to diagnose the failure.
+          export DATABASE=elasticsearch
           if [[ "${{ inputs.branch }}" == "stable/8.7" ]]; then
             docker compose logs tasklist
             docker compose logs operate


### PR DESCRIPTION
## Problem

The 8.9 nightly E2E **Tasklist v2** job failed at the *Start Camunda* step ([run 26793804429](https://github.com/camunda/camunda/actions/runs/26793804429)) on a transient Docker Hub registry timeout:

```
camunda Error Get "https://registry-1.docker.io/v2/": context deadline exceeded
```

The image-pull retry that absorbs those transient timeouts has since been added to this reusable workflow on `main`, so the primary cause is already mitigated.

What remained broken is the **diagnostic** step. When *Start Camunda* (or *Wait for services*) fails, `Print Docker logs before failing` runs `docker compose logs camunda` **without `DATABASE` set**. The compose file (`qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml`) references `${DATABASE}` in both `depends_on` and `env_file`, so an unset value aborts the command with:

```
service "camunda" depends on undefined service "": invalid compose project
```

i.e. the step that exists to surface container logs printed a compose error instead — masking the real diagnostics (this is exactly what happened in the run above).

## Fix

Export `DATABASE=elasticsearch` at the top of the *Print Docker logs before failing* step, matching the value the *Start Camunda* step already uses. The container logs now print as intended on failure.

CI-only change. `actionlint` (with embedded shellcheck) passes.

Originating nightly run: https://github.com/camunda/camunda/actions/runs/26793804429

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## On-demand verification runs
- https://github.com/camunda/camunda/actions/runs/26814387590
