### PR TITLE
Agent flag on process definition update

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/writer/ProcessDefinitionWriterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/writer/ProcessDefinitionWriterES.java
@@ -13,6 +13,7 @@ import static io.camunda.optimize.service.db.schema.index.DecisionDefinitionInde
 import static io.camunda.optimize.service.db.schema.index.DecisionDefinitionIndex.DECISION_DEFINITION_KEY;
 import static io.camunda.optimize.service.db.schema.index.DecisionDefinitionIndex.DECISION_DEFINITION_VERSION;
 import static io.camunda.optimize.service.db.schema.index.DecisionDefinitionIndex.TENANT_ID;
+import static io.camunda.optimize.service.db.schema.index.ProcessDefinitionIndex.PROCESS_DEFINITION_ID;
 import static io.camunda.optimize.service.db.schema.index.ProcessDefinitionIndex.PROCESS_DEFINITION_KEY;
 
 import co.elastic.clients.elasticsearch._types.FieldValue;
@@ -48,6 +49,13 @@ public class ProcessDefinitionWriterES extends AbstractProcessDefinitionWriterES
 
   private static final Script MARK_AS_ONBOARDED_SCRIPT =
       Script.of(s -> s.lang(ScriptLanguage.Painless).source("ctx._source.onboarded = true"));
+
+  private static final Script MARK_AS_AGENTIC_PROCESS_SCRIPT =
+      Script.of(
+          s ->
+              s.lang(ScriptLanguage.Painless)
+                  .source(
+                      "if (ctx._source.agenticProcess != true) { ctx._source.agenticProcess = true; }"));
   private static final Logger LOG =
       org.slf4j.LoggerFactory.getLogger(ProcessDefinitionWriterES.class);
 
@@ -166,6 +174,32 @@ public class ProcessDefinitionWriterES extends AbstractProcessDefinitionWriterES
                                                 tt ->
                                                     tt.value(
                                                         definitionKeys.stream()
+                                                            .map(FieldValue::of)
+                                                            .toList())))))),
+        PROCESS_DEFINITION_INDEX_NAME);
+  }
+
+  @Override
+  public void markDefinitionsAsAgenticProcesses(final Set<String> definitionIds) {
+    if (definitionIds == null || definitionIds.isEmpty()) {
+      return;
+    }
+    taskRepositoryES.tryUpdateByQueryRequest(
+        "process definitions agentic process flag",
+        MARK_AS_AGENTIC_PROCESS_SCRIPT,
+        Query.of(
+            q ->
+                q.bool(
+                    b ->
+                        b.must(
+                            m ->
+                                m.terms(
+                                    t ->
+                                        t.field(PROCESS_DEFINITION_ID)
+                                            .terms(
+                                                tt ->
+                                                    tt.value(
+                                                        definitionIds.stream()
                                                             .map(FieldValue::of)
                                                             .toList())))))),
         PROCESS_DEFINITION_INDEX_NAME);

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/writer/ProcessDefinitionWriterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/writer/ProcessDefinitionWriterOS.java
@@ -46,6 +46,11 @@ public class ProcessDefinitionWriterOS extends AbstractProcessDefinitionWriterOS
   private static final Script MARK_AS_ONBOARDED_SCRIPT =
       OpenSearchWriterUtil.createDefaultScriptWithPrimitiveParams(
           "ctx._source.onboarded = true", Collections.emptyMap());
+
+  private static final Script MARK_AS_AGENTIC_PROCESS_SCRIPT =
+      OpenSearchWriterUtil.createDefaultScriptWithPrimitiveParams(
+          "if (ctx._source.agenticProcess != true) { ctx._source.agenticProcess = true; }",
+          Collections.emptyMap());
   private static final Logger LOG =
       org.slf4j.LoggerFactory.getLogger(ProcessDefinitionWriterOS.class);
 
@@ -137,6 +142,20 @@ public class ProcessDefinitionWriterOS extends AbstractProcessDefinitionWriterOS
             .build()
             .toQuery(),
         MARK_AS_ONBOARDED_SCRIPT);
