### PR TITLE
ci: try different maven lock

### DIFF
--- a/.github/actions/setup-maven-cache/action.yaml
+++ b/.github/actions/setup-maven-cache/action.yaml
@@ -27,8 +27,10 @@ runs:
       #
       # `aether.enhancedLocalRepository.split` splits between local and remote artifacts.
       # `aether.enhancedLocalRepository.splitRemote` splits remote artifacts into released and snapshot
-      # `aether.syncContext.*` config ensures that maven uses file locks to prevent corruption
-      #      from downloading multiple artifacts at the same time.
+      # `aether.syncContext.*` config ensures that maven uses JVM in-memory read-write locks
+      #      to prevent corruption from downloading multiple artifacts at the same time.
+      #      `rwlock-local` is preferred over `file-lock` for CI where only one Maven process runs
+      #      per job. File locks caused timeouts on high-core-count runners (inc-5871).
       # `aether.dependencyCollector.impl=bf` uses a breadth first algorithm when resolving/downloading poms.
       #     The `bf` collector is suggested when the project contains many modules and dependencies.
       run: |
@@ -41,9 +43,8 @@ runs:
         -D aether.transport.http.retryHandler.count=5
         -D aether.enhancedLocalRepository.split=true
         -D aether.enhancedLocalRepository.splitRemote=true
-        -D aether.syncContext.named.nameMapper=file-gav
-        -D aether.syncContext.named.factory=file-lock
-        -D aether.syncContext.named.time=180
+        -D aether.syncContext.named.nameMapper=gav
+        -D aether.syncContext.named.factory=rwlock-local
         -D maven.artifact.threads=32
         -D aether.dependencyCollector.impl=bf
         EOF
@@ -105,3 +106,10 @@ runs:
         key: ${{ env.MAVEN_CACHE_KEY }}
         restore-keys: |
           ${{ env.MAVEN_CACHE_KEY_PREFIX }}
+
+    - name: DEBUG
+      shell: bash
+      run: |
+        ls -lah ~/.m2/repository/ || true
+        ls -lah ~/.m2/repository/.locks || true
+        rm -rf ~/.m2/repository/.locks || true


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
