### PR TITLE
test: cover web-session handler override against bean-definition clash

### DIFF
--- a/dist/src/test/java/io/camunda/application/commons/identity/WebSessionRepositoryConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/identity/WebSessionRepositoryConfigurationTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.identity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import io.camunda.db.rdbms.read.service.PersistentWebSessionDbReader;
+import io.camunda.db.rdbms.write.service.PersistentWebSessionWriter;
+import io.camunda.search.connect.configuration.ConnectConfiguration;
+import java.lang.Thread.UncaughtExceptionHandler;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+
+class WebSessionRepositoryConfigurationTest {
+
+  private final WebApplicationContextRunner runner =
+      new WebApplicationContextRunner()
+          .withBean(ConnectConfiguration.class, ConnectConfiguration::new)
+          .withBean(
+              PersistentWebSessionDbReader.class, () -> mock(PersistentWebSessionDbReader.class))
+          .withBean(PersistentWebSessionWriter.class, () -> mock(PersistentWebSessionWriter.class))
+          .withUserConfiguration(WebSessionRepositoryConfiguration.class)
+          .withPropertyValues("camunda.data.secondary-storage.type=rdbms");
+
+  @Test
+  void shouldWireHostFatalErrorHandlerWhenPersistentSessionsEnabled() {
+    runner
+        .withPropertyValues("camunda.security.session.persistent.enabled=true")
+        .run(
+            ctx ->
+                assertThat(ctx)
+                    .getBean(
+                        "webSessionDeletionUncaughtExceptionHandler",
+                        UncaughtExceptionHandler.class)
+                    .satisfies(
+                        handler ->
+                            assertThat(handler.getClass().getSimpleName())
+                                .as(
+                                    "expected host's FatalErrorHandler-backed handler; got %s",
+                                    handler.getClass().getName())
+                                .isEqualTo("VirtualMachineErrorHandler")));
+  }
+
+  @Test
+  void shouldNotRegisterWebSessionBeansWhenPersistentSessionsDisabled() {
+    runner
+        .withPropertyValues("camunda.security.session.persistent.enabled=false")
+        .run(ctx -> assertThat(ctx).doesNotHaveBean("webSessionDeletionUncaughtExceptionHandler"));
+  }
+}


### PR DESCRIPTION
## Summary

Adds two focused `ApplicationContextRunner` tests for `WebSessionRepositoryConfiguration`, backed by realistic rdbms secondary storage:

- `shouldWireHostFatalErrorHandlerWhenPersistentSessionsEnabled` — with `camunda.security.session.persistent.enabled=true`, asserts the bean factory exposes the host's `FatalErrorHandler`-backed `webSessionDeletionUncaughtExceptionHandler` (a `VirtualMachineErrorHandler`).
- `shouldNotRegisterWebSessionBeansWhenPersistentSessionsDisabled` — with the property set to `false`, asserts the handler bean is absent, guarding the `@ConditionalOnPersistentWebSessionEnabled` gate.

## Why

Closes the test gap that allowed the bean-definition clash fixed in #54550 to land unnoticed. Before this commit, **no** test in the monorepo boots a Spring context with persistent sessions enabled (neither the canonical `camunda.security.session.persistent.enabled` nor any of the legacy keys bridged by `PersistentWebSessionPropertiesPostProcessor`). The only "persistent session" test in dist exercises the property-bridge logic in isolation.

Local verification: reverting the `@ImportAutoConfiguration` swap from #54550 makes the enabled-case test fail (1 failure out of 2); with the fix in place both pass.

## Stacking

Based on `fix/web-session-handler-bean-clash` (PR #54550). Will need rebase onto `main` once #54550 merges.

## Test plan

- [x] `./mvnw test -pl dist -Dtest=WebSessionRepositoryConfigurationTest` — 2/2 green with the fix; 1/2 green without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)