### PR TITLE
fix: validate parent path id on sub-resource search endpoints

### DIFF
--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/GroupMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/GroupMapper.java
@@ -15,6 +15,7 @@ import io.camunda.security.api.model.authz.EntityType;
 import io.camunda.service.GroupServices.GroupDTO;
 import io.camunda.service.GroupServices.GroupMemberDTO;
 import io.camunda.zeebe.util.Either;
+import java.util.Optional;
 import org.springframework.http.ProblemDetail;
 
 public class GroupMapper {
@@ -23,6 +24,10 @@ public class GroupMapper {
 
   public GroupMapper(final GroupRequestValidator groupRequestValidator) {
     this.groupRequestValidator = groupRequestValidator;
+  }
+
+  public Optional<ProblemDetail> validateGroupId(final String groupId) {
+    return groupRequestValidator.validateGroupId(groupId);
   }
 
   public Either<ProblemDetail, GroupDTO> toGroupCreateRequest(

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/RoleMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/RoleMapper.java
@@ -16,6 +16,7 @@ import io.camunda.service.RoleServices.CreateRoleRequest;
 import io.camunda.service.RoleServices.RoleMemberRequest;
 import io.camunda.service.RoleServices.UpdateRoleRequest;
 import io.camunda.zeebe.util.Either;
+import java.util.Optional;
 import org.springframework.http.ProblemDetail;
 
 public class RoleMapper {
@@ -24,6 +25,10 @@ public class RoleMapper {
 
   public RoleMapper(final RoleRequestValidator roleRequestValidator) {
     this.roleRequestValidator = roleRequestValidator;
+  }
+
+  public Optional<ProblemDetail> validateRoleId(final String roleId) {
+    return roleRequestValidator.validateRoleId(roleId);
   }
 
   public Either<ProblemDetail, CreateRoleRequest> toRoleCreateRequest(

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/TenantMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/TenantMapper.java
@@ -15,6 +15,7 @@ import io.camunda.security.api.model.authz.EntityType;
 import io.camunda.service.TenantServices.TenantMemberRequest;
 import io.camunda.service.TenantServices.TenantRequest;
 import io.camunda.zeebe.util.Either;
+import java.util.Optional;
 import org.springframework.http.ProblemDetail;
 
 public class TenantMapper {
@@ -23,6 +24,10 @@ public class TenantMapper {
 
   public TenantMapper(final TenantRequestValidator tenantRequestValidator) {
     this.tenantRequestValidator = tenantRequestValidator;
+  }
+
+  public Optional<ProblemDetail> validateTenantId(final String tenantId) {
+    return tenantRequestValidator.validateTenantId(tenantId);
   }
 
   public Either<ProblemDetail, TenantRequest> toTenantCreateDto(

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/GroupRequestValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/GroupRequestValidator.java
@@ -33,6 +33,10 @@ public final class GroupRequestValidator {
     return validate(() -> groupValidator.validate(groupId, request.getName()));
   }
 
+  public Optional<ProblemDetail> validateGroupId(final String groupId) {
+    return validate(() -> groupValidator.validateId(groupId));
+  }
+
   public Optional<ProblemDetail> validateMemberRequest(
       final String roleId, final String memberId, final EntityType memberType) {
     return validate(() -> groupValidator.validateMember(roleId, memberId, memberType));

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/RoleRequestValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/RoleRequestValidator.java
@@ -33,6 +33,10 @@ public final class RoleRequestValidator {
     return validate(() -> roleValidator.validate(roleId, request.getName()));
   }
 
+  public Optional<ProblemDetail> validateRoleId(final String roleId) {
+    return validate(() -> roleValidator.validateId(roleId));
+  }
+
   public Optional<ProblemDetail> validateMemberRequest(
       final String roleId, final String memberId, final EntityType memberType) {
     return validate(() -> roleValidator.validateMember(roleId, memberId, memberType));

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/TenantRequestValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/TenantRequestValidator.java
@@ -32,6 +32,10 @@ public final class TenantRequestValidator {
     return validate(() -> tenantValidator.validateUpdate(request.getName()));
   }
 
+  public Optional<ProblemDetail> validateTenantId(final String tenantId) {
+    return validate(() -> tenantValidator.validateId(tenantId));
+  }
+
   public Optional<ProblemDetail> validateMemberRequest(
       final String tenantId, final String memberId, final EntityType memberType) {
     return validate(() -> tenantValidator.validateTenantMember(tenantId, memberId, memberType));

--- a/security/security-validation/src/main/java/io/camunda/security/validation/GroupValidator.java
+++ b/security/security-validation/src/main/java/io/camunda/security/validation/GroupValidator.java
@@ -32,6 +32,12 @@ public final class GroupValidator {
     return identifierValidator.validateMembers(memberIds, memberType);
   }
 
+  public List<String> validateId(final String groupId) {
+    final List<String> violations = new ArrayList<>();
+    validateGroupId(groupId, violations);
+    return violations;
+  }
+
   public List<String> validateMember(
       final String roleId, final String memberId, final EntityType memberType) {
     final List<String> violations = new ArrayList<>();

--- a/security/security-validation/src/main/java/io/camunda/security/validation/RoleValidator.java
+++ b/security/security-validation/src/main/java/io/camunda/security/validation/RoleValidator.java
@@ -40,6 +40,12 @@ public final class RoleValidator {
     return violations;
   }
 
+  public List<String> validateId(final String roleId) {
+    final List<String> violations = new ArrayList<>();
+    validateRoleId(roleId, violations);
+    return violations;
+  }
+
   public List<String> validateMember(
       final String roleId, final String memberId, final EntityType memberType) {
     final List<String> violations = new ArrayList<>();

--- a/security/security-validation/src/main/java/io/camunda/security/validation/TenantValidator.java
+++ b/security/security-validation/src/main/java/io/camunda/security/validation/TenantValidator.java
@@ -40,6 +40,12 @@ public class TenantValidator {
     return identifierValidator.validateMembers(memberIds, memberType);
   }
 
+  public List<String> validateId(final String tenantId) {
+    final List<String> violations = new ArrayList<>();
+    validateTenantId(tenantId, violations);
+    return violations;
+  }
+
   public List<String> validateTenantMember(
       final String tenantId, final String memberId, final EntityType memberType) {
     final List<String> violations = new ArrayList<>();

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
@@ -142,6 +142,10 @@ public class TenantController {
       @PhysicalTenantId final String physicalTenantId,
       @PathVariable final String tenantId,
       @RequestBody(required = false) final TenantUserSearchQueryRequest query) {
+    final var idProblem = tenantMapper.validateTenantId(tenantId);
+    if (idProblem.isPresent()) {
+      return RestErrorMapper.mapProblemToResponse(idProblem.get());
+    }
     return SearchQueryRequestMapper.toTenantMemberQuery(query)
         .fold(
             RestErrorMapper::mapProblemToResponse,
@@ -237,6 +241,10 @@ public class TenantController {
       @PhysicalTenantId final String physicalTenantId,
       @PathVariable final String tenantId,
       @RequestBody(required = false) final MappingRuleSearchQueryRequest query) {
+    final var idProblem = tenantMapper.validateTenantId(tenantId);
+    if (idProblem.isPresent()) {
+      return RestErrorMapper.mapProblemToResponse(idProblem.get());
+    }
     return SearchQueryRequestMapper.toMappingRuleQuery(query)
         .fold(
             RestErrorMapper::mapProblemToResponse,
@@ -286,6 +294,10 @@ public class TenantController {
       @PhysicalTenantId final String physicalTenantId,
       @PathVariable final String tenantId,
       @RequestBody(required = false) final TenantGroupSearchQueryRequest query) {
+    final var idProblem = tenantMapper.validateTenantId(tenantId);
+    if (idProblem.isPresent()) {
+      return RestErrorMapper.mapProblemToResponse(idProblem.get());
+    }
     return SearchQueryRequestMapper.toTenantMemberQuery(query)
         .fold(
             RestErrorMapper::mapProblemToResponse,
@@ -312,6 +324,10 @@ public class TenantController {
       @PhysicalTenantId final String physicalTenantId,
       @PathVariable final String tenantId,
       @RequestBody(required = false) final RoleSearchQueryRequest query) {
+    final var idProblem = tenantMapper.validateTenantId(tenantId);
+    if (idProblem.isPresent()) {
+      return RestErrorMapper.mapProblemToResponse(idProblem.get());
+    }
     return SearchQueryRequestMapper.toRoleQuery(query)
         .fold(
             RestErrorMapper::mapProblemToResponse,
@@ -324,6 +340,10 @@ public class TenantController {
       @PhysicalTenantId final String physicalTenantId,
       @PathVariable final String tenantId,
       @RequestBody(required = false) final TenantClientSearchQueryRequest query) {
+    final var idProblem = tenantMapper.validateTenantId(tenantId);
+    if (idProblem.isPresent()) {
+      return RestErrorMapper.mapProblemToResponse(idProblem.get());
+    }
     return SearchQueryRequestMapper.toTenantMemberQuery(query)
         .fold(
             RestErrorMapper::mapProblemToResponse,

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupController.java
@@ -183,6 +183,10 @@ public class GroupController {
       @PhysicalTenantId final String physicalTenantId,
       @PathVariable final String groupId,
       @RequestBody(required = false) final GroupUserSearchQueryRequest query) {
+    final var idProblem = groupMapper.validateGroupId(groupId);
+    if (idProblem.isPresent()) {
+      return RestErrorMapper.mapProblemToResponse(idProblem.get());
+    }
     return SearchQueryRequestMapper.toGroupMemberQuery(query)
         .fold(
             RestErrorMapper::mapProblemToResponse,
@@ -195,6 +199,10 @@ public class GroupController {
       @PhysicalTenantId final String physicalTenantId,
       @PathVariable final String groupId,
       @RequestBody(required = false) final MappingRuleSearchQueryRequest query) {
+    final var idProblem = groupMapper.validateGroupId(groupId);
+    if (idProblem.isPresent()) {
+      return RestErrorMapper.mapProblemToResponse(idProblem.get());
+    }
     return SearchQueryRequestMapper.toMappingRuleQuery(query)
         .fold(
             RestErrorMapper::mapProblemToResponse,
@@ -207,6 +215,10 @@ public class GroupController {
       @PhysicalTenantId final String physicalTenantId,
       @PathVariable final String groupId,
       @RequestBody(required = false) final RoleSearchQueryRequest query) {
+    final var idProblem = groupMapper.validateGroupId(groupId);
+    if (idProblem.isPresent()) {
+      return RestErrorMapper.mapProblemToResponse(idProblem.get());
+    }
     return SearchQueryRequestMapper.toRoleQuery(query)
         .fold(
             RestErrorMapper::mapProblemToResponse,
@@ -219,6 +231,10 @@ public class GroupController {
       @PhysicalTenantId final String physicalTenantId,
       @PathVariable final String groupId,
       @RequestBody(required = false) final GroupClientSearchQueryRequest query) {
+    final var idProblem = groupMapper.validateGroupId(groupId);
+    if (idProblem.isPresent()) {
+      return RestErrorMapper.mapProblemToResponse(idProblem.get());
+    }
     return SearchQueryRequestMapper.toGroupMemberQuery(query)
         .fold(
             RestErrorMapper::mapProblemToResponse,

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
@@ -162,6 +162,10 @@ public class RoleController {
       @PhysicalTenantId final String physicalTenantId,
       @PathVariable final String roleId,
       @RequestBody(required = false) final RoleUserSearchQueryRequest query) {
+    final var idProblem = roleMapper.validateRoleId(roleId);
+    if (idProblem.isPresent()) {
+      return RestErrorMapper.mapProblemToResponse(idProblem.get());
+    }
     return SearchQueryRequestMapper.toRoleMemberQuery(query)
         .fold(
             RestErrorMapper::mapProblemToResponse,
@@ -188,6 +192,10 @@ public class RoleController {
       @PhysicalTenantId final String physicalTenantId,
       @PathVariable final String roleId,
       @RequestBody(required = false) final RoleClientSearchQueryRequest query) {
+    final var idProblem = roleMapper.validateRoleId(roleId);
+    if (idProblem.isPresent()) {
+      return RestErrorMapper.mapProblemToResponse(idProblem.get());
+    }
     return SearchQueryRequestMapper.toRoleMemberQuery(query)
         .fold(
             RestErrorMapper::mapProblemToResponse,
@@ -221,6 +229,10 @@ public class RoleController {
       @PhysicalTenantId final String physicalTenantId,
       @PathVariable final String roleId,
       @RequestBody(required = false) final MappingRuleSearchQueryRequest query) {
+    final var idProblem = roleMapper.validateRoleId(roleId);
+    if (idProblem.isPresent()) {
+      return RestErrorMapper.mapProblemToResponse(idProblem.get());
+    }
     return SearchQueryRequestMapper.toMappingRuleQuery(query)
         .fold(
             RestErrorMapper::mapProblemToResponse,
@@ -357,7 +369,10 @@ public class RoleController {
       @PhysicalTenantId final String physicalTenantId,
       @PathVariable final String roleId,
       @RequestBody(required = false) final RoleGroupSearchQueryRequest query) {
-
+    final var idProblem = roleMapper.validateRoleId(roleId);
+    if (idProblem.isPresent()) {
+      return RestErrorMapper.mapProblemToResponse(idProblem.get());
+    }
     return SearchQueryRequestMapper.toRoleMemberQuery(query)
         .fold(
             RestErrorMapper::mapProblemToResponse,

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
@@ -12,6 +12,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.search.entities.GroupEntity;
@@ -29,6 +30,7 @@ import io.camunda.search.sort.TenantSort;
 import io.camunda.security.api.context.CamundaAuthenticationProvider;
 import io.camunda.security.api.model.authz.EntityType;
 import io.camunda.security.spring.CamundaSecurityLibraryProperties;
+import io.camunda.security.validation.IdentifierValidator;
 import io.camunda.service.GroupServices;
 import io.camunda.service.MappingRuleServices;
 import io.camunda.service.RoleServices;
@@ -45,6 +47,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -54,6 +57,10 @@ import org.springframework.test.json.JsonCompareMode;
 public class TenantQueryControllerTest extends RestControllerTest {
   private static final String TENANT_BASE_URL = "/v2/tenants";
   private static final String SEARCH_TENANT_URL = "%s/search".formatted(TENANT_BASE_URL);
+  // When building the expected error messages including this regex, for some reason the backslashes
+  // disappear and have to be doubled to prevent that.
+  private static final String TENANT_ID_PATTERN =
+      IdentifierValidator.TENANT_ID_MASK.pattern().replace("\\", "\\\\");
   private static final Pattern ID_PATTERN =
       Pattern.compile(CamundaSecurityLibraryProperties.DEFAULT_ID_REGEX);
 
@@ -753,5 +760,37 @@ public class TenantQueryControllerTest extends RestControllerTest {
                       "instance": "%s"
                     }""",
                 SEARCH_TENANT_URL)));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"users", "clients", "mapping-rules", "groups", "roles"})
+  void shouldRejectSearchByTenantWithMalformedTenantId(final String subResource) {
+    // given
+    final var tenantId = "tenantId!";
+    final var path = "%s/%s/%s/search".formatted(TENANT_BASE_URL, tenantId, subResource);
+
+    // when / then
+    webClient
+        .post()
+        .uri(path)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{}")
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectBody()
+        .json(
+            """
+            {
+              "type": "about:blank",
+              "status": 400,
+              "title": "INVALID_ARGUMENT",
+              "detail": "The provided tenantId contains illegal characters. It must match the pattern '%s'.",
+              "instance": "%s"
+            }"""
+                .formatted(TENANT_ID_PATTERN, path),
+            JsonCompareMode.STRICT);
+    verifyNoInteractions(tenantServices, mappingRuleServices, groupServices, roleServices);
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupQueryControllerTest.java
@@ -12,6 +12,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -45,6 +46,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -981,5 +983,37 @@ public class GroupQueryControllerTest extends RestControllerTest {
                       "instance": "%s"
                     }""",
                 endpoint)));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"users", "clients", "mapping-rules", "roles"})
+  void shouldRejectSearchByGroupWithMalformedGroupId(final String subResource) {
+    // given
+    final var groupId = "groupId!";
+    final var path = "%s/%s/%s/search".formatted(GROUP_BASE_URL, groupId, subResource);
+
+    // when / then
+    webClient
+        .post()
+        .uri(path)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{}")
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectBody()
+        .json(
+            """
+            {
+              "type": "about:blank",
+              "status": 400,
+              "title": "INVALID_ARGUMENT",
+              "detail": "The provided groupId contains illegal characters. It must match the pattern '%s'.",
+              "instance": "%s"
+            }"""
+                .formatted(CamundaSecurityLibraryProperties.DEFAULT_ID_REGEX, path),
+            JsonCompareMode.STRICT);
+    verifyNoInteractions(groupServices, mappingServices, roleServices);
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleQueryControllerTest.java
@@ -11,6 +11,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.search.entities.MappingRuleEntity;
@@ -38,6 +39,8 @@ import java.util.List;
 import java.util.regex.Pattern;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -515,5 +518,37 @@ public class RoleQueryControllerTest extends RestControllerTest {
                     .filter(f -> f.roleId(roleId).memberType(EntityType.GROUP))
                     .build()),
             any());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"users", "clients", "mapping-rules", "groups"})
+  void shouldRejectSearchByRoleWithMalformedRoleId(final String subResource) {
+    // given
+    final var roleId = "roleId!";
+    final var path = "%s/%s/%s/search".formatted(ROLE_BASE_URL, roleId, subResource);
+
+    // when / then
+    webClient
+        .post()
+        .uri(path)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{}")
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectBody()
+        .json(
+            """
+            {
+              "type": "about:blank",
+              "status": 400,
+              "title": "INVALID_ARGUMENT",
+              "detail": "The provided roleId contains illegal characters. It must match the pattern '%s'.",
+              "instance": "%s"
+            }"""
+                .formatted(CamundaSecurityLibraryProperties.DEFAULT_ID_REGEX, path),
+            JsonCompareMode.STRICT);
+    verifyNoInteractions(roleServices, mappingRuleServices);
   }
 }


### PR DESCRIPTION
## Description

The v2 REST sub-resource collection-search endpoints `POST /v2/{collection}/{parentId}/{sub}/search` did not validate the `{parentId}` path parameter. A syntactically-illegal parent id — one that violates the parameter's declared `pattern`/`maxLength` in the OpenAPI spec — was silently accepted, and the server returned `200` with an empty result set instead of `400`.


## Fix

Validate the parent id (`roleId`/`groupId`/`tenantId`) at the start of each affected search endpoint, reusing the existing identifier validators (`RoleValidator`/`GroupValidator`/`TenantValidator` via the respective mappers). A malformed parent id now returns `400 INVALID_ARGUMENT` before the search executes, matching create/member-mutation behavior and the OpenAPI contract.

### Affected operations (13)
- **roleId**: searchUsersByRole, searchClientsByRole, searchMappingRulesByRole, searchGroupsByRole
- **groupId**: usersByGroup, mappingRulesByGroup, rolesByGroup, clientsByGroup
- **tenantId**: searchUsersInTenant, searchClientsInTenant, searchMappingRulesForTenant, searchGroupIdsInTenant, searchRolesInTenant

## Scope
- Only syntactically-malformed parent ids are rejected with `400`. Well-formed-but-nonexistent ids continue to return an empty result set (no `404`) — search endpoints conventionally return empty collections for no matches.

## Backward compatibility
There is a behavior change for clients that relied on `200`-empty for malformed parent ids. Because the OpenAPI contract already declares the path-parameter constraints, returning `400` is contract-correct.

## Tests
Added parameterized controller tests asserting `400` for a malformed parent id across all 13 endpoints (RoleQueryControllerTest, GroupQueryControllerTest, TenantQueryControllerTest).

## Discovered via
camunda/api-test-generator#125 (request-validation false-200 on path-param constraint violations).

Closes #54630