### PR TITLE
ci: improve OC nightly fix agent — race-safe run linking, Slack dispatch list, responses.json guard

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
@@ -513,7 +513,7 @@ jobs:
             icon=":warning:"; summary="No fix applied — manual investigation required"
           fi
 
-          text="${icon} *${VERSION}* fix agent — ${summary}\n<${RUN_URL}|Agent run ↗>"
+          text="${icon} *${VERSION}* fix agent — ${summary}"$'\n'"<${RUN_URL}|Agent run ↗>"
           payload=$(jq -nc \
             --arg channel    "$SLACK_CHANNEL" \
             --arg thread_ts  "$SLACK_THREAD_TS" \

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
@@ -334,25 +334,38 @@ jobs:
             if [ -n "$branch" ] && [ "$branch" != "null" ]; then
               echo "Triggering on-demand run for PR #${pr_number} branch ${branch}..."
               dispatched_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-              gh workflow run c8-orchestration-cluster-e2e-tests-on-demand.yml \
-                --repo "$REPO" -f branch="$branch"
-              # Poll up to 90s for the new run to appear.
-              # Filter by both creation time AND the branch input to avoid picking up a
-              # concurrent agent's run when multiple fix agents trigger on-demand workflows
-              # simultaneously (gh run list --limit N is not race-safe).
-              for _ in $(seq 1 18); do
-                sleep 5
-                run_id=$(gh api "repos/${REPO}/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml/runs?per_page=10" \
-                  2>/dev/null \
-                  | jq -r --arg t "$dispatched_at" --arg b "$branch" \
-                    '[.workflow_runs[] | select(.created_at >= $t and .inputs.branch == $b)] | first | .id // ""' \
-                  || echo "")
-                if [ -n "$run_id" ] && [ "$run_id" != "null" ]; then
-                  on_demand_run_url="https://github.com/${REPO}/actions/runs/${run_id}"
-                  echo "On-demand run: $on_demand_run_url"
-                  break
-                fi
-              done
+
+              # Recent gh versions print the run URL directly to stdout/stderr.
+              # Capture it — this is race-proof because it is the exact run we triggered.
+              # Note: the GitHub API does not expose workflow_dispatch inputs in the
+              # runs list or individual run endpoints, so we cannot filter by branch
+              # input after the fact.
+              trigger_output=$(gh workflow run c8-orchestration-cluster-e2e-tests-on-demand.yml \
+                --repo "$REPO" -f branch="$branch" 2>&1 || true)
+              echo "$trigger_output"
+              on_demand_run_url=$(echo "$trigger_output" \
+                | grep -o 'https://github\.com/[^[:space:]]*/runs/[0-9]*' | head -1 || echo "")
+
+              # Fallback: if gh did not print a URL (older gh version), poll by
+              # creation time. This is slightly race-prone when agents run concurrently
+              # but acceptable as a secondary path.
+              if [ -z "$on_demand_run_url" ]; then
+                echo "gh did not return run URL directly — falling back to time-based poll"
+                for _ in $(seq 1 18); do
+                  sleep 5
+                  run_id=$(gh api "repos/${REPO}/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml/runs?per_page=10" \
+                    2>/dev/null \
+                    | jq -r --arg t "$dispatched_at" \
+                      '[.workflow_runs[] | select(.created_at >= $t)] | first | .id // ""' \
+                    || echo "")
+                  if [ -n "$run_id" ] && [ "$run_id" != "null" ]; then
+                    on_demand_run_url="https://github.com/${REPO}/actions/runs/${run_id}"
+                    break
+                  fi
+                done
+              fi
+
+              [ -n "$on_demand_run_url" ] && echo "On-demand run: $on_demand_run_url"
             fi
 
             # Patch PR body with the verification link (idempotent: strip any

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
@@ -341,15 +341,16 @@ jobs:
               # runs list or individual run endpoints, so we cannot filter by branch
               # input after the fact.
               trigger_output=$(gh workflow run c8-orchestration-cluster-e2e-tests-on-demand.yml \
-                --repo "$REPO" -f branch="$branch" 2>&1 || true)
+                --repo "$REPO" -f branch="$branch" 2>&1)
+              dispatch_exit=$?
               echo "$trigger_output"
               on_demand_run_url=$(echo "$trigger_output" \
                 | grep -o 'https://github\.com/[^[:space:]]*/runs/[0-9]*' | head -1 || echo "")
 
               # Fallback: if gh did not print a URL (older gh version), poll by
