### PR TITLE
test: default DATABASE to elasticsearch in e2e compose project

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml
@@ -134,8 +134,8 @@ services:
       - 9600:9600
       - 8080:8080
     depends_on:
-      - ${DATABASE}
+      - ${DATABASE:-elasticsearch}
     networks:
       - zeebe_network
     env_file:
-      - envs/.env.database.${DATABASE}
+      - envs/.env.database.${DATABASE:-elasticsearch}


### PR DESCRIPTION
## Problem

Nightly run [26859461961](https://github.com/camunda/camunda/actions/runs/26859461961) (and [26793804429](https://github.com/camunda/camunda/actions/runs/26793804429) the day before) failed in the **Tasklist v2** E2E job.

The **root cause of the red job is a transient Docker Hub registry timeout** while pulling `camunda/camunda:8.9-SNAPSHOT` in the *Start Camunda* step:

```
camunda Error Get "https://registry-1.docker.io/v2/": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```

All 3 retry attempts hit it; the sibling **v1** job pulled the same image fine, confirming infrastructure flakiness rather than a code defect. **This PR does not — and cannot — fix that network timeout.**

## What this PR fixes

The same run exposed a *deterministic* bug in this branch's compose file. When *Start Camunda* fails, the *Print Docker logs before failing* step runs `docker compose logs camunda` **without exporting `DATABASE`**, and the project becomes invalid:

```
service "camunda" depends on undefined service "": invalid compose project
```

The `camunda` service interpolated `${DATABASE}` into both `depends_on` and `env_file`, so with the variable unset the diagnostic step crashed instead of printing Camunda's logs — hiding the real startup output during every triage.

The fix defaults `DATABASE` to `elasticsearch` (the only DB env file present, and the documented default) in both interpolations, matching the file's existing `CAMUNDA_DOCKER_IMAGE:-...` and `CAMUNDA_TASKLIST_V2_MODE_ENABLED:-true` defaults. Explicit `DATABASE` values are unaffected.

## Verification

Reproduced the failing diagnostic command locally:

| | `docker compose logs camunda` (DATABASE unset) |
|---|---|
| before | `exit 1` — `invalid compose project` |
| after | `exit 0` |

`DATABASE=elasticsearch docker compose config` still resolves `depends_on: elasticsearch` correctly.

Nightly run: https://github.com/camunda/camunda/actions/runs/26859461961

## On-demand verification runs
- https://github.com/camunda/camunda/actions/runs/26877759067
