### PR TITLE
test: widen ACTIVE window for suspend-batch-twice API test

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts
@@ -65,12 +65,15 @@ test.describe('Suspend & Resume Batch Operation Tests', () => {
   }) => {
     const key =
       await test.step('Create cancelable batch operation', async () => {
-        // Use 20 instances so the batch stays ACTIVE long enough for the
-        // suspend command to take effect before the engine finishes it. With
-        // only 3 instances the batch can reach COMPLETED before the suspend is
-        // applied, so the poll for SUSPENDED never succeeds (same race the
-        // first suspend test guards against — not an indexing lag).
-        return createCancellationBatch(request, 20, 'batch_suspension_process');
+        // Use 30 instances so the batch stays ACTIVE long enough for the
+        // suspend command to take effect before the engine finishes it.
+        // With 20 instances, the engine (warmed up by the preceding test in
+        // this serial describe) can finish cancelling every instance before
+        // the first suspend arrives, leaving the batch COMPLETED so suspend
+        // is permanently rejected with NOT_FOUND (404). 30 matches the proven
+        // cancel-active test's ACTIVE window for the same race — not an
+        // indexing lag.
+        return createCancellationBatch(request, 30, 'batch_suspension_process');
       });
 
     await test.step('Suspend batch operation once', async () => {


### PR DESCRIPTION
## Description

The nightly C8 orchestration-cluster API (Elasticsearch) run on `stable/8.9` failed the test **"Suspend batch operation twice fails on second request, finally resumes"** (`tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts`).

The first `suspend` request is expected to return `204` while the batch operation is still `ACTIVE`. The test creates a cancellation batch over **20** process instances. On the nightly run the engine — warmed up by the preceding (passing) test in the same serial `describe` — finished cancelling all 20 instances before the suspend HTTP request arrived, so the batch was already `COMPLETED` and suspend was permanently rejected with `NOT_FOUND` (`404`). The `suspendBatchOperation` retry loop then exhausted its full 240s budget. Both the initial attempt and the retry failed identically (deterministic, not flake-on-retry).

## Fix

Bump the instance count from **20 → 30**, matching the proven `cancel-active` test that guards the identical race in the sibling cancel spec. This widens the `ACTIVE` window so the first suspend reliably lands while the batch is still processing. No `skip`/`fixme`, no change to any assertion.

The sibling first suspend test (also 20 instances) passed in this run and is left untouched per the nightly-fix scope.

Nightly run: https://github.com/camunda/camunda/actions/runs/26858900848

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## On-demand verification runs
- https://github.com/camunda/camunda/actions/runs/26866009194 ✅ 
