### PR TITLE
feat: transport layer client is aware of partition groups

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/broker/client/BrokerClientConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/broker/client/BrokerClientConfiguration.java
@@ -14,7 +14,6 @@ import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import io.camunda.zeebe.broker.client.impl.BrokerClientImpl;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
-import io.camunda.zeebe.transport.impl.AtomixServerTransport.TopicSupplier;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -46,11 +45,6 @@ public final class BrokerClientConfiguration {
 
   @Bean(destroyMethod = "close")
   public BrokerClient brokerClient() {
-    final TopicSupplier sendingTopicSupplier =
-        config.sendOnLegacySubject()
-            ? TopicSupplier.withLegacyTopicName()
-            : TopicSupplier.withPrefix(config.tenantName());
-
     final var brokerClient =
         new BrokerClientImpl(
             config.requestTimeout(),
@@ -58,12 +52,10 @@ public final class BrokerClientConfiguration {
             cluster.getEventService(),
             scheduler,
             topologyManager,
-            metrics,
-            sendingTopicSupplier);
+            metrics);
     brokerClient.start().forEach(ActorFuture::join);
     return brokerClient;
   }
 
-  public record BrokerClientCfg(
-      Duration requestTimeout, boolean sendOnLegacySubject, String tenantName) {}
+  public record BrokerClientCfg(Duration requestTimeout) {}
 }

--- a/dist/src/main/java/io/camunda/application/commons/configuration/BrokerBasedConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/configuration/BrokerBasedConfiguration.java
@@ -66,10 +66,7 @@ public class BrokerBasedConfiguration {
 
   @Bean
   public BrokerClientCfg brokerClientConfig() {
-    return new BrokerClientCfg(
-        properties.getGateway().getCluster().getRequestTimeout(),
-        properties.getExperimental().isSendOnLegacySubject(),
-        properties.getExperimental().getDefaultTenantName());
+    return new BrokerClientCfg(properties.getGateway().getCluster().getRequestTimeout());
   }
 
   @Bean

--- a/dist/src/main/java/io/camunda/application/commons/configuration/GatewayBasedConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/configuration/GatewayBasedConfiguration.java
@@ -78,10 +78,7 @@ public final class GatewayBasedConfiguration {
 
   @Bean
   public BrokerClientCfg brokerClientConfig() {
-    return new BrokerClientCfg(
-        properties.getCluster().getRequestTimeout(),
-        properties.getCluster().isSendOnLegacySubject(),
-        properties.getCluster().getDefaultTenantName());
+    return new BrokerClientCfg(properties.getCluster().getRequestTimeout());
   }
 
   @Bean

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/dto/BrokerRequest.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/dto/BrokerRequest.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.transport.ClientRequest;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
@@ -48,6 +49,10 @@ public abstract class BrokerRequest<T> implements ClientRequest {
   }
 
   public void setPartitionGroup(final String partitionGroup) {
+    Objects.requireNonNull(partitionGroup, "partitionGroup must not be null");
+    if (partitionGroup.isBlank()) {
+      throw new IllegalArgumentException("partitionGroup must not be blank");
+    }
     this.partitionGroup = partitionGroup;
   }
 

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/dto/BrokerRequest.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/dto/BrokerRequest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.broker.client.api.dto;
 import io.atomix.cluster.BrokerMemberId;
 import io.camunda.zeebe.broker.client.api.RequestDispatchStrategy;
 import io.camunda.zeebe.broker.client.api.UnsupportedBrokerResponseException;
+import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.encoding.ErrorResponse;
 import io.camunda.zeebe.protocol.record.ErrorResponseDecoder;
 import io.camunda.zeebe.protocol.record.ErrorResponseEncoder;
@@ -34,9 +35,20 @@ public abstract class BrokerRequest<T> implements ClientRequest {
   protected final int schemaId;
   protected final int templateId;
 
+  private String partitionGroup = Protocol.DEFAULT_PARTITION_GROUP_NAME;
+
   public BrokerRequest(final int schemaId, final int templateId) {
     this.schemaId = schemaId;
     this.templateId = templateId;
+  }
+
+  @Override
+  public String getPartitionGroup() {
+    return partitionGroup;
+  }
+
+  public void setPartitionGroup(final String partitionGroup) {
+    this.partitionGroup = partitionGroup;
   }
 
   public Optional<BrokerMemberId> getBrokerId() {

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerClientImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerClientImpl.java
@@ -19,7 +19,6 @@ import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.transport.impl.AtomixClientTransportAdapter;
-import io.camunda.zeebe.transport.impl.AtomixServerTransport.TopicSupplier;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
@@ -46,14 +45,12 @@ public final class BrokerClientImpl implements BrokerClient {
       final ClusterEventService eventService,
       final ActorSchedulingService schedulingService,
       final BrokerTopologyManager topologyManager,
-      final BrokerClientRequestMetrics metrics,
-      final TopicSupplier sendingTopicSupplier) {
+      final BrokerClientRequestMetrics metrics) {
     this.eventService = eventService;
     this.schedulingService = schedulingService;
 
     this.topologyManager = topologyManager;
-    atomixTransportAdapter =
-        new AtomixClientTransportAdapter(messagingService, sendingTopicSupplier);
+    atomixTransportAdapter = new AtomixClientTransportAdapter(messagingService);
     requestManager =
         new BrokerRequestManager(
             atomixTransportAdapter,

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerClientTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerClientTest.java
@@ -39,7 +39,6 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.test.broker.protocol.brokerapi.ExecuteCommandRequest;
 import io.camunda.zeebe.test.broker.protocol.brokerapi.StubBroker;
 import io.camunda.zeebe.test.util.socket.SocketUtil;
-import io.camunda.zeebe.transport.impl.AtomixServerTransport.TopicSupplier;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -122,8 +121,7 @@ public final class BrokerClientTest {
             atomixCluster.getEventService(),
             actorScheduler,
             topologyManager,
-            new BrokerClientRequestMetrics(meterRegistry),
-            TopicSupplier.withLegacyTopicName());
+            new BrokerClientRequestMetrics(meterRegistry));
     client.start().forEach(ActorFuture::join);
   }
 

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/dto/BrokerRequestTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/dto/BrokerRequestTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.broker.client.api.dto;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.transport.RequestType;
@@ -37,6 +38,28 @@ class BrokerRequestTest {
 
     // then
     assertThat(request.getPartitionGroup()).isEqualTo("tenant1");
+  }
+
+  @Test
+  void shouldRejectNullPartitionGroup() {
+    // given
+    final var request = new TestBrokerRequest();
+
+    // when / then
+    assertThatThrownBy(() -> request.setPartitionGroup(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("partitionGroup must not be null");
+  }
+
+  @Test
+  void shouldRejectBlankPartitionGroup() {
+    // given
+    final var request = new TestBrokerRequest();
+
+    // when / then
+    assertThatThrownBy(() -> request.setPartitionGroup(" "))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("partitionGroup must not be blank");
   }
 
   /** Minimal concrete subclass for testing. */

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/dto/BrokerRequestTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/dto/BrokerRequestTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.client.api.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.transport.RequestType;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+import org.junit.jupiter.api.Test;
+
+class BrokerRequestTest {
+
+  @Test
+  void shouldReturnDefaultPartitionGroup() {
+    // given
+    final var request = new TestBrokerRequest();
+
+    // then
+    assertThat(request.getPartitionGroup()).isEqualTo(Protocol.DEFAULT_PARTITION_GROUP_NAME);
+  }
+
+  @Test
+  void shouldReturnSetPartitionGroup() {
+    // given
+    final var request = new TestBrokerRequest();
+
+    // when
+    request.setPartitionGroup("tenant1");
+
+    // then
+    assertThat(request.getPartitionGroup()).isEqualTo("tenant1");
+  }
+
+  /** Minimal concrete subclass for testing. */
+  private static final class TestBrokerRequest extends BrokerRequest<Void> {
+
+    TestBrokerRequest() {
+      super(0, 0);
+    }
+
+    @Override
+    public void setPartitionId(final int partitionId) {}
+
+    @Override
+    public int getPartitionId() {
+      return 1;
+    }
+
+    @Override
+    public RequestType getRequestType() {
+      return RequestType.COMMAND;
+    }
+
+    @Override
+    public boolean addressesSpecificPartition() {
+      return true;
+    }
+
+    @Override
+    public boolean requiresPartitionId() {
+      return false;
+    }
+
+    @Override
+    public BufferWriter getRequestWriter() {
+      return null;
+    }
+
+    @Override
+    protected void setSerializedValue(final DirectBuffer buffer) {}
+
+    @Override
+    protected void wrapResponse(final DirectBuffer buffer) {}
+
+    @Override
+    protected BrokerResponse<Void> readResponse() {
+      return null;
+    }
+
+    @Override
+    protected Void toResponseDto(final DirectBuffer buffer) {
+      return null;
+    }
+
+    @Override
+    public String getType() {
+      return "test";
+    }
+
+    @Override
+    public int getLength() {
+      return 0;
+    }
+
+    @Override
+    public int write(final MutableDirectBuffer buffer, final int offset) {
+      return 0;
+    }
+  }
+}

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/test/TestBrokerClientFactory.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/test/TestBrokerClientFactory.java
@@ -17,7 +17,6 @@ import io.camunda.zeebe.broker.client.impl.BrokerClientImpl;
 import io.camunda.zeebe.broker.client.impl.BrokerTopologyManagerImpl;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
-import io.camunda.zeebe.transport.impl.AtomixServerTransport.TopicSupplier;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
 public final class TestBrokerClientFactory {
@@ -38,8 +37,7 @@ public final class TestBrokerClientFactory {
             atomixCluster.getEventService(),
             actorScheduler,
             topologyManager,
-            new BrokerClientRequestMetrics(meterRegistry),
-            TopicSupplier.withLegacyTopicName());
+            new BrokerClientRequestMetrics(meterRegistry));
     client.start().forEach(ActorFuture::join);
     return client;
   }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestHandlerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestHandlerTest.java
@@ -111,8 +111,7 @@ public class SnapshotApiRequestHandlerTest {
             clusterService,
             scheduler.getActorScheduler(),
             brokerTopology,
-            metrics,
-            TopicSupplier.withLegacyTopicName());
+            metrics);
     brokerClient.start();
 
     serverTransport =

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/UnavailableBrokersTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/UnavailableBrokersTest.java
@@ -33,7 +33,6 @@ import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.test.util.asserts.grpc.ClientStatusExceptionAssert;
 import io.camunda.zeebe.test.util.socket.SocketUtil;
-import io.camunda.zeebe.transport.impl.AtomixServerTransport.TopicSupplier;
 import io.camunda.zeebe.util.micrometer.MicrometerUtil;
 import io.grpc.Status.Code;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -92,8 +91,7 @@ class UnavailableBrokersTest {
             cluster.getEventService(),
             actorScheduler,
             topologyManager,
-            new BrokerClientRequestMetrics(REGISTRY),
-            TopicSupplier.withLegacyTopicName());
+            new BrokerClientRequestMetrics(REGISTRY));
     jobStreamClient =
         new JobStreamClientImpl(actorScheduler, cluster.getCommunicationService(), REGISTRY);
     jobStreamClient.start().join();

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/InterceptorIT.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/InterceptorIT.java
@@ -33,7 +33,6 @@ import io.camunda.zeebe.gateway.interceptors.util.TestInterceptor;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.test.util.socket.SocketUtil;
-import io.camunda.zeebe.transport.impl.AtomixServerTransport.TopicSupplier;
 import io.grpc.StatusRuntimeException;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -93,8 +92,7 @@ final class InterceptorIT {
             cluster.getEventService(),
             scheduler,
             topologyManager,
-            new BrokerClientRequestMetrics(meterRegistry),
-            TopicSupplier.withLegacyTopicName());
+            new BrokerClientRequestMetrics(meterRegistry));
 
     jobStreamClient =
         new JobStreamClientImpl(scheduler, cluster.getCommunicationService(), meterRegistry);

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/security/SecurityTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/security/SecurityTest.java
@@ -29,7 +29,6 @@ import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.test.util.asserts.SslAssert;
 import io.camunda.zeebe.test.util.socket.SocketUtil;
-import io.camunda.zeebe.transport.impl.AtomixServerTransport.TopicSupplier;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
@@ -185,8 +184,7 @@ final class SecurityTest {
             atomix.getEventService(),
             actorScheduler,
             topologyManager,
-            new BrokerClientRequestMetrics(meterRegistry),
-            TopicSupplier.withLegacyTopicName());
+            new BrokerClientRequestMetrics(meterRegistry));
     jobStreamClient =
         new JobStreamClientImpl(actorScheduler, atomix.getCommunicationService(), meterRegistry);
     jobStreamClient.start().join();

--- a/zeebe/transport/pom.xml
+++ b/zeebe/transport/pom.xml
@@ -38,6 +38,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.agrona</groupId>
       <artifactId>agrona</artifactId>
     </dependency>

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/ClientRequest.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/ClientRequest.java
@@ -20,4 +20,12 @@ public interface ClientRequest extends BufferWriter {
    * @return the type of this request
    */
   RequestType getRequestType();
+
+  /**
+   * @return the partition group (physical tenant) this request targets; defaults to {@code
+   *     "default"} for backward compatibility
+   */
+  default String getPartitionGroup() {
+    return "default";
+  }
 }

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/ClientRequest.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/ClientRequest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.transport;
 
+import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 
 public interface ClientRequest extends BufferWriter {
@@ -26,6 +27,6 @@ public interface ClientRequest extends BufferWriter {
    *     "default"} for backward compatibility
    */
   default String getPartitionGroup() {
-    return "default";
+    return Protocol.DEFAULT_PARTITION_GROUP_NAME;
   }
 }

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/TransportFactory.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/TransportFactory.java
@@ -50,13 +50,7 @@ public final class TransportFactory {
   }
 
   public ClientTransport createClientTransport(final MessagingService messagingService) {
-    return createClientTransport(messagingService, TopicSupplier.withLegacyTopicName());
-  }
-
-  public ClientTransport createClientTransport(
-      final MessagingService messagingService, final TopicSupplier topicSupplier) {
-    final var atomixClientTransportAdapter =
-        new AtomixClientTransportAdapter(messagingService, topicSupplier);
+    final var atomixClientTransportAdapter = new AtomixClientTransportAdapter(messagingService);
     actorSchedulingService.submitActor(atomixClientTransportAdapter);
     return atomixClientTransportAdapter;
   }

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/impl/AtomixClientTransportAdapter.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/impl/AtomixClientTransportAdapter.java
@@ -14,7 +14,6 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.transport.ClientRequest;
 import io.camunda.zeebe.transport.ClientTransport;
-import io.camunda.zeebe.transport.impl.AtomixServerTransport.TopicSupplier;
 import java.net.ConnectException;
 import java.time.Duration;
 import java.util.function.Predicate;
@@ -33,16 +32,9 @@ public final class AtomixClientTransportAdapter extends Actor implements ClientT
       "Failed to send request to %s, no remote address found.";
 
   private final MessagingService messagingService;
-  private final TopicSupplier topicSupplier;
 
   public AtomixClientTransportAdapter(final MessagingService messagingService) {
-    this(messagingService, TopicSupplier.withLegacyTopicName());
-  }
-
-  public AtomixClientTransportAdapter(
-      final MessagingService messagingService, final TopicSupplier topicSupplier) {
     this.messagingService = messagingService;
-    this.topicSupplier = topicSupplier;
   }
 
   @Override
@@ -78,7 +70,9 @@ public final class AtomixClientTransportAdapter extends Actor implements ClientT
 
     final var partitionId = clientRequest.getPartitionId();
     final var requestType = clientRequest.getRequestType();
-    final var topicName = topicSupplier.apply(partitionId, requestType);
+    final var topicName =
+        AtomixServerTransport.topicName(
+            clientRequest.getPartitionGroup(), partitionId, requestType);
 
     final var requestFuture = new CompletableActorFuture<DirectBuffer>();
     final var requestContext =

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/impl/AtomixTransportTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/impl/AtomixTransportTest.java
@@ -16,6 +16,7 @@ import io.atomix.cluster.messaging.MessagingConfig;
 import io.atomix.cluster.messaging.MessagingException;
 import io.atomix.cluster.messaging.impl.NettyMessagingService;
 import io.atomix.utils.net.Address;
+import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.scheduler.testing.ActorSchedulerRule;
 import io.camunda.zeebe.test.util.socket.SocketUtil;
 import io.camunda.zeebe.transport.ClientRequest;
@@ -76,6 +77,7 @@ public class AtomixTransportTest {
   private static TransportFactory transportFactory;
   private static NettyMessagingService nettyMessagingService;
   @AutoClose private static MeterRegistry meterRegistry = new SimpleMeterRegistry();
+  private static final String MESSAGE_CONTENT = "messageABC";
 
   @Parameter(0)
   public String testName;
@@ -86,8 +88,12 @@ public class AtomixTransportTest {
   @Parameter(2)
   public Function<AtomixCluster, ServerTransport> serverTransportFunction;
 
+  @Parameter(3)
+  public String topicPrefix;
+
   private ClientTransport clientTransport;
   private ServerTransport serverTransport;
+  private Request request;
 
   @Parameters(name = "{0}")
   public static Collection<Object[]> data() {
@@ -95,7 +101,7 @@ public class AtomixTransportTest {
     return Arrays.asList(
         new Object[][] {
           {
-            "use same messaging service",
+            "use same messaging service (default topic)",
             (Function<AtomixCluster, ClientTransport>)
                 (cluster) -> {
                   final var messagingService = cluster.getMessagingService();
@@ -106,25 +112,28 @@ public class AtomixTransportTest {
                   final var messagingService = cluster.getMessagingService();
                   return transportFactory.createServerTransport(
                       messagingService, requestIdGenerator, TOPIC_SUPPLIERS);
-                }
+                },
+            "default"
           },
           {
-            "use default-{topic}-prefixed topics in client requests",
+            "use same messaging service (non-default topic)",
             (Function<AtomixCluster, ClientTransport>)
                 (cluster) -> {
                   final var messagingService = cluster.getMessagingService();
-                  return transportFactory.createClientTransport(
-                      messagingService, TopicSupplier.withPrefix(TOPIC_PREFIX));
+                  return transportFactory.createClientTransport(messagingService);
                 },
             (Function<AtomixCluster, ServerTransport>)
                 (cluster) -> {
                   final var messagingService = cluster.getMessagingService();
                   return transportFactory.createServerTransport(
-                      messagingService, requestIdGenerator, TOPIC_SUPPLIERS);
-                }
+                      messagingService,
+                      requestIdGenerator,
+                      List.of(TopicSupplier.withPrefix("tenant1")));
+                },
+            "tenant1"
           },
           {
-            "use different messaging service",
+            "use different messaging service (default topic)",
             (Function<AtomixCluster, ClientTransport>)
                 (cluster) -> {
                   final var messagingService = cluster.getMessagingService();
@@ -135,22 +144,25 @@ public class AtomixTransportTest {
                   createNettyMessagingServiceIfNull();
                   return transportFactory.createServerTransport(
                       nettyMessagingService, requestIdGenerator, TOPIC_SUPPLIERS);
-                }
+                },
+            "default"
           },
           {
-            "use different messaging service and prefixed client requests",
+            "use different messaging service (non-default topic)",
             (Function<AtomixCluster, ClientTransport>)
                 (cluster) -> {
                   final var messagingService = cluster.getMessagingService();
-                  return transportFactory.createClientTransport(
-                      messagingService, TopicSupplier.withPrefix(TOPIC_PREFIX));
+                  return transportFactory.createClientTransport(messagingService);
                 },
             (Function<AtomixCluster, ServerTransport>)
                 (cluster) -> {
                   createNettyMessagingServiceIfNull();
                   return transportFactory.createServerTransport(
-                      nettyMessagingService, requestIdGenerator, TOPIC_SUPPLIERS);
-                }
+                      nettyMessagingService,
+                      requestIdGenerator,
+                      List.of(TopicSupplier.withPrefix("tenant1")));
+                },
+            "tenant1"
           }
         });
   }