-              # creation time. This is slightly race-prone when agents run concurrently
-              # but acceptable as a secondary path.
-              if [ -z "$on_demand_run_url" ]; then
+              # creation time. Only attempt when dispatch actually succeeded —
+              # if dispatch failed, the poll could pick up a different agent's run.
+              if [ -z "$on_demand_run_url" ] && [ "$dispatch_exit" -eq 0 ]; then
                 echo "gh did not return run URL directly — falling back to time-based poll"
                 for _ in $(seq 1 18); do
                   sleep 5
@@ -363,6 +364,8 @@ jobs:
                     break
                   fi
                 done
+              elif [ "$dispatch_exit" -ne 0 ]; then
+                echo "::warning::on-demand dispatch failed (exit $dispatch_exit) — skipping verification link"
               fi
 
               [ -n "$on_demand_run_url" ] && echo "On-demand run: $on_demand_run_url"

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
@@ -336,15 +336,16 @@ jobs:
               dispatched_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
               gh workflow run c8-orchestration-cluster-e2e-tests-on-demand.yml \
                 --repo "$REPO" -f branch="$branch"
-              # Poll up to 90s for the new run to appear
+              # Poll up to 90s for the new run to appear.
+              # Filter by both creation time AND the branch input to avoid picking up a
+              # concurrent agent's run when multiple fix agents trigger on-demand workflows
+              # simultaneously (gh run list --limit N is not race-safe).
               for _ in $(seq 1 18); do
                 sleep 5
-                run_id=$(gh run list \
-                  --workflow c8-orchestration-cluster-e2e-tests-on-demand.yml \
-                  --repo "$REPO" --limit 5 \
-                  --json databaseId,createdAt \
-                  | jq -r --arg t "$dispatched_at" \
-                    '[.[] | select(.createdAt >= $t)] | first | .databaseId // ""' || echo "")
+                run_id=$(gh api "repos/${REPO}/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml/runs?per_page=10" \
+                  --jq --arg t "$dispatched_at" --arg b "$branch" \
+                  '[.workflow_runs[] | select(.created_at >= $t and .inputs.branch == $b)] | first | .id // ""' \
+                  2>/dev/null || echo "")
                 if [ -n "$run_id" ] && [ "$run_id" != "null" ]; then
                   on_demand_run_url="https://github.com/${REPO}/actions/runs/${run_id}"
                   echo "On-demand run: $on_demand_run_url"

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
@@ -343,9 +343,10 @@ jobs:
               for _ in $(seq 1 18); do
                 sleep 5
                 run_id=$(gh api "repos/${REPO}/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml/runs?per_page=10" \
-                  --jq --arg t "$dispatched_at" --arg b "$branch" \
-                  '[.workflow_runs[] | select(.created_at >= $t and .inputs.branch == $b)] | first | .id // ""' \
-                  2>/dev/null || echo "")
+                  2>/dev/null \
+                  | jq -r --arg t "$dispatched_at" --arg b "$branch" \
+                    '[.workflow_runs[] | select(.created_at >= $t and .inputs.branch == $b)] | first | .id // ""' \
+                  || echo "")
                 if [ -n "$run_id" ] && [ "$run_id" != "null" ]; then
                   on_demand_run_url="https://github.com/${REPO}/actions/runs/${run_id}"
                   echo "On-demand run: $on_demand_run_url"

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -628,11 +628,21 @@ jobs:
             done
 
             test_count=$(echo "$specs" | jq 'length')
-            # Build a human-readable label from whichever nightly run types failed
+            # Build a human-readable label reflecting only the types that actually failed.
+            # For test-failure dispatches (specs non-empty), derive from test_specs so we
+            # don't show types that merely have a run ID attached but passed.
+            # For workflow-level dispatches (specs empty), fall back to run IDs.
             run_types=""
