### PR TITLE
ci: widen Camunda start retry window with exponential backoff in OC test workflows

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-e2e-api-test-branch-on-demand.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-api-test-branch-on-demand.yml
@@ -151,7 +151,8 @@ jobs:
             fi
           }
 
-          attempts=3
+          attempts=5
+          delay=15
           for attempt in $(seq 1 "$attempts"); do
             if start_camunda; then
               echo "Camunda started on attempt ${attempt}."
@@ -159,8 +160,9 @@ jobs:
             fi
             echo "Attempt ${attempt}/${attempts} to start Camunda failed."
             if [[ "$attempt" -lt "$attempts" ]]; then
-              echo "Retrying in 15s..."
-              sleep 15
+              echo "Retrying in ${delay}s (exponential backoff)..."
+              sleep "$delay"
+              delay=$(( delay * 2 ))
             fi
           done
 

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml
@@ -98,7 +98,8 @@ jobs:
             fi
           }
 
-          attempts=3
+          attempts=5
+          delay=15
           for attempt in $(seq 1 "$attempts"); do
             if start_camunda; then
               echo "Camunda started on attempt ${attempt}."
@@ -106,8 +107,9 @@ jobs:
             fi
             echo "Attempt ${attempt}/${attempts} to start Camunda failed."
             if [[ "$attempt" -lt "$attempts" ]]; then
-              echo "Retrying in 15s..."
-              sleep 15
+              echo "Retrying in ${delay}s (exponential backoff)..."
+              sleep "$delay"
+              delay=$(( delay * 2 ))
             fi
           done
 
@@ -492,7 +494,8 @@ jobs:
             fi
           }
 
-          attempts=3
+          attempts=5
+          delay=15
           for attempt in $(seq 1 "$attempts"); do
             if start_camunda; then
               echo "Camunda started on attempt ${attempt}."
@@ -500,8 +503,9 @@ jobs:
             fi
             echo "Attempt ${attempt}/${attempts} to start Camunda failed."
             if [[ "$attempt" -lt "$attempts" ]]; then
-              echo "Retrying in 15s..."
-              sleep 15
+              echo "Retrying in ${delay}s (exponential backoff)..."
+              sleep "$delay"
+              delay=$(( delay * 2 ))
             fi
           done
 

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
@@ -227,7 +227,8 @@ jobs:
             fi
           }
 
-          attempts=3
+          attempts=5
+          delay=15
           for attempt in $(seq 1 "$attempts"); do
             if start_camunda; then
               echo "Camunda started on attempt ${attempt}."
@@ -235,8 +236,9 @@ jobs:
             fi
             echo "Attempt ${attempt}/${attempts} to start Camunda failed."
             if [[ "$attempt" -lt "$attempts" ]]; then
-              echo "Retrying in 15s..."
-              sleep 15
+              echo "Retrying in ${delay}s (exponential backoff)..."
+              sleep "$delay"
+              delay=$(( delay * 2 ))
             fi
           done
 
@@ -901,7 +903,8 @@ jobs:
             fi
           }
 
-          attempts=3
+          attempts=5
+          delay=15
           for attempt in $(seq 1 "$attempts"); do
             if start_camunda; then
               echo "Camunda started on attempt ${attempt}."
@@ -909,8 +912,9 @@ jobs:
             fi
             echo "Attempt ${attempt}/${attempts} to start Camunda failed."
             if [[ "$attempt" -lt "$attempts" ]]; then
-              echo "Retrying in 15s..."
-              sleep 15
+              echo "Retrying in ${delay}s (exponential backoff)..."
+              sleep "$delay"
+              delay=$(( delay * 2 ))
             fi
           done
 

--- a/.github/workflows/c8-orchestration-cluster-forward-compatibility-tests.yml
+++ b/.github/workflows/c8-orchestration-cluster-forward-compatibility-tests.yml
@@ -153,7 +153,8 @@ jobs:
           echo "Pulling image: ${{ matrix.server_image }}"
           # Retry to absorb transient Docker Hub registry timeouts
           # (e.g. "Get https://registry-1.docker.io/v2/: context deadline exceeded").
-          attempts=3
+          attempts=5
+          delay=15
           for attempt in $(seq 1 "$attempts"); do
             if docker pull "${{ matrix.server_image }}"; then
               echo "Image pulled on attempt ${attempt}."
@@ -161,8 +162,9 @@ jobs:
             fi
             echo "Attempt ${attempt}/${attempts} to pull image failed."
             if [[ "$attempt" -lt "$attempts" ]]; then
-              echo "Retrying in 15s..."
-              sleep 15
+              echo "Retrying in ${delay}s (exponential backoff)..."
+              sleep "$delay"
+              delay=$(( delay * 2 ))
             fi
           done
           echo "Failed to pull image after ${attempts} attempts."

