### PR TITLE
Backport setup-build action to release/optimize-8.7.22 (fix Post Setup Maven)

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -1,0 +1,273 @@
+---
+name: Setup build
+
+# owner: @camunda/monorepo-devops-team
+
+description: Sets up the required stack to build, install, and run monorepo projects
+
+inputs:
+  camunda-nexus:
+    description: |
+      If enabled, Camunda Nexus will be configured and used as a mirror for Maven repositories
+      Camunda Nexus is automatically disabled for fork PRs.
+    required: false
+    default: "true"
+  dockerhub:
+    description: |
+      If enabled, logs into DockerHub with a CI account.
+      DockerHub login is automatically disabled for fork PRs.
+    required: false
+    default: "false"
+  dockerhub-readonly:
+    description: |
+      If enabled, logs into DockerHub with a read-only CI account.
+      Useful to avoid being rate-limited when using an anonymous account from GitHub-managed runners.
+      DockerHub login is automatically disabled for fork PRs.
+    required: false
+    default: "false"
+  harbor:
+    description: |
+      If enabled, logs into Harbor with a CI account.
+      Harbor login is automatically disabled for fork PRs.
+    required: false
+    default: "false"
+  java-distribution:
+    description: Java distribution to use
+    required: false
+    default: temurin
+  java-version:
+    description: JDK version to install
+    required: false
+    default: "21"
+  maven-cache-key-modifier:
+    description: A modifier to use for maven cache key
+    required: false
+    default: "shared"
+  maven-mirrors:
+    description: |
+      JSON list of extra Maven mirrors.
+      It will be merged with Camunda Nexus settings (if enabled ), with precedence."
+    required: false
+    default: '[]'
+  maven-servers:
+    description: |
+      JSON list of extra Maven servers.
+      It will be merged with Camunda Nexus settings (if enabled), with precedence."
+    required: false
+    default: '[]'
+  minimus:
+    description: |
+      If enabled, logs into Minimus registry with a CI account.
+      Minimus login is automatically disabled for fork PRs.
+    required: false
+    default: "false"
+  time-zone:
+    description: |
+      Time zone to set for the build environment. Use TZ identifiers, e.g., 'Europe/Berlin'.
+      https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    required: false
+  vault-address:
+    description: Vault URL to retrieve secrets from
+    required: false
+  vault-role-id:
+    description: Vault Role ID to use
+    required: false
+  vault-secret-id:
+    description: Vault Secret ID to use
+    required: false
+
+outputs: {}
+
+runs:
+  using: composite
+  steps:
+  - name: Preliminary checks
+    id: checks
+    env:
+      DOCKERHUB: ${{ inputs.dockerhub }}
+      DOCKERHUB_READONLY: ${{ inputs.dockerhub-readonly }}
+      # Paths to Vault secrets for DockerHub accounts
+      DOCKERHUB_VAULT_PATHS: >-
+        {
+          "camunda": {
+            "path": "secret/data/products/camunda/ci/github-actions"
+          },
+          "operate": {
+            "path": "secret/data/products/operate/ci/github-actions"
+          },
+          "optimize": {
+            "path": "secret/data/products/optimize/ci/camunda-optimize"
+          },
+          "tasklist": {
+            "path": "secret/data/products/tasklist/ci/tasklist"
+          },
+          "zeebe": {
+            "path": "secret/data/products/zeebe/ci/zeebe"
+          }
+        }
+      IS_FORK: >-
+        ${{
+          github.event.name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name != 'camunda/camunda'
+        }}
+      WORKFLOW_REF: ${{ github.workflow_ref }}
+    run: |
+      ## Preliminary checks
+
+      # Check if current workflow run is related to a fork PR
+      if [[ "${IS_FORK}" == "true" ]]; then
+        echo "The current workflow run is related to a fork PR."
+        echo "As a result, Vault secrets cannot be recovered, Camunda Nexus and DockerHub/Harbor login will be disabled."
+      fi
+
+      # Check if DockerHub and DockerHub-readonly are both enabled
+      if [[ "${DOCKERHUB}" == "true" && "${DOCKERHUB_READONLY}" == "true" ]]; then
+        echo "Both dockerhub and dockerhub-readonly inputs are enabled. Only one can be enabled at a time."
+        exit 1
+      fi
+
+      # Infer team from workflow (.yml) file name if possible, otherwise default to camunda
+      worklow=$(basename ${WORKFLOW_REF%@*})  # remove Github ref part and extract filename
+      team=camunda
+      if [[ "$worklow" =~ ^(operate|optimize|tasklist|zeebe)-.*\.(yml|yaml)$ ]]; then
+        team=${BASH_REMATCH[1]}
+      fi
+
+      # Get Vault path to the DockerHub account to use, and check JSON validity at the same time
+      dockerhub_vault_path=$(echo ${DOCKERHUB_VAULT_PATHS} | jq -r --arg team "$team" '.[$team].path')
+
+      echo dockerhub-vault-path="${dockerhub_vault_path}" | tee -a $GITHUB_OUTPUT
+      echo is-fork="${IS_FORK}" | tee -a $GITHUB_OUTPUT
+    shell: bash
+  - name: Import Secrets
+    # Secrets are imported only if current workflow run is not related to a fork PR
+    if: steps.checks.outputs.is-fork != 'true'
+    id: secrets
+    uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+    with:
+      url: ${{ inputs.vault-address }}
+      method: approle
+      roleId: ${{ inputs.vault-role-id }}
+      secretId: ${{ inputs.vault-secret-id }}
+      secrets: |
+        secret/data/github.com/organizations/camunda NEXUS_PSW | ci-account-password;
+        secret/data/github.com/organizations/camunda NEXUS_USR | ci-account-username;
+        ${{ steps.checks.outputs.dockerhub-vault-path }} REGISTRY_HUB_DOCKER_COM_PSW${{ inputs.dockerhub-readonly == 'true' && '_READ_ONLY' || ''}} | dockerhub-token;
+        ${{ steps.checks.outputs.dockerhub-vault-path }} REGISTRY_HUB_DOCKER_COM_USR | dockerhub-username;
+        secret/data/products/camunda/ci/github-actions REGISTRY_MINIMUS_PSW | minimus-token
+  - name: Logs on to Minimus    # Minimus login is disabled for fork PRs
+    if: >-
+      steps.checks.outputs.is-fork != 'true' &&
+      inputs.minimus == 'true'
+    uses: docker/login-action@v3
+    with:
+      registry: reg.mini.dev
+      username: minimus
+      password: ${{ steps.secrets.outputs.minimus-token }}
+  - name: Setup Java
+    uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+    with:
+      distribution: ${{ inputs.java-distribution }}
+      java-version: ${{ inputs.java-version }}
+  - name: Configure Maven cache
+    uses: ./.github/actions/setup-maven-cache
+    with:
+      maven-cache-key-modifier: ${{ inputs.maven-cache-key-modifier }}
+  # Camunda Nexus and extra mirrors/servers must be merged on ids (extra values have precedence).
+  - name: Get Maven mirrors and servers to use
+    id: maven
+    env:
+      # Camunda Nexus is disabled for fork PRs
+      CAMUNDA_NEXUS_ENABLED: >-
+        ${{
+          steps.checks.outputs.is-fork != 'true' &&
+          inputs.camunda-nexus == 'true'
+        }}
+      CAMUNDA_NEXUS_MAVEN_MIRROR: >-
+        [{
+          "id": "camunda-nexus",
+          "name": "Camunda Nexus",
+          "url": "https://repository.nexus.camunda.cloud/content/groups/internal/",
+          "mirrorOf": "zeebe,zeebe-snapshots"
+        }]
+      CAMUNDA_NEXUS_MAVEN_SERVER: >-
+        [{
+          "id": "camunda-nexus",
+          "username": "${{ steps.secrets.outputs.ci-account-username }}",
+          "password": "${{ steps.secrets.outputs.ci-account-password }}"
+        }]
+      # Avoid rate limiting on repo.maven.apache.org by mirroring central via Google's
+      # public Maven Central mirror. Applies to all artifacts (deps, plugins, extensions, BOM).
+      CENTRAL_MAVEN_MIRROR: >-
+        [{
+          "id": "google-maven-central",
+          "name": "Google Maven Central Mirror",
+          "url": "https://maven-central.storage-download.googleapis.com/maven2",
+          "mirrorOf": "central"
+        }]
+      EXTRA_MAVEN_MIRRORS: ${{ inputs.maven-mirrors }}
+      EXTRA_MAVEN_SERVERS: ${{ inputs.maven-servers }}
+    run: |
+      # If Camunda Nexus is disabled, reset default mirrors/servers to empty lists
+      if [ "${CAMUNDA_NEXUS_ENABLED}" != "true" ]; then
+        CAMUNDA_NEXUS_MAVEN_MIRROR="[]"
+        CAMUNDA_NEXUS_MAVEN_SERVER="[]"
+      fi
+
+      # Use jq 'add' operator to merge grouped sublists
+      mirrors=$(\
+        jq -n \
+        --argjson nexus_mirror "${CAMUNDA_NEXUS_MAVEN_MIRROR}" \
+        --argjson central_mirror "${CENTRAL_MAVEN_MIRROR}" \
+        --argjson maven_mirrors "${EXTRA_MAVEN_MIRRORS}" \
+        '[ $nexus_mirror + $central_mirror + $maven_mirrors | group_by(.id)[] | add ]'
+      )
+      servers=$(\
+        jq -n \
+        --argjson nexus_server "${CAMUNDA_NEXUS_MAVEN_SERVER}" \
+        --argjson maven_servers "${EXTRA_MAVEN_SERVERS}" \
+        '[ $nexus_server + $maven_servers | group_by(.id)[] | add ]'
+      )
+
+      echo mirrors=$mirrors >> $GITHUB_OUTPUT
+      echo servers=$servers >> $GITHUB_OUTPUT
+    shell: bash
+  - name: Update Maven settings.xml
+    uses: s4u/maven-settings-action@894661b3ddae382f1ae8edbeab60987e08cf0788 # v4.0.0
+    with:
+      githubServer: false
+      servers: ${{ steps.maven.outputs.servers }}
+      mirrors: ${{ steps.maven.outputs.mirrors }}
+  - name: Set Time Zone
+    if: inputs.time-zone != '' && runner.os == 'Linux'
+    env:
+      TZ_IDENTIFIER: ${{ inputs.time-zone }}
+    run: |
+      # tzdata is not installed in self-hosted runners
+      sudo apt-get update && sudo apt-get install -y tzdata
+      echo ${TZ_IDENTIFIER} | sudo tee /etc/timezone
+      sudo rm -rf /etc/localtime
+      sudo ln -s /usr/share/zoneinfo/${TZ_IDENTIFIER} /etc/localtime
+    shell: bash
+  - name: Logs on to DockerHub
+    # DockerHub login is disabled for fork PRs
+    if: >-
+      steps.checks.outputs.is-fork != 'true' &&
+      (
+        inputs.dockerhub == 'true' ||
+        inputs.dockerhub-readonly == 'true'
+      )
+    uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+    with:
+      username: ${{ steps.secrets.outputs.dockerhub-username }}
+      password: ${{ steps.secrets.outputs.dockerhub-token }}
+  - name: Logs on to Harbor
+    # Harbor login is disabled for fork PRs
+    if: >-
+      steps.checks.outputs.is-fork != 'true' &&
+      inputs.harbor == 'true'
+    uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+    with:
+      registry: registry.camunda.cloud
+      username: ${{ steps.secrets.outputs.ci-account-username }}
+      password: ${{ steps.secrets.outputs.ci-account-password }}


### PR DESCRIPTION
# Description

Backports the `setup-build` composite action (and the local nested actions it requires) to `release/optimize-8.7.22` to fix the Post Setup Maven failure in the Optimize 8.7.22 release build. The release workflow dispatches from `main` and runs `./.github/actions/setup-build`; its auto-generated post step resolves the action from the workspace after the second checkout of the release branch, where `setup-build` did not exist, so the post step failed with "Can't find 'action.yml' under '.github/actions/setup-build'". Restoring the action on the release branch lets the post hook resolve and the job finish green. No workflow files are changed.

Source: `stable/8.7` (used because `stable/optimize-8.7` does not have `setup-build`; confirmed `stable/8.7`'s copy supports the `minimus` and `maven-servers` inputs that the main workflow passes).


# Checklist

- [ ] Enable backports when necessary (fex. for bug fixes, for CI changes, or for documentation changes).
- [ ] If this PR modifies the C8 Orchestration Cluster E2E Test Suite, the relevant tests have been run via the on-demand workflow before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

# Related issues

closes #