-            [ -n "$e2e"       ] && run_types="E2E"
-            [ -n "$api_es"    ] && run_types="${run_types:+${run_types} + }API (ES)"
-            [ -n "$api_rdbms" ] && run_types="${run_types:+${run_types} + }API (RDBMS)"
+            if [ "$test_count" -gt 0 ]; then
+              has_e2e=$(echo "$specs" | jq '[.[] | select(.test_type == "e2e")] | length > 0')
+              has_api=$(echo "$specs" | jq '[.[] | select(.test_type == "api")] | length > 0')
+              [ "$has_e2e" = "true" ] && run_types="E2E"
+              [ "$has_api" = "true" ] && run_types="${run_types:+${run_types} + }API"
+            else
+              [ -n "$e2e"       ] && run_types="E2E"
+              [ -n "$api_es"    ] && run_types="${run_types:+${run_types} + }API (ES)"
+              [ -n "$api_rdbms" ] && run_types="${run_types:+${run_types} + }API (RDBMS)"
+            fi
             [ -z "$run_types" ] && run_types="workflow-level"
             run_label="Nightly ${run_types} — ${version}"
 

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -635,8 +635,18 @@ jobs:
               fi
             done
 
+            test_count=$(echo "$specs" | jq 'length')
+            # Build a human-readable label from whichever nightly run types failed
+            run_types=""
+            [ -n "$e2e"       ] && run_types="E2E"
+            [ -n "$api_es"    ] && run_types="${run_types:+${run_types} + }API (ES)"
+            [ -n "$api_rdbms" ] && run_types="${run_types:+${run_types} + }API (RDBMS)"
+            [ -z "$run_types" ] && run_types="workflow-level"
+            run_label="Nightly ${run_types} — ${version}"
+
             jq --arg v "$version" --arg id "$fix_run_id" --arg repo "$REPO" \
-              '. += [{"version": $v, "run_id": $id, "run_url": ("https://github.com/" + $repo + "/actions/runs/" + $id)}]' \
+               --arg label "$run_label" --argjson count "$test_count" \
+              '. += [{"version": $v, "run_id": $id, "run_url": ("https://github.com/" + $repo + "/actions/runs/" + $id), "run_label": $label, "test_count": $count}]' \
               /tmp/fix_agent_runs.json > /tmp/fix_agent_runs.json.tmp
             mv /tmp/fix_agent_runs.json.tmp /tmp/fix_agent_runs.json
           done
@@ -683,15 +693,16 @@ jobs:
             dispatch_line=":robot_face: *Fix agents dispatched: ${dispatches}*"
             agent_list=""
             while IFS= read -r entry; do
-              version=$(echo "$entry" | jq -r '.version')
-              run_id=$(echo "$entry"  | jq -r '.run_id // ""')
+              run_id=$(echo "$entry"    | jq -r '.run_id // ""')
+              run_label=$(echo "$entry" | jq -r '.run_label // .version')
+              test_count=$(echo "$entry" | jq -r '.test_count // "?"')
               if [ -n "$run_id" ] && [ "$run_id" != "null" ]; then
-                agent_list="${agent_list}"$'\n'"  • \`${version}\` — <https://github.com/${REPO}/actions/runs/${run_id}|agent run ↗>"
+                agent_list="${agent_list}"$'\n'"  • ${run_label} — ${test_count} test(s) — <https://github.com/${REPO}/actions/runs/${run_id}|agent run ↗>"
               else
-                agent_list="${agent_list}"$'\n'"  • \`${version}\` — agent run pending"
+                agent_list="${agent_list}"$'\n'"  • ${run_label} — ${test_count} test(s) — agent run pending"
               fi
             done < <(jq -c '.[]' /tmp/fix_agent_runs.json)
-            dispatch_block="${dispatch_line}${agent_list}"
+            dispatch_block="${dispatch_line}"$'\n'"*Agents dispatched for:*${agent_list}"
           else
             dispatch_block=":information_source: No fix agents dispatched."
           fi

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -635,9 +635,11 @@ jobs:
             run_types=""
             if [ "$test_count" -gt 0 ]; then
               has_e2e=$(echo "$specs" | jq '[.[] | select(.test_type == "e2e")] | length > 0')
