### PR TITLE
ci: build distball once and consume in docker-checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ env:
   DOCKER_PLATFORMS: "linux/amd64,linux/arm64"
   GHA_BEST_PRACTICES_LINTER: enabled
   FLAKY_TEST_RERUN_COUNT: ${{ github.event_name == 'pull_request' && '3' || '7' }}
+  # Run-scoped CI artifact bucket (camunda-ci, europe-west1 = same region as the
+  # gcp-perf runners, so traffic is non-billable). See camunda/team-infrastructure#1079.
+  GCS_BUILD_CACHE_BUCKET: camunda-monorepo-ci-artifacts
 
 jobs:
   detect-changes:
@@ -379,6 +382,161 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+
+  build-distball:
+    name: "Build / Distribution Tarball"
+    # Build the distball once and share it, replacing a ~15 min reactor build in each
+    # consumer. Transport differs by runner: docker-checks (GitHub-hosted) uses the GHA
+    # artifact API; the integration-tests shards (self-hosted gcp-perf) use GCS, since
+    # the artifact API is throughput-capped on self-hosted runners. Gated on the union
+    # of both consumers' conditions so the artifact exists whenever one runs. See #52693.
+    if: needs.detect-changes.outputs.camunda-docker-tests == 'true' || needs.detect-changes.outputs.java-code-changes == 'true'
+    needs: [ detect-changes ]
+    runs-on: gcp-perf-core-8-default
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write  # google-github-actions/auth (WIF) mints a GitHub OIDC token
+    steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@b4ba25e5825dccf0f4d25c103b63569a5d1d30c5 # main
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        timeout-minutes: 1
+      - uses: ./.github/actions/setup-build
+        with:
+          maven-cache-key-modifier: build-shared
+          dockerhub-readonly: true
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          minimus: true
+      - uses: ./.github/actions/build-zeebe
+        id: build-zeebe
+        with:
+          maven-extra-args: -T1C -PskipFrontendBuild
+      - name: Log distball size
+        run: ls -lh "${{ steps.build-zeebe.outputs.distball }}"
+      # build-zeebe installs this run's io.camunda SNAPSHOTs into ~/.m2; consumers
+      # resolve them via `mvn verify`, but the GHA Maven cache never propagates
+      # locally-installed SNAPSHOTs between jobs, so archive them for the consumers.
+      - name: Archive local Maven SNAPSHOT artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Only io.camunda reactor SNAPSHOTs are needed; drop the distro assemblies
+          # (shipped as the distball), sources/javadoc and bookkeeping to ~halve the payload.
+          tar \
+            --exclude='*.tar.gz' \
+            --exclude='*-sources.jar' \
+            --exclude='*-javadoc.jar' \
+            --exclude='*.lastUpdated' \
+            --exclude='_remote.repositories' \
+            --exclude='*.repositories' \
+            -cf m2-installed.tar -C "${HOME}/.m2/repository/installed" io/camunda
+          ls -lh m2-installed.tar
+      # docker-checks (GitHub-hosted) consumes these via the artifact API.
+      - name: Upload distball (artifact)
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: distball-${{ github.run_id }}
+          path: ${{ steps.build-zeebe.outputs.distball }}
+          retention-days: 1
+          compression-level: 0  # tarball is already gzipped
+          if-no-files-found: error
+      - name: Upload local Maven SNAPSHOT artifacts (artifact)
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: m2-installed-${{ github.run_id }}
+          path: m2-installed.tar
+          retention-days: 1
+          compression-level: 6
+          if-no-files-found: error
+      # integration-tests' gcp-perf shards consume these from GCS (ingress is free).
+      - name: Fetch GCS build-cache credentials
+        id: gcs-secrets
+        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/camunda/ci/build-cache/monorepo-build-cache-sa SERVICE_ACCOUNT | GCS_SA;
+            secret/data/products/camunda/ci/build-cache/monorepo-build-cache-sa WORKLOAD_IDENTITY_PROVIDER | GCS_WIF;
+      - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ steps.gcs-secrets.outputs.GCS_WIF }}
+          service_account: ${{ steps.gcs-secrets.outputs.GCS_SA }}
+      - uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
+      - name: Upload distball + SNAPSHOTs to GCS
+        shell: bash
+        # SA lacks storage.buckets.get, so gcloud's parallel-composite precheck fails; disable it.
+        env:
+          CLOUDSDK_STORAGE_PARALLEL_COMPOSITE_UPLOAD_ENABLED: "False"
+        run: |
+          set -euo pipefail
+          gcloud storage cp "${{ steps.build-zeebe.outputs.distball }}" \
+            "gs://${GCS_BUILD_CACHE_BUCKET}/${GITHUB_RUN_ID}/$(basename "${{ steps.build-zeebe.outputs.distball }}")"
+          gcloud storage cp m2-installed.tar \
+            "gs://${GCS_BUILD_CACHE_BUCKET}/${GITHUB_RUN_ID}/m2-installed.tar"
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+
+  utils-cleanup-distball:
+    name: "Cleanup / Distribution Tarball Artifact"
+    # Delete the run-scoped GCS objects after consumers finish. The `utils-` prefix
+    # exempts it from the check-results gate; artifacts self-expire (retention-days: 1)
+    # and the bucket TTL covers runs cancelled before this fires.
+    needs: [ build-distball, docker-checks, integration-tests ]
+    if: always() && needs.build-distball.result != 'skipped'
+    runs-on: ubuntu-slim  # short auth-and-delete job; no need for a full runner
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@b4ba25e5825dccf0f4d25c103b63569a5d1d30c5 # main
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        timeout-minutes: 1
+      - name: Fetch GCS build-cache credentials
+        id: gcs-secrets
+        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/camunda/ci/build-cache/monorepo-build-cache-sa SERVICE_ACCOUNT | GCS_SA;
+            secret/data/products/camunda/ci/build-cache/monorepo-build-cache-sa WORKLOAD_IDENTITY_PROVIDER | GCS_WIF;
+      - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ steps.gcs-secrets.outputs.GCS_WIF }}
+          service_account: ${{ steps.gcs-secrets.outputs.GCS_SA }}
+      - uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
+      - name: Delete run-scoped GCS objects
+        shell: bash
+        run: |
+          set -euo pipefail
+          gcloud storage rm --recursive "gs://${GCS_BUILD_CACHE_BUCKET}/${GITHUB_RUN_ID}/" \
+            || echo "No objects to delete for run ${GITHUB_RUN_ID}"
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
   build-platform-frontend:
     if: needs.detect-changes.outputs.frontend-changes == 'true'
