### PR TITLE
test: bump postMigrationAssertionOptions timeout to 480s

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/batch-operation-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/batch-operation-requestHelpers.ts
@@ -140,10 +140,14 @@ export async function expectBatchState(
 // Post-migration user-task search has to wait for the secondary-storage
 // indexer to reflect the migrated elementId. On a loaded shared cluster the
 // 180s budget proved tight (seen as flake on nightly runs), 240s proved tight
-// too (observed in nightly runs on 2026-06-03), so allow up to 360s.
+// too (observed in nightly runs on 2026-06-03), 360s proved tight too
+// (observed in nightly runs on 2026-06-04), so allow up to 480s.
 export const postMigrationAssertionOptions = {
-  intervals: [5_000, 10_000, 15_000, 25_000, 35_000, 45_000, 60_000, 60_000],
-  timeout: 360_000,
+  intervals: [
+    5_000, 10_000, 15_000, 25_000, 35_000, 45_000, 60_000, 60_000, 60_000,
+    60_000,
+  ],
+  timeout: 480_000,
 };
 
 export const notFoundDetail = (key: string) =>


### PR DESCRIPTION
## Description

The `postMigrationAssertionOptions` timeout (used when polling for the Elasticsearch indexer to reflect a migrated user-task `elementId`) timed out at 360 s on the 2026-06-04 nightly run: https://github.com/camunda/camunda/actions/runs/26925957367/job/79435995899

Failure: test **"Create a Batch Operation to Migrate Process Instances - With Multiple Filters"** in `qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-create-batch-to-migrate-api.spec.ts`. The assertion waited the full 360 s but the ES secondary-storage indexer had not yet reflected the migrated `elementId` on the loaded shared CI cluster.

Timeline of budget increases:
- 180 s → too tight (original)
- 240 s → too tight (nightly 2026-06-03)
- 360 s → too tight (nightly 2026-06-04)
- **480 s** → this PR

Also extends the explicit intervals list by two more 60 s entries so the polling schedule covers more of the new budget explicitly.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #