### PR TITLE
[optimize] Agentic data importing ITs

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/AbstractBrokerlessZeebeCCSMIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/AbstractBrokerlessZeebeCCSMIT.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize;
+
+import static io.camunda.optimize.service.util.configuration.ConfigurationServiceConstants.CCSM_PROFILE;
+
+import io.camunda.optimize.service.util.IdGenerator;
+import io.camunda.optimize.service.util.importing.ZeebeConstants;
+import java.util.HashMap;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * Base class for CCSM integration tests that seed Zeebe records directly into ES indices without
+ * requiring a live Zeebe broker. Use this instead of {@link AbstractCCSMIT} when the test verifies
+ * import pipeline or script logic by writing fake records directly to the Zeebe export index.
+ */
+@Tag("ccsm-test")
+@ActiveProfiles(CCSM_PROFILE)
+public abstract class AbstractBrokerlessZeebeCCSMIT extends AbstractIT {
+
+  protected static final String ZEEBE_RECORD_PREFIX =
+      ZeebeConstants.ZEEBE_RECORD_TEST_PREFIX + "-" + IdGenerator.getNextId();
+
+  /**
+   * Defensive pre-test cleanup: removes any Zeebe records that may have been left behind if the
+   * previous test's {@code @AfterEach} did not run (e.g. after a JVM crash or a failed teardown).
+   * Under normal conditions the {@link #cleanupZeebeRecords()} after-hook already ensures a clean
+   * slate, so this is a no-op for well-behaved tests.
+   */
+  @BeforeEach
+  @Order(1)
+  public void ensureCleanZeebeState() {
+    databaseIntegrationTestExtension.deleteAllZeebeRecordsForPrefix(ZEEBE_RECORD_PREFIX);
+  }
+
+  @BeforeEach
+  @Order(2)
+  public void configureZeebeImport() {
+    embeddedOptimizeExtension
+        .getConfigurationService()
+        .getConfiguredZeebe()
+        .setName(ZEEBE_RECORD_PREFIX);
+    embeddedOptimizeExtension.reloadConfiguration();
+  }
+
+  @AfterEach
+  @Order(1)
+  public void cleanupZeebeRecords() {
+    databaseIntegrationTestExtension.deleteAllZeebeRecordsForPrefix(ZEEBE_RECORD_PREFIX);
+  }
+
+  /**
+   * Clears Optimize-side data (process instance docs, etc.) between tests so subclasses sharing
+   * fixed instance IDs do not leak documents from one test into the next. Mirrors the cleanup that
+   * {@link AbstractCCSMIT} performs for live-broker tests.
+   */
+  @AfterEach
+  @Order(2)
+  public void cleanupOptimizeData() {
+    databaseIntegrationTestExtension.deleteAllOptimizeData();
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+  }
+
+  /**
+   * Tears down the per-class Zeebe indices created during this suite. Runs after all test methods
+   * to remove the indices themselves (not just the documents), avoiding leftover indices in the
+   * cluster between test runs.
+   */
+  @AfterAll
+  static void deleteZeebeIndices() {
+    databaseIntegrationTestExtension.deleteAllZeebeIndicesForPrefix(ZEEBE_RECORD_PREFIX);
+  }
+
+  @Override
+  protected void startAndUseNewOptimizeInstance() {
+    startAndUseNewOptimizeInstance(new HashMap<>(), CCSM_PROFILE);
+  }
+
+  protected void importAllZeebeEntitiesFromScratch() {
+    embeddedOptimizeExtension.importAllZeebeEntitiesFromScratch();
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+  }
+
+  /**
+   * Runs one import round from the current import positions, without resetting them. Use this after
+   * {@link #importAllZeebeEntitiesFromScratch()} to simulate records arriving in a later broker
+   * export batch, exercising the cross-batch Painless merge path.
+   */
+  protected void importAllZeebeEntitiesFromLastIndex() {
+    embeddedOptimizeExtension.importAllZeebeEntitiesFromLastIndex();
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+  }
+}

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeAgentInstanceImportIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeAgentInstanceImportIT.java
@@ -1,0 +1,750 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.importing;
+
+import static io.camunda.optimize.service.db.DatabaseConstants.ZEEBE_AGENT_INSTANCE_INDEX_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.optimize.AbstractBrokerlessZeebeCCSMIT;
+import io.camunda.optimize.dto.optimize.query.process.AgentInstanceDto;
+import io.camunda.optimize.dto.zeebe.agentinstance.ZeebeAgentInstanceDataDto;
+import io.camunda.optimize.dto.zeebe.agentinstance.ZeebeAgentInstanceDataDto.AgentDefinitionValueDto;
+import io.camunda.optimize.dto.zeebe.agentinstance.ZeebeAgentInstanceDataDto.AgentMetricsValueDto;
+import io.camunda.optimize.dto.zeebe.agentinstance.ZeebeAgentInstanceDataDto.AgentToolValueDto;
+import io.camunda.optimize.dto.zeebe.agentinstance.ZeebeAgentInstanceRecordDto;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.AgentInstanceStatus;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Full pipeline IT: seeds fake AGENT_INSTANCE records directly into the Zeebe export index, runs
+ * the Optimize import pipeline, and verifies the resulting ProcessInstance document.
+ *
+ * <p>Seeding fake records avoids a live Zeebe broker dependency and makes the tests fast and
+ * deterministic.
+ */
+class ZeebeAgentInstanceImportIT extends AbstractBrokerlessZeebeCCSMIT {
+
+  private static final long PROCESS_INSTANCE_KEY = 100L;
+  private static final long PROCESS_DEFINITION_KEY = 10L;
+  private static final String BPMN_PROCESS_ID = "agentTestProcess";
+  private static final String ELEMENT_ID = "agentTask";
+  private static final String MODEL = "gpt-4o";
+  private static final String PROVIDER = "openai";
+  private static final String SYSTEM_PROMPT = "You are a helpful assistant.";
+  // Fixed base timestamp so seeded record times are deterministic across runs (no wall-clock
+  // dependency). Each seeded record's timestamp = BASE + position * 1000ms.
+  private static final long BASE_TIMESTAMP_MS =
+      OffsetDateTime.parse("2024-01-01T10:00:00+00:00").toInstant().toEpochMilli();
+
+  // Counters are instance fields, not static: JUnit Jupiter creates a fresh test instance per
+  // method, so positionCounter and keyCounter reset between tests and stay isolated.
+  private final AtomicLong positionCounter = new AtomicLong(1);
+  private final AtomicLong keyCounter = new AtomicLong(200);
+
+  private String agentInstanceIndex;
+
+  @BeforeEach
+  void setUp() {
+    agentInstanceIndex = ZEEBE_RECORD_PREFIX + "-" + ZEEBE_AGENT_INSTANCE_INDEX_NAME;
+  }
+
+  @Test
+  void shouldImportCreatedAgentInstance() {
+    // given
+    final long agentKey = keyCounter.getAndIncrement();
+    seedRecord(
+        agentKey, AgentInstanceIntent.CREATED, AgentInstanceStatus.INITIALIZING, 0L, 0L, 0, 0);
+
+    // when
+    importAllZeebeEntitiesFromScratch();
+
+    // then
+    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+        .singleElement()
+        .satisfies(
+            pi -> {
+              assertThat(pi.getProcessInstanceId()).isEqualTo(String.valueOf(PROCESS_INSTANCE_KEY));
+              assertThat(pi.getAgentInstances()).hasSize(1);
+              final AgentInstanceDto agent = pi.getAgentInstances().get(0);
+              assertThat(agent.getAgentInstanceId()).isEqualTo(String.valueOf(agentKey));
+              assertThat(agent.getFlowNodeId()).isEqualTo(ELEMENT_ID);
+              assertThat(agent.getStatus()).isEqualTo(AgentInstanceStatus.INITIALIZING.name());
+              assertThat(agent.getStartDate()).isNotNull();
+              assertThat(agent.getEndDate()).isNull();
+              assertThat(agent.getTotalDurationInMs()).isNull();
+              assertThat(agent.getDefinition()).isNotNull();
+              assertThat(agent.getDefinition().getModel()).isEqualTo(MODEL);
+              assertThat(agent.getDefinition().getProvider()).isEqualTo(PROVIDER);
+              assertThat(agent.getMetrics().getInputTokens()).isZero();
+              assertThat(agent.getMetrics().getOutputTokens()).isZero();
+              assertThat(agent.getMetrics().getModelCalls()).isZero();
+              assertThat(agent.getMetrics().getToolCalls()).isZero();
+            });
+  }
+
+  @Test
+  void shouldImportUpdatedAgentInstance_accumulatesMetrics() {
+    // given
+    final long agentKey = keyCounter.getAndIncrement();
+    seedRecord(
+        agentKey, AgentInstanceIntent.CREATED, AgentInstanceStatus.INITIALIZING, 0L, 0L, 0, 0);
+    seedRecord(
+        agentKey, AgentInstanceIntent.UPDATED, AgentInstanceStatus.THINKING, 512L, 128L, 1, 2);
+
+    // when
+    importAllZeebeEntitiesFromScratch();
+
+    // then
+    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+        .singleElement()
+        .satisfies(
+            pi -> {
+              assertThat(pi.getProcessInstanceId()).isEqualTo(String.valueOf(PROCESS_INSTANCE_KEY));
+              assertThat(pi.getAgentInstances()).hasSize(1);
+              final AgentInstanceDto agent = pi.getAgentInstances().get(0);
+              assertThat(agent.getStatus()).isEqualTo(AgentInstanceStatus.THINKING.name());
+              assertThat(agent.getMetrics().getInputTokens()).isEqualTo(512L);
+              assertThat(agent.getMetrics().getOutputTokens()).isEqualTo(128L);
+              assertThat(agent.getMetrics().getModelCalls()).isEqualTo(1L);
+              assertThat(agent.getMetrics().getToolCalls()).isEqualTo(2L);
+
+              assertThat(pi.getAgentTotalInputTokens()).isEqualTo(512L);
+              assertThat(pi.getAgentTotalOutputTokens()).isEqualTo(128L);
+              assertThat(pi.getAgentTotalModelCalls()).isEqualTo(1L);
+              assertThat(pi.getAgentTotalToolCalls()).isEqualTo(2L);
+              assertThat(pi.getAgentTotalTokens()).isEqualTo(640L);
+            });
+  }
+
+  @Test
+  void shouldImportCompletedAgentInstance_setsDurationAndEndDate() {
+    // given
+    final long agentKey = keyCounter.getAndIncrement();
+    seedRecord(
+        agentKey, AgentInstanceIntent.CREATED, AgentInstanceStatus.INITIALIZING, 0L, 0L, 0, 0);
+    seedRecord(
+        agentKey, AgentInstanceIntent.UPDATED, AgentInstanceStatus.THINKING, 500L, 200L, 2, 3);
+    seedRecord(
+        agentKey, AgentInstanceIntent.COMPLETED, AgentInstanceStatus.COMPLETED, 800L, 300L, 3, 4);
+
+    // when
+    importAllZeebeEntitiesFromScratch();
+
+    // then
+    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+        .singleElement()
+        .satisfies(
+            pi -> {
+              assertThat(pi.getAgentInstances()).hasSize(1);
+              final AgentInstanceDto agent = pi.getAgentInstances().get(0);
+              assertThat(agent.getStatus()).isEqualTo(AgentInstanceStatus.COMPLETED.name());
+              assertThat(agent.getEndDate()).isNotNull();
+              // CREATED seeded at position 1 (timestamp +1000ms), COMPLETED at position 3
+              // (+3000ms); see seedRecord -> setTimestamp(now + position * 1000).
+              assertThat(agent.getTotalDurationInMs()).isEqualTo(2000L);
+              // Metrics reflect final cumulative totals from the COMPLETED event
+              assertThat(agent.getMetrics().getInputTokens()).isEqualTo(800L);
+              assertThat(agent.getMetrics().getOutputTokens()).isEqualTo(300L);
+              assertThat(agent.getMetrics().getModelCalls()).isEqualTo(3L);
+              assertThat(agent.getMetrics().getToolCalls()).isEqualTo(4L);
+            });
+  }
+
+  @Test
+  void shouldImportMultipleAgentInstancesForSameProcessInstance() {
+    // given: two distinct agent instances on the same process instance
+    final long agentKey1 = keyCounter.getAndIncrement();
+    final long agentKey2 = keyCounter.getAndIncrement();
+    seedRecord(
+        agentKey1, AgentInstanceIntent.CREATED, AgentInstanceStatus.INITIALIZING, 0L, 0L, 0, 0);
+    seedRecord(
+        agentKey2, AgentInstanceIntent.CREATED, AgentInstanceStatus.INITIALIZING, 0L, 0L, 0, 0);
+
+    // when
+    importAllZeebeEntitiesFromScratch();
+
+    // then
+    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+        .singleElement()
+        .satisfies(
+            pi -> {
+              assertThat(pi.getProcessInstanceId()).isEqualTo(String.valueOf(PROCESS_INSTANCE_KEY));
+              assertThat(pi.getAgentInstances()).hasSize(2);
+            });
+  }
+
+  @Test
+  void shouldHandleNullMetricsFromZeebeRecord() {
+    // given: Zeebe exports AGENT_INSTANCE record with metrics=null
+    final long agentKey = keyCounter.getAndIncrement();
+    seedRecord(agentKey, AgentInstanceIntent.CREATED, AgentInstanceStatus.INITIALIZING, null, null);
+
+    // when
+    importAllZeebeEntitiesFromScratch();
+
+    // then: import succeeds, metrics are null (mapMetrics leaves metrics unset when source has
+    // no metrics)
+    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+        .singleElement()
+        .satisfies(
+            pi -> {
+              assertThat(pi.getProcessInstanceId()).isEqualTo(String.valueOf(PROCESS_INSTANCE_KEY));
+              assertThat(pi.getAgentInstances()).hasSize(1);
+              final AgentInstanceDto agent = pi.getAgentInstances().get(0);
+              assertThat(agent.getAgentInstanceId()).isEqualTo(String.valueOf(agentKey));
+              // When source metrics is absent, mapMetrics() does not populate the DTO, so the
+              // ES document has no metrics object rather than a misleading zero-value one.
+              assertThat(agent.getMetrics()).isNull();
+              // Aggregates should be zero when metrics is null
+              assertThat(pi.getAgentTotalInputTokens()).isZero();
+              assertThat(pi.getAgentTotalOutputTokens()).isZero();
+              assertThat(pi.getAgentTotalModelCalls()).isZero();
+              assertThat(pi.getAgentTotalToolCalls()).isZero();
+              assertThat(pi.getAgentTotalTokens()).isZero();
+            });
+  }
+
+  @Test
+  void shouldHandleNullDefinitionFromZeebeRecord() {
+    // given: Zeebe exports AGENT_INSTANCE record with definition=null
+    final long agentKey = keyCounter.getAndIncrement();
+    seedRecord(
+        PROCESS_INSTANCE_KEY,
+        agentKey,
+        AgentInstanceIntent.CREATED,
+        AgentInstanceStatus.INITIALIZING,
+        null,
+        null,
+        List.of(),
+        List.of(),
+        RecordType.EVENT);
+
+    // when: import must not throw NPE inside mapDefinition()
+    importAllZeebeEntitiesFromScratch();
+
+    // then: import succeeds and definition is stored as null (not an empty object)
+    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+        .singleElement()
+        .satisfies(
+            pi -> {
+              assertThat(pi.getAgentInstances()).hasSize(1);
+              final AgentInstanceDto agent = pi.getAgentInstances().get(0);
+              assertThat(agent.getAgentInstanceId()).isEqualTo(String.valueOf(agentKey));
+              assertThat(agent.getDefinition())
+                  .as("definition must be null when absent from Zeebe record")
+                  .isNull();
+            });
+  }
+
+  @Test
+  void shouldPopulateFlowNodeInstanceIdsFromElementInstanceKeys() {
+    // given: Agent with elementInstanceKeys representing migration across flow nodes
+    final long agentKey = keyCounter.getAndIncrement();
+    final List<Long> migrationHistory = List.of(1001L, 1002L, 1003L);
+
+    seedRecord(
+        agentKey,
+        AgentInstanceIntent.UPDATED,
+        AgentInstanceStatus.THINKING,
+        metrics(100L, 50L, 1, 2),
+        migrationHistory);
+
+    // when
+    importAllZeebeEntitiesFromScratch();
+
+    // then: import maps Zeebe's elementInstanceKey -> Optimize's flowNodeInstanceId, and
+    // elementInstanceKeys -> flowNodeInstanceIds, both stringified.
+    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+        .singleElement()
+        .satisfies(
+            pi -> {
+              assertThat(pi.getAgentInstances()).hasSize(1);
+              final AgentInstanceDto agent = pi.getAgentInstances().get(0);
+              assertThat(agent.getFlowNodeInstanceId()).isEqualTo("1003");
+              assertThat(agent.getFlowNodeInstanceIds()).containsExactly("1001", "1002", "1003");
+            });
+  }
+
+  @Test
+  void shouldMergeAgentInstanceAcrossImportBatches() {
+    // Verifies the full pipeline (import service → Painless merge script) across two separate
+    // import rounds, simulating records arriving in different Zeebe broker export batches.
+    final long agentKey = keyCounter.getAndIncrement();
+
+    // given: batch 1 — CREATED record imported on its own
+    seedRecord(
+        agentKey, AgentInstanceIntent.CREATED, AgentInstanceStatus.INITIALIZING, 0L, 0L, 0, 0);
+    importAllZeebeEntitiesFromScratch();
+
+    // Intermediate assertion: doc exists with initial state before the second batch arrives
+    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+        .singleElement()
+        .satisfies(
+            pi -> {
+              assertThat(pi.getAgentInstances()).hasSize(1);
+              assertThat(pi.getAgentInstances().get(0).getStatus())
+                  .isEqualTo(AgentInstanceStatus.INITIALIZING.name());
+              assertThat(pi.getAgentTotalInputTokens()).isZero();
+            });
+
+    // when: batch 2 — UPDATED record arrives in a new import round
+    seedRecord(
+        agentKey, AgentInstanceIntent.UPDATED, AgentInstanceStatus.THINKING, 512L, 128L, 1, 2);
+    importAllZeebeEntitiesFromLastIndex();
+
+    // then: Painless script merges the UPDATED record into the existing doc
+    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+        .singleElement()
+        .satisfies(
+            pi -> {
+              assertThat(pi.getProcessInstanceId()).isEqualTo(String.valueOf(PROCESS_INSTANCE_KEY));
+              assertThat(pi.getAgentInstances()).hasSize(1);
+              final AgentInstanceDto agent = pi.getAgentInstances().get(0);
+              assertThat(agent.getStatus()).isEqualTo(AgentInstanceStatus.THINKING.name());
+              assertThat(agent.getMetrics().getInputTokens()).isEqualTo(512L);
+              assertThat(agent.getMetrics().getOutputTokens()).isEqualTo(128L);
+              assertThat(agent.getMetrics().getModelCalls()).isEqualTo(1L);
+              assertThat(agent.getMetrics().getToolCalls()).isEqualTo(2L);
+              assertThat(pi.getAgentTotalInputTokens()).isEqualTo(512L);
+              assertThat(pi.getAgentTotalOutputTokens()).isEqualTo(128L);
+              assertThat(pi.getAgentTotalModelCalls()).isEqualTo(1L);
+              assertThat(pi.getAgentTotalToolCalls()).isEqualTo(2L);
+              assertThat(pi.getAgentTotalTokens()).isEqualTo(640L);
+            });
+  }
+
+  @Test
+  void shouldCompleteAgentInstanceAcrossThreeImportBatches() {
+    // Verifies the full CREATED → UPDATED → COMPLETED lifecycle when each event arrives in its own
+    // separate import round, exercising the Painless merge script at every transition.
+    final long agentKey = keyCounter.getAndIncrement();
+
+    // given: batch 1 — CREATED
+    seedRecord(
+        agentKey, AgentInstanceIntent.CREATED, AgentInstanceStatus.INITIALIZING, 0L, 0L, 0, 0);
+    importAllZeebeEntitiesFromScratch();
+
+    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+        .singleElement()
+        .satisfies(
+            pi -> {
+              final AgentInstanceDto agent = pi.getAgentInstances().get(0);
+              assertThat(agent.getStatus()).isEqualTo(AgentInstanceStatus.INITIALIZING.name());
+              assertThat(agent.getStartDate()).isNotNull();
+              assertThat(agent.getEndDate()).isNull();
+              assertThat(agent.getTotalDurationInMs()).isNull();
+              assertThat(pi.getAgentTotalInputTokens()).isZero();
+            });
+
+    // when: batch 2 — UPDATED
+    seedRecord(
+        agentKey, AgentInstanceIntent.UPDATED, AgentInstanceStatus.THINKING, 500L, 200L, 2, 3);
+    importAllZeebeEntitiesFromLastIndex();
+
+    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+        .singleElement()
+        .satisfies(
+            pi -> {
+              final AgentInstanceDto agent = pi.getAgentInstances().get(0);
+              assertThat(agent.getStatus()).isEqualTo(AgentInstanceStatus.THINKING.name());
+              assertThat(agent.getEndDate()).isNull();
+              assertThat(agent.getTotalDurationInMs()).isNull();
+              assertThat(agent.getMetrics().getInputTokens()).isEqualTo(500L);
+              assertThat(pi.getAgentTotalInputTokens()).isEqualTo(500L);
+            });
+
+    // when: batch 3 — COMPLETED
+    seedRecord(
+        agentKey, AgentInstanceIntent.COMPLETED, AgentInstanceStatus.COMPLETED, 800L, 300L, 3, 4);
+    importAllZeebeEntitiesFromLastIndex();
+
+    // then: COMPLETED merged — endDate set, duration correct, final metrics
+    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+        .singleElement()
+        .satisfies(
+            pi -> {
+              assertThat(pi.getAgentInstances()).hasSize(1);
+              final AgentInstanceDto agent = pi.getAgentInstances().get(0);
+              assertThat(agent.getStatus()).isEqualTo(AgentInstanceStatus.COMPLETED.name());
+              assertThat(agent.getEndDate()).isNotNull();
+              // CREATED at position 1 (BASE+1000ms), COMPLETED at position 3 (BASE+3000ms)
+              assertThat(agent.getTotalDurationInMs()).isEqualTo(2000L);
+              assertThat(agent.getMetrics().getInputTokens()).isEqualTo(800L);
+              assertThat(agent.getMetrics().getOutputTokens()).isEqualTo(300L);
+              assertThat(agent.getMetrics().getModelCalls()).isEqualTo(3L);
+              assertThat(agent.getMetrics().getToolCalls()).isEqualTo(4L);
+              assertThat(pi.getAgentTotalInputTokens()).isEqualTo(800L);
+              assertThat(pi.getAgentTotalOutputTokens()).isEqualTo(300L);
+              assertThat(pi.getAgentTotalModelCalls()).isEqualTo(3L);
+              assertThat(pi.getAgentTotalToolCalls()).isEqualTo(4L);
+              assertThat(pi.getAgentTotalTokens()).isEqualTo(1100L);
+            });
+  }
+
+  @Test
+  void shouldPreserveMetricsWhenSubsequentUpdateHasNoMetrics() {
+    // Verifies that a later UPDATED record with null metrics does NOT overwrite metrics that were
+    // established by an earlier UPDATED record. This relies on AgentInstanceDto.metrics being
+    // nullable: the Painless upsert script only skips the metrics write when newAgent.metrics IS
+    // null, so a non-null zero-value default would pass the guard and clobber real data.
+    final long agentKey = keyCounter.getAndIncrement();
+
+    // given: batch 1 — CREATED
+    seedRecord(
+        agentKey, AgentInstanceIntent.CREATED, AgentInstanceStatus.INITIALIZING, 0L, 0L, 0, 0);
+    importAllZeebeEntitiesFromScratch();
+
+    // when: batch 2 — UPDATED with real metrics
+    seedRecord(
+        agentKey, AgentInstanceIntent.UPDATED, AgentInstanceStatus.THINKING, 512L, 128L, 1, 2);
+    importAllZeebeEntitiesFromLastIndex();
+
+    // when: batch 3 — UPDATED with null metrics (e.g. partial record from Zeebe)
+    seedRecord(agentKey, AgentInstanceIntent.UPDATED, AgentInstanceStatus.IDLE, null, null);
+    importAllZeebeEntitiesFromLastIndex();
+
+    // then: metrics from batch 2 are preserved, not overwritten by the null-metrics record
+    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+        .singleElement()
+        .satisfies(
+            pi -> {
+              assertThat(pi.getAgentInstances()).hasSize(1);
+              final AgentInstanceDto agent = pi.getAgentInstances().get(0);
+              assertThat(agent.getStatus()).isEqualTo(AgentInstanceStatus.IDLE.name());
+              assertThat(agent.getMetrics()).isNotNull();
+              assertThat(agent.getMetrics().getInputTokens()).isEqualTo(512L);
+              assertThat(agent.getMetrics().getOutputTokens()).isEqualTo(128L);
+              assertThat(agent.getMetrics().getModelCalls()).isEqualTo(1L);
+              assertThat(agent.getMetrics().getToolCalls()).isEqualTo(2L);
+              assertThat(pi.getAgentTotalInputTokens()).isEqualTo(512L);
+              assertThat(pi.getAgentTotalOutputTokens()).isEqualTo(128L);
+              assertThat(pi.getAgentTotalTokens()).isEqualTo(640L);
+            });
+  }
+
+  @Test
+  void shouldPropagateToolsThroughFullPipeline() {
+    // Verifies that tools seeded in the Zeebe record are correctly mapped by the import service
+    // (mapTools) and persisted in the resulting AgentInstanceDto.
+    final long agentKey = keyCounter.getAndIncrement();
+    final List<AgentToolValueDto> tools = List.of(tool("search_web"), tool("code_executor"));
+    seedRecord(
+        PROCESS_INSTANCE_KEY,
+        agentKey,
+        AgentInstanceIntent.CREATED,
+        AgentInstanceStatus.INITIALIZING,
+        metrics(0L, 0L, 0, 2),
+        defaultDefinition(),
+        List.of(),
+        tools,
+        RecordType.EVENT);
+
+    // when
+    importAllZeebeEntitiesFromScratch();
+
+    // then: both tools propagated through the full import pipeline
+    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+        .singleElement()
+        .satisfies(
+            pi -> {
+              assertThat(pi.getAgentInstances()).hasSize(1);
+              final AgentInstanceDto agent = pi.getAgentInstances().get(0);
+              assertThat(agent.getTools())
+                  .extracting(AgentInstanceDto.AgentToolDto::getName)
+                  .containsExactlyInAnyOrder("search_web", "code_executor");
+            });
+  }
+
+  @Test
+  void shouldImportAgentInstancesForMultipleProcessInstancesInSameBatch() {
+    // Verifies the groupingBy(processInstanceKey) path: records belonging to two different process
+    // instances that arrive in the same import batch produce two separate ProcessInstance
+    // documents.
+    final long agentKey1 = keyCounter.getAndIncrement();
+    final long agentKey2 = keyCounter.getAndIncrement();
+    final long secondProcessInstanceKey = 200L;
+
+    seedRecord(
+        PROCESS_INSTANCE_KEY,
+        agentKey1,
+        AgentInstanceIntent.CREATED,
+        AgentInstanceStatus.INITIALIZING,
+        metrics(100L, 50L, 1, 0),
+        defaultDefinition(),
+        List.of(),
+        List.of(),
+        RecordType.EVENT);
+    seedRecord(
+        secondProcessInstanceKey,
+        agentKey2,
+        AgentInstanceIntent.CREATED,
+        AgentInstanceStatus.INITIALIZING,
+        metrics(200L, 75L, 1, 0),
+        defaultDefinition(),
+        List.of(),
+        List.of(),
+        RecordType.EVENT);
+
+    // when
+    importAllZeebeEntitiesFromScratch();
+
+    // then: two separate ProcessInstance documents, one per PI key
+    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+        .hasSize(2)
+        .extracting(pi -> pi.getProcessInstanceId())
+        .containsExactlyInAnyOrder(
+            String.valueOf(PROCESS_INSTANCE_KEY), String.valueOf(secondProcessInstanceKey));
+  }
+
+  @Test
+  void shouldIgnoreCommandIntentRecords() {
+    // Verifies that COMMAND records (CREATE/UPDATE/COMPLETE intents) are filtered out by the import
+    // service before any processing. Only EVENT records (CREATED/UPDATED/COMPLETED) are imported.
+    final long agentKey = keyCounter.getAndIncrement();
+    seedRecord(
+        PROCESS_INSTANCE_KEY,
+        agentKey,
+        AgentInstanceIntent.CREATE,
+        AgentInstanceStatus.UNSPECIFIED,
+        null,
+        defaultDefinition(),
+        List.of(),
+        List.of(),
+        RecordType.COMMAND);
+
+    // when
+    importAllZeebeEntitiesFromScratch();
+
+    // then: command records are excluded; no documents created
+    assertThat(databaseIntegrationTestExtension.getAllProcessInstances()).isEmpty();
+  }
+
+  @Test
+  void shouldPersistLastUpdatedDate() {
+    // Verifies that lastUpdatedDate is set on the initial CREATED record and then advances to a
+    // later value when a subsequent UPDATED record arrives in a separate batch. lastUpdatedDate is
+    // critical: the Painless script uses it as a timestamp guard to prevent out-of-order records
+    // from overwriting newer state.
+    final long agentKey = keyCounter.getAndIncrement();
+
+    // given: batch 1 — CREATED
+    seedRecord(
+        agentKey, AgentInstanceIntent.CREATED, AgentInstanceStatus.INITIALIZING, 0L, 0L, 0, 0);
+    importAllZeebeEntitiesFromScratch();
+
+    // capture the date after the first batch
+    final OffsetDateTime[] createdDate = new OffsetDateTime[1];
+    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+        .singleElement()
+        .satisfies(
+            pi -> {
+              final AgentInstanceDto agent = pi.getAgentInstances().get(0);
+              assertThat(agent.getLastUpdatedDate())
+                  .as("lastUpdatedDate must be set after CREATED import")
+                  .isNotNull();
+              createdDate[0] = agent.getLastUpdatedDate();
+            });
+
+    // when: batch 2 — UPDATED with a later timestamp (positionCounter advances → timestamp is +1s)
+    seedRecord(
+        agentKey, AgentInstanceIntent.UPDATED, AgentInstanceStatus.THINKING, 100L, 50L, 1, 0);
+    importAllZeebeEntitiesFromLastIndex();
+
+    // then: lastUpdatedDate advanced to the UPDATED record's timestamp
+    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+        .singleElement()
+        .satisfies(
+            pi -> {
+              final AgentInstanceDto agent = pi.getAgentInstances().get(0);
+              assertThat(agent.getLastUpdatedDate())
+                  .as("lastUpdatedDate must advance after UPDATED import")
+                  .isNotNull()
+                  .isAfter(createdDate[0]);
+            });
+  }
+
+  @Test
+  void shouldPreserveDefinitionAcrossCrossBatchUpdate() {
+    // Verifies that agent definition (model + provider) set on CREATED is not lost when an UPDATED
+    // record arrives in a separate batch. The Painless script is "set-once" for definition:
+    // it only writes definition if the existing value is null, so it must survive cross-batch
+    // updates without being wiped.
+    final long agentKey = keyCounter.getAndIncrement();
+
+    // given: batch 1 — CREATED, definition is set
+    seedRecord(
+        agentKey, AgentInstanceIntent.CREATED, AgentInstanceStatus.INITIALIZING, 0L, 0L, 0, 0);
+    importAllZeebeEntitiesFromScratch();
+
+    // when: batch 2 — UPDATED (definition is always present in seeded records; script guards it)
+    seedRecord(
+        agentKey, AgentInstanceIntent.UPDATED, AgentInstanceStatus.THINKING, 100L, 50L, 1, 0);
+    importAllZeebeEntitiesFromLastIndex();
+
+    // then: definition fields from CREATED are still present
+    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+        .singleElement()
+        .satisfies(
+            pi -> {
+              final AgentInstanceDto agent = pi.getAgentInstances().get(0);
+              assertThat(agent.getDefinition())
+                  .as("definition must not be null after cross-batch update")
+                  .isNotNull();
+              assertThat(agent.getDefinition().getModel())
+                  .as("definition.model must survive cross-batch update")
+                  .isEqualTo(MODEL);
+              assertThat(agent.getDefinition().getProvider())
+                  .as("definition.provider must survive cross-batch update")
+                  .isEqualTo(PROVIDER);
+            });
+  }
+
+  // --- helpers ---
+
+  /**
+   * Convenience overload: primitive metrics, default processInstanceKey, no tools, no custom
+   * elementInstanceKeys.
+   */
+  private void seedRecord(
+      final long agentKey,
+      final AgentInstanceIntent intent,
+      final AgentInstanceStatus status,
+      final long inputTokens,
+      final long outputTokens,
+      final int modelCalls,
+      final int toolCalls) {
+    seedRecord(
+        PROCESS_INSTANCE_KEY,
+        agentKey,
+        intent,
+        status,
+        metrics(inputTokens, outputTokens, modelCalls, toolCalls),
+        defaultDefinition(),
+        List.of(),
+        List.of(),
+        RecordType.EVENT);
+  }
+
+  /**
+   * Convenience overload: explicit metrics and elementInstanceKeys, default processInstanceKey, no
+   * tools.
+   *
+   * @param metrics nullable; pass {@code null} to exercise the null-metrics import path
+   * @param elementInstanceKeys nullable/empty; falls back to a single default key derived from
+   *     {@code agentKey}
+   */
+  private void seedRecord(
+      final long agentKey,
+      final AgentInstanceIntent intent,
+      final AgentInstanceStatus status,
+      final AgentMetricsValueDto metrics,
+      final List<Long> elementInstanceKeys) {
+    seedRecord(
+        PROCESS_INSTANCE_KEY,
+        agentKey,
+        intent,
+        status,
+        metrics,
+        defaultDefinition(),
+        elementInstanceKeys,
+        List.of(),
+        RecordType.EVENT);
+  }
+
+  /**
+   * Full record builder: supports custom processInstanceKey, tools list, and RecordType.
+   *
+   * @param metrics nullable; pass {@code null} to exercise the null-metrics import path
+   * @param definition nullable; pass {@code null} to exercise the null-definition import path
+   * @param elementInstanceKeys nullable/empty; falls back to a single default key derived from
+   *     {@code agentKey}
+   * @param tools empty list for no tools; non-empty to set tools on the record
+   * @param recordType use {@link RecordType#EVENT} for normal import, {@link RecordType#COMMAND} to
+   *     test command filtering
+   */
+  private void seedRecord(
+      final long processInstanceKey,
+      final long agentKey,
+      final AgentInstanceIntent intent,
+      final AgentInstanceStatus status,
+      final AgentMetricsValueDto metrics,
+      final AgentDefinitionValueDto definition,
+      final List<Long> elementInstanceKeys,
+      final List<AgentToolValueDto> tools,
+      final RecordType recordType) {
+
+    final List<Long> resolvedKeys =
+        (elementInstanceKeys == null || elementInstanceKeys.isEmpty())
+            ? List.of(agentKey + 1000)
+            : elementInstanceKeys;
+    final long currentElementInstanceKey = resolvedKeys.get(resolvedKeys.size() - 1);
+
+    final ZeebeAgentInstanceDataDto value = new ZeebeAgentInstanceDataDto();
+    value.setAgentInstanceKey(agentKey);
+    value.setElementInstanceKey(currentElementInstanceKey);
+    value.setElementInstanceKeys(resolvedKeys);
+    value.setElementId(ELEMENT_ID);
+    value.setProcessInstanceKey(processInstanceKey);
+    value.setBpmnProcessId(BPMN_PROCESS_ID);
+    value.setProcessDefinitionKey(PROCESS_DEFINITION_KEY);
+    value.setProcessDefinitionVersion(1);
+    value.setStatus(status);
+
+    value.setDefinition(definition);
+
+    value.setMetrics(metrics);
+    if (!tools.isEmpty()) {
+      value.setTools(tools);
+    }
+
+    final long position = positionCounter.getAndIncrement();
+    final ZeebeAgentInstanceRecordDto record = new ZeebeAgentInstanceRecordDto();
+    record.setPosition(position);
+    record.setKey(agentKey);
+    record.setPartitionId(1);
+    record.setTimestamp(BASE_TIMESTAMP_MS + position * 1000);
+    record.setRecordType(recordType);
+    record.setValueType(ValueType.AGENT_INSTANCE);
+    record.setIntent(intent);
+    record.setValue(value);
+
+    databaseIntegrationTestExtension.addEntryWithRawIndex(
+        agentInstanceIndex, String.valueOf(position), record);
+  }
+
+  private AgentToolValueDto tool(final String name) {
+    final AgentToolValueDto t = new AgentToolValueDto();
+    t.setName(name);
+    return t;
+  }
+
+  private AgentDefinitionValueDto defaultDefinition() {
+    final AgentDefinitionValueDto def = new AgentDefinitionValueDto();
+    def.setModel(MODEL);
+    def.setProvider(PROVIDER);
+    def.setSystemPrompt(SYSTEM_PROMPT);
+    return def;
+  }
+
+  private AgentMetricsValueDto metrics(
+      final long inputTokens, final long outputTokens, final int modelCalls, final int toolCalls) {
+    final AgentMetricsValueDto m = new AgentMetricsValueDto();
+    m.setInputTokens(inputTokens);
+    m.setOutputTokens(outputTokens);
+    m.setModelCalls(modelCalls);
+    m.setToolCalls(toolCalls);
+    return m;
+  }
+}

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeAgentInstanceScriptIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeAgentInstanceScriptIT.java
@@ -1,0 +1,470 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.importing;
+
+import static io.camunda.optimize.service.db.DatabaseConstants.ZEEBE_AGENT_INSTANCE_INDEX_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.optimize.AbstractBrokerlessZeebeCCSMIT;
+import io.camunda.optimize.dto.optimize.ProcessInstanceDto;
+import io.camunda.optimize.dto.optimize.datasource.ZeebeDataSourceDto;
+import io.camunda.optimize.dto.optimize.query.process.AgentInstanceDto;
+import io.camunda.optimize.dto.optimize.query.process.AgentInstanceDto.AgentMetricsDto;
+import io.camunda.optimize.dto.optimize.query.process.AgentInstanceDto.AgentToolDto;
+import io.camunda.optimize.service.db.DatabaseClient;
+import io.camunda.optimize.service.db.writer.ProcessInstanceWriter;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ZeebeAgentInstanceScriptIT extends AbstractBrokerlessZeebeCCSMIT {
+
+  private static final String PROCESS_KEY = "testProcess";
+  private static final String INSTANCE_ID = "100";
+  private static final String AGENT_ID = "agent-a";
+  private static final String AGENT_ID_2 = "agent-b";
+  private static final OffsetDateTime START_TIME =
+      OffsetDateTime.parse("2024-01-01T10:00:00+00:00");
+  private static final OffsetDateTime END_TIME = OffsetDateTime.parse("2024-01-01T10:00:05+00:00");
+
+  private ProcessInstanceWriter processInstanceWriter;
+  private DatabaseClient databaseClient;
+
+  @BeforeEach
+  void setUp() {
+    processInstanceWriter = embeddedOptimizeExtension.getBean(ProcessInstanceWriter.class);
+    databaseClient = embeddedOptimizeExtension.getBean(DatabaseClient.class);
+  }
+
+  @Test
+  void shouldInsertCreatedAgentInstanceWithoutEndDate() {
+    // given
+    final ProcessInstanceDto dto = buildBaseInstance();
+    dto.setAgentInstances(List.of(createdAgent(AGENT_ID)));
+    computeAgentTotals(dto);
+
+    // when
+    importProcessInstances(List.of(dto));
+
+    // then
+    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+        .singleElement()
+        .satisfies(
+            saved -> {
+              assertThat(saved.getAgentInstances()).hasSize(1);
+              assertThat(saved.getAgentInstances().get(0).getAgentInstanceId()).isEqualTo(AGENT_ID);
+              assertThat(saved.getAgentInstances().get(0).getEndDate()).isNull();
+              assertThat(saved.getAgentInstances().get(0).getTotalDurationInMs()).isNull();
+              assertThat(saved.getAgentTotalInputTokens()).isEqualTo(0L);
+              assertThat(saved.getAgentTotalOutputTokens()).isEqualTo(0L);
+              assertThat(saved.getAgentTotalModelCalls()).isEqualTo(0L);
+              assertThat(saved.getAgentTotalToolCalls()).isEqualTo(0L);
+              assertThat(saved.getAgentTotalTokens()).isEqualTo(0L);
+            });
+  }
+
+  @Test
+  void shouldInsertCompletedOnlyAgentWithoutDuration() {
+    // given: no prior CREATED — COMPLETED arrives first (out-of-order across batches)
+    final ProcessInstanceDto dto = buildBaseInstance();
+    dto.setAgentInstances(List.of(completedAgent(AGENT_ID)));
+    computeAgentTotals(dto);
+
+    // when
+    importProcessInstances(List.of(dto));
+
+    // then: entry inserted, duration null because startDate and endDate are not both set
+    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+        .singleElement()
+        .satisfies(
+            saved -> {
+              assertThat(saved.getAgentInstances()).hasSize(1);
+              assertThat(saved.getAgentInstances().get(0).getEndDate()).isNotNull();
+              assertThat(saved.getAgentInstances().get(0).getTotalDurationInMs()).isNull();
+              assertThat(saved.getAgentTotalInputTokens()).isEqualTo(100L);
+              assertThat(saved.getAgentTotalToolCalls()).isEqualTo(7L);
+              assertThat(saved.getAgentTotalTokens()).isEqualTo(300L);
+            });
+  }
+
+  @Test
+  void shouldPersistMergedDtoOnInitialInsert() {
+    // given: import service merged CREATED + COMPLETED into one entry before calling the writer
+    final ProcessInstanceDto dto = buildBaseInstance();
+    final AgentInstanceDto merged = createdAgent(AGENT_ID);
+    merged.setEndDate(END_TIME);
+    merged.setMetrics(metrics());
+    merged.setTools(tools());
+    dto.setAgentInstances(List.of(merged));
+    dto.setAgentTotalInputTokens(100L);
+    dto.setAgentTotalOutputTokens(200L);
+    dto.setAgentTotalModelCalls(3L);
+    dto.setAgentTotalToolCalls(7L);
+
+    // when: first import → upsert creates doc from source (script not executed)
+    importProcessInstances(List.of(dto));
+
+    // then: doc persisted exactly as the merged source DTO
+    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+        .singleElement()
+        .satisfies(
+            saved -> {
+              assertThat(saved.getAgentInstances()).hasSize(1);
+              final AgentInstanceDto agent = saved.getAgentInstances().get(0);
+              assertThat(agent.getAgentInstanceId()).isEqualTo(AGENT_ID);
+              assertThat(agent.getStartDate()).isEqualTo(START_TIME);
+              assertThat(agent.getEndDate()).isEqualTo(END_TIME);
+              assertThat(agent.getTools())
+                  .extracting(AgentToolDto::getName)
+                  .containsExactly("search");
+              assertThat(saved.getAgentTotalInputTokens()).isEqualTo(100L);
+              assertThat(saved.getAgentTotalOutputTokens()).isEqualTo(200L);
+              assertThat(saved.getAgentTotalModelCalls()).isEqualTo(3L);
+              assertThat(saved.getAgentTotalToolCalls()).isEqualTo(7L);
+            });
+  }
+
+  @Test
+  void shouldReAggregateAgentTotalsAfterMergingSecondAgent() {
+    // given: two agents, CREATED for both
+    final ProcessInstanceDto created = buildBaseInstance();
+    created.setAgentInstances(List.of(createdAgent(AGENT_ID), createdAgent(AGENT_ID_2)));
+    importProcessInstances(List.of(created));
+
+    // when: COMPLETED for both agents arrives
+    final ProcessInstanceDto completed = buildBaseInstance();
+    completed.setAgentInstances(List.of(completedAgent(AGENT_ID), completedAgent(AGENT_ID_2)));
+    importProcessInstances(List.of(completed));
+
+    // then: totals summed across both agents
+    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+        .singleElement()
+        .satisfies(
+            saved -> {
+              assertThat(saved.getAgentInstances()).hasSize(2);
+              assertThat(saved.getAgentTotalInputTokens()).isEqualTo(200L);
+              assertThat(saved.getAgentTotalOutputTokens()).isEqualTo(400L);
+              assertThat(saved.getAgentTotalModelCalls()).isEqualTo(6L);
+              assertThat(saved.getAgentTotalToolCalls()).isEqualTo(14L);
+              assertThat(saved.getAgentTotalTokens()).isEqualTo(600L);
+            });
+  }
+
+  @Test
+  void shouldHandleDocWithNoAgentInstancesField() {
+    // given: existing process instance without any agent data (pre-feature document)
+    final ProcessInstanceDto base = buildBaseInstance();
+    base.setAgentInstances(null);
+    base.setAgentTotalInputTokens(null);
+    base.setAgentTotalOutputTokens(null);
+    base.setAgentTotalModelCalls(null);
+    base.setAgentTotalToolCalls(null);
+    importProcessInstances(List.of(base));
+
+    // when: agent CREATED import runs the script against the existing doc
+    final ProcessInstanceDto agentBatch = buildBaseInstance();
+    agentBatch.setAgentInstances(List.of(createdAgent(AGENT_ID)));
+    importProcessInstances(List.of(agentBatch));
+
+    // then: null guard in script prevents NPE; agent entry inserted with fields preserved
+    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+        .singleElement()
+        .satisfies(
+            saved -> {
+              assertThat(saved.getAgentInstances()).hasSize(1);
+              final AgentInstanceDto agent = saved.getAgentInstances().get(0);
+              assertThat(agent.getAgentInstanceId()).isEqualTo(AGENT_ID);
+              assertThat(agent.getFlowNodeId()).isEqualTo("agentTask");
+              assertThat(agent.getStartDate()).isEqualTo(START_TIME);
+              assertThat(agent.getStatus()).isEqualTo("INITIALIZING");
+              // aggregates recomputed from merged agentInstances (one agent with zero metrics)
+              assertThat(saved.getAgentTotalInputTokens()).isEqualTo(0L);
+              assertThat(saved.getAgentTotalOutputTokens()).isEqualTo(0L);
+              assertThat(saved.getAgentTotalModelCalls()).isEqualTo(0L);
+              assertThat(saved.getAgentTotalToolCalls()).isEqualTo(0L);
+              assertThat(saved.getAgentTotalTokens()).isEqualTo(0L);
+            });
+  }
+
+  @Test
+  void shouldApplyUpdatedStatusAndMetrics() {
+    // given: CREATED batch
+    final ProcessInstanceDto created = buildBaseInstance();
+    created.setAgentInstances(List.of(createdAgentWithDefinition(AGENT_ID)));
+    importProcessInstances(List.of(created));
+
+    // when: UPDATED batch with new status, metrics, tools
+    final ProcessInstanceDto updated = buildBaseInstance();
+    final AgentInstanceDto updatedAgent = new AgentInstanceDto();
+    updatedAgent.setAgentInstanceId(AGENT_ID);
+    updatedAgent.setFlowNodeId("agentTask");
+    updatedAgent.setStatus("THINKING");
+    updatedAgent.setLastUpdatedDate(OffsetDateTime.parse("2024-01-01T10:00:03+00:00"));
+    updatedAgent.setMetrics(metrics());
+    updatedAgent.setTools(tools());
+    updated.setAgentInstances(List.of(updatedAgent));
+    importProcessInstances(List.of(updated));
+
+    // then
+    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+        .singleElement()
+        .satisfies(
+            saved -> {
+              assertThat(saved.getAgentInstances()).hasSize(1);
+              final AgentInstanceDto agent = saved.getAgentInstances().get(0);
+              assertThat(agent.getStatus()).isEqualTo("THINKING");
+              assertThat(agent.getLastUpdatedDate()).isNotNull();
+              assertThat(agent.getStartDate()).isNotNull();
+              assertThat(agent.getEndDate()).isNull();
+              assertThat(agent.getMetrics().getInputTokens()).isEqualTo(100L);
+              assertThat(agent.getMetrics().getOutputTokens()).isEqualTo(200L);
+              assertThat(agent.getMetrics().getModelCalls()).isEqualTo(3L);
+              assertThat(agent.getMetrics().getToolCalls()).isEqualTo(7L);
+              assertThat(agent.getTools())
+                  .extracting(AgentToolDto::getName)
+                  .containsExactly("search");
+              assertThat(saved.getAgentTotalInputTokens()).isEqualTo(100L);
+              assertThat(saved.getAgentTotalOutputTokens()).isEqualTo(200L);
+              assertThat(saved.getAgentTotalModelCalls()).isEqualTo(3L);
+              assertThat(saved.getAgentTotalToolCalls()).isEqualTo(7L);
+              assertThat(saved.getAgentTotalTokens()).isEqualTo(300L);
+            });
+  }
+
+  @Test
+  void shouldNotOverwriteTerminalStatusEvenWithNewerUpdate() {
+    // given: COMPLETED sets terminal status at END_TIME (10:00:05)
+    final ProcessInstanceDto completed = buildBaseInstance();
+    completed.setAgentInstances(List.of(completedAgent(AGENT_ID)));
+    importProcessInstances(List.of(completed));
+
+    // when: an UPDATED arrives later with lastUpdatedDate 10:01:00 — NEWER than the existing
+    // COMPLETED's lastUpdatedDate. The timestamp branch alone would let the write through; only
+    // the terminal-status guard should block it.
+    final ProcessInstanceDto updated = buildBaseInstance();
+    final AgentInstanceDto updatedAgent = new AgentInstanceDto();
+    updatedAgent.setAgentInstanceId(AGENT_ID);
+    updatedAgent.setFlowNodeId("agentTask");
+    updatedAgent.setStatus("THINKING");
+    updatedAgent.setLastUpdatedDate(OffsetDateTime.parse("2024-01-01T10:01:00+00:00"));
+    updatedAgent.setMetrics(new AgentMetricsDto());
+    updated.setAgentInstances(List.of(updatedAgent));
+    importProcessInstances(List.of(updated));
+
+    // then: COMPLETED status preserved — proves the isTerminal branch blocks even when the
+    // timestamp comparison would otherwise allow the overwrite.
+    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+        .singleElement()
+        .satisfies(
+            saved -> {
+              assertThat(saved.getAgentInstances()).hasSize(1);
+              assertThat(saved.getAgentInstances().get(0).getStatus()).isEqualTo("COMPLETED");
+            });
+  }
+
+  @Test
+  void shouldNotOverwriteNewerNonTerminalStateWithStaleUpdate() {
+    // given: non-terminal status THINKING at lastUpdatedDate = START_TIME (10:00:00, newer)
+    final ProcessInstanceDto fresh = buildBaseInstance();
+    final AgentInstanceDto freshAgent = createdAgent(AGENT_ID);
+    freshAgent.setStatus("THINKING");
+    freshAgent.setMetrics(metrics());
+    fresh.setAgentInstances(List.of(freshAgent));
+    importProcessInstances(List.of(fresh));
+
+    // when: stale UPDATED arrives with lastUpdatedDate 09:59:00 (older) and INITIALIZING status
+    final ProcessInstanceDto stale = buildBaseInstance();
+    final AgentInstanceDto staleAgent = new AgentInstanceDto();
+    staleAgent.setAgentInstanceId(AGENT_ID);
+    staleAgent.setFlowNodeId("agentTask");
+    staleAgent.setStatus("INITIALIZING");
+    staleAgent.setLastUpdatedDate(OffsetDateTime.parse("2024-01-01T09:59:00+00:00"));
+    staleAgent.setMetrics(new AgentMetricsDto());
+    stale.setAgentInstances(List.of(staleAgent));
+    importProcessInstances(List.of(stale));
+
+    // then: existing newer state preserved — exercises the newTs < existingTs branch
+    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+        .singleElement()
+        .satisfies(
+            saved -> {
+              assertThat(saved.getAgentInstances()).hasSize(1);
+              final AgentInstanceDto agent = saved.getAgentInstances().get(0);
+              assertThat(agent.getStatus()).isEqualTo("THINKING");
+              assertThat(agent.getMetrics().getInputTokens()).isEqualTo(100L);
+            });
+  }
+
+  @Test
+  void shouldPopulateDefinitionFields() {
+    // given: CREATED event carries model/provider
+    final ProcessInstanceDto dto = buildBaseInstance();
+    dto.setAgentInstances(List.of(createdAgentWithDefinition(AGENT_ID)));
+
+    // when
+    importProcessInstances(List.of(dto));
+
+    // then: definition stored on the nested entry
+    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+        .singleElement()
+        .satisfies(
+            saved -> {
+              assertThat(saved.getAgentInstances()).hasSize(1);
+              final AgentInstanceDto agent = saved.getAgentInstances().get(0);
+              assertThat(agent.getDefinition()).isNotNull();
+              assertThat(agent.getDefinition().getModel()).isEqualTo("gpt-4o");
+              assertThat(agent.getDefinition().getProvider()).isEqualTo("openai");
+            });
+  }
+
+  @Test
+  void shouldComputeDurationWhenCreatedArrivesAfterCompleted() {
+    // given: COMPLETED arrives first (out-of-order across batches)
+    final ProcessInstanceDto completed = buildBaseInstance();
+    completed.setAgentInstances(List.of(completedAgent(AGENT_ID)));
+    computeAgentTotals(completed);
+    importProcessInstances(List.of(completed));
+
+    // when: CREATED arrives later — script merges startDate
+    final ProcessInstanceDto created = buildBaseInstance();
+    created.setAgentInstances(List.of(createdAgent(AGENT_ID)));
+    importProcessInstances(List.of(created));
+
+    // then: duration computed retroactively from startDate + endDate
+    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+        .singleElement()
+        .satisfies(
+            saved -> {
+              assertThat(saved.getAgentInstances()).hasSize(1);
+              final AgentInstanceDto agent = saved.getAgentInstances().get(0);
+              assertThat(agent.getStartDate()).isNotNull();
+              assertThat(agent.getEndDate()).isNotNull();
+              assertThat(agent.getTotalDurationInMs()).isEqualTo(5_000L);
+              assertThat(saved.getAgentTotalInputTokens()).isEqualTo(100L);
+              assertThat(saved.getAgentTotalToolCalls()).isEqualTo(7L);
+              assertThat(saved.getAgentTotalTokens()).isEqualTo(300L);
+            });
+  }
+
+  @Test
+  void shouldComputeDurationWhenCompletedArrivesAfterCreated() {
+    // given: CREATED batch
+    final ProcessInstanceDto created = buildBaseInstance();
+    created.setAgentInstances(List.of(createdAgent(AGENT_ID)));
+    importProcessInstances(List.of(created));
+
+    // when: COMPLETED batch — script merges endDate and computes duration
+    final ProcessInstanceDto completed = buildBaseInstance();
+    completed.setAgentInstances(List.of(completedAgent(AGENT_ID)));
+    importProcessInstances(List.of(completed));
+
+    // then
+    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+        .singleElement()
+        .satisfies(
+            saved -> {
+              assertThat(saved.getAgentInstances()).hasSize(1);
+              final AgentInstanceDto agent = saved.getAgentInstances().get(0);
+              assertThat(agent.getStartDate()).isEqualTo(START_TIME);
+              assertThat(agent.getEndDate()).isEqualTo(END_TIME);
+              assertThat(agent.getTotalDurationInMs()).isEqualTo(5_000L);
+              assertThat(saved.getAgentTotalInputTokens()).isEqualTo(100L);
+              assertThat(saved.getAgentTotalOutputTokens()).isEqualTo(200L);
+              assertThat(saved.getAgentTotalModelCalls()).isEqualTo(3L);
+              assertThat(saved.getAgentTotalToolCalls()).isEqualTo(7L);
+              assertThat(saved.getAgentTotalTokens()).isEqualTo(300L);
+            });
+  }
+
+  private void computeAgentTotals(final ProcessInstanceDto dto) {
+    long totalInput = 0L, totalOutput = 0L, totalModel = 0L, totalTool = 0L;
+    for (final AgentInstanceDto agent : dto.getAgentInstances()) {
+      final AgentMetricsDto m = agent.getMetrics();
+      if (m != null) {
+        totalInput += m.getInputTokens();
+        totalOutput += m.getOutputTokens();
+        totalModel += m.getModelCalls();
+        totalTool += m.getToolCalls();
+      }
+    }
+    dto.setAgentTotalInputTokens(totalInput);
+    dto.setAgentTotalOutputTokens(totalOutput);
+    dto.setAgentTotalModelCalls(totalModel);
+    dto.setAgentTotalToolCalls(totalTool);
+    dto.setAgentTotalTokens(totalInput + totalOutput);
+  }
+
+  private void importProcessInstances(final List<ProcessInstanceDto> instances) {
+    // sourceExportIndex tells the merge script which import variant produced the batch (user-task
+    // import gets special-cased; agent-instance does not). Use the agent index name for self-doc.
+    final var requests =
+        processInstanceWriter.generateProcessInstanceImports(
+            instances, ZEEBE_AGENT_INSTANCE_INDEX_NAME);
+    databaseClient.executeImportRequestsAsBulk("agent-instance-script-test", requests, false);
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+  }
+
+  private ProcessInstanceDto buildBaseInstance() {
+    final ProcessInstanceDto dto = new ProcessInstanceDto();
+    dto.setProcessInstanceId(INSTANCE_ID);
+    dto.setProcessDefinitionKey(PROCESS_KEY);
+    dto.setProcessDefinitionId("1");
+    dto.setProcessDefinitionVersion("1");
+    dto.setDataSource(new ZeebeDataSourceDto("default", 1));
+    return dto;
+  }
+
+  private AgentInstanceDto createdAgent(final String agentId) {
+    final AgentInstanceDto dto = new AgentInstanceDto();
+    dto.setAgentInstanceId(agentId);
+    dto.setFlowNodeId("agentTask");
+    dto.setStartDate(START_TIME);
+    dto.setLastUpdatedDate(START_TIME);
+    dto.setStatus("INITIALIZING");
+    dto.setMetrics(new AgentMetricsDto());
+    return dto;
+  }
+
+  private AgentInstanceDto createdAgentWithDefinition(final String agentId) {
+    final AgentInstanceDto dto = createdAgent(agentId);
+    final AgentInstanceDto.AgentDefinitionDto definition =
+        new AgentInstanceDto.AgentDefinitionDto();
+    definition.setModel("gpt-4o");
+    definition.setProvider("openai");
+    dto.setDefinition(definition);
+    return dto;
+  }
+
+  private AgentInstanceDto completedAgent(final String agentId) {
+    final AgentInstanceDto dto = new AgentInstanceDto();
+    dto.setAgentInstanceId(agentId);
+    dto.setFlowNodeId("agentTask");
+    dto.setStatus("COMPLETED");
+    dto.setEndDate(END_TIME);
+    dto.setLastUpdatedDate(END_TIME);
+    dto.setMetrics(metrics());
+    dto.setTools(tools());
+    return dto;
+  }
+
+  private AgentMetricsDto metrics() {
+    final AgentMetricsDto m = new AgentMetricsDto();
+    m.setInputTokens(100L);
+    m.setOutputTokens(200L);
+    m.setModelCalls(3L);
+    m.setToolCalls(7L);
+    return m;
+  }
+
+  private List<AgentToolDto> tools() {
+    final AgentToolDto tool = new AgentToolDto();
+    tool.setName("search");
+    return List.of(tool);
+  }
+}

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebePositionBasedImportIndexIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebePositionBasedImportIndexIT.java
@@ -148,6 +148,60 @@ public class ZeebePositionBasedImportIndexIT extends AbstractCCSMIT {
   }
 
   @Test
+  public void shouldResumeAgentInstanceImportFromLastPosition() {
+    // given: deploy process and import from scratch
+    deployZeebeData();
+    importAllZeebeEntitiesFromScratch();
+
+    embeddedOptimizeExtension.storeImportIndexesToElasticsearch();
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+    final PositionBasedImportIndexHandler agentHandler =
+        embeddedOptimizeExtension.getAllPositionBasedImportHandlers().stream()
+            .filter(
+                h ->
+                    h
+                        instanceof
+                        io.camunda.optimize.service.importing.zeebe.handler
+                            .ZeebeAgentInstanceImportIndexHandler)
+            .findFirst()
+            .orElseThrow(
+                () ->
+                    new AssertionError(
+                        "ZeebeAgentInstanceImportIndexHandler not found — handler was not registered"));
+
+    // deployZeebeData() creates process records, not agent records, so positionBeforeRestart
+    // is 0. The assertions below verify the persistence/restore round-trip is wired correctly
+    // for this handler, not that the position value itself is meaningful.
+    final long positionBeforeRestart = agentHandler.getPersistedPositionOfLastEntity();
+    final OffsetDateTime timestampBeforeRestart = agentHandler.getTimestampOfLastPersistedEntity();
+
+    // when: Optimize restarts
+    startAndUseNewOptimizeInstance();
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+    // then: handler restored the persisted position and timestamp from the index document
+    final PositionBasedImportIndexHandler agentHandlerAfterRestart =
+        embeddedOptimizeExtension.getAllPositionBasedImportHandlers().stream()
+            .filter(
+                h ->
+                    h
+                        instanceof
+                        io.camunda.optimize.service.importing.zeebe.handler
+                            .ZeebeAgentInstanceImportIndexHandler)
+            .findFirst()
+            .orElseThrow(
+                () ->
+                    new AssertionError(
+                        "ZeebeAgentInstanceImportIndexHandler not found after restart"));
+
+    assertThat(agentHandlerAfterRestart.getPersistedPositionOfLastEntity())
+        .isEqualTo(positionBeforeRestart);
+    assertThat(agentHandlerAfterRestart.getTimestampOfLastPersistedEntity())
+        .isEqualTo(timestampBeforeRestart);
+  }
+
+  @Test
   public void recordsAreFetchedWithSequenceOrPosition() {
     // given
     embeddedOptimizeExtension

--- a/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/DatabaseIntegrationTestExtension.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/DatabaseIntegrationTestExtension.java
@@ -218,6 +218,14 @@ public class DatabaseIntegrationTestExtension implements BeforeEachCallback, Aft
     databaseTestService.insertTestDocuments(amount, indexName, documentContentAsJson);
   }
 