@@ -2072,6 +2230,7 @@ jobs:
     needs: # BELOW LIST IS IN ALPHABETICAL ORDER
       - actionlint
       - archunit-tests
+      - build-distball
       - build-platform-frontend
       - c8-e2e-test-suite
       - codeowners-check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1413,7 +1413,7 @@ jobs:
   docker-checks:
     if: needs.detect-changes.outputs.camunda-docker-tests == 'true'
     name: "Docker / Tool / Checks"
-    needs: [ detect-changes, generate-db-versions ]
+    needs: [ detect-changes, generate-db-versions, build-distball ]
     runs-on: ubuntu-latest
     outputs:
       flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}
@@ -1450,22 +1450,37 @@ jobs:
           sarif_file: ./hadolint.sarif
       - uses: ./.github/actions/setup-build
         with:
-          maven-cache-key-modifier: docker-checks
+          maven-cache-key-modifier: build-shared
           dockerhub-readonly: true
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           minimus: true
-      - uses: ./.github/actions/build-zeebe
-        id: build-camunda
+      # Consume the shared distball instead of a ~15 min reactor build; GitHub-hosted,
+      # so it stays on the GHA artifact API.
+      - name: Download distball
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          maven-extra-args: -PskipFrontendBuild,-include-optimize
+          name: distball-${{ github.run_id }}
+          path: dist/target/
+      # Restore the io.camunda SNAPSHOTs archived by build-distball for the `mvn -pl dist/
+      # verify` step below (the GHA Maven cache doesn't carry locally-installed SNAPSHOTs).
+      - name: Download local Maven SNAPSHOT artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: m2-installed-${{ github.run_id }}
+          path: ${{ runner.temp }}
+      - name: Restore local Maven SNAPSHOT artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "${HOME}/.m2/repository/installed"
+          tar -xf "${{ runner.temp }}/m2-installed.tar" -C "${HOME}/.m2/repository/installed"
       - uses: ./.github/actions/build-platform-docker
         id: build-camunda-docker
         with:
           # we use a local registry for pushing
           repository: ${{ env.LOCAL_DOCKER_IMAGE }}
-          distball: ${{ steps.build-camunda.outputs.distball }}
           platforms: ${{ env.DOCKER_PLATFORMS }}
           dockerfile: camunda.Dockerfile
           # push is needed for multi-arch images as buildkit does not support loading them locally

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1215,9 +1215,11 @@ jobs:
   integration-tests:
     if: needs.detect-changes.outputs.java-code-changes == 'true'
     name: "${{ matrix.module }} / Integration / ${{ matrix.name }} ITs (${{ matrix.stressRun }})"
