### PR TITLE
feat: extend pi schema

### DIFF
--- a/webapp/client/apps/orchestration-cluster-webapp/package.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/package.json
@@ -17,7 +17,7 @@
 		"generate:svg": "svgr --typescript --no-index --out-dir src/modules/svg src/assets/svg"
 	},
 	"dependencies": {
-		"@camunda/camunda-api-zod-schemas": "0.0.69",
+		"@camunda/camunda-api-zod-schemas": "0.0.70",
 		"@camunda/camunda-composite-components": "0.23.3",
 		"@tanstack/react-query": "5.100.14",
 		"@tanstack/react-query-devtools": "5.100.14",

--- a/webapp/client/package-lock.json
+++ b/webapp/client/package-lock.json
@@ -22,7 +22,7 @@
 		"apps/orchestration-cluster-webapp": {
 			"name": "@camunda/orchestration-cluster-webapp",
 			"dependencies": {
-				"@camunda/camunda-api-zod-schemas": "0.0.69",
+				"@camunda/camunda-api-zod-schemas": "0.0.70",
 				"@camunda/camunda-composite-components": "0.23.3",
 				"@tanstack/react-query": "5.100.14",
 				"@tanstack/react-query-devtools": "5.100.14",
@@ -9567,13 +9567,13 @@
 			"version": "0.0.1",
 			"license": "LicenseRef-Camunda-1.0",
 			"devDependencies": {
-				"@camunda/camunda-api-zod-schemas": "0.0.69",
+				"@camunda/camunda-api-zod-schemas": "0.0.70",
 				"typescript": "6.0.3"
 			}
 		},
 		"packages/camunda-api-zod-schemas": {
 			"name": "@camunda/camunda-api-zod-schemas",
-			"version": "0.0.69",
+			"version": "0.0.70",
 			"license": "LicenseRef-Camunda-1.0",
 			"devDependencies": {
 				"@types/node": "25.9.1",

--- a/webapp/client/packages/c8-mocks/package.json
+++ b/webapp/client/packages/c8-mocks/package.json
@@ -18,7 +18,7 @@
 		"typecheck": "tsc"
 	},
 	"devDependencies": {
-		"@camunda/camunda-api-zod-schemas": "0.0.69",
+		"@camunda/camunda-api-zod-schemas": "0.0.70",
 		"typescript": "6.0.3"
 	}
 }

--- a/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
+++ b/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## v0.0.70
+
+### 🚀 Enhancements
+
+- Add typed variable filter schemas for `8.10/process-instance`
+  - `processInstanceVariableValueFilterSchema` a discriminated union of single-key operator objects (`$eq` / `$neq` / `$like` / `$in` / `$notIn` / `$exists`) plus the shorthand bare-string form; mirrors
+     backend schema
+  - `processInstanceVariableFilterSchema` now uses the tighter value schema and is exported top-level
+  - `ProcessInstanceVariableFilter` and `ProcessInstanceVariableValueFilter` types exported
+  - Tightens variable filter validation: rejects multi-operator combinations (e.g. `{$eq: "x", $neq: "y"}`), unknown keys, and operator-shape mismatches
+
+### ❤️ Contributors
+
+- Yuliia Saienko ([@juliasaienko](https://github.com/juliasaienko))
+
+
 ## v0.0.69
 
 ### 🚀 Enhancements

--- a/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/index.ts
+++ b/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/index.ts
@@ -756,6 +756,8 @@ export {
 	processInstanceSchema,
 	sequenceFlowSchema,
 	callHierarchySchema,
+	processInstanceVariableFilterSchema,
+	processInstanceVariableValueFilterSchema,
 	type CreateProcessInstanceRequestBody,
 	type CreateProcessInstanceResponseBody,
 	type QueryProcessInstancesRequestBody,
@@ -782,6 +784,8 @@ export {
 	type CreateModificationBatchOperationRequestBody,
 	type CreateModificationBatchOperationResponseBody,
 	type ResolveProcessInstanceIncidentsResponseBody,
+	type ProcessInstanceVariableFilter,
+	type ProcessInstanceVariableValueFilter,
 } from './process-instance';
 export {
 	userTaskSchema,

--- a/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/process-instance.ts
+++ b/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/process-instance.ts
@@ -36,10 +36,24 @@ const processInstanceBatchOperationTypeSchema = z.union([
 	z.literal('DELETE_DECISION_INSTANCE'),
 ]);
 
-const processInstanceVariableFilterSchema = z.object({
-	name: z.string(),
-	value: advancedStringFilterSchema,
-});
+const processInstanceVariableValueFilterSchema = z.union([
+	z.string(),
+	z.object({$eq: z.string()}).strict(),
+	z.object({$neq: z.string()}).strict(),
+	z.object({$like: z.string()}).strict(),
+	z.object({$in: z.array(z.string())}).strict(),
+	z.object({$notIn: z.array(z.string())}).strict(),
+	z.object({$exists: z.boolean()}).strict(),
+]);
+type ProcessInstanceVariableValueFilter = z.infer<typeof processInstanceVariableValueFilterSchema>;
+
+const processInstanceVariableFilterSchema = z
+	.object({
+		name: z.string(),
+		value: processInstanceVariableValueFilterSchema,
+	})
+	.strict();
+type ProcessInstanceVariableFilter = z.infer<typeof processInstanceVariableFilterSchema>;
 
 const advancedProcessInstanceStateFilterSchema = z
 	.object({
@@ -421,6 +435,8 @@ export {
 	processInstanceSchema,
 	sequenceFlowSchema,
 	callHierarchySchema,
+	processInstanceVariableFilterSchema,
+	processInstanceVariableValueFilterSchema,
 };
 export type {
 	CreateProcessInstanceRequestBody,
@@ -450,4 +466,6 @@ export type {
 	CreateModificationBatchOperationResponseBody,
 	ModifyProcessInstanceRequestBody,
 	ResolveProcessInstanceIncidentsResponseBody,
+	ProcessInstanceVariableFilter,
+	ProcessInstanceVariableValueFilter,
 };

--- a/webapp/client/packages/camunda-api-zod-schemas/package.json
+++ b/webapp/client/packages/camunda-api-zod-schemas/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda/camunda-api-zod-schemas",
-	"version": "0.0.69",
+	"version": "0.0.70",
 	"license": "LicenseRef-Camunda-1.0",
 	"description": "Zod schemas and TypeScript types for Camunda 8 unified API",
 	"author": "Vinicius Goulart <vinicius.goulart@camunda.com>",


### PR DESCRIPTION
## Description

 Add typed variable filter schemas for `8.10/process-instance`, tightening validation so it actually catches malformed operator objects

## Related issues

related to #54031 
