### PR TITLE
fix: use @ConditionalOnBean in VirtualThreadsAutoConfiguration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -704,7 +704,7 @@ jobs:
           DISTRIBUTED="':zeebe-atomix-cluster',':zeebe-atomix-utils',':zeebe-broker',':zeebe-broker-client',':zeebe-cluster-config',':dynamic-node-id-provider',':zeebe-journal',':zeebe-logstreams',':zeebe-restore',':zeebe-scheduler',':zeebe-snapshots',':zeebe-stream-platform',':zeebe-transport'"
 
           # Zeebe modules owned by @camunda/camundaex
-          CLIENT="':camunda-client-java',':camunda-spring-boot-starter-virtual-threads'"
+          CLIENT="':camunda-client-java'"
 
           # General UT configuration
           GENERAL_UT_EXTRA_SKIP="camunda-exporter rdbms-exporter"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -704,7 +704,7 @@ jobs:
           DISTRIBUTED="':zeebe-atomix-cluster',':zeebe-atomix-utils',':zeebe-broker',':zeebe-broker-client',':zeebe-cluster-config',':dynamic-node-id-provider',':zeebe-journal',':zeebe-logstreams',':zeebe-restore',':zeebe-scheduler',':zeebe-snapshots',':zeebe-stream-platform',':zeebe-transport'"
 
           # Zeebe modules owned by @camunda/camundaex
-          CLIENT="':camunda-client-java'"
+          CLIENT="':camunda-client-java',':camunda-spring-boot-starter-virtual-threads'"
 
           # General UT configuration
           GENERAL_UT_EXTRA_SKIP="camunda-exporter rdbms-exporter"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -906,6 +906,17 @@ jobs:
               "stressRun": 1
             },
             {
+              "group": "qa-clients",
+              "name": "Clients",
+              "maven-modules": "clients/camunda-spring-boot-starter,clients/camunda-spring-boot-3-starter,clients/camunda-spring-boot-starter-virtual-threads,clients/java",
+              "maven-build-threads": 1,
+              "maven-test-fork-count": 1,
+              "runs-on": "gcp-perf-core-8-default",
+              "owner": "@camunda/camundaex",
+              "module": "Clients",
+              "stressRun": 1
+            },
+            {
               "group": "qa-update",
               "name": "Zeebe QA - Update",
               "maven-modules": "zeebe/qa/update-tests",

--- a/clients/camunda-spring-boot-starter-virtual-threads/src/main/java/io/camunda/client/virtualthreads/VirtualThreadsAutoConfiguration.java
+++ b/clients/camunda-spring-boot-starter-virtual-threads/src/main/java/io/camunda/client/virtualthreads/VirtualThreadsAutoConfiguration.java
@@ -25,8 +25,9 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
@@ -51,7 +52,7 @@ public class VirtualThreadsAutoConfiguration {
    * @return the configured executor service without metrics
    */
   @Bean
-  @ConditionalOnMissingClass("io.micrometer.core.instrument.MeterRegistry")
+  @ConditionalOnMissingBean(type = "io.micrometer.core.instrument.MeterRegistry")
   public CamundaClientExecutorService camundaClientExecutorServiceWithoutMetrics() {
     final ThreadFactory virtualThreadFactory = createVirtualThreadFactory();
     final ExecutorService jobHandlingExecutor =
@@ -75,10 +76,8 @@ public class VirtualThreadsAutoConfiguration {
    */
   @Configuration(proxyBeanMethods = false)
   @ConditionalOnClass(
-      name = {
-        "io.micrometer.core.instrument.MeterRegistry",
-        "org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration"
-      })
+      name = {"org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration"})
+  @ConditionalOnBean(type = "io.micrometer.core.instrument.MeterRegistry")
   static class MeteredConfiguration {
 
     /**

--- a/clients/camunda-spring-boot-starter-virtual-threads/src/main/java/io/camunda/client/virtualthreads/VirtualThreadsAutoConfiguration.java
+++ b/clients/camunda-spring-boot-starter-virtual-threads/src/main/java/io/camunda/client/virtualthreads/VirtualThreadsAutoConfiguration.java
@@ -47,7 +47,9 @@ import org.springframework.context.annotation.Lazy;
 public class VirtualThreadsAutoConfiguration {
 
   /**
-   * Fallback bean when Micrometer is not on the classpath.
+   * Fallback bean used when no {@link io.micrometer.core.instrument.MeterRegistry} bean is
+   * available — either because Micrometer is absent from the classpath, or because it is present
+   * but no registry bean has been configured.
    *
    * @return the configured executor service without metrics
    */
@@ -76,7 +78,10 @@ public class VirtualThreadsAutoConfiguration {
    */
   @Configuration(proxyBeanMethods = false)
   @ConditionalOnClass(
-      name = {"org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration"})
+      name = {
+        "io.micrometer.core.instrument.MeterRegistry",
+        "org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration"
+      })
   @ConditionalOnBean(type = "io.micrometer.core.instrument.MeterRegistry")
   static class MeteredConfiguration {
 

--- a/clients/camunda-spring-boot-starter-virtual-threads/src/test/java/io/camunda/client/virtualthreads/VirtualThreadsAutoConfigurationTest.java
+++ b/clients/camunda-spring-boot-starter-virtual-threads/src/test/java/io/camunda/client/virtualthreads/VirtualThreadsAutoConfigurationTest.java
@@ -58,6 +58,20 @@ class VirtualThreadsAutoConfigurationTest {
   }
 
   @Test
+  void shouldFallBackToUnmeteredExecutorWhenMeterRegistryBeanMissing() {
+    // micrometer-core and actuator are on the classpath, but no MeterRegistry bean is configured —
+    // the context must still start using the unmetered executor (regression test for the startup
+    // failure this configuration guards against)
+    contextRunner()
+        .run(
+            context -> {
+              assertThat(context).hasSingleBean(CamundaClientExecutorService.class);
+              assertThat(context.getBean(CamundaClientExecutorService.class))
+                  .isNotInstanceOf(MeteredCamundaClientExecutorService.class);
+            });
+  }
+
+  @Test
   void shouldNotCreateMeteredExecutorWhenActuatorAbsent() {
     // micrometer is on test classpath, but actuator is filtered out — metered bean requires both
     contextRunner()


### PR DESCRIPTION
## Description
`VirtualThreadsAutoConfigurationIT.shouldCreateCamundaClientExecutorServiceBean` was failing to run as the micrometer class was present in the class path but not valid bean was present, failing to start the application.

The module was not part of the test, so the run is not currently being run in the CI

## Checklist

<!--- Please delete options that are not relevant. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

