### PR TITLE
ci: enforce CI health submission on push workflows (backport #54599)

### DIFF
--- a/.github/conftest-gha-best-practices.rego
+++ b/.github/conftest-gha-best-practices.rego
@@ -66,6 +66,17 @@ deny[msg] {
         [concat(", ", get_matrix_jobs_with_cihealthbutnojobname(input.jobs))])
 }
 
+deny[msg] {
+    # This rule ensures that jobs submitting CI health metrics have checked out
+    # the repository beforehand — the observe-build-status composite action
+    # requires local access to .github/actions/observe-build-status/action.yml.
+
+    count(get_jobs_with_cihealth_but_no_checkout(input.jobs)) > 0
+
+    msg := sprintf("There are GitHub Actions jobs with observe-build-status but without a preceding checkout step! Affected job IDs: %s",
+        [concat(", ", get_jobs_with_cihealth_but_no_checkout(input.jobs))])
+}
+
 warn[msg] {
     # This rule warns in situations where no "secrets: inherit" is passed on
     # calling other workflows as this is usually an oversight that prevents
@@ -142,5 +153,38 @@ get_matrix_jobs_with_cihealthbutnojobname(jobInput) = matrix_jobs_with_cihealthb
             not step["with"].job_name
         }
         count(missing_job_name_steps) > 0
+    }
+}
+
+get_jobs_with_cihealth_but_no_checkout(jobInput) = result {
+    result := { job_id |
+        job := jobInput[job_id]
+
+        # not enforced on jobs that invoke other reusable workflows
+        not job.uses
+
+        # check that there is at least one observe-build-status step
+        cihealth_steps := { i |
+            step := job.steps[i]
+            step.name == "Observe build status"
+            step.uses == "./.github/actions/observe-build-status"
+        }
+        count(cihealth_steps) > 0
+
+        # check that there is no checkout step anywhere before any cihealth step
+        checkout_indices := { i |
+            step := job.steps[i]
+            startswith(step.uses, "actions/checkout@")
+        }
+
+        # get the earliest observe-build-status index
+        earliest_cihealth := min(cihealth_steps)
+
+        # count checkouts that appear before the earliest cihealth step
+        checkouts_before := { i |
+            i := checkout_indices[_]
+            i < earliest_cihealth
+        }
+        count(checkouts_before) == 0
     }
 }

--- a/.github/conftest-unified-ci-rules.rego
+++ b/.github/conftest-unified-ci-rules.rego
@@ -28,8 +28,7 @@ warn[msg] {
 }
 
 deny[msg] {
-    # only enforced on workflows that opted-in
-    input.env.GHA_BEST_PRACTICES_LINTER == "enabled"
+    is_push_or_bestpractices_workflow
 
     count(get_jobs_without_cihealth(input.jobs)) > 0
 
@@ -314,4 +313,14 @@ get_jobs_without_printmetadata(jobInput) = jobs_without_printmetadata {
         }
         count(printmetadata_steps) == 0
     }
+}
+
+# multiple functions with the same name act as logical OR
+is_push_or_bestpractices_workflow {
+    # "on:" is parsed as boolean true by the YAML 1.1 parser
+    input["true"].push
+}
+is_push_or_bestpractices_workflow {
+    # only enforced on workflows that opted-in
+    input.env.GHA_BEST_PRACTICES_LINTER == "enabled"
 }

--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -58,6 +58,15 @@ jobs:
         with:
           working-directory: ./c8run
           skip-cache: true
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
   test_c8run_unittests:
     strategy:
@@ -82,6 +91,16 @@ jobs:
 
       - name: Unit tests
         run: go test ./...
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          job_name: "test_c8run_unittests/${{ matrix.os }}"
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
   camunda-dist-build:
     name: Build camunda-dist
@@ -120,6 +139,15 @@ jobs:
         with:
           name: camunda-platform-dist-zip
           path: ${{ steps.build-dist.outputs.distzip }}
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
   test_c8run_on_unix:
     strategy:
