### PR TITLE
perf: skip metadata serialization when no handler matched

### DIFF
--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporter.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporter.java
@@ -114,13 +114,18 @@ public class AnalyticsExporter implements Exporter {
 
   @Override
   public void export(final Record<?> record) {
+    boolean hasHandledRecord = false;
     try {
-      handlers.handle(record);
+      hasHandledRecord = handlers.handle(record);
     } catch (final Exception e) {
       SAMPLED_WARN_LOG.warn("Failed to handle record at position {}", record.getPosition(), e);
     }
-
-    controller.updateLastExportedRecordPosition(record.getPosition(), metadata.serialize());
+    if (hasHandledRecord) {
+      controller.updateLastExportedRecordPosition(record.getPosition(), metadata.serialize());
+    } else {
+      // No need to serialize the metadata if it didn't change.
+      controller.updateLastExportedRecordPosition(record.getPosition());
+    }
   }
 
   private void scheduleMetricFlush() {

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporter.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporter.java
@@ -114,17 +114,20 @@ public class AnalyticsExporter implements Exporter {
 
   @Override
   public void export(final Record<?> record) {
-    boolean hasHandledRecord = false;
-    try {
-      hasHandledRecord = handlers.handle(record);
-    } catch (final Exception e) {
-      SAMPLED_WARN_LOG.warn("Failed to handle record at position {}", record.getPosition(), e);
-    }
-    if (hasHandledRecord) {
+    if (tryHandle(record)) {
       controller.updateLastExportedRecordPosition(record.getPosition(), metadata.serialize());
     } else {
       // No need to serialize the metadata if it didn't change.
       controller.updateLastExportedRecordPosition(record.getPosition());
+    }
+  }
+
+  private boolean tryHandle(final Record<?> record) {
+    try {
+      return handlers.handle(record);
+    } catch (final Exception e) {
+      SAMPLED_WARN_LOG.warn("Failed to handle record at position {}", record.getPosition(), e);
+      return false;
     }
   }
 

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporter.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporter.java
@@ -114,20 +114,17 @@ public class AnalyticsExporter implements Exporter {
 
   @Override
   public void export(final Record<?> record) {
-    if (tryHandle(record)) {
+    boolean hasHandledRecord = false;
+    try {
+      hasHandledRecord = handlers.handle(record);
+    } catch (final Exception e) {
+      SAMPLED_WARN_LOG.warn("Failed to handle record at position {}", record.getPosition(), e);
+    }
+    if (hasHandledRecord) {
       controller.updateLastExportedRecordPosition(record.getPosition(), metadata.serialize());
     } else {
       // No need to serialize the metadata if it didn't change.
       controller.updateLastExportedRecordPosition(record.getPosition());
-    }
-  }
-
-  private boolean tryHandle(final Record<?> record) {
-    try {
-      return handlers.handle(record);
-    } catch (final Exception e) {
-      SAMPLED_WARN_LOG.warn("Failed to handle record at position {}", record.getPosition(), e);
-      return false;
     }
   }
 

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporter.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporter.java
@@ -114,13 +114,12 @@ public class AnalyticsExporter implements Exporter {
 
   @Override
   public void export(final Record<?> record) {
-    boolean hasHandledRecord = false;
     try {
-      hasHandledRecord = handlers.handle(record);
+      handlers.handle(record);
     } catch (final Exception e) {
       SAMPLED_WARN_LOG.warn("Failed to handle record at position {}", record.getPosition(), e);
     }
-    if (hasHandledRecord) {
+    if (metadata.isDirty()) {
       controller.updateLastExportedRecordPosition(record.getPosition(), metadata.serialize());
     } else {
       // No need to serialize the metadata if it didn't change.

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporterMetadata.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporterMetadata.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.analytics;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -21,6 +22,13 @@ final class AnalyticsExporterMetadata {
   private long eventSequenceNumber;
 
   private long metricSequenceNumber;
+
+  /**
+   * Transient flag: true when a mutating method has been called since the last {@link #serialize()}
+   * or construction. Never persisted — Jackson setters must NOT set this flag so that a freshly
+   * deserialized object starts clean.
+   */
+  @JsonIgnore private boolean dirty;
 
   /** No-arg constructor required by Jackson. */
   AnalyticsExporterMetadata() {}
@@ -39,6 +47,7 @@ final class AnalyticsExporterMetadata {
   }
 
   public long incrementAndGetEventSequenceNumber() {
+    dirty = true;
     return ++eventSequenceNumber;
   }
 
@@ -51,12 +60,21 @@ final class AnalyticsExporterMetadata {
   }
 
   public long incrementAndGetMetricSequenceNumber() {
+    dirty = true;
     return ++metricSequenceNumber;
+  }
+
+  /** Returns true if a mutating method has been called since construction or last serialization. */
+  @JsonIgnore
+  boolean isDirty() {
+    return dirty;
   }
 
   byte[] serialize() {
     try {
-      return OBJECT_MAPPER.writeValueAsBytes(this);
+      final var bytes = OBJECT_MAPPER.writeValueAsBytes(this);
+      dirty = false;
+      return bytes;
     } catch (final JsonProcessingException e) {
       throw new RuntimeException("Failed to serialize exporter metadata", e);
     }

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/HandlerRegistry.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/HandlerRegistry.java
@@ -52,14 +52,16 @@ final class HandlerRegistry {
 
   /** Routes the record to its handler. Does nothing if no handler is registered. */
   @SuppressWarnings({"unchecked", "rawtypes"})
-  void handle(final Record<?> record) {
+  boolean handle(final Record<?> record) {
     final var intentMap = handlers.get(record.getValueType());
     if (intentMap == null) {
-      return;
+      return false;
     }
     final AnalyticsHandler handler = intentMap.get(record.getIntent());
     if (handler != null) {
       handler.handle(record);
+      return true;
     }
+    return false;
   }
 }

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/HandlerRegistry.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/HandlerRegistry.java
@@ -52,16 +52,15 @@ final class HandlerRegistry {
 
   /** Routes the record to its handler. Does nothing if no handler is registered. */
   @SuppressWarnings({"unchecked", "rawtypes"})
-  boolean handle(final Record<?> record) {
+  void handle(final Record<?> record) {
     final var intentMap = handlers.get(record.getValueType());
     if (intentMap == null) {
-      return false;
+      return;
     }
     final AnalyticsHandler handler = intentMap.get(record.getIntent());
     if (handler == null) {
-      return false;
+      return;
     }
     handler.handle(record);
-    return true;
   }
 }

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/HandlerRegistry.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/HandlerRegistry.java
@@ -58,10 +58,10 @@ final class HandlerRegistry {
       return false;
     }
     final AnalyticsHandler handler = intentMap.get(record.getIntent());
-    if (handler != null) {
-      handler.handle(record);
-      return true;
+    if (handler == null) {
+      return false;
     }
-    return false;
+    handler.handle(record);
+    return true;
   }
 }

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterMetadataTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterMetadataTest.java
@@ -48,4 +48,64 @@ class AnalyticsExporterMetadataTest {
     assertThat(metadata.incrementAndGetMetricSequenceNumber()).isEqualTo(11);
     assertThat(metadata.incrementAndGetMetricSequenceNumber()).isEqualTo(12);
   }
+
+  @Test
+  void shouldNotBeDirtyOnConstruction() {
+    // given / when
+    final var metadata = new AnalyticsExporterMetadata();
+
+    // then
+    assertThat(metadata.isDirty()).isFalse();
+  }
+
+  @Test
+  void shouldBeDirtyAfterIncrementingEventSequenceNumber() {
+    // given
+    final var metadata = new AnalyticsExporterMetadata();
+
+    // when
+    metadata.incrementAndGetEventSequenceNumber();
+
+    // then
+    assertThat(metadata.isDirty()).isTrue();
+  }
+
+  @Test
+  void shouldBeDirtyAfterIncrementingMetricSequenceNumber() {
+    // given
+    final var metadata = new AnalyticsExporterMetadata();
+
+    // when
+    metadata.incrementAndGetMetricSequenceNumber();
+
+    // then
+    assertThat(metadata.isDirty()).isTrue();
+  }
+
+  @Test
+  void shouldNotBeDirtyAfterSerialize() {
+    // given
+    final var metadata = new AnalyticsExporterMetadata();
+    metadata.incrementAndGetEventSequenceNumber();
+    assertThat(metadata.isDirty()).isTrue();
+
+    // when
+    metadata.serialize();
+
+    // then
+    assertThat(metadata.isDirty()).isFalse();
+  }
+
+  @Test
+  void shouldNotBeDirtyAfterDeserialize() {
+    // given
+    final var original = new AnalyticsExporterMetadata(3, 7);
+    final var bytes = original.serialize();
+
+    // when
+    final var restored = AnalyticsExporterMetadata.deserialize(bytes);
+
+    // then — Jackson setters must not mark the restored object as dirty
+    assertThat(restored.isDirty()).isFalse();
+  }
 }

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterTest.java
@@ -18,6 +18,9 @@ import io.camunda.zeebe.exporter.test.ExporterTestController;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import io.opentelemetry.api.logs.LogRecordBuilder;
@@ -145,16 +148,27 @@ class AnalyticsExporterTest {
   }
 
   @Test
-  void shouldNotSerializeMetadataForUnhandledRecords() {
-    // given — fresh controller with no pre-existing metadata
-    final var unhandledRecord = FACTORY.generateRecord(ValueType.JOB);
+  void shouldNotSerializeMetadataWhenHandlerNoOps() {
+    // given — a record that passes the AnalyticsRecordFilter but the handler skips because the
+    // element isn't an ad-hoc sub-process. This is the realistic hot-path no-op case.
+    final var value =
+        ImmutableProcessInstanceRecordValue.builder()
+            .withBpmnElementType(BpmnElementType.SERVICE_TASK)
+            .build();
+    final var record =
+        FACTORY.generateRecord(
+            ValueType.PROCESS_INSTANCE,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                    .withValue(value));
 
     // when
-    exporter.export(unhandledRecord);
+    exporter.export(record);
 
-    // then — position advances but no metadata was written, because the handler did not
-    // touch the metadata so serializing it again would be wasted work
-    assertThat(controller.getPosition()).isEqualTo(unhandledRecord.getPosition());
+    // then — position advances but no metadata was written, because the handler didn't touch
+    // it so serializing again would be wasted work
+    assertThat(controller.getPosition()).isEqualTo(record.getPosition());
     assertThat(controller.readMetadata()).isEmpty();
   }
 

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterTest.java
@@ -145,6 +145,20 @@ class AnalyticsExporterTest {
   }
 
   @Test
+  void shouldNotSerializeMetadataForUnhandledRecords() {
+    // given — fresh controller with no pre-existing metadata
+    final var unhandledRecord = FACTORY.generateRecord(ValueType.JOB);
+
+    // when
+    exporter.export(unhandledRecord);
+
+    // then — position advances but no metadata was written, because the handler did not
+    // touch the metadata so serializing it again would be wasted work
+    assertThat(controller.getPosition()).isEqualTo(unhandledRecord.getPosition());
+    assertThat(controller.readMetadata()).isEmpty();
+  }
+
+  @Test
   void shouldInstallRecordFilterOnConfigure() {
     // given
     final var context =

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterTest.java
@@ -159,6 +159,74 @@ class AnalyticsExporterTest {
   }
 
   @Test
+  void shouldPersistMetadataWhenHandlerThrowsAfterMutation() {
+    // given — OtelSdkManager that increments the sequence number and then throws
+    final var throwingController = new ExporterTestController();
+    final var throwingExporter = exporterWithMutatingThrowingOtel(throwingController);
+    final var record = piCreatedEvent();
+
+    // when — export must not propagate the exception
+    assertThatCode(() -> throwingExporter.export(record)).doesNotThrowAnyException();
+
+    // then — metadata was persisted despite the exception, because the mutation happened before
+    // throw
+    assertThat(throwingController.readMetadata())
+        .isPresent()
+        .get()
+        .satisfies(
+            bytes -> {
+              final var persisted = AnalyticsExporterMetadata.deserialize(bytes);
+              assertThat(persisted.getEventSequenceNumber()).isEqualTo(1L);
+            });
+  }
+
+  @Test
+  void shouldPersistMetadataMutatedOutsideHandler() {
+    // given — a custom OtelSdkManager that exposes the metadata so the test can simulate a gauge
+    // flush callback (which bumps the metric sequence number outside the export path)
+    final var metricOnlyController = new ExporterTestController();
+    final var metadataHolder = new AnalyticsExporterMetadata[1];
+    final var metricOnlyExporter =
+        newExporter(
+            new OtelSdkManager() {
+              @Override
+              OtelSdkManager initialize(
+                  final AnalyticsExporterConfig cfg,
+                  final AnalyticsExporterContext ctx,
+                  final AnalyticsExporterMetadata meta) {
+                metadataHolder[0] = meta;
+                return this;
+              }
+
+              @Override
+              public void logEvent(
+                  final String eventName,
+                  final long logPosition,
+                  final Consumer<LogRecordBuilder> builder) {
+                // no-op — event logging is not under test here
+              }
+            },
+            metricOnlyController);
+
+    // Simulate the gauge flush callback bumping the metric sequence number outside the export path.
+    metadataHolder[0].incrementAndGetMetricSequenceNumber();
+
+    // when — export an unhandled record (no handler runs, but metadata is already dirty)
+    final var unhandledRecord = FACTORY.generateRecord(ValueType.JOB);
+    metricOnlyExporter.export(unhandledRecord);
+
+    // then — metadata was persisted because the metric seqnum was bumped outside the export path
+    assertThat(metricOnlyController.readMetadata())
+        .isPresent()
+        .get()
+        .satisfies(
+            bytes -> {
+              final var persisted = AnalyticsExporterMetadata.deserialize(bytes);
+              assertThat(persisted.getMetricSequenceNumber()).isEqualTo(1L);
+            });
+  }
+
+  @Test
   void shouldInstallRecordFilterOnConfigure() {
     // given
     final var context =
@@ -248,6 +316,37 @@ class AnalyticsExporterTest {
               final long logPosition,
               final Consumer<LogRecordBuilder> builder) {
             throw new RuntimeException("simulated failure");
+          }
+        },
+        controller);
+  }
+
+  /**
+   * Builds an exporter whose {@code OtelSdkManager.logEvent} increments the event sequence number
+   * (via the metadata reference captured during {@code initialize}) and then throws. This simulates
+   * a handler that mutates metadata and then fails mid-way.
+   */
+  private static AnalyticsExporter exporterWithMutatingThrowingOtel(
+      final ExporterTestController controller) {
+    final var metadataHolder = new AnalyticsExporterMetadata[1];
+    return newExporter(
+        new OtelSdkManager() {
+          @Override
+          OtelSdkManager initialize(
+              final AnalyticsExporterConfig cfg,
+              final AnalyticsExporterContext ctx,
+              final AnalyticsExporterMetadata meta) {
+            metadataHolder[0] = meta;
+            return this;
+          }
+
+          @Override
+          public void logEvent(
+              final String eventName,
+              final long logPosition,
+              final Consumer<LogRecordBuilder> builder) {
+            metadataHolder[0].incrementAndGetEventSequenceNumber();
+            throw new RuntimeException("simulated failure after mutation");
           }
         },
         controller);


### PR DESCRIPTION
## Description

The analytics exporter serialized its metadata on every exported record, even for records no handler cared about. Since unhandled records dominate the stream, that was a lot of wasted CPU and allocation on the hot path.

The `AnalyticsExporterMetadata` tacks if it's dirty or not, which `serialize()` clears. `AnalyticsExporter.export` only passes the serialized metadata to the controller when `metadata.isDirty()` is true. This way we no longer serialize the metadata on unhandled exporterd records.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #54643