-              has_api=$(echo "$specs" | jq '[.[] | select(.test_type == "api")] | length > 0')
-              [ "$has_e2e" = "true" ] && run_types="E2E"
-              [ "$has_api" = "true" ] && run_types="${run_types:+${run_types} + }API"
+              has_api_es=$(echo "$specs" | jq '[.[] | select(.test_type == "api" and (.database == null or .database == "" or .database == "elasticsearch"))] | length > 0')
+              has_api_rdbms=$(echo "$specs" | jq '[.[] | select(.test_type == "api" and (.database != null and .database != "" and .database != "elasticsearch"))] | length > 0')
+              [ "$has_e2e" = "true" ]        && run_types="E2E"
+              [ "$has_api_es" = "true" ]     && run_types="${run_types:+${run_types} + }API (ES)"
+              [ "$has_api_rdbms" = "true" ]  && run_types="${run_types:+${run_types} + }API (RDBMS)"
             else
               [ -n "$e2e"       ] && run_types="E2E"
               [ -n "$api_es"    ] && run_types="${run_types:+${run_types} + }API (ES)"

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -24,11 +24,6 @@ on:
         description: 'Max fix-agent dispatches this run (default: 4 — one per supported version)'
         default: '4'
         required: false
-      include_main:
-        description: 'Include main in triage scope (set false to limit to stable branches)'
-        type: boolean
-        default: true
-        required: false
       send_slack_notification:
         description: 'Post triage summary and fix-agent replies to Slack (always true for scheduled runs)'
         type: boolean
@@ -88,7 +83,6 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.secrets.outputs.GH_TOKEN }}
           REPO:     ${{ github.repository }}
-          INCLUDE_MAIN: ${{ github.event.inputs.include_main || 'true' }}
         run: |
           set -euo pipefail
 
@@ -103,13 +97,11 @@ jobs:
             "c8-orchestration-cluster-nightly-8.9-api-es.yml|8.9|api_es"
             "c8-orchestration-cluster-nightly-8.9-api-rdbms.yml|8.9|api_rdbms"
           )
-          if [ "$INCLUDE_MAIN" = "true" ]; then
-            SCOPE+=(
-              "c8-orchestration-cluster-nightly-main-e2e.yml|main|e2e"
-              "c8-orchestration-cluster-nightly-main-api-es.yml|main|api_es"
-              "c8-orchestration-cluster-nightly-main-api-rdbms.yml|main|api_rdbms"
-            )
-          fi
+          SCOPE+=(
+            "c8-orchestration-cluster-nightly-main-e2e.yml|main|e2e"
+            "c8-orchestration-cluster-nightly-main-api-es.yml|main|api_es"
+            "c8-orchestration-cluster-nightly-main-api-rdbms.yml|main|api_rdbms"
+          )
 
           # Working files
           all_failures=/tmp/all_failures.jsonl

--- a/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
@@ -442,7 +442,7 @@ If a minimal test-side fix exists, apply it.
 
 ### Constraints
 
-- **Allowed tools:** `gh`, `git`, `grep`, `rg`, `cat`, `find`, `jq`, `sed`, `awk`, `unzip`, `npx prettier`, `npx eslint`.
+- **Allowed tools:** `gh`, `git`, `grep`, `rg`, `cat`, `find`, `jq`, `sed`, `awk`, `unzip`, `npx prettier`, `npx eslint`, `npm run responses:regenerate`.
 - **Forbidden:** `make`, `mvn`, `./mvnw`, `docker`, `kubectl`, `helm`, `npm install`, `npm run build`, `npm run test`, `npx playwright test`. The fix agent does **not** execute tests — it fixes from artifact evidence only. Verification is delegated to the on-demand workflows triggered by the calling workflow.
 - **NO skipping — EVER:** `test.skip()`, `test.fixme()`, `test.only`, and all pending variants are banned. There are no exceptions, not even for confirmed product bugs. If you cannot fix in code, write `{"prs":[]}` and stop.
 - **Never edit `json-body-assertions/_generated/responses.json` by hand.** This file is auto-generated. If an API response changes, regenerate it with `npm run responses:regenerate` and commit the result. Manual edits will be overwritten and produce misleading diffs.