-    needs: [ detect-changes, setup-tests ]
+    needs: [ detect-changes, setup-tests, build-distball ]
     timeout-minutes: 30
-    permissions: { }  # GITHUB_TOKEN unused in this job
+    permissions:
+      contents: read
+      id-token: write  # google-github-actions/auth (WIF) mints a GitHub OIDC token
     runs-on: ${{ matrix.runs-on }}
     outputs:
       flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}
@@ -1265,15 +1267,41 @@ jobs:
       - uses: ./.github/actions/setup-build
         with:
           dockerhub-readonly: true
-          maven-cache-key-modifier: it-${{ matrix.group }}
+          maven-cache-key-modifier: build-shared
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           minimus: true
-      - uses: ./.github/actions/build-zeebe
-        id: build-zeebe
+      # Consume the shared distball instead of a ~15 min reactor build. These shards run
+      # on self-hosted gcp-perf runners where the artifact API is throughput-capped, so
+      # they pull from GCS (same-region, non-billable). See build-distball.
+      - name: Fetch GCS build-cache credentials
+        id: gcs-secrets
+        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
         with:
-          maven-extra-args: -T1C -PskipFrontendBuild
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/camunda/ci/build-cache/monorepo-build-cache-sa SERVICE_ACCOUNT | GCS_SA;
+            secret/data/products/camunda/ci/build-cache/monorepo-build-cache-sa WORKLOAD_IDENTITY_PROVIDER | GCS_WIF;
+      - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ steps.gcs-secrets.outputs.GCS_WIF }}
+          service_account: ${{ steps.gcs-secrets.outputs.GCS_SA }}
+      - uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
+      # Restore the io.camunda SNAPSHOTs archived by build-distball for `mvn verify` below
+      # (the GHA Maven cache doesn't carry locally-installed SNAPSHOTs between jobs).
+      - name: Download distball + SNAPSHOTs from GCS
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p dist/target "${HOME}/.m2/repository/installed"
+          gcloud storage cp "gs://${GCS_BUILD_CACHE_BUCKET}/${GITHUB_RUN_ID}/camunda-zeebe-*.tar.gz" dist/target/
+          gcloud storage cp "gs://${GCS_BUILD_CACHE_BUCKET}/${GITHUB_RUN_ID}/m2-installed.tar" "${RUNNER_TEMP}/m2-installed.tar"
+          tar -xf "${RUNNER_TEMP}/m2-installed.tar" -C "${HOME}/.m2/repository/installed"
       - uses: ./.github/actions/build-platform-docker
         if: ${{ matrix.docker-file != '' }}
         with:
@@ -1281,7 +1309,6 @@ jobs:
           version: ${{ env.DOCKER_IMAGE_TAG }}
           dockerfile: ${{ matrix.docker-file }}
           push: true
-          distball: ${{ steps.build-zeebe.outputs.distball }}
       - name: Create build output log file
         run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> "$GITHUB_ENV"
       - name: Maven Test Build Integration


### PR DESCRIPTION
## Summary

