### PR TITLE
fix: reuse credentials when already in use

### DIFF
--- a/.github/workflows/camunda-load-test-smoke.yml
+++ b/.github/workflows/camunda-load-test-smoke.yml
@@ -91,39 +91,16 @@ jobs:
       # Issues with the load test applications, should ideally catched with integration tests.
       orchestration-tag: SNAPSHOT
 
-
   verify-install:
     name: Verify Install
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
     needs: [sanitize-branch-name, smoke-install]
     permissions:
       contents: 'read'
       id-token: 'write'
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: teleport-actions/setup@b638ff596557cc3959eb6b5287d5e58e0c8ac6a6 # v1.1.1
-        with:
-          proxy: camunda.teleport.sh:443
-          version: auto
-      - uses: teleport-actions/auth-k8s@0f46164469ae4fcd4d359d40e06bab17d4be17c9 # v2.0.6
-        with:
-          proxy: camunda.teleport.sh:443
-          token: ${{ env.TELEPORT_JOIN_TOKEN }}
-          kubernetes-cluster: ${{ env.CLUSTER }}
-      - uses: ./.github/actions/await-load-test
-        with:
-          namespace: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          build_status: ${{ job.status }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-
+    uses: ./.github/workflows/camunda-verify-load-test.yml
+    secrets: inherit
+    with:
+      namespace: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}
 
   # This is to validate whether the load test can be updated successfully, without issues in the update process itself.
   # To prevent regressions like regenerating credentials on every update, which can cause downtime and failed updates.
@@ -146,35 +123,14 @@ jobs:
 
   verify-update:
     name: Verify update
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
     needs: [sanitize-branch-name, smoke-update]
     permissions:
       contents: 'read'
       id-token: 'write'
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: teleport-actions/setup@b638ff596557cc3959eb6b5287d5e58e0c8ac6a6 # v1.1.1
-        with:
-          proxy: camunda.teleport.sh:443
-          version: auto
-      - uses: teleport-actions/auth-k8s@0f46164469ae4fcd4d359d40e06bab17d4be17c9 # v2.0.6
-        with:
-          proxy: camunda.teleport.sh:443
-          token: ${{ env.TELEPORT_JOIN_TOKEN }}
-          kubernetes-cluster: ${{ env.CLUSTER }}
-      - uses: ./.github/actions/await-load-test
-        with:
-          namespace: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          build_status: ${{ job.status }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+    uses: ./.github/workflows/camunda-verify-load-test.yml
+    secrets: inherit
+    with:
+      namespace: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}
 
   cleanup:
     name: Cleanup

--- a/.github/workflows/camunda-load-test-smoke.yml
+++ b/.github/workflows/camunda-load-test-smoke.yml
@@ -29,6 +29,10 @@ concurrency:
   group: smoke-load-test-${{ github.event.pull_request.id || github.event.inputs.ref }}
   cancel-in-progress: true
 
+env:
+  CLUSTER: camunda-benchmark-prod
+  TELEPORT_JOIN_TOKEN: infra-benchmark-prod-github-action-zeebe
+
 defaults:
   run:
     # use bash shell by default to ensure pipefail behavior is the default
@@ -88,11 +92,98 @@ jobs:
       orchestration-tag: SNAPSHOT
 
 