@@ -188,6 +200,7 @@ public class AtomixTransportTest {
   public void beforeTest() {
     clientTransport = clientTransportFunction.apply(cluster);
     serverTransport = serverTransportFunction.apply(cluster);
+    request = new Request(MESSAGE_CONTENT).withPartitionGroup(topicPrefix);
   }
 
   @After
@@ -216,13 +229,12 @@ public class AtomixTransportTest {
 
     // when
     final var requestFuture =
-        clientTransport.sendRequestWithRetry(
-            nodeAddressSupplier, new Request("messageABC"), REQUEST_TIMEOUT);
+        clientTransport.sendRequestWithRetry(nodeAddressSupplier, request, REQUEST_TIMEOUT);
 
     // then
     final var response = requestFuture.join();
-    assertThat(response.byteArray()).isEqualTo("messageABC".getBytes());
-    assertThat(incomingRequestFuture.join()).isEqualTo("messageABC".getBytes());
+    assertThat(response.byteArray()).isEqualTo(MESSAGE_CONTENT.getBytes());
+    assertThat(incomingRequestFuture.join()).isEqualTo(MESSAGE_CONTENT.getBytes());
   }
 
   @Test
@@ -235,7 +247,7 @@ public class AtomixTransportTest {
 
     // when
     clientTransport.sendRequestWithRetry(
-        nodeAddressSupplier, (response) -> false, new Request("messageABC"), REQUEST_TIMEOUT);
+        nodeAddressSupplier, (response) -> false, request, REQUEST_TIMEOUT);
 
     // then
     final var success = retryLatch.await(REQUEST_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
@@ -258,8 +270,7 @@ public class AtomixTransportTest {
 
     // when
     final var requestFuture =
-        clientTransport.sendRequestWithRetry(
-            nodeAddressSupplier, new Request("messageABC"), REQUEST_TIMEOUT);
+        clientTransport.sendRequestWithRetry(nodeAddressSupplier, request, REQUEST_TIMEOUT);
 
     // then
     assertThatThrownBy(requestFuture::join)
@@ -280,7 +291,7 @@ public class AtomixTransportTest {
 
     final var requestFuture =
         clientTransport.sendRequestWithRetry(
-            nodeAddressSupplier, new Request("messageABC"), REQUEST_TIMEOUT_NO_SUCCESS);
+            nodeAddressSupplier, request, REQUEST_TIMEOUT_NO_SUCCESS);
 
     // then
     assertThatThrownBy(requestFuture::join).hasCauseInstanceOf(TimeoutException.class);
@@ -294,7 +305,7 @@ public class AtomixTransportTest {
     // when
     final var requestFuture =
         clientTransport.sendRequestWithRetry(
-            () -> "0.0.0.0:26499", new Request("messageABC"), REQUEST_TIMEOUT_NO_SUCCESS);
+            () -> "0.0.0.0:26499", request, REQUEST_TIMEOUT_NO_SUCCESS);
 
     // then
     assertThatThrownBy(requestFuture::join).hasCauseInstanceOf(TimeoutException.class);
@@ -305,8 +316,7 @@ public class AtomixTransportTest {
     // given
 
     // when
-    final var requestFuture =
-        clientTransport.sendRequest(() -> null, new Request("messageABC"), REQUEST_TIMEOUT);
+    final var requestFuture = clientTransport.sendRequest(() -> null, request, REQUEST_TIMEOUT);
 
     // then
     assertThatThrownBy(requestFuture::join)
@@ -327,7 +337,7 @@ public class AtomixTransportTest {
               retryLatch.countDown();
               return nodeAddressRef.get();
             },
-            new Request("messageABC"),
+            request,
             REQUEST_TIMEOUT);
 
     // when
@@ -352,7 +362,7 @@ public class AtomixTransportTest {
         clientTransport.sendRequestWithRetry(
             nodeAddressSupplier,
             (responseToValidate) -> responseValidation.get(),
-            new Request("messageABC"),
+            request,
             REQUEST_TIMEOUT);
 
     // when
@@ -361,7 +371,7 @@ public class AtomixTransportTest {
 
     // then
     final var response = requestFuture.join();
-    assertThat(response.byteArray()).isEqualTo("messageABC".getBytes());
+    assertThat(response.byteArray()).isEqualTo(MESSAGE_CONTENT.getBytes());
   }
 
   @Test
@@ -371,7 +381,7 @@ public class AtomixTransportTest {
     // when
     final var requestFuture =
         clientTransport.sendRequestWithRetry(
-            () -> "0.0.0.0:26499", new Request("messageABC"), REQUEST_TIMEOUT_NO_SUCCESS);
+            () -> "0.0.0.0:26499", request, REQUEST_TIMEOUT_NO_SUCCESS);
 
     // then
     assertThatThrownBy(requestFuture::join).hasCauseInstanceOf(TimeoutException.class);
@@ -387,7 +397,7 @@ public class AtomixTransportTest {
               retryLatch.countDown();
               return serverAddress;
             },
-            new Request("messageABC"),
+            request,
             REQUEST_TIMEOUT);
 
     // when
@@ -396,7 +406,7 @@ public class AtomixTransportTest {
 
     // then
     final var response = requestFuture.join();
-    assertThat(response.byteArray()).isEqualTo("messageABC".getBytes());
+    assertThat(response.byteArray()).isEqualTo(MESSAGE_CONTENT.getBytes());
   }
 
   @Test
@@ -407,12 +417,11 @@ public class AtomixTransportTest {
 
     // when
     final var requestFuture =
-        clientTransport.sendRequest(
-            () -> serverAddress, new Request("messageABC"), REQUEST_TIMEOUT);
+        clientTransport.sendRequest(() -> serverAddress, request, REQUEST_TIMEOUT);
 
     // then
     final var response = requestFuture.join();
-    assertThat(response.byteArray()).isEqualTo("messageABC".getBytes());
+    assertThat(response.byteArray()).isEqualTo(MESSAGE_CONTENT.getBytes());
   }
 
   @Test
@@ -423,14 +432,12 @@ public class AtomixTransportTest {
 
     // when
     final var requestFuture1 =
-        clientTransport.sendRequestWithRetry(
-            nodeAddressSupplier, new Request("messageABC"), REQUEST_TIMEOUT);
+        clientTransport.sendRequestWithRetry(nodeAddressSupplier, request, REQUEST_TIMEOUT);
     requestFuture1.join();
     final long requestId1 = directlyResponder.serverResponse.getRequestId();
 
     final var requestFuture2 =
-        clientTransport.sendRequestWithRetry(
-            nodeAddressSupplier, new Request("messageABC"), REQUEST_TIMEOUT);
+        clientTransport.sendRequestWithRetry(nodeAddressSupplier, request, REQUEST_TIMEOUT);
     requestFuture2.join();
     final long requestId2 = directlyResponder.serverResponse.getRequestId();
 
@@ -441,9 +448,15 @@ public class AtomixTransportTest {
   private static final class Request implements ClientRequest {
 
     private final String msg;
+    private String partitionGroup = Protocol.DEFAULT_PARTITION_GROUP_NAME;
 
     public Request(final String msg) {
       this.msg = msg;
+    }
+
+    public Request withPartitionGroup(final String partitionGroup) {
+      this.partitionGroup = partitionGroup;
+      return this;
     }
 
     @Override
@@ -454,6 +467,11 @@ public class AtomixTransportTest {
     @Override
     public RequestType getRequestType() {
       return RequestType.COMMAND;
+    }
+
+    @Override
+    public String getPartitionGroup() {
+      return partitionGroup;
     }
 
     @Override


### PR DESCRIPTION
## Summary

Part of #50514 (Transport is aware of partition groups).

#### `ClientRequest` gets a partition group field (#50550)

- `ClientRequest` gains a `default String getPartitionGroup()` method returning `"default"`. All existing implementations get this automatically (non-breaking).
- `BrokerRequest` overrides `getPartitionGroup()` with a backing field (defaulting to `Protocol.DEFAULT_PARTITION_GROUP_NAME`) and exposes `setPartitionGroup(String)` so callers can target a specific engine.

#### `AtomixClientTransportAdapter` routes by partition group (#50551)

- The adapter now always computes the topic as `topicName(request.getPartitionGroup(), partitionId, requestType)`, producing topics like `default-command-api-1` or `tenant1-command-api-1`.
- The fixed `TopicSupplier` field and the `useLegacyTopics` boolean are removed entirely. Senders always use the new prefixed format; brokers already listen on both legacy and prefixed topics for the default tenant during rolling upgrades.
- `TransportFactory`, `BrokerClientImpl`, and `BrokerClientConfiguration` are simplified accordingly — `BrokerClientCfg` now only carries `requestTimeout`.

### Rolling upgrade compatibility

Brokers register handlers on both legacy topics (`command-api-1`) and prefixed topics (`default-command-api-1`) via `GatewayBrokerTransportStep`. Senders moving to prefixed-only sending is safe: old brokers accept the prefixed format and new brokers continue to accept both (for default physical tenant).

closes #50550
closes #50551

🤖 Generated with [Claude Code](https://claude.com/claude-code)