### PR TITLE
ci: set DATABASE for compose logs in OC E2E failure diagnostics

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-reusable-e2e-tests.yml
+++ b/.github/workflows/c8-orchestration-cluster-reusable-e2e-tests.yml
@@ -131,11 +131,15 @@ jobs:
       - name: Print Docker logs before failing
         if: failure()
         run: |
+          # DATABASE must be set: the compose file declares the camunda service's
+          # depends_on as "${DATABASE}", so an unset DATABASE makes compose reject
+          # the project ("depends on undefined service \"\"") and these diagnostic
+          # logs never print. Match the value used by the Start Camunda step.
           if [[ "${{ inputs.branch }}" == "stable/8.7" ]]; then
-            docker compose logs tasklist
-            docker compose logs operate
+            DATABASE=elasticsearch docker compose logs tasklist
+            DATABASE=elasticsearch docker compose logs operate
           else
-            docker compose logs camunda
+            DATABASE=elasticsearch docker compose logs camunda
           fi
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
 


### PR DESCRIPTION
## Problem

In the stable/8.9 nightly E2E **v2** run ([run 26793804429](https://github.com/camunda/camunda/actions/runs/26793804429)), the `Start Camunda` step hit a transient Docker Hub pull timeout (`Get "https://registry-1.docker.io/v2/": context deadline exceeded`). The retry-on-pull-timeout hardening for that has already landed on `main` (commit `7c65f39`, *"ci: retry docker image pull when starting Camunda in OC test workflows"*).

However the on-failure diagnostic step then failed too:

```
The "DATABASE" variable is not set. Defaulting to a blank string.
service "camunda" depends on undefined service "": invalid compose project
```

`Print Docker logs before failing` runs `docker compose logs ...` **without** `DATABASE` set. The compose file (`qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml`) declares the camunda service's `depends_on` as `${DATABASE}`, so an unset `DATABASE` makes compose reject the whole project and the diagnostic logs never print — masking the real cause of every E2E startup failure.

## Fix

Prefix the three `docker compose logs` commands with `DATABASE=elasticsearch`, matching the value already used by the `Start Camunda` step. Every other `docker compose` invocation in this workflow already sets `DATABASE` inline; this step was the only one missing it.

This is diagnostics-only — no test behavior changes. It ensures container logs are actually emitted when an E2E run fails to start.

Nightly run: https://github.com/camunda/camunda/actions/runs/26793804429

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## On-demand verification runs
- https://github.com/camunda/camunda/actions/runs/26815583767
