### PR TITLE
ci: enforce CI health submission on push workflows (backport #54599)

### DIFF
--- a/.github/conftest-gha-best-practices.rego
+++ b/.github/conftest-gha-best-practices.rego
@@ -66,6 +66,17 @@ deny[msg] {
         [concat(", ", get_matrix_jobs_with_cihealthbutnojobname(input.jobs))])
 }
 
+deny[msg] {
+    # This rule ensures that jobs submitting CI health metrics have checked out
+    # the repository beforehand — the observe-build-status composite action
+    # requires local access to .github/actions/observe-build-status/action.yml.
+
+    count(get_jobs_with_cihealth_but_no_checkout(input.jobs)) > 0
+
+    msg := sprintf("There are GitHub Actions jobs with observe-build-status but without a preceding checkout step! Affected job IDs: %s",
+        [concat(", ", get_jobs_with_cihealth_but_no_checkout(input.jobs))])
+}
+
 warn[msg] {
     # This rule warns in situations where no "secrets: inherit" is passed on
     # calling other workflows as this is usually an oversight that prevents
@@ -142,5 +153,38 @@ get_matrix_jobs_with_cihealthbutnojobname(jobInput) = matrix_jobs_with_cihealthb
             not step["with"].job_name
         }
         count(missing_job_name_steps) > 0
+    }
+}
+
+get_jobs_with_cihealth_but_no_checkout(jobInput) = result {
+    result := { job_id |
+        job := jobInput[job_id]
+
+        # not enforced on jobs that invoke other reusable workflows
+        not job.uses
+
+        # check that there is at least one observe-build-status step
+        cihealth_steps := { i |
+            step := job.steps[i]
+            step.name == "Observe build status"
+            step.uses == "./.github/actions/observe-build-status"
+        }
+        count(cihealth_steps) > 0
+
+        # check that there is no checkout step anywhere before any cihealth step
+        checkout_indices := { i |
+            step := job.steps[i]
+            startswith(step.uses, "actions/checkout@")
+        }
+
+        # get the earliest observe-build-status index
+        earliest_cihealth := min(cihealth_steps)
+
+        # count checkouts that appear before the earliest cihealth step
+        checkouts_before := { i |
+            i := checkout_indices[_]
+            i < earliest_cihealth
+        }
+        count(checkouts_before) == 0
     }
 }

