### PR TITLE
fix: partition health status was published after leaving partition

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/PartitionRegistrationStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/PartitionRegistrationStep.java
@@ -47,6 +47,7 @@ public final class PartitionRegistrationStep implements StartupStep<PartitionSta
     context.diskSpaceUsageMonitor().removeDiskUsageListener(context.zeebePartition());
     context.brokerHealthCheckService().removeMonitoredPartition(context.zeebePartition());
     context.topologyManager().removePartition(partitionId);
+    // TODO: failure listener added to ZeebePartition is not removed here.
 
     result.complete(context);
     return result;

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyManagerImpl.java
@@ -240,6 +240,9 @@ public final class TopologyManagerImpl extends Actor
   public void onHealthChanged(final int partitionId, final HealthStatus status) {
     actor.run(
         () -> {
+          if (!localPartitionGroupInfo.getPartitionRoles().containsKey(partitionId)) {
+            return;
+          }
           if (status == HealthStatus.HEALTHY) {
             localPartitionGroupInfo.setPartitionHealthy(partitionId);
           } else if (status == HealthStatus.UNHEALTHY) {
@@ -257,6 +260,7 @@ public final class TopologyManagerImpl extends Actor
         () -> {
           removeIfLeader(localPartitionGroupInfo, partitionId);
           localPartitionGroupInfo.removePartition(partitionId);
+          publishTopologyChanges();
         });
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/topology/TopologyManagerImplTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/topology/TopologyManagerImplTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.partitioning.topology;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.atomix.cluster.ClusterMembershipService;
+import io.atomix.cluster.Member;
+import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
+import io.camunda.zeebe.scheduler.ActorScheduler;
+import io.camunda.zeebe.util.health.HealthStatus;
+import java.time.Duration;
+import java.util.Properties;
+import java.util.Set;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+final class TopologyManagerImplTest {
+
+  private static final int PARTITION_ID = 1;
+  private static final Duration TIMEOUT = Duration.ofSeconds(5);
+
+  @AutoClose private ActorScheduler scheduler;
+  private BrokerInfo brokerInfo;
+  private TopologyManagerImpl topologyManager;
+
+  @BeforeEach
+  void setUp() {
+    final var localMember = mock(Member.class);
+    when(localMember.properties()).thenReturn(new Properties());
+
+    final var membershipService = mock(ClusterMembershipService.class);
+    when(membershipService.getLocalMember()).thenReturn(localMember);
+    when(membershipService.getMembers()).thenReturn(Set.of());
+
+    brokerInfo = new BrokerInfo(0, null, "localhost:26501");
+    brokerInfo.setFollowerForPartition(PARTITION_ID);
+
+    scheduler = ActorScheduler.newActorScheduler().build();
+    scheduler.start();
+
+    topologyManager = new TopologyManagerImpl(membershipService, brokerInfo);
+    scheduler.submitActor(topologyManager).join();
+  }
+
+  @Test
+  void shouldIgnoreHealthChangedAfterPartitionRemoved() {
+    // given - removePartition queued first, onHealthChanged(DEAD) queued second
+    topologyManager.removePartition(PARTITION_ID);
+    topologyManager.onHealthChanged(PARTITION_ID, HealthStatus.DEAD);
+
+    // then - partition must not appear in broker info even after the stale health event fires.
+    // `during` covers the window after removePartition completes but before onHealthChanged runs.
+    Awaitility.await()
+        .atMost(TIMEOUT)
+        .during(Duration.ofMillis(200))
+        .untilAsserted(
+            () -> {
+              assertThat(brokerInfo.getPartitionRoles()).doesNotContainKey(PARTITION_ID);
+              assertThat(brokerInfo.getPartitionHealthStatuses()).doesNotContainKey(PARTITION_ID);
+            });
+  }
+
+  @Test
+  void shouldRemovePartitionAfterHealthTransitionToDeadDuringShutdown() {
+    // given - health transitions to DEAD before removePartition is called (Order A)
+    topologyManager.onHealthChanged(PARTITION_ID, HealthStatus.DEAD);
+    // removePartition queued after onHealthChanged
+    topologyManager.removePartition(PARTITION_ID);
+
+    // then - partition must be cleared after removePartition runs.
+    // Since onHealthChanged was queued first, it ran first; removePartition cleans up after it.
+    Awaitility.await()
+        .atMost(TIMEOUT)
+        .untilAsserted(
+            () -> {
+              assertThat(brokerInfo.getPartitionRoles()).doesNotContainKey(PARTITION_ID);
+              assertThat(brokerInfo.getPartitionHealthStatuses()).doesNotContainKey(PARTITION_ID);
+            });
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/PartitionJoinTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/PartitionJoinTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.it.cluster.clustering.dynamic;
 
 import static io.camunda.zeebe.it.cluster.clustering.dynamic.Utils.assertChangeIsPlanned;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.management.cluster.PlannedOperationsResponse;
 import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
@@ -62,8 +63,30 @@ final class PartitionJoinTest {
           .untilAsserted(
               () -> ClusterActuatorAssert.assertThat(cluster).hasCompletedChanges(leave));
       ClusterActuatorAssert.assertThat(cluster).hasAppliedChanges(leave);
+      assertPartitionIsAbsent(cluster, scenario);
       cluster.awaitHealthyTopology();
     }
+  }
+
+  private void assertPartitionIsAbsent(final TestCluster cluster, final Scenario scenario) {
+    Awaitility.await("broker no longer reports partition in gRPC topology")
+        .atMost(JOIN_TIMEOUT)
+        .untilAsserted(
+            () -> {
+              try (final var client =
+                  cluster.newClientBuilder().preferRestOverGrpc(false).build()) {
+                final var topology = client.newTopologyRequest().send().join();
+                assertThat(topology.getBrokers())
+                    .filteredOn(b -> b.getNodeId() == scenario.operation().brokerId())
+                    .hasSize(1)
+                    .element(0)
+                    .satisfies(
+                        b ->
+                            assertThat(b.getPartitions())
+                                .noneMatch(
+                                    p -> p.getPartitionId() == scenario.operation().partitionId()));
+              }
+            });
   }
 
   static Stream<Scenario> testScenarios() {


### PR DESCRIPTION
## Description
There's a race condition between setting partition health in ZeebePartition failure listener and TopologyManagerImpl.removePartition. They run on different actors and it might happen that the partition UNHEALTHY status is published after the partition was removed. Before the fix, the UNHEALTHY status was added even if the partition was already removed.

The IT test assertion has been hardened to verify that the removed partition is not present in the health  status

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #51938