+  /**
+   * Indexes an entry into the given raw index name (no Optimize prefix applied). Used to seed Zeebe
+   * export indices in tests.
+   */
+  public void addEntryWithRawIndex(final String rawIndexName, final String id, final Object entry) {
+    databaseTestService.addEntryWithRawIndex(rawIndexName, id, entry);
+  }
+
   public void initSchema(final DatabaseSchemaManager schemaManager) {
     databaseTestService.initSchema(schemaManager);
   }

--- a/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/db/DatabaseTestService.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/db/DatabaseTestService.java
@@ -176,6 +176,12 @@ public abstract class DatabaseTestService {
       final TermsQueryContainer queryForZeebeRecords,
       final Class<T> zeebeRecordClass);
 
+  /**
+   * Indexes an entry into the given raw index name (no Optimize prefix applied). Used to seed Zeebe
+   * test data.
+   */
+  public abstract void addEntryWithRawIndex(String rawIndexName, String id, Object entry);
+
   public abstract void deleteProcessInstancesFromIndex(final String indexName, final String id);
 
   public abstract DatabaseType getDatabaseVendor();

--- a/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/db/ElasticsearchDatabaseTestService.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/db/ElasticsearchDatabaseTestService.java
@@ -42,6 +42,7 @@ import co.elastic.clients.elasticsearch.core.DeleteByQueryRequest;
 import co.elastic.clients.elasticsearch.core.DeleteRequest;
 import co.elastic.clients.elasticsearch.core.GetRequest;
 import co.elastic.clients.elasticsearch.core.GetResponse;
