### PR TITLE
fix: resolve Zeebe Harbor image tag to immutable digest before SaaS E2E dispatch

### DIFF
--- a/.github/actions/build-platform-docker/action.yml
+++ b/.github/actions/build-platform-docker/action.yml
@@ -52,6 +52,9 @@ outputs:
   version:
     description: "The semantic version of the packaged artifact"
     value: ${{ steps.get-version.outputs.result }}
+  digest:
+    description: "The immutable manifest digest (sha256:...) of the pushed image. Empty when push is false."
+    value: ${{ steps.build-image.outputs.digest }}
 
 runs:
   using: composite
@@ -137,6 +140,7 @@ runs:
         fi
 
     - name: Build Docker image
+      id: build-image
       uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
       env:
         DOCKER_BUILD_SUMMARY: false

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -487,28 +487,30 @@ jobs:
           dockerfile: camunda.Dockerfile
           push: true
 
-      - name: Resolve image digest
+      - name: Build pinned image reference
         id: resolve-digest
         env:
           TAG: ${{ steps.set-image-tag.outputs.tag }}
           HARBOR_REPO: ${{ env.HARBOR_REPOSITORY }}
+          # Native digest emitted by docker/build-push-action for the manifest
+          # it just pushed to Harbor. Digests are content-addressable, so this
+          # is identical to the digest in AWS ECR after Harbor's event-based
+          # replication — the SaaS clusters can pull harbor/...@sha256:<digest>
+          # safely without any risk of a floating SNAPSHOT tag drifting.
+          DIGEST: ${{ steps.build-docker.outputs.digest }}
         run: |
           set -euo pipefail
-          FULL_REF="${HARBOR_REPO}:${TAG}"
           # Strip the registry hostname to get the short path used by the
-          # receiving workflow's harbor/ prefix convention, e.g.
+          # receiving workflow's harbor/ prefix convention (the harbor/ prefix
+          # maps to the replicated ECR namespace), e.g.
           # registry.camunda.cloud/team-camunda/camunda -> team-camunda/camunda
           SHORT_REPO="${HARBOR_REPO#*/}"
-          # Run digest lookup non-fatally so the fallback branch can execute
-          # even when imagetools inspect fails (e.g. transient registry error).
-          DIGEST=$(docker buildx imagetools inspect "${FULL_REF}" 2>/dev/null \
-            | awk '/^Digest:/ {print $2}' | tr -d '\r' || true)
           if [[ -z "$DIGEST" || "$DIGEST" == "null" ]]; then
-            echo "::warning::Could not resolve digest for ${FULL_REF}; falling back to tag reference"
+            echo "::warning::build-push-action did not return a digest; falling back to tag reference"
             echo "image-ref=harbor/${SHORT_REPO}:${TAG}" >> "$GITHUB_OUTPUT"
           else
             echo "image-ref=harbor/${SHORT_REPO}@${DIGEST}" >> "$GITHUB_OUTPUT"
-            echo "Resolved pinned ref: harbor/${SHORT_REPO}@${DIGEST}"
+            echo "Pinned ref: harbor/${SHORT_REPO}@${DIGEST}"
           fi
 
       - name: Output image details

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -491,17 +491,24 @@ jobs:
         id: resolve-digest
         env:
           TAG: ${{ steps.set-image-tag.outputs.tag }}
+          HARBOR_REPO: ${{ env.HARBOR_REPOSITORY }}
         run: |
           set -euo pipefail
-          FULL_REF="${{ env.HARBOR_REPOSITORY }}:${TAG}"
+          FULL_REF="${HARBOR_REPO}:${TAG}"
+          # Strip the registry hostname to get the short path used by the
+          # receiving workflow's harbor/ prefix convention, e.g.
+          # registry.camunda.cloud/team-camunda/camunda -> team-camunda/camunda
+          SHORT_REPO="${HARBOR_REPO#*/}"
+          # Run digest lookup non-fatally so the fallback branch can execute
+          # even when imagetools inspect fails (e.g. transient registry error).
           DIGEST=$(docker buildx imagetools inspect "${FULL_REF}" 2>/dev/null \
-            | awk '/^Digest:/ {print $2}' | tr -d '\r')
+            | awk '/^Digest:/ {print $2}' | tr -d '\r' || true)
           if [[ -z "$DIGEST" || "$DIGEST" == "null" ]]; then
             echo "::warning::Could not resolve digest for ${FULL_REF}; falling back to tag reference"