--- a/.github/workflows/c8-orchestration-cluster-request-validation-nightly.yml
+++ b/.github/workflows/c8-orchestration-cluster-request-validation-nightly.yml
@@ -33,7 +33,8 @@ jobs:
           # image pull (e.g. "Get https://registry-1.docker.io/v2/: context
           # deadline exceeded"). docker compose up -d is idempotent, so a retry
           # simply resumes the pull and starts the container.
-          attempts=3
+          attempts=5
+          delay=15
           for attempt in $(seq 1 "$attempts"); do
             if DATABASE=elasticsearch docker compose up -d camunda; then
               echo "Camunda started on attempt ${attempt}."
@@ -41,8 +42,9 @@ jobs:
             fi
             echo "Attempt ${attempt}/${attempts} to start Camunda failed."
             if [[ "$attempt" -lt "$attempts" ]]; then
-              echo "Retrying in 15s..."
-              sleep 15
+              echo "Retrying in ${delay}s (exponential backoff)..."
+              sleep "$delay"
+              delay=$(( delay * 2 ))
             fi
           done
           echo "Failed to start Camunda after ${attempts} attempts."

--- a/.github/workflows/c8-orchestration-cluster-reusable-api-tests.yml
+++ b/.github/workflows/c8-orchestration-cluster-reusable-api-tests.yml
@@ -54,7 +54,8 @@ jobs:
             fi
           }
 
-          attempts=3
+          attempts=5
+          delay=15
           for attempt in $(seq 1 "$attempts"); do
             if start_camunda; then
               echo "Camunda started on attempt ${attempt}."
@@ -62,8 +63,9 @@ jobs:
             fi
             echo "Attempt ${attempt}/${attempts} to start Camunda failed."
             if [[ "$attempt" -lt "$attempts" ]]; then
-              echo "Retrying in 15s..."
-              sleep 15
+              echo "Retrying in ${delay}s (exponential backoff)..."
+              sleep "$delay"
+              delay=$(( delay * 2 ))
             fi
           done
 

--- a/.github/workflows/c8-orchestration-cluster-reusable-e2e-tests.yml
+++ b/.github/workflows/c8-orchestration-cluster-reusable-e2e-tests.yml
@@ -63,7 +63,8 @@ jobs:
             fi
           }
 
-          attempts=3
+          attempts=5
+          delay=15
           for attempt in $(seq 1 "$attempts"); do
             if start_camunda; then
               echo "Camunda started on attempt ${attempt}."
@@ -71,8 +72,9 @@ jobs:
             fi
             echo "Attempt ${attempt}/${attempts} to start Camunda failed."
             if [[ "$attempt" -lt "$attempts" ]]; then
-              echo "Retrying in 15s..."
-              sleep 15
+              echo "Retrying in ${delay}s (exponential backoff)..."
+              sleep "$delay"
+              delay=$(( delay * 2 ))
             fi
           done
 


### PR DESCRIPTION
## Problem

The nightly **C8 Orchestration Cluster 8.9 E2E** run failed at the **Start Camunda** step in the v2 (Tasklist V2) job. All three `docker compose up` image-pull attempts hit Docker Hub registry timeouts within a ~75s window:

```
camunda Error Get "https://registry-1.docker.io/v2/": context deadline exceeded
Attempt 1/3 to start Camunda failed.
... Attempt 2/3 ... Attempt 3/3 ...
Failed to start Camunda after 3 attempts.
```

The v1 job, pulling the same images, succeeded — confirming a transient Docker Hub blip rather than a bad image or test regression. The existing retry (added in `7c65f3937d0`) used a fixed 15s sleep and only 3 attempts, so the loop finished (~30s of backoff) before the registry outage cleared.

## Fix

Widen the retry window in the shared "Start Camunda" / image-pull retry blocks:

- `attempts` 3 → 5
- fixed `sleep 15` → exponential backoff: 15s, 30s, 60s, 120s

Total backoff window grows from ~30s to ~225s, enough to ride out a longer Docker Hub timeout like the one observed. No test behavior changes — `docker compose up -d` remains idempotent, so a retry simply resumes the partial pull.

Applied consistently to every OC test workflow that carries this identical retry block (e2e nightly/on-demand/release, api tests, request-validation nightly) plus the forward-compatibility image-pull retry.

## Validation

- `bash -n` on the new loop — clean
- YAML parse of all 7 changed files — clean
- `actionlint` — no new findings (only pre-existing self-hosted runner-label warnings)

Nightly run: https://github.com/camunda/camunda/actions/runs/26859461961

🤖 Generated with [Claude Code](https://claude.com/claude-code)