### PR TITLE
fix: roll back ProcessInstanceIndex version from v9 to v8

### DIFF
--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/ProcessInstanceIndex.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/ProcessInstanceIndex.java
@@ -24,7 +24,10 @@ import java.util.Locale;
 
 public abstract class ProcessInstanceIndex<TBuilder> extends AbstractInstanceIndex<TBuilder> {
 
-  public static final int VERSION = 9;
+  // Bump this only for breaking mapping changes that require reindexing.
+  // Backwards-compatible additions (new fields, nested type additions) must NOT increment the
+  // version, as doing so forces a full migration for all customers on minor updates.
+  public static final int VERSION = 8;
 
   public static final String START_DATE = ProcessInstanceDto.Fields.startDate;
   public static final String END_DATE = ProcessInstanceDto.Fields.endDate;

--- a/optimize/util/optimize-commons/src/test/java/io/camunda/optimize/service/db/schema/index/ProcessInstanceIndexMappingTest.java
+++ b/optimize/util/optimize-commons/src/test/java/io/camunda/optimize/service/db/schema/index/ProcessInstanceIndexMappingTest.java
@@ -34,7 +34,7 @@ class ProcessInstanceIndexMappingTest {
   }
 
   @Test
-  void shouldHaveVersionNine() {
-    assertThat(ProcessInstanceIndex.VERSION).isEqualTo(9);
+  void shouldHaveVersionEight() {
+    assertThat(ProcessInstanceIndex.VERSION).isEqualTo(8);
   }
 }


### PR DESCRIPTION
## Description

The index schema changes introduced in #54263 are backwards compatible and do not require a full reindex. Keeping the version at v9 would force Optimize to trigger an index migration during a minor update, creating unnecessary friction for customers with large data volumes.

Rolling back to v8 avoids this migration cost while preserving the schema changes themselves. The index version should only be bumped when the mapping changes are genuinely breaking and a reindex is unavoidable.

Also updates ProcessInstanceIndexMappingTest to assert the correct version.

## Related issues

closes https://github.com/camunda/camunda/issues/54674