-            echo "image-ref=harbor/team-camunda/camunda:${TAG}" >> "$GITHUB_OUTPUT"
+            echo "image-ref=harbor/${SHORT_REPO}:${TAG}" >> "$GITHUB_OUTPUT"
           else
-            echo "image-ref=harbor/team-camunda/camunda@${DIGEST}" >> "$GITHUB_OUTPUT"
-            echo "Resolved pinned ref: harbor/team-camunda/camunda@${DIGEST}"
+            echo "image-ref=harbor/${SHORT_REPO}@${DIGEST}" >> "$GITHUB_OUTPUT"
+            echo "Resolved pinned ref: harbor/${SHORT_REPO}@${DIGEST}"
           fi
 
       - name: Output image details

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -408,6 +408,7 @@ jobs:
     continue-on-error: ${{ github.event_name == 'merge_group' }}
     outputs:
       image-tag: ${{ steps.set-image-tag.outputs.tag }}
+      image-ref: ${{ steps.resolve-digest.outputs.image-ref }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -486,6 +487,23 @@ jobs:
           dockerfile: camunda.Dockerfile
           push: true
 
+      - name: Resolve image digest
+        id: resolve-digest
+        env:
+          TAG: ${{ steps.set-image-tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          FULL_REF="${{ env.HARBOR_REPOSITORY }}:${TAG}"
+          DIGEST=$(docker buildx imagetools inspect "${FULL_REF}" 2>/dev/null \
+            | awk '/^Digest:/ {print $2}' | tr -d '\r')
+          if [[ -z "$DIGEST" || "$DIGEST" == "null" ]]; then
+            echo "::warning::Could not resolve digest for ${FULL_REF}; falling back to tag reference"
+            echo "image-ref=harbor/team-camunda/camunda:${TAG}" >> "$GITHUB_OUTPUT"
+          else
+            echo "image-ref=harbor/team-camunda/camunda@${DIGEST}" >> "$GITHUB_OUTPUT"
+            echo "Resolved pinned ref: harbor/team-camunda/camunda@${DIGEST}"
+          fi
+
       - name: Output image details
         run: |
           {
@@ -494,6 +512,7 @@ jobs:
             echo "**Repository:** ${{ env.HARBOR_REPOSITORY }}"
             echo "**Tag:** ${{ steps.set-image-tag.outputs.tag }}"
             echo "**Full Image:** ${{ env.HARBOR_REPOSITORY }}:${{ steps.set-image-tag.outputs.tag }}"
+            echo "**Pinned Ref:** ${{ steps.resolve-digest.outputs.image-ref }}"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Observe build status
@@ -737,7 +756,7 @@ jobs:
                       "source_sha": "${{ github.sha }}",
                       "gen_name": "'"${GEN_NAME}"'",
                       "c8Version": "8.10",
-                      "zeebeVersion": "${{ needs.build-and-push.outputs.image-tag }}",
+                      "zeebeVersion": "${{ needs.build-and-push.outputs.image-ref }}",
                       "operateVersion": "SNAPSHOT",
                       "tasklistVersion": "SNAPSHOT",
                       "connectorsVersion": "SNAPSHOT",


### PR DESCRIPTION
$(cat <<'EOF'
## Problem

SNAPSHOT tags (e.g. `8.10.0-SNAPSHOT-main-run12345678-a1`) are floating — if a new snapshot is published mid-provisioning, different Zeebe pods can pull different builds, causing `IncompatibleVersionException` crash-loops that block SaaS E2E test runs.

## Solution

In the `build-and-push` job of `docker-build-helm-integration.yml`, resolve the pushed Harbor image to its manifest digest immediately after push using `docker buildx imagetools inspect`. Pass the pinned reference (`harbor/team-camunda/camunda@sha256:<digest>`) as `zeebeVersion` in the `repository_dispatch` payload to `camunda/c8-cross-component-e2e-tests`.

Falls back to the tag reference with a `::warning::` annotation if digest resolution fails, so the dispatch still proceeds.

## Related

- Coordinates with [camunda/c8-cross-component-e2e-tests#2507](https://github.com/camunda/c8-cross-component-e2e-tests/pull/2507) (digest pinning on the receiving side)
- Companion PR in c8-cross-component-e2e-tests fixes the `ids` step to handle pre-pinned digest references without double-wrapping
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GFLgy5bdVvR6zP431RHnxE)_