### PR TITLE
feat: add analytics events for document downloads and preview

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentList/DocumentListModal.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentList/DocumentListModal.tsx
@@ -73,8 +73,7 @@ const DocumentListModal: React.FC<StateProps & Props> = ({
               variableName={variableName}
             />
             <DownloadDocumentButton
-              fileName={document.fileName}
-              documentLink={document.link}
+              document={document}
               variableName={variableName}
             />
           </DocumentListItem>

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentPreview/PreviewDocumentButton.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentPreview/PreviewDocumentButton.test.tsx
@@ -12,6 +12,7 @@ import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 import {mockDownloadDocument} from 'modules/mocks/api/v2/documents/downloadDocument';
 import {PreviewDocumentButton} from './PreviewDocumentButton';
 import type {DocumentInfo} from '../DocumentValueCell/parseDocumentVariable';
+import {tracking} from 'modules/tracking';
 
 const createWrapper = (): React.FC<{children?: React.ReactNode}> => {
   const client = getMockQueryClient();
@@ -24,6 +25,7 @@ const imageDocument: DocumentInfo = {
   link: '/v2/documents/img',
   fileName: 'photo.png',
   type: 'image',
+  contentType: 'image/png',
   size: 1024,
 };
 
@@ -31,6 +33,7 @@ const pdfDocument: DocumentInfo = {
   link: '/v2/documents/pdf',
   fileName: 'report.pdf',
   type: 'pdf',
+  contentType: 'application/pdf',
   size: 2048,
 };
 
@@ -38,6 +41,7 @@ const jsonDocument: DocumentInfo = {
   link: '/v2/documents/json',
   fileName: 'data.json',
   type: 'json',
+  contentType: 'application/json',
   size: 256,
 };
 
@@ -179,5 +183,23 @@ describe('<PreviewDocumentButton />', () => {
     expect(
       screen.getByRole('heading', {name: 'Preview: photo.png'}),
     ).toBeInTheDocument();
+  });
+
+  it('should track "document-previewed" events', async () => {
+    const trackSpy = vi.spyOn(tracking, 'track');
+    const {user} = render(
+      <PreviewDocumentButton document={imageDocument} variableName="myImage" />,
+    );
+
+    await user.click(
+      screen.getByLabelText('Preview document for variable myImage'),
+    );
+
+    expect(trackSpy).toHaveBeenCalledWith({
+      eventName: 'document-previewed',
+      documentType: 'image',
+      contentType: 'image/png',
+      size: 1024,
+    });
   });
 });

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentPreview/PreviewDocumentButton.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentPreview/PreviewDocumentButton.tsx
@@ -11,6 +11,7 @@ import {View} from '@carbon/react/icons';
 import {ModalStateManager} from 'modules/components/ModalStateManager';
 import type {DocumentInfo} from '../DocumentValueCell/parseDocumentVariable';
 import {DocumentPreviewModal} from './DocumentPreviewModal';
+import {tracking} from 'modules/tracking';
 
 type Props = {
   document: DocumentInfo;
@@ -37,7 +38,15 @@ const PreviewDocumentButton: React.FC<Props> = ({document, variableName}) => {
           autoAlign={true}
           aria-label={`Preview document for variable ${variableName}`}
           disabled={document.type === 'unknown'}
-          onClick={() => setOpen(true)}
+          onClick={() => {
+            tracking.track({
+              eventName: 'document-previewed',
+              documentType: document.type,
+              contentType: document.contentType ?? null,
+              size: document.size ?? null,
+            });
+            setOpen(true);
+          }}
         />
       )}
     >

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/parseDocumentVariable.test.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/parseDocumentVariable.test.ts
@@ -40,6 +40,7 @@ describe('parseDocumentVariable', () => {
         link: '/v2/documents/doc-123?storeId=in-memory&contentHash=sha256%3Aabc',
         fileName: 'photo.png',
         type: 'image',
+        contentType: 'image/png',
         size: 109748,
       },
     });
@@ -55,6 +56,7 @@ describe('parseDocumentVariable', () => {
         link: '/v2/documents/doc-123?storeId=in-memory&contentHash=sha256%3Aabc',
         fileName: 'photo.png',
         type: 'image',
+        contentType: 'image/png',
         size: 109748,
       },
     });
@@ -99,18 +101,21 @@ describe('parseDocumentVariable', () => {
           link: '/v2/documents/doc-123?storeId=in-memory&contentHash=sha256%3Aabc',
           fileName: 'a.pdf',
           type: 'pdf',
+          contentType: 'application/pdf',
           size: 1000,
         },
         {
           link: '/v2/documents/doc-124?storeId=in-memory&contentHash=sha256%3Aabc',
           fileName: 'b.json',
           type: 'json',
+          contentType: 'application/json',
           size: 500,
         },
         {
           link: '/v2/documents/doc-125?storeId=in-memory&contentHash=sha256%3Aabc',
           fileName: 'c.txt',
           type: 'unknown',
+          contentType: 'text/plain',
           size: 200,
         },
       ],
@@ -133,6 +138,7 @@ describe('parseDocumentVariable', () => {
         link: '/some-context/v2/documents/doc-123?storeId=in-memory&contentHash=sha256%3Aabc',
         fileName: 'photo.png',
         type: 'image',
+        contentType: 'image/png',
         size: 109748,
       },
     });