-  verify-and-cleanup:
-    name: Verify and cleanup
+  verify-install:
+    name: Verify Install
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [sanitize-branch-name, smoke-install]
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: teleport-actions/setup@b638ff596557cc3959eb6b5287d5e58e0c8ac6a6 # v1.1.1
+        with:
+          proxy: camunda.teleport.sh:443
+          version: auto
+      - uses: teleport-actions/auth-k8s@0f46164469ae4fcd4d359d40e06bab17d4be17c9 # v2.0.6
+        with:
+          proxy: camunda.teleport.sh:443
+          token: ${{ env.TELEPORT_JOIN_TOKEN }}
+          kubernetes-cluster: ${{ env.CLUSTER }}
+      - uses: ./.github/actions/await-load-test
+        with:
+          namespace: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+
+
+  # This is to validate whether the load test can be updated successfully, without issues in the update process itself.
+  # To prevent regressions like regenerating credentials on every update, which can cause downtime and failed updates.
+  smoke-update:
+    name: Smoke update
+    needs: [sanitize-branch-name, verify-install]
+    uses: ./.github/workflows/camunda-load-test.yml
+    secrets: inherit
+    with:
+      name: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}
+      ref: ${{ github.event.pull_request.head.ref || github.event.inputs.ref }}
+      scenario: realistic
+      secondary-storage-type: elasticsearch
+      # Short TTL acts as a safety net; verify-and-cleanup deletes the namespace explicitly.
+      ttl: 1
+      # We make use of the official docker image (SNAPSHOT TAG) this is to reduce CI runtime and feedback cycle.
+      # Setting the focus only on the installation and connectivity part of the load test.
+      # Issues with the load test applications, should ideally catched with integration tests.
+      orchestration-tag: SNAPSHOT
+
+  verify-update:
+    name: Verify update
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    needs: [sanitize-branch-name, smoke-update]
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: teleport-actions/setup@b638ff596557cc3959eb6b5287d5e58e0c8ac6a6 # v1.1.1
+        with:
+          proxy: camunda.teleport.sh:443
+          version: auto
+      - uses: teleport-actions/auth-k8s@0f46164469ae4fcd4d359d40e06bab17d4be17c9 # v2.0.6
+        with:
+          proxy: camunda.teleport.sh:443
+          token: ${{ env.TELEPORT_JOIN_TOKEN }}
+          kubernetes-cluster: ${{ env.CLUSTER }}
+      - uses: ./.github/actions/await-load-test
+        with:
+          namespace: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+
+  cleanup:
+    name: Cleanup
+    needs: [sanitize-branch-name, verify-update]
     if: always()
-    uses: ./.github/workflows/camunda-verify-and-cleanup-load-test.yml
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/camunda-delete-load-test.yml
     secrets: inherit
     with:
       namespace: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}

--- a/load-tests/setup/newLoadTest.sh
+++ b/load-tests/setup/newLoadTest.sh
@@ -141,27 +141,6 @@ else
   exit 1
 fi
 
-# Generate credentials. These are baked into resources/camunda-credentials.yaml
-# and (for the orchestration OIDC secret) into load-test-values.yaml. Any
-# subsequent `make install` reapplies the same manifest, so the secret in the
-# cluster always matches the value the load test starter authenticates with.
-# `head -c 20` closes the pipe early; upstream `tr` then takes SIGPIPE and
-# returns 141 under `set -o pipefail`. Wrap in a subshell so the harmless
-# SIGPIPE doesn't trip `set -e` in the caller.
-gen_password() { ( set +o pipefail; LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 20 ); }
-gen_token()    { openssl rand -hex 16; }
-
-IDENTITY_FIRSTUSER_PASSWORD=$(gen_password)
-IDENTITY_KEYCLOAK_ADMIN_PASSWORD=$(gen_password)
-IDENTITY_KEYCLOAK_POSTGRESQL_ADMIN_PASSWORD=$(gen_password)
-IDENTITY_KEYCLOAK_POSTGRESQL_USER_PASSWORD=$(gen_password)
-IDENTITY_POSTGRESQL_ADMIN_PASSWORD=$(gen_password)
-IDENTITY_POSTGRESQL_USER_PASSWORD=$(gen_password)
-CONNECTORS_SECRET=$(gen_password)
-ORCHESTRATION_SECRET=$(gen_password)
-IDENTITY_OPTIMIZE_LOADTEST_CLIENT_SECRET=$(gen_password)
-IDENTITY_ADMIN_CLIENT_TOKEN=$(gen_token)
-IDENTITY_OPTIMIZE_CLIENT_TOKEN=$(gen_token)
 
 # Scaffold the namespace folder with only the files this $secondaryStorage uses.
 # A namespace is bound to its storage at create time; to switch storage, create
@@ -235,6 +214,66 @@ if [[ "$enable_single_zone" != "true" ]]; then
   else
     sed -i    -e '/^  annotations:$/d' resources/namespace.yaml
   fi