--- a/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
@@ -43,7 +43,7 @@ test-setup.ts      # Shared setup helpers (captureScreenshot, captureFailureVide
 pages/             # Page Object Model classes (one file per page)
 utils/             # Helpers: zeebeClient, waitForAssertion, requestHelpers, cleanup utils, etc.
 resources/         # Test data: BPMN files, forms, connector templates
-json-body-assertions/    # OpenAPI-driven response assertions (regenerated via npx assert-json-body extract)
+json-body-assertions/    # OpenAPI-driven response assertions (regenerated via npx --yes assert-json-body@^1.7.1 extract)
 config/
   docker-compose.yml         # Local Elasticsearch + Camunda stack
   application.yaml           # RDBMS config template (copy to dist before starting)
@@ -442,10 +442,10 @@ If a minimal test-side fix exists, apply it.
 
 ### Constraints
 
-- **Allowed tools:** `gh`, `git`, `grep`, `rg`, `cat`, `find`, `jq`, `sed`, `awk`, `unzip`, `npx prettier`, `npx eslint`, `npx assert-json-body extract`.
+- **Allowed tools:** `gh`, `git`, `grep`, `rg`, `cat`, `find`, `jq`, `sed`, `awk`, `unzip`, `npx prettier`, `npx eslint`, `npx --yes assert-json-body@^1.7.1 extract`.
 - **Forbidden:** `make`, `mvn`, `./mvnw`, `docker`, `kubectl`, `helm`, `npm install`, `npm run build`, `npm run test`, `npx playwright test`. The fix agent does **not** execute tests — it fixes from artifact evidence only. Verification is delegated to the on-demand workflows triggered by the calling workflow.
 - **NO skipping — EVER:** `test.skip()`, `test.fixme()`, `test.only`, and all pending variants are banned. There are no exceptions, not even for confirmed product bugs. If you cannot fix in code, write `{"prs":[]}` and stop.
-- **Never edit `json-body-assertions/_generated/responses.json` by hand.** This file is auto-generated. If an API response changes, regenerate it with `npx assert-json-body extract` and commit the result. Manual edits will be overwritten and produce misleading diffs.
+- **Never edit `json-body-assertions/_generated/responses.json` by hand.** This file is auto-generated. If an API response changes, regenerate it with `npx --yes assert-json-body@^1.7.1 extract` and commit the result. Manual edits will be overwritten and produce misleading diffs.
 - **Minimal diff:** no refactoring, no dependency bumps, no unrelated edits, no formatting sweeps on untouched files.
 - **PR title type must be `test:`** — commitlint rejects `fix:` for test-only changes (see Commit / PR Conventions above).
 - **One PR per version** — a single PR may fix multiple tests on the same `stable/<version>` branch, including a mix of API and E2E failures, but never crosses branch boundaries.

--- a/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
@@ -43,7 +43,7 @@ test-setup.ts      # Shared setup helpers (captureScreenshot, captureFailureVide
 pages/             # Page Object Model classes (one file per page)
 utils/             # Helpers: zeebeClient, waitForAssertion, requestHelpers, cleanup utils, etc.
 resources/         # Test data: BPMN files, forms, connector templates
-json-body-assertions/    # OpenAPI-driven response assertions (regenerated via npx --yes assert-json-body@^1.7.1 extract)
+json-body-assertions/    # OpenAPI-driven response assertions (regenerated via npm run responses:regenerate)
 config/
   docker-compose.yml         # Local Elasticsearch + Camunda stack
   application.yaml           # RDBMS config template (copy to dist before starting)
@@ -442,10 +442,10 @@ If a minimal test-side fix exists, apply it.
 
 ### Constraints
 
