### PR TITLE
feat: add mvf smart value transformation

### DIFF
--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterRow.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterRow.tsx
@@ -11,6 +11,7 @@ import {Close, Maximize} from '@carbon/react/icons';
 import {Field, useForm} from 'react-final-form';
 import {IconTextInput} from 'modules/components/IconInput';
 import type {VariableFilterOperator} from 'modules/stores/variableFilter';
+import {IS_VARIABLE_FILTER_V2_ENABLED} from 'modules/feature-flags';
 import {VARIABLE_FILTER_OPERATORS} from './constants';
 import {FilterRow, ValueFieldContainer, DeleteButton} from './styled';
 
@@ -27,9 +28,11 @@ const getValuePlaceholder = (operator: VariableFilterOperator): string => {
     case 'contains':
       return 'search text';
     case 'oneOf':
-      return '["val1", "val2"]';
+      return IS_VARIABLE_FILTER_V2_ENABLED ? 'val1, val2' : '["val1", "val2"]';
     default:
-      return 'value in JSON format';
+      return IS_VARIABLE_FILTER_V2_ENABLED
+        ? 'e.g. true, 42, hello'
+        : 'value in JSON format';
   }
 };
 

--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/validation.ts
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/validation.ts
@@ -31,7 +31,6 @@ const validateCondition = (condition: DraftCondition): RowErrors => {
     if (!condition.value?.trim()) {
       errors.value = 'Value is required';
     } else if (IS_VARIABLE_FILTER_V2_ENABLED) {
-      // Contains passes raw text straight through to $like; no transform.
       if (condition.operator !== 'contains') {
         try {
           smartTransformValue(condition.value);

--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/validation.ts
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/validation.ts
@@ -8,6 +8,8 @@
 
 import {isValidJSON} from 'modules/utils';
 import type {VariableCondition} from 'modules/stores/variableFilter';
+import {IS_VARIABLE_FILTER_V2_ENABLED} from 'modules/feature-flags';
+import {smartTransformValue} from 'modules/utils/smartTransform';
 import type {DraftCondition} from './constants';
 
 type RowErrors = {
@@ -28,6 +30,15 @@ const validateCondition = (condition: DraftCondition): RowErrors => {
   ) {
     if (!condition.value?.trim()) {
       errors.value = 'Value is required';
+    } else if (IS_VARIABLE_FILTER_V2_ENABLED) {
+      // Contains passes raw text straight through to $like; no transform.
+      if (condition.operator !== 'contains') {
+        try {
+          smartTransformValue(condition.value);
+        } catch (e) {
+          errors.value = e instanceof Error ? e.message : 'Invalid value';
+        }
+      }
     } else if (condition.operator === 'oneOf') {
       let parsed: unknown;
       try {

--- a/operate/client/src/modules/hooks/processInstancesSearch.test.ts
+++ b/operate/client/src/modules/hooks/processInstancesSearch.test.ts
@@ -6,18 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-vi.mock('modules/feature-flags', async () => {
-  const actual = await vi.importActual<typeof import('modules/feature-flags')>(
-    'modules/feature-flags',
-  );
-  return {...actual, IS_VARIABLE_FILTER_V2_ENABLED: false};
-});
-
-import {
-  buildVariableEntry,
-  buildSmartVariableEntry,
-  parseOneOfValues,
-} from './processInstancesSearch';
+import {buildVariableEntry, parseOneOfValues} from './processInstancesSearch';
 import type {VariableCondition} from 'modules/stores/variableFilter';
 
 const mockCondition = {
@@ -148,93 +137,5 @@ describe('buildVariableEntry — multi-condition', () => {
     };
 
     expect(mvfResult).toEqual(legacyResult);
-  });
-});
-
-describe('buildSmartVariableEntry', () => {
-  it('should JSON-encode a number typed without quotes', () => {
-    expect(
-      buildSmartVariableEntry({
-        name: 'amount',
-        operator: 'equals',
-        value: '42',
-      }),
-    ).toEqual({name: 'amount', value: {$eq: '42'}});
-  });
-
-  it('should auto-quote a bare string for equals', () => {
-    expect(
-      buildSmartVariableEntry({
-        name: 'status',
-        operator: 'equals',
-        value: 'active',
-      }),
-    ).toEqual({name: 'status', value: {$eq: '"active"'}});
-  });
-
-  it('should JSON-encode a boolean for notEqual', () => {
-    expect(
-      buildSmartVariableEntry({
-        name: 'flag',
-        operator: 'notEqual',
-        value: 'true',
-      }),
-    ).toEqual({name: 'flag', value: {$neq: 'true'}});
-  });
-
-  it('should pass raw text through $like for contains', () => {
-    expect(
-      buildSmartVariableEntry({
-        name: 'desc',
-        operator: 'contains',
-        value: 'order',
-      }),
-    ).toEqual({name: 'desc', value: {$like: '*order*'}});
-  });
-
-  it('should split a comma list into a JSON-encoded $in array', () => {
-    expect(
-      buildSmartVariableEntry({
-        name: 'tag',
-        operator: 'oneOf',
-        value: 'gold, silver, bronze',
-      }),
-    ).toEqual({
-      name: 'tag',
-      value: {$in: ['"gold"', '"silver"', '"bronze"']},
-    });
-  });
-
-  it('should accept a JSON array literal for oneOf', () => {
-    expect(
-      buildSmartVariableEntry({
-        name: 'tag',
-        operator: 'oneOf',
-        value: '["gold","silver"]',
-      }),
-    ).toEqual({
-      name: 'tag',
-      value: {$in: ['"gold"', '"silver"']},
-    });
-  });
-
-  it('should emit $exists true for exists regardless of value', () => {
-    expect(
-      buildSmartVariableEntry({
-        name: 'x',
-        operator: 'exists',
-        value: '',
-      }),
-    ).toEqual({name: 'x', value: {$exists: true}});
-  });
-
-  it('should emit $exists false for doesNotExist', () => {
-    expect(
-      buildSmartVariableEntry({
-        name: 'x',
-        operator: 'doesNotExist',
-        value: '',
-      }),
-    ).toEqual({name: 'x', value: {$exists: false}});
   });
 });

--- a/operate/client/src/modules/hooks/processInstancesSearch.test.ts
+++ b/operate/client/src/modules/hooks/processInstancesSearch.test.ts
@@ -6,7 +6,18 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {buildVariableEntry, parseOneOfValues} from './processInstancesSearch';
+vi.mock('modules/feature-flags', async () => {
+  const actual = await vi.importActual<typeof import('modules/feature-flags')>(
+    'modules/feature-flags',
+  );
+  return {...actual, IS_VARIABLE_FILTER_V2_ENABLED: false};
+});
+
+import {
+  buildVariableEntry,
+  buildSmartVariableEntry,
+  parseOneOfValues,
+} from './processInstancesSearch';
 import type {VariableCondition} from 'modules/stores/variableFilter';
 
 const mockCondition = {
@@ -137,5 +148,93 @@ describe('buildVariableEntry — multi-condition', () => {
     };
 
     expect(mvfResult).toEqual(legacyResult);
+  });
+});
+
+describe('buildSmartVariableEntry', () => {
+  it('should JSON-encode a number typed without quotes', () => {
+    expect(
+      buildSmartVariableEntry({
+        name: 'amount',
+        operator: 'equals',
+        value: '42',
+      }),
+    ).toEqual({name: 'amount', value: {$eq: '42'}});
+  });
+
+  it('should auto-quote a bare string for equals', () => {
+    expect(
+      buildSmartVariableEntry({
+        name: 'status',
+        operator: 'equals',
+        value: 'active',
+      }),
+    ).toEqual({name: 'status', value: {$eq: '"active"'}});
+  });
+
+  it('should JSON-encode a boolean for notEqual', () => {
+    expect(
+      buildSmartVariableEntry({
+        name: 'flag',
+        operator: 'notEqual',
+        value: 'true',
+      }),
+    ).toEqual({name: 'flag', value: {$neq: 'true'}});
+  });
+
+  it('should pass raw text through $like for contains', () => {
+    expect(
+      buildSmartVariableEntry({
+        name: 'desc',
+        operator: 'contains',
+        value: 'order',
+      }),
+    ).toEqual({name: 'desc', value: {$like: '*order*'}});
+  });
+
+  it('should split a comma list into a JSON-encoded $in array', () => {
+    expect(
+      buildSmartVariableEntry({
+        name: 'tag',
+        operator: 'oneOf',
+        value: 'gold, silver, bronze',
+      }),
+    ).toEqual({
+      name: 'tag',
+      value: {$in: ['"gold"', '"silver"', '"bronze"']},
+    });
+  });
+
+  it('should accept a JSON array literal for oneOf', () => {
+    expect(
+      buildSmartVariableEntry({
+        name: 'tag',
+        operator: 'oneOf',
+        value: '["gold","silver"]',
+      }),
+    ).toEqual({
+      name: 'tag',
+      value: {$in: ['"gold"', '"silver"']},
+    });
+  });
+
+  it('should emit $exists true for exists regardless of value', () => {
+    expect(
+      buildSmartVariableEntry({
+        name: 'x',
+        operator: 'exists',
+        value: '',
+      }),
+    ).toEqual({name: 'x', value: {$exists: true}});
+  });
+
+  it('should emit $exists false for doesNotExist', () => {
+    expect(
+      buildSmartVariableEntry({
+        name: 'x',
+        operator: 'doesNotExist',
+        value: '',
+      }),
+    ).toEqual({name: 'x', value: {$exists: false}});
   });
 });

--- a/operate/client/src/modules/hooks/processInstancesSearch.ts
+++ b/operate/client/src/modules/hooks/processInstancesSearch.ts
@@ -110,6 +110,5 @@ export {
   useProcessInstancesSearchFilter,
   useProcessInstancesSearchSort,
   buildVariableEntry,
-  buildSmartVariableEntry,
   parseOneOfValues,
 };

--- a/operate/client/src/modules/hooks/processInstancesSearch.ts
+++ b/operate/client/src/modules/hooks/processInstancesSearch.ts
@@ -14,6 +14,11 @@ import {useMemo} from 'react';
 import {useSearchParams} from 'react-router-dom';
 import type {VariableCondition} from 'modules/stores/variableFilter';
 import type {QueryProcessInstancesRequestBody} from '@camunda/camunda-api-zod-schemas/8.10';
+import {IS_VARIABLE_FILTER_V2_ENABLED} from 'modules/feature-flags';
+import {
+  smartTransformValue,
+  toStringFilterProperty,
+} from 'modules/utils/smartTransform';
 
 type VariableEntry = NonNullable<
   NonNullable<QueryProcessInstancesRequestBody['filter']>['variables']
@@ -34,6 +39,13 @@ function useProcessInstancesSearchFilter(conditions?: VariableCondition[]) {
 }
 
 function buildVariableEntry(condition: VariableCondition): VariableEntry {
+  if (IS_VARIABLE_FILTER_V2_ENABLED) {
+    return buildSmartVariableEntry(condition);
+  }
+  return buildLegacyVariableEntry(condition);
+}
+
+function buildLegacyVariableEntry(condition: VariableCondition): VariableEntry {
   switch (condition.operator) {
     case 'equals':
       return {name: condition.name, value: condition.value};
@@ -51,6 +63,23 @@ function buildVariableEntry(condition: VariableCondition): VariableEntry {
     case 'doesNotExist':
       return {name: condition.name, value: {$exists: false}};
   }
+}
+
+function buildSmartVariableEntry(condition: VariableCondition): VariableEntry {
+  if (
+    condition.operator === 'exists' ||
+    condition.operator === 'doesNotExist'
+  ) {
+    return {
+      name: condition.name,
+      value: toStringFilterProperty(condition.operator, undefined),
+    };
+  }
+  const transformed = smartTransformValue(condition.value);
+  return {
+    name: condition.name,
+    value: toStringFilterProperty(condition.operator, transformed),
+  };
 }
 
 function parseOneOfValues(raw: string): string[] {
@@ -81,5 +110,6 @@ export {
   useProcessInstancesSearchFilter,
   useProcessInstancesSearchSort,
   buildVariableEntry,
+  buildSmartVariableEntry,
   parseOneOfValues,
 };

--- a/operate/client/src/modules/utils/smartTransform.test.ts
+++ b/operate/client/src/modules/utils/smartTransform.test.ts
@@ -1,0 +1,165 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {
+  smartTransformValue,
+  toStringFilterProperty,
+  operatorTakesValue,
+} from './smartTransform';
+
+describe('smartTransformValue', () => {
+  it('should auto-quote a bare string', () => {
+    expect(smartTransformValue('hello')).toBe('hello');
+  });
+
+  it('should parse a numeric literal as a number', () => {
+    expect(smartTransformValue('42')).toBe(42);
+  });
+
+  it('should parse boolean literals as booleans', () => {
+    expect(smartTransformValue('true')).toBe(true);
+    expect(smartTransformValue('false')).toBe(false);
+  });
+
+  it('should parse null literal as null', () => {
+    expect(smartTransformValue('null')).toBeNull();
+  });
+
+  it('should keep an explicitly-quoted string as a string', () => {
+    expect(smartTransformValue('"hello"')).toBe('hello');
+  });
+
+  it('should split a bare comma list into an array', () => {
+    expect(smartTransformValue('val1, val2')).toEqual(['val1', 'val2']);
+  });
+
+  it('should parse each element of a comma list independently', () => {
+    expect(smartTransformValue('1, two, true')).toEqual([1, 'two', true]);
+  });
+
+  it('should strip leading and trailing commas before parsing', () => {
+    expect(smartTransformValue(',hello,')).toBe('hello');
+    expect(smartTransformValue(',a, b,')).toEqual(['a', 'b']);
+  });
+
+  it('should parse valid JSON objects and arrays', () => {
+    expect(smartTransformValue('{"x":1}')).toEqual({x: 1});
+    expect(smartTransformValue('[1,2,3]')).toEqual([1, 2, 3]);
+  });
+
+  it('should return empty string for empty or whitespace-only input', () => {
+    expect(smartTransformValue('')).toBe('');
+    expect(smartTransformValue('   ')).toBe('');
+  });
+
+  it('should throw on structurally-JSON-looking but invalid input', () => {
+    expect(() => smartTransformValue('{not json')).toThrow();
+  });
+
+  it('should keep leading-zero strings as strings (documented hazard)', () => {
+    expect(smartTransformValue('01234')).toBe('01234');
+    expect(smartTransformValue('1234')).toBe(1234);
+  });
+
+  it('should treat a quoted comma-string as a single string', () => {
+    expect(smartTransformValue('"a, b"')).toBe('a, b');
+  });
+});
+
+describe('toStringFilterProperty', () => {
+  it('should map equals to $eq with JSON-encoded value', () => {
+    expect(toStringFilterProperty('equals', 'active')).toEqual({
+      $eq: '"active"',
+    });
+    expect(toStringFilterProperty('equals', 42)).toEqual({$eq: '42'});
+    expect(toStringFilterProperty('equals', true)).toEqual({$eq: 'true'});
+    expect(toStringFilterProperty('equals', null)).toEqual({$eq: 'null'});
+    expect(toStringFilterProperty('equals', {x: 1})).toEqual({
+      $eq: '{"x":1}',
+    });
+  });
+
+  it('should map notEqual to $neq with JSON-encoded value', () => {
+    expect(toStringFilterProperty('notEqual', 0)).toEqual({$neq: '0'});
+    expect(toStringFilterProperty('notEqual', 'foo')).toEqual({
+      $neq: '"foo"',
+    });
+  });
+
+  it('should map contains to $like with wildcards wrapped around the raw value', () => {
+    expect(toStringFilterProperty('contains', 'abc')).toEqual({
+      $like: '*abc*',
+    });
+  });
+
+  it('should pass user-typed wildcards through $like unescaped', () => {
+    expect(toStringFilterProperty('contains', 'order-*')).toEqual({
+      $like: '*order-**',
+    });
+    expect(toStringFilterProperty('contains', 'C?T')).toEqual({
+      $like: '*C?T*',
+    });
+  });
+
+  it('should map oneOf to $in with each element JSON-encoded', () => {
+    expect(toStringFilterProperty('oneOf', ['gold', 'silver'])).toEqual({
+      $in: ['"gold"', '"silver"'],
+    });
+    expect(toStringFilterProperty('oneOf', [1, 2, 3])).toEqual({
+      $in: ['1', '2', '3'],
+    });
+  });
+
+  it('should wrap a non-array value in a single-element array for oneOf', () => {
+    expect(toStringFilterProperty('oneOf', 'only')).toEqual({
+      $in: ['"only"'],
+    });
+  });
+
+  it('should map exists to $exists true (ignoring value)', () => {
+    expect(toStringFilterProperty('exists', undefined)).toEqual({
+      $exists: true,
+    });
+  });
+
+  it('should map doesNotExist to $exists false (ignoring value)', () => {
+    expect(toStringFilterProperty('doesNotExist', undefined)).toEqual({
+      $exists: false,
+    });
+  });
+});
+
+describe('operatorTakesValue', () => {
+  it('should return false only for exists and doesNotExist', () => {
+    expect(operatorTakesValue('equals')).toBe(true);
+    expect(operatorTakesValue('notEqual')).toBe(true);
+    expect(operatorTakesValue('contains')).toBe(true);
+    expect(operatorTakesValue('oneOf')).toBe(true);
+    expect(operatorTakesValue('exists')).toBe(false);
+    expect(operatorTakesValue('doesNotExist')).toBe(false);
+  });
+});
+
+describe('integration: transform then build filter property', () => {
+  it('plain string equals produces JSON-encoded $eq', () => {
+    const v = smartTransformValue('approved');
+    expect(toStringFilterProperty('equals', v)).toEqual({$eq: '"approved"'});
+  });
+
+  it('number equals produces unquoted JSON-encoded $eq', () => {
+    const v = smartTransformValue('42');
+    expect(toStringFilterProperty('equals', v)).toEqual({$eq: '42'});
+  });
+
+  it('comma list with oneOf produces $in array of JSON-encoded values', () => {
+    const v = smartTransformValue('gold, silver, bronze');
+    expect(toStringFilterProperty('oneOf', v)).toEqual({
+      $in: ['"gold"', '"silver"', '"bronze"'],
+    });
+  });
+});

--- a/operate/client/src/modules/utils/smartTransform.test.ts
+++ b/operate/client/src/modules/utils/smartTransform.test.ts
@@ -6,11 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {
-  smartTransformValue,
-  toStringFilterProperty,
-  operatorTakesValue,
-} from './smartTransform';
+import {smartTransformValue, toStringFilterProperty} from './smartTransform';
 
 describe('smartTransformValue', () => {
   it('should auto-quote a bare string', () => {
@@ -130,36 +126,6 @@ describe('toStringFilterProperty', () => {
   it('should map doesNotExist to $exists false (ignoring value)', () => {
     expect(toStringFilterProperty('doesNotExist', undefined)).toEqual({
       $exists: false,
-    });
-  });
-});
-
-describe('operatorTakesValue', () => {
-  it('should return false only for exists and doesNotExist', () => {
-    expect(operatorTakesValue('equals')).toBe(true);
-    expect(operatorTakesValue('notEqual')).toBe(true);
-    expect(operatorTakesValue('contains')).toBe(true);
-    expect(operatorTakesValue('oneOf')).toBe(true);
-    expect(operatorTakesValue('exists')).toBe(false);
-    expect(operatorTakesValue('doesNotExist')).toBe(false);
-  });
-});
-
-describe('integration: transform then build filter property', () => {
-  it('plain string equals produces JSON-encoded $eq', () => {
-    const v = smartTransformValue('approved');
-    expect(toStringFilterProperty('equals', v)).toEqual({$eq: '"approved"'});
-  });
-
-  it('number equals produces unquoted JSON-encoded $eq', () => {
-    const v = smartTransformValue('42');
-    expect(toStringFilterProperty('equals', v)).toEqual({$eq: '42'});
-  });
-
-  it('comma list with oneOf produces $in array of JSON-encoded values', () => {
-    const v = smartTransformValue('gold, silver, bronze');
-    expect(toStringFilterProperty('oneOf', v)).toEqual({
-      $in: ['"gold"', '"silver"', '"bronze"'],
     });
   });
 });

--- a/operate/client/src/modules/utils/smartTransform.ts
+++ b/operate/client/src/modules/utils/smartTransform.ts
@@ -7,6 +7,7 @@
  */
 
 import type {VariableFilterOperator} from 'modules/stores/variableFilter';
+import type {ProcessInstanceVariableValueFilter} from '@camunda/camunda-api-zod-schemas/8.10';
 
 const STRUCTURAL_CHARS_RE = /[{}[\]"]/;
 
@@ -30,7 +31,6 @@ const smartTransformValue = (raw: string): unknown => {
   try {
     return JSON.parse(trimmed);
   } catch {
-    // Not whole-string JSON. Try comma-split for unquoted lists.
     if (trimmed.includes(',') && !STRUCTURAL_CHARS_RE.test(trimmed)) {
       return trimmed
         .split(',')
@@ -38,7 +38,6 @@ const smartTransformValue = (raw: string): unknown => {
         .filter((part) => part !== '')
         .map(parseScalar);
     }
-    // Auto-quote bare strings (no structural JSON characters).
     if (!STRUCTURAL_CHARS_RE.test(trimmed)) {
       return trimmed;
     }
@@ -49,15 +48,13 @@ const smartTransformValue = (raw: string): unknown => {
 const toStringFilterProperty = (
   operator: VariableFilterOperator,
   value: unknown,
-): Record<string, unknown> => {
+): ProcessInstanceVariableValueFilter => {
   switch (operator) {
     case 'equals':
       return {$eq: JSON.stringify(value)};
     case 'notEqual':
       return {$neq: JSON.stringify(value)};
     case 'contains':
-      // $like is a glob pattern: `*` matches any chars, `?` matches one.
-      // User-typed wildcards pass through unchanged (backend-documented).
       return {$like: `*${String(value)}*`};
     case 'oneOf': {
       const arr = Array.isArray(value) ? value : [value];

--- a/operate/client/src/modules/utils/smartTransform.ts
+++ b/operate/client/src/modules/utils/smartTransform.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {VariableFilterOperator} from 'modules/stores/variableFilter';
+
+const STRUCTURAL_CHARS_RE = /[{}[\]"]/;
+
+const parseScalar = (input: string): unknown => {
+  try {
+    return JSON.parse(input);
+  } catch {
+    return input;
+  }
+};
+
+const smartTransformValue = (raw: string): unknown => {
+  const trimmed = raw
+    .trim()
+    .replace(/^,+|,+$/g, '')
+    .trim();
+  if (trimmed === '') {
+    return '';
+  }
+
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    // Not whole-string JSON. Try comma-split for unquoted lists.
+    if (trimmed.includes(',') && !STRUCTURAL_CHARS_RE.test(trimmed)) {
+      return trimmed
+        .split(',')
+        .map((part) => part.trim())
+        .filter((part) => part !== '')
+        .map(parseScalar);
+    }
+    // Auto-quote bare strings (no structural JSON characters).
+    if (!STRUCTURAL_CHARS_RE.test(trimmed)) {
+      return trimmed;
+    }
+    throw new Error(`Invalid value: ${raw}`);
+  }
+};
+
+const toStringFilterProperty = (
+  operator: VariableFilterOperator,
+  value: unknown,
+): Record<string, unknown> => {
+  switch (operator) {
+    case 'equals':
+      return {$eq: JSON.stringify(value)};
+    case 'notEqual':
+      return {$neq: JSON.stringify(value)};
+    case 'contains':
+      // $like is a glob pattern: `*` matches any chars, `?` matches one.
+      // User-typed wildcards pass through unchanged (backend-documented).
+      return {$like: `*${String(value)}*`};
+    case 'oneOf': {
+      const arr = Array.isArray(value) ? value : [value];
+      return {$in: arr.map((v) => JSON.stringify(v))};
+    }
+    case 'exists':
+      return {$exists: true};
+    case 'doesNotExist':
+      return {$exists: false};
+  }
+};
+
+const operatorTakesValue = (operator: VariableFilterOperator): boolean =>
+  operator !== 'exists' && operator !== 'doesNotExist';
+
+export {smartTransformValue, toStringFilterProperty, operatorTakesValue};

--- a/operate/client/src/modules/utils/smartTransform.ts
+++ b/operate/client/src/modules/utils/smartTransform.ts
@@ -67,7 +67,4 @@ const toStringFilterProperty = (
   }
 };
 
-const operatorTakesValue = (operator: VariableFilterOperator): boolean =>
-  operator !== 'exists' && operator !== 'doesNotExist';
-
-export {smartTransformValue, toStringFilterProperty, operatorTakesValue};
+export {smartTransformValue, toStringFilterProperty};


### PR DESCRIPTION
## Description

Adds a transformation layer at the boundary between the Variable Filter UI and the API so users can type natural values (`hello`, `42`, `true`, `val1, val2`) instead of strict JSON literals


## Related issues

closes #54029 