+  }
+
+  @Override
+  public void markDefinitionsAsAgenticProcesses(final Set<String> definitionIds) {
+    if (definitionIds == null || definitionIds.isEmpty()) {
+      return;
+    }
+    osClient.updateByQuery(
+        PROCESS_DEFINITION_INDEX_NAME,
+        new BoolQuery.Builder()
+            .must(QueryDSL.terms(PROCESS_DEFINITION_ID, definitionIds, FieldValue::of))
+            .build()
+            .toQuery(),
+        MARK_AS_AGENTIC_PROCESS_SCRIPT);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/writer/ProcessDefinitionWriter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/writer/ProcessDefinitionWriter.java
@@ -37,4 +37,6 @@ public interface ProcessDefinitionWriter {
       final List<ProcessDefinitionOptimizeDto> importedDefinitions);
 
   void markDefinitionKeysAsOnboarded(final Set<String> definitionKeys);
+
+  void markDefinitionsAsAgenticProcesses(final Set<String> definitionIds);
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/importing/engine/service/zeebe/ZeebeAgentInstanceImportService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/importing/engine/service/zeebe/ZeebeAgentInstanceImportService.java
@@ -15,7 +15,11 @@ import io.camunda.optimize.dto.zeebe.agentinstance.ZeebeAgentInstanceDataDto;
 import io.camunda.optimize.dto.zeebe.agentinstance.ZeebeAgentInstanceRecordDto;
 import io.camunda.optimize.service.db.DatabaseClient;
 import io.camunda.optimize.service.db.reader.ProcessDefinitionReader;
+import io.camunda.optimize.service.db.writer.ProcessDefinitionWriter;
 import io.camunda.optimize.service.db.writer.ProcessInstanceWriter;
+import io.camunda.optimize.service.importing.job.AgentInstanceDatabaseImportJob;
+import io.camunda.optimize.service.importing.job.AgenticProcessFlagCache;
+import io.camunda.optimize.service.importing.job.ProcessInstanceDatabaseImportJob;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.AgentInstanceStatus;
@@ -38,12 +42,17 @@ public class ZeebeAgentInstanceImportService
   private static final Logger LOG =
       org.slf4j.LoggerFactory.getLogger(ZeebeAgentInstanceImportService.class);
 
+  private final ProcessDefinitionWriter processDefinitionWriter;
+  private final AgenticProcessFlagCache agenticProcessFlagCache;
+
   public ZeebeAgentInstanceImportService(
       final ConfigurationService configurationService,
       final ProcessInstanceWriter processInstanceWriter,
       final int partitionId,
       final ProcessDefinitionReader processDefinitionReader,
-      final DatabaseClient databaseClient) {
+      final DatabaseClient databaseClient,
+      final ProcessDefinitionWriter processDefinitionWriter,
+      final AgenticProcessFlagCache agenticProcessFlagCache) {
     super(
         configurationService,
         processInstanceWriter,
@@ -51,6 +60,24 @@ public class ZeebeAgentInstanceImportService
         processDefinitionReader,
         databaseClient,
         ZEEBE_AGENT_INSTANCE_INDEX_NAME);
+    this.processDefinitionWriter = processDefinitionWriter;
+    this.agenticProcessFlagCache = agenticProcessFlagCache;
+  }
+
+  @Override
+  protected ProcessInstanceDatabaseImportJob newImportJob(
+      final Runnable importCompleteCallback,
+      final ProcessInstanceWriter processInstanceWriter,
+      final String sourceExportIndex,
+      final DatabaseClient databaseClient) {
+    return new AgentInstanceDatabaseImportJob(
+        processInstanceWriter,
+        configurationService,
+        importCompleteCallback,
+        sourceExportIndex,
+        databaseClient,
+        processDefinitionWriter,
+        agenticProcessFlagCache);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/importing/engine/service/zeebe/ZeebeProcessInstanceSubEntityImportService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/importing/engine/service/zeebe/ZeebeProcessInstanceSubEntityImportService.java
@@ -21,12 +21,9 @@ import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.util.List;
-import org.slf4j.Logger;
 
 public abstract class ZeebeProcessInstanceSubEntityImportService<T> implements ImportService<T> {
 
-  private static final Logger LOG =
-      org.slf4j.LoggerFactory.getLogger(ZeebeProcessInstanceSubEntityImportService.class);
   protected final DatabaseImportJobExecutor databaseImportJobExecutor;
   protected final ConfigurationService configurationService;
   protected final ProcessDefinitionReader processDefinitionReader;
@@ -109,17 +106,31 @@ public abstract class ZeebeProcessInstanceSubEntityImportService<T> implements I
     databaseImportJobExecutor.executeImportJob(databaseImportJob);
   }
 
-  private DatabaseImportJob<ProcessInstanceDto> createDatabaseImportJob(
+  protected final DatabaseImportJob<ProcessInstanceDto> createDatabaseImportJob(
       final List<ProcessInstanceDto> processInstanceDtos, final Runnable importCompleteCallback) {
-    final ProcessInstanceDatabaseImportJob processInstanceImportJob =
-        new ProcessInstanceDatabaseImportJob(
-            processInstanceWriter,
-            configurationService,
-            importCompleteCallback,
-            sourceExportIndex,
-            databaseClient);
-    processInstanceImportJob.setEntitiesToImport(processInstanceDtos);
-    return processInstanceImportJob;
+    final ProcessInstanceDatabaseImportJob job =
+        newImportJob(
+            importCompleteCallback, processInstanceWriter, sourceExportIndex, databaseClient);
+    job.setEntitiesToImport(processInstanceDtos);
+    return job;
+  }
+
+  /**
+   * Hook for subclasses to substitute a custom {@link ProcessInstanceDatabaseImportJob}. The parent
+   * passes its own collaborators in as arguments so subclasses do not need direct access to the
+   * private fields.
+   */
+  protected ProcessInstanceDatabaseImportJob newImportJob(
+      final Runnable importCompleteCallback,
+      final ProcessInstanceWriter processInstanceWriter,
+      final String sourceExportIndex,
+      final DatabaseClient databaseClient) {
+    return new ProcessInstanceDatabaseImportJob(
+        processInstanceWriter,
+        configurationService,
+        importCompleteCallback,
+        sourceExportIndex,
+        databaseClient);
   }
 
   /**

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/importing/job/AgentInstanceDatabaseImportJob.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/importing/job/AgentInstanceDatabaseImportJob.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.importing.job;
+
+import io.camunda.optimize.dto.optimize.ProcessInstanceDto;
+import io.camunda.optimize.service.db.DatabaseClient;
+import io.camunda.optimize.service.db.writer.ProcessDefinitionWriter;
+import io.camunda.optimize.service.db.writer.ProcessInstanceWriter;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+
+/**
+ * Process instance import job that, after persisting agent-bearing instances, denormalizes the
+ * agentic-process flag onto the affected process definitions. The {@link AgenticProcessFlagCache}
+ * is JVM-wide to reduce redundant flips across partitions; under concurrency, duplicate flip
+ * attempts are still possible but safe due to the idempotent update script.
+ */
+public class AgentInstanceDatabaseImportJob extends ProcessInstanceDatabaseImportJob {
+
+  private static final Logger LOG =
+      org.slf4j.LoggerFactory.getLogger(AgentInstanceDatabaseImportJob.class);
+
+  private final ProcessDefinitionWriter processDefinitionWriter;
+  private final AgenticProcessFlagCache agenticProcessFlagCache;
+
+  public AgentInstanceDatabaseImportJob(
+      final ProcessInstanceWriter zeebeProcessInstanceWriter,
+      final ConfigurationService configurationService,
+      final Runnable importCompleteCallback,
+      final String sourceExportIndex,
+      final DatabaseClient databaseClient,
+      final ProcessDefinitionWriter processDefinitionWriter,
+      final AgenticProcessFlagCache agenticProcessFlagCache) {
+    super(
+        zeebeProcessInstanceWriter,
+        configurationService,
+        importCompleteCallback,
+        sourceExportIndex,
+        databaseClient);
+    this.processDefinitionWriter = processDefinitionWriter;
+    this.agenticProcessFlagCache = agenticProcessFlagCache;
+  }
+
+  @Override
+  protected void persistEntities(final List<ProcessInstanceDto> processInstances) {
+    super.persistEntities(processInstances);
+    flipAgenticProcessFlagIfNeeded(processInstances);
+  }
+
+  /** Post-persist hook; package-private for unit testing. */
+  void flipAgenticProcessFlagIfNeeded(final List<ProcessInstanceDto> processInstances) {
+    final Set<String> idsToFlip =
+        agenticProcessFlagCache.filterUnflipped(
+            processInstances.stream()
+                .map(ProcessInstanceDto::getProcessDefinitionId)
+                .collect(Collectors.toSet()));
+    if (idsToFlip.isEmpty()) {
+      return;
+    }
+    try {
+      processDefinitionWriter.markDefinitionsAsAgenticProcesses(idsToFlip);
+      agenticProcessFlagCache.markFlipped(idsToFlip);
+    } catch (final RuntimeException e) {
+      LOG.warn(
+          "Failed to flip agenticProcess flag for definition ids {}; will retry on next batch",
+          idsToFlip,
+          e);
+    }
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/importing/job/AgenticProcessFlagCache.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/importing/job/AgenticProcessFlagCache.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.importing.job;
+
+import java.util.Collection;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+
+/**
+ * JVM-wide cache of process definition IDs already marked as agenticProcess=true. The flag is
+ * per-version (one ES doc per {@code processDefinitionId}), so the cache is keyed by the unique
+ * definition ID, not the non-unique BPMN key. Shared across all agent instance import partitions to
+ * reduce redundant per-batch flag flips across partitions. Under concurrency, a flip attempt may be
+ * issued more than once, but the underlying ES/OS update script is idempotent and the flag is
+ * monotonic (forward-only), so this remains safe regardless of which partition flips first.
+ *
+ * <p><b>Memory:</b> O(distinct agentic definition IDs imported since JVM start). The cache is
+ * forward-only and never evicts; bounded in practice by the total number of agentic definition
+ * versions deployed against the cluster (typically tens to low thousands). Cleared on JVM restart.
+ */
+@Component
+public final class AgenticProcessFlagCache {
+
+  private final Set<String> flippedIds = ConcurrentHashMap.newKeySet();
+
+  /**
+   * Returns the subset of the given IDs that have not yet been flipped this JVM lifetime. Null or
+   * empty input returns an empty set; null elements in the input are silently dropped.
+   */
+  public Set<String> filterUnflipped(final Collection<String> definitionIds) {
+    if (definitionIds == null || definitionIds.isEmpty()) {
+      return Set.of();
+    }
+    return definitionIds.stream()
+        .filter(Objects::nonNull)
+        .filter(id -> !flippedIds.contains(id))
+        .collect(Collectors.toSet());
+  }
+
+  /**
+   * Records the given IDs as flipped. Idempotent; safe to call with overlapping sets. Null or empty
+   * input is a no-op; null elements in the input are silently dropped (the backing {@link
+   * ConcurrentHashMap#newKeySet()} rejects nulls).
+   */
+  public void markFlipped(final Collection<String> definitionIds) {
+    if (definitionIds == null || definitionIds.isEmpty()) {
+      return;
+    }
+    definitionIds.stream().filter(Objects::nonNull).forEach(flippedIds::add);
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/importing/zeebe/mediator/factory/ZeebeAgentInstanceImportMediatorFactory.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/importing/zeebe/mediator/factory/ZeebeAgentInstanceImportMediatorFactory.java
@@ -11,10 +11,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.optimize.dto.optimize.datasource.ZeebeDataSourceDto;
 import io.camunda.optimize.service.db.DatabaseClient;
 import io.camunda.optimize.service.db.reader.ProcessDefinitionReader;
+import io.camunda.optimize.service.db.writer.ProcessDefinitionWriter;
 import io.camunda.optimize.service.db.writer.ProcessInstanceWriter;
 import io.camunda.optimize.service.importing.ImportIndexHandlerRegistry;
 import io.camunda.optimize.service.importing.ImportMediator;
 import io.camunda.optimize.service.importing.engine.service.zeebe.ZeebeAgentInstanceImportService;
+import io.camunda.optimize.service.importing.job.AgenticProcessFlagCache;
 import io.camunda.optimize.service.importing.zeebe.db.ZeebeAgentInstanceFetcher;
 import io.camunda.optimize.service.importing.zeebe.mediator.ZeebeAgentInstanceImportMediator;
 import io.camunda.optimize.service.util.BackoffCalculator;
@@ -29,6 +31,8 @@ public class ZeebeAgentInstanceImportMediatorFactory extends AbstractZeebeImport
 
   private final ProcessInstanceWriter zeebeProcessInstanceWriter;
   private final ProcessDefinitionReader processDefinitionReader;
+  private final ProcessDefinitionWriter processDefinitionWriter;
+  private final AgenticProcessFlagCache agenticProcessFlagCache;
 
   public ZeebeAgentInstanceImportMediatorFactory(
       final BeanFactory beanFactory,
@@ -36,6 +40,8 @@ public class ZeebeAgentInstanceImportMediatorFactory extends AbstractZeebeImport
       final ConfigurationService configurationService,
       final ProcessInstanceWriter zeebeProcessInstanceWriter,
       final ProcessDefinitionReader processDefinitionReader,
+      final ProcessDefinitionWriter processDefinitionWriter,
+      final AgenticProcessFlagCache agenticProcessFlagCache,
       final ObjectMapper objectMapper,
       final DatabaseClient databaseClient) {
     super(
@@ -46,6 +52,8 @@ public class ZeebeAgentInstanceImportMediatorFactory extends AbstractZeebeImport
         databaseClient);
     this.zeebeProcessInstanceWriter = zeebeProcessInstanceWriter;
     this.processDefinitionReader = processDefinitionReader;
+    this.processDefinitionWriter = processDefinitionWriter;
+    this.agenticProcessFlagCache = agenticProcessFlagCache;
   }
 
   @Override
@@ -65,7 +73,9 @@ public class ZeebeAgentInstanceImportMediatorFactory extends AbstractZeebeImport
                 zeebeProcessInstanceWriter,
                 zeebeDataSourceDto.getPartitionId(),
                 processDefinitionReader,
-                databaseClient),
+                databaseClient,
+                processDefinitionWriter,
+                agenticProcessFlagCache),
             configurationService,
             new BackoffCalculator(configurationService)));
   }

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/importing/engine/service/zeebe/ZeebeAgentInstanceImportServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/importing/engine/service/zeebe/ZeebeAgentInstanceImportServiceTest.java
@@ -21,7 +21,9 @@ import io.camunda.optimize.dto.zeebe.agentinstance.ZeebeAgentInstanceDataDto.Age
 import io.camunda.optimize.dto.zeebe.agentinstance.ZeebeAgentInstanceRecordDto;
 import io.camunda.optimize.service.db.DatabaseClient;
 import io.camunda.optimize.service.db.reader.ProcessDefinitionReader;
+import io.camunda.optimize.service.db.writer.ProcessDefinitionWriter;
 import io.camunda.optimize.service.db.writer.ProcessInstanceWriter;
+import io.camunda.optimize.service.importing.job.AgenticProcessFlagCache;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.AgentInstanceStatus;
@@ -45,6 +47,8 @@ class ZeebeAgentInstanceImportServiceTest {
   @Mock private ProcessInstanceWriter processInstanceWriter;
   @Mock private ProcessDefinitionReader processDefinitionReader;
   @Mock private DatabaseClient databaseClient;
+  @Mock private ProcessDefinitionWriter processDefinitionWriter;
+  @Mock private AgenticProcessFlagCache agenticProcessFlagCache;
 
   private ZeebeAgentInstanceImportService underTest;
 
@@ -58,7 +62,9 @@ class ZeebeAgentInstanceImportServiceTest {
             processInstanceWriter,
             1,
             processDefinitionReader,
-            databaseClient);
+            databaseClient,
+            processDefinitionWriter,
+            agenticProcessFlagCache);
   }
 
   @Test

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/importing/job/AgentInstanceDatabaseImportJobTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/importing/job/AgentInstanceDatabaseImportJobTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.importing.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import io.camunda.optimize.dto.optimize.ProcessInstanceDto;
+import io.camunda.optimize.service.db.DatabaseClient;
+import io.camunda.optimize.service.db.writer.ProcessDefinitionWriter;
+import io.camunda.optimize.service.db.writer.ProcessInstanceWriter;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AgentInstanceDatabaseImportJobTest {
+
+  @Mock private ProcessInstanceWriter processInstanceWriter;
+  @Mock private ConfigurationService configurationService;
+  @Mock private DatabaseClient databaseClient;
+  @Mock private ProcessDefinitionWriter processDefinitionWriter;
+
+  // Use a real cache instance (not a mock) so behavior matches production exactly.
+  private AgenticProcessFlagCache agenticProcessFlagCache;
+  private AgentInstanceDatabaseImportJob job;
+
+  @BeforeEach
+  void setUp() {
+    agenticProcessFlagCache = new AgenticProcessFlagCache();
+    job =
+        new AgentInstanceDatabaseImportJob(
+            processInstanceWriter,
+            configurationService,
+            () -> {},
+            "agent-instance",
+            databaseClient,
+            processDefinitionWriter,
+            agenticProcessFlagCache);
+  }
+
+  @Test
+  void shouldFlipFlagForNewDefinitionIds() {
+    // given
+    final List<ProcessInstanceDto> instances = List.of(instance("def-1"), instance("def-2"));
+
+    // when
+    job.flipAgenticProcessFlagIfNeeded(instances);
+
+    // then
+    verify(processDefinitionWriter)
+        .markDefinitionsAsAgenticProcesses(java.util.Set.of("def-1", "def-2"));
+    assertThat(agenticProcessFlagCache.filterUnflipped(List.of("def-1", "def-2"))).isEmpty();
+  }
+
+  @Test
+  void shouldOnlyFlipIdsNotYetInCache() {
+    // given
+    agenticProcessFlagCache.markFlipped(List.of("def-1"));
+    final List<ProcessInstanceDto> instances = List.of(instance("def-1"), instance("def-2"));
+
+    // when
+    job.flipAgenticProcessFlagIfNeeded(instances);
+
+    // then — only the new id is flipped
+    verify(processDefinitionWriter).markDefinitionsAsAgenticProcesses(java.util.Set.of("def-2"));
+    assertThat(agenticProcessFlagCache.filterUnflipped(List.of("def-1", "def-2"))).isEmpty();
+  }
+
+  @Test
+  void shouldNotCallWriterWhenAllIdsAlreadyFlipped() {
+    // given
+    agenticProcessFlagCache.markFlipped(List.of("def-1", "def-2"));
+    final List<ProcessInstanceDto> instances = List.of(instance("def-1"), instance("def-2"));
+
+    // when
+    job.flipAgenticProcessFlagIfNeeded(instances);
+
+    // then
+    verifyNoInteractions(processDefinitionWriter);
+  }
+
+  @Test
+  void shouldNotPersistFlipWhenWriterFails() {
+    // given
+    doThrow(new RuntimeException("ES down"))
+        .when(processDefinitionWriter)
+        .markDefinitionsAsAgenticProcesses(anySet());
+
+    // when — no exception bubbles up
+    job.flipAgenticProcessFlagIfNeeded(List.of(instance("def-1")));
+
+    // then — cache stays empty so the next batch retries
+    assertThat(agenticProcessFlagCache.filterUnflipped(List.of("def-1"))).containsExactly("def-1");
+  }
+
+  @Test
+  void shouldSkipFlipWhenDefinitionIdIsNull() {
+    // given
+    final ProcessInstanceDto withoutId = new ProcessInstanceDto();
+    withoutId.setProcessDefinitionId(null);
+
+    // when
+    job.flipAgenticProcessFlagIfNeeded(List.of(withoutId));
+
+    // then
+    verify(processDefinitionWriter, never()).markDefinitionsAsAgenticProcesses(any());
+  }
+
+  @Test
+  void shouldFlipDistinctIdsForDifferentVersionsOfSameKey() {
+    // given — two versions of the same BPMN key produce two distinct definition IDs
+    final ProcessInstanceDto v1 = new ProcessInstanceDto();
+    v1.setProcessDefinitionKey("invoice-process");
+    v1.setProcessDefinitionId("invoice-process:1");
+    final ProcessInstanceDto v2 = new ProcessInstanceDto();
+    v2.setProcessDefinitionKey("invoice-process");
+    v2.setProcessDefinitionId("invoice-process:2");
+
+    // when
+    job.flipAgenticProcessFlagIfNeeded(List.of(v1, v2));
+
+    // then — both versions get flipped independently
+    verify(processDefinitionWriter)
+        .markDefinitionsAsAgenticProcesses(
+            java.util.Set.of("invoice-process:1", "invoice-process:2"));
+  }
+
+  @Test
+  void shouldNotCallWriterWhenInputIsEmpty() {
+    // when
+    job.flipAgenticProcessFlagIfNeeded(List.of());
+
+    // then
+    verifyNoInteractions(processDefinitionWriter);
+  }
+
+  private ProcessInstanceDto instance(final String definitionId) {
+    final ProcessInstanceDto dto = new ProcessInstanceDto();
+    dto.setProcessDefinitionId(definitionId);
+    return dto;
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/importing/job/AgenticProcessFlagCacheTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/importing/job/AgenticProcessFlagCacheTest.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.importing.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AgenticProcessFlagCacheTest {
+
+  private AgenticProcessFlagCache cache;
+
+  @BeforeEach
+  void setUp() {
+    cache = new AgenticProcessFlagCache();
+  }
+
+  @Test
+  void shouldReturnAllInputWhenCacheIsEmpty() {
+    // when
+    final Set<String> unflipped = cache.filterUnflipped(List.of("a", "b", "c"));
+
+    // then
+    assertThat(unflipped).containsExactlyInAnyOrder("a", "b", "c");
+  }
+
+  @Test
+  void shouldFilterOutAlreadyFlippedIds() {
+    // given
+    cache.markFlipped(List.of("a", "b"));
+
+    // when
+    final Set<String> unflipped = cache.filterUnflipped(List.of("a", "b", "c", "d"));
+
+    // then — only c and d remain
+    assertThat(unflipped).containsExactlyInAnyOrder("c", "d");
+  }
+
+  @Test
+  void shouldReturnEmptyWhenAllInputIdsAreFlipped() {
+    // given
+    cache.markFlipped(List.of("a", "b"));
+
+    // when
+    final Set<String> unflipped = cache.filterUnflipped(List.of("a", "b"));
+
+    // then
+    assertThat(unflipped).isEmpty();
+  }
+
+  @Test
+  void shouldReturnEmptyForEmptyInput() {
+    // when
+    final Set<String> unflipped = cache.filterUnflipped(List.of());
+
+    // then
+    assertThat(unflipped).isEmpty();
+  }
+
+  @Test
+  void shouldReturnEmptyForNullInputToFilterUnflipped() {
+    // when
+    final Set<String> unflipped = cache.filterUnflipped(null);
+
+    // then — no NPE; safe-empty contract
+    assertThat(unflipped).isEmpty();
+  }
+
+  @Test
+  void shouldBeNoOpForNullInputToMarkFlipped() {
+    // when — no NPE
+    cache.markFlipped(null);
+
+    // then — cache stays empty
+    assertThat(cache.filterUnflipped(List.of("a"))).containsExactly("a");
+  }
+
+  @Test
+  void shouldBeNoOpForEmptyInputToMarkFlipped() {
+    // when
+    cache.markFlipped(List.of());
+
+    // then
+    assertThat(cache.filterUnflipped(List.of("a"))).containsExactly("a");
+  }
+
+  @Test
+  void shouldStripNullElementsFromMarkFlipped() {
+    // when — null element in the collection must not NPE the underlying ConcurrentHashMap
+    cache.markFlipped(Arrays.asList("a", null, "b"));
+
+    // then — non-null ids recorded, nulls silently dropped
+    assertThat(cache.filterUnflipped(List.of("a", "b", "c"))).containsExactly("c");
+  }
+
+  @Test
+  void shouldStripNullIdsFromInput() {
+    // when
+    final Set<String> unflipped = cache.filterUnflipped(Arrays.asList("a", null, "b", null));
+
+    // then — nulls dropped, real ids kept
+    assertThat(unflipped).containsExactlyInAnyOrder("a", "b");
+  }
+
+  @Test
+  void shouldDeduplicateInputViaReturnedSet() {
+    // when — same id appears twice in input
+    final Set<String> unflipped = cache.filterUnflipped(List.of("a", "a", "b", "b"));
+
+    // then — Set return type collapses duplicates
+    assertThat(unflipped).containsExactlyInAnyOrder("a", "b");
+  }
+
+  @Test
+  void shouldBeIdempotentWhenMarkingSameIdTwice() {
+    // given
+    cache.markFlipped(List.of("a"));
+    cache.markFlipped(List.of("a"));
+
+    // when
+    final Set<String> unflipped = cache.filterUnflipped(List.of("a"));
+
+    // then
+    assertThat(unflipped).isEmpty();
+  }
+
+  @Test
+  void shouldAcceptOverlappingMarkFlippedCalls() {
+    // given
+    cache.markFlipped(List.of("a", "b"));
+    cache.markFlipped(List.of("b", "c"));
+
+    // when
+    final Set<String> unflipped = cache.filterUnflipped(List.of("a", "b", "c", "d"));
+
+    // then
+    assertThat(unflipped).containsExactly("d");
+  }
+
+  @Test
+  void shouldBeThreadSafeUnderConcurrentMarkFlipped() throws Exception {
+    // given — many concurrent writers marking overlapping id ranges
+    final int threads = 16;
+    final int idsPerThread = 250;
+    final ExecutorService pool = Executors.newFixedThreadPool(threads);
+
+    // when
+    try {
+      IntStream.range(0, threads)
+          .forEach(
+              t ->
+                  pool.submit(
+                      () -> {
+                        final int base = (t * idsPerThread) / 2; // overlap between threads
+                        final List<String> ids =
+                            IntStream.range(base, base + idsPerThread)
+                                .mapToObj(i -> "id-" + i)
+                                .toList();
+                        cache.markFlipped(ids);
+                      }));
+    } finally {
+      pool.shutdown();
+      assertThat(pool.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+    }
+
+    // then — all unique ids present, no exception thrown
+    final int expectedUniqueCount = (threads * idsPerThread) / 2 + idsPerThread / 2;
+    final Set<String> probe =
+        cache.filterUnflipped(
+            IntStream.range(0, expectedUniqueCount).mapToObj(i -> "id-" + i).toList());
+    assertThat(probe).as("All marked ids should have been recorded").isEmpty();
+  }
+}

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/ProcessDefinitionOptimizeDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/ProcessDefinitionOptimizeDto.java
@@ -23,6 +23,7 @@ public class ProcessDefinitionOptimizeDto extends DefinitionOptimizeResponseDto 
   private List<FlowNodeDataDto> flowNodeData = new ArrayList<>();
   private Map<String, String> userTaskNames = new HashMap<>();
   private boolean onboarded = false;
+  private boolean agenticProcess = false;
 
   public ProcessDefinitionOptimizeDto() {
     setType(DefinitionType.PROCESS);
@@ -126,6 +127,14 @@ public class ProcessDefinitionOptimizeDto extends DefinitionOptimizeResponseDto 
     this.onboarded = onboarded;
   }
 
+  public boolean isAgenticProcess() {
+    return agenticProcess;
+  }
+
+  public void setAgenticProcess(final boolean agenticProcess) {
+    this.agenticProcess = agenticProcess;
+  }
+
   @Override
   protected boolean canEqual(final Object other) {
     return other instanceof ProcessDefinitionOptimizeDto;
@@ -133,7 +142,8 @@ public class ProcessDefinitionOptimizeDto extends DefinitionOptimizeResponseDto 
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), bpmn20Xml, flowNodeData, userTaskNames, onboarded);
+    return Objects.hash(
+        super.hashCode(), bpmn20Xml, flowNodeData, userTaskNames, onboarded, agenticProcess);
   }
 
   @Override
@@ -149,6 +159,7 @@ public class ProcessDefinitionOptimizeDto extends DefinitionOptimizeResponseDto 
     }
     final ProcessDefinitionOptimizeDto that = (ProcessDefinitionOptimizeDto) o;
     return onboarded == that.onboarded
+        && agenticProcess == that.agenticProcess
         && Objects.equals(bpmn20Xml, that.bpmn20Xml)
         && Objects.equals(flowNodeData, that.flowNodeData)
         && Objects.equals(userTaskNames, that.userTaskNames);
@@ -164,6 +175,8 @@ public class ProcessDefinitionOptimizeDto extends DefinitionOptimizeResponseDto 
         + getUserTaskNames()
         + ", onboarded="
         + isOnboarded()
+        + ", agenticProcess="
+        + isAgenticProcess()
         + ")";
   }
 
