### PR TITLE
fix: revert Optimize 8.7 release Docker base image to JDK 21

### DIFF
--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -345,8 +345,11 @@ jobs:
           DATE="$(date +%FT%TZ)"
           export DATE
           export REVISION="${REVISION}"
-          export BASE_IMAGE="reg.mini.dev/1212/openjre-base:25-dev"
-          export BASE_DIGEST="sha256:e2772c8469b0b3cfc792708153d075fcf17778444d6d57792e4ba83d49bf82e6"
+          # optimize.Dockerfile here is from the checked-out release branch (see "Checkout release branch" step above)
+          BASE_IMAGE="$(sed -nE 's/^ARG BASE_IMAGE="([^"]+)".*/\1/p' optimize.Dockerfile | head -n 1)"
+          export BASE_IMAGE
+          BASE_DIGEST="$(sed -nE 's/^ARG BASE_DIGEST="([^"]+)".*/\1/p' optimize.Dockerfile | head -n 1)"
+          export BASE_DIGEST
 
           # if CI (GHA) export the variables for pushing in a later step
           if [ "${CI}" = "true" ]; then


### PR DESCRIPTION
# Description

Reverts the Optimize 8.7 release workflow (`optimize-release-optimize-c8-only.yml`) Docker base image from JDK 25 back to JDK 21. The workflow dispatches from `main` but builds the `release/optimize-8.7.22` code, which is JDK 21. PR #51203 forced JDK 25 base args (`openjre-base:25-dev` / `e2772c...`), so `verify.sh` failed with a label mismatch (`io.minimus.images.line` 21 vs 25, base digest mismatch). JDK 25 was intentionally not backported to 8.7, so this restores the JDK 21 base image/digest the release branch Dockerfile + golden file expect. Note: the release branch pins `openjre-base-compat:21-dev` (not `openjre-base:21-dev`), so the revert uses that exact image tag. Only the `BASE_IMAGE`/`BASE_DIGEST` lines change; the Artifactory/`camunda-cpm` fix from #54672 is untouched.

# Checklist

- [ ] Enable backports when necessary (fex. for bug fixes, for CI changes, or for documentation changes).
- [ ] If this PR modifies the C8 Orchestration Cluster E2E Test Suite, the relevant tests have been run via the on-demand workflow before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

# Related issues

closes #