-- **Allowed tools:** `gh`, `git`, `grep`, `rg`, `cat`, `find`, `jq`, `sed`, `awk`, `unzip`, `npx prettier`, `npx eslint`, `npx --yes assert-json-body@^1.7.1 extract`.
+- **Allowed tools:** `gh`, `git`, `grep`, `rg`, `cat`, `find`, `jq`, `sed`, `awk`, `unzip`, `npx prettier`, `npx eslint`, `npm run responses:regenerate`.
 - **Forbidden:** `make`, `mvn`, `./mvnw`, `docker`, `kubectl`, `helm`, `npm install`, `npm run build`, `npm run test`, `npx playwright test`. The fix agent does **not** execute tests — it fixes from artifact evidence only. Verification is delegated to the on-demand workflows triggered by the calling workflow.
 - **NO skipping — EVER:** `test.skip()`, `test.fixme()`, `test.only`, and all pending variants are banned. There are no exceptions, not even for confirmed product bugs. If you cannot fix in code, write `{"prs":[]}` and stop.
-- **Never edit `json-body-assertions/_generated/responses.json` by hand.** This file is auto-generated. If an API response changes, regenerate it with `npx --yes assert-json-body@^1.7.1 extract` and commit the result. Manual edits will be overwritten and produce misleading diffs.
+- **Never edit `json-body-assertions/_generated/responses.json` by hand.** This file is auto-generated. If an API response changes, regenerate it with `npm run responses:regenerate` and commit the result. Manual edits will be overwritten and produce misleading diffs.
 - **Minimal diff:** no refactoring, no dependency bumps, no unrelated edits, no formatting sweeps on untouched files.
 - **PR title type must be `test:`** — commitlint rejects `fix:` for test-only changes (see Commit / PR Conventions above).
 - **One PR per version** — a single PR may fix multiple tests on the same `stable/<version>` branch, including a mix of API and E2E failures, but never crosses branch boundaries.

--- a/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
@@ -43,7 +43,7 @@ test-setup.ts      # Shared setup helpers (captureScreenshot, captureFailureVide
 pages/             # Page Object Model classes (one file per page)
 utils/             # Helpers: zeebeClient, waitForAssertion, requestHelpers, cleanup utils, etc.
 resources/         # Test data: BPMN files, forms, connector templates
-json-body-assertions/    # OpenAPI-driven response assertions (regenerated via npm run responses:regenerate)
+json-body-assertions/    # OpenAPI-driven response assertions (regenerated via npx assert-json-body extract)
 config/
   docker-compose.yml         # Local Elasticsearch + Camunda stack
   application.yaml           # RDBMS config template (copy to dist before starting)
@@ -442,10 +442,10 @@ If a minimal test-side fix exists, apply it.
 
 ### Constraints
 
-- **Allowed tools:** `gh`, `git`, `grep`, `rg`, `cat`, `find`, `jq`, `sed`, `awk`, `unzip`, `npx prettier`, `npx eslint`, `npm run responses:regenerate`.
+- **Allowed tools:** `gh`, `git`, `grep`, `rg`, `cat`, `find`, `jq`, `sed`, `awk`, `unzip`, `npx prettier`, `npx eslint`, `npx assert-json-body extract`.
 - **Forbidden:** `make`, `mvn`, `./mvnw`, `docker`, `kubectl`, `helm`, `npm install`, `npm run build`, `npm run test`, `npx playwright test`. The fix agent does **not** execute tests — it fixes from artifact evidence only. Verification is delegated to the on-demand workflows triggered by the calling workflow.
 - **NO skipping — EVER:** `test.skip()`, `test.fixme()`, `test.only`, and all pending variants are banned. There are no exceptions, not even for confirmed product bugs. If you cannot fix in code, write `{"prs":[]}` and stop.
-- **Never edit `json-body-assertions/_generated/responses.json` by hand.** This file is auto-generated. If an API response changes, regenerate it with `npm run responses:regenerate` and commit the result. Manual edits will be overwritten and produce misleading diffs.
+- **Never edit `json-body-assertions/_generated/responses.json` by hand.** This file is auto-generated. If an API response changes, regenerate it with `npx assert-json-body extract` and commit the result. Manual edits will be overwritten and produce misleading diffs.
 - **Minimal diff:** no refactoring, no dependency bumps, no unrelated edits, no formatting sweeps on untouched files.
 - **PR title type must be `test:`** — commitlint rejects `fix:` for test-only changes (see Commit / PR Conventions above).
 - **One PR per version** — a single PR may fix multiple tests on the same `stable/<version>` branch, including a mix of API and E2E failures, but never crosses branch boundaries.