@@ -204,6 +232,16 @@ jobs:
             "text": "Job *${{ github.job }}* in workflow *${{ github.workflow }}* failed for *${{ github.repository }}*!\nBranch: ${{ github.ref }}\nCommit: ${{ github.sha }}\nRun: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>\nLogs: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts|View Artifacts>"
           }' \
           "$SLACK_WEBHOOK_URL"
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          job_name: "test_c8run_on_unix/${{ matrix.os }}"
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
   test_c8run_e2e_on_windows:
     name: C8Run Test Windows
@@ -341,3 +379,12 @@ jobs:
             "text": "Job *${{ github.job }}* in workflow *${{ github.workflow }}* failed for *${{ github.repository }}*!\nBranch: ${{ github.ref }}\nCommit: ${{ github.sha }}\nRun: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>\nLogs: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts|View Artifacts>"
           }' \
           $SLACK_WEBHOOK_URL
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/camunda-pr-load-test.yaml
+++ b/.github/workflows/camunda-pr-load-test.yaml
@@ -74,6 +74,10 @@ jobs:
           pr_number="${{ github.event.pull_request.number }}"
           echo "namespace=c8-${author}-pr-${pr_number}-${db_type}" >> "$GITHUB_OUTPUT"
 
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/.github/workflows/camunda-release-load-test.yaml
+++ b/.github/workflows/camunda-release-load-test.yaml
@@ -90,6 +90,10 @@ jobs:
           max_length: 50  # reduced to account for load-test prefix "c8-" and potential suffixes for uniqueness
       - id: prepare_tag
         run: echo "test-tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/.github/workflows/camunda8-getting-started-bundle.yaml
+++ b/.github/workflows/camunda8-getting-started-bundle.yaml
@@ -889,6 +889,10 @@ jobs:
             -H "Content-Type: application/json" \
             -d "$PAYLOAD"
 
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/.github/workflows/ci-database-integration-tests-reusable.yml
+++ b/.github/workflows/ci-database-integration-tests-reusable.yml
@@ -197,6 +197,10 @@ jobs:
                   type: "mrkdwn"
                   text: "Scheduled Database Integration Tests for **${{inputs.database-name}}** on **${{ github.ref_name }}** FAILED or WERE CANCELLED\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
       # Send metrics about CI health
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/.github/workflows/maven-dependency-snapshot.yml
+++ b/.github/workflows/maven-dependency-snapshot.yml
@@ -45,3 +45,12 @@ jobs:
             -am
             -Dquickly
           correlator: ${{ github.job }}-maven
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/operate-e2e-tests.yml
+++ b/.github/workflows/operate-e2e-tests.yml
@@ -52,6 +52,15 @@ jobs:
       - name: Read DB versions
         id: db-versions
         uses: ./.github/actions/read-db-versions
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
   test:
     runs-on: gcp-core-4-default

--- a/.github/workflows/optimize-check-c4.yml
+++ b/.github/workflows/optimize-check-c4.yml
@@ -55,3 +55,12 @@ jobs:
       - name: Build C4 package
         working-directory: ./optimize/c4
         run: yarn build
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/optimize-ci-core-features.yml
+++ b/.github/workflows/optimize-ci-core-features.yml
@@ -141,6 +141,16 @@ jobs:
         if: always()
         with:
           archive_name: integration-tests-elasticsearch-${{ matrix.includedGroups }}-docker
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          job_name: "integration-tests/${{ matrix.includedGroups }}"
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
   integration-tests-os:
     name: "[IT] Run on OpenSearch"
@@ -224,6 +234,16 @@ jobs:
         if: always()
         with:
           archive_name: integration-tests-opensearch-${{ matrix.includedGroups }}-docker
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          job_name: "integration-tests-os/${{ matrix.includedGroups }}"
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
   # Only deploy artifacts on push event, which in this case can only be triggered by main and stable
   deploy-artifacts:
@@ -253,3 +273,16 @@ jobs:
           vault-addr: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/optimize-ci-data-layer.yml
+++ b/.github/workflows/optimize-ci-data-layer.yml
@@ -124,6 +124,16 @@ jobs:
         if: always()
         with:
           archive_name: upgrade-docker-${{ matrix.database }}
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          job_name: "upgrade-tests/${{ matrix.database }}"
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
 
   # Rerun failed jobs running on self-hosted runners in case of network issues or node preemption
