### PR TITLE
test: regenerate API response assertions from latest main OpenAPI spec

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/_generated/index.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/_generated/index.ts
@@ -673,6 +673,7 @@ export function validateResponseShape<
     configPath?: string;
     throw?: boolean;
     record?: boolean | {label?: string};
+    truncateValidationErrors?: boolean;
   },
 ) {
   // Cast to base signature (method/status widened to string) for internal call.
@@ -700,6 +701,7 @@ export function validateResponse<
     configPath?: string;
     throw?: boolean;
     record?: boolean | {label?: string};
+    truncateValidationErrors?: boolean;
   },
 ) {
   return _baseValidateResponse(spec, response, options);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/_generated/responses.json
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/_generated/responses.json
@@ -1,10 +1,10 @@
 {
   "metadata": {
     "sourceRepo": "https://github.com/camunda/camunda",
-    "commit": "168e118db8d26b7283ccd36a3fef1834dc1f7c20",
-    "generatedAt": "2026-05-29T07:50:19.279Z",
+    "commit": "cda9ec35a56a71873bd9eb0daac70f21af285277",
+    "generatedAt": "2026-06-03T10:53:40.676Z",
     "specPath": "zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml",
-    "specSha256": "1c86dd320071c70c1cd2a97d3d29cb4aeb9e39d11b01b44dbb9e5c13f688fd02"
+    "specSha256": "993c5f0583b61f0d486171aaebc45db58771759734629e2a3f810aa822d0fecf"
   },
   "responses": [
     {
@@ -142,8 +142,7 @@
           },
           {
             "name": "rootProcessInstanceKey",
-            "type": "string",
-            "nullable": true
+            "type": "string"
           },
           {
             "name": "status",
@@ -315,8 +314,7 @@
                 },
                 {
                   "name": "rootProcessInstanceKey",
-                  "type": "string",
-                  "nullable": true
+                  "type": "string"
                 },
                 {
                   "name": "status",
@@ -3073,7 +3071,125 @@
         "required": [
           {
             "name": "items",
-            "type": "array<object|0>"
+            "type": "array<object>",
+            "children": {
+              "required": [
+                {
+                  "name": "elementId",
+                  "type": "string"
+                },
+                {
+                  "name": "elementInstanceKey",
+                  "type": "string"
+                },
+                {
+                  "name": "elementType",
+                  "type": "string",
+                  "enumValues": [
+                    "AD_HOC_SUB_PROCESS",
+                    "AD_HOC_SUB_PROCESS_INNER_INSTANCE",
+                    "BOUNDARY_EVENT",
+                    "BUSINESS_RULE_TASK",
+                    "CALL_ACTIVITY",
+                    "END_EVENT",
+                    "EVENT_BASED_GATEWAY",
+                    "EVENT_SUB_PROCESS",
+                    "EXCLUSIVE_GATEWAY",
+                    "INCLUSIVE_GATEWAY",
+                    "INTERMEDIATE_CATCH_EVENT",
+                    "INTERMEDIATE_THROW_EVENT",
+                    "MANUAL_TASK",
+                    "MULTI_INSTANCE_BODY",
+                    "PARALLEL_GATEWAY",
+                    "PROCESS",
+                    "RECEIVE_TASK",
+                    "SCRIPT_TASK",
+                    "SEND_TASK",
+                    "SEQUENCE_FLOW",
+                    "SERVICE_TASK",
+                    "START_EVENT",
+                    "SUB_PROCESS",
+                    "TASK",
+                    "UNKNOWN",
+                    "UNSPECIFIED",
+                    "USER_TASK"
+                  ]
+                },
+                {
+                  "name": "jobDetails",
+                  "type": "object",
+                  "nullable": true,
+                  "children": {
+                    "required": [
+                      {
+                        "name": "jobKey",
+                        "type": "string"
+                      },
+                      {
+                        "name": "jobKind",
+                        "type": "string"
+                      },
+                      {
+                        "name": "jobType",
+                        "type": "string"
+                      },
+                      {
+                        "name": "listenerEventType",
+                        "type": "string",
+                        "nullable": true
+                      },
+                      {
+                        "name": "retries",
+                        "type": "number",
+                        "nullable": true
+                      }
+                    ],
+                    "optional": []
+                  }
+                },
+                {
+                  "name": "messageDetails",
+                  "type": "object",
+                  "nullable": true,
+                  "children": {
+                    "required": [
+                      {
+                        "name": "correlationKey",
+                        "type": "string",
+                        "nullable": true
+                      },
+                      {
+                        "name": "messageName",
+                        "type": "string"
+                      }
+                    ],
+                    "optional": []
+                  }
+                },
+                {
+                  "name": "processInstanceKey",
+                  "type": "string"
+                },
+                {
+                  "name": "rootProcessInstanceKey",
+                  "type": "string",
+                  "nullable": true
+                },
+                {
+                  "name": "tenantId",
+                  "type": "string"
+                },
+                {
+                  "name": "waitStateType",
+                  "type": "string",
+                  "enumValues": [
+                    "JOB",
+                    "MESSAGE"
+                  ]
+                }
+              ],
+              "optional": []
+            }
           },
           {
             "name": "page",
@@ -4516,6 +4632,10 @@
                   "underlyingPrimitive": "string",
                   "rawRefName": "listenerEventType",
                   "wrapper": true
+                },
+                {
+                  "name": "priority",
+                  "type": "number"
                 },
                 {
                   "name": "processDefinitionId",

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-statistics-time-series-job-type-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-statistics-time-series-job-type-api-tests.spec.ts
@@ -139,11 +139,25 @@ test.describe
           extendedSearchRes,
         );
         const extendedResponseBody = await extendedSearchRes.json();
-        const extendedItem = extendedResponseBody.items[0];
-        expect(extendedItem).toBeDefined();
-        expect(extendedItem.created.count).toBe(item.created.count);
-        expect(extendedItem.completed.count).toBe(item.completed.count);
-        expect(extendedItem.failed.count).toBe(item.failed.count);
+        expect(extendedResponseBody.items.length).toBeGreaterThan(0);
+        // Sum across all time buckets: jobs on a shared cluster can be spread
+        // over multiple minute buckets, so only the aggregate matches by-types.
+        const totalCreated = extendedResponseBody.items.reduce(
+          (sum: number, i: {created: {count: number}}) => sum + i.created.count,
+          0,
+        );
+        const totalCompleted = extendedResponseBody.items.reduce(
+          (sum: number, i: {completed: {count: number}}) =>
+            sum + i.completed.count,
+          0,
+        );
+        const totalFailed = extendedResponseBody.items.reduce(
+          (sum: number, i: {failed: {count: number}}) => sum + i.failed.count,
+          0,
+        );
+        expect(totalCreated).toBe(item.created.count);
+        expect(totalCompleted).toBe(item.completed.count);
+        expect(totalFailed).toBe(item.failed.count);
       }).toPass(extendedAssertionOptions);
     });
   });
