### PR TITLE
test: reduce rolling update test matrix

### DIFF
--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/SecondaryStorageRollingUpdateTest.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/SecondaryStorageRollingUpdateTest.java
@@ -48,18 +48,13 @@ import org.testcontainers.containers.Network;
  */
 final class SecondaryStorageRollingUpdateTest {
 
-  private static List<Arguments> cachedVersionMatrix;
-
   private static final List<StorageTestCase> STORAGE_TEST_CASES =
       List.of(
           StorageTestCase.rdbms(), StorageTestCase.elasticsearch(), StorageTestCase.opensearch());
 
   static Stream<Arguments> versionAndStorageMatrix() {
-    if (cachedVersionMatrix == null) {
-      cachedVersionMatrix = VersionCompatibilityMatrix.auto().toList();
-    }
-
-    return cachedVersionMatrix.stream()
+    return VersionCompatibilityMatrix.useCached()
+        .fromPreviousMinorToCurrent()
         .flatMap(
             versionArgs -> {
               final var arguments = versionArgs.get();


### PR DESCRIPTION
## Description

Reduce the test matrix for the `SecondaryStorageRollingUpgradeIT` for faster execution.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.
