### PR TITLE
Properly release backup store semaphore

### DIFF
--- a/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupStore.java
+++ b/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupStore.java
@@ -28,7 +28,6 @@ import io.camunda.zeebe.backup.common.BackupStatusImpl;
 import io.camunda.zeebe.backup.common.BackupStoreException.UnexpectedManifestState;
 import io.camunda.zeebe.backup.common.Manifest;
 import io.camunda.zeebe.backup.common.Manifest.StatusCode;
-import io.camunda.zeebe.backup.common.SemaphoreLeasedScheduler;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -38,7 +37,6 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.ReentrantLock;
@@ -59,15 +57,13 @@ public final class AzureBackupStore implements BackupStore {
   public static final String SNAPSHOT_FILESET_NAME = "snapshot";
   public static final String SEGMENTS_FILESET_NAME = "segments";
   public static final String METADATA_OBJECT_NAME = "metadata.json";
-  static final int MAX_CONCURRENT_SAVES = 128;
+  static final int MAX_CONCURRENT_FILE_OPERATIONS = 128;
   private static final Logger LOG = LoggerFactory.getLogger(AzureBackupStore.class);
   private final ExecutorService executor;
-  private final Semaphore saveSemaphore = new Semaphore(MAX_CONCURRENT_SAVES);
   private final ReentrantLock containerCreationLock = new ReentrantLock();
   private final FileSetManager fileSetManager;
   private final ManifestManager manifestManager;
   private final BlobContainerClient blobContainerClient;
-  private final AzureBackupConfig config;
   private volatile boolean containerCreated;
 
   AzureBackupStore(final AzureBackupConfig config) {
@@ -83,7 +79,13 @@ public final class AzureBackupStore implements BackupStore {
     containerCreated = !createContainer;
 
     final var blobBatchClient = new BlobBatchClientBuilder(client).buildClient();
-    fileSetManager = new FileSetManager(blobContainerClient, blobBatchClient, createContainer);
+    fileSetManager =
+        new FileSetManager(
+            blobContainerClient,
+            blobBatchClient,
+            createContainer,
+            executor,
+            MAX_CONCURRENT_FILE_OPERATIONS);
     manifestManager = new ManifestManager(blobContainerClient, createContainer);
   }
 
@@ -148,50 +150,45 @@ public final class AzureBackupStore implements BackupStore {
 
   @Override
   public CompletableFuture<Void> save(final Backup backup) {
-    return SemaphoreLeasedScheduler.scheduleAsync(
-        () ->
-            CompletableFuture.supplyAsync(
-                    () -> manifestManager.createInitialManifest(backup), executor)
-                .thenComposeAsync(
-                    persistedManifest -> {
-                      final var snapshotFuture =
-                          CompletableFuture.runAsync(
-                              () ->
-                                  fileSetManager.save(
-                                      backup.id(), SNAPSHOT_FILESET_NAME, backup.snapshot()),
-                              executor);
-                      final var segmentsFuture =
-                          CompletableFuture.runAsync(
-                              () ->
-                                  fileSetManager.save(
-                                      backup.id(), SEGMENTS_FILESET_NAME, backup.segments()),
-                              executor);
+    return CompletableFuture.supplyAsync(
+            () -> manifestManager.createInitialManifest(backup), executor)
+        .thenComposeAsync(
+            persistedManifest -> {
+              final var snapshotFuture =
+                  CompletableFuture.runAsync(
+                      () ->
+                          fileSetManager.save(
+                              backup.id(), SNAPSHOT_FILESET_NAME, backup.snapshot()),
+                      executor);
+              final var segmentsFuture =
+                  CompletableFuture.runAsync(
+                      () ->
+                          fileSetManager.save(
+                              backup.id(), SEGMENTS_FILESET_NAME, backup.segments()),
+                      executor);
 
-                      return CompletableFuture.allOf(snapshotFuture, segmentsFuture)
-                          .whenCompleteAsync(
-                              (ignored, error) -> {
-                                if (error != null) {
-                                  manifestManager.markAsFailed(
-                                      persistedManifest.manifest().id(), error.getMessage());
-                                }
-                              },
-                              executor)
-                          .thenApplyAsync(ignored -> persistedManifest, executor);
-                    },
-                    executor)
-                .thenAcceptAsync(
-                    persistedManifest -> {
-                      try {
-                        manifestManager.completeManifest(persistedManifest);
-                      } catch (final Exception e) {
-                        manifestManager.markAsFailed(
-                            persistedManifest.manifest().id(), e.getMessage());
-                        throw e;
-                      }
-                    },
-                    executor),
-        executor,
-        saveSemaphore);
+              return CompletableFuture.allOf(snapshotFuture, segmentsFuture)
+                  .whenCompleteAsync(
+                      (ignored, error) -> {
+                        if (error != null) {
+                          manifestManager.markAsFailed(
+                              persistedManifest.manifest().id(), error.getMessage());
+                        }
+                      },
+                      executor)
+                  .thenApplyAsync(ignored -> persistedManifest, executor);
+            },
+            executor)
+        .thenAcceptAsync(
+            persistedManifest -> {
+              try {
+                manifestManager.completeManifest(persistedManifest);
+              } catch (final Exception e) {
+                manifestManager.markAsFailed(persistedManifest.manifest().id(), e.getMessage());
+                throw e;
+              }
+            },
+            executor);
   }
 
   @Override

--- a/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupStore.java
+++ b/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupStore.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.backup.common.BackupStatusImpl;
 import io.camunda.zeebe.backup.common.BackupStoreException.UnexpectedManifestState;
 import io.camunda.zeebe.backup.common.Manifest;
 import io.camunda.zeebe.backup.common.Manifest.StatusCode;
+import io.camunda.zeebe.backup.common.SemaphoreLeasedScheduler;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -146,55 +147,50 @@ public final class AzureBackupStore implements BackupStore {
 
   @Override
   public CompletableFuture<Void> save(final Backup backup) {
-    return CompletableFuture.runAsync(
-            () -> {
-              try {
-                saveSemaphore.acquire();
-              } catch (final InterruptedException e) {
-                Thread.currentThread().interrupt();
-                throw new RuntimeException("Interrupted while waiting to save backup", e);
-              }
-            },
-            executor)
-        .thenApplyAsync(ignored -> manifestManager.createInitialManifest(backup), executor)
-        .thenComposeAsync(
-            persistedManifest -> {
-              final var snapshotFuture =
-                  CompletableFuture.runAsync(
-                      () ->
-                          fileSetManager.save(
-                              backup.id(), SNAPSHOT_FILESET_NAME, backup.snapshot()),
-                      executor);
-              final var segmentsFuture =
-                  CompletableFuture.runAsync(
-                      () ->
-                          fileSetManager.save(
-                              backup.id(), SEGMENTS_FILESET_NAME, backup.segments()),
-                      executor);
+    return SemaphoreLeasedScheduler.scheduleAsync(
+        () ->
+            CompletableFuture.supplyAsync(
+                    () -> manifestManager.createInitialManifest(backup), executor)
+                .thenComposeAsync(
+                    persistedManifest -> {
+                      final var snapshotFuture =
+                          CompletableFuture.runAsync(
+                              () ->
+                                  fileSetManager.save(
+                                      backup.id(), SNAPSHOT_FILESET_NAME, backup.snapshot()),
+                              executor);
+                      final var segmentsFuture =
+                          CompletableFuture.runAsync(
+                              () ->
+                                  fileSetManager.save(
+                                      backup.id(), SEGMENTS_FILESET_NAME, backup.segments()),
+                              executor);
 
-              return CompletableFuture.allOf(snapshotFuture, segmentsFuture)
-                  .whenCompleteAsync(
-                      (ignored, error) -> {
-                        if (error != null) {
-                          manifestManager.markAsFailed(
-                              persistedManifest.manifest().id(), error.getMessage());
-                        }
-                      },
-                      executor)
-                  .thenApplyAsync(ignored -> persistedManifest, executor);
-            },
-            executor)
-        .thenAcceptAsync(
-            persistedManifest -> {
-              try {
-                manifestManager.completeManifest(persistedManifest);
-              } catch (final Exception e) {
-                manifestManager.markAsFailed(persistedManifest.manifest().id(), e.getMessage());
-                throw e;
-              }
-            },
-            executor)
-        .whenComplete((ignored, error) -> saveSemaphore.release());
+                      return CompletableFuture.allOf(snapshotFuture, segmentsFuture)
+                          .whenCompleteAsync(
+                              (ignored, error) -> {
+                                if (error != null) {
+                                  manifestManager.markAsFailed(
+                                      persistedManifest.manifest().id(), error.getMessage());
+                                }
+                              },
+                              executor)
+                          .thenApplyAsync(ignored -> persistedManifest, executor);
+                    },
+                    executor)
+                .thenAcceptAsync(
+                    persistedManifest -> {
+                      try {
+                        manifestManager.completeManifest(persistedManifest);
+                      } catch (final Exception e) {
+                        manifestManager.markAsFailed(
+                            persistedManifest.manifest().id(), e.getMessage());
+                        throw e;
+                      }
+                    },
+                    executor),
+        executor,
+        saveSemaphore);
   }
 
   @Override

--- a/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupStore.java
+++ b/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupStore.java
@@ -75,8 +75,9 @@ public final class AzureBackupStore implements BackupStore {
   }
 
   AzureBackupStore(final AzureBackupConfig config, final BlobServiceClient client) {
-    this.config = config;
-    executor = Executors.newVirtualThreadPerTaskExecutor();
+    executor =
+        Executors.newThreadPerTaskExecutor(
+            Thread.ofVirtual().name("zeebe-backup-azure-", 0).factory());
     blobContainerClient = getContainerClient(client, config);
     final boolean createContainer = isCreateContainer(config);
     containerCreated = !createContainer;

--- a/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/FileSetManager.java
+++ b/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/FileSetManager.java
@@ -25,10 +25,14 @@ import io.camunda.zeebe.backup.azure.AzureBackupStoreException.BlobAlreadyExists
 import io.camunda.zeebe.backup.common.FileSet;
 import io.camunda.zeebe.backup.common.FileSet.NamedFile;
 import io.camunda.zeebe.backup.common.NamedFileSetImpl;
+import io.camunda.zeebe.backup.common.SemaphoreLeasedScheduler;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 
@@ -49,33 +53,55 @@ final class FileSetManager {
   private final BlobBatchClient blobBatchClient;
   private final ReentrantLock containerCreationLock = new ReentrantLock();
   private volatile boolean containerCreated = false;
+  private final Executor executor;
+  private final Semaphore concurrencyLimit;
 
   FileSetManager(
       final BlobContainerClient containerClient,
       final BlobBatchClient blobBatchClient,
-      final boolean createContainer) {
+      final boolean createContainer,
+      final Executor executor,
+      final int maxConcurrentOperations) {
     this.containerClient = containerClient;
     this.blobBatchClient = blobBatchClient;
     containerCreated = !createContainer;
+    this.executor = executor;
+    concurrencyLimit = new Semaphore(maxConcurrentOperations);
   }
 
   void save(final BackupIdentifier id, final String fileSetName, final NamedFileSet fileSet) {
     assureContainerCreated();
-    for (final var namedFile : fileSet.namedFiles().entrySet()) {
-      final var fileName = namedFile.getKey();
-      final var filePath = namedFile.getValue();
-      final String fileSetPath = fileSetPath(id, fileSetName);
+    final var uploadFutures =
+        fileSet.namedFiles().entrySet().stream()
+            .map(
+                namedFile ->
+                    SemaphoreLeasedScheduler.schedule(
+                        () -> {
+                          saveFile(id, fileSetName, namedFile.getKey(), namedFile.getValue());
+                          return null;
+                        },
+                        executor,
+                        concurrencyLimit))
+            .toList();
 
-      final BlobClient blobClient = containerClient.getBlobClient(fileSetPath + fileName);
+    // Wait for all uploads to complete.
+    CompletableFuture.allOf(uploadFutures.toArray(new CompletableFuture[0])).join();
+  }
 
-      try {
-        upload(blobClient, filePath);
-      } catch (final BlobStorageException e) {
-        if (e.getErrorCode() == BlobErrorCode.BLOB_ALREADY_EXISTS) {
-          throw new BlobAlreadyExists("File already exists.", e.getCause());
-        }
-        throw e;
+  private void saveFile(
+      final BackupIdentifier id,
+      final String fileSetName,
+      final String fileName,
+      final Path filePath) {
+    final BlobClient blobClient =
+        containerClient.getBlobClient(fileSetPath(id, fileSetName) + fileName);
+    try {
+      upload(blobClient, filePath);
+    } catch (final BlobStorageException e) {
+      if (e.getErrorCode() == BlobErrorCode.BLOB_ALREADY_EXISTS) {
+        throw new BlobAlreadyExists("File already exists.", e.getCause());
       }
+      throw e;
     }
   }
 
@@ -109,18 +135,33 @@ final class FileSetManager {
         fileSet.files().stream()
             .collect(Collectors.toMap(NamedFile::name, f -> targetFolder.resolve(f.name())));
 
-    for (final var entry : pathByName.entrySet()) {
-      final var fileName = entry.getKey();
-      final var filePath = entry.getValue();
+    final var downloadFutures =
+        pathByName.entrySet().stream()
+            .map(
+                entry ->
+                    SemaphoreLeasedScheduler.schedule(
+                        () -> {
+                          downloadFile(id, fileSetName, entry.getKey(), entry.getValue());
+                          return null;
+                        },
+                        executor,
+                        concurrencyLimit))
+            .toList();
 
-      final BlockBlobClient blobClient =
-          containerClient
-              .getBlobClient(fileSetPath(id, fileSetName) + fileName)
-              .getBlockBlobClient();
-      blobClient.downloadToFile(String.valueOf(filePath), true);
-    }
+    // Wait for all downloads to complete.
+    CompletableFuture.allOf(downloadFutures.toArray(new CompletableFuture[0])).join();
 
     return new NamedFileSetImpl(pathByName);
+  }
+
+  private void downloadFile(
+      final BackupIdentifier id,
+      final String fileSetName,
+      final String fileName,
+      final Path filePath) {
+    final BlockBlobClient blobClient =
+        containerClient.getBlobClient(fileSetPath(id, fileSetName) + fileName).getBlockBlobClient();
+    blobClient.downloadToFile(String.valueOf(filePath), true);
   }
 
   void assureContainerCreated() {

--- a/zeebe/backup-stores/azure/src/test/java/io/camunda/zeebe/backup/azure/AzureBackupStoreSaveTest.java
+++ b/zeebe/backup-stores/azure/src/test/java/io/camunda/zeebe/backup/azure/AzureBackupStoreSaveTest.java
@@ -11,7 +11,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -34,9 +33,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Map;
 import java.util.concurrent.CompletionException;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Semaphore;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -55,7 +52,6 @@ final class AzureBackupStoreSaveTest {
   private AzureBackupStore store;
   private Backup backup;
   private PersistedManifest persistedManifest;
-  private Semaphore saveSemaphore;
 
   @BeforeEach
   void setUp() throws Exception {
@@ -81,10 +77,6 @@ final class AzureBackupStoreSaveTest {
     fileSetManagerField.setAccessible(true);
     fileSetManagerField.set(realStore, fileSetManager);
 
-    final Field semaphoreField = AzureBackupStore.class.getDeclaredField("saveSemaphore");
-    semaphoreField.setAccessible(true);
-    saveSemaphore = (Semaphore) semaphoreField.get(realStore);
-
     store = spy(realStore);
 
     final var id = new BackupIdentifierImpl(1, 0, 1L);
@@ -104,7 +96,23 @@ final class AzureBackupStoreSaveTest {
   }
 
   @Test
-  void shouldCompleteExceptionallyWhenSnapshotUploadFails() {
+  void shouldUploadFileSetsAndCompleteManifestOnSuccess() {
+    // given
+    when(manifestManager.createInitialManifest(any())).thenReturn(persistedManifest);
+
+    // when
+    store.save(backup).join();
+
+    // then
+    verify(fileSetManager)
+        .save(backup.id(), AzureBackupStore.SNAPSHOT_FILESET_NAME, backup.snapshot());
+    verify(fileSetManager)
+        .save(backup.id(), AzureBackupStore.SEGMENTS_FILESET_NAME, backup.segments());
+    verify(manifestManager).completeManifest(persistedManifest);
+  }
+
+  @Test
+  void shouldCompleteExceptionallyAndMarkAsFailedWhenUploadFails() {
     // given
     when(manifestManager.createInitialManifest(any())).thenReturn(persistedManifest);
     final var uploadError = new RuntimeException("snapshot upload failed");
@@ -124,86 +132,15 @@ final class AzureBackupStoreSaveTest {
   }
 
   @Test
-  void shouldAcquireAndReleaseTheSemaphoreOnSuccess() {
+  void shouldCompleteExceptionallyWhenCreateInitialManifestFails() {
     // given
-    when(manifestManager.createInitialManifest(any())).thenReturn(persistedManifest);
-    final int permitsBefore = saveSemaphore.availablePermits();
-
-    // when
-    store.save(backup).join();
-
-    // then
-    assertThat(saveSemaphore.availablePermits())
-        .as("semaphore permits should be fully restored after a successful save")
-        .isEqualTo(permitsBefore);
-  }
-
-  @Test
-  void shouldAcquireAndReleaseTheSemaphoreWhenUploadFails() {
-    // given
-
-    lenient()
-        .doThrow(new RuntimeException("upload failed"))
-        .when(fileSetManager)
-        .save(any(), anyString(), any());
-    final int permitsBefore = saveSemaphore.availablePermits();
-
-    // when
-    store.save(backup).exceptionally(e -> null).join();
-
-    // then
-    assertThat(saveSemaphore.availablePermits())
-        .as("semaphore permits should be fully restored after a failed upload")
-        .isEqualTo(permitsBefore);
-  }
-
-  @Test
-  void shouldAcquireAndReleaseTheSemaphoreWhenCreateInitialManifestFails() {
-    // given
-    Mockito.lenient()
-        .when(manifestManager.createInitialManifest(any()))
+    Mockito.when(manifestManager.createInitialManifest(any()))
         .thenThrow(new RuntimeException("manifest creation failed"));
-    final int permitsBefore = saveSemaphore.availablePermits();
 
-    // when
-    store.save(backup).exceptionally(e -> null).join();
-
-    // then
-    assertThat(saveSemaphore.availablePermits())
-        .as("semaphore permits should be fully restored after a failed manifest creation")
-        .isEqualTo(permitsBefore);
-  }
-
-  @Test
-  void shouldDecrementPermitWhileSaveIsInFlight() throws Exception {
-    // given – block the upload so the save is still in progress when we sample the semaphore
-    when(manifestManager.createInitialManifest(any())).thenReturn(persistedManifest);
-    final var uploadStarted = new CountDownLatch(1);
-    final var releaseUpload = new CountDownLatch(1);
-    Mockito.doAnswer(
-            inv -> {
-              uploadStarted.countDown();
-              releaseUpload.await();
-              return null;
-            })
-        .when(fileSetManager)
-        .save(any(), anyString(), any());
-
-    // when
-    final var future = store.save(backup);
-    uploadStarted.await();
-
-    // then – one permit must be held while the save is in progress
-    assertThat(saveSemaphore.availablePermits())
-        .as("one permit should be held while a save is in progress")
-        .isEqualTo(AzureBackupStore.MAX_CONCURRENT_SAVES - 1);
-
-    // cleanup – let the upload finish and confirm the permit is restored
-    releaseUpload.countDown();
-    future.join();
-
-    assertThat(saveSemaphore.availablePermits())
-        .as("permit should be restored after the in-flight save completes")
-        .isEqualTo(AzureBackupStore.MAX_CONCURRENT_SAVES);
+    // when / then
+    assertThat(store.save(backup))
+        .failsWithin(Duration.ofSeconds(5))
+        .withThrowableOfType(ExecutionException.class)
+        .withCauseInstanceOf(RuntimeException.class);
   }
 }

--- a/zeebe/backup-stores/azure/src/test/java/io/camunda/zeebe/backup/azure/FileSetManagerTest.java
+++ b/zeebe/backup-stores/azure/src/test/java/io/camunda/zeebe/backup/azure/FileSetManagerTest.java
@@ -37,7 +37,7 @@ final class FileSetManagerTest {
 
   @BeforeEach
   void setUp() {
-    manager = new FileSetManager(containerClient, blobBatchClient, false);
+    manager = new FileSetManager(containerClient, blobBatchClient, false, Runnable::run, 1);
   }
 
   @Test

--- a/zeebe/backup-stores/common/src/main/java/io/camunda/zeebe/backup/common/SemaphoreLeasedScheduler.java
+++ b/zeebe/backup-stores/common/src/main/java/io/camunda/zeebe/backup/common/SemaphoreLeasedScheduler.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.common;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Semaphore;
+import java.util.function.Supplier;
+
+public final class SemaphoreLeasedScheduler {
+
+  private SemaphoreLeasedScheduler() {}
+
+  /**
+   * Schedules a task to be executed asynchronously, respecting the concurrency limit imposed by the
+   * semaphore.
+   *
+   * @param task the task to execute
+   * @param executor the executor to run the task
+   * @param concurrencyLimit the semaphore to limit concurrency
+   * @param <T> the type of the result
+   * @return a future that completes with the result of the task
+   */
+  public static <T> CompletableFuture<T> schedule(
+      final Supplier<T> task, final Executor executor, final Semaphore concurrencyLimit) {
+    return scheduleAsync(
+        () -> CompletableFuture.completedFuture(task.get()), executor, concurrencyLimit);
+  }
+
+  /**
+   * Schedules an asynchronous task to be executed, respecting the concurrency limit imposed by the
+   * semaphore. The permit is held until the future returned by the task completed.
+   *
+   * @param task the task to execute
+   * @param executor the executor to run the task
+   * @param concurrencyLimit the semaphore to limit concurrency
+   * @param <T> the type of the result
+   * @return a future that completes when the task's future completes
+   */
+  public static <T> CompletableFuture<T> scheduleAsync(
+      final Supplier<CompletableFuture<T>> task,
+      final Executor executor,
+      final Semaphore concurrencyLimit) {
+    final var result = new CompletableFuture<T>();
+
+    executor.execute(
+        () -> {
+          try {
+            concurrencyLimit.acquire();
+          } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            result.completeExceptionally(e);
+            // The permit was never acquired
+            return;
+          }
+
+          try {
+            task.get()
+                .whenComplete(
+                    (res, err) -> {
+                      try {
+                        if (err != null) {
+                          result.completeExceptionally(err);
+                        } else {
+                          result.complete(res);
+                        }
+                      } finally {
+                        concurrencyLimit.release();
+                      }
+                    });
+          } catch (final Exception e) {
+            result.completeExceptionally(e);
+            concurrencyLimit.release();
+          }
+        });
+
+    return result;
+  }
+}

--- a/zeebe/backup-stores/common/src/main/java/io/camunda/zeebe/backup/common/SemaphoreLeasedScheduler.java
+++ b/zeebe/backup-stores/common/src/main/java/io/camunda/zeebe/backup/common/SemaphoreLeasedScheduler.java
@@ -17,35 +17,30 @@ public final class SemaphoreLeasedScheduler {
   private SemaphoreLeasedScheduler() {}
 
   /**
-   * Schedules a task to be executed asynchronously, respecting the concurrency limit imposed by the
-   * semaphore.
+   * Schedules a (blocking) task to be executed on the given executor, respecting the concurrency
+   * limit imposed by the semaphore.
+   *
+   * <p>Semaphore acquire, executing task and release all run in a single submitted unit of work:
+   * the worker thread acquires a permit, runs the task, and releases the permit in a {@code
+   * finally} block on that same thread. The release itself never needs an additional thread, so a
+   * permit freed by a finishing task immediately unblocks a worker parked in {@link
+   * Semaphore#acquire()}.
+   *
+   * <p><strong>Executor sizing:</strong> the scheduling itself is safe with a bounded executor.
+   * However, if the {@code task} blocks on further work submitted back to the <em>same</em>
+   * executor (e.g. it submits sub-tasks and joins on them), that executor must be unbounded (such
+   * as a virtual-thread-per-task executor). With a bounded executor in that case all worker threads
+   * can be parked waiting on tasks that can never be scheduled, which deadlocks. All current
+   * callers use unbounded virtual-thread executors for this reason.
    *
    * @param task the task to execute
-   * @param executor the executor to run the task
+   * @param executor the executor to run the task (see the executor sizing note above)
    * @param concurrencyLimit the semaphore to limit concurrency
    * @param <T> the type of the result
    * @return a future that completes with the result of the task
    */
   public static <T> CompletableFuture<T> schedule(
       final Supplier<T> task, final Executor executor, final Semaphore concurrencyLimit) {
-    return scheduleAsync(
-        () -> CompletableFuture.completedFuture(task.get()), executor, concurrencyLimit);
-  }
-
-  /**
-   * Schedules an asynchronous task to be executed, respecting the concurrency limit imposed by the
-   * semaphore. The permit is held until the future returned by the task completed.
-   *
-   * @param task the task to execute
-   * @param executor the executor to run the task
-   * @param concurrencyLimit the semaphore to limit concurrency
-   * @param <T> the type of the result
-   * @return a future that completes when the task's future completes
-   */
-  public static <T> CompletableFuture<T> scheduleAsync(
-      final Supplier<CompletableFuture<T>> task,
-      final Executor executor,
-      final Semaphore concurrencyLimit) {
     final var result = new CompletableFuture<T>();
 
     executor.execute(
@@ -55,26 +50,15 @@ public final class SemaphoreLeasedScheduler {
           } catch (final InterruptedException e) {
             Thread.currentThread().interrupt();
             result.completeExceptionally(e);
-            // The permit was never acquired
+            // The permit was never acquired, so it must not be released.
             return;
           }
 
           try {
-            task.get()
-                .whenComplete(
-                    (res, err) -> {
-                      try {
-                        if (err != null) {
-                          result.completeExceptionally(err);
-                        } else {
-                          result.complete(res);
-                        }
-                      } finally {
-                        concurrencyLimit.release();
-                      }
-                    });
-          } catch (final Exception e) {
-            result.completeExceptionally(e);
+            result.complete(task.get());
+          } catch (final Throwable t) {
+            result.completeExceptionally(t);
+          } finally {
             concurrencyLimit.release();
           }
         });

--- a/zeebe/backup-stores/common/src/test/java/io/camunda/zeebe/backup/common/SemaphoreLeasedSchedulerTest.java
+++ b/zeebe/backup-stores/common/src/test/java/io/camunda/zeebe/backup/common/SemaphoreLeasedSchedulerTest.java
@@ -10,13 +10,17 @@ package io.camunda.zeebe.backup.common;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -66,63 +70,6 @@ class SemaphoreLeasedSchedulerTest {
   }
 
   @Test
-  void shouldReleasePermitWhenAsyncFutureFails() throws Exception {
-    // given
-    final var released = new CountDownLatch(1);
-    final var semaphore = releaseSignallingSemaphore(1, released);
-
-    // when
-    final var result =
-        SemaphoreLeasedScheduler.scheduleAsync(
-            () -> CompletableFuture.failedFuture(new RuntimeException("boom")),
-            executor,
-            semaphore);
-
-    // then
-    assertThatThrownBy(result::join).hasRootCauseMessage("boom");
-    assertThat(released.await(5, TimeUnit.SECONDS)).isTrue();
-    assertThat(semaphore.availablePermits()).isOne();
-  }
-
-  @Test
-  void shouldHoldPermitUntilAsyncFutureCompletes() throws Exception {
-    // given
-    final var acquired = new CountDownLatch(1);
-    final var released = new CountDownLatch(1);
-    final var semaphore =
-        new Semaphore(1) {
-          @Override
-          public void acquire() throws InterruptedException {
-            super.acquire();
-            acquired.countDown();
-          }
-
-          @Override
-          public void release() {
-            super.release();
-            released.countDown();
-          }
-        };
-    final var inner = new CompletableFuture<String>();
-
-    // when - the task returns a future that is not yet completed
-    final var result = SemaphoreLeasedScheduler.scheduleAsync(() -> inner, executor, semaphore);
-
-    // then - the permit is held while the inner future is pending
-    assertThat(acquired.await(5, TimeUnit.SECONDS)).isTrue();
-    assertThat(semaphore.availablePermits()).isZero();
-    assertThat(result).isNotDone();
-
-    // when - the inner future completes
-    inner.complete("done");
-
-    // then - the result completes and the permit is released
-    assertThat(result.get(5, TimeUnit.SECONDS)).isEqualTo("done");
-    assertThat(released.await(5, TimeUnit.SECONDS)).isTrue();
-    assertThat(semaphore.availablePermits()).isOne();
-  }
-
-  @Test
   void shouldNotReleasePermitWhenAcquireIsInterrupted() throws Exception {
     // given - a semaphore with no available permits; the worker thread will block in acquire().
     // The latch signals when the worker has entered acquire() and is about to (or already does)
@@ -158,6 +105,63 @@ class SemaphoreLeasedSchedulerTest {
     // release() is never invoked, so the drained permit count stays at zero
     assertThat(releaseCalled.await(500, TimeUnit.MILLISECONDS)).isFalse();
     assertThat(semaphore.availablePermits()).isZero();
+  }
+
+  @Test
+  void shouldNeverExceedPermitLimitUnderConcurrentLoad() throws Exception {
+    // given - far more concurrent tasks than permits, on a bounded pool. schedule() acquires, runs
+    // and releases within a single submitted unit of work, so a freed permit immediately unblocks a
+    // worker parked in acquire() - no extra thread is needed to release, hence no deadlock even
+    // when
+    // every pool thread is contending for a permit.
+    final int permits = 4;
+    final int tasks = 200; // multiple of permits so the barrier batches divide evenly
+    final var semaphore = new Semaphore(permits);
+    final var pool = Executors.newFixedThreadPool(permits * 4);
+
+    // A barrier of `permits` parties forces exactly that many tasks to run simultaneously: it only
+    // trips once `permits` tasks are inside the body at the same time. If the scheduler ever let
+    // fewer permits through, the barrier would never trip and the test would time out; if it let
+    // more through, the observed concurrency below would exceed the limit.
+    final var barrier = new CyclicBarrier(permits);
+    final var running = new AtomicInteger();
+    final var maxObserved = new AtomicInteger();
+
+    try {
+      // when - all tasks are scheduled concurrently
+      final List<CompletableFuture<Integer>> futures =
+          IntStream.range(0, tasks)
+              .mapToObj(
+                  i ->
+                      SemaphoreLeasedScheduler.schedule(
+                          () -> {
+                            final int concurrent = running.incrementAndGet();
+                            maxObserved.accumulateAndGet(concurrent, Math::max);
+                            try {
+                              barrier.await(10, TimeUnit.SECONDS);
+                              return i;
+                            } catch (final Exception e) {
+                              throw new RuntimeException(e);
+                            } finally {
+                              running.decrementAndGet();
+                            }
+                          },
+                          pool,
+                          semaphore))
+              .toList();
+
+      // then - all tasks complete, never more than `permits` ran at once, and the limit was fully
+      // used (the barrier could only trip because exactly `permits` tasks ran together)
+      CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get(30, TimeUnit.SECONDS);
+      assertThat(futures.stream().map(CompletableFuture::join))
+          .containsExactlyInAnyOrderElementsOf(IntStream.range(0, tasks).boxed().toList());
+      assertThat(maxObserved.get()).isEqualTo(permits);
+      assertThat(running.get()).isZero();
+      // every acquired permit was released
+      assertThat(semaphore.availablePermits()).isEqualTo(permits);
+    } finally {
+      pool.shutdownNow();
+    }
   }
 
   private static Semaphore releaseSignallingSemaphore(

--- a/zeebe/backup-stores/common/src/test/java/io/camunda/zeebe/backup/common/SemaphoreLeasedSchedulerTest.java
+++ b/zeebe/backup-stores/common/src/test/java/io/camunda/zeebe/backup/common/SemaphoreLeasedSchedulerTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class SemaphoreLeasedSchedulerTest {
+
+  private final ExecutorService executor = Executors.newSingleThreadExecutor();
+
+  @AfterEach
+  void tearDown() {
+    executor.shutdownNow();
+  }
+
+  @Test
+  void shouldReleasePermitWhenTaskCompletes() throws Exception {
+    // given
+    final var released = new CountDownLatch(1);
+    final var semaphore = releaseSignallingSemaphore(1, released);
+
+    // when
+    final var result = SemaphoreLeasedScheduler.schedule(() -> "done", executor, semaphore);
+
+    // then
+    assertThat(result.join()).isEqualTo("done");
+    assertThat(released.await(5, TimeUnit.SECONDS)).isTrue();
+    assertThat(semaphore.availablePermits()).isOne();
+  }
+
+  @Test
+  void shouldReleasePermitWhenTaskThrows() throws Exception {
+    // given
+    final var released = new CountDownLatch(1);
+    final var semaphore = releaseSignallingSemaphore(1, released);
+
+    // when
+    final var result =
+        SemaphoreLeasedScheduler.schedule(
+            () -> {
+              throw new RuntimeException("boom");
+            },
+            executor,
+            semaphore);
+
+    // then
+    assertThatThrownBy(result::join).hasRootCauseMessage("boom");
+    assertThat(released.await(5, TimeUnit.SECONDS)).isTrue();
+    assertThat(semaphore.availablePermits()).isOne();
+  }
+
+  @Test
+  void shouldReleasePermitWhenAsyncFutureFails() throws Exception {
+    // given
+    final var released = new CountDownLatch(1);
+    final var semaphore = releaseSignallingSemaphore(1, released);
+
+    // when
+    final var result =
+        SemaphoreLeasedScheduler.scheduleAsync(
+            () -> CompletableFuture.failedFuture(new RuntimeException("boom")),
+            executor,
+            semaphore);
+
+    // then
+    assertThatThrownBy(result::join).hasRootCauseMessage("boom");
+    assertThat(released.await(5, TimeUnit.SECONDS)).isTrue();
+    assertThat(semaphore.availablePermits()).isOne();
+  }
+
+  @Test
+  void shouldHoldPermitUntilAsyncFutureCompletes() throws Exception {
+    // given
+    final var acquired = new CountDownLatch(1);
+    final var released = new CountDownLatch(1);
+    final var semaphore =
+        new Semaphore(1) {
+          @Override
+          public void acquire() throws InterruptedException {
+            super.acquire();
+            acquired.countDown();
+          }
+
+          @Override
+          public void release() {
+            super.release();
+            released.countDown();
+          }
+        };
+    final var inner = new CompletableFuture<String>();
+
+    // when - the task returns a future that is not yet completed
+    final var result = SemaphoreLeasedScheduler.scheduleAsync(() -> inner, executor, semaphore);
+
+    // then - the permit is held while the inner future is pending
+    assertThat(acquired.await(5, TimeUnit.SECONDS)).isTrue();
+    assertThat(semaphore.availablePermits()).isZero();
+    assertThat(result).isNotDone();
+
+    // when - the inner future completes
+    inner.complete("done");
+
+    // then - the result completes and the permit is released
+    assertThat(result.get(5, TimeUnit.SECONDS)).isEqualTo("done");
+    assertThat(released.await(5, TimeUnit.SECONDS)).isTrue();
+    assertThat(semaphore.availablePermits()).isOne();
+  }
+
+  @Test
+  void shouldNotReleasePermitWhenAcquireIsInterrupted() throws Exception {
+    // given - a semaphore with no available permits; the worker thread will block in acquire().
+    // The latch signals when the worker has entered acquire() and is about to (or already does)
+    // block, so the interrupt below is guaranteed to hit a blocked/blocking acquire.
+    final var enteredAcquire = new CountDownLatch(1);
+    final var releaseCalled = new CountDownLatch(1);
+    final var semaphore =
+        new Semaphore(1) {
+          @Override
+          public void acquire() throws InterruptedException {
+            enteredAcquire.countDown();
+            super.acquire();
+          }
+
+          @Override
+          public void release() {
+            super.release();
+            releaseCalled.countDown();
+          }
+        };
+    semaphore.acquireUninterruptibly(); // drain the only permit
+    assertThat(semaphore.availablePermits()).isZero();
+
+    // when - a task is scheduled while no permit is available, then the worker is interrupted
+    final var result = SemaphoreLeasedScheduler.schedule(() -> "done", executor, semaphore);
+    assertThat(enteredAcquire.await(5, TimeUnit.SECONDS)).isTrue();
+    executor.shutdownNow();
+
+    // then - the future fails with an InterruptedException and the permit is NOT released
+    assertThatThrownBy(result::join)
+        .isInstanceOf(CompletionException.class)
+        .hasCauseInstanceOf(InterruptedException.class);
+    // release() is never invoked, so the drained permit count stays at zero
+    assertThat(releaseCalled.await(500, TimeUnit.MILLISECONDS)).isFalse();
+    assertThat(semaphore.availablePermits()).isZero();
+  }
+
+  private static Semaphore releaseSignallingSemaphore(
+      final int permits, final CountDownLatch released) {
+    return new Semaphore(permits) {
+      @Override
+      public void release() {
+        super.release();
+        released.countDown();
+      }
+    };
+  }
+}

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/FileSetManager.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/FileSetManager.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.backup.api.NamedFileSet;
 import io.camunda.zeebe.backup.common.FileSet;
 import io.camunda.zeebe.backup.common.FileSet.NamedFile;
 import io.camunda.zeebe.backup.common.NamedFileSetImpl;
+import io.camunda.zeebe.backup.common.SemaphoreLeasedScheduler;
 import io.camunda.zeebe.backup.gcs.GcsBackupStoreException.BatchOperationException;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -34,7 +35,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Semaphore;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 final class FileSetManager {
@@ -93,38 +93,17 @@ final class FileSetManager {
         fileSet.namedFiles().entrySet().stream()
             .map(
                 namedFile ->
-                    schedule(
+                    SemaphoreLeasedScheduler.schedule(
                         () -> {
                           uploadFile(id, fileSetName, namedFile.getKey(), namedFile.getValue());
                           return null;
-                        }))
+                        },
+                        executor,
+                        concurrencyLimit))
             .toList();
 
     // Wait for all uploads to complete
     CompletableFuture.allOf(uploadFutures.toArray(new CompletableFuture[0])).join();
-  }
-
-  /**
-   * Schedules a task to be executed asynchronously using virtual threads, respecting the
-   * concurrency limit imposed by the semaphore.
-   */
-  private <T> CompletableFuture<T> schedule(final Supplier<T> task) {
-    final var result = new CompletableFuture<T>();
-    executor.execute(
-        () -> {
-          try {
-            concurrencyLimit.acquire();
-            result.complete(task.get());
-          } catch (final InterruptedException e) {
-            Thread.currentThread().interrupt();
-            result.completeExceptionally(e);
-          } catch (final Exception e) {
-            result.completeExceptionally(e);
-          } finally {
-            concurrencyLimit.release();
-          }
-        });
-    return result;
   }
 
   private void uploadFile(
@@ -186,8 +165,10 @@ final class FileSetManager {
                 Collectors.toMap(
                     NamedFile::name,
                     namedFile ->
-                        schedule(
-                            () -> downloadFile(id, filesetName, namedFile.name(), targetFolder))));
+                        SemaphoreLeasedScheduler.schedule(
+                            () -> downloadFile(id, filesetName, namedFile.name(), targetFolder),
+                            executor,
+                            concurrencyLimit)));
 
     // Wait for all downloads to complete
     CompletableFuture.allOf(downloadFutures.values().toArray(new CompletableFuture[0])).join();

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
@@ -65,7 +65,9 @@ public final class GcsBackupStore implements BackupStore {
     bucketInfo = BucketInfo.of(config.bucketName());
     basePath = Optional.ofNullable(config.basePath()).map(s -> s + "/").orElse("");
     this.client = client;
-    executor = Executors.newVirtualThreadPerTaskExecutor();
+    executor =
+        Executors.newThreadPerTaskExecutor(
+            Thread.ofVirtual().name("zeebe-backup-gcs-", 0).factory());
     manifestManager = new ManifestManager(client, bucketInfo, basePath, executor);
     fileSetManager =
         new FileSetManager(

--- a/zeebe/backup-stores/s3/pom.xml
+++ b/zeebe/backup-stores/s3/pom.xml
@@ -21,6 +21,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-backup-store-common</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/FileSetManager.java
+++ b/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/FileSetManager.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.backup.s3;
 
 import io.camunda.zeebe.backup.api.NamedFileSet;
 import io.camunda.zeebe.backup.common.NamedFileSetImpl;
+import io.camunda.zeebe.backup.common.SemaphoreLeasedScheduler;
 import io.camunda.zeebe.backup.s3.S3BackupStoreException.BackupCompressionFailed;
 import io.camunda.zeebe.backup.s3.manifest.FileSet;
 import io.camunda.zeebe.backup.s3.manifest.FileSet.FileMetadata;
@@ -21,9 +22,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
-import java.util.function.Supplier;
 import org.apache.commons.compress.compressors.CompressorStreamFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,17 +46,14 @@ final class FileSetManager {
   private final S3BackupConfig config;
   private final Semaphore concurrencyLimit;
   private final Thread.Builder threadBuilder;
+  private final Executor schedulerExecutor;
 
   public FileSetManager(final S3AsyncClient client, final S3BackupConfig config) {
     this.client = client;
     this.config = config;
-
-    // We try not to exhaust the available connections by restricting the number of
-    // concurrent uploads to half of the number of available connections.
-    // This should prevent ConnectionAcquisitionTimeout for backups with many and/or large files
-    // where we would otherwise occupy all connections, preventing some uploads from starting.
     concurrencyLimit = new Semaphore(Math.max(1, config.maxConcurrentConnections() / 2));
     threadBuilder = Thread.ofVirtual().name("zeebe-backup-s3", 0);
+    schedulerExecutor = threadBuilder::start;
   }
 
   CompletableFuture<FileSet> save(final String prefix, final NamedFileSet files) {
@@ -63,29 +61,12 @@ final class FileSetManager {
     return CompletableFutureUtils.mapAsync(
             files.namedFiles().entrySet(),
             Entry::getKey,
-            namedFile -> schedule(() -> saveFile(prefix, namedFile.getKey(), namedFile.getValue())))
+            namedFile ->
+                SemaphoreLeasedScheduler.schedule(
+                    () -> saveFile(prefix, namedFile.getKey(), namedFile.getValue()),
+                    schedulerExecutor,
+                    concurrencyLimit))
         .thenApply(FileSet::new);
-  }
-
-  /** Schedules a task to be executed asynchronously, respecting the concurrency limit. */
-  private <T> CompletableFuture<T> schedule(final Supplier<T> task) {
-    final var result = new CompletableFuture<T>();
-    threadBuilder.start(
-        () -> {
-          try {
-            concurrencyLimit.acquire();
-            result.complete(task.get());
-          } catch (final InterruptedException e) {
-            Thread.currentThread().interrupt();
-            LOG.warn("Backup operation failed due to interruption", e);
-            result.completeExceptionally(e);
-          } catch (final Exception e) {
-            result.completeExceptionally(e);
-          } finally {
-            concurrencyLimit.release();
-          }
-        });
-    return result;
   }
 
   private FileSet.FileMetadata saveFile(
@@ -178,10 +159,12 @@ final class FileSetManager {
             fileSet.files().entrySet(),
             Entry::getKey,
             namedFile ->
-                schedule(
+                SemaphoreLeasedScheduler.schedule(
                     () ->
                         restoreFile(
-                            sourcePrefix, targetFolder, namedFile.getKey(), namedFile.getValue())))
+                            sourcePrefix, targetFolder, namedFile.getKey(), namedFile.getValue()),
+                    schedulerExecutor,
+                    concurrencyLimit))
         .thenApply(NamedFileSetImpl::new);
   }
 

--- a/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/FileSetManager.java
+++ b/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/FileSetManager.java
@@ -45,15 +45,19 @@ final class FileSetManager {
   private final S3AsyncClient client;
   private final S3BackupConfig config;
   private final Semaphore concurrencyLimit;
-  private final Thread.Builder threadBuilder;
-  private final Executor schedulerExecutor;
+  private final ExecutorService schedulerExecutor;
 
   public FileSetManager(final S3AsyncClient client, final S3BackupConfig config) {
     this.client = client;
     this.config = config;
+    // We try not to exhaust the available connections by restricting the number of
+    // concurrent uploads to half of the number of available connections.
+    // This should prevent ConnectionAcquisitionTimeout for backups with many and/or large files
+    // where we would otherwise occupy all connections, preventing some uploads from starting.
     concurrencyLimit = new Semaphore(Math.max(1, config.maxConcurrentConnections() / 2));
-    threadBuilder = Thread.ofVirtual().name("zeebe-backup-s3", 0);
-    schedulerExecutor = threadBuilder::start;
+    schedulerExecutor =
+        Executors.newThreadPerTaskExecutor(
+            Thread.ofVirtual().name("zeebe-backup-s3-", 0).factory());
   }
 
   CompletableFuture<FileSet> save(final String prefix, final NamedFileSet files) {
@@ -230,6 +234,18 @@ final class FileSetManager {
           e);
     } finally {
       cleanupCompressedFile(compressed);
+    }
+  }
+
+  void close() {
+    schedulerExecutor.shutdown();
+    try {
+      if (!schedulerExecutor.awaitTermination(1, TimeUnit.MINUTES)) {
+        schedulerExecutor.shutdownNow();
+      }
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      schedulerExecutor.shutdownNow();
     }
   }
 }

--- a/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/FileSetManager.java
+++ b/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/FileSetManager.java
@@ -22,9 +22,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
 import org.apache.commons.compress.compressors.CompressorStreamFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -93,13 +94,12 @@ final class FileSetManager {
       LOG.trace("Saving file {}({}) in prefix {}", fileName, filePath, prefix);
       // Use InputStream instead of File to bypass AWS SDK's file modification time
       // check: https://github.com/camunda/camunda/issues/44035
-      try (final var inputStream = Files.newInputStream(filePath);
-          final var executor = Executors.newThreadPerTaskExecutor(threadBuilder.factory())) {
+      try (final var inputStream = Files.newInputStream(filePath)) {
         final var fileSize = Files.size(filePath);
         client
             .putObject(
                 put -> put.bucket(config.bucketName()).key(prefix + fileName),
-                AsyncRequestBody.fromInputStream(inputStream, fileSize, executor))
+                AsyncRequestBody.fromInputStream(inputStream, fileSize, schedulerExecutor))
             .join();
       } catch (final IOException e) {
         throw new UncheckedIOException("Failed to upload file: " + filePath, e);

--- a/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
+++ b/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
@@ -354,8 +354,11 @@ public final class S3BackupStore implements BackupStore {
 
   @Override
   public CompletableFuture<Void> closeAsync() {
-    client.close();
-    return CompletableFuture.completedFuture(null);
+    return CompletableFuture.runAsync(
+        () -> {
+          fileSetManager.close();
+          client.close();
+        });
   }
 
   @Override


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

- Use a shared thread-safe semaphore for parallel uploads on backup stores. Make sure the lease is released only if acquired.
- Refactor Azure's save mechanism to apply semaphore limits on file transfers as it was previously only limiting whole backup save
- Properly name backup store executor threads

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
