### PR TITLE
ci: set DATABASE for Print Docker logs step in reusable E2E workflow

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-reusable-e2e-tests.yml
+++ b/.github/workflows/c8-orchestration-cluster-reusable-e2e-tests.yml
@@ -130,12 +130,16 @@ jobs:
 
       - name: Print Docker logs before failing
         if: failure()
+        # DATABASE must be set: docker-compose.yml interpolates it into the
+        # camunda service's depends_on / env_file, so an unset value makes the
+        # compose project invalid ("depends on undefined service") and this
+        # diagnostic step errors out instead of printing the container logs.
         run: |
           if [[ "${{ inputs.branch }}" == "stable/8.7" ]]; then
-            docker compose logs tasklist
-            docker compose logs operate
+            DATABASE=elasticsearch docker compose logs tasklist
+            DATABASE=elasticsearch docker compose logs operate
           else
-            docker compose logs camunda
+            DATABASE=elasticsearch docker compose logs camunda
           fi
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
 


### PR DESCRIPTION
## Problem

The nightly **C8 Orchestration Cluster 8.9 E2E** run failed at the `Start Camunda` step with a transient Docker Hub registry timeout:

```
camunda Error Get "https://registry-1.docker.io/v2/": context deadline exceeded
Failed to start Camunda after 3 attempts.
```

That first failure is transient infra (already mitigated by the 3-attempt retry added in `7c65f3937d0`). But the run then hit a **second, deterministic** failure in the `Print Docker logs before failing` diagnostic step:

```
service "camunda" depends on undefined service "": invalid compose project
##[error]Process completed with exit code 1.
```

`docker-compose.yml` interpolates `${DATABASE}` into the `camunda` service's `depends_on` and `env_file`. The diagnostic step ran `docker compose logs` **without** setting `DATABASE`, so the unset value produced an invalid compose project — the step exited 1 and printed **no logs at all**, defeating its entire purpose right when diagnostics are needed.

## Fix

Set `DATABASE=elasticsearch` on the `docker compose logs` commands, matching how every `docker compose up` invocation in this workflow already sets it.

Verified locally against `qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml`:
- Without `DATABASE` → `service "camunda" depends on undefined service "": invalid compose project` (reproduces the run error)
- With `DATABASE=elasticsearch` → compose project resolves; `camunda` service is valid.

## Notes

- This does not change the transient Docker Hub timeout behavior (infra, already retried); it ensures the failure path is actually diagnosable instead of producing a spurious second failure.
- The same bare-`docker compose logs` pattern exists in sibling orchestration-cluster workflows (`reusable-api-tests`, `e2e-tests-on-demand`, `e2e-tests-release`, `request-validation-nightly`, `forward-compatibility-tests`). Left out of this focused fix; happy to follow up with a sweep if maintainers prefer.

Nightly run: https://github.com/camunda/camunda/actions/runs/26859461961

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## On-demand verification runs
- https://github.com/camunda/camunda/actions/runs/26872411218 ✅ 