@@ -287,11 +301,25 @@ test.describe
           extendedSearchRes,
         );
         const extendedResponseBody = await extendedSearchRes.json();
-        const extendedItem = extendedResponseBody.items[0];
-        expect(extendedItem).toBeDefined();
-        expect(extendedItem.created.count).toBe(item.created.count);
-        expect(extendedItem.completed.count).toBe(item.completed.count);
-        expect(extendedItem.failed.count).toBe(item.failed.count);
+        expect(extendedResponseBody.items.length).toBeGreaterThan(0);
+        // Sum across all time buckets: jobs on a shared cluster can be spread
+        // over multiple minute buckets, so only the aggregate matches by-types.
+        const totalCreated = extendedResponseBody.items.reduce(
+          (sum: number, i: {created: {count: number}}) => sum + i.created.count,
+          0,
+        );
+        const totalCompleted = extendedResponseBody.items.reduce(
+          (sum: number, i: {completed: {count: number}}) =>
+            sum + i.completed.count,
+          0,
+        );
+        const totalFailed = extendedResponseBody.items.reduce(
+          (sum: number, i: {failed: {count: number}}) => sum + i.failed.count,
+          0,
+        );
+        expect(totalCreated).toBe(item.created.count);
+        expect(totalCompleted).toBe(item.completed.count);
+        expect(totalFailed).toBe(item.failed.count);
       }).toPass(extendedAssertionOptions);
     });
   });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-message-statistics-subscription-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-message-statistics-subscription-api.spec.ts
