### PR TITLE
fix: Disabling SpringDoc API docs breaks startup in Tasklist

### DIFF
--- a/operate/webapp/pom.xml
+++ b/operate/webapp/pom.xml
@@ -107,6 +107,10 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-tomcat</artifactId>
     </dependency>
     <!-- OAuth2 token authorization -->

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/OpenApiConfig.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/OpenApiConfig.java
@@ -13,10 +13,15 @@ import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@ConditionalOnProperty(
+    name = "springdoc.api-docs.enabled",
+    havingValue = "true",
+    matchIfMissing = true)
 public class OpenApiConfig {
 
   /**

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/SwaggerConfig.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/SwaggerConfig.java
@@ -11,12 +11,17 @@ import io.swagger.v3.oas.models.info.Contact;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;
 import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 
 @Profile("dev")
 @Configuration
+@ConditionalOnProperty(
+    name = "springdoc.api-docs.enabled",
+    havingValue = "true",
+    matchIfMissing = true)
 public class SwaggerConfig {
   @Bean
   public GroupedOpenApi internalAPI() {

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/api/OpenApiConditionalConfigTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/api/OpenApiConditionalConfigTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.webapp.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+class OpenApiConditionalConfigTest {
+
+  @Nested
+  @SpringJUnitConfig
+  @ContextConfiguration(classes = OpenApiConfig.class)
+  @TestPropertySource(properties = "springdoc.api-docs.enabled=true")
+  class WhenEnabled {
+    @Autowired ApplicationContext context;
+
+    @Test
+    void shouldRegisterApiV1BeanWhenApiDocsEnabled() {
+      assertThat(context.containsBean("apiV1")).isTrue();
+    }
+  }
+
+  @Nested
+  @SpringJUnitConfig
+  @ContextConfiguration(classes = OpenApiConfig.class)
+  @TestPropertySource(properties = "springdoc.api-docs.enabled=false")
+  class WhenDisabled {
+    @Autowired ApplicationContext context;
+
+    @Test
+    void shouldNotRegisterApiV1BeanWhenApiDocsDisabled() {
+      assertThat(context.containsBean("apiV1")).isFalse();
+    }
+  }
+}

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/config/OpenApiConfig.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/config/OpenApiConfig.java
@@ -16,11 +16,16 @@ import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springdoc.core.models.GroupedOpenApi;
 import org.springdoc.core.properties.SpringDocConfigProperties;
 import org.springdoc.core.providers.ObjectMapperProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 
 @Configuration
+@ConditionalOnProperty(
+    name = "springdoc.api-docs.enabled",
+    havingValue = "true",
+    matchIfMissing = true)
 public class OpenApiConfig {
 
   public static final String COOKIE_SECURITY_SCHEMA_NAME = "cookie";

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/config/OpenApiConditionalConfigTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/config/OpenApiConditionalConfigTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.tasklist.webapp.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springdoc.core.properties.SpringDocConfigProperties;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+class OpenApiConditionalConfigTest {
+
+  @Nested
+  @SpringJUnitConfig
+  @ContextConfiguration(
+      classes = {OpenApiConfig.class, OpenApiConditionalConfigTest.MockConfig.class})
+  @TestPropertySource(properties = "springdoc.api-docs.enabled=true")
+  class WhenEnabled {
+    @Autowired ApplicationContext context;
+
+    @Test
+    void shouldRegisterObjectMapperProviderWhenApiDocsEnabled() {
+      assertThat(context.containsBean("springdocObjectMapperProvider")).isTrue();
+    }
+  }
+
+  @Nested
+  @SpringJUnitConfig
+  @ContextConfiguration(classes = OpenApiConfig.class)
+  @TestPropertySource(properties = "springdoc.api-docs.enabled=false")
+  class WhenDisabled {
+    @Autowired ApplicationContext context;
+
+    @Test
+    void shouldNotRegisterObjectMapperProviderWhenApiDocsDisabled() {
+      assertThat(context.containsBean("springdocObjectMapperProvider")).isFalse();
+    }
+  }
+
+  @Configuration
+  static class MockConfig {
+    @Bean
+    SpringDocConfigProperties springDocConfigProperties() {
+      return new SpringDocConfigProperties();
+    }
+  }
+}


### PR DESCRIPTION
## Description

Disabling Swagger / SpringDoc endpoints should prevent exposure of:

- /swagger-ui.html
- /swagger-ui/**
- /v3/api-docs
- /v3/api-docs/**

without breaking application startup.

## Checklist

<!--- Please delete options that are not relevant. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #54463
