### PR TITLE
feat: support request source in record metadata

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/ZeebeRecordDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/ZeebeRecordDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.zeebe;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.protocol.record.Agent;
+import io.camunda.zeebe.protocol.record.ChannelType;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RecordValue;
@@ -109,6 +110,16 @@ public abstract class ZeebeRecordDto<VALUE extends RecordValue, INTENT extends I
 
   @Override
   public Agent getAgent() {
+    return null;
+  }
+
+  @Override
+  public ChannelType getRequestChannelType() {
+    return null;
+  }
+
+  @Override
+  public String getRequestToolName() {
     return null;
   }
 

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/MockTypedCheckpointRecord.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/MockTypedCheckpointRecord.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.backup.processing;
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
 import io.camunda.zeebe.protocol.record.Agent;
+import io.camunda.zeebe.protocol.record.ChannelType;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -96,6 +97,16 @@ record MockTypedCheckpointRecord(
 
   @Override
   public Agent getAgent() {
+    return null;
+  }
+
+  @Override
+  public ChannelType getRequestChannelType() {
+    return null;
+  }
+
+  @Override
+  public String getRequestToolName() {
     return null;
   }
 

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/dto/BrokerExecuteCommand.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/dto/BrokerExecuteCommand.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.broker.client.api.UnsupportedBrokerResponseException;
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.encoding.ExecuteCommandRequest;
 import io.camunda.zeebe.protocol.impl.encoding.ExecuteCommandResponse;
+import io.camunda.zeebe.protocol.record.ChannelType;
 import io.camunda.zeebe.protocol.record.ExecuteCommandRequestEncoder;
 import io.camunda.zeebe.protocol.record.ExecuteCommandResponseDecoder;
 import io.camunda.zeebe.protocol.record.RecordType;
@@ -138,5 +139,15 @@ public abstract class BrokerExecuteCommand<T> extends BrokerRequest<T> {
 
   public void setOperationReference(final long operationReference) {
     request.setOperationReference(operationReference);
+  }
+
+  public BrokerExecuteCommand<T> setChannelType(final ChannelType channelType) {
+    request.setChannelType(channelType);
+    return this;
+  }
+
+  public BrokerExecuteCommand<T> setToolName(final String toolName) {
+    request.setToolName(toolName);
+    return this;
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
@@ -19,12 +19,14 @@ import io.camunda.zeebe.protocol.record.ExecuteCommandRequestDecoder;
 import io.camunda.zeebe.protocol.record.MessageHeaderDecoder;
 import io.camunda.zeebe.protocol.record.ValueTypes;
 import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
 
 public class CommandApiRequestReader implements RequestReader {
 
   private UnifiedRecordValue value;
   private final RecordMetadata metadata = new RecordMetadata();
   private final AuthInfo authInfo = new AuthInfo();
+  private final DirectBuffer toolName = new UnsafeBuffer(0, 0);
   private final MessageHeaderDecoder messageHeaderDecoder = new MessageHeaderDecoder();
   private final ExecuteCommandRequestDecoder commandRequestDecoder =
       new ExecuteCommandRequestDecoder();
@@ -75,20 +77,17 @@ public class CommandApiRequestReader implements RequestReader {
     if (commandRequestDecoder.limit() < buffer.capacity()) {
       final int authOffset =
           commandRequestDecoder.limit() + ExecuteCommandRequestDecoder.authorizationHeaderLength();
-      final int authLength = commandRequestDecoder.authorizationLength();
-      authInfo.wrap(buffer, authOffset, authLength);
+      final int authorizationLength = commandRequestDecoder.authorizationLength();
+      authInfo.wrap(buffer, authOffset, authorizationLength);
       metadata.authorization(authInfo);
-      // advance the decoder past the authorization data
-      commandRequestDecoder.limit(authOffset + authLength);
+      commandRequestDecoder.limit(authOffset + authorizationLength);
     }
+
     if (commandRequestDecoder.limit() < buffer.capacity()) {
-      final int toolNameLength = commandRequestDecoder.toolNameLength();
       final int toolNameOffset =
           commandRequestDecoder.limit() + ExecuteCommandRequestDecoder.toolNameHeaderLength();
-      if (toolNameLength > 0) {
-        metadata.requestToolName(commandRequestDecoder.toolName());
-      }
-      commandRequestDecoder.limit(toolNameOffset + toolNameLength);
+      toolName.wrap(buffer, toolNameOffset, commandRequestDecoder.toolNameLength());
+      metadata.requestToolName(toolName);
     }
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
@@ -77,16 +77,13 @@ public class CommandApiRequestReader implements RequestReader {
     if (commandRequestDecoder.limit() < buffer.capacity()) {
       final int authOffset =
           commandRequestDecoder.limit() + ExecuteCommandRequestDecoder.authorizationHeaderLength();
-      final int authorizationLength = commandRequestDecoder.authorizationLength();
-      authInfo.wrap(buffer, authOffset, authorizationLength);
+      authInfo.wrap(buffer, authOffset, commandRequestDecoder.authorizationLength());
       metadata.authorization(authInfo);
-      commandRequestDecoder.limit(authOffset + authorizationLength);
+      commandRequestDecoder.skipAuthorization();
     }
 
     if (commandRequestDecoder.limit() < buffer.capacity()) {
-      final int toolNameOffset =
-          commandRequestDecoder.limit() + ExecuteCommandRequestDecoder.toolNameHeaderLength();
-      toolName.wrap(buffer, toolNameOffset, commandRequestDecoder.toolNameLength());
+      commandRequestDecoder.wrapToolName(toolName);
       metadata.requestToolName(toolName);
     }
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.broker.transport.RequestReaderException;
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.ChannelType;
 import io.camunda.zeebe.protocol.record.ExecuteCommandRequestDecoder;
 import io.camunda.zeebe.protocol.record.MessageHeaderDecoder;
 import io.camunda.zeebe.protocol.record.ValueTypes;
@@ -54,6 +55,11 @@ public class CommandApiRequestReader implements RequestReader {
 
     metadata.protocolVersion(messageHeaderDecoder.version());
     final var valueType = commandRequestDecoder.valueType();
+    final var requestChannelType = commandRequestDecoder.channelType();
+    if (requestChannelType != ChannelType.NULL_VAL
+        && requestChannelType != ChannelType.SBE_UNKNOWN) {
+      metadata.requestChannelType(requestChannelType);
+    }
     if (ValueTypes.isUserCommand(valueType)) {
       final var record = UnifiedRecordValue.fromValueType(valueType);
       if (record != null) {
@@ -69,8 +75,20 @@ public class CommandApiRequestReader implements RequestReader {
     if (commandRequestDecoder.limit() < buffer.capacity()) {
       final int authOffset =
           commandRequestDecoder.limit() + ExecuteCommandRequestDecoder.authorizationHeaderLength();
-      authInfo.wrap(buffer, authOffset, commandRequestDecoder.authorizationLength());
+      final int authLength = commandRequestDecoder.authorizationLength();
+      authInfo.wrap(buffer, authOffset, authLength);
       metadata.authorization(authInfo);
+      // advance the decoder past the authorization data
+      commandRequestDecoder.limit(authOffset + authLength);
+    }
+    if (commandRequestDecoder.limit() < buffer.capacity()) {
+      final int toolNameLength = commandRequestDecoder.toolNameLength();
+      final int toolNameOffset =
+          commandRequestDecoder.limit() + ExecuteCommandRequestDecoder.toolNameHeaderLength();
+      if (toolNameLength > 0) {
+        metadata.requestToolName(commandRequestDecoder.toolName());
+      }
+      commandRequestDecoder.limit(toolNameOffset + toolNameLength);
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/RetryTypedRecord.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/RetryTypedRecord.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.incident;
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.Agent;
+import io.camunda.zeebe.protocol.record.ChannelType;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordMetadataEncoder;
 import io.camunda.zeebe.protocol.record.RecordType;
@@ -100,6 +101,16 @@ public final class RetryTypedRecord<T extends UnifiedRecordValue> implements Typ
 
   @Override
   public Agent getAgent() {
+    return null;
+  }
+
+  @Override
+  public ChannelType getRequestChannelType() {
+    return null;
+  }
+
+  @Override
+  public String getRequestToolName() {
     return null;
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/MockTypedRecord.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/MockTypedRecord.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.Agent;
+import io.camunda.zeebe.protocol.record.ChannelType;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -129,6 +130,16 @@ public final class MockTypedRecord<T extends UnifiedRecordValue> implements Type
   @Override
   public Agent getAgent() {
     return metadata.getAgent();
+  }
+
+  @Override
+  public ChannelType getRequestChannelType() {
+    return metadata.getRequestChannelType();
+  }
+
+  @Override
+  public String getRequestToolName() {
+    return metadata.getRequestToolName();
   }
 
   @Override

--- a/zeebe/exporter-api/src/test/java/io/camunda/zeebe/exporter/api/ExporterTest.java
+++ b/zeebe/exporter-api/src/test/java/io/camunda/zeebe/exporter/api/ExporterTest.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.exporter.api.context.Configuration;
 import io.camunda.zeebe.exporter.api.context.Context;
 import io.camunda.zeebe.exporter.api.context.Context.RecordFilter;
 import io.camunda.zeebe.protocol.record.Agent;
+import io.camunda.zeebe.protocol.record.ChannelType;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -248,6 +249,16 @@ public final class ExporterTest {
 
     @Override
     public Agent getAgent() {
+      return null;
+    }
+
+    @Override
+    public ChannelType getRequestChannelType() {
+      return null;
+    }
+
+    @Override
+    public String getRequestToolName() {
       return null;
     }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/protocol/TestRecord.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/protocol/TestRecord.java
@@ -8,6 +8,7 @@
 package io.camunda.protocol;
 
 import io.camunda.zeebe.protocol.record.Agent;
+import io.camunda.zeebe.protocol.record.ChannelType;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -74,6 +75,16 @@ public record TestRecord(long position, ValueType valueType) implements Record<T
 
   @Override
   public Agent getAgent() {
+    return null;
+  }
+
+  @Override
+  public ChannelType getRequestChannelType() {
+    return null;
+  }
+
+  @Override
+  public String getRequestToolName() {
     return null;
   }
 

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
@@ -48,6 +48,8 @@ final class BulkIndexRequest {
   private static final String RECORD_SEQUENCE_PROPERTY = "sequence";
   private static final String RECORD_AUTHORIZATIONS_PROPERTY = "authorizations";
   private static final String RECORD_AGENT_PROPERTY = "agent";
+  private static final String RECORD_REQUEST_CHANNEL_TYPE_PROPERTY = "requestChannelType";
+  private static final String RECORD_REQUEST_TOOL_NAME_PROPERTY = "requestToolName";
   private static final String RECORD_DECISION_EVALUATION_INSTANCE_KEY_PROPERTY =
       "decisionEvaluationInstanceKey";
   private static final String AUTH_INFO_PROPERTY = "authInfo";
@@ -158,7 +160,12 @@ final class BulkIndexRequest {
   record IndexOperation(BulkIndexAction metadata, byte[] source) {}
 
   @JsonAppend(attrs = {@JsonAppend.Attr(value = RECORD_SEQUENCE_PROPERTY)})
-  @JsonIgnoreProperties({RECORD_AUTHORIZATIONS_PROPERTY, RECORD_AGENT_PROPERTY})
+  @JsonIgnoreProperties({
+    RECORD_AUTHORIZATIONS_PROPERTY,
+    RECORD_AGENT_PROPERTY,
+    RECORD_REQUEST_CHANNEL_TYPE_PROPERTY,
+    RECORD_REQUEST_TOOL_NAME_PROPERTY
+  })
   private static final class RecordSequenceMixin {}
 
   @JsonIgnoreProperties({RECORD_DECISION_EVALUATION_INSTANCE_KEY_PROPERTY})

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
@@ -84,6 +84,8 @@ final class BulkIndexRequestTest {
     recordAsMap.put("sequence", recordSequence.sequence());
     recordAsMap.remove("authorizations");
     recordAsMap.remove("agent");
+    recordAsMap.remove("requestChannelType");
+    recordAsMap.remove("requestToolName");
     return MAPPER.writeValueAsBytes(recordAsMap).length;
   }
 
@@ -246,6 +248,18 @@ final class BulkIndexRequestTest {
           .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
           .extracting(source -> source.get("agent"))
           .describedAs("Expect that the records are NOT serialized with agent")
+          .containsExactly(new Object[] {null});
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("requestChannelType"))
+          .describedAs("Expect that the records are NOT serialized with requestChannelType")
+          .containsExactly(new Object[] {null});
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("requestToolName"))
+          .describedAs("Expect that the records are NOT serialized with requestToolName")
           .containsExactly(new Object[] {null});
     }
 

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
@@ -76,10 +76,16 @@ final class ElasticsearchExporterIT {
   private static TestClient testClient;
   private static ExporterTestContext exporterTestContext;
   private static String previousTestMethod = null;
-  // omit authorizations and agent since they are removed from the records during serialization
+  // omit authorizations, agent, requestChannelType and requestToolName since they are removed from
+  // the records during serialization
   private final ProtocolFactory factory =
       new ProtocolFactory(b -> b.withAuthorizations(Map.of()))
-          .registerRandomizer(field -> "agent".equals(field.getName()), random -> null);
+          .registerRandomizer(
+              field ->
+                  "agent".equals(field.getName())
+                      || "requestChannelType".equals(field.getName())
+                      || "requestToolName".equals(field.getName()),
+              random -> null);
 
   @BeforeEach
   public void beforeEach(final TestInfo testInfo) {

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/FaultToleranceIT.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/FaultToleranceIT.java
@@ -31,10 +31,16 @@ final class FaultToleranceIT {
 
   private final ElasticsearchExporterConfiguration config =
       new ElasticsearchExporterConfiguration();
-  // omit authorizations and agent since they are removed from the records during serialization
+  // omit authorizations, agent, requestChannelType and requestToolName since they are removed from
+  // the records during serialization
   private final ProtocolFactory factory =
       new ProtocolFactory(b -> b.withAuthorizations(Map.of()))
-          .registerRandomizer(field -> "agent".equals(field.getName()), random -> null);
+          .registerRandomizer(
+              field ->
+                  "agent".equals(field.getName())
+                      || "requestChannelType".equals(field.getName())
+                      || "requestToolName".equals(field.getName()),
+              random -> null);
   private final ExporterTestController controller = new ExporterTestController();
   private final ElasticsearchExporter exporter = new ElasticsearchExporter();
   private final RecordIndexRouter indexRouter = new RecordIndexRouter(config.index);

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
@@ -48,6 +48,8 @@ final class BulkIndexRequest {
   private static final String RECORD_SEQUENCE_PROPERTY = "sequence";
   private static final String RECORD_AUTHORIZATIONS_PROPERTY = "authorizations";
   private static final String RECORD_AGENT_PROPERTY = "agent";
+  private static final String RECORD_REQUEST_CHANNEL_TYPE_PROPERTY = "requestChannelType";
+  private static final String RECORD_REQUEST_TOOL_NAME_PROPERTY = "requestToolName";
   private static final String RECORD_DECISION_EVALUATION_INSTANCE_KEY_PROPERTY =
       "decisionEvaluationInstanceKey";
   private static final String AUTH_INFO_PROPERTY = "authInfo";
@@ -158,7 +160,12 @@ final class BulkIndexRequest {
   record IndexOperation(BulkIndexAction metadata, byte[] source) {}
 
   @JsonAppend(attrs = {@JsonAppend.Attr(value = RECORD_SEQUENCE_PROPERTY)})
-  @JsonIgnoreProperties({RECORD_AUTHORIZATIONS_PROPERTY, RECORD_AGENT_PROPERTY})
+  @JsonIgnoreProperties({
+    RECORD_AUTHORIZATIONS_PROPERTY,
+    RECORD_AGENT_PROPERTY,
+    RECORD_REQUEST_CHANNEL_TYPE_PROPERTY,
+    RECORD_REQUEST_TOOL_NAME_PROPERTY
+  })
   private static final class RecordSequenceMixin {}
 
   @JsonIgnoreProperties({RECORD_DECISION_EVALUATION_INSTANCE_KEY_PROPERTY})

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
@@ -266,13 +266,13 @@ final class BulkIndexRequestTest {
           .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
           .extracting(source -> source.get("requestChannelType"))
           .describedAs("Expect that the records are NOT serialized with requestChannelType")
-          .isNull();
+          .containsExactly(new Object[] {null});
       assertThat(request.bulkOperations())
           .hasSize(1)
           .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
           .extracting(source -> source.get("requestToolName"))
           .describedAs("Expect that the records are NOT serialized with requestToolName")
-          .isNull();
+          .containsExactly(new Object[] {null});
     }
 
     @Test

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
@@ -84,6 +84,8 @@ final class BulkIndexRequestTest {
     recordAsMap.put("sequence", recordSequence.sequence());
     recordAsMap.remove("authorizations");
     recordAsMap.remove("agent");
+    recordAsMap.remove("requestChannelType");
+    recordAsMap.remove("requestToolName");
     return MAPPER.writeValueAsBytes(recordAsMap).length;
   }
 
@@ -198,6 +200,8 @@ final class BulkIndexRequestTest {
       // Verify excluded fields are null/empty
       assertThat(deserialized.getAuthorizations()).isEmpty();
       assertThat(deserialized.getAgent()).isNull();
+      assertThat(deserialized.getRequestChannelType()).isNull();
+      assertThat(deserialized.getRequestToolName()).isNull();
     }
 
     @Test
@@ -257,6 +261,18 @@ final class BulkIndexRequestTest {
           .extracting(source -> source.get("agent"))
           .describedAs("Expect that the records are NOT serialized with agent")
           .containsExactly(new Object[] {null});
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("requestChannelType"))
+          .describedAs("Expect that the records are NOT serialized with requestChannelType")
+          .isNull();
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("requestToolName"))
+          .describedAs("Expect that the records are NOT serialized with requestToolName")
+          .isNull();
     }
 
     @Test

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/FaultToleranceIT.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/FaultToleranceIT.java
@@ -30,10 +30,16 @@ import org.testcontainers.containers.SocatContainer;
 final class FaultToleranceIT {
 
   private final OpensearchExporterConfiguration config = new OpensearchExporterConfiguration();
-  // omit authorizations and agent since they are removed from the records during serialization
+  // omit authorizations, agent, requestChannelType and requestToolName since they are removed from
+  // the records during serialization
   private final ProtocolFactory factory =
       new ProtocolFactory(b -> b.withAuthorizations(Map.of()))
-          .registerRandomizer(field -> "agent".equals(field.getName()), random -> null);
+          .registerRandomizer(
+              field ->
+                  "agent".equals(field.getName())
+                      || "requestChannelType".equals(field.getName())
+                      || "requestToolName".equals(field.getName()),
+              random -> null);
   private final ExporterTestController controller = new ExporterTestController();
   private final OpensearchExporter exporter = new OpensearchExporter();
   private final RecordIndexRouter indexRouter = new RecordIndexRouter(config.index);

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
@@ -76,10 +76,16 @@ final class OpensearchExporterIT {
   private static TestClient testClient;
   private static ExporterTestContext exporterTestContext;
   private static String previousTestMethod = null;
-  // omit authorizations and agent since they are removed from the records during serialization
+  // omit authorizations, agent, requestChannelType and requestToolName since they are removed from
+  // the records during serialization
   private final ProtocolFactory factory =
       new ProtocolFactory(b -> b.withAuthorizations(Map.of()))
-          .registerRandomizer(field -> "agent".equals(field.getName()), random -> null);
+          .registerRandomizer(
+              field ->
+                  "agent".equals(field.getName())
+                      || "requestChannelType".equals(field.getName())
+                      || "requestToolName".equals(field.getName()),
+              random -> null);
 
   @BeforeEach
   public void beforeEach(final TestInfo testInfo) {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/ExecuteCommandRequest.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/ExecuteCommandRequest.java
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.protocol.record.ExecuteCommandRequestEncoder.oper
 import static io.camunda.zeebe.protocol.record.ExecuteCommandRequestEncoder.partitionIdNullValue;
 
 import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.record.ChannelType;
 import io.camunda.zeebe.protocol.record.ExecuteCommandRequestDecoder;
 import io.camunda.zeebe.protocol.record.ExecuteCommandRequestEncoder;
 import io.camunda.zeebe.protocol.record.MessageHeaderDecoder;
@@ -19,6 +20,7 @@ import io.camunda.zeebe.protocol.record.MessageHeaderEncoder;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.util.buffer.BufferReader;
+import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
@@ -38,6 +40,8 @@ public final class ExecuteCommandRequest implements BufferReader, BufferWriter {
   private ValueType valueType;
   private Intent intent;
   private final AuthInfo authorization = new AuthInfo();
+  private ChannelType channelType = ChannelType.NULL_VAL;
+  private String toolName = "";
 
   public ExecuteCommandRequest() {
     reset();
@@ -51,6 +55,8 @@ public final class ExecuteCommandRequest implements BufferReader, BufferWriter {
     intent = Intent.UNKNOWN;
     value.wrap(0, 0);
     authorization.reset();
+    channelType = ChannelType.NULL_VAL;
+    toolName = "";
 
     return this;
   }
@@ -142,6 +148,24 @@ public final class ExecuteCommandRequest implements BufferReader, BufferWriter {
     return this;
   }
 
+  public ChannelType getChannelType() {
+    return channelType;
+  }
+
+  public ExecuteCommandRequest setChannelType(final ChannelType channelType) {
+    this.channelType = channelType;
+    return this;
+  }
+
+  public String getToolName() {
+    return toolName;
+  }
+
+  public ExecuteCommandRequest setToolName(final String toolName) {
+    this.toolName = toolName;
+    return this;
+  }
+
   @Override
   public void wrap(final DirectBuffer buffer, int offset, final int length) {
     reset();
@@ -159,6 +183,11 @@ public final class ExecuteCommandRequest implements BufferReader, BufferWriter {
     operationReference = bodyDecoder.operationReference();
     valueType = bodyDecoder.valueType();
     intent = Intent.fromProtocolValue(valueType, bodyDecoder.intent());
+    final var decodedChannelType = bodyDecoder.channelType();
+    if (decodedChannelType != ChannelType.NULL_VAL
+        && decodedChannelType != ChannelType.SBE_UNKNOWN) {
+      channelType = decodedChannelType;
+    }
 
     offset += bodyDecoder.sbeBlockLength();
 
@@ -173,6 +202,15 @@ public final class ExecuteCommandRequest implements BufferReader, BufferWriter {
 
     authorization.wrap(buffer, offset, authorizationLength);
     offset += authorizationLength;
+
+    if (bodyDecoder.limit() < frameEnd) {
+      final int toolNameLength = bodyDecoder.toolNameLength();
+      offset += ExecuteCommandRequestDecoder.toolNameHeaderLength();
+      if (toolNameLength > 0) {
+        toolName = BufferUtil.bufferAsString(buffer, offset, toolNameLength);
+      }
+      offset += toolNameLength;
+    }
 
     bodyDecoder.limit(offset);
 
@@ -191,7 +229,11 @@ public final class ExecuteCommandRequest implements BufferReader, BufferWriter {
         + ExecuteCommandRequestEncoder.valueHeaderLength()
         + value.capacity()
         + ExecuteCommandRequestEncoder.authorizationHeaderLength()
-        + authorization.getLength();
+        + authorization.getLength()
+        + ExecuteCommandRequestEncoder.toolNameHeaderLength()
+        + (!toolName.isEmpty()
+            ? toolName.getBytes(java.nio.charset.StandardCharsets.UTF_8).length
+            : 0);
   }
 
   @Override
@@ -203,8 +245,10 @@ public final class ExecuteCommandRequest implements BufferReader, BufferWriter {
         .operationReference(operationReference)
         .valueType(valueType)
         .intent(intent.value())
+        .channelType(channelType)
         .putValue(value, 0, value.capacity())
-        .putAuthorization(authorization.toDirectBuffer(), 0, authorization.getLength());
+        .putAuthorization(authorization.toDirectBuffer(), 0, authorization.getLength())
+        .toolName(toolName);
 
     return headerEncoder.encodedLength() + bodyEncoder.encodedLength();
   }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/ExecuteCommandRequest.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/ExecuteCommandRequest.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.util.buffer.BufferReader;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.camunda.zeebe.util.buffer.BufferWriter;
+import java.nio.charset.StandardCharsets;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -41,7 +42,7 @@ public final class ExecuteCommandRequest implements BufferReader, BufferWriter {
   private Intent intent;
   private final AuthInfo authorization = new AuthInfo();
   private ChannelType channelType = ChannelType.NULL_VAL;
-  private String toolName = "";
+  private final DirectBuffer toolName = new UnsafeBuffer(0, 0);
 
   public ExecuteCommandRequest() {
     reset();
@@ -56,7 +57,7 @@ public final class ExecuteCommandRequest implements BufferReader, BufferWriter {
     value.wrap(0, 0);
     authorization.reset();
     channelType = ChannelType.NULL_VAL;
-    toolName = "";
+    toolName.wrap(0, 0);
 
     return this;
   }
@@ -153,16 +154,21 @@ public final class ExecuteCommandRequest implements BufferReader, BufferWriter {
   }
 
   public ExecuteCommandRequest setChannelType(final ChannelType channelType) {
-    this.channelType = channelType;
+    this.channelType = channelType == null ? ChannelType.NULL_VAL : channelType;
     return this;
   }
 
   public String getToolName() {
-    return toolName;
+    return BufferUtil.bufferAsString(toolName);
   }
 
   public ExecuteCommandRequest setToolName(final String toolName) {
-    this.toolName = toolName;
+    if (toolName == null) {
+      this.toolName.wrap(0, 0);
+    } else {
+      final byte[] bytes = toolName.getBytes(StandardCharsets.UTF_8);
+      this.toolName.wrap(bytes);
+    }
     return this;
   }
 
@@ -203,14 +209,11 @@ public final class ExecuteCommandRequest implements BufferReader, BufferWriter {
     authorization.wrap(buffer, offset, authorizationLength);
     offset += authorizationLength;
 
-    if (bodyDecoder.limit() < frameEnd) {
-      final int toolNameLength = bodyDecoder.toolNameLength();
-      offset += ExecuteCommandRequestDecoder.toolNameHeaderLength();
-      if (toolNameLength > 0) {
-        toolName = BufferUtil.bufferAsString(buffer, offset, toolNameLength);
-      }
-      offset += toolNameLength;
-    }
+    final int toolNameLength = bodyDecoder.toolNameLength();
+    offset += ExecuteCommandRequestDecoder.toolNameHeaderLength();
+
+    toolName.wrap(buffer, offset, toolNameLength);
+    offset += toolNameLength;
 
     bodyDecoder.limit(offset);
 
@@ -231,9 +234,7 @@ public final class ExecuteCommandRequest implements BufferReader, BufferWriter {
         + ExecuteCommandRequestEncoder.authorizationHeaderLength()
         + authorization.getLength()
         + ExecuteCommandRequestEncoder.toolNameHeaderLength()
-        + (!toolName.isEmpty()
-            ? toolName.getBytes(java.nio.charset.StandardCharsets.UTF_8).length
-            : 0);
+        + toolName.capacity();
   }
 
   @Override
@@ -248,7 +249,7 @@ public final class ExecuteCommandRequest implements BufferReader, BufferWriter {
         .channelType(channelType)
         .putValue(value, 0, value.capacity())
         .putAuthorization(authorization.toDirectBuffer(), 0, authorization.getLength())
-        .toolName(toolName);
+        .putToolName(toolName, 0, toolName.capacity());
 
     return headerEncoder.encodedLength() + bodyEncoder.encodedLength();
   }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/ExecuteCommandRequest.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/ExecuteCommandRequest.java
@@ -41,7 +41,7 @@ public final class ExecuteCommandRequest implements BufferReader, BufferWriter {
   private ValueType valueType;
   private Intent intent;
   private final AuthInfo authorization = new AuthInfo();
-  private ChannelType channelType = ChannelType.NULL_VAL;
+  private ChannelType channelType;
   private final DirectBuffer toolName = new UnsafeBuffer(0, 0);
 
   public ExecuteCommandRequest() {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/CopiedRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/CopiedRecord.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.protocol.impl.encoding.AgentInfo;
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.record.Agent;
+import io.camunda.zeebe.protocol.record.ChannelType;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -36,6 +37,8 @@ public final class CopiedRecord<T extends UnifiedRecordValue> implements Record<
   private final String brokerVersion;
   private final AuthInfo authorization;
   private final Agent agent;
+  private final ChannelType requestChannelType;
+  private final String requestToolName;
   private final int recordVersion;
   private final long operationReference;
   private final long batchOperationReference;
@@ -66,6 +69,8 @@ public final class CopiedRecord<T extends UnifiedRecordValue> implements Record<
     operationReference = metadata.getOperationReference();
     batchOperationReference = metadata.getBatchOperationReference();
     agent = AgentInfo.of(metadata.getAgent());
+    requestChannelType = metadata.getRequestChannelType();
+    requestToolName = metadata.getRequestToolName();
   }
 
   private CopiedRecord(final CopiedRecord<T> copiedRecord) {
@@ -103,6 +108,8 @@ public final class CopiedRecord<T extends UnifiedRecordValue> implements Record<
     operationReference = copiedRecord.operationReference;
     batchOperationReference = copiedRecord.batchOperationReference;
     agent = AgentInfo.of(copiedRecord.agent);
+    requestChannelType = copiedRecord.requestChannelType;
+    requestToolName = copiedRecord.requestToolName;
   }
 
   @Override
@@ -163,6 +170,16 @@ public final class CopiedRecord<T extends UnifiedRecordValue> implements Record<
   @Override
   public Agent getAgent() {
     return agent;
+  }
+
+  @Override
+  public ChannelType getRequestChannelType() {
+    return requestChannelType;
+  }
+
+  @Override
+  public String getRequestToolName() {
+    return requestToolName;
   }
 
   @Override

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.protocol.impl.record;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.encoding.AgentInfo;
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
+import io.camunda.zeebe.protocol.record.ChannelType;
 import io.camunda.zeebe.protocol.record.MessageHeaderDecoder;
 import io.camunda.zeebe.protocol.record.MessageHeaderEncoder;
 import io.camunda.zeebe.protocol.record.RecordMetadataDecoder;
@@ -52,6 +53,8 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
   private RejectionType rejectionType;
   private final UnsafeBuffer rejectionReason = new UnsafeBuffer(0, 0);
   private AgentInfo agent;
+  private ChannelType requestChannelType = ChannelType.NULL_VAL;
+  private String requestToolName = "";
 
   // always the current version by default
   private int protocolVersion = Protocol.PROTOCOL_VERSION;
@@ -84,6 +87,11 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
     rejectionType = decoder.rejectionType();
     operationReference = decoder.operationReference();
     batchOperationReference = decoder.batchOperationReference();
+    final var requestChannelType = decoder.requestChannelType();
+    if (requestChannelType != ChannelType.NULL_VAL
+        && requestChannelType != ChannelType.SBE_UNKNOWN) {
+      this.requestChannelType = requestChannelType;
+    }
 
     brokerVersion =
         Optional.ofNullable(decoder.brokerVersion())
@@ -129,6 +137,11 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
     } else {
       decoder.skipAgent();
     }
+
+    final String decodedToolName = decoder.requestToolName();
+    if (!decodedToolName.isEmpty()) {
+      requestToolName = decodedToolName;
+    }
   }
 
   @Override
@@ -139,7 +152,11 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
         + RecordMetadataEncoder.authorizationHeaderLength()
         + authorization.getLength()
         + RecordMetadataEncoder.agentHeaderLength()
-        + (agent != null ? agent.getLength() : 0);
+        + (agent != null ? agent.getLength() : 0)
+        + RecordMetadataEncoder.requestToolNameHeaderLength()
+        + (!requestToolName.isEmpty()
+            ? requestToolName.getBytes(java.nio.charset.StandardCharsets.UTF_8).length
+            : 0);
   }
 
   @Override
@@ -157,7 +174,8 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
         .rejectionType(rejectionType)
         .recordVersion(recordVersion)
         .operationReference(operationReference)
-        .batchOperationReference(batchOperationReference);
+        .batchOperationReference(batchOperationReference)
+        .requestChannelType(requestChannelType);
 
     encoder
         .brokerVersion()
@@ -182,6 +200,9 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
     } else {
       encoder.agent("");
     }
+
+    encoder.requestToolName(requestToolName);
+
     return headerEncoder.encodedLength() + encoder.encodedLength();
   }
 
@@ -287,6 +308,24 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
     return this;
   }
 
+  public ChannelType getRequestChannelType() {
+    return requestChannelType == ChannelType.NULL_VAL ? null : requestChannelType;
+  }
+
+  public RecordMetadata requestChannelType(final ChannelType requestChannelType) {
+    this.requestChannelType = requestChannelType;
+    return this;
+  }
+
+  public String getRequestToolName() {
+    return requestToolName.isEmpty() ? null : requestToolName;
+  }
+
+  public RecordMetadata requestToolName(final String requestToolName) {
+    this.requestToolName = requestToolName != null ? requestToolName : "";
+    return this;
+  }
+
   public RecordMetadata brokerVersion(final VersionInfo brokerVersion) {
     this.brokerVersion = brokerVersion;
     return this;
@@ -335,6 +374,8 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
     rejectionReason.wrap(0, 0);
     authorization.reset();
     agent = null;
+    requestChannelType = ChannelType.NULL_VAL;
+    requestToolName = "";
     brokerVersion = CURRENT_BROKER_VERSION;
     recordVersion = DEFAULT_RECORD_VERSION;
     operationReference = RecordMetadataEncoder.operationReferenceNullValue();
@@ -358,7 +399,9 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
         recordVersion,
         operationReference,
         batchOperationReference,
-        agent);
+        agent,
+        requestChannelType,
+        requestToolName);
   }
 
   @Override
@@ -380,6 +423,8 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
         && rejectionReason.equals(that.rejectionReason)
         && authorization.equals(that.authorization)
         && Objects.equals(agent, that.agent)
+        && requestChannelType == that.requestChannelType
+        && Objects.equals(requestToolName, that.requestToolName)
         && brokerVersion.equals(that.brokerVersion)
         && recordVersion == that.recordVersion
         && operationReference == that.operationReference
@@ -419,6 +464,12 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
     }
     if (agent != null) {
       builder.append(", agent=").append(agent);
+    }
+    if (requestChannelType != ChannelType.NULL_VAL) {
+      builder.append(", requestChannelType=").append(requestChannelType);
+    }
+    if (!requestToolName.isEmpty()) {
+      builder.append(", requestToolName=").append(requestToolName);
     }
 
     builder.append('}');

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
@@ -54,7 +54,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
   private final UnsafeBuffer rejectionReason = new UnsafeBuffer(0, 0);
   private AgentInfo agent;
   private ChannelType requestChannelType = ChannelType.NULL_VAL;
-  private String requestToolName = "";
+  private final DirectBuffer requestToolName = new UnsafeBuffer(0, 0);
 
   // always the current version by default
   private int protocolVersion = Protocol.PROTOCOL_VERSION;
@@ -138,9 +138,11 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
       decoder.skipAgent();
     }
 
-    final String decodedToolName = decoder.requestToolName();
-    if (!decodedToolName.isEmpty()) {
-      requestToolName = decodedToolName;
+    final int toolNameLength = decoder.requestToolNameLength();
+    if (toolNameLength > 0) {
+      decoder.wrapRequestToolName(requestToolName);
+    } else {
+      decoder.skipRequestToolName();
     }
   }
 
@@ -154,9 +156,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
         + RecordMetadataEncoder.agentHeaderLength()
         + (agent != null ? agent.getLength() : 0)
         + RecordMetadataEncoder.requestToolNameHeaderLength()
-        + (!requestToolName.isEmpty()
-            ? requestToolName.getBytes(java.nio.charset.StandardCharsets.UTF_8).length
-            : 0);
+        + requestToolName.capacity();
   }
 
   @Override
@@ -201,7 +201,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
       encoder.agent("");
     }
 
-    encoder.requestToolName(requestToolName);
+    encoder.putRequestToolName(requestToolName, 0, requestToolName.capacity());
 
     return headerEncoder.encodedLength() + encoder.encodedLength();
   }
@@ -313,16 +313,27 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
   }
 
   public RecordMetadata requestChannelType(final ChannelType requestChannelType) {
-    this.requestChannelType = requestChannelType;
+    this.requestChannelType =
+        requestChannelType == null ? ChannelType.NULL_VAL : requestChannelType;
     return this;
   }
 
   public String getRequestToolName() {
-    return requestToolName.isEmpty() ? null : requestToolName;
+    return BufferUtil.bufferAsString(requestToolName);
   }
 
   public RecordMetadata requestToolName(final String requestToolName) {
-    this.requestToolName = requestToolName != null ? requestToolName : "";
+    if (requestToolName == null) {
+      this.requestToolName.wrap(0, 0);
+    } else {
+      final byte[] bytes = requestToolName.getBytes(StandardCharsets.UTF_8);
+      this.requestToolName.wrap(bytes);
+    }
+    return this;
+  }
+
+  public RecordMetadata requestToolName(final DirectBuffer buffer) {
+    requestToolName.wrap(BufferUtil.cloneBuffer(buffer));
     return this;
   }
 
@@ -375,7 +386,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
     authorization.reset();
     agent = null;
     requestChannelType = ChannelType.NULL_VAL;
-    requestToolName = "";
+    requestToolName.wrap(0, 0);
     brokerVersion = CURRENT_BROKER_VERSION;
     recordVersion = DEFAULT_RECORD_VERSION;
     operationReference = RecordMetadataEncoder.operationReferenceNullValue();
@@ -424,7 +435,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
         && authorization.equals(that.authorization)
         && Objects.equals(agent, that.agent)
         && requestChannelType == that.requestChannelType
-        && Objects.equals(requestToolName, that.requestToolName)
+        && requestToolName.equals(that.requestToolName)
         && brokerVersion.equals(that.brokerVersion)
         && recordVersion == that.recordVersion
         && operationReference == that.operationReference
@@ -468,8 +479,8 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
     if (requestChannelType != ChannelType.NULL_VAL) {
       builder.append(", requestChannelType=").append(requestChannelType);
     }
-    if (!requestToolName.isEmpty()) {
-      builder.append(", requestToolName=").append(requestToolName);
+    if (requestToolName.capacity() > 0) {
+      builder.append(", requestToolName=").append(BufferUtil.bufferAsString(requestToolName));
     }
 
     builder.append('}');

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -333,7 +333,7 @@ final class JsonSerializableToJsonTest {
                   "authorizations": {},
                   "agent": null,
                   "requestChannelType": null,
-                  "requestToolName": null,
+                  "requestToolName": "",
                   "recordVersion": 1,
                   "operationReference": -1,
                   "batchOperationReference": -1,

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -93,6 +93,7 @@ import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.impl.record.value.variable.VariableDocumentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.variable.VariableRecord;
 import io.camunda.zeebe.protocol.impl.record.value.variable.VariableSourceRecord;
+import io.camunda.zeebe.protocol.record.ChannelType;
 import io.camunda.zeebe.protocol.record.JsonSerializable;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -195,7 +196,6 @@ final class JsonSerializableToJsonTest {
 
               final AuthInfo authInfo = new AuthInfo().setClaims(Map.of("foo", "bar"));
               final AgentInfo agentInfo = new AgentInfo().setElementId("agent-element");
-
               recordMetadata
                   .intent(intent)
                   .protocolVersion(protocolVersion)
@@ -209,6 +209,8 @@ final class JsonSerializableToJsonTest {
                   .requestStreamId(requestStreamId)
                   .authorization(authInfo)
                   .agent(agentInfo)
+                  .requestChannelType(ChannelType.MCP)
+                  .requestToolName("myTool")
                   .operationReference(1234)
                   .batchOperationReference(5678);
 
@@ -260,6 +262,8 @@ final class JsonSerializableToJsonTest {
                   "agent": {
                     "elementId": "agent-element"
                   },
+                  "requestChannelType": "MCP",
+                  "requestToolName": "myTool",
                   "recordVersion": 10,
                   "operationReference": 1234,
                   "batchOperationReference": 5678,
@@ -328,6 +332,8 @@ final class JsonSerializableToJsonTest {
                   "brokerVersion": "0.0.0",
                   "authorizations": {},
                   "agent": null,
+                  "requestChannelType": null,
+                  "requestToolName": null,
                   "recordVersion": 1,
                   "operationReference": -1,
                   "batchOperationReference": -1,

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/CopiedRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/CopiedRecord.golden
@@ -7,9 +7,11 @@
  */
 package io.camunda.zeebe.protocol.impl.record;
 
+import io.camunda.zeebe.protocol.impl.encoding.AgentInfo;
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.record.Agent;
+import io.camunda.zeebe.protocol.record.ChannelType;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -35,6 +37,8 @@ public final class CopiedRecord<T extends UnifiedRecordValue> implements Record<
   private final String brokerVersion;
   private final AuthInfo authorization;
   private final Agent agent;
+  private final ChannelType requestChannelType;
+  private final String requestToolName;
   private final int recordVersion;
   private final long operationReference;
   private final long batchOperationReference;
@@ -64,7 +68,9 @@ public final class CopiedRecord<T extends UnifiedRecordValue> implements Record<
     recordVersion = metadata.getRecordVersion();
     operationReference = metadata.getOperationReference();
     batchOperationReference = metadata.getBatchOperationReference();
-    agent = metadata.getAgent();
+    agent = AgentInfo.of(metadata.getAgent());
+    requestChannelType = metadata.getRequestChannelType();
+    requestToolName = metadata.getRequestToolName();
   }
 
   private CopiedRecord(final CopiedRecord<T> copiedRecord) {
@@ -101,7 +107,9 @@ public final class CopiedRecord<T extends UnifiedRecordValue> implements Record<
     recordVersion = copiedRecord.recordVersion;
     operationReference = copiedRecord.operationReference;
     batchOperationReference = copiedRecord.batchOperationReference;
-    agent = copiedRecord.agent;
+    agent = AgentInfo.of(copiedRecord.agent);
+    requestChannelType = copiedRecord.requestChannelType;
+    requestToolName = copiedRecord.requestToolName;
   }
 
   @Override
@@ -162,6 +170,16 @@ public final class CopiedRecord<T extends UnifiedRecordValue> implements Record<
   @Override
   public Agent getAgent() {
     return agent;
+  }
+
+  @Override
+  public ChannelType getRequestChannelType() {
+    return requestChannelType;
+  }
+
+  @Override
+  public String getRequestToolName() {
+    return requestToolName;
   }
 
   @Override

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/RecordMetadata.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/RecordMetadata.golden
@@ -8,7 +8,9 @@
 package io.camunda.zeebe.protocol.impl.record;
 
 import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.encoding.AgentInfo;
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
+import io.camunda.zeebe.protocol.record.ChannelType;
 import io.camunda.zeebe.protocol.record.MessageHeaderDecoder;
 import io.camunda.zeebe.protocol.record.MessageHeaderEncoder;
 import io.camunda.zeebe.protocol.record.RecordMetadataDecoder;
@@ -50,6 +52,9 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
   private final AuthInfo authorization = new AuthInfo();
   private RejectionType rejectionType;
   private final UnsafeBuffer rejectionReason = new UnsafeBuffer(0, 0);
+  private AgentInfo agent;
+  private ChannelType requestChannelType = ChannelType.NULL_VAL;
+  private String requestToolName = "";
 
   // always the current version by default
   private int protocolVersion = Protocol.PROTOCOL_VERSION;
@@ -82,6 +87,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
     rejectionType = decoder.rejectionType();
     operationReference = decoder.operationReference();
     batchOperationReference = decoder.batchOperationReference();
+    final var requestChannelType = decoder.requestChannelType();
 
     brokerVersion =
         Optional.ofNullable(decoder.brokerVersion())
@@ -117,6 +123,23 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
     } else {
       decoder.skipAuthorization();
     }
+
+    final int agentLength = decoder.agentLength();
+    if (agentLength > 0) {
+      agent = new AgentInfo();
+      final var agentBuffer = new UnsafeBuffer();
+      decoder.wrapAgent(agentBuffer);
+      agent.wrap(agentBuffer);
+    } else {
+      decoder.skipAgent();
+    }
+
+    final String decodedToolName = decoder.requestToolName();
+    if (requestChannelType != ChannelType.NULL_VAL
+        && requestChannelType != ChannelType.SBE_UNKNOWN) {
+      this.requestChannelType = requestChannelType;
+      this.requestToolName = decodedToolName;
+    }
   }
 
   @Override
@@ -125,21 +148,18 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
         + RecordMetadataEncoder.rejectionReasonHeaderLength()
         + rejectionReason.capacity()
         + RecordMetadataEncoder.authorizationHeaderLength()
-        + authorization.getLength();
+        + authorization.getLength()
+        + RecordMetadataEncoder.agentHeaderLength()
+        + (agent != null ? agent.getLength() : 0)
+        + RecordMetadataEncoder.requestToolNameHeaderLength()
+        + (!requestToolName.isEmpty()
+            ? requestToolName.getBytes(java.nio.charset.StandardCharsets.UTF_8).length
+            : 0);
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, int offset) {
-    headerEncoder.wrap(buffer, offset);
-
-    headerEncoder
-        .blockLength(encoder.sbeBlockLength())
-        .templateId(encoder.sbeTemplateId())
-        .schemaId(encoder.sbeSchemaId())
-        .version(encoder.sbeSchemaVersion());
-
-    offset += headerEncoder.encodedLength();
-    encoder.wrap(buffer, offset);
+  public int write(final MutableDirectBuffer buffer, final int offset) {
+    encoder.wrapAndApplyHeader(buffer, offset, headerEncoder);
 
     // working with fixed-length fields
     encoder
@@ -152,7 +172,8 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
         .rejectionType(rejectionType)
         .recordVersion(recordVersion)
         .operationReference(operationReference)
-        .batchOperationReference(batchOperationReference);
+        .batchOperationReference(batchOperationReference)
+        .requestChannelType(requestChannelType);
 
     encoder
         .brokerVersion()
@@ -162,7 +183,25 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
 
     // working with variable-length fields
     encoder.putRejectionReason(rejectionReason, 0, rejectionReason.capacity());
-    encoder.putAuthorization(authorization.toDirectBuffer(), 0, authorization.getLength());
+    BufferUtil.writeLengthPrefixed(
+        authorization,
+        encoder,
+        RecordMetadataEncoder.authorizationHeaderLength(),
+        RecordMetadataEncoder.BYTE_ORDER);
+
+    if (agent != null) {
+      BufferUtil.writeLengthPrefixed(
+          agent,
+          encoder,
+          RecordMetadataEncoder.agentHeaderLength(),
+          RecordMetadataEncoder.BYTE_ORDER);
+    } else {
+      encoder.agent("");
+    }
+
+    encoder.requestToolName(requestToolName);
+
+    return headerEncoder.encodedLength() + encoder.encodedLength();
   }
 
   public long getRequestId() {
@@ -258,6 +297,33 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
     return authorization;
   }
 
+  public AgentInfo getAgent() {
+    return agent;
+  }
+
+  public RecordMetadata agent(final AgentInfo agent) {
+    this.agent = agent;
+    return this;
+  }
+
+  public ChannelType getRequestChannelType() {
+    return requestChannelType == ChannelType.NULL_VAL ? null : requestChannelType;
+  }
+
+  public RecordMetadata requestChannelType(final ChannelType requestChannelType) {
+    this.requestChannelType = requestChannelType;
+    return this;
+  }
+
+  public String getRequestToolName() {
+    return requestToolName.isEmpty() ? null : requestToolName;
+  }
+
+  public RecordMetadata requestToolName(final String requestToolName) {
+    this.requestToolName = requestToolName != null ? requestToolName : "";
+    return this;
+  }
+
   public RecordMetadata brokerVersion(final VersionInfo brokerVersion) {
     this.brokerVersion = brokerVersion;
     return this;
@@ -305,6 +371,9 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
     rejectionType = RejectionType.NULL_VAL;
     rejectionReason.wrap(0, 0);
     authorization.reset();
+    agent = null;
+    requestChannelType = ChannelType.NULL_VAL;
+    requestToolName = "";
     brokerVersion = CURRENT_BROKER_VERSION;
     recordVersion = DEFAULT_RECORD_VERSION;
     operationReference = RecordMetadataEncoder.operationReferenceNullValue();
@@ -327,7 +396,10 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
         brokerVersion,
         recordVersion,
         operationReference,
-        batchOperationReference);
+        batchOperationReference,
+        agent,
+        requestChannelType,
+        requestToolName);
   }
 
   @Override
@@ -348,6 +420,9 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
         && rejectionType == that.rejectionType
         && rejectionReason.equals(that.rejectionReason)
         && authorization.equals(that.authorization)
+        && Objects.equals(agent, that.agent)
+        && requestChannelType == that.requestChannelType
+        && Objects.equals(requestToolName, that.requestToolName)
         && brokerVersion.equals(that.brokerVersion)
         && recordVersion == that.recordVersion
         && operationReference == that.operationReference
@@ -384,6 +459,13 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
     }
     if (batchOperationReference != RecordMetadataEncoder.batchOperationReferenceNullValue()) {
       builder.append(", batchOperationReference=").append(batchOperationReference);
+    }
+    if (agent != null) {
+      builder.append(", agent=").append(agent);
+    }
+    if (requestChannelType != ChannelType.NULL_VAL) {
+      builder.append(", requestChannelType=").append(requestChannelType);
+      builder.append(", requestToolName=").append(requestToolName);
     }
 
     builder.append('}');

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/RecordMetadata.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/RecordMetadata.golden
@@ -54,7 +54,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
   private final UnsafeBuffer rejectionReason = new UnsafeBuffer(0, 0);
   private AgentInfo agent;
   private ChannelType requestChannelType = ChannelType.NULL_VAL;
-  private String requestToolName = "";
+  private final DirectBuffer requestToolName = new UnsafeBuffer(0, 0);
 
   // always the current version by default
   private int protocolVersion = Protocol.PROTOCOL_VERSION;
@@ -88,6 +88,10 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
     operationReference = decoder.operationReference();
     batchOperationReference = decoder.batchOperationReference();
     final var requestChannelType = decoder.requestChannelType();
+    if (requestChannelType != ChannelType.NULL_VAL
+        && requestChannelType != ChannelType.SBE_UNKNOWN) {
+      this.requestChannelType = requestChannelType;
+    }
 
     brokerVersion =
         Optional.ofNullable(decoder.brokerVersion())
@@ -134,11 +138,11 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
       decoder.skipAgent();
     }
 
-    final String decodedToolName = decoder.requestToolName();
-    if (requestChannelType != ChannelType.NULL_VAL
-        && requestChannelType != ChannelType.SBE_UNKNOWN) {
-      this.requestChannelType = requestChannelType;
-      this.requestToolName = decodedToolName;
+    final int toolNameLength = decoder.requestToolNameLength();
+    if (toolNameLength > 0) {
+      decoder.wrapRequestToolName(requestToolName);
+    } else {
+      decoder.skipRequestToolName();
     }
   }
 
@@ -152,9 +156,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
         + RecordMetadataEncoder.agentHeaderLength()
         + (agent != null ? agent.getLength() : 0)
         + RecordMetadataEncoder.requestToolNameHeaderLength()
-        + (!requestToolName.isEmpty()
-            ? requestToolName.getBytes(java.nio.charset.StandardCharsets.UTF_8).length
-            : 0);
+        + requestToolName.capacity();
   }
 
   @Override
@@ -199,7 +201,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
       encoder.agent("");
     }
 
-    encoder.requestToolName(requestToolName);
+    encoder.putRequestToolName(requestToolName, 0, requestToolName.capacity());
 
     return headerEncoder.encodedLength() + encoder.encodedLength();
   }
@@ -311,16 +313,27 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
   }
 
   public RecordMetadata requestChannelType(final ChannelType requestChannelType) {
-    this.requestChannelType = requestChannelType;
+    this.requestChannelType =
+        requestChannelType == null ? ChannelType.NULL_VAL : requestChannelType;
     return this;
   }
 
   public String getRequestToolName() {
-    return requestToolName.isEmpty() ? null : requestToolName;
+    return BufferUtil.bufferAsString(requestToolName);
   }
 
   public RecordMetadata requestToolName(final String requestToolName) {
-    this.requestToolName = requestToolName != null ? requestToolName : "";
+    if (requestToolName == null) {
+      this.requestToolName.wrap(0, 0);
+    } else {
+      final byte[] bytes = requestToolName.getBytes(StandardCharsets.UTF_8);
+      this.requestToolName.wrap(bytes);
+    }
+    return this;
+  }
+
+  public RecordMetadata requestToolName(final DirectBuffer buffer) {
+    requestToolName.wrap(BufferUtil.cloneBuffer(buffer));
     return this;
   }
 
@@ -373,7 +386,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
     authorization.reset();
     agent = null;
     requestChannelType = ChannelType.NULL_VAL;
-    requestToolName = "";
+    requestToolName.wrap(0, 0);
     brokerVersion = CURRENT_BROKER_VERSION;
     recordVersion = DEFAULT_RECORD_VERSION;
     operationReference = RecordMetadataEncoder.operationReferenceNullValue();
@@ -422,7 +435,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
         && authorization.equals(that.authorization)
         && Objects.equals(agent, that.agent)
         && requestChannelType == that.requestChannelType
-        && Objects.equals(requestToolName, that.requestToolName)
+        && requestToolName.equals(that.requestToolName)
         && brokerVersion.equals(that.brokerVersion)
         && recordVersion == that.recordVersion
         && operationReference == that.operationReference
@@ -465,7 +478,9 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
     }
     if (requestChannelType != ChannelType.NULL_VAL) {
       builder.append(", requestChannelType=").append(requestChannelType);
-      builder.append(", requestToolName=").append(requestToolName);
+    }
+    if (requestToolName.capacity() > 0) {
+      builder.append(", requestToolName=").append(BufferUtil.bufferAsString(requestToolName));
     }
 
     builder.append('}');

--- a/zeebe/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/RecordMixin.java
+++ b/zeebe/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/RecordMixin.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver;
 import io.camunda.zeebe.protocol.record.Agent;
+import io.camunda.zeebe.protocol.record.ChannelType;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.Intent;
@@ -48,4 +49,10 @@ abstract class RecordMixin<T extends RecordValue> {
 
   @JsonSetter(nulls = Nulls.SKIP)
   private Agent agent;
+
+  @JsonSetter(nulls = Nulls.SKIP)
+  private ChannelType requestChannelType;
+
+  @JsonSetter(nulls = Nulls.SKIP)
+  private String requestToolName;
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/Record.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/Record.java
@@ -114,6 +114,23 @@ public interface Record<T extends RecordValue> extends JsonSerializable {
   Agent getAgent();
 
   /**
+   * Identifies the inbound channel through which the command that produced this record was received
+   * (e.g. REST, gRPC, MCP).
+   *
+   * @return the channel type, or {@code null} if not set
+   */
+  @Nullable
+  ChannelType getRequestChannelType();
+
+  /**
+   * The name of the MCP tool that was called. Empty for non-MCP channels.
+   *
+   * @return the tool name, or {@code null} if not set
+   */
+  @Nullable
+  String getRequestToolName();
+
+  /**
    * A record version is an integer starting from 1. The version of a record is defined when it is
    * written. It allows different versions of the same record to be processed or applied
    * differently.

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/Record.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/Record.java
@@ -123,7 +123,7 @@ public interface Record<T extends RecordValue> extends JsonSerializable {
   ChannelType getRequestChannelType();
 
   /**
-   * The name of the MCP tool that was called. Empty for non-MCP channels.
+   * An optional tool name associated with the command, e.g. the MCP tool that triggered it.
    *
    * @return the tool name, or {@code null} if not set
    */

--- a/zeebe/protocol/src/main/resources/protocol.xml
+++ b/zeebe/protocol/src/main/resources/protocol.xml
@@ -157,7 +157,7 @@
     <data name="value" id="7" type="varDataEncoding"/>
     <!-- populated when RecordType is COMMAND -->
     <data name="authorization" id="8" type="varDataEncoding" sinceVersion="4"/>
-    <!-- populated when set in a gateway for API requests; only non-empty for MCP channel -->
+    <!-- populated when set in a gateway for API requests; carries an optional tool name -->
     <data name="toolName" id="10" type="varDataEncoding" sinceVersion="10"/>
   </sbe:message>
 
@@ -210,7 +210,7 @@
     <!-- populated when RecordType is COMMAND -->
     <data name="authorization" id="11" type="varDataEncoding" sinceVersion="4"/>
     <data name="agent" id="14" type="varDataEncoding" sinceVersion="7"/>
-    <!-- populated when set in a gateway for API requests; only non-empty for MCP channel -->
+    <!-- populated when set in a gateway for API requests; carries an optional tool name -->
     <data name="requestToolName" id="15" type="varDataEncoding" sinceVersion="10"/>
   </sbe:message>
 

--- a/zeebe/protocol/src/main/resources/protocol.xml
+++ b/zeebe/protocol/src/main/resources/protocol.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
   xmlns:xi="http://www.w3.org/2001/XInclude" package="io.camunda.zeebe.protocol.record"
-  id="0" version="9"
+  id="0" version="10"
   description="Zeebe Protocol" byteOrder="littleEndian">
 
   <xi:include href="common-types.xml"/>
@@ -19,6 +19,14 @@
       <validValue name="PROCESS_NOT_FOUND">7</validValue>
       <validValue name="RESOURCE_EXHAUSTED">8</validValue>
       <validValue name="PARTITION_UNAVAILABLE">9</validValue>
+    </enum>
+
+    <enum name="ChannelType" encodingType="uint8"
+      description="The inbound channel through which a command was received">
+      <validValue name="GRPC">0</validValue>
+      <validValue name="MCP">1</validValue>
+      <validValue name="REST">2</validValue>
+      <validValue name="INTERNAL">3</validValue>
     </enum>
 
     <enum name="ValueType" encodingType="uint8" description="The type of a record value">
@@ -144,9 +152,13 @@
     <field name="intent" id="6" type="uint8"/>
     <!-- populated when the client passes an operation reference to the gateway-->
     <field name="operationReference" id="9" type="uint64" presence="optional" sinceVersion="5"/>
+    <!-- populated when set in a gateway for API requests -->
+    <field name="channelType" id="11" type="ChannelType" presence="optional" sinceVersion="10"/>
     <data name="value" id="7" type="varDataEncoding"/>
     <!-- populated when RecordType is COMMAND -->
     <data name="authorization" id="8" type="varDataEncoding" sinceVersion="4"/>
+    <!-- populated when set in a gateway for API requests; only non-empty for MCP channel -->
+    <data name="toolName" id="10" type="varDataEncoding" sinceVersion="10"/>
   </sbe:message>
 
   <sbe:message name="ExecuteCommandResponse" id="21">
@@ -191,11 +203,15 @@
     <field name="operationReference" id="12" type="uint64" presence="optional" sinceVersion="5"/>
     <!-- populated when the record was created as part of a batch operation -->
     <field name="batchOperationReference" id="13" type="uint64" presence="optional" sinceVersion="6"/>
+    <!-- populated when set in a gateway for API requests -->
+    <field name="requestChannelType" id="16" type="ChannelType" presence="optional" sinceVersion="10"/>
     <!-- populated when RecordType is COMMAND_REJECTION, UTF-8-encoded String -->
     <data name="rejectionReason" id="8" type="varDataEncoding"/>
     <!-- populated when RecordType is COMMAND -->
     <data name="authorization" id="11" type="varDataEncoding" sinceVersion="4"/>
     <data name="agent" id="14" type="varDataEncoding" sinceVersion="7"/>
+    <!-- populated when set in a gateway for API requests; only non-empty for MCP channel -->
+    <data name="requestToolName" id="15" type="varDataEncoding" sinceVersion="10"/>
   </sbe:message>
 
   <sbe:message name="BrokerInfo" id="201" description="Broker topology information">

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/SingleBrokerDataDeletionTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/SingleBrokerDataDeletionTest.java
@@ -46,8 +46,8 @@ import org.springframework.util.unit.DataSize;
 public class SingleBrokerDataDeletionTest {
 
   private static final Duration SNAPSHOT_PERIOD = Duration.ofMinutes(5);
-  private static final DataSize LOG_SEGMENT_SIZE = DataSize.ofKilobytes(32);
-  private static final DataSize MAX_MESSAGE_SIZE = DataSize.ofKilobytes(32);
+  private static final DataSize LOG_SEGMENT_SIZE = DataSize.ofKilobytes(48);
+  private static final DataSize MAX_MESSAGE_SIZE = DataSize.ofKilobytes(48);
   private static final int PARTITION_ID = 1;
 
   @Rule

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ProcessingSession.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ProcessingSession.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.protocol.impl.encoding.AgentInfo;
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.record.Agent;
+import io.camunda.zeebe.protocol.record.ChannelType;
 import java.util.function.Consumer;
 
 public interface ProcessingSession {
@@ -51,6 +52,16 @@ public interface ProcessingSession {
       // make a copy to rule out any side effects
       final var agent = AgentInfo.of(agentInfo);
       appendMetadataToFollowUps(metadata -> metadata.agent(agent));
+    }
+  }
+
+  default void appendRequestSourceToFollowUps(
+      final ChannelType channelType, final String toolName) {
+    if (channelType != null) {
+      appendMetadataToFollowUps(metadata -> metadata.requestChannelType(channelType));
+    }
+    if (toolName != null && !toolName.isEmpty()) {
+      appendMetadataToFollowUps(metadata -> metadata.requestToolName(toolName));
     }
   }
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -822,7 +822,7 @@ public final class ProcessingStateMachine {
     builder.appendAgentInfoToFollowUps(command.getAgent());
 
     // Ensure request source is forwarded to all follow-up commands & events
-    // so the inbound channel (e.g. MCP) is visible in the audit log for each record
+    // so the inbound channel and tool name are visible in the audit log for each record
     builder.appendRequestSourceToFollowUps(
         command.getRequestChannelType(), command.getRequestToolName());
 

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -821,6 +821,11 @@ public final class ProcessingStateMachine {
     // e.g. to have the full agent trail in the audit log
     builder.appendAgentInfoToFollowUps(command.getAgent());
 
+    // Ensure request source is forwarded to all follow-up commands & events
+    // so the inbound channel (e.g. MCP) is visible in the audit log for each record
+    builder.appendRequestSourceToFollowUps(
+        command.getRequestChannelType(), command.getRequestToolName());
+
     return builder;
   }
 

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/TypedRecordImpl.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/TypedRecordImpl.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.Agent;
+import io.camunda.zeebe.protocol.record.ChannelType;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -99,6 +100,16 @@ public final class TypedRecordImpl implements TypedRecord, WrittenRecord {
   @Override
   public Agent getAgent() {
     return metadata.getAgent();
+  }
+
+  @Override
+  public ChannelType getRequestChannelType() {
+    return metadata.getRequestChannelType();
+  }
+
+  @Override
+  public String getRequestToolName() {
+    return metadata.getRequestToolName();
   }
 
   @Override

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/UnwrittenRecord.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/UnwrittenRecord.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.Agent;
+import io.camunda.zeebe.protocol.record.ChannelType;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -89,6 +90,16 @@ public class UnwrittenRecord implements TypedRecord {
   @Override
   public Agent getAgent() {
     return metadata.getAgent();
+  }
+
+  @Override
+  public ChannelType getRequestChannelType() {
+    return metadata.getRequestChannelType();
+  }
+
+  @Override
+  public String getRequestToolName() {
+    return metadata.getRequestToolName();
   }
 
   @Override

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/RecordBatchTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/RecordBatchTest.java
@@ -159,7 +159,7 @@ class RecordBatchTest {
     assertThat(either.isLeft()).isTrue();
     assertThat(either.getLeft())
         .hasMessageContaining("Can't append entry")
-        .hasMessageContaining("[ currentBatchEntryCount: 1, currentBatchSize: 464]");
+        .hasMessageContaining("[ currentBatchEntryCount: 1, currentBatchSize: 469]");
   }
 
   @Test
@@ -189,7 +189,7 @@ class RecordBatchTest {
   @Test
   void shouldOnlyReturnTrueUntilMaxBatchSizeIsReached() {
     // given
-    final var recordBatch = new RecordBatch((count, size) -> size < 465);
+    final var recordBatch = new RecordBatch((count, size) -> size < 470);
     final var processInstanceRecord = Records.processInstance(1);
 
     recordBatch.appendRecord(1, RECORD_METADATA, -1, processInstanceRecord);

--- a/zeebe/test-util/src/test/java/io/camunda/zeebe/test/util/record/RecordingExporterTest.java
+++ b/zeebe/test-util/src/test/java/io/camunda/zeebe/test/util/record/RecordingExporterTest.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.test.util.record.RecordingExporter.records;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.protocol.record.Agent;
+import io.camunda.zeebe.protocol.record.ChannelType;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RecordValue;
@@ -146,6 +147,16 @@ public final class RecordingExporterTest {
 
     @Override
     public Agent getAgent() {
+      return null;
+    }
+
+    @Override
+    public ChannelType getRequestChannelType() {
+      return null;
+    }
+
+    @Override
+    public String getRequestToolName() {
       return null;
     }
 


### PR DESCRIPTION
## Description

This pull request introduces support for two new fields, `requestChannelType` and `requestToolName`, across various modules in the codebase. The changes ensure these fields can be set, read, and passed through the broker, while also updating exporters and their tests to handle (and ignore during serialization) these new fields. Most test and mock classes have been updated to implement new interface methods for compatibility.

**Support for request channel and tool name fields:**

* Added `ChannelType` and `requestToolName` support to the `BrokerExecuteCommand` class, allowing these fields to be set on outgoing commands.
* Updated `CommandApiRequestReader` to extract `channelType` and `toolName` from incoming requests and set them in record metadata. 

**Exporter and serialization updates:**

* Modified Elasticsearch and OpenSearch exporters to recognize and ignore `requestChannelType` and `requestToolName` during record serialization, ensuring backward compatibility and test coverage.
* Updated related exporter tests to assert that these fields are not serialized and are handled correctly.
* Adjusted integration test factories to ignore these fields when generating test data. 

**Interface and mock/test class compatibility:**

* Added `getRequestChannelType()` and `getRequestToolName()` methods (returning null or delegating to metadata) to various DTOs, mock records, and test classes to satisfy interface changes and ensure test coverage. 

## Related issues

closes #54580 