### PR TITLE
fix: clear C8 REST OpenAPI lint warnings (ScopeKey example, ancestor key allOf)

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/keys.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/keys.yaml
@@ -69,7 +69,6 @@ components:
       type: string
       format: ScopeKey
       x-semantic-type: ScopeKey
-      example: "2251799813683890"
       oneOf:
         - $ref: '#/components/schemas/ProcessInstanceKey'
         - $ref: '#/components/schemas/ElementInstanceKey'

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
@@ -1809,7 +1809,7 @@ components:
             Set to -1 to create the new element instance within an existing element instance of the
             flow scope. If multiple instances of the target element's flow scope exist, choose one
             specifically with this property by providing its key.
-          oneOf:
+          allOf:
             - $ref: 'keys.yaml#/components/schemas/ElementInstanceKey'
       required:
         - ancestorElementInstanceKey


### PR DESCRIPTION
## Why

`main` is green for the **Lint / C8 REST OpenAPI** job, but the spec still emits a few non-fatal lint warnings. This PR clears them so the OpenAPI spec lints with **0 errors and 0 warnings**, making future regressions easier to spot (the linter runs with `--fail-severity error`, so warnings otherwise accumulate unnoticed).

This is purely warning cleanup — no OpenAPI errors exist on `main`, and there is no API or wire-contract change.

## What changed

### 1. `keys.yaml` — clear `oas3-valid-schema-example` warnings (ScopeKey)
`ScopeKey` is a `oneOf` of `ProcessInstanceKey` and `ElementInstanceKey`, which are structurally identical string schemas. Any example value validates against **both** branches, so the linter always warned "example must match exactly one schema in oneOf". No example value can satisfy this, and the schema cannot change (`oneOf` is required for Java code generation). Removed the optional `ScopeKey` example — the only example-level fix. This also clears the warnings that propagated into the variables and user-task variable-search responses that embed `ScopeKey`.

### 2. `process-instances.yaml` — clear `schema-key-properties-must-be-strings` warning
`DirectAncestorKeyInstruction.ancestorElementInstanceKey` used a single-member `oneOf`, which the custom `schema-key-properties-must-be-strings` rule does not recognize as a string composition (it only accepts `type: string` or `allOf`). Switched to `allOf`, which is semantically identical for a single `$ref`.

## Effects

- OpenAPI linter is green with **0 errors and 0 warnings** on both passes (structural + file-level).
- No API/wire-contract change.

## How it was tested

**Linter** — ran the exact CI tool (`@camunda8/spectral-cli@6.16.1`) locally on both passes:
- Structural pass (`rest-api.yaml`): `No results with a severity of 'error' found!`
- File-level pass (per-file glob): `No results with a severity of 'error' found!`

**Code-generation impact of the `oneOf` -> `allOf` change** — regenerated the **REST gateway** (`gateways/gateway-model`) and the **Java client** (`clients/java`) before and after the change and diffed all 1595 generated files:
- gateway-model **advanced** model (custom `ModelGenerator`): byte-identical.
- gateway-model **simple** model and **Java client** (openapi-generator): the only change is that the property `description` is now surfaced in the Javadoc and `@Schema(description=...)`. The Java type stays `String`; field, getter/setter, constructor, `@JsonProperty` binding, `requiredMode`, and `equals`/`hashCode`/`toString` are unchanged. No files added or removed.
- The unrelated `ProcessInstanceModificationActivateInstruction.ancestorElementInstanceKey` (separate `typeMapping`) is unaffected — still `String`.

**Compilation** — built `gateways/gateway-mapping-http` (and dependencies) on this branch: `BUILD SUCCESS`.

Conclusion: the `allOf` change is wire- and API-compatible and additionally surfaces a description that `oneOf` was previously dropping.
