### PR TITLE
feat: support flamegraph profiling in analytics microbenchmarks

### DIFF
--- a/zeebe/exporters/analytics-exporter/README.md
+++ b/zeebe/exporters/analytics-exporter/README.md
@@ -304,3 +304,24 @@ End-to-end tests using a real OTel Collector in Docker (Testcontainers). No mock
 overrides — uses the default `AnalyticsExporter` constructor with the production
 `BatchLogRecordProcessor` and real OTLP/HTTP transport. Tests event delivery with
 attribute verification and batching behavior.
+
+### Microbenchmarks (`AnalyticsExporterBenchmark`)
+
+JMH benchmarks measuring per-record overhead across the main hot paths. Run manually only — not
+wired into CI.
+
+```bash
+./mvnw verify -pl zeebe/exporters/analytics-exporter \
+    -Dtest=AnalyticsExporterBenchmark -DskipTests=false -Dbenchmark=true
+```
+
+To profile, add `-Dbenchmark.profiler=jfr+gc`:
+
+```bash
+./mvnw verify -pl zeebe/exporters/analytics-exporter \
+    -Dtest=AnalyticsExporterBenchmark -DskipTests=false \
+    -Dbenchmark=true -Dbenchmark.profiler=jfr+gc
+```
+
+JMH writes the `.jfr` file to `target/jmh-jfr/`. Open it in IntelliJ Ultimate
+("Open Profiler Results") or JDK Mission Control.

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterBenchmark.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterBenchmark.java
@@ -21,6 +21,7 @@ import io.opentelemetry.sdk.logs.data.LogRecordData;
 import io.opentelemetry.sdk.logs.export.LogRecordExporter;
 import io.opentelemetry.sdk.logs.export.SimpleLogRecordProcessor;
 import java.util.Collection;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
@@ -35,12 +36,19 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 /**
  * JMH microbenchmarks for the {@link AnalyticsExporter} hot paths.
  *
  * <p>Run manually via the main method or: {@code mvn verify -pl zeebe/exporters/analytics-exporter
  * -Dtest=AnalyticsExporterBenchmark -DskipTests=false}
+ *
+ * <p>Pass {@code -Dbenchmark.profiler=jfr} to capture a Java Flight Recorder {@code .jfr} file
+ * (built into the JVM; no native dependency). JMH writes the output to {@code target/jmh-jfr/}. The
+ * {@code .jfr} file can be opened in IntelliJ Ultimate ("Open Profiler Results") or JDK Mission
+ * Control. Combine with {@code gc} via {@code -Dbenchmark.profiler=jfr+gc}.
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
@@ -152,17 +160,35 @@ public class AnalyticsExporterBenchmark {
   /**
    * Run benchmarks from IntelliJ via the play button. Skipped in CI by the {@code
    * EnabledIfSystemProperty} condition — pass {@code -Dbenchmark=true} to enable.
+   *
+   * <p>Note: passing {@code -Dbenchmark.profiler=jfr} forces {@code forks=1} so the JFR profiler
+   * can attach to the forked JVM — this breaks IntelliJ in-process debugging. Leave the flag unset
+   * to preserve the debug workflow.
    */
   @Test
   @EnabledIfSystemProperty(named = "benchmark", matches = "true")
   void runBenchmarks() throws Exception {
-    final var options =
-        new org.openjdk.jmh.runner.options.OptionsBuilder()
+    final var profilerProp = System.getProperty("benchmark.profiler", "none");
+    final var profilers = Set.of(profilerProp.split("\\+"));
+
+    final var builder =
+        new OptionsBuilder()
             .include(AnalyticsExporterBenchmark.class.getSimpleName())
             .warmupIterations(5)
-            .measurementIterations(10)
-            .forks(0) // no fork — run in same JVM so IntelliJ can debug
-            .build();
-    new org.openjdk.jmh.runner.Runner(options).run();
+            .measurementIterations(10);
+
+    final var needsFork = profilers.contains("jfr");
+
+    if (profilers.contains("jfr")) {
+      builder.addProfiler("jfr", "dir=target/jmh-jfr");
+    }
+    if (profilers.contains("gc")) {
+      builder.addProfiler("gc");
+    }
+
+    // JFR needs a forked JVM; in-process runs cannot attach the profiler
+    builder.forks(needsFork ? 1 : 0);
+
+    new Runner(builder.build()).run();
   }
 }

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterBenchmark.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterBenchmark.java
@@ -20,9 +20,11 @@ import io.opentelemetry.sdk.logs.SdkLoggerProvider;
 import io.opentelemetry.sdk.logs.data.LogRecordData;
 import io.opentelemetry.sdk.logs.export.LogRecordExporter;
 import io.opentelemetry.sdk.logs.export.SimpleLogRecordProcessor;
+import java.util.Arrays;
 import java.util.Collection;
-import java.util.Set;
+import java.util.Locale;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -36,14 +38,15 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.results.format.ResultFormatType;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 /**
  * JMH microbenchmarks for the {@link AnalyticsExporter} hot paths.
  *
- * <p>Run manually via the main method or: {@code mvn verify -pl zeebe/exporters/analytics-exporter
- * -Dtest=AnalyticsExporterBenchmark -DskipTests=false}
+ * <p>Run via: {@code mvn verify -pl zeebe/exporters/analytics-exporter
+ * -Dtest=AnalyticsExporterBenchmark -DskipTests=false -Dbenchmark=true}
  *
  * <p>Pass {@code -Dbenchmark.profiler=jfr} to capture a Java Flight Recorder {@code .jfr} file
  * (built into the JVM; no native dependency). JMH writes the output to {@code target/jmh-jfr/}. The
@@ -169,13 +172,20 @@ public class AnalyticsExporterBenchmark {
   @EnabledIfSystemProperty(named = "benchmark", matches = "true")
   void runBenchmarks() throws Exception {
     final var profilerProp = System.getProperty("benchmark.profiler", "none");
-    final var profilers = Set.of(profilerProp.split("\\+"));
+    final var profilers =
+        Arrays.stream(profilerProp.split("\\+"))
+            .map(String::trim)
+            .filter(s -> !s.isEmpty())
+            .map(s -> s.toLowerCase(Locale.ROOT))
+            .collect(Collectors.toUnmodifiableSet());
 
     final var builder =
         new OptionsBuilder()
             .include(AnalyticsExporterBenchmark.class.getSimpleName())
             .warmupIterations(5)
-            .measurementIterations(10);
+            .measurementIterations(10)
+            .resultFormat(ResultFormatType.JSON)
+            .result("target/jmh-result.json");
 
     final var needsFork = profilers.contains("jfr");
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Running the test as described in the README output a .jfr file in the target folder. This can be used to figure out where we can improve the exporter.

ℹ️ I've opted to create .jfr files as for an .svg external tools were required. This is convenient as jfr is part of the JDK.
ℹ️ I'll analyze the .jfr files and create issues for improvements.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #52490
