### PR TITLE
feat: add wait states search layer implementation including queries

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/WaitStateDbQuery.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/WaitStateDbQuery.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.domain;
+
+import io.camunda.search.entities.WaitStateEntity;
+import io.camunda.search.filter.ElementInstanceWaitStateFilter;
+import io.camunda.search.filter.FilterBuilders;
+import io.camunda.util.ObjectBuilder;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+
+public record WaitStateDbQuery(
+    ElementInstanceWaitStateFilter filter,
+    List<String> authorizedTenantIds,
+    DbQuerySorting<WaitStateEntity> sort,
+    DbQueryPage page) {
+
+  public static WaitStateDbQuery of(
+      final Function<WaitStateDbQuery.Builder, ObjectBuilder<WaitStateDbQuery>> fn) {
+    return fn.apply(new WaitStateDbQuery.Builder()).build();
+  }
+
+  public static final class Builder implements ObjectBuilder<WaitStateDbQuery> {
+
+    private static final ElementInstanceWaitStateFilter EMPTY_FILTER =
+        FilterBuilders.elementInstanceWaitState().build();
+
+    private ElementInstanceWaitStateFilter filter;
+    private List<String> authorizedTenantIds;
+    private DbQuerySorting<WaitStateEntity> sort;
+    private DbQueryPage page;
+
+    public Builder filter(final ElementInstanceWaitStateFilter value) {
+      filter = value;
+      return this;
+    }
+
+    public Builder sort(final DbQuerySorting<WaitStateEntity> value) {
+      sort = value;
+      return this;
+    }
+
+    public Builder page(final DbQueryPage value) {
+      page = value;
+      return this;
+    }
+
+    public Builder authorizedTenantIds(final List<String> value) {
+      authorizedTenantIds = value;
+      return this;
+    }
+
+    @Override
+    public WaitStateDbQuery build() {
+      filter = Objects.requireNonNullElse(filter, EMPTY_FILTER);
+      sort = Objects.requireNonNullElse(sort, new DbQuerySorting<>(List.of()));
+      authorizedTenantIds = Objects.requireNonNullElse(authorizedTenantIds, List.of());
+      return new WaitStateDbQuery(filter, authorizedTenantIds, sort, page);
+    }
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/WaitStateEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/WaitStateEntityMapper.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.mapper;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.db.rdbms.write.domain.WaitStateDbModel;
+import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeType;
+import io.camunda.search.entities.WaitStateDetails;
+import io.camunda.search.entities.WaitStateDetails.WaitStateType;
+import io.camunda.search.entities.WaitStateEntity;
+import io.camunda.search.entities.WaitStateJobDetails;
+import io.camunda.search.entities.WaitStateMessageDetails;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class WaitStateEntityMapper {
+
+  private static final Logger LOG = LoggerFactory.getLogger(WaitStateEntityMapper.class);
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  public static WaitStateEntity toEntity(final WaitStateDbModel dbModel) {
+    return new WaitStateEntity(
+        dbModel.processInstanceKey(),
+        dbModel.elementInstanceKey(),
+        dbModel.elementId(),
+        toFlowNodeType(dbModel.elementType()),
+        dbModel.rootProcessInstanceKey(),
+        parseDetails(dbModel.waitStateType(), dbModel.details()),
+        dbModel.tenantId());
+  }
+
+  private static FlowNodeType toFlowNodeType(final String elementType) {
+    if (elementType == null) {
+      return FlowNodeType.UNSPECIFIED;
+    }
+    try {
+      return FlowNodeType.valueOf(elementType);
+    } catch (final IllegalArgumentException e) {
+      LOG.warn("Unknown element type: {}", elementType);
+      return FlowNodeType.UNKNOWN;
+    }
+  }
+
+  private static WaitStateDetails parseDetails(
+      final String waitStateType, final String detailsJson) {
+    if (waitStateType == null || detailsJson == null) {
+      return null;
+    }
+    try {
+      final WaitStateType type = WaitStateType.valueOf(waitStateType);
+      return switch (type) {
+        case JOB -> OBJECT_MAPPER.readValue(detailsJson, WaitStateJobDetails.class);
+        case MESSAGE -> OBJECT_MAPPER.readValue(detailsJson, WaitStateMessageDetails.class);
+      };
+    } catch (final Exception e) {
+      LOG.warn("Failed to parse wait state details for type {}: {}", waitStateType, e.getMessage());
+      return null;
+    }
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/WaitStateDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/WaitStateDbReader.java
@@ -7,22 +7,60 @@
  */
 package io.camunda.db.rdbms.read.service;
 
+import io.camunda.db.rdbms.read.RdbmsReaderConfig;
+import io.camunda.db.rdbms.read.domain.WaitStateDbQuery;
+import io.camunda.db.rdbms.read.mapper.WaitStateEntityMapper;
 import io.camunda.db.rdbms.sql.WaitStateMapper;
+import io.camunda.db.rdbms.sql.columns.WaitStateSearchColumn;
 import io.camunda.db.rdbms.write.domain.WaitStateDbModel;
+import io.camunda.search.clients.reader.WaitStateReader;
+import io.camunda.search.entities.WaitStateEntity;
+import io.camunda.search.query.ElementInstanceWaitStateQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.reader.ResourceAccessChecks;
+import java.util.List;
 import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-/**
- * Reads wait-state rows by key.
- *
- * <p>Only key-based lookup is provided; the searchable read layer for waiting states is built
- * separately on top of the wait-state index.
- */
-public class WaitStateDbReader {
+public class WaitStateDbReader extends AbstractEntityReader<WaitStateEntity>
+    implements WaitStateReader {
+
+  private static final Logger LOG = LoggerFactory.getLogger(WaitStateDbReader.class);
 
   private final WaitStateMapper waitStateMapper;
 
-  public WaitStateDbReader(final WaitStateMapper waitStateMapper) {
+  public WaitStateDbReader(
+      final WaitStateMapper waitStateMapper, final RdbmsReaderConfig readerConfig) {
+    super(WaitStateSearchColumn.values(), readerConfig);
     this.waitStateMapper = waitStateMapper;
+  }
+
+  @Override
+  public SearchQueryResult<WaitStateEntity> search(
+      final ElementInstanceWaitStateQuery query, final ResourceAccessChecks resourceAccessChecks) {
+    final var dbSort = convertSort(query.sort(), WaitStateSearchColumn.ELEMENT_INSTANCE_KEY);
+
+    if (shouldReturnEmptyResult(resourceAccessChecks)) {
+      return buildSearchQueryResult(0, List.of(), dbSort);
+    }
+
+    final var dbPage = convertPaging(dbSort, query.page());
+    final var dbQuery =
+        WaitStateDbQuery.of(
+            b ->
+                b.filter(query.filter())
+                    .authorizedTenantIds(resourceAccessChecks.getAuthorizedTenantIds())
+                    .sort(dbSort)
+                    .page(dbPage));
+
+    LOG.trace("[RDBMS DB] Search for wait states with filter {}", dbQuery);
+    return executePagedQuery(
+        () -> waitStateMapper.count(dbQuery),
+        () ->
+            waitStateMapper.search(dbQuery).stream().map(WaitStateEntityMapper::toEntity).toList(),
+        dbPage,
+        dbSort);
   }
 
   public Optional<WaitStateDbModel> findOne(final long waitStateKey) {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/WaitStateMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/WaitStateMapper.java
@@ -7,7 +7,9 @@
  */
 package io.camunda.db.rdbms.sql;
 
+import io.camunda.db.rdbms.read.domain.WaitStateDbQuery;
 import io.camunda.db.rdbms.write.domain.WaitStateDbModel;
+import java.util.List;
 
 public interface WaitStateMapper {
 
@@ -16,4 +18,8 @@ public interface WaitStateMapper {
   void delete(Long waitStateKey);
 
   WaitStateDbModel findOne(Long waitStateKey);
+
+  long count(WaitStateDbQuery query);
+
+  List<WaitStateDbModel> search(WaitStateDbQuery query);
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/WaitStateSearchColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/WaitStateSearchColumn.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.sql.columns;
+
+import io.camunda.search.entities.WaitStateEntity;
+
+public enum WaitStateSearchColumn implements SearchColumn<WaitStateEntity> {
+  ELEMENT_INSTANCE_KEY("elementInstanceKey"),
+  PROCESS_INSTANCE_KEY("processInstanceKey"),
+  ROOT_PROCESS_INSTANCE_KEY("rootProcessInstanceKey"),
+  ELEMENT_ID("elementId");
+
+  private final String property;
+
+  WaitStateSearchColumn(final String property) {
+    this.property = property;
+  }
+
+  @Override
+  public String property() {
+    return property;
+  }
+
+  @Override
+  public Class<WaitStateEntity> getEntityClass() {
+    return WaitStateEntity.class;
+  }
+}

--- a/db/rdbms/src/main/resources/mapper/WaitStateMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/WaitStateMapper.xml
@@ -33,6 +33,85 @@
     WHERE WAIT_STATE_KEY = #{waitStateKey}
   </select>
 
+  <select id="count" resultType="java.lang.Long"
+    parameterType="io.camunda.db.rdbms.read.domain.WaitStateDbQuery">
+    SELECT COUNT(*) FROM (
+      SELECT 1 as col
+      FROM ${prefix}WAIT_STATE
+      <include refid="io.camunda.db.rdbms.sql.WaitStateMapper.searchFilter"/>
+      ${count.limit}
+    ) t
+  </select>
+
+  <select id="search" parameterType="io.camunda.db.rdbms.read.domain.WaitStateDbQuery"
+    resultMap="io.camunda.db.rdbms.sql.WaitStateMapper.waitStateResultMap">
+    SELECT * FROM (
+    SELECT
+      WAIT_STATE_KEY,
+      ROOT_PROCESS_INSTANCE_KEY,
+      PROCESS_INSTANCE_KEY,
+      ELEMENT_INSTANCE_KEY,
+      ELEMENT_ID,
+      ELEMENT_TYPE,
+      WAIT_STATE_TYPE,
+      DETAILS,
+      TENANT_ID,
+      PARTITION_ID
+    FROM ${prefix}WAIT_STATE
+    <include refid="io.camunda.db.rdbms.sql.WaitStateMapper.searchFilter"/>
+    ) t
+    <include refid="io.camunda.db.rdbms.sql.Commons.keySetPageFilter"/>
+    <include refid="io.camunda.db.rdbms.sql.Commons.orderBy"/>
+    <include refid="io.camunda.db.rdbms.sql.Commons.paging"/>
+  </select>
+
+  <sql id="searchFilter">
+    <where>
+      <if test="authorizedTenantIds != null and !authorizedTenantIds.isEmpty()">
+        AND TENANT_ID IN
+        <foreach collection="authorizedTenantIds" item="tenantId" open="(" separator="," close=")">
+          #{tenantId}
+        </foreach>
+      </if>
+      <if test="filter.elementInstanceKeyOperations != null and !filter.elementInstanceKeyOperations.isEmpty()">
+        <foreach collection="filter.elementInstanceKeyOperations" item="operation">
+          AND ELEMENT_INSTANCE_KEY
+          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
+      <if test="filter.processInstanceKeyOperations != null and !filter.processInstanceKeyOperations.isEmpty()">
+        <foreach collection="filter.processInstanceKeyOperations" item="operation">
+          AND PROCESS_INSTANCE_KEY
+          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
+      <if test="filter.rootProcessInstanceKeyOperations != null and !filter.rootProcessInstanceKeyOperations.isEmpty()">
+        <foreach collection="filter.rootProcessInstanceKeyOperations" item="operation">
+          AND ROOT_PROCESS_INSTANCE_KEY
+          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
+      <if test="filter.elementIdOperations != null and !filter.elementIdOperations.isEmpty()">
+        <foreach collection="filter.elementIdOperations" item="operation">
+          AND ELEMENT_ID
+          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
+      <if test="filter.elementTypeOperations != null and !filter.elementTypeOperations.isEmpty()">
+        <foreach collection="filter.elementTypeOperations" item="operation">
+          AND ELEMENT_TYPE
+          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
+      <if test="filter.waitStateTypeOperations != null and !filter.waitStateTypeOperations.isEmpty()">
+        <foreach collection="filter.waitStateTypeOperations" item="operation">
+          AND WAIT_STATE_TYPE
+          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
+    </where>
+  </sql>
+
   <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.WaitStateDbModel">
     INSERT INTO ${prefix}WAIT_STATE (WAIT_STATE_KEY, ROOT_PROCESS_INSTANCE_KEY, PROCESS_INSTANCE_KEY,
                                      ELEMENT_INSTANCE_KEY, ELEMENT_ID, ELEMENT_TYPE, WAIT_STATE_TYPE,

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
@@ -144,8 +144,9 @@ public class RdbmsConfiguration {
   }
 
   @Bean
-  public WaitStateDbReader waitStateRdbmsReader(final WaitStateMapper waitStateMapper) {
-    return new WaitStateDbReader(waitStateMapper);
+  public WaitStateDbReader waitStateRdbmsReader(
+      final WaitStateMapper waitStateMapper, final RdbmsReaderConfig readerConfig) {
+    return new WaitStateDbReader(waitStateMapper, readerConfig);
   }
 
   @Bean

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchClientConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchClientConfiguration.java
@@ -54,6 +54,7 @@ import io.camunda.search.clients.reader.UsageMetricsTUReader;
 import io.camunda.search.clients.reader.UserReader;
 import io.camunda.search.clients.reader.UserTaskReader;
 import io.camunda.search.clients.reader.VariableReader;
+import io.camunda.search.clients.reader.WaitStateReader;
 import io.camunda.search.clients.reader.impl.NoopAuthorizationReader;
 import io.camunda.search.es.clients.ElasticsearchSearchClient;
 import io.camunda.search.os.clients.OpensearchSearchClient;
@@ -149,7 +150,8 @@ public class SearchClientConfiguration {
       final IncidentProcessInstanceStatisticsByDefinitionReader
           incidentProcessInstanceStatisticsByDefinitionReader,
       final GlobalListenerReader globalListenerReader,
-      final DeployedResourceReader deployedResourceReader) {
+      final DeployedResourceReader deployedResourceReader,
+      final WaitStateReader waitStateReader) {
     return new SearchClientReaders(
         agentInstanceReader,
         authorizationReader,
@@ -190,6 +192,7 @@ public class SearchClientConfiguration {
         auditLogReader,
         incidentProcessInstanceStatisticsByErrorReader,
         incidentProcessInstanceStatisticsByDefinitionReader,
-        globalListenerReader);
+        globalListenerReader,
+        waitStateReader);
   }
 }

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchClientReadersFactory.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchClientReadersFactory.java
@@ -50,6 +50,7 @@ import io.camunda.search.clients.reader.UsageMetricsTUDocumentReader;
 import io.camunda.search.clients.reader.UserDocumentReader;
 import io.camunda.search.clients.reader.UserTaskDocumentReader;
 import io.camunda.search.clients.reader.VariableDocumentReader;
+import io.camunda.search.clients.reader.WaitStateDocumentReader;
 import io.camunda.search.clients.reader.utils.IncidentErrorHashCodeNormalizer;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import io.camunda.webapps.schema.descriptors.index.AuthorizationIndex;
@@ -82,6 +83,7 @@ import io.camunda.webapps.schema.descriptors.template.TaskTemplate;
 import io.camunda.webapps.schema.descriptors.template.UsageMetricTUTemplate;
 import io.camunda.webapps.schema.descriptors.template.UsageMetricTemplate;
 import io.camunda.webapps.schema.descriptors.template.VariableTemplate;
+import io.camunda.webapps.schema.descriptors.template.WaitStateTemplate;
 
 /** Static factory that creates a complete set of ES/OS document readers for one physical tenant. */
 public final class SearchClientReadersFactory {
@@ -117,6 +119,8 @@ public final class SearchClientReadersFactory {
     final var flowNodeInstanceReader =
         new FlowNodeInstanceDocumentReader(
             executor, descriptors.get(FlowNodeInstanceTemplate.class));
+    final var waitStateReader =
+        new WaitStateDocumentReader(executor, descriptors.get(WaitStateTemplate.class));
     final var formReader = new FormDocumentReader(executor, descriptors.get(FormIndex.class));
     final var incidentReader =
         new IncidentDocumentReader(executor, descriptors.get(IncidentTemplate.class));
@@ -248,6 +252,7 @@ public final class SearchClientReadersFactory {
         auditLogReader,
         incidentProcessInstanceStatisticsByErrorReader,
         incidentProcessInstanceStatisticsByDefinitionReader,
-        globalListenerReader);
+        globalListenerReader,
+        waitStateReader);
   }
 }

--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -181,6 +181,7 @@ public class CamundaServicesConfiguration {
                       brokerClient,
                       securityContextProvider,
                       search,
+                      search,
                       processCache,
                       incident,
                       executor,

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/WaitStateDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/WaitStateDocumentReader.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.reader;
+
+import io.camunda.search.clients.SearchClientBasedQueryExecutor;
+import io.camunda.search.entities.WaitStateEntity;
+import io.camunda.search.query.ElementInstanceWaitStateQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+
+public class WaitStateDocumentReader extends DocumentBasedReader implements WaitStateReader {
+
+  public WaitStateDocumentReader(
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptor indexDescriptor) {
+    super(executor, indexDescriptor);
+  }
+
+  @Override
+  public SearchQueryResult<WaitStateEntity> search(
+      final ElementInstanceWaitStateQuery query, final ResourceAccessChecks resourceAccessChecks) {
+    return getSearchExecutor()
+        .search(
+            query,
+            io.camunda.webapps.schema.entities.waitstate.WaitStateEntity.class,
+            resourceAccessChecks);
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
@@ -109,6 +109,7 @@ import io.camunda.search.clients.transformers.entity.TenantMemberEntityTransform
 import io.camunda.search.clients.transformers.entity.UserEntityTransformer;
 import io.camunda.search.clients.transformers.entity.UserTaskEntityTransformer;
 import io.camunda.search.clients.transformers.entity.VariableEntityTransformer;
+import io.camunda.search.clients.transformers.entity.WaitStateEntityTransformer;
 import io.camunda.search.clients.transformers.filter.AgentInstanceFilterTransformer;
 import io.camunda.search.clients.transformers.filter.AuditLogFilterTransformer;
 import io.camunda.search.clients.transformers.filter.AuthorizationFilterTransformer;
@@ -152,6 +153,7 @@ import io.camunda.search.clients.transformers.filter.UserFilterTransformer;
 import io.camunda.search.clients.transformers.filter.UserTaskFilterTransformer;
 import io.camunda.search.clients.transformers.filter.VariableFilterTransformer;
 import io.camunda.search.clients.transformers.filter.VariableValueFilterTransformer;
+import io.camunda.search.clients.transformers.filter.WaitStateFilterTransformer;
 import io.camunda.search.clients.transformers.query.TypedSearchQueryTransformer;
 import io.camunda.search.clients.transformers.result.DecisionInstanceResultConfigTransformer;
 import io.camunda.search.clients.transformers.result.DecisionRequirementsResultConfigTransformer;
@@ -201,6 +203,7 @@ import io.camunda.search.filter.DecisionDefinitionFilter;
 import io.camunda.search.filter.DecisionInstanceFilter;
 import io.camunda.search.filter.DecisionRequirementsFilter;
 import io.camunda.search.filter.DeployedResourceFilter;
+import io.camunda.search.filter.ElementInstanceWaitStateFilter;
 import io.camunda.search.filter.FilterBase;
 import io.camunda.search.filter.FlowNodeInstanceFilter;
 import io.camunda.search.filter.FormFilter;
@@ -243,6 +246,7 @@ import io.camunda.search.query.DecisionDefinitionQuery;
 import io.camunda.search.query.DecisionInstanceQuery;
 import io.camunda.search.query.DecisionRequirementsQuery;
 import io.camunda.search.query.DeployedResourceQuery;
+import io.camunda.search.query.ElementInstanceWaitStateQuery;
 import io.camunda.search.query.FlowNodeInstanceQuery;
 import io.camunda.search.query.FormQuery;
 import io.camunda.search.query.GlobalJobStatisticsQuery;
@@ -345,6 +349,7 @@ import io.camunda.webapps.schema.descriptors.template.TaskTemplate;
 import io.camunda.webapps.schema.descriptors.template.UsageMetricTUTemplate;
 import io.camunda.webapps.schema.descriptors.template.UsageMetricTemplate;
 import io.camunda.webapps.schema.descriptors.template.VariableTemplate;
+import io.camunda.webapps.schema.descriptors.template.WaitStateTemplate;
 import io.camunda.webapps.schema.entities.CorrelatedMessageSubscriptionEntity;
 import io.camunda.webapps.schema.entities.JobEntity;
 import io.camunda.webapps.schema.entities.ProcessEntity;
@@ -484,7 +489,8 @@ public final class ServiceTransformers {
             JobTimeSeriesStatisticsQuery.class,
             JobErrorStatisticsQuery.class,
             GlobalListenerQuery.class,
-            DeployedResourceQuery.class)
+            DeployedResourceQuery.class,
+            ElementInstanceWaitStateQuery.class)
         .forEach(cls -> mappers.put(cls, searchQueryTransformer));
 
     // document entity -> domain entity
@@ -499,6 +505,9 @@ public final class ServiceTransformers {
     mappers.put(DecisionInstanceEntity.class, new DecisionInstanceEntityTransformer());
     mappers.put(MessageSubscriptionEntity.class, new MessageSubscriptionEntityTransformer());
     mappers.put(FlowNodeInstanceEntity.class, new FlowNodeInstanceEntityTransformer());
+    mappers.put(
+        io.camunda.webapps.schema.entities.waitstate.WaitStateEntity.class,
+        new WaitStateEntityTransformer());
     mappers.put(FormEntity.class, new FormEntityTransformer());
     mappers.put(GroupEntity.class, new GroupEntityTransformer());
     mappers.put(GroupMemberEntity.class, new GroupMemberEntityTransformer());
@@ -691,6 +700,9 @@ public final class ServiceTransformers {
     mappers.put(
         DeployedResourceFilter.class,
         new DeployedResourceFilterTransformer(indexDescriptors.get(DeployedResourceIndex.class)));
+    mappers.put(
+        ElementInstanceWaitStateFilter.class,
+        new WaitStateFilterTransformer(indexDescriptors.get(WaitStateTemplate.class)));
     // result config -> source config
     mappers.put(
         DecisionInstanceQueryResultConfig.class, new DecisionInstanceResultConfigTransformer());

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/WaitStateEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/WaitStateEntityTransformer.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.entity;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.search.clients.transformers.ServiceTransformer;
+import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeType;
+import io.camunda.search.entities.WaitStateDetails;
+import io.camunda.search.entities.WaitStateDetails.WaitStateType;
+import io.camunda.search.entities.WaitStateEntity;
+import io.camunda.search.entities.WaitStateJobDetails;
+import io.camunda.search.entities.WaitStateMessageDetails;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class WaitStateEntityTransformer
+    implements ServiceTransformer<
+        io.camunda.webapps.schema.entities.waitstate.WaitStateEntity, WaitStateEntity> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(WaitStateEntityTransformer.class);
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  @Override
+  public WaitStateEntity apply(
+      final io.camunda.webapps.schema.entities.waitstate.WaitStateEntity value) {
+    return new WaitStateEntity(
+        value.getProcessInstanceKey(),
+        value.getElementInstanceKey(),
+        value.getElementId(),
+        toFlowNodeType(value.getElementType()),
+        value.getRootProcessInstanceKey(),
+        parseDetails(value.getWaitStateType(), value.getDetails()),
+        value.getTenantId());
+  }
+
+  private FlowNodeType toFlowNodeType(final String elementType) {
+    if (elementType == null) {
+      return FlowNodeType.UNSPECIFIED;
+    }
+    try {
+      return FlowNodeType.valueOf(elementType);
+    } catch (final IllegalArgumentException e) {
+      LOG.warn("Unknown element type: {}", elementType);
+      return FlowNodeType.UNKNOWN;
+    }
+  }
+
+  private WaitStateDetails parseDetails(final String waitStateType, final String detailsJson) {
+    if (waitStateType == null || detailsJson == null) {
+      return null;
+    }
+    try {
+      return switch (WaitStateType.valueOf(waitStateType)) {
+        case JOB -> OBJECT_MAPPER.readValue(detailsJson, WaitStateJobDetails.class);
+        case MESSAGE -> OBJECT_MAPPER.readValue(detailsJson, WaitStateMessageDetails.class);
+      };
+    } catch (final Exception e) {
+      LOG.warn("Failed to parse wait state details for type {}: {}", waitStateType, e.getMessage());
+      return null;
+    }
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/WaitStateFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/WaitStateFilterTransformer.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.filter;
+
+import static io.camunda.search.clients.query.SearchQueryBuilders.and;
+import static io.camunda.search.clients.query.SearchQueryBuilders.longOperations;
+import static io.camunda.search.clients.query.SearchQueryBuilders.matchAll;
+import static io.camunda.search.clients.query.SearchQueryBuilders.stringOperations;
+import static io.camunda.webapps.schema.descriptors.template.WaitStateTemplate.ELEMENT_ID;
+import static io.camunda.webapps.schema.descriptors.template.WaitStateTemplate.ELEMENT_INSTANCE_KEY;
+import static io.camunda.webapps.schema.descriptors.template.WaitStateTemplate.ELEMENT_TYPE;
+import static io.camunda.webapps.schema.descriptors.template.WaitStateTemplate.PROCESS_INSTANCE_KEY;
+import static io.camunda.webapps.schema.descriptors.template.WaitStateTemplate.ROOT_PROCESS_INSTANCE_KEY;
+import static io.camunda.webapps.schema.descriptors.template.WaitStateTemplate.WAIT_STATE_TYPE;
+
+import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.search.filter.ElementInstanceWaitStateFilter;
+import io.camunda.security.auth.Authorization;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import java.util.ArrayList;
+import java.util.List;
+
+public class WaitStateFilterTransformer
+    extends IndexFilterTransformer<ElementInstanceWaitStateFilter> {
+
+  public WaitStateFilterTransformer(final IndexDescriptor indexDescriptor) {
+    super(indexDescriptor);
+  }
+
+  @Override
+  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization<?> authorization) {
+    return matchAll();
+  }
+
+  @Override
+  public SearchQuery toSearchQuery(final ElementInstanceWaitStateFilter filter) {
+    return and(toSearchQueryFields(filter));
+  }
+
+  private List<SearchQuery> toSearchQueryFields(final ElementInstanceWaitStateFilter filter) {
+    final var queries = new ArrayList<SearchQuery>();
+    queries.addAll(longOperations(ELEMENT_INSTANCE_KEY, filter.elementInstanceKeyOperations()));
+    queries.addAll(longOperations(PROCESS_INSTANCE_KEY, filter.processInstanceKeyOperations()));
+    queries.addAll(
+        longOperations(ROOT_PROCESS_INSTANCE_KEY, filter.rootProcessInstanceKeyOperations()));
+    queries.addAll(stringOperations(ELEMENT_ID, filter.elementIdOperations()));
+    queries.addAll(stringOperations(ELEMENT_TYPE, filter.elementTypeOperations()));
+    queries.addAll(stringOperations(WAIT_STATE_TYPE, filter.waitStateTypeOperations()));
+    return queries;
+  }
+}

--- a/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/SearchClientReaders.java
+++ b/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/SearchClientReaders.java
@@ -50,4 +50,5 @@ public record SearchClientReaders(
     IncidentProcessInstanceStatisticsByErrorReader incidentProcessInstanceStatisticsByErrorReader,
     IncidentProcessInstanceStatisticsByDefinitionReader
         incidentProcessInstanceStatisticsByDefinitionReader,
-    GlobalListenerReader globalListenerReader) {}
+    GlobalListenerReader globalListenerReader,
+    WaitStateReader waitStateReader) {}

--- a/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/WaitStateReader.java
+++ b/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/WaitStateReader.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.reader;
+
+import io.camunda.search.entities.WaitStateEntity;
+import io.camunda.search.query.ElementInstanceWaitStateQuery;
+
+public interface WaitStateReader
+    extends SearchEntityReader<WaitStateEntity, ElementInstanceWaitStateQuery> {}

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -58,6 +58,7 @@ import io.camunda.search.entities.UsageMetricTUStatisticsEntity;
 import io.camunda.search.entities.UserEntity;
 import io.camunda.search.entities.UserTaskEntity;
 import io.camunda.search.entities.VariableEntity;
+import io.camunda.search.entities.WaitStateEntity;
 import io.camunda.search.exception.CamundaSearchException;
 import io.camunda.search.exception.CamundaSearchException.Reason;
 import io.camunda.search.exception.ErrorMessages;
@@ -76,6 +77,7 @@ import io.camunda.search.query.DecisionDefinitionQuery;
 import io.camunda.search.query.DecisionInstanceQuery;
 import io.camunda.search.query.DecisionRequirementsQuery;
 import io.camunda.search.query.DeployedResourceQuery;
+import io.camunda.search.query.ElementInstanceWaitStateQuery;
 import io.camunda.search.query.FlowNodeInstanceQuery;
 import io.camunda.search.query.FormQuery;
 import io.camunda.search.query.GlobalJobStatisticsQuery;
@@ -761,6 +763,12 @@ public class CamundaSearchClients implements SearchClientsProxy {
 
   protected CamundaSearchException entityByUsernameNotFoundException(final String id) {
     return entityByIdNotFoundException("User", "username", id);
+  }
+
+  @Override
+  public SearchQueryResult<WaitStateEntity> searchWaitStates(
+      final ElementInstanceWaitStateQuery query) {
+    return doSearchWithReader(readers.waitStateReader(), query);
   }
 
   private CamundaSearchException entityByIdNotFoundException(

--- a/search/search-client/src/main/java/io/camunda/search/clients/SearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/SearchClientsProxy.java
@@ -38,6 +38,7 @@ public interface SearchClientsProxy
         ClusterVariableSearchClient,
         GlobalListenerSearchClient,
         DeployedResourceSearchClient,
+        WaitStateSearchClient,
         PhysicalTenantScoped<SearchClientsProxy> {
 
   @Override

--- a/search/search-client/src/main/java/io/camunda/search/clients/WaitStateSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/WaitStateSearchClient.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients;
+
+import io.camunda.search.entities.WaitStateEntity;
+import io.camunda.search.query.ElementInstanceWaitStateQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.SecurityContext;
+
+public interface WaitStateSearchClient {
+
+  SearchQueryResult<WaitStateEntity> searchWaitStates(ElementInstanceWaitStateQuery query);
+
+  WaitStateSearchClient withSecurityContext(SecurityContext securityContext);
+}

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
@@ -52,6 +52,7 @@ import io.camunda.search.entities.UsageMetricTUStatisticsEntity;
 import io.camunda.search.entities.UserEntity;
 import io.camunda.search.entities.UserTaskEntity;
 import io.camunda.search.entities.VariableEntity;
+import io.camunda.search.entities.WaitStateEntity;
 import io.camunda.search.exception.NoSecondaryStorageException;
 import io.camunda.search.filter.ProcessDefinitionStatisticsFilter;
 import io.camunda.search.query.AgentInstanceQuery;
@@ -65,6 +66,7 @@ import io.camunda.search.query.DecisionDefinitionQuery;
 import io.camunda.search.query.DecisionInstanceQuery;
 import io.camunda.search.query.DecisionRequirementsQuery;
 import io.camunda.search.query.DeployedResourceQuery;
+import io.camunda.search.query.ElementInstanceWaitStateQuery;
 import io.camunda.search.query.FlowNodeInstanceQuery;
 import io.camunda.search.query.FormQuery;
 import io.camunda.search.query.GlobalJobStatisticsQuery;
@@ -487,6 +489,12 @@ public class NoDBSearchClientsProxy implements SearchClientsProxy {
   @Override
   public SearchQueryResult<DeployedResourceEntity> searchDeployedResources(
       final DeployedResourceQuery query) {
+    throw new NoSecondaryStorageException();
+  }
+
+  @Override
+  public SearchQueryResult<WaitStateEntity> searchWaitStates(
+      final ElementInstanceWaitStateQuery query) {
     throw new NoSecondaryStorageException();
   }
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
@@ -54,6 +54,7 @@ import io.camunda.search.entities.UsageMetricTUStatisticsEntity;
 import io.camunda.search.entities.UserEntity;
 import io.camunda.search.entities.UserTaskEntity;
 import io.camunda.search.entities.VariableEntity;
+import io.camunda.search.entities.WaitStateEntity;
 import io.camunda.search.filter.ProcessDefinitionStatisticsFilter;
 import io.camunda.search.query.AgentInstanceQuery;
 import io.camunda.search.query.AuditLogQuery;
@@ -66,6 +67,7 @@ import io.camunda.search.query.DecisionDefinitionQuery;
 import io.camunda.search.query.DecisionInstanceQuery;
 import io.camunda.search.query.DecisionRequirementsQuery;
 import io.camunda.search.query.DeployedResourceQuery;
+import io.camunda.search.query.ElementInstanceWaitStateQuery;
 import io.camunda.search.query.FlowNodeInstanceQuery;
 import io.camunda.search.query.FormQuery;
 import io.camunda.search.query.GlobalJobStatisticsQuery;
@@ -489,6 +491,12 @@ public class NoopSearchClientsProxy implements SearchClientsProxy {
   @Override
   public SearchQueryResult<DeployedResourceEntity> searchDeployedResources(
       final DeployedResourceQuery query) {
+    return SearchQueryResult.empty();
+  }
+
+  @Override
+  public SearchQueryResult<WaitStateEntity> searchWaitStates(
+      final ElementInstanceWaitStateQuery query) {
     return SearchQueryResult.empty();
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/entities/WaitStateEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/WaitStateEntity.java
@@ -15,8 +15,8 @@ import org.jspecify.annotations.Nullable;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record WaitStateEntity(
-    long processInstanceKey,
-    long elementInstanceKey,
+    Long processInstanceKey,
+    Long elementInstanceKey,
     String elementId,
     FlowNodeType elementType,
     @Nullable Long rootProcessInstanceKey,
@@ -24,6 +24,8 @@ public record WaitStateEntity(
     String tenantId) {
 
   public WaitStateEntity {
+    Objects.requireNonNull(processInstanceKey, "processInstanceKey");
+    Objects.requireNonNull(elementInstanceKey, "elementInstanceKey");
     Objects.requireNonNull(elementId, "elementId");
     Objects.requireNonNull(elementType, "elementType");
     Objects.requireNonNull(tenantId, "tenantId");
@@ -31,20 +33,20 @@ public record WaitStateEntity(
   }
 
   public static class Builder implements ObjectBuilder<WaitStateEntity> {
-    private long processInstanceKey;
-    private long elementInstanceKey;
+    private @Nullable Long processInstanceKey;
+    private @Nullable Long elementInstanceKey;
     private @Nullable String elementId;
     private @Nullable FlowNodeType elementType;
     private @Nullable Long rootProcessInstanceKey;
     private @Nullable WaitStateDetails details;
     private @Nullable String tenantId;
 
-    public Builder processInstanceKey(final long processInstanceKey) {
+    public Builder processInstanceKey(final Long processInstanceKey) {
       this.processInstanceKey = processInstanceKey;
       return this;
     }
 
-    public Builder elementInstanceKey(final long elementInstanceKey) {
+    public Builder elementInstanceKey(final Long elementInstanceKey) {
       this.elementInstanceKey = elementInstanceKey;
       return this;
     }
@@ -59,7 +61,7 @@ public record WaitStateEntity(
       return this;
     }
 
-    public Builder rootProcessInstanceKey(final @Nullable Long rootProcessInstanceKey) {
+    public Builder rootProcessInstanceKey(final Long rootProcessInstanceKey) {
       this.rootProcessInstanceKey = rootProcessInstanceKey;
       return this;
     }
@@ -69,7 +71,7 @@ public record WaitStateEntity(
       return this;
     }
 
-    public Builder tenantId(final @Nullable String tenantId) {
+    public Builder tenantId(final String tenantId) {
       this.tenantId = tenantId;
       return this;
     }
@@ -77,8 +79,8 @@ public record WaitStateEntity(
     @Override
     public WaitStateEntity build() {
       return new WaitStateEntity(
-          processInstanceKey,
-          elementInstanceKey,
+          Objects.requireNonNull(processInstanceKey, "processInstanceKey"),
+          Objects.requireNonNull(elementInstanceKey, "elementInstanceKey"),
           Objects.requireNonNull(elementId, "elementId"),
           Objects.requireNonNull(elementType, "elementType"),
           Objects.requireNonNull(rootProcessInstanceKey, "rootProcessInstanceKey"),

--- a/service/src/main/java/io/camunda/service/ElementInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ElementInstanceServices.java
@@ -11,6 +11,7 @@ import static io.camunda.security.auth.Authorization.withAuthorization;
 import static io.camunda.service.authorization.Authorizations.ELEMENT_INSTANCE_READ_AUTHORIZATION;
 
 import io.camunda.search.clients.FlowNodeInstanceSearchClient;
+import io.camunda.search.clients.WaitStateSearchClient;
 import io.camunda.search.entities.FlowNodeInstanceEntity;
 import io.camunda.search.entities.IncidentEntity;
 import io.camunda.search.entities.WaitStateEntity;
@@ -39,6 +40,7 @@ public final class ElementInstanceServices
 
   private static final String FNI_ELEMENT_INSTANCE_PATTERN = "*FNI_%d*";
   private final FlowNodeInstanceSearchClient flowNodeInstanceSearchClient;
+  private final WaitStateSearchClient waitStateSearchClient;
   private final ProcessCache processCache;
   private final IncidentServices incidentServices;
 
@@ -46,6 +48,7 @@ public final class ElementInstanceServices
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final FlowNodeInstanceSearchClient flowNodeInstanceSearchClient,
+      final WaitStateSearchClient waitStateSearchClient,
       final ProcessCache processCache,
       final IncidentServices incidentServices,
       final ApiServicesExecutorProvider executorProvider,
@@ -56,6 +59,7 @@ public final class ElementInstanceServices
         executorProvider,
         brokerRequestAuthorizationConverter);
     this.flowNodeInstanceSearchClient = flowNodeInstanceSearchClient;
+    this.waitStateSearchClient = waitStateSearchClient;
     this.processCache = processCache;
     this.incidentServices = incidentServices;
   }
@@ -168,8 +172,13 @@ public final class ElementInstanceServices
 
   public SearchQueryResult<WaitStateEntity> searchWaitStates(
       final ElementInstanceWaitStateQuery query, final CamundaAuthentication authentication) {
-    // TODO: not implemented yet
-    return SearchQueryResult.empty();
+    return executeSearchRequest(
+        () ->
+            waitStateSearchClient
+                .withSecurityContext(
+                    securityContextProvider.provideSecurityContext(
+                        authentication, ELEMENT_INSTANCE_READ_AUTHORIZATION))
+                .searchWaitStates(query));
   }
 
   public record SetVariablesRequest(

--- a/service/src/test/java/io/camunda/service/ElementInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ElementInstanceServiceTest.java
@@ -15,9 +15,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.camunda.search.clients.FlowNodeInstanceSearchClient;
+import io.camunda.search.clients.WaitStateSearchClient;
 import io.camunda.search.entities.FlowNodeInstanceEntity;
 import io.camunda.search.entities.IncidentEntity;
+import io.camunda.search.entities.WaitStateEntity;
 import io.camunda.search.exception.ResourceAccessDeniedException;
+import io.camunda.search.query.ElementInstanceWaitStateQuery;
 import io.camunda.search.query.FlowNodeInstanceQuery;
 import io.camunda.search.query.IncidentQuery;
 import io.camunda.search.query.SearchQueryBuilders;
@@ -44,6 +47,7 @@ public final class ElementInstanceServiceTest {
 
   private ElementInstanceServices services;
   private FlowNodeInstanceSearchClient client;
+  private WaitStateSearchClient waitStateSearchClient;
   private ProcessCache processCache;
   @Mock private IncidentServices incidentServices;
   @Mock private CamundaAuthentication authentication;
@@ -51,6 +55,7 @@ public final class ElementInstanceServiceTest {
   @BeforeEach
   public void before() {
     client = mock(FlowNodeInstanceSearchClient.class);
+    waitStateSearchClient = mock(WaitStateSearchClient.class);
     processCache = mock(ProcessCache.class);
     incidentServices = mock(IncidentServices.class);
     services =
@@ -58,13 +63,33 @@ public final class ElementInstanceServiceTest {
             mock(BrokerClient.class),
             mock(SecurityContextProvider.class),
             client,
+            waitStateSearchClient,
             processCache,
             incidentServices,
             mock(ApiServicesExecutorProvider.class),
             null);
 
     when(client.withSecurityContext(any())).thenReturn(client);
+    when(waitStateSearchClient.withSecurityContext(any())).thenReturn(waitStateSearchClient);
     when(processCache.getCacheItems(any())).thenReturn(ProcessCacheResult.EMPTY);
+  }
+
+  @Nested
+  class SearchWaitStates {
+
+    @Test
+    void shouldReturnWaitStates() {
+      // given
+      final var entity = Instancio.create(WaitStateEntity.class);
+      when(waitStateSearchClient.searchWaitStates(any())).thenReturn(SearchQueryResult.of(entity));
+
+      // when
+      final var result =
+          services.searchWaitStates(ElementInstanceWaitStateQuery.of(q -> q), authentication);
+
+      // then
+      assertThat(result.items()).containsExactly(entity);
+    }
   }
 
   @Nested


### PR DESCRIPTION
## Description

- Introduced a search layer for wait states across all supported backends (Elasticsearch, OpenSearch, RDBMS)
- Implemented backend-specific query, filtering, and entity transformation for each storage type
- Exposed wait state search as a new operation on the element instance service with proper authorization
- Wired all new components into existing Spring configurations for automatic discovery
- Added unit test coverage for the new service operation

## Related issues

closes https://github.com/camunda/camunda/issues/53993