@@ -294,6 +300,7 @@ describe('parseDocumentVariable', () => {
         link: '/v2/documents/doc-no-meta?storeId=in-memory&contentHash=sha256%3Aabc',
         fileName: 'doc-no-meta',
         type: 'unknown',
+        contentType: undefined,
         size: undefined,
       },
     });

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/parseDocumentVariable.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/parseDocumentVariable.ts
@@ -19,7 +19,8 @@ type DocumentInfo = {
   fileName: string;
   link: string;
   type: DocumentType;
-  size: number | undefined;
+  contentType?: string | undefined;
+  size?: number | undefined;
 };
 
 type DocumentParseResult =
@@ -76,6 +77,7 @@ function toDocumentInfo(ref: DetectedDocumentReference): DocumentInfo {
     link,
     fileName: ref.metadata?.fileName ?? ref.documentId,
     type: getDocumentType(ref.metadata?.contentType),
+    contentType: ref.metadata?.contentType,
     size: ref.metadata?.size,
   };
 }

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DownloadDocumentButton/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DownloadDocumentButton/index.test.tsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {render, screen} from 'modules/testing-library';
+import {DownloadDocumentButton} from '.';
+import type {DocumentInfo} from '../DocumentValueCell/parseDocumentVariable';
+import {tracking} from 'modules/tracking';
+
+const pdfDocument: DocumentInfo = {
+  link: '/v2/documents/pdf',
+  fileName: 'report.pdf',
+  type: 'pdf',
+  contentType: 'application/pdf',
+  size: 2048,
+};
+
+describe('<DownloadDocumentButton />', () => {
+  it('should render a download link with correct href and filename', () => {
+    render(
+      <DownloadDocumentButton document={pdfDocument} variableName="myPdf" />,
+    );
+
+    const link = screen.getByLabelText('Download document for variable myPdf');
+    expect(link).toHaveAttribute('href', '/v2/documents/pdf');
+    expect(link).toHaveAttribute('download', 'report.pdf');
+  });
+
+  it('should track document-downloaded events', async () => {
+    // Prevents JSDOM from throwing "Error: Not implemented: navigation (except hash changes)".
+    window.addEventListener('click', (e) => e.preventDefault(), {once: true});
+    const trackSpy = vi.spyOn(tracking, 'track');
+    const {user} = render(
+      <DownloadDocumentButton document={pdfDocument} variableName="myPdf" />,
+    );
+
+    await user.click(
+      screen.getByLabelText('Download document for variable myPdf'),
+    );
+
+    expect(trackSpy).toHaveBeenCalledWith({
+      eventName: 'document-downloaded',
+      documentType: 'pdf',
+      contentType: 'application/pdf',
+      size: 2048,
+    });
+  });
+});

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DownloadDocumentButton/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DownloadDocumentButton/index.tsx
@@ -8,23 +8,20 @@
 
 import {Button} from '@carbon/react';
 import {Download} from '@carbon/react/icons';
+import type {DocumentInfo} from '../DocumentValueCell/parseDocumentVariable';
+import {tracking} from 'modules/tracking';
 
 type Props = {
-  fileName: string;
-  documentLink: string;
+  document: DocumentInfo;
   variableName: string;
 };
 
-const DownloadDocumentButton: React.FC<Props> = ({
-  fileName,
-  documentLink,
-  variableName,
-}) => {
+const DownloadDocumentButton: React.FC<Props> = ({document, variableName}) => {
   return (
     <Button
       as="a"
-      href={documentLink}
-      download={fileName}
+      href={document.link}
+      download={document.fileName}
       rel="noopener"
       kind="ghost"
       size="sm"
@@ -36,6 +33,14 @@ const DownloadDocumentButton: React.FC<Props> = ({
       // @ts-expect-error - Solves rendering issues in `DocumentListModal`. Not exposed through TS but used at runtime.
       autoAlign={true}
       aria-label={`Download document for variable ${variableName}`}
+      onClick={() => {
+        tracking.track({
+          eventName: 'document-downloaded',
+          documentType: document.type,
+          contentType: document.contentType ?? null,
+          size: document.size ?? null,
+        });
+      }}
     />
   );
 };

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/VariablesTable.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/VariablesTable.tsx
@@ -131,8 +131,7 @@ const VariablesTable: React.FC<Props> = ({
                             variableName={name}
                           />
                           <DownloadDocumentButton
-                            documentLink={documentResult.document.link}
-                            fileName={documentResult.document.fileName}
+                            document={documentResult.document}
                             variableName={name}
                           />
                         </>

--- a/operate/client/src/modules/tracking/index.ts
+++ b/operate/client/src/modules/tracking/index.ts
@@ -337,6 +337,15 @@ type Events =
     }
   | {
       eventName: 'audit-logs-fetch-failed';
+    }
+  /**
+   * Document analytics
+   */
+  | {
+      eventName: 'document-previewed' | 'document-downloaded';
+      documentType: 'image' | 'pdf' | 'json' | 'unknown';
+      contentType: string | null;
+      size: number | null;
     };
 
 const STAGE_ENV = getStage(window.location.host);


### PR DESCRIPTION
## Description

This PR adds two analytic tracking events for document- downloaded and previewed. The events contain the same payload. Namely, it contains the `documentType` parsed from the MIME type, as well as the raw MIME type `contentType`. I think the latter can be especially interesting for download events. In combination with the parsed `documentType: 'unknown'`, it can hint at new MIME types that may be worth to support in a built-in preview.

```ts
type PreviewEvent = {
  eventName: 'document-previewed';
  documentType: 'image' | 'pdf' | 'json' | 'unknown';
  contentType: string | null;
  size: number | null;
};

type DownloadEvent = {
  eventName: 'document-downloaded';
  documentType: 'image' | 'pdf' | 'json' | 'unknown';
  contentType: string | null;
  size: number | null;
};
```

## Related issues

closes #52208
