### PR TITLE
chore: regenerate OC e2e responses.json from stable/8.9 spec

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/_generated/responses.json
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/_generated/responses.json
@@ -1,10 +1,10 @@
 {
   "metadata": {
     "sourceRepo": "https://github.com/camunda/camunda",
-    "commit": "10b0db39f1a0f7c7e0f8859285e5f7764281a903",
-    "generatedAt": "2026-05-20T09:03:01.007Z",
+    "commit": "12c766cb3c874ef313d14561ca8df727df185816",
+    "generatedAt": "2026-06-03T11:15:48.188Z",
     "specPath": "zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml",
-    "specSha256": "9119b94564a3f9939c10765718ef4b0c41d6544a21047a7841870b018d40182d"
+    "specSha256": "063547a6b94323ba8fcf13f7c5f2972a4ee710da0aebe072f9f65b38c337be9c"
   },
   "responses": [
     {


### PR DESCRIPTION
## Description

Regenerates `qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/_generated/responses.json` from the latest `stable/8.9` REST API spec (`zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml`).

The spec SHA changed since the last regeneration (commit `10b0db39` → `12c766cb`), indicating API spec updates that need to be reflected in the assertion baseline.

Run: `npm run responses:regenerate` in `qa/c8-orchestration-cluster-e2e-test-suite/`.

## Checklist

- [ ] Enable backports when necessary (fex. for bug fixes, for CI changes, or for documentation changes).

## Related issues

closes #