--- a/.github/conftest-unified-ci-rules.rego
+++ b/.github/conftest-unified-ci-rules.rego
@@ -28,8 +28,7 @@ warn[msg] {
 }
 
 deny[msg] {
-    # only enforced on workflows that opted-in
-    input.env.GHA_BEST_PRACTICES_LINTER == "enabled"
+    is_push_or_bestpractices_workflow
 
     count(get_jobs_without_cihealth(input.jobs)) > 0
 
@@ -236,4 +235,14 @@ get_jobs_without_monitor_as_first_step(jobInput) = result {
 job_has_monitor_as_first_step(job) {
     step := job.steps[0]
     startswith(step.uses, "camunda/infra-global-github-actions/start-build-monitor@")
+}
+
+# multiple functions with the same name act as logical OR
+is_push_or_bestpractices_workflow {
+    # "on:" is parsed as boolean true by the YAML 1.1 parser
+    input["true"].push
+}
+is_push_or_bestpractices_workflow {
+    # only enforced on workflows that opted-in
+    input.env.GHA_BEST_PRACTICES_LINTER == "enabled"
 }

--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -71,6 +71,15 @@ jobs:
         with:
           name: camunda-platform-dist-zip
           path: ${{ steps.build-dist.outputs.distzip }}
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
   test_c8run:
     strategy:
@@ -160,6 +169,16 @@ jobs:
           name: c8run-logs-${{ matrix.os }}
           path: ./c8run/log/*.log
           retention-days: 10
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          job_name: "test_c8run/${{ matrix.os }}"
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
   test_c8run_windows:
     name: C8Run Test Windows
@@ -282,3 +301,12 @@ jobs:
           name: c8run-logs
           path: .\c8run\log\*.log
           retention-days: 10
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/camunda-pr-load-test.yaml
+++ b/.github/workflows/camunda-pr-load-test.yaml
@@ -43,6 +43,10 @@ jobs:
         with:
           branch: ${{ github.event.pull_request.head.ref }}
           max_length: 50  # reduced to account for load-test prefix "c8-" and potential suffixes for uniqueness
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -77,6 +81,10 @@ jobs:
     steps:
       - name: Wait for load test to stabilize
         run: sleep 1800  # 30 minutes
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -338,6 +346,10 @@ jobs:
               repo: context.repo.repo,
               body: comment
             });
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/.github/workflows/camunda-release-load-test.yaml
+++ b/.github/workflows/camunda-release-load-test.yaml
@@ -90,6 +90,10 @@ jobs:
           max_length: 50  # reduced to account for load-test prefix "c8-" and potential suffixes for uniqueness
       - id: prepare_tag
         run: echo "test-tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/.github/workflows/maven-dependency-snapshot.yml
+++ b/.github/workflows/maven-dependency-snapshot.yml
@@ -45,3 +45,12 @@ jobs:
             -am
             -Dquickly
           correlator: ${{ github.job }}-maven
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/operate-e2e-tests.yml
+++ b/.github/workflows/operate-e2e-tests.yml
@@ -45,6 +45,15 @@ jobs:
       - name: Read DB versions
         id: db-versions
         uses: ./.github/actions/read-db-versions
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
   test:
     runs-on: gcp-core-4-default

--- a/.github/workflows/operate-test-backup-restore.yml
+++ b/.github/workflows/operate-test-backup-restore.yml
@@ -64,3 +64,12 @@ jobs:
         uses: ./.github/actions/collect-test-artifacts
         with:
           name: "[Legacy] Operate Test Backup Restore"
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/release-branch-notifications.yml
+++ b/.github/workflows/release-branch-notifications.yml
@@ -65,6 +65,19 @@ jobs:
 
           echo "🔍 Validation result: $VALID"
           echo "valid=$VALID" >> "$GITHUB_OUTPUT"
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
   notify-release-activity:
     name: Send Slack notification for release branch activity
     runs-on: ubuntu-latest
@@ -268,6 +281,10 @@ jobs:
             echo "⚠️ Slack notification failed but workflow continues"
             echo "::warning::Failed to notify #top-monorepo-release about ${{ steps.extract-data.outputs.action_type }} on ${{ steps.extract-data.outputs.branch_name }}"
           fi
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/.github/workflows/tasklist-e2e-tests.yml
+++ b/.github/workflows/tasklist-e2e-tests.yml
@@ -61,6 +61,15 @@ jobs:
       - name: Read DB versions
         id: db-versions
         uses: ./.github/actions/read-db-versions
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-identity.yml
+++ b/.github/workflows/update-identity.yml
@@ -122,6 +122,10 @@ jobs:
               ]
             }
 
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github
       - name: Observe build status
         if: always()
         continue-on-error: true


### PR DESCRIPTION
## Description

Selective backport of the push-relevant parts of camunda/camunda#54599 to `stable/8.7`. See [#54676](https://github.com/camunda/camunda/pull/54676) and [#54678](https://github.com/camunda/camunda/pull/54678) for the parallel `stable/8.9` and `stable/8.8` backports.

**Scope:**
- Enforce CI Health submission on `push`-triggered workflows (no `schedule`)
- Add new lint requiring a `Checkout` step before any `observe-build-status` step
- Add observers/checkouts where needed so the new rules pass on `stable/8.7`

**Branch-specific notes:**
- 8 workflows from the original PR don't exist on `stable/8.7` (the `optimize-*` series, `camunda8-getting-started-bundle`, `ci-database-integration-tests-reusable`, `zeebe-aws-aurora-dispatch-tests`) — skipped.
- `c8run-build.yaml` has only 3 jobs on 8.7 (vs. 5 on 8.9); observers added accordingly.
- `camunda-pr-load-test.yaml` uses a different job structure (no `compute-namespace`); checkout added in the simpler path. Two extra jobs (`await-benchmark`, `comment-pr`) had observer-without-checkout and got a Checkout step added.
- `operate-test-backup-restore.yml` is an 8.7-only push workflow that lacked an observer — added.
- `conftest-unified-ci-rules.rego` 8.7 lacks the `get_jobs_without_printmetadata` rule from later branches; only the new `is_push_or_bestpractices_workflow` helper is appended.

## Test plan

- [ ] `conftest test` passes locally (1335 tests, 0 failures)
- [ ] CI on this PR passes