@@ -178,6 +191,7 @@ public class ProcessDefinitionOptimizeDto extends DefinitionOptimizeResponseDto 
     public static final String flowNodeData = "flowNodeData";
     public static final String userTaskNames = "userTaskNames";
     public static final String onboarded = "onboarded";
+    public static final String agenticProcess = "agenticProcess";
     public static final String eventBased = "eventBased";
   }
 

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/ProcessDefinitionIndex.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/ProcessDefinitionIndex.java
@@ -13,7 +13,7 @@ import io.camunda.optimize.service.db.DatabaseConstants;
 
 public abstract class ProcessDefinitionIndex<TBuilder> extends AbstractDefinitionIndex<TBuilder> {
 
-  public static final int VERSION = 6;
+  public static final int VERSION = 7;
 
   public static final String PROCESS_DEFINITION_ID = DEFINITION_ID;
   public static final String PROCESS_DEFINITION_KEY = DEFINITION_KEY;
@@ -25,6 +25,8 @@ public abstract class ProcessDefinitionIndex<TBuilder> extends AbstractDefinitio
   public static final String USER_TASK_NAMES = ProcessDefinitionOptimizeDto.Fields.userTaskNames;
   public static final String TENANT_ID = DEFINITION_TENANT_ID;
   public static final String ONBOARDED = ProcessDefinitionOptimizeDto.Fields.onboarded;
+  public static final String IS_AGENTIC_PROCESS =
+      ProcessDefinitionOptimizeDto.Fields.agenticProcess;
 
   @Override
   public String getIndexName() {
@@ -44,6 +46,7 @@ public abstract class ProcessDefinitionIndex<TBuilder> extends AbstractDefinitio
         .properties(USER_TASK_NAMES, p -> p.object(o -> o.enabled(false)))
         .properties(
             PROCESS_DEFINITION_XML, p -> p.text(o -> o.index(true).analyzer("is_present_analyzer")))
-        .properties(ONBOARDED, p -> p.boolean_(b -> b));
+        .properties(ONBOARDED, p -> p.boolean_(b -> b))
+        .properties(IS_AGENTIC_PROCESS, p -> p.boolean_(b -> b));
   }
 }


