### PR TITLE
54128 process filter fe

### DIFF
--- a/optimize/backend/src/main/resources/localization/de.json
+++ b/optimize/backend/src/main/resources/localization/de.json
@@ -11,6 +11,10 @@
       "last3Months": "Letzte 3 Monate",
       "last6Months": "Letzte 6 Monate",
       "last12Months": "Letzte 12 Monate"
+    },
+    "processFilter": {
+      "label": "Prozess",
+      "placeholder": "Alle Prozesse"
     }
   },
   "navigation": {

--- a/optimize/backend/src/main/resources/localization/en.json
+++ b/optimize/backend/src/main/resources/localization/en.json
@@ -11,6 +11,10 @@
       "last3Months": "Last 3 months",
       "last6Months": "Last 6 months",
       "last12Months": "Last 12 months"
+    },
+    "processFilter": {
+      "label": "Process",
+      "placeholder": "All processes"
     }
   },
   "navigation": {

--- a/optimize/client/src/components/AgenticControlPlane/AgenticControlPlane.js
+++ b/optimize/client/src/components/AgenticControlPlane/AgenticControlPlane.js
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {useState, useEffect} from 'react';
+import {useState, useEffect, useCallback} from 'react';
 
 import {useErrorHandling} from 'hooks';
 import {showError} from 'notifications';
@@ -36,6 +36,7 @@ function presetToFilter(preset) {
 export function AgenticControlPlane() {
   const [preset, setPreset] = useState('30d');
   const [dashboard, setDashboard] = useState(null);
+  const [processScope, setProcessScope] = useState(null);
   const {mightFail} = useErrorHandling();
 
   useEffect(() => {
@@ -45,9 +46,30 @@ export function AgenticControlPlane() {
   const selectedPreset = DATE_PRESETS.find((p) => p.id === preset);
   const filter = [presetToFilter(selectedPreset)];
 
+  const scopedEvaluateReport = useCallback(
+    (id, tileFilter, query) =>
+      evaluateReport(
+        id,
+        tileFilter,
+        query,
+        processScope ? [{key: processScope, versions: ['all']}] : []
+      ),
+    [processScope]
+  );
+
   if (!dashboard) {
     return <Loading />;
   }
+
+  const visibleTiles = dashboard.tiles?.filter((tile) => {
+    if (processScope && tile.configuration?.visibleInL0Only) {
+      return false;
+    }
+    if (!processScope && tile.configuration?.visibleInL1Only) {
+      return false;
+    }
+    return true;
+  });
 
   return (
     <div className="AgenticControlPlane">
@@ -55,8 +77,13 @@ export function AgenticControlPlane() {
         <h1 className="AgenticControlPlane__title">{t('agenticControlPlane.title')}</h1>
         <p className="AgenticControlPlane__description">{t('agenticControlPlane.description')}</p>
       </div>
-      <FilterBar preset={preset} onPresetChange={setPreset} />
-      <DashboardRenderer loadTile={evaluateReport} tiles={dashboard.tiles} filter={filter} />
+      <FilterBar
+        preset={preset}
+        onPresetChange={setPreset}
+        processScope={processScope}
+        onProcessScopeChange={setProcessScope}
+      />
+      <DashboardRenderer loadTile={scopedEvaluateReport} tiles={visibleTiles} filter={filter} />
     </div>
   );
 }

--- a/optimize/client/src/components/AgenticControlPlane/AgenticControlPlane.test.js
+++ b/optimize/client/src/components/AgenticControlPlane/AgenticControlPlane.test.js
@@ -9,6 +9,8 @@
 import {runAllEffects} from 'react';
 import {shallow} from 'enzyme';
 
+import {evaluateReport} from 'services';
+
 import {AgenticControlPlane} from './AgenticControlPlane';
 import {loadAgenticDashboard} from './service';
 
@@ -117,4 +119,60 @@ it('should pass the loaded tiles to DashboardRenderer', async () => {
   await runAllEffects();
 
   expect(node.find('DashboardRenderer').prop('tiles')).toEqual(tiles);
+});
+
+it('should hide visibleInL0Only tiles when a process is selected', async () => {
+  const tiles = [
+    {id: 'l0-tile', configuration: {visibleInL0Only: true}},
+    {id: 'l1-tile', configuration: {visibleInL1Only: true}},
+    {id: 'common-tile', configuration: {}},
+  ];
+  loadAgenticDashboard.mockReturnValueOnce({tiles, availableFilters: []});
+
+  const node = shallow(<AgenticControlPlane />);
+  await runAllEffects();
+
+  node.find('FilterBar').prop('onProcessScopeChange')('my-process');
+
+  const visibleTiles = node.find('DashboardRenderer').prop('tiles');
+  expect(visibleTiles.map((t) => t.id)).toEqual(['l1-tile', 'common-tile']);
+});
+
+it('should hide visibleInL1Only tiles when no process is selected (L0)', async () => {
+  const tiles = [
+    {id: 'l0-tile', configuration: {visibleInL0Only: true}},
+    {id: 'l1-tile', configuration: {visibleInL1Only: true}},
+    {id: 'common-tile', configuration: {}},
+  ];
+  loadAgenticDashboard.mockReturnValueOnce({tiles, availableFilters: []});
+
+  const node = shallow(<AgenticControlPlane />);
+  await runAllEffects();
+
+  const visibleTiles = node.find('DashboardRenderer').prop('tiles');
+  expect(visibleTiles.map((t) => t.id)).toEqual(['l0-tile', 'common-tile']);
+});
+
+it('should include definitions in evaluate calls when a process is selected', async () => {
+  const node = shallow(<AgenticControlPlane />);
+  await runAllEffects();
+
+  node.find('FilterBar').prop('onProcessScopeChange')('my-process');
+
+  const loadTile = node.find('DashboardRenderer').prop('loadTile');
+  loadTile('report-id', [], {});
+
+  expect(evaluateReport).toHaveBeenCalledWith('report-id', [], {}, [
+    {key: 'my-process', versions: ['all']},
+  ]);
+});
+
+it('should pass empty definitions in evaluate calls when no process is selected', async () => {
+  const node = shallow(<AgenticControlPlane />);
+  await runAllEffects();
+
+  const loadTile = node.find('DashboardRenderer').prop('loadTile');
+  loadTile('report-id', [], {});
+
+  expect(evaluateReport).toHaveBeenCalledWith('report-id', [], {}, []);
 });

--- a/optimize/client/src/components/AgenticControlPlane/FilterBar.js
+++ b/optimize/client/src/components/AgenticControlPlane/FilterBar.js
@@ -6,9 +6,11 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {MenuItemSelectable} from '@carbon/react';
+import {useState, useEffect} from 'react';
+import {ComboBox, MenuItemSelectable} from '@carbon/react';
 
 import {MenuDropdown} from 'components';
+import {loadDefinitions} from 'services';
 import {t} from 'translation';
 
 import './FilterBar.scss';
@@ -21,11 +23,31 @@ export const DATE_PRESETS = [
   {id: '12m', translationKey: 'agenticControlPlane.presets.last12Months', value: 12, unit: 'months'},
 ];
 
-export function FilterBar({preset, onPresetChange}) {
+export function FilterBar({preset, onPresetChange, processScope, onProcessScopeChange}) {
   const selected = DATE_PRESETS.find((p) => p.id === preset);
+  const [processDefinitions, setProcessDefinitions] = useState([]);
+
+  useEffect(() => {
+    loadDefinitions('process', null).then(setProcessDefinitions);
+  }, []);
+
+  const selectedProcess = processDefinitions.find((d) => d.key === processScope) ?? null;
 
   return (
     <div className="FilterBar">
+      <div className="FilterBar__processScope">
+        <span className="FilterBar__label">{t('agenticControlPlane.processFilter.label')}</span>
+        <ComboBox
+          id="process-scope-filter"
+          size="sm"
+          items={processDefinitions}
+          itemToString={(item) => item?.name ?? item?.key ?? ''}
+          selectedItem={selectedProcess}
+          onChange={({selectedItem}) => onProcessScopeChange?.(selectedItem?.key ?? null)}
+          placeholder={t('agenticControlPlane.processFilter.placeholder')}
+          titleText=""
+        />
+      </div>
       <div className="FilterBar__dateRange">
         <span className="FilterBar__label">{t('agenticControlPlane.dateRange')}</span>
         <MenuDropdown label={t(selected.translationKey)} size="sm">

--- a/optimize/client/src/components/AgenticControlPlane/FilterBar.scss
+++ b/optimize/client/src/components/AgenticControlPlane/FilterBar.scss
@@ -8,12 +8,18 @@
 
 .FilterBar {
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
   align-items: center;
   padding: 0.75rem 0;
   border-top: 1px solid var(--cds-border-subtle);
   border-bottom: 1px solid var(--cds-border-subtle);
   margin-bottom: 1rem;
+
+  &__processScope {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
 
   &__dateRange {
     display: flex;

--- a/optimize/client/src/components/AgenticControlPlane/FilterBar.test.js
+++ b/optimize/client/src/components/AgenticControlPlane/FilterBar.test.js
@@ -6,16 +6,28 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import {runAllEffects} from 'react';
 import {shallow} from 'enzyme';
-import {MenuItemSelectable} from '@carbon/react';
+import {ComboBox, MenuItemSelectable} from '@carbon/react';
 
 import {MenuDropdown} from 'components';
+import {loadDefinitions} from 'services';
 
 import {FilterBar, DATE_PRESETS} from './FilterBar';
+
+jest.mock('services', () => ({
+  ...jest.requireActual('services'),
+  loadDefinitions: jest.fn().mockResolvedValue([
+    {key: 'process-a', name: 'Process A'},
+    {key: 'process-b', name: 'Process B'},
+  ]),
+}));
 
 const props = {
   preset: '30d',
   onPresetChange: jest.fn(),
+  processScope: null,
+  onProcessScopeChange: jest.fn(),
 };
 
 beforeEach(() => {
@@ -55,4 +67,44 @@ it('should default to Last 30 days being selected when preset is 30d', () => {
 
   const selectedItem = node.find(MenuItemSelectable).filterWhere((n) => n.prop('selected'));
   expect(selectedItem.prop('label')).toBe('Last 30 days');
+});
+
+it('should render a process scope ComboBox', () => {
+  const node = shallow(<FilterBar {...props} />);
+
+  expect(node.find(ComboBox)).toExist();
+});
+
+it('should load agent-enabled process definitions on mount', async () => {
+  shallow(<FilterBar {...props} />);
+
+  await runAllEffects();
+
+  expect(loadDefinitions).toHaveBeenCalledWith('process', null);
+});
+
+it('should call onProcessScopeChange with the definition key when a process is selected', async () => {
+  const node = shallow(<FilterBar {...props} />);
+
+  await runAllEffects();
+
+  node.find(ComboBox).prop('onChange')({selectedItem: {key: 'process-a', name: 'Process A'}});
+
+  expect(props.onProcessScopeChange).toHaveBeenCalledWith('process-a');
+});
+
+it('should call onProcessScopeChange with null when the ComboBox is cleared', async () => {
+  const node = shallow(<FilterBar {...props} processScope="process-a" />);
+
+  await runAllEffects();
+
+  node.find(ComboBox).prop('onChange')({selectedItem: null});
+
+  expect(props.onProcessScopeChange).toHaveBeenCalledWith(null);
+});
+
+it('should show null selectedItem in ComboBox when no process is selected', () => {
+  const node = shallow(<FilterBar {...props} processScope={null} />);
+
+  expect(node.find(ComboBox).prop('selectedItem')).toBeNull();
 });

--- a/optimize/client/src/components/AgenticControlPlane/service.js
+++ b/optimize/client/src/components/AgenticControlPlane/service.js
@@ -14,5 +14,8 @@
 // }
 
 export async function loadAgenticDashboard() {
-  return {tiles: [], availableFilters: []};
+  return {
+    availableFilters: [{type: 'processScope'}],
+    tiles: [],
+  };
 }

--- a/optimize/client/src/modules/services/loadDefinitions.ts
+++ b/optimize/client/src/modules/services/loadDefinitions.ts
@@ -15,12 +15,17 @@ export type Definition = {
 
 export async function loadDefinitions(
   type: string,
-  collectionId: string | null
+  collectionId: string | null,
+  options?: {onlyWithAgentRuns?: boolean}
 ): Promise<Definition[]> {
-  const params: {filterByCollectionScope?: string} = {};
+  const params: {filterByCollectionScope?: string; onlyWithAgentRuns?: boolean} = {};
 
   if (collectionId) {
     params.filterByCollectionScope = collectionId;
+  }
+
+  if (options?.onlyWithAgentRuns) {
+    params.onlyWithAgentRuns = true;
   }
 
   const response = await get(`api/definition/${type}/keys`, params);

--- a/optimize/client/src/modules/services/reportService.ts
+++ b/optimize/client/src/modules/services/reportService.ts
@@ -47,13 +47,15 @@ export type ReportEvaluationPayload = DeepPartial<Report>;
 export async function evaluateReport(
   payload: ReportEvaluationPayload,
   filter = [],
-  query = {}
+  query = {},
+  definitions: {key: string; versions: string[]}[] = []
 ): Promise<Report> {
   let response;
 
   if (typeof payload !== 'object') {
     // evaluate saved report
-    response = await post(`api/report/${payload}/evaluate`, {filter}, {query});
+    const body = definitions.length > 0 ? {filter, definitions} : {filter};
+    response = await post(`api/report/${payload}/evaluate`, body, {query});
   } else {
     // evaluate unsaved report
     // we dont want to send report result in payload to prevent exceedeing request size limit


### PR DESCRIPTION
## Description

- **Process ComboBox in `FilterBar`** — loads all process definitions on mount via `loadDefinitions('process', null)`. Default (null) = L0 fleet-wide view. Selecting a process = L1 per-process view.
- **L0/L1 tile visibility** — tiles with `configuration.visibleInL0Only` are hidden when a process is selected; tiles with `configuration.visibleInL1Only` are hidden when no process is selected (fleet-wide).
- **`definitions` in evaluate body** — `scopedEvaluateReport` wraps `evaluateReport` and passes `[{key, versions: ['all']}]` as the 4th argument, which is included in the `POST /api/report/{id}/evaluate` request body alongside `filter`. This is a no-op at the API level until the backend adds support ([#54707](https://github.com/camunda/camunda/issues/54707)).
- **`reportService.ts`** — backward-compatible `definitions` 4th param added. Existing callers are unaffected (defaults to `[]`).
- **`loadDefinitions.ts`** — optional `onlyWithAgentRuns` option wired for future use (ignored by backend until [#53301](https://github.com/camunda/camunda/issues/53301) lands).
- **Localization** — `agenticControlPlane.processFilter.label/placeholder` keys added in EN and DE.

## Test plan

- [ ] `yarn test --testPathPattern="AgenticControlPlane|FilterBar|loadDefinitions" --watchAll=false` passes with no failures
- [ ] Process ComboBox renders in the filter bar alongside the date preset dropdown
- [ ] Date preset changes are preserved when process scope changes (and vice versa)
- [ ] Evaluate calls include `definitions: [{key, versions: ['all']}]` in the request body when a process is selected (verify via network tab)
- [ ] Evaluate calls use `definitions: []` (body omits the field) when no process is selected

## Related issues

closes #54128
