### PR TITLE
fix: make cursor pagination after/before optional

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/search-models.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/search-models.yaml
@@ -58,8 +58,6 @@ components:
     CursorForwardPagination:
       type: object
       title: Cursor-based forward pagination
-      required:
-        - after
       properties:
         after:
           description: Use the `endCursor` value from the previous response to fetch the next page of results.
@@ -81,8 +79,6 @@ components:
     CursorBackwardPagination:
       type: object
       title: Cursor-based backward pagination
-      required:
-        - before
       properties:
         before:
           description: Use the `startCursor` value from the previous response to fetch the previous page of results.


### PR DESCRIPTION
## Description

In the v2 REST API OpenAPI spec, `CursorForwardPagination` and `CursorBackwardPagination` marked their cursor field (`after`/`before`) as `required`. This is semantically incorrect — a first-page request legitimately omits the cursor — and it does not match the server's actual behavior, which accepts a cursor-less page object and returns 200.

`after` is "the `endCursor` value from the previous response". On the first request there is no previous response, so the client omits `after` and the server returns the first page. The cursor is therefore optional by construction, the same way `OffsetPagination.from` and `LimitPagination.limit` are optional.

This fix removes `after` from `CursorForwardPagination.required` and `before` from `CursorBackwardPagination.required` in `search-models.yaml`. The cursor fields stay declared; they are just no longer mandatory — matching offset/limit pagination and the server's real behavior.

No client code needs to change; this is a spec-accuracy fix.

Closes #54628