### PR TITLE
test: valid schema change for Spectral linter verification

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/system.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/system.yaml
@@ -162,6 +162,7 @@ components:
         - processInstances
         - decisionInstances
         - assignees
+        - taskCompletions
       type: object
       properties:
         processInstances:
@@ -176,6 +177,13 @@ components:
           description: The amount of unique active task users.
           type: integer
           format: int64
+        taskCompletions:
+          description: The amount of completed user tasks.
+          type: integer
+          format: int64
+      x-properties-added-in-version:
+        - propertyName: "taskCompletions"
+          addedInVersion: "8.10"
 
     SystemConfigurationResponse:
       description: |


### PR DESCRIPTION
**Test PR — do not merge.**

Adds a valid schema property (`taskCompletions`) to `UsageMetricsResponseItem` to verify that the Spectral linter passes on well-formed schema changes after merging #54164.

This PR should **pass** the OpenAPI linter CI step.