### PR TITLE
fix: remove key field from TenantFilter and MappingRuleFilter builders

### DIFF
--- a/db/rdbms/src/main/resources/mapper/MappingRuleMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/MappingRuleMapper.xml
@@ -84,9 +84,6 @@
       <if test="filter.mappingRuleId != null">
         AND MAPPING_RULE_ID = #{filter.mappingRuleId}
       </if>
-      <if test="filter.mappingRuleKey != null">
-        AND MAPPING_RULE_KEY = #{filter.mappingRuleKey}
-      </if>
       <if test="filter.claimName != null">
         AND CLAIM_NAME = #{filter.claimName}
       </if>

--- a/db/rdbms/src/main/resources/mapper/TenantMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/TenantMapper.xml
@@ -74,7 +74,6 @@
           #{resourceId}
         </foreach>
       </if>
-      <if test="filter.key != null">AND TENANT_KEY = #{filter.key}</if>
       <if test="filter.tenantIds != null and !filter.tenantIds.isEmpty()">
         AND t.TENANT_ID IN
         <foreach collection="filter.tenantIds" item="value" open="(" separator=", " close=")">

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/mappingrules/MappingRuleIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/mappingrules/MappingRuleIT.java
@@ -265,7 +265,6 @@ public class MappingRuleIT {
         mappingRuleReader.search(
             new MappingRuleQuery(
                 new MappingRuleFilter.Builder()
-                    .mappingRuleKey(randomizedMappingRule.mappingRuleKey())
                     .mappingRuleId(randomizedMappingRule.mappingRuleId())
                     .claimName(randomizedMappingRule.claimName())
                     .claimValue(randomizedMappingRule.claimValue())

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/tenant/TenantIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/tenant/TenantIT.java
@@ -191,7 +191,6 @@ public class TenantIT {
         reader.search(
             new TenantQuery(
                 new TenantFilter.Builder()
-                    .key(instance.tenantKey())
                     .tenantId(instance.tenantId())
                     .name(instance.name())
                     .build(),

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/tenant/TenantSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/tenant/TenantSortIT.java
@@ -7,15 +7,16 @@
  */
 package io.camunda.it.rdbms.db.tenant;
 
-import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextKey;
 import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextStringId;
 import static io.camunda.it.rdbms.db.fixtures.TenantFixtures.createAndSaveRandomTenants;
+import static io.camunda.it.rdbms.db.fixtures.TenantFixtures.createAndSaveTenant;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.read.service.TenantDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.db.rdbms.write.domain.TenantDbModel;
+import io.camunda.it.rdbms.db.fixtures.TenantFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
 import io.camunda.search.entities.TenantEntity;
@@ -25,7 +26,9 @@ import io.camunda.search.query.TenantQuery;
 import io.camunda.search.sort.TenantSort;
 import io.camunda.search.sort.TenantSort.Builder;
 import io.camunda.util.ObjectBuilder;
+import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.List;
 import java.util.function.Function;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestTemplate;
@@ -78,14 +81,32 @@ public class TenantSortIT {
 
   @TestTemplate
   public void shouldSortByNameAsc(final CamundaRdbmsTestApplication testApplication) {
-    final var aggregator = nextKey(); // Will be used to have isolated test data
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final TenantDbReader reader = rdbmsService.getTenantReader();
 
-    testSorting(
-        testApplication.getRdbmsService(),
-        b -> b.name().asc(),
-        Comparator.comparing(TenantEntity::name),
-        b -> b.tenantKey(aggregator),
-        b -> b.key(aggregator));
+    // create 20 tenants with unique, ordered names and collect their IDs for isolated filtering
+    // (aggregator approach can't be used as name is the sort field and must vary)
+    final var namePrefix = nextStringId() + "-";
+    final List<String> createdTenantIds = new ArrayList<>();
+    for (int i = 0; i < 20; i++) {
+      final var name = namePrefix + String.format("%02d", i);
+      final var tenant = TenantFixtures.createRandomized(b -> b.name(name));
+      createdTenantIds.add(tenant.tenantId());
+      createAndSaveTenant(rdbmsWriters, tenant);
+    }
+
+    final var searchResult =
+        reader
+            .search(
+                new TenantQuery(
+                    TenantFilter.of(b -> b.tenantIds(createdTenantIds)),
+                    TenantSort.of(b -> b.name().asc()),
+                    SearchQueryPage.of(b -> b)))
+            .items();
+
+    assertThat(searchResult).hasSize(20);
+    assertThat(searchResult).isSortedAccordingTo(Comparator.comparing(TenantEntity::name));
   }
 
   private void testSorting(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/tenant/TenantSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/tenant/TenantSpecificFilterIT.java
@@ -115,9 +115,7 @@ public class TenantSpecificFilterIT {
 
   static List<TenantFilter> shouldFindTenantWithSpecificFilterParameters() {
     return List.of(
-        TenantFilter.of(b -> b.key(42L)),
-        TenantFilter.of(b -> b.tenantId("tenant-42")),
-        TenantFilter.of(b -> b.name("Tenant 42")));
+        TenantFilter.of(b -> b.tenantId("tenant-42")), TenantFilter.of(b -> b.name("Tenant 42")));
   }
 
   private void addGroupToTenant(final String tenantId, final String entityId) {

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/TenantFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/TenantFilterTransformer.java
@@ -13,7 +13,6 @@ import static io.camunda.search.clients.query.SearchQueryBuilders.matchNone;
 import static io.camunda.search.clients.query.SearchQueryBuilders.or;
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
 import static io.camunda.search.clients.query.SearchQueryBuilders.term;
-import static io.camunda.webapps.schema.descriptors.index.TenantIndex.KEY;
 import static io.camunda.webapps.schema.descriptors.index.TenantIndex.NAME;
 import static io.camunda.webapps.schema.descriptors.index.TenantIndex.TENANT_ID;
 
@@ -75,7 +74,6 @@ public class TenantFilterTransformer extends IndexFilterTransformer<TenantFilter
 
   private SearchQuery buildCoreFilters(final TenantFilter filter) {
     return and(
-        filter.key() == null ? null : term(KEY, filter.key()),
         filter.tenantIds() == null ? null : stringTerms(TENANT_ID, filter.tenantIds()),
         filter.name() == null ? null : term(NAME, filter.name()),
         term(TenantIndex.JOIN, IdentityJoinRelationshipType.TENANT.getType()));

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/TenantQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/TenantQueryTransformerTest.java
@@ -29,28 +29,6 @@ import org.junit.jupiter.api.Test;
 public class TenantQueryTransformerTest extends AbstractTransformerTest {
 
   @Test
-  public void shouldQueryByTenantKey() {
-    // given
-    final var filter = FilterBuilders.tenant((f) -> f.key(12345L));
-
-    // when
-    final var searchRequest = transformQuery(filter);
-
-    // then
-    assertThat(searchRequest)
-        .isEqualTo(
-            SearchQuery.of(
-                q ->
-                    q.bool(
-                        b ->
-                            b.must(
-                                List.of(
-                                    SearchQuery.of(q1 -> q.term(t -> t.field("key").value(12345L))),
-                                    SearchQuery.of(
-                                        q1 -> q.term(t -> t.field("join").value("tenant"))))))));
-  }
-
-  @Test
   public void shouldQueryByTenantId() {
     // given
     final var filter = FilterBuilders.tenant((f) -> f.tenantId("tenant1"));
@@ -126,8 +104,7 @@ public class TenantQueryTransformerTest extends AbstractTransformerTest {
   @Test
   public void shouldQueryByMultipleTenantFields() {
     // given
-    final var filter =
-        FilterBuilders.tenant((f) -> f.key(12345L).tenantId("tenant1").name("TestTenant"));
+    final var filter = FilterBuilders.tenant((f) -> f.tenantId("tenant1").name("TestTenant"));
 
     // when
     final var searchRequest = transformQuery(filter);
@@ -141,7 +118,6 @@ public class TenantQueryTransformerTest extends AbstractTransformerTest {
                         b ->
                             b.must(
                                 List.of(
-                                    SearchQuery.of(q -> q.term(t -> t.field("key").value(12345L))),
                                     SearchQuery.of(
                                         q -> q.term(t -> t.field("tenantId").value("tenant1"))),
                                     SearchQuery.of(

--- a/search/search-domain/src/main/java/io/camunda/search/filter/MappingRuleFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/MappingRuleFilter.java
@@ -15,7 +15,6 @@ import java.util.Set;
 
 public record MappingRuleFilter(
     String mappingRuleId,
-    Long mappingRuleKey,
     String claimName,
     List<String> claimNames,
     String claimValue,
@@ -30,7 +29,6 @@ public record MappingRuleFilter(
   public MappingRuleFilter.Builder toBuilder() {
     return new Builder()
         .mappingRuleId(mappingRuleId)
-        .mappingRuleKey(mappingRuleKey)
         .claimName(claimName)
         .claimNames(claimNames)
         .claimValue(claimValue)
@@ -45,7 +43,6 @@ public record MappingRuleFilter(
   public static final class Builder implements ObjectBuilder<MappingRuleFilter> {
     private String mappingRuleId;
     private Set<String> mappingRuleIds;
-    private Long mappingRuleKey;
     private String claimName;
     private List<String> claimNames;
     private String claimValue;
@@ -57,11 +54,6 @@ public record MappingRuleFilter(
 
     public Builder mappingRuleId(final String value) {
       mappingRuleId = value;
-      return this;
-    }
-
-    public Builder mappingRuleKey(final Long value) {
-      mappingRuleKey = value;
       return this;
     }
 
@@ -114,7 +106,6 @@ public record MappingRuleFilter(
     public MappingRuleFilter build() {
       return new MappingRuleFilter(
           mappingRuleId,
-          mappingRuleKey,
           claimName,
           claimNames,
           claimValue,

--- a/search/search-domain/src/main/java/io/camunda/search/filter/TenantFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/TenantFilter.java
@@ -18,7 +18,6 @@ import java.util.Set;
 import java.util.function.Function;
 
 public record TenantFilter(
-    Long key,
     List<String> tenantIds,
     String name,
     Set<String> memberIds,
@@ -32,7 +31,6 @@ public record TenantFilter(
 
   public Builder toBuilder() {
     return new Builder()
-        .key(key)
         .tenantIds(tenantIds)
         .name(name)
         .memberIds(memberIds)
@@ -42,17 +40,11 @@ public record TenantFilter(
 
   public static final class Builder implements ObjectBuilder<TenantFilter> {
 
-    private Long key;
     private List<String> tenantIds;
     private String name;
     private Set<String> memberIds;
     private EntityType childMemberType;
     private Map<EntityType, Set<String>> memberIdsByType;
-
-    public Builder key(final Long value) {
-      key = value;
-      return this;
-    }
 
     public Builder tenantId(final String value, final String... values) {
       return tenantIds(collectValues(value, values));
@@ -85,7 +77,7 @@ public record TenantFilter(
 
     @Override
     public TenantFilter build() {
-      return new TenantFilter(key, tenantIds, name, memberIds, childMemberType, memberIdsByType);
+      return new TenantFilter(tenantIds, name, memberIds, childMemberType, memberIdsByType);
     }
   }
 }


### PR DESCRIPTION
## Summary

- Removes internal numeric `Long key` from `TenantFilter` and `Long mappingRuleKey` from `MappingRuleFilter` record components and their `Builder` methods
- These fields are broker-assigned surrogate IDs never exposed via the REST API or public Java client — their presence in the filter builder API is misleading
- Follows the precedent set by `roleKey` removal from `RoleFilter` and the parallel cleanup of `UserFilter`/`GroupFilter` in #51088

## Out of scope (per issue notes)

- `AuthorizationFilter.authorizationKey` — not affected; authorizations use numeric key as the REST-exposed primary identifier
- `TenantSort.tenantKey()` / `MappingRuleSort.mappingRuleKey()` — sort fields are tracked in a separate issue

Closes #51089