### PR TITLE
test: invalid schema change for Spectral linter verification

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/system.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/system.yaml
@@ -176,6 +176,9 @@ components:
           description: The amount of unique active task users.
           type: integer
           format: int64
+        taskCompletions:
+          type: integer
+          format: int64
 
     SystemConfigurationResponse:
       description: |


### PR DESCRIPTION
**Test PR — do not merge.**

Adds a media example with a type mismatch (`processInstances: "not-a-number"` instead of an integer) to the usage metrics response.

**Before #54164 merges:** `oas3-valid-media-example` is at default severity (`warn`), so this produces a warning that passes `--fail-severity error`. CI should **pass**.

**After #54164 merges:** `oas3-valid-media-example` is elevated to `error`, so this type mismatch will cause CI to **fail**.