### PR TITLE
test: sync jobs/activation priority field and fix MI beforeAll listener selection (nightly main)

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-create-batch-to-migrate-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-create-batch-to-migrate-api.spec.ts
@@ -26,18 +26,10 @@ import {DeployResourceResponse} from '@camunda8/sdk/dist/c8/lib/C8Dto';
 import {
   expectBatchState,
   findUserTask,
+  postMigrationAssertionOptions,
   searchElementInstanceByElementIdAndState,
 } from '@requestHelpers';
 import {validateResponse} from 'json-body-assertions';
-
-// After element-instance search confirms the engine moved the token, the
-// secondary-storage pipeline is already partially caught up. 120s is enough
-// for the user-task indexer to reflect the updated elementId and stays within
-// the 2-minute budget.
-const postMigrationUserTaskOptions = {
-  intervals: [5_000, 10_000, 15_000, 20_000, 25_000, 25_000],
-  timeout: 120_000,
-};
 
 /* eslint-disable playwright/expect-expect */
 test.describe.serial('Create Process Instance Batch to Migrate Tests', () => {
@@ -297,7 +289,7 @@ test.describe.serial('Create Process Instance Batch to Migrate Tests', () => {
         localState.processInstanceKey2,
         'CREATED',
         'do_something_else',
-        postMigrationUserTaskOptions,
+        postMigrationAssertionOptions,
       );
     });
   });
@@ -434,14 +426,14 @@ test.describe.serial('Create Process Instance Batch to Migrate Tests', () => {
       processInstanceKey1,
       'CREATED',
       elementId,
-      postMigrationUserTaskOptions,
+      postMigrationAssertionOptions,
     );
     await findUserTask(
       request,
       processInstanceKey2,
       'CREATED',
       elementId,
-      postMigrationUserTaskOptions,
+      postMigrationAssertionOptions,
     );
   };
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-create-batch-to-migrate-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-create-batch-to-migrate-api.spec.ts
@@ -30,6 +30,15 @@ import {
 } from '@requestHelpers';
 import {validateResponse} from 'json-body-assertions';
 
+// After element-instance search confirms the engine moved the token, the
+// secondary-storage pipeline is already partially caught up. 120s is enough
+// for the user-task indexer to reflect the updated elementId and stays within
+// the 2-minute budget.
+const postMigrationUserTaskOptions = {
+  intervals: [5_000, 10_000, 15_000, 20_000, 25_000, 25_000],
+  timeout: 120_000,
+};
+
 /* eslint-disable playwright/expect-expect */
 test.describe.serial('Create Process Instance Batch to Migrate Tests', () => {
   const instanceKeys: string[] = [];
@@ -275,13 +284,20 @@ test.describe.serial('Create Process Instance Batch to Migrate Tests', () => {
         'CREATED',
         'test_migration_api_user_task',
       );
-      // Instance 2 was migrated — confirm via element-instance search which
-      // reflects engine state faster than user-task secondary-storage indexing.
+      // Instance 2 was migrated — first confirm via element-instance (fast),
+      // then verify the user-task API reflects the updated elementId.
       await searchElementInstanceByElementIdAndState(
         request,
         localState.processInstanceKey2,
         'do_something_else',
         'ACTIVE',
+      );
+      await findUserTask(
+        request,
+        localState.processInstanceKey2,
+        'CREATED',
+        'do_something_else',
+        postMigrationUserTaskOptions,
       );
     });
   });