@@ -180,7 +180,7 @@ test.describe.parallel('Get message subscription statistics API Tests', () => {
       res,
     );
     expect(body.page.totalItems).toBe(1);
-    expect(body.items.length).toBe(1);
+    expect(body.items).toHaveLength(1);
     expect(body.items[0].processDefinitionId).toBe(processDefinitionId);
   });
 
@@ -233,7 +233,7 @@ test.describe.parallel('Get message subscription statistics API Tests', () => {
         res,
       );
       expect(body.page.totalItems).toBe(1);
-      expect(body.items.length).toBe(1);
+      expect(body.items).toHaveLength(1);
       const item = body.items[0];
       expect(item.processDefinitionKey).toBe(processDefinitionKey);
       expect(item.processDefinitionId).toBe(processDefinitionId);
@@ -319,6 +319,6 @@ test.describe.parallel('Get message subscription statistics API Tests', () => {
       res,
     );
     expect(body.page.totalItems).toBe(0);
-    expect(body.items.length).toBe(0);
+    expect(body.items).toHaveLength(0);
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-process-instance-statistics-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-process-instance-statistics-api.spec.ts
@@ -275,7 +275,7 @@ test.describe.parallel('Get process instance statistics API Tests', () => {
         res,
       );
       expect(body.page.totalItems).toBeGreaterThanOrEqual(1);
-      expect(body.items.length).toEqual(1);
+      expect(body.items).toHaveLength(1);
     }).toPass(defaultAssertionOptions);
   });
 
@@ -334,7 +334,7 @@ test.describe.parallel('Get process instance statistics API Tests', () => {
       res,
     );
     expect(body.page.totalItems).toEqual(0);
-    expect(body.items.length).toEqual(0);
+    expect(body.items).toHaveLength(0);
     expect(body.page.hasMoreTotalItems).toBe(false);
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-process-instance-statistics-by-version-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-process-instance-statistics-by-version-api.spec.ts
@@ -258,7 +258,7 @@ test.describe.parallel('Process instance statistics by version', () => {
       res,
     );
     expect(body.page.totalItems).toBe(0);
-    expect(body.items.length).toEqual(0);
+    expect(body.items).toHaveLength(0);
   });
 
   test('Get process instance statistics by version without authorization - Unauthorized', async ({
@@ -306,6 +306,6 @@ test.describe.parallel('Process instance statistics by version', () => {
       res,
     );
     expect(body.page.totalItems).toBe(0);
-    expect(body.items.length).toEqual(0);
+    expect(body.items).toHaveLength(0);
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/batch-operation-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/batch-operation-requestHelpers.ts
@@ -139,11 +139,11 @@ export async function expectBatchState(
 
 // Post-migration user-task search has to wait for the secondary-storage
 // indexer to reflect the migrated elementId. On a loaded shared cluster the
-// 180s budget proved tight (seen as flake on nightly runs), so allow up to
-// 240s with a longer tail interval.
+// 180s budget proved tight (seen as flake on nightly runs), 240s proved tight
+// too (observed in nightly runs on 2026-06-03), so allow up to 360s.
 export const postMigrationAssertionOptions = {
-  intervals: [5_000, 10_000, 15_000, 25_000, 35_000, 45_000, 60_000],
-  timeout: 240_000,
+  intervals: [5_000, 10_000, 15_000, 25_000, 35_000, 45_000, 60_000, 60_000],
+  timeout: 360_000,
 };
 
 export const notFoundDetail = (key: string) =>


### PR DESCRIPTION
## Summary

[Successful API runs](https://github.com/camunda/camunda/actions/runs/26882197390) ✅ 

Regenerates the auto-generated API response assertion files in `qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/_generated/` from the latest `main` OpenAPI spec (`cda9ec35a56`).

Applied changes for flakiness.

### Changes
- `json-body-assertions/_generated/responses.json` — updated response schemas extracted from `zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml`
- `json-body-assertions/_generated/index.ts` — regenerated index with prettier + license header applied
- Three `process-definition` spec files: eslint auto-fix (`expect(...length).toBe` → `expect(...).toHaveLength`)

### How to regenerate
```bash
cd qa/c8-orchestration-cluster-e2e-test-suite
npm run responses:regenerate
npm run lint:fix
```

## Related

None — routine regeneration to keep assertions in sync with the API spec.