@@ -144,3 +154,16 @@ jobs:
           vault-addr: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/optimize-e2e-test-cloud.yml
+++ b/.github/workflows/optimize-e2e-test-cloud.yml
@@ -103,3 +103,12 @@ jobs:
         with:
           name: logs
           path: ./optimize/client/build/*.log
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/optimize-e2e-tests-sm.yml
+++ b/.github/workflows/optimize-e2e-tests-sm.yml
@@ -136,3 +136,12 @@ jobs:
         if: always()
         with:
           archive_name: e2e-docker-logs
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/release-branch-notifications.yml
+++ b/.github/workflows/release-branch-notifications.yml
@@ -65,6 +65,19 @@ jobs:
 
           echo "🔍 Validation result: $VALID"
           echo "valid=$VALID" >> "$GITHUB_OUTPUT"
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
   notify-release-activity:
     name: Send Slack notification for release branch activity
     runs-on: ubuntu-latest
@@ -268,6 +281,10 @@ jobs:
             echo "⚠️ Slack notification failed but workflow continues"
             echo "::warning::Failed to notify #top-monorepo-release about ${{ steps.extract-data.outputs.action_type }} on ${{ steps.extract-data.outputs.branch_name }}"
           fi
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/.github/workflows/tasklist-e2e-tests.yml
+++ b/.github/workflows/tasklist-e2e-tests.yml
@@ -48,6 +48,15 @@ jobs:
       - name: Read DB versions
         id: db-versions
         uses: ./.github/actions/read-db-versions
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
   test:
     strategy:

--- a/.github/workflows/update-identity.yml
+++ b/.github/workflows/update-identity.yml
@@ -153,6 +153,10 @@ jobs:
               ]
             }
 
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/.github/workflows/zeebe-aws-aurora-dispatch-tests.yml
+++ b/.github/workflows/zeebe-aws-aurora-dispatch-tests.yml
@@ -160,6 +160,10 @@ jobs:
                 type: "mrkdwn"
                 text: "AWS Aurora Manual/Scheduled Run Integration Tests FAILED or WERE CANCELLED\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
       # Send metrics about CI health
+    - name: Checkout
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        sparse-checkout: .github
     - name: Observe build status
       if: always()
       continue-on-error: true


### PR DESCRIPTION
## Description

Selective backport of the push-relevant parts of camunda/camunda#54599 to `stable/8.9`.

**Scope (per discussion):**
- Enforce CI Health submission on `push`-triggered workflows (drops `schedule` clause from the helper)
- Add new lint requiring a `Checkout` step before any `observe-build-status` step
- Add observers/checkouts where needed so the new rules pass on `stable/8.9`

**Files changed:**
- `.github/conftest-unified-ci-rules.rego` — new `is_push_or_bestpractices_workflow` helper; enforcement broadens from opt-in only to "push or opt-in".
- `.github/conftest-gha-best-practices.rego` — new rule + `get_jobs_with_cihealth_but_no_checkout` helper.
- 16 workflows updated to either add an `Observe build status` step (plus `Checkout` where needed) or to add a `Checkout` before an existing observer.
  - From PR #54599 directly: `c8run-build`, `camunda-pr-load-test`, `camunda8-getting-started-bundle`, `ci-database-integration-tests-reusable`, `maven-dependency-snapshot`, `release-branch-notifications`, `update-identity`, `zeebe-aws-aurora-dispatch-tests`
  - Stable-only drift (workflows push-triggered on stable but removed/disabled on main): `operate-e2e-tests`, `tasklist-e2e-tests`, `optimize-check-c4`, `optimize-ci-core-features`, `optimize-ci-data-layer`, `optimize-e2e-test-cloud`, `optimize-e2e-tests-sm`, `camunda-release-load-test`

**Out of scope (intentionally excluded):**
- Schedule-only workflows from #54599 (per "push only" filter).
- The PR's helper schedule clause (`is_push_or_schedule_or_bestpractices_workflow`).

## Test plan

- [ ] `conftest test` passes locally (3078 tests, 0 failures, only pre-existing print-metadata warnings)
- [ ] CI on this PR passes