### PR TITLE
Fix CI: restore version compat and add testcontainer coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -538,6 +538,19 @@ jobs:
               "stressRun": 1
             },
             {
+              "group": "qa-testcontainer",
+              "name": "Testcontainer Tests",
+              "maven-modules": "'qa/testcontainer'",
+              "maven-build-threads": 1,
+              "maven-test-fork-count": 1,
+              "runs-on": "gcp-perf-core-8-default",
+              "docker-repository": "localhost:5000/camunda/camunda",
+              "docker-file": "camunda.Dockerfile",
+              "owner": "Distributed Platform",
+              "module": "Zeebe",
+              "stressRun": 1
+            },
+            {
               "group": "zeebe-ds-modules",
               "name": "Zeebe Distributed Platform Modules",
               "maven-modules": "${ZEEBE_IT_DISTRIBUTED_MODULES}",

--- a/qa/testcontainer/src/main/java/io/camunda/container/ExtendedConfigurationBuilder.java
+++ b/qa/testcontainer/src/main/java/io/camunda/container/ExtendedConfigurationBuilder.java
@@ -10,7 +10,6 @@ package io.camunda.container;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -102,7 +101,7 @@ public class ExtendedConfigurationBuilder {
             .setVisibility(PropertyAccessor.FIELD, Visibility.ANY)
             .setPropertyNamingStrategy(PropertyNamingStrategies.KEBAB_CASE);
 
-    mapper.addMixIn(Cluster.class, ClusterMixIn.class);
+    mapper.addMixIn(Cluster.class, LegacyPropertiesMapMixIn.class);
     mapper.addMixIn(Grpc.class, LegacyPropertiesMapMixIn.class);
     mapper.addMixIn(InternalApi.class, LegacyPropertiesMapMixIn.class);
     mapper.addMixIn(LongPolling.class, LegacyPropertiesMapMixIn.class);
@@ -292,7 +291,7 @@ public class ExtendedConfigurationBuilder {
       final Map<String, Object> defaultMap = flatten(createDefaultCamunda());
       final Map<String, Object> configuredMap = flatten(unifiedConfig);
       final Map<String, Object> diff = diffMaps(defaultMap, configuredMap);
-
+      putLegacyNodeIdPropertyIfNeeded(diff);
       final Map<String, Object> fullConfig = new LinkedHashMap<>();
       if (!diff.isEmpty()) {
         fullConfig.put(CAMUNDA_HEADER, diff);
@@ -326,6 +325,7 @@ public class ExtendedConfigurationBuilder {
     final Map<String, Object> defaultMap = flatten(new Camunda());
     final Map<String, Object> configuredMap = flatten(config);
     final Map<String, Object> diff = diffMaps(defaultMap, configuredMap);
+    putLegacyNodeIdPropertyIfNeeded(diff);
     final Map<String, Object> flat = new LinkedHashMap<>();
     flattenInto(diff, CAMUNDA_HEADER, flat);
     return flat;
@@ -352,6 +352,40 @@ public class ExtendedConfigurationBuilder {
     } else if (node != null) {
       flat.put(key, node);
     }
+  }
+
+  /**
+   * Mirrors a configured fixed node id onto the legacy flat {@code camunda.cluster.node-id}
+   * property.
+   *
+   * <p>Camunda versions before 8.9 do not understand the {@code node-id-provider} structure and
+   * expect the node id under the flat {@code camunda.cluster.node-id} key. Since this builder uses
+   * the current configuration classes, which express a fixed node id as {@code
+   * node-id-provider.fixed.node-id}, we additionally copy that value to the legacy key so the
+   * generated config also binds on older versions.
+   */
+  private static void putLegacyNodeIdPropertyIfNeeded(final Map<String, Object> diff) {
+    final var clusterNode = diff.get("cluster");
+    if (clusterNode instanceof final Map clusterMap) {
+      final Integer nodeId = getFixedNodeId(clusterMap);
+      if (nodeId != null) {
+        clusterMap.put("node-id", nodeId);
+      }
+    }
+  }
+
+  private static Integer getFixedNodeId(final Map clusterMap) {
+    final var providerNode = clusterMap.get("node-id-provider");
+    if (providerNode instanceof final Map providerMap) {
+      final var fixedNode = providerMap.get("fixed");
+      if (fixedNode instanceof final Map fixedMap) {
+        final var nodeIdNode = fixedMap.get("node-id");
+        if (nodeIdNode instanceof final Integer nodeId) {
+          return nodeId;
+        }
+      }
+    }
+    return null;
   }
 
   /**
@@ -435,15 +469,6 @@ public class ExtendedConfigurationBuilder {
   /** Hides the legacy-property-name lookup map shared by many unified-config classes. */
   private abstract static class LegacyPropertiesMapMixIn {
     @JsonIgnore private Map<String, String> legacyPropertiesMap;
-  }
-
-  /** Hides {@code nodeIdProvider} and re-exposes node ID directly to emit flat {@code node-id}. */
-  private abstract static class ClusterMixIn {
-    @JsonIgnore private Map<String, String> legacyPropertiesMap;
-    @JsonIgnore private Object nodeIdProvider;
-
-    @JsonProperty("node-id")
-    abstract Integer getNodeId();
   }
 
   /** {@link KeyStore} additionally has a constructor-injected {@code prefix}. */

--- a/qa/testcontainer/src/main/java/io/camunda/container/ExtendedConfigurationBuilder.java
+++ b/qa/testcontainer/src/main/java/io/camunda/container/ExtendedConfigurationBuilder.java
@@ -10,6 +10,7 @@ package io.camunda.container;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -101,7 +102,7 @@ public class ExtendedConfigurationBuilder {
             .setVisibility(PropertyAccessor.FIELD, Visibility.ANY)
             .setPropertyNamingStrategy(PropertyNamingStrategies.KEBAB_CASE);
 
-    mapper.addMixIn(Cluster.class, LegacyPropertiesMapMixIn.class);
+    mapper.addMixIn(Cluster.class, ClusterMixIn.class);
     mapper.addMixIn(Grpc.class, LegacyPropertiesMapMixIn.class);
     mapper.addMixIn(InternalApi.class, LegacyPropertiesMapMixIn.class);
     mapper.addMixIn(LongPolling.class, LegacyPropertiesMapMixIn.class);
@@ -434,6 +435,15 @@ public class ExtendedConfigurationBuilder {
   /** Hides the legacy-property-name lookup map shared by many unified-config classes. */
   private abstract static class LegacyPropertiesMapMixIn {
     @JsonIgnore private Map<String, String> legacyPropertiesMap;
+  }
+
+  /** Hides {@code nodeIdProvider} and re-exposes node ID directly to emit flat {@code node-id}. */
+  private abstract static class ClusterMixIn {
+    @JsonIgnore private Map<String, String> legacyPropertiesMap;
+    @JsonIgnore private Object nodeIdProvider;
+
+    @JsonProperty("node-id")
+    abstract Integer getNodeId();
   }
 
   /** {@link KeyStore} additionally has a constructor-injected {@code prefix}. */

--- a/qa/testcontainer/src/test/java/io/camunda/container/BrokerContainerConfigIT.java
+++ b/qa/testcontainer/src/test/java/io/camunda/container/BrokerContainerConfigIT.java
@@ -19,6 +19,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.Map;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -47,6 +48,7 @@ class BrokerContainerConfigIT {
           .withProperty("zeebe.broker.gateway.enable", true);
 
   @Test
+  @Disabled("https://github.com/camunda/camunda/issues/54702")
   @SuppressWarnings("unchecked")
   void shouldUploadConfigWithCustomUnifiedConfigValues() throws Exception {
     // given — the container is already started with the custom config by @Container

--- a/qa/testcontainer/src/test/java/io/camunda/container/BrokerContainerConfigIT.java
+++ b/qa/testcontainer/src/test/java/io/camunda/container/BrokerContainerConfigIT.java
@@ -19,7 +19,6 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.Map;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -48,7 +47,6 @@ class BrokerContainerConfigIT {
           .withProperty("zeebe.broker.gateway.enable", true);
 
   @Test
-  @Disabled("https://github.com/camunda/camunda/issues/54702")
   @SuppressWarnings("unchecked")
   void shouldUploadConfigWithCustomUnifiedConfigValues() throws Exception {
     // given — the container is already started with the custom config by @Container
@@ -66,13 +64,13 @@ class BrokerContainerConfigIT {
         .as("camunda.cluster section should be present")
         .isNotNull()
         .containsEntry("name", CUSTOM_CLUSTER_NAME)
-        .containsEntry("partitionCount", CUSTOM_PARTITION_COUNT);
+        .containsEntry("partition-count", CUSTOM_PARTITION_COUNT);
 
     final var processing = (Map<String, Object>) camunda.get("processing");
     assertThat(processing)
         .as("camunda.processing section should be present")
         .isNotNull()
-        .containsEntry("maxCommandsInBatch", 200);
+        .containsEntry("max-commands-in-batch", 200);
 
     // verify that additional zeebe properties are present
     final var zeebe = (Map<String, Object>) yaml.get("zeebe");

--- a/qa/testcontainer/src/test/java/io/camunda/container/BrokerContainerConfigIT.java
+++ b/qa/testcontainer/src/test/java/io/camunda/container/BrokerContainerConfigIT.java
@@ -18,14 +18,20 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.time.Duration;
 import java.util.Map;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
 class BrokerContainerConfigIT {
 
+  private static final Logger LOG = LoggerFactory.getLogger(BrokerContainerConfigIT.class);
   private static final String CONFIG_PATH = "/usr/local/camunda/config/application.yml";
   private static final String CUSTOM_CLUSTER_NAME = "config-test-cluster";
   private static final int CUSTOM_PARTITION_COUNT = 3;
@@ -34,6 +40,7 @@ class BrokerContainerConfigIT {
   @Container
   private final BrokerContainer broker =
       new BrokerContainer(CamundaContainer.getBrokerImageName())
+          .withLogConsumer(new Slf4jLogConsumer(LOG))
           .withoutTopologyCheck()
           .withUnifiedConfig(
               cfg -> {
@@ -104,18 +111,27 @@ class BrokerContainerConfigIT {
           .contains("_links");
 
       // when — request the health endpoint
-      final var healthRequest =
-          HttpRequest.newBuilder().uri(monitoringBaseUri.resolve("/actuator/health")).GET().build();
-      final var healthResponse =
-          httpClient.send(healthRequest, HttpResponse.BodyHandlers.ofString());
+      Awaitility.await()
+          .atMost(Duration.ofSeconds(20))
+          .pollInterval(Duration.ofSeconds(1))
+          .untilAsserted(
+              () -> {
+                final var healthRequest =
+                    HttpRequest.newBuilder()
+                        .uri(monitoringBaseUri.resolve("/actuator/health"))
+                        .GET()
+                        .build();
+                final var healthResponse =
+                    httpClient.send(healthRequest, HttpResponse.BodyHandlers.ofString());
 
-      // then — the health endpoint should be accessible
-      assertThat(healthResponse.statusCode())
-          .as("actuator health endpoint should return HTTP 200")
-          .isEqualTo(200);
-      assertThat(healthResponse.body())
-          .as("health response should contain status field")
-          .contains("status");
+                // then — the health endpoint should be accessible
+                assertThat(healthResponse.statusCode())
+                    .as("actuator health endpoint should return HTTP 200")
+                    .isEqualTo(200);
+                assertThat(healthResponse.body())
+                    .as("health response should contain status field")
+                    .contains("status");
+              });
     }
   }
 }

--- a/qa/testcontainer/src/test/java/io/camunda/container/ExtendedConfigurationBuilderTest.java
+++ b/qa/testcontainer/src/test/java/io/camunda/container/ExtendedConfigurationBuilderTest.java
@@ -106,6 +106,20 @@ final class ExtendedConfigurationBuilderTest {
   }
 
   @Test
+  void shouldEmitNodeIdAsPlainInteger() {
+    // given
+    final var config = new Camunda();
+    config.getCluster().setNodeId(2);
+
+    // when
+    final var flat = ExtendedConfigurationBuilder.flatPropertiesFor(config);
+
+    // then
+    assertThat(flat).containsEntry("camunda.cluster.node-id", 2);
+    assertThat(flat.keySet()).noneMatch(k -> k.contains("node-id-provider"));
+  }
+
+  @Test
   void shouldIgnoreInternalHelperFields() {
     // given
     final var config = new Camunda();

--- a/qa/testcontainer/src/test/java/io/camunda/container/ExtendedConfigurationBuilderTest.java
+++ b/qa/testcontainer/src/test/java/io/camunda/container/ExtendedConfigurationBuilderTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.configuration.Camunda;
 import io.camunda.configuration.Exporter;
+import io.camunda.configuration.NodeIdProvider.Type;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import java.time.Duration;
 import java.util.List;
@@ -106,7 +107,7 @@ final class ExtendedConfigurationBuilderTest {
   }
 
   @Test
-  void shouldEmitNodeIdAsPlainInteger() {
+  void shouldMirrorFixedNodeIdToLegacyNodeIdProperty() {
     // given
     final var config = new Camunda();
     config.getCluster().setNodeId(2);
@@ -114,9 +115,40 @@ final class ExtendedConfigurationBuilderTest {
     // when
     final var flat = ExtendedConfigurationBuilder.flatPropertiesFor(config);
 
-    // then
+    // then — the fixed node id is emitted under the current key and mirrored to the legacy flat
+    // `camunda.cluster.node-id` so the config also binds on pre-8.9 versions
+    assertThat(flat).containsEntry("camunda.cluster.node-id-provider.fixed.node-id", 2);
     assertThat(flat).containsEntry("camunda.cluster.node-id", 2);
-    assertThat(flat.keySet()).noneMatch(k -> k.contains("node-id-provider"));
+  }
+
+  @Test
+  void shouldMirrorFixedNodeIdToLegacyNodeIdPropertyWhenSetViaFixedNodeIdProvider() {
+    // given
+    final var config = new Camunda();
+    config.getCluster().getNodeIdProvider().fixed().setNodeId(2);
+
+    // when
+    final var flat = ExtendedConfigurationBuilder.flatPropertiesFor(config);
+
+    // then — setting the node id directly on the fixed provider yields the same legacy mirror
+    assertThat(flat).containsEntry("camunda.cluster.node-id-provider.fixed.node-id", 2);
+    assertThat(flat).containsEntry("camunda.cluster.node-id", 2);
+  }
+
+  @Test
+  void shouldNotMirrorLegacyNodeIdWhenNodeIdProviderIsNotFixed() {
+    // given
+    final var config = new Camunda();
+    config.getCluster().getNodeIdProvider().setType(Type.S3);
+
+    // when
+    final var flat = ExtendedConfigurationBuilder.flatPropertiesFor(config);
+
+    // then — a non-FIXED provider has no flat node id, so nothing is mirrored to the legacy key
+    assertThat(flat)
+        .containsEntry("camunda.cluster.node-id-provider.type", "S3")
+        .doesNotContainKeys(
+            "camunda.cluster.node-id", "camunda.cluster.node-id-provider.fixed.node-id");
   }
 
   @Test

--- a/qa/testcontainer/src/test/java/io/camunda/container/cluster/CamundaClusterBuilderTest.java
+++ b/qa/testcontainer/src/test/java/io/camunda/container/cluster/CamundaClusterBuilderTest.java
@@ -14,7 +14,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
@@ -268,7 +267,6 @@ final class CamundaClusterBuilderTest {
   }
 
   @Test
-  @Disabled("https://github.com/camunda/camunda/issues/54703")
   @SuppressWarnings("unchecked")
   void shouldAssignDifferentClusterHostsToAllNodes() {
     // given
@@ -281,11 +279,8 @@ final class CamundaClusterBuilderTest {
     // then
     final Set<String> advertisedHosts = new HashSet<>();
     cluster.getBrokers().values().stream()
-        .map(ClusterNode::getAdditionalConfigs)
-        .map(config -> (Map<String, Object>) config.get("zeebe"))
-        .map(config -> (Map<String, Object>) config.get("broker"))
-        .map(config -> (Map<String, Object>) config.get("network"))
-        .map(config -> (String) config.get("advertised-host"))
+        .map(ClusterNode::getConfiguration)
+        .map(config -> config.getCluster().getNetwork().getAdvertisedHost())
         .forEach(advertisedHosts::add);
     cluster.getGateways().values().stream()
         .map(GatewayNode::getAdditionalConfigs)

--- a/qa/testcontainer/src/test/java/io/camunda/container/cluster/CamundaClusterBuilderTest.java
+++ b/qa/testcontainer/src/test/java/io/camunda/container/cluster/CamundaClusterBuilderTest.java
@@ -14,6 +14,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
@@ -267,6 +268,7 @@ final class CamundaClusterBuilderTest {
   }
 
   @Test
+  @Disabled("https://github.com/camunda/camunda/issues/54703")
   @SuppressWarnings("unchecked")
   void shouldAssignDifferentClusterHostsToAllNodes() {
     // given


### PR DESCRIPTION
## Description

`zeebe-version-compatibility.yml` has been failing for every version pair involving 8.8.25 as the upgrade target: brokers default to `nodeId=0` regardless of their slot, causing a Raft storage lock conflict.

**Root cause:** `ExtendedConfigurationBuilder` switched to field-based Jackson serialization in 8b807311021. The `Cluster` class has an internal `nodeIdProvider` wrapper field that Jackson now walks directly, emitting `camunda.cluster.node-id-provider.fixed.node-id=2` instead of the expected flat property `camunda.cluster.node-id=2`. Every version prior to the `nodeIdProvider` refactor ignores the nested key and falls back to `nodeId=0`.

**Why this was not caught:** `qa/testcontainer` — the module that owns `ExtendedConfigurationBuilder` and its tests — was never wired into CI. The test suite existed and a regression test for exactly this case was missing, but even if it had been there, no CI job would have run it.

**Fix:**
- Added a dedicated `Zeebe / Integration / Testcontainer Tests` CI job so `qa/testcontainer` is no longer invisible to CI
- Replaced `LegacyPropertiesMapMixIn` on `Cluster.class` with a new `ClusterMixIn` that `@JsonIgnore`s `nodeIdProvider` and re-exposes `getNodeId()` as `@JsonProperty("node-id")`
- Added a regression test asserting the flat `camunda.cluster.node-id` key
- Disabled two pre-existing broken tests uncovered by the new CI job and opened tracking issues for them
  - #54702 
  - #54703

## Checklist

- [x] Enable backports when necessary — backporting to `stable/8.8` and `stable/8.9`

## Related issues

closes #54663
closes #54690