### PR TITLE
test: stabilize suspend-batch-twice nightly flake on stable/8.9

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts
@@ -65,12 +65,14 @@ test.describe('Suspend & Resume Batch Operation Tests', () => {
   }) => {
     const key =
       await test.step('Create cancelable batch operation', async () => {
-        // Use 20 instances so the batch stays ACTIVE long enough for the
+        // Use 30 instances so the batch stays ACTIVE long enough for the
         // suspend command to take effect before the engine finishes it. With
-        // only 3 instances the batch can reach COMPLETED before the suspend is
-        // applied, so the poll for SUSPENDED never succeeds (same race the
-        // first suspend test guards against — not an indexing lag).
-        return createCancellationBatch(request, 20, 'batch_suspension_process');
+        // fewer instances the batch can reach COMPLETED before the suspend is
+        // applied, so suspend returns a permanent NOT_FOUND (404) and the poll
+        // never succeeds (same race the first suspend test guards against — not
+        // an indexing lag). 20 still flaked on the loaded nightly cluster, so
+        // match the count used on main.
+        return createCancellationBatch(request, 30, 'batch_suspension_process');
       });
 
     await test.step('Suspend batch operation once', async () => {


### PR DESCRIPTION
## Problem

The nightly API test **"Suspend batch operation twice fails on second request, finally resumes"** (`tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts`) failed on `stable/8.9`.

The `Suspend batch operation once` step returned a permanent **404 (NOT_FOUND)** for the full 240s poll budget:

```
Expected: 204
Received: 404
Timeout 240000ms exceeded while waiting on the predicate
  at suspendBatchOperation (utils/requestHelpers/batch-operation-requestHelpers.ts:52)
```

## Root cause

With only 20 simple process instances, the cancellation batch can reach `COMPLETED` before the suspend command is applied by the engine. Suspending a finished batch is a permanent `NOT_FOUND`, so the retry loop never recovers — it is a race, not indexing lag. The sibling "Suspend active batch operation..." test shares the same race and only passed in this run by timing luck.

## Fix

Bump the instance count for this test from **20 → 30**, matching the value already used for the same tests on `main`. More in-flight cancellations keep the batch `ACTIVE` long enough for the suspend command to land while it is still running.

Minimal, test-only change; no skip/fixme introduced.

Nightly run: https://github.com/camunda/camunda/actions/runs/26859461961

🤖 Generated with [Claude Code](https://claude.com/claude-code)