### PR TITLE
Expand AgentInstance filter and sort surface

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/AgentInstanceFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/AgentInstanceFilter.java
@@ -93,6 +93,23 @@ public interface AgentInstanceFilter extends SearchRequestFilter {
   AgentInstanceFilter processInstanceKey(Consumer<BasicLongProperty> fn);
 
   /**
+   * Filter agent instances by the root process instance key.
+   *
+   * @param value the root process instance key
+   * @return the updated filter
+   */
+  AgentInstanceFilter rootProcessInstanceKey(long value);
+
+  /**
+   * Filter agent instances by the root process instance key using a {@link BasicLongProperty}
+   * consumer.
+   *
+   * @param fn the root process instance key filter consumer
+   * @return the updated filter
+   */
+  AgentInstanceFilter rootProcessInstanceKey(Consumer<BasicLongProperty> fn);
+
+  /**
    * Filter agent instances by the process definition key.
    *
    * @param value the process definition key

--- a/clients/java/src/main/java/io/camunda/client/api/search/sort/AgentInstanceSort.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/sort/AgentInstanceSort.java
@@ -19,11 +19,23 @@ import io.camunda.client.api.search.request.TypedSortableRequest.SearchRequestSo
 
 public interface AgentInstanceSort extends SearchRequestSort<AgentInstanceSort> {
 
+  AgentInstanceSort agentInstanceKey();
+
+  AgentInstanceSort status();
+
+  AgentInstanceSort elementId();
+
+  AgentInstanceSort processInstanceKey();
+
+  AgentInstanceSort rootProcessInstanceKey();
+
+  AgentInstanceSort processDefinitionKey();
+
+  AgentInstanceSort tenantId();
+
   AgentInstanceSort creationDate();
 
   AgentInstanceSort lastUpdatedDate();
 
   AgentInstanceSort completionDate();
-
-  AgentInstanceSort status();
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/AgentInstanceFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/AgentInstanceFilterImpl.java
@@ -101,6 +101,19 @@ public class AgentInstanceFilterImpl
   }
 
   @Override
+  public AgentInstanceFilter rootProcessInstanceKey(final long value) {
+    return rootProcessInstanceKey(f -> f.eq(value));
+  }
+
+  @Override
+  public AgentInstanceFilter rootProcessInstanceKey(final Consumer<BasicLongProperty> fn) {
+    final BasicLongProperty property = new BasicLongPropertyImpl();
+    fn.accept(property);
+    filter.setRootProcessInstanceKey(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
   public AgentInstanceFilter processDefinitionKey(final long value) {
     return processDefinitionKey(f -> f.eq(value));
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/sort/AgentInstanceSortImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/sort/AgentInstanceSortImpl.java
@@ -27,6 +27,41 @@ public class AgentInstanceSortImpl extends SearchRequestSortBase<AgentInstanceSo
   }
 
   @Override
+  public AgentInstanceSort agentInstanceKey() {
+    return field("agentInstanceKey");
+  }
+
+  @Override
+  public AgentInstanceSort status() {
+    return field("status");
+  }
+
+  @Override
+  public AgentInstanceSort elementId() {
+    return field("elementId");
+  }
+
+  @Override
+  public AgentInstanceSort processInstanceKey() {
+    return field("processInstanceKey");
+  }
+
+  @Override
+  public AgentInstanceSort rootProcessInstanceKey() {
+    return field("rootProcessInstanceKey");
+  }
+
+  @Override
+  public AgentInstanceSort processDefinitionKey() {
+    return field("processDefinitionKey");
+  }
+
+  @Override
+  public AgentInstanceSort tenantId() {
+    return field("tenantId");
+  }
+
+  @Override
   public AgentInstanceSort creationDate() {
     return field("creationDate");
   }
@@ -39,10 +74,5 @@ public class AgentInstanceSortImpl extends SearchRequestSortBase<AgentInstanceSo
   @Override
   public AgentInstanceSort completionDate() {
     return field("completionDate");
-  }
-
-  @Override
-  public AgentInstanceSort status() {
-    return field("status");
   }
 }

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
@@ -210,6 +210,32 @@
     </createIndex>
   </changeSet>
 
+  <changeSet id="create_agent_instance_pd_key_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_AGENT_INSTANCE_PD_KEY"
+          tableName="${prefix}AGENT_INSTANCE"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}AGENT_INSTANCE"
+      indexName="${prefix}IDX_AGENT_INSTANCE_PD_KEY">
+      <column name="PROCESS_DEFINITION_KEY"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_agent_instance_element_id_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_AGENT_INSTANCE_ELEMENT_ID"
+          tableName="${prefix}AGENT_INSTANCE"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}AGENT_INSTANCE"
+      indexName="${prefix}IDX_AGENT_INSTANCE_ELEMENT_ID">
+      <column name="ELEMENT_ID"/>
+    </createIndex>
+  </changeSet>
+
   <changeSet id="create_agent_instance_element_instance_table" author="camunda">
     <preConditions onFail="MARK_RAN">
       <not>

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/AgentInstanceSearchColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/AgentInstanceSearchColumn.java
@@ -11,14 +11,15 @@ import io.camunda.search.entities.AgentInstanceEntity;
 
 public enum AgentInstanceSearchColumn implements SearchColumn<AgentInstanceEntity> {
   AGENT_INSTANCE_KEY("agentInstanceKey"),
+  STATUS("status"),
+  ELEMENT_ID("elementId"),
+  PROCESS_INSTANCE_KEY("processInstanceKey"),
+  ROOT_PROCESS_INSTANCE_KEY("rootProcessInstanceKey"),
+  PROCESS_DEFINITION_KEY("processDefinitionKey"),
+  TENANT_ID("tenantId"),
   CREATION_DATE("creationDate"),
   LAST_UPDATED_DATE("lastUpdatedDate"),
-  COMPLETION_DATE("completionDate"),
-  STATUS("status"),
-  PROCESS_INSTANCE_KEY("processInstanceKey"),
-  PROCESS_DEFINITION_KEY("processDefinitionKey"),
-  ELEMENT_ID("elementId"),
-  TENANT_ID("tenantId");
+  COMPLETION_DATE("completionDate");
 
   private final String property;
 

--- a/db/rdbms/src/main/resources/mapper/AgentInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/AgentInstanceMapper.xml
@@ -261,6 +261,12 @@
           <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
         </foreach>
       </if>
+      <if test="filter.rootProcessInstanceKeyOperations != null and !filter.rootProcessInstanceKeyOperations.isEmpty()">
+        <foreach collection="filter.rootProcessInstanceKeyOperations" item="operation">
+          AND ai.ROOT_PROCESS_INSTANCE_KEY
+          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
       <if test="filter.processDefinitionIdOperations != null and !filter.processDefinitionIdOperations.isEmpty()">
         <foreach collection="filter.processDefinitionIdOperations" item="operation">
           AND ai.PROCESS_DEFINITION_ID

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
@@ -1526,6 +1526,9 @@ public class SearchQueryFilterMapper {
       ofNullable(filter.getProcessInstanceKey())
           .map(mapToKeyOperations("processInstanceKey", validationErrors))
           .ifPresent(builder::processInstanceKeyOperations);
+      ofNullable(filter.getRootProcessInstanceKey())
+          .map(mapToKeyOperations("rootProcessInstanceKey", validationErrors))
+          .ifPresent(builder::rootProcessInstanceKeyOperations);
       ofNullable(filter.getProcessDefinitionKey())
           .map(mapToKeyOperations("processDefinitionKey", validationErrors))
           .ifPresent(builder::processDefinitionKeyOperations);

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQuerySortRequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQuerySortRequestMapper.java
@@ -1026,10 +1026,16 @@ public class SearchQuerySortRequestMapper {
       validationErrors.add(ERROR_SORT_FIELD_MUST_NOT_BE_NULL);
     } else {
       switch (field) {
+        case AGENT_INSTANCE_KEY -> builder.agentInstanceKey();
+        case STATUS -> builder.status();
+        case ELEMENT_ID -> builder.elementId();
+        case PROCESS_INSTANCE_KEY -> builder.processInstanceKey();
+        case ROOT_PROCESS_INSTANCE_KEY -> builder.rootProcessInstanceKey();
+        case PROCESS_DEFINITION_KEY -> builder.processDefinitionKey();
+        case TENANT_ID -> builder.tenantId();
         case CREATION_DATE -> builder.creationDate();
         case LAST_UPDATED_DATE -> builder.lastUpdatedDate();
         case COMPLETION_DATE -> builder.completionDate();
-        case STATUS -> builder.status();
         default -> validationErrors.add(ERROR_UNKNOWN_SORT_BY.formatted(field));
       }
     }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceSearchIT.java
@@ -326,6 +326,20 @@ public class AgentInstanceSearchIT {
   }
 
   @Test
+  void shouldSortByAgentInstanceKeyAscending() {
+    // given — three agent instances created in order; engine assigns monotonically increasing keys
+    // when
+    final var response =
+        camundaClient
+            .newAgentInstanceSearchRequest()
+            .sort(s -> s.agentInstanceKey().asc())
+            .execute();
+
+    // then — keys must be in ascending order; this is the canonical stable pagination tiebreaker
+    assertThat(response.items()).extracting(AgentInstance::getAgentInstanceKey).isSorted();
+  }
+
+  @Test
   void shouldSortByCreationDateDescending() {
     // when
     final var response =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceSearchIT.java
@@ -326,6 +326,24 @@ public class AgentInstanceSearchIT {
   }
 
   @Test
+  void shouldFilterByRootProcessInstanceKey() {
+    // given — all three process instances are root processes (no call-activity parent),
+    // so rootProcessInstanceKey == processInstanceKey for each agent instance.
+    // ai1 belongs to processInstanceKey1; filtering by that key returns only ai1.
+    // when
+    final var response =
+        camundaClient
+            .newAgentInstanceSearchRequest()
+            .filter(f -> f.rootProcessInstanceKey(processInstanceKey1))
+            .execute();
+
+    // then
+    assertThat(response.items())
+        .extracting(AgentInstance::getAgentInstanceKey)
+        .containsExactly(agentInstanceKey1);
+  }
+
+  @Test
   void shouldSortByAgentInstanceKeyAscending() {
     // given — three agent instances created in order; engine assigns monotonically increasing keys
     // when

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agentinstance/AgentInstanceFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agentinstance/AgentInstanceFilterIT.java
@@ -128,6 +128,24 @@ public class AgentInstanceFilterIT {
   }
 
   @TestTemplate
+  public void shouldFilterByRootProcessInstanceKey(
+      final CamundaRdbmsTestApplication testApplication) {
+    final long rootKey = nextKey();
+    final var model =
+        createAndSaveRandomAgentInstance(testApplication, b -> b.rootProcessInstanceKey(rootKey));
+    createAndSaveRandomAgentInstance(testApplication, b -> b);
+
+    final var result =
+        search(
+            testApplication,
+            new AgentInstanceFilter.Builder().rootProcessInstanceKeys(rootKey).build());
+
+    assertThat(result.total()).isEqualTo(1);
+    assertThat(result.items().getFirst().agentInstanceKey()).isEqualTo(model.agentInstanceKey());
+    assertThat(result.items().getFirst().rootProcessInstanceKey()).isEqualTo(rootKey);
+  }
+
+  @TestTemplate
   public void shouldFilterByElementInstanceKey(final CamundaRdbmsTestApplication testApplication) {
     final long elementInstanceKey = nextKey();
     final var model =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agentinstance/AgentInstanceSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agentinstance/AgentInstanceSortIT.java
@@ -79,6 +79,107 @@ public class AgentInstanceSortIT {
         Comparator.comparing((AgentInstanceEntity e) -> e.status().name()).reversed());
   }
 
+  @TestTemplate
+  public void shouldSortByAgentInstanceKeyAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication,
+        b -> b.agentInstanceKey().asc(),
+        Comparator.comparingLong(AgentInstanceEntity::agentInstanceKey));
+  }
+
+  @TestTemplate
+  public void shouldSortByAgentInstanceKeyDesc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication,
+        b -> b.agentInstanceKey().desc(),
+        Comparator.comparingLong(AgentInstanceEntity::agentInstanceKey).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortByProcessInstanceKeyAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication,
+        b -> b.processInstanceKey().asc(),
+        Comparator.comparingLong(AgentInstanceEntity::processInstanceKey));
+  }
+
+  @TestTemplate
+  public void shouldSortByProcessInstanceKeyDesc(
+      final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication,
+        b -> b.processInstanceKey().desc(),
+        Comparator.comparingLong(AgentInstanceEntity::processInstanceKey).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortByProcessDefinitionKeyAsc(
+      final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication,
+        b -> b.processDefinitionKey().asc(),
+        Comparator.comparingLong(AgentInstanceEntity::processDefinitionKey));
+  }
+
+  @TestTemplate
+  public void shouldSortByProcessDefinitionKeyDesc(
+      final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication,
+        b -> b.processDefinitionKey().desc(),
+        Comparator.comparingLong(AgentInstanceEntity::processDefinitionKey).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortByElementIdAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication,
+        b -> b.elementId().asc(),
+        Comparator.comparing(AgentInstanceEntity::elementId));
+  }
+
+  @TestTemplate
+  public void shouldSortByElementIdDesc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication,
+        b -> b.elementId().desc(),
+        Comparator.comparing(AgentInstanceEntity::elementId).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortByTenantIdAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication,
+        b -> b.tenantId().asc(),
+        Comparator.comparing(AgentInstanceEntity::tenantId));
+  }
+
+  @TestTemplate
+  public void shouldSortByTenantIdDesc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication,
+        b -> b.tenantId().desc(),
+        Comparator.comparing(AgentInstanceEntity::tenantId).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortByRootProcessInstanceKeyAsc(
+      final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication,
+        b -> b.rootProcessInstanceKey().asc(),
+        Comparator.comparingLong(AgentInstanceEntity::rootProcessInstanceKey));
+  }
+
+  @TestTemplate
+  public void shouldSortByRootProcessInstanceKeyDesc(
+      final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication,
+        b -> b.rootProcessInstanceKey().desc(),
+        Comparator.comparingLong(AgentInstanceEntity::rootProcessInstanceKey).reversed());
+  }
+
   private void testSorting(
       final CamundaRdbmsTestApplication testApplication,
       final Function<Builder, ObjectBuilder<AgentInstanceSort>> sortBuilder,

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/AgentInstanceFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/AgentInstanceFixtures.java
@@ -34,7 +34,7 @@ public final class AgentInstanceFixtures extends CommonFixtures {
             .processDefinitionId("process-" + nextStringKey())
             .processDefinitionKey(nextKey())
             .processDefinitionVersion(1)
-            .tenantId("<default>")
+            .tenantId("tenant-" + key)
             .partitionId(1)
             .status(AgentInstanceStatus.IDLE)
             .model("gpt-4o")

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/AgentInstanceFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/AgentInstanceFilterTransformer.java
@@ -14,6 +14,7 @@ import static io.camunda.search.clients.query.SearchQueryBuilders.longOperations
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringOperations;
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
 import static io.camunda.webapps.schema.descriptors.ProcessInstanceDependant.PROCESS_INSTANCE_KEY;
+import static io.camunda.webapps.schema.descriptors.ProcessInstanceDependant.ROOT_PROCESS_INSTANCE_KEY;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.BPMN_PROCESS_ID;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.COMPLETION_DATE;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.CREATION_DATE;
@@ -45,6 +46,8 @@ public class AgentInstanceFilterTransformer extends IndexFilterTransformer<Agent
     queries.addAll(longOperations(KEY, filter.agentInstanceKeyOperations()));
     queries.addAll(longOperations(ELEMENT_INSTANCE_KEYS, filter.elementInstanceKeyOperations()));
     queries.addAll(longOperations(PROCESS_INSTANCE_KEY, filter.processInstanceKeyOperations()));
+    queries.addAll(
+        longOperations(ROOT_PROCESS_INSTANCE_KEY, filter.rootProcessInstanceKeyOperations()));
     queries.addAll(longOperations(PROCESS_DEFINITION_KEY, filter.processDefinitionKeyOperations()));
     queries.addAll(stringOperations(BPMN_PROCESS_ID, filter.processDefinitionIdOperations()));
     queries.addAll(

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/AgentInstanceFieldSortingTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/AgentInstanceFieldSortingTransformer.java
@@ -7,20 +7,32 @@
  */
 package io.camunda.search.clients.transformers.sort;
 
+import static io.camunda.webapps.schema.descriptors.ProcessInstanceDependant.PROCESS_INSTANCE_KEY;
+import static io.camunda.webapps.schema.descriptors.ProcessInstanceDependant.ROOT_PROCESS_INSTANCE_KEY;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.COMPLETION_DATE;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.CREATION_DATE;
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.ELEMENT_ID;
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.KEY;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.LAST_UPDATED_DATE;
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.PROCESS_DEFINITION_KEY;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.STATUS;
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.TENANT_ID;
 
 public class AgentInstanceFieldSortingTransformer implements FieldSortingTransformer {
 
   @Override
   public String apply(final String domainField) {
     return switch (domainField) {
+      case "agentInstanceKey" -> KEY; // ES/OS stores the key as "key", not "agentInstanceKey"
+      case "status" -> STATUS;
+      case "elementId" -> ELEMENT_ID;
+      case "processInstanceKey" -> PROCESS_INSTANCE_KEY;
+      case "rootProcessInstanceKey" -> ROOT_PROCESS_INSTANCE_KEY;
+      case "processDefinitionKey" -> PROCESS_DEFINITION_KEY;
+      case "tenantId" -> TENANT_ID;
       case "creationDate" -> CREATION_DATE;
       case "lastUpdatedDate" -> LAST_UPDATED_DATE;
       case "completionDate" -> COMPLETION_DATE;
-      case "status" -> STATUS;
       default -> throw new IllegalArgumentException("Unknown sortField: " + domainField);
     };
   }

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/AgentInstanceFilterTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/AgentInstanceFilterTransformerTest.java
@@ -220,6 +220,21 @@ class AgentInstanceFilterTransformerTest extends AbstractTransformerTest {
   }
 
   @Test
+  void shouldQueryByRootProcessInstanceKey() {
+    final var filter = FilterBuilders.agentInstance(f -> f.rootProcessInstanceKeys(300L));
+
+    final var searchRequest = transformQuery(filter);
+
+    assertThat(searchRequest.queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("rootProcessInstanceKey");
+              assertThat(t.value().longValue()).isEqualTo(300L);
+            });
+  }
+
+  @Test
   void shouldQueryByAllFields() {
     final var filter =
         FilterBuilders.agentInstance(
@@ -227,6 +242,7 @@ class AgentInstanceFilterTransformerTest extends AbstractTransformerTest {
                 f.agentInstanceKeys(100L)
                     .elementInstanceKeys(1L)
                     .processInstanceKeys(200L)
+                    .rootProcessInstanceKeys(300L)
                     .processDefinitionKeys(400L)
                     .processDefinitionIds("myProcess")
                     .processDefinitionVersions(2)
@@ -244,6 +260,6 @@ class AgentInstanceFilterTransformerTest extends AbstractTransformerTest {
     final var searchRequest = transformQuery(filter);
 
     assertThat(searchRequest.queryOption()).isInstanceOf(SearchBoolQuery.class);
-    assertThat(((SearchBoolQuery) searchRequest.queryOption()).must()).hasSize(13);
+    assertThat(((SearchBoolQuery) searchRequest.queryOption()).must()).hasSize(14);
   }
 }

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/AgentInstanceFieldSortingTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/AgentInstanceFieldSortingTransformerTest.java
@@ -15,6 +15,7 @@ import io.camunda.search.sort.AgentInstanceSort;
 import io.camunda.search.sort.SearchSortOptions;
 import io.camunda.search.sort.SortOrder;
 import io.camunda.util.ObjectBuilder;
+import io.camunda.webapps.schema.descriptors.ProcessInstanceDependant;
 import io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -28,17 +29,35 @@ public class AgentInstanceFieldSortingTransformerTest extends AbstractSortTransf
   private static Stream<Arguments> provideSortParameters() {
     return Stream.of(
         new TestArguments(
+            AgentInstanceTemplate.KEY, SortOrder.DESC, s -> s.agentInstanceKey().desc()),
+        new TestArguments(AgentInstanceTemplate.STATUS, SortOrder.ASC, s -> s.status().asc()),
+        new TestArguments(
+            AgentInstanceTemplate.ELEMENT_ID, SortOrder.ASC, s -> s.elementId().asc()),
+        new TestArguments(
+            ProcessInstanceDependant.PROCESS_INSTANCE_KEY,
+            SortOrder.ASC,
+            s -> s.processInstanceKey().asc()),
+        new TestArguments(
+            ProcessInstanceDependant.ROOT_PROCESS_INSTANCE_KEY,
+            SortOrder.DESC,
+            s -> s.rootProcessInstanceKey().desc()),
+        new TestArguments(
+            AgentInstanceTemplate.PROCESS_DEFINITION_KEY,
+            SortOrder.ASC,
+            s -> s.processDefinitionKey().asc()),
+        new TestArguments(
+            AgentInstanceTemplate.TENANT_ID, SortOrder.DESC, s -> s.tenantId().desc()),
+        new TestArguments(
             AgentInstanceTemplate.CREATION_DATE, SortOrder.ASC, s -> s.creationDate().asc()),
         new TestArguments(
             AgentInstanceTemplate.LAST_UPDATED_DATE,
             SortOrder.DESC,
             s -> s.lastUpdatedDate().desc()),
         new TestArguments(
-            AgentInstanceTemplate.COMPLETION_DATE, SortOrder.ASC, s -> s.completionDate().asc()),
-        new TestArguments(AgentInstanceTemplate.STATUS, SortOrder.DESC, s -> s.status().desc()));
+            AgentInstanceTemplate.COMPLETION_DATE, SortOrder.ASC, s -> s.completionDate().asc()));
   }
 
-  @ParameterizedTest
+  @ParameterizedTest(name = "should sort by {0} in ''{1}'' direction")
   @MethodSource("provideSortParameters")
   void shouldSortByField(
       final String expectedField,
@@ -56,6 +75,23 @@ public class AgentInstanceFieldSortingTransformerTest extends AbstractSortTransf
               assertThat(t.field().order()).isEqualTo(sortOrder);
             });
     assertThat(sort.get(1))