Builds the Zeebe distribution tarball **once per run** (`build-distball`) and shares it with the two consumers instead of each rebuilding it, eliminating a full ≈15 min Maven reactor build per consumer. Implements original **PR 2** (build-distball + cleanup) and **PR 3 + PR 4** (docker-checks and integration-tests consumers) from the [#52693](https://github.com/camunda/camunda/issues/52693) plan.

Each consumer uses the transport that fits its runner (hybrid by necessity, not preference):

| Consumer | Runner | Transport | Why |
|---|---|---|---|
| `docker-checks` | GitHub-hosted `ubuntu-latest` | **GHA artifact** | fast next to the artifact store; GCS egress to gh-hosted would be billable |
| `integration-tests` (11 shards) | self-hosted `gcp-perf-*` | **GCS** (`camunda-monorepo-ci-artifacts`) | the artifact API is throughput-capped on self-hosted runners; the bucket is same-region (europe-west1) → fast and non-billable |

The GCS bucket + `monorepo-build-cache-sa` service account (WIF) were provisioned by [camunda/team-infrastructure#1079](https://github.com/camunda/team-infrastructure/issues/1079).

## What each commit does

1. `ci: introduce build-distball job sharing distball via artifact and GCS` — new producer job + `utils-cleanup-distball`; no existing job modified. Also archives the run's locally-installed `io.camunda` SNAPSHOTs (`m2-installed.tar`) because consumers resolve them via `mvn verify` and the GHA Maven cache never propagates locally-installed SNAPSHOTs between jobs.
2. `ci: consume shared distball in docker-checks via artifact` — docker-checks downloads distball + SNAPSHOTs instead of building.
3. `ci: consume shared distball in integration-tests via GCS` — the 11 IT shards download from GCS via Workload Identity Federation (≈165 CPU-min/run saved).

## Notes for reviewers

- **`build-distball.if`** = `camunda-docker-tests == 'true' || java-code-changes == 'true'` — exactly the union of the two consumers' conditions, so the artifact is present whenever a consumer runs and is skipped otherwise.
- **Optimize in the shared distball.** `build-distball` builds with `-PskipFrontendBuild` only, so the distball includes Optimize; `docker-checks` previously excluded it (`-include-optimize`). The image grows ≈50 MB. Label verification (golden-file diff) and DockerIT tests do not reference Optimize bundles, so behaviour is unchanged.
- **`m2-installed.tar` archives only `io/camunda`.** That is the complete set of reactor SNAPSHOTs consumers resolve — the `bom` module installs under `io.camunda:camunda-bom`, and the only `org.camunda` coordinate (`camunda-release-parent`) is an external release resolved into `cached/releases/`, never `installed/`.
- **Cleanup.** `utils-cleanup-distball` removes the run-scoped GCS objects after consumers finish; the artifacts self-expire (`retention-days: 1`) and the bucket TTL (Infra-owned) is the safety net for cancelled runs. The `utils-` prefix exempts it from the `check-results.needs` merge-queue gate.

## Test plan

Verified on the first fully-green run [`28524081269`](https://github.com/camunda/camunda/actions/runs/28524081269) (0 failures):

- [x] CI green on this branch — [run `28524081269`](https://github.com/camunda/camunda/actions/runs/28524081269)
- [x] `build-distball` produces the distball + `m2-installed.tar`, uploads both as artifacts and to GCS — [Build / Distribution Tarball](https://github.com/camunda/camunda/actions/runs/28524081269/job/84556671913)
<img width="1435" height="241" alt="Screenshot 2026-07-01 at 15 52 28" src="https://github.com/user-attachments/assets/f6e2617d-d957-4133-91ba-2893c2f5236c" />

- [x] `docker-checks` downloads the artifact (no reactor build) and passes `verify-platform-docker` + DockerIT — [Docker / Tool / Checks](https://github.com/camunda/camunda/actions/runs/28524081269/job/84558408429)
- [x] `integration-tests` shards download from GCS and pass — all 16 shards green, e.g. [RDBMS ITs](https://github.com/camunda/camunda/actions/runs/28524081269/job/84556672092), [Zeebe Engine Modules ITs](https://github.com/camunda/camunda/actions/runs/28524081269/job/84558408518), [Zeebe Exporter Modules ITs](https://github.com/camunda/camunda/actions/runs/28524081269/job/84558408598)
- [x] `utils-cleanup-distball` removes the GCS objects after consumers finish — [Cleanup / Distribution Tarball Artifact](https://github.com/camunda/camunda/actions/runs/28524081269/job/84562279663)

## Measured impact

Baseline `main` run vs this branch's first green run (`28524081269`):

| | Before (inline builds) | After (shared distball) |
|---|---|---|
| Reactor build | 16 IT shards × ≈2.4 min = **38.4 gcp-perf runner-min** + docker-checks ≈3.9 min | **1× `build-distball`** (6.1 min cold, ≈2.5–3 min warm) |
| Per-shard fetch | built in place | **GCS download + m2 restore ≈ 4 s** |
| `docker-checks` job | 13 m 06 s | **10 m 15 s** |

- Eliminates **15 of 16** redundant reactor builds → **≈31 gcp-perf runner-min/run** (cold) → **≈35 min warm** post-merge; a **≈80–90%** cut in redundant-build compute. The shared fetch is **≈36× faster** than rebuilding.
- **0 `io.camunda` SNAPSHOT re-downloads** (the `m2-installed` restore is verified working). Third-party downloads seen on this run are the expected **cold `build-shared` cache** — a new cache key that warms once this lands on `main`.

**Scaled:** ≈150–200 qualifying runs/day (of ≈300 `ci.yml` runs) → **≈80–110 gcp-perf runner-hours/day freed** (≈2,400–3,300/month). On the C2D spot `-default` runners that's ≈ **$400–550/month** (≈$1,500–2,100 at on-demand rates). The bigger win is **runner-capacity relief** on a frequently saturation-constrained fleet.

Refs #52693, camunda/team-infrastructure#1079