### PR TITLE
fix: defer CSL WebSessionConfiguration import so host handler override wins

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/identity/WebSessionRepositoryConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/identity/WebSessionRepositoryConfiguration.java
@@ -29,9 +29,9 @@ import io.camunda.zeebe.util.error.FatalErrorHandler;
 import java.lang.Thread.UncaughtExceptionHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
 
 /**
  * Host-side wiring for persistent web sessions. The session lifecycle beans (repository, mapper,
@@ -47,7 +47,7 @@ import org.springframework.context.annotation.Import;
 @Configuration
 @ConditionalOnRestGatewayEnabled
 @ConditionalOnPersistentWebSessionEnabled
-@Import(WebSessionConfiguration.class)
+@ImportAutoConfiguration(WebSessionConfiguration.class)
 public class WebSessionRepositoryConfiguration {
 
   private static final Logger WEB_SESSION_DELETION_LOGGER =


### PR DESCRIPTION
## Summary

Swap `@Import(WebSessionConfiguration.class)` for `@ImportAutoConfiguration(WebSessionConfiguration.class)` on `WebSessionRepositoryConfiguration` so CSL's session config is processed in the deferred auto-config phase. This lets CSL's `@ConditionalOnMissingBean` see the host's `webSessionDeletionUncaughtExceptionHandler` bean and correctly back off, instead of both definitions trying to register and failing with `BeanDefinitionOverrideException`.

## Why

With persistent web sessions enabled the application failed to start:

```
BeanDefinitionOverrideException: Invalid bean definition with name
'webSessionDeletionUncaughtExceptionHandler' defined in
io.camunda.application.commons.identity.WebSessionRepositoryConfiguration:
Cannot register bean definition ... since there is already
[... io.camunda.security.spring.session.WebSessionConfiguration ...] bound.
```

`@Import` causes the imported class to be parsed before the importing class's `@Bean` methods, so CSL's default registers first and the host's override can't bind. `@ImportAutoConfiguration` defers CSL to after host configuration — this is exactly the workaround documented in `CamundaSecurityAutoConfiguration`'s javadoc for hosts that prefer direct imports over the umbrella opt-in.

## Test plan

- [x] `./mvnw verify -pl dist -DskipITs -T1C` — clean.
- [x] `./mvnw install -Dquickly -T1C` — full repo compile clean.
- [ ] Smoke-test against a running dist instance with persistent sessions enabled (`camunda.security.session.persistent.enabled=true`) — recommended before un-drafting.
- [ ] Decide whether this needs backporting to active `stable/*` branches (depends on whether buggy commit `46c3689ad50` was backported).

## Follow-up

Regression test that boots a context with persistent sessions enabled and asserts the host's `FatalErrorHandler` handler wins lands separately — see #54553.

🤖 Generated with [Claude Code](https://claude.com/claude-code)