### PR TITLE
test: run prometheus elasticsearch exporter for opensearch in benchmarks

### DIFF
--- a/load-tests/setup/default/Makefile
+++ b/load-tests/setup/default/Makefile
@@ -78,6 +78,19 @@ endif
 # Platform values with stable configuration
 platform_values_stable := $(platform_values) -f values-stable.yaml
 
+ifeq ($(secondary_storage),elasticsearch)
+	install_es_prom_exporter := true
+	es_prom_exporter_es_uri := http://elastic:9200
+else ifeq ($(secondary_storage),opensearch)
+	install_es_prom_exporter := true
+	es_prom_exporter_es_uri := http://opensearch:9200
+else ifeq ($(enable_optimize),true)
+	install_es_prom_exporter := true
+	es_prom_exporter_es_uri := http://elastic:9200
+else
+	install_es_prom_exporter := false
+endif
+
 .PHONY: all
 all: install
 
@@ -162,16 +175,17 @@ else
 	@echo "Skipping secondary storage installation (secondary_storage=$(secondary_storage))"
 endif
 
-# Install Elasticsearch Prometheus exporter if secondary_storage is elasticsearch
+# Install Elasticsearch Prometheus exporter if Elasticsearch/OpenSearch is deployed (secondary storage or Optimize)
 .PHONY: install-elasticsearch-exporter
 install-elasticsearch-exporter:
-ifeq ($(secondary_storage),elasticsearch)
+ifeq ($(install_es_prom_exporter),true)
 	@echo "Installing Elasticsearch Prometheus Exporter for namespace $(namespace)..."
 	helm upgrade --install elasticsearch-exporter oci://ghcr.io/prometheus-community/charts/prometheus-elasticsearch-exporter \
     --namespace $(namespace) \
     --version $(prometheus_elasticsearch_exporter_chart_version) \
     --wait --timeout 5m0s \
-    -f prometheus-elasticsearch-exporter-values.yaml
+    -f prometheus-elasticsearch-exporter-values.yaml \
+    --set "es.uri=$(es_prom_exporter_es_uri)"
 else
 	@echo "Skipping Elasticsearch Prometheus Exporter installation (secondary_storage=$(secondary_storage))"
 endif

--- a/load-tests/setup/default/values/prometheus-elasticsearch-exporter-values.yaml
+++ b/load-tests/setup/default/values/prometheus-elasticsearch-exporter-values.yaml
@@ -1,7 +1,7 @@
 fullnameOverride: "prom-els-exporter"
 
-es:
-  uri: http://elastic:9200
+# The target Elasticsearch/OpenSearch cluster is configured at deployment time
+# via: --set es.uri
 
 commonLabels:
   camunda.io/created-by: __AUTHOR__

--- a/load-tests/setup/newLoadTest.sh
+++ b/load-tests/setup/newLoadTest.sh
@@ -183,7 +183,7 @@ cp -v "default/values/camunda-platform-values-${secondaryStorage}.yaml" "$namesp
 
 # Storage-specific copies. databases/ is created only for mssql/oracle.
 case "$secondaryStorage" in
-  elasticsearch)
+  elasticsearch|opensearch)
     cp -v default/values/prometheus-elasticsearch-exporter-values.yaml "$namespace/"
     ;;
   postgresql|mysql|mariadb)
@@ -200,6 +200,7 @@ if [[ "$enable_optimize" == "true" ]]; then
   # Optimize needs specifically Elasticsearch (independently from the secondary
   # storage configuration).
   cp -v default/values/camunda-platform-values-optimize-elasticsearch.yaml "$namespace/"
+  cp -v default/values/prometheus-elasticsearch-exporter-values.yaml "$namespace/"
 fi
 
 cd "$namespace"


### PR DESCRIPTION
so we can see metrics for opensearch.

also enables it when we are running RDBMS + Optimize

## Related issues

refs #54331
