### PR TITLE
deps: add ES 8.17.4 and set as SaaS version for stable/8.8

### DIFF
--- a/.ci/db-versions.yml
+++ b/.ci/db-versions.yml
@@ -14,7 +14,8 @@
 
 elasticsearch:
   es8:
-    - &saas "8.16.4"
+    - "8.16.4"
+    - &saas "8.17.4"
     - "8.18.8"
   saas: *saas
 


### PR DESCRIPTION
Adds ES 8.17.4 to the tested versions list in `.ci/db-versions.yml` and sets it as the SaaS version for the `stable/8.8` branch.