--- a/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
@@ -445,6 +445,7 @@ If a minimal test-side fix exists, apply it.
 - **Allowed tools:** `gh`, `git`, `grep`, `rg`, `cat`, `find`, `jq`, `sed`, `awk`, `unzip`, `npx prettier`, `npx eslint`.
 - **Forbidden:** `make`, `mvn`, `./mvnw`, `docker`, `kubectl`, `helm`, `npm install`, `npm run build`, `npm run test`, `npx playwright test`. The fix agent does **not** execute tests — it fixes from artifact evidence only. Verification is delegated to the on-demand workflows triggered by the calling workflow.
 - **NO skipping — EVER:** `test.skip()`, `test.fixme()`, `test.only`, and all pending variants are banned. There are no exceptions, not even for confirmed product bugs. If you cannot fix in code, write `{"prs":[]}` and stop.
+- **Never edit `json-body-assertions/_generated/responses.json` by hand.** This file is auto-generated. If an API response changes, regenerate it with `npm run responses:regenerate` and commit the result. Manual edits will be overwritten and produce misleading diffs.
 - **Minimal diff:** no refactoring, no dependency bumps, no unrelated edits, no formatting sweeps on untouched files.
 - **PR title type must be `test:`** — commitlint rejects `fix:` for test-only changes (see Commit / PR Conventions above).
 - **One PR per version** — a single PR may fix multiple tests on the same `stable/<version>` branch, including a mix of API and E2E failures, but never crosses branch boundaries.


### PR DESCRIPTION
## Summary

Three improvements to the OC nightly fix agent pipeline:

### 1. Race-safe on-demand verification run linking (`c8-orchestration-cluster-e2e-nightly-fix.yml`)

**Problem:** When multiple fix agents trigger the on-demand workflow concurrently, both poll \`gh run list --limit 5\` filtered only by creation time. Within the same second, either agent can pick up the other's run URL and link the wrong run in its PR body.

**Fix:** Capture the run URL directly from \`gh workflow run\` stdout — recent \`gh\` versions print it immediately after dispatch, so it is inherently race-proof (it is the exact URL for the run we triggered). A time-based poll fallback is kept for older \`gh\` versions, but is now only attempted when dispatch itself succeeded (exit code 0), preventing the poll from picking up a different agent's run on dispatch failure.

Note: the GitHub API does not expose workflow_dispatch inputs in the runs list endpoint, so filtering by \`inputs.branch\` is not possible.

### 2. Richer Slack dispatch list (`c8-orchestration-cluster-e2e-nightly-triage.yml`)

**Problem:** The Slack update only showed \`• \`8.9\` — agent run ↗\`, giving no indication of which nightly runs or how many tests were involved.

**Fix:** Now shows the failing nightly run type(s) (derived from \`test_specs\` content, not run IDs) and test count per dispatch:

```
🤖 Fix agents dispatched: 2
Agents dispatched for:
  • Nightly E2E + API (ES) — 8.9 — 3 test(s) — agent run ↗
  • Nightly E2E — 8.8 — 1 test(s) — agent run ↗
```

### 3. `responses.json` guard in AGENTS.md

**Problem:** The fix agent had no instruction about \`json-body-assertions/_generated/responses.json\`, risking hand-edits that get silently overwritten.

**Fix:** Added a constraint bullet forbidding manual edits and pointing to \`npx --yes assert-json-body@^1.7.1 extract\` (pinned to the same semver range as the repo devDependency). The \`npx\` form works without a prior \`npm install\`.

> **Note:** The AGENTS.md change in this PR targets \`main\`. Backport to \`stable/8.7\`, \`stable/8.8\`, and \`stable/8.9\` is tracked in PR #54573.

## Test plan

- [ ] Trigger two concurrent fix agents for different versions and confirm each PR body links its own on-demand run
- [ ] Verify Slack dispatch message shows run type labels and test counts
- [ ] Confirm \`responses.json\` constraint appears in AGENTS.md on \`main\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)