### PR TITLE
test: widen ACTIVE window for suspend-twice batch operation test

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts
@@ -65,12 +65,16 @@ test.describe('Suspend & Resume Batch Operation Tests', () => {
   }) => {
     const key =
       await test.step('Create cancelable batch operation', async () => {
-        // Use 20 instances so the batch stays ACTIVE long enough for the
-        // suspend command to take effect before the engine finishes it. With
-        // only 3 instances the batch can reach COMPLETED before the suspend is
-        // applied, so the poll for SUSPENDED never succeeds (same race the
-        // first suspend test guards against — not an indexing lag).
-        return createCancellationBatch(request, 20, 'batch_suspension_process');
+        // The cancellation batch over service-task-blocked instances finishes
+        // in milliseconds, and once it reaches COMPLETED the suspend command is
+        // rejected with a permanent NOT_FOUND (404) that the 240s retry budget
+        // can never recover from. The batch's ACTIVE window must therefore be
+        // wide enough that the first suspend lands before completion. 20
+        // instances proved too tight on the loaded ES nightly cluster (404 for
+        // the full 240s on both attempts); 50 gives a comfortable margin over
+        // the boundary — well above the sibling cancel-active test's 30, since
+        // this test must additionally reach SUSPENDED before the batch finishes.
+        return createCancellationBatch(request, 50, 'batch_suspension_process');
       });
 
     await test.step('Suspend batch operation once', async () => {


### PR DESCRIPTION
## Problem

The nightly API (ES) run for `stable/8.9` failed the test **"Suspend batch operation twice fails on second request, finally resumes"** (`tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts`). Both attempts failed at the first `Suspend batch operation once` step:

```
Expected: 204
Received: 404
Timeout 240000ms exceeded while waiting on the predicate
```

## Root cause

This is a timing race, **not** indexing lag. The cancellation batch is created over process instances blocked at an unworked service task, so cancelling them is near-instant — the batch reaches `COMPLETED` in milliseconds. Once a batch operation is `COMPLETED`, the engine rejects `SUSPEND` with a permanent `NOT_FOUND` (404), which the helper's 240s lifecycle retry can never recover from. The first suspend must therefore land while the batch is still `ACTIVE`.

The previous escalation to **20 instances** was still on the boundary: the sibling `suspend-active` test passed at 20 in the same run, but this stricter test — which must additionally reach `SUSPENDED` before the batch finishes — lost the race on both attempts.

## Fix

Increase the cancellation batch to **50 instances**, widening the `ACTIVE` window for a comfortable margin (well above the stable `cancel-active` test's 30). Minimal, in-pattern change scoped to the one failing test; the comment is updated to reflect the real cause. No `skip`/`fixme` introduced.

Nightly run: https://github.com/camunda/camunda/actions/runs/26858900848

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## On-demand verification runs
- https://github.com/camunda/camunda/actions/runs/26877712345
