### PR TITLE
Backport read-db-versions action (#51049, 8.7 scope) to release/optimize-8.7.22

### DIFF
--- a/.ci/db-versions.yml
+++ b/.ci/db-versions.yml
@@ -1,0 +1,19 @@
+# Database versions
+#
+# Single source of truth for all database versions tested in CI and deployed to SaaS.
+#
+# ── How to use this file in CI workflows ────────────────────────────────────────
+#   CI workflows read versions from this file via the reusable action:
+#     .github/actions/read-db-versions
+#
+# ── SaaS version ────────────────────────────────────────────────────────────────
+#   The `saas` field under elasticsearch identifies which version is deployed to
+#   SaaS environments. It must always reference one of the listed es8 versions via
+#   a YAML anchor so that the SaaS version cannot drift from what is tested in CI.
+# ────────────────────────────────────────────────────────────────────────────────
+
+elasticsearch:
+  es8:
+    - &saas "8.13.4"
+    - "8.13.0"
+  saas: *saas

--- a/.github/actions/read-db-versions/README.md
+++ b/.github/actions/read-db-versions/README.md
@@ -1,0 +1,51 @@
+# Read DB Versions
+
+Parses `.ci/db-versions.yml` and exposes the configured database versions as
+named outputs that downstream jobs can consume in service container image tags
+or environment variables.
+
+## Purpose
+
+Centralises all database version pins in a single YAML file (`.ci/db-versions.yml`)
+so that a version bump is a one-line change rather than a grep-and-replace across
+multiple workflow files.
+
+## Outputs
+
+|      Output       |                          Description                           |
+|-------------------|----------------------------------------------------------------|
+| `elasticsearch-8` | Latest supported ES 8 minor version (last entry in `es8` list) |
+| `saas`            | Elasticsearch version currently deployed to SaaS environments  |
+
+## Example usage
+
+```yaml
+jobs:
+  read-versions:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      elasticsearch-8: ${{ steps.db-versions.outputs.elasticsearch-8 }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Read DB versions
+        id: db-versions
+        uses: ./.github/actions/read-db-versions
+
+  test:
+    needs: [read-versions]
+    services:
+      elasticsearch:
+        image: docker.elastic.co/elasticsearch/elasticsearch:${{ needs.read-versions.outputs.elasticsearch-8 }}
+```
+
+## How to update a version
+
+Edit `.ci/db-versions.yml`. The YAML anchor on the SaaS entry (`&saas`) ensures
+`saas` always references a version that is also present in the `es8` test list —
+update the anchor value when promoting SaaS to a new minor.
+
+## Owner
+
+@camunda/data-layer

--- a/.github/actions/read-db-versions/action.yml
+++ b/.github/actions/read-db-versions/action.yml
@@ -1,0 +1,25 @@
+name: Read DB Versions
+description: |
+  Parses .ci/db-versions.yml and exposes the configured database versions as named outputs.
+  The repository must already be checked out before this action is called.
+
+outputs:
+  elasticsearch-8:
+    value: ${{ steps.parse.outputs.elasticsearch-8 }}
+  saas:
+    value: ${{ steps.parse.outputs.saas }}
+
+runs:
+  using: composite
+  steps:
+    - name: Python setup
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      with:
+        python-version: "3.x"
+    - name: Install Python dependencies
+      shell: bash
+      run: python3 -m pip install -q --disable-pip-version-check pyyaml==6.0.2
+    - name: Parse DB versions
+      id: parse
+      shell: bash
+      run: python3 .github/actions/read-db-versions/generate-db-versions.py >> "$GITHUB_OUTPUT"

--- a/.github/actions/read-db-versions/generate-db-versions.py
+++ b/.github/actions/read-db-versions/generate-db-versions.py
@@ -1,0 +1,19 @@
+"""
+Reads .ci/db-versions.yml and writes the configured database versions as key=value
+lines to stdout, ready to be appended to $GITHUB_OUTPUT.
+"""
+
+import yaml
+
+
+def set_output(name, value):
+    print(f"{name}={value}")
+
+
+with open(".ci/db-versions.yml") as f:
+    versions = yaml.safe_load(f)
+
+es8_versions = versions["elasticsearch"]["es8"]
+
+set_output("elasticsearch-8", es8_versions[-1])
+set_output("saas",            versions["elasticsearch"]["saas"])

--- a/.github/conftest-unified-ci-rules.rego
+++ b/.github/conftest-unified-ci-rules.rego
@@ -1,0 +1,197 @@
+package main
+
+# This file contains rules checking GHA workflow files of the Unified CI to be
+# aligned with the inclusion criteria and best practices:
+# See https://github.com/camunda/camunda/wiki/CI-&-Automation#unified-ci
+
+# The `input` variable is a data structure that contains a YAML file's contents
+# as objects and arrays. See https://www.openpolicyagent.org/docs/latest/philosophy/#how-does-opa-work
+
+deny[msg] {
+    # only enforced on workflows that opted-in
+    input.env.GHA_BEST_PRACTICES_LINTER == "enabled"
+
+    count(get_jobs_without_timeoutminutes(input.jobs)) > 0
+
+    msg := sprintf("There are GitHub Actions jobs without timeout-minutes! Affected job IDs: %s",
+        [concat(", ", get_jobs_without_timeoutminutes(input.jobs))])
+}
+
+warn[msg] {
+    # only enforced on workflows that opted-in
+    input.env.GHA_BEST_PRACTICES_LINTER == "enabled"
+
+    count(get_jobs_with_timeoutminutes_higher_than(input.jobs, 15)) > 0
+
+    msg := sprintf("There are GitHub Actions jobs with too high (>15) timeout-minutes! Affected job IDs: %s",
+        [concat(", ", get_jobs_with_timeoutminutes_higher_than(input.jobs, 15))])
+}
+
+deny[msg] {
+    # only enforced on workflows that opted-in
+    input.env.GHA_BEST_PRACTICES_LINTER == "enabled"
+
+    count(get_jobs_without_cihealth(input.jobs)) > 0
+
+    msg := sprintf("There are GitHub Actions jobs that don't send CI Health metrics! Affected job IDs: %s",
+        [concat(", ", get_jobs_without_cihealth(input.jobs))])
+}
+
+deny[msg] {
+    # only enforced on workflows that opted-in
+    input.env.GHA_BEST_PRACTICES_LINTER == "enabled"
+
+    count(get_jobs_without_permissions(input.jobs)) > 0
+
+    msg := sprintf("There are GitHub Actions jobs using default GITHUB_TOKEN permissions which are too wide! Affected job IDs: %s",
+        [concat(", ", get_jobs_without_permissions(input.jobs))])
+}
+
+deny[msg] {
+    # only enforced on Unified CI since it is specific to detect-changes job
+    input.name == "CI"
+
+    count(get_jobs_not_needing_detectchanges(input.jobs)) > 0
+
+    msg := sprintf("There are GitHub Actions jobs in Unified CI that don't depend on detect-changes job! Affected job IDs: %s",
+        [concat(", ", get_jobs_not_needing_detectchanges(input.jobs))])
+}
+
+deny[msg] {
+    # only enforced on Unified CI since it is specific to check-results job
+    input.name == "CI"
+
+    jobs_that_should_fail_checkresults := { job_id |
+        job := input.jobs[job_id]
+
+        # no Unified CI jobs running after (and including) "check-results" job
+        job_id != "check-results"
+        not startswith(job_id, "deploy-")
+        not startswith(job_id, "utils-")
+    }
+
+    jobs_that_actually_fail_checkresults := {x | x := input.jobs["check-results"].needs[_]}
+
+    jobs_that_should_fail_checkresults != jobs_that_actually_fail_checkresults
+
+    msg := sprintf("There are GitHub Actions jobs in Unified CI that check-results job doesn't depend on! Affected job IDs: %s",
+        [concat(", ", jobs_that_should_fail_checkresults - jobs_that_actually_fail_checkresults)])
+}
+
+deny[msg] {
+    # only enforced on Unified CI since it is specific to jobs after check-results job
+    input.name == "CI"
+
+    count(get_jobs_after_checkresults_without_ifalways(input.jobs)) > 0
+
+    msg := sprintf("There are GitHub Actions jobs in Unified CI that depend on check-results but without specifying `if: always()...` which means they will get skipped! Affected job IDs: %s",
+        [concat(", ", get_jobs_after_checkresults_without_ifalways(input.jobs))])
+}
+
+###########################   RULE HELPERS   ##################################
+
+get_jobs_without_timeoutminutes(jobInput) = jobs_without_timeoutminutes {
+    jobs_without_timeoutminutes := { job_id |
+        job := jobInput[job_id]
+
+        # not enforced on jobs that invoke other reusable workflows (instead enforced there)
+        not job.uses
+
+        # check if there is timeout-minutes specified
+        not job["timeout-minutes"]
+    }
+}
+
+get_jobs_with_timeoutminutes_higher_than(jobInput, max_timeout) = jobs_without_timeoutminutes {
+    jobs_without_timeoutminutes := { job_id |
+        job := jobInput[job_id]
+
+        # not enforced on jobs that invoke other reusable workflows (instead enforced there)
+        not job.uses
+
+        # check if timeout-minutes is higher than allowed maximum
+        job["timeout-minutes"] > max_timeout
+    }
+}
+
+get_jobs_without_cihealth(jobInput) = jobs_without_cihealth {
+    jobs_without_cihealth := { job_id |
+        job := jobInput[job_id]
+
+        # not enforced on "special" jobs needed for control flow in Unified CI
+        job_id != "detect-changes"
+        job_id != "generate-db-versions"
+        job_id != "check-results"
+        job_id != "test-summary"
+        job_id != "get-concurrency-group-dynamically"
+        job_id != "get-snapshot-docker-version-tag"
+        # temporary for docker-build-helm-integration.yml workflow from alwaysgreen
+        job_id != "format-identifier"
+        job_id != "should-run"
+
+        # not enforced on jobs that invoke other reusable workflows (instead enforced there)
+        not job.uses
+
+        # check that there is at least one step that invokes CI Health metric submission helper action
+        cihealth_steps := { step |
+            step := job.steps[_]
+            step.name == "Observe build status"
+            step.uses == "./.github/actions/observe-build-status"
+        }
+        count(cihealth_steps) < 1
+    }
+}
+
+get_jobs_without_permissions(jobInput) = jobs_without_permissions {
+    jobs_without_permissions := { job_id |
+        job := jobInput[job_id]
+
+        # not enforced on jobs that invoke other reusable workflows (instead enforced there)
+        not job.uses
+
+        not job.permissions
+    }
+}
+
+get_jobs_not_needing_detectchanges(jobInput) = jobs_not_needing_detectchanges {
+    jobs_not_needing_detectchanges := { job_id |
+        job := jobInput[job_id]
+
+        # not enforced on Unified CI jobs that are part of change detection control flow structure
+        job_id != "detect-changes"
+        job_id != "check-results"
+
+        # not enforced on Unified CI jobs running after "check-results" job
+        not startswith(job_id, "deploy-")
+        not startswith(job_id, "utils-")
+
+        # check if job declares dependency on "detect-changes" job anywhere
+        job_needs_detectchanges := { need |
+            need := job.needs[_]
+            need == "detect-changes"
+        }
+        count(job_needs_detectchanges) == 0
+    }
+}
+
+get_jobs_after_checkresults_without_ifalways(jobInput) = jobs_after_checkresults_without_ifalways {
+    jobs_after_checkresults_without_ifalways := { job_id |
+        job := jobInput[job_id]
+
+        # check if job declares dependency on "check-results" job anywhere
+        job_needs_checkresults := { need |
+            need := job.needs[_]
+            need == "check-results"
+        }
+        count(job_needs_checkresults) == 1
+
+        # check that the job declares an `if: ...` condition and it contains `always()`
+        #
+        # this is important because GHA by default skips execution of jobs that itself
+        # depend on jobs (transitively) that were skipped - which happens a lot in Unified CI
+        # and we want to avoid accidentally skipping deploy jobs or similar
+        #
+        job_if := object.get(job, "if", "")  # get with empty default value
+        not contains(job_if, "always() && needs.check-results.result == 'success'")
+    }
+}

--- a/.github/workflows/check-saas-version.yml
+++ b/.github/workflows/check-saas-version.yml
@@ -1,0 +1,71 @@
+# description: Guards against accidentally downgrading the SaaS Elasticsearch version in .ci/db-versions.yml
+# test location: .ci/db-versions.yml
+# type: CI
+# owner: @camunda/data-layer
+---
+# Guards against accidentally downgrading the SaaS Elasticsearch version in
+# .ci/db-versions.yml.
+#
+# To enforce this as a merge requirement, add "Check SaaS version / Check SaaS
+# version does not decrease" to the required status checks in branch protection.
+
+name: Check SaaS version
+
+on:
+  pull_request:
+    paths:
+      - .ci/db-versions.yml
+
+jobs:
+  check-saas-version:
+    name: Check SaaS version does not decrease
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Install Python dependencies
+        run: python3 -m pip install -q --disable-pip-version-check pyyaml==6.0.2
+      - name: Compare SaaS version against base branch
+        env:
+          SKIP_LABEL: "ci:allow-saas-downgrade"
+          PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+          BASE_BRANCH: ${{ github.base_ref }}
+        shell: bash
+        run: |
+          if echo "$PR_LABELS" | python3 -c "import json,sys; sys.exit(0 if '$SKIP_LABEL' in json.load(sys.stdin) else 1)"; then
+            echo "Label '$SKIP_LABEL' is set — skipping version check."
+            exit 0
+          fi
+
+          PR_VERSION=$(python3 -c "import yaml; print(yaml.safe_load(open('.ci/db-versions.yml'))['elasticsearch']['saas'])")
+          git fetch origin "$BASE_BRANCH" --depth=1
+          if ! git show "origin/$BASE_BRANCH:.ci/db-versions.yml" > /dev/null 2>&1; then
+            echo ".ci/db-versions.yml does not exist on $BASE_BRANCH — nothing to compare against."
+            exit 0
+          fi
+          BASE_VERSION=$(git show "origin/$BASE_BRANCH:.ci/db-versions.yml" | python3 -c "import yaml,sys; print(yaml.safe_load(sys.stdin)['elasticsearch']['saas'])")
+
+          echo "SaaS version on $BASE_BRANCH: $BASE_VERSION"
+          echo "SaaS version on this PR:      $PR_VERSION"
+
+          python3 - <<EOF
+          import sys
+
+          def parse(v):
+              return tuple(int(x) for x in v.split("."))
+
+          pr   = parse("$PR_VERSION")
+          base = parse("$BASE_VERSION")
+
+          if pr < base:
+              print(f"::error::SaaS version decreased: {base} -> {pr}.")
+              print(f"::error::If this is intentional, add the label '$SKIP_LABEL' to the PR.")
+              sys.exit(1)
+
+          print(f"OK: {base} -> {pr}")
+          EOF

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,22 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
+  generate-db-versions:
+    name: "Generate DB versions"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: [ detect-changes ]
+    permissions:
+      contents: read
+    outputs:
+      elasticsearch-8: ${{ steps.db-versions.outputs.elasticsearch-8 }}
+      saas: ${{ steps.db-versions.outputs.saas }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Read DB versions
+        id: db-versions
+        uses: ./.github/actions/read-db-versions
+
   optimize-frontend-unit-tests:
     if: needs.detect-changes.outputs.optimize-frontend-changes == 'true'
     needs: [detect-changes]
@@ -322,6 +338,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - actionlint
+      - generate-db-versions
       - java-unit-tests
       - java-checks
       - optimize-frontend-unit-tests


### PR DESCRIPTION
## Intent

Restores the `read-db-versions` composite action so the Optimize 8.7.22 release-candidate build stops failing at **Read DB versions** / **Post Setup Maven**.

The Optimize Release Camunda Optimize C8 workflow (`.github/workflows/optimize-release-optimize-c8-only.yml`) first checks out `main` (where the action exists), runs Setup Maven, then does a second checkout of `release/optimize-8.7.22`. After that second checkout, any call to `./.github/actions/read-db-versions` fails with "Can't find 'action.yml'" because the action was introduced after this release branch was cut.

**This is a release-branch backport. Do NOT auto-merge or squash into `stable/8.7`.**

## Cherry-picked commit

Source commit: `c0d8f621e85dc38e26cc3a3f10690c74be53a631` from `stable/8.7`  
PR on stable/8.7: #52483 ("Backport of #51049 to stable/8.7 — partial, 8.7 scope only")  
Commit message: `ci: centralize database versions as SSOT in .ci/db-versions.yml`

## Files changed (`git show --stat`)

```
 .ci/db-versions.yml                                |  19 ++
 .github/actions/read-db-versions/README.md         |  51 ++++++
 .github/actions/read-db-versions/action.yml        |  25 +++
 .github/actions/read-db-versions/generate-db-versions.py |  19 ++
 .github/conftest-unified-ci-rules.rego             | 197 +++++++++++++++++++++
 .github/workflows/check-saas-version.yml           |  71 ++++++++
 .github/workflows/ci.yml                           |  17 ++
 7 files changed, 399 insertions(+)
```

No ES9 / OpenSearch 3 / RDBMS matrix content — this branch is ES8-only and the `.ci/db-versions.yml` is ES8-only.

## ES version alignment

The backport commit's `.ci/db-versions.yml` had `elasticsearch-8: 8.14.1`. This branch's `pom.xml` has `elasticsearch.test.version=8.13.0` and the smoketest compose (`docker-compose.smoketest.yml`) defaults to `${ELASTIC_VERSION:-8.13.0}`.

**Before:** `8.14.1`  
**After:** `8.13.0`

The `saas` anchor (`8.13.4`) is unchanged — it is not consumed by the smoketest compose.

## Conflict resolution

The cherry-pick produced four conflicts, resolved as follows:

| File | Conflict type | Resolution |
|------|--------------|-----------|
| `.github/workflows/operate-e2e-tests.yml` | modify/delete (deleted on release branch) | Kept deleted (`git rm`) |
| `.github/workflows/tasklist-e2e-tests.yml` | modify/delete (deleted on release branch) | Kept deleted (`git rm`) |
| `.github/conftest-unified-ci-rules.rego` | modify/delete (absent on release branch) | Took incoming version (adds `generate-db-versions` CI Health exemption) |
| `.github/workflows/ci.yml` | content conflict | Added only the `generate-db-versions` job + its `check-results` needs entry; skipped `integration-tests`, `archunit-tests`, `docker-checks` (not relevant to Optimize release branch) |