+        .isInstanceOfSatisfying(
+            SearchSortOptions.class,
+            t -> {
+              assertThat(t.field().field()).isEqualTo(AgentInstanceTemplate.KEY);
+              assertThat(t.field().order()).isEqualTo(SortOrder.ASC);
+            });
+  }
+
+  @Test
+  void shouldUseAgentInstanceKeyAsDefaultTiebreakerWhenNoSortSpecified() {
+    // given — query with no explicit sort
+    final var request = SearchQueryBuilders.agentInstanceSearchQuery(q -> q);
+    // when
+    final var sort = transformRequest(request);
+    // then — only the implicit default tiebreaker is appended
+    assertThat(sort).hasSize(1);
+    assertThat(sort.get(0))
         .isInstanceOfSatisfying(
             SearchSortOptions.class,
             t -> {

--- a/search/search-domain/src/main/java/io/camunda/search/filter/AgentInstanceFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/AgentInstanceFilter.java
@@ -22,6 +22,7 @@ public record AgentInstanceFilter(
     List<Operation<Long>> agentInstanceKeyOperations,
     List<Operation<Long>> elementInstanceKeyOperations,
     List<Operation<Long>> processInstanceKeyOperations,
+    List<Operation<Long>> rootProcessInstanceKeyOperations,
     List<Operation<Long>> processDefinitionKeyOperations,
     List<Operation<String>> processDefinitionIdOperations,
     List<Operation<Integer>> processDefinitionVersionOperations,
@@ -44,6 +45,7 @@ public record AgentInstanceFilter(
     private List<Operation<Long>> agentInstanceKeyOperations;
     private List<Operation<Long>> elementInstanceKeyOperations;
     private List<Operation<Long>> processInstanceKeyOperations;
+    private List<Operation<Long>> rootProcessInstanceKeyOperations;
     private List<Operation<Long>> processDefinitionKeyOperations;
     private List<Operation<String>> processDefinitionIdOperations;
     private List<Operation<Integer>> processDefinitionVersionOperations;
@@ -98,6 +100,22 @@ public record AgentInstanceFilter(
 
     public Builder processInstanceKeys(final Long value, final Long... values) {
       return processInstanceKeyOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder rootProcessInstanceKeyOperations(final List<Operation<Long>> operations) {
+      rootProcessInstanceKeyOperations =
+          addValuesToList(rootProcessInstanceKeyOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder rootProcessInstanceKeyOperations(
+        final Operation<Long> operation, final Operation<Long>... operations) {
+      return rootProcessInstanceKeyOperations(collectValues(operation, operations));
+    }
+
+    public Builder rootProcessInstanceKeys(final Long value, final Long... values) {
+      return rootProcessInstanceKeyOperations(FilterUtil.mapDefaultToOperation(value, values));
     }
 
     public Builder processDefinitionKeyOperations(final List<Operation<Long>> operations) {
@@ -245,6 +263,7 @@ public record AgentInstanceFilter(
           Objects.requireNonNullElse(agentInstanceKeyOperations, Collections.emptyList()),
           Objects.requireNonNullElse(elementInstanceKeyOperations, Collections.emptyList()),
           Objects.requireNonNullElse(processInstanceKeyOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(rootProcessInstanceKeyOperations, Collections.emptyList()),
           Objects.requireNonNullElse(processDefinitionKeyOperations, Collections.emptyList()),
           Objects.requireNonNullElse(processDefinitionIdOperations, Collections.emptyList()),
           Objects.requireNonNullElse(processDefinitionVersionOperations, Collections.emptyList()),

--- a/search/search-domain/src/main/java/io/camunda/search/sort/AgentInstanceSort.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/AgentInstanceSort.java
@@ -26,6 +26,41 @@ public record AgentInstanceSort(List<FieldSorting> orderings) implements SortOpt
   public static final class Builder extends AbstractBuilder<Builder>
       implements ObjectBuilder<AgentInstanceSort> {
 
+    public Builder agentInstanceKey() {
+      currentOrdering = new FieldSorting("agentInstanceKey", null);
+      return this;
+    }
+
+    public Builder status() {
+      currentOrdering = new FieldSorting("status", null);
+      return this;
+    }
+
+    public Builder elementId() {
+      currentOrdering = new FieldSorting("elementId", null);
+      return this;
+    }
+
+    public Builder processInstanceKey() {
+      currentOrdering = new FieldSorting("processInstanceKey", null);
+      return this;
+    }
+
+    public Builder rootProcessInstanceKey() {
+      currentOrdering = new FieldSorting("rootProcessInstanceKey", null);
+      return this;
+    }
+
+    public Builder processDefinitionKey() {
+      currentOrdering = new FieldSorting("processDefinitionKey", null);
+      return this;
+    }
+
+    public Builder tenantId() {
+      currentOrdering = new FieldSorting("tenantId", null);
+      return this;
+    }
+
     public Builder creationDate() {
       currentOrdering = new FieldSorting("creationDate", null);
       return this;
@@ -38,11 +73,6 @@ public record AgentInstanceSort(List<FieldSorting> orderings) implements SortOpt
 
     public Builder completionDate() {
       currentOrdering = new FieldSorting("completionDate", null);
-      return this;
-    }
-
-    public Builder status() {
-      currentOrdering = new FieldSorting("status", null);
       return this;
     }
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -236,6 +236,13 @@ components:
           description: The key of the process instance that owns this agent instance.
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKeyFilterProperty'
+        rootProcessInstanceKey:
+          description: |
+            The key of the root process instance. Filters agent instances belonging to a specific
+            call hierarchy. The root process instance is the top-level ancestor in the process
+            instance hierarchy.
+          allOf:
+            - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKeyFilterProperty'
         processDefinitionKey:
           description: The key of the process definition associated with this agent instance.
           allOf:

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -186,10 +186,16 @@ components:
           description: The field to sort by.
           type: string
           enum:
+            - agentInstanceKey
+            - status
+            - elementId
+            - processInstanceKey
+            - rootProcessInstanceKey
+            - processDefinitionKey
+            - tenantId
             - creationDate
             - lastUpdatedDate
             - completionDate
-            - status
         order:
           $ref: 'search-models.yaml#/components/schemas/SortOrderEnum'
 


### PR DESCRIPTION
## Description

Expands the filter and sort surfaces of `POST /v2/agent-instances/search` to match the `AgentInstanceResult` response shape and sibling entities (ProcessInstance, FlowNodeInstance, Job).

### Motivation

The initial agent instance search endpoint shipped with a minimal filter/sort surface to unblock parallel secondary-storage work. Now that all readers are merged, this PR completes the API surface before alpha.

### New sort fields (6)

Field order mirrors the `AgentInstanceResult` response field sequence in the OpenAPI spec.

- `agentInstanceKey` — **default sort**; canonical stable tiebreaker for cursor-based pagination
- `status`
- `elementId`
- `processInstanceKey`
- `rootProcessInstanceKey`
- `processDefinitionKey`
- `tenantId`

### New filter field (1)

- `rootProcessInstanceKey` — always populated since #54321; use to scope a search to all agent instances within a call hierarchy

### RDBMS schema

Adds B-tree indices on `PROCESS_DEFINITION_KEY` and `ELEMENT_ID` — two newly sort-eligible columns that had no index. Follows the existing per-sort-column index pattern already applied to `PROCESS_INSTANCE_KEY`, `ROOT_PROCESS_INSTANCE_KEY`, and `TENANT_ID`.

### Layers touched

All changes are wired through every layer: domain record → ES/OS transformer → RDBMS column enum → OpenAPI spec → REST request mapper → CamundaClient Java API.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #53823