+fi
+
+#############################################################################################
+################################ CREDENTIALS ################################################
+#############################################################################################
+
+function get_existing_secret() {
+  jsonObject=$1
+  key=$2
+  existing_secret=$(echo "$jsonObject" | jq --raw-output --arg key "$key" '.[$key] // empty' | base64 -d)
+  if [ -z "$existing_secret" ]; then
+    echo "ERROR: existing camunda-credentials secret is missing key '$key'."
+    exit 1
+  fi
+  echo "$existing_secret"
+}
+
+# Generate credentials. These are baked into resources/camunda-credentials.yaml
+# and (for the orchestration OIDC secret) into load-test-values.yaml. Any
+# subsequent `make install` reapplies the same manifest, so the secret in the
+# cluster always matches the value the load test starter authenticates with.
+# `head -c 20` closes the pipe early; upstream `tr` then takes SIGPIPE and
+# returns 141 under `set -o pipefail`. Wrap in a subshell so the harmless
+# SIGPIPE doesn't trip `set -e` in the caller.
+function gen_password() { ( set +o pipefail; LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 20 ); }
+function gen_token()    { openssl rand -hex 16; }
+
+
+# If the secret already exists in the cluster, preserve all existing values to avoid breaking any live load test.
+# If the secret doesn't exist, generate new random values for all keys.
+# This might happend on CI/GitHub Workflows that update existing load tests but do not persist the credentials across runs.
+if kubectl -n "$namespace" get secret camunda-credentials >/dev/null 2>&1; then
+  echo "Secret 'camunda-credentials' already exists in namespace '$namespace'; preserving existing credentials."
+  jsonObject=$(kubectl -n "$namespace" get secret camunda-credentials -o jsonpath='{.data}')
+
+  IDENTITY_FIRSTUSER_PASSWORD=$(get_existing_secret "$jsonObject" "identity-firstuser-password")
+  IDENTITY_KEYCLOAK_ADMIN_PASSWORD=$(get_existing_secret "$jsonObject" "identity-keycloak-admin-password")
+  IDENTITY_KEYCLOAK_POSTGRESQL_ADMIN_PASSWORD=$(get_existing_secret "$jsonObject" "identity-keycloak-postgresql-admin-password")
+  IDENTITY_KEYCLOAK_POSTGRESQL_USER_PASSWORD=$(get_existing_secret "$jsonObject" "identity-keycloak-postgresql-user-password")
+  IDENTITY_POSTGRESQL_ADMIN_PASSWORD=$(get_existing_secret "$jsonObject" "identity-postgresql-admin-password")
+  IDENTITY_POSTGRESQL_USER_PASSWORD=$(get_existing_secret "$jsonObject" "identity-postgresql-user-password")
+  CONNECTORS_SECRET=$(get_existing_secret "$jsonObject" "connectors-security-authentication-oidc-secret")
+  ORCHESTRATION_SECRET=$(get_existing_secret "$jsonObject" "orchestration-security-authentication-oidc-secret")
+  IDENTITY_OPTIMIZE_LOADTEST_CLIENT_SECRET=$(get_existing_secret "$jsonObject" "identity-optimize-loadtest-client-secret")
+  IDENTITY_ADMIN_CLIENT_TOKEN=$(get_existing_secret "$jsonObject" "identity-admin-client-token")
+  IDENTITY_OPTIMIZE_CLIENT_TOKEN=$(get_existing_secret "$jsonObject" "identity-optimize-client-token")
+
+else
+  echo "Generating new credentials for secret 'camunda-credentials'."
+  IDENTITY_FIRSTUSER_PASSWORD=$(gen_password)
+  IDENTITY_KEYCLOAK_ADMIN_PASSWORD=$(gen_password)
+  IDENTITY_KEYCLOAK_POSTGRESQL_ADMIN_PASSWORD=$(gen_password)
+  IDENTITY_KEYCLOAK_POSTGRESQL_USER_PASSWORD=$(gen_password)
+  IDENTITY_POSTGRESQL_ADMIN_PASSWORD=$(gen_password)
+  IDENTITY_POSTGRESQL_USER_PASSWORD=$(gen_password)
+  CONNECTORS_SECRET=$(gen_password)
+  ORCHESTRATION_SECRET=$(gen_password)
+  IDENTITY_OPTIMIZE_LOADTEST_CLIENT_SECRET=$(gen_password)
+  IDENTITY_ADMIN_CLIENT_TOKEN=$(gen_token)
+  IDENTITY_OPTIMIZE_CLIENT_TOKEN=$(gen_token)
 fi
 
 # Bake the orchestration OIDC secret into the load-test starter values.


### PR DESCRIPTION
## Description

 - If credentials have already been generated and are in use, we must not regenerate new credentials
 - This might happen during release load test updates, where credentials are not persisted
 - We need to make sure to reuse existing secrets

Adds in addition a separate step in the smoke tests to validate an update 


<img width="3397" height="850" alt="2026-06-04_17-31" src="https://github.com/user-attachments/assets/5c6f70b5-9583-4c7d-ac20-2a01920a12bb" />

<!-- Describe the goal and purpose of this PR. -->


## Related issues

related to incident https://app.slack.com/client/T0PM0P1SA/C0B793P25V5
