### PR TITLE
fix: Prevent users from claiming tasks as other users

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskClaimProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskClaimProcessor.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.usertask.processors;
 import static io.camunda.zeebe.engine.processing.usertask.processors.UserTaskAuthorizationHelper.buildProcessDefinitionRequest;
 import static io.camunda.zeebe.engine.processing.usertask.processors.UserTaskAuthorizationHelper.buildUserTaskRequest;
 
+import io.camunda.zeebe.auth.Authorization;
 import io.camunda.zeebe.engine.processing.AsyncRequestBehavior;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
@@ -28,6 +29,7 @@ import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.Either;
 import java.util.List;
+import java.util.Optional;
 
 public final class UserTaskClaimProcessor implements UserTaskCommandProcessor {
 
@@ -37,6 +39,8 @@ public final class UserTaskClaimProcessor implements UserTaskCommandProcessor {
       "Expected to claim user task with key '%d', but it has already been assigned";
   private static final String INVALID_USER_TASK_EMPTY_ASSIGNEE_MESSAGE =
       "Expected to claim user task with key '%d', but provided assignee is empty";
+  private static final String INVALID_USER_TASK_CLAIM_FOR_OTHER_USER_MESSAGE =
+      "Expected to claim user task with key '%d', but the assignee '%s' does not match the calling user '%s'";
 
   private final StateWriter stateWriter;
   private final TypedResponseWriter responseWriter;
@@ -140,6 +144,18 @@ public final class UserTaskClaimProcessor implements UserTaskCommandProcessor {
               String.format(INVALID_USER_TASK_EMPTY_ASSIGNEE_MESSAGE, userTaskKey)));
     }
 
