### PR TITLE
fix: provide anonymous SecurityContext in Operate data generator

### DIFF
--- a/operate/data-generator/pom.xml
+++ b/operate/data-generator/pom.xml
@@ -48,6 +48,11 @@
       <artifactId>camunda-search-client</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-security-core</artifactId>
+    </dependency>
+
     <!-- SPRING -->
     <dependency>
       <groupId>org.springframework</groupId>

--- a/operate/data-generator/src/main/java/io/camunda/operate/data/AbstractDataGenerator.java
+++ b/operate/data-generator/src/main/java/io/camunda/operate/data/AbstractDataGenerator.java
@@ -15,6 +15,7 @@ import io.camunda.client.api.worker.JobWorker;
 import io.camunda.operate.data.usertest.UserTestDataGenerator;
 import io.camunda.search.clients.ProcessDefinitionSearchClient;
 import io.camunda.search.query.ProcessDefinitionQuery;
+import io.camunda.security.auth.SecurityContext;
 import io.camunda.security.spring.CamundaSecurityLibraryProperties;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
@@ -116,6 +117,8 @@ public abstract class AbstractDataGenerator implements DataGenerator {
       final boolean exists;
       exists =
           processDefinitionSearchClient
+                  .withSecurityContext(
+                      SecurityContext.of(b -> b.withAuthentication(a -> a.anonymous(true))))
                   .searchProcessDefinitions(ProcessDefinitionQuery.of(q -> q))
                   .total()
               > 0;


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

It seems like this PR https://github.com/camunda/camunda/pull/54557 add a bug when we're running `make env-up` on Operate

This PR addresses that