### PR TITLE
build: ignore Revapi enum order change for IncidentFilter ErrorType

### DIFF
--- a/clients/java/revapi.json
+++ b/clients/java/revapi.json
@@ -520,6 +520,13 @@
           "code": "java.class.removed",
           "old": "class io.camunda.zeebe.client.protocol.rest.UserTaskVariableFilterRequest",
           "justification": "Backport changes from 8.7: the Search Tasks by Variables experimental API was removed and will be reintroduced under different API specifications."
+        },
+        {
+          "ignore": true,
+          "code": "java.field.enumConstantOrderChanged",
+          "regex": true,
+          "old": "field io\\.camunda\\.zeebe\\.client\\.protocol\\.rest\\.(IncidentFilter|IncidentFilterRequestBase|IncidentItemBase|IncidentResult)\\.ErrorTypeEnum\\.UNKNOWN_DEFAULT_OPEN_API",
+          "justification": "Generated OpenAPI enum: UNKNOWN_DEFAULT_OPEN_API is always appended last by the OpenAPI generator, so adding new ErrorType constants shifts its ordinal. This is backward-compatible for consumers, who should not rely on enum ordinal() values."
         }
       ]
     }


### PR DESCRIPTION
## What

Adds a `revapi.differences` ignore entry in `clients/java/revapi.json` for the `java.field.enumConstantOrderChanged` difference on the generated `ErrorTypeEnum` (`IncidentFilter`, `IncidentFilterRequestBase`, `IncidentItemBase`, `IncidentResult`).

## Why

The **Java checks** job on `release-8.7.30` fails in the `zeebe-client-java` Revapi check ([example run](https://github.com/camunda/camunda/actions/runs/26819979821/job/79094177383)) with:

> `java.field.enumConstantOrderChanged: field ...IncidentFilter.ErrorTypeEnum.UNKNOWN_DEFAULT_OPEN_API: The enum constant was defined on position 12 but is now on 14.`

The OpenAPI generator is configured with `enumUnknownDefaultCase=true` (`clients/java/pom.xml`), so the synthetic `UNKNOWN_DEFAULT_OPEN_API` constant is always appended **last** to each generated `ErrorTypeEnum`. New `ErrorType` values added since the `8.6.39` backwards-compatibility baseline pushed that constant's ordinal from 12 to 14, which Revapi flags as a breaking change.

This is backward-compatible for consumers (who must not rely on enum `ordinal()` values), so the difference is safe to ignore.

## Validation

Ran the Revapi check locally (`revapi-maven-plugin:check`, baseline `8.6.39`):
- Before: 4 x `enumConstantOrderChanged` failures.
- After: all 4 are gone.

## Notes

Targets `release-8.7.30` so that the back-merge PR #54461 re-runs green.
