### PR TITLE
docs: forbid manual edits to responses.json — run npm run responses:regenerate

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
@@ -78,6 +78,9 @@ carries a `GENERATED FILE - DO NOT EDIT MANUALLY` header. **To change behaviour,
 generator (`scripts/`, `src/`) and re-run `npm run regenerate` from the generator directory** —
 never patch the generated `.spec.ts` files directly.
 
+`json-body-assertions/_generated/responses.json` is also auto-generated — **never edit it by hand**.
+If an API response changes, regenerate it with `npm run responses:regenerate` and commit the result.
+
 ## TypeScript Path Aliases
 
 Defined in `tsconfig.json`. Use these consistently in new tests and page objects:


### PR DESCRIPTION
`json-body-assertions/_generated/responses.json` is auto-generated. Manual edits are silently overwritten on the next `npm run responses:regenerate` run and produce misleading diffs in PRs.

Added a note in AGENTS.md next to the existing generated-file paragraph so the fix agent (and human contributors) know to regenerate rather than hand-edit.

Use the backport tool to port this to `stable/8.7` and `stable/8.8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)