@@ -387,9 +403,14 @@ test.describe.serial('Create Process Instance Batch to Migrate Tests', () => {
   };
 
   // Used after migration to confirm instances reached the target element.
-  // Element-instance search reflects engine state faster than the user-task
-  // secondary-storage indexer, so it avoids the ever-growing timeout that
-  // plagued the previous findUserTask-based approach on a loaded shared cluster.
+  // Two-phase: element-instance search first (engine-level, fast) then
+  // user-task search (secondary-storage). Per the migration docs, the existing
+  // user task is preserved through migration with only its elementId updated —
+  // it is NOT deleted and recreated — so verifying the user-task API reflects
+  // the new elementId is a valid assertion. Gating on element-instance first
+  // means the secondary-storage pipeline is already partially caught up, so
+  // a 120s budget for the user-task check is sufficient and stays within the
+  // 2-minute limit.
   const verifyBothInstancesMigratedToElement = async (
     request: APIRequestContext,
     processInstanceKey1: string,
@@ -407,6 +428,20 @@ test.describe.serial('Create Process Instance Batch to Migrate Tests', () => {
       processInstanceKey2,
       elementId,
       'ACTIVE',
+    );
+    await findUserTask(
+      request,
+      processInstanceKey1,
+      'CREATED',
+      elementId,
+      postMigrationUserTaskOptions,
+    );
+    await findUserTask(
+      request,
+      processInstanceKey2,
+      'CREATED',
+      elementId,
+      postMigrationUserTaskOptions,
     );
   };
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-create-batch-to-migrate-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-create-batch-to-migrate-api.spec.ts
@@ -22,22 +22,28 @@ import {
 import {defaultAssertionOptions} from '../../../../utils/constants';
 import {APIRequestContext} from 'playwright-core';
 import {JSONDoc} from '@camunda8/sdk/dist/zeebe/types.js';
+import {DeployResourceResponse} from '@camunda8/sdk/dist/c8/lib/C8Dto';
 import {
   expectBatchState,
   findUserTask,
-  postMigrationAssertionOptions,
+  searchElementInstanceByElementIdAndState,
 } from '@requestHelpers';
 import {validateResponse} from 'json-body-assertions';
 
 /* eslint-disable playwright/expect-expect */
 test.describe.serial('Create Process Instance Batch to Migrate Tests', () => {
   const instanceKeys: string[] = [];
+  // Captured once in beforeAll and shared across all tests — avoids
+  // re-deploying v2 on every prepareTestCases call which would create
+  // a new deployment version each time and add noise to the shared cluster.
+  let sharedTargetProcessDefinitionKey: string;
 
   test.beforeAll(async () => {
-    await deploy([
-      './resources/test_migration_process_v1.bpmn',
+    await deploy(['./resources/test_migration_process_v1.bpmn']);
+    const v2Result: DeployResourceResponse = await deploy([
       './resources/test_migration_process_v2.bpmn',
     ]);
+    sharedTargetProcessDefinitionKey = v2Result.processes[0].processDefinitionKey;
   });
 
   test.afterAll(async () => {
@@ -192,12 +198,11 @@ test.describe.serial('Create Process Instance Batch to Migrate Tests', () => {
     });
 
     await test.step('Verify both instances migrated to target task', async () => {
-      await verifyBothInstancesAreAtElementId(
+      await verifyBothInstancesMigratedToElement(
         request,
         localState.processInstanceKey1,
         localState.processInstanceKey2,
         'do_something_else',
-        postMigrationAssertionOptions,
       );
     });
   });
@@ -262,19 +267,20 @@ test.describe.serial('Create Process Instance Batch to Migrate Tests', () => {
     });
 
     await test.step('Verify only second instance migrated', async () => {
+      // Instance 1 was filtered out — still at the source element.
       await findUserTask(
         request,
         localState.processInstanceKey1,
         'CREATED',
         'test_migration_api_user_task',
       );
-
-      await findUserTask(
+      // Instance 2 was migrated — confirm via element-instance search which
+      // reflects engine state faster than user-task secondary-storage indexing.
+      await searchElementInstanceByElementIdAndState(
         request,
         localState.processInstanceKey2,
-        'CREATED',
         'do_something_else',
-        postMigrationAssertionOptions,
+        'ACTIVE',
       );
     });
   });
@@ -344,16 +350,17 @@ test.describe.serial('Create Process Instance Batch to Migrate Tests', () => {
     });
 
     await test.step('Verify both instances migrated', async () => {
-      await verifyBothInstancesAreAtElementId(
+      await verifyBothInstancesMigratedToElement(
         request,
         localState.processInstanceKey1,
         localState.processInstanceKey2,
         'do_something_else',
-        postMigrationAssertionOptions,
       );
     });
   });
 
+  // Used before migration to confirm instances are at the source element via
+  // user-task search (only called with defaultAssertionOptions / 30s budget).
   const verifyBothInstancesAreAtElementId = async (
     request: APIRequestContext,
     processInstanceKey1: string,
@@ -375,6 +382,30 @@ test.describe.serial('Create Process Instance Batch to Migrate Tests', () => {
       'CREATED',
       elementId,
       assertionOptions,
+    );
+  };
+
+  // Used after migration to confirm instances reached the target element.
+  // Element-instance search reflects engine state faster than the user-task
+  // secondary-storage indexer, so it avoids the ever-growing timeout that
+  // plagued the previous findUserTask-based approach on a loaded shared cluster.
+  const verifyBothInstancesMigratedToElement = async (
+    request: APIRequestContext,
+    processInstanceKey1: string,
+    processInstanceKey2: string,
+    elementId: string,
+  ) => {
+    await searchElementInstanceByElementIdAndState(
+      request,
+      processInstanceKey1,
+      elementId,
+      'ACTIVE',
+    );
+    await searchElementInstanceByElementIdAndState(
+      request,
+      processInstanceKey2,
+      elementId,
+      'ACTIVE',
     );
   };
 
@@ -418,15 +449,8 @@ test.describe.serial('Create Process Instance Batch to Migrate Tests', () => {
       );
     });
 
-    await test.step('Deploy version 2 and get target process definition key', async () => {
-      await deploy(['./resources/test_migration_process_v2.bpmn']);
-      const instances = await createInstances(
-        'test_migration_process_v2',
-        1,
-        1,
-      );
-      localState.targetProcessDefinitionKey = instances[0].processDefinitionKey;
-      instanceKeys.push(instances[0].processInstanceKey);
+    await test.step('Use pre-deployed version 2 process definition key', async () => {
+      localState.targetProcessDefinitionKey = sharedTargetProcessDefinitionKey;
     });
 
     return localState;

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-create-batch-to-migrate-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-create-batch-to-migrate-api.spec.ts
@@ -43,7 +43,8 @@ test.describe.serial('Create Process Instance Batch to Migrate Tests', () => {
     const v2Result: DeployResourceResponse = await deploy([
       './resources/test_migration_process_v2.bpmn',
     ]);
-    sharedTargetProcessDefinitionKey = v2Result.processes[0].processDefinitionKey;
+    sharedTargetProcessDefinitionKey =
+      v2Result.processes[0].processDefinitionKey;
   });
 
   test.afterAll(async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/multiInstanceBeforeAllListener.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/multiInstanceBeforeAllListener.spec.ts
@@ -84,6 +84,14 @@ test.describe('Operate — Multi-Instance beforeAll listener visibility', () => 
       await operateProcessInstancePage.diagramHelper.clickFlowNode(
         'MI Service Task',
       );
+      // For a multi-instance element the diagram selection does not resolve to
+      // a single flow node instance, so the listeners panel stays scoped to the
+      // root process instance. Select the multi-instance body row in the
+      // instance history so the beforeAll execution listener (attached to the
+      // MI body element instance) is the one queried.
+      await operateProcessInstancePage.clickInstanceHistoryElement(
+        /MI Service Task \(Parallel\) \(Multi Instance\)/i,
+      );
     });
 
     await test.step('Listeners tab shows the beforeAll execution listener', async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/batch-operation-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/batch-operation-requestHelpers.ts
@@ -140,10 +140,14 @@ export async function expectBatchState(
 // Post-migration user-task search has to wait for the secondary-storage
 // indexer to reflect the migrated elementId. On a loaded shared cluster the
 // 180s budget proved tight (seen as flake on nightly runs), 240s proved tight
-// too (observed in nightly runs on 2026-06-03), so allow up to 360s.
+// too (observed in nightly runs on 2026-06-03), 360s proved tight too
+// (observed in nightly runs on 2026-06-04), so allow up to 480s.
 export const postMigrationAssertionOptions = {
-  intervals: [5_000, 10_000, 15_000, 25_000, 35_000, 45_000, 60_000, 60_000],
-  timeout: 360_000,
+  intervals: [
+    5_000, 10_000, 15_000, 25_000, 35_000, 45_000, 60_000, 60_000, 60_000,
+    60_000,
+  ],
+  timeout: 480_000,
 };
 
 export const notFoundDetail = (key: string) =>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/batch-operation-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/batch-operation-requestHelpers.ts
@@ -137,19 +137,6 @@ export async function expectBatchState(
   });
 }
 
-// Post-migration user-task search has to wait for the secondary-storage
-// indexer to reflect the migrated elementId. On a loaded shared cluster the
-// 180s budget proved tight (seen as flake on nightly runs), 240s proved tight
-// too (observed in nightly runs on 2026-06-03), 360s proved tight too
-// (observed in nightly runs on 2026-06-04), so allow up to 480s.
-export const postMigrationAssertionOptions = {
-  intervals: [
-    5_000, 10_000, 15_000, 25_000, 35_000, 45_000, 60_000, 60_000, 60_000,
-    60_000,
-  ],
-  timeout: 480_000,
-};
-
 export const notFoundDetail = (key: string) =>
   `Command 'SUSPEND' rejected with code 'NOT_FOUND': Expected to suspend a batch operation with key '${key}', but no such batch operation was found`;
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/batch-operation-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/batch-operation-requestHelpers.ts
@@ -137,6 +137,15 @@ export async function expectBatchState(
   });
 }
 
+// Post-migration user-task search waits for the secondary-storage indexer to
+// reflect the migrated elementId. Used as the second phase after
+// searchElementInstanceByElementIdAndState confirms the engine already moved
+// the token, so the pipeline is partially warm and 120s is sufficient.
+export const postMigrationAssertionOptions = {
+  intervals: [5_000, 10_000, 15_000, 20_000, 25_000, 25_000],
+  timeout: 120_000,
+};
+
 export const notFoundDetail = (key: string) =>
   `Command 'SUSPEND' rejected with code 'NOT_FOUND': Expected to suspend a batch operation with key '${key}', but no such batch operation was found`;
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/user-task-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/user-task-requestHelpers.ts
@@ -28,9 +28,17 @@ export async function findUserTask(
 ) {
   const localState: Record<string, unknown> = {};
   await expect(async () => {
+    // Include elementId in the filter when provided so the API only returns
+    // results once the indexer has reflected the correct element — avoids
+    // intermediate states where the task is found but still carries the old
+    // elementId, which would burn retry budget and require a larger timeout.
+    const filter: Record<string, string> = {processInstanceKey: procKey};
+    if (elementId) {
+      filter.elementId = elementId;
+    }
     const searchRes = await request.post(buildUrl('/user-tasks/search'), {
       headers: jsonHeaders(),
-      data: {filter: {processInstanceKey: procKey}},
+      data: {filter},
     });
     await assertStatusCode(searchRes, 200);
     await validateResponse(


### PR DESCRIPTION
## Root cause

Two independent root causes across the 20 originally failing nightly tests, plus a structural flakiness fix applied on top:

### 1. `/jobs/activation` response shape (18 API tests + 1 cascade)

The v2 `POST /jobs/activation` response now returns a `priority` field on each
job. `priority` was added to the `ActivatedJobResult` schema in the product
OpenAPI spec (`zeebe/gateway-protocol/.../jobs.yaml`, `addedInVersion: "8.10"`,
required), but the test suite's generated response-shape spec
(`json-body-assertions/_generated/responses.json`) predates that addition and
did not declare it. Every test that activates a job therefore failed with:

```
Response shape errors for route POST 200 /jobs/activation:
[EXTRA] /jobs/0/priority is not declared in spec
```

This also caused the **element-instance-update** failure: on the first attempt
the update returned `204`, but the later `/jobs/activation` shape error
triggered a Playwright retry. Since `beforeAll` does not re-run on retry, the
retry hit a stale element instance and returned `409`.

### 2. Operate MI beforeAll listener selection (1 E2E test)

`Operate shows beforeAll execution listener on MI task...` selected the
multi-instance service task only via the diagram. For a multi-instance element
the diagram click does not resolve to a single flow node instance, so the
Listeners panel stayed scoped to the root process instance and returned no
listeners. The beforeAll execution listener job is attached to the MI body
element instance, not the root.

### 3. `process-instance-create-batch-to-migrate` structural flakiness

The batch migration tests were using an ever-growing `postMigrationAssertionOptions`
timeout (180s → 240s → 360s → 480s) to wait for Elasticsearch to reflect the
migrated `elementId` in `/user-tasks/search`. The test `With Multiple Filters`
failed on 2026-06-04 because:

- It ran immediately after the `Success` test, which had already generated a
  wave of ES indexing events from its own migration.
- `prepareTestCases` re-deployed `test_migration_process_v2.bpmn` on every test
  call (3×), adding more indexing events to the backlog per call.
- By the time post-migration verification started, ES had a large backlog and
  could not reflect the updated `elementId` within the 360s budget.

The root problem was the test polling the wrong signal: `/user-tasks/search`
goes through the slow secondary-storage indexer, while `/element-instances/search`
reflects engine state faster.

## Fix

**Shape fix (root cause 1):**
Add `priority` (`{"name":"priority","type":"number"}`) to the `/jobs/activation`
200 schema in `responses.json`, matching the OpenAPI spec and the existing
`/jobs/search` entry.

**E2E fix (root cause 2):**
In the MI listener E2E, after clicking the diagram node, select the
multi-instance body row in the instance history so the listeners panel
queries the correct `elementInstanceKey`. Follows the existing convention
in `processInstanceListeners.spec.ts`.

**Migration test redesign (root cause 3):**
- **Two-phase post-migration verification**: first gate on
  `searchElementInstanceByElementIdAndState` (60s) to confirm the engine moved
  the token, then verify `/user-tasks/search` with `postMigrationAssertionOptions`
  (120s). Per the migration docs, user tasks are preserved through migration with
  only their `elementId` updated — not deleted and recreated — so verifying the
  user-task API is a valid assertion. Gating on element-instance first means the
  indexing pipeline is already partially warm, so 120s is sufficient (vs the
  previous 480s blind-wait).
- **`elementId` added to the user-task search filter** when provided, so the poll
  only returns results once the correct element is indexed. Avoids intermediate
  states where `totalItems=1` but `elementId` is still stale, which burned retry
  budget unnecessarily.
- **v2 deployed once in `beforeAll`**: `processDefinitionKey` is read directly
  from the deploy result and shared across all tests. Previously `prepareTestCases`
  re-deployed on every call (3×), creating a new deployment version each time
  and leaving extra live instances on the shared cluster.
- **`postMigrationAssertionOptions` capped at 120s** and kept in
  `batch-operation-requestHelpers.ts` so it remains a shared, named constant
  rather than an inline escape hatch.

## Tests fixed (20 originally failing)

**E2E (1):**
- `tests/operate/multiInstanceBeforeAllListener.spec.ts` — Operate shows beforeAll execution listener on MI task and variables produced by beforeAll

**API (19), all caused by the `/jobs/activation` priority field:**
- `tests/api/v2/element-instance/element-instance-search-incident-api.spec.ts`
- `tests/api/v2/element-instance/element-instance-update-api.spec.ts`
- `tests/api/v2/incident/incident-resolve-api.spec.ts`
- `tests/api/v2/job/el-header-basic-tests.spec.ts` (2 tests)
- `tests/api/v2/job/el-header-cross-task-tests.spec.ts`
- `tests/api/v2/job/el-header-element-types-tests.spec.ts` (2 tests)
- `tests/api/v2/job/el-header-merge-conflict-tests.spec.ts`
- `tests/api/v2/job/job-api-tests.spec.ts`
- `tests/api/v2/job/job-completion-api-tests.spec.ts` (2 tests)
- `tests/api/v2/job/job-error-api-tests.spec.ts` (2 tests)
- `tests/api/v2/job/job-failure-api-tests.spec.ts` (2 tests)
- `tests/api/v2/job/job-update-api-tests.spec.ts`
- `tests/api/v2/job/mi-el-before-all-tests.spec.ts`
- `tests/api/v2/job/mi-el-start-end-tests.spec.ts`

## References

- Failing nightly E2E run: https://github.com/camunda/camunda/actions/runs/26860435581
- Failing nightly API (ES) run: https://github.com/camunda/camunda/actions/runs/26859682627
- Migration batch timeout failure: https://github.com/camunda/camunda/actions/runs/26925957367/job/79435995899
- Triage run: https://github.com/camunda/camunda/actions/runs/26865804444

## On-demand verification runs
- https://github.com/camunda/camunda/actions/runs/26943971457 API and e2e test were successful ✅  
  RDBMS will be investigated later