+    final Optional<String> callerUsername = getCallerUsername(command);
+    if (callerUsername.isPresent() && !callerUsername.get().equals(newAssignee)) {
+      return Either.left(
+          new Rejection(
+              RejectionType.FORBIDDEN,
+              String.format(
+                  INVALID_USER_TASK_CLAIM_FOR_OTHER_USER_MESSAGE,
+                  userTaskKey,
+                  newAssignee,
+                  callerUsername.get())));
+    }
+
     final String currentAssignee = userTaskRecord.getAssignee();
     final boolean canClaim = currentAssignee.isBlank() || currentAssignee.equals(newAssignee);
     if (!canClaim) {
@@ -150,5 +166,10 @@ public final class UserTaskClaimProcessor implements UserTaskCommandProcessor {
     }
 
     return Either.right(userTaskRecord);
+  }
+
+  private static Optional<String> getCallerUsername(final TypedRecord<?> command) {
+    return Optional.ofNullable(
+        (String) command.getAuthorizations().get(Authorization.AUTHORIZED_USERNAME));
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/ClaimUserTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/ClaimUserTaskTest.java
@@ -251,6 +251,36 @@ public class ClaimUserTaskTest {
   }
 
   @Test
+  public void shouldAllowServiceAccountToClaimUserTaskForAnotherUser() {
+    // given
+    ENGINE.deployment().withXmlResource(process()).deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final long userTaskKey =
+        RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst()
+            .getKey();
+
+    // when
+    final var claimingRecord =
+        ENGINE.userTask().withKey(userTaskKey).withAssignee("target-user").claimAsClient("svc");
+
+    // then
+    Assertions.assertThat(claimingRecord)
+        .hasRecordType(RecordType.EVENT)
+        .hasIntent(UserTaskIntent.CLAIMING);
+
+    final var assignedRecord =
+        RecordingExporter.userTaskRecords(UserTaskIntent.ASSIGNED)
+            .filter(r -> r.getPosition() > claimingRecord.getPosition())
+            .getFirst();
+
+    Assertions.assertThat(assignedRecord.getValue())
+        .hasUserTaskKey(userTaskKey)
+        .hasAssignee("target-user");
+  }
+
+  @Test
   public void shouldRejectClaimIfUserTaskIsCompleted() {
     // given
     ENGINE.deployment().withXmlResource(process()).deploy();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/MultiTenantUserTaskOperationsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/MultiTenantUserTaskOperationsTest.java
@@ -129,7 +129,7 @@ public class MultiTenantUserTaskOperationsTest {
 
     // when
     final var claimingRecord =
-        ENGINE.userTask().ofInstance(processInstanceKey).withAssignee("foo").claim(username);
+        ENGINE.userTask().ofInstance(processInstanceKey).withAssignee(username).claim(username);
 
     // then
     Assertions.assertThat(claimingRecord)
@@ -148,7 +148,7 @@ public class MultiTenantUserTaskOperationsTest {
             recordValue ->
                 Assertions.assertThat(recordValue)
                     .hasAction("claim")
-                    .hasAssignee("foo")
+                    .hasAssignee(username)
                     .hasTenantId(tenantId));
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskClaimAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskClaimAuthorizationTest.java
@@ -83,7 +83,7 @@ public class UserTaskClaimAuthorizationTest {
     engine
         .userTask()
         .ofInstance(processInstanceKey)
-        .withAssignee("assignee")
+        .withAssignee(DEFAULT_USER.getUsername())
         .claim(DEFAULT_USER.getUsername());
 
     // then
@@ -490,6 +490,39 @@ public class UserTaskClaimAuthorizationTest {
                 .withProcessInstanceKey(processInstanceKey)
                 .exists())
         .isTrue();
+  }
+
+  @Test
+  public void shouldRejectClaimWhenAssigneeDoesNotMatchCaller() {
+    // given
+    final var processInstanceKey = createProcessInstance(process());
+    final var caller = createUser();
+    final var otherUser = createUser();
+    authorizationHelper.addPermissionsToUser(
+        caller.getUsername(),
+        DEFAULT_USER.getUsername(),
+        AuthorizationResourceType.PROCESS_DEFINITION,
+        PermissionType.CLAIM_USER_TASK,
+        AuthorizationScope.WILDCARD);
+
+    // when
+    final var rejection =
+        engine
+            .userTask()
+            .ofInstance(processInstanceKey)
+            .withAssignee(otherUser.getUsername())
+            .expectRejection()
+            .claim(caller.getUsername());
+
+    // then
+    Assertions.assertThat(rejection)
+        .hasRejectionType(RejectionType.FORBIDDEN)
+        .hasRejectionReason(
+            "Expected to claim user task with key '%d', but the assignee '%s' does not match the calling user '%s'"
+                .formatted(
+                    getUserTaskKey(processInstanceKey),
+                    otherUser.getUsername(),
+                    caller.getUsername()));
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskRejectionCommandTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskRejectionCommandTest.java
@@ -33,19 +33,26 @@ public class UserTaskRejectionCommandTest {
 
   private static final String TENANT = "custom-tenant";
   private static final String USERNAME = "tenant-user";
+  private static final String USERNAME2 = "tenant-user-2";
 
   @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
 
   @BeforeClass
   public static void setUp() {
+    ENGINE.tenant().newTenant().withTenantId(TENANT).create();
     final var user = ENGINE.user().newUser(USERNAME).create().getValue();
-    final var createdUsername = user.getUsername();
-    ENGINE.tenant().newTenant().withTenantId(TENANT).create().getValue().getTenantKey();
     ENGINE
         .tenant()
         .addEntity(TENANT)
         .withEntityType(EntityType.USER)
-        .withEntityId(createdUsername)
+        .withEntityId(user.getUsername())
+        .add();
+    final var user2 = ENGINE.user().newUser(USERNAME2).create().getValue();
+    ENGINE
+        .tenant()
+        .addEntity(TENANT)
+        .withEntityType(EntityType.USER)
+        .withEntityId(user2.getUsername())
         .add();
   }
 
@@ -124,22 +131,22 @@ public class UserTaskRejectionCommandTest {
             .withProcessInstanceKey(processInstanceKey)
             .getFirst();
 
-    // Claim the user task with user1
-    ENGINE.userTask().ofInstance(processInstanceKey).withAssignee("user1").claim(USERNAME);
+    // Claim the user task (self-claim: assignee == caller)
+    ENGINE.userTask().ofInstance(processInstanceKey).withAssignee(USERNAME).claim(USERNAME);
 
     // Wait for the task to be claimed
     RecordingExporter.userTaskRecords(UserTaskIntent.ASSIGNED)
         .withProcessInstanceKey(processInstanceKey)
         .await();
 
-    // when - try to claim the already claimed user task with user2
+    // when - a different tenant user tries to claim the already claimed user task
     final var rejectionRecord =
         ENGINE
             .userTask()
             .ofInstance(processInstanceKey)
-            .withAssignee("user2")
+            .withAssignee(USERNAME2)
             .expectRejection()
-            .claim(USERNAME);
+            .claim(USERNAME2);
 
     // then - verify the rejection record is enriched
     assertThat(rejectionRecord)
@@ -203,22 +210,22 @@ public class UserTaskRejectionCommandTest {
             .withProcessInstanceKey(childProcessInstanceKey)
             .getFirst();
 
-    // Claim the user task with user1
-    ENGINE.userTask().withKey(userTaskCreated.getKey()).withAssignee("user1").claim(USERNAME);
+    // Claim the user task (self-claim: assignee == caller)
+    ENGINE.userTask().withKey(userTaskCreated.getKey()).withAssignee(USERNAME).claim(USERNAME);
 
     // Wait for the task to be claimed
     RecordingExporter.userTaskRecords(UserTaskIntent.ASSIGNED)
         .withProcessInstanceKey(childProcessInstanceKey)
         .await();
 
-    // when - try to claim the already claimed user task
+    // when - a different tenant user tries to claim the already claimed user task
     final var rejectionRecord =
         ENGINE
             .userTask()
             .withKey(userTaskCreated.getKey())
-            .withAssignee("user2")
+            .withAssignee(USERNAME2)
             .expectRejection()
-            .claim(USERNAME);
+            .claim(USERNAME2);
 
     // then - verify the rejection record has the ROOT process instance key (parent), not the child
     assertThat(rejectionRecord)
@@ -365,22 +372,22 @@ public class UserTaskRejectionCommandTest {
             .withProcessInstanceKey(processInstanceKey)
             .getFirst();
 
-    // Claim the user task first with user1
-    ENGINE.userTask().withKey(userTaskCreated.getKey()).withAssignee("user1").claim(USERNAME);
+    // Claim the user task first (self-claim: assignee == caller)
+    ENGINE.userTask().withKey(userTaskCreated.getKey()).withAssignee(USERNAME).claim(USERNAME);
 
     // Wait for the task to be claimed
     RecordingExporter.userTaskRecords(UserTaskIntent.ASSIGNED)
         .withProcessInstanceKey(processInstanceKey)
         .await();
 
-    // when - try to claim the already claimed task with a different user (user2)
+    // when - a different tenant user tries to claim the already claimed task
     final var rejectionRecord =
         ENGINE
             .userTask()
             .withKey(userTaskCreated.getKey())
-            .withAssignee("user2")
+            .withAssignee(USERNAME2)
             .expectRejection()
-            .claim(USERNAME);
+            .claim(USERNAME2);
 
     // then - verify the rejection record is enriched (task exists, just can't be claimed again)
     assertThat(rejectionRecord)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/AuthorizationUtil.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/AuthorizationUtil.java
@@ -50,4 +50,16 @@ public class AuthorizationUtil {
     auth.setClaims(Map.of(claim, claimValue));
     return auth;
   }
+
+  public static AuthInfo getClientIdAuthInfo(
+      final String clientId, final String... authorizedTenantIds) {
+    final var auth = new AuthInfo();
+    auth.setClaims(
+        Map.of(
+            Authorization.AUTHORIZED_CLIENT_ID,
+            clientId,
+            Authorization.AUTHORIZED_TENANTS,
+            List.of(authorizedTenantIds)));
+    return auth;
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessingComposite.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessingComposite.java
@@ -363,6 +363,27 @@ public class StreamProcessingComposite implements CommandWriter {
 
   @Override
   public long writeCommand(
+      final long key,
+      final int requestStreamId,
+      final long requestId,
+      final Intent intent,
+      final AuthInfo authorizations,
+      final UnifiedRecordValue recordValue) {
+    final var writer =
+        streams
+            .newRecord(getLogName(partitionId))
+            .recordType(RecordType.COMMAND)
+            .key(key)
+            .requestStreamId(requestStreamId)
+            .requestId(requestId)
+            .intent(intent)
+            .authorizations(authorizations)
+            .event(recordValue);
+    return writeActor.submit(writer::write).join();
+  }
+
+  @Override
+  public long writeCommand(
       final int requestStreamId,
       final long requestId,
       final Intent intent,

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
@@ -326,6 +326,18 @@ public final class StreamProcessorRule implements TestRule, CommandWriter {
 
   @Override
   public long writeCommand(
+      final long key,
+      final int requestStreamId,
+      final long requestId,
+      final Intent intent,
+      final AuthInfo authorizations,
+      final UnifiedRecordValue recordValue) {
+    return streamProcessingComposite.writeCommand(
+        key, requestStreamId, requestId, intent, authorizations, recordValue);
+  }
+
+  @Override
+  public long writeCommand(
       final int requestStreamId,
       final long requestId,
       final Intent intent,

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/CommandWriter.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/CommandWriter.java
@@ -69,6 +69,14 @@ public interface CommandWriter {
       final String... authorizedTenants);
 
   long writeCommand(
+      final long key,
+      final int requestStreamId,
+      final long requestId,
+      final Intent intent,
+      final AuthInfo authorizations,
+      final UnifiedRecordValue recordValue);
+
+  long writeCommand(
       final int requestStreamId,
       final long requestId,
       final Intent intent,

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/UserTaskClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/UserTaskClient.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.util.client;
 
+import io.camunda.zeebe.engine.util.AuthorizationUtil;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
@@ -248,6 +249,21 @@ public final class UserTaskClient {
             username,
             userTaskRecord.setUserTaskKey(userTaskKey),
             TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+    return expectation.apply(position);
+  }
+
+  public Record<UserTaskRecordValue> claimAsClient(final String clientId) {
+    final long userTaskKey = findUserTaskKey();
+    final var authInfo =
+        AuthorizationUtil.getClientIdAuthInfo(clientId, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+    final long position =
+        writer.writeCommand(
+            userTaskKey,
+            DEFAULT_REQUEST_STREAM_ID,
+            DEFAULT_REQUEST_ID,
+            UserTaskIntent.CLAIM,
+            authInfo,
+            userTaskRecord.setUserTaskKey(userTaskKey));
     return expectation.apply(position);
   }
 


### PR DESCRIPTION
## Description

This PR hardens Zeebe’s user task claiming logic to prevent IDOR-style behavior where an authenticated user could claim a task for a different user by setting a mismatching assignee in the claim command, while still allowing service-account/client initiated claiming for another user.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes https://github.com/camunda/camunda/issues/49490
