### PR TITLE
ci: add .ci/db-versions.yml to maven-change path filter

### DIFF
--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -247,6 +247,7 @@ runs:
           - 'parent/**'
           - '**/pom.xml'
           - '.mvn/**'
+          - '.ci/db-versions.yml'
 
         validate-pom-metadata-extra-change:
           - 'mvnw'


### PR DESCRIPTION
PRs that only touch `.ci/db-versions.yml` (e.g. ES version bumps) do not trigger integration tests because the file is missing from the `maven-change` path filter. Backport of the fix already present on `main`.