### PR TITLE
Add Camunda client wait state search command

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -155,6 +155,7 @@ import io.camunda.client.api.search.request.DecisionDefinitionSearchRequest;
 import io.camunda.client.api.search.request.DecisionInstanceSearchRequest;
 import io.camunda.client.api.search.request.DecisionRequirementsSearchRequest;
 import io.camunda.client.api.search.request.ElementInstanceSearchRequest;
+import io.camunda.client.api.search.request.ElementInstanceWaitStateSearchRequest;
 import io.camunda.client.api.search.request.GlobalTaskListenerSearchRequest;
 import io.camunda.client.api.search.request.GroupsByRoleSearchRequest;
 import io.camunda.client.api.search.request.GroupsByTenantSearchRequest;
@@ -3264,6 +3265,21 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder for the incidents by element instance search request
    */
   AuditLogSearchRequest newAuditLogSearchRequest();
+
+  /**
+   * Executes a search request to query element instance wait states.
+   *
+   * <pre>
+   *   camundaClient
+   *    .newElementInstanceWaitStateSearchRequest()
+   *    .filter((f) -> f.processInstanceKey(myProcessInstanceKey))
+   *    .page((p) -> p.limit(100))
+   *    .send();
+   * </pre>
+   *
+   * @return a builder for the element instance wait state search request
+   */
+  ElementInstanceWaitStateSearchRequest newElementInstanceWaitStateSearchRequest();
 
   /**
    * Executes a search request to query audit logs related to a user task.

--- a/clients/java/src/main/java/io/camunda/client/api/search/enums/WaitStateElementType.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/enums/WaitStateElementType.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.enums;
+
+public enum WaitStateElementType {
+  AD_HOC_SUB_PROCESS,
+  AD_HOC_SUB_PROCESS_INNER_INSTANCE,
+  BOUNDARY_EVENT,
+  BUSINESS_RULE_TASK,
+  CALL_ACTIVITY,
+  END_EVENT,
+  EVENT_BASED_GATEWAY,
+  EVENT_SUB_PROCESS,
+  EXCLUSIVE_GATEWAY,
+  INCLUSIVE_GATEWAY,
+  INTERMEDIATE_CATCH_EVENT,
+  INTERMEDIATE_THROW_EVENT,
+  MANUAL_TASK,
+  MULTI_INSTANCE_BODY,
+  PARALLEL_GATEWAY,
+  PROCESS,
+  RECEIVE_TASK,
+  SCRIPT_TASK,
+  SEND_TASK,
+  SEQUENCE_FLOW,
+  SERVICE_TASK,
+  START_EVENT,
+  SUB_PROCESS,
+  TASK,
+  UNKNOWN,
+  UNSPECIFIED,
+  USER_TASK,
+  UNKNOWN_ENUM_VALUE;
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/enums/WaitStateType.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/enums/WaitStateType.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.enums;
+
+public enum WaitStateType {
+  JOB,
+  MESSAGE,
+  UNKNOWN_ENUM_VALUE;
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/ElementInstanceWaitStateFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/ElementInstanceWaitStateFilter.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.filter;
+
+import io.camunda.client.api.search.enums.WaitStateElementType;
+import io.camunda.client.api.search.enums.WaitStateType;
+import io.camunda.client.api.search.filter.builder.BasicStringProperty;
+import io.camunda.client.api.search.filter.builder.StringProperty;
+import io.camunda.client.api.search.filter.builder.WaitStateElementTypeProperty;
+import io.camunda.client.api.search.filter.builder.WaitStateTypeProperty;
+import io.camunda.client.api.search.request.TypedFilterableRequest.SearchRequestFilter;
+import java.util.function.Consumer;
+
+public interface ElementInstanceWaitStateFilter extends SearchRequestFilter {
+
+  ElementInstanceWaitStateFilter elementInstanceKey(long value);
+
+  ElementInstanceWaitStateFilter elementInstanceKey(Consumer<BasicStringProperty> fn);
+
+  ElementInstanceWaitStateFilter processInstanceKey(long value);
+
+  ElementInstanceWaitStateFilter processInstanceKey(Consumer<BasicStringProperty> fn);
+
+  ElementInstanceWaitStateFilter rootProcessInstanceKey(long value);
+
+  ElementInstanceWaitStateFilter rootProcessInstanceKey(Consumer<BasicStringProperty> fn);
+
+  ElementInstanceWaitStateFilter elementId(String value);
+
+  ElementInstanceWaitStateFilter elementId(Consumer<StringProperty> fn);
+
+  ElementInstanceWaitStateFilter elementType(WaitStateElementType value);
+
+  ElementInstanceWaitStateFilter elementType(Consumer<WaitStateElementTypeProperty> fn);
+
+  ElementInstanceWaitStateFilter waitStateType(WaitStateType value);
+
+  ElementInstanceWaitStateFilter waitStateType(Consumer<WaitStateTypeProperty> fn);
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/builder/WaitStateElementTypeProperty.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/builder/WaitStateElementTypeProperty.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.filter.builder;
+
+import io.camunda.client.api.search.enums.WaitStateElementType;
+
+public interface WaitStateElementTypeProperty
+    extends PropertyBase<WaitStateElementType, WaitStateElementTypeProperty> {}

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/builder/WaitStateTypeProperty.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/builder/WaitStateTypeProperty.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.filter.builder;
+
+import io.camunda.client.api.search.enums.WaitStateType;
+
+public interface WaitStateTypeProperty extends PropertyBase<WaitStateType, WaitStateTypeProperty> {}

--- a/clients/java/src/main/java/io/camunda/client/api/search/request/ElementInstanceWaitStateSearchRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/ElementInstanceWaitStateSearchRequest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.request;
+
+import io.camunda.client.api.search.filter.ElementInstanceWaitStateFilter;
+import io.camunda.client.api.search.page.AnyPage;
+import io.camunda.client.api.search.response.ElementInstanceWaitStateResult;
+
+public interface ElementInstanceWaitStateSearchRequest
+    extends TypedFilterableRequest<
+            ElementInstanceWaitStateFilter, ElementInstanceWaitStateSearchRequest>,
+        TypedPageableRequest<AnyPage, ElementInstanceWaitStateSearchRequest>,
+        FinalSearchRequestStep<ElementInstanceWaitStateResult> {}

--- a/clients/java/src/main/java/io/camunda/client/api/search/request/SearchRequestBuilders.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/SearchRequestBuilders.java
@@ -543,6 +543,15 @@ public final class SearchRequestBuilders {
     return filter;
   }
 
+  public static io.camunda.client.api.search.filter.ElementInstanceWaitStateFilter
+      elementInstanceWaitStateFilter(
+          final Consumer<io.camunda.client.api.search.filter.ElementInstanceWaitStateFilter> fn) {
+    final io.camunda.client.api.search.filter.ElementInstanceWaitStateFilter filter =
+        new io.camunda.client.impl.search.filter.ElementInstanceWaitStateFilterImpl();
+    fn.accept(filter);
+    return filter;
+  }
+
   public static AuditLogSort auditLogSort(final Consumer<AuditLogSort> fn) {
     final AuditLogSort sort = new AuditLogSortImpl();
     fn.accept(sort);

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/ElementInstanceWaitStateResult.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/ElementInstanceWaitStateResult.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.response;
+
+import io.camunda.client.api.search.enums.WaitStateElementType;
+import io.camunda.client.api.search.enums.WaitStateType;
+
+public interface ElementInstanceWaitStateResult {
+
+  WaitStateType getWaitStateType();
+
+  String getRootProcessInstanceKey();
+
+  String getProcessInstanceKey();
+
+  String getElementInstanceKey();
+
+  String getElementId();
+
+  WaitStateElementType getElementType();
+
+  String getTenantId();
+
+  /**
+   * Returns the wait-state-specific details, or {@code null} if absent. Resolves to {@link
+   * JobWaitStateDetails} or {@link MessageWaitStateDetails} depending on {@link
+   * #getWaitStateType()}.
+   */
+  WaitStateDetails getDetails();
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/JobWaitStateDetails.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/JobWaitStateDetails.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.response;
+
+import io.camunda.client.api.search.enums.JobKind;
+import io.camunda.client.api.search.enums.ListenerEventType;
+
+/** Details of an element instance waiting on a job. */
+public interface JobWaitStateDetails extends WaitStateDetails {
+
+  String getJobKey();
+
+  String getJobType();
+
+  JobKind getJobKind();
+
+  ListenerEventType getListenerEventType();
+
+  Integer getRetries();
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/MessageWaitStateDetails.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/MessageWaitStateDetails.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.response;
+
+/** Details of an element instance waiting on a message. */
+public interface MessageWaitStateDetails extends WaitStateDetails {
+
+  String getMessageName();
+
+  String getCorrelationKey();
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/WaitStateDetails.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/WaitStateDetails.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.response;
+
+import io.camunda.client.api.search.enums.WaitStateType;
+
+/**
+ * Wait-state-specific details of an element instance. Resolves to {@link JobWaitStateDetails} or
+ * {@link MessageWaitStateDetails} depending on {@link #getWaitStateType()}.
+ */
+public interface WaitStateDetails {
+
+  WaitStateType getWaitStateType();
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -166,6 +166,7 @@ import io.camunda.client.api.search.request.DecisionDefinitionSearchRequest;
 import io.camunda.client.api.search.request.DecisionInstanceSearchRequest;
 import io.camunda.client.api.search.request.DecisionRequirementsSearchRequest;
 import io.camunda.client.api.search.request.ElementInstanceSearchRequest;
+import io.camunda.client.api.search.request.ElementInstanceWaitStateSearchRequest;
 import io.camunda.client.api.search.request.GlobalTaskListenerSearchRequest;
 import io.camunda.client.api.search.request.GroupsByRoleSearchRequest;
 import io.camunda.client.api.search.request.GroupsByTenantSearchRequest;
@@ -350,6 +351,7 @@ import io.camunda.client.impl.search.request.DecisionDefinitionSearchRequestImpl
 import io.camunda.client.impl.search.request.DecisionInstanceSearchRequestImpl;
 import io.camunda.client.impl.search.request.DecisionRequirementsSearchRequestImpl;
 import io.camunda.client.impl.search.request.ElementInstanceSearchRequestImpl;
+import io.camunda.client.impl.search.request.ElementInstanceWaitStateSearchRequestImpl;
 import io.camunda.client.impl.search.request.GlobalTaskListenerSearchRequestImpl;
 import io.camunda.client.impl.search.request.GroupSearchRequestImpl;
 import io.camunda.client.impl.search.request.GroupsByRoleSearchRequestImpl;
@@ -1659,6 +1661,11 @@ public final class CamundaClientImpl implements CamundaClient {
   @Override
   public AuditLogSearchRequest newAuditLogSearchRequest() {
     return new AuditLogSearchRequestImpl(httpClient, jsonMapper);
+  }
+
+  @Override
+  public ElementInstanceWaitStateSearchRequest newElementInstanceWaitStateSearchRequest() {
+    return new ElementInstanceWaitStateSearchRequestImpl(httpClient, jsonMapper);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/ElementInstanceWaitStateFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/ElementInstanceWaitStateFilterImpl.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.filter;
+
+import io.camunda.client.api.search.enums.WaitStateElementType;
+import io.camunda.client.api.search.enums.WaitStateType;
+import io.camunda.client.api.search.filter.ElementInstanceWaitStateFilter;
+import io.camunda.client.api.search.filter.builder.BasicStringProperty;
+import io.camunda.client.api.search.filter.builder.StringProperty;
+import io.camunda.client.api.search.filter.builder.WaitStateElementTypeProperty;
+import io.camunda.client.api.search.filter.builder.WaitStateTypeProperty;
+import io.camunda.client.impl.search.filter.builder.BasicStringPropertyImpl;
+import io.camunda.client.impl.search.filter.builder.StringPropertyImpl;
+import io.camunda.client.impl.search.filter.builder.WaitStateElementTypePropertyImpl;
+import io.camunda.client.impl.search.filter.builder.WaitStateTypePropertyImpl;
+import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
+import io.camunda.client.impl.util.ParseUtil;
+import java.util.function.Consumer;
+
+public class ElementInstanceWaitStateFilterImpl
+    extends TypedSearchRequestPropertyProvider<
+        io.camunda.client.protocol.rest.ElementInstanceWaitStateFilter>
+    implements ElementInstanceWaitStateFilter {
+
+  private final io.camunda.client.protocol.rest.ElementInstanceWaitStateFilter filter;
+
+  public ElementInstanceWaitStateFilterImpl() {
+    filter = new io.camunda.client.protocol.rest.ElementInstanceWaitStateFilter();
+  }
+
+  @Override
+  public ElementInstanceWaitStateFilter elementInstanceKey(final long value) {
+    return elementInstanceKey(b -> b.eq(ParseUtil.keyToString(value)));
+  }
+
+  @Override
+  public ElementInstanceWaitStateFilter elementInstanceKey(final Consumer<BasicStringProperty> fn) {
+    final BasicStringPropertyImpl property = new BasicStringPropertyImpl();
+    fn.accept(property);
+    filter.setElementInstanceKey(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
+  public ElementInstanceWaitStateFilter processInstanceKey(final long value) {
+    return processInstanceKey(b -> b.eq(ParseUtil.keyToString(value)));
+  }
+
+  @Override
+  public ElementInstanceWaitStateFilter processInstanceKey(final Consumer<BasicStringProperty> fn) {
+    final BasicStringPropertyImpl property = new BasicStringPropertyImpl();
+    fn.accept(property);
+    filter.setProcessInstanceKey(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
+  public ElementInstanceWaitStateFilter rootProcessInstanceKey(final long value) {
+    return rootProcessInstanceKey(b -> b.eq(ParseUtil.keyToString(value)));
+  }
+
+  @Override
+  public ElementInstanceWaitStateFilter rootProcessInstanceKey(
+      final Consumer<BasicStringProperty> fn) {
+    final BasicStringPropertyImpl property = new BasicStringPropertyImpl();
+    fn.accept(property);
+    filter.setRootProcessInstanceKey(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
+  public ElementInstanceWaitStateFilter elementId(final String value) {
+    return elementId(b -> b.eq(value));
+  }
+
+  @Override
+  public ElementInstanceWaitStateFilter elementId(final Consumer<StringProperty> fn) {
+    final StringPropertyImpl property = new StringPropertyImpl();
+    fn.accept(property);
+    filter.setElementId(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
+  public ElementInstanceWaitStateFilter elementType(final WaitStateElementType value) {
+    return elementType(b -> b.eq(value));
+  }
+
+  @Override
+  public ElementInstanceWaitStateFilter elementType(
+      final Consumer<WaitStateElementTypeProperty> fn) {
+    final WaitStateElementTypePropertyImpl property = new WaitStateElementTypePropertyImpl();
+    fn.accept(property);
+    filter.setElementType(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
+  public ElementInstanceWaitStateFilter waitStateType(final WaitStateType value) {
+    return waitStateType(b -> b.eq(value));
+  }
+
+  @Override
+  public ElementInstanceWaitStateFilter waitStateType(final Consumer<WaitStateTypeProperty> fn) {
+    final WaitStateTypePropertyImpl property = new WaitStateTypePropertyImpl();
+    fn.accept(property);
+    filter.setWaitStateType(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
+  protected io.camunda.client.protocol.rest.ElementInstanceWaitStateFilter
+      getSearchRequestProperty() {
+    return filter;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/builder/WaitStateElementTypePropertyImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/builder/WaitStateElementTypePropertyImpl.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.filter.builder;
+
+import io.camunda.client.api.search.enums.WaitStateElementType;
+import io.camunda.client.api.search.filter.builder.WaitStateElementTypeProperty;
+import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
+import io.camunda.client.impl.util.CollectionUtil;
+import io.camunda.client.impl.util.EnumUtil;
+import io.camunda.client.protocol.rest.WaitStateElementTypeEnum;
+import io.camunda.client.protocol.rest.WaitStateElementTypeFilterProperty;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class WaitStateElementTypePropertyImpl
+    extends TypedSearchRequestPropertyProvider<WaitStateElementTypeFilterProperty>
+    implements WaitStateElementTypeProperty {
+
+  private final WaitStateElementTypeFilterProperty filterProperty =
+      new WaitStateElementTypeFilterProperty();
+
+  @Override
+  public WaitStateElementTypeProperty eq(final WaitStateElementType value) {
+    filterProperty.set$Eq(EnumUtil.convert(value, WaitStateElementTypeEnum.class));
+    return this;
+  }
+
+  @Override
+  public WaitStateElementTypeProperty neq(final WaitStateElementType value) {
+    filterProperty.set$Neq(EnumUtil.convert(value, WaitStateElementTypeEnum.class));
+    return this;
+  }
+
+  @Override
+  public WaitStateElementTypeProperty exists(final boolean value) {
+    filterProperty.set$Exists(value);
+    return this;
+  }
+
+  @Override
+  public WaitStateElementTypeProperty in(final List<WaitStateElementType> values) {
+    filterProperty.set$In(
+        values.stream()
+            .map(source -> EnumUtil.convert(source, WaitStateElementTypeEnum.class))
+            .collect(Collectors.toList()));
+    return this;
+  }
+
+  @Override
+  public WaitStateElementTypeProperty in(final WaitStateElementType... values) {
+    return in(CollectionUtil.toList(values));
+  }
+
+  @Override
+  protected WaitStateElementTypeFilterProperty getSearchRequestProperty() {
+    return filterProperty;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/builder/WaitStateTypePropertyImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/builder/WaitStateTypePropertyImpl.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.filter.builder;
+
+import io.camunda.client.api.search.enums.WaitStateType;
+import io.camunda.client.api.search.filter.builder.WaitStateTypeProperty;
+import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
+import io.camunda.client.impl.util.CollectionUtil;
+import io.camunda.client.impl.util.EnumUtil;
+import io.camunda.client.protocol.rest.WaitStateTypeEnum;
+import io.camunda.client.protocol.rest.WaitStateTypeFilterProperty;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class WaitStateTypePropertyImpl
+    extends TypedSearchRequestPropertyProvider<WaitStateTypeFilterProperty>
+    implements WaitStateTypeProperty {
+
+  private final WaitStateTypeFilterProperty filterProperty = new WaitStateTypeFilterProperty();
+
+  @Override
+  public WaitStateTypeProperty eq(final WaitStateType value) {
+    filterProperty.set$Eq(EnumUtil.convert(value, WaitStateTypeEnum.class));
+    return this;
+  }
+
+  @Override
+  public WaitStateTypeProperty neq(final WaitStateType value) {
+    filterProperty.set$Neq(EnumUtil.convert(value, WaitStateTypeEnum.class));
+    return this;
+  }
+
+  @Override
+  public WaitStateTypeProperty exists(final boolean value) {
+    filterProperty.set$Exists(value);
+    return this;
+  }
+
+  @Override
+  public WaitStateTypeProperty in(final List<WaitStateType> values) {
+    filterProperty.set$In(
+        values.stream()
+            .map(source -> EnumUtil.convert(source, WaitStateTypeEnum.class))
+            .collect(Collectors.toList()));
+    return this;
+  }
+
+  @Override
+  public WaitStateTypeProperty in(final WaitStateType... values) {
+    return in(CollectionUtil.toList(values));
+  }
+
+  @Override
+  protected WaitStateTypeFilterProperty getSearchRequestProperty() {
+    return filterProperty;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/ElementInstanceWaitStateSearchRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/ElementInstanceWaitStateSearchRequestImpl.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.request;
+
+import static io.camunda.client.api.search.request.SearchRequestBuilders.anyPage;
+import static io.camunda.client.api.search.request.SearchRequestBuilders.elementInstanceWaitStateFilter;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.search.filter.ElementInstanceWaitStateFilter;
+import io.camunda.client.api.search.page.AnyPage;
+import io.camunda.client.api.search.request.ElementInstanceWaitStateSearchRequest;
+import io.camunda.client.api.search.request.FinalSearchRequestStep;
+import io.camunda.client.api.search.response.ElementInstanceWaitStateResult;
+import io.camunda.client.api.search.response.SearchResponse;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.search.response.SearchResponseMapper;
+import io.camunda.client.protocol.rest.ElementInstanceWaitStateQuery;
+import io.camunda.client.protocol.rest.ElementInstanceWaitStateQueryResult;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class ElementInstanceWaitStateSearchRequestImpl
+    extends TypedSearchRequestPropertyProvider<ElementInstanceWaitStateQuery>
+    implements ElementInstanceWaitStateSearchRequest {
+
+  private final ElementInstanceWaitStateQuery request;
+  private final HttpClient httpClient;
+  private final JsonMapper jsonMapper;
+  private final RequestConfig.Builder httpRequestConfig;
+
+  public ElementInstanceWaitStateSearchRequestImpl(
+      final HttpClient httpClient, final JsonMapper jsonMapper) {
+    this.httpClient = httpClient;
+    this.jsonMapper = jsonMapper;
+    httpRequestConfig = httpClient.newRequestConfig();
+    request = new ElementInstanceWaitStateQuery();
+  }
+
+  @Override
+  public FinalSearchRequestStep<ElementInstanceWaitStateResult> requestTimeout(
+      final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<SearchResponse<ElementInstanceWaitStateResult>> send() {
+    final HttpCamundaFuture<SearchResponse<ElementInstanceWaitStateResult>> result =
+        new HttpCamundaFuture<>();
+    httpClient.post(
+        "/element-instances/wait-states/search",
+        jsonMapper.toJson(request),
+        httpRequestConfig.build(),
+        ElementInstanceWaitStateQueryResult.class,
+        SearchResponseMapper::toElementInstanceWaitStateSearchResponse,
+        result);
+    return result;
+  }
+
+  @Override
+  public ElementInstanceWaitStateSearchRequest filter(final ElementInstanceWaitStateFilter value) {
+    request.setFilter(provideSearchRequestProperty(value));
+    return this;
+  }
+
+  @Override
+  public ElementInstanceWaitStateSearchRequest filter(
+      final Consumer<ElementInstanceWaitStateFilter> fn) {
+    return filter(elementInstanceWaitStateFilter(fn));
+  }
+
+  @Override
+  public ElementInstanceWaitStateSearchRequest page(final AnyPage value) {
+    request.setPage(provideSearchRequestProperty(value));
+    return this;
+  }
+
+  @Override
+  public ElementInstanceWaitStateSearchRequest page(final Consumer<AnyPage> fn) {
+    return page(anyPage(fn));
+  }
+
+  @Override
+  protected ElementInstanceWaitStateQuery getSearchRequestProperty() {
+    return request;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/ElementInstanceWaitStateResultImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/ElementInstanceWaitStateResultImpl.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.response;
+
+import io.camunda.client.api.search.enums.WaitStateElementType;
+import io.camunda.client.api.search.enums.WaitStateType;
+import io.camunda.client.api.search.response.ElementInstanceWaitStateResult;
+import io.camunda.client.api.search.response.WaitStateDetails;
+import io.camunda.client.impl.util.EnumUtil;
+
+public class ElementInstanceWaitStateResultImpl implements ElementInstanceWaitStateResult {
+
+  private final WaitStateType waitStateType;
+  private final String rootProcessInstanceKey;
+  private final String processInstanceKey;
+  private final String elementInstanceKey;
+  private final String elementId;
+  private final WaitStateElementType elementType;
+  private final String tenantId;
+  private final WaitStateDetails details;
+
+  public ElementInstanceWaitStateResultImpl(
+      final io.camunda.client.protocol.rest.ElementInstanceWaitStateResult item) {
+    waitStateType =
+        parseWaitStateType(item.getWaitStateType() != null ? item.getWaitStateType().name() : null);
+    rootProcessInstanceKey = item.getRootProcessInstanceKey();
+    processInstanceKey = item.getProcessInstanceKey();
+    elementInstanceKey = item.getElementInstanceKey();
+    elementId = item.getElementId();
+    elementType = EnumUtil.convert(item.getElementType(), WaitStateElementType.class);
+    tenantId = item.getTenantId();
+    details = extractDetails(waitStateType, item);
+  }
+
+  private static WaitStateType parseWaitStateType(final String value) {
+    if (value == null) {
+      return WaitStateType.UNKNOWN_ENUM_VALUE;
+    }
+    try {
+      return WaitStateType.valueOf(value);
+    } catch (final IllegalArgumentException e) {
+      return WaitStateType.UNKNOWN_ENUM_VALUE;
+    }
+  }
+
+  private static WaitStateDetails extractDetails(
+      final WaitStateType waitStateType,
+      final io.camunda.client.protocol.rest.ElementInstanceWaitStateResult item) {
+    switch (waitStateType) {
+      case JOB:
+        return item.getJobDetails() == null
+            ? null
+            : new JobWaitStateDetailsImpl(item.getJobDetails());
+      case MESSAGE:
+        return item.getMessageDetails() == null
+            ? null
+            : new MessageWaitStateDetailsImpl(item.getMessageDetails());
+      default:
+        return null;
+    }
+  }
+
+  @Override
+  public WaitStateType getWaitStateType() {
+    return waitStateType;
+  }
+
+  @Override
+  public String getRootProcessInstanceKey() {
+    return rootProcessInstanceKey;
+  }
+
+  @Override
+  public String getProcessInstanceKey() {
+    return processInstanceKey;
+  }
+
+  @Override
+  public String getElementInstanceKey() {
+    return elementInstanceKey;
+  }
+
+  @Override
+  public String getElementId() {
+    return elementId;
+  }
+
+  @Override
+  public WaitStateElementType getElementType() {
+    return elementType;
+  }
+
+  @Override
+  public String getTenantId() {
+    return tenantId;
+  }
+
+  @Override
+  public WaitStateDetails getDetails() {
+    return details;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/JobWaitStateDetailsImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/JobWaitStateDetailsImpl.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.response;
+
+import io.camunda.client.api.search.enums.JobKind;
+import io.camunda.client.api.search.enums.ListenerEventType;
+import io.camunda.client.api.search.enums.WaitStateType;
+import io.camunda.client.api.search.response.JobWaitStateDetails;
+import io.camunda.client.impl.util.EnumUtil;
+
+public class JobWaitStateDetailsImpl implements JobWaitStateDetails {
+
+  private final String jobKey;
+  private final String jobType;
+  private final JobKind jobKind;
+  private final ListenerEventType listenerEventType;
+  private final Integer retries;
+
+  public JobWaitStateDetailsImpl(
+      final io.camunda.client.protocol.rest.JobWaitStateDetails details) {
+    jobKey = details.getJobKey();
+    jobType = details.getJobType();
+    jobKind = EnumUtil.convert(details.getJobKind(), JobKind.class);
+    listenerEventType = EnumUtil.convert(details.getListenerEventType(), ListenerEventType.class);
+    retries = details.getRetries();
+  }
+
+  @Override
+  public WaitStateType getWaitStateType() {
+    return WaitStateType.JOB;
+  }
+
+  @Override
+  public String getJobKey() {
+    return jobKey;
+  }
+
+  @Override
+  public String getJobType() {
+    return jobType;
+  }
+
+  @Override
+  public JobKind getJobKind() {
+    return jobKind;
+  }
+
+  @Override
+  public ListenerEventType getListenerEventType() {
+    return listenerEventType;
+  }
+
+  @Override
+  public Integer getRetries() {
+    return retries;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/MessageWaitStateDetailsImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/MessageWaitStateDetailsImpl.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.response;
+
+import io.camunda.client.api.search.enums.WaitStateType;
+import io.camunda.client.api.search.response.MessageWaitStateDetails;
+
+public class MessageWaitStateDetailsImpl implements MessageWaitStateDetails {
+
+  private final String messageName;
+  private final String correlationKey;
+
+  public MessageWaitStateDetailsImpl(
+      final io.camunda.client.protocol.rest.MessageWaitStateDetails details) {
+    messageName = details.getMessageName();
+    correlationKey = details.getCorrelationKey();
+  }
+
+  @Override
+  public WaitStateType getWaitStateType() {
+    return WaitStateType.MESSAGE;
+  }
+
+  @Override
+  public String getMessageName() {
+    return messageName;
+  }
+
+  @Override
+  public String getCorrelationKey() {
+    return correlationKey;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
@@ -33,6 +33,7 @@ import io.camunda.client.api.search.response.DecisionDefinition;
 import io.camunda.client.api.search.response.DecisionInstance;
 import io.camunda.client.api.search.response.DecisionRequirements;
 import io.camunda.client.api.search.response.ElementInstance;
+import io.camunda.client.api.search.response.ElementInstanceWaitStateResult;
 import io.camunda.client.api.search.response.GlobalTaskListener;
 import io.camunda.client.api.search.response.Group;
 import io.camunda.client.api.search.response.GroupUser;
@@ -460,6 +461,15 @@ public final class SearchResponseMapper {
     final SearchResponsePage page = toSearchResponsePage(response.getPage());
     final List<AuditLogResult> instances =
         toSearchResponseInstances(response.getItems(), AuditLogResultImpl::new);
+    return new SearchResponseImpl<>(instances, page);
+  }
+
+  public static SearchResponse<ElementInstanceWaitStateResult>
+      toElementInstanceWaitStateSearchResponse(
+          final io.camunda.client.protocol.rest.ElementInstanceWaitStateQueryResult response) {
+    final SearchResponsePage page = toSearchResponsePage(response.getPage());
+    final List<ElementInstanceWaitStateResult> instances =
+        toSearchResponseInstances(response.getItems(), ElementInstanceWaitStateResultImpl::new);
     return new SearchResponseImpl<>(instances, page);
   }
 

--- a/clients/java/src/test/java/io/camunda/client/elementinstancewaitstate/SearchElementInstanceWaitStatesTest.java
+++ b/clients/java/src/test/java/io/camunda/client/elementinstancewaitstate/SearchElementInstanceWaitStatesTest.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.elementinstancewaitstate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.api.search.enums.JobKind;
+import io.camunda.client.api.search.enums.ListenerEventType;
+import io.camunda.client.api.search.enums.WaitStateElementType;
+import io.camunda.client.api.search.enums.WaitStateType;
+import io.camunda.client.api.search.response.JobWaitStateDetails;
+import io.camunda.client.api.search.response.MessageWaitStateDetails;
+import io.camunda.client.api.search.response.SearchResponse;
+import io.camunda.client.protocol.rest.ElementInstanceWaitStateFilter;
+import io.camunda.client.protocol.rest.ElementInstanceWaitStateQuery;
+import io.camunda.client.protocol.rest.ElementInstanceWaitStateQueryResult;
+import io.camunda.client.protocol.rest.JobKindEnum;
+import io.camunda.client.protocol.rest.JobListenerEventTypeEnum;
+import io.camunda.client.protocol.rest.SearchQueryPageResponse;
+import io.camunda.client.protocol.rest.WaitStateElementTypeEnum;
+import io.camunda.client.protocol.rest.WaitStateTypeEnum;
+import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayPaths;
+import java.util.ArrayList;
+import org.junit.jupiter.api.Test;
+
+public class SearchElementInstanceWaitStatesTest extends ClientRestTest {
+
+  @Test
+  public void shouldSearchWithEmptyQuery() {
+    // given
+    final ElementInstanceWaitStateQueryResult response = buildEmptyResponse();
+    gatewayService.onSearchElementInstanceWaitStatesRequest(response);
+
+    // when
+    client.newElementInstanceWaitStateSearchRequest().send().join();
+
+    // then
+    final LoggedRequest request = gatewayService.getLastRequest();
+    assertThat(request.getUrl()).isEqualTo(RestGatewayPaths.getElementInstanceWaitStateSearchUrl());
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.POST);
+  }
+
+  @Test
+  public void shouldSearchWithKeyFilters() {
+    // given
+    gatewayService.onSearchElementInstanceWaitStatesRequest(buildEmptyResponse());
+
+    // when
+    client
+        .newElementInstanceWaitStateSearchRequest()
+        .filter(
+            f ->
+                f.processInstanceKey(100L)
+                    .rootProcessInstanceKey(200L)
+                    .elementInstanceKey(300L)
+                    .elementId("task-1"))
+        .send()
+        .join();
+
+    // then
+    final ElementInstanceWaitStateQuery request =
+        gatewayService.getLastRequest(ElementInstanceWaitStateQuery.class);
+    final ElementInstanceWaitStateFilter filter = request.getFilter();
+    assertThat(filter).isNotNull();
+    assertThat(filter.getProcessInstanceKey().get$Eq()).isEqualTo("100");
+    assertThat(filter.getRootProcessInstanceKey().get$Eq()).isEqualTo("200");
+    assertThat(filter.getElementInstanceKey().get$Eq()).isEqualTo("300");
+    assertThat(filter.getElementId().get$Eq()).isEqualTo("task-1");
+  }
+
+  @Test
+  public void shouldSearchWithEnumFilters() {
+    // given
+    gatewayService.onSearchElementInstanceWaitStatesRequest(buildEmptyResponse());
+
+    // when
+    client
+        .newElementInstanceWaitStateSearchRequest()
+        .filter(
+            f -> f.elementType(WaitStateElementType.SERVICE_TASK).waitStateType(WaitStateType.JOB))
+        .send()
+        .join();
+
+    // then
+    final ElementInstanceWaitStateQuery request =
+        gatewayService.getLastRequest(ElementInstanceWaitStateQuery.class);
+    final ElementInstanceWaitStateFilter filter = request.getFilter();
+    assertThat(filter).isNotNull();
+    assertThat(filter.getElementType().get$Eq()).isEqualTo(WaitStateElementTypeEnum.SERVICE_TASK);
+    assertThat(filter.getWaitStateType().get$Eq()).isEqualTo(WaitStateTypeEnum.JOB);
+  }
+
+  @Test
+  public void shouldSearchWithPage() {
+    // given
+    gatewayService.onSearchElementInstanceWaitStatesRequest(buildEmptyResponse());
+
+    // when
+    client.newElementInstanceWaitStateSearchRequest().page(p -> p.limit(5)).send().join();
+
+    // then
+    final ElementInstanceWaitStateQuery request =
+        gatewayService.getLastRequest(ElementInstanceWaitStateQuery.class);
+    assertThat(request.getPage()).isNotNull();
+    assertThat(request.getPage().getLimit()).isEqualTo(5);
+  }
+
+  @Test
+  public void shouldMapJobResponseFields() {
+    // given
+    final io.camunda.client.protocol.rest.JobWaitStateDetails jobDetails =
+        new io.camunda.client.protocol.rest.JobWaitStateDetails();
+    jobDetails.setJobKey("999");
+    jobDetails.setJobType("payment");
+    jobDetails.setJobKind(JobKindEnum.BPMN_ELEMENT);
+    jobDetails.setListenerEventType(JobListenerEventTypeEnum.UNSPECIFIED);
+    jobDetails.setRetries(3);
+
+    final io.camunda.client.protocol.rest.ElementInstanceWaitStateResult item =
+        new io.camunda.client.protocol.rest.ElementInstanceWaitStateResult();
+    item.setWaitStateType(WaitStateTypeEnum.JOB);
+    item.setProcessInstanceKey("200");
+    item.setRootProcessInstanceKey("100");
+    item.setElementInstanceKey("300");
+    item.setElementId("task-1");
+    item.setTenantId("<default>");
+    item.setJobDetails(jobDetails);
+
+    final ElementInstanceWaitStateQueryResult response = buildEmptyResponse();
+    response.addItemsItem(item);
+    gatewayService.onSearchElementInstanceWaitStatesRequest(response);
+
+    // when
+    final SearchResponse<io.camunda.client.api.search.response.ElementInstanceWaitStateResult>
+        result = client.newElementInstanceWaitStateSearchRequest().send().join();
+
+    // then
+    assertThat(result.items()).hasSize(1);
+    final io.camunda.client.api.search.response.ElementInstanceWaitStateResult mapped =
+        result.items().get(0);
+    assertThat(mapped.getWaitStateType()).isEqualTo(WaitStateType.JOB);
+    assertThat(mapped.getProcessInstanceKey()).isEqualTo("200");
+    assertThat(mapped.getRootProcessInstanceKey()).isEqualTo("100");
+    assertThat(mapped.getElementInstanceKey()).isEqualTo("300");
+    assertThat(mapped.getElementId()).isEqualTo("task-1");
+    assertThat(mapped.getTenantId()).isEqualTo("<default>");
+    assertThat(mapped.getDetails()).isInstanceOf(JobWaitStateDetails.class);
+    final JobWaitStateDetails details = (JobWaitStateDetails) mapped.getDetails();
+    assertThat(details.getWaitStateType()).isEqualTo(WaitStateType.JOB);
+    assertThat(details.getJobKey()).isEqualTo("999");
+    assertThat(details.getJobType()).isEqualTo("payment");
+    assertThat(details.getJobKind()).isEqualTo(JobKind.BPMN_ELEMENT);
+    assertThat(details.getListenerEventType()).isEqualTo(ListenerEventType.UNSPECIFIED);
+    assertThat(details.getRetries()).isEqualTo(3);
+  }
+
+  @Test
+  public void shouldMapMessageResponseFields() {
+    // given
+    final io.camunda.client.protocol.rest.MessageWaitStateDetails messageDetails =
+        new io.camunda.client.protocol.rest.MessageWaitStateDetails();
+    messageDetails.setMessageName("order-received");
+    messageDetails.setCorrelationKey("order-42");
+
+    final io.camunda.client.protocol.rest.ElementInstanceWaitStateResult item =
+        new io.camunda.client.protocol.rest.ElementInstanceWaitStateResult();
+    item.setWaitStateType(WaitStateTypeEnum.MESSAGE);
+    item.setProcessInstanceKey("200");
+    item.setElementInstanceKey("300");
+    item.setElementId("receive-1");
+    item.setTenantId("<default>");
+    item.setMessageDetails(messageDetails);
+
+    final ElementInstanceWaitStateQueryResult response = buildEmptyResponse();
+    response.addItemsItem(item);
+    gatewayService.onSearchElementInstanceWaitStatesRequest(response);
+
+    // when
+    final SearchResponse<io.camunda.client.api.search.response.ElementInstanceWaitStateResult>
+        result = client.newElementInstanceWaitStateSearchRequest().send().join();
+
+    // then
+    assertThat(result.items()).hasSize(1);
+    final io.camunda.client.api.search.response.ElementInstanceWaitStateResult mapped =
+        result.items().get(0);
+    assertThat(mapped.getWaitStateType()).isEqualTo(WaitStateType.MESSAGE);
+    assertThat(mapped.getDetails()).isInstanceOf(MessageWaitStateDetails.class);
+    final MessageWaitStateDetails details = (MessageWaitStateDetails) mapped.getDetails();
+    assertThat(details.getWaitStateType()).isEqualTo(WaitStateType.MESSAGE);
+    assertThat(details.getMessageName()).isEqualTo("order-received");
+    assertThat(details.getCorrelationKey()).isEqualTo("order-42");
+  }
+
+  private static ElementInstanceWaitStateQueryResult buildEmptyResponse() {
+    final ElementInstanceWaitStateQueryResult response = new ElementInstanceWaitStateQueryResult();
+    final SearchQueryPageResponse page = new SearchQueryPageResponse();
+    page.setTotalItems(0L);
+    response.setPage(page);
+    response.setItems(new ArrayList<>());
+    return response;
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
@@ -115,6 +115,8 @@ public class RestGatewayPaths {
   private static final String URL_VARIABLE = REST_API_PATH + "/variables/%s";
   private static final String URL_AUDIT_LOG_GET = REST_API_PATH + "/audit-logs/%s";
   private static final String URL_AUDIT_LOG_SEARCH = REST_API_PATH + "/audit-logs/search";
+  private static final String URL_ELEMENT_INSTANCE_WAIT_STATE_SEARCH =
+      REST_API_PATH + "/element-instances/wait-states/search";
   private static final String URL_PROCESS_DEFINITION_INSTANCE_STATISTICS =
       REST_API_PATH + "/process-definitions/statistics/process-instances";
   private static final String URL_PROCESS_DEFINITION_INSTANCE_VERSION_STATISTICS =
@@ -435,6 +437,10 @@ public class RestGatewayPaths {
 
   public static String getAuditLogSearchUrl() {
     return String.format(URL_AUDIT_LOG_SEARCH);
+  }
+
+  public static String getElementInstanceWaitStateSearchUrl() {
+    return URL_ELEMENT_INSTANCE_WAIT_STATE_SEARCH;
   }
 
   public static String getUserTaskAuditLogSearchUrl(final long userTaskKey) {

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
@@ -470,6 +470,11 @@ public class RestGatewayService {
     registerPost(RestGatewayPaths.getAuditLogSearchUrl(), response);
   }
 
+  public void onSearchElementInstanceWaitStatesRequest(
+      final io.camunda.client.protocol.rest.ElementInstanceWaitStateQueryResult response) {
+    registerPost(RestGatewayPaths.getElementInstanceWaitStateSearchUrl(), response);
+  }
+
   public void onSearchUserTaskAuditLogRequest(
       final long userTaskKey, final AuditLogSearchQueryResult response) {
     registerPost(RestGatewayPaths.getUserTaskAuditLogSearchUrl(userTaskKey), response);


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Adds a Java client search command for querying **element instance wait states**, backing the new `POST /element-instances/wait-states/search` endpoint. It lets users find element instances currently parked on a **job** or **message** wait state, with advanced filtering and typed results.

## Changes

- New command: `client.newElementInstanceWaitStateSearchRequest()` → `SearchResponse<ElementInstanceWaitStateResult>`.
- `ElementInstanceWaitStateFilter` with advanced operators (`$eq` / `$neq` / `$exists` / `$in`) on: `elementInstanceKey`, `processInstanceKey`, `rootProcessInstanceKey`, `elementId`, `elementType` (`WaitStateElementType`), `waitStateType` (`WaitStateType`).
- Typed `ElementInstanceWaitStateResult` exposing the base fields plus a typed `WaitStateDetails`, resolved by `waitStateType`:
  - `JobWaitStateDetails` — `jobKey`, `jobType`, `jobKind`, `retries`
  - `MessageWaitStateDetails` — `messageName`, `correlationKey`
- New client enums `WaitStateType` and `WaitStateElementType`.
- Pagination supported (no sort — the endpoint exposes none).
- OpenAPI spec additions in `element-instances.yaml` (endpoint, filters, result/detail schemas) that regenerate the client `protocol.rest` model.

## Example

```java
SearchResponse<ElementInstanceWaitStateResult> result =
    client.newElementInstanceWaitStateSearchRequest()
        .filter(f -> f.processInstanceKey(pik).waitStateType(WaitStateType.JOB))
        .page(p -> p.limit(50))
        .send()
        .join();

for (ElementInstanceWaitStateResult item : result.items()) {
  if (item.getDetails() instanceof JobWaitStateDetails job) {
    // job.getJobType(), job.getRetries(), ...
  }
}
```

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #54444
