### PR TITLE
fix(cpt): evaluate variable semantic similarity once instead of on every retry

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/VariableAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/VariableAssertj.java
@@ -466,10 +466,12 @@ public class VariableAssertj extends AbstractAssert<VariableAssertj, String> {
     similarityAssertj.assertSimilarityHasAllRequiredSettings();
     assertExpectationNotEmpty(expectedValue);
 
-    hasVariableSatisfies(
-        variableSelector,
-        rawValue -> evaluateSimilarity(variableSelector.describe(), expectedValue, rawValue),
-        () -> findGlobalVariablesBySelector(processInstanceKey, variableSelector));
+    final String rawValue =
+        waitForVariable(
+            variableSelector,
+            () -> findGlobalVariablesBySelector(processInstanceKey, variableSelector));
+
+    evaluateSimilarity(variableSelector.describe(), expectedValue, rawValue);
   }
 
   public void hasLocalVariableSimilarTo(
@@ -481,17 +483,9 @@ public class VariableAssertj extends AbstractAssert<VariableAssertj, String> {
     similarityAssertj.assertSimilarityHasAllRequiredSettings();
     assertExpectationNotEmpty(expectedValue);
 
-    withLocalVariableAssertion(
-        processInstanceKey,
-        selector,
-        instance ->
-            hasVariableSatisfies(
-                variableSelector,
-                rawValue ->
-                    evaluateSimilarity(variableSelector.describe(), expectedValue, rawValue),
-                () ->
-                    findLocalVariablesBySelector(
-                        processInstanceKey, instance.getElementInstanceKey(), variableSelector)));
+    final String rawValue = waitForLocalVariable(processInstanceKey, selector, variableSelector);
+
+    evaluateSimilarity(variableSelector.describe(), expectedValue, rawValue);
   }
 
   private static void assertExpectationNotEmpty(final String expectation) {

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/SemanticSimilarityAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/SemanticSimilarityAssertTest.java
@@ -160,6 +160,31 @@ public class SemanticSimilarityAssertTest {
 
     @Test
     @CamundaAssertExpectFailure
+    void shouldEvaluateSimilarityOnlyOnceWhenFailing() {
+      // given - orthogonal vectors → score below threshold; the variable exists, so the await
+      // resolves on the first poll and the (expensive) embedding must run exactly once.
+      when(embeddingModel.embed("hello there")).thenReturn(UNIT_VEC_X);
+      when(embeddingModel.embed("\"hello, world!\"")).thenReturn(UNIT_VEC_Y);
+      CamundaAssert.setSemanticSimilarityConfig(SemanticSimilarityConfig.of(embeddingModel));
+
+      final Variable variable = newVariable("result", "\"Hello, World!\"");
+      when(camundaDataSource.findVariables(any())).thenReturn(Collections.singletonList(variable));
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // when / then - the assertion fails, but the embedding is not repeated per poll
+      Assertions.assertThatThrownBy(
+              () ->
+                  CamundaAssert.assertThatProcessInstance(processInstanceEvent)
+                      .hasVariableSimilarTo("result", "Hello there"))
+          .isInstanceOf(AssertionError.class)
+          .hasMessageContaining("did not satisfy similarity check");
+
+      verify(embeddingModel, times(1)).embed("hello there");
+      verify(embeddingModel, times(1)).embed("\"hello, world!\"");
+    }
+
+    @Test
+    @CamundaAssertExpectFailure
     void shouldFailWhenVariableDoesNotExist() {
       // given
       CamundaAssert.setSemanticSimilarityConfig(SemanticSimilarityConfig.of(embeddingModel));
@@ -289,6 +314,43 @@ public class SemanticSimilarityAssertTest {
           .hasMessageContaining("0.00")
           .hasMessageContaining("0.50")
           .hasMessageContaining("some expectation");
+    }
+
+    @Test
+    @CamundaAssertExpectFailure
+    void shouldEvaluateLocalVariableSimilarityOnlyOnceWhenFailing() {
+      // given - orthogonal vectors → score below threshold; the variable exists, so the await
+      // resolves on the first poll and the (expensive) embedding must run exactly once.
+      when(embeddingModel.embed("some expectation")).thenReturn(UNIT_VEC_X);
+      when(embeddingModel.embed("\"local value\"")).thenReturn(UNIT_VEC_Y);
+      CamundaAssert.setSemanticSimilarityConfig(SemanticSimilarityConfig.of(embeddingModel));
+
+      when(camundaDataSource.findElementInstances(any()))
+          .thenReturn(
+              Collections.singletonList(
+                  ElementInstanceBuilder.newActiveElementInstance("task1", PROCESS_INSTANCE_KEY)
+                      .setElementInstanceKey(ELEMENT_INSTANCE_KEY)
+                      .build()));
+
+      final Variable variable =
+          VariableBuilder.newVariable("localVar", "\"local value\"")
+              .setProcessInstanceKey(PROCESS_INSTANCE_KEY)
+              .setScopeKey(ELEMENT_INSTANCE_KEY)
+              .build();
+      when(camundaDataSource.findVariables(any())).thenReturn(Collections.singletonList(variable));
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // when / then - the assertion fails, but the embedding is not repeated per poll
+      Assertions.assertThatThrownBy(
+              () ->
+                  CamundaAssert.assertThatProcessInstance(processInstanceEvent)
+                      .hasLocalVariableSimilarTo(
+                          ElementSelectors.byId("task1"), "localVar", "some expectation"))
+          .isInstanceOf(AssertionError.class)
+          .hasMessageContaining("did not satisfy similarity check");
+
+      verify(embeddingModel, times(1)).embed("some expectation");
+      verify(embeddingModel, times(1)).embed("\"local value\"");
     }
 
     @Test


### PR DESCRIPTION
## Description

The variable similarity assertions (hasVariableSimilarTo, hasLocalVariableSimilarTo) ran the embedding + cosine-similarity computation inside the Awaitility retry loop. When the score was below the threshold the evaluation threw an AssertionError, which Awaitility swallowed and re-polled. 

This wasted the entire timeout window and issued redundant `EmbeddingModelAdapter.embed()`calls (potentially remote/paid model calls), re-embedding the invariant expected value every iteration on top of that.

Mirror the judge variable assertions (hasVariableSatisfiesJudge), which already await only the variable's existence via waitForVariable/waitForLocalVariable and then evaluate exactly once outside the loop. Add regression tests asserting the embedding runs exactly once even when the similarity assertion fails.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #54576
