### PR TITLE
feat: perform schema check before taking a backup

### DIFF
--- a/dist/src/main/java/io/camunda/application/StandaloneBackupManager.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneBackupManager.java
@@ -11,6 +11,7 @@ import io.camunda.application.commons.configuration.UnifiedConfigurationModule;
 import io.camunda.application.commons.search.NativeSearchClientsConfiguration;
 import io.camunda.application.commons.search.PhysicalTenantSearchClientReadersConfiguration;
 import io.camunda.application.commons.search.SearchClientReaderConfiguration;
+import io.camunda.search.schema.config.SearchEngineConfiguration;
 import io.camunda.webapps.backup.BackupService;
 import io.camunda.webapps.backup.BackupStateDto;
 import io.camunda.webapps.backup.TakeBackupRequestDto;
@@ -22,6 +23,7 @@ import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.ExitCodeExceptionMapper;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGenerator;
@@ -51,6 +53,8 @@ import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGe
 @SpringBootConfiguration(proxyBeanMethods = false)
 public class StandaloneBackupManager implements CommandLineRunner {
 
+  private static final String WRONG_ARGUMENTS_ERROR =
+      "Expected 1 or 2 arguments: <backupId> [--skip-schema-check], but got %d argument(s): %s";
   private static final Logger LOG = LoggerFactory.getLogger(StandaloneBackupManager.class);
   private final BackupService backupService;
 
@@ -94,9 +98,9 @@ public class StandaloneBackupManager implements CommandLineRunner {
 
   @Override
   public void run(final String... args) throws Exception {
-    if (args.length != 1) {
+    if (args.length < 1 || args.length > 2) {
       throw new IllegalArgumentException(
-          String.format("Expected one argument, the backup ID, but got: %s", Arrays.asList(args)));
+          String.format(WRONG_ARGUMENTS_ERROR, args.length, Arrays.asList(args)));
     }
 
     final long backupId;
@@ -107,9 +111,15 @@ public class StandaloneBackupManager implements CommandLineRunner {
           String.format("Expected as argument the backup ID as long, but got %s", args[0]));
     }
 
+    boolean skipSchemaCheck = false;
+    if (args.length == 2) {
+      skipSchemaCheck = parseSchemaCheckArg(args[1]);
+    }
+
     try {
       final var takeBackupRequestDto = new TakeBackupRequestDto();
       takeBackupRequestDto.setBackupId(backupId);
+      takeBackupRequestDto.setSkipSchemaCheck(skipSchemaCheck);
       final var backupResponse = backupService.takeBackup(takeBackupRequestDto);
       LOG.info("Triggered search engine snapshots: {}", backupResponse.getScheduledSnapshots());
     } catch (final Exception e) {
@@ -153,6 +163,24 @@ public class StandaloneBackupManager implements CommandLineRunner {
     return EnumSet.of(BackupStateDto.FAILED, BackupStateDto.INCOMPATIBLE).contains(backupStateDto);
   }
 
+  private boolean parseSchemaCheckArg(final String arg) {
+    final String[] parts = arg.split("=", 2);
+
+    if (!"--skip-schema-check".equals(parts[0])) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Unexpected second argument '%s'. Expected '--skip-schema-check'.", parts[0]));
+    }
+
+    if (parts.length == 1) {
+      // case --skip-schema-check
+      return true;
+    }
+
+    // case --skip-schema-check=true|false
+    return Boolean.parseBoolean(parts[1]);
+  }
+
   @ComponentScan(
       basePackages = "io.camunda.application.commons.backup",
       nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class)
@@ -161,6 +189,12 @@ public class StandaloneBackupManager implements CommandLineRunner {
     @Bean
     public ExitCodeExceptionMapper exitCodeExceptionMapper() {
       return ex -> 1;
+    }
+
+    @Bean
+    @ConfigurationProperties(prefix = "camunda.database")
+    public SearchEngineConfiguration searchEngineConfiguration() {
+      return SearchEngineConfiguration.of(b -> b);
     }
   }
 }

--- a/dist/src/main/java/io/camunda/application/commons/backup/HistoryBackupComponent.java
+++ b/dist/src/main/java/io/camunda/application/commons/backup/HistoryBackupComponent.java
@@ -11,10 +11,12 @@ import static io.camunda.configuration.SecondaryStorage.SecondaryStorageType.ela
 import static io.camunda.configuration.SecondaryStorage.SecondaryStorageType.opensearch;
 
 import io.camunda.configuration.conditions.ConditionalOnSecondaryStorageType;
+import io.camunda.search.schema.config.SearchEngineConfiguration;
 import io.camunda.webapps.backup.BackupRepository;
 import io.camunda.webapps.backup.BackupService;
 import io.camunda.webapps.backup.BackupServiceImpl;
 import io.camunda.webapps.backup.repository.BackupRepositoryProps;
+import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import io.camunda.webapps.schema.descriptors.backup.BackupPriorities;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
@@ -31,21 +33,36 @@ public class HistoryBackupComponent {
   private final BackupPriorities backupPriorities;
   private final BackupRepositoryProps backupRepositoryProps;
   private final BackupRepository backupRepository;
+  private final SearchEngineConfiguration searchEngineConfiguration;
 
   public HistoryBackupComponent(
       @Qualifier("backupThreadPoolExecutor") final ThreadPoolTaskExecutor threadPoolTaskExecutor,
       final BackupPriorities backupPriorities,
       final BackupRepositoryProps backupRepositoryProps,
-      final BackupRepository backupRepository) {
+      final BackupRepository backupRepository,
+      final SearchEngineConfiguration searchEngineConfiguration) {
     this.threadPoolTaskExecutor = threadPoolTaskExecutor;
     this.backupPriorities = backupPriorities;
     this.backupRepositoryProps = backupRepositoryProps;
     this.backupRepository = backupRepository;
+    this.searchEngineConfiguration = searchEngineConfiguration;
   }
 
   @Bean
   public BackupService backupService() {
+
+    final var indexDescriptors =
+        new IndexDescriptors(
+            searchEngineConfiguration.connect().getIndexPrefix(),
+            searchEngineConfiguration.connect().getTypeEnum().isElasticSearch());
+
     return new BackupServiceImpl(
-        threadPoolTaskExecutor, backupPriorities, backupRepositoryProps, backupRepository);
+        threadPoolTaskExecutor,
+        backupPriorities,
+        backupRepositoryProps,
+        backupRepository,
+        searchEngineConfiguration,
+        indexDescriptors.indices(),
+        indexDescriptors.templates());
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/backup/BackupAliasIntegrityIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/backup/BackupAliasIntegrityIT.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.backup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.search.connect.configuration.DatabaseType;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneApplication;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.testcontainers.AzuriteContainer;
+import io.camunda.zeebe.test.util.testcontainers.ContainerLogsDumper;
+import io.camunda.zeebe.util.VersionUtil;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import org.agrona.CloseHelper;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+@ZeebeIntegration
+public class BackupAliasIntegrityIT extends AbstractBackupRestoreIT {
+
+  private static final String REPOSITORY_NAME = "test-repository";
+  private static final String INDEX_PREFIX = "";
+  private static final String TEST_INDEX_1 = "operate-post-importer-queue-8.3.0_";
+  private static final String TEST_INDEX_2 = "operate-incident-8.3.1_";
+  private static final long BACKUP_ID = 1L;
+  private static final Duration CLIENT_TIMEOUT = Duration.ofSeconds(60);
+
+  @Container private static final AzuriteContainer AZURITE_CONTAINER = new AzuriteContainer();
+  @AutoClose private static final Executor EXECUTOR = Executors.newSingleThreadExecutor();
+
+  @TestZeebe(autoStart = false)
+  protected TestStandaloneApplication<?> testStandaloneApplication;
+
+  @RegisterExtension
+  @SuppressWarnings("unused")
+  final ContainerLogsDumper logsWatcher =
+      new ContainerLogsDumper(() -> Map.of("azurite", AZURITE_CONTAINER));
+
+  @BeforeAll
+  public static void beforeAll() {
+    VersionUtil.overridePrerelease();
+  }
+
+  @AfterEach
+  public void afterEach() {
+    CloseHelper.quietCloseAll(
+        webappsDBClient, camundaClient, searchContainer, testStandaloneApplication);
+  }
+
+  @AfterAll
+  public static void afterAll() {
+    VersionUtil.resetVersionForTesting();
+  }
+
+  @ParameterizedTest
+  @MethodSource("supportedDatabases")
+  void shouldFailBackupWhenAliasPointsToMultipleIndexes(final DatabaseType databaseType)
+      throws Exception {
+    testStandaloneApplication =
+        super.setup(
+            databaseType,
+            REPOSITORY_NAME,
+            INDEX_PREFIX,
+            CLIENT_TIMEOUT,
+            AZURITE_CONTAINER,
+            EXECUTOR);
+
+    testStandaloneApplication.awaitCompleteTopology();
+
+    // given: pick two existing indices and assign the same alias to both
+    final var indices = webappsDBClient.cat(INDEX_PREFIX);
+    assertThat(indices).hasSizeGreaterThanOrEqualTo(2);
+    assertThat(indices).contains(TEST_INDEX_1);
+    assertThat(indices).contains(TEST_INDEX_2);
+
+    final String duplicateAlias = "duplicate-alias-test";
+    webappsDBClient.createAlias(TEST_INDEX_1, duplicateAlias);
+    webappsDBClient.createAlias(TEST_INDEX_2, duplicateAlias);
+
+    // when / then
+    assertThatThrownBy(() -> historyBackupClient.takeBackup(BACKUP_ID))
+        .hasMessageContaining("Errors when validating alias integrity")
+        .hasMessageContaining(TEST_INDEX_1)
+        .hasMessageContaining(TEST_INDEX_2);
+  }
+
+  @ParameterizedTest
+  @MethodSource("supportedDatabases")
+  void shouldFailBackupWhenIndexIsMissingExpectedAlias(final DatabaseType databaseType)
+      throws Exception {
+    testStandaloneApplication =
+        super.setup(
+            databaseType,
+            REPOSITORY_NAME,
+            INDEX_PREFIX,
+            CLIENT_TIMEOUT,
+            AZURITE_CONTAINER,
+            EXECUTOR);
+
+    testStandaloneApplication.awaitCompleteTopology();
+
+    // pre-check: the test index exists
+    final var indices = webappsDBClient.cat(INDEX_PREFIX);
+    assertThat(indices).contains(TEST_INDEX_1);
+
+    // alter the schema by removing an alias
+    final String aliasToRemove = TEST_INDEX_1 + "alias";
+    webappsDBClient.deleteAlias(TEST_INDEX_1, aliasToRemove);
+
+    // when / then
+    assertThatThrownBy(() -> historyBackupClient.takeBackup(BACKUP_ID))
+        .hasMessageContaining("Errors when validating alias integrity")
+        .hasMessageContaining(TEST_INDEX_1);
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/backup/StandaloneBackupManagerIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/backup/StandaloneBackupManagerIT.java
@@ -83,7 +83,7 @@ final class StandaloneBackupManagerIT {
 
       // WHEN
       // Start the backup process with a specific backup ID
-      backupManager.withBackupId(BACKUP_ID).start();
+      backupManager.withBackupId(BACKUP_ID).withSkipSchemaCheck(true).start();
 
       // Wait for snapshots to be completed
       final List<String> snapshots = waitForSnapshotsToBeCompleted(strategy, SNAPSHOT_NAME_PREFIX);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/document/DocumentClient.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/document/DocumentClient.java
@@ -26,6 +26,10 @@ public interface DocumentClient extends AutoCloseable {
 
   void createRepository(String repositoryName) throws IOException;
 
+  void createAlias(String indexName, String aliasName) throws IOException;
+
+  void deleteAlias(String indexName, String aliasName) throws IOException;
+
   static DocumentClient create(
       final String url, final DatabaseType databaseType, final Executor executor)
       throws IOException {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/document/ESClient.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/document/ESClient.java
@@ -73,6 +73,16 @@ public class ESClient implements DocumentClient {
   }
 
   @Override
+  public void createAlias(final String indexName, final String aliasName) throws IOException {
+    esClient.indices().putAlias(b -> b.index(indexName).name(aliasName));
+  }
+
+  @Override
+  public void deleteAlias(final String indexName, final String aliasName) throws IOException {
+    esClient.indices().deleteAlias(b -> b.index(indexName).name(aliasName));
+  }
+
+  @Override
   public void deleteAllIndices(final String indexPrefix) throws IOException {
     esClient.indices().delete(DeleteIndexRequest.of(b -> b.index("*")));
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/document/OSClient.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/document/OSClient.java
@@ -89,6 +89,16 @@ public class OSClient implements DocumentClient {
   }
 
   @Override
+  public void createAlias(final String indexName, final String aliasName) throws IOException {
+    opensearchClient.indices().putAlias(b -> b.index(indexName).name(aliasName));
+  }
+
+  @Override
+  public void deleteAlias(final String indexName, final String aliasName) throws IOException {
+    opensearchClient.indices().deleteAlias(b -> b.index(indexName).name(aliasName));
+  }
+
+  @Override
   public void deleteAllIndices(final String indexPrefix) throws IOException {
     opensearchClient.indices().delete(DeleteIndexRequest.of(b -> b.index("*")));
   }

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestStandaloneBackupManager.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestStandaloneBackupManager.java
@@ -28,6 +28,7 @@ public class TestStandaloneBackupManager
     extends TestSpringApplication<TestStandaloneBackupManager> {
 
   private Long backupId;
+  private boolean skipSchemaCheck;
   private final Camunda unifiedConfig;
 
   public TestStandaloneBackupManager() {
@@ -76,7 +77,13 @@ public class TestStandaloneBackupManager
 
   @Override
   protected String[] commandLineArgs() {
-    return backupId == null ? super.commandLineArgs() : new String[] {String.valueOf(backupId)};
+    if (backupId == null) {
+      return super.commandLineArgs();
+    }
+
+    return skipSchemaCheck
+        ? new String[] {String.valueOf(backupId), "--skip-schema-check"}
+        : new String[] {String.valueOf(backupId)};
   }
 
   @Override
@@ -89,6 +96,11 @@ public class TestStandaloneBackupManager
 
   public TestStandaloneBackupManager withBackupId(final Long backupId) {
     this.backupId = backupId;
+    return this;
+  }
+
+  public TestStandaloneBackupManager withSkipSchemaCheck(final boolean skipSchemaCheck) {
+    this.skipSchemaCheck = skipSchemaCheck;
     return this;
   }
 

--- a/schema-manager/src/main/java/io/camunda/search/schema/SchemaManager.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/SchemaManager.java
@@ -31,6 +31,9 @@ import io.camunda.zeebe.util.migration.VersionCompatibilityCheck.CheckResult.Ind
 import io.camunda.zeebe.util.retry.RetryDecorator;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -47,6 +50,8 @@ import org.slf4j.LoggerFactory;
 public class SchemaManager implements CloseableSilently {
 
   public static final int INDEX_CREATION_TIMEOUT_SECONDS = 60;
+  private static final String INDICES_MISSING_ALIAS = "Indices missing their expected alias: ";
+  private static final String ALIAS_INTEGRITY_ERR = "Alias '%s' points to more than 1 index: [%s]";
   private static final Logger LOG = LoggerFactory.getLogger(SchemaManager.class);
   private final SearchEngineClient searchEngineClient;
   private final Collection<IndexDescriptor> allIndexDescriptors;
@@ -166,7 +171,7 @@ public class SchemaManager implements CloseableSilently {
     // missing index templates after a backup restore
     initialiseIndexTemplates();
     if (upgradeSchema) {
-      final var newIndexProperties = validateIndices(allIndexDescriptors);
+      final var newIndexProperties = validateIndices();
       // create any missing indices
       initialiseIndices();
 
@@ -480,20 +485,19 @@ public class SchemaManager implements CloseableSilently {
         .getOrDefault(indexName, config.index().getRefreshInterval());
   }
 
-  private Map<IndexDescriptor, Collection<IndexMappingProperty>> validateIndices(
-      final Collection<IndexDescriptor> indexDescriptors) {
-    if (indexDescriptors.isEmpty()) {
+  public Map<IndexDescriptor, Collection<IndexMappingProperty>> validateIndices() {
+    if (allIndexDescriptors.isEmpty()) {
       LOG.info("No validation of indices, as there are no descriptors");
       return Map.of();
     }
 
     final var currentIndices =
-        searchEngineClient.getMappings(allIndexNames(indexDescriptors), MappingSource.INDEX);
+        searchEngineClient.getMappings(allIndexNames(allIndexDescriptors), MappingSource.INDEX);
     LOG.info(
         "Validate '{}' existing indices based on '{}' descriptors",
         currentIndices.size(),
-        indexDescriptors.size());
-    return schemaValidator.validateIndexMappings(currentIndices, indexDescriptors);
+        allIndexDescriptors.size());
+    return schemaValidator.validateIndexMappings(currentIndices, allIndexDescriptors);
   }
 
   private Set<String> existingIndexNames(final Collection<IndexDescriptor> indexDescriptors) {
@@ -518,9 +522,11 @@ public class SchemaManager implements CloseableSilently {
     if (!config.schemaManager().isCreateSchema()) {
       return true;
     }
+
     return getMissingIndices(allIndexDescriptors).isEmpty()
         && getMissingIndexTemplates(indexTemplateDescriptors).isEmpty()
-        && validateIndices(allIndexDescriptors).isEmpty();
+        && validateIndices().isEmpty()
+        && isAliasIntegrityValid(false);
   }
 
   public boolean isAllIndicesExist() {
@@ -530,5 +536,62 @@ public class SchemaManager implements CloseableSilently {
   @Override
   public void close() {
     virtualThreadExecutor.close();
+  }
+
+  public boolean isAliasIntegrityValid(final boolean throwException) {
+    final List<String> indexNames =
+        allIndexDescriptors.stream().map(IndexDescriptor::getFullQualifiedName).toList();
+
+    final Map<String, Set<String>> aliasByIndex = searchEngineClient.getAliases(indexNames);
+
+    final Set<String> indexesWithMissingAliases = new LinkedHashSet<>();
+    final Map<String, Set<String>> aliasToIndices = new HashMap<>();
+
+    for (final IndexDescriptor indexDescriptor : allIndexDescriptors) {
+      final Set<String> aliases =
+          aliasByIndex.getOrDefault(indexDescriptor.getFullQualifiedName(), Set.of());
+
+      /* index with missing alias */
+      if (!aliases.contains(indexDescriptor.getAlias())) {
+        indexesWithMissingAliases.add(indexDescriptor.getFullQualifiedName());
+      }
+
+      /* alias that points to multiple indexes */
+      for (final String alias : aliases) {
+        aliasToIndices
+            .computeIfAbsent(alias, k -> new HashSet<>())
+            .add(indexDescriptor.getFullQualifiedName());
+      }
+    }
+
+    final var duplicateAliases =
+        aliasToIndices.entrySet().stream()
+            .filter(e -> e.getValue().size() > 1)
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+    if (indexesWithMissingAliases.isEmpty() && duplicateAliases.isEmpty()) {
+      return true;
+    }
+
+    final StringBuilder sb = new StringBuilder();
+    if (!indexesWithMissingAliases.isEmpty()) {
+      sb.append(INDICES_MISSING_ALIAS)
+          .append(String.join(", ", indexesWithMissingAliases))
+          .append("\n");
+    }
+    duplicateAliases.forEach(
+        (alias, indices) -> {
+          sb.append(String.format(ALIAS_INTEGRITY_ERR, alias, String.join(", ", indices)));
+          sb.append("\n");
+        });
+
+    final String errorMessage =
+        String.format("Errors when validating alias integrity: %s", sb.toString());
+    if (throwException) {
+      throw new IllegalStateException(errorMessage);
+    }
+
+    LOG.warn(errorMessage);
+    return false;
   }
 }

--- a/schema-manager/src/main/java/io/camunda/search/schema/SearchEngineClient.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/SearchEngineClient.java
@@ -39,6 +39,14 @@ public interface SearchEngineClient extends CloseableSilently {
   Map<String, IndexMapping> getMappings(
       final String namePattern, final MappingSource mappingSource);
 
+  /**
+   * Retrieve all aliases for the given indexes
+   *
+   * @param indexNames the exact index names to look up aliases for
+   * @return a map of index name to the set of alias names pointing to it
+   */
+  Map<String, Set<String>> getAliases(Collection<String> indexNames);
+
   void putSettings(
       final List<IndexDescriptor> indexDescriptors, final Map<String, String> toAppendSettings);
 

--- a/schema-manager/src/main/java/io/camunda/search/schema/elasticsearch/ElasticsearchEngineClient.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/elasticsearch/ElasticsearchEngineClient.java
@@ -196,6 +196,23 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
   }
 
   @Override
+  public Map<String, Set<String>> getAliases(final Collection<String> indexNames) {
+    try {
+      return client
+          .indices()
+          .getAlias(req -> req.index(List.copyOf(indexNames)))
+          .result()
+          .entrySet()
+          .stream()
+          .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().aliases().keySet()));
+    } catch (final IOException | ElasticsearchException e) {
+      final var errMsg = String.format("Failed to retrieve aliases for indexes '%s'", indexNames);
+      LOG.error(errMsg, e);
+      throw new SearchEngineException(errMsg, e);
+    }
+  }
+
+  @Override
   public void putSettings(
       final List<IndexDescriptor> indexDescriptors, final Map<String, String> toAppendSettings) {
     final var request = putIndexSettingsRequest(indexDescriptors, toAppendSettings);

--- a/schema-manager/src/main/java/io/camunda/search/schema/opensearch/OpensearchEngineClient.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/opensearch/OpensearchEngineClient.java
@@ -211,6 +211,23 @@ public class OpensearchEngineClient implements SearchEngineClient {
   }
 
   @Override
+  public Map<String, Set<String>> getAliases(final Collection<String> indexNames) {
+    try {
+      return client
+          .indices()
+          .getAlias(req -> req.index(List.copyOf(indexNames)))
+          .result()
+          .entrySet()
+          .stream()
+          .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().aliases().keySet()));
+    } catch (final IOException | OpenSearchException e) {
+      final var errMsg = String.format("Failed to retrieve aliases for index '%s'", indexNames);
+      LOG.error(errMsg, e);
+      throw new SearchEngineException(errMsg, e);
+    }
+  }
+
+  @Override
   public void putSettings(
       final List<IndexDescriptor> indexDescriptors, final Map<String, String> toAppendSettings) {
     final var request = putIndexSettingsRequest(indexDescriptors, toAppendSettings);

--- a/webapps-backup/pom.xml
+++ b/webapps-backup/pom.xml
@@ -27,6 +27,14 @@
     </dependency>
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>camunda-exporter</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-search-client-connect</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>webapps-schema</artifactId>
     </dependency>
     <dependency>
@@ -83,14 +91,17 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-schema-manager</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
     </dependency>
   </dependencies>
   <build>

--- a/webapps-backup/src/main/java/io/camunda/webapps/backup/BackupServiceImpl.java
+++ b/webapps-backup/src/main/java/io/camunda/webapps/backup/BackupServiceImpl.java
@@ -7,12 +7,19 @@
  */
 package io.camunda.webapps.backup;
 
+import io.camunda.exporter.adapters.ClientAdapter;
+import io.camunda.search.schema.SchemaManager;
+import io.camunda.search.schema.config.SearchEngineConfiguration;
 import io.camunda.webapps.backup.BackupException.*;
 import io.camunda.webapps.backup.repository.BackupRepositoryProps;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.backup.BackupPriorities;
 import io.camunda.webapps.schema.descriptors.backup.SnapshotIndexCollection;
 import io.camunda.zeebe.util.VisibleForTesting;
+import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -22,24 +29,36 @@ import org.slf4j.LoggerFactory;
 
 public class BackupServiceImpl implements BackupService {
 
+  private static final String ANOTHER_BACKUP_RUNS_MSG = "Another backup is running at the moment";
   private static final Logger LOGGER = LoggerFactory.getLogger(BackupServiceImpl.class);
-  private final Executor threadPoolTaskExecutor;
+
   private final Queue<SnapshotRequest> requestsQueue = new ConcurrentLinkedQueue<>();
 
+  private final Executor threadPoolTaskExecutor;
   private final BackupPriorities backupPriorities;
+  private final BackupRepository repository;
   private final BackupRepositoryProps backupProps;
 
-  private final BackupRepository repository;
+  /* arguments needed for the alias integrity check */
+  private final SearchEngineConfiguration searchEngineConfiguration;
+  private final Collection<IndexDescriptor> indexDescriptors;
+  private final Collection<IndexTemplateDescriptor> templateDescriptors;
 
   public BackupServiceImpl(
       final Executor threadPoolTaskExecutor,
       final BackupPriorities backupPriorities,
       final BackupRepositoryProps backupProps,
-      final BackupRepository repository) {
+      final BackupRepository repository,
+      final SearchEngineConfiguration searchEngineConfiguration,
+      final Collection<IndexDescriptor> indexDescriptors,
+      final Collection<IndexTemplateDescriptor> templateDescriptors) {
     this.threadPoolTaskExecutor = threadPoolTaskExecutor;
     this.backupPriorities = backupPriorities;
     this.repository = repository;
     this.backupProps = backupProps;
+    this.searchEngineConfiguration = searchEngineConfiguration;
+    this.indexDescriptors = indexDescriptors;
+    this.templateDescriptors = templateDescriptors;
   }
 
   @Override
@@ -67,14 +86,43 @@ public class BackupServiceImpl implements BackupService {
   public TakeBackupResponseDto takeBackup(final TakeBackupRequestDto request) {
     repository.validateRepositoryExists(backupProps.repositoryName());
     repository.validateNoDuplicateBackupId(backupProps.repositoryName(), request.getBackupId());
+
+    // NOTE: The following checks are non-locking on purpose to be quick.
+
     if (!requestsQueue.isEmpty()) {
-      throw new InvalidRequestException("Another backup is running at the moment");
-    } // TODO remove duplicate
+      throw new InvalidRequestException(ANOTHER_BACKUP_RUNS_MSG);
+    }
+
+    if (!request.isSkipSchemaCheck()) {
+      try {
+        performSchemaIntegrityChecks();
+      } catch (IOException ex) {
+        throw new BackupException("Unexpected error when taking a backup", ex);
+      }
+    }
+
     synchronized (requestsQueue) {
       if (!requestsQueue.isEmpty()) {
-        throw new InvalidRequestException("Another backup is running at the moment");
+        throw new InvalidRequestException(ANOTHER_BACKUP_RUNS_MSG);
       }
+
       return scheduleSnapshots(request);
+    }
+  }
+
+  private void performSchemaIntegrityChecks() throws IOException {
+    try (final ClientAdapter clientAdapter = ClientAdapter.of(searchEngineConfiguration.connect());
+        final SchemaManager schemaManager =
+            new SchemaManager(
+                clientAdapter.getSearchEngineClient(),
+                indexDescriptors,
+                templateDescriptors,
+                searchEngineConfiguration,
+                clientAdapter.objectMapper())) {
+      if (!schemaManager.validateIndices().isEmpty()) {
+        throw new InvalidRequestException("Indexes validation failed when taking a backup");
+      }
+      schemaManager.isAliasIntegrityValid(true);
     }
   }
 

--- a/webapps-backup/src/main/java/io/camunda/webapps/backup/TakeBackupRequestDto.java
+++ b/webapps-backup/src/main/java/io/camunda/webapps/backup/TakeBackupRequestDto.java
@@ -10,13 +10,23 @@ package io.camunda.webapps.backup;
 public class TakeBackupRequestDto {
 
   private Long backupId;
+  private boolean skipSchemaCheck = false;
 
   public Long getBackupId() {
     return backupId;
   }
 
+  public boolean isSkipSchemaCheck() {
+    return skipSchemaCheck;
+  }
+
   public TakeBackupRequestDto setBackupId(final Long backupId) {
     this.backupId = backupId;
+    return this;
+  }
+
+  public TakeBackupRequestDto setSkipSchemaCheck(final boolean skipSchemaCheck) {
+    this.skipSchemaCheck = skipSchemaCheck;
     return this;
   }
 }

--- a/webapps-backup/src/test/java/io/camunda/webapps/backup/BackupServiceImplTest.java
+++ b/webapps-backup/src/test/java/io/camunda/webapps/backup/BackupServiceImplTest.java
@@ -10,6 +10,8 @@ package io.camunda.webapps.backup;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.camunda.search.connect.configuration.ConnectConfiguration;
+import io.camunda.search.schema.config.SearchEngineConfiguration;
 import io.camunda.webapps.backup.BackupException.IndexNotFoundException;
 import io.camunda.webapps.backup.BackupService.SnapshotRequest;
 import io.camunda.webapps.backup.repository.BackupRepositoryProps;
@@ -65,8 +67,18 @@ public class BackupServiceImplTest {
       };
 
   public BackupServiceImpl makeBackupService(final BackupPriorities backupPriorities) {
+    final ConnectConfiguration connectConfiguration = new ConnectConfiguration();
+    final SearchEngineConfiguration searchEngineConfiguration =
+        new SearchEngineConfiguration(connectConfiguration, null, null, null);
+
     return new BackupServiceImpl(
-        executor, backupPriorities, backupRepositoryProps, backupRepository);
+        executor,
+        backupPriorities,
+        backupRepositoryProps,
+        backupRepository,
+        searchEngineConfiguration,
+        List.of(),
+        List.of());
   }
 
   @BeforeEach
@@ -84,7 +96,9 @@ public class BackupServiceImplTest {
   @Test
   public void shouldCreateBackupWithAllIndices() {
     // when
-    final var backup = backupService.takeBackup(new TakeBackupRequestDto().setBackupId(1L));
+    final var backup =
+        backupService.takeBackup(
+            new TakeBackupRequestDto().setBackupId(1L).setSkipSchemaCheck(true));
 
     // then
     assertThat(backup.getScheduledSnapshots())
@@ -134,7 +148,9 @@ public class BackupServiceImplTest {
             new BackupPriorities(
                 List.of(() -> "prio1"), List.of(() -> "prio2"), List.of(() -> "prio3"), List.of()));
     // backup #1 is taken with only 3 parts
-    final var response = backupService.takeBackup(new TakeBackupRequestDto().setBackupId(1L));
+    final var response =
+        backupService.takeBackup(
+            new TakeBackupRequestDto().setBackupId(1L).setSkipSchemaCheck(true));
     assertThat(response.getScheduledSnapshots()).hasSize(3);
 
     // when


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Context:
https://github.com/camunda/camunda/issues/42450

With this PR:
* we perform an index sanity check before taking a backup
* we perform an alias sanity check before taking a backup (all of the indexes have their correct alias, all of the aliases point to one index)
* we introduce the --skip-schema-check argument to the takeBackup that allows to skip the sanity checks

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes https://github.com/camunda/camunda/issues/42450
