### PR TITLE
deps: add ES 8.17.4 and set as SaaS version for stable/8.7

### DIFF
--- a/.ci/db-versions.yml
+++ b/.ci/db-versions.yml
@@ -14,6 +14,7 @@
 
 elasticsearch:
   es8:
-    - &saas "8.13.4"
+    - "8.13.4"
     - "8.14.1"
+    - &saas "8.17.4"
   saas: *saas


### PR DESCRIPTION
Adds ES 8.17.4 to the tested versions list in `.ci/db-versions.yml` and sets it as the SaaS version for the `stable/8.7` branch.