+import co.elastic.clients.elasticsearch.core.IndexRequest;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.UpdateByQueryRequest;
@@ -222,6 +223,19 @@ public class ElasticsearchDatabaseTestService extends DatabaseTestService {
                           .refresh(Refresh.True)));
     } catch (final IOException e) {
       throw new OptimizeIntegrationTestException("Unable to add an entry to elasticsearch", e);
+    }
+  }
+
+  @Override
+  public void addEntryWithRawIndex(final String rawIndexName, final String id, final Object entry) {
+    try {
+      getOptimizeElasticClient()
+          .elasticsearchClient()
+          .index(
+              IndexRequest.of(
+                  i -> i.index(rawIndexName).id(id).document(entry).refresh(Refresh.True)));
+    } catch (final IOException e) {
+      throw new OptimizeIntegrationTestException("Unable to add a raw entry to elasticsearch", e);
     }
   }
 

--- a/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/db/OpenSearchDatabaseTestService.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/db/OpenSearchDatabaseTestService.java
@@ -213,6 +213,26 @@ public class OpenSearchDatabaseTestService extends DatabaseTestService {
   }
 
   @Override
+  public void addEntryWithRawIndex(final String rawIndexName, final String id, final Object entry) {
+    try {
+      final IndexRequest.Builder<Object> request =
+          new IndexRequest.Builder<>()
+              .document(entry)
+              .index(rawIndexName)
+              .id(id)
+              .refresh(Refresh.True);
+      final IndexResponse response =
+          getOptimizeOpenSearchClient().getOpenSearchClient().index(request.build());
+      if (!response.shards().failures().isEmpty()) {
+        throw new OptimizeIntegrationTestException(
+            String.format("Could not add raw entry to index %s with id %s", rawIndexName, id));
+      }
+    } catch (final IOException e) {
+      throw new OptimizeIntegrationTestException("Unable to add a raw entry to OpenSearch", e);
+    }
+  }
+
+  @Override
   public void addEntriesToDatabase(final String indexName, final Map<String, Object> idToEntryMap) {
     StreamSupport.stream(Iterables.partition(idToEntryMap.entrySet(), 10_000).spliterator(), false)
         .forEach(

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/importing/engine/service/zeebe/ZeebeAgentInstanceImportService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/importing/engine/service/zeebe/ZeebeAgentInstanceImportService.java
@@ -126,11 +126,14 @@ public class ZeebeAgentInstanceImportService
 
   private void mapDefinition(
       final AgentInstanceDto agentDto, final ZeebeAgentInstanceDataDto data) {
-    final AgentInstanceDto.AgentDefinitionDto definitionDto =
-        new AgentInstanceDto.AgentDefinitionDto();
-    definitionDto.setModel(data.getDefinition().getModel());
-    definitionDto.setProvider(data.getDefinition().getProvider());
-    agentDto.setDefinition(definitionDto);
+    final ZeebeAgentInstanceDataDto.AgentDefinitionValueDto zeebeDefinition = data.getDefinition();
+    if (zeebeDefinition != null) {
+      final AgentInstanceDto.AgentDefinitionDto definitionDto =
+          new AgentInstanceDto.AgentDefinitionDto();
+      definitionDto.setModel(zeebeDefinition.getModel());
+      definitionDto.setProvider(zeebeDefinition.getProvider());
+      agentDto.setDefinition(definitionDto);
+    }
   }
 
   private void mapMetrics(final AgentInstanceDto agentDto, final ZeebeAgentInstanceDataDto data) {

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/importing/engine/service/zeebe/ZeebeAgentInstanceImportServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/importing/engine/service/zeebe/ZeebeAgentInstanceImportServiceTest.java
@@ -618,7 +618,7 @@ class ZeebeAgentInstanceImportServiceTest {
     assertThat(agent.getStartDate())
         .as("startDate must only be seeded by a CREATED record")
         .isNull();
-    assertThat(agent.getDefinition().getModel())
+    assertThat(agent.getDefinition())
         .as("definition must only be mapped from a CREATED record")
         .isNull();
     assertThat(agent.getLastUpdatedDate()).isNotNull();

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/process/AgentInstanceDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/process/AgentInstanceDto.java
@@ -25,8 +25,8 @@ public class AgentInstanceDto implements Serializable, OptimizeDto {
   private OffsetDateTime lastUpdatedDate;
   private Long totalDurationInMs;
   private List<String> flowNodeInstanceIds = new ArrayList<>();
-  private AgentDefinitionDto definition = new AgentDefinitionDto();
-  private AgentMetricsDto metrics = new AgentMetricsDto();
+  private AgentDefinitionDto definition;
+  private AgentMetricsDto metrics;
   private List<AgentToolDto> tools = new ArrayList<>();
 
   public AgentInstanceDto() {}


### PR DESCRIPTION
## Description

Add IT coverage for Zeebe agent instance import

  Adds 15 integration test scenarios for the agent instance import pipeline, covering the full CREATED → UPDATED → COMPLETED lifecycle, cross-batch merging, null-safe field handling, and metrics
  accumulation.

  Two bugs discovered during test authoring:

   - Metrics data loss: AgentInstanceDto.metrics defaulted to new AgentMetricsDto(), which passed the Painless if (newAgent.metrics != null) guard and silently overwrote accumulated counters. Made
  nullable.
   - NPE in mapDefinition(): called data.getDefinition().getModel() unconditionally. Added null guard (same pattern as mapMetrics()). AgentInstanceDto.definition also made nullable for consistency.

  Files changed:

   - ZeebeAgentInstanceImportService — null guards for metrics and definition
   - AgentInstanceDto — nullable metrics and definition fields
   - AbstractBrokerlessZeebeCCSMIT — new brokerless IT base class with seedRecord() helper
   - ZeebeAgentInstanceImportIT / ZeebeAgentInstanceScriptIT / ZeebePositionBasedImportIndexIT — new/updated tests

## Related issues

closes https://github.com/camunda/camunda/issues/54068
