### PR TITLE
feat: improve error handling for document preview

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentPreview/DocumentPreviewModal.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentPreview/DocumentPreviewModal.tsx
@@ -9,7 +9,8 @@
 import {Modal} from '@carbon/react';
 import type {StateProps} from 'modules/components/ModalStateManager';
 import type {DocumentInfo} from '../DocumentValueCell/parseDocumentVariable';
-import {PreviewImage, PreviewPdf} from './styled';
+import {PreviewImage} from './PreviewImage';
+import {PreviewPdf} from './styled';
 import {PreviewJson} from './PreviewJson';
 
 type DocumentPreviewProps = {
@@ -36,7 +37,7 @@ const DocumentPreviewModal: React.FC<StateProps & DocumentPreviewProps> = ({
 
 const ModalContent: React.FC<DocumentPreviewProps> = ({document}) => {
   if (document.type === 'image') {
-    return <PreviewImage src={document.link} alt={document.fileName} />;
+    return <PreviewImage src={document.link} fileName={document.fileName} />;
   }
 
   if (document.type === 'pdf') {

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentPreview/PreviewDocumentButton.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentPreview/PreviewDocumentButton.test.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {render, screen} from 'modules/testing-library';
+import {render, screen, fireEvent} from 'modules/testing-library';
 import {QueryClientProvider} from '@tanstack/react-query';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 import {mockDownloadDocument} from 'modules/mocks/api/v2/documents/downloadDocument';
@@ -165,7 +165,7 @@ describe('<PreviewDocumentButton />', () => {
 
     expect(
       await screen.findByText(
-        `Failed to prepare JSON preview for document "${jsonDocument.fileName}".`,
+        `Failed to load JSON preview for "${jsonDocument.fileName}".`,
       ),
     ).toBeInTheDocument();
     expect(screen.queryByTestId('monaco-editor')).not.toBeInTheDocument();
@@ -201,5 +201,27 @@ describe('<PreviewDocumentButton />', () => {
       contentType: 'image/png',
       size: 1024,
     });
+  });
+
+  it('should show an error notification when the image fails to load', async () => {
+    const {user} = render(
+      <PreviewDocumentButton document={imageDocument} variableName="myImage" />,
+    );
+
+    await user.click(
+      screen.getByLabelText('Preview document for variable myImage'),
+    );
+
+    const image = screen.getByRole('img', {name: 'photo.png'});
+    fireEvent.error(image);
+
+    expect(
+      await screen.findByText(
+        `Failed to load image preview for "${imageDocument.fileName}".`,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('img', {name: 'photo.png'}),
+    ).not.toBeInTheDocument();
   });
 });

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentPreview/PreviewImage.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentPreview/PreviewImage.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useState} from 'react';
+import {InlineNotification} from '@carbon/react';
+import {PreviewImg} from './styled';
+
+type Props = {
+  src: string;
+  fileName: string;
+};
+
+const PreviewImage: React.FC<Props> = ({src, fileName}) => {
+  const [hasError, setHasError] = useState(false);
+
+  if (hasError) {
+    return (
+      <InlineNotification
+        kind="error"
+        subtitle={`Failed to load image preview for "${fileName}".`}
+        hideCloseButton
+        lowContrast
+      />
+    );
+  }
+
+  return (
+    <PreviewImg src={src} alt={fileName} onError={() => setHasError(true)} />
+  );
+};
+
+export {PreviewImage};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentPreview/PreviewJson.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentPreview/PreviewJson.tsx
@@ -59,7 +59,7 @@ const PreviewJson: React.FC<PreviewJsonProps> = ({document}) => {
       {isError && (
         <InlineNotification
           kind="error"
-          subtitle={`Failed to prepare JSON preview for document "${document.fileName}".`}
+          subtitle={`Failed to load JSON preview for "${document.fileName}".`}
           hideCloseButton
           lowContrast
         />

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentPreview/styled.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentPreview/styled.tsx
@@ -8,7 +8,7 @@
 
 import styled from 'styled-components';
 
-const PreviewImage = styled.img`
+const PreviewImg = styled.img`
   display: block;
   max-width: 100%;
   max-height: 80vh;
@@ -27,4 +27,4 @@ const PreviewJSONContainer = styled.div`
   min-height: 80vh;
 `;
 
-export {PreviewImage, PreviewPdf, PreviewJSONContainer};
+export {PreviewImg, PreviewPdf, PreviewJSONContainer};


### PR DESCRIPTION

## Description

Add error handling for corrupted or inaccessible image previews in the process instance variables tab. When an image fails to load in the preview modal, the component now displays an inline error notification instead of showing a broken preview.

### Changes

- Extract `PreviewImage` wrapper component that manages load-error state
- Show an `InlineNotification` with a descriptive message when the image fails to load
- Hide the broken element when an error occurs
- Align error message format across all preview types (image, JSON)
- Add test coverage for the image error scenario

Note: PDF previews rely on the browser's native PDF viewer which handles its own error display, so no additional error handling is needed there.


## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #54478