### PR DESCRIPTION
## Description

  - Denormalizes `isAgenticProcess` onto process definition documents in `ProcessDefinitionIndex` (per version, keyed on the unique `processDefinitionId`) so the agentic-process dropdown can be served by a single `term(isAgenticProcess=true)` query on the definition index instead of aggregating millions of process instance docs.
  - Adds `ProcessDefinitionWriter.markDefinitionsAsAgenticProcesses` (ES + OS), mirroring the `markDefinitionKeysAsOnboarded` pattern. The painless script is idempotency-guarded (`if (ctx._source.agenticProcess != true) ...`) so concurrent or repeat calls across nodes are no-ops at the ES/OS level.
  - Wires the flag flip into the agent instance import pipeline via a new `AgentInstanceDatabaseImportJob` that flips post-`persistEntities` — a bulk failure never leaves a falsely-flipped flag. Per-batch writes are deduplicated through `AgenticProcessFlagCache`, a JVM-wide `@Component`, so each definition version is flipped at most once per JVM lifetime regardless of partition count.
  - Refactors `ZeebeProcessInstanceSubEntityImportService` to expose a `protected newImportJob(...)` template hook; `createDatabaseImportJob` is now `final`. Subclasses receive parent collaborators as method args and never reach into parent state.

  Performance: in steady state the flip is a no-op (cache hit), zero extra ES round trips. Cold cost ~50–200ms `update_by_query` per new agentic definition per JVM lifetime — O(distinct definition versions) total writes regardless of partition count.

## Related issues

closes https://github.com/camunda/camunda/issues/54481
