### PR TITLE
fix(ci): add camunda-cpm Artifactory credentials to optimize release workflow

### DIFF
--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -91,6 +91,8 @@ jobs:
             secret/data/github.com/organizations/camunda MAVEN_CENTRAL_GPG_SIGNING_KEY_PUB;
             secret/data/github.com/organizations/camunda MAVEN_CENTRAL_DEPLOYMENT_USR;
             secret/data/github.com/organizations/camunda MAVEN_CENTRAL_DEPLOYMENT_PSW;
+            secret/data/products/optimize/ci/artifactory USER | ARTIFACTORY_USERNAME;
+            secret/data/products/optimize/ci/artifactory TOKEN | ARTIFACTORY_TOKEN;
 
       - name: Git User Setup
         run: |
@@ -136,6 +138,11 @@ jobs:
                 "id": "central",
                 "username": "${{ steps.secrets.outputs.MAVEN_CENTRAL_DEPLOYMENT_USR }}",
                 "password": "${{ steps.secrets.outputs.MAVEN_CENTRAL_DEPLOYMENT_PSW }}"
+            },
+            {
+                "id": "camunda-cpm",
+                "username": "${{ steps.secrets.outputs.ARTIFACTORY_USERNAME }}",
+                "password": "${{ steps.secrets.outputs.ARTIFACTORY_TOKEN }}"
             }]
 
       - name: Is current release major or minor.


### PR DESCRIPTION
# Description

Adds `camunda-cpm` Artifactory credentials to the Optimize 8.7.22 release workflow (`optimize-release-optimize-c8-only.yml`). The workflow dispatches from `main` and uses `setup-build`, whose Nexus mirror covers specific repo IDs (`camunda-bpm,camunda-identity,zeebe,zeebe-snapshots`) but not `camunda-cpm`. Maven therefore goes direct to `https://artifacts.camunda.com/artifactory/camunda-bpm/` for `org.camunda.bpm:camunda-license-check` and similar C7 artifacts, and fails with 401 because no server credentials existed for that repo ID.

The fix reads dedicated Artifactory credentials (`secret/data/products/optimize/ci/artifactory`, keys `USER`/`TOKEN`) in the `Import Secrets` step and passes a `camunda-cpm` server entry to `setup-build` via its `maven-servers` input, alongside the existing `central` entry. The `camunda-nexus` entry and mirror are unchanged.

Reference: camunda-optimize#16578 (same credential split, different scenario — that PR fixed deploy; this fixes download from `camunda-cpm`). Vault path: `secret/data/products/optimize/ci/artifactory`. If that path is not in the release runner's AppRole scope, the build will fail with 403 (Infra dependency) rather than 401.

# Checklist

- [ ] Enable backports when necessary (fex. for bug fixes, for CI changes, or for documentation changes).
- [ ] If this PR modifies the C8 Orchestration Cluster E2E Test Suite, the relevant tests have been run via the on-demand workflow before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

